### PR TITLE
Introduce SearchSpaceDigest, pass more information to models

### DIFF
--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -6,7 +6,8 @@
 
 # pyre-strict
 
-from typing import Dict, List, Optional
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple, Union
 
 from ax.core.arm import Arm
 from ax.core.parameter import FixedParameter, Parameter, RangeParameter
@@ -324,3 +325,40 @@ class SearchSpace(Base):
             "parameters=" + repr(list(self._parameters.values())) + ", "
             "parameter_constraints=" + repr(self._parameter_constraints) + ")"
         )
+
+
+@dataclass
+class SearchSpaceDigest:
+    """Container for lightweight representation of search space properties.
+
+    This is used for communicating between modelbridge and models. This is
+    an ephemeral object and not meant to be stored / serialized.
+
+    Attributes:
+        feature_names: A list of parameter names.
+        bounds: A list [(l_0, u_0), ..., (l_d, u_d)] of tuples representing the
+            lower and upper bounds on the respective parameter (both inclusive).
+        ordinal_features: A list of indices corresponding to the parameters
+            to be considered as ordinal discrete parameters. The corresponding
+            bounds are assumed to be integers, and parameter `i` is assumed
+            to take on values `l_i, l_i+1, ..., u_i`.
+        categorical_features: A list of indices corresponding to the parameters
+            to be considered as categorical discrete parameters. The corresponding
+            bounds are assumed to be integers, and parameter `i` is assumed
+            to take on values `l_i, l_i+1, ..., u_i`.
+        task_features: A list of parameter indices to be considered as
+            task parameters.
+        fidelity_features: A list of parameter indices to be considered as
+            fidelity parameters.
+        target_fidelities: A dict mapping parameter indices (of fidelity
+            parameters) to their respective target fidelity value. Only used
+            when generating candidates.
+    """
+
+    feature_names: List[str]
+    bounds: List[Tuple[Union[int, float], Union[int, float]]]
+    ordinal_features: List[int] = field(default_factory=list)
+    categorical_features: List[int] = field(default_factory=list)
+    task_features: List[int] = field(default_factory=list)
+    fidelity_features: List[int] = field(default_factory=list)
+    target_fidelities: Dict[int, Union[int, float]] = field(default_factory=dict)

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import dataclasses
+
 from ax.core.arm import Arm
 from ax.core.parameter import (
     ChoiceParameter,
@@ -16,7 +18,7 @@ from ax.core.parameter_constraint import (
     ParameterConstraint,
     SumConstraint,
 )
-from ax.core.search_space import SearchSpace
+from ax.core.search_space import SearchSpace, SearchSpaceDigest
 from ax.utils.common.testutils import TestCase
 
 
@@ -330,3 +332,33 @@ class SearchSpaceTest(TestCase):
         # Test constructing an arm with a bad param name
         with self.assertRaises(ValueError):
             self.ss1.construct_arm({"a": "notafloat"})
+
+
+class SearchSpaceDigestTest(TestCase):
+    def setUp(self):
+        self.kwargs = {
+            "feature_names": ["a", "b", "c"],
+            "bounds": [(0.0, 1.0), (0, 2), (0, 4)],
+            "ordinal_features": [1],
+            "categorical_features": [2],
+            "task_features": [3],
+            "fidelity_features": [0],
+            "target_fidelities": {0: 1.0},
+        }
+
+    def testSearchSpaceDigest(self):
+        # test required fields
+        with self.assertRaises(TypeError):
+            SearchSpaceDigest(bounds=[])
+        with self.assertRaises(TypeError):
+            SearchSpaceDigest(feature_names=[])
+        # test instantiation
+        ssd = SearchSpaceDigest(**self.kwargs)
+        self.assertEqual(dataclasses.asdict(ssd), self.kwargs)
+        # test default instatiation
+        for arg in self.kwargs:
+            if arg in {"feature_names", "bounds"}:
+                continue
+            ssd = SearchSpaceDigest(
+                **{k: v for k, v in self.kwargs.items() if k != arg}
+            )

--- a/ax/modelbridge/random.py
+++ b/ax/modelbridge/random.py
@@ -15,7 +15,7 @@ from ax.core.types import TConfig, TGenMetadata
 from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.modelbridge_utils import (
     extract_parameter_constraints,
-    get_bounds_and_task,
+    extract_search_space_digest,
     get_fixed_features,
     parse_observation_features,
     transform_callback,
@@ -75,7 +75,7 @@ class RandomModelBridge(ModelBridge):
     ]:
         """Generate new candidates according to a search_space."""
         # Extract parameter values
-        bounds, _, _ = get_bounds_and_task(search_space, self.parameters)
+        search_space_digest = extract_search_space_digest(search_space, self.parameters)
         # Get fixed features
         fixed_features_dict = get_fixed_features(fixed_features, self.parameters)
         # Extract param constraints
@@ -85,7 +85,7 @@ class RandomModelBridge(ModelBridge):
         # Generate the candidates
         X, w = self.model.gen(
             n=n,
-            bounds=bounds,
+            bounds=search_space_digest.bounds,
             linear_constraints=linear_constraints,
             fixed_features=fixed_features_dict,
             model_gen_options=model_gen_options,

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -9,6 +9,7 @@ from unittest import mock
 import numpy as np
 import torch
 from ax.core.observation import ObservationFeatures
+from ax.core.search_space import SearchSpaceDigest
 from ax.modelbridge.array import ArrayModelBridge
 from ax.modelbridge.torch import TorchModelBridge
 from ax.modelbridge.transforms.base import Transform
@@ -47,11 +48,8 @@ class TorchModelBridgeTest(TestCase):
             Xs=[X],
             Ys=[Y],
             Yvars=[var],
-            bounds=None,
-            feature_names=[],
+            search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
             metric_names=[],
-            task_features=[],
-            fidelity_features=[],
             candidate_metadata=[],
         )
         model_fit_args = model.fit.mock_calls[0][2]
@@ -80,13 +78,9 @@ class TorchModelBridgeTest(TestCase):
             Xs=[X],
             Ys=[Y],
             Yvars=[var],
-            candidate_metadata=[],
-            bounds=None,
-            feature_names=[],
+            search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
             metric_names=[],
-            task_features=[],
-            fidelity_features=[],
-            target_fidelities=[],
+            candidate_metadata=[],
         )
         model_update_args = model.update.mock_calls[0][2]
         self.assertTrue(
@@ -177,11 +171,11 @@ class TorchModelBridgeTest(TestCase):
             Ys_train=[Y],
             Yvars_train=[var],
             X_test=X,
-            bounds=[(0, 1)],
-            task_features=[],
-            feature_names=[],
+            search_space_digest=SearchSpaceDigest(
+                feature_names=[],
+                bounds=[(0, 1)],
+            ),
             metric_names=[],
-            fidelity_features=[],
         )
         model_cv_args = model.cross_validate.mock_calls[0][2]
         self.assertTrue(

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -15,7 +15,10 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.core.types import TCandidateMetadata, TConfig, TGenMetadata
 from ax.modelbridge.array import FIT_MODEL_ERROR, ArrayModelBridge
-from ax.modelbridge.modelbridge_utils import validate_and_apply_final_transform
+from ax.modelbridge.modelbridge_utils import (
+    validate_and_apply_final_transform,
+    SearchSpaceDigest,
+)
 from ax.modelbridge.transforms.base import Transform
 from ax.models.torch_base import TorchModel
 from ax.utils.common.typeutils import not_none
@@ -118,11 +121,8 @@ class TorchModelBridge(ArrayModelBridge):
         Xs: List[np.ndarray],
         Ys: List[np.ndarray],
         Yvars: List[np.ndarray],
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
         candidate_metadata: Optional[List[List[TCandidateMetadata]]],
     ) -> None:
         self.model = model
