### PR TITLE
Handle missing SQLAlchemy import

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -69,8 +69,13 @@ try:  # We don't require SQLAlchemy by default.
         save_new_trial,
         save_updated_trial,
     )
+
+    retry_exception_type_tuple = (OperationalError,)
 except ModuleNotFoundError:  # pragma: no cover
     DBSettings = None
+    # Return a list of suppressable exceptions not including unimportable ones.
+    # pyre-fixme[9]: declared as `Tuple[...[OperationalError]]` but used as `Tuple[]`.
+    retry_exception_type_tuple = ()
 
 
 class AxClient:
@@ -827,7 +832,7 @@ class AxClient:
     @retry_on_exception(
         retries=3,
         default_return_on_suppression=False,
-        exception_type=(OperationalError,),
+        exception_type=retry_exception_type_tuple,
     )
     def _save_experiment_to_db_if_possible(
         self, suppress_all_errors: bool = False
@@ -846,7 +851,7 @@ class AxClient:
     @retry_on_exception(
         retries=3,
         default_return_on_suppression=False,
-        exception_type=(OperationalError,),
+        exception_type=retry_exception_type_tuple,
     )
     def _save_new_trial_to_db_if_possible(
         self, trial: BaseTrial, suppress_all_errors: bool = False
@@ -867,7 +872,7 @@ class AxClient:
     @retry_on_exception(
         retries=3,
         default_return_on_suppression=False,
-        exception_type=(OperationalError,),
+        exception_type=retry_exception_type_tuple,
     )
     def _save_updated_trial_to_db_if_possible(
         self, trial: BaseTrial, suppress_all_errors: bool = False
@@ -888,7 +893,7 @@ class AxClient:
     @retry_on_exception(
         retries=3,
         default_return_on_suppression=False,
-        exception_type=(OperationalError,),
+        exception_type=retry_exception_type_tuple,
     )
     def _save_generation_strategy_to_db_if_possible(
         self, suppress_all_errors: bool = False

--- a/ax/utils/common/tests/test_exec_utils.py
+++ b/ax/utils/common/tests/test_exec_utils.py
@@ -67,12 +67,37 @@ class TestRetryDecorator(TestCase):
                 suppress_all_errors=False,
             )
             def error_throwing_function(self):
-                # The execption thrown below should be caught and handled since it
+                # The exception thrown below should be caught and handled since it
                 # has the keywords we want
                 raise RuntimeError("Hello World")
 
         decorator_tester = DecoratorTester()
         self.assertEqual("SUCCESS", decorator_tester.error_throwing_function())
+
+    def test_empty_exception_type_tuple(self):
+        """
+        Tests if the decorator correctly handles an empty list
+        of exception types to suppress.
+        """
+
+        # Also pass along the logger to ensure coverage
+        logger = logging.getLogger("test_message_checking")
+
+        class DecoratorTester:
+            @retry_on_exception(
+                default_return_on_suppression="SUCCESS",
+                exception_type=(),
+                logger=logger,
+                suppress_all_errors=False,
+            )
+            def error_throwing_function(self):
+                # The exception thrown below should not be caught
+                # because we specified an empty list.
+                raise RuntimeError("Hello World")
+
+        decorator_tester = DecoratorTester()
+        with self.assertRaises(RuntimeError):
+            decorator_tester.error_throwing_function()
 
     def test_message_checking_fail(self):
         """


### PR DESCRIPTION
Summary: Do not handle SQLAlchemy OperationalErrors if SQLAlchemy is not loaded.

Differential Revision: D20964014

