### PR TITLE
Short-circuit _update_current_model if no newly completed trials

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -486,6 +486,8 @@ class GenerationStrategy(Base):
         # Should only pass data that is new since last call to `gen`, to the
         # underlying model's `update`.
         newly_completed_trials = self._find_trials_completed_since_last_gen()
+        if len(newly_completed_trials) == 0:
+            return
         if data is None:
             new_data = self.experiment.fetch_trials_data(
                 trial_indices=newly_completed_trials


### PR DESCRIPTION
Summary: If `newly_completed_trials` is empty, there is no reason to do anything, so we can just short-circuit the data fetching logic.

Reviewed By: lena-kashtelyan

Differential Revision: D21620434