@@ -138,11 +138,8 @@ class TorchModelBridge(ArrayModelBridge):
             Xs=Xs,
             Ys=Ys,
             Yvars=Yvars,
-            bounds=bounds,
-            task_features=task_features,
-            feature_names=feature_names,
+            search_space_digest=search_space_digest,
             metric_names=metric_names,
-            fidelity_features=fidelity_features,
             candidate_metadata=candidate_metadata,
         )
 
@@ -151,13 +148,9 @@ class TorchModelBridge(ArrayModelBridge):
         Xs: List[np.ndarray],
         Ys: List[np.ndarray],
         Yvars: List[np.ndarray],
+        search_space_digest: SearchSpaceDigest,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]],
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
         metric_names: List[str],
-        fidelity_features: List[int],
-        target_fidelities: Optional[Dict[int, float]],
     ) -> None:
         if not self.model:  # pragma: no cover
             raise ValueError(FIT_MODEL_ERROR.format(action="_model_update"))
@@ -172,14 +165,9 @@ class TorchModelBridge(ArrayModelBridge):
             Xs=Xs,
             Ys=Ys,
             Yvars=Yvars,
-            candidate_metadata=candidate_metadata,
-            bounds=bounds,
-            task_features=task_features,
-            feature_names=self.parameters,
+            search_space_digest=search_space_digest,
             metric_names=self.outcomes,
-            fidelity_features=list(target_fidelities.keys())
-            if target_fidelities
-            else None,
+            candidate_metadata=candidate_metadata,
         )
 
     def _model_predict(self, X: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
@@ -276,11 +264,8 @@ class TorchModelBridge(ArrayModelBridge):
         Ys_train: List[np.ndarray],
         Yvars_train: List[np.ndarray],
         X_test: np.ndarray,
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
     ) -> Tuple[np.ndarray, np.ndarray]:
         if not self.model:  # pragma: no cover
             raise ValueError(FIT_MODEL_ERROR.format(action="_model_cross_validate"))
@@ -298,11 +283,8 @@ class TorchModelBridge(ArrayModelBridge):
             Ys_train=Ys_train,
             Yvars_train=Yvars_train,
             X_test=X_test,
-            bounds=bounds,
-            task_features=task_features,
-            feature_names=feature_names,
+            search_space_digest=search_space_digest,
             metric_names=metric_names,
-            fidelity_features=fidelity_features,
         )
         return (
             f_test.detach().cpu().clone().numpy(),

--- a/ax/models/numpy/randomforest.py
+++ b/ax/models/numpy/randomforest.py
@@ -7,6 +7,7 @@
 from typing import List, Optional, Tuple
 
 import numpy as np
+from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
 from ax.models.numpy_base import NumpyModel
 from ax.utils.common.docutils import copy_doc
@@ -42,11 +43,8 @@ class RandomForest(NumpyModel):
         Xs: List[np.ndarray],
         Ys: List[np.ndarray],
         Yvars: List[np.ndarray],
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
         for i, X in enumerate(Xs):

--- a/ax/models/numpy_base.py
+++ b/ax/models/numpy_base.py
@@ -7,6 +7,7 @@
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
+from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata, TConfig, TGenMetadata
 from ax.models.base import Model
 
@@ -23,11 +24,8 @@ class NumpyModel(Model):
         Xs: List[np.ndarray],
         Ys: List[np.ndarray],
         Yvars: List[np.ndarray],
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
         """Fit model to m outcomes.
@@ -38,13 +36,9 @@ class NumpyModel(Model):
             Ys: The corresponding list of m (k_i x 1) outcome arrays Y, for
                 each outcome.
             Yvars: The variances of each entry in Ys, same shape.
-            bounds: A list of d (lower, upper) tuples for each column of X.
-            task_features: Columns of X that take integer values and should be
-                treated as task parameters.
-            feature_names: Names of each column of X.
+            search_space_digest: A SearchSpaceDigest object containing
+                metadata on the features in X.
             metric_names: Names of each outcome Y in Ys.
-            fidelity_features: Columns of X that should be treated as fidelity
-                parameters.
             candidate_metadata: Model-produced metadata for candidates, in
                 the order corresponding to the Xs.
         """

--- a/ax/models/tests/test_alebo.py
+++ b/ax/models/tests/test_alebo.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import numpy as np
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.alebo import (
     ALEBO,
     ALEBOGP,
@@ -278,11 +279,11 @@ class ALEBOTest(TestCase):
             Xs=[train_X, train_X],
             Ys=[train_Y, train_Y],
             Yvars=[train_Yvar, train_Yvar],
-            bounds=[(-1, 1)] * 5,
-            task_features=[],
-            feature_names=[],
+            search_space_digest=SearchSpaceDigest(
+                feature_names=[],
+                bounds=[(-1, 1)] * 5,
+            ),
             metric_names=[],
-            fidelity_features=[],
         )
         self.assertIsInstance(m.model, ModelListGP)
         self.assertTrue(torch.allclose(m.Xs[0], (B @ train_X.t()).t()))

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -7,6 +7,7 @@
 from unittest import mock
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.botorch_kg import KnowledgeGradient, _instantiate_KG
 from ax.models.torch.utils import get_botorch_objective
 from ax.utils.common.testutils import TestCase
@@ -64,11 +65,11 @@ class KnowledgeGradientTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+            ),
             metric_names=self.metric_names,
