### PR TITLE
Revamp handling of base_samples

### DIFF
--- a/ae/models/tests/test_torch_model_utils.py
+++ b/ae/models/tests/test_torch_model_utils.py
@@ -29,7 +29,7 @@ class MockAcquisitionFunction:
     def __call__(self, X):
         return X[..., 0].max(dim=-1)[0]
 
-    def set_X_pending(self, X_pending):
+    def _set_X_pending(self, X_pending):
         self.X_pending = X_pending
 
 

--- a/ae/models/torch/utils.py
+++ b/ae/models/torch/utils.py
@@ -89,7 +89,7 @@ def _sequential_optimize(
     candidates = None
     base_X_pending = acq_function.X_pending
     # Needed to clear base_samples
-    acq_function.set_X_pending(base_X_pending)
+    acq_function._set_X_pending(base_X_pending)
     for _ in range(n):
         candidate = _joint_optimize(
             acq_function=acq_function,
@@ -106,13 +106,13 @@ def _sequential_optimize(
             candidate = rounding_func(candidate.view(-1)).view(*candidate_shape)
         candidate_list.append(candidate)
         candidates = torch.cat(candidate_list, dim=-2)
-        acq_function.set_X_pending(
+        acq_function._set_X_pending(
             torch.cat([base_X_pending, candidates], dim=-2)
             if base_X_pending is not None
             else candidates
         )
     # Reset acq_func to previous X_pending state
-    acq_function.set_X_pending(base_X_pending)
+    acq_function._set_X_pending(base_X_pending)
     return candidates
 
 


### PR DESCRIPTION
Summary:
- revamps usage of base_samples, so that we don't have to do the weird thing of passing tuples of tensors and ints around
- simplifies batch_mode_transform
- takes some steps in supporting arbitrary batch shapes (though not all)
- cleans up documentation

Reviewed By: sdaulton

Differential Revision: D14280371
