### PR TITLE
Fix pytest versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ DEV_REQUIRES = [
     "beautifulsoup4",
     "black",
     "flake8",
-    "pytest>=3.6",
+    "pytest>=4.6",
     "pytest-cov",
     "sphinx<3.0.0",
     "sphinx-autodoc-typehints",


### PR DESCRIPTION
Summary:
See the latest release for pytest-cov: https://pypi.org/project/pytest-cov/2.10.0/

It now requires pytest version >=4.6. We are using 4.3.1, which is breaking the Travis test runs atm

Differential Revision: D22024400