-            task_features=[],
-            fidelity_features=[],
         )
 
         n = 2
@@ -168,11 +169,11 @@ class KnowledgeGradientTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+            ),
             metric_names=self.metric_names,
-            task_features=[],
-            fidelity_features=[],
         )
         self.assertTrue(model.use_input_warping)
         self.assertTrue(hasattr(model.model, "input_transform"))
@@ -185,11 +186,11 @@ class KnowledgeGradientTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+            ),
             metric_names=self.metric_names,
-            task_features=[],
-            fidelity_features=[],
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
@@ -199,11 +200,12 @@ class KnowledgeGradientTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            task_features=[],
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+                fidelity_features=[2],
+            ),
             metric_names=["L2NormMetric"],
-            fidelity_features=[2],
         )
 
         # Check best point selection within bounds (some numerical tolerance)
@@ -265,11 +267,12 @@ class KnowledgeGradientTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            task_features=[],
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+                fidelity_features=[2],
+            ),
             metric_names=["L2NormMetric"],
-            fidelity_features=[2],
         )
         self.assertTrue(model.use_input_warping)
         self.assertTrue(hasattr(model.model, "input_transform"))
@@ -282,11 +285,12 @@ class KnowledgeGradientTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            task_features=[],
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+                fidelity_features=[2],
+            ),
             metric_names=["L2NormMetric"],
-            fidelity_features=[2],
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
@@ -297,11 +301,11 @@ class KnowledgeGradientTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+            ),
             metric_names=self.metric_names,
-            task_features=[],
-            fidelity_features=[],
         )
 
         # test _instantiate_KG
@@ -407,11 +411,12 @@ class KnowledgeGradientTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            task_features=[],
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+                fidelity_features=[-1],
+            ),
             metric_names=self.metric_names,
-            fidelity_features=[-1],
         )
 
         acq_function = _instantiate_KG(

--- a/ax/models/tests/test_botorch_mes.py
+++ b/ax/models/tests/test_botorch_mes.py
@@ -7,6 +7,7 @@
 from unittest import mock
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.botorch_mes import MaxValueEntropySearch, _instantiate_MES
 from ax.utils.common.testutils import TestCase
 from botorch.acquisition.max_value_entropy_search import (
@@ -54,11 +55,11 @@ class MaxValueEntropySearchTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+            ),
             metric_names=self.metric_names,
-            task_features=[],
-            fidelity_features=[],
         )
 
         # test model.gen()
@@ -139,11 +140,11 @@ class MaxValueEntropySearchTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+            ),
             metric_names=self.metric_names,
-            task_features=[],
-            fidelity_features=[],
         )
         self.assertTrue(model.use_input_warping)
         self.assertTrue(hasattr(model.model, "input_transform"))
@@ -156,11 +157,11 @@ class MaxValueEntropySearchTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+            ),
             metric_names=self.metric_names,
-            task_features=[],
-            fidelity_features=[],
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
@@ -170,11 +171,12 @@ class MaxValueEntropySearchTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            task_features=[],
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+                fidelity_features=[-1],
+            ),
             metric_names=self.metric_names,
-            fidelity_features=[-1],
         )
 
         # Check best point selection within bounds (some numerical tolerance)
@@ -232,11 +234,12 @@ class MaxValueEntropySearchTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            task_features=[],
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+                fidelity_features=[-1],
+            ),
             metric_names=self.metric_names,
-            fidelity_features=[-1],
         )
         self.assertTrue(model.use_input_warping)
         self.assertTrue(hasattr(model.model, "input_transform"))
@@ -249,11 +252,12 @@ class MaxValueEntropySearchTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            task_features=[],
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+                fidelity_features=[-1],
+            ),
             metric_names=self.metric_names,
-            fidelity_features=[-1],
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
@@ -264,11 +268,11 @@ class MaxValueEntropySearchTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+            ),
             metric_names=self.metric_names,
-            task_features=[],
-            fidelity_features=[],
         )
 
         # test acquisition setting
@@ -295,11 +299,12 @@ class MaxValueEntropySearchTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            task_features=[],
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+                fidelity_features=[-1],
+            ),
             metric_names=self.metric_names,
-            fidelity_features=[-1],
         )
 
         candidate_set = torch.rand(10, 3, dtype=self.dtype, device=self.device)

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -8,6 +8,7 @@ from itertools import chain, product
 from unittest import mock
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.botorch import BotorchModel, get_rounding_func
 from ax.models.torch.botorch_defaults import (
     get_and_fit_model,
@@ -54,11 +55,12 @@ class BotorchModelTest(TestCase):
                 Xs=Xs1 + Xs2,
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
-                bounds=bounds,
-                task_features=[0],
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=[0],
+                ),
                 metric_names=["y", "w"],
-                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 
@@ -88,11 +90,12 @@ class BotorchModelTest(TestCase):
                 Xs=Xs1 + Xs2,
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
-                bounds=bounds,
-                task_features=[0],
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=[0],
+                ),
                 metric_names=["y", "w"],
