### PR TITLE
exclude Base from autodoc

### DIFF
--- a/sphinx/source/storage.rst
+++ b/sphinx/source/storage.rst
@@ -93,6 +93,7 @@ ax.storage.sqa\_store.db module
     :members:
     :undoc-members:
     :show-inheritance:
+    :exclude-members: Base
 
 ax.storage.sqa\_store.json module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The most recent version of Sphinx includes [this commit](https://github.com/sphinx-doc/sphinx/commit/27dd8367c65c4313d499d945e7a2804865a1754a) which starts running autodoc on module level variables, like `Base = declarative_base(cls=SQABase)` in db.py. Autodoc does not like declarative_base (neither does pyre or any of our tools, really). So let's exclude it.