### PR TITLE
Make `overwrite_existing_experiment` in `create_experiment` fail if experiment set locally

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -188,10 +188,9 @@ class AxClient:
             status_quo: Parameterization of the current state of the system.
                 If set, this will be added to each trial to be evaluated alongside
                 test configurations.
-            overwrite_existing_experiment: If `DBSettings` were provided on
-                instantiation and the experiment being created has the same name
-                as some experiment already stored, whether to overwrite the
-                existing experiment. Defaults to False.
+            overwrite_existing_experiment: If the experiment being created has the same
+                name as the locally created experiment or a DB stored experiment, 
+                whether to overwrite the existing experiment. Defaults to False.
             choose_generation_strategy_kwargs: Keyword arguments to pass to
                 `choose_generation_strategy` function which determines what
                 generation strategy should be used when none was specified on init.
@@ -217,6 +216,13 @@ class AxClient:
                     "or use `ax_client.load_experiment_from_database` to "
                     "continue an existing experiment."
                 )
+        if not overwrite_existing_experiment and self._experiment and name == self._experiment._name:
+            # todo: Replace this with a less generic error
+            raise ValueError(
+                f"Experiment already created {f'with name "{name}"' if name} "
+                "for this client. Set the `overwrite_existing_experiment` to "
+                "`True` to overwrite with new experiment."
+            )
 
         self._experiment = make_experiment(
             name=name,

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -219,9 +219,9 @@ class AxClient:
         if not overwrite_existing_experiment and self._experiment and name == self._experiment._name:
             # todo: Replace this with a less generic error
             raise ValueError(
-                f"Experiment already created {f'with name "{name}"' if name} "
-                "for this client. Set the `overwrite_existing_experiment` to "
-                "`True` to overwrite with new experiment."
+                f"Experiment already created for this client instance. "
+                "Set the `overwrite_existing_experiment` to `True` to overwrite "
+                "with new experiment."
             )
 
         self._experiment = make_experiment(

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -639,6 +639,57 @@ class TestAxClient(TestCase):
         )
         # There should be no trials, as we just put in a fresh experiment.
         self.assertEqual(len(ax_client.experiment.trials), 0)
+        
+    def test_overwrite(self):
+        init_test_engine_and_session_factory(force_init=True)
+        ax_client = AxClient()
+        ax_client.create_experiment(
+            name="test_experiment",
+            parameters=[
+                {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
+                {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
+            ],
+            minimize=True,
+        )
+        
+        # Log a trial
+        parameters, trial_index = ax_client.get_next_trial()
+        ax_client.complete_trial(
+            trial_index=trial_index, raw_data=branin(*parameters.values())
+        )
+
+        with self.assertRaises(ValueError):
+            # Overwriting existing experiment.
+            ax_client.create_experiment(
+                name="test_experiment",
+                parameters=[
+                    {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
+                    {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
+                ],
+                minimize=True,
+            )
+        # Overwriting existing experiment with overwrite flag.
+        ax_client.create_experiment(
+            name="test_experiment",
+            parameters=[{"name": "x", "type": "range", "bounds": [-5.0, 10.0]}],
+            overwrite_existing_experiment=True,
+        )
+        # There should be no trials, as we just put in a fresh experiment.
+        self.assertEqual(len(ax_client.experiment.trials), 0)
+        
+        # Log a trial
+        parameters, trial_index = ax_client.get_next_trial()
+        ax_client.complete_trial(
+            trial_index=trial_index, raw_data=branin(*parameters.values())
+        )
+        
+        # Overwriting existing experiment with different name
+        ax_client.create_experiment(
+            name="test_experiment_2",
+            parameters=[{"name": "x", "type": "range", "bounds": [-5.0, 10.0]}],
+        )
+        # There should be no trials, as we just put in a fresh experiment.
+        self.assertEqual(len(ax_client.experiment.trials), 0)
 
     def test_fixed_random_seed_reproducibility(self):
         ax_client = AxClient(random_seed=239)


### PR DESCRIPTION
Overwrite flag on `AxClient.create_experiment` should check for local experiments in addition  of DB experiments. This helps prevent accidental experiment deletion for use cases where the internal DB is not used as the persistent layer.

I added a test as I think it should behave like. Not sure if passes or not as I did not have it set up to run tests locally.

Closes #215