### PR TITLE
Support building from versioned sdist.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=34.4", "wheel", "setuptools_scm"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -33,72 +33,14 @@ MYSQL_REQUIRES = ["SQLAlchemy>=1.1.13"]
 NOTEBOOK_REQUIRES = ["jupyter"]
 
 
-def get_git_version(abbreviate: bool = False) -> str:
-    """Gets the latest Git tag (as a string), e.g. 0.1.2.
-
-    Note that `git describe --tags` works as follows:
-    - Finds the most recent tag that is reachable from a commit.
-    - If the tag points to the commit, then only the tag is shown.
-    - Otherwise, it suffixes the tag name with the number of additional commits
-      on top of the tag, and the abbreviated name of the most recent commit,
-      e.g. 0.1.2-9-g2118b21. If you add `--abbrev=0`, this suffix is removed.
-      This behavior is controlled by the `abbrev` parameter.
-    """
-    cmd = ["git", "describe", "--tags"]
-    if abbreviate:
-        cmd.append("--abbrev=0")
-    try:
-        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        return out.strip().decode("ascii")
-    except (subprocess.SubprocessError, OSError):
-        d = datetime.datetime.today()
-        return f"{d.year}.{d.month}.{d.day}.{d.hour}"
-
-
-def write_version_py(version: str) -> None:
-    """Write the current package version to a Python file (ax/version.py)
-
-    This file will be imported by ax/__init__.py, so that users can determine
-    the current version by running `from ax import __version__`.
-    """
-    content = """#!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
-
-# THIS FILE IS GENERATED FROM AX SETUP.PY
-
-version = "%s"
-"""
-    f = open("ax/version.py", "w")
-    try:
-        f.write(content % version)
-    finally:
-        f.close()
-    return version
-
-
 def setup_package() -> None:
-    """Used for installing the Ax package.
-
-    First, we determine the current version by getting the latest tag from Git.
-    We write this version to a file (ax/version.py), which is imported by
-    __init__.py. We also pass this version to setuptools below.
-    """
-
-    # Grab current version from Git
-    # Abbreviated version (e.g. 0.1.2) will be used by setuptools
-    # Unabbreviated version (e.g. 0.1.2-9-g2118b21) will be used by __init__.py
-    abbreviated_version = get_git_version(abbreviate=True)
-    version = get_git_version(abbreviate=False)
-
-    # Write unabbreviated version to version.py
-    write_version_py(version)
+    """Used for installing the Ax package."""
 
     with open("README.md", "r") as fh:
         long_description = fh.read()
 
     setup(
         name="ax-platform",
-        version=abbreviated_version,
         description="Adaptive Experimentation",
         author="Facebook, Inc.",
         license="MIT",
@@ -124,6 +66,8 @@ def setup_package() -> None:
             "mysql": MYSQL_REQUIRES,
             "notebook": NOTEBOOK_REQUIRES,
         },
+        use_scm_version={"write_to": "ax/version.py"},
+        setup_requires=["setuptools_scm"],
     )
 
 


### PR DESCRIPTION
This switches the custom version writer to use `setuptools_scm` which is
a fairly popular method of determining version numbers from git tags
automatically.

Prior to this commit, building an sdist and then building a wheel from
that will use a date-based version, rather than the version of the
sdist.

As an example of the format, here is the version it would have for this
commit before I made it:

```
Version: 0.1.15.dev44+ge1cb797.d20200814
```

and after (it won't have this has anymore, after editing the message,
but you get the idea):

```
Version: 0.1.15.dev45+g5ae1e1c
```

I've done cursory testing that this produces a compatible version string on tags, and what I expect on non-tags; I don't know if you have any CI that relies on a particular format.