### PR TITLE
Introduce `BoTorchModel` to OSS

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -252,13 +252,33 @@ def full_benchmark_run(  # Full run, multiple tests.
     by passing in a wrapped (in some scheduling logic) version of a corresponding
     function from this module.
 
+    Here, `problem_groups` and `method_groups` are dictionaries that have the same
+    keys such that we can run a specific subset of problems with a corresponding
+    subset of methods.
+
+    Example:
+
+    ::
+
+        problem_groups = {
+            "single_fidelity": [ackley, branin],
+            "multi_fidelity": [augmented_hartmann],
+        }
+        method_groups = {
+            "single_fidelity": [single_task_GP_and_NEI_strategy],
+            "multi_fidelity": [fixed_noise_MFGP_and_MFKG_strategy],
+        }
+
+    Here, `ackley` and `branin` will be run against `single_task_GP_and_NEI_strategy`
+    and `augmented_hartmann` against `fixed_noise_MFGP_and_MFKG_strategy`.
+
     Args:
         problem_groups: Problems to benchmark on, represented as a dictionary from
             category string to List of BenchmarkProblem-s or string keys (must be
-            in standard BOProblems). More on `problem_groups` below.
+            in standard BOProblems).
         method_groups: Methods to benchmark on, represented as a dictionary from
             category string to List of generation strategies or string keys (must
-            be in standard BOMethods). More on `method_groups` below.
+            be in standard BOMethods).
         num_replications: Number of times to run each test (each problem-method
             combination), for an aggregated result.
         num_trials: Number of trials in each test experiment.
