### PR TITLE
Properly handle target values in transforms

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -132,7 +132,7 @@ class RangeParameter(Parameter):
         self._upper = self._cast(upper)
         self._log_scale = log_scale
         self._is_fidelity = is_fidelity
-        self._target_value = target_value
+        self._target_value = self._cast(target_value)
 
         self._validate_range_param(
             parameter_type=parameter_type, lower=lower, upper=upper, log_scale=log_scale
@@ -336,6 +336,7 @@ class ChoiceParameter(Parameter):
             values: List of allowed values for the parameter.
             is_ordered: If False, the parameter is a categorical variable.
             is_task: Treat the parameter as a task parameter for modeling.
+            is_fidelity: Whether this parameter is a fidelity parameter.
             target_value: Target value of this parameter if it's fidelity.
         """
         if is_fidelity and (target_value is None):
@@ -344,12 +345,12 @@ class ChoiceParameter(Parameter):
                 "{}".format(name)
             )
 
+        self._name = name
+        self._parameter_type = parameter_type
         self._is_ordered = is_ordered
         self._is_task = is_task
         self._is_fidelity = is_fidelity
-        self._target_value = target_value
-        self._name = name
-        self._parameter_type = parameter_type
+        self._target_value = self._cast(target_value)
         # A choice parameter with only one value is a FixedParameter.
         if not len(values) > 1:
             raise ValueError(FIXED_CHOICE_PARAM_ERROR)
@@ -457,6 +458,7 @@ class FixedParameter(Parameter):
             parameter_type: Enum indicating the type of parameter
                 value (e.g. string, int).
             value: The fixed value of the parameter.
+            is_fidelity: Whether this parameter is a fidelity parameter.
             target_value: Target value of this parameter if it is a fidelity.
         """
         if is_fidelity and (target_value is None):
@@ -469,7 +471,7 @@ class FixedParameter(Parameter):
         self._parameter_type = parameter_type
         self._value = self._cast(value)
         self._is_fidelity = is_fidelity
-        self._target_value = target_value
+        self._target_value = self._cast(target_value)
 
     @property
     def value(self) -> TParamValue:

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -25,7 +25,7 @@ class RangeParameterTest(TestCase):
         self.param1_repr = (
             "RangeParameter(name='x', parameter_type=FLOAT, "
             "range=[1.0, 3.0], log_scale=True, digits=5, fidelity=True, target_"
-            "value=2)"
+            "value=2.0)"
         )
 
         self.param2 = RangeParameter(

--- a/ax/modelbridge/tests/test_centered_unit_x_transform.py
+++ b/ax/modelbridge/tests/test_centered_unit_x_transform.py
@@ -35,6 +35,18 @@ class CenteredUnitXTransformTest(TestCase):
             ],
             parameter_constraints=[],
         )
+        self.search_space_with_target = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    "x",
+                    lower=1,
+                    upper=3,
+                    parameter_type=ParameterType.FLOAT,
+                    is_fidelity=True,
+                    target_value=3,
+                )
+            ]
+        )
         self.t = CenteredUnitX(
             search_space=self.search_space,
             observation_features=None,
@@ -92,3 +104,12 @@ class CenteredUnitXTransformTest(TestCase):
         )
         with self.assertRaises(ValueError):
             ss2 = self.t.transform_search_space(ss2)
+        t = CenteredUnitX(
+            search_space=self.search_space_with_target,
+            observation_features=None,
+            observation_data=None,
+        )
+        t.transform_search_space(self.search_space_with_target)
+        self.assertEqual(
+            self.search_space_with_target.parameters["x"].target_value, 1.0
+        )

--- a/ax/modelbridge/tests/test_log_transform.py
+++ b/ax/modelbridge/tests/test_log_transform.py
@@ -33,6 +33,19 @@ class LogTransformTest(TestCase):
             observation_features=None,
             observation_data=None,
         )
+        self.search_space_with_target = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    "x",
+                    lower=1,
+                    upper=3,
+                    parameter_type=ParameterType.FLOAT,
+                    log_scale=True,
+                    is_fidelity=True,
+                    target_value=3,
+                )
+            ]
+        )
 
     def testInit(self):
         self.assertEqual(self.t.transform_parameters, {"x"})
@@ -56,3 +69,12 @@ class LogTransformTest(TestCase):
         ss2 = self.t.transform_search_space(ss2)
         self.assertEqual(ss2.parameters["x"].lower, math.log10(1))
         self.assertEqual(ss2.parameters["x"].upper, math.log10(3))
+        t2 = Log(
+            search_space=self.search_space_with_target,
+            observation_features=None,
+            observation_data=None,
+        )
+        t2.transform_search_space(self.search_space_with_target)
+        self.assertEqual(
+            self.search_space_with_target.parameters["x"].target_value, math.log10(3)
+        )

--- a/ax/modelbridge/tests/test_one_hot_transform.py
+++ b/ax/modelbridge/tests/test_one_hot_transform.py
@@ -125,3 +125,19 @@ class OneHotTransformTest(TestCase):
         self.assertEqual(ss2.parameters["b" + OH_PARAM_INFIX + "_1"].upper, 1.0)
         self.assertEqual(ss2.parameters["c" + OH_PARAM_INFIX].lower, 0.0)
         self.assertEqual(ss2.parameters["c" + OH_PARAM_INFIX].upper, 1.0)
+
+        # Ensure we error if we try to transform a fidelity parameter
+        ss3 = SearchSpace(
+            parameters=[
+                ChoiceParameter(
+                    "b",
+                    parameter_type=ParameterType.STRING,
+                    values=["a", "b", "c"],
+                    is_fidelity=True,
+                    target_value="c",
+                )
+            ]
+        )
+        t = OneHot(search_space=ss3, observation_features=None, observation_data=None)
+        with self.assertRaises(ValueError):
+            t.transform_search_space(ss3)

--- a/ax/modelbridge/tests/test_ordered_choice_encode_transform.py
+++ b/ax/modelbridge/tests/test_ordered_choice_encode_transform.py
@@ -96,3 +96,22 @@ class OrderedChoiceEncodeTransformTest(TestCase):
         self.assertEqual(ss2.parameters["b"].upper, 2)
         self.assertEqual(ss2.parameters["c"].lower, 0)
         self.assertEqual(ss2.parameters["c"].upper, 2)
+
+        # Ensure we error if we try to transform a fidelity parameter
+        ss3 = SearchSpace(
+            parameters=[
+                ChoiceParameter(
+                    "b",
+                    parameter_type=ParameterType.FLOAT,
+                    values=[1.0, 10.0, 100.0],
+                    is_ordered=True,
+                    is_fidelity=True,
+                    target_value=100.0,
+                )
+            ]
+        )
+        t = OrderedChoiceEncode(
+            search_space=ss3, observation_features=None, observation_data=None
+        )
+        with self.assertRaises(ValueError):
+            t.transform_search_space(ss3)

--- a/ax/modelbridge/tests/test_search_space_to_choice_transform.py
+++ b/ax/modelbridge/tests/test_search_space_to_choice_transform.py
@@ -70,6 +70,26 @@ class SearchSpaceToChoiceTest(TestCase):
         )
         self.assertEqual(ss2.parameters.get("arms"), expected_parameter)
 
+        # Test error if there are fidelities
+        ss3 = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    "a",
+                    lower=1,
+                    upper=3,
+                    parameter_type=ParameterType.FLOAT,
+                    is_fidelity=True,
+                    target_value=3,
+                )
+            ]
+        )
+        with self.assertRaises(ValueError):
+            SearchSpaceToChoice(
+                search_space=ss3,
+                observation_features=self.observation_features,
+                observation_data=None,
+            )
+
     def testTransformSearchSpaceWithFixedParam(self):
         ss2 = self.search_space.clone()
         ss2 = self.t2.transform_search_space(ss2)

--- a/ax/modelbridge/tests/test_task_encode_transform.py
+++ b/ax/modelbridge/tests/test_task_encode_transform.py
@@ -69,3 +69,21 @@ class TaskEncodeTransformTest(TestCase):
 
         self.assertEqual(ss2.parameters["c"].lower, 0)
         self.assertEqual(ss2.parameters["c"].upper, 1)
+
+        # Test error if there are fidelities
+        ss3 = SearchSpace(
+            parameters=[
+                ChoiceParameter(
+                    "c",
+                    parameter_type=ParameterType.STRING,
+                    values=["online", "offline"],
+                    is_task=True,
+                    is_fidelity=True,
+                    target_value="online",
+                )
+            ]
+        )
+        with self.assertRaises(ValueError):
+            TaskEncode(
+                search_space=ss3, observation_features=None, observation_data=None
+            )

--- a/ax/modelbridge/tests/test_unit_x_transform.py
+++ b/ax/modelbridge/tests/test_unit_x_transform.py
@@ -43,6 +43,18 @@ class UnitXTransformTest(TestCase):
             observation_features=None,
             observation_data=None,
         )
