### PR TITLE
Warm start model fitting

### DIFF
--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -46,6 +46,7 @@ class BotorchDefaultsTest(TestCase):
             task_features=[1],
             fidelity_features=[],
             state_dict=[],
+            refit_model=False,
         )
         # Check that task feature was correctly passed to _get_model
         self.assertEqual(get_model_mock.mock_calls[0][2]["task_feature"], 1)
@@ -58,6 +59,7 @@ class BotorchDefaultsTest(TestCase):
                 task_features=[0, 1],
                 fidelity_features=[],
                 state_dict=[],
+                refit_model=False,
             )
 
         with self.assertRaises(NotImplementedError):
@@ -69,6 +71,7 @@ class BotorchDefaultsTest(TestCase):
                 fidelity_features=[],
                 state_dict=[],
                 fidelity_model_id=0,
+                refit_model=False,
             )
 
         with self.assertRaises(UnsupportedError):
@@ -80,4 +83,5 @@ class BotorchDefaultsTest(TestCase):
                 fidelity_features=[-1, -2],
                 state_dict=[],
                 fidelity_model_id=0,
+                refit_model=False,
             )

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -186,6 +186,7 @@ class BotorchModel(TorchModel):
         acqf_optimizer: TOptimizer = scipy_optimizer,
         refit_on_cv: bool = False,
         refit_on_update: bool = True,
+        warm_start_refitting: bool = True,
         **kwargs: Any,
     ) -> None:
         self.model_constructor = model_constructor
@@ -203,6 +204,7 @@ class BotorchModel(TorchModel):
         self.task_features: List[int] = []
         self.fidelity_features: List[int] = []
         self.fidelity_model_id = kwargs.get("fidelity_model_id", None)
+        self.warm_start_refitting = warm_start_refitting
 
     @copy_doc(TorchModel.fit)
     def fit(
@@ -382,7 +384,7 @@ class BotorchModel(TorchModel):
         self.Xs = Xs
         self.Ys = Ys
         self.Yvars = Yvars
-        if self.refit_on_update:
+        if self.refit_on_update and not self.warm_start_refitting:
             state_dict = None
         else:
             state_dict = deepcopy(self.model.state_dict())  # pyre-ignore: [16]
@@ -394,6 +396,7 @@ class BotorchModel(TorchModel):
             state_dict=state_dict,
             fidelity_features=self.fidelity_features,
             fidelity_model_id=self.fidelity_model_id,
+            refit_model=self.refit_on_update,
         )
 
 


### PR DESCRIPTION
Summary:
Adds a warm_start_model_fit attribute to `BotorchModel` to extract the state_dict from a previous model & pass it to get_and_fit_model along with a keyword argument that indicates that the model should be refit.

get_and_fit_model loads the state_dict if provided and refits the model when specified.

Reviewed By: Balandat

Differential Revision: D16792879

