### PR TITLE
Test against botorch + gpytorch master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
       python: "3.6"
       install:
         - pip install cython numpy
+        - pip install git+https://github.com/cornellius-gp/gpytorch.git
+        - pip install git+https://github.com/pytorch/botorch.git
         - pip install -q -e .[dev,mysql,notebook]
       script:
         - pytest -ra --cov=ax
@@ -19,6 +21,8 @@ matrix:
       dist: xenial
       install:
         - pip install cython numpy
+        - pip install git+https://github.com/cornellius-gp/gpytorch.git
+        - pip install git+https://github.com/pytorch/botorch.git
         - pip install -q -e .[dev,mysql,notebook]
       script:
         - pytest -ra
@@ -39,6 +43,8 @@ matrix:
       python: "3.6"
       install:
         - pip install cython numpy
+        - pip install git+https://github.com/cornellius-gp/gpytorch.git
+        - pip install git+https://github.com/pytorch/botorch.git
         - pip install -q -e .[dev,mysql,notebook,gpy]
       script:
         # warnings treated as errors


### PR DESCRIPTION
We develop against gpytorch + botorch master, which means that tests will fail if we run them against the latest released version. This changes the CI settings in travis to use the most recent master for now, until we have a more stable base to work from.