### PR TITLE
Update typeutils.py

### DIFF
--- a/ax/utils/common/typeutils.py
+++ b/ax/utils/common/typeutils.py
@@ -91,8 +91,8 @@ def numpy_type_to_python_type(value: Any) -> Any:
     """If `value` is a Numpy int or float, coerce to a Python int or float.
     This is necessary because some of our transforms return Numpy values.
     """
-    if type(value) == np.int64:
+    if isinstance(value, np.integer):
         value = int(value)  # pragma: nocover (covered by generator tests)
-    if type(value) == np.float64:
+    if isinstance(value, np.floating):
         value = float(value)  # pragma: nocover  (covered by generator tests)
     return value


### PR DESCRIPTION
dtypes `np.float32`, `np.int32`, ... is not under consideration, fixed it by calling general `isinstance`
+ Without fixing it, Ax on Windows [Anaconda Distribution] will raise tons of bugs due to `json.dump`