### PR TITLE
Add MOOAcquisition to sphinx.

### DIFF
--- a/ax/models/torch/tests/test_moo_acquisition.py
+++ b/ax/models/torch/tests/test_moo_acquisition.py
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Any
+from unittest import mock
 from unittest.mock import patch
 
-import mock
 import torch
 from ax.exceptions.core import UnsupportedError
 from ax.models.torch.botorch_modular.acquisition import Acquisition

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -235,6 +235,15 @@ ax.models.torch.botorch_modular.model module
     :undoc-members:
     :show-inheritance:
 
+ax.models.torch.botorch_modular.moo_acquisition module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.models.torch.botorch_modular.moo_acquisition
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 ax.models.torch.botorch_modular.multi_fidelity module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary: Fix sphinx errors by adding MOOAcquisition to sphinx.

Reviewed By: stevemandala

Differential Revision: D27134119

