### PR TITLE
disable silently_filter_kwargs to allow validate_kwarg_typing

### DIFF
--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -243,7 +243,7 @@ class Models(Enum):
         search_space: Optional[SearchSpace] = None,
         experiment: Optional[Experiment] = None,
         data: Optional[Data] = None,
-        silently_filter_kwargs: bool = True,  # TODO[Lena]: default to False
+        silently_filter_kwargs: bool = False,
         **kwargs: Any,
     ) -> ModelBridge:
         assert self.value in MODEL_KEY_TO_MODEL_SETUP, f"Unknown model {self.value}"

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -39,14 +39,14 @@ class TestGenerationStrategy(TestCase):
 
         # Mock out slow GPEI.
         self.torch_model_bridge_patcher = patch(
-            f"{TorchModelBridge.__module__}.TorchModelBridge", spec=True
+            f"{TorchModelBridge.__module__}.TorchModelBridge", autospec=True
         )
         self.mock_torch_model_bridge = self.torch_model_bridge_patcher.start()
         self.mock_torch_model_bridge.return_value.gen.return_value = self.gr
 
         # Mock out slow TS.
         self.discrete_model_bridge_patcher = patch(
-            f"{DiscreteModelBridge.__module__}.DiscreteModelBridge", spec=True
+            f"{DiscreteModelBridge.__module__}.DiscreteModelBridge", autospec=True
         )
         self.mock_discrete_model_bridge = self.discrete_model_bridge_patcher.start()
         self.mock_discrete_model_bridge.return_value.gen.return_value = self.gr

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -249,10 +249,11 @@ class ModelRegistryTest(TestCase):
         # Check restoration of GPEI, to ensure proper restoration of callable kwargs
         gpei = Models.GPEI(experiment=exp, data=get_branin_data())
         # Punch GPEI model + bridge kwargs into the Sobol generator run, to avoid
-        # a slow call to `gpei.gen`.
+        # a slow call to `gpei.gen`, and remove Sobol's model state.
         gr._model_key = "GPEI"
         gr._model_kwargs = gpei._model_kwargs
         gr._bridge_kwargs = gpei._bridge_kwargs
+        gr._model_state_after_gen = {}
         gpei_restored = get_model_from_generator_run(
             gr, experiment=exp, data=get_branin_data()
         )

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -373,8 +373,10 @@ class JSONStoreTest(TestCase):
         self.assertIsNone(new_generation_strategy.model)
 
         # Check that we can encode and decode the generation strategy after
-        # it has generated some generator runs.
-        generation_strategy = new_generation_strategy
+        # it has generated some generator runs. Since we now need to `gen`,
+        # we remove the fake callable kwarg we added, since model does not
+        # expect it.
+        generation_strategy = get_generation_strategy(with_callable_model_kwarg=False)
         gr = generation_strategy.gen(experiment)
         gs_json = object_to_json(generation_strategy)
         new_generation_strategy = generation_strategy_from_json(gs_json)

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -987,7 +987,9 @@ class SQAStoreTest(TestCase):
 
         # Check that we can encode and decode the generation strategy *after*
         # it has generated some trials and been updated with some data.
-        generation_strategy = new_generation_strategy
+        # Since we now need to `gen`, we remove the fake callable kwarg we added,
+        # since model does not expect it.
+        generation_strategy = get_generation_strategy(with_callable_model_kwarg=False)
         experiment.new_trial(generation_strategy.gen(experiment=experiment))
         generation_strategy.gen(experiment, data=get_branin_data())
         save_generation_strategy(generation_strategy=generation_strategy)
@@ -1004,11 +1006,10 @@ class SQAStoreTest(TestCase):
         self.assertEqual(new_generation_strategy._experiment._name, experiment._name)
 
     def testUpdateGenerationStrategy(self):
-        generation_strategy = get_generation_strategy()
+        generation_strategy = get_generation_strategy(with_callable_model_kwarg=False)
         save_generation_strategy(generation_strategy=generation_strategy)
 
         experiment = get_branin_experiment()
-        generation_strategy = get_generation_strategy()
         save_experiment(experiment)
 
         # add generator run, save, reload

--- a/ax/utils/common/kwargs.py
+++ b/ax/utils/common/kwargs.py
@@ -72,14 +72,17 @@ def validate_kwarg_typing(typed_callables: List[Callable], **kwargs: Any) -> Non
                 else:
                     checked_kwargs.add(kw)
                     kw_val = kwargs.get(kw)
-                    try:
-                        check_type(kw, kw_val, param.annotation)
-                    except TypeError:
-                        message = (
-                            f"Expected argument `{kw}` to be of type {param.annotation}"
-                            + f". Got {kw_val} (type: {type(kw_val)})."
-                        )
-                        logger.warning(message)
+                    # if the keyword is a callable, we only do shallow checks
+                    if not (callable(kw_val) and callable(param.annotation)):
+                        try:
+                            check_type(kw, kw_val, param.annotation)
+                        except TypeError:
+                            message = (
+                                f"`{typed_callable}` expected argument `{kw}` to be of"
+                                f" type {param.annotation}. Got {kw_val}"
+                                f" (type: {type(kw_val)})."
+                            )
+                            logger.warning(message)
 
     # check if kwargs contains keywords not exist in any callables
     extra_keywords = [kw for kw in kwargs.keys() if kw not in checked_kwargs]

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -140,14 +140,17 @@ def get_observation2trans() -> Observation:
 # Modeling layer
 
 
-def get_generation_strategy(with_experiment: bool = False) -> GenerationStrategy:
+def get_generation_strategy(
+    with_experiment: bool = False, with_callable_model_kwarg: bool = True
+) -> GenerationStrategy:
     gs = choose_generation_strategy(search_space=get_search_space())
     if with_experiment:
         gs._experiment = get_experiment()
     fake_func = get_experiment
-    # pyre-ignore[16]: testing hack to test serialization of callable kwargs
-    # in generation steps.
-    gs._steps[0].model_kwargs["model_constructor"] = fake_func
+    if with_callable_model_kwarg:
+        # pyre-ignore[16]: testing hack to test serialization of callable kwargs
+        # in generation steps.
+        gs._steps[0].model_kwargs["model_constructor"] = fake_func
     return gs
 
 


### PR DESCRIPTION
Summary:
1. Disable silently_filter_kwargs to allow validating kwargs
2. Add special handles for keyword is callable case

Reviewed By: lena-kashtelyan

Differential Revision: D24339272

