### PR TITLE
Updated Readme.md - Added MacOS version, links to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ You need Python 3.7 or later to run Ax.
 The required Python dependencies are:
 
 * [botorch](https://www.botorch.org)
-* jinja2
-* pandas
-* scipy
-* sklearn
-* plotly >=2.2.1
+* [jinja2](https://pypi.org/project/Jinja2/)
+* [pandas](https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html)
+* [scipy](https://pypi.org/project/scipy/)
+* [sklearn](https://scikit-learn.org/stable/install.html)
+* [plotly >=2.2.1](https://pypi.org/project/plotly/)
 
 ### Stable Version
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ cd ax
 pip3 install -e .[notebook,mysql,dev]
 ```
 
-See recommendation for installing PyTorch for MacOS users above.
+See [Recommendation](https://pytorch.org/get-started/locally/#macos-version) for installing PyTorch for MacOS10.10 (Yosemite) users or above.
+
+.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can install the latest (bleeding edge) version from Git:
 pip3 install git+ssh://git@github.com/facebook/Ax.git#egg=Ax
 ```
 
-See recommendation for installing PyTorch for MacOS users above.
+See [Recommendation](https://pytorch.org/get-started/locally/#macos-version) for installing PyTorch for MacOS10.10 (Yosemite) users or above.
 
 At times, the bleeding edge for Ax can depend on bleeding edge versions of BoTorch (or GPyTorch). We therefore recommend installing those from Git as well:
 ```


### PR DESCRIPTION
Changed Branch to patch-1 containing all the changes.

The changes were
a. To add all the respective links to python dependencies, in Line 70-74
![image](https://user-images.githubusercontent.com/23498248/90318659-9d23c900-df4f-11ea-9e51-e18c034784b4.png)

b. To add links and macos version for recommendation, in Lines 120 & 164
![image](https://user-images.githubusercontent.com/23498248/90318680-cf352b00-df4f-11ea-8149-2b7dbb3c05e6.png)

