### PR TITLE
Verifying kwarg typing in `Models` enum

### DIFF
--- a/ax/utils/common/tests/test_kwargutils.py
+++ b/ax/utils/common/tests/test_kwargutils.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Dict
+from unittest.mock import patch
+
+from ax.utils.common.kwargs import validate_kwarg_typing
+from ax.utils.common.logger import get_logger
+from ax.utils.common.testutils import TestCase
+
+
+class TestKwargUtils(TestCase):
+    def test_validate_kwarg_typing(self):
+        def typed_callable(arg1: int, arg2: str = None) -> None:
+            pass
+
+        def typed_callable_with_dict(arg3: int, arg4: Dict[str, int]) -> None:
+            pass
+
+        def typed_callable_valid(arg3: int, arg4: str = None) -> None:
+            pass
+
+        def typed_callable_dup_keyword(arg2: int, arg4: str = None) -> None:
+            pass
+
+        # pass
+        try:
+            kwargs = {"arg1": 1, "arg2": "test", "arg3": 2}
+            validate_kwarg_typing([typed_callable, typed_callable_valid], **kwargs)
+        except Exception:
+            self.assertTrue(False, "Exception raised on valid kwargs")
+
+        # pass with complex data structure
+        try:
+            kwargs = {"arg1": 1, "arg2": "test", "arg3": 2, "arg4": {"k1": 1}}
+            validate_kwarg_typing([typed_callable, typed_callable_with_dict], **kwargs)
+        except Exception:
+            self.assertTrue(False, "Exception raised on valid kwargs")
+
+        # kwargs contains extra keywords
+        with self.assertRaises(ValueError):
+            kwargs = {"arg1": 1, "arg2": "test", "arg3": 3, "arg5": 4}
+            typed_callables = [typed_callable, typed_callable_valid]
+            validate_kwarg_typing(typed_callables, **kwargs)
+
+        # callables have duplicate keywords
+        logger = get_logger("ax.utils.common.kwargs")
+        with patch.object(logger, "debug") as mock_debug:
+            kwargs = {"arg1": 1, "arg2": "test", "arg4": "test_again"}
+            typed_callables = [typed_callable, typed_callable_dup_keyword]
+            validate_kwarg_typing(typed_callables, **kwargs)
+            mock_debug.assert_called_once_with(
+                f"`{typed_callables}` have duplicate keyword argument: arg2."
+            )
+
+        # mismatch types
+        with patch.object(logger, "warning") as mock_warning:
+            kwargs = {"arg1": 1, "arg2": "test", "arg3": "test_again"}
+            validate_kwarg_typing([typed_callable, typed_callable_valid], **kwargs)
+            expected_message = (
+                f"Expected argument `arg3` to be of type {type(1)}. "
+                f"Got test_again (type: {type('test_again')})."
+            )
+            mock_warning.assert_called_once_with(expected_message)
+
+        # mismatch types with Dict
+        with patch.object(logger, "warning") as mock_warning:
+            str_dic = {"k1": "test"}
+            kwargs = {"arg1": 1, "arg2": "test", "arg3": 2, "arg4": str_dic}
+            validate_kwarg_typing([typed_callable, typed_callable_with_dict], **kwargs)
+            expected_message = (
+                f"Expected argument `arg4` to be of type typing.Dict[str, int]. "
+                f"Got {str_dic} (type: {type(str_dic)})."
+            )
+            mock_warning.assert_called_once_with(expected_message)

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ REQUIRES = [
     "scipy",
     "scikit-learn",
     "plotly",
+    "typeguard",
 ]
 
 # pytest-cov requires pytest >= 3.6


### PR DESCRIPTION
Summary:
add validation of kwargs to:
1. check if callables have duplicate keywords
2. check if keywords in kwargs have the correct type (only doing shallow checks)
3. check if kwargs contains keywords not match any params of callables

Reviewed By: lena-kashtelyan

Differential Revision: D24269108

