### PR TITLE
Update botorch version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 
 
 REQUIRES = [
-    "botorch>=0.1.3",
+    "botorch==0.1.4",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
This PR updates the botorch version to 0.1.4 instead of the latest avaiable. In the current implementation latest botorch version is installed as a dependency and #237 issue is happening. Note: Travis will fail as the latest version from master.