-                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 
@@ -135,11 +138,12 @@ class BotorchModelTest(TestCase):
                         Xs=Xs1 + Xs2_diff,
                         Ys=Ys1 + Ys2,
                         Yvars=Yvars1 + Yvars2,
-                        bounds=bounds,
-                        task_features=tfs,
-                        feature_names=fns,
+                        search_space_digest=SearchSpaceDigest(
+                            feature_names=fns,
+                            bounds=bounds,
+                            task_features=tfs,
+                        ),
                         metric_names=mns,
-                        fidelity_features=[],
                     )
                     _mock_fit_model.assert_called_once()
                     if use_loocv_pseudo_likelihood:
@@ -184,11 +188,12 @@ class BotorchModelTest(TestCase):
                     Xs=Xs1 + Xs2,
                     Ys=Ys1 + Ys2,
                     Yvars=Yvars1 + Yvars2,
-                    bounds=bounds,
-                    task_features=tfs,
-                    feature_names=fns,
+                    search_space_digest=SearchSpaceDigest(
+                        feature_names=fns,
+                        bounds=bounds,
+                        task_features=tfs,
+                    ),
                     metric_names=mns,
-                    fidelity_features=[],
                 )
                 _mock_fit_model.assert_called_once()
 
@@ -477,11 +482,12 @@ class BotorchModelTest(TestCase):
                 Xs=Xs1 + Xs2_diff,
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
-                bounds=bounds,
-                task_features=tfs,
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=tfs,
+                ),
                 metric_names=mns,
-                fidelity_features=[],
             )
         with self.assertRaises(RuntimeError):
             xbest = model.best_point(bounds=bounds, objective_weights=objective_weights)
@@ -513,11 +519,12 @@ class BotorchModelTest(TestCase):
                     Xs=Xs1,
                     Ys=Ys1,
                     Yvars=Yvars1,
-                    bounds=bounds,
-                    task_features=tfs,
-                    feature_names=fns,
+                    search_space_digest=SearchSpaceDigest(
+                        feature_names=fns,
+                        bounds=bounds,
+                        task_features=tfs,
+                    ),
                     metric_names=mns[0],
-                    fidelity_features=[],
                 )
                 _mock_fit_model.assert_called_once()
                 if use_loocv_pseudo_likelihood:
@@ -557,11 +564,12 @@ class BotorchModelTest(TestCase):
                 Xs=Xs1 + Xs2,
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
-                bounds=bounds,
-                task_features=tfs,
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=tfs,
+                ),
                 metric_names=mns,
-                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -8,6 +8,7 @@ import warnings
 from unittest import mock
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.botorch_defaults import get_NEI
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.botorch_moo_defaults import (
@@ -16,7 +17,6 @@ from ax.models.torch.botorch_moo_defaults import (
     get_default_partitioning_alpha,
 )
 from ax.utils.common.testutils import TestCase
-
 
 FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_gpytorch_model"
 
@@ -56,11 +56,11 @@ class FrontierEvaluatorTest(TestCase):
                 Xs=[self.X],
                 Ys=[self.Y],
                 Yvars=[self.Yvar],
-                bounds=bounds,
-                task_features=[],
-                feature_names=["x1", "x2"],
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=["x1", "x2"],
+                    bounds=bounds,
+                ),
                 metric_names=["a", "b", "c"],
-                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -8,6 +8,7 @@ from typing import Dict
 from unittest import mock
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.botorch_defaults import get_NEI
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.botorch_moo_defaults import get_EHVI
@@ -17,7 +18,6 @@ from botorch.acquisition.multi_objective import monte_carlo as moo_monte_carlo
 from botorch.models import ModelListGP
 from botorch.models.transforms.input import Warp
 from botorch.utils.multi_objective.scalarization import get_chebyshev_scalarization
-
 
 FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_gpytorch_model"
 SAMPLE_SIMPLEX_UTIL_PATH = "ax.models.torch.utils.sample_simplex"
@@ -94,11 +94,12 @@ class BotorchMOOModelTest(TestCase):
                 Xs=Xs1 + Xs2,
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
-                bounds=bounds,
-                task_features=tfs,
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=tfs,
+                ),
                 metric_names=mns,
-                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 
@@ -154,11 +155,12 @@ class BotorchMOOModelTest(TestCase):
             Xs=Xs1 + Xs2,
             Ys=Ys1 + Ys2,
             Yvars=Yvars1 + Yvars2,
-            bounds=bounds,
-            task_features=tfs,
-            feature_names=fns,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=fns,
+                bounds=bounds,
+                task_features=tfs,
+            ),
             metric_names=mns,
-            fidelity_features=[],
         )
         self.assertTrue(model.use_input_warping)
         self.assertIsInstance(model.model, ModelListGP)
@@ -176,11 +178,12 @@ class BotorchMOOModelTest(TestCase):
             Xs=Xs1 + Xs2,
             Ys=Ys1 + Ys2,
             Yvars=Yvars1 + Yvars2,
-            bounds=bounds,
-            task_features=tfs,
-            feature_names=fns,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=fns,
+                bounds=bounds,
+                task_features=tfs,
+            ),
             metric_names=mns,
-            fidelity_features=[],
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
@@ -209,11 +212,12 @@ class BotorchMOOModelTest(TestCase):
                 Xs=Xs1 + Xs2,
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
-                bounds=bounds,
-                task_features=tfs,
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=tfs,
+                ),
                 metric_names=mns,
-                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 
@@ -258,11 +262,12 @@ class BotorchMOOModelTest(TestCase):
                 Xs=Xs1 + Xs2,
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
-                bounds=bounds,
-                task_features=tfs,
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=tfs,
+                ),
                 metric_names=mns,
-                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 
@@ -292,11 +297,12 @@ class BotorchMOOModelTest(TestCase):
                 Xs=Xs1 + Xs2 + Xs2,
                 Ys=Ys1 + Ys2 + Ys2,
                 Yvars=Yvars1 + Yvars2 + Yvars2,
-                bounds=bounds,
-                task_features=tfs,
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=tfs,
+                ),
                 metric_names=mns,
