### PR TITLE
remove sphinx-autodoc-typehints

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -36,7 +36,6 @@ sys.path.insert(0, os.path.abspath("../.."))
 extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
-    "sphinx_autodoc_typehints",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.coverage",


### PR DESCRIPTION
Remove sphinx-autodoc-typehints from the sphinx/source/conf.py file. This was breaking our sphinx build, and is a temporary solution that will remove typehints from our docs. 