### PR TITLE
Fix include option for numpy header files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ from setuptools import find_packages, setup
 from setuptools.extension import Extension
 
 
-EXTENSIONS = [Extension("ax.utils.stats.sobol", ["ax/utils/stats/sobol.pyx"])]
+EXTENSIONS = [Extension("ax.utils.stats.sobol", ["ax/utils/stats/sobol.pyx"],
+                        include_dirs=[numpy.get_include()])]
 
 REQUIRES = [
     "botorch",
@@ -55,7 +56,6 @@ setup(
     python_requires=">=3.6",
     setup_requires=["cython", "numpy"],
     install_requires=REQUIRES,
-    include_dirs=[numpy.get_include()],
     packages=find_packages(),
     ext_modules=cythonize(EXTENSIONS),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,13 @@ from setuptools import find_packages, setup
 from setuptools.extension import Extension
 
 
-EXTENSIONS = [Extension("ax.utils.stats.sobol", ["ax/utils/stats/sobol.pyx"],
-                        include_dirs=[numpy.get_include()])]
+EXTENSIONS = [
+    Extension(
+        "ax.utils.stats.sobol",
+        ["ax/utils/stats/sobol.pyx"],
+        include_dirs=[numpy.get_include()],
+    )
+]
 
 REQUIRES = [
     "botorch",


### PR DESCRIPTION
Hi, I tried to build this project, then got following error.

```
$ python setup.py develop
running develop
running egg_info
writing ax_platform.egg-info/PKG-INFO
writing dependency_links to ax_platform.egg-info/dependency_links.txt
writing requirements to ax_platform.egg-info/requires.txt
writing top-level names to ax_platform.egg-info/top_level.txt
reading manifest file 'ax_platform.egg-info/SOURCES.txt'
writing manifest file 'ax_platform.egg-info/SOURCES.txt'
running build_ext
building 'ax.utils.stats.sobol' extension
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers -I/usr/local/opt/icu4c/include -I/usr/local/include -I/usr/local/opt/openssl/include -I/usr/local/opt/sqlite/include -I/Users/c-bata/src/github.com/facebook/Ax/venv/include -I/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/include/python3.7m -c ax/utils/stats/sobol.c -o build/temp.macosx-10.14-x86_64-3.7/ax/utils/stats/sobol.o
ax/utils/stats/sobol.c:606:10: fatal error: 'numpy/arrayobject.h' file not found
#include "numpy/arrayobject.h"
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.

```

As the error message implies, the directory path of numpy header files isn't passed to `-I` option of clang. The return value of ``numpy.get_include()`` should be added in clang include option.

```
>>> import numpy
>>> numpy.get_include()
'/Users/c-bata/src/github.com/facebook/Ax/venv/lib/python3.7/site-packages/numpy/core/include'
```

To set the include_dirs for numpy header files, I read the docs of [this section of cython documentation](https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#configuring-the-c-build) and adds the changes of this PR, then ``python setup.py develop`` is pass.


## Context

* Python3.7
* Cython 0.29.7
* revision of ax: eebb8c7
* os: macOS
