### PR TITLE
Pass target values of fidelity parameters to MF BoTorch models

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -117,7 +117,7 @@ class RangeParameter(Parameter):
                 random values of the parameter.
             digits: Number of digits to round values to for float type.
             is_fidelity: Whether this parameter is a fidelity parameter.
-            target_value: Target value of this parameter if it's fidelity.
+            target_value: Target value of this parameter if it is a fidelity.
         """
         self._name = name
         self._parameter_type = parameter_type
@@ -276,6 +276,7 @@ class RangeParameter(Parameter):
             log_scale=self._log_scale,
             digits=self._digits,
             is_fidelity=self._is_fidelity,
+            target_value=self._target_value,
         )
 
     def _cast(self, value: TParamValue) -> TParamValue:
@@ -408,15 +409,22 @@ class ChoiceParameter(Parameter):
             values=self._values,
             is_task=self._is_task,
             is_fidelity=self._is_fidelity,
+            target_value=self._target_value,
         )
 
     def __repr__(self) -> str:
-        return (
-            f"ChoiceParameter("
+        ret_val = (
+            "ChoiceParameter("
             f"name='{self._name}', "
             f"parameter_type={self.parameter_type.name}, "
-            f"values={self._values})"
+            f"values={self._values}"
         )
+        if self._is_fidelity:
+            tval_rep = self.target_value
+            if self.parameter_type == ParameterType.STRING:
+                tval_rep = f"'{tval_rep}'"
+            ret_val += f", fidelity={self.is_fidelity}, target_value={tval_rep}"
+        return ret_val + ")"
 
 
 class FixedParameter(Parameter):
@@ -437,7 +445,7 @@ class FixedParameter(Parameter):
             parameter_type: Enum indicating the type of parameter
                 value (e.g. string, int).
             value: The fixed value of the parameter.
-            target_value: Target value of this parameter if it's fidelity.
+            target_value: Target value of this parameter if it is a fidelity.
         """
         self._name = name
         self._parameter_type = parameter_type
@@ -478,12 +486,18 @@ class FixedParameter(Parameter):
             parameter_type=self._parameter_type,
             value=self._value,
             is_fidelity=self._is_fidelity,
+            target_value=self._target_value,
         )
 
     def __repr__(self) -> str:
