### PR TITLE
fix bug in choice param decoder

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -46,6 +46,7 @@ DATA_TYPE_LOOKUP: Dict[DataType, Type] = {
     DataType.MAP_DATA: MapData,
 }
 
+
 # pyre-fixme[13]: Attribute `_search_space` is never initialized.
 class Experiment(Base):
     """Base class for defining an experiment."""

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -311,6 +311,8 @@ class Decoder:
                 values=parameter_sqa.choice_values,
                 is_fidelity=parameter_sqa.is_fidelity or False,
                 target_value=parameter_sqa.target_value,
+                is_ordered=parameter_sqa.is_ordered,
+                is_task=parameter_sqa.is_task,
             )
         elif parameter_sqa.domain_type == DomainType.FIXED:
             # Don't throw an error if parameter_sqa.fixed_value is None;

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -11,7 +11,6 @@ from ax.core.abstract_data import AbstractDataFrameData
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import AbandonedArm, BatchTrial
-from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun, GeneratorRunType
 from ax.core.metric import Metric

--- a/ax/storage/sqa_store/tests/utils.py
+++ b/ax/storage/sqa_store/tests/utils.py
@@ -15,6 +15,8 @@ from ax.utils.testing.core_stubs import (
     get_branin_objective,
     get_branin_outcome_constraint,
     get_choice_parameter,
+    get_ordered_choice_parameter,
+    get_task_choice_parameter,
     get_experiment_with_batch_and_single_trial,
     get_experiment_with_batch_trial,
     get_experiment_with_data,
@@ -66,6 +68,18 @@ TEST_CASES = [
     (
         "ChoiceParameter",
         get_choice_parameter,
+        Encoder.parameter_to_sqa,
+        Decoder.parameter_from_sqa,
+    ),
+    (
+        "ChoiceParameter",
+        get_ordered_choice_parameter,
+        Encoder.parameter_to_sqa,
+        Decoder.parameter_from_sqa,
+    ),
+    (
+        "ChoiceParameter",
+        get_task_choice_parameter,
         Encoder.parameter_to_sqa,
         Decoder.parameter_from_sqa,
     ),

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -614,6 +614,30 @@ def get_choice_parameter() -> ChoiceParameter:
     )
 
 
+def get_ordered_choice_parameter() -> ChoiceParameter:
+    return ChoiceParameter(
+        name="y",
+        parameter_type=ParameterType.INT,
+        # Expected `List[typing.Optional[typing.Union[bool, float, str]]]` for 4th
+        # parameter `values` to call
+        # `ax.core.parameter.ChoiceParameter.__init__` but got `List[str]`.
+        values=[1, 2, 3],
+        is_ordered=True,
+    )
+
+
+def get_task_choice_parameter() -> ChoiceParameter:
+    return ChoiceParameter(
+        name="y",
+        parameter_type=ParameterType.INT,
+        # Expected `List[typing.Optional[typing.Union[bool, float, str]]]` for 4th
+        # parameter `values` to call
+        # `ax.core.parameter.ChoiceParameter.__init__` but got `List[str]`.
+        values=[1, 2, 3],
+        is_task=True,
+    )
+
+
 def get_fixed_parameter() -> FixedParameter:
     return FixedParameter(name="z", parameter_type=ParameterType.BOOL, value=True)
 


### PR DESCRIPTION
Summary: Choice params for saved experiments did not reload is_ordered and is_task in the decoder

Differential Revision: D27450228

