### PR TITLE
Fix sphinx by extending title underline

### DIFF
--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -85,7 +85,7 @@ Torch Model Bridge
     :show-inheritance:
 
 Multi-Objective Torch Model Bridge
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.modelbridge.multi_objective_torch
     :members:


### PR DESCRIPTION
Summary:
really sphinx? you had nothing better to do than complain about this?

```
Multi-Objective Torch Model Bridge
~~~~~~~~~~~~~~~~~~~
Warning, treated as error:
/home/travis/build/facebook/Ax/sphinx/source/modelbridge.rst:88:Title underline too short.
```

https://travis-ci.com/github/facebook/Ax/jobs/378004689

Differential Revision: D23348979

