### PR TITLE
Add trials_by_status helper

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -530,6 +530,14 @@ class Experiment(Base):
         """The trials associated with the experiment."""
         return self._trials
 
+    @property
+    def trials_by_status(self) -> Dict[TrialStatus, List[BaseTrial]]:
+        """The trials associated with the experiment grouped by trial status."""
+        output = defaultdict(list)
+        for trial in self.trials.values():
+            output[trial.status].append(trial)
+        return dict(output)
+
     def new_trial(
         self,
         generator_run: Optional[GeneratorRun] = None,

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -378,6 +378,10 @@ class ExperimentTest(TestCase):
         candidate_batch.run()
         candidate_batch._status = TrialStatus.CANDIDATE
         self.assertEqual(self.experiment.trials_expecting_data, [batch])
+        tbs = self.experiment.trials_by_status
+        self.assertEqual(len(tbs), 2)
+        self.assertEqual(tbs[TrialStatus.RUNNING], [batch])
+        self.assertEqual(tbs[TrialStatus.CANDIDATE], [candidate_batch])
 
         identifier = {"new_runner": True}
         new_runner = SyntheticRunner(dummy_metadata=identifier)


### PR DESCRIPTION
Summary: Simple helper on `Experiment` that returns the experiment trials by status as a dictionary.

Reviewed By: ldworkin

Differential Revision: D21009733

