### PR TITLE
Update tests to use an explicit output dim

### DIFF
--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -15,12 +15,13 @@ from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
 class BotorchDefaultsTest(TestCase):
     def test_get_model(self):
         x = torch.zeros(2, 2)
-        y = torch.zeros(2)
-        se = torch.zeros(2)
+        y = torch.zeros(2, 1)
+        se = torch.zeros(2, 1)
         partial_se = torch.tensor([0, float("nan")])
         unknown_se = torch.tensor([float("nan"), float("nan")])
         model = _get_model(x, y, unknown_se, None)
         self.assertIsInstance(model, SingleTaskGP)
+
         model = _get_model(x, y, se, None)
         self.assertIsInstance(model, FixedNoiseGP)
         model = _get_model(x, y, unknown_se, 1)

--- a/ax/models/tests/test_torch_model_utils.py
+++ b/ax/models/tests/test_torch_model_utils.py
@@ -11,8 +11,8 @@ from botorch.models import HeteroskedasticSingleTaskGP, ModelListGP, SingleTaskG
 class TorchModelUtilsTest(TestCase):
     def test_is_noiseless(self):
         x = torch.zeros(1, 1)
-        y = torch.zeros(1)
-        se = torch.zeros(1)
+        y = torch.zeros(1, 1)
+        se = torch.zeros(1, 1)
         model = SingleTaskGP(x, y)
         self.assertTrue(is_noiseless(model))
         model = HeteroskedasticSingleTaskGP(x, y, se)


### PR DESCRIPTION
Summary: https://github.com/pytorch/botorch/pull/238 will make botorch models require an output dimension. This diff fixes the Ax tests broken by this change.

Reviewed By: danielrjiang

Differential Revision: D16635974

