### PR TITLE
Print all Sphinx warnings before treating them as errors

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,6 +79,4 @@ jobs:
       if: ${{ always() }}
       run: |
         # warnings treated as errors
-        sphinx-build -WT sphinx/source sphinx/build
-        # since -W flag breaks on first error, re-run without it to print all
-        sphinx-build sphinx/source sphinx/build
+        sphinx-build -WT --keep-going sphinx/source sphinx/build


### PR DESCRIPTION
Summary: Trying out a version where hopefully all the warnings will be printed at once

Differential Revision: D25885900

