### PR TITLE
`Experiment.fetch_trials_data` + small data-fetching refactor

### DIFF
--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 from ax.core.base import Base
@@ -37,16 +39,14 @@ class Metric(Base):
         """Get name of metric."""
         return self._name
 
-    def fetch_trial_data(
-        self, trial: "core.base_trial.BaseTrial", **kwargs: Any
-    ) -> Data:
+    def fetch_trial_data(self, trial: core.base_trial.BaseTrial, **kwargs: Any) -> Data:
         """Fetch data for one trial."""
         raise NotImplementedError(
             f"Metric {self.name} does not implement data-fetching logic."
         )  # pragma: no cover
 
     def fetch_experiment_data(
-        self, experiment: "core.experiment.Experiment", **kwargs: Any
+        self, experiment: core.experiment.Experiment, **kwargs: Any
     ) -> Data:
         """Fetch this metric's data for an experiment.
 
@@ -64,10 +64,7 @@ class Metric(Base):
 
     @classmethod
     def fetch_trial_data_multi(
-        cls,
-        trial: "core.base_trial.BaseTrial",
-        metrics: Iterable["Metric"],
-        **kwargs: Any,
+        cls, trial: core.base_trial.BaseTrial, metrics: Iterable[Metric], **kwargs: Any
     ) -> Data:
         """Fetch multiple metrics data for one trial.
 
@@ -81,8 +78,9 @@ class Metric(Base):
     @classmethod
     def fetch_experiment_data_multi(
         cls,
-        experiment: "core.experiment.Experiment",
-        metrics: Iterable["Metric"],
+        experiment: core.experiment.Experiment,
+        metrics: Iterable[Metric],
+        trials: Optional[Iterable[core.base_trial.BaseTrial]] = None,
         **kwargs: Any,
     ) -> Data:
         """Fetch multiple metrics data for an experiment.
@@ -95,7 +93,7 @@ class Metric(Base):
                 cls.fetch_trial_data_multi(trial, metrics, **kwargs)
                 if trial.status.expecting_data
                 else Data()
-                for trial in experiment.trials.values()
+                for trial in (trials or experiment.trials.values())
             ]
         )
 

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -220,7 +220,7 @@ def get_pending_observation_features(
                 if (
                     (trial.status.is_deployed or include_since_failed)
                     and metric_name not in trial.fetch_data().df.metric_name.values
-                    # and trial.arms is not None
+                    and trial.arms is not None
                 ):
                     for arm in trial.arms:
                         not_none(pending_features.get(metric_name)).append(

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -45,8 +45,7 @@ class TestModelbridgeUtils(TestCase):
                 {self.trial.arm.name: {"m2": (1, 0)}}, trial_index=self.trial.index
             )
         )
-        # Not m2 should have empty pending features, since the trial was updated
-        # for m2.
+        # m2 should have empty pending features, since the trial was updated for m2.
         self.assertEqual(
             get_pending_observation_features(self.experiment),
             {"tracking": [self.obs_feat], "m2": [], "m1": [self.obs_feat]},
@@ -59,7 +58,7 @@ class TestModelbridgeUtils(TestCase):
             get_pending_observation_features(
                 self.experiment, include_failed_as_pending=True
             ),
-            {"tracking": [self.obs_feat], "m2": [self.obs_feat], "m1": [self.obs_feat]},
+            {"tracking": [self.obs_feat], "m2": [], "m1": [self.obs_feat]},
         )
 
     def test_get_pending_observation_features_batch_trial(self):

--- a/ax/utils/common/constants.py
+++ b/ax/utils/common/constants.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+UNEXPECTED_METRIC_COMBINATION = """
+Unexpected combination of dummy base `Metric` class metrics and `Metric`
+subclasses with defined fetching logic.
+"""


### PR DESCRIPTION
Summary: Allow for fetching just some trials on the experiment; needed for `model.update` functionality in the generation strategy

Reviewed By: Balandat

Differential Revision: D21209429