-        return (
+        ret_val = (
             f"FixedParameter("
             f"name='{self._name}', "
             f"parameter_type={self.parameter_type.name}, "
-            f"value={self._value})"
+            f"value={self._value}"
         )
+        if self._is_fidelity:
+            ret_val += (
+                f", fidelity={self.is_fidelity}, target_value={self.target_value}"
+            )
+        return ret_val + ")"

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -136,6 +136,10 @@ class ChoiceParameterTest(TestCase):
         self.param1 = ChoiceParameter(
             name="x", parameter_type=ParameterType.STRING, values=["foo", "bar", "baz"]
         )
+        self.param1_repr = (
+            "ChoiceParameter(name='x', parameter_type=STRING, "
+            "values=['foo', 'bar', 'baz'])"
+        )
         self.param2 = ChoiceParameter(
             name="x",
             parameter_type=ParameterType.STRING,
@@ -143,22 +147,29 @@ class ChoiceParameterTest(TestCase):
             is_ordered=True,
             is_task=True,
         )
-        self.param1_repr = (
+        self.param3 = ChoiceParameter(
+            name="x",
+            parameter_type=ParameterType.STRING,
+            values=["foo", "bar"],
+            is_fidelity=True,
+            target_value="bar",
+        )
+        self.param3_repr = (
             "ChoiceParameter(name='x', parameter_type=STRING, "
-            "values=['foo', 'bar', 'baz'])"
+            "values=['foo', 'bar'], fidelity=True, target_value='bar')"
         )
 
     def testEq(self):
-        param3 = ChoiceParameter(
+        param4 = ChoiceParameter(
             name="x", parameter_type=ParameterType.STRING, values=["foo", "bar", "baz"]
         )
-        self.assertEqual(self.param1, param3)
+        self.assertEqual(self.param1, param4)
         self.assertNotEqual(self.param1, self.param2)
 
-        param4 = ChoiceParameter(
+        param5 = ChoiceParameter(
             name="x", parameter_type=ParameterType.STRING, values=["foo", "foobar"]
         )
-        self.assertNotEqual(self.param1, param4)
+        self.assertNotEqual(self.param1, param5)
 
     def testProperties(self):
         self.assertEqual(self.param1.name, "x")
@@ -172,6 +183,7 @@ class ChoiceParameterTest(TestCase):
 
     def testRepr(self):
         self.assertEqual(str(self.param1), self.param1_repr)
+        self.assertEqual(str(self.param3), self.param3_repr)
 
     def testValidate(self):
         self.assertFalse(self.param1.validate(None))

--- a/ax/modelbridge/__init__.py
+++ b/ax/modelbridge/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "TorchModelBridge",
     "get_factorial",
     "get_GPEI",
+    "get_GPKG",
     "get_sobol",
     "get_thompson",
     "get_uniform",

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -11,7 +11,7 @@ from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
-from ax.core.types import TBounds
+from ax.core.types import TBounds, TParamValue
 from ax.modelbridge.transforms.base import Transform
 from ax.utils.common.typeutils import not_none
 
@@ -35,13 +35,13 @@ def extract_parameter_constraints(
 
 def get_bounds_and_task(
     search_space: SearchSpace, param_names: List[str]
-) -> Tuple[List[Tuple[float, float]], List[int], List[int]]:
+) -> Tuple[List[Tuple[float, float]], List[int], Dict[int, TParamValue]]:
     """Extract box bounds from a search space in the usual Scipy format.
     Identify integer parameters as task features.
     """
     bounds: List[Tuple[float, float]] = []
     task_features: List[int] = []
-    fidelity_features: List[int] = []
+    target_fidelities: Dict[int, TParamValue] = {}
     for i, p_name in enumerate(param_names):
         p = search_space.parameters[p_name]
         # Validation
@@ -54,9 +54,9 @@ def get_bounds_and_task(
         if p.parameter_type == ParameterType.INT:
             task_features.append(i)
         if p.is_fidelity:
-            fidelity_features.append(i)
+            target_fidelities[i] = p.target_value
 
-    return bounds, task_features, fidelity_features
+    return bounds, task_features, target_fidelities
 
 
 def get_fixed_features(

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -36,6 +36,7 @@ from ax.models.discrete.thompson import ThompsonSampler
 from ax.models.random.sobol import SobolGenerator
 from ax.models.random.uniform import UniformGenerator
 from ax.models.torch.botorch import BotorchModel
+from ax.models.torch.botorch_kg import KnowledgeGradient
 from ax.models.torch_base import TorchModel
 from ax.utils.common.kwargs import (
     consolidate_kwargs,
@@ -127,6 +128,12 @@ MODEL_KEY_TO_MODEL_SETUP: Dict[str, ModelSetup] = {
         transforms=Cont_X_trans + Y_trans,
         standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
+    "GPKG": ModelSetup(
+        bridge_class=TorchModelBridge,
+        model_class=KnowledgeGradient,
+        transforms=Cont_X_trans + Y_trans,
+        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
+    ),
     "EB": ModelSetup(
         bridge_class=DiscreteModelBridge,
         model_class=EmpiricalBayesThompsonSampler,
@@ -174,6 +181,7 @@ class Models(Enum):
 
     SOBOL = "Sobol"
     GPEI = "GPEI"
+    GPKG = "GPKG"
     FACTORIAL = "Factorial"
     THOMPSON = "Thompson"
     BOTORCH = "BO"

--- a/ax/modelbridge/tests/test_array_modelbridge.py
+++ b/ax/modelbridge/tests/test_array_modelbridge.py
@@ -155,6 +155,9 @@ class ArrayModelBridgeTest(TestCase):
         self.assertEqual(arm.parameters, {})
         self.assertEqual(predictions[0], {"m": 1.0})
         self.assertEqual(predictions[1], {"m": {"m": 2.0}})
+        # test check that optimization config is required
+        with self.assertRaises(ValueError):
+            run = modelbridge.gen(n=1, optimization_config=None)
 
     @patch(
         f"{ModelBridge.__module__}.observations_from_data",

--- a/ax/modelbridge/tests/test_factory.py
+++ b/ax/modelbridge/tests/test_factory.py
@@ -7,6 +7,7 @@ from ax.modelbridge.factory import (
     get_empirical_bayes_thompson,
     get_factorial,
     get_GPEI,
+    get_GPKG,
     get_MTGP,
     get_sobol,
     get_thompson,
@@ -78,6 +79,23 @@ class ModelBridgeFactoryTest(TestCase):
 
         with self.assertRaises(ValueError):
             get_MTGP(experiment=exp, data=exp.fetch_data(), trial_index=0)
+
+    def test_GPKG(self):
+        """Tests GPKG instantiation."""
+        exp = get_branin_experiment(with_batch=True)
+        with self.assertRaises(ValueError):
+            get_GPKG(experiment=exp, data=exp.fetch_data())
+        exp.trials[0].run()
+        gpkg = get_GPKG(experiment=exp, data=exp.fetch_data())
+        self.assertIsInstance(gpkg, TorchModelBridge)
+        gpkg_win = get_GPKG(
+            experiment=exp, data=exp.fetch_data(), winsorization_limits=[0.1, 0.1]
+        )
+        self.assertIsInstance(gpkg_win, TorchModelBridge)
+        configs_expected = {
+            "Winsorize": {"winsorization_lower": 0.1, "winsorization_upper": 0.1}
+        }
+        self.assertEqual(gpkg_win._transform_configs, configs_expected)
 
     def test_model_kwargs(self):
         """Tests that model kwargs are passed correctly."""

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -112,6 +112,7 @@ class TorchModelBridgeTest(TestCase):
             pending_observations=[np.array([]), np.array([1.0, 2.0, 3.0])],
             model_gen_options={"option": "yes"},
             rounding_func=np.round,
+            target_fidelities=None,
         )
         gen_args = model.gen.mock_calls[0][2]
         self.assertEqual(gen_args["n"], 3)
@@ -138,8 +139,14 @@ class TorchModelBridgeTest(TestCase):
             )
         )
         self.assertEqual(gen_args["model_gen_options"], {"option": "yes"})
+        self.assertIsNone(gen_args["target_fidelities"])
+        # check rounding function
+        t = torch.tensor([0.1, 0.6], dtype=torch_dtype, device=torch_device)
+        self.assertTrue(torch.equal(gen_args["rounding_func"](t), torch.round(t)))
+
         self.assertTrue(np.array_equal(X, np.array([1.0, 2.0, 3.0])))
         self.assertTrue(np.array_equal(w, np.array([1.0])))
+
         # Cross-validate
         model.cross_validate.return_value = (torch.tensor([3.0]), torch.tensor([4.0]))
         f, var = ma._model_cross_validate(

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -184,6 +184,7 @@ class TorchModelBridge(ArrayModelBridge):
         pending_observations: Optional[List[np.ndarray]],
         model_gen_options: Optional[TConfig],
         rounding_func: Callable[[np.ndarray], np.ndarray],
+        target_fidelities: Optional[Dict[int, float]],
     ) -> Tuple[np.ndarray, np.ndarray, TGenMetadata]:
         if not self.model:  # pragma: no cover
             raise ValueError(FIT_MODEL_ERROR.format(action="_model_gen"))
@@ -205,6 +206,7 @@ class TorchModelBridge(ArrayModelBridge):
             pending_observations=pend_obs,
             model_gen_options=model_gen_options,
             rounding_func=tensor_rounding_func,
+            target_fidelities=target_fidelities,
         )
         return (
             X.detach().cpu().clone().numpy(),
@@ -220,6 +222,7 @@ class TorchModelBridge(ArrayModelBridge):
         linear_constraints: Optional[Tuple[np.ndarray, np.ndarray]],
         fixed_features: Optional[Dict[int, float]],
         model_gen_options: Optional[TConfig],
+        target_fidelities: Optional[Dict[int, float]],
     ) -> Optional[np.ndarray]:  # pragma: no cover
         if not self.model:  # pragma: no cover
             raise ValueError(FIT_MODEL_ERROR.format(action="_model_gen"))
@@ -238,6 +241,7 @@ class TorchModelBridge(ArrayModelBridge):
                 linear_constraints=l_c,
                 fixed_features=fixed_features,
                 model_gen_options=model_gen_options,
+                target_fidelities=target_fidelities,
             )
             return None if X is None else X.detach().cpu().clone().numpy()
 

--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -6,9 +6,8 @@ from unittest import mock
 import torch
 from ax.models.torch.botorch_defaults import _get_model, get_and_fit_model
 from ax.utils.common.testutils import TestCase
-from botorch.exceptions.errors import UnsupportedError
 from botorch.models import FixedNoiseGP, SingleTaskGP
-from botorch.models.fidelity.gp_regression_fidelity import SingleTaskGPLTKernel
+from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
 
 
@@ -16,22 +15,24 @@ class BotorchDefaultsTest(TestCase):
     def test_get_model(self):
         x = torch.zeros(2, 2)
         y = torch.zeros(2, 1)
-        se = torch.zeros(2, 1)
-        partial_se = torch.tensor([0, float("nan")])
-        unknown_se = torch.tensor([float("nan"), float("nan")])
-        model = _get_model(x, y, unknown_se, None)
+        var = torch.zeros(2, 1)
+        partial_var = torch.tensor([0, float("nan")])
+        unknown_var = torch.tensor([float("nan"), float("nan")])
+        model = _get_model(x, y, unknown_var, None)
         self.assertIsInstance(model, SingleTaskGP)
 
-        model = _get_model(x, y, se, None)
+        model = _get_model(X=x, Y=y, Yvar=var)
         self.assertIsInstance(model, FixedNoiseGP)
-        model = _get_model(x, y, unknown_se, 1)
+        model = _get_model(X=x, Y=y, Yvar=unknown_var, task_feature=1)
         self.assertTrue(type(model) == MultiTaskGP)  # Don't accept subclasses.
-        model = _get_model(x, y, se, 1)
+        model = _get_model(X=x, Y=y, Yvar=var, task_feature=1)
         self.assertIsInstance(model, FixedNoiseMultiTaskGP)
         with self.assertRaises(ValueError):
-            model = _get_model(x, y, partial_se, None)
-        model = _get_model(x, y, se, 1, fidelity_model_id=0, fidelity_features=[-1])
-        self.assertTrue(isinstance(model, SingleTaskGPLTKernel))
+            model = _get_model(X=x, Y=y, Yvar=partial_var, task_feature=None)
+        model = _get_model(X=x, Y=y, Yvar=var, fidelity_features=[-1])
+        self.assertTrue(isinstance(model, SingleTaskMultiFidelityGP))
+        with self.assertRaises(NotImplementedError):
+            _get_model(X=x, Y=y, Yvar=var, task_feature=1, fidelity_features=[-1])
 
     @mock.patch("ax.models.torch.botorch_defaults._get_model", autospec=True)
     @mock.patch("ax.models.torch.botorch_defaults.ModelListGP", autospec=True)
@@ -51,17 +52,7 @@ class BotorchDefaultsTest(TestCase):
         # Check that task feature was correctly passed to _get_model
         self.assertEqual(get_model_mock.mock_calls[0][2]["task_feature"], 1)
 
-        with self.assertRaises(ValueError):
-            get_and_fit_model(
-                Xs=x,
-                Ys=y,
-                Yvars=yvars,
-                task_features=[0, 1],
-                fidelity_features=[],
-                state_dict=[],
-                refit_model=False,
-            )
-
+        # check error on multiple task features
         with self.assertRaises(NotImplementedError):
             get_and_fit_model(
                 Xs=x,
@@ -70,11 +61,11 @@ class BotorchDefaultsTest(TestCase):
                 task_features=[0, 1],
                 fidelity_features=[],
                 state_dict=[],
-                fidelity_model_id=0,
                 refit_model=False,
             )
 
-        with self.assertRaises(UnsupportedError):
+        # check error on multiple fidelity features
+        with self.assertRaises(NotImplementedError):
             get_and_fit_model(
                 Xs=x,
                 Ys=y,
@@ -82,6 +73,17 @@ class BotorchDefaultsTest(TestCase):
                 task_features=[],
                 fidelity_features=[-1, -2],
                 state_dict=[],
-                fidelity_model_id=0,
+                refit_model=False,
+            )
+
+        # check error on botch task and fidelity feature
+        with self.assertRaises(NotImplementedError):
+            get_and_fit_model(
+                Xs=x,
+                Ys=y,
+                Yvars=yvars,
+                task_features=[1],
+                fidelity_features=[-1],
+                state_dict=[],
                 refit_model=False,
             )

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+
+import mock
+import torch
+from ax.models.torch.botorch_kg import (
+    KnowledgeGradient,
+    _get_objective,
+    _instantiate_KG,
+    _set_best_point_acq,
+)
+from ax.utils.common.testutils import TestCase
+from botorch.acquisition.analytic import PosteriorMean
+from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
+from botorch.acquisition.knowledge_gradient import qMultiFidelityKnowledgeGradient
+from botorch.acquisition.monte_carlo import qSimpleRegret
+from botorch.acquisition.objective import (
+    ConstrainedMCObjective,
+    LinearMCObjective,
+    ScalarizedObjective,
+)
+from botorch.exceptions.errors import UnsupportedError
+from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
+
+
+def dummy_func(X: torch.Tensor) -> torch.Tensor:
+    return X
+
+
+class KnowledgeGradientTest(TestCase):
+    def test_KnowledgeGradient(self):
+        device = torch.device("cpu")
+        dtype = torch.double
+
+        Xs = [
+            torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], dtype=dtype, device=device)
+        ]
+        Ys = [torch.tensor([[3.0], [4.0]], dtype=dtype, device=device)]
+        Yvars = [torch.tensor([[0.0], [2.0]], dtype=dtype, device=device)]
+        bounds = [(0.0, 1.0), (1.0, 4.0), (2.0, 5.0)]
+        task_features = []
+        feature_names = ["x1", "x2", "x3"]
+
+        acq_options = {"num_fantasies": 30, "mc_samples": 30}
+
+        optimizer_options = {
+            "num_restarts": 12,
+            "raw_samples": 12,
+            "maxiter": 5,
+            "batch_limit": 1,
+        }
+
+        model = KnowledgeGradient()
+        objective_weights = torch.tensor([1.0], dtype=dtype, device=device)
+        model.fit(
+            Xs=Xs,
+            Ys=Ys,
+            Yvars=Yvars,
+            bounds=bounds,
+            task_features=task_features,
+            feature_names=feature_names,
+            fidelity_features=[],
+        )
+
+        n = 2
+
+        X_dummy = torch.rand(1, n, 4, dtype=dtype, device=device)
+        acq_dummy = torch.tensor(0.0, dtype=dtype, device=device)
+
+        with mock.patch(
+            "ax.models.torch.botorch_kg.optimize_acqf",
+            return_value=(X_dummy, acq_dummy),
+        ) as mock_optimize_acqf:
+            Xgen, wgen, _ = model.gen(
+                n=n,
+                bounds=bounds,
+                objective_weights=objective_weights,
+                outcome_constraints=None,
+                linear_constraints=None,
+                model_gen_options={
+                    "acquisition_function_kwargs": acq_options,
+                    "optimizer_kwargs": optimizer_options,
+                },
+            )
+            self.assertTrue(torch.equal(Xgen, X_dummy[:, :2, :].cpu()))
+            self.assertEqual(Xgen.size(), torch.Size([1, 2, 4]))
+            self.assertTrue(torch.equal(wgen, torch.ones(n, dtype=dtype)))
+            mock_optimize_acqf.assert_called()  # called twice, once for best_point
+
+        ini_dummy = torch.rand(10, 32, 3, dtype=dtype, device=device)
+        optimizer_options2 = {
+            "num_restarts": 10,
+            "raw_samples": 12,
+            "maxiter": 5,
+            "batch_limit": 1,
+            "partial_restarts": 2,
+        }
+        with mock.patch(
+            "ax.models.torch.botorch_kg.gen_one_shot_kg_initial_conditions",
+            return_value=ini_dummy,
+        ) as mock_warmstart_initialization:
+            Xgen, wgen, _ = model.gen(
+                n=n,
+                bounds=bounds,
+                objective_weights=objective_weights,
+                outcome_constraints=None,
+                linear_constraints=None,
+                model_gen_options={
+                    "acquisition_function_kwargs": acq_options,
+                    "optimizer_kwargs": optimizer_options2,
+                },
+            )
+            mock_warmstart_initialization.assert_called_once()
+
+        obj = ScalarizedObjective(weights=objective_weights)
+        dummy_acq = PosteriorMean(model=model.model, objective=obj)
+        with mock.patch(
+            "ax.models.torch.botorch_kg.PosteriorMean", return_value=dummy_acq
+        ) as mock_posterior_mean:
+            Xgen, wgen, _ = model.gen(
+                n=n,
+                bounds=bounds,
+                objective_weights=objective_weights,
+                outcome_constraints=None,
+                linear_constraints=None,
+                model_gen_options={
+                    "acquisition_function_kwargs": acq_options,
+                    "optimizer_kwargs": optimizer_options2,
+                },
+            )
+            self.assertEqual(mock_posterior_mean.call_count, 2)
+
+        X_dummy = torch.rand(3)
+        acq_dummy = torch.tensor(0.0)
+        # Check best point selection
+        with mock.patch(
+            "ax.models.torch.botorch_kg.optimize_acqf",
+            return_value=(X_dummy, acq_dummy),
+        ) as mock_optimize_acqf:
+            xbest = model.best_point(bounds=bounds, objective_weights=objective_weights)
+            self.assertTrue(torch.equal(xbest, X_dummy))
+            mock_optimize_acqf.assert_called_once()
+
+        X_dummy = torch.tensor([1.0, 2.0])
+        acq_dummy = torch.tensor(0.0)
+        model.fit(
+            Xs=Xs,
+            Ys=Ys,
+            Yvars=Yvars,
+            bounds=bounds,
+            task_features=task_features,
+            feature_names=feature_names,
+            fidelity_features=[-1],
+        )
+        # Check best point selection
+        with mock.patch(
+            "ax.models.torch.botorch_kg.optimize_acqf",
+            return_value=(X_dummy, acq_dummy),
+        ) as mock_optimize_acqf:
+            xbest = model.best_point(bounds=bounds, objective_weights=objective_weights)
+            self.assertTrue(torch.equal(xbest, torch.tensor([1.0, 2.0, 1.0])))
+            mock_optimize_acqf.assert_called_once()
+
+        X_dummy = torch.zeros(12, 1, 2, dtype=dtype, device=device)
+        X_dummy2 = torch.zeros(1, 32, 3, dtype=dtype, device=device)
+        acq_dummy = torch.tensor(0.0, dtype=dtype, device=device)
+        dummy1 = (X_dummy, acq_dummy)
+        dummy2 = (X_dummy2, acq_dummy)
+        with mock.patch(
+            "ax.models.torch.botorch_kg.optimize_acqf",
+            side_effect=[dummy1, dummy2, dummy1, dummy2],
+        ) as mock_optimize_acqf:
+            mock_optimize_acqf(
+                Xgen,
+                wgen=model.gen(
+                    n=n,
+                    bounds=bounds,
+                    objective_weights=objective_weights,
+                    outcome_constraints=None,
+                    linear_constraints=None,
+                    model_gen_options={
+                        "acquisition_function_kwargs": acq_options,
+                        "optimizer_kwargs": optimizer_options,
+                    },
+                ),
+            )
+
+        # test error message
+        linear_constraints = (
+            torch.tensor([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+            torch.tensor([[0.5], [1.0]]),
+        )
+        with self.assertRaises(UnsupportedError):
+            Xgen, wgen, _ = model.gen(
+                n=n,
+                bounds=bounds,
+                objective_weights=objective_weights,
+                outcome_constraints=None,
+                linear_constraints=linear_constraints,
+            )
+
+        with self.assertRaises(UnsupportedError):
+            xbest = model.best_point(
+                bounds=bounds,
+                linear_constraints=linear_constraints,
+                objective_weights=objective_weights,
+            )
+
+        # test _instantiate_KG
+        objective = ScalarizedObjective(weights=objective_weights)
+        X_dummy = torch.ones(1, 3, dtype=dtype, device=device)
+        # test acquisition setting
+        acq_function = _instantiate_KG(
+            model=model.model, objective=objective, n_fantasies=10, qmc=True
+        )
+        self.assertIsInstance(acq_function.sampler, SobolQMCNormalSampler)
+        self.assertIsInstance(acq_function.objective, ScalarizedObjective)
+        self.assertEqual(acq_function.num_fantasies, 10)
+
+        acq_function = _instantiate_KG(
+            model=model.model, objective=objective, n_fantasies=10, qmc=False
+        )
+        self.assertIsInstance(acq_function.sampler, IIDNormalSampler)
+
+        acq_function = _instantiate_KG(
+            model=model.model, objective=objective, qmc=False
+        )
+        self.assertIsNone(acq_function.inner_sampler)
+
+        acq_function = _instantiate_KG(
+            model=model.model, objective=objective, qmc=True, X_pending=X_dummy
+        )
+        self.assertIsNone(acq_function.inner_sampler)
+        self.assertTrue(torch.equal(acq_function.X_pending, X_dummy))
+
+        acq_function = _instantiate_KG(
+            model=model.model,
+            objective=objective,
+            fidelity_features=[-1],
+            current_value=0,
+        )
+        self.assertIsInstance(acq_function, qMultiFidelityKnowledgeGradient)
+
+        acq_function = _instantiate_KG(
+            model=model.model, objective=LinearMCObjective(weights=objective_weights)
+        )
+        self.assertIsInstance(acq_function.inner_sampler, SobolQMCNormalSampler)
+
+        # test _get_obj()
+        outcome_constraints = (
+            torch.tensor([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+            torch.tensor([[0.5], [1.0]]),
+        )
+        objective_weights = None
+        self.assertIsInstance(
+            _get_objective(
+                model=model.model,
+                outcome_constraints=outcome_constraints,
+                objective_weights=objective_weights,
+                X_observed=X_dummy,
+            ),
+            ConstrainedMCObjective,
+        )
+        # test _set_best_point_acq
+        acq_function = _set_best_point_acq(
+            model=model.model,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            X_observed=X_dummy,
+        )
+        self.assertIsInstance(acq_function, qSimpleRegret)
+        self.assertIsInstance(acq_function.sampler, SobolQMCNormalSampler)
+
+        acq_function = _set_best_point_acq(
+            model=model.model,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            X_observed=X_dummy,
+            qmc=False,
+        )
+        self.assertIsInstance(acq_function.sampler, IIDNormalSampler)
+
+        objective_weights = torch.tensor([1.0], dtype=dtype, device=device)
+        acq_function = _set_best_point_acq(
+            model=model.model,
+            objective_weights=objective_weights,
+            X_observed=X_dummy,
+            fidelity_features=[-1],
+        )
+        self.assertIsInstance(acq_function, FixedFeatureAcquisitionFunction)

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -190,6 +190,20 @@ class BotorchModelTest(TestCase):
             self.assertTrue(torch.equal(wgen, torch.ones(n, dtype=dtype)))
             mock_optimize_acqf.assert_called_once()
 
+        # test that fidelity features are unsupported
+        with self.assertRaises(NotImplementedError):
+            Xgen, wgen = model.gen(
+                n=n,
+                bounds=bounds,
+                objective_weights=objective_weights,
+                outcome_constraints=None,
+                linear_constraints=None,
+                fixed_features=fixed_features,
+                pending_observations=pending_observations,
+                model_gen_options={"optimizer_kwargs": {"joint_optimization": True}},
+                target_fidelities={0: 3.0},
+            )
+
         # test get_rounding_func
         dummy_rounding = get_rounding_func(rounding_func=dummy_func)
         X_temp = torch.rand(1, 2, 3, 4)
@@ -203,6 +217,15 @@ class BotorchModelTest(TestCase):
             fixed_features={0: 100.0},
         )
         self.assertIsNone(xbest)
+
+        # test that fidelity features are unsupported
+        with self.assertRaises(NotImplementedError):
+            xbest = model.best_point(
+                bounds=bounds,
+                objective_weights=objective_weights,
+                fixed_features={0: 100.0},
+                target_fidelities={0: 3.0},
+            )
 
         # Test cross-validation
         mean, variance = model.cross_validate(

--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -2,6 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
 import numpy as np
+from ax.models.torch.utils import normalize_indices
 from ax.models.torch_base import TorchModel
 from ax.utils.common.testutils import TestCase
 
@@ -51,3 +52,19 @@ class TorchModelTest(TestCase):
         numpy_model = TorchModel()
         with self.assertRaises(NotImplementedError):
             numpy_model.update(Xs=[np.array(0)], Ys=[np.array(0)], Yvars=[np.array(1)])
+
+
+class TorchUtilsTest(TestCase):
+    def testNormalizeIndices(self):
+        indices = [0, 2]
+        nlzd_indices = normalize_indices(indices, 3)
+        self.assertEqual(nlzd_indices, indices)
+        nlzd_indices = normalize_indices(indices, 4)
+        self.assertEqual(nlzd_indices, indices)
+        indices = [0, -1]
+        nlzd_indices = normalize_indices(indices, 3)
+        self.assertEqual(nlzd_indices, [0, 2])
+        with self.assertRaises(ValueError):
+            nlzd_indices = normalize_indices([3], 3)
+        with self.assertRaises(ValueError):
+            nlzd_indices = normalize_indices([-4], 3)

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -242,6 +242,7 @@ class BotorchModel(TorchModel):
     def predict(self, X: Tensor) -> Tuple[Tensor, Tensor]:
         return self.model_predictor(model=self.model, X=X)  # pyre-ignore [28]
 
+    @copy_doc(TorchModel.gen)
     def gen(
         self,
         n: int,
@@ -253,39 +254,16 @@ class BotorchModel(TorchModel):
         pending_observations: Optional[List[Tensor]] = None,
         model_gen_options: Optional[TConfig] = None,
         rounding_func: Optional[Callable[[Tensor], Tensor]] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
     ) -> Tuple[Tensor, Tensor, TGenMetadata]:
-        """Generate new candidates.
-
-        An initialized acquisition function can be passed in as
-        model_gen_options["acquisition_function"].
-
-        Args:
-            n: Number of candidates to generate.
-            bounds: A list of (lower, upper) tuples for each column of X.
-            objective_weights: The objective is to maximize a weighted sum of
-                the columns of f(x). These are the weights.
-            outcome_constraints: A tuple of (A, b). For k outcome constraints
-                and m outputs at f(x), A is (k x m) and b is (k x 1) such that
-                A f(x) <= b. (Not used by single task models)
-            linear_constraints: A tuple of (A, b). For k linear constraints on
-                d-dimensional x, A is (k x d) and b is (k x 1) such that
-                A x <= b.
-            fixed_features: A map {feature_index: value} for features that
-                should be fixed to a particular value during generation.
-            pending_observations:  A list of m (k_i x d) feature tensors X
-                for m outcomes and k_i pending observations for outcome i.
-            model_gen_options: A config dictionary that can contain
-                model-specific options.
-            rounding_func: A function that rounds an optimization result
-                appropriately (i.e., according to `round-trip` transformations).
-
-        Returns:
-            Tensor: `n x d`-dim Tensor of generated points.
-            Tensor: `n`-dim Tensor of weights for each point.
-        """
         options = model_gen_options or {}
         acf_options = options.get("acquisition_function_kwargs", {})
         optimizer_options = options.get("optimizer_kwargs", {})
+
+        if target_fidelities:
+            raise NotImplementedError(
+                "target_fidelities not implemented for base BotorchModel"
+            )
 
         X_pending, X_observed = _get_X_pending_and_observed(
             Xs=self.Xs,
@@ -346,7 +324,14 @@ class BotorchModel(TorchModel):
         linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
         fixed_features: Optional[Dict[int, float]] = None,
         model_gen_options: Optional[TConfig] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
     ) -> Optional[Tensor]:
+
+        if target_fidelities:
+            raise NotImplementedError(
+                "target_fidelities not implemented for base BotorchModel"
+            )
+
         x_best = best_observed_point(
             model=self,
             bounds=bounds,

--- a/ax/models/torch/botorch_kg.py
+++ b/ax/models/torch/botorch_kg.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import torch
+from ax.core.types import TConfig, TGenMetadata
+from ax.models.model_utils import get_observed
+from ax.models.torch.botorch import BotorchModel, get_rounding_func
+from ax.models.torch.utils import _get_X_pending_and_observed
+from ax.models.torch_base import TorchModel
+from ax.utils.common.docutils import copy_doc
+from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.analytic import PosteriorMean
+from botorch.acquisition.cost_aware import InverseCostWeightedUtility
+from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
+from botorch.acquisition.knowledge_gradient import (
+    qKnowledgeGradient,
+    qMultiFidelityKnowledgeGradient,
+)
+from botorch.acquisition.monte_carlo import qSimpleRegret
+from botorch.acquisition.objective import (
+    AcquisitionObjective,
+    ConstrainedMCObjective,
+    MCAcquisitionObjective,
+    ScalarizedObjective,
+)
+from botorch.acquisition.utils import (
+    expand_trace_observations,
+    get_infeasible_cost,
+    project_to_target_fidelity,
+)
+from botorch.exceptions.errors import UnsupportedError
+from botorch.models.cost import AffineFidelityCostModel
+from botorch.models.model import Model
+from botorch.optim.initializers import gen_one_shot_kg_initial_conditions
+from botorch.optim.optimize import optimize_acqf
+from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
+from botorch.utils.constraints import get_outcome_constraint_transforms
+from botorch.utils.objective import get_objective_weights_transform
+from torch import Tensor
+
+
+class KnowledgeGradient(BotorchModel):
+    r""" The Knowledge Gradient with one shot optimization
+
+    Args:
+        cost_intercept: The cost intercept for the affine cost of the form
+            `cost_intercept + n`, where `n` is the number of generated points.
+            Only used for multi-fidelity optimzation (i.e., if fidelity_features
+            are present).
+        linear_truncated: If `False`, use an alternate downsampling + exponential
+            decay Kernel instead of the default `LinearTruncatedFidelityKernel`
+            (only relevant for multi-fidelity optimization).
+        kwargs: Model-specific kwargs.
+    """
+
+    def __init__(
+        self, cost_intercept: float = 1.0, linear_truncated: bool = True, **kwargs: Any
+    ) -> None:
+        super().__init__(linear_truncated=linear_truncated, **kwargs)
+        self.cost_intercept = cost_intercept
+
+    @copy_doc(TorchModel.gen)
+    def gen(
+        self,
+        n: int,
+        bounds: List,
+        objective_weights: Tensor,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        pending_observations: Optional[List[Tensor]] = None,
+        model_gen_options: Optional[TConfig] = None,
+        rounding_func: Optional[Callable[[Tensor], Tensor]] = None,
+    ) -> Tuple[Tensor, Tensor, TGenMetadata]:
+        options = model_gen_options or {}
+        acf_options = options.get("acquisition_function_kwargs", {})
+        optimizer_options = options.get("optimizer_kwargs", {})
+
+        X_pending, X_observed = _get_X_pending_and_observed(
+            Xs=self.Xs,
+            pending_observations=pending_observations,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            bounds=bounds,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+        )
+        objective = _get_objective(
+            model=self.model,  # pyre-ignore: [6]
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            X_observed=X_observed,
+        )
+        # get the acquisition function
+        n_fantasies = acf_options.get("num_fantasies", 64)
+        qmc = acf_options.get("qmc", True)
+        seed_inner = acf_options.get("seed_inner", None)
+        num_restarts = optimizer_options.get("num_restarts", 40)
+        raw_samples = optimizer_options.get("raw_samples", 1024)
+
+        inequality_constraints = _to_inequality_constraints(linear_constraints)
+        # TODO: update optimizers to handle inequality_constraints
+        if inequality_constraints is not None:
+            raise UnsupportedError(
+                "Inequality constraints are not yet supported for KnowledgeGradient!"
+            )
+
+        # get current value
+        best_point_acqf = _set_best_point_acq(
+            model=self.model,  # pyre-ignore: [6]
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            X_observed=X_observed,
+            seed_inner=seed_inner,
+            fidelity_features=self.fidelity_features,
+            qmc=qmc,
+        )
+        # solution from previous iteration
+        recommended_point = self.best_point(
+            bounds=bounds,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+            model_gen_options=model_gen_options,
+        )
+        recommended_point = recommended_point.detach()  # pyre-ignore: [16]
+        idxr = [
+            i
+            for i in range(X_observed.size(-1))  # pyre-ignore: [16]
+            if i not in self.fidelity_features
+        ]
+        acq_value = best_point_acqf(recommended_point.unsqueeze(0)[..., idxr])
+        current_value = acq_value.max()
+
+        acq_function = _instantiate_KG(
+            model=self.model,  # pyre-ignore: [6]
+            objective=objective,
+            qmc=qmc,
+            n_fantasies=n_fantasies,
+            num_trace_observations=options.get("num_trace_observations", 0),
+            mc_samples=acf_options.get("mc_samples", 256),
+            seed_inner=seed_inner,
+            seed_outer=acf_options.get("seed_outer", None),
+            X_pending=X_pending,
+            fidelity_features=self.fidelity_features,
+            current_value=current_value,
+            cost_intercept=self.cost_intercept,
+        )
+
+        # optimize and get new points
+        bounds_ = torch.tensor(bounds, dtype=self.dtype, device=self.device)
+        bounds_ = bounds_.transpose(0, 1)
+
+        batch_initial_conditions = gen_one_shot_kg_initial_conditions(
+            acq_function=acq_function,
+            bounds=bounds_,
+            q=n,
+            num_restarts=num_restarts,
+            raw_samples=raw_samples,
+            options={
+                "frac_random": optimizer_options.get("frac_random", 0.1),
+                "num_inner_restarts": num_restarts,
+                "raw_inner_samples": raw_samples,
+            },
+        )
+
+        botorch_rounding_func = get_rounding_func(rounding_func)
+
+        candidates, _ = optimize_acqf(
+            acq_function=acq_function,
+            bounds=bounds_,
+            q=n,
+            inequality_constraints=inequality_constraints,
+            fixed_features=fixed_features,
+            post_processing_func=botorch_rounding_func,
+            num_restarts=num_restarts,
+            raw_samples=raw_samples,
+            options={
+                "batch_limit": optimizer_options.get("batch_limit", 8),
+                "maxiter": optimizer_options.get("maxiter", 200),
+                "method": "L-BFGS-B",
+                "nonnegative": optimizer_options.get("nonnegative", False),
+            },
+            batch_initial_conditions=batch_initial_conditions,
+        )
+        new_x = candidates.detach().cpu()
+        return new_x, torch.ones(n, dtype=self.dtype), {}
+
+    @copy_doc(TorchModel.best_point)
+    def best_point(
+        self,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        model_gen_options: Optional[TConfig] = None,
+    ) -> Optional[Tensor]:
+        options = model_gen_options or {}
+        acf_options = options.get("acquisition_function_kwargs", {})
+        optimizer_options = options.get("optimizer_kwargs", {})
+
+        inequality_constraints = _to_inequality_constraints(linear_constraints)
+        # TODO: update optimizers to handle inequality_constraints
+        if inequality_constraints is not None:
+            raise UnsupportedError("Inequality constraints are not supported!")
+
+        # The only difference between constrained and unconstrained version is the
+        # `acq_function` in optimize_acqf.
+        X_observed = get_observed(
+            Xs=self.Xs,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+        )
+
+        acq_function = _set_best_point_acq(
+            model=self.model,  # pyre-ignore: [6]
+            mc_samples=acf_options.get("mc_samples", 512),
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            X_observed=X_observed,
+            seed_inner=acf_options.get("seed_inner", None),
+            fidelity_features=self.fidelity_features,
+            qmc=acf_options.get("qmc", True),
+        )
+        return_best_only = optimizer_options.get("return_best_only", True)
+        bounds_ = torch.tensor(bounds, dtype=self.dtype, device=self.device)
+        is_fixed = isinstance(acq_function, FixedFeatureAcquisitionFunction)
+        dimension = X_observed.shape[-1] - is_fixed * len(self.fidelity_features)
+        bounds_ = bounds_.transpose(0, 1)[..., :dimension]
+        candidates, _ = optimize_acqf(
+            acq_function=acq_function,
+            bounds=bounds_,
+            q=1,
+            num_restarts=optimizer_options.get("num_restarts", 60),
+            raw_samples=optimizer_options.get("raw_samples", 1024),
+            inequality_constraints=inequality_constraints,
+            fixed_features=fixed_features,
+            options={
+                "batch_limit": optimizer_options.get("batch_limit", 8),
+                "maxiter": optimizer_options.get("maxiter", 200),
+                "nonnegative": optimizer_options.get("nonnegative", False),
+                "method": "L-BFGS-B",
+            },
+            return_best_only=return_best_only,
+        )
+        recommended_point = candidates.detach().cpu()
+        if is_fixed:
+            recommended_point = acq_function._construct_X_full(  # pyre-ignore: [16]
+                recommended_point
+            )
+        if return_best_only:
+            recommended_point = recommended_point.view(-1)
+        return recommended_point
+
+
+def _get_objective(
+    model: Model,
+    objective_weights: Tensor,
+    outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+    X_observed: Optional[Tensor] = None,
+) -> AcquisitionObjective:
+    if outcome_constraints is None:
+        objective = ScalarizedObjective(weights=objective_weights)
+    else:
+        X_observed = torch.as_tensor(X_observed)
+        obj_tf = get_objective_weights_transform(objective_weights)
+        con_tfs = get_outcome_constraint_transforms(outcome_constraints)
+        inf_cost = get_infeasible_cost(X=X_observed, model=model, objective=obj_tf)
+        objective = ConstrainedMCObjective(
+            objective=obj_tf, constraints=con_tfs or [], infeasible_cost=inf_cost
+        )
+    return objective
+
+
+def _instantiate_KG(
+    model: Model,
+    objective: AcquisitionObjective,
+    qmc: bool = True,
+    n_fantasies: int = 64,
+    mc_samples: int = 256,
+    num_trace_observations: int = 0,
+    seed_inner: Optional[int] = None,
+    seed_outer: Optional[int] = None,
+    X_pending: Optional[Tensor] = None,
+    current_value: Optional[Tensor] = None,
+    fidelity_features: Optional[List[int]] = None,
+    cost_intercept: float = 1.0,
+) -> qKnowledgeGradient:
+    sampler_cls = SobolQMCNormalSampler if qmc else IIDNormalSampler
+    fantasy_sampler = sampler_cls(num_samples=n_fantasies, seed=seed_outer)
+    if isinstance(objective, MCAcquisitionObjective):
+        inner_sampler = sampler_cls(num_samples=mc_samples, seed=seed_inner)
+    else:
+        inner_sampler = None
+    if fidelity_features:
+        cost_model = AffineFidelityCostModel(
+            fidelity_weights={f: 1.0 for f in fidelity_features},
+            fixed_cost=cost_intercept,
+        )
+        cost_aware_utility = InverseCostWeightedUtility(cost_model=cost_model)
+        target_fidelities = {i: 1.0 for i in fidelity_features}
+
+        def project(X: Tensor) -> Tensor:
+            return project_to_target_fidelity(X=X, target_fidelities=target_fidelities)
+
+        def expand(X: Tensor) -> Tensor:
+            return expand_trace_observations(
+                X=X,
+                fidelity_dims=sorted(target_fidelities),
+                num_trace_obs=num_trace_observations,
+            )
+
+        return qMultiFidelityKnowledgeGradient(
+            model=model,
+            num_fantasies=n_fantasies,
+            sampler=fantasy_sampler,
+            objective=objective,
+            inner_sampler=inner_sampler,
+            X_pending=X_pending,
+            current_value=current_value,
+            cost_aware_utility=cost_aware_utility,
+            project=project,
+            expand=expand,
+        )
+
+    return qKnowledgeGradient(
+        model=model,
+        num_fantasies=n_fantasies,
+        sampler=fantasy_sampler,
+        objective=objective,
+        inner_sampler=inner_sampler,
+        X_pending=X_pending,
+        current_value=current_value,
+    )
+
+
+def _set_best_point_acq(
+    model: Model,
+    X_observed: Tensor,
+    objective_weights: Tensor,
+    mc_samples: int = 512,
+    fidelity_features: Optional[List[int]] = None,
+    outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+    seed_inner: Optional[int] = None,
+    qmc: bool = True,
+) -> AcquisitionFunction:
+    objective = _get_objective(
+        model=model,
+        objective_weights=objective_weights,
+        outcome_constraints=outcome_constraints,
+        X_observed=X_observed,
+    )
+    if isinstance(objective, ScalarizedObjective):
+        acq_function = PosteriorMean(model=model, objective=objective)
+    elif isinstance(objective, MCAcquisitionObjective):
+        if qmc:
+            sampler = SobolQMCNormalSampler(num_samples=mc_samples, seed=seed_inner)
+        else:
+            sampler = IIDNormalSampler(num_samples=mc_samples, seed=seed_inner)
+        acq_function = qSimpleRegret(model=model, sampler=sampler, objective=objective)
+    else:
+        raise UnsupportedError(
+            f"Unknown objective type: {objective.__class__}"  # pragma: nocover
+        )
+    if fidelity_features:
+        acq_function = FixedFeatureAcquisitionFunction(
+            acq_function=acq_function,
+            d=X_observed.size(-1),
+            columns=fidelity_features,
+            values=[1.0],
+        )
+    return acq_function
+
+
+def _to_inequality_constraints(
+    linear_constraints: Optional[Tuple[Tensor, Tensor]] = None
+) -> Optional[List[Tuple[Tensor, Tensor, float]]]:
+    if linear_constraints is not None:
+        A, b = linear_constraints
+        inequality_constraints = []
+        k, d = A.shape
+        for i in range(k):
+            indicies = A[i, :].nonzero().squeeze()
+            coefficients = -A[i, indicies]
+            rhs = -b[i, 0]
+            inequality_constraints.append((indicies, coefficients, rhs))
+    else:
+        inequality_constraints = None
+    return inequality_constraints

--- a/ax/models/torch/utils.py
+++ b/ax/models/torch/utils.py
@@ -122,3 +122,24 @@ def _get_X_pending_and_observed(
         fixed_features=fixed_features,
     )
     return X_pending, X_observed
+
+
+def normalize_indices(indices: List[int], d: int) -> List[int]:
+    r"""Normalize a list of indices to ensure that they are positive.
+
+    Args:
+        indices: A list of indices (may contain negative indices for indexing
+            "from the back").
+        d: The dimension of the tensor to index.
+
+    Returns:
+        A normalized list of indices such that each index is between `0` and `d-1`.
+    """
+    normalized_indices = []
+    for i in indices:
+        if i < 0:
+            i = i + d
+        if i < 0 or i > d - 1:
+            raise ValueError(f"Index {i} out of bounds for tensor or length {d}.")
+        normalized_indices.append(i)
+    return normalized_indices

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -74,6 +74,7 @@ class TorchModel(Model):
         pending_observations: Optional[List[Tensor]] = None,
         model_gen_options: Optional[TConfig] = None,
         rounding_func: Optional[Callable[[Tensor], Tensor]] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
     ) -> Tuple[Tensor, Tensor, TGenMetadata]:
         """
         Generate new candidates.
@@ -95,6 +96,11 @@ class TorchModel(Model):
                 for m outcomes and k_i pending observations for outcome i.
             model_gen_options: A config dictionary that can contain
                 model-specific options.
+            rounding_func: A function that rounds an optimization result
+                appropriately (i.e., according to `round-trip` transformations).
+            target_fidelities: A map {feature_index: value} of fidelity feature
+                column indices to their respective target fidelities. Used for
+                multi-fidelity optimization.
 
         Returns:
             3-element tuple containing
@@ -114,6 +120,7 @@ class TorchModel(Model):
         linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
         fixed_features: Optional[Dict[int, float]] = None,
         model_gen_options: Optional[TConfig] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
     ) -> Optional[Tensor]:
         """
         Identify the current best point, satisfying the constraints in the same
@@ -135,6 +142,9 @@ class TorchModel(Model):
                 should be fixed to a particular value in the best point.
             model_gen_options: A config dictionary that can contain
                 model-specific options.
+            target_fidelities: A map {feature_index: value} of fidelity feature
+                column indices to their respective target fidelities. Used for
+                multi-fidelity optimization.
 
         Returns:
             d-tensor of the best point.


### PR DESCRIPTION
Summary:
Add a `target_fidelities` argument to `gen` and `best_point` methods of the `TorchModel`.

Make sure that target values defined for fidelity parameters are passed down through the model bridge to the models.

Various other fixes, including to the core parameters to properly handle fidelity parmeters and target values throughout.

Reviewed By: lena-kashtelyan

Differential Revision: D18284657

