### PR TITLE
Smarter objective initialization

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -435,7 +435,6 @@ class Decoder:
                     "The metric corresponding to regular objective does not \
                     have weight attribute"
                 )
-            # pyre-fixme[6]: Expected `bool` for 2nd param but got `Optional[bool]`.
             return Objective(metric=metric, minimize=metric_sqa.minimize)
         elif (
             metric_sqa.intent == MetricIntent.MULTI_OBJECTIVE


### PR DESCRIPTION
Summary:
Currently Ax will maximizing a metric that had `lower_is_better=True` without any complaints/warnings. I fell victim to this gotcha more than once.

This change now ensures that we emit a warning in this situation.

It also modifies things the constructor to choose appropriate default behavior when passing in a metric with the `lower_is_better` property set.

The behavior if neither a `lower_is_better` property is set on the metric nor a `minimize` arg is provided to the objective remains the same for backward compatibility, but this usage is discouraged via a `DeprecationWarning`. Eventually, I would like to disallow this non-explicit behavior altogether.

Reviewed By: ldworkin

Differential Revision: D21487528

