### PR TITLE
Fix sourceTensor.clone().detach() warning

### DIFF
--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -281,7 +281,7 @@ class TorchModelBridge(ArrayModelBridge):
         )
 
     def _array_to_tensor(self, array: Union[np.ndarray, List[float]]) -> Tensor:
-        return torch.tensor(array, dtype=self.dtype, device=self.device)
+        return torch.as_tensor(array, dtype=self.dtype, device=self.device)
 
     def _array_list_to_tensors(self, arrays: List[np.ndarray]) -> List[Tensor]:
         return [self._array_to_tensor(x) for x in arrays]


### PR DESCRIPTION
This gets rid of the following warning:
```
/home/travis/build/facebook/Ax/ax/modelbridge/torch.py:274: UserWarning:
To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
```