### PR TITLE
Temporarily skip version website deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,8 @@ jobs:
         - pip install -q -e .[dev,mysql,notebook]
         - pip install torchvision  # Required for building tutorial notebooks.
       script:
-        - travis_wait 90 bash scripts/publish_site.sh -d -v $TRAVIS_TAG
-        # - python -c "print('Skipping tests...')"  # Use for testing deployment.
+        # - travis_wait 90 bash scripts/publish_site.sh -d -v $TRAVIS_TAG
+        - python -c "print('Skipping website deployment...')"  # Use for testing deployment.
       deploy:
         provider: pypi
         # server: https://test.pypi.org/legacy/ # For testing; use test.pypi pw.


### PR DESCRIPTION
Website is already deployed for 0.1.6, but PyPI wheel is not, so we need to run the job without website publishing this one time