### PR TITLE
Unquiet workflow pip, allow gating latest botorch via env var

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,11 +22,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      env:
+        ALLOW_BOTORCH_MASTER: true
       run: |
         # use master Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -q -e .[dev,mysql,notebook]
+        pip install -e .[dev,mysql,notebook]
     - name: Tests and coverage
       run: |
         pytest -ra --cov=ax
@@ -69,11 +71,13 @@ jobs:
       with:
         python-version: 3.7
     - name: Install dependencies
+      env:
+        ALLOW_BOTORCH_MASTER: true
       run: |
         # use master Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -q -e .[dev,mysql,notebook]
+        pip install -e .[dev,mysql,notebook]
     - name: Validate Sphinx
       run: |
         python scripts/validate_sphinx.py -p "${pwd}"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       env:
-        ALLOW_BOTORCH_MASTER: true
+        ALLOW_BOTORCH_LATEST: true
       run: |
         # use master Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
@@ -72,7 +72,7 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       env:
-        ALLOW_BOTORCH_MASTER: true
+        ALLOW_BOTORCH_LATEST: true
       run: |
         # use master Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        botorch: ['stable', 'latest']
+        botorch: ['stable', 'latest']  # 'stable' is pinned BoTorch version
       fail-fast: false
 
     steps:
@@ -29,7 +29,7 @@ jobs:
         # will automatically install latest stable Botorch (pinned in setup.py)
         pip install -e .[dev,mysql,notebook]
       if: matrix.botorch == 'stable'
-    - name: Install dependencies (pinned Botorch)
+    - name: Install dependencies (Botorch master)
       env:
         ALLOW_BOTORCH_LATEST: true
       run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        botorch: ['stable', 'pinned']
+        botorch: ['stable', 'latest']
       fail-fast: false
 
     steps:
@@ -26,15 +26,17 @@ jobs:
         python-version: 3.7
     - name: Install dependencies (stable Botorch)
       run: |
-        # will automatically install latest stable Botorch
-        pip install -q -e .[dev,mysql,notebook]
+        # will automatically install latest stable Botorch (pinned in setup.py)
+        pip install -e .[dev,mysql,notebook]
       if: matrix.botorch == 'stable'
     - name: Install dependencies (pinned Botorch)
+      env:
+        ALLOW_BOTORCH_MASTER: true
       run: |
-        # TODO: read pinned Botorch version from a shared source
-        pip install botorch==0.4.0
-        pip install -q -e .[dev,mysql,notebook]
-      if: matrix.botorch == 'pinned'
+        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install git+https://github.com/pytorch/botorch.git
+        pip install -e .[dev,mysql,notebook]
+      if: matrix.botorch == 'latest'
     - name: Import Ax
       run: |
         python scripts/import_ax.py
@@ -55,11 +57,13 @@ jobs:
       with:
         python-version: 3.7
     - name: Install dependencies
+      env:
+        ALLOW_BOTORCH_MASTER: true
       run: |
         # use master Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -q -e .[dev,mysql,notebook]
+        pip install -e .[dev,mysql,notebook]
         pip install psycopg2  # Used in example DBSettings in a tutorial (as part of postgres).
         pip install torchvision  # required for tutorials
         pip install ray  # Required for building RayTune tutorial notebook.
@@ -85,11 +89,13 @@ jobs:
       with:
         python-version: 3.7
     - name: Install dependencies
+      env:
+        ALLOW_BOTORCH_MASTER: true
       run: |
         # use master Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -q -e .[dev,mysql,notebook]
+        pip install -e .[dev,mysql,notebook]
         pip install wheel
     - name: Build wheel
       run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -31,7 +31,7 @@ jobs:
       if: matrix.botorch == 'stable'
     - name: Install dependencies (pinned Botorch)
       env:
-        ALLOW_BOTORCH_MASTER: true
+        ALLOW_BOTORCH_LATEST: true
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
@@ -58,7 +58,7 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       env:
-        ALLOW_BOTORCH_MASTER: true
+        ALLOW_BOTORCH_LATEST: true
       run: |
         # use master Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
@@ -90,7 +90,7 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       env:
-        ALLOW_BOTORCH_MASTER: true
+        ALLOW_BOTORCH_LATEST: true
       run: |
         # use master Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,13 +24,13 @@ jobs:
     - name: Install dependencies (stable Botorch)
       run: |
         # will automatically install latest stable Botorch
-        pip install -q -e .[dev,mysql,notebook]
+        pip install -e .[dev,mysql,notebook]
       if: matrix.botorch == 'stable'
     - name: Install dependencies (pinned Botorch)
       run: |
         # TODO: read pinned Botorch version from a shared source
         pip install botorch==0.4.0
-        pip install -q -e .[dev,mysql,notebook]
+        pip install -e .[dev,mysql,notebook]
       if: matrix.botorch == 'pinned'
     - name: Import Ax
       run: |
@@ -53,7 +53,7 @@ jobs:
     - name: Install dependencies
       run: |
         # use stable Botorch
-        pip install -q -e .[dev,mysql,notebook]
+        pip install -e .[dev,mysql,notebook]
         pip install psycopg2  # Used in example DBSettings in a tutorial (as part of postgres).
         pip install torchvision  # required for tutorials
         pip install ray  # Required for building RayTune tutorial notebook.
@@ -80,7 +80,7 @@ jobs:
     - name: Install dependencies
       run: |
         # use stable Botorch
-        pip install -q -e .[dev,mysql,notebook]
+        pip install -e .[dev,mysql,notebook]
         pip install wheel
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 # TODO: read pinned Botorch version from a shared source
 PINNED_BOTORCH_VERSION = "0.4.0"
 
-if os.environ.get("ALLOW_BOTORCH_MASTER"):
+if os.environ.get("ALLOW_BOTORCH_LATEST"):
     # allows installing using a more recent botorch dev version
     botorch_req = "botorch"
 else:

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,22 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
+import os
+
 from setuptools import find_packages, setup
 
 # TODO: read pinned Botorch version from a shared source
 PINNED_BOTORCH_VERSION = "0.4.0"
 
+if os.environ.get("ALLOW_BOTORCH_MASTER"):
+    # allows installing using a more recent botorch dev version
+    botorch_req = "botorch"
+else:
+    f"botorch=={PINNED_BOTORCH_VERSION}"
+
+
 REQUIRES = [
-    f"botorch=={PINNED_BOTORCH_VERSION}",
+    botorch_req,
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
This makes it clear when we use botorch latest vs botorch pinned in CI