### PR TITLE
Do not override torch device default

### DIFF
--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -110,10 +110,7 @@ Specified_Task_ST_MTGP_trans: List[Type[Transform]] = (
     Cont_X_trans + [Derelativize, StratifiedStandardizeY, TaskEncode]
 )
 
-STANDARD_TORCH_BRIDGE_KWARGS: Dict[str, Any] = {
-    "torch_dtype": torch.double,
-    "torch_device": torch.device("cpu"),
-}
+STANDARD_TORCH_BRIDGE_KWARGS: Dict[str, Any] = {"torch_dtype": torch.double}
 
 
 class ModelSetup(NamedTuple):


### PR DESCRIPTION
Summary: Defaulting to CPU is unnecessary; if we are on CPU this will be the default for an empty/None value, anyways.

Reviewed By: Balandat

Differential Revision: D24083858

