### PR TITLE
add metric_names to support cost modeling

### DIFF
--- a/ax/modelbridge/array.py
+++ b/ax/modelbridge/array.py
@@ -76,6 +76,7 @@ class ArrayModelBridge(ModelBridge):
             bounds=bounds,
             task_features=task_features,
             feature_names=self.parameters,
+            metric_names=self.outcomes,
             fidelity_features=list(target_fidelities.keys()),
         )
 
@@ -88,6 +89,7 @@ class ArrayModelBridge(ModelBridge):
         bounds: List[Tuple[float, float]],
         task_features: List[int],
         feature_names: List[str],
+        metric_names: List[str],
         fidelity_features: List[int],
     ) -> None:
         """Fit the model, given numpy types.
@@ -100,6 +102,7 @@ class ArrayModelBridge(ModelBridge):
             bounds=bounds,
             task_features=task_features,
             feature_names=feature_names,
+            metric_names=metric_names,
             fidelity_features=fidelity_features,
         )
 

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -42,6 +42,7 @@ class TorchModelBridgeTest(TestCase):
             Yvars=[var],
             bounds=None,
             feature_names=[],
+            metric_names=[],
             task_features=[],
             fidelity_features=[],
         )

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -95,6 +95,7 @@ class TorchModelBridge(ArrayModelBridge):
         bounds: List[Tuple[float, float]],
         task_features: List[int],
         feature_names: List[str],
+        metric_names: List[str],
         fidelity_features: List[int],
     ) -> None:
         self.model = model
@@ -110,6 +111,7 @@ class TorchModelBridge(ArrayModelBridge):
             bounds=bounds,
             task_features=task_features,
             feature_names=feature_names,
+            metric_names=metric_names,
             fidelity_features=fidelity_features,
         )
 

--- a/ax/models/numpy/randomforest.py
+++ b/ax/models/numpy/randomforest.py
@@ -41,6 +41,7 @@ class RandomForest(NumpyModel):
         bounds: List[Tuple[float, float]],
         task_features: List[int],
         feature_names: List[str],
+        metric_names: List[str],
         fidelity_features: List[int],
     ) -> None:
         for i, X in enumerate(Xs):

--- a/ax/models/numpy_base.py
+++ b/ax/models/numpy_base.py
@@ -23,6 +23,7 @@ class NumpyModel(Model):
         bounds: List[Tuple[float, float]],
         task_features: List[int],
         feature_names: List[str],
+        metric_names: List[str],
         fidelity_features: List[int],
     ) -> None:
         """Fit model to m outcomes.
@@ -37,6 +38,7 @@ class NumpyModel(Model):
             task_features: Columns of X that take integer values and should be
                 treated as task parameters.
             feature_names: Names of each column of X.
