### PR TITLE
Add minimum botorch test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,18 @@ jobs:
         - pip install -q -e .[dev,mysql,notebook]
       script:
         - pytest -ra
+    - name: "Build with minimum supported BoTorch (for pushing new release)"
+      # Checks whether the current version on Ax master is compatible with the
+      # minimum allowed BoTorch release; this test should be passing before cutting new
+      # version of Ax.
+      python: "3.7"
+      env: ALLOW_FAILURE=true
+      install:
+        # TODO: read from a shared source.
+        - pip install botorch==0.3.1
+        - pip install -q -e .[dev,mysql,notebook]
+      script:
+        - pytest -ra
     - name: "Docs: Sphinx Coverage: Python 3.7"
       python: "3.7"
       script:

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,10 @@
 from setuptools import find_packages, setup
 
 
+MIN_BOTORCH_VERSION = "0.3.1"
+
 REQUIRES = [
-    "botorch>=0.3.1",
+    f"botorch>={MIN_BOTORCH_VERSION}",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
Summary:
The only real trick here is getting the minimum version.
YAML can't read from python (or anything); so the only possible path is for setup to read from yaml. this requires a yaml dep, however, which will require some significant restructuring of setup to two-stages.

Differential Revision: D24395914

