### PR TITLE
Make sphinx happy

### DIFF
--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -258,7 +258,7 @@ def scipy_optimizer_list(
 ) -> Tuple[Tensor, Tensor]:
     r"""Sequential optimizer using scipy's minimize module on a numpy-adaptor.
 
-    The `i`th acquisition in the sequence uses the `i`th given acquisition_function.
+    The ith acquisition in the sequence uses the ith given acquisition_function.
 
     Args:
         acq_function_list: A list of botorch AcquisitionFunctions,


### PR DESCRIPTION
Summary:
Sphinx doesn't like text characters following "`", apparently!

https://stackoverflow.com/questions/58633196/restructuredtext-inline-code-followed-by-s-results-in-inline-interpreted-text

error here: https://travis-ci.com/github/facebook/Ax/jobs/352923081

Differential Revision: D22207502

