### PR TITLE
Add a Yeo-Johnson power transform to Ax

### DIFF
--- a/ax/modelbridge/tests/test_power_transform_y.py
+++ b/ax/modelbridge/tests/test_power_transform_y.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from copy import deepcopy
+from math import isfinite, isnan
+
+import numpy as np
+from ax.core.observation import ObservationData
+from ax.modelbridge.transforms.power_transform_y import (
+    PowerTransformY,
+    _compute_power_transforms,
+    _compute_inverse_bounds,
+)
+from ax.modelbridge.transforms.utils import get_data, match_ci_width_truncated
+from ax.utils.common.testutils import TestCase
+from sklearn.preprocessing import PowerTransformer
+
+
+class PowerTransformYTest(TestCase):
+    def setUp(self):
+        self.obsd1 = ObservationData(
+            metric_names=["m1", "m2"],
+            means=np.array([0.5, 0.9]),
+            covariance=np.array([[0.03, 0.0], [0.0, 0.001]]),
+        )
+        self.obsd2 = ObservationData(
+            metric_names=["m1", "m2"],
+            means=np.array([0.1, 0.4]),
+            covariance=np.array([[0.005, 0.0], [0.0, 0.05]]),
+        )
+        self.obsd3 = ObservationData(
+            metric_names=["m1", "m2"],
+            means=np.array([0.9, 0.8]),
+            covariance=np.array([[0.02, 0.0], [0.0, 0.01]]),
+        )
+        self.obsd_nan = ObservationData(
+            metric_names=["m1", "m2"],
+            means=np.array([0.3, 0.2]),
+            covariance=np.array([[float("nan"), 0.0], [0.0, float("nan")]]),
+        )
+
+    def testInit(self):
+        shared_init_args = {
+            "search_space": None,
+            "observation_features": None,
+            "observation_data": [self.obsd1, self.obsd2],
+        }
+        # Test error for not specifying a config
+        with self.assertRaises(ValueError):
+            PowerTransformY(**shared_init_args)
+        # Test error for not specifying at least one metric
+        with self.assertRaises(ValueError):
+            PowerTransformY(**shared_init_args, config={})
+        # Test default init
+        for m in ["m1", "m2"]:
+            tf = PowerTransformY(**shared_init_args, config={"metrics": [m]})
+            # tf.power_transforms should only exist for m and be a PowerTransformer
+            self.assertIsInstance(tf.power_transforms, dict)
+            self.assertEqual([*tf.power_transforms], [m])  # Check keys
+            self.assertIsInstance(tf.power_transforms[m], PowerTransformer)
+            # tf.inv_bounds should only exist for m and be a tuple of length 2
+            self.assertIsInstance(tf.inv_bounds, dict)
+            self.assertEqual([*tf.inv_bounds], [m])  # Check keys
+            self.assertIsInstance(tf.inv_bounds[m], tuple)
+            self.assertTrue(len(tf.inv_bounds[m]) == 2)
+
+    def testGetData(self):
+        for m in ["m1", "m2"]:
+            Ys = get_data([self.obsd1, self.obsd2, self.obsd3], m)
+            self.assertIsInstance(Ys, dict)
+            self.assertEqual([*Ys], [m])
+            if m == "m1":
+                self.assertEqual(Ys[m], [0.5, 0.1, 0.9])
+            else:
+                self.assertEqual(Ys[m], [0.9, 0.4, 0.8])
+
+    def testComputePowerTransform(self):
+        Ys = get_data([self.obsd1, self.obsd2, self.obsd3], ["m2"])
+        pts = _compute_power_transforms(Ys)
+        self.assertEqual(pts["m2"].method, "yeo-johnson")
+        self.assertIsInstance(pts["m2"].lambdas_, np.ndarray)
+        self.assertEqual(pts["m2"].lambdas_.shape, (1,))
+        Y_np = np.array(Ys["m2"])[:, None]
+        Y_trans = pts["m2"].transform(Y_np)
+        # Output should be standardized
+        self.assertAlmostEqual(Y_trans.mean(), 0.0)
+        self.assertAlmostEqual(Y_trans.std(), 1.0)
+        # Transform back
+        Y_np2 = pts["m2"].inverse_transform(Y_trans)
+        self.assertAlmostEqual(np.max(np.abs(Y_np - Y_np2)), 0.0)
+
+    def testComputeInverseBounds(self):
+        Ys = get_data([self.obsd1, self.obsd2, self.obsd3], ["m2"])
+        pt = _compute_power_transforms(Ys)["m2"]
+        # lambda < 0: im(f) = (-inf, -1/lambda) without standardization
+        pt.lambdas_.fill(-2.5)
+        bounds = _compute_inverse_bounds({"m2": pt})["m2"]
+        self.assertEqual(bounds[0], -np.inf)
+        # Make sure we got the boundary right
+        left = pt.inverse_transform(np.array(bounds[1] - 0.01, ndmin=2))
+        right = pt.inverse_transform(np.array(bounds[1] + 0.01, ndmin=2))
+        self.assertTrue(isnan(right) and not isnan(left))
+        # 0 <= lambda <= 2: im(f) = R
+        pt.lambdas_.fill(1.0)
+        bounds = _compute_inverse_bounds({"m2": pt})["m2"]
+        self.assertTrue(bounds == (-np.inf, np.inf))
+        # lambda > 2: im(f) = (1 / (2 - lambda), inf) without standardization
+        pt.lambdas_.fill(3.5)
+        bounds = _compute_inverse_bounds({"m2": pt})["m2"]
+        self.assertEqual(bounds[1], np.inf)
+        # Make sure we got the boundary right
+        left = pt.inverse_transform(np.array(bounds[0] - 0.01, ndmin=2))
+        right = pt.inverse_transform(np.array(bounds[0] + 0.01, ndmin=2))
+        self.assertTrue(not isnan(right) and isnan(left))
+
+    def testMatchCIWidth(self):
+        Ys = get_data([self.obsd1, self.obsd2, self.obsd3], ["m2"])
+        pt = _compute_power_transforms(Ys)
+        pt["m2"].lambdas_.fill(-3.0)
+        bounds = _compute_inverse_bounds(pt)["m2"]
+
+        # Both will be NaN since we are far outside the bounds
+        new_mean_1, new_var_1 = match_ci_width_truncated(
+            mean=bounds[1] + 2.0,
+            variance=0.1,
+            transform=lambda y: pt["m2"].inverse_transform(np.array(y, ndmin=2)),
+            lower_bound=bounds[0],
+            upper_bound=bounds[1],
+            margin=0.001,
+            clip_mean=False,
+        )
+        # This will be finite since we clip
+        new_mean_2, new_var_2 = match_ci_width_truncated(
+            mean=bounds[1] + 2.0,
+            variance=0.1,
+            transform=lambda y: pt["m2"].inverse_transform(np.array(y, ndmin=2)),
+            lower_bound=bounds[0],
+            upper_bound=bounds[1],
+            margin=0.001,
+            clip_mean=True,
+        )
+        self.assertTrue(isnan(new_mean_1) and isnan(new_var_1))
+        self.assertTrue(isfinite(new_mean_2) and isfinite(new_var_2))
+
+    def testTransformAndUntransformOneMetric(self):
+        observation_data = [deepcopy(self.obsd1), deepcopy(self.obsd2)]
+        pt = PowerTransformY(
+            search_space=None,
+            observation_features=None,
+            observation_data=observation_data,
+            config={"metrics": ["m1"]},
+        )
+
+        # Transform the data and make sure we don't touch m1
+        observation_data_tf = pt.transform_observation_data(observation_data, [])
+        for obsd, obsd_orig in zip(observation_data_tf, [self.obsd1, self.obsd2]):
+            self.assertNotAlmostEqual(obsd.means[0], obsd_orig.means[0])
+            self.assertNotAlmostEqual(obsd.covariance[0][0], obsd_orig.covariance[0][0])
+            self.assertAlmostEqual(obsd.means[1], obsd_orig.means[1])
+            self.assertAlmostEqual(obsd.covariance[1][1], obsd_orig.covariance[1][1])
+
+        # Untransform the data and make sure the means are the same
+        observation_data_untf = pt.untransform_observation_data(observation_data_tf, [])
+        for obsd, obsd_orig in zip(observation_data_untf, [self.obsd1, self.obsd2]):
+            self.assertAlmostEqual(obsd.means[0], obsd_orig.means[0], places=4)
+            self.assertAlmostEqual(obsd.means[1], obsd_orig.means[1], places=4)
+
+        # NaN covar values remain as NaNs
+        transformed_obsd_nan = pt.transform_observation_data(
+            [deepcopy(self.obsd_nan)], []
+        )[0]
+        cov_results = np.array(transformed_obsd_nan.covariance)
+        self.assertTrue(np.all(np.isnan(np.diag(cov_results))))
+
+    def testTransformAndUntransformAllMetrics(self):
+        observation_data = [deepcopy(self.obsd1), deepcopy(self.obsd2)]
+        pt = PowerTransformY(
+            search_space=None,
+            observation_features=None,
+            observation_data=observation_data,
+            config={"metrics": ["m1", "m2"]},
+        )
+
+        observation_data_tf = pt.transform_observation_data(observation_data, [])
+        for obsd, obsd_orig in zip(observation_data_tf, [self.obsd1, self.obsd2]):
+            for i in range(2):  # Both metrics should be transformed
+                self.assertNotAlmostEqual(obsd.means[i], obsd_orig.means[i])
+                self.assertNotAlmostEqual(
+                    obsd.covariance[i][i], obsd_orig.covariance[i][i]
+                )
+
+        # Untransform the data and make sure the means are the same
+        observation_data_untf = pt.untransform_observation_data(observation_data_tf, [])
+        for obsd, obsd_orig in zip(observation_data_untf, [self.obsd1, self.obsd2]):
+            for i in range(2):  # Both metrics should be transformed
+                self.assertAlmostEqual(obsd.means[i], obsd_orig.means[i])
+
+        # NaN covar values remain as NaNs
+        transformed_obsd_nan = pt.transform_observation_data(
+            [deepcopy(self.obsd_nan)], []
+        )[0]
+        cov_results = np.array(transformed_obsd_nan.covariance)
+        self.assertTrue(np.all(np.isnan(np.diag(cov_results))))
+
+    def testCompareToSklearn(self):
+        # Make sure the transformed values agree with Sklearn
+        observation_data = [self.obsd1, self.obsd2, self.obsd3]
+
+        y_orig = np.array([data.means[0] for data in observation_data])[:, None]
+        y1 = PowerTransformer("yeo-johnson").fit(y_orig).transform(y_orig).ravel()
+
+        pt = PowerTransformY(
+            search_space=None,
+            observation_features=None,
+            observation_data=deepcopy(observation_data),
+            config={"metrics": ["m1"]},
+        )
+        observation_data_tf = pt.transform_observation_data(observation_data, [])
+        y2 = [data.means[0] for data in observation_data_tf]
+        for y1_, y2_ in zip(y1, y2):
+            self.assertAlmostEqual(y1_, y2_)

