### PR TITLE
Fixed one_hot.py

### DIFF
--- a/ax/modelbridge/transforms/one_hot.py
+++ b/ax/modelbridge/transforms/one_hot.py
@@ -151,6 +151,8 @@ class OneHot(Transform):
                 val = self.encoder[p_name].inverse_transform(encoded_labels=x[None, :])[
                     0
                 ]
+                if isinstance(val, np.str_):
+                    val = str(val)
                 if isinstance(val, np.bool_):
                     val = bool(val)  # Numpy bools don't serialize
                 obsf.parameters[p_name] = val


### PR DESCRIPTION
This is a hot fix for `is_valid_type` checking in ./core/search_space.py:
```python
if not self._parameters[name].is_valid_type(value):
    if raise_error:
        raise ValueError(
            f"{value} is not a valid value for "
            f"parameter {self._parameters[name]}"
        )
    return False
```
Since np.str_ couldn't pass the type checking