### PR TITLE
Bump min botorch version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import find_packages, setup
 
 
-MIN_BOTORCH_VERSION = "0.3.2"
+MIN_BOTORCH_VERSION = "0.3.3"
 
 REQUIRES = [
     f"botorch>={MIN_BOTORCH_VERSION}",


### PR DESCRIPTION
Summary: To make the new contextual libraries happy, bump the botorch version (see failures in: https://fburl.com/kbkoen5s)

Differential Revision: D25397593