-                fidelity_features=[],
             )
 
         with mock.patch(
@@ -342,11 +348,12 @@ class BotorchMOOModelTest(TestCase):
                 Xs=Xs1 + Xs2,
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
-                bounds=bounds,
-                task_features=tfs,
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=tfs,
+                ),
                 metric_names=mns,
-                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 
@@ -398,11 +405,12 @@ class BotorchMOOModelTest(TestCase):
                 Xs=Xs1 + Xs2,
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
-                bounds=bounds,
-                task_features=tfs,
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=tfs,
+                ),
                 metric_names=mns,
-                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 
@@ -453,11 +461,12 @@ class BotorchMOOModelTest(TestCase):
                 Xs=Xs1 + Xs2,
                 Ys=Ys1 + Ys2,
                 Yvars=Yvars1 + Yvars2,
-                bounds=bounds,
-                task_features=tfs,
-                feature_names=fns,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=fns,
+                    bounds=bounds,
+                    task_features=tfs,
+                ),
                 metric_names=mns,
-                fidelity_features=[],
             )
             _mock_fit_model.assert_called_once()
 

--- a/ax/models/tests/test_cbo_lcea.py
+++ b/ax/models/tests/test_cbo_lcea.py
@@ -7,6 +7,7 @@
 from unittest import mock
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.cbo_lcea import LCEABO
 from ax.utils.common.testutils import TestCase
 from botorch.models.contextual import LCEAGP
@@ -36,11 +37,11 @@ class LCEABOTest(TestCase):
             Xs=[train_X],
             Ys=[train_Y],
             Yvars=[train_Yvar],
-            bounds=[(0.0, 1.0) for _ in range(4)],
-            task_features=[],
-            feature_names=["0", "1", "2", "3"],
+            search_space_digest=SearchSpaceDigest(
+                feature_names=["0", "1", "2", "3"],
+                bounds=[(0.0, 1.0) for _ in range(4)],
+            ),
             metric_names=["y"],
-            fidelity_features=[],
         )
         self.assertIsInstance(m1.model, LCEAGP)
 
@@ -76,11 +77,11 @@ class LCEABOTest(TestCase):
             Xs=[train_X],
             Ys=[train_Y],
             Yvars=[train_Yvar],
-            bounds=[(0.0, 1.0) for _ in range(4)],
-            task_features=[],
-            feature_names=["x1", "x2", "x3", "x4"],
+            search_space_digest=SearchSpaceDigest(
+                feature_names=["x1", "x2", "x3", "x4"],
+                bounds=[(0.0, 1.0) for _ in range(4)],
+            ),
             metric_names=["y"],
-            fidelity_features=[],
         )
         self.assertDictEqual(m2.model.decomposition, {"1": [0, 2], "2": [1, 3]})
 
@@ -91,11 +92,11 @@ class LCEABOTest(TestCase):
                 Xs=[train_X],
                 Ys=[train_Y],
                 Yvars=[train_Yvar],
-                bounds=[(0.0, 1.0) for _ in range(4)],
-                task_features=[],
-                feature_names=[],
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[],
+                    bounds=[(0.0, 1.0) for _ in range(4)],
+                ),
                 metric_names=[],
-                fidelity_features=[],
             )
 
         # pass wrong feature names
@@ -104,9 +105,9 @@ class LCEABOTest(TestCase):
                 Xs=[train_X],
                 Ys=[train_Y],
                 Yvars=[train_Yvar],
-                bounds=[(0.0, 1.0) for _ in range(4)],
-                task_features=[],
-                feature_names=["x0", "x1", "x2", "x3"],
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=["x0", "x1", "x2", "x3"],
+                    bounds=[(0.0, 1.0) for _ in range(4)],
+                ),
                 metric_names=["y"],
-                fidelity_features=[],
             )

--- a/ax/models/tests/test_cbo_sac.py
+++ b/ax/models/tests/test_cbo_sac.py
@@ -7,6 +7,7 @@
 from unittest import mock
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.cbo_sac import SACBO, SACGP
 from ax.utils.common.testutils import TestCase
 from botorch.models.model_list_gp_regression import ModelListGP
@@ -31,11 +32,11 @@ class SACBOTest(TestCase):
             Xs=[train_X],
             Ys=[train_Y],
             Yvars=[train_Yvar],
-            bounds=[(0.0, 1.0) for _ in range(4)],
-            task_features=[],
-            feature_names=["0", "1", "2", "3"],
+            search_space_digest=SearchSpaceDigest(
+                feature_names=["0", "1", "2", "3"],
+                bounds=[(0.0, 1.0) for _ in range(4)],
+            ),
             metric_names=["y"],
-            fidelity_features=[],
         )
         self.assertIsInstance(m1.model, SACGP)
 
@@ -71,11 +72,11 @@ class SACBOTest(TestCase):
             Xs=[train_X],
             Ys=[train_Y],
             Yvars=[train_Yvar],
-            bounds=[(0.0, 1.0) for _ in range(4)],
-            task_features=[],
-            feature_names=["x1", "x2", "x3", "x4"],
+            search_space_digest=SearchSpaceDigest(
+                feature_names=["x1", "x2", "x3", "x4"],
+                bounds=[(0.0, 1.0) for _ in range(4)],
+            ),
             metric_names=["y"],
-            fidelity_features=[],
         )
         self.assertDictEqual(m2.model.decomposition, {"1": [0, 2], "2": [1, 3]})
 
@@ -86,11 +87,11 @@ class SACBOTest(TestCase):
                 Xs=[train_X],
                 Ys=[train_Y],
                 Yvars=[train_Yvar],
-                bounds=[(0.0, 1.0) for _ in range(4)],
-                task_features=[],
-                feature_names=[],
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[],
+                    bounds=[(0.0, 1.0) for _ in range(4)],
+                ),
                 metric_names=[],
-                fidelity_features=[],
             )
 
         # pass wrong feature_names
@@ -99,9 +100,9 @@ class SACBOTest(TestCase):
                 Xs=[train_X],
                 Ys=[train_Y],
                 Yvars=[train_Yvar],
