### PR TITLE
Remove hardcoded black version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
     - name: "Lint: black: Python 3.7"
       python: "3.7"
       install:
-        - pip install black==19.3b0
+        - pip install black
       script:
         - black --check --diff .
     - name: "Lint: flake8: Python 3.7"


### PR DESCRIPTION
Summary: The Travis build is failing due to discrepancies in black between FB and OSS. No need to hardcode black version; looks like FB updates rapidly these days.

Differential Revision: D24905697