+        self.search_space_with_target = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    "x",
+                    lower=1,
+                    upper=3,
+                    parameter_type=ParameterType.FLOAT,
+                    is_fidelity=True,
+                    target_value=3,
+                )
+            ]
+        )
 
     def testInit(self):
         self.assertEqual(self.t.bounds, {"x": (1.0, 3.0), "y": (1.0, 2.0)})
@@ -95,3 +107,14 @@ class UnitXTransformTest(TestCase):
             ss2.parameter_constraints[1].constraint_dict, {"x": -1.0, "a": 1.0}
         )
         self.assertEqual(ss2.parameter_constraints[1].bound, 1.0)
+
+        # Test transform of target value
+        t = UnitX(
+            search_space=self.search_space_with_target,
+            observation_features=None,
+            observation_data=None,
+        )
+        t.transform_search_space(self.search_space_with_target)
+        self.assertEqual(
+            self.search_space_with_target.parameters["x"].target_value, 1.0
+        )

--- a/ax/modelbridge/transforms/centered_unit_x.py
+++ b/ax/modelbridge/transforms/centered_unit_x.py
@@ -53,8 +53,12 @@ class CenteredUnitX(Transform):
     @copy_doc(Transform.transform_search_space)
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         for p_name, p in search_space.parameters.items():
-            if isinstance(p, RangeParameter) and p_name in self.bounds:
+            if p_name in self.bounds and isinstance(p, RangeParameter):
                 p.update_range(lower=-1.0, upper=1.0)
+            if p.target_value is not None:
+                l, u = self.bounds[p_name]
+                new_tval = -1 + 2 * (p.target_value - l) / (u - l)  # pyre-ignore [16]
+                p._target_value = new_tval
         for c in search_space.parameter_constraints:
             for p_name in c.constraint_dict:
                 if p_name in self.bounds:

