### PR TITLE
Specify fidelity_parameters in Ax

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -31,12 +31,13 @@ def extract_parameter_constraints(
 
 def get_bounds_and_task(
     search_space: SearchSpace, param_names: List[str]
-) -> Tuple[List[Tuple[float, float]], List[int]]:
+) -> Tuple[List[Tuple[float, float]], List[int], List[int]]:
     """Extract box bounds from a search space in the usual Scipy format.
     Identify integer parameters as task features.
     """
     bounds: List[Tuple[float, float]] = []
     task_features: List[int] = []
+    fidelity_features: List[int] = []
     for i, p_name in enumerate(param_names):
         p = search_space.parameters[p_name]
         # Validation
@@ -48,7 +49,10 @@ def get_bounds_and_task(
         bounds.append((p.lower, p.upper))
         if p.parameter_type == ParameterType.INT:
             task_features.append(i)
-    return bounds, task_features
+        if p.is_fidelity:
+            fidelity_features.append(i)
+
+    return bounds, task_features, fidelity_features
 
 
 def get_fixed_features(

--- a/ax/modelbridge/random.py
+++ b/ax/modelbridge/random.py
@@ -65,7 +65,7 @@ class RandomModelBridge(ModelBridge):
     ) -> Tuple[List[ObservationFeatures], List[float], Optional[ObservationFeatures]]:
         """Generate new candidates according to a search_space."""
         # Extract parameter values
-        bounds, _ = get_bounds_and_task(search_space, self.parameters)
+        bounds, _, _ = get_bounds_and_task(search_space, self.parameters)
         # Get fixed features
         fixed_features_dict = get_fixed_features(fixed_features, self.parameters)
         # Extract param constraints

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -43,6 +43,7 @@ class TorchModelBridgeTest(TestCase):
             bounds=None,
             feature_names=[],
             task_features=[],
+            fidelity_features=[],
         )
         model_fit_args = model.fit.mock_calls[0][2]
         self.assertTrue(
@@ -111,7 +112,6 @@ class TorchModelBridgeTest(TestCase):
         gen_args = model.gen.mock_calls[0][2]
         self.assertEqual(gen_args["n"], 3)
         self.assertEqual(gen_args["bounds"], [(0, 1)])
-        print(gen_args["objective_weights"])
         self.assertTrue(
             torch.equal(
                 gen_args["objective_weights"],

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -91,6 +91,7 @@ class TorchModelBridge(ArrayModelBridge):
         bounds: List[Tuple[float, float]],
         task_features: List[int],
         feature_names: List[str],
+        fidelity_features: List[int],
     ) -> None:
         self.model = model
         # Convert numpy arrays to torch tensors
@@ -104,6 +105,7 @@ class TorchModelBridge(ArrayModelBridge):
             bounds=bounds,
             task_features=task_features,
             feature_names=feature_names,
+            fidelity_features=fidelity_features,
         )
 
     def _model_update(

--- a/ax/models/numpy/randomforest.py
+++ b/ax/models/numpy/randomforest.py
@@ -41,6 +41,7 @@ class RandomForest(NumpyModel):
         bounds: List[Tuple[float, float]],
         task_features: List[int],
         feature_names: List[str],
+        fidelity_features: List[int],
     ) -> None:
         for i, X in enumerate(Xs):
             self.models.append(

--- a/ax/models/numpy_base.py
+++ b/ax/models/numpy_base.py
@@ -22,6 +22,7 @@ class NumpyModel:
         bounds: List[Tuple[float, float]],
         task_features: List[int],
         feature_names: List[str],
+        fidelity_features: List[int],
     ) -> None:
         """Fit model to m outcomes.
 
@@ -35,6 +36,8 @@ class NumpyModel:
             task_features: Columns of X that take integer values and should be
                 treated as task parameters.
             feature_names: Names of each column of X.
+            fidelity_features: Columns of X that should be treated as fidelity
+                parameters.
         """
         pass
 

--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -26,11 +26,23 @@ class BotorchDefaultsTest(TestCase):
         x = [torch.zeros(2, 2)]
         y = [torch.zeros(2, 1)]
         yvars = [torch.ones(2, 1)]
-        get_and_fit_model(Xs=x, Ys=y, Yvars=yvars, task_features=[1], state_dict=[])
+        get_and_fit_model(
+            Xs=x,
+            Ys=y,
+            Yvars=yvars,
+            task_features=[1],
+            fidelity_features=[],
+            state_dict=[],
+        )
         # Check that task feature was correctly passed to _get_model
         self.assertEqual(get_model_mock.mock_calls[0][2]["task_feature"], 1)
 
         with self.assertRaises(ValueError):
             get_and_fit_model(
-                Xs=x, Ys=y, Yvars=yvars, task_features=[0, 1], state_dict=[]
+                Xs=x,
+                Ys=y,
+                Yvars=yvars,
+                task_features=[0, 1],
+                fidelity_features=[],
+                state_dict=[],
             )

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -54,6 +54,7 @@ class BotorchModelTest(TestCase):
                 bounds=bounds,
                 task_features=task_features,
                 feature_names=feature_names,
+                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
         # Check attributes
@@ -81,6 +82,7 @@ class BotorchModelTest(TestCase):
                 bounds=bounds,
                 task_features=task_features,
                 feature_names=feature_names,
+                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 
@@ -263,7 +265,12 @@ class BotorchModelTest(TestCase):
             key: torch.tensor(val, **tkwargs) for key, val in true_state_dict.items()
         }
         model = get_and_fit_model(
-            Xs=Xs1, Ys=Ys1, Yvars=Yvars1, task_features=[], state_dict=true_state_dict
+            Xs=Xs1,
+            Ys=Ys1,
+            Yvars=Yvars1,
+            task_features=[],
+            fidelity_features=[],
+            state_dict=true_state_dict,
         )
         for k, v in chain(model.named_parameters(), model.named_buffers()):
             self.assertTrue(torch.equal(true_state_dict[k], v))