--- a/ax/modelbridge/transforms/percentile_y.py
+++ b/ax/modelbridge/transforms/percentile_y.py
@@ -11,6 +11,7 @@ from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.search_space import SearchSpace
 from ax.core.types import TConfig
 from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.utils import get_data
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast
 from scipy import stats
@@ -34,11 +35,7 @@ class PercentileY(Transform):
             raise ValueError(
                 "Percentile transform requires non-empty observation data."
             )
-        metric_names = {x for obsd in observation_data for x in obsd.metric_names}
-        metric_values = {metric_name: [] for metric_name in metric_names}
-        for obsd in observation_data:
-            for i, metric_name in enumerate(obsd.metric_names):
-                metric_values[metric_name].append(obsd.means[i])
+        metric_values = get_data(observation_data=observation_data)
         self.percentiles = {
             metric_name: vals for metric_name, vals in metric_values.items()
         }

--- a/ax/modelbridge/transforms/power_transform_y.py
+++ b/ax/modelbridge/transforms/power_transform_y.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.search_space import SearchSpace
+from ax.core.types import TConfig
+from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.utils import get_data, match_ci_width_truncated
+from ax.utils.common.logger import get_logger
+from ax.utils.common.typeutils import checked_cast_list
+from sklearn.preprocessing import PowerTransformer
+
+
+logger = get_logger(__name__)
+
+
+class PowerTransformY(Transform):
+    """Transform the values to look as normally distributed as possible.
+
+    This fits a power transform to the data with the goal of making the transformed
+    values look as normally distributed as possible. We use Yeo-Johnson
+    (https://www.stat.umn.edu/arc/yjpower.pdf), which can handle both positive and
+    negative values.
+
+    While the transform seems to be quite robust, it probably makes sense to apply a
+    bit of winsorization and also standardize the inputs before applying the power
+    transform. The power transform will automatically standardize the data so the
+    data will remain standardized.
+
+    The transform can't be inverted for all values, so we apply clipping to move
+    values to the image of the transform. This behavior can be controlled via the
+    `clip_mean` setting.
+    """
+
+    def __init__(
+        self,
+        search_space: SearchSpace,
+        observation_features: List[ObservationFeatures],
+        observation_data: List[ObservationData],
+        config: Optional[TConfig] = None,
+    ) -> None:
+        if config is None:
+            raise ValueError("PowerTransform requires a config.")
+        # pyre-fixme[6]: Same issue as for LogY
+        metric_names = list(config.get("metrics", []))
+        if len(metric_names) == 0:
+            raise ValueError("Must specify at least one metric in the config.")
+        self.clip_mean = config.get("clip_mean", True)
+        self.metric_names = metric_names
+        Ys = get_data(observation_data=observation_data, metric_names=metric_names)
+        self.power_transforms = _compute_power_transforms(Ys=Ys)
+        self.inv_bounds = _compute_inverse_bounds(self.power_transforms, tol=1e-10)
+
+    def transform_observation_data(
+        self,
+        observation_data: List[ObservationData],
+        observation_features: List[ObservationFeatures],
+    ) -> List[ObservationData]:
+        """Winsorize observation data in place."""
+        for obsd in observation_data:
+            for i, m in enumerate(obsd.metric_names):
+                if m in self.metric_names:
+                    transform = self.power_transforms[m].transform
+                    obsd.means[i], obsd.covariance[i, i] = match_ci_width_truncated(
+                        mean=obsd.means[i],
+                        variance=obsd.covariance[i, i],
+                        transform=lambda y: transform(np.array(y, ndmin=2)),
+                        lower_bound=-np.inf,
+                        upper_bound=np.inf,
+                    )
+        return observation_data
+
+    def untransform_observation_data(
+        self,
+        observation_data: List[ObservationData],
+        observation_features: List[ObservationFeatures],
+    ) -> List[ObservationData]:
+        """Winsorize observation data in place."""
+        for obsd in observation_data:
+            for i, m in enumerate(obsd.metric_names):
+                if m in self.metric_names:
+                    l, u = self.inv_bounds[m]
+                    transform = self.power_transforms[m].inverse_transform
+                    if not self.clip_mean and (obsd.means[i] < l or obsd.means[i] > u):
+                        raise ValueError(
+                            "Can't untransform mean outside the bounds without clipping"
+                        )
+                    obsd.means[i], obsd.covariance[i, i] = match_ci_width_truncated(
+                        mean=obsd.means[i],
+                        variance=obsd.covariance[i, i],
+                        transform=lambda y: transform(np.array(y, ndmin=2)),
+                        lower_bound=l,
+                        upper_bound=u,
+                        clip_mean=True,
+                    )
+        return observation_data
+
+
+def _compute_power_transforms(
+    Ys: Dict[str, List[float]]
+) -> Dict[str, PowerTransformer]:
+    """Compute power transforms."""
+    power_transforms = {}
+    for k, ys in Ys.items():
+        y = np.array(ys)[:, None]  # Need to unsqueeze the last dimension
+        pt = PowerTransformer(method="yeo-johnson").fit(y)
+        power_transforms[k] = pt
+    return power_transforms
+
+
+def _compute_inverse_bounds(
+    power_transforms: Dict[str, PowerTransformer], tol: float = 1e-10
+) -> Dict[str, Tuple[float, float]]:
+    """Computes the image of the transform so we can clip when we untransform.
+
+    The inverse of the Yeo-Johnson transform is given by:
+    if X >= 0 and lambda == 0:
+        X = exp(X_trans) - 1
+    elif X >= 0 and lambda != 0:
+        X = (X_trans * lambda + 1) ** (1 / lambda) - 1
+    elif X < 0 and lambda != 2:
+        X = 1 - (-(2 - lambda) * X_trans + 1) ** (1 / (2 - lambda))
+    elif X < 0 and lambda == 2:
+        X = 1 - exp(-X_trans)
+
+    We can break this down into three cases:
+    lambda < 0:        X < -1 / lambda
+    0 <= lambda <= 2:  X is unbounded
+    lambda > 2:        X > 1 / (2 - lambda)
+
+    Sklearn standardizes the transformed values to have mean zero and standard
+    deviation 1, so we also need to account for this when we compute the bounds.
+    """
+    inv_bounds = defaultdict()
+    for k, pt in power_transforms.items():
+        bounds = [-np.inf, np.inf]
+        mu, sigma = pt._scaler.mean_.item(), pt._scaler.scale_.item()  # pyre-ignore
+        lambda_ = pt.lambdas_.item()  # pyre-ignore
+        if lambda_ < -1 * tol:
+            bounds[1] = (-1.0 / lambda_ - mu) / sigma
+        elif lambda_ > 2.0 + tol:
+            bounds[0] = (1.0 / (2.0 - lambda_) - mu) / sigma
+        inv_bounds[k] = tuple(checked_cast_list(float, bounds))
+    return inv_bounds

