### PR TITLE
fit_model -> fit_gpytorch_model

### DIFF
--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -13,7 +13,7 @@ from botorch.utils import get_objective_weights_transform
 from gpytorch.likelihoods import _GaussianLikelihoodBase
 
 
-FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_model"
+FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_gpytorch_model"
 
 
 def dummy_func(X: torch.Tensor) -> torch.Tensor:

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -6,7 +6,7 @@ import torch
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.objective import ConstrainedMCObjective, LinearMCObjective
 from botorch.acquisition.utils import get_acquisition_function, get_infeasible_cost
-from botorch.fit import fit_model
+from botorch.fit import fit_gpytorch_model
 from botorch.models.constant_noise import ConstantNoiseGP
 from botorch.models.gp_regression import HeteroskedasticSingleTaskGP
 from botorch.models.model import Model
@@ -49,7 +49,7 @@ def get_and_fit_model(
         # TODO: Add bounds for optimization stability - requires revamp upstream
         bounds = {}
         mll = SumMarginalLogLikelihood(model.likelihood, model)
-        mll = fit_model(mll, bounds=bounds)
+        mll = fit_gpytorch_model(mll, bounds=bounds)
     else:
         model.load_state_dict(state_dict)
     return model


### PR DESCRIPTION
Summary:
It really only works with gpytorch models right now, so let's have the
name reflect that.

This will require some changes to the docs wherever `fit_model` appears.

Differential Revision: D14748515
