### PR TITLE
Add missing modules to Sphinx documentation

### DIFF
--- a/ax/exceptions/data_provider.py
+++ b/ax/exceptions/data_provider.py
@@ -7,7 +7,7 @@ from typing import Any
 class DataProviderError(Exception):
     """Base Exception for Ax DataProviders.
 
-    The type of the driver must be included.
+    The type of the data provider must be included.
     The raw error is stored in the data_provider_error section,
     and an Ax-friendly message is stored as the actual error message.
     """

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -223,15 +223,16 @@ def scipy_optimizer(
             appropriately (i.e., according to `round-trip` transformations).
 
     Returns:
-        A two-element tuple with the following elements:
+        2-element tuple containing
 
-        Tensor: A `n x d`-dim tensor of generated candidates.
-        Tensor: In the case of joint optimization, a scalar tensor containing
-            the joint acquisition value of the `n` points. In the case of
-            sequential optimization, a `n`-dim tensor of conditional acquisition
-            values, where `i`-th element is the expected acquisition value
-            conditional on having observed candidates `0,1,...,i-1`.
+        - A `n x d`-dim tensor of generated candidates.
+        - In the case of joint optimization, a scalar tensor containing
+          the joint acquisition value of the `n` points. In the case of
+          sequential optimization, a `n`-dim tensor of conditional acquisition
+          values, where `i`-th element is the expected acquisition value
+          conditional on having observed candidates `0,1,...,i-1`.
     """
+
     num_restarts: int = kwargs.get("num_restarts", 20)
     raw_samples: int = kwargs.get("num_raw_samples", 50 * num_restarts)
 

--- a/scripts/make_docs.sh
+++ b/scripts/make_docs.sh
@@ -50,11 +50,6 @@ while getopts 'hbotrk:' flag; do
 done
 
 if [[ $ONLY_DOCUSAURUS == false ]]; then
-  # echo "-----------------------------------"
-  # echo "Building Cython modules"
-  # echo "-----------------------------------"
-  # python3 setup.py build_ext --inplace
-
   # generate Sphinx documentation
   echo "-----------------------------------"
   echo "Generating API reference via Sphinx"

--- a/scripts/make_docs.sh
+++ b/scripts/make_docs.sh
@@ -50,10 +50,10 @@ while getopts 'hbotrk:' flag; do
 done
 
 if [[ $ONLY_DOCUSAURUS == false ]]; then
-  echo "-----------------------------------"
-  echo "Building Cython modules"
-  echo "-----------------------------------"
-  python3 setup.py build_ext --inplace
+  # echo "-----------------------------------"
+  # echo "Building Cython modules"
+  # echo "-----------------------------------"
+  # python3 setup.py build_ext --inplace
 
   # generate Sphinx documentation
   echo "-----------------------------------"

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ DEV_REQUIRES = [
     "pytest-cov",
     "sphinx",
     "sphinx-autodoc-typehints",
+    "torchvision",
 ]
 
 MYSQL_REQUIRES = ["SQLAlchemy>=1.1.13"]

--- a/sphinx/source/exceptions.rst
+++ b/sphinx/source/exceptions.rst
@@ -8,32 +8,32 @@ ax.exceptions
 .. currentmodule:: ax.exceptions
 
 
-ax.exceptions.core module
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Core
+~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.exceptions.core
     :members:
     :undoc-members:
     :show-inheritance:
 
-ax.exceptions.data\_provider module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Data
+~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.exceptions.data_provider
     :members:
     :undoc-members:
     :show-inheritance:
 
-ax.exceptions.model module
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Model
+~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.exceptions.model
     :members:
     :undoc-members:
     :show-inheritance:
 
-ax.exceptions.storage module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Storage
+~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.exceptions.storage
     :members:

--- a/sphinx/source/metrics.rst
+++ b/sphinx/source/metrics.rst
@@ -32,6 +32,14 @@ Hartmann6
     :undoc-members:
     :show-inheritance:
 
+L2 Norm
+~~~~~~~~~
+
+.. automodule:: ax.metrics.l2norm
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Noisy Functions
 ~~~~~~~~~~~~~~~
 

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -8,25 +8,29 @@ ax.modelbridge
 .. currentmodule:: ax.modelbridge
 
 
-Factory and Generation Strategy
--------------------------------
+Generation Strategy, Registry, and Factory
+-------------------------------------------
 
-`GenerationStrategy`
+Generation Strategy
 ~~~~~~~~~~~~~~~~~~~~
-
 .. automodule:: ax.modelbridge.generation_strategy
     :members:
     :undoc-members:
     :show-inheritance:
 
+Registry
+~~~~~~~~~~~~~~~~~~~~
+.. automodule:: ax.modelbridge.registry
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
-Model Bridge Factory
+Factory
 ~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: ax.modelbridge.factory
     :members:
     :undoc-members:
     :show-inheritance:
-
 
 
 Model Bridges
@@ -64,6 +68,14 @@ NumPy Model Bridge
     :undoc-members:
     :show-inheritance:
 
+Random Model Bridge
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.random
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Torch Model Bridge
 ~~~~~~~~~~~~~~~~~~~
 
@@ -76,13 +88,19 @@ Torch Model Bridge
 Utilities
 ---------------
 
+General Utilities
+~~~~~~~~~~~~~~~~~~
+.. automodule:: ax.modelbridge.modelbridge_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Cross Validation
 ~~~~~~~~~~~~~~~~~
 .. automodule:: ax.modelbridge.cross_validation
     :members:
     :undoc-members:
     :show-inheritance:
-
 
 Transforms
 -------------
@@ -91,6 +109,30 @@ Transforms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.modelbridge.transforms.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`ax.modelbridge.transforms.cap_parameter`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.cap_parameter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`ax.modelbridge.transforms.centered_unit_x`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.centered_unit_x
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`ax.modelbridge.transforms.convert_metric_names`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.convert_metric_names
     :members:
     :undoc-members:
     :show-inheritance:
@@ -211,6 +253,14 @@ Transforms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.modelbridge.transforms.unit_x
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`ax.modelbridge.winsorize`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.winsorize
     :members:
     :undoc-members:
     :show-inheritance:

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -11,6 +11,14 @@ ax.models
 Base Models
 ---------------
 
+ax.models.base
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.models.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ax.models.discrete\_base module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -118,6 +126,14 @@ ax.models.torch.botorch module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.models.torch.botorch
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ax.models.torch.botorch_defaults module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.models.torch.botorch_defaults
     :members:
     :undoc-members:
     :show-inheritance:

--- a/sphinx/source/plot.rst
+++ b/sphinx/source/plot.rst
@@ -8,6 +8,15 @@ ax.plot
 .. currentmodule:: ax.plot
 
 
+Rendering
+------------
+
+.. automodule:: ax.plot.render
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Plots
 ----------
 
@@ -19,10 +28,9 @@ Base
     :undoc-members:
     :show-inheritance:
 
-Color
-~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: ax.plot.color
+Bandit Rollout
+~~~~~~~~~~~~~~~~
+.. automodule:: ax.plot.bandit_rollout
     :members:
     :undoc-members:
     :show-inheritance:
@@ -35,26 +43,26 @@ Contour Plot
     :undoc-members:
     :show-inheritance:
 
-Model Diagnostic Plot
+Feature Importances
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.plot.feature_importances
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Marginal Effects
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.plot.marginal_effects
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Model Diagnostics
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.plot.diagnostic
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-Helpers
-~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: ax.plot.helper
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-Rendering
-~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: ax.plot.render
     :members:
     :undoc-members:
     :show-inheritance:
@@ -76,7 +84,7 @@ Slice Plot
     :show-inheritance:
 
 Table
---------------------------
+~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.plot.table_view
     :members:
@@ -84,9 +92,28 @@ Table
     :show-inheritance:
 
 Trace Plots
---------------------
+~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.plot.trace
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Plotting Utilities
+-------------------
+
+.. automodule:: ax.plot.color
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: ax.plot.exp_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: ax.plot.helper
     :members:
     :undoc-members:
     :show-inheritance:

--- a/sphinx/source/service.rst
+++ b/sphinx/source/service.rst
@@ -28,6 +28,14 @@ Managed Loop
 Utils
 ------
 
+Best Point Identification
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.service.utils.best_point
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Dispatch
 ~~~~~~~~~~~~~~~~
 

--- a/sphinx/source/storage.rst
+++ b/sphinx/source/storage.rst
@@ -77,7 +77,6 @@ ax.storage.sqa\_store.base\_decoder module
     :undoc-members:
     :show-inheritance:
 
-
 ax.storage.sqa\_store.base\_encoder module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -119,10 +118,26 @@ ax.storage.sqa\_store.save module
     :undoc-members:
     :show-inheritance:
 
+ax.storage.sqa\_store.structs module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.storage.sqa_store.structs
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ax.storage.sqa\_store.sqa\_classes module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.storage.sqa_store.sqa_classes
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ax.storage.sqa\_store.sqa\_config module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.storage.sqa_store.sqa_config
     :members:
     :undoc-members:
     :show-inheritance:
@@ -168,6 +183,11 @@ Registries
     :show-inheritance:
 
 .. automodule:: ax.storage.runner_registry
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. automodule:: ax.storage.transform_registry
     :members:
     :undoc-members:
     :show-inheritance:

--- a/sphinx/source/utils.rst
+++ b/sphinx/source/utils.rst
@@ -11,10 +11,26 @@ ax.utils
 Common
 ---------------
 
+Docutils
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.common.docutils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Equality
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.utils.common.equality
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Kwargs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.common.kwargs
     :members:
     :undoc-members:
     :show-inheritance:
@@ -27,10 +43,26 @@ Logger
     :undoc-members:
     :show-inheritance:
 
-Docutils
+Serialization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automodule:: ax.utils.common.docutils
+.. automodule:: ax.utils.common.serialization
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Testutils
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.common.testutils
+    :members:
+    :no-undoc-members:
+    :show-inheritance:
+
+Timeutils
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.common.timeutils
     :members:
     :undoc-members:
     :show-inheritance:
@@ -39,6 +71,17 @@ Typeutils
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.utils.common.typeutils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Measurement
+---------------
+
+Synthetic Functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.measurement.synthetic_functions
     :members:
     :undoc-members:
     :show-inheritance:
@@ -72,6 +115,37 @@ Statstools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.utils.stats.statstools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Testing
+---------------
+
+Core Stubs
+~~~~~~~~~~~
+
+.. automodule:: ax.utils.testing.core_stubs
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Modeling Stubs
+~~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.testing.modeling_stubs
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Tutorials
+---------------
+
+Neural Net
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.tutorials.cnn_utils
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
This is necessary for enabling checks that Sphinx documentation should be present for all modules.

Also squeezing in a couple of other small fixes:
* Removing cython step from make_docs.sh
* Clean up docstring for botorch defaults to prevent parsing error