### PR TITLE
Wipe website history on deploy

### DIFF
--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -216,13 +216,12 @@ else
   cd "${WORK_DIR}" || exit
   python3 Ax-master/scripts/update_versions_html.py -p "${WORK_DIR}"
 
-  # move contents of newsite to Ax-gh-pages, preserving commit history
-  rm -rfv ./Ax-gh-pages/*
-  rsync -avh ./new-site/ ./Ax-gh-pages/
-  cd Ax-gh-pages
+  # Init as Git repo and push to gh-pages
+  cd new-site || exit
+  git init
   git add --all
   git commit -m "Publish version ${VERSION} of site"
-  git push
+  git push --force "https://github.com/facebook/Ax" master:gh-pages
 
 fi
 


### PR DESCRIPTION
Reverting https://github.com/facebook/Ax/commit/ea6bb51a35fa43c49acff2320f499e4a52ba9719#diff-432be1e744c78f0c8997376c47f60742 to go back to wiping the git history. This will help keep the repo size under control.