+            metric_names: Names of each outcome Y in Ys.
             fidelity_features: Columns of X that should be treated as fidelity
                 parameters.
         """

--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -46,6 +46,7 @@ class BotorchDefaultsTest(TestCase):
             Yvars=yvars,
             task_features=[1],
             fidelity_features=[],
+            metric_names=[],
             state_dict=[],
             refit_model=False,
         )
@@ -60,6 +61,7 @@ class BotorchDefaultsTest(TestCase):
                 Yvars=yvars,
                 task_features=[0, 1],
                 fidelity_features=[],
+                metric_names=[],
                 state_dict=[],
                 refit_model=False,
             )
@@ -72,6 +74,7 @@ class BotorchDefaultsTest(TestCase):
                 Yvars=yvars,
                 task_features=[],
                 fidelity_features=[-1, -2],
+                metric_names=[],
                 state_dict=[],
                 refit_model=False,
             )
@@ -84,6 +87,7 @@ class BotorchDefaultsTest(TestCase):
                 Yvars=yvars,
                 task_features=[1],
                 fidelity_features=[-1],
+                metric_names=[],
                 state_dict=[],
                 refit_model=False,
             )

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -41,6 +41,7 @@ class KnowledgeGradientTest(TestCase):
         ]
         self.bounds = [(0.0, 1.0), (1.0, 4.0), (2.0, 5.0)]
         self.feature_names = ["x1", "x2", "x3"]
+        self.metric_names = ["y"]
         self.acq_options = {"num_fantasies": 30, "mc_samples": 30}
         self.objective_weights = torch.tensor(
             [1.0], dtype=self.dtype, device=self.device
@@ -62,6 +63,7 @@ class KnowledgeGradientTest(TestCase):
             Yvars=self.Yvars,
             bounds=self.bounds,
             feature_names=self.feature_names,
+            metric_names=self.metric_names,
             task_features=[],
             fidelity_features=[],
         )
@@ -170,6 +172,7 @@ class KnowledgeGradientTest(TestCase):
             bounds=self.bounds,
             task_features=[],
             feature_names=self.feature_names,
+            metric_names=[],
             fidelity_features=[-1],
         )
 
@@ -241,6 +244,7 @@ class KnowledgeGradientTest(TestCase):
             Yvars=self.Yvars,
             bounds=self.bounds,
             feature_names=self.feature_names,
+            metric_names=self.metric_names,
             task_features=[],
             fidelity_features=[],
         )
@@ -326,6 +330,7 @@ class KnowledgeGradientTest(TestCase):
             bounds=self.bounds,
             task_features=[],
             feature_names=self.feature_names,
+            metric_names=self.metric_names,
             fidelity_features=[-1],
         )
 

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -31,15 +31,16 @@ def _get_torch_test_data(dtype=torch.float, cuda=False, constant_noise=True):
     bounds = [(0.0, 1.0), (1.0, 4.0), (2.0, 5.0)]
     task_features = []
     feature_names = ["x1", "x2", "x3"]
-    return Xs, Ys, Yvars, bounds, task_features, feature_names
+    metric_names = ["y"]
+    return Xs, Ys, Yvars, bounds, task_features, feature_names, metric_names
 
 
 class BotorchModelTest(TestCase):
     def test_BotorchModel(self, dtype=torch.float, cuda=False):
-        Xs1, Ys1, Yvars1, bounds, task_features, feature_names = _get_torch_test_data(
+        Xs1, Ys1, Yvars1, bounds, tfs, fns, mns = _get_torch_test_data(
             dtype=dtype, cuda=cuda, constant_noise=True
         )
-        Xs2, Ys2, Yvars2, _, _, _ = _get_torch_test_data(
+        Xs2, Ys2, Yvars2, _, _, _, _ = _get_torch_test_data(
             dtype=dtype, cuda=cuda, constant_noise=True
         )
         model = BotorchModel()
@@ -52,8 +53,9 @@ class BotorchModelTest(TestCase):
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
                 bounds=bounds,
-                task_features=task_features,
-                feature_names=feature_names,
+                task_features=tfs,
+                feature_names=fns,
+                metric_names=mns,
                 fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
@@ -80,8 +82,9 @@ class BotorchModelTest(TestCase):
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
                 bounds=bounds,
-                task_features=task_features,
-                feature_names=feature_names,
+                task_features=tfs,
+                feature_names=fns,
+                metric_names=mns,
                 fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
@@ -304,6 +307,7 @@ class BotorchModelTest(TestCase):
             Yvars=Yvars1,
             task_features=[],
             fidelity_features=[],
+            metric_names=[],
             state_dict=true_state_dict,
             refit_model=False,
         )
@@ -323,6 +327,7 @@ class BotorchModelTest(TestCase):
             Yvars=Yvars1,
             task_features=[],
             fidelity_features=[],
+            metric_names=[],
             state_dict=true_state_dict,
             refit_model=True,
         )
@@ -345,7 +350,7 @@ class BotorchModelTest(TestCase):
             self.test_BotorchModel(dtype=torch.double, cuda=True)
 
     def test_BotorchModelOneOutcome(self):
-        Xs1, Ys1, Yvars1, bounds, task_features, feature_names = _get_torch_test_data(
+        Xs1, Ys1, Yvars1, bounds, tfs, fns, mns = _get_torch_test_data(
             dtype=torch.float, cuda=False, constant_noise=True
         )
         model = BotorchModel()
@@ -355,8 +360,9 @@ class BotorchModelTest(TestCase):
                 Ys=Ys1,
                 Yvars=Yvars1,
                 bounds=bounds,
-                task_features=task_features,
-                feature_names=feature_names,
+                task_features=tfs,
+                feature_names=fns,
+                metric_names=mns,
                 fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
@@ -366,10 +372,10 @@ class BotorchModelTest(TestCase):
         self.assertTrue(f_cov.shape == torch.Size([2, 1, 1]))
 
     def test_BotorchModelConstraints(self):
-        Xs1, Ys1, Yvars1, bounds, task_features, feature_names = _get_torch_test_data(
+        Xs1, Ys1, Yvars1, bounds, tfs, fns, mns = _get_torch_test_data(
             dtype=torch.float, cuda=False, constant_noise=True
         )
-        Xs2, Ys2, Yvars2, _, _, _ = _get_torch_test_data(
+        Xs2, Ys2, Yvars2, _, _, _, _ = _get_torch_test_data(
             dtype=torch.float, cuda=False, constant_noise=True
         )
         # make infeasible
@@ -385,8 +391,9 @@ class BotorchModelTest(TestCase):
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1,
                 bounds=bounds,
-                task_features=task_features,
-                feature_names=feature_names,
+                task_features=tfs,
+                feature_names=fns,
+                metric_names=mns,
                 fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()

--- a/ax/models/tests/test_numpy.py
+++ b/ax/models/tests/test_numpy.py
@@ -19,6 +19,7 @@ class NumpyModelTest(TestCase):
             bounds=[(0, 1)],
             task_features=[],
             feature_names=["x"],
+            metric_names=["y"],
             fidelity_features=[],
         )
 

--- a/ax/models/tests/test_randomforest.py
+++ b/ax/models/tests/test_randomforest.py
@@ -20,6 +20,7 @@ class RandomForestTest(TestCase):
             bounds=[(0, 1)] * 2,
             task_features=[],
             feature_names=["x1", "x2"],
+            metric_names=["y"],
             fidelity_features=[],
         )
         self.assertEqual(len(m.models), 2)

--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -20,6 +20,7 @@ class TorchModelTest(TestCase):
             bounds=[(0, 1)],
             task_features=[],
             feature_names=["x1"],
+            metric_names=["y"],
             fidelity_features=[],
         )
 

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -33,6 +33,7 @@ def get_and_fit_model(
     Yvars: List[Tensor],
     task_features: List[int],
     fidelity_features: List[int],
+    metric_names: List[str],
     state_dict: Optional[Dict[str, Tensor]] = None,
     refit_model: bool = True,
     **kwargs: Any,
@@ -40,11 +41,12 @@ def get_and_fit_model(
     r"""Instantiates and fits a botorch ModelListGP using the given data.
 
     Args:
-        Xs: List of X data, one tensor per outcome
-        Ys: List of Y data, one tensor per outcome
+        Xs: List of X data, one tensor per outcome.
+        Ys: List of Y data, one tensor per outcome.
         Yvars: List of observed variance of Ys.
         task_features: List of columns of X that are tasks.
         fidelity_features: List of columns of X that are fidelity parameters.
+        metric_names: Names of each outcome Y in Ys.
         state_dict: If provided, will set model parameters to this state
             dictionary. Otherwise, will fit the model.
         refit_model: Flag for refitting model.

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -29,6 +29,7 @@ class TorchModel(Model):
         bounds: List[Tuple[float, float]],
         task_features: List[int],
         feature_names: List[str],
+        metric_names: List[str],
         fidelity_features: List[int],
     ) -> None:
         """Fit model to m outcomes.
@@ -43,6 +44,7 @@ class TorchModel(Model):
             task_features: Columns of X that take integer values and should be
                 treated as task parameters.
             feature_names: Names of each column of X.
+            metric_names: Names of each outcome Y in Ys.
             fidelity_features: Columns of X that should be treated as fidelity
                 parameters.
         """


### PR DESCRIPTION
Summary: pass metric_names through so that fitting (and gen) can use this information; useful for learned cost models where the cost model requires log transform / potentially special modeling

Reviewed By: Balandat

Differential Revision: D18667214

