### PR TITLE
Pin BoTorch to 0.4.0

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        botorch: ['stable', 'minimum']
+        botorch: ['stable', 'pinned']
       fail-fast: false
 
     steps:
@@ -29,12 +29,12 @@ jobs:
         # will automatically install latest stable Botorch
         pip install -q -e .[dev,mysql,notebook]
       if: matrix.botorch == 'stable'
-    - name: Install dependencies (minimum Botorch)
+    - name: Install dependencies (pinned Botorch)
       run: |
-        # TODO: read minimum supported Botorch version from a shared source
-        pip install botorch==0.3.3
+        # TODO: read pinned Botorch version from a shared source
+        pip install botorch==0.4.0
         pip install -q -e .[dev,mysql,notebook]
-      if: matrix.botorch == 'minimum'
+      if: matrix.botorch == 'pinned'
     - name: Import Ax
       run: |
         python scripts/import_ax.py

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        botorch: ['stable', 'minimum']
+        botorch: ['stable', 'pinned']
 
     steps:
     - uses: actions/checkout@v2
@@ -26,12 +26,12 @@ jobs:
         # will automatically install latest stable Botorch
         pip install -q -e .[dev,mysql,notebook]
       if: matrix.botorch == 'stable'
-    - name: Install dependencies (minimum Botorch)
+    - name: Install dependencies (pinned Botorch)
       run: |
-        # TODO: read minimum supported Botorch version from a shared source
-        pip install botorch==0.3.3
+        # TODO: read pinned Botorch version from a shared source
+        pip install botorch==0.4.0
         pip install -q -e .[dev,mysql,notebook]
-      if: matrix.botorch == 'minimum'
+      if: matrix.botorch == 'pinned'
     - name: Import Ax
       run: |
         python scripts/import_ax.py

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@
 
 from setuptools import find_packages, setup
 
-
-MIN_BOTORCH_VERSION = "0.3.3"
+# TODO: read pinned Botorch version from a shared source
+PINNED_BOTORCH_VERSION = "0.4.0"
 
 REQUIRES = [
-    f"botorch>={MIN_BOTORCH_VERSION}",
+    f"botorch=={PINNED_BOTORCH_VERSION}",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
Summary:
As discussed with Balandat offline yesterday, we should pin BoTorch versions so that we don't always have to release Ax right after BoTorch.

Right now, we're in a slightly dangerous state where BoTorch 0.4.0 is released, and so because our setup.py file runs `pip install botorch>=0.3.3`, pip will install 0.4.0 now. But the stable version of Ax is actually not compatible with this newest version of BoTorch (as you can see from the failure of this test: https://github.com/facebook/Ax/runs/1967381927?check_suite_focus=true).

Differential Revision: D26635518

