### PR TITLE
Add "import ax" test to travis to validate installation without extra requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ jobs:
     # create custom environment variable for flagging jobs that are allowed to fail
     - env: ALLOW_FAILURE=true
   include:
+    - name: "Validate 'import ax' without extra requirements: Python 3.7"
+      install:
+        - pip install -q .
+      script:
+        - python scripts/import_ax.py
     - name: "Tests + Coverage: Python 3.7"
       python: "3.7"
       install:

--- a/scripts/import_ax.py
+++ b/scripts/import_ax.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import ax
+
+
+if __name__ == "__main__":
+    assert ax is not None


### PR DESCRIPTION
Summary: Add "import ax" test to travis to validate installation without extra requirements

Differential Revision: D24318211

