### PR TITLE
Move `Base` from `ax/core` to `ax/utils/common/equality`

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -7,11 +7,10 @@
 from types import FunctionType
 from typing import Dict, List, Optional, Tuple, Union
 
-from ax.core.base import Base
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
-from ax.utils.common.equality import equality_typechecker
+from ax.utils.common.equality import Base, equality_typechecker
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast
 from ax.utils.measurement.synthetic_functions import SyntheticFunction

--- a/ax/core/arm.py
+++ b/ax/core/arm.py
@@ -10,9 +10,8 @@ import hashlib
 import json
 from typing import Optional
 
-from ax.core.base import Base
 from ax.core.types import TParameterization
-from ax.utils.common.equality import equality_typechecker
+from ax.utils.common.equality import Base, equality_typechecker
 from ax.utils.common.typeutils import numpy_type_to_python_type
 
 

--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -12,12 +12,12 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 from ax.core.arm import Arm
-from ax.core.base import Base
 from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.runner import Runner
 from ax.core.types import TCandidateMetadata
+from ax.utils.common.equality import Base
 from ax.utils.common.typeutils import not_none
 
 

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -10,8 +10,8 @@ from typing import Dict, Iterable, Optional, Set, Type
 
 import numpy as np
 import pandas as pd
-from ax.core.base import Base
 from ax.core.types import TFidelityTrialEvaluation, TTrialEvaluation
+from ax.utils.common.equality import Base
 
 
 TPdTimestamp = pd.Timestamp

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type
 
 import pandas as pd
 from ax.core.arm import Arm
-from ax.core.base import Base
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
@@ -26,6 +25,7 @@ from ax.core.trial import Trial
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.constants import UNEXPECTED_METRIC_COMBINATION, Keys
 from ax.utils.common.docutils import copy_doc
+from ax.utils.common.equality import Base
 from ax.utils.common.logger import get_logger
 from ax.utils.common.timeutils import current_timestamp_in_millis
 

--- a/ax/core/generator_run.py
+++ b/ax/core/generator_run.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, MutableMapping, NamedTuple, Optional, Set, T
 
 import pandas as pd
 from ax.core.arm import Arm
