### PR TITLE
The README file in this repo has a bad link - [404:NotFound] - "License MIT"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Build Status](https://img.shields.io/pypi/wheel/ax-platform.svg)](https://pypi.org/project/ax-platform/)
 [![Build Status](https://github.com/facebook/Ax/workflows/Build%20and%20Test%20Workflow/badge.svg)](https://github.com/facebook/Ax/actions?query=workflow%3A%22Build+and+Test+Workflow%22)
 [![codecov](https://codecov.io/gh/facebook/Ax/branch/master/graph/badge.svg)](https://codecov.io/gh/facebook/Ax)
-[![Build Status](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE.md)
+[![Build Status](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 Ax is an accessible, general-purpose platform for understanding, managing,
 deploying, and automating adaptive experiments.


### PR DESCRIPTION
The markup version of the readme that is displayed for the main page in this repo contains the following bad link:

Under the "License  MIT" image
Status code [404:NotFound] - Link: https://github.com/facebook/Ax/blob/master/LICENSE.md

It looks like the link should be: https://github.com/facebook/Ax/blob/master/LICENSE
So I've submitted this PR (and completed the "CLA")

**Extra**

This bad link was found by a tool I recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder

Re-check this Repo via: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2ffacebook%2fAx

If you have any feedback on the tool itself, or the information provided here, then please feel free to share your thoughts by adding a comment here, or adding a “Discussions” comment in the tool’s Repo.