### PR TITLE
Get transform_callback tests to pass

### DIFF
--- a/ax/modelbridge/tests/test_transform_callback.py
+++ b/ax/modelbridge/tests/test_transform_callback.py
@@ -18,8 +18,15 @@ from ax.utils.testing.core_stubs import get_branin_experiment
 
 
 class TransformCallbackTest(TestCase):
-    @patch("ax.modelbridge.torch.TorchModelBridge._model_fit", return_value=None)
-    def test_transform_callback_int(self, _):
+    def setUp(self):
+        self.model_fit_patcher = patch(
+            f"{TorchModelBridge.__module__}.TorchModelBridge._model_fit",
+            return_value=None,
+            autospec=True,
+        )
+        self.model_fit_patcher.start()
+
+    def test_transform_callback_int(self):
         exp = get_branin_experiment()
         parameters = [
             RangeParameter(
@@ -49,8 +56,7 @@ class TransformCallbackTest(TestCase):
         transformed = np_mb._transform_callback(np.array([5.4, 7.6]))
         self.assertTrue(np.allclose(transformed, [5, 8]))
 
-    @patch("ax.modelbridge.torch.TorchModelBridge._model_fit", return_value=None)
-    def test_transform_callback_log(self, _):
+    def test_transform_callback_log(self):
         exp = get_branin_experiment()
         parameters = [
             RangeParameter(
@@ -79,8 +85,7 @@ class TransformCallbackTest(TestCase):
         transformed = gpei._transform_callback([1.2, 2.5])
         self.assertTrue(np.allclose(transformed, [1.2, 2.5]))
 
-    @patch("ax.modelbridge.torch.TorchModelBridge._model_fit", return_value=None)
-    def test_transform_callback_unitx(self, _):
+    def test_transform_callback_unitx(self):
         exp = get_branin_experiment()
         parameters = [
             RangeParameter(
@@ -100,8 +105,7 @@ class TransformCallbackTest(TestCase):
         transformed = gpei._transform_callback([0.75, 0.35])
         self.assertTrue(np.allclose(transformed, [0.75, 0.35]))
 
-    @patch("ax.modelbridge.torch.TorchModelBridge._model_fit", return_value=None)
-    def test_transform_callback_int_log(self, _):
+    def test_transform_callback_int_log(self):
         exp = get_branin_experiment()
         parameters = [
             RangeParameter(
@@ -130,8 +134,7 @@ class TransformCallbackTest(TestCase):
         transformed = gpei._transform_callback([0.5, 1.5])
         self.assertTrue(np.allclose(transformed, [0.47712, 1.50515]))
 
-    @patch("ax.modelbridge.torch.TorchModelBridge._model_fit", return_value=None)
-    def test_transform_callback_int_unitx(self, _):
+    def test_transform_callback_int_unitx(self):
         exp = get_branin_experiment()
         parameters = [
             RangeParameter(


### PR DESCRIPTION
Summary:
In the [build log](https://travis-ci.com/facebook/Ax/jobs/263099308), there are errors in transform callback tests:

```
______________ TransformCallbackTest.test_transform_callback_int _______________
self = <ax.modelbridge.tests.test_transform_callback.TransformCallbackTest testMethod=test_transform_callback_int>
_ = <MagicMock name='_model_fit' id='140538501451448'>
    patch("ax.modelbridge.torch.TorchModelBridge._model_fit", return_value=None)
    def test_transform_callback_int(self, _):
        exp = get_branin_experiment()
        parameters = [
            RangeParameter(
                name="x1", parameter_type=ParameterType.INT, lower=1, upper=10
            ),
            RangeParameter(
                name="x2", parameter_type=ParameterType.INT, lower=5, upper=15
            ),
        ]
        gpei = TorchModelBridge(
            experiment=exp,
            data=exp.fetch_data(),
            search_space=SearchSpace(parameters=parameters),
            model=BotorchModel(),
            transforms=[IntToFloat],
>           torch_dtype=torch.double,
        )
ax/modelbridge/tests/test_transform_callback.py:38:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ax/modelbridge/torch.py:72: in __init__
    optimization_config=optimization_config,
ax/modelbridge/base.py:146: in __init__
    observation_data=obs_data,
ax/modelbridge/torch.py:86: in _fit
    observation_data=observation_data,
ax/modelbridge/array.py:79: in _fit
    fidelity_features=list(target_fidelities.keys()),
ax/modelbridge/torch.py:113: in _model_fit
    fidelity_features=fidelity_features,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
```

I'm going to try and get at least these to pass, since it's a case of simple mock not applying where it is supposed to (you can see in stack trace that the function gets into `torch.TorchModelBridge._model_fit`, even though that is directly mocked in the decorator of the test. I think that if this doesn't work, we might need to contact Travis support, since there is definitely something going wrong there.
