### PR TITLE
Fix build errors

### DIFF
--- a/ax/modelbridge/tests/test_multi_objective_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_multi_objective_torch_modelbridge.py
@@ -170,7 +170,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
                 modelbridge=modelbridge, objective_thresholds=objective_thresholds
             )
             wrapped_frontier_evaluator.assert_called_once()
-            self.assertIsNone(wrapped_frontier_evaluator.call_args.kwargs["X"])
+            self.assertIsNone(wrapped_frontier_evaluator.call_args[1]["X"])
             self.assertEqual(1, len(observed_frontier))
             self.assertEqual(observed_frontier[0].arm_name, "0_0")
 
@@ -224,7 +224,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             wrapped_frontier_evaluator.assert_called_once()
             self.assertTrue(
                 torch.equal(
-                    wrapped_frontier_evaluator.call_args.kwargs["X"],
+                    wrapped_frontier_evaluator.call_args[1]["X"],
                     torch.tensor([[1.0, 4.0], [4.0, 1.0]]),
                 )
             )
@@ -240,10 +240,10 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
                 use_model_predictions=False,
             )
             wrapped_frontier_evaluator.assert_called_once()
-            self.assertIsNone(wrapped_frontier_evaluator.call_args.kwargs["X"])
+            self.assertIsNone(wrapped_frontier_evaluator.call_args[1]["X"])
             self.assertTrue(
                 torch.equal(
-                    wrapped_frontier_evaluator.call_args.kwargs["Y"],
+                    wrapped_frontier_evaluator.call_args[1]["Y"],
                     torch.tensor([[9.0, 4.0], [16.0, 25.0]]),
                 )
             )

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -44,19 +44,19 @@ class ParetoFrontierResults(NamedTuple):
     Fields are:
     - param_dicts: The parameter dicts of the points generated on the Pareto Frontier.
     - means: The posterior mean predictions of the model for each metric (same order as
-        the param dicts). These must be as a percent change relative to status quo for
-        any metric not listed in absolute_metrics.
+    the param dicts). These must be as a percent change relative to status quo for
+    any metric not listed in absolute_metrics.
     - sems: The posterior sem predictions of the model for each metric (same order as
-        the param dicts). Also must be relativized wrt status quo for any metric not
-        listed in absolute_metrics.
+    the param dicts). Also must be relativized wrt status quo for any metric not
+    listed in absolute_metrics.
     - primary_metric: The name of the primary metric.
     - secondary_metric: The name of the secondary metric.
     - absolute_metrics: List of outcome metrics that are NOT be relativized w.r.t. the
-        status quo. All other metrics are assumed to be given here as % relative to
-        status_quo.
+    status quo. All other metrics are assumed to be given here as % relative to
+    status_quo.
     - objective_thresholds: Threshold for each objective. Must be on the same scale as
-        means, so if means is relativized it should be the relative value, otherwise it
-        should be absolute.
+    means, so if means is relativized it should be the relative value, otherwise it
+    should be absolute.
     - arm_names: Optional list of arm names for each parameterization.
     """
 


### PR DESCRIPTION
My last stack of commits introduced two build issues: A test failure in py3.7 because I used `mock.call_args.kwargs` which apparently was introduced in py3.8, and a sphinx error from putting an indention in my docstring.