### PR TITLE
Fix Sphinx `benchmark` and `AxClient` linting

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -252,6 +252,26 @@ def full_benchmark_run(  # Full run, multiple tests.
     by passing in a wrapped (in some scheduling logic) version of a corresponding
     function from this module.
 
+    Here, `problem_groups` and `method_groups` are dictionaries that have the same
+    keys such that we can run a specific subset of problems with a corresponding
+    subset of methods.
+
+    Example:
+
+    ::
+
+        problem_groups = {
+            "single_fidelity": [ackley, branin],
+            "multi_fidelity": [augmented_hartmann],
+        }
+        method_groups = {
+            "single_fidelity": [single_task_GP_and_NEI_strategy],
+            "multi_fidelity": [fixed_noise_MFGP_and_MFKG_strategy],
+        }
+
+    Here, `ackley` and `branin` will be run against `single_task_GP_and_NEI_strategy`
+    and `augmented_hartmann` against `fixed_noise_MFGP_and_MFKG_strategy`.
+
     Args:
         problem_groups: Problems to benchmark on, represented as a dictionary from
             category string to List of BenchmarkProblem-s or string keys (must be
@@ -280,21 +300,6 @@ def full_benchmark_run(  # Full run, multiple tests.
             considered failed and aborted. Defaults to 5.
         failed_replications_tolerated: How many replications can fail before a
             test is considered failed and aborted. Defaults to 3.
-
-    Here, `problem_groups` and `method_groups` are dictionaries that have the same
-    keys such that we can run a specific subset of problems with a corresponding
-    subset of methods.
-    Example:
-        problem_groups = {
-            "single_fidelity": [ackley, branin],
-            "multi_fidelity": [augmented_hartmann],
-        }
-        method_groups = {
-            "single_fidelity": [single_task_GP_and_NEI_strategy],
-            "multi_fidelity": [fixed_noise_MFGP_and_MFKG_strategy],
-        }
-    Here, `ackley` and `branin` will be run against `single_task_GP_and_NEI_strategy`
-    and `augmented_hartmann` against `fixed_noise_MFGP_and_MFKG_strategy`.
     """
     problem_groups = problem_groups or {}
     method_groups = method_groups or {}

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -168,23 +168,23 @@ class AxClient(WithDBSettingsBase):
 
         Args:
             parameters: List of dictionaries representing parameters in the
-                experiment search space. Required elements in the dictionaries
-                are:
-                - "name" (name of this parameter, string),
-                - "type" (type of the
-                parameter: "range", "fixed", or "choice", string), and
-                  - "bounds" for range parameters (list of two values, lower bound
-                  first),
-                  - "values" for choice parameters (list of values), and
-                  - "value" for fixed parameters (single value).
+                experiment search space.
+                Required elements in the dictionaries are:
+                1. "name" (name of parameter, string),
+                2. "type" (type of parameter: "range", "fixed", or "choice", string),
+                and one of the following:
+                3a. "bounds" for range parameters (list of two values, lower bound
+                first),
+                3b. "values" for choice parameters (list of values), or
+                3c. "value" for fixed parameters (single value).
                 Optional elements are:
-                - "log_scale" (for float-valued range parameters, bool),
-                - "value_type" (to specify type that values of this parameter should
-                take; expects "float", "int", "bool" or "str".)
-                - "is_fidelity" (bool) and "target_value" (float) for fidelity
+                1. "log_scale" (for float-valued range parameters, bool),
+                2. "value_type" (to specify type that values of this parameter should
+                take; expects "float", "int", "bool" or "str"),
+                3. "is_fidelity" (bool) and "target_value" (float) for fidelity
                 parameters,
-                - "is_ordered" (bool) for choice parameters,
-                - "is_task" (bool) for task parameters.
+                4. "is_ordered" (bool) for choice parameters, and
+                5. "is_task" (bool) for task parameters.
             objective: Name of the metric used as objective in this experiment.
                 This metric must be present in `raw_data` argument to `complete_trial`.
             name: Name of the experiment to be created.


### PR DESCRIPTION
Summary:
This fixes two of the current Sphinx errors for docs in Ax OSS:
- `ax.benchmark.benchmark.full_benchmark_run`
- `ax.service.ax_client.AxClient.create_experiment`

Differential Revision: D23400888

