### PR TITLE
Change default to L-BFGS-B for high-dimensional problems

### DIFF
--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -318,9 +318,6 @@ def scipy_optimizer(
         sequential = False
     else:
         sequential = True
-        # use SLSQP by default for small problems since it yields faster wall times
-        if "method" not in kwargs:
-            kwargs["method"] = "SLSQP"
     X, expected_acquisition_value = optimize_acqf(
         acq_function=acq_function,
         bounds=bounds,


### PR DESCRIPTION
Summary: L-BFGS-B is significantly faster for high-dimensional optimization problems so let's turn it on by default if there are no constraints.

Reviewed By: Balandat

Differential Revision: D27298046

