### PR TITLE
fix pyre for stats.norm and starts.t

### DIFF
--- a/ax/modelbridge/transforms/log_y.py
+++ b/ax/modelbridge/transforms/log_y.py
@@ -136,7 +136,7 @@ def match_ci_width(
     transform: Callable[[np.ndarray], np.ndarray],
     level: float = 0.95,
 ) -> np.ndarray:
-    fac = norm.ppf(1 - (1 - level) / 2)  # pyre-ignore [16]
+    fac = norm.ppf(1 - (1 - level) / 2)
     d = fac * np.sqrt(variance)
     width_asym = transform(mean + d) - transform(mean - d)
     new_mean = transform(mean)


### PR DESCRIPTION
Summary:
fix pyre error by adding
stats.norm: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.norm.html
starts.t: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.t.html
ppf and interval function in rv_continuous: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_continuous.html#scipy.stats.rv_continuous

Reviewed By: dkgi

Differential Revision: D18685932

