### PR TITLE
Fix MLL JSON-encoding test

### DIFF
--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -45,6 +45,7 @@ from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
 # BoTorch `MarginalLogLikelihood` imports
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
+from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
 
 
 # NOTE: When adding a new registry for a class, make sure to make changes
@@ -92,7 +93,10 @@ ACQUISITION_FUNCTION_REGISTRY: Dict[Type[AcquisitionFunction], int] = {
 """
 Mapping of BoTorch `MarginalLogLikelihood` classes to ints.
 """
-MLL_REGISTRY: Dict[Type[MarginalLogLikelihood], int] = {ExactMarginalLogLikelihood: 0}
+MLL_REGISTRY: Dict[Type[MarginalLogLikelihood], int] = {
+    ExactMarginalLogLikelihood: 0,
+    SumMarginalLogLikelihood: 1,
+}
 
 
 """

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -232,7 +232,14 @@ ENCODE_DECODE_FIELD_MAPS = {
         encoded_only=["index", "class"],
     ),
     "Type[MarginalLogLikelihood]": EncodeDecodeFieldsMap(
-        python_only=["_module__", "_doc__", "_init__", "forward", "pyro_factor"],
+        python_only=[
+            "_module__",
+            "_doc__",
+            "_init__",
+            "forward",
+            "pyro_factor",
+            "add_other_terms",
+        ],
         encoded_only=["index", "class"],
     ),
     "Type[Transform]": EncodeDecodeFieldsMap(
@@ -336,7 +343,7 @@ class JSONStoreTest(TestCase):
                     json_keys.remove(encoded)
                     json_keys.add(python)
             # TODO: Remove this check if able. `_slotnames__` is not a class attribute
-            # when testing locally, but it is a class attribute on Travis.
+            # when testing locally, but it is a class attribute on Travis
             if class_ == "Type[Model]":
                 object_keys.discard("_slotnames__")
             self.assertEqual(


### PR DESCRIPTION
Summary: Fixing test that broke as result of upgrading GPytorch, reasoning here: https://www.internalfb.com/intern/diff/D24430968/?dest_fbid=682568432636040&transaction_id=691161204859426

Differential Revision: D24459289