--- a/ax/modelbridge/transforms/int_to_float.py
+++ b/ax/modelbridge/transforms/int_to_float.py
@@ -52,19 +52,17 @@ class IntToFloat(Transform):
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         transformed_parameters: Dict[str, Parameter] = {}
-        for p in search_space.parameters.values():
-            # Refine type, since we've only added RangeParameters above.
-            if p.name in self.transform_parameters:
-                # pyre: p_cast is declared to have type `RangeParameter` but
-                # pyre-fixme[9]: is used as type `Parameter`.
-                p_cast: RangeParameter = p
-                transformed_parameters[p.name] = RangeParameter(
-                    name=p_cast.name,
+        for p_name, p in search_space.parameters.items():
+            if p_name in self.transform_parameters and isinstance(p, RangeParameter):
+                transformed_parameters[p_name] = RangeParameter(
+                    name=p_name,
                     parameter_type=ParameterType.FLOAT,
-                    lower=p_cast.lower,
-                    upper=p_cast.upper,
-                    log_scale=p_cast.log_scale,
-                    digits=p_cast.digits,
+                    lower=p.lower,
+                    upper=p.upper,
+                    log_scale=p.log_scale,
+                    digits=p.digits,
+                    is_fidelity=p.is_fidelity,
+                    target_value=p.target_value,  # casting happens in constructor
                 )
             else:
                 transformed_parameters[p.name] = p

--- a/ax/modelbridge/transforms/log.py
+++ b/ax/modelbridge/transforms/log.py
@@ -47,13 +47,12 @@ class Log(Transform):
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         for p_name, p in search_space.parameters.items():
-            if p_name in self.transform_parameters:
-                # pyre: p_cast is declared to have type `RangeParameter` but
-                # pyre-fixme[9]: is used as type `ax.core.parameter.Parameter`.
-                p_cast: RangeParameter = p
-                p_cast.set_log_scale(False).update_range(
-                    lower=math.log10(p_cast.lower), upper=math.log10(p_cast.upper)
+            if p_name in self.transform_parameters and isinstance(p, RangeParameter):
+                p.set_log_scale(False).update_range(
+                    lower=math.log10(p.lower), upper=math.log10(p.upper)
                 )
+                if p.target_value is not None:
+                    p._target_value = math.log10(p.target_value)  # pyre-ignore [6]
         return search_space
 
     def untransform_observation_features(

--- a/ax/modelbridge/transforms/one_hot.py
+++ b/ax/modelbridge/transforms/one_hot.py
@@ -118,9 +118,13 @@ class OneHot(Transform):
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         transformed_parameters: Dict[str, Parameter] = {}
-        for p in search_space.parameters.values():
-            if p.name in self.encoded_parameters:
-                for new_p_name in self.encoded_parameters[p.name]:
+        for p_name, p in search_space.parameters.items():
+            if p_name in self.encoded_parameters:
+                if p.is_fidelity:
+                    raise ValueError(
+                        f"Cannot one-hot-encode fidelity parameter {p_name}"
+                    )
+                for new_p_name in self.encoded_parameters[p_name]:
                     transformed_parameters[new_p_name] = RangeParameter(
                         name=new_p_name,
                         parameter_type=ParameterType.FLOAT,
@@ -128,7 +132,7 @@ class OneHot(Transform):
                         upper=1,
                     )
             else:
-                transformed_parameters[p.name] = p
+                transformed_parameters[p_name] = p
         return SearchSpace(
             parameters=list(transformed_parameters.values()),
             parameter_constraints=[

--- a/ax/modelbridge/transforms/ordered_choice_encode.py
+++ b/ax/modelbridge/transforms/ordered_choice_encode.py
@@ -58,18 +58,18 @@ class OrderedChoiceEncode(Transform):
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         transformed_parameters: Dict[str, Parameter] = {}
-        for p in search_space.parameters.values():
-            if p.name in self.encoded_parameters:
-                # TypeAssert. Only ChoiceParameters present here.
-                # pyre: p_ is declared to have type `ChoiceParameter` but is
-                # pyre-fixme[9]: used as type `Parameter`.
-                p_: ChoiceParameter = p
+        for p_name, p in search_space.parameters.items():
+            if p_name in self.encoded_parameters and isinstance(p, ChoiceParameter):
+                if p.is_fidelity:
+                    raise ValueError(
+                        f"Cannot choice-encode fidelity parameter {p_name}"
+                    )
                 # Choice(|K|) => Range(0, K-1)
-                transformed_parameters[p.name] = RangeParameter(
-                    name=p_.name,
+                transformed_parameters[p_name] = RangeParameter(
+                    name=p_name,
                     parameter_type=ParameterType.INT,
                     lower=0,
-                    upper=len(p_.values) - 1,
+                    upper=len(p.values) - 1,
                 )
             else:
                 transformed_parameters[p.name] = p

--- a/ax/modelbridge/transforms/search_space_to_choice.py
+++ b/ax/modelbridge/transforms/search_space_to_choice.py
@@ -27,6 +27,11 @@ class SearchSpaceToChoice(Transform):
         observation_data: List[ObservationData],
         config: Optional[TConfig] = None,
     ) -> None:
+        if any(p.is_fidelity for p in search_space.parameters.values()):
+            raise ValueError(
+                "Cannot perform SearchSpaceToChoice conversion if fidelity "
+                "parameters are present"
+            )
         self.parameter_name = "arms"
         self.signature_to_parameterization = {
             Arm(parameters=obsf.parameters).signature: obsf.parameters

--- a/ax/modelbridge/transforms/task_encode.py
+++ b/ax/modelbridge/transforms/task_encode.py
@@ -32,6 +32,11 @@ class TaskEncode(OrderedChoiceEncode):
         self.encoded_parameters: Dict[str, Dict[TParamValue, int]] = {}
         for p in search_space.parameters.values():
             if isinstance(p, ChoiceParameter) and p.is_task:
+                if p.is_fidelity:
+                    raise ValueError(
+                        f"Task parameter {p.name} cannot simultaneously be "
+                        "fideliy parameter"
+                    )
                 self.encoded_parameters[p.name] = {
                     original_value: transformed_value
                     for transformed_value, original_value in enumerate(p.values)

--- a/ax/modelbridge/transforms/unit_x.py
+++ b/ax/modelbridge/transforms/unit_x.py
@@ -52,8 +52,11 @@ class UnitX(Transform):
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         for p_name, p in search_space.parameters.items():
-            if isinstance(p, RangeParameter) and p_name in self.bounds:
+            if p_name in self.bounds and isinstance(p, RangeParameter):
                 p.update_range(lower=0.0, upper=1.0)
+            if p.target_value is not None:
+                l, u = self.bounds[p_name]
+                p._target_value = (p.target_value - l) / (u - l)  # pyre-ignore [16]
         new_constraints: List[ParameterConstraint] = []
         for c in search_space.parameter_constraints:
             constraint_dict: Dict[str, float] = {}


### PR DESCRIPTION
Summary:
Currently, target values of fidelity parameters (and for that matter, fidelity parameters more generally) are not properly handled in the Ax transforms.
This diff makes sure that any transform that modifies the search space also properly handles target values of fidelity parameters.
It also adds some additional errors to be raised when we attempt things with fidelity parameters that we should not.

Differential Revision: D18648222