-                bounds=[(0.0, 1.0) for _ in range(4)],
-                task_features=[],
-                feature_names=["x0", "x1", "x2", "x3"],
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=["x0", "x1", "x2", "x3"],
+                    bounds=[(0.0, 1.0) for _ in range(4)],
+                ),
                 metric_names=["y"],
-                fidelity_features=[],
             )

--- a/ax/models/tests/test_numpy.py
+++ b/ax/models/tests/test_numpy.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.numpy_base import NumpyModel
 from ax.utils.common.testutils import TestCase
 
@@ -19,11 +20,11 @@ class NumpyModelTest(TestCase):
             Xs=[np.array(0)],
             Ys=[np.array(0)],
             Yvars=[np.array(1)],
-            bounds=[(0, 1)],
-            task_features=[],
-            feature_names=["x"],
+            search_space_digest=SearchSpaceDigest(
+                feature_names=["x"],
+                bounds=[(0, 1)],
+            ),
             metric_names=["y"],
-            fidelity_features=[],
         )
 
     def testNumpyModelFeatureImportances(self):

--- a/ax/models/tests/test_posterior_mean.py
+++ b/ax/models/tests/test_posterior_mean.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.botorch import BotorchModel
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.posterior_mean import get_PosteriorMean
@@ -44,11 +45,11 @@ class PosteriorMeanTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+            ),
             metric_names=self.metric_names,
-            task_features=[],
-            fidelity_features=[],
         )
 
         # test model.gen() with no outcome_constraints. Analytic.
@@ -77,11 +78,11 @@ class PosteriorMeanTest(TestCase):
             Xs=self.Xs,
             Ys=self.Ys,
             Yvars=self.Yvars,
-            bounds=self.bounds,
-            feature_names=self.feature_names,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=self.bounds,
+            ),
             metric_names=self.metric_names,
-            task_features=[],
-            fidelity_features=[],
         )
         new_X_dummy = torch.rand(1, 1, 3, dtype=self.dtype, device=self.device)
         Xgen, w, _, __ = model.gen(

--- a/ax/models/tests/test_randomforest.py
+++ b/ax/models/tests/test_randomforest.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.numpy.randomforest import RandomForest
 from ax.utils.common.testutils import TestCase
 
@@ -20,11 +21,11 @@ class RandomForestTest(TestCase):
             Xs=Xs,
             Ys=Ys,
             Yvars=Yvars,
-            bounds=[(0, 1)] * 2,
-            task_features=[],
-            feature_names=["x1", "x2"],
+            search_space_digest=SearchSpaceDigest(
+                feature_names=["x1", "x2"],
+                bounds=[(0, 1)] * 2,
+            ),
             metric_names=["y"],
-            fidelity_features=[],
         )
         self.assertEqual(len(m.models), 2)
         self.assertEqual(len(m.models[0].estimators_), 5)

--- a/ax/models/tests/test_rembo.py
+++ b/ax/models/tests/test_rembo.py
@@ -7,6 +7,7 @@
 from unittest import mock
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.rembo import REMBO
 from ax.utils.common.testutils import TestCase
 
@@ -37,11 +38,11 @@ class REMBOTest(TestCase):
                 Xs=Xs,
                 Ys=Ys,
                 Yvars=Yvars,
-                bounds=[(0, 1)] * 4,
-                task_features=[],
-                feature_names=[],
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[],
+                    bounds=[(0, 1)] * 4,
+                ),
                 metric_names=my_metric_names,
-                fidelity_features=[],
             )
 
         with mock.patch(
@@ -51,11 +52,11 @@ class REMBOTest(TestCase):
                 Xs=Xs,
                 Ys=Ys,
                 Yvars=Yvars,
-                bounds=bounds,
-                task_features=[],
-                feature_names=[],
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[],
+                    bounds=bounds,
+                ),
                 metric_names=my_metric_names,
-                fidelity_features=[],
             )
         # Check was fit with the low-d data.
         for x in m.Xs:

--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch_base import TorchModel
 from ax.utils.common.testutils import TestCase
 
@@ -19,11 +20,11 @@ class TorchModelTest(TestCase):
             Xs=[np.array(0)],
             Ys=[np.array(0)],
             Yvars=[np.array(1)],
-            bounds=[(0, 1)],
-            task_features=[],
-            feature_names=["x1"],
+            search_space_digest=SearchSpaceDigest(
+                feature_names=["x1"],
+                bounds=[(0, 1)],
+            ),
             metric_names=["y"],
-            fidelity_features=[],
         )
 
     def testTorchModelPredict(self):
@@ -49,23 +50,17 @@ class TorchModelTest(TestCase):
                 Ys_train=[np.array([1])],
                 Yvars_train=[np.array([1])],
                 X_test=np.array([1]),
-                bounds=[],
-                task_features=[],
-                fidelity_features=[],
-                feature_names=[],
+                search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
                 metric_names=[],
             )
 
     def testTorchModelUpdate(self):
-        numpy_model = TorchModel()
+        model = TorchModel()
         with self.assertRaises(NotImplementedError):
