### PR TITLE
Fix handling of linear parameter constraints

### DIFF
--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -308,7 +308,7 @@ class BotorchModel(TorchModel):
             inequality_constraints = []
             k, d = A.shape
             for i in range(k):
-                indicies = A[i, :].nonzero().squeeze()
+                indicies = A[i, :].nonzero().view(-1)
                 coefficients = -A[i, indicies]
                 rhs = -b[i, 0]
                 inequality_constraints.append((indicies, coefficients, rhs))


### PR DESCRIPTION
Summary:
Make sure that the indices are passed as expected by BoTorch.

Fixes #169

Differential Revision: D17505167