--- a/ax/modelbridge/transforms/standardize_y.py
+++ b/ax/modelbridge/transforms/standardize_y.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections import defaultdict
 from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -13,6 +12,7 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.core.types import TConfig, TParamValue
 from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.utils import get_data
 from ax.utils.common.logger import get_logger
 
 
@@ -41,15 +41,8 @@ class StandardizeY(Transform):
             raise ValueError(
                 "StandardizeY transform requires non-empty observation data."
             )
+        Ys = get_data(observation_data=observation_data)
         # Compute means and SDs
-        Ys: DefaultDict[str, List[float]] = defaultdict(list)
-        for obsd in observation_data:
-            for i, m in enumerate(obsd.metric_names):
-                Ys[m].append(obsd.means[i])
-        # Expected `DefaultDict[Union[str, typing.Tuple[str, Optional[Union[bool, float,
-        # str]]]], List[float]]` for 1st anonymous parameter to call
-        # `ax.modelbridge.transforms.standardize_y.compute_standardization_parameters`
-        # but got `DefaultDict[str, List[float]]`.
         # pyre-fixme[6]: Expected `DefaultDict[Union[str, Tuple[str, Optional[Union[b...
         self.Ymean, self.Ystd = compute_standardization_parameters(Ys)
 

--- a/ax/modelbridge/transforms/utils.py
+++ b/ax/modelbridge/transforms/utils.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections import defaultdict
+from math import isnan
+from typing import Callable, Dict, List, Tuple, Union
+
+import numpy as np
+from ax.core.observation import ObservationData
+from scipy.stats import norm
+
+
+def get_data(
+    observation_data: List[ObservationData], metric_names: Union[List[str], None] = None
+) -> Dict[str, List[float]]:
+    """Extract all metrics if `metric_names` is None."""
+    Ys = defaultdict(list)
+    for obsd in observation_data:
+        for i, m in enumerate(obsd.metric_names):
+            if metric_names is None or m in metric_names:
+                Ys[m].append(obsd.means[i])
+    return Ys
+
+
+def match_ci_width_truncated(
+    mean: float,
+    variance: float,
+    transform: Callable[[float], float],
+    level: float = 0.95,
+    margin: float = 0.001,
+    lower_bound: float = 0.0,
+    upper_bound: float = 1.0,
+    clip_mean: bool = False,
+) -> Tuple[float, float]:
+    """Estimate a transformed variance using the match ci width method.
+
+    See log_y transform for the original. Here, bounds are forced to lie
+    within a [lower_bound, upper_bound] interval after transformation."""
+    fac = norm.ppf(1 - (1 - level) / 2)
+    d = fac * np.sqrt(variance)
+    if clip_mean:
+        mean = np.clip(mean, lower_bound + margin, upper_bound - margin)
+    right = min(mean + d, upper_bound - margin)
+    left = max(mean - d, lower_bound + margin)
+    width_asym = transform(right) - transform(left)
+    new_mean = transform(mean)
+    new_variance = float("nan") if isnan(variance) else (width_asym / 2 / fac) ** 2
+    return new_mean, new_variance

