### PR TITLE
Do not use mock (use unittest.mock instead)

### DIFF
--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
-import mock
+
+from unittest import mock
+
 import torch
 from ax.models.torch.botorch_defaults import _get_model, get_and_fit_model
 from ax.utils.common.testutils import TestCase


### PR DESCRIPTION
no reason to use the backport here, in fact this will cause issues with testing if not manually installed because it's not part of the [dev] install