### PR TITLE
Don't error in MTGP if status quo is missing

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -273,7 +273,6 @@ class ModelBridge(ABC):
         experiment: Optional[Experiment],
         status_quo_name: Optional[str],
         status_quo_features: Optional[ObservationFeatures],
-        # plot.help_rel (model, ) <- trial_index that we'll pass to the status_quo_index
     ) -> None:
         """Set model status quo.
 
@@ -318,8 +317,6 @@ class ModelBridge(ABC):
                 self._status_quo = sq_obs[0]
 
         elif status_quo_features is not None:
-            # TODO(T52873772): Check which field from the status_quo_features to
-            # compare with the training_data to select the status_quo.
             sq_obs = [
                 obs
                 for obs in self._training_data

--- a/ax/modelbridge/factory.py
+++ b/ax/modelbridge/factory.py
@@ -197,8 +197,8 @@ def get_MTGP(
         transform_configs = None
 
     # Choose the status quo features for the experiment from the selected trial.
-    # If trial_index is None, the status quo from the last experiment trial
-    # will be used as a status quo for the experiment.
+    # If trial_index is None, we will look for a status quo from the last
+    # experiment trial to use as a status quo for the experiment.
     if trial_index is None:
         trial_index = len(experiment.trials) - 1
     elif trial_index >= len(experiment.trials):
@@ -207,7 +207,7 @@ def get_MTGP(
     # pyre-fixme[16]: `ax.core.base_trial.BaseTrial` has no attribute `status_quo`.
     status_quo = experiment.trials[trial_index].status_quo
     if status_quo is None:
-        raise ValueError("status_quo is not defined for the selected trial.")
+        status_quo_features = None
     else:
         status_quo_features = ObservationFeatures(
             parameters=status_quo.parameters, trial_index=trial_index


### PR DESCRIPTION
Summary:
Not all uses of MT-GP (for example, the tutorial!) require a status quo.

This removes that requirement from the MT-GP factory (and cleans up some other cruft).

This addresses https://github.com/facebook/Ax/issues/183

Reviewed By: bletham

Differential Revision: D18193212

