### PR TITLE
Fix plot_contour for choice parameters

### DIFF
--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -400,7 +400,7 @@ def get_fixed_values(
             if isinstance(parameter, FixedParameter):
                 setx[p_name] = parameter.value
             elif isinstance(parameter, ChoiceParameter):
-                setx[p_name] = Counter(vals).most_common(1)[0][1]
+                setx[p_name] = Counter(vals).most_common(1)[0][0]
             elif isinstance(parameter, RangeParameter):
                 setx[p_name] = parameter._cast(np.mean(vals))
 


### PR DESCRIPTION
These indices are flipped--the value we want is the actual parameter value, not the number of occurrences. 

Fixes #68 