@@ -280,21 +300,6 @@ def full_benchmark_run(  # Full run, multiple tests.
             considered failed and aborted. Defaults to 5.
         failed_replications_tolerated: How many replications can fail before a
             test is considered failed and aborted. Defaults to 3.
-
-    Here, `problem_groups` and `method_groups` are dictionaries that have the same
-    keys such that we can run a specific subset of problems with a corresponding
-    subset of methods.
-    Example:
-        problem_groups = {
-            "single_fidelity": [ackley, branin],
-            "multi_fidelity": [augmented_hartmann],
-        }
-        method_groups = {
-            "single_fidelity": [single_task_GP_and_NEI_strategy],
-            "multi_fidelity": [fixed_noise_MFGP_and_MFKG_strategy],
-        }
-    Here, `ackley` and `branin` will be run against `single_task_GP_and_NEI_strategy`
-    and `augmented_hartmann` against `fixed_noise_MFGP_and_MFKG_strategy`.
     """
     problem_groups = problem_groups or {}
     method_groups = method_groups or {}

--- a/ax/benchmark/botorch_modular/standard_methods.py
+++ b/ax/benchmark/botorch_modular/standard_methods.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.registry import Models
+from ax.models.torch.botorch_modular.kg import (
+    KnowledgeGradient,
+    MultiFidelityKnowledgeGradient,
+)
+from ax.models.torch.botorch_modular.mes import (
+    MaxValueEntropySearch,
+    MultiFidelityMaxValueEntropySearch,
+)
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.constants import Keys
+from botorch.acquisition.monte_carlo import (
+    qExpectedImprovement,
+    qNoisyExpectedImprovement,
+)
+from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
+from botorch.models.gp_regression_fidelity import (
+    FixedNoiseMultiFidelityGP,
+    SingleTaskMultiFidelityGP,
+)
+
+
+DEFAULT_ACQUISITION_OPTIONS = {
+    "num_fantasies": 16,
+    "num_mv_samples": 10,
+    "num_y_samples": 128,
+    "candidate_size": 1000,
+    "best_f": 0.0,
+}
+DEFAULT_OPTIMIZER_OPTIONS = {"num_restarts": 40, "raw_samples": 1024}
+
+
+# BoTorch `Model` and Ax `Acquisition` combinations to be benchmarked.
+
+
+# All of the single-fidelity models:
+
+# Single Task GP + NEI
+single_task_NEI_kwargs = {
+    "surrogate": Surrogate(SingleTaskGP),
+    "botorch_acqf_class": qNoisyExpectedImprovement,
+    "acquisition_options": DEFAULT_ACQUISITION_OPTIONS,
+}
+# Fixed Noise GP + EI
+fixed_noise_EI_kwargs = {
+    "surrogate": Surrogate(FixedNoiseGP),
+    "botorch_acqf_class": qExpectedImprovement,
+    "acquisition_options": DEFAULT_ACQUISITION_OPTIONS,
+}
+# Single Task GP + KG
+single_task_KG_kwargs = {
+    "surrogate": Surrogate(SingleTaskGP),
+    "acquisition_class": KnowledgeGradient,
+    "acquisition_options": DEFAULT_ACQUISITION_OPTIONS,
+}
+# Fixed Noise GP + KG
+fixed_noise_KG_kwargs = {
+    "surrogate": Surrogate(FixedNoiseGP),
+    "acquisition_class": KnowledgeGradient,
+    "acquisition_options": DEFAULT_ACQUISITION_OPTIONS,
+}
+# Single Task GP + MES
+single_task_MES_kwargs = {
+    "surrogate": Surrogate(SingleTaskGP),
+    "acquisition_class": MaxValueEntropySearch,
+    "acquisition_options": DEFAULT_ACQUISITION_OPTIONS,
+}
+# Fixed Noise GP + MES
+fixed_noise_MES_kwargs = {
+    "surrogate": Surrogate(FixedNoiseGP),
+    "acquisition_class": MaxValueEntropySearch,
+    "acquisition_options": DEFAULT_ACQUISITION_OPTIONS,
+}
+
+
+# All of the multi-fidelity models:
+
+# Single Task GP + KG
+mf_single_task_KG_kwargs = {
+    "surrogate": Surrogate(SingleTaskMultiFidelityGP),
+    "acquisition_class": MultiFidelityKnowledgeGradient,
+    "acquisition_options": DEFAULT_ACQUISITION_OPTIONS,
+}
+# Fixed Noise GP + KG
+mf_fixed_noise_KG_kwargs = {
+    "surrogate": Surrogate(FixedNoiseMultiFidelityGP),
+    "acquisition_class": MultiFidelityKnowledgeGradient,
+    "acquisition_options": DEFAULT_ACQUISITION_OPTIONS,
+}
+# Single Task GP + MES
+mf_single_task_MES_kwargs = {
+    "surrogate": Surrogate(SingleTaskMultiFidelityGP),
+    "acquisition_class": MultiFidelityMaxValueEntropySearch,
+    "acquisition_options": DEFAULT_ACQUISITION_OPTIONS,
+}
+# Fixed Noise GP + MES
+mf_fixed_noise_MES_kwargs = {
+    "surrogate": Surrogate(FixedNoiseMultiFidelityGP),
+    "acquisition_class": MultiFidelityMaxValueEntropySearch,
+    "acquisition_options": DEFAULT_ACQUISITION_OPTIONS,
+}
+
+
+# Gather all of the models:
+
+single_fidelity_name_to_model_kwargs = {
+    "Sobol+single_task_NEI": single_task_NEI_kwargs,
+    "Sobol+fixed_noise_EI": fixed_noise_EI_kwargs,
+    "Sobol+single_task_KG": single_task_KG_kwargs,
+    "Sobol+fixed_noise_KG": fixed_noise_KG_kwargs,
+    # TODO: Add these methods when numerical instability in MES is fixed.
+    # "Sobol+single_task_MES": single_task_MES_kwargs,
+    # "Sobol+fixed_noise_MES": fixed_noise_MES_kwargs,
+}
+multi_fidelity_name_to_model_kwargs = {
+    "Sobol+multi_fidelity_single_task_KG": mf_single_task_KG_kwargs,
+    "Sobol+multi_fidelity_fixed_noise_KG": mf_fixed_noise_KG_kwargs,
+    # TODO: Add these methods when numerical instability in MES is fixed.
+    # "Sobol+multi_fidelity_single_task_MES": mf_single_task_MES_kwargs,
+    # "Sobol+multi_fidelity_fixed_noise_MES": mf_fixed_noise_MES_kwargs,
+}
+
+
+# NOTE: `name_to_model_kwargs` and `MODULAR_BOTORCH_METHOD_GROUPS` must
+# have the same keys.
+name_to_model_kwargs = {
+    "single_fidelity_models": single_fidelity_name_to_model_kwargs,
+    "multi_fidelity_models": multi_fidelity_name_to_model_kwargs,
+}
+MODULAR_BOTORCH_METHOD_GROUPS = {
+    "single_fidelity_models": [],
+    "multi_fidelity_models": [],
+}
+assert name_to_model_kwargs.keys() == MODULAR_BOTORCH_METHOD_GROUPS.keys()
+
+# Populate the lists in `MODULAR_BOTORCH_METHODS_GROUPS`.
+for group_name in MODULAR_BOTORCH_METHOD_GROUPS:
+    for name, model_kwargs in name_to_model_kwargs[group_name].items():
+        MODULAR_BOTORCH_METHOD_GROUPS[group_name].append(
+            GenerationStrategy(
+                name=name,
+                steps=[
+                    GenerationStep(
+                        model=Models.SOBOL, num_trials=5, min_trials_observed=3
+                    ),
+                    GenerationStep(
+                        model=Models.BOTORCH_MODULAR,
+                        num_trials=-1,
+                        model_kwargs=model_kwargs,
+                        model_gen_kwargs={
+                            "model_gen_options": {
+                                Keys.OPTIMIZER_KWARGS: DEFAULT_OPTIMIZER_OPTIONS
+                            }
+                        },
+                    ),
+                ],
+            )
+        )

--- a/ax/benchmark/botorch_modular/standard_problems.py
+++ b/ax/benchmark/botorch_modular/standard_problems.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from ax.benchmark.benchmark_problem import BenchmarkProblem, SimpleBenchmarkProblem
+from ax.utils.measurement.synthetic_functions import from_botorch
+from ax.utils.testing.core_stubs import (
+    get_augmented_branin_optimization_config,
+    get_augmented_hartmann_optimization_config,
+    get_branin_search_space,
+    get_hartmann_search_space,
+)
+from botorch.test_functions.synthetic import Ackley, Branin
+
+
+# Initialize the single-fidelity problems
+ackley = SimpleBenchmarkProblem(f=from_botorch(Ackley()), noise_sd=0.0, minimize=True)
+branin = SimpleBenchmarkProblem(f=from_botorch(Branin()), noise_sd=0.0, minimize=True)
+single_fidelity_problem_group = [ackley, branin]
+
+# Initialize the multi-fidelity problems
+augmented_branin = BenchmarkProblem(
+    search_space=get_branin_search_space(with_fidelity_parameter=True),
+    optimization_config=get_augmented_branin_optimization_config(),
+)
+augmented_hartmann = BenchmarkProblem(
+    search_space=get_hartmann_search_space(with_fidelity_parameter=True),
+    optimization_config=get_augmented_hartmann_optimization_config(),
+)
+multi_fidelity_problem_group = [augmented_branin, augmented_hartmann]
+
+# Gather all of the problems
+MODULAR_BOTORCH_PROBLEM_GROUPS = {
+    "single_fidelity_models": single_fidelity_problem_group,
+    "multi_fidelity_models": multi_fidelity_problem_group,
+}

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -45,6 +45,7 @@ from ax.models.random.uniform import UniformGenerator
 from ax.models.torch.botorch import BotorchModel
 from ax.models.torch.botorch_kg import KnowledgeGradient
 from ax.models.torch.botorch_mes import MaxValueEntropySearch
+from ax.models.torch.botorch_modular.model import BoTorchModel
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.utils.common.kwargs import (
     consolidate_kwargs,
@@ -140,6 +141,12 @@ MODEL_KEY_TO_MODEL_SETUP: Dict[str, ModelSetup] = {
         transforms=Cont_X_trans + Y_trans,
         standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
+    "BoTorch": ModelSetup(
+        bridge_class=TorchModelBridge,
+        model_class=BoTorchModel,
+        transforms=Cont_X_trans + Y_trans,
+        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
+    ),
     "GPEI": ModelSetup(
         bridge_class=TorchModelBridge,
         model_class=BotorchModel,
@@ -216,6 +223,7 @@ class Models(Enum):
     FACTORIAL = "Factorial"
     THOMPSON = "Thompson"
     BOTORCH = "BO"
+    BOTORCH_MODULAR = "BoTorch"
     EMPIRICAL_BAYES_THOMPSON = "EB"
     UNIFORM = "Uniform"
     MOO = "MOO"

--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+
+from ax.core.types import TConfig
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.models.torch.utils import (
+    _get_X_pending_and_observed,
+    get_botorch_objective,
+    subset_model,
+)
+from ax.utils.common.constants import Keys
+from ax.utils.common.docutils import copy_doc
+from ax.utils.common.equality import Base
+from ax.utils.common.typeutils import not_none
+from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.analytic import AnalyticAcquisitionFunction
+from botorch.optim.optimize import optimize_acqf
+from botorch.utils.containers import TrainingData
+from torch import Tensor
+
+
+class Optimizer:  # NOTE: Stub for future BoTorch optimizer class.
+    pass
+
+
+class Acquisition(Base):
+    """
+    **All classes in 'botorch_modular' directory are under
+    construction, incomplete, and should be treated as alpha
+    versions only.**
+
+    Ax wrapper for BoTorch `AcquisitionFunction`, subcomponent
+    of `BoTorchModel` and is not meant to be used outside of it.
+
+    Args:
+        surrogate: Surrogate model, with which this acquisition function
+            will be used.
+        bounds: A list of (lower, upper) tuples for each column of X in
+            the training data of the surrogate model.
+        objective_weights: The objective is to maximize a weighted sum of
+            the columns of f(x). These are the weights.
+        botorch_acqf_class: Type of BoTorch `AcquistitionFunction` that
+            should be used. Subclasses of `Acquisition` often specify
+            these via `default_botorch_acqf_class` attribute, in which
+            case specifying one here is not required.
+        options: Optional mapping of kwargs to the underlying `Acquisition
+            Function` in BoTorch.
+        pending_observations: A list of tensors, each of which contains
+            points whose evaluation is pending (i.e. that have been
+            submitted for evaluation) for a given outcome. A list
+            of m (k_i x d) feature tensors X for m outcomes and k_i,
+            pending observations for outcome i.
+        outcome_constraints: A tuple of (A, b). For k outcome constraints
+            and m outputs at f(x), A is (k x m) and b is (k x 1) such that
+            A f(x) <= b. (Not used by single task models)
+        linear_constraints: A tuple of (A, b). For k linear constraints on
+            d-dimensional x, A is (k x d) and b is (k x 1) such that
+            A x <= b. (Not used by single task models)
+        fixed_features: A map {feature_index: value} for features that
+            should be fixed to a particular value during generation.
+        target_fidelities: Optional mapping from parameter name to its
+            target fidelity, applicable to fidelity parameters only.
+    """
+
+    surrogate: Surrogate
+    acqf: AcquisitionFunction
+    # BoTorch `AcquisitionFunction` class associated with this `Acquisition`
+    # class by default. `None` for the base `Acquisition` class, but can be
+    # specified in subclasses.
+    default_botorch_acqf_class: Optional[Type[AcquisitionFunction]] = None
+
+    def __init__(
+        self,
+        surrogate: Surrogate,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        botorch_acqf_class: Optional[Type[AcquisitionFunction]] = None,
+        options: Optional[Dict[str, Any]] = None,
+        pending_observations: Optional[List[Tensor]] = None,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
+    ) -> None:
+        if not botorch_acqf_class and not self.default_botorch_acqf_class:
+            raise ValueError(
+                f"Acquisition class {self.__class__} does not specify a default "
+                "BoTorch `AcquisitionFunction`, so `botorch_acqf_class` "
+                "argument must be specified."
+            )
+        botorch_acqf_class = not_none(
+            botorch_acqf_class or self.default_botorch_acqf_class
+        )
+        self.surrogate = surrogate
+        self.options = options or {}
+        X_pending, X_observed = _get_X_pending_and_observed(
+            Xs=self.surrogate.training_data.Xs,
+            pending_observations=pending_observations,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            bounds=bounds,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+        )
+
+        # Subset model only to the outcomes we need for the optimization.
+        if self.options.get(Keys.SUBSET_MODEL, True):
+            model, objective_weights, outcome_constraints, _ = subset_model(
+                self.surrogate.model,
+                objective_weights=objective_weights,
+                outcome_constraints=outcome_constraints,
+            )
+        else:
+            model = self.surrogate.model
+
+        objective = get_botorch_objective(
+            model=model,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            X_observed=X_observed,
+            use_scalarized_objective=issubclass(
+                botorch_acqf_class, AnalyticAcquisitionFunction
+            ),
+        )
+        # NOTE: Computing model dependencies might be handled entirely on
+        # BoTorch side.
+        model_deps = self.compute_model_dependencies(
+            surrogate=surrogate,
+            bounds=bounds,
+            objective_weights=objective_weights,
+            pending_observations=pending_observations,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+            target_fidelities=target_fidelities,
+            options=self.options,
+        )
+        data_deps = self.compute_data_dependencies(
+            training_data=self.surrogate.training_data
+        )
+        # pyre-ignore[28]: Some kwargs are not expected in base `Model`
+        # but are expected in its subclasses.
+        self.acqf = botorch_acqf_class(
+            model=model,
+            objective=objective,
+            X_pending=X_pending,
+            X_baseline=X_observed,
+            **self.options,
+            **model_deps,
+            **data_deps,
+        )
+
+    def optimize(
+        self,
+        bounds: Tensor,
+        n: int,
+        optimizer_class: Optional[Optimizer] = None,
+        inequality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        rounding_func: Optional[Callable[[Tensor], Tensor]] = None,
+        optimizer_options: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        """Generate a set of candidates via multi-start optimization. Obtains
+        candidates and their associated acquisition function values.
+        """
+        optimizer_options = optimizer_options or {}
+        # TODO: make use of `optimizer_class` when its added to BoTorch.
+        return optimize_acqf(
+            self.acqf,
+            bounds=bounds,
+            q=n,
+            inequality_constraints=inequality_constraints,
+            fixed_features=fixed_features,
+            post_processing_func=rounding_func,
+            **optimizer_options,
+        )
+
+    # pyre-fixme[56]: While applying decorator
+    #  `ax.utils.common.docutils.copy_doc(...)`: Argument `bounds` expected.
+    @copy_doc(Surrogate.best_in_sample_point)
+    def best_point(
+        self,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
+        options: Optional[TConfig] = None,
+    ) -> Tuple[Tensor, float]:
+        return self.surrogate.best_in_sample_point(
+            bounds=bounds,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+            options=options,
+        )
+
+    @classmethod
+    def compute_model_dependencies(
+        cls,
+        surrogate: Surrogate,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        pending_observations: Optional[List[Tensor]] = None,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Computes inputs to acquisition function class based on the given
+        surrogate model.
+
+        NOTE: May not be needed if model dependencies are handled entirely on
+        the BoTorch side.
+        """
+        return {}
+
+    @classmethod
+    def compute_data_dependencies(cls, training_data: TrainingData) -> Dict[str, Any]:
+        """Computes inputs to acquisition function class based on the given
+        data in model's training data.
+
+        NOTE: May not be needed if model dependencies are handled entirely on
+        the BoTorch side.
+        """
+        return {}

--- a/ax/models/torch/botorch_modular/kg.py
+++ b/ax/models/torch/botorch_modular/kg.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from ax.models.torch.botorch_modular.acquisition import Acquisition, Optimizer
+from ax.models.torch.botorch_modular.multi_fidelity import MultiFidelityAcquisition
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.constants import Keys
+from ax.utils.common.typeutils import checked_cast
+from botorch.acquisition.knowledge_gradient import (
+    qKnowledgeGradient,
+    qMultiFidelityKnowledgeGradient,
+)
+from botorch.optim.initializers import gen_one_shot_kg_initial_conditions
+from torch import Tensor
+
+
+class OneShotAcquisition(Acquisition):
+    def optimize(
+        self,
+        bounds: Tensor,
+        n: int,
+        optimizer_class: Optional[Optimizer] = None,
+        inequality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        rounding_func: Optional[Callable[[Tensor], Tensor]] = None,
+        optimizer_options: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        optimizer_options = optimizer_options or {}
+        init_conditions = gen_one_shot_kg_initial_conditions(
+            acq_function=checked_cast(qKnowledgeGradient, self.acqf),
+            bounds=bounds,
+            q=n,
+            num_restarts=optimizer_options.get(Keys.NUM_RESTARTS),
+            raw_samples=optimizer_options.get(Keys.RAW_SAMPLES),
+            options={
+                Keys.FRAC_RANDOM: optimizer_options.get(Keys.FRAC_RANDOM, 0.1),
+                Keys.NUM_INNER_RESTARTS: optimizer_options.get(Keys.NUM_RESTARTS),
+                Keys.RAW_INNER_SAMPLES: optimizer_options.get(Keys.RAW_SAMPLES),
+            },
+        )
+        optimizer_options[Keys.BATCH_INIT_CONDITIONS] = init_conditions
+        return super().optimize(
+            bounds=bounds,
+            n=n,
+            inequality_constraints=inequality_constraints,
+            fixed_features=fixed_features,
+            rounding_func=rounding_func,
+            optimizer_options=optimizer_options,
+        )
+
+
+class KnowledgeGradient(OneShotAcquisition):
+    default_botorch_acqf_class = qKnowledgeGradient
+
+
+class MultiFidelityKnowledgeGradient(MultiFidelityAcquisition, KnowledgeGradient):
+    default_botorch_acqf_class = qMultiFidelityKnowledgeGradient
+
+    @classmethod
+    def compute_model_dependencies(
+        cls,
+        surrogate: Surrogate,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        target_fidelities: Dict[int, float],
+        pending_observations: Optional[List[Tensor]] = None,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        # Compute generic multi-fidelity dependencies first
+        dependencies = super().compute_model_dependencies(
+            surrogate=surrogate,
+            bounds=bounds,
+            objective_weights=objective_weights,
+            pending_observations=pending_observations,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+            target_fidelities=target_fidelities,
+            options=options,
+        )
+
+        _, best_point_acqf_value = surrogate.best_in_sample_point(
+            bounds=bounds,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+        )
+
+        dependencies.update({Keys.CURRENT_VALUE: best_point_acqf_value})
+        return dependencies

--- a/ax/models/torch/botorch_modular/mes.py
+++ b/ax/models/torch/botorch_modular/mes.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import torch
+from ax.models.torch.botorch_modular.acquisition import Acquisition, Optimizer
+from ax.models.torch.botorch_modular.multi_fidelity import MultiFidelityAcquisition
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.constants import Keys
+from botorch.acquisition.max_value_entropy_search import (
+    qMaxValueEntropy,
+    qMultiFidelityMaxValueEntropy,
+)
+from torch import Tensor
+
+
+class MaxValueEntropySearch(Acquisition):
+    default_botorch_acqf_class = qMaxValueEntropy
+
+    def optimize(
+        self,
+        bounds: Tensor,
+        n: int,
+        optimizer_class: Optional[Optimizer] = None,
+        inequality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        rounding_func: Optional[Callable[[Tensor], Tensor]] = None,
+        optimizer_options: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        optimizer_options = optimizer_options or {}
+        optimizer_options[Keys.SEQUENTIAL] = True
+        return super().optimize(
+            bounds=bounds,
+            n=n,
+            inequality_constraints=None,
+            fixed_features=fixed_features,
+            rounding_func=rounding_func,
+            optimizer_options=optimizer_options,
+        )
+
+    @classmethod
+    def compute_model_dependencies(
+        cls,
+        surrogate: Surrogate,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        pending_observations: Optional[List[Tensor]] = None,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+
+        dependencies = super().compute_model_dependencies(
+            surrogate=surrogate,
+            bounds=bounds,
+            objective_weights=objective_weights,
+            pending_observations=pending_observations,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+            target_fidelities=target_fidelities,
+            options=options,
+        )
+
+        options = options or {}
+
+        bounds_ = torch.tensor(
+            bounds, dtype=surrogate.dtype, device=surrogate.device
+        ).transpose(0, 1)
+
+        candidate_size = options.get(Keys.CANDIDATE_SIZE, 1000)
+        candidate_set = torch.rand(candidate_size, bounds_.size(1))
+        candidate_set = bounds_[0] + (bounds_[1] - bounds_[0]) * candidate_set
+
+        maximize = True if objective_weights[0] == 1 else False
+
+        dependencies.update(
+            {Keys.CANDIDATE_SET: candidate_set, Keys.MAXIMIZE: maximize}
+        )
+        return dependencies
+
+
+class MultiFidelityMaxValueEntropySearch(MaxValueEntropySearch):
+    default_botorch_acqf_class = qMultiFidelityMaxValueEntropy
+
+    @classmethod
+    def compute_model_dependencies(
+        cls,
+        surrogate: Surrogate,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        target_fidelities: Dict[int, float],
+        pending_observations: Optional[List[Tensor]] = None,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+
+        dependencies = super().compute_model_dependencies(
+            surrogate=surrogate,
+            bounds=bounds,
+            objective_weights=objective_weights,
+            pending_observations=pending_observations,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+            target_fidelities=target_fidelities,
+            options=options,
+        )
+        dependencies.update(
+            MultiFidelityAcquisition.compute_model_dependencies(
+                surrogate=surrogate,
+                bounds=bounds,
+                objective_weights=objective_weights,
+                pending_observations=pending_observations,
+                outcome_constraints=outcome_constraints,
+                linear_constraints=linear_constraints,
+                fixed_features=fixed_features,
+                target_fidelities=target_fidelities,
+                options=options,
+            )
+        )
+        return dependencies

--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+
+import torch
+from ax.core.types import TCandidateMetadata, TConfig, TGenMetadata
+from ax.models.torch.botorch import get_rounding_func
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.surrogate import Surrogate, TrainingData
+from ax.models.torch.botorch_modular.utils import (
+    choose_botorch_acqf_class,
+    choose_mll_class,
+    choose_model_class,
+)
+from ax.models.torch.utils import _to_inequality_constraints
+from ax.models.torch_base import TorchModel
+from ax.utils.common.constants import Keys
+from ax.utils.common.docutils import copy_doc
+from ax.utils.common.equality import Base
+from ax.utils.common.typeutils import checked_cast, not_none
+from botorch.acquisition.acquisition import AcquisitionFunction
+from torch import Tensor
+
+
+class BoTorchModel(TorchModel, Base):
+    """
+    **All classes in 'botorch_modular' directory are under
+    construction, incomplete, and should be treated as alpha
+    versions only.**
+
+    Modular `Model` class for combining BoTorch subcomponents
+    in Ax. Specified via `Surrogate` and `Acquisition`, which wrap
+    BoTorch `Model` and `AcquisitionFunction`, respectively, for
+    convenient use in Ax.
+
+    Args:
+        acquisition_class: Type of `Acquisition` to be used in
+            this model, auto-selected based on experiment and data
+            if not specified.
+        acquisition_options: Optional dict of kwargs, passed to
+            the constructor of BoTorch `AcquisitionFunction`.
+        botorch_acqf_class: Type of `AcquisitionFunction` to be
+            used in this model, auto-selected based on experiment
+            and data if not specified.
+        surrogate: An instance of `Surrogate` to be used as part of
+            this model; if not specified, type of `Surrogate` and
+            underlying BoTorch `Model` will be auto-selected based
+            on experiment and data.
+        surrogate_fit_options: Optional dict of kwargs, passed to
+            `Surrogate.fit`, like `state_dict` or `refit_on_update`.
+    """
+
+    acquisition_class: Type[Acquisition]
+    acquisition_options: TConfig
+    surrogate_fit_options: Dict[str, Any]
+    _surrogate: Optional[Surrogate]
+    _botorch_acqf_class: Optional[Type[AcquisitionFunction]]
+
+    def __init__(
+        self,
+        acquisition_class: Optional[Type[Acquisition]] = None,
+        acquisition_options: Optional[TConfig] = None,
+        botorch_acqf_class: Optional[Type[AcquisitionFunction]] = None,
+        surrogate: Optional[Surrogate] = None,
+        surrogate_fit_options: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._surrogate = surrogate
+        self.surrogate_fit_options = surrogate_fit_options or {}
+        self.acquisition_class = acquisition_class or Acquisition
+        # `_botorch_acqf_class` can be set to `None` here. If so,
+        # `Model.gen` will set it with `choose_botorch_acqf_class`.
+        self._botorch_acqf_class = (
+            botorch_acqf_class or self.acquisition_class.default_botorch_acqf_class
+        )
+        self.acquisition_options = acquisition_options or {}
+
+    @property
+    def surrogate(self) -> Surrogate:
+        if not self._surrogate:
+            raise ValueError("Surrogate has not yet been set.")
+        return not_none(self._surrogate)
+
+    @property
+    def botorch_acqf_class(self) -> Type[AcquisitionFunction]:
+        if not self._botorch_acqf_class:
+            raise ValueError("BoTorch `AcquisitionFunction` has not yet been set.")
+        return not_none(self._botorch_acqf_class)
+
+    # pyre-fixme[56]: While applying decorator
+    #  `ax.utils.common.docutils.copy_doc(...)`: Argument `Xs` expected.
+    @copy_doc(TorchModel.fit)
+    def fit(
+        self,
+        Xs: List[Tensor],
+        Ys: List[Tensor],
+        Yvars: List[Tensor],
+        bounds: List[Tuple[float, float]],
+        task_features: List[int],
+        feature_names: List[str],
+        metric_names: List[str],
+        fidelity_features: List[int],
+        target_fidelities: Optional[Dict[int, float]] = None,
+        candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
+    ) -> None:
+        if not self._surrogate:
+            model_class = choose_model_class(
+                training_data=TrainingData(Xs=Xs, Ys=Ys, Yvars=Yvars),
+                task_features=task_features,
+                fidelity_features=fidelity_features,
+            )
+            mll_class = choose_mll_class(
+                model_class=model_class,
+                state_dict=self.surrogate_fit_options.get(Keys.STATE_DICT, None),
+                refit=self.surrogate_fit_options.get(Keys.REFIT_ON_UPDATE, True),
+            )
+            self._surrogate = Surrogate(
+                botorch_model_class=model_class, mll_class=mll_class
+            )
+        if self.surrogate_fit_options.get(
+            Keys.REFIT_ON_UPDATE, True
+        ) and not self.surrogate_fit_options.get(Keys.WARM_START_REFITTING, True):
+            self.surrogate_fit_options[Keys.STATE_DICT] = None
+        self.surrogate.fit(
+            training_data=TrainingData(Xs=Xs, Ys=Ys, Yvars=Yvars),
+            bounds=bounds,
+            task_features=task_features,
+            feature_names=feature_names,
+            fidelity_features=fidelity_features,
+            target_fidelities=target_fidelities,
+            metric_names=metric_names,
+            candidate_metadata=candidate_metadata,
+            state_dict=self.surrogate_fit_options.get(Keys.STATE_DICT, None),
+            refit=self.surrogate_fit_options.get(Keys.REFIT_ON_UPDATE, True),
+        )
+
+    # pyre-fixme[56]: While applying decorator
+    #  `ax.utils.common.docutils.copy_doc(...)`: Argument `X` expected.
+    @copy_doc(TorchModel.predict)
+    def predict(self, X: Tensor) -> Tuple[Tensor, Tensor]:
+        return self.surrogate.predict(X=X)
+
+    # pyre-fixme[56]: While applying decorator
+    #  `ax.utils.common.docutils.copy_doc(...)`: Argument `bounds` expected.
+    @copy_doc(TorchModel.gen)
+    def gen(
+        self,
+        n: int,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        pending_observations: Optional[List[Tensor]] = None,
+        model_gen_options: Optional[TConfig] = None,
+        rounding_func: Optional[Callable[[Tensor], Tensor]] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
+    ) -> Tuple[Tensor, Tensor, TGenMetadata, Optional[List[TCandidateMetadata]]]:
+        acq_options, opt_options = construct_acquisition_and_optimizer_options(
+            acqf_options=self.acquisition_options, model_gen_options=model_gen_options
+        )
+
+        if not self._botorch_acqf_class:
+            self._botorch_acqf_class = choose_botorch_acqf_class()
+
+        acqf = self.acquisition_class(
+            surrogate=self.surrogate,
+            botorch_acqf_class=self.botorch_acqf_class,
+            bounds=bounds,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+            target_fidelities=target_fidelities,
+            options=acq_options,
+        )
+
+        botorch_rounding_func = get_rounding_func(rounding_func)
+
+        # TODO: Would be good to abstract away bounds reformatting.
+        bounds_ = torch.tensor(
+            bounds, dtype=self.surrogate.dtype, device=self.surrogate.device
+        )
+        bounds_ = bounds_.transpose(0, 1)
+        candidates, expected_acquisition_value = acqf.optimize(
+            bounds=bounds_,
+            n=n,
+            inequality_constraints=_to_inequality_constraints(
+                linear_constraints=linear_constraints
+            ),
+            fixed_features=fixed_features,
+            rounding_func=botorch_rounding_func,
+            optimizer_options=checked_cast(dict, opt_options),
+        )
+        return (
+            candidates.detach().cpu(),
+            torch.ones(n, dtype=self.surrogate.dtype),
+            {Keys.EXPECTED_ACQF_VAL: expected_acquisition_value.tolist()},
+            None,
+        )
+
+    # pyre-fixme[56]: While applying decorator
+    #  `ax.utils.common.docutils.copy_doc(...)`: Argument `bounds` expected.
+    @copy_doc(TorchModel.best_point)
+    def best_point(
+        self,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        model_gen_options: Optional[TConfig] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
+    ) -> Optional[Tensor]:
+        raise NotImplementedError("Coming soon.")
+
+
+def construct_acquisition_and_optimizer_options(
+    acqf_options: TConfig, model_gen_options: Optional[TConfig] = None
+) -> Tuple[TConfig, TConfig]:
+    """Extract acquisition and optimizer options from `model_gen_options`."""
+    acq_options = acqf_options.copy()
+    opt_options = {}
+
+    if model_gen_options:
+        acq_options.update(
+            checked_cast(dict, model_gen_options.get(Keys.ACQF_KWARGS, {}))
+        )
+        # TODO: Add this if all acq. functions accept the `subset_model`
+        # kwarg or opt for kwarg filtering.
+        # acq_options[SUBSET_MODEL] = model_gen_options.get(SUBSET_MODEL)
+        opt_options = checked_cast(
+            dict, model_gen_options.get(Keys.OPTIMIZER_KWARGS, {})
+        ).copy()
+    return acq_options, opt_options

--- a/ax/models/torch/botorch_modular/multi_fidelity.py
+++ b/ax/models/torch/botorch_modular/multi_fidelity.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.constants import Keys
+from botorch.acquisition.cost_aware import InverseCostWeightedUtility
+from botorch.acquisition.utils import (
+    expand_trace_observations,
+    project_to_target_fidelity,
+)
+from botorch.models.cost import AffineFidelityCostModel
+from torch import Tensor
+
+
+class MultiFidelityAcquisition(Acquisition):
+
+    # NOTE: Here, we do not consider using `IIDNormalSampler` and always
+    # use the `SobolQMCNormalSampler`.
+    @classmethod
+    def compute_model_dependencies(
+        cls,
+        surrogate: Surrogate,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        target_fidelities: Dict[int, float],
+        pending_observations: Optional[List[Tensor]] = None,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+
+        dependencies = super().compute_model_dependencies(
+            surrogate=surrogate,
+            bounds=bounds,
+            objective_weights=objective_weights,
+            pending_observations=pending_observations,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+            target_fidelities=target_fidelities,
+            options=options,
+        )
+
+        options = options or {}
+
+        fidelity_weights = options.get(Keys.FIDELITY_WEIGHTS, None)
+        if fidelity_weights is None:
+            fidelity_weights = {f: 1.0 for f in target_fidelities}
+        if not set(target_fidelities) == set(fidelity_weights):
+            raise RuntimeError(
+                "Must provide the same indices for target_fidelities "
+                f"({set(target_fidelities)}) and fidelity_weights "
+                f" ({set(fidelity_weights)})."
+            )
+
+        cost_intercept = options.get(Keys.COST_INTERCEPT, 1.0)
+
+        cost_model = AffineFidelityCostModel(
+            fidelity_weights=fidelity_weights, fixed_cost=cost_intercept
+        )
+        cost_aware_utility = InverseCostWeightedUtility(cost_model=cost_model)
+
+        def project(X: Tensor) -> Tensor:
+            return project_to_target_fidelity(X=X, target_fidelities=target_fidelities)
+
+        def expand(X: Tensor) -> Tensor:
+            return expand_trace_observations(
+                X=X,
+                fidelity_dims=sorted(target_fidelities),
+                # pyre-fixme[16]: `Optional` has no attribute `get`.
+                num_trace_obs=options.get(Keys.NUM_TRACE_OBSERVATIONS, 0),
+            )
+
+        dependencies.update(
+            {
+                Keys.COST_AWARE_UTILITY: cost_aware_utility,
+                Keys.PROJECT: project,
+                Keys.EXPAND: expand,
+            }
+        )
+        return dependencies

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from inspect import isabstract
+from typing import Any, Dict, List, Optional, Tuple, Type
+
+import torch
+from ax.core.types import TCandidateMetadata, TConfig
+from ax.models.model_utils import best_in_sample_point
+from ax.models.torch.utils import (
+    _to_inequality_constraints,
+    pick_best_out_of_sample_point_acqf_class,
+    predict_from_model,
+)
+from ax.utils.common.constants import Keys
+from ax.utils.common.equality import Base
+from ax.utils.common.typeutils import checked_cast, checked_cast_optional, not_none
+from botorch.fit import fit_gpytorch_model
+from botorch.models.model import Model, TrainingData
+from gpytorch.kernels import Kernel
+from gpytorch.likelihoods.likelihood import Likelihood
+from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
+from torch import Tensor
+
+
+class Surrogate(Base):
+    """
+    **All classes in 'botorch_modular' directory are under
+    construction, incomplete, and should be treated as alpha
+    versions only.**
+
+    Ax wrapper for BoTorch `Model`, subcomponent of `BoTorchModel`
+    and is not meant to be used outside of it.
+
+    Args:
+        botorch_model_class: `Model` class to be used as the underlying
+            BoTorch model.
+        mll_class: `MarginalLogLikelihood` class to use for model-fitting.
+        kernel_class: `Kernel` class, not yet used. Will be used to
+            construct custom BoTorch `Model` in the future.
+        kernel_options: Kernel kwargs, not yet used. Will be used to
+            construct custom BoTorch `Model` in the future.
+        likelihood: `Likelihood` class, not yet used. Will be used to
+            construct custom BoTorch `Model` in the future.
+    """
+
+    botorch_model_class: Type[Model]
+    mll_class: Type[MarginalLogLikelihood]
+    kernel_class: Optional[Type[Kernel]] = None
+    _training_data: Optional[TrainingData] = None
+    _model: Optional[Model] = None
+    # Special setting for surrogates instantiated via `Surrogate.from_BoTorch`,
+    # to avoid re-constructing the underlying BoTorch model on `Surrogate.fit`
+    # when set to `False`.
+    _should_reconstruct: bool = True
+
+    def __init__(
+        self,
+        # TODO: make optional when BoTorch model factory is checked in.
+        # Construction will then be possible from likelihood, kernel, etc.
+        botorch_model_class: Type[Model],
+        mll_class: Type[MarginalLogLikelihood] = ExactMarginalLogLikelihood,
+        kernel_class: Optional[Type[Kernel]] = None,  # TODO: use.
+        kernel_options: Optional[Dict[str, Any]] = None,  # TODO: use.
+        likelihood: Optional[Type[Likelihood]] = None,  # TODO: use.
+    ) -> None:
+        self.botorch_model_class = botorch_model_class
+        self.mll_class = mll_class
+        # NOTE: assuming here that plugging in kernels will be made easier on the
+        # BoTorch side (for v0 can just always raise `NotImplementedError` if
+        # `kernel` kwarg is not None).
+        if kernel_class:
+            self.kernel_class = kernel_class
+            # NOTE: `validate_kernel_class` to be implemented on BoTorch `Model`.
+            # self.botorch_model_class.validate_kernel_class(kernel_class)
+
+        # Temporary validation while we develop these customizations.
+        if likelihood is not None:
+            raise NotImplementedError("Customizing likelihood not yet implemented.")
+        if kernel_class is not None or kernel_options:
+            raise NotImplementedError("Customizing kernel not yet implemented.")
+
+    @property
+    def model(self) -> Model:
+        if self._model is None:
+            raise ValueError("BoTorch `Model` has not yet been constructed.")
+        return not_none(self._model)
+
+    @property
+    def training_data(self) -> TrainingData:
+        if self._training_data is None:
+            raise ValueError(
+                "Underlying BoTorch `Model` has not yet received its training_data."
+            )
+        return not_none(self._training_data)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.training_data.Xs[0].dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.training_data.Xs[0].device
+
+    @classmethod
+    def from_BoTorch(
+        cls,
+        model: Model,
+        mll_class: Type[MarginalLogLikelihood] = ExactMarginalLogLikelihood,
+    ) -> Surrogate:
+        """Instantiate a `Surrogate` from a pre-instantiated Botorch `Model`."""
+        surrogate = cls(botorch_model_class=model.__class__, mll_class=mll_class)
+        surrogate._model = model
+        # Temporarily disallowing `update` for surrogates instantiated from
+        # pre-made BoTorch `Model` instances to avoid reconstructing models
+        # that were likely pre-constructed for a reason (e.g. if this setup
+        # doesn't fully allow to constuct them).
+        surrogate._should_reconstruct = False
+        return surrogate
+
+    def construct(
+        self, training_data: TrainingData, fidelity_features: List[int]
+    ) -> None:
+        # NOTE: `validate_training_data` to be implemented on BoTorch `Model`.
+        # self.botorch_model_class.validate_training_data(training_data)
+        self._training_data = training_data
+
+        if isabstract(self.botorch_model_class):
+            raise TypeError("Cannot construct an abstract model.")
+
+        formatted_model_inputs = self.botorch_model_class.construct_inputs(
+            training_data=training_data, fidelity_features=fidelity_features
+        )
+        # pyre-ignore[45]: Model isn't abstract per the check above.
+        self._model = self.botorch_model_class(**formatted_model_inputs)
+        # TODO: Instantiate / pass kernel here somewhere.
+
+    def fit(
+        self,
+        training_data: TrainingData,
+        bounds: List[Tuple[float, float]],
+        task_features: List[int],
+        feature_names: List[str],
+        metric_names: List[str],
+        fidelity_features: List[int],
+        target_fidelities: Optional[Dict[int, float]] = None,
+        candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
+        state_dict: Optional[Dict[str, Tensor]] = None,
+        refit: bool = True,
+    ) -> None:
+        if self._model is None or self._should_reconstruct:
+            self.construct(
+                training_data=training_data, fidelity_features=fidelity_features
+            )
+        if state_dict is not None:
+            self.model.load_state_dict(state_dict)
+        if state_dict is None or refit:
+            # pyre-ignore[16]: Model has no attribute likelihood.
+            # All BoTorch `Model`-s expected to work with this setup have likelihood.
+            mll = self.mll_class(self.model.likelihood, self.model)
+            fit_gpytorch_model(mll)
+
+    def predict(self, X: Tensor) -> Tuple[Tensor, Tensor]:
+        """Predicts outcomes given a model and input tensor.
+
+        Args:
+            model: A botorch Model.
+            X: A `n x d` tensor of input parameters.
+
+        Returns:
+            Tensor: The predicted posterior mean as an `n x o`-dim tensor.
+            Tensor: The predicted posterior covariance as a `n x o x o`-dim tensor.
+        """
+        return predict_from_model(model=self.model, X=X)
+
+    def best_in_sample_point(
+        self,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Optional[Tensor],
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        options: Optional[TConfig] = None,
+    ) -> Tuple[Tensor, float]:
+        """Finds the best observed point and the corresponding observed outcome
+        values.
+        """
+        best_point_and_observed_value = best_in_sample_point(
+            Xs=self.training_data.Xs,
+            # pyre-ignore[6]: `best_in_sample_point` currently expects a `TorchModel`
+            # or a `NumpyModel` as `model` kwarg, but only uses them for `predict`
+            # function, the signature for which is the same on this `Surrogate`.
+            # TODO: When we move `botorch_modular` directory to OSS, we will extend
+            # the annotation for `model` kwarg to accept `Surrogate` too.
+            model=self,
+            bounds=bounds,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+            options=options,
+        )
+        if best_point_and_observed_value is None:
+            raise ValueError("Could not obtain best in-sample point.")
+        best_point, observed_value = best_point_and_observed_value
+        return checked_cast(Tensor, best_point), observed_value
+
+    def best_out_of_sample_point(
+        self,
+        bounds: List[Tuple[float, float]],
+        objective_weights: Tensor,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        fidelity_features: Optional[List[int]] = None,
+        target_fidelities: Optional[Dict[int, float]] = None,
+        options: Optional[TConfig] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        """Finds the best predicted point and the corresponding value of the
+        appropriate best point acquisition function.
+        """
+        if fixed_features:
+            # When have fixed features, need `FixedFeatureAcquisitionFunction`
+            # which has peculiar instantiation (wraps another acquisition fn.),
+            # so need to figure out how to handle.
+            # TODO (ref: https://fburl.com/diff/uneqb3n9)
+            raise NotImplementedError("Fixed features not yet implemented.")
+
+        options = options or {}
+        acqf_class, acqf_options = pick_best_out_of_sample_point_acqf_class(
+            Xs=self.training_data.Xs,
+            outcome_constraints=outcome_constraints,
+            seed_inner=checked_cast_optional(int, options.get(Keys.SEED_INNER, None)),
+            qmc=checked_cast(bool, options.get(Keys.QMC, True)),
+        )
+
+        # Avoiding circular import between `Surrogate` and `Acquisition`.
+        from ax.models.torch.botorch_modular.acquisition import Acquisition
+
+        acqf = Acquisition(  # TODO: For multi-fidelity, might need diff. class.
+            surrogate=self,
+            botorch_acqf_class=acqf_class,
+            bounds=bounds,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+            linear_constraints=linear_constraints,
+            fixed_features=fixed_features,
+            target_fidelities=target_fidelities,
+            options=acqf_options,
+        )
+        candidates, acqf_values = acqf.optimize(
+            # pyre-ignore[6]: Exp. Tensor, got List[Tuple[float, float]].
+            # TODO: Fix typing of `bounds` in `TorchModel`-s.
+            bounds=bounds,
+            n=1,
+            inequality_constraints=_to_inequality_constraints(
+                linear_constraints=linear_constraints
+            ),
+            fixed_features=fixed_features,
+        )
+        return candidates[0], acqf_values[0]
+
+    def pareto_frontier(self) -> Tuple[Tensor, Tensor]:
+        """For multi-objective optimization, retrieve Pareto frontier instead
+        of best point.
+
+        Returns: A two-tuple of:
+            - tensor of points in the feature space,
+            - tensor of corresponding (multiple) outcomes.
+        """
+        pass
+
+    def compute_diagnostics(self) -> Dict[str, Any]:
+        """Computes model diagnostics like cross-validation measure of fit, etc.
+        """
+        return {}
+
+    def update(
+        self,
+        training_data: TrainingData,
+        bounds: List[Tuple[float, float]],
+        task_features: List[int],
+        feature_names: List[str],
+        metric_names: List[str],
+        fidelity_features: List[int],
+        candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
+        state_dict: Optional[Dict[str, Tensor]] = None,
+        refit: bool = True,
+    ) -> None:
+        """Updates the surrogate model with new data.
+
+        Args:
+            training_data: Surrogate training_data containing all the data the model
+                should use for inference. NOTE: this should not be just the new data
+                since the last time the model was updated, but all available
+                data.
+            refit: Whether to re-optimize model parameters or just add the new
+                data to data used for inference.
+        """
+        # NOTE: In the future, could have `incremental` kwarg, in which case
+        # `training_data` could contain just the new data.
+        state_dict = self.model.state_dict
+        if not self._should_reconstruct:
+            raise NotImplementedError(
+                "`update` not yet implemented for models that should "
+                "not be re-constructed."
+            )
+        self.fit(
+            training_data=training_data,
+            bounds=bounds,
+            task_features=task_features,
+            feature_names=feature_names,
+            metric_names=metric_names,
+            fidelity_features=fidelity_features,
+            candidate_metadata=candidate_metadata,
+            state_dict=state_dict,
+            refit=refit,
+        )

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, List, Optional, Type
+
+import torch
+from ax.utils.common.typeutils import not_none
+from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
+from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
+from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
+from botorch.models.model import Model
+from botorch.models.model_list_gp_regression import ModelListGP
+from botorch.utils.containers import TrainingData
+from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
+from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
+from torch import Tensor
+
+
+MIN_OBSERVED_NOISE_LEVEL = 1e-7
+
+
+def choose_model_class(
+    training_data: TrainingData, task_features: List[int], fidelity_features: List[int]
+) -> Type[Model]:
+    r"""Chooses a BoTorch `Model` using the given data.
+
+    Args:
+        training_data: NamedTuple with Xs, Ys, and Yvars.
+        task_features: List of columns of X that are tasks.
+        fidelity_features: List of columns of X that are fidelity parameters.
+
+    Returns:
+        A BoTorch `Model` class.
+    """
+    if len(task_features) > 0:
+        raise NotImplementedError("Currently do not support `task_features`!")
+    if len(fidelity_features) > 1:
+        raise NotImplementedError("Currently support only a single fidelity parameter!")
+
+    # NOTE: We currently do not support `task_features`. This code block will only
+    # be relevant once we support `task_features`.
+    if len(task_features) > 1:
+        raise NotImplementedError(
+            f"This model only supports 1 task feature (got {task_features})"
+        )
+    elif len(task_features) == 1:
+        task_feature = task_features[0]
+    else:
+        task_feature = None
+
+    # NOTE: In the current setup, `task_feature = None` always.
+    if task_feature is None:
+        Yvars = torch.cat(not_none(training_data.Yvars)).clamp_min_(
+            MIN_OBSERVED_NOISE_LEVEL
+        )
+        is_nan = torch.isnan(Yvars)
+        any_nan_Yvar = torch.any(is_nan)
+        all_nan_Yvar = torch.all(is_nan)
+        if any_nan_Yvar and not all_nan_Yvar:
+            raise ValueError(
+                "Mix of known and unknown variances indicates valuation function "
+                "errors. Variances should all be specified, or none should be."
+            )
+        if len(fidelity_features or []) > 0:
+            return SingleTaskMultiFidelityGP
+        elif all_nan_Yvar:
+            return SingleTaskGP
+        return FixedNoiseGP
+    # TODO: Replace ValueError with `ModelListGP`.
+    raise ValueError("Unexpected training data format. Cannot choose `Model`.")
+
+
+def choose_mll_class(
+    model_class: Type[Model],
+    state_dict: Optional[Dict[str, Tensor]] = None,
+    refit: bool = True,
+) -> Type[MarginalLogLikelihood]:
+    r"""Chooses a BoTorch `MarginalLogLikelihood` class using the given `Model` class.
+
+    Args:
+        model_class: BoTorch `Model` class.
+        state_dict: If provided, will set model parameters to this state
+            dictionary. Otherwise, will fit the model.
+        refit: Flag for refitting model.
+
+    Returns:
+        A `MarginalLogLikelihood` class.
+    """
+    # NOTE: We currently do not support `ModelListGP`. This code block will only
+    # be relevant once we support `ModelListGP`.
+    if (state_dict is None or refit) and issubclass(model_class, ModelListGP):
+        return SumMarginalLogLikelihood
+    return ExactMarginalLogLikelihood
+
+
+def choose_botorch_acqf_class() -> Type[AcquisitionFunction]:
+    r"""Chooses a BoTorch `AcquisitionFunction` class."""
+    # NOTE: In the future, this dispatch function could leverage any
+    # of the attributes of `BoTorchModel` or kwargs passed to
+    # `BoTorchModel.gen` to intelligently select acquisition function.
+    return qNoisyExpectedImprovement

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any
+from unittest.mock import patch
+
+import torch
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.testutils import TestCase
+from botorch.acquisition.objective import LinearMCObjective
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.model import TrainingData
+
+
+ACQUISITION_PATH = f"{Acquisition.__module__}"
+CURRENT_PATH = f"{__name__}"
+SURROGATE_PATH = f"{Surrogate.__module__}"
+
+
+# Used to avoid going through BoTorch `Acquisition.__init__` which
+# requires valid kwargs (correct sizes and lengths of tensors, etc).
+class DummyACQFClass:
+    def __init__(self, **kwargs: Any) -> None:
+        pass
+
+
+class AcquisitionTest(TestCase):
+    def setUp(self):
+        self.botorch_model_class = SingleTaskGP
+        self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
+        self.Xs = [torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])]
+        self.Ys = [torch.tensor([[3.0], [4.0]])]
+        self.Yvars = [torch.tensor([[0.0], [2.0]])]
+        self.training_data = TrainingData(Xs=self.Xs, Ys=self.Ys, Yvars=self.Yvars)
+        self.fidelity_features = [2]
+        self.surrogate.construct(
+            training_data=self.training_data, fidelity_features=self.fidelity_features
+        )
+
+        self.bounds = [(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)]
+        self.botorch_acqf_class = DummyACQFClass
+        self.objective_weights = torch.tensor([1.0])
+        self.pending_observations = [
+            torch.tensor([[1.0, 3.0, 4.0]]),
+            torch.tensor([[2.0, 6.0, 8.0]]),
+        ]
+        self.outcome_constraints = (torch.tensor([[1.0]]), torch.tensor([[0.5]]))
+        self.linear_constraints = None
+        self.fixed_features = {1: 2.0}
+        self.target_fidelities = {2: 1.0}
+        self.options = {"best_f": 0.0}
+        self.acquisition = Acquisition(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            botorch_acqf_class=self.botorch_acqf_class,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+
+        self.inequality_constraints = [
+            (torch.tensor([0, 1]), torch.tensor([-1.0, 1.0]), 1)
+        ]
+        self.rounding_func = lambda x: x
+        self.optimizer_options = {"num_restarts": 40, "raw_samples": 1024}
+
+    @patch(
+        f"{ACQUISITION_PATH}._get_X_pending_and_observed",
+        return_value=(torch.tensor([2.0]), torch.tensor([3.0])),
+    )
+    @patch(f"{ACQUISITION_PATH}.subset_model", return_value=(None, None, None, None))
+    @patch(f"{ACQUISITION_PATH}.get_botorch_objective")
+    @patch(
+        f"{CURRENT_PATH}.Acquisition.compute_model_dependencies",
+        return_value={"current_value": 1.2},
+    )
+    @patch(f"{CURRENT_PATH}.Acquisition.compute_data_dependencies", return_value={})
+    @patch(f"{DummyACQFClass.__module__}.DummyACQFClass.__init__", return_value=None)
+    def test_init(
+        self,
+        mock_botorch_acqf_class,
+        mock_compute_data_deps,
+        mock_compute_model_deps,
+        mock_get_objective,
+        mock_subset_model,
+        mock_get_X,
+    ):
+        self.acquisition.default_botorch_acqf_class = None
+        with self.assertRaisesRegex(
+            ValueError, ".*`botorch_acqf_class` argument must be specified."
+        ):
+            Acquisition(
+                surrogate=self.surrogate,
+                bounds=self.bounds,
+                objective_weights=self.objective_weights,
+            )
+
+        botorch_objective = LinearMCObjective(weights=torch.tensor([1.0]))
+        mock_get_objective.return_value = botorch_objective
+        acquisition = Acquisition(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            botorch_acqf_class=self.botorch_acqf_class,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+
+        # Check `_get_X_pending_and_observed` kwargs
+        mock_get_X.assert_called_with(
+            Xs=self.training_data.Xs,
+            pending_observations=self.pending_observations,
+            objective_weights=self.objective_weights,
+            outcome_constraints=self.outcome_constraints,
+            bounds=self.bounds,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+        )
+        # Call `subset_model` only when needed
+        mock_subset_model.assert_called_with(
+            acquisition.surrogate.model,
+            objective_weights=self.objective_weights,
+            outcome_constraints=self.outcome_constraints,
+        )
+        mock_subset_model.reset_mock()
+        self.options["subset_model"] = False
+        acquisition = Acquisition(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            botorch_acqf_class=self.botorch_acqf_class,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+        mock_subset_model.assert_not_called()
+        # Check `get_botorch_objective` kwargs
+        mock_get_objective.assert_called_with(
+            model=self.acquisition.surrogate.model,
+            objective_weights=self.objective_weights,
+            outcome_constraints=self.outcome_constraints,
+            X_observed=torch.tensor([3.0]),
+            use_scalarized_objective=False,
+        )
+        # Check `compute_model_dependencies` kwargs
+        mock_compute_model_deps.assert_called_with(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+        # Check `compute_data_dependencies` kwargs
+        mock_compute_data_deps.assert_called_with(training_data=self.training_data)
+        # Check final `acqf` creation
+        model_deps = {"current_value": 1.2}
+        data_deps = {}
+        mock_botorch_acqf_class.assert_called_with(
+            model=self.acquisition.surrogate.model,
+            objective=botorch_objective,
+            X_pending=torch.tensor([2.0]),
+            X_baseline=torch.tensor([3.0]),
+            **self.options,
+            **model_deps,
+            **data_deps,
+        )
+
+    @patch(f"{ACQUISITION_PATH}.optimize_acqf")
+    def test_optimize(self, mock_optimize_acqf):
+        self.acquisition.optimize(
+            bounds=self.bounds,
+            n=3,
+            optimizer_class=None,
+            inequality_constraints=self.inequality_constraints,
+            fixed_features=self.fixed_features,
+            rounding_func=self.rounding_func,
+            optimizer_options=self.optimizer_options,
+        )
+        mock_optimize_acqf.assert_called_with(
+            self.acquisition.acqf,
+            bounds=self.bounds,
+            q=3,
+            inequality_constraints=self.inequality_constraints,
+            fixed_features=self.fixed_features,
+            post_processing_func=self.rounding_func,
+            **self.optimizer_options,
+        )
+
+    @patch(f"{SURROGATE_PATH}.Surrogate.best_in_sample_point")
+    def test_best_point(self, mock_best_point):
+        self.acquisition.best_point(
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+        mock_best_point.assert_called_with(
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            options=self.options,
+        )

--- a/ax/models/torch/tests/test_kg.py
+++ b/ax/models/torch/tests/test_kg.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import ANY, patch
+
+import torch
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.kg import (
+    KnowledgeGradient,
+    MultiFidelityKnowledgeGradient,
+    OneShotAcquisition,
+)
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.constants import Keys
+from ax.utils.common.testutils import TestCase
+from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.model import TrainingData
+
+
+ACQUISITION_PATH = f"{Acquisition.__module__}"
+KG_PATH = f"{KnowledgeGradient.__module__}"
+
+
+class AcquisitionSetUp:
+    def setUp(self):
+        self.botorch_model_class = SingleTaskGP
+        self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
+        self.Xs = [torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])]
+        self.Ys = [torch.tensor([[3.0], [4.0]])]
+        self.Yvars = [torch.tensor([[0.0], [2.0]])]
+        self.training_data = TrainingData(Xs=self.Xs, Ys=self.Ys, Yvars=self.Yvars)
+        self.fidelity_features = [2]
+        self.surrogate.construct(
+            training_data=self.training_data, fidelity_features=self.fidelity_features
+        )
+
+        self.bounds = [(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)]
+        self.botorch_acqf_class = qKnowledgeGradient
+        self.objective_weights = torch.tensor([1.0])
+        self.target_fidelities = {2: 1.0}
+        self.pending_observations = [
+            torch.tensor([[1.0, 3.0, 4.0]]),
+            torch.tensor([[2.0, 6.0, 8.0]]),
+        ]
+        self.outcome_constraints = (torch.tensor([[1.0]]), torch.tensor([[0.5]]))
+        self.linear_constraints = None
+        self.fixed_features = {1: 2.0}
+        self.options = {
+            Keys.FIDELITY_WEIGHTS: {2: 1.0},
+            Keys.COST_INTERCEPT: 1.0,
+            Keys.NUM_TRACE_OBSERVATIONS: 0,
+        }
+
+        self.optimizer_options = {
+            Keys.NUM_RESTARTS: 40,
+            Keys.RAW_SAMPLES: 1024,
+            Keys.FRAC_RANDOM: 0.2,
+        }
+        self.inequality_constraints = [
+            (torch.tensor([0, 1]), torch.tensor([-1.0, 1.0]), 1)
+        ]
+
+
+class OneShotAcquisitionTest(AcquisitionSetUp, TestCase):
+    def setUp(self):
+        super().setUp()
+
+    @patch(
+        f"{KG_PATH}.gen_one_shot_kg_initial_conditions",
+        return_value=torch.tensor([1.0]),
+    )
+    @patch(f"{ACQUISITION_PATH}.Acquisition.optimize")
+    def test_optimize(self, mock_parent_optimize, mock_init_conditions):
+        self.acquisition = OneShotAcquisition(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            botorch_acqf_class=self.botorch_acqf_class,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+        self.acquisition.optimize(
+            bounds=self.bounds,
+            n=1,
+            optimizer_class=None,
+            inequality_constraints=self.inequality_constraints,
+            fixed_features=self.fixed_features,
+            rounding_func="func",
+            optimizer_options=self.optimizer_options,
+        )
+        mock_init_conditions.assert_called_with(
+            acq_function=ANY,
+            bounds=self.bounds,
+            q=1,
+            num_restarts=self.optimizer_options[Keys.NUM_RESTARTS],
+            raw_samples=self.optimizer_options[Keys.RAW_SAMPLES],
+            options={
+                Keys.FRAC_RANDOM: self.optimizer_options[Keys.FRAC_RANDOM],
+                Keys.NUM_INNER_RESTARTS: self.optimizer_options[Keys.NUM_RESTARTS],
+                Keys.RAW_INNER_SAMPLES: self.optimizer_options[Keys.RAW_SAMPLES],
+            },
+        )
+        self.optimizer_options[Keys.BATCH_INIT_CONDITIONS] = torch.tensor([1.0])
+        # `OneShotAcquisition.optimize()` should call `Acquisition.optimize()` once.
+        mock_parent_optimize.assert_called_once()
+        mock_parent_optimize.assert_called_with(
+            bounds=self.bounds,
+            n=1,
+            inequality_constraints=self.inequality_constraints,
+            fixed_features=self.fixed_features,
+            rounding_func="func",
+            optimizer_options=self.optimizer_options,
+        )
+
+
+class KnowledgeGradientTest(AcquisitionSetUp, TestCase):
+    def setUp(self):
+        super().setUp()
+
+    @patch(
+        f"{ACQUISITION_PATH}.Acquisition.compute_model_dependencies", return_value={}
+    )
+    def test_compute_model_dependencies(self, mock_Acquisition_compute):
+        # `KnowledgeGradient.compute_model_dependencies` should call
+        # `Acquisition.compute_model_dependencies` once.
+        dependencies = KnowledgeGradient.compute_model_dependencies(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+        )
+        mock_Acquisition_compute.assert_called_once()
+        self.assertEqual(dependencies, {})
+
+    @patch(f"{KG_PATH}.OneShotAcquisition.optimize")
+    def test_optimize(self, mock_OneShot_optimize):
+        self.acquisition = KnowledgeGradient(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            botorch_acqf_class=self.botorch_acqf_class,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+        # `KnowledgeGradient.optimize()` should call `OneShotAcquisition.optimize()`
+        # once.
+        self.acquisition.optimize(
+            bounds=self.bounds,
+            n=1,
+            optimizer_class=None,
+            inequality_constraints=self.inequality_constraints,
+            fixed_features=self.fixed_features,
+            rounding_func="func",
+            optimizer_options=self.optimizer_options,
+        )
+        mock_OneShot_optimize.assert_called_once()
+
+
+class MultiFidelityKnowledgeGradientTest(AcquisitionSetUp, TestCase):
+    def setUp(self):
+        super().setUp()
+
+    @patch(
+        f"{ACQUISITION_PATH}.Acquisition.compute_model_dependencies", return_value={}
+    )
+    def test_compute_model_dependencies(self, mock_Acquisition_compute):
+        # `MultiFidelityKnowledgeGradient.compute_model_dependencies` should
+        # call `Acquisition.compute_model_dependencies` once.
+        dependencies = MultiFidelityKnowledgeGradient.compute_model_dependencies(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+        mock_Acquisition_compute.assert_called_once()
+        # Dependencies list should have `Keys.CURRENT_VALUE` in it
+        self.assertTrue(Keys.CURRENT_VALUE in dependencies)
+
+    @patch(f"{KG_PATH}.OneShotAcquisition.optimize")
+    def test_optimize(self, mock_OneShot_optimize):
+        self.acquisition = MultiFidelityKnowledgeGradient(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            botorch_acqf_class=self.botorch_acqf_class,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+        # `MultiFidelityKnowledgeGradient.optimize()` should call
+        # `OneShotAcquisition.optimize()` once.
+        self.acquisition.optimize(
+            bounds=self.bounds,
+            n=1,
+            optimizer_class=None,
+            inequality_constraints=self.inequality_constraints,
+            fixed_features=self.fixed_features,
+            rounding_func="func",
+            optimizer_options=self.optimizer_options,
+        )
+        mock_OneShot_optimize.assert_called_once()

--- a/ax/models/torch/tests/test_mes.py
+++ b/ax/models/torch/tests/test_mes.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import patch
+
+import torch
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.mes import (
+    MaxValueEntropySearch,
+    MultiFidelityMaxValueEntropySearch,
+)
+from ax.models.torch.botorch_modular.multi_fidelity import MultiFidelityAcquisition
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.constants import Keys
+from ax.utils.common.testutils import TestCase
+from botorch.acquisition.max_value_entropy_search import qMaxValueEntropy
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.model import TrainingData
+
+
+ACQUISITION_PATH = f"{Acquisition.__module__}"
+MES_PATH = f"{MaxValueEntropySearch.__module__}"
+MULTI_FIDELITY_PATH = f"{MultiFidelityAcquisition.__module__}"
+
+
+class AcquisitionSetUp:
+    def setUp(self):
+        self.botorch_model_class = SingleTaskGP
+        self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
+        self.Xs = [torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])]
+        self.Ys = [torch.tensor([[3.0], [4.0]])]
+        self.Yvars = [torch.tensor([[0.0], [2.0]])]
+        self.training_data = TrainingData(Xs=self.Xs, Ys=self.Ys, Yvars=self.Yvars)
+        self.fidelity_features = [2]
+        self.surrogate.construct(
+            training_data=self.training_data, fidelity_features=self.fidelity_features
+        )
+
+        self.bounds = [(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)]
+        self.botorch_acqf_class = qMaxValueEntropy
+        self.objective_weights = torch.tensor([1.0])
+        self.target_fidelities = {2: 1.0}
+        self.pending_observations = [
+            torch.tensor([[1.0, 3.0, 4.0]]),
+            torch.tensor([[2.0, 6.0, 8.0]]),
+        ]
+        self.outcome_constraints = (torch.tensor([[1.0]]), torch.tensor([[0.5]]))
+        self.linear_constraints = None
+        self.fixed_features = {1: 2.0}
+        self.options = {
+            Keys.FIDELITY_WEIGHTS: {2: 1.0},
+            Keys.COST_INTERCEPT: 1.0,
+            Keys.NUM_TRACE_OBSERVATIONS: 0,
+        }
+
+        self.optimizer_options = {
+            Keys.NUM_RESTARTS: 40,
+            Keys.RAW_SAMPLES: 1024,
+            Keys.FRAC_RANDOM: 0.2,
+        }
+        self.inequality_constraints = [
+            (torch.tensor([0, 1]), torch.tensor([-1.0, 1.0]), 1)
+        ]
+
+
+class MaxValueEntropySearchTest(AcquisitionSetUp, TestCase):
+    def setUp(self):
+        super().setUp()
+
+    @patch(
+        f"{ACQUISITION_PATH}.Acquisition.compute_model_dependencies", return_value={}
+    )
+    def test_compute_model_dependencies(self, mock_Acquisition_compute):
+        # `MaxValueEntropySearch.compute_model_dependencies` should call
+        # `Acquisition.compute_model_dependencies` once.
+        depedencies = MaxValueEntropySearch.compute_model_dependencies(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+        )
+        mock_Acquisition_compute.assert_called_once()
+        self.assertTrue(Keys.CANDIDATE_SET in depedencies)
+        self.assertTrue(Keys.MAXIMIZE in depedencies)
+
+    @patch(f"{ACQUISITION_PATH}.Acquisition.optimize")
+    def test_optimize(self, mock_Acquisition_optimize):
+        self.acquisition = MaxValueEntropySearch(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            botorch_acqf_class=self.botorch_acqf_class,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+        # `MaxValueEntropySearch.optimize()` should call
+        # `Acquisition.optimize()` once.
+        self.acquisition.optimize(
+            bounds=self.bounds,
+            n=1,
+            optimizer_class=None,
+            inequality_constraints=self.inequality_constraints,
+            fixed_features=self.fixed_features,
+            rounding_func="func",
+            optimizer_options=self.optimizer_options,
+        )
+        mock_Acquisition_optimize.assert_called_once()
+        # `sequential` should be set to True
+        self.optimizer_options.update({Keys.SEQUENTIAL: True})
+        mock_Acquisition_optimize.assert_called_with(
+            bounds=self.bounds,
+            n=1,
+            inequality_constraints=None,
+            fixed_features=self.fixed_features,
+            rounding_func="func",
+            optimizer_options=self.optimizer_options,
+        )
+
+
+class MultiFidelityMaxValueEntropySearchTest(AcquisitionSetUp, TestCase):
+    def setUp(self):
+        super().setUp()
+
+    @patch(
+        f"{MES_PATH}.MaxValueEntropySearch.compute_model_dependencies",
+        return_value={Keys.CANDIDATE_SET: None, Keys.MAXIMIZE: True},
+    )
+    @patch(
+        f"{MULTI_FIDELITY_PATH}.MultiFidelityAcquisition.compute_model_dependencies",
+        return_value={Keys.CURRENT_VALUE: 0.0},
+    )
+    def test_compute_model_dependencies(self, mock_MF_compute, mock_MES_compute):
+        # `MultiFidelityMaxValueEntropySearch.compute_model_dependencies` should
+        # call `MaxValueEntropySearch.compute_model_dependencies` once and
+        # call `MultiFidelityAcquisition.compute_model_dependencies` once.
+        depedencies = MultiFidelityMaxValueEntropySearch.compute_model_dependencies(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            target_fidelities=self.target_fidelities,
+        )
+        mock_MES_compute.assert_called_once()
+        mock_MF_compute.assert_called_once()
+        # `dependencies` should be combination of `MaxValueEntropySearch` dependencies
+        # and `MultiFidelityAcquisition` dependencies.
+        self.assertTrue(Keys.CANDIDATE_SET in depedencies)
+        self.assertTrue(Keys.MAXIMIZE in depedencies)
+        self.assertTrue(Keys.CURRENT_VALUE in depedencies)
+
+    @patch(f"{MES_PATH}.MaxValueEntropySearch.optimize")
+    def test_optimize(self, mock_MES_optimize):
+        self.acquisition = MultiFidelityMaxValueEntropySearch(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            botorch_acqf_class=self.botorch_acqf_class,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+        # `MultiFidelityMaxValueEntropySearch.optimize()` should call
+        # `MaxValueEntropySearch.optimize()` once.
+        self.acquisition.optimize(
+            bounds=self.bounds,
+            n=1,
+            optimizer_class=None,
+            inequality_constraints=self.inequality_constraints,
+            fixed_features=self.fixed_features,
+            rounding_func="func",
+            optimizer_options=self.optimizer_options,
+        )
+        mock_MES_optimize.assert_called_once()
+        mock_MES_optimize.assert_called_with(
+            bounds=self.bounds,
+            n=1,
+            optimizer_class=None,
+            inequality_constraints=self.inequality_constraints,
+            fixed_features=self.fixed_features,
+            rounding_func="func",
+            optimizer_options=self.optimizer_options,
+        )

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import ANY, patch
+
+import torch
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.kg import KnowledgeGradient
+from ax.models.torch.botorch_modular.mes import MaxValueEntropySearch
+from ax.models.torch.botorch_modular.model import (
+    BoTorchModel,
+    construct_acquisition_and_optimizer_options,
+)
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.testutils import TestCase
+from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
+from botorch.acquisition.max_value_entropy_search import qMaxValueEntropy
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.utils.containers import TrainingData
+
+
+CURRENT_PATH = f"{__name__}"
+MODEL_PATH = f"{BoTorchModel.__module__}"
+SURROGATE_PATH = f"{Surrogate.__module__}"
+
+
+class BoTorchModelTest(TestCase):
+    def setUp(self):
+        self.botorch_model_class = SingleTaskGP
+        self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
+        self.acquisition_class = KnowledgeGradient
+        self.acquisition_options = {"num_fantasies": 64}
+        self.model = BoTorchModel(
+            surrogate=self.surrogate,
+            acquisition_class=self.acquisition_class,
+            acquisition_options=self.acquisition_options,
+        )
+
+        self.Xs = [torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])]
+        self.Ys = [torch.tensor([[3.0], [4.0]])]
+        self.Yvars = [torch.tensor([[0.0], [2.0]])]
+        self.training_data = TrainingData(Xs=self.Xs, Ys=self.Ys, Yvars=self.Yvars)
+        self.bounds = [(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)]
+        self.task_features = []
+        self.feature_names = ["x1", "x2", "x3"]
+        self.metric_names = ["y"]
+        self.fidelity_features = [2]
+        self.target_fidelities = {1: 1.0}
+        self.candidate_metadata = []
+
+        self.optimizer_options = {"num_restarts": 40, "raw_samples": 1024}
+        self.model_gen_options = {"optimizer_kwargs": self.optimizer_options}
+        self.objective_weights = torch.tensor([1.0])
+        self.outcome_constraints = None
+        self.linear_constraints = None
+        self.fixed_features = None
+        self.pending_observations = None
+        self.rounding_func = "func"
+
+    def test_init(self):
+        # Default model with no specifications.
+        model = BoTorchModel()
+        self.assertEqual(model.acquisition_class, Acquisition)
+        with self.assertRaisesRegex(
+            ValueError, "`AcquisitionFunction` has not yet been set."
+        ):
+            model.botorch_acqf_class
+        # Model that specifies `botorch_acqf_class`.
+        model = BoTorchModel(botorch_acqf_class=qKnowledgeGradient)
+        self.assertEqual(model.acquisition_class, Acquisition)
+        self.assertEqual(model.botorch_acqf_class, qKnowledgeGradient)
+        # Model with `Acquisition` that specifies a `default_botorch_acqf_class`.
+        model = BoTorchModel(acquisition_class=MaxValueEntropySearch)
+        self.assertEqual(model.acquisition_class, MaxValueEntropySearch)
+        self.assertEqual(model.botorch_acqf_class, qMaxValueEntropy)
+
+    @patch(f"{SURROGATE_PATH}.Surrogate.fit")
+    def test_fit(self, mock_fit):
+        self.model.fit(
+            Xs=self.Xs,
+            Ys=self.Ys,
+            Yvars=self.Yvars,
+            bounds=self.bounds,
+            task_features=self.task_features,
+            feature_names=self.feature_names,
+            metric_names=self.metric_names,
+            fidelity_features=self.fidelity_features,
+            target_fidelities=self.target_fidelities,
+            candidate_metadata=self.candidate_metadata,
+        )
+        mock_fit.assert_called_with(
+            training_data=self.training_data,
+            bounds=self.bounds,
+            task_features=self.task_features,
+            feature_names=self.feature_names,
+            fidelity_features=self.fidelity_features,
+            target_fidelities=self.target_fidelities,
+            metric_names=self.metric_names,
+            candidate_metadata=self.candidate_metadata,
+            state_dict=None,
+            refit=True,
+        )
+
+    @patch(f"{SURROGATE_PATH}.Surrogate.predict")
+    def test_predict(self, mock_predict):
+        self.model.predict(X=self.Xs[0])
+        mock_predict.assert_called_with(X=self.Xs[0])
+
+    @patch(
+        f"{MODEL_PATH}.construct_acquisition_and_optimizer_options",
+        return_value=({"num_fantasies": 64}, {"num_restarts": 40, "raw_samples": 1024}),
+    )
+    @patch(f"{CURRENT_PATH}.KnowledgeGradient")
+    @patch(f"{MODEL_PATH}.get_rounding_func", return_value="func")
+    @patch(f"{MODEL_PATH}._to_inequality_constraints", return_value=[])
+    def test_gen(
+        self,
+        mock_inequality_constraints,
+        mock_rounding,
+        mock_kg,
+        mock_construct_options,
+    ):
+        mock_kg.return_value.optimize.return_value = (
+            torch.tensor([1.0]),
+            torch.tensor([2.0]),
+        )
+        model = BoTorchModel(
+            surrogate=self.surrogate,
+            acquisition_class=KnowledgeGradient,
+            acquisition_options=self.acquisition_options,
+        )
+        model.surrogate.construct(
+            training_data=self.training_data, fidelity_features=self.fidelity_features
+        )
+        model.gen(
+            n=1,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            pending_observations=self.pending_observations,
+            model_gen_options=self.model_gen_options,
+            rounding_func=self.rounding_func,
+            target_fidelities=self.target_fidelities,
+        )
+        # Assert `construct_acquisition_and_optimizer_options` called with kwargs
+        mock_construct_options.assert_called_with(
+            acqf_options=self.acquisition_options,
+            model_gen_options=self.model_gen_options,
+        )
+        # Assert `acquisition_class` called with kwargs
+        mock_kg.assert_called_with(
+            surrogate=self.surrogate,
+            botorch_acqf_class=model.botorch_acqf_class,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            target_fidelities=self.target_fidelities,
+            options=self.acquisition_options,
+        )
+        # Assert `optimize` called with kwargs
+        mock_kg.return_value.optimize.assert_called_with(
+            bounds=ANY,
+            n=1,
+            inequality_constraints=[],
+            fixed_features=self.fixed_features,
+            rounding_func="func",
+            optimizer_options=self.optimizer_options,
+        )
+
+    def test_construct_acquisition_and_optimizer_options(self):
+        # two dicts for `Acquisition` should be concatenated
+        acqf_options = {"num_fantasies": 64}
+
+        acquisition_function_kwargs = {"current_value": torch.tensor([1.0])}
+        optimizer_kwargs = {"num_restarts": 40, "raw_samples": 1024}
+        model_gen_options = {
+            "acquisition_function_kwargs": acquisition_function_kwargs,
+            "optimizer_kwargs": optimizer_kwargs,
+        }
+
+        (
+            final_acq_options,
+            final_opt_options,
+        ) = construct_acquisition_and_optimizer_options(
+            acqf_options=acqf_options, model_gen_options=model_gen_options
+        )
+        self.assertEqual(
+            final_acq_options,
+            {"num_fantasies": 64, "current_value": torch.tensor([1.0])},
+        )
+        self.assertEqual(final_opt_options, optimizer_kwargs)

--- a/ax/models/torch/tests/test_multi_fidelity.py
+++ b/ax/models/torch/tests/test_multi_fidelity.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import patch
+
+import torch
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.multi_fidelity import MultiFidelityAcquisition
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.testutils import TestCase
+from botorch.models.gp_regression import SingleTaskGP
+
+
+ACQUISITION_PATH = f"{Acquisition.__module__}"
+MULTI_FIDELITY_PATH = f"{MultiFidelityAcquisition.__module__}"
+
+
+class MultiFidelityAcquisitionTest(TestCase):
+    def setUp(self):
+
+        self.botorch_model_class = SingleTaskGP
+        self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
+
+        self.acquisition_options = {"num_fantasies": 64}
+        self.bounds = [(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)]
+        self.objective_weights = torch.tensor([1.0])
+        self.target_fidelities = {2: 1.0}
+        self.pending_observations = [
+            torch.tensor([[1.0, 3.0, 4.0]]),
+            torch.tensor([[2.0, 6.0, 8.0]]),
+        ]
+        self.outcome_constraints = (torch.tensor([[1.0]]), torch.tensor([[0.5]]))
+        self.linear_constraints = None
+        self.fixed_features = {1: 2.0}
+        self.options = {
+            "fidelity_weights": {2: 1.0},
+            "cost_intercept": 1.0,
+            "num_trace_observations": 0,
+        }
+
+    @patch(f"{ACQUISITION_PATH}.Acquisition.__init__", return_value=None)
+    @patch(f"{ACQUISITION_PATH}.Acquisition.optimize")
+    def test_optimize(self, mock_Acquisition_optimize, mock_Acquisition_init):
+        # `MultiFidelityAcquisition.optimize()` should call `Acquisition.optimize()`
+        # once.
+        self.acquisition = MultiFidelityAcquisition(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+        )
+        self.acquisition.optimize(bounds=self.bounds, n=1)
+        mock_Acquisition_optimize.assert_called_once()
+
+    @patch(f"{MULTI_FIDELITY_PATH}.AffineFidelityCostModel", return_value="cost_model")
+    @patch(f"{MULTI_FIDELITY_PATH}.InverseCostWeightedUtility", return_value=None)
+    def test_compute_model_dependencies(self, mock_inverse_utility, mock_affine_model):
+        # Raise Error if `fidelity_weights` and `target_fidelities` do
+        # not align.
+        with self.assertRaisesRegex(RuntimeError, "Must provide the same indices"):
+            MultiFidelityAcquisition.compute_model_dependencies(
+                surrogate=self.surrogate,
+                bounds=self.bounds,
+                objective_weights=self.objective_weights,
+                target_fidelities={1: 5.0},
+                pending_observations=self.pending_observations,
+                outcome_constraints=self.outcome_constraints,
+                linear_constraints=self.linear_constraints,
+                fixed_features=self.fixed_features,
+                options=self.options,
+            )
+
+        dependencies = MultiFidelityAcquisition.compute_model_dependencies(
+            surrogate=self.surrogate,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            target_fidelities=self.target_fidelities,
+            pending_observations=self.pending_observations,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=self.fixed_features,
+            options=self.options,
+        )
+        mock_affine_model.assert_called_with(
+            fidelity_weights=self.options["fidelity_weights"],
+            fixed_cost=self.options["cost_intercept"],
+        )
+        mock_inverse_utility.assert_called_with(cost_model="cost_model")
+        self.assertTrue("cost_aware_utility" in dependencies)
+        self.assertTrue("project" in dependencies)
+        self.assertTrue("expand" in dependencies)

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import patch
+
+import torch
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.testutils import TestCase
+from botorch.acquisition.monte_carlo import qSimpleRegret
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.model import Model, TrainingData
+from botorch.sampling.samplers import SobolQMCNormalSampler
+from gpytorch.kernels import Kernel
+from gpytorch.likelihoods.likelihood import Likelihood
+from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+
+
+ACQUISITION_PATH = f"{Acquisition.__module__}"
+CURRENT_PATH = f"{__name__}"
+SURROGATE_PATH = f"{Surrogate.__module__}"
+
+
+class SurrogateTest(TestCase):
+    def setUp(self):
+        self.botorch_model_class = SingleTaskGP
+        self.mll_class = ExactMarginalLogLikelihood
+        self.device = torch.device("cpu")
+        self.dtype = torch.float
+        self.Xs = [
+            torch.tensor(
+                [[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], dtype=self.dtype, device=self.device
+            )
+        ]
+        self.Ys = [torch.tensor([[3.0], [4.0]], dtype=self.dtype, device=self.device)]
+        self.Yvars = [
+            torch.tensor([[0.0], [2.0]], dtype=self.dtype, device=self.device)
+        ]
+        self.training_data = TrainingData(Xs=self.Xs, Ys=self.Ys, Yvars=self.Yvars)
+        self.surrogate_kwargs = self.botorch_model_class.construct_inputs(
+            self.training_data
+        )
+        self.surrogate = Surrogate(
+            botorch_model_class=self.botorch_model_class, mll_class=self.mll_class
+        )
+        self.bounds = [(0.0, 1.0), (1.0, 4.0), (2.0, 5.0)]
+        self.task_features = []
+        self.feature_names = ["x1", "x2", "x3"]
+        self.metric_names = ["y"]
+        self.fidelity_features = []
+        self.target_fidelities = {1: 1.0}
+        self.fixed_features = {1: 2.0}
+        self.refit = True
+        self.objective_weights = torch.tensor(
+            [-1.0, 1.0], dtype=self.dtype, device=self.device
+        )
+        self.outcome_constraints = (torch.tensor([[1.0]]), torch.tensor([[0.5]]))
+        self.linear_constraints = (
+            torch.tensor([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+            torch.tensor([[0.5], [1.0]]),
+        )
+        self.options = {}
+
+    @patch(f"{CURRENT_PATH}.Kernel")
+    @patch(f"{CURRENT_PATH}.Likelihood")
+    def test_init(self, mock_Likelihood, mock_Kernel):
+        self.assertEqual(self.surrogate.botorch_model_class, self.botorch_model_class)
+        self.assertEqual(self.surrogate.mll_class, self.mll_class)
+        with self.assertRaisesRegex(NotImplementedError, "Customizing likelihood"):
+            Surrogate(
+                botorch_model_class=self.botorch_model_class, likelihood=Likelihood()
+            )
+        with self.assertRaisesRegex(NotImplementedError, "Customizing kernel"):
+            Surrogate(
+                botorch_model_class=self.botorch_model_class, kernel_class=Kernel()
+            )
+
+    def test_model_property(self):
+        with self.assertRaisesRegex(
+            ValueError, "BoTorch `Model` has not yet been constructed."
+        ):
+            self.surrogate.model
+
+    def test_training_data_property(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Underlying BoTorch `Model` has not yet received its training_data.",
+        ):
+            self.surrogate.training_data
+
+    def test_from_BoTorch(self):
+        surrogate = Surrogate.from_BoTorch(
+            self.botorch_model_class(**self.surrogate_kwargs)
+        )
+        self.assertIsInstance(surrogate.model, self.botorch_model_class)
+        self.assertFalse(surrogate._should_reconstruct)
+
+    @patch(f"{CURRENT_PATH}.SingleTaskGP.__init__", return_value=None)
+    def test_construct(self, mock_GP):
+        base_surrogate = Surrogate(botorch_model_class=Model)
+        with self.assertRaisesRegex(TypeError, "Cannot construct an abstract model."):
+            base_surrogate.construct(
+                training_data=self.training_data,
+                fidelity_features=self.fidelity_features,
+            )
+        self.surrogate.construct(
+            training_data=self.training_data, fidelity_features=self.fidelity_features
+        )
+        mock_GP.assert_called_with(train_X=self.Xs[0], train_Y=self.Ys[0])
+
+    @patch(f"{CURRENT_PATH}.SingleTaskGP.load_state_dict", return_value=None)
+    @patch(f"{CURRENT_PATH}.ExactMarginalLogLikelihood")
+    @patch(f"{SURROGATE_PATH}.fit_gpytorch_model")
+    def test_fit(self, mock_fit_gpytorch, mock_MLL, mock_state_dict):
+        surrogate = Surrogate(
+            botorch_model_class=self.botorch_model_class,
+            mll_class=ExactMarginalLogLikelihood,
+        )
+        # Checking that model is None before `fit` (and `construct`) calls.
+        self.assertIsNone(surrogate._model)
+        # Should instantiate mll and `fit_gpytorch_model` when `state_dict`
+        # is `None`.
+        surrogate.fit(
+            training_data=self.training_data,
+            bounds=self.bounds,
+            task_features=self.task_features,
+            feature_names=self.feature_names,
+            metric_names=self.metric_names,
+            fidelity_features=self.fidelity_features,
+            target_fidelities=self.target_fidelities,
+            refit=self.refit,
+        )
+        mock_state_dict.assert_not_called()
+        mock_MLL.assert_called_once()
+        mock_fit_gpytorch.assert_called_once()
+        mock_state_dict.reset_mock()
+        mock_MLL.reset_mock()
+        mock_fit_gpytorch.reset_mock()
+        # Should `load_state_dict` when `state_dict` is not `None`
+        # and `refit` is `False`.
+        state_dict = {}
+        surrogate.fit(
+            training_data=self.training_data,
+            bounds=self.bounds,
+            task_features=self.task_features,
+            feature_names=self.feature_names,
+            metric_names=self.metric_names,
+            fidelity_features=self.fidelity_features,
+            target_fidelities=self.target_fidelities,
+            refit=False,
+            state_dict=state_dict,
+        )
+        mock_state_dict.assert_called_once()
+        mock_MLL.assert_not_called()
+        mock_fit_gpytorch.assert_not_called()
+
+    @patch(f"{SURROGATE_PATH}.predict_from_model")
+    def test_predict(self, mock_predict):
+        self.surrogate.construct(
+            training_data=self.training_data, fidelity_features=self.fidelity_features
+        )
+        self.surrogate.predict(X=self.Xs[0])
+        mock_predict.assert_called_with(model=self.surrogate.model, X=self.Xs[0])
+
+    def test_best_in_sample_point(self):
+        self.surrogate.construct(
+            training_data=self.training_data, fidelity_features=self.fidelity_features
+        )
+        # `best_in_sample_point` requires `objective_weights`
+        with patch(
+            f"{SURROGATE_PATH}.best_in_sample_point", return_value=None
+        ) as mock_best_in_sample:
+            with self.assertRaisesRegex(ValueError, "Could not obtain"):
+                self.surrogate.best_in_sample_point(
+                    bounds=self.bounds, objective_weights=None
+                )
+        with patch(
+            f"{SURROGATE_PATH}.best_in_sample_point", return_value=(self.Xs[0], 0.0)
+        ) as mock_best_in_sample:
+            best_point, observed_value = self.surrogate.best_in_sample_point(
+                bounds=self.bounds,
+                objective_weights=self.objective_weights,
+                outcome_constraints=self.outcome_constraints,
+                linear_constraints=self.linear_constraints,
+                fixed_features=self.fixed_features,
+                options=self.options,
+            )
+            mock_best_in_sample.assert_called_with(
+                Xs=self.training_data.Xs,
+                model=self.surrogate,
+                bounds=self.bounds,
+                objective_weights=self.objective_weights,
+                outcome_constraints=self.outcome_constraints,
+                linear_constraints=self.linear_constraints,
+                fixed_features=self.fixed_features,
+                options=self.options,
+            )
+
+    @patch(f"{ACQUISITION_PATH}.Acquisition.__init__", return_value=None)
+    @patch(
+        f"{ACQUISITION_PATH}.Acquisition.optimize",
+        return_value=([torch.tensor([0.0])], [torch.tensor([1.0])]),
+    )
+    @patch(
+        f"{SURROGATE_PATH}.pick_best_out_of_sample_point_acqf_class",
+        return_value=(qSimpleRegret, {"sampler": SobolQMCNormalSampler}),
+    )
+    def test_best_out_of_sample_point(
+        self, mock_best_point_util, mock_acqf_optimize, mock_acqf_init
+    ):
+        self.surrogate.construct(
+            training_data=self.training_data, fidelity_features=self.fidelity_features
+        )
+        # currently cannot use function with fixed features
+        with self.assertRaisesRegex(NotImplementedError, "Fixed features"):
+            self.surrogate.best_out_of_sample_point(
+                bounds=self.bounds,
+                objective_weights=self.objective_weights,
+                fixed_features=self.fixed_features,
+            )
+        candidate, acqf_value = self.surrogate.best_out_of_sample_point(
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fidelity_features=self.fidelity_features,
+            target_fidelities=self.target_fidelities,
+            options=self.options,
+        )
+        mock_acqf_init.assert_called_with(
+            surrogate=self.surrogate,
+            botorch_acqf_class=qSimpleRegret,
+            bounds=self.bounds,
+            objective_weights=self.objective_weights,
+            outcome_constraints=self.outcome_constraints,
+            linear_constraints=self.linear_constraints,
+            fixed_features=None,
+            target_fidelities=self.target_fidelities,
+            options={"sampler": SobolQMCNormalSampler},
+        )
+        self.assertTrue(torch.equal(candidate, torch.tensor([0.0])))
+        self.assertTrue(torch.equal(acqf_value, torch.tensor([1.0])))
+
+    @patch(f"{SURROGATE_PATH}.Surrogate.fit")
+    def test_update(self, mock_fit):
+        self.surrogate.construct(
+            training_data=self.training_data, fidelity_features=self.fidelity_features
+        )
+        # Call `fit` by default
+        self.surrogate.update(
+            training_data=self.training_data,
+            bounds=self.bounds,
+            task_features=self.task_features,
+            feature_names=self.feature_names,
+            metric_names=self.metric_names,
+            fidelity_features=self.fidelity_features,
+            refit=self.refit,
+        )
+        mock_fit.assert_called_with(
+            training_data=self.training_data,
+            bounds=self.bounds,
+            task_features=self.task_features,
+            feature_names=self.feature_names,
+            metric_names=self.metric_names,
+            fidelity_features=self.fidelity_features,
+            candidate_metadata=None,
+            state_dict=self.surrogate.model.state_dict,
+            refit=self.refit,
+        )
+        # If should not be reconstructed, raise Error
+        self.surrogate._should_reconstruct = False
+        with self.assertRaisesRegex(
+            NotImplementedError, ".* models that should not be re-constructed"
+        ):
+            self.surrogate.update(
+                training_data=self.training_data,
+                bounds=self.bounds,
+                task_features=self.task_features,
+                feature_names=self.feature_names,
+                metric_names=self.metric_names,
+                fidelity_features=self.fidelity_features,
+                refit=self.refit,
+            )

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from ax.models.torch.botorch_modular.utils import choose_mll_class, choose_model_class
+from ax.utils.common.testutils import TestCase
+from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
+from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
+from botorch.models.model_list_gp_regression import ModelListGP
+from botorch.utils.containers import TrainingData
+from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
+
+
+class UtilsTest(TestCase):
+    def test_choose_model_class(self):
+        self.Xs = [torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])]
+        self.Ys = [torch.tensor([[3.0], [4.0]])]
+        self.Yvars = [torch.tensor([[0.0], [2.0]])]
+        self.training_data = TrainingData(Xs=self.Xs, Ys=self.Ys, Yvars=self.Yvars)
+        self.task_features = []
+        # Task features is not implemented yet
+        with self.assertRaisesRegex(
+            NotImplementedError, "Currently do not support `task_features`!"
+        ):
+            choose_model_class(
+                training_data=self.training_data,
+                task_features=[1],
+                fidelity_features=[],
+            )
+        # Only a single fidelity feature can be used
+        with self.assertRaisesRegex(
+            NotImplementedError, ".* only a single fidelity parameter!"
+        ):
+            choose_model_class(
+                training_data=self.training_data,
+                task_features=self.task_features,
+                fidelity_features=[1, 2],
+            )
+        # Yvars is not all nan
+        self.assertEqual(
+            SingleTaskMultiFidelityGP,
+            choose_model_class(
+                training_data=self.training_data,
+                task_features=self.task_features,
+                fidelity_features=[2],
+            ),
+        )
+        self.assertEqual(
+            FixedNoiseGP,
+            choose_model_class(
+                training_data=self.training_data,
+                task_features=self.task_features,
+                fidelity_features=[],
+            ),
+        )
+        # Yvars is all nan
+        self.Yvars = [torch.tensor([[float("nan")], [float("nan")]])]
+        self.training_data = TrainingData(Xs=self.Xs, Ys=self.Ys, Yvars=self.Yvars)
+        self.assertEqual(
+            SingleTaskGP,
+            choose_model_class(
+                training_data=self.training_data,
+                task_features=self.task_features,
+                fidelity_features=[],
+            ),
+        )
+
+    def test_choose_mll_class(self):
+        self.assertEqual(
+            SumMarginalLogLikelihood,
+            choose_mll_class(model_class=ModelListGP, state_dict=None, refit=True),
+        )
+        self.assertEqual(
+            ExactMarginalLogLikelihood,
+            choose_mll_class(model_class=SingleTaskGP, state_dict=None, refit=True),
+        )

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, Type
+
+# Ax `Acquisition` imports
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.kg import (
+    KnowledgeGradient,
+    MultiFidelityKnowledgeGradient,
+)
+from ax.models.torch.botorch_modular.mes import (
+    MaxValueEntropySearch,
+    MultiFidelityMaxValueEntropySearch,
+)
+
+# BoTorch `AcquisitionFunction` imports
+from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.knowledge_gradient import (
+    qKnowledgeGradient,
+    qMultiFidelityKnowledgeGradient,
+)
+from botorch.acquisition.max_value_entropy_search import (
+    qMaxValueEntropy,
+    qMultiFidelityMaxValueEntropy,
+)
+from botorch.acquisition.monte_carlo import (
+    qExpectedImprovement,
+    qNoisyExpectedImprovement,
+)
+
+# BoTorch `Model` imports
+from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
+from botorch.models.gp_regression_fidelity import (
+    FixedNoiseMultiFidelityGP,
+    SingleTaskMultiFidelityGP,
+)
+from botorch.models.model import Model
+
+# BoTorch `MarginalLogLikelihood` imports
+from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
+
+
+# NOTE: When adding a new registry for a class, make sure to make changes
+# to `CLASS_TO_REGISTRY` and `CLASS_TO_REVERSE_REGISTRY` in this file.
+
+"""
+Mapping of modular Ax `Acquisition` classes to ints.
+"""
+ACQUISITION_REGISTRY: Dict[Type[Acquisition], int] = {
+    Acquisition: 0,
+    KnowledgeGradient: 1,
+    MultiFidelityKnowledgeGradient: 2,
+    MaxValueEntropySearch: 3,
+    MultiFidelityMaxValueEntropySearch: 4,
+}
+
+
+"""
+Mapping of BoTorch `Model` classes to ints.
+"""
+MODEL_REGISTRY: Dict[Type[Model], int] = {
+    FixedNoiseGP: 0,
+    SingleTaskGP: 1,
+    FixedNoiseMultiFidelityGP: 2,
+    SingleTaskMultiFidelityGP: 3,
+}
+
+
+"""
+Mapping of Botorch `AcquisitionFunction` classes to ints.
+"""
+ACQUISITION_FUNCTION_REGISTRY: Dict[Type[AcquisitionFunction], int] = {
+    qExpectedImprovement: 0,
+    qNoisyExpectedImprovement: 1,
+    qKnowledgeGradient: 2,
+    qMultiFidelityKnowledgeGradient: 3,
+    qMaxValueEntropy: 4,
+    qMultiFidelityMaxValueEntropy: 5,
+}
+
+
+"""
+Mapping of BoTorch `MarginalLogLikelihood` classes to ints.
+"""
+MLL_REGISTRY: Dict[Type[MarginalLogLikelihood], int] = {ExactMarginalLogLikelihood: 0}
+
+
+"""
+Overarching mapping from encoded classes to registry map.
+"""
+CLASS_TO_REGISTRY: Dict[Any, Dict[Type[Any], int]] = {
+    Acquisition: ACQUISITION_REGISTRY,
+    AcquisitionFunction: ACQUISITION_FUNCTION_REGISTRY,
+    MarginalLogLikelihood: MLL_REGISTRY,
+    Model: MODEL_REGISTRY,
+}
+
+
+"""
+Reverse registries for decoding.
+"""
+REVERSE_ACQUISITION_REGISTRY: Dict[int, Type[Acquisition]] = {
+    v: k for k, v in ACQUISITION_REGISTRY.items()
+}
+
+
+REVERSE_MODEL_REGISTRY: Dict[int, Type[Model]] = {
+    v: k for k, v in MODEL_REGISTRY.items()
+}
+
+
+REVERSE_ACQUISITION_FUNCTION_REGISTRY: Dict[int, Type[AcquisitionFunction]] = {
+    v: k for k, v in ACQUISITION_FUNCTION_REGISTRY.items()
+}
+
+
+REVERSE_MLL_REGISTRY: Dict[int, Type[MarginalLogLikelihood]] = {
+    v: k for k, v in MLL_REGISTRY.items()
+}
+
+
+"""
+Overarching mapping from encoded classes to reverse registry map.
+"""
+CLASS_TO_REVERSE_REGISTRY: Dict[Any, Dict[int, Type[Any]]] = {
+    Acquisition: REVERSE_ACQUISITION_REGISTRY,
+    AcquisitionFunction: REVERSE_ACQUISITION_FUNCTION_REGISTRY,
+    MarginalLogLikelihood: REVERSE_MLL_REGISTRY,
+    Model: REVERSE_MODEL_REGISTRY,
+}

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -14,6 +14,7 @@ from ax.core.generator_run import GeneratorRun
 from ax.core.runner import Runner
 from ax.core.trial import Trial
 from ax.modelbridge.transforms.base import Transform
+from ax.storage.botorch_modular_registry import CLASS_TO_REVERSE_REGISTRY
 from ax.storage.transform_registry import REVERSE_TRANSFORM_REGISTRY
 
 
@@ -129,3 +130,21 @@ def transform_type_from_json(object_json: Dict[str, Any]) -> Type[Transform]:
     if index_in_registry not in REVERSE_TRANSFORM_REGISTRY:  # pragma: no cover
         raise ValueError(f"Unknown transform '{object_json.pop('transform_type')}'")
     return REVERSE_TRANSFORM_REGISTRY[index_in_registry]
+
+
+def class_from_json(json: Dict[str, Any]) -> Type[Any]:
+    """Load any class registered in `CLASS_DECODER_REGISTRY` from JSON."""
+    index_in_registry = json.pop("index")
+    class_path = json.pop("class")
+    for _class in CLASS_TO_REVERSE_REGISTRY:
+        if class_path == f"{_class}":
+            reverse_registry = CLASS_TO_REVERSE_REGISTRY[_class]
+            if index_in_registry not in reverse_registry:  # pragma: no cover
+                raise ValueError(
+                    f"'{class_path}' is not registered in the reverse registry."
+                )
+            return reverse_registry[index_in_registry]
+    raise ValueError(
+        f"{class_path} does not have a corresponding entry in "
+        "CLASS_TO_REVERSE_REGISTRY."
+    )

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -43,12 +43,17 @@ from ax.metrics.noisy_function import NoisyFunctionMetric
 from ax.modelbridge.factory import Models
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.transforms.base import Transform
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.model import BoTorchModel
+from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.runners.synthetic import SyntheticRunner
-from ax.storage.json_store.decoders import transform_type_from_json
+from ax.storage.json_store.decoders import class_from_json, transform_type_from_json
 from ax.storage.json_store.encoders import (
     arm_to_dict,
     batch_to_dict,
     benchmark_problem_to_dict,
+    botorch_model_to_dict,
+    botorch_modular_to_dict,
     choice_parameter_to_dict,
     data_to_dict,
     experiment_to_dict,
@@ -71,10 +76,14 @@ from ax.storage.json_store.encoders import (
     search_space_to_dict,
     simple_experiment_to_dict,
     sum_parameter_constraint_to_dict,
+    surrogate_to_dict,
     transform_type_to_dict,
     trial_to_dict,
 )
 from ax.storage.utils import DomainType, ParameterConstraintType
+from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.models.model import Model
+from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 
 
 ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
@@ -83,6 +92,7 @@ ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     AugmentedHartmann6Metric: metric_to_dict,
     BatchTrial: batch_to_dict,
     BenchmarkProblem: benchmark_problem_to_dict,
+    BoTorchModel: botorch_model_to_dict,
     BraninMetric: metric_to_dict,
     ChoiceParameter: choice_parameter_to_dict,
     Data: data_to_dict,
@@ -110,6 +120,7 @@ ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     SimpleBenchmarkProblem: benchmark_problem_to_dict,
     SimpleExperiment: simple_experiment_to_dict,
     SumConstraint: sum_parameter_constraint_to_dict,
+    Surrogate: surrogate_to_dict,
     SyntheticRunner: runner_to_dict,
     Trial: trial_to_dict,
     ObservationFeatures: observation_features_to_dict,
@@ -120,7 +131,11 @@ ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
 # The encoder iterates through this dictionary and uses the first superclass that
 # it finds, which might not be the intended superclass.
 CLASS_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
-    Transform: transform_type_to_dict
+    Acquisition: botorch_modular_to_dict,
+    AcquisitionFunction: botorch_modular_to_dict,
+    MarginalLogLikelihood: botorch_modular_to_dict,
+    Model: botorch_modular_to_dict,
+    Transform: transform_type_to_dict,
 }
 
 DECODER_REGISTRY: Dict[str, Type] = {
@@ -131,6 +146,7 @@ DECODER_REGISTRY: Dict[str, Type] = {
     "BatchTrial": BatchTrial,
     "BenchmarkProblem": BenchmarkProblem,
     "BenchmarkResult": BenchmarkResult,
+    "BoTorchModel": BoTorchModel,
     "BraninMetric": BraninMetric,
     "ChoiceParameter": ChoiceParameter,
     "ComparisonOp": ComparisonOp,
@@ -164,6 +180,7 @@ DECODER_REGISTRY: Dict[str, Type] = {
     "SimpleBenchmarkProblem": SimpleBenchmarkProblem,
     "SimpleExperiment": SimpleExperiment,
     "SumConstraint": SumConstraint,
+    "Surrogate": Surrogate,
     "SyntheticRunner": SyntheticRunner,
     "Trial": Trial,
     "TrialStatus": TrialStatus,
@@ -173,5 +190,9 @@ DECODER_REGISTRY: Dict[str, Type] = {
 
 # Registry for class types, not instances.
 CLASS_DECODER_REGISTRY: Dict[str, Callable[[Dict[str, Any]], Any]] = {
-    "Type[Transform]": transform_type_from_json
+    "Type[Acquisition]": class_from_json,
+    "Type[AcquisitionFunction]": class_from_json,
+    "Type[MarginalLogLikelihood]": class_from_json,
+    "Type[Model]": class_from_json,
+    "Type[Transform]": transform_type_from_json,
 }

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -35,10 +35,14 @@ from ax.utils.testing.benchmark_stubs import (
     get_sum_simple_benchmark_problem,
 )
 from ax.utils.testing.core_stubs import (
+    get_acquisition_function_type,
+    get_acquisition_type,
     get_arm,
     get_augmented_branin_metric,
     get_augmented_hartmann_metric,
     get_batch_trial,
+    get_botorch_model,
+    get_botorch_model_with_default_acquisition_class,
     get_branin_data,
     get_branin_experiment,
     get_branin_metric,
@@ -50,6 +54,8 @@ from ax.utils.testing.core_stubs import (
     get_generator_run,
     get_hartmann_metric,
     get_metric,
+    get_mll_type,
+    get_model_type,
     get_multi_objective,
     get_multi_type_experiment,
     get_objective,
@@ -63,6 +69,7 @@ from ax.utils.testing.core_stubs import (
     get_simple_experiment_with_batch_trial,
     get_sum_constraint1,
     get_sum_constraint2,
+    get_surrogate,
     get_synthetic_runner,
     get_trial,
 )
@@ -80,6 +87,11 @@ TEST_CASES = [
     ("AugmentedHartmannMetric", get_augmented_hartmann_metric),
     ("BatchTrial", get_batch_trial),
     ("BenchmarkProblem", get_branin_benchmark_problem),
+    ("BoTorchModel", get_botorch_model),
+    (
+        "BoTorchModelWithDefaultAcquisitionClass",
+        get_botorch_model_with_default_acquisition_class,
+    ),
     ("BraninMetric", get_branin_metric),
     ("ChoiceParameter", get_choice_parameter),
     ("Experiment", get_experiment_with_batch_and_single_trial),
@@ -107,7 +119,12 @@ TEST_CASES = [
     ("SimpleExperiment", get_simple_experiment_with_batch_trial),
     ("SumConstraint", get_sum_constraint1),
     ("SumConstraint", get_sum_constraint2),
+    ("Surrogate", get_surrogate),
     ("SyntheticRunner", get_synthetic_runner),
+    ("Type[Acquisition]", get_acquisition_type),
+    ("Type[AcquisitionFunction]", get_acquisition_function_type),
+    ("Type[Model]", get_model_type),
+    ("Type[MarginalLogLikelihood]", get_mll_type),
     ("Type[Transform]", get_transform_type),
     ("Trial", get_trial),
 ]
@@ -177,6 +194,37 @@ ENCODE_DECODE_FIELD_MAPS = {
     ),
     "Trial": EncodeDecodeFieldsMap(
         python_only=["experiment"], python_to_encoded={"BaseTrial__status": "status"}
+    ),
+    "Type[Acquisition]": EncodeDecodeFieldsMap(
+        python_only=["_module__", "_doc__", "default_botorch_acqf_class"],
+        encoded_only=["index", "class"],
+    ),
+    "Type[AcquisitionFunction]": EncodeDecodeFieldsMap(
+        python_only=[
+            "_module__",
+            "_doc__",
+            "_init__",
+            "_abstractmethods__",
+            "forward",
+            "abc_impl",
+        ],
+        encoded_only=["index", "class"],
+    ),
+    "Type[Model]": EncodeDecodeFieldsMap(
+        python_only=[
+            "_module__",
+            "_doc__",
+            "_init__",
+            "_abstractmethods__",
+            "forward",
+            "construct_inputs",
+            "abc_impl",
+        ],
+        encoded_only=["index", "class"],
+    ),
+    "Type[MarginalLogLikelihood]": EncodeDecodeFieldsMap(
+        python_only=["_module__", "_doc__", "_init__", "forward", "pyro_factor"],
+        encoded_only=["index", "class"],
     ),
     "Type[Transform]": EncodeDecodeFieldsMap(
         python_only=[
@@ -278,6 +326,10 @@ class JSONStoreTest(TestCase):
                 for python, encoded in map.python_to_encoded.items():
                     json_keys.remove(encoded)
                     json_keys.add(python)
+            # TODO: Remove this check if able. `_slotnames__` is not a class attribute
+            # when testing locally, but it is a class attribute on Travis.
+            if class_ == "Type[Model]":
+                object_keys.discard("_slotnames__")
             self.assertEqual(
                 object_keys,
                 json_keys,

--- a/sphinx/source/storage.rst
+++ b/sphinx/source/storage.rst
@@ -177,6 +177,11 @@ ax.storage.sqa\_store.validation module
 Registries
 -----------------
 
+.. automodule:: ax.storage.botorch_modular_registry
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. automodule:: ax.storage.metric_registry
     :members:
     :undoc-members:

--- a/tutorials/botorch_modular.ipynb
+++ b/tutorials/botorch_modular.ipynb
@@ -1,0 +1,628 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "59a44903-3946-4c41-abc4-1c915eefeac4",
+        "showInput": false
+      },
+      "source": [
+        "# Tutorial notebook for modular `BoTorchModel` customization\n",
+        "\n",
+        "NOTE: The functionality in this tutorial is still in its alpha stages.\n",
+        "\n",
+        "Contents:\n",
+        "1. Overview of modular `BoTorchModel`\n",
+        "2. `BoTorchModel` instantiation\n",
+        "3. Use a custom BoTorch `AcquisitionFunction`\n",
+        "  1. [Path 1] Use the default Ax `Acquisition` class\n",
+        "  2. [Path 2] Create a custom Ax `Acquisition` subclass\n",
+        "  3. Set up storage for the new setup\n",
+        "4. Details of `BoTorchModel` Subcomponent Classes"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "collapsed": true,
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "701d6c9c-506c-43b8-b065-18b2a1f39271",
+        "showInput": false
+      },
+      "source": [
+        "# Overview of modular `BoTorchModel`\n",
+        "\n",
+        "**`BoTorchModel` = `Surrogate` + `Acquisition`**\n",
+        "\n",
+        "A `BoTorchModel` consists of two main subcomponents: a surrogate model and an acquisition function. A surrogate model is represented as an instance of Ax’s `Surrogate` class, a wrapper around the BoTorch `Model` [TODO: add links to both]. The acquisition function is represented as an instance of Ax’s `Acquisition` class, a wrapper around the BoTorch `AcquisitionFunction` [TODO: add links to both]. These two subcomponents are described in greater detail at the bottom of this tutorial.\n",
+        "\n",
+        "**Core methods of BoTorchmodel:** <br>\n",
+        "`fit` calls `Surrogate.fit` <br>\n",
+        "`predict` calls `Surrogate.predict` <br>\n",
+        "`gen` calls `Acquisition.optimize`"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "b6eaa943-3dbc-4f4a-b994-1e9d5d418bfa",
+        "showInput": false
+      },
+      "source": [
+        "# `BoTorchModel` instantiation"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 36,
+      "metadata": {
+        "code_folding": [],
+        "hidden_ranges": [],
+        "originalKey": "12d1d68e-b74b-455d-aeb9-ed9542db38c3"
+      },
+      "outputs": [],
+      "source": [
+        "from ax.models.torch.botorch_modular.acquisition import Acquisition\n",
+        "from ax.models.torch.botorch_modular.kg import KnowledgeGradient\n",
+        "from ax.models.torch.botorch_modular.model import BoTorchModel\n",
+        "from ax.models.torch.botorch_modular.surrogate import Surrogate\n",
+        "from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP\n",
+        "\n",
+        "# Explicit instantiation of `BoTorchModel`.\n",
+        "model = BoTorchModel(\n",
+        "    surrogate=Surrogate(FixedNoiseGP),\n",
+        "    acquisition_class=KnowledgeGradient,     # This is a subclass of `Acquisition`.\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "b915025a-8153-4f42-ae50-c3621dccb1b5",
+        "showInput": false
+      },
+      "source": [
+        "If `surrogate` and/or `acquisition_class` are not passed into the constructor, then they will auto-selected based on properties of the experiment, search space, and the data available for it."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 37,
+      "metadata": {
+        "code_folding": [],
+        "hidden_ranges": [],
+        "originalKey": "034b0bac-e8ea-4519-9e03-54ffec9555f8"
+      },
+      "outputs": [],
+      "source": [
+        "# The surrogate is not specified, so it will be auto-selected during `model.fit`.\n",
+        "model = BoTorchModel(\n",
+        "    acquisition_class=KnowledgeGradient\n",
+        ")\n",
+        "\n",
+        "# The acquisition class is not specified, so it will be auto-selected during `model.gen`.\n",
+        "model = BoTorchModel(\n",
+        "    surrogate=Surrogate(FixedNoiseGP)\n",
+        ")\n",
+        "\n",
+        "# Both the surrogate and acquisition class will be auto-selected.\n",
+        "model = BoTorchModel()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "581a5223-211f-4feb-abeb-57426cd55019",
+        "showInput": false
+      },
+      "source": [
+        "To use `ExpectedImprovement` and `NoisyExpectedImprovement`, initialize the `BoTorchModel` with the kwarg `botorch_acqf_class` instead of `acquisition_class`. By default, `acquisition_class` will be set to the base Ax `Acquisition` class."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 38,
+      "metadata": {
+        "code_folding": [],
+        "hidden_ranges": [],
+        "originalKey": "9ff9184e-50bf-404a-9b12-fa1ee9bd659c"
+      },
+      "outputs": [],
+      "source": [
+        "from botorch.acquisition.monte_carlo import qExpectedImprovement\n",
+        "from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement\n",
+        "\n",
+        "EI_model = BoTorchModel(\n",
+        "    surrogate=Surrogate(FixedNoiseGP),\n",
+        "    botorch_acqf_class=qExpectedImprovement\n",
+        ")\n",
+        "NEI_model = BoTorchModel(\n",
+        "    surrogate=Surrogate(SingleTaskGP),\n",
+        "    botorch_acqf_class=qNoisyExpectedImprovement\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "0dfbc6b9-55bc-46de-8885-827e435a6f1a",
+        "showInput": false
+      },
+      "source": [
+        "# Use a Custom BoTorch `AcquisitionFunction`"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "b668732c-3a5b-48c3-b2e0-36fe9a61aefa",
+        "showInput": false
+      },
+      "source": [
+        "## Choose between the default Ax `Acquisition` class and creating a custom `Acquisition` subclass \n",
+        "In many cases, even when you want to use a custom BoTorch `AcquisitionFunction`, the default Ax `Acquisition` class may be enough **[Path 1]**. A custom Ax `Acquisition` subclass **[Path 2]** will be needed only if:\n",
+        "\n",
+        "- a custom acquisition function optimization method is required\n",
+        "- a custom “model dependency” is required, where a “model dependency” is defined as any value that is computed based on the state or properties of the `Surrogate` model and needs to be passed into the constructor for the `AcquisitionFunction`"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "ae275edd-8e58-4f97-af53-726248693e84",
+        "showInput": false
+      },
+      "source": [
+        "## [Path 1] Use the default Ax `Acquisition` class\n",
+        "\n",
+        "Construct your model in the same way that `ExpectedImprovement` and `NoisyExpectedImprovement` are constructed above. Then, if you want to set up storage for the model, skip to after **[Path 2]**."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "55a556f1-d073-4663-842a-975612679510",
+        "showInput": false
+      },
+      "source": [
+        "## [Path 2] Create a custom Ax `Acquisition` subclass\n",
+        "\n",
+        "To start, here is the inheritance tree for the `KnowledgeGradient` and `MultiFidelityKnowledgeGradient` subclasses. \n",
+        "\n",
+        "`Acquisition` <br>\n",
+        "↳  `MultiFidelityAcquisition(Acquisition)` <br>\n",
+        "↳  `KnowledgeGradient(Acquisition)` <br>\n",
+        "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;↳  `MultiFidelityKnowledgeGradient(MultiFidelityAcquisition, KnowledgeGradient)` <br>\n",
+        "↳  `MyAcquisition(Acquisition)`    **← your new subclass**\n",
+        "\n",
+        "The `Acquisition` class defines a default `optimize` function and `compute_model_dependencies` function. <br>\n",
+        "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\n",
+        "**`optimize`**: makes a call to `botorch.optim.optimize.optimize_acqf` with a specific set of kwargs specified by this function. <br>\n",
+        "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\n",
+        "**`compute_model_dependencies`**: returns a dict of inputs to the BoTorch `AcquisitionFunction`.\n",
+        "\n",
+        "Creating a custom `Acquisition` subclass involves overriding either (or both) of these two functions."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "dd019da9-0796-43ea-83f4-9d10008ba191",
+        "showInput": false
+      },
+      "source": [
+        "First, create the structure for your `Acquisition` subclass. Each `Acquisition` subclass must have a BoTorch `AcquisitionFunction` class associated with it. We will add **`optimize`** and **`compute_model_dependencies`** to this class."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 50,
+      "metadata": {
+        "code_folding": [],
+        "hidden_ranges": [],
+        "originalKey": "dd0eea28-8558-4cde-a131-dceec090248c",
+        "showInput": true
+      },
+      "outputs": [],
+      "source": [
+        "# `qKnowledgeGradient` is being used as a placeholder here.\n",
+        "\n",
+        "# from botorch.acquisition.my_acquisition import qMyAcquisition\n",
+        "from botorch.acquisition.knowledge_gradient import qKnowledgeGradient\n",
+        "\n",
+        "class MyAcquisition(Acquisition):\n",
+        "    # default_botorch_acqf_class = qMyAcquisition\n",
+        "    default_botorch_acqf_class = qKnowledgeGradient\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "01a2e99b-fa8b-4d57-802c-1a47250d0ee0",
+        "showInput": false
+      },
+      "source": [
+        "### [Path 2: Step 1] Override `Acquisition.optimize`\n",
+        "\n",
+        "Here is the base `Acquisition.optimize` function [TODO: put a code pointer to base `Acquisition.optimize` here]. By default, the `Acquisition` subclasses run `super().optimize` but they specify their own `optimizer_options` (if needed). These `optimizer_options` are sent into the optimizer as `**optimizer_options`. On the BoTorch side, this [TODO: put a code pointer to `optimize_acqf`] is the optimization function that `Acquisition.optimize` ultimately calls.\n",
+        "\n",
+        "The following arguments are always passed into the optimizer:\n",
+        "- `bounds`\n",
+        "- `q`\n",
+        "- `inequality_constraints`\n",
+        "- `fixed_features`\n",
+        "- `post_processing_func`\n",
+        "\n",
+        "Any kwargs that `optimize_acqf` takes in that are not part of this list can be set by `optimizer_options`.\n",
+        "\n",
+        "**NOTE:** If the optimizer for the BoTorch `AcquisitionFunction` that you want to use does not require any kwargs other than those in the list, then you do not need to override `Acquisition.optimize`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "7d4cd54e-8766-4d89-b8a8-15b778eb46ff",
+        "showInput": false
+      },
+      "source": [
+        "As an example, for `MaxValueEntropySearch`, we want to use \"sequential greedy\" optimization of the acquisition function with a batch of `q > 1` candidates. So, we want `sequential=True` to be passed into `optimize_acqf`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 39,
+      "metadata": {
+        "code_folding": [],
+        "hidden_ranges": [],
+        "originalKey": "52bcaf22-7c44-43dc-8377-cd7275c719ed",
+        "showInput": true
+      },
+      "outputs": [],
+      "source": [
+        "from typing import Any, Callable, Dict, List, Optional, Tuple\n",
+        "from ax.models.torch.botorch_modular.acquisition import Optimizer\n",
+        "from torch import Tensor\n",
+        "\n",
+        "def optimize(\n",
+        "    self,\n",
+        "    bounds: Tensor,\n",
+        "    n: int,\n",
+        "    optimizer_class: Optional[Optimizer] = None,\n",
+        "    inequality_constraints: Optional[List[Tuple[Tensor, Tensor, float]]] = None,\n",
+        "    fixed_features: Optional[Dict[int, float]] = None,\n",
+        "    rounding_func: Optional[Callable[[Tensor], Tensor]] = None,\n",
+        "    optimizer_options: Optional[Dict[str, Any]] = None,\n",
+        ") -> Tuple[Tensor, Tensor]:\n",
+        "    optimizer_options = optimizer_options or {}\n",
+        "    optimizer_options[\"sequential\"] = True\n",
+        "    return super().optimize(\n",
+        "        bounds=bounds,\n",
+        "        n=n,\n",
+        "        inequality_constraints=None,\n",
+        "        fixed_features=fixed_features,\n",
+        "        rounding_func=rounding_func,\n",
+        "        optimizer_options=optimizer_options,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "953a43e7-72c7-4aa6-b39d-8512b0e29aff",
+        "showInput": false
+      },
+      "source": [
+        "And with that, we are done overriding `Acquisition.optimize`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "28930608-cf7f-491c-a1f7-e32387433ff3",
+        "showInput": false
+      },
+      "source": [
+        "### [Path 2: Step 2] Override Acquisition.compute_model_dependencies\n",
+        "\n",
+        "Similar to the base `Acquisition.optimize`, here is the base \n",
+        "`Acquisition.compute_model_dependencies` function [TODO: put a code pointer here]. The `Acquisition` subclasses run `super().compute_model_dependencies` but they add to the dictionary their own dependencies (if any). This `model_deps` dictionary is then sent into the BoTorch `AcquisitionFunction` constructor as `**model_deps`. \n",
+        "\n",
+        "**NOTE:** If the BoTorch `AcquisitionFunction` that you want to use does not require any special `__init__` arguments other than `model`, `objective`, `X_pending`, and `X_baseline`, then you do not need to override `Acquisition.compute_model_dependencies`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "005dbad9-2eec-446f-9ab3-2fbf84051370",
+        "showInput": false
+      },
+      "source": [
+        "As an example, for `MaxValueEntropySearch`, we must pass into `qMaxValueEntropy.__init__` a `candidate_set: Tensor` and we also want to specify `maximize: bool`. For the exact code, see here [TODO: put link to `mes.py`]."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 40,
+      "metadata": {
+        "code_folding": [],
+        "hidden_ranges": [],
+        "originalKey": "fef17722-fb2b-4cf7-b5bd-4adbcbcaa054",
+        "showInput": true
+      },
+      "outputs": [],
+      "source": [
+        "@classmethod\n",
+        "def compute_model_dependencies(\n",
+        "    cls,\n",
+        "    surrogate: Surrogate,\n",
+        "    bounds: List[Tuple[float, float]],\n",
+        "    objective_weights: Tensor,\n",
+        "    pending_observations: Optional[List[Tensor]] = None,\n",
+        "    outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,\n",
+        "    linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,\n",
+        "    fixed_features: Optional[Dict[int, float]] = None,\n",
+        "    target_fidelities: Optional[Dict[int, float]] = None,\n",
+        "    options: Optional[Dict[str, Any]] = None,\n",
+        ") -> Dict[str, Any]:\n",
+        "\n",
+        "    # Get the dependencies of the parent class.\n",
+        "    dependencies = super().compute_model_dependencies(...)\n",
+        "\n",
+        "    # Calculate `candidate_set`.\n",
+        "    candidate_set = ...\n",
+        "    # Calculate `maximize`.\n",
+        "    maximize = ...\n",
+        "\n",
+        "    # Update and return the model dependencies.\n",
+        "    dependencies.update(\n",
+        "        {\"candidate_set\": candidate_set, \"maximize\": maximize}\n",
+        "    )\n",
+        "    return dependencies"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "169feed0-9ee7-40c6-b6c2-023b8eb11c8e",
+        "showInput": false
+      },
+      "source": [
+        "And with that, we are done overriding `Acquisition.compute_model_dependencies`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "5ffc51b3-2256-47e1-9d20-4283221a411e",
+        "showInput": false
+      },
+      "source": [
+        "### [Path 2: Step 3] Put it all together and try it out"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 51,
+      "metadata": {
+        "code_folding": [],
+        "hidden_ranges": [],
+        "originalKey": "99050062-63b1-4c29-a0ff-58742e660c96",
+        "showInput": true
+      },
+      "outputs": [],
+      "source": [
+        "# `qKnowledgeGradient` is being used as a placeholder here.\n",
+        "\n",
+        "# from botorch.acquisition.my_acquisition import qMyAcquisition\n",
+        "from botorch.acquisition.knowledge_gradient import qKnowledgeGradient\n",
+        "\n",
+        "class MyAcquisition(Acquisition):\n",
+        "    # default_botorch_acqf_class = qMyAcquisition\n",
+        "    default_botorch_acqf_class = qKnowledgeGradient\n",
+        "    \n",
+        "    def optimize(\n",
+        "        self,\n",
+        "        # other kwargs,\n",
+        "    ) -> Tuple[Tensor, Tensor]:\n",
+        "        ...\n",
+        "        return super().optimize(...)\n",
+        "    \n",
+        "    @classmethod\n",
+        "    def compute_model_dependencies(\n",
+        "        cls,\n",
+        "        # other kwargs,\n",
+        "    ) -> Dict[str, Any]:\n",
+        "        dependencies = super().compute_model_dependencies(...)\n",
+        "        ...\n",
+        "        return dependencies"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "368af6d0-4d8a-4b9d-9873-9bf093fba451",
+        "showInput": false
+      },
+      "source": [
+        "Now, we can use the new custom `Acquisition` subclass in the same way as we do for `KnowledgeGradient` in the **`BoTorchModel` instantiation** section."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "a201541d-2670-46d4-9358-2fa53d3fe55d",
+        "showInput": false
+      },
+      "source": [
+        "## Set up storage for the new setup\n",
+        "\n",
+        "Optionally, to allow the Ax models to be serializable (and allow for resumable optimization via JSON or SQL storage), navigate to `ax/storage/class_registry.py`.\n",
+        "\n",
+        "1. If you created a new `Acquisition` subclass, add it to `ACQUISITION_REGISTRY`.\n",
+        "2. Add the corresponding BoTorch `AcquisitionFunction` class to `ACQUISITION_FUNCTION_REGISTRY`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "055bce82-fcef-4ed8-b251-605250c5b947",
+        "showInput": false
+      },
+      "source": [
+        "```\n",
+        "ACQUISITION_REGISTRY: Dict[Type[Acquisition], int] = {\n",
+        "    Acquisition: 0,\n",
+        "    KnowledgeGradient: 1,\n",
+        "    ...\n",
+        "    MyAcquisition: 5,            # Add this line.\n",
+        "}\n",
+        "\n",
+        "ACQUISITION_FUNCTION_REGISTRY: Dict[Type[AcquisitionFunction], int] = {\n",
+        "    qExpectedImprovement: 0,\n",
+        "    qNoisyExpectedImprovement: 1,\n",
+        "    ...\n",
+        "    qMyAcquisition: 6,           # Add this line.\n",
+        "}\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "6ee7ee9d-b5ad-46a5-bcef-228892ff94ca",
+        "showInput": false
+      },
+      "source": [
+        "# Details of `BoTorchModel` Subcomponent Classes"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "d652d0e5-45ca-48a9-ad95-a275f05e722d",
+        "showInput": false
+      },
+      "source": [
+        "## class `Surrogate`\n",
+        "\n",
+        "Ax wrapper for BoTorch GP `Model` classes. Optionally, a BoTorch `MarginalLogLikelihood` class can also be passed into the construction of Surrogate.\n",
+        "\n",
+        "**Core methods:** `fit`, `predict`, `update`, `construct`, `best_in_sample_point`, `best_out_of_sample_point`\n",
+        "These core methods are all called by BoTorchModel internally.\n",
+        "\n",
+        "\n",
+        "\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 48,
+      "metadata": {
+        "originalKey": "994b3976-2486-4a4b-9c34-4c2ba93fe816"
+      },
+      "outputs": [],
+      "source": [
+        "from botorch.models.gp_regression import FixedNoiseGP\n",
+        "from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood\n",
+        "\n",
+        "surrogate = Surrogate(\n",
+        "    botorch_model_class=FixedNoiseGP,       # required kwarg\n",
+        "    mll_class=ExactMarginalLogLikelihood,   # optional kwarg\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "code_folding": [],
+        "customInput": null,
+        "hidden_ranges": [],
+        "originalKey": "acdc8efc-5376-46b3-b0d4-3976cdb6a828",
+        "showInput": false
+      },
+      "source": [
+        "## class `Acquisition`\n",
+        "\n",
+        "Base Ax class for BoTorch `AcquisitionFunction` classes.\n",
+        "\n",
+        "**Core methods:** `optimize`, `compute_model_dependencies`"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "python3",
+      "language": "python",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
Summary:
This PR introduces a simple way to create a custom BoTorch model in Ax.

The new modular `BoTorchModel` object is composed of a choice of a `Surrogate` class and a choice of an `Acquisition` class. The `Surrogate` is a wrapper around a BoTorch GP `Model` and the `Acquisition` is a wrapper around a BoTorch `AcquisitionFunction`. These `BoTorchModel`-s are also storable with JSON and SQL.

Note that the functionality in this commit is under construction and not yet finalized.

A work-in-progress tutorial for the new setup is also part of this commit, as 'tutorials/botorch_modular.ipynb'.

--------

Reviewed By: lena-kashtelyan

Differential Revision: D23376065

