### PR TITLE
Update href link of MIT License in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,4 +165,4 @@ See recommendation for installing PyTorch for MacOS users above.
 
 ## License
 
-Ax is licensed under the [MIT license](LICENSE.md).
+Ax is licensed under the [MIT license](./LICENSE).


### PR DESCRIPTION
A previous link of MIT License can't be accessed from README.md.
Correct the href link of MIT License