-            numpy_model.update(
+            model.update(
                 Xs=[np.array(0)],
                 Ys=[np.array(0)],
                 Yvars=[np.array(1)],
-                bounds=[],
-                task_features=[],
-                fidelity_features=[],
-                feature_names=[],
+                search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
                 metric_names=[],
             )

--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, MutableMapping, Optional, Tuple, U
 import gpytorch
 import numpy as np
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata, TConfig, TGenMetadata
 from ax.models.random.alebo_initializer import ALEBOInitializer
 from ax.models.torch.botorch import BotorchModel
@@ -575,16 +576,13 @@ class ALEBO(BotorchModel):
         Xs: List[Tensor],
         Ys: List[Tensor],
         Yvars: List[Tensor],
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
-        assert len(task_features) == 0
-        assert len(fidelity_features) == 0
-        for b in bounds:
+        assert len(search_space_digest.task_features) == 0
+        assert len(search_space_digest.fidelity_features) == 0
+        for b in search_space_digest.bounds:
             assert b == (-1, 1)
         # GP is fit in the low-d space, so project Xs down.
         self.Xs = [(self.B @ X.t()).t() for X in Xs]

--- a/ax/models/torch/botorch_modular/list_surrogate.py
+++ b/ax/models/torch/botorch_modular/list_surrogate.py
@@ -6,9 +6,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Type
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
 from ax.models.torch.botorch_modular.surrogate import NOT_YET_FIT_MSG, Surrogate
 from ax.utils.common.constants import Keys
@@ -168,12 +169,8 @@ class ListSurrogate(Surrogate):
     def fit(
         self,
         training_data: List[TrainingData],
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
-        target_fidelities: Optional[Dict[int, float]] = None,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
         state_dict: Optional[Dict[str, torch.Tensor]] = None,
         refit: bool = True,
@@ -201,13 +198,9 @@ class ListSurrogate(Surrogate):
                 to the order of outcome names in ``metric_names``. Each ``TrainingData``
                 from this list will be passed to ``Model.construct_inputs`` method
                 of the corresponding submodel in ``ModelListGP``.
-            bounds: A list of d (lower, upper) tuples for each column of X.
-            task_features: Columns of X that take integer values and should be
-                treated as task parameters.
-            feature_names: Names of each column of X.
+            search_space_digest: A SearchSpaceDigest object containing
+                metadata on the features in the training data.
             metric_names: Names of each outcome Y in Ys.
-            fidelity_features: Columns of X that should be treated as fidelity
-                parameters.
             candidate_metadata: Model-produced metadata for candidates, in
                 the order corresponding to the Xs.
             state_dict: Optional state dict to load.
@@ -217,12 +210,8 @@ class ListSurrogate(Surrogate):
             # pyre-ignore[6]: `Surrogate.fit` expects single training data
             # and in `ListSurrogate` we use a list of training data.
             training_data=training_data,
-            bounds=bounds,
-            task_features=task_features,
-            feature_names=feature_names,
+            search_space_digest=search_space_digest,
             metric_names=metric_names,
-            fidelity_features=fidelity_features,
-            target_fidelities=target_fidelities,
             candidate_metadata=candidate_metadata,
             state_dict=state_dict,
             refit=refit,

--- a/ax/models/torch/cbo_lcea.py
+++ b/ax/models/torch/cbo_lcea.py
@@ -6,6 +6,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple
 
+from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata, TConfig
 from ax.models.torch.alebo import ei_or_nei
 from ax.models.torch.botorch import BotorchModel
@@ -102,25 +103,19 @@ class LCEABO(BotorchModel):
         Xs: List[Tensor],
         Ys: List[Tensor],
         Yvars: List[Tensor],
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
-        if len(feature_names) == 0:
+        if len(search_space_digest.feature_names) == 0:
             raise ValueError("feature names are required for LCEABO")
-        self.feature_names = feature_names
+        self.feature_names = search_space_digest.feature_names
         super().fit(
             Xs=Xs,
             Ys=Ys,
             Yvars=Yvars,
-            bounds=bounds,
-            task_features=task_features,
-            feature_names=feature_names,
+            search_space_digest=search_space_digest,
             metric_names=metric_names,
-            fidelity_features=fidelity_features,
         )
 
     @copy_doc(TorchModel.best_point)

--- a/ax/models/torch/cbo_sac.py
+++ b/ax/models/torch/cbo_sac.py
@@ -4,8 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
+from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
 from ax.models.torch.botorch import BotorchModel
 from ax.models.torch_base import TorchModel
@@ -49,25 +50,19 @@ class SACBO(BotorchModel):
         Xs: List[Tensor],
         Ys: List[Tensor],
         Yvars: List[Tensor],
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
-        if len(feature_names) == 0:
+        if len(search_space_digest.feature_names) == 0:
             raise ValueError("feature names are required for SACBO")
-        self.feature_names = feature_names
+        self.feature_names = search_space_digest.feature_names
         super().fit(
             Xs=Xs,
             Ys=Ys,
             Yvars=Yvars,
-            bounds=bounds,
-            task_features=task_features,
-            feature_names=feature_names,
+            search_space_digest=search_space_digest,
             metric_names=metric_names,
-            fidelity_features=fidelity_features,
         )
 
     def get_and_fit_model(

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.botorch_modular.utils import (
     choose_botorch_acqf_class,
     choose_model_class,
@@ -46,25 +47,44 @@ class BoTorchModelUtilsTest(TestCase):
             NotImplementedError, "Only a single fidelity feature"
         ):
             choose_model_class(
-                Yvars=self.Yvars, task_features=[], fidelity_features=[1, 2]
+                Yvars=self.Yvars,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[], bounds=[], fidelity_features=[1, 2]
+                ),
             )
         # No support for non-empty task & fidelity features yet.
         with self.assertRaisesRegex(NotImplementedError, "Multi-task multi-fidelity"):
             choose_model_class(
-                Yvars=self.Yvars, task_features=[1], fidelity_features=[1]
+                Yvars=self.Yvars,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[],
+                    bounds=[],
+                    task_features=[1],
+                    fidelity_features=[1],
+                ),
             )
         # With fidelity features and unknown variances, use SingleTaskMultiFidelityGP.
         self.assertEqual(
             SingleTaskMultiFidelityGP,
             choose_model_class(
-                Yvars=self.none_Yvars, task_features=[], fidelity_features=[2]
+                Yvars=self.none_Yvars,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[],
+                    bounds=[],
+                    fidelity_features=[2],
+                ),
             ),
         )
         # With fidelity features and known variances, use FixedNoiseMultiFidelityGP.
         self.assertEqual(
             FixedNoiseMultiFidelityGP,
             choose_model_class(
-                Yvars=self.Yvars, task_features=[], fidelity_features=[2]
+                Yvars=self.Yvars,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[],
+                    bounds=[],
+                    fidelity_features=[2],
+                ),
             ),
         )
 
