### PR TITLE
add fit_out_of_design arg to TorchModelBridge

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -265,14 +265,18 @@ class ModelBridge(ABC):
         observation_data: List[ObservationData],
     ) -> Tuple[List[ObservationFeatures], List[ObservationData]]:
         """Set training_in_design, and decide whether to filter out of design points."""
+        # Don't filter points.
+        if self._fit_out_of_design:
+            # Use all data for training
+            # Set training_in_design to True for all observations so that
+            # all observations are used in CV and plotting
+            self.training_in_design = [True] * len(observation_features)
+            return observation_features, observation_data
         in_design = [
             search_space.check_membership(obsf.parameters)
             for obsf in observation_features
         ]
         self.training_in_design = in_design
-        # Don't filter points.
-        if self._fit_out_of_design:
-            return observation_features, observation_data
         in_design_indices = [i for i, in_design in enumerate(in_design) if in_design]
         in_design_features = [observation_features[i] for i in in_design_indices]
         in_design_data = [observation_data[i] for i in in_design_indices]

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -84,6 +84,7 @@ class ModelRegistryTest(TestCase):
                 "status_quo_features": None,
                 "optimization_config": None,
                 "transforms": Cont_X_trans + Y_trans,
+                "fit_out_of_design": False,
             },
         )
         gpei = Models.GPEI(

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -34,6 +34,7 @@ class TorchModelBridgeTest(TestCase):
         )
         self.assertEqual(ma.dtype, torch.float64)
         self.assertEqual(ma.device, torch.device("cpu"))
+        self.assertFalse(mock_init.call_args[-1]["fit_out_of_design"])
         # Fit
         model = mock.MagicMock(TorchModel, autospec=True, instance=True)
         X = np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])
@@ -194,3 +195,15 @@ class TorchModelBridgeTest(TestCase):
                 X, torch.tensor([[1.0, 2.0]], dtype=torch_dtype, device=torch_device)
             )
         )
+        # test fit out of design
+        ma = TorchModelBridge(
+            experiment=None,
+            search_space=None,
+            data=None,
+            model=None,
+            transforms=[],
+            torch_dtype=torch.float64,
+            torch_device=torch.device("cpu"),
+            fit_out_of_design=True,
+        )
+        self.assertTrue(mock_init.call_args[-1]["fit_out_of_design"])

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -58,6 +58,7 @@ class TorchModelBridge(ArrayModelBridge):
         status_quo_name: Optional[str] = None,
         status_quo_features: Optional[ObservationFeatures] = None,
         optimization_config: Optional[OptimizationConfig] = None,
+        fit_out_of_design: bool = False,
     ) -> None:
         if torch_dtype is None:  # pragma: no cover
             torch_dtype = torch.float  # noqa T484
@@ -73,6 +74,7 @@ class TorchModelBridge(ArrayModelBridge):
             status_quo_name=status_quo_name,
             status_quo_features=status_quo_features,
             optimization_config=optimization_config,
+            fit_out_of_design=fit_out_of_design,
         )
 
     def _fit(


### PR DESCRIPTION
Summary: Setting this to `True` avoids validating every parameter in every row of the training data. This is a massive speed up in the high-dim/large data regime

Reviewed By: bletham

Differential Revision: D21470595

