### PR TITLE
Add mark_as method to BaseTrial

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -479,3 +479,27 @@ class BaseTrial(ABC, Base):
         self._status = TrialStatus.FAILED
         self._time_completed = datetime.now()
         return self
+
+    def mark_as(self, status: TrialStatus, **kwargs: Any) -> BaseTrial:
+        """Mark trial with a new TrialStatus.
+
+        Args:
+            status: The new status of the trial.
+            kwargs: Additional keyword args, as can be ued in the respective `mark_`
+                methods associated with the trial status.
+
+        Returns:
+            The trial instance.
+        """
+        if status == TrialStatus.STAGED:
+            self.mark_staged()
+        if status == TrialStatus.RUNNING:
+            no_runner_required = kwargs.get("no_runner_required", False)
+            self.mark_running(no_runner_required=no_runner_required)
+        if status == TrialStatus.ABANDONED:
+            self.mark_abandoned(reason=kwargs.get("reason"))
+        if status == TrialStatus.FAILED:
+            self.mark_failed()
+        if status == TrialStatus.COMPLETED:
+            self.mark_completed()
+        return self

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -102,6 +102,27 @@ class TrialTest(TestCase):
         self.assertFalse(self.trial.status.is_failed)
         self.assertTrue(self.trial.did_not_complete)
 
+    def test_mark_as(self):
+        for terminal_status in (
+            TrialStatus.ABANDONED,
+            TrialStatus.FAILED,
+            TrialStatus.COMPLETED,
+        ):
+            self.setUp()
+            # Note: This only tests the no-runner case (and thus not staging)
+            for status in (TrialStatus.RUNNING, terminal_status):
+                kwargs = {}
+                if status == TrialStatus.RUNNING:
+                    kwargs["no_runner_required"] = True
+                if status == TrialStatus.ABANDONED:
+                    kwargs["reason"] = "test_reason"
+                self.trial.mark_as(status=status, **kwargs)
+                self.assertTrue(self.trial.status == status)
+                if status == TrialStatus.ABANDONED:
+                    self.assertEqual(self.trial.abandoned_reason, "test_reason")
+                else:
+                    self.assertIsNone(self.trial.abandoned_reason)
+
     @patch(
         f"{BaseTrial.__module__}.{BaseTrial.__name__}.fetch_data",
         return_value=TEST_DATA,


### PR DESCRIPTION
Summary: Conveneince method that makes it easier to mark trial status programmatically.

Differential Revision: D21204023

