### PR TITLE
Fix (quasi-)random sampling for integer parameters

### DIFF
--- a/ax/modelbridge/tests/test_int_to_float_transform.py
+++ b/ax/modelbridge/tests/test_int_to_float_transform.py
@@ -49,13 +49,13 @@ class IntToFloatTransformTest(TestCase):
 
     def testTransformObservationFeatures(self):
         observation_features = [
-            ObservationFeatures(parameters={"x": 2.2, "a": 2, "b": "b", "d": 4})
+            ObservationFeatures(parameters={"x": 2.2, "a": 2, "b": "b", "d": 3})
         ]
         obs_ft2 = deepcopy(observation_features)
         obs_ft2 = self.t.transform_observation_features(obs_ft2)
         self.assertEqual(
             obs_ft2,
-            [ObservationFeatures(parameters={"x": 2.2, "a": 2, "b": "b", "d": 4})],
+            [ObservationFeatures(parameters={"x": 2.2, "a": 2, "b": "b", "d": 3})],
         )
         self.assertTrue(isinstance(obs_ft2[0].parameters["a"], float))
         self.assertTrue(isinstance(obs_ft2[0].parameters["d"], float))
@@ -64,18 +64,29 @@ class IntToFloatTransformTest(TestCase):
 
         # Let the transformed space be a float, verify it becomes an int.
         obs_ft3 = [
-            ObservationFeatures(parameters={"x": 2.2, "a": 2.2, "b": "b", "d": 3.8})
+            ObservationFeatures(parameters={"x": 2.2, "a": 2.2, "b": "b", "d": 2.9})
         ]
         obs_ft3 = self.t.untransform_observation_features(obs_ft3)
         self.assertEqual(obs_ft3, observation_features)
 
         # Test forward transform on partial observation
-        obs_ft4 = [ObservationFeatures(parameters={"x": 2.2, "d": 4})]
+        obs_ft4 = [ObservationFeatures(parameters={"x": 2.2, "d": 3})]
         obs_ft4 = self.t.transform_observation_features(obs_ft4)
-        self.assertEqual(obs_ft4, [ObservationFeatures(parameters={"x": 2.2, "d": 4})])
+        self.assertEqual(obs_ft4, [ObservationFeatures(parameters={"x": 2.2, "d": 3})])
         self.assertTrue(isinstance(obs_ft4[0].parameters["d"], float))
         obs_ft5 = self.t.transform_observation_features([ObservationFeatures({})])
         self.assertEqual(obs_ft5[0], ObservationFeatures({}))
+
+        # test untransforming integer params that are outside of the range, but within
+        # 0.5 of the range limit
+        obs_ft6 = [
+            ObservationFeatures(parameters={"x": 2.2, "a": 0.6, "b": "b", "d": 3.3})
+        ]
+        obs_ft6 = self.t.untransform_observation_features(obs_ft6)
+        self.assertEqual(
+            obs_ft6,
+            [ObservationFeatures(parameters={"x": 2.2, "a": 1, "b": "b", "d": 3})],
+        )
 
     def testTransformObservationFeaturesRandomized(self):
         observation_features = [

--- a/ax/modelbridge/transforms/int_to_float.py
+++ b/ax/modelbridge/transforms/int_to_float.py
@@ -78,8 +78,13 @@ class IntToFloat(Transform):
                 transformed_parameters[p_name] = RangeParameter(
                     name=p_name,
                     parameter_type=ParameterType.FLOAT,
-                    lower=p.lower,
-                    upper=p.upper,
+                    # +/- 0.5 ensures that sampling
+                    # 1) floating point numbers from (quasi-)Uniform(0,1)
+                    # 2) unnormalizing to the raw search space
+                    # 3) rounding
+                    # results in uniform (quasi-)random integers
+                    lower=p.lower - 0.5,
+                    upper=p.upper + 0.5,
                     log_scale=p.log_scale,
                     digits=p.digits,
                     is_fidelity=p.is_fidelity,


### PR DESCRIPTION
Summary: Previously for integer parameters, we were twice as likely to select any given interior point as end point. This fixes that issue

Differential Revision: D22980892

