### PR TITLE
remove "warnings treated as errors" from sphinx build command.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -85,5 +85,5 @@ jobs:
       # run even if previous step (validate Sphinx) failed
       if: ${{ always() }}
       run: |
-        # warnings treated as errors
-        sphinx-build -WT --keep-going sphinx/source sphinx/build
+        # warnings no longer treated as errors.
+        sphinx-build -T --keep-going sphinx/source sphinx/build


### PR DESCRIPTION
Summary: No longer treat sphinx warnings as errors.

Differential Revision: D27438448

