### PR TITLE
Enable mocking of functions in `ax/storage/sqa_store/save.py` and `load.py` (there was aliasing that got in the way)

### DIFF
--- a/ax/__init__.py
+++ b/ax/__init__.py
@@ -33,7 +33,7 @@ from ax.core import (
 )
 from ax.modelbridge import Models
 from ax.service import OptimizationLoop, optimize
-from ax.storage import load, save
+from ax.storage import json_load, json_save
 
 
 try:
@@ -71,6 +71,6 @@ __all__ = [
     "SumConstraint",
     "Trial",
     "optimize",
-    "save",
-    "load",
+    "json_save",
+    "json_load",
 ]

--- a/ax/storage/__init__.py
+++ b/ax/storage/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ax.storage.json_store import load, save
+from ax.storage.json_store import load as json_load, save as json_save
 
 
-__all__ = ["save", "load"]
+__all__ = ["json_save", "json_load"]

--- a/ax/storage/json_store/__init__.py
+++ b/ax/storage/json_store/__init__.py
@@ -4,8 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ax.storage.json_store.load import load_experiment as load
-from ax.storage.json_store.save import save_experiment as save
+from ax.storage.json_store.load import load_experiment as json_load
+from ax.storage.json_store.save import save_experiment as json_save
 
 
-__all__ = ["load", "save"]
+__all__ = ["json_load", "json_save"]

--- a/ax/storage/sqa_store/__init__.py
+++ b/ax/storage/sqa_store/__init__.py
@@ -7,10 +7,10 @@
 # necessary to import this file so SQLAlchemy knows about the event listeners
 # see https://fburl.com/8mn7yjt2
 from ax.storage.sqa_store import validation
-from ax.storage.sqa_store.load import load_experiment as load
-from ax.storage.sqa_store.save import save_experiment as save
+from ax.storage.sqa_store.load import load_experiment as sqa_load
+from ax.storage.sqa_store.save import save_experiment as sqa_save
 
 
-__all__ = ["load", "save"]
+__all__ = ["sqa_load", "sqa_save"]
 
 del validation


### PR DESCRIPTION
Summary:
The way our init files are currently specified in `ax/storage/sqa_store` creates some shadowing: we have `ax.storage.sqa_store.save` the module (from `save.py` file) and the function ––`save_experiment`, aliased as `save` (or maybe even two of them, as the JSON save is aliased in `sqa_store/__init__.py` and then SQL `save_experiment` is aliased in `storage/__init__.py` –– not sure if aliasing gets chained or not, but this is beside the point). This makes it so that it's impossible do to something like `patch("ax.storage.sqa_store.save.<my_function>"`), because `ax.storage.sqa_store.save` is translated to a function (`save_experiment`) instead of a module and results in an error like:
```
AttributeError: <function save_experiment at 0x7f8a787eddc0> does not have the attribute 'my_function'
```

This was done for a good reason in D14997052 (https://github.com/facebook/Ax/commit/0bdbcbc53252e423898e9f088b740d52358eafc1), so putting up an RfC to collectively brainstorm how to fix. I can just not mock things in that file (although it is very helpful for testing and will also happen the same way for `load.py`), but I think we should at least all be aware of this behavior if not fix it.

Reviewed By: ldworkin

Differential Revision: D27128028