--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -11,6 +11,7 @@ from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.search_space import SearchSpace
 from ax.core.types import TConfig
 from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.utils import get_data
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast
 
@@ -49,11 +50,7 @@ class Winsorize(Transform):
         upper = 0.0
         if config is not None and "winsorization_upper" in config:
             upper = checked_cast(float, (config.get("winsorization_upper") or 0.0))
-        metric_names = {x for obsd in observation_data for x in obsd.metric_names}
-        metric_values = {metric_name: [] for metric_name in metric_names}
-        for obsd in observation_data:
-            for i, metric_name in enumerate(obsd.metric_names):
-                metric_values[metric_name].append(obsd.means[i])
+        metric_values = get_data(observation_data=observation_data)
         if lower >= 1 - upper:
             raise ValueError(  # pragma: no cover
                 f"Lower bound: {lower} was greater than the inverse of the upper "

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -16,6 +16,7 @@ from ax.modelbridge.transforms.ivw import IVW
 from ax.modelbridge.transforms.log import Log
 from ax.modelbridge.transforms.one_hot import OneHot
 from ax.modelbridge.transforms.ordered_choice_encode import OrderedChoiceEncode
+from ax.modelbridge.transforms.power_transform_y import PowerTransformY
 from ax.modelbridge.transforms.remove_fixed import RemoveFixed
 from ax.modelbridge.transforms.search_space_to_choice import SearchSpaceToChoice
 from ax.modelbridge.transforms.standardize_y import StandardizeY
@@ -60,6 +61,7 @@ TRANSFORM_REGISTRY: Dict[Type[Transform], int] = {
     UnitX: 15,
     Winsorize: 16,
     CapParameter: 17,
+    PowerTransformY: 18,
 }
 
 

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -242,6 +242,13 @@ Transforms
     :undoc-members:
     :show-inheritance:
 
+`ax.modelbridge.transforms.power\_transform\_y`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.power_transform_y
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 `ax.modelbridge.transforms.remove\_fixed`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -303,6 +310,14 @@ Transforms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.modelbridge.transforms.unit_x
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`ax.modelbridge.transforms.utils`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.utils
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Summary:
This adds a Yeo-Johnson power transform to Ax. I have modeled this based of `InverseGaussianCdfY` as these are very similar except for the difference that the power transform can be inverted. We could also have used Box-Cox, but sklearn only implements the one-parameter version which can only be used for positive values, while Yeo-Johnson handles any inputs.

I currently use CI matching to untransform the values, but there are some issues with this. The first one is that not all values can be untransformed, so we need to clip the values back in the range that we can invert (similar to `InverseGaussianCdfY`). The second issue is that outliers tend to get massive error bars when they are untransformed because of the fact that the derivative of the inverse tends to be very large  there. Thing behave very well in the transformed space though which is what I'm most interested in shadowing.

A couple of things that would be great to get some feedback on:
- I use the  `PowerTransformer` in Sklearn to fit the transform. This means that I'm holding on to (rather simple) Sklearn objects that I need to transform and untransform. I'm not sure if this causes any issues with serialization.
- I currently don't touch off-diagonal covariance entries, similarly to `InverseGaussianCdfY`. I assume these are mostly present in field experiments and not AutoML, but please let me know what to do about that. Some better input checking probably makes sense there.

Reviewed By: Balandat

Differential Revision: D26383524

