### PR TITLE
[Ax] Handle tutorial directories

### DIFF
--- a/scripts/parse_tutorials.py
+++ b/scripts/parse_tutorials.py
@@ -4,6 +4,7 @@
 import argparse
 import json
 import os
+import tarfile
 
 import nbformat
 from bs4 import BeautifulSoup
@@ -19,7 +20,7 @@ class TutorialPage extends React.Component {{
   render() {{
       const {{config: siteConfig}} = this.props;
       const {{baseUrl}} = siteConfig;
-      return <Tutorial baseUrl={{baseUrl}} tutorialID="{}"/>;
+      return <Tutorial baseUrl={{baseUrl}} tutorialDir="{t_dir}" tutorialID="{tid}"/>;
   }}
 }}
 
@@ -44,15 +45,36 @@ def gen_tutorials(repo_dir: str) -> None:
     with open(os.path.join(repo_dir, "website", "tutorials.json"), "r") as infile:
         tutorial_config = json.loads(infile.read())
 
-    tutorial_ids = {x["id"] for v in tutorial_config.values() for x in v}
+    tutorial_ids = [x["id"] for v in tutorial_config.values() for x in v]
+    tutorial_dirs = [x.get("dir") for v in tutorial_config.values() for x in v]
 
-    for tid in tutorial_ids:
+    for tid, t_dir in zip(tutorial_ids, tutorial_dirs):
         print("Generating {} tutorial".format(tid))
 
+        if t_dir is not None:
+            tutorial_dir = os.path.join(repo_dir, "tutorials", t_dir)
+            html_dir = os.path.join(repo_dir, "website", "_tutorials", t_dir)
+            js_dir = os.path.join(repo_dir, "website", "pages", "tutorials", t_dir)
+            py_dir = os.path.join(repo_dir, "website", "static", "files", t_dir)
+
+            for d in [tutorial_dir, html_dir, js_dir, py_dir]:
+                os.makedirs(d, exist_ok=True)
+
+            tutorial_path = os.path.join(tutorial_dir, "{}.ipynb".format(tid))
+            html_path = os.path.join(html_dir, "{}.html".format(tid))
+            js_path = os.path.join(js_dir, "{}.js".format(tid))
+            ipynb_path = os.path.join(py_dir, "{}.ipynb".format(tid))
+            py_path = os.path.join(py_dir, "{}.py".format(tid))
+            tar_path = os.path.join(py_dir, "{}.tar.gz".format(tid))
+        else:
+            tutorial_path = os.path.join(repo_dir, "tutorials", "{}.ipynb".format(tid))
+            html_path = os.path.join(repo_dir, "website", "_tutorials", "{}.html".format(tid))
+            js_path = os.path.join(repo_dir, "website", "pages", "tutorials", "{}.js".format(tid))
+            ipynb_path = os.path.join(repo_dir, "website", "static", "files", "{}.ipynb".format(tid))
+            py_path = os.path.join(repo_dir, "website", "static", "files", "{}.py".format(tid))
+
         # convert notebook to HTML
-        with open(
-            os.path.join(repo_dir, "tutorials", "{}.ipynb".format(tid)), "r"
-        ) as infile:
+        with open(tutorial_path, "r") as infile:
             nb_str = infile.read()
             nb = nbformat.reads(nb_str, nbformat.NO_CONVERT)
 
@@ -78,36 +100,28 @@ def gen_tutorials(repo_dir: str) -> None:
 
         html_out = "".join([JS_SCRIPT_TAGS.format(src) for src in SRCS]) + str(nb_meat)
 
-        with open(
-            os.path.join(repo_dir, "website", "_tutorials", "{}.html".format(tid)), "w"
-        ) as html_outfile:
+        # generate HTML file
+        with open(html_path, 'w') as html_outfile:
             html_outfile.write(html_out)
 
         # generate JS file
-        script = TEMPLATE.format(tid)
-        with open(
-            os.path.join(
-                repo_dir, "website", "pages", "tutorials", "{}.js".format(tid)
-            ),
-            "w",
-        ) as js_outfile:
+        t_dir_js = t_dir if t_dir else ''
+        script = TEMPLATE.format(t_dir=t_dir_js, tid=tid)
+        with open(js_path, "w") as js_outfile:
             js_outfile.write(script)
 
         # output tutorial in both ipynb & py form
