### PR TITLE
Require py>=3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,52 +1,49 @@
 language: python
 
 python:
-  - 3.6
+  - 3.7
+
 
 jobs:
   allow_failures:
     # create custom environment variable for flagging jobs that are allowed to fail
     - env: ALLOW_FAILURE=true
   include:
-    - name: "Tests + Coverage: Python 3.6"
-      stage: Test
-      python: "3.6"
+    - name: "Tests + Coverage: Python 3.7"
+      python: "3.7"
       install:
         - pip install git+https://github.com/cornellius-gp/gpytorch.git
         - pip install git+https://github.com/pytorch/botorch.git
         - pip install -q -e .[dev,mysql,notebook]
       script:
         - pytest -ra --cov=ax
-    - name: "Tests: Python 3.7"
-      # Enable Python 3.7 w/o without globally enabling sudo and xenial dist
-      # See https://github.com/travis-ci/travis-ci/issues/9815
-      python: "3.7"
-      dist: xenial
+    - name: "Tests: Python 3.8"
+      python: "3.8"
       install:
         - pip install git+https://github.com/cornellius-gp/gpytorch.git
         - pip install git+https://github.com/pytorch/botorch.git
         - pip install -q -e .[dev,mysql,notebook]
       script:
         - pytest -ra
-    - name: "Lint: black (Python 3.6)"
-      python: "3.6"
+    - name: "Lint: black: Python 3.7"
+      python: "3.7"
       install:
         - pip install black
       script:
         - black --check --diff .
-    - name: "Lint: flake8 (Python 3.6)"
-      python: "3.6"
+    - name: "Lint: flake8: Python 3.7"
+      python: "3.7"
       install:
         - pip install flake8
       script:
         # don't use .flake8 config for now, since don't need custom plugin
         - flake8 --isolated --ignore=T484,T499,W503,E704,E231,E203 --max-line-length=88
-    - name: "Docs: Sphinx (Python 3.6)"
-      python: "3.6"
+    - name: "Docs: Sphinx: Python 3.7"
+      python: "3.7"
       install:
         - pip install git+https://github.com/cornellius-gp/gpytorch.git
         - pip install git+https://github.com/pytorch/botorch.git
-        - pip install -q -e .[dev,mysql,notebook,gpy]
+        - pip install -q -e .[dev,mysql,notebook]
       script:
         # warnings treated as errors
         - sphinx-build -WT sphinx/source sphinx/build
@@ -56,17 +53,17 @@ jobs:
       # Checks whether the current version on Ax master is compatible with latest
       # stable BoTorch release; this test should be passing before cutting new
       # version of Ax.
-      python: "3.6"
+      python: "3.7"
       env: ALLOW_FAILURE=true
       install:
         - pip install botorch
         - pip install -q -e .[dev,mysql,notebook]
       script:
         - pytest -ra
-    - name: "Docs: Sphinx Coverage (Python 3.6)"
-      python: "3.6"
+    - name: "Docs: Sphinx Coverage: Python 3.7"
+      python: "3.7"
       script:
-        - python3 scripts/validate_sphinx.py -p "${pwd}"
+        - python scripts/validate_sphinx.py -p "${pwd}"
     # Pre-deployment stage enforces compatibility with stable BoTorch.
     - name: "Build with BoTorch Version in setup.py (only for tagged versions)"
       # Checks whether the current version on Ax master is compatible with latest
@@ -76,7 +73,7 @@ jobs:
       # TODO: add the same test for compatibility with the minimum BoTorch
       # version listed in Ax' `setup.py`.
       stage: Pre-deploy
-      python: "3.6"
+      python: "3.7"
       install:
         - pip install -q -e .[dev,mysql,notebook]
       script:
@@ -84,7 +81,7 @@ jobs:
     # Version website-building stage is triggered on a tag that starts with 'v'
     # if the pre-deploy stage (previous) passes.
     - stage: Deploy Version Website + deploy to PyPI (On Release)
-      python: "3.6"
+      python: "3.7"
       install:
         - pip install -q -e .[dev,mysql,notebook]
         - pip install torchvision  # Required for building tutorial notebooks.
@@ -105,7 +102,7 @@ jobs:
           tags: true
     # Daily website deployment stage is triggered via cron job.
     - stage: Deploy Latest Website And Upload To Test PyPI (Daily)
-      python: "3.6"
+      python: "3.7"
       install:
         - pip install git+https://github.com/cornellius-gp/gpytorch.git
         - pip install git+https://github.com/pytorch/botorch.git
@@ -127,7 +124,7 @@ jobs:
         on:
           branch: master
           tags: false
-          python: 3.6
+          python: 3.7
 
 stages:
   - name: Test

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ artificial evaluation function):
 ## Installation
 
 ### Requirements
-You need Python 3.6 or later to run Ax.
+You need Python 3.7 or later to run Ax.
 
 The required Python dependencies are:
 

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -443,7 +443,7 @@ def _get_model(
     all_nan_Yvar = torch.all(is_nan)
     if any_nan_Yvar and not all_nan_Yvar:
         if task_feature:
-            # TODO (jej): Replace with inferred noise before making performance judgments.
+            # TODO (jej): Replace with inferred noise before making perf judgements.
             Yvar[Yvar != Yvar] = MIN_OBSERVED_NOISE_LEVEL
         else:
             raise ValueError(

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ title: Installation
 ---
 
 ## Requirements
-You need Python 3.6 or later to run Ax.
+You need Python 3.7 or later to run Ax.
 
 The required Python dependencies are:
 

--- a/scripts/build_ax.sh
+++ b/scripts/build_ax.sh
@@ -12,15 +12,10 @@ docker container run --mount type=bind,source="$(pwd)/../",target=/Ax-master -it
 # Now, in Docker container, cd Ax-master and MANUALLY RUN ./docker_install.sh
 
 # LOCAL BUILD
-# Requires Python 3.6+3.7 installed locally, and on path
-cd .. 
-pip3.6 install numpy
-python3.6 setup.py bdist_wheel
-
-# Build Linux Python3.7
+# Requires Python 3.7 installed locally, and on path
+cd ..
 pip3.7 install numpy
 python3.7 setup.py bdist_wheel
 
 # Final PyPI Upload
 twine upload dist/*
-

--- a/scripts/docker_install.sh
+++ b/scripts/docker_install.sh
@@ -6,19 +6,14 @@
 
 VERSION=$1
 
-# Build Linux Python3.6
+# Build Linux Python3.7
 # Execute from Ax root directory.
 cd ../ || exit
-/opt/python/cp36-cp36m/bin/pip3.6 install numpy
-/opt/python/cp36-cp36m/bin/python3.6 setup.py bdist_wheel
-
-# Build Linux Python3.7
 /opt/python/cp37-cp37m/bin/pip3.7 install numpy
 /opt/python/cp37-cp37m/bin/python3.7 setup.py bdist_wheel
 
 # Convert to manylinux
 cd dist || exit
-auditwheel repair ax_platform-"$VERSION"-cp36-cp36m-linux_x86_64.whl
 auditwheel repair ax_platform-"$VERSION"-cp37-cp37m-linux_x86_64.whl
 rm ./*
 mv wheelhouse/* .

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ def setup_package() -> None:
         ],
         long_description=long_description,
         long_description_content_type="text/markdown",
-        python_requires=">=3.6",
+        python_requires=">=3.7",
         install_requires=REQUIRES,
         packages=find_packages(),
         package_data={


### PR DESCRIPTION
Bumps require python version to >=3.7 and changes the travis CI setup accordingly.

Also tests with py 3.8