### PR TITLE
Unpin pillow version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,7 @@ DEV_REQUIRES = [
     "pytest-cov",
     "sphinx",
     "sphinx-autodoc-typehints",
-    "torchvision",
-    # TODO(jej): Remove pillow from dependencies after torchvision includes the
-    # following change: https://github.com/pytorch/vision/pull/1501.
-    "pillow<7",
+    "torchvision>=0.5.0",
 ]
 
 MYSQL_REQUIRES = ["SQLAlchemy>=1.1.13"]


### PR DESCRIPTION
Summary: With Torchvision new release, it's not longer necessary to restrict the pillow version

Differential Revision: D19431825

