### PR TITLE
fix the issue of linear_truncated kwargs in BotorchModel

### DIFF
--- a/ax/modelbridge/factory.py
+++ b/ax/modelbridge/factory.py
@@ -189,20 +189,22 @@ def get_GPKG(
             "winsorization_lower": winsorization_limits[0] or 0.0,
             "winsorization_upper": winsorization_limits[1] or 0.0,
         }
-    return checked_cast(
-        TorchModelBridge,
-        Models.GPKG(
-            search_space=search_space,
-            experiment=experiment,
-            data=data,
-            cost_intercept=cost_intercept,
-            linear_truncated=kwargs.get("linear_truncated", True),
-            torch_dtype=dtype,
-            torch_device=device,
-            transforms=transforms,
-            transform_configs=transform_configs,
-        ),
-    )
+
+    inputs = {
+        "search_space": search_space,
+        "experiment": experiment,
+        "data": data,
+        "cost_intercept": cost_intercept,
+        "torch_dtype": dtype,
+        "torch_device": device,
+        "transforms": transforms,
+        "transform_configs": transform_configs,
+    }
+
+    is_fidelity = any(p.is_fidelity for k, p in experiment.parameters.items())
+    if is_fidelity:
+        inputs["linear_truncated"] = kwargs.get("linear_truncated", True)
+    return checked_cast(TorchModelBridge, Models.GPKG(**inputs))  # pyre-ignore: [16]
 
 
 # TODO[Lena]: how to instantiate MTGP through the enum? The Multi-type MTGP requires

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -228,14 +228,14 @@ class BotorchModel(TorchModel):
         kwargs = self._kwargs
         if len(self.fidelity_features) == 0:
             # only pass linear_truncated arg if there are fidelities
-            kwargs = {k: v for k, v in kwargs.items() if k != "linear_truncated"}
+            self._kwargs = {k: v for k, v in kwargs.items() if k != "linear_truncated"}
         self.model = self.model_constructor(  # pyre-ignore [28]
             Xs=Xs,
             Ys=Ys,
             Yvars=Yvars,
             task_features=self.task_features,
             fidelity_features=self.fidelity_features,
-            **kwargs,
+            **self._kwargs,
         )
 
     @copy_doc(TorchModel.predict)


### PR DESCRIPTION
Summary: Since `self.model_constructor()` is called also in `update()` and `cross_validate()`, we need to make sure the `kwargs` does not include the `linear_truncated` kwarg for non MF models.

Reviewed By: bletham

Differential Revision: D18639828

