### PR TITLE
Add ability to subset model along outcome dimensions

### DIFF
--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -2,7 +2,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
 import numpy as np
-from ax.models.torch.utils import normalize_indices
 from ax.models.torch_base import TorchModel
 from ax.utils.common.testutils import TestCase
 
@@ -53,19 +52,3 @@ class TorchModelTest(TestCase):
         numpy_model = TorchModel()
         with self.assertRaises(NotImplementedError):
             numpy_model.update(Xs=[np.array(0)], Ys=[np.array(0)], Yvars=[np.array(1)])
-
-
-class TorchUtilsTest(TestCase):
-    def testNormalizeIndices(self):
-        indices = [0, 2]
-        nlzd_indices = normalize_indices(indices, 3)
-        self.assertEqual(nlzd_indices, indices)
-        nlzd_indices = normalize_indices(indices, 4)
-        self.assertEqual(nlzd_indices, indices)
-        indices = [0, -1]
-        nlzd_indices = normalize_indices(indices, 3)
-        self.assertEqual(nlzd_indices, [0, 2])
-        with self.assertRaises(ValueError):
-            nlzd_indices = normalize_indices([3], 3)
-        with self.assertRaises(ValueError):
-            nlzd_indices = normalize_indices([-4], 3)

--- a/ax/models/tests/test_torch_model_utils.py
+++ b/ax/models/tests/test_torch_model_utils.py
@@ -3,12 +3,12 @@
 
 import torch
 from ax.exceptions.model import ModelError
-from ax.models.torch.utils import is_noiseless
+from ax.models.torch.utils import is_noiseless, normalize_indices, subset_model
 from ax.utils.common.testutils import TestCase
 from botorch.models import HeteroskedasticSingleTaskGP, ModelListGP, SingleTaskGP
 
 
-class TorchModelUtilsTest(TestCase):
+class TorchUtilsTest(TestCase):
     def test_is_noiseless(self):
         x = torch.zeros(1, 1)
         y = torch.zeros(1, 1)
@@ -19,3 +19,61 @@ class TorchModelUtilsTest(TestCase):
         self.assertFalse(is_noiseless(model))
         with self.assertRaises(ModelError):
             is_noiseless(ModelListGP())
+
+    def testNormalizeIndices(self):
+        indices = [0, 2]
+        nlzd_indices = normalize_indices(indices, 3)
+        self.assertEqual(nlzd_indices, indices)
+        nlzd_indices = normalize_indices(indices, 4)
+        self.assertEqual(nlzd_indices, indices)
+        indices = [0, -1]
+        nlzd_indices = normalize_indices(indices, 3)
+        self.assertEqual(nlzd_indices, [0, 2])
+        with self.assertRaises(ValueError):
+            nlzd_indices = normalize_indices([3], 3)
+        with self.assertRaises(ValueError):
+            nlzd_indices = normalize_indices([-4], 3)
+
+    def testSubsetModel(self):
+        x = torch.zeros(1, 1)
+        y = torch.zeros(1, 2)
+        model = SingleTaskGP(x, y)
+        self.assertEqual(model.num_outputs, 2)
+        # basic test, can subset
+        obj_weights = torch.tensor([1.0, 0.0])
+        model_sub, obj_weights_sub, ocs_sub = subset_model(model, obj_weights)
+        self.assertIsNone(ocs_sub)
+        self.assertEqual(model_sub.num_outputs, 1)
+        self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
+        # basic test, cannot subset
+        obj_weights = torch.tensor([1.0, 2.0])
+        model_sub, obj_weights_sub, ocs_sub = subset_model(model, obj_weights)
+        self.assertIsNone(ocs_sub)
+        self.assertIs(model_sub, model)  # check identity
+        self.assertIs(obj_weights_sub, obj_weights)  # check identity
+        # test w/ outcome constraints, can subset
+        obj_weights = torch.tensor([1.0, 0.0])
+        ocs = (torch.tensor([[1.0, 0.0]]), torch.tensor([1.0]))
+        model_sub, obj_weights_sub, ocs_sub = subset_model(model, obj_weights, ocs)
+        self.assertEqual(model_sub.num_outputs, 1)
+        self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
+        self.assertTrue(torch.equal(ocs_sub[0], torch.tensor([[1.0]])))
+        self.assertTrue(torch.equal(ocs_sub[1], torch.tensor([1.0])))
+        # test w/ outcome constraints, cannot subset
+        obj_weights = torch.tensor([1.0, 0.0])
+        ocs = (torch.tensor([[0.0, 1.0]]), torch.tensor([1.0]))
+        model_sub, obj_weights_sub, ocs_sub = subset_model(model, obj_weights, ocs)
+        self.assertIs(model_sub, model)  # check identity
+        self.assertIs(obj_weights_sub, obj_weights)  # check identity
+        self.assertIs(ocs_sub, ocs)  # check identity
+        # test unsupported
+        yvar = torch.ones(1, 2)
+        model = HeteroskedasticSingleTaskGP(x, y, yvar)
+        model_sub, obj_weights_sub, ocs = subset_model(model, obj_weights)
+        self.assertIsNone(ocs)
+        self.assertIs(model_sub, model)  # check identity
+        self.assertIs(obj_weights_sub, obj_weights)  # check identity
+        # test error on size inconsistency
+        obj_weights = torch.ones(3)
+        with self.assertRaises(RuntimeError):
+            subset_model(model, obj_weights)


### PR DESCRIPTION
Summary:
Candidate generation currently by default uses a full model for all outcomes, even those not appearing in the OptimizationConfig. This is very wasteful in the current implementation, and leads to high memory consumption and long generation times (=this is likely what causes #202). See https://github.com/facebook/Ax/issues/205.

This diff provides a skeleton for subsetting the model to only those outcome dimensions that are needed for optimization during the generation step (i.e.those outcomes that have nonzero weight in `objective_weights` or `outcome_constraints`.

Right now this is just a skeleton, and will require implementing a `subset_output` method on the botorch models. The diff is written such that even without this being implemented on the model Ax falls back gracefully to the existing (wasteful) implementation.

Reviewed By: sdaulton

Differential Revision: D18666578

