### PR TITLE
Disable shallow clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,8 @@ jobs:
         - pip install torchvision  # Required for building tutorial notebooks.
         - pip install ray  # Required for building RayTune tutorial notebook.
         - pip install tabulate  # Required for building RayTune tutorial notebook.
+      git:
+        depth: false
       script:
         - travis_wait 90 bash scripts/publish_site.sh -d -k python3 -v $TRAVIS_TAG
         # - python -c "print('Skipping website deployment...')"  # Use for testing deployment.
@@ -119,6 +121,8 @@ jobs:
         - pip install torchvision  # required for tutorials
         - pip install ray  # Required for building RayTune tutorial notebook.
         - pip install tabulate  # Required for building RayTune tutorial notebook.
+      git:
+        depth: false
       script:
         - travis_wait 90 bash scripts/publish_site.sh -d
       # Uploading to test.pypi to check that deployment works.


### PR DESCRIPTION
Summary: See https://github.com/pypa/setuptools_scm/issues/93. Travis does a 50 commit clone by default, which means any tags on commits before will not show up. This caused setuptools_scm to fallback to local versions, which pypl didn't like at all. Let's disable shallow clones so we can start releasing again

Reviewed By: Balandat

Differential Revision: D23964139

