### PR TITLE
Typo ? sklearn -> scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIRES = [
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",
-    "sklearn",
+    "scikit-learn",
     "plotly",
 ]
 


### PR DESCRIPTION
Hi, 
I just wonder whether it was intended to install `sklearn` instead of `scikit-learn`. The first installs on the system a package
```
sklearn-0.0
```
whos metadata says:
```
Metadata-Version: 2.1
Name: sklearn
Version: 0.0
Summary: A set of python modules for machine learning and data mining
Home-page: https://pypi.python.org/pypi/scikit-learn/
Author: UNKNOWN
Author-email: UNKNOWN
....
UNKNOWN
Maintainer: UNKNOWN
Maintainer-email: UNKNOWN
UNKNOWN
License: UNKNOWN
Description: Use `scikit-learn <https://pypi.python.org/pypi/scikit-learn/>`_ instead.
```
thanks