### PR TITLE
fix recent MOO bugs

### DIFF
--- a/ax/modelbridge/multi_objective_torch.py
+++ b/ax/modelbridge/multi_objective_torch.py
@@ -137,15 +137,16 @@ class MultiObjectiveTorchModelBridge(TorchModelBridge):
         model_gen_options: Optional[TConfig],
         rounding_func: Callable[[np.ndarray], np.ndarray],
         target_fidelities: Optional[Dict[int, float]],
-        objective_thresholds: Optional[torch.Tensor] = None,
+        objective_thresholds: Optional[np.ndarray] = None,
     ) -> Tuple[np.ndarray, np.ndarray, TGenMetadata, List[TCandidateMetadata]]:
         if not self.model:  # pragma: no cover
             raise ValueError(FIT_MODEL_ERROR.format(action="_model_gen"))
-        obj_w, oc_c, l_c, pend_obs = validate_and_apply_final_transform(
+        (obj_w, oc_c, l_c, pend_obs, obj_t,) = validate_and_apply_final_transform(
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
             linear_constraints=linear_constraints,
             pending_observations=pending_observations,
+            objective_thresholds=objective_thresholds,
             final_transform=self._array_to_tensor,
         )
         tensor_rounding_func = self._array_callable_to_tensor_callable(rounding_func)
@@ -159,7 +160,7 @@ class MultiObjectiveTorchModelBridge(TorchModelBridge):
             bounds=bounds,
             objective_weights=obj_w,
             outcome_constraints=oc_c,
-            objective_thresholds=objective_thresholds,
+            objective_thresholds=obj_t,
             linear_constraints=l_c,
             fixed_features=fixed_features,
             pending_observations=pend_obs,

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -302,7 +302,10 @@ class TestModelbridgeUtils(TestCase):
             objective=objective,
             outcomes=outcomes,
         )
-        self.assertTrue(np.array_equal(obj_t, np.array([2.0, 3.0, 4.0, 0.0])))
+        expected_obj_t_not_nan = np.array([2.0, 3.0, 4.0])
+        self.assertTrue(np.array_equal(obj_t[:3], expected_obj_t_not_nan[:3]))
+        self.assertTrue(np.isnan(obj_t[-1]))
+        self.assertEqual(obj_t.shape[0], 4)
 
         # Fails if threshold not provided for all objective metrics
         with self.assertRaises(ValueError):
@@ -327,7 +330,9 @@ class TestModelbridgeUtils(TestCase):
             objective=objective2,
             outcomes=outcomes,
         )
-        self.assertTrue(np.array_equal(obj_t, np.array([2.0, 0.0, 0.0, 0.0])))
+        self.assertEqual(obj_t[0], 2.0)
+        self.assertTrue(np.all(np.isnan(obj_t[1:])))
+        self.assertEqual(obj_t.shape[0], 4)
 
         # Fails if relative
         objective_thresholds[2] = ObjectiveThreshold(

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -191,7 +191,7 @@ class TorchModelBridge(ArrayModelBridge):
     ) -> Tuple[np.ndarray, np.ndarray, TGenMetadata, List[TCandidateMetadata]]:
         if not self.model:  # pragma: no cover
             raise ValueError(FIT_MODEL_ERROR.format(action="_model_gen"))
-        obj_w, oc_c, l_c, pend_obs = validate_and_apply_final_transform(
+        obj_w, oc_c, l_c, pend_obs, _ = validate_and_apply_final_transform(
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
             linear_constraints=linear_constraints,
@@ -235,7 +235,7 @@ class TorchModelBridge(ArrayModelBridge):
     ) -> Optional[np.ndarray]:  # pragma: no cover
         if not self.model:  # pragma: no cover
             raise ValueError(FIT_MODEL_ERROR.format(action="_model_gen"))
-        obj_w, oc_c, l_c, _ = validate_and_apply_final_transform(
+        obj_w, oc_c, l_c, _, _ = validate_and_apply_final_transform(
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
             linear_constraints=linear_constraints,

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -5,18 +5,31 @@
 # LICENSE file in the root directory of this source tree.
 
 import warnings
+from contextlib import ExitStack
 from unittest import mock
 
 import torch
 from ax.core.search_space import SearchSpaceDigest
-from ax.models.torch.botorch_defaults import get_NEI
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.botorch_moo_defaults import (
     get_EHVI,
     pareto_frontier_evaluator,
     get_default_partitioning_alpha,
+    get_weighted_mc_objective_and_objective_thresholds,
+    get_outcome_constraint_transforms,
 )
 from ax.utils.common.testutils import TestCase
+from botorch.utils.sampling import manual_seed
+from botorch.utils.testing import MockModel, MockPosterior
+
+GET_ACQF_PATH = "ax.models.torch.botorch_moo_defaults.get_acquisition_function"
+GET_CONSTRAINT_PATH = (
+    "ax.models.torch.botorch_moo_defaults.get_outcome_constraint_transforms"
+)
+GET_OBJ_PATH = (
+    "ax.models.torch.botorch_moo_defaults."
+    "get_weighted_mc_objective_and_objective_thresholds"
+)
 
 FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_gpytorch_model"
 
@@ -158,39 +171,15 @@ class FrontierEvaluatorTest(TestCase):
 
 
 class BotorchMOODefaultsTest(TestCase):
-    def test_get_NEI_with_chebyshev_and_missing_Ys_error(self):
-        model = MultiObjectiveBotorchModel()
-        x = torch.zeros(2, 2)
-        weights = torch.ones(2)
-        with self.assertRaisesRegex(
-            ValueError, "Chebyshev Scalarization requires Ys argument"
-        ):
-            get_NEI(
-                model=model,
-                X_observed=x,
-                objective_weights=weights,
-                chebyshev_scalarization=True,
-            )
-
     def test_get_EHVI_input_validation_errors(self):
-        model = MultiObjectiveBotorchModel()
-        x = torch.zeros(2, 2)
         weights = torch.ones(2)
         objective_thresholds = torch.zeros(2)
+        mm = MockModel(MockPosterior())
         with self.assertRaisesRegex(
             ValueError, "There are no feasible observed points."
         ):
             get_EHVI(
-                model=model,
-                objective_weights=weights,
-                objective_thresholds=objective_thresholds,
-            )
-        with self.assertRaisesRegex(
-            ValueError, "Expected Hypervolume Improvement requires Ys argument"
-        ):
-            get_EHVI(
-                model=model,
-                X_observed=x,
+                model=mm,
                 objective_weights=weights,
                 objective_thresholds=objective_thresholds,
             )
@@ -202,3 +191,61 @@ class BotorchMOODefaultsTest(TestCase):
         with warnings.catch_warnings(record=True) as ws:
             self.assertEqual(0.1, get_default_partitioning_alpha(7))
         self.assertEqual(len(ws), 1)
+
+    def test_get_weighted_mc_objective_and_objective_thresholds(self):
+        objective_weights = torch.tensor([0.0, 1.0, 0.0, 1.0])
+        objective_thresholds = torch.arange(4, dtype=torch.float)
+        (
+            weighted_obj,
+            new_obj_thresholds,
+        ) = get_weighted_mc_objective_and_objective_thresholds(
+            objective_weights=objective_weights,
+            objective_thresholds=objective_thresholds,
+        )
+        self.assertTrue(torch.equal(weighted_obj.weights, objective_weights[[1, 3]]))
+        self.assertEqual(weighted_obj.outcomes.tolist(), [1, 3])
+        self.assertTrue(torch.equal(new_obj_thresholds, objective_thresholds[[1, 3]]))
+
+    def test_get_ehvi(self):
+        weights = torch.tensor([0.0, 1.0, 1.0])
+        X_observed = torch.rand(4, 3)
+        X_pending = torch.rand(1, 3)
+        constraints = (torch.tensor([1.0, 0.0, 0.0]), torch.tensor([[10.0]]))
+        Y = torch.rand(4, 3)
+        mm = MockModel(MockPosterior(mean=Y))
+        objective_thresholds = torch.arange(3, dtype=torch.float)
+        obj_and_obj_t = get_weighted_mc_objective_and_objective_thresholds(
+            objective_weights=weights,
+            objective_thresholds=objective_thresholds,
+        )
+        (weighted_obj, new_obj_thresholds) = obj_and_obj_t
+        cons_tfs = get_outcome_constraint_transforms(constraints)
+        with manual_seed(0):
+            seed = torch.randint(1, 10000, (1,)).item()
+        with ExitStack() as es:
+            mock_get_acqf = es.enter_context(mock.patch(GET_ACQF_PATH))
+            es.enter_context(mock.patch(GET_CONSTRAINT_PATH, return_value=cons_tfs))
+            es.enter_context(mock.patch(GET_OBJ_PATH, return_value=obj_and_obj_t))
+            es.enter_context(manual_seed(0))
+            get_EHVI(
+                model=mm,
+                objective_weights=weights,
+                outcome_constraints=constraints,
+                objective_thresholds=objective_thresholds,
+                X_observed=X_observed,
+                X_pending=X_pending,
+            )
+            mock_get_acqf.assert_called_once_with(
+                acquisition_function_name="qEHVI",
+                model=mm,
+                objective=weighted_obj,
+                X_observed=X_observed,
+                X_pending=X_pending,
+                constraints=cons_tfs,
+                mc_samples=128,
+                qmc=True,
+                alpha=0.0,
+                seed=seed,
+                ref_point=new_obj_thresholds.tolist(),
+                Y=Y,
+            )

--- a/ax/models/tests/test_posterior_mean.py
+++ b/ax/models/tests/test_posterior_mean.py
@@ -75,21 +75,25 @@ class PosteriorMeanTest(TestCase):
         # test model.gen() works with chebyshev scalarization.
         model = MultiObjectiveBotorchModel(acqf_constructor=get_PosteriorMean)
         model.fit(
-            Xs=self.Xs,
-            Ys=self.Ys,
-            Yvars=self.Yvars,
+            Xs=self.Xs * 2,
+            Ys=self.Ys * 2,
+            Yvars=self.Yvars * 2,
             search_space_digest=SearchSpaceDigest(
                 feature_names=self.feature_names,
                 bounds=self.bounds,
             ),
-            metric_names=self.metric_names,
+            metric_names=["m1", "m2"],
         )
         new_X_dummy = torch.rand(1, 1, 3, dtype=self.dtype, device=self.device)
         Xgen, w, _, __ = model.gen(
             n=1,
             bounds=self.bounds,
-            objective_weights=self.objective_weights,
-            outcome_constraints=self.outcome_constraints,
+            objective_weights=torch.ones(2, dtype=self.dtype, device=self.device),
+            outcome_constraints=(
+                torch.tensor([[1.0, 0.0]], dtype=self.dtype, device=self.device),
+                torch.tensor([[5.0]], dtype=self.dtype, device=self.device),
+            ),
+            objective_thresholds=torch.zeros(2, dtype=self.dtype, device=self.device),
             linear_constraints=None,
             model_gen_options={
                 "acquisition_function_kwargs": {"chebyshev_scalarization": True}

--- a/ax/models/tests/test_torch_model_utils.py
+++ b/ax/models/tests/test_torch_model_utils.py
@@ -48,64 +48,80 @@ class TorchUtilsTest(TestCase):
     def testSubsetModel(self):
         x = torch.zeros(1, 1)
         y = torch.rand(1, 2)
-        Ys = [y[:, :1], y[:, 1:]]
+        obj_t = torch.rand(2)
         model = SingleTaskGP(x, y)
         self.assertEqual(model.num_outputs, 2)
         # basic test, can subset
         obj_weights = torch.tensor([1.0, 0.0])
-        model_sub, obj_weights_sub, ocs_sub, Ys_sub = subset_model(
-            model, obj_weights, Ys=Ys
+        model_sub, obj_weights_sub, ocs_sub, obj_t_sub = subset_model(
+            model, obj_weights
         )
         self.assertIsNone(ocs_sub)
+        self.assertIsNone(obj_t_sub)
         self.assertEqual(model_sub.num_outputs, 1)
         self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
-        self.assertEqual(Ys_sub[0], Ys[0])
-        self.assertEqual(len(Ys_sub), 1)
         # basic test, cannot subset
         obj_weights = torch.tensor([1.0, 2.0])
-        model_sub, obj_weights_sub, ocs_sub, Ys_sub = subset_model(
-            model, obj_weights, Ys=Ys
+        model_sub, obj_weights_sub, ocs_sub, obj_t_sub = subset_model(
+            model, obj_weights
         )
         self.assertIsNone(ocs_sub)
+        self.assertIsNone(obj_t_sub)
         self.assertIs(model_sub, model)  # check identity
         self.assertIs(obj_weights_sub, obj_weights)  # check identity
-        self.assertIs(Ys_sub, Ys)
         # test w/ outcome constraints, can subset
         obj_weights = torch.tensor([1.0, 0.0])
         ocs = (torch.tensor([[1.0, 0.0]]), torch.tensor([1.0]))
-        model_sub, obj_weights_sub, ocs_sub, Ys_sub = subset_model(
-            model, obj_weights, ocs, Ys
+        model_sub, obj_weights_sub, ocs_sub, obj_t_sub = subset_model(
+            model, obj_weights, ocs
         )
         self.assertEqual(model_sub.num_outputs, 1)
+        self.assertIsNone(obj_t_sub)
         self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
         self.assertTrue(torch.equal(ocs_sub[0], torch.tensor([[1.0]])))
         self.assertTrue(torch.equal(ocs_sub[1], torch.tensor([1.0])))
-        self.assertIs(Ys_sub[0], Ys[0])
-        self.assertEqual(len(Ys_sub), 1)
         # test w/ outcome constraints, cannot subset
         obj_weights = torch.tensor([1.0, 0.0])
         ocs = (torch.tensor([[0.0, 1.0]]), torch.tensor([1.0]))
-        model_sub, obj_weights_sub, ocs_sub, Ys_sub = subset_model(
-            model, obj_weights, ocs, Ys
+        model_sub, obj_weights_sub, ocs_sub, obj_t_sub = subset_model(
+            model, obj_weights, ocs
         )
         self.assertIs(model_sub, model)  # check identity
+        self.assertIsNone(obj_t_sub)
         self.assertIs(obj_weights_sub, obj_weights)  # check identity
         self.assertIs(ocs_sub, ocs)  # check identity
-        self.assertIs(Ys_sub, Ys)
+        # test w/ objective thresholds, cannot subset
+        obj_weights = torch.tensor([1.0, 0.0])
+        ocs = (torch.tensor([[0.0, 1.0]]), torch.tensor([1.0]))
+        model_sub, obj_weights_sub, ocs_sub, obj_t_sub = subset_model(
+            model, obj_weights, ocs, obj_t
+        )
+        self.assertIs(model_sub, model)  # check identity
+        self.assertIs(obj_t, obj_t_sub)
+        self.assertIs(obj_weights_sub, obj_weights)  # check identity
+        self.assertIs(ocs_sub, ocs)  # check identity
+        # test w/ objective thresholds, can subset
+        obj_weights = torch.tensor([1.0, 0.0])
+        ocs = (torch.tensor([[1.0, 0.0]]), torch.tensor([1.0]))
+        model_sub, obj_weights_sub, ocs_sub, obj_t_sub = subset_model(
+            model, obj_weights, ocs, obj_t
+        )
+        self.assertEqual(model_sub.num_outputs, 1)
+        self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
+        self.assertTrue(torch.equal(obj_t_sub, obj_t[:1]))
+        self.assertTrue(torch.equal(ocs_sub[0], torch.tensor([[1.0]])))
+        self.assertTrue(torch.equal(ocs_sub[1], torch.tensor([1.0])))
         # test unsupported
         yvar = torch.ones(1, 2)
         model = HeteroskedasticSingleTaskGP(x, y, yvar)
-        model_sub, obj_weights_sub, ocs, Ys_sub = subset_model(
-            model, obj_weights, Ys=Ys
-        )
+        model_sub, obj_weights_sub, ocs, obj_t_sub = subset_model(model, obj_weights)
         self.assertIsNone(ocs)
         self.assertIs(model_sub, model)  # check identity
         self.assertIs(obj_weights_sub, obj_weights)  # check identity
-        self.assertIs(Ys_sub, Ys)
         # test error on size inconsistency
         obj_weights = torch.ones(3)
         with self.assertRaises(RuntimeError):
-            subset_model(model, obj_weights, Ys=Ys)
+            subset_model(model, obj_weights)
 
     def testGenerateSobolPoints(self):
         bounds = [(0.0, 1.0) for _ in range(3)]

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -239,10 +239,9 @@ def _get_acqusition_func(
         raise ValueError("There are no feasible observed points.")
     # construct Objective module
     if kwargs.get("chebyshev_scalarization", False):
-        if "Ys" not in kwargs:
-            raise ValueError("Chebyshev Scalarization requires Ys argument")
-        Y_tensor = torch.cat(kwargs.get("Ys"), dim=-1)
-        obj_tf = get_chebyshev_scalarization(weights=objective_weights, Y=Y_tensor)
+        with torch.no_grad():
+            Y = model.posterior(X_observed).mean
+        obj_tf = get_chebyshev_scalarization(weights=objective_weights, Y=Y)
     else:
         obj_tf = get_objective_weights_transform(objective_weights)
 

--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -126,9 +126,15 @@ class Acquisition(Base):
 
         # Subset model only to the outcomes we need for the optimization.
         if self.options.get(Keys.SUBSET_MODEL, True):
-            model, objective_weights, outcome_constraints, _ = subset_model(
+            (
+                model,
+                objective_weights,
+                outcome_constraints,
+                objective_thresholds,
+            ) = subset_model(
                 self.surrogate.model,
                 objective_weights=objective_weights,
+                objective_thresholds=objective_thresholds,
                 outcome_constraints=outcome_constraints,
             )
         else:

--- a/ax/models/torch/posterior_mean.py
+++ b/ax/models/torch/posterior_mean.py
@@ -56,10 +56,9 @@ def get_PosteriorMean(
         raise ValueError("There are no feasible observed points.")
     # construct Objective module
     if kwargs.get("chebyshev_scalarization", False):
-        obj_tf = get_chebyshev_scalarization(
-            weights=objective_weights,
-            Y=torch.stack(kwargs.get("Ys")).transpose(0, 1).squeeze(-1),
-        )
+        with torch.no_grad():
+            Y = model.posterior(X_observed).mean
+        obj_tf = get_chebyshev_scalarization(weights=objective_weights, Y=Y)
     else:
         obj_tf = get_objective_weights_transform(objective_weights)
 


### PR DESCRIPTION
Summary:
Fixes a bug introduced in D27095987 (https://github.com/facebook/Ax/commit/f36e409c0bdc4d40636a788930dc1d2ae31c90a3), where objective thresholds now has num_outcomes elements rather than num_objectives elements, which is problematic when there are outcome constraints or tracking metrics. See comment on https://www.internalfb.com/diff/D27095987 (https://github.com/facebook/Ax/commit/f36e409c0bdc4d40636a788930dc1d2ae31c90a3)?dst_version_fbid=874021586508656&transaction_fbid=142110821165226.

The fix is 1) to pass objective_thresholds to subset_model so that we only include objective thresholds for the relevant dimensions (and so that the dimension matches the subsetted dimension of objective_weights) and 2) only keep the elements in objective_thresholds that have a corresponding nonzero element in objective_weights (this will happen in get_weighted_mc_objective_and_objective_thresholds). Without 2) objective_thresholds has the wrong number of dimensions.

Differential Revision: D27539652

