### PR TITLE
Add fidelity support to the service API

### DIFF
--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -179,7 +179,8 @@ def observations_from_data(experiment: Experiment, data: Data) -> List[Observati
     """Convert Data to observations.
 
     Converts a Data object to a list of Observation objects. Pulls
-    arm parameters from experiment.
+    arm parameters from experiment.  Overrides fidelity parameters in the arm
+    with those found in the Data object.
 
     Uses a diagonal covariance matrix across metric_names.
 
@@ -196,6 +197,7 @@ def observations_from_data(experiment: Experiment, data: Data) -> List[Observati
             "start_time",
             "end_time",
             "random_split",
+            "fidelities",
         }.intersection(data.df.columns)
     )
     observations = []
@@ -211,6 +213,10 @@ def observations_from_data(experiment: Experiment, data: Data) -> List[Observati
             obs_kwargs["parameters"] = obs_parameters
         for f in ["trial_index", "start_time", "end_time", "random_split"]:
             obs_kwargs[f] = features.get(f, None)
+        if "fidelities" in features:
+            fidelity_dict = json.loads(features["fidelities"])
+            for param_name, val in fidelity_dict.items():
+                obs_parameters[param_name] = val
         observations.append(
             Observation(
                 features=ObservationFeatures(**obs_kwargs),

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -126,3 +126,16 @@ class DataTest(TestCase):
             sample_sizes={"0_1": 2},
         )
         self.assertEqual(len(data.df), 1)
+
+    def testFromFidelityEvaluations(self):
+        data = Data.from_fidelity_evaluations(
+            evaluations={
+                "0_1": [
+                    ({"f1": 1.0, "f2": 0.5}, {"b": (3.7, 0.5)}),
+                    ({"f1": 1.0, "f2": 0.75}, {"b": (3.8, 0.5)}),
+                ]
+            },
+            trial_index=0,
+            sample_sizes={"0_1": 2},
+        )
+        self.assertEqual(len(data.df), 2)

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -25,11 +25,17 @@ TModelPredictArm = Tuple[Dict[str, float], Optional[Dict[str, Dict[str, float]]]
 # 1-arm `Trial` evaluation data: {metric_name -> (mean, standard error)}}.
 TTrialEvaluation = Dict[str, Tuple[float, float]]
 
+# 1-arm evaluation data with trace fidelities
+TFidelityTrialEvaluation = List[Tuple[TParameterization, TTrialEvaluation]]
+
 # Format for trasmitting evaluation data to Ax is either:
 # 1) {metric_name -> (mean, standard error)} (TTrialEvaluation)
 # 2) (mean, standard error) and we assume metric name == objective name
 # 3) only the mean, and we assume metric name == objective name and standard error == 0
-TEvaluationOutcome = Union[TTrialEvaluation, Tuple[float, float], float]
+# 4) [({fidelity_param -> value}, {metric_name} -> (mean, standard error))]
+TEvaluationOutcome = Union[
+    TTrialEvaluation, Tuple[float, float], float, TFidelityTrialEvaluation
+]
 
 TConfig = Dict[str, Union[int, float, str, AcquisitionFunction]]
 TBucket = List[Dict[str, List[str]]]

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -281,8 +281,26 @@ class TestServiceAPI(TestCase):
             x1, x2 = parameterization.get("x1"), parameterization.get("x2")
             ax.complete_trial(trial_index, raw_data=(branin(x1, x2), 0.0))
         with self.assertRaisesRegex(ValueError, "Raw data has an invalid type"):
+            ax.complete_trial(trial_index, raw_data="invalid_data")
+
+    def test_raw_data_format_with_fidelities(self):
+        ax = AxClient()
+        ax.create_experiment(
+            parameters=[
+                {"name": "x1", "type": "range", "bounds": [-5.0, 10.0]},
+                {"name": "x2", "type": "range", "bounds": [0.0, 1.0]},
+            ],
+            minimize=True,
+        )
+        for _ in range(6):
+            parameterization, trial_index = ax.get_next_trial()
+            x1, x2 = parameterization.get("x1"), parameterization.get("x2")
             ax.complete_trial(
-                trial_index, raw_data=[(branin(x1, x2), 0.0), (branin(x1, x2), 0.0)]
+                trial_index,
+                raw_data=[
+                    ({"x2": x2 / 2.0}, {"objective": (branin(x1, x2 / 2.0), 0.0)}),
+                    ({"x2": x2}, {"objective": (branin(x1, x2), 0.0)}),
+                ],
             )
 
     def test_keep_generating_without_data(self):

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -29,6 +29,7 @@ from ax.core.simple_experiment import DEFAULT_OBJECTIVE_NAME
 from ax.core.types import (
     ComparisonOp,
     TEvaluationOutcome,
+    TFidelityTrialEvaluation,
     TParameterization,
     TParamValue,
     TTrialEvaluation,
@@ -278,9 +279,10 @@ def make_experiment(
 
 def raw_data_to_evaluation(
     raw_data: TEvaluationOutcome, objective_name: str
-) -> TTrialEvaluation:
+) -> Union[TTrialEvaluation, TFidelityTrialEvaluation]:
     """Format the trial evaluation data to a standard `TTrialEvaluation`
-    (mapping from metric names to a tuple of mean and SEM) representation.
+    (mapping from metric names to a tuple of mean and SEM) representation, or
+    to a TFidelityTrialEvaluation.
 
     Note: this function expects raw_data to be data for a `Trial`, not a
     `BatchedTrial`.
@@ -288,6 +290,8 @@ def raw_data_to_evaluation(
     # `BatchedTrial` data not expected because it was not needed, to add (if
     # need arises), make raw_data a mapping from arm name to TEvaluationOutcome.
     if isinstance(raw_data, dict):
+        return raw_data
+    elif isinstance(raw_data, list):
         return raw_data
     elif isinstance(raw_data, tuple):
         return {objective_name: raw_data}


### PR DESCRIPTION
Summary: This overwrites arm parameters in observations when optional fidelity inputs are provided to the service API.  It adds an alternative input format to complete_trial that specifies these fidelity parameters, and stores these fidelity parameters within an optional json-encoded dictionary in the Data class.

Reviewed By: lena-kashtelyan

Differential Revision: D16586847