@@ -72,20 +92,29 @@ class BoTorchModelUtilsTest(TestCase):
         # Only a single task feature can be used.
         with self.assertRaisesRegex(NotImplementedError, "Only a single task feature"):
             choose_model_class(
-                Yvars=self.Yvars, task_features=[1, 2], fidelity_features=[]
+                Yvars=self.Yvars,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[], bounds=[], task_features=[1, 2]
+                ),
             )
         # With fidelity features and unknown variances, use SingleTaskMultiFidelityGP.
         self.assertEqual(
             MultiTaskGP,
             choose_model_class(
-                Yvars=self.none_Yvars, task_features=[1], fidelity_features=[]
+                Yvars=self.none_Yvars,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[], bounds=[], task_features=[1]
+                ),
             ),
         )
         # With fidelity features and known variances, use FixedNoiseMultiFidelityGP.
         self.assertEqual(
             FixedNoiseMultiTaskGP,
             choose_model_class(
-                Yvars=self.Yvars, task_features=[1], fidelity_features=[]
+                Yvars=self.Yvars,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[], bounds=[], task_features=[1]
+                ),
             ),
         )
 
@@ -96,14 +125,20 @@ class BoTorchModelUtilsTest(TestCase):
         ):
             choose_model_class(
                 Yvars=[torch.tensor([[0.0], [np.nan]])],
-                task_features=[],
-                fidelity_features=[],
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[],
+                    bounds=[],
+                ),
             )
         # Without fidelity/task features but with Yvar specifications, use FixedNoiseGP.
         self.assertEqual(
             FixedNoiseGP,
             choose_model_class(
-                Yvars=self.Yvars, task_features=[], fidelity_features=[]
+                Yvars=self.Yvars,
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[],
+                    bounds=[],
+                ),
             ),
         )
         # W/out fidelity/task features and w/out Yvar specifications, use SingleTaskGP.
@@ -111,8 +146,10 @@ class BoTorchModelUtilsTest(TestCase):
             SingleTaskGP,
             choose_model_class(
                 Yvars=[torch.tensor([[float("nan")], [float("nan")]])],
-                task_features=[],
-                fidelity_features=[],
+                search_space_digest=SearchSpaceDigest(
+                    feature_names=[],
+                    bounds=[],
+                ),
             ),
         )
 

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -7,6 +7,7 @@
 from typing import Callable, Dict, List, Optional, Tuple
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata, TConfig, TGenMetadata
 from ax.models.base import Model
 from torch import Tensor
@@ -29,11 +30,8 @@ class TorchModel(Model):
         Xs: List[Tensor],
         Ys: List[Tensor],
         Yvars: List[Tensor],
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
         """Fit model to m outcomes.
@@ -44,13 +42,9 @@ class TorchModel(Model):
             Ys: The corresponding list of m (k_i x 1) outcome tensors Y, for
                 each outcome.
             Yvars: The variances of each entry in Ys, same shape.
-            bounds: A list of d (lower, upper) tuples for each column of X.
-            task_features: Columns of X that take integer values and should be
-                treated as task parameters.
-            feature_names: Names of each column of X.
+            search_space_digest: A SearchSpaceDigest object containing
+                metadata on the features in X.
             metric_names: Names of each outcome Y in Ys.
-            fidelity_features: Columns of X that should be treated as fidelity
-                parameters.
             candidate_metadata: Model-produced metadata for candidates, in
                 the order corresponding to the Xs.
         """
@@ -166,11 +160,8 @@ class TorchModel(Model):
         Ys_train: List[Tensor],
         Yvars_train: List[Tensor],
         X_test: Tensor,
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
     ) -> Tuple[Tensor, Tensor]:
         """Do cross validation with the given training and test sets.
 
@@ -184,13 +175,9 @@ class TorchModel(Model):
                 for each outcome.
             Yvars_train: The variances of each entry in Ys, same shape.
             X_test: (j x d) tensor of the j points at which to make predictions.
-            bounds: A list of d (lower, upper) tuples for each column of X.
-            task_features: Columns of X that take integer values and should be
-                treated as task parameters.
-            feature_names: Names of each column of X.
+            search_space_digest: A SearchSpaceDigest object containing
+                metadata on the features in X.
             metric_names: Names of each outcome Y in Ys.
-            fidelity_features: Columns of X that should be treated as fidelity
-                parameters.
 
         Returns:
             2-element tuple containing
@@ -206,12 +193,8 @@ class TorchModel(Model):
         Xs: List[Tensor],
         Ys: List[Tensor],
         Yvars: List[Tensor],
-        bounds: List[Tuple[float, float]],
-        task_features: List[int],
-        feature_names: List[str],
+        search_space_digest: SearchSpaceDigest,
         metric_names: List[str],
-        fidelity_features: List[int],
-        target_fidelities: Optional[Dict[int, float]] = None,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
         """Update the model.
@@ -226,15 +209,9 @@ class TorchModel(Model):
                 in the same format as for `fit`.
             Yvars: Existing + additional data for the model,
                 in the same format as for `fit`.
-            bounds: A list of d (lower, upper) tuples for each column of X.
-            task_features: Columns of X that take integer values and should be
-                treated as task parameters.
-            feature_names: Names of each column of X.
+            search_space_digest: A SearchSpaceDigest object containing
+                metadata on the features in X.
             metric_names: Names of each outcome Y in Ys.
-            fidelity_features: Columns of X that should be treated as fidelity
-                parameters.
-            target_fidelities: Target values for fidelity parameters, representing
-                full-fidelity value.
             candidate_metadata: Model-produced metadata for candidates, in
                 the order corresponding to the Xs.
         """


### PR DESCRIPTION
Summary:
Introduces `SearchSpaceDigest`, a container for lightweight representation of search space properties.

This is used for communicating between modelbridge and models. It contains additional information on `ordinal_features` and `categorical_features`, which is necessary information for models to be able to use discrete parameters directly (e.g. for categorical kernels). This will be utilized in subsequent diffs (currently the behavior for converting int parameters to tasks is unchanged, this will be modified in the future).

`SearchSpaceDigest` is an ephemeral object and not meant to be stored / serialized.

Differential Revision: D27214304

