### PR TITLE
Back out "allow passing batch_shape for input warping"

### DIFF
--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -161,7 +161,3 @@ class BotorchDefaultsTest(TestCase):
         self.assertEqual(warp_tf.indices.tolist(), list(range(4)))
         warp_tf = get_warping_transform(d=4, task_feature=2)
         self.assertEqual(warp_tf.indices.tolist(), [0, 1, 3])
-        warp_tf = get_warping_transform(d=4, batch_shape=torch.Size([2]))
-        self.assertIsInstance(warp_tf, Warp)
-        self.assertEqual(warp_tf.indices.tolist(), list(range(4)))
-        self.assertEqual(warp_tf.batch_shape, torch.Size([2]))

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -269,7 +269,6 @@ def _get_acqusition_func(
         # pyre-fixme[6]: Expected `Optional[int]` for 9th param but got
         #  `Union[float, int]`.
         seed=torch.randint(1, 10000, (1,)).item(),
-        marginalize_dim=kwargs.get("marginalize_dim"),
     )
 
 

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -530,7 +530,6 @@ def _get_model(
         warp_tf = get_warping_transform(
             d=X.shape[-1],
             task_feature=task_feature,
-            batch_shape=X.shape[:-2],  # pyre-ignore [6]
         )
     else:
         warp_tf = None
@@ -604,15 +603,13 @@ def _get_model(
 
 def get_warping_transform(
     d: int,
-    batch_shape: Optional[torch.Size] = None,
     task_feature: Optional[int] = None,
 ) -> Warp:
     """Construct input warping transform.
 
     Args:
         d: The dimension of the input, including task features
-        batch_shape: The batch_shape of the model
-        task_feature: The index of the task feature
+        task_feature: the index of the task feature
 
     Returns:
         The input warping transform.
@@ -627,6 +624,5 @@ def get_warping_transform(
         # prior with a median of 1
         concentration1_prior=LogNormalPrior(0.0, 0.75 ** 0.5),
         concentration0_prior=LogNormalPrior(0.0, 0.75 ** 0.5),
-        batch_shape=batch_shape,
     )
     return tf


### PR DESCRIPTION
Summary: Original commit changeset: 1991e3f5fc47

Differential Revision: D26947780

