### PR TITLE
Consolidate sequential_optimize and joint_optimize

### DIFF
--- a/ax/models/model_utils.py
+++ b/ax/models/model_utils.py
@@ -189,10 +189,7 @@ def tunable_feature_indices(
     Returns:
         The indices of tunable features.
     """
-    if fixed_features:
-        fixed_feature_indices = np.array(list(fixed_features.keys()))
-    else:
-        fixed_feature_indices = np.array([])
+    fixed_feature_indices = list(fixed_features.keys()) if fixed_features else []
     feature_indices = np.arange(len(bounds))
     return np.delete(feature_indices, fixed_feature_indices)
 

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -148,10 +148,12 @@ class BotorchModelTest(TestCase):
         n = 3
 
         X_dummy = torch.tensor([[[1.0, 2.0, 3.0]]], dtype=dtype, device=device)
+        acq_dummy = torch.tensor(0.0, dtype=dtype, device=device)
         model_gen_options = {}
         # test sequential optimize
         with mock.patch(
-            "ax.models.torch.botorch_defaults.sequential_optimize", return_value=X_dummy
+            "ax.models.torch.botorch_defaults.sequential_optimize",
+            return_value=(X_dummy, acq_dummy),
         ) as mock_sequential_optimize:
 
             Xgen, wgen = model.gen(
@@ -175,7 +177,8 @@ class BotorchModelTest(TestCase):
 
         # test joint optimize
         with mock.patch(
-            "ax.models.torch.botorch_defaults.joint_optimize", return_value=X_dummy
+            "ax.models.torch.botorch_defaults.joint_optimize",
+            return_value=(X_dummy, acq_dummy),
         ) as mock_joint_optimize:
             Xgen, wgen = model.gen(
                 n=n,

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -152,9 +152,9 @@ class BotorchModelTest(TestCase):
         model_gen_options = {}
         # test sequential optimize
         with mock.patch(
-            "ax.models.torch.botorch_defaults.sequential_optimize",
+            "ax.models.torch.botorch_defaults.optimize_acqf",
             return_value=(X_dummy, acq_dummy),
-        ) as mock_sequential_optimize:
+        ) as mock_optimize_acqf:
 
             Xgen, wgen = model.gen(
                 n=n,
@@ -170,16 +170,12 @@ class BotorchModelTest(TestCase):
             # note: gen() always returns CPU tensors
             self.assertTrue(torch.equal(Xgen, X_dummy.cpu()))
             self.assertTrue(torch.equal(wgen, torch.ones(n, dtype=dtype)))
-            self.assertEqual(
-                mock_sequential_optimize.call_args_list[-1][1]["post_processing_func"],
-                dummy_func,
-            )
 
         # test joint optimize
         with mock.patch(
-            "ax.models.torch.botorch_defaults.joint_optimize",
+            "ax.models.torch.botorch_defaults.optimize_acqf",
             return_value=(X_dummy, acq_dummy),
-        ) as mock_joint_optimize:
+        ) as mock_optimize_acqf:
             Xgen, wgen = model.gen(
                 n=n,
                 bounds=bounds,
@@ -193,7 +189,7 @@ class BotorchModelTest(TestCase):
             # note: gen() always returns CPU tensors
             self.assertTrue(torch.equal(Xgen, X_dummy.cpu()))
             self.assertTrue(torch.equal(wgen, torch.ones(n, dtype=dtype)))
-            mock_joint_optimize.assert_called_once()
+            mock_optimize_acqf.assert_called_once()
 
         # Check best point selection
         xbest = model.best_point(bounds=bounds, objective_weights=objective_weights)

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -55,7 +55,7 @@ TOptimizer = Callable[
         Optional[Callable[[Tensor], Tensor]],
         Any,
     ],
-    Tensor,
+    Tuple[Tensor, Tensor],
 ]
 
 
@@ -146,15 +146,16 @@ class BotorchModel(TorchModel):
             fixed_features,
             rounding_func,
             **kwargs,
-        ) -> candidates
+        ) -> (candidates, acq_values)
 
-    Here `acq_function` is a botorch `AcquisitionFunciton`, `bounds` is a
+    Here `acq_function` is a BoTorch `AcquisitionFunction`, `bounds` is a
     tensor containing bounds on the parameters, `n` is the number of
     candidates to be generated, `inequality_constraints` are inequality
     constraints on parameter values, `fixed_features` specifies features that
     should be fixed during generation, and `rounding_func` is a callback
     that rounds an optimization result appropriately. `candidates` is
-    a tensor of generated candidates. For additional details on the
+    a tensor of generated candidates, and `acq_values` are the acquisition
+    values associated with the candidates. For additional details on the
     arguments, see `scipy_optimizer`.
     """
 
@@ -311,7 +312,7 @@ class BotorchModel(TorchModel):
         else:
             inequality_constraints = None
 
-        candidates = self.acqf_optimizer(  # pyre-ignore: [28]
+        candidates, _ = self.acqf_optimizer(  # pyre-ignore: [28]
             acq_function=checked_cast(AcquisitionFunction, acquisition_function),
             bounds=bounds_,
             n=n,

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -173,7 +173,7 @@ def scipy_optimizer(
     fixed_features: Optional[Dict[int, float]] = None,
     rounding_func: Optional[Callable[[Tensor], Tensor]] = None,
     **kwargs: Any,
-) -> Tensor:
+) -> Tuple[Tensor, Tensor]:
     r"""Optimizer using scipy's minimize module on a numpy-adpator.
 
     Args:
@@ -190,7 +190,14 @@ def scipy_optimizer(
             appropriately (i.e., according to `round-trip` transformations).
 
     Returns:
+        A two-element tuple with the following elements:
+
         Tensor: A `n x d`-dim tensor of generated candidates.
+        Tensor: In the case of joint optimization, a scalar tensor containing
+            the joint acquisition value of the `n` points. In the case of
+            sequential optimization, a `n`-dim tensor of conditional acquisition
+            values, where `i`-th element is the expected acquisition value
+            conditional on having observed candidates `0,1,...,i-1`.
     """
     num_restarts: int = kwargs.get("num_restarts", 20)
     raw_samples: int = kwargs.get("num_raw_samples", 50 * num_restarts)


### PR DESCRIPTION
Summary:
Adds `optimize_acqf` that implements functionality of both `sequential_optimize` and `joint_optimize`.
Sequential optimization is performed when passing in `sequential=True` kwarg.

`sequential_optimize` and `joint_optimize` are soft-deprecate by raising a `DeprecationWarning` and calling `optimize_acqf` with the appropriate args.

Differential Revision: D16706214