-        with open(
-            os.path.join(
-                repo_dir, "website", "static", "files", "{}.ipynb".format(tid)
-            ),
-            "w",
-        ) as ipynb_outfile:
+        with open(ipynb_path, "w") as ipynb_outfile:
             ipynb_outfile.write(nb_str)
         exporter = ScriptExporter()
         script, meta = exporter.from_notebook_node(nb)
-        with open(
-            os.path.join(repo_dir, "website", "static", "files", "{}.py".format(tid)),
-            "w",
-        ) as py_outfile:
+        with open(py_path, "w") as py_outfile:
             py_outfile.write(script)
+
+        # create .tar archive (if necessary)
+        if t_dir is not None:
+	        with tarfile.open(tar_path, "w:gz") as tar:
+	            tar.add(tutorial_dir, arcname=os.path.basename(tutorial_dir))
 
 
 if __name__ == "__main__":

--- a/website/core/Tutorial.js
+++ b/website/core/Tutorial.js
@@ -39,10 +39,38 @@ function renderDownloadIcon() {
 
 class Tutorial extends React.Component {
   render() {
-    const {baseUrl, tutorialID} = this.props;
+    const {baseUrl, tutorialDir, tutorialID} = this.props;
 
-    const htmlFile = `${CWD}/_tutorials/${tutorialID}.html`;
+    let htmlFile = null;
+    let pyFile = null;
+    let ipynbFile = null;
+    let directoryDownloadButton = null;
+
+    if (tutorialDir != null && tutorialDir !== '') {
+      htmlFile = `${CWD}/_tutorials/${tutorialDir}/${tutorialID}.html`;
+      ipynbFile = `${baseUrl}files/${tutorialDir}/${tutorialID}.ipynb`;
+      pyFile = `${baseUrl}files/${tutorialDir}/${tutorialID}.py`;
+      directoryDownloadButton = (
+        <div className="tutorialButtonWrapper buttonWrapper">
+          <a
+            className="tutorialButton button"
+            download
+            href={`${baseUrl}files/${tutorialDir}/${tutorialID}.tar.gz`}
+            target="_blank">
+            {renderDownloadIcon()}
+            {'Download Tutorial Archive (.tar.gz): Notebook, Source and Data'}
+          </a>
+        </div>
+      );
+    }
+    else {
+      htmlFile = `${CWD}/_tutorials/${tutorialID}.html`;
+      ipynbFile = `${baseUrl}files/${tutorialID}.ipynb`;
+      pyFile = `${baseUrl}files/${tutorialDir}/${tutorialID}.py`;
+    }
     const normalizedHtmlFile = path.normalize(htmlFile);
+
+
 
     return (
       <div className="docMainWrapper wrapper">
@@ -54,11 +82,12 @@ class Tutorial extends React.Component {
               __html: fs.readFileSync(normalizedHtmlFile, {encoding: 'utf8'}),
             }}
           />
+          {directoryDownloadButton}
           <div className="tutorialButtonWrapper buttonWrapper">
             <a
               className="tutorialButton button"
               download
-              href={`${baseUrl}files/${tutorialID}.ipynb`}
+              href={ipynbFile}
               target="_blank">
               {renderDownloadIcon()}
               {'Download Tutorial Jupyter Notebook'}
@@ -68,7 +97,7 @@ class Tutorial extends React.Component {
             <a
               className="tutorialButton button"
               download
-              href={`${baseUrl}files/${tutorialID}.py`}
+              href={pyFile}
               target="_blank">
               {renderDownloadIcon()}
               {'Download Tutorial Source Code'}

--- a/website/tutorials.json
+++ b/website/tutorials.json
@@ -25,7 +25,8 @@
       "title": "Bandit Optimization"
     },
     {
-      "id": "human_loop",
+      "dir": "human_in_the_loop",
+      "id": "human_in_the_loop",
       "title": "Human-in-the-Loop Optimization"
     }
   ],


### PR DESCRIPTION
If a tutorial has associated files (e.g. Human in the loop), our current structure doesn't handle that. 
This adds a dir flag in the tutorials json that can be used to set up the correct structure, and offer a button for downloading the data + source + notebook as a tar.gz