### PR TITLE
Pin black to internal version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
     - name: "Lint: black: Python 3.7"
       python: "3.7"
       install:
-        - pip install black
+        - pip install black==19.3b0
       script:
         - black --check --diff .
     - name: "Lint: flake8: Python 3.7"


### PR DESCRIPTION
Summary: black just got upgraded to a new version (https://pypi.org/project/black/20.8b0/#history) which is causing Travis failures (https://travis-ci.com/github/facebook/Ax/jobs/378004687) but the internal version is still on 19. Let's pin it until the internal version gets upgraded.

Differential Revision: D23349210

