### PR TITLE
Validate coverage of modules within Sphinx API + add to Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - 3.6
 
 jobs:
+  allow_failures:
+    # create custom environment variable for flagging jobs that are allowed to fail
+    - env: ALLOW_FAILURE=true
   include:
     - name: "Tests + Coverage: Python 3.6"
       stage: Test
@@ -52,6 +55,12 @@ jobs:
         - sphinx-build -WT sphinx/source sphinx/build
         # since -W flag breaks on first error, re-run without it to print all
         - sphinx-build sphinx/source sphinx/build
+    - name: "Docs: Sphinx Coverage (Python 3.6)"
+      python: "3.6"
+      # Allow failure for now, until missing modules are added to documentation.
+      env: ALLOW_FAILURE=true
+      script:
+        - python3 scripts/validate_sphinx.py -p "${pwd}"
     - stage: Deploy Website
       python: "3.6"
       install:

--- a/scripts/validate_sphinx.py
+++ b/scripts/validate_sphinx.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import pkgutil
+import re
+from typing import Set
+
+
+# Paths are relative to top-level Ax directory (which is passed into fxn below)
+SPHINX_RST_PATH = os.path.join("sphinx", "source")
+AX_LIBRARY_PATH = "ax"
+
+# Regex for automodule directive used in Sphinx docs
+AUTOMODULE_REGEX = re.compile(r"\.\. automodule:: ([\.\w]*)")
+
+
+def parse_rst(rst_filename: str) -> Set[str]:
+    """Extract automodule directives from rst."""
+    ret = set()
+    with open(rst_filename, "r") as f:
+        lines = f.readlines()
+        for line in lines:
+            line = line.strip()
+            name = AUTOMODULE_REGEX.findall(line)
+            if name:
+                ret.add(name[0])
+    return ret
+
+
+def validate_complete_sphinx(path_to_ax: str) -> None:
+    """Validate that Sphinx-based API documentation is complete.
+
+    * Every top-level module (e.g., core, models, etc.) should have corresponding rst
+      file.
+    * Every single non-package (i.e. py file) module should be included in rst file with
+      `automodule::` directive. Sphinx will then automatically include all members from
+       the module in the documentation.
+
+    Note: this function does not validate any documentation for the 'ax' module.
+
+    Args:
+      path_to_ax: the path to the top-level ax directory (directory that includes ax
+        library, sphinx, website, etc.).
+
+    """
+    # Load top-level modules used in Ax (e.g., core, models; exclude 'fb' and 'version')
+    modules = {
+        modname
+        for importer, modname, ispkg in pkgutil.walk_packages(
+            path=[AX_LIBRARY_PATH], onerror=lambda x: None
+        )
+        if modname not in {"fb", "version"}
+    }
+
+    # Load all rst files (these contain the documentation for Sphinx)
+    rstpath = os.path.join(path_to_ax, SPHINX_RST_PATH)
+    rsts = {f.replace(".rst", "") for f in os.listdir(rstpath) if f.endswith(".rst")}
+
+    # Verify that all top-level modules have a corresponding rst
+    assert len(modules.difference(rsts)) == 0, "Not all modules have corresponding rst."
+
+    # Track all modules that are not in docs (so can print all)
+    modules_not_in_docs = []
+
+    # Iterate over top-level modules
+    for module in modules.intersection(rsts):
+        # Parse rst & extract all modules use automodule directive
+        modules_in_rst = parse_rst(os.path.join(rstpath, module + ".rst"))
+
+        # Extract all non-package modules
+        for _importer, modname, ispkg in pkgutil.walk_packages(
+            path=[os.path.join(AX_LIBRARY_PATH, module)],  # ax.__path__[0], module),
+            prefix="ax." + module + ".",
+            onerror=lambda x: None,
+        ):
+            if not ispkg and ".tests" not in modname and modname not in modules_in_rst:
+                modules_not_in_docs.append(modname)
+
+    assert len(modules_not_in_docs) == 0, "Not all modules are documented: {}".format(
+        modules_not_in_docs
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=("Validate that Sphinx documentation is complete.")
+    )
+    parser.add_argument(
+        "-p",
+        "--path",
+        metavar="path",
+        required=True,
+        help="Path to the top-level ax directory.",
+    )
+    args = parser.parse_args()
+    validate_complete_sphinx(args.path)


### PR DESCRIPTION
This is useful because it's easy to forget adding a module to the appropriate rst file within the Sphinx docs during development. The rst files are not automatically re-generated (given the manual organization & categorization that goes into them), so modules must be added manually. If modules are not added, API docs on our site will not be complete.

Add to Travis (but as a non-breaking test for now) until we add missing modules.

Example usage from `Ax-master`:
```
> python3 scripts/validate_sphinx.py -p "${pwd}"
AssertionError: Not all modules are documented: ['ax.utils.common.kwargs', 'ax.utils.common.serialization', 'ax.utils.common.testutils', 'ax.utils.common.timeutils', 'ax.utils.measurement.synthetic_functions', 'ax.utils.stats.sobol', 'ax.utils.testing.fake', 'ax.utils.tutorials.cnn_utils', 'ax.service.utils.best_point', 'ax.models.torch.botorch_defaults', 'ax.metrics.l2norm', 'ax.plot.bandit_rollout', 'ax.plot.marginal_effects', 'ax.modelbridge.modelbridge_utils', 'ax.modelbridge.random', 'ax.modelbridge.registry', 'ax.modelbridge.transforms.convert_metric_names', 'ax.modelbridge.transforms.out_of_design', 'ax.modelbridge.transforms.winsorize', 'ax.storage.sqa_store.sqa_config', 'ax.storage.sqa_store.structs', 'ax.storage.transform_registry']
```