### PR TITLE
ensure all trials are evaluated in benchmark_replication

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -155,7 +155,7 @@ def benchmark_replication(  # One optimization loop.
         verbose_logging=verbose_logging,
         failed_trials_tolerated=failed_trials_tolerated,
     )
-
+    experiment.fetch_data()
     trial_exceptions.extend(exceptions)
     return experiment
 


### PR DESCRIPTION
Summary: see title. Previously, the last trial may not have been evaluated in the benchmark_replication and instead was evaluated in generate_report, which was quite slow with many method groups and replications.

Differential Revision: D27165388

