### PR TITLE
fix the bug of target_fidelities

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -119,6 +119,12 @@ class RangeParameter(Parameter):
             is_fidelity: Whether this parameter is a fidelity parameter.
             target_value: Target value of this parameter if it is a fidelity.
         """
+        if is_fidelity and (target_value is None):
+            raise ValueError(
+                "`target_value` should not be None for the fidelity parameter: "
+                "{}".format(name)
+            )
+
         self._name = name
         self._parameter_type = parameter_type
         self._digits = digits
@@ -332,6 +338,12 @@ class ChoiceParameter(Parameter):
             is_task: Treat the parameter as a task parameter for modeling.
             target_value: Target value of this parameter if it's fidelity.
         """
+        if is_fidelity and (target_value is None):
+            raise ValueError(
+                "`target_value` should not be None for the fidelity parameter: "
+                "{}".format(name)
+            )
+
         self._is_ordered = is_ordered
         self._is_task = is_task
         self._is_fidelity = is_fidelity
@@ -447,6 +459,12 @@ class FixedParameter(Parameter):
             value: The fixed value of the parameter.
             target_value: Target value of this parameter if it is a fidelity.
         """
+        if is_fidelity and (target_value is None):
+            raise ValueError(
+                "`target_value` should not be None for the fidelity parameter: "
+                "{}".format(name)
+            )
+
         self._name = name
         self._parameter_type = parameter_type
         self._value = self._cast(value)

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -86,6 +86,9 @@ class RangeParameterTest(TestCase):
         with self.assertRaises(ValueError):
             RangeParameter("x", ParameterType.INT, 0.5, 1)
 
+        with self.assertRaises(ValueError):
+            RangeParameter("x", ParameterType.INT, 0.5, 1, is_fidelity=True)
+
     def testBadSetter(self):
         with self.assertRaises(ValueError):
             self.param1.update_range(upper="foo")
@@ -159,6 +162,15 @@ class ChoiceParameterTest(TestCase):
             "values=['foo', 'bar'], fidelity=True, target_value='bar')"
         )
 
+    def testBadCreations(self):
+        with self.assertRaises(ValueError):
+            ChoiceParameter(
+                name="x",
+                parameter_type=ParameterType.STRING,
+                values=["foo", "foo2"],
+                is_fidelity=True,
+            )
+
     def testEq(self):
         param4 = ChoiceParameter(
             name="x", parameter_type=ParameterType.STRING, values=["foo", "bar", "baz"]
@@ -222,6 +234,15 @@ class FixedParameterTest(TestCase):
             name="x", parameter_type=ParameterType.BOOL, value=True
         )
         self.param1_repr = "FixedParameter(name='x', parameter_type=BOOL, value=True)"
+
+    def testBadCreations(self):
+        with self.assertRaises(ValueError):
+            FixedParameter(
+                name="x",
+                parameter_type=ParameterType.BOOL,
+                value=True,
+                is_fidelity=True,
+            )
 
     def testEq(self):
         param2 = FixedParameter(name="x", parameter_type=ParameterType.BOOL, value=True)

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -85,6 +85,7 @@ def _make_range_param(
         upper=checked_cast_to_tuple((float, int), bounds[1]),
         log_scale=checked_cast(bool, representation.get("log_scale", False)),
         is_fidelity=checked_cast(bool, representation.get("is_fidelity", False)),
+        target_value=representation.get("target_value", None),  # pyre-ignore[6]
     )
 
 
@@ -102,6 +103,8 @@ def _make_choice_param(
         parameter_type=_to_parameter_type(values, parameter_type, name, "values"),
         values=values,
         is_ordered=checked_cast(bool, representation.get("is_ordered", False)),
+        is_fidelity=checked_cast(bool, representation.get("is_fidelity", False)),
+        target_value=representation.get("target_value", None),  # pyre-ignore[6]
     )
 
 
@@ -120,6 +123,8 @@ def _make_fixed_param(
         if parameter_type is None
         else _get_parameter_type(PARAM_TYPES[parameter_type]),  # pyre-ignore[6]
         value=value,
+        is_fidelity=checked_cast(bool, representation.get("is_fidelity", False)),
+        target_value=representation.get("target_value", None),
     )
 
 


### PR DESCRIPTION
Summary: the code fails when target_fidelities contains None due to float(v)

Reviewed By: Balandat

Differential Revision: D18492186