-from ax.core.base import Base
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.core.types import (
@@ -21,6 +20,7 @@ from ax.core.types import (
     TModelPredict,
     TModelPredictArm,
 )
+from ax.utils.common.equality import Base
 from ax.utils.common.typeutils import not_none
 
 

--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Type
 
-from ax.core.base import Base
 from ax.core.data import Data
+from ax.utils.common.equality import Base
 from ax.utils.common.serialization import extract_init_args, serialize_init_args
 
 

--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -7,8 +7,8 @@
 import warnings
 from typing import Any, Iterable, List, Optional, Tuple
 
-from ax.core.base import Base
 from ax.core.metric import Metric
+from ax.utils.common.equality import Base
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -13,11 +13,11 @@ from typing import List, Optional, Tuple
 import numpy as np
 import pandas as pd
 from ax.core.arm import Arm
-from ax.core.base import Base
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.types import TCandidateMetadata, TParameterization
 from ax.utils.common.constants import Keys
+from ax.utils.common.equality import Base
 from ax.utils.common.timeutils import current_timestamp_in_millis
 
 

--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -9,11 +9,11 @@
 from itertools import groupby
 from typing import Dict, List, Optional
 
-from ax.core.base import Base
 from ax.core.metric import Metric
 from ax.core.objective import Objective
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.types import ComparisonOp
+from ax.utils.common.equality import Base
 
 
 MAX_OBJECTIVES: int = 4

--- a/ax/core/outcome_constraint.py
+++ b/ax/core/outcome_constraint.py
@@ -9,9 +9,9 @@
 import logging
 from typing import Dict
 
-from ax.core.base import Base
 from ax.core.metric import Metric
 from ax.core.types import ComparisonOp
+from ax.utils.common.equality import Base
 from ax.utils.common.logger import get_logger
 
 

--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -8,8 +8,8 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from enum import Enum
 from typing import Dict, List, Optional, Type, Union
 
-from ax.core.base import Base
 from ax.core.types import TParamValue
+from ax.utils.common.equality import Base
 
 
 FIXED_CHOICE_PARAM_ERROR = (

--- a/ax/core/parameter_constraint.py
+++ b/ax/core/parameter_constraint.py
@@ -8,9 +8,9 @@
 
 from typing import Dict, List, Union
 
-from ax.core.base import Base
 from ax.core.parameter import ChoiceParameter, FixedParameter, Parameter, RangeParameter
 from ax.core.types import ComparisonOp
+from ax.utils.common.equality import Base
 
 
 class ParameterConstraint(Base):

--- a/ax/core/runner.py
+++ b/ax/core/runner.py
@@ -7,7 +7,7 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict
 
-from ax.core.base import Base
+from ax.utils.common.equality import Base
 from ax.utils.common.serialization import extract_init_args, serialize_init_args
 
 

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -9,7 +9,6 @@
 from typing import Dict, List, Optional
 
 from ax.core.arm import Arm
-from ax.core.base import Base
 from ax.core.parameter import FixedParameter, Parameter
 from ax.core.parameter_constraint import (
     OrderConstraint,
@@ -17,6 +16,7 @@ from ax.core.parameter_constraint import (
     SumConstraint,
 )
 from ax.core.types import TParameterization
+from ax.utils.common.equality import Base
 from ax.utils.common.typeutils import not_none
 
 

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -12,7 +12,6 @@ from inspect import signature
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Type, Union
 
 import pandas as pd
-from ax.core.base import Base
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.data import Data
 from ax.core.experiment import Experiment
@@ -28,7 +27,11 @@ from ax.modelbridge.registry import (
     _combine_model_kwargs_and_state,
     get_model_from_generator_run,
 )
-from ax.utils.common.equality import equality_typechecker, object_attribute_dicts_equal
+from ax.utils.common.equality import (
+    Base,
+    equality_typechecker,
+    object_attribute_dicts_equal,
+)
 from ax.utils.common.kwargs import consolidate_kwargs, get_function_argument_names
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
 from ax.utils.common.typeutils import checked_cast, not_none

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -8,7 +8,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Type, cast
 
 from ax.core.arm import Arm
-from ax.core.base import Base
 from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import AbandonedArm, BatchTrial
 from ax.core.data import Data
@@ -50,7 +49,7 @@ from ax.storage.sqa_store.sqa_classes import (
 from ax.storage.sqa_store.sqa_config import SQAConfig
 from ax.storage.utils import DomainType, MetricIntent, ParameterConstraintType
 from ax.utils.common.constants import Keys
-from ax.utils.common.equality import datetime_equals
+from ax.utils.common.equality import Base, datetime_equals
 from ax.utils.common.typeutils import not_none
 
 

--- a/ax/storage/sqa_store/sqa_config.py
+++ b/ax/storage/sqa_store/sqa_config.py
@@ -8,7 +8,6 @@ from enum import Enum
 from typing import Dict, NamedTuple, Optional, Type
 
 from ax.core.arm import Arm
-from ax.core.base import Base
 from ax.core.batch_trial import AbandonedArm
 from ax.core.data import Data
 from ax.core.experiment import Experiment
@@ -33,6 +32,7 @@ from ax.storage.sqa_store.sqa_classes import (
     SQARunner,
     SQATrial,
 )
+from ax.utils.common.equality import Base
 
 
 # pyre-fixme[9]: class_to_sqa_class has type `Dict[Type[Base], Type[SQABase]]`; used

--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
@@ -24,6 +26,16 @@ def equality_typechecker(eq_func: Callable) -> Callable:
         return eq_func(self, other)
 
     return _type_safe_equals
+
+
+class Base(object):
+    """Metaclass for core Ax classes."""
+
+    @equality_typechecker
+    def __eq__(self, other: Base) -> bool:
+        return object_attribute_dicts_equal(
+            one_dict=self.__dict__, other_dict=other.__dict__
+        )
 
 
 def same_elements(list1: List[Any], list2: List[Any]) -> bool:


### PR DESCRIPTION
Summary: Moving our `Base` class (just implements an equality utility) to utils/common to be able to access it outside of ax/core (for the purpose of D23002626, instrumenting our object equality assertion to better report differing fields on objects)

Differential Revision: D22986355

