### PR TITLE
move the logic of linear_truncated out of botorch.py

### DIFF
--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -220,6 +220,12 @@ class Models(Enum):
             kwargs_iterable=[get_function_default_arguments(model_class), kwargs],
             keywords=get_function_argument_names(model_class),
         )
+        # linear_truncated is needed for multi-fidelty models.
+        search_space = search_space or not_none(experiment).search_space
+        is_fidelity = any(p.is_fidelity for k, p in search_space.parameters.items())
+        if is_fidelity and ("linear_truncated" in kwargs):
+            model_kwargs["linear_truncated"] = kwargs["linear_truncated"]
+
         model = model_class(**model_kwargs)
 
         # Create `ModelBridge`: defaults + standard kwargs + passed in kwargs.

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -225,10 +225,6 @@ class BotorchModel(TorchModel):
         # ensure indices are non-negative
         self.task_features = normalize_indices(task_features, d=Xs[0].size(-1))
         self.fidelity_features = normalize_indices(fidelity_features, d=Xs[0].size(-1))
-        kwargs = self._kwargs
-        if len(self.fidelity_features) == 0:
-            # only pass linear_truncated arg if there are fidelities
-            self._kwargs = {k: v for k, v in kwargs.items() if k != "linear_truncated"}
         self.model = self.model_constructor(  # pyre-ignore [28]
             Xs=Xs,
             Ys=Ys,

--- a/ax/models/torch/botorch_kg.py
+++ b/ax/models/torch/botorch_kg.py
@@ -47,16 +47,14 @@ class KnowledgeGradient(BotorchModel):
             `cost_intercept + n`, where `n` is the number of generated points.
             Only used for multi-fidelity optimzation (i.e., if fidelity_features
             are present).
-        linear_truncated: If `False`, use an alternate downsampling + exponential
-            decay Kernel instead of the default `LinearTruncatedFidelityKernel`
-            (only relevant for multi-fidelity optimization).
-        kwargs: Model-specific kwargs.
+        kwargs: Model-specific kwargs. E.g. specifying `linear_truncated=False`
+            will use an alternate downsampling + exponential decay Kernel
+            instead of the default `LinearTruncatedFidelityKernel` (only relevant
+            for multi-fidelity optimization).
     """
 
-    def __init__(
-        self, cost_intercept: float = 1.0, linear_truncated: bool = True, **kwargs: Any
-    ) -> None:
-        super().__init__(linear_truncated=linear_truncated, **kwargs)
+    def __init__(self, cost_intercept: float = 1.0, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
         self.cost_intercept = cost_intercept
 
     def gen(


### PR DESCRIPTION
Summary: remove the logic from botorch.py and model constructor, and add the logic of linear_truncated to registry.py

Differential Revision: D18661912

