### PR TITLE
Pin Sphinx < 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ DEV_REQUIRES = [
     "flake8",
     "pytest>=3.6",
     "pytest-cov",
-    "sphinx",
+    "sphinx<3.0.0",
     "sphinx-autodoc-typehints",
     "torchvision>=0.5.0",
 ]


### PR DESCRIPTION
Summary:
Travis build is failing due to Sphinx failure.
Similar issue filed on Sphinx suggests a bug, pinned to previous stable release: https://github.com/sphinx-doc/sphinx/issues/7422

Reviewed By: stevemandala

Differential Revision: D20870347

