### PR TITLE
Use SearchSpaceDigest in modular Botorch model

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -25,7 +25,6 @@ from ax.exceptions.generation_strategy import (
 )
 from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.registry import (
-    Models,
     ModelRegistryBase,
     _combine_model_kwargs_and_state,
     get_model_from_generator_run,

--- a/ax/models/torch/botorch_modular/list_surrogate.py
+++ b/ax/models/torch/botorch_modular/list_surrogate.py
@@ -56,7 +56,7 @@ class ListSurrogate(Surrogate):
 
     _training_data_per_outcome: Optional[Dict[str, TrainingData]] = None
     _model: Optional[Model] = None
-    # Special setting for surrogates instantiated via `Surrogate.from_BoTorch`,
+    # Special setting for surrogates instantiated via `Surrogate.from_botorch`,
     # to avoid re-constructing the underlying BoTorch model on `Surrogate.fit`
     # when set to `False`.
     _should_reconstruct: bool = True

--- a/sphinx/source/storage.rst
+++ b/sphinx/source/storage.rst
@@ -94,6 +94,14 @@ ax.storage.sqa\_store.db module
     :show-inheritance:
     :exclude-members: Base
 
+ax.storage.sqa\_store.delete module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.storage.sqa_store.delete
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ax.storage.sqa\_store.json module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary:
Follow-up on D27214304 (https://github.com/facebook/Ax/commit/00f3cb0eae88c82327161ad1eb16cdad665e6635), uses `SearchSpaceDigest` also in the `compute_model_dependencies`, `best_point`, `optimize`, and `evaluate_acquisition_function` APIs of the modular BoTorch model.

This allows doing things like using the information about categorical parameters in the optimization for models that can/must use it (e.g. those using categorical kernels), see e.g. D27419520.

An alternative would be to also change then `gen` API of model/modelbridge, but that's more work and also has some drawbacks (see Ben's comments).

Reviewed By: lena-kashtelyan

Differential Revision: D27419522