@@ -292,6 +299,7 @@ class BotorchModelTest(TestCase):
                 bounds=bounds,
                 task_features=task_features,
                 feature_names=feature_names,
+                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
         X = torch.rand(2, 3, dtype=torch.float)
@@ -321,6 +329,7 @@ class BotorchModelTest(TestCase):
                 bounds=bounds,
                 task_features=task_features,
                 feature_names=feature_names,
+                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 

--- a/ax/models/tests/test_numpy.py
+++ b/ax/models/tests/test_numpy.py
@@ -19,6 +19,7 @@ class NumpyModelTest(TestCase):
             bounds=[(0, 1)],
             task_features=[],
             feature_names=["x"],
+            fidelity_features=[],
         )
 
     def testNumpyModelPredict(self):

--- a/ax/models/tests/test_randomforest.py
+++ b/ax/models/tests/test_randomforest.py
@@ -20,6 +20,7 @@ class RandomForestTest(TestCase):
             bounds=[(0, 1)] * 2,
             task_features=[],
             feature_names=["x1", "x2"],
+            fidelity_features=[],
         )
         self.assertEqual(len(m.models), 2)
         self.assertEqual(len(m.models[0].estimators_), 5)

--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -19,6 +19,7 @@ class TorchModelTest(TestCase):
             bounds=[(0, 1)],
             task_features=[],
             feature_names=["x1"],
+            fidelity_features=[],
         )
 
     def testTorchModelPredict(self):

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -31,6 +31,7 @@ def get_and_fit_model(
     Ys: List[Tensor],
     Yvars: List[Tensor],
     task_features: List[int],
+    fidelity_features: List[int],
     state_dict: Optional[Dict[str, Tensor]] = None,
     **kwargs: Any,
 ) -> GPyTorchModel:
@@ -41,6 +42,7 @@ def get_and_fit_model(
         Ys: List of Y data, one tensor per outcome
         Yvars: List of observed variance of Ys.
         task_features: List of columns of X that are tasks.
+        fidelity_features: List of columns of X that are fidelity parameters.
         state_dict: If provided, will set model parameters to this state
             dictionary. Otherwise, will fit the model.
 

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -26,6 +26,7 @@ class TorchModel:
         bounds: List[Tuple[float, float]],
         task_features: List[int],
         feature_names: List[str],
+        fidelity_features: List[int],
     ) -> None:
         """Fit model to m outcomes.
 
@@ -39,6 +40,8 @@ class TorchModel:
             task_features: Columns of X that take integer values and should be
                 treated as task parameters.
             feature_names: Names of each column of X.
+            fidelity_features: Columns of X that should be treated as fidelity
+                parameters.
         """
         pass
 


### PR DESCRIPTION
Summary:
Specify fidelity_dims (which is used by fidelity models) in `fit()`

Put fidelity parameters to the last columns.

Reviewed By: bletham

Differential Revision: D16122299

