### PR TITLE
Switch AbandonedArm and GeneratorRunStruct to dataclasses

### DIFF
--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict, defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
@@ -14,7 +15,6 @@ from typing import (
     Dict,
     List,
     MutableMapping,
-    NamedTuple,
     Optional,
     Union,
 )
@@ -25,6 +25,7 @@ from ax.core.base_trial import BaseTrial
 from ax.core.generator_run import GeneratorRun, GeneratorRunType
 from ax.core.trial import immutable_once_run
 from ax.core.types import TCandidateMetadata
+from ax.utils.common.base import Base
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.equality import datetime_equals, equality_typechecker
 from ax.utils.common.logger import get_logger
@@ -39,8 +40,9 @@ if TYPE_CHECKING:
     from ax import core  # noqa F401  # pragma: no cover
 
 
-class AbandonedArm(NamedTuple):
-    """Tuple storing metadata of arm that has been abandoned within
+@dataclass
+class AbandonedArm(Base):
+    """Class storing metadata of arm that has been abandoned within
     a BatchTrial.
     """
 
@@ -57,7 +59,8 @@ class AbandonedArm(NamedTuple):
         )
 
 
-class GeneratorRunStruct(NamedTuple):
+@dataclass
+class GeneratorRunStruct(Base):
     """Stores GeneratorRun object as well as the weight with which it was added."""
 
     generator_run: GeneratorRun

--- a/ax/storage/json_store/encoder.py
+++ b/ax/storage/json_store/encoder.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import dataclasses
 import datetime
 import enum
 from collections import OrderedDict
@@ -62,9 +63,14 @@ def object_to_json(obj: Any) -> Any:
     elif _type is dict:
         return {k: object_to_json(v) for k, v in obj.items()}
     elif _is_named_tuple(obj):
-        return {
+        return {  # pragma: no cover
             "__type": _type.__name__,
             **{k: object_to_json(v) for k, v in obj._asdict().items()},
+        }
+    elif dataclasses.is_dataclass(obj):
+        return {
+            "__type": _type.__name__,
+            **{k: object_to_json(v) for k, v in dataclasses.asdict(obj).items()},
         }
 
     # Types from libraries, commonly used in Ax (e.g., numpy, pandas, torch)

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -38,6 +38,7 @@ from ax.utils.testing.benchmark_stubs import (
     get_sum_simple_benchmark_problem,
 )
 from ax.utils.testing.core_stubs import (
+    get_abandoned_arm,
     get_acquisition_function_type,
     get_acquisition_type,
     get_arm,
@@ -89,6 +90,7 @@ from botorch.test_functions.synthetic import Ackley
 
 
 TEST_CASES = [
+    ("AbandonedArm", get_abandoned_arm),
     ("Arm", get_arm),
     ("AugmentedBraninMetric", get_augmented_branin_metric),
     ("AugmentedHartmannMetric", get_augmented_hartmann_metric),

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -651,7 +651,6 @@ class Encoder:
         """Convert Ax AbandonedArm to SQLAlchemy."""
         # pyre-fixme[9]: abandoned_arm_class is ....sqa_store.db.SQABase]`.
         abandoned_arm_class: SQAAbandonedArm = self.config.class_to_sqa_class[
-            # pyre-fixme[6]: Expected `typing.Type[B...ing.Type[AbandonedArm]`.
             AbandonedArm
         ]
         # pyre-fixme[29]: `SQAAbandonedArm` is not a function.


### PR DESCRIPTION
Summary: For upcoming storage work, I need to be able to save db_id on AbandonedArms. Most of our classes get that for free because they inherit from Base. Namedtuples can't use inheritance, but Dataclasses can.

Reviewed By: lena-kashtelyan

Differential Revision: D27089875

