### PR TITLE
Let `retry_on_exception` handle async functions

### DIFF
--- a/ax/utils/common/executils.py
+++ b/ax/utils/common/executils.py
@@ -6,8 +6,10 @@
 
 import functools
 import time
+from asyncio import iscoroutinefunction
+from contextlib import contextmanager
 from logging import Logger
-from typing import Any, List, Optional, Tuple, Type
+from typing import Any, Generator, List, Optional, Tuple, Type
 
 
 MAX_WAIT_SECONDS: int = 600
@@ -70,77 +72,153 @@ def retry_on_exception(
         initial_wait_seconds: Initial length of time to wait between failures,
             doubled after each failure up to a maximum of 10 minutes. If unspecified
             then there is no wait between retries.
-
     """
 
     def func_wrapper(func):
+        # Depending on whether `func` is async or not, we use a sligtly different
+        # wrapper; if wrapping an async function, decorator will await it.
+        # `async_actual_wrapper` and `actual_wrapper` are almost exactly the same,
+        # except that the former is async and awaits the wrapped function.
+        if iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_actual_wrapper(*args, **kwargs):
+                (
+                    retry_exceptions,
+                    no_retry_exceptions,
+                    suppress_errors,
+                ) = _validate_and_fill_defaults(
+                    retry_on_exception_types=exception_types,
+                    no_retry_on_exception_types=no_retry_on_exception_types,
+                    suppress_errors=suppress_all_errors,
+                    **kwargs,
+                )
+
+                for i in range(retries):
+                    with handle_exceptions_in_retries(
+                        no_retry_exceptions=no_retry_exceptions,
+                        retry_exceptions=retry_exceptions,
+                        suppress_errors=suppress_errors,
+                        check_message_contains=check_message_contains,
+                        last_retry=i >= retries - 1,
+                        logger=logger,
+                        wrap_error_message_in=wrap_error_message_in,
+                    ):
+                        if i > 0 and initial_wait_seconds is not None:
+                            wait_interval = min(
+                                MAX_WAIT_SECONDS, initial_wait_seconds * 2 ** (i - 1)
+                            )
+                            time.sleep(wait_interval)
+                        return await func(*args, **kwargs)
+                # If we are here, it means the retries were finished but
+                # The error was suppressed. Hence return the default value provided.
+                return default_return_on_suppression
+
+            return async_actual_wrapper
+
         @functools.wraps(func)
         def actual_wrapper(*args, **kwargs):
-            retriable_exceptions = exception_types
-            if exception_types is None:
-                # If no exception type provided, we catch all errors.
-                retriable_exceptions = (Exception,)
-            if not isinstance(retriable_exceptions, tuple):
-                raise ValueError("Expected a tuple of exception types.")
-
-            if no_retry_on_exception_types is not None:
-                if not isinstance(no_retry_on_exception_types, tuple):
-                    raise ValueError(
-                        "Expected a tuple of non-retriable exception types."
-                    )
-                if set(no_retry_on_exception_types).intersection(
-                    set(retriable_exceptions)
-                ):
-                    raise ValueError(
-                        "Same exception type cannot appear in both "
-                        "`exception_types` and `no_retry_on_exception_types`."
-                    )
-
-            # `suppress_all_errors` could be a flag to the underlying function
-            # when used on instance methods.
-            suppress_errors = suppress_all_errors or (
-                "suppress_all_errors" in kwargs and kwargs["suppress_all_errors"]
+            (
+                retry_exceptions,
+                no_retry_exceptions,
+                suppress_errors,
+            ) = _validate_and_fill_defaults(
+                retry_on_exception_types=exception_types,
+                no_retry_on_exception_types=no_retry_on_exception_types,
+                suppress_errors=suppress_all_errors,
+                **kwargs,
             )
 
             for i in range(retries):
-                try:
+                with handle_exceptions_in_retries(
+                    no_retry_exceptions=no_retry_exceptions,
+                    retry_exceptions=retry_exceptions,
+                    suppress_errors=suppress_errors,
+                    check_message_contains=check_message_contains,
+                    last_retry=i >= retries - 1,
+                    logger=logger,
+                    wrap_error_message_in=wrap_error_message_in,
+                ):
                     if i > 0 and initial_wait_seconds is not None:
                         wait_interval = min(
                             MAX_WAIT_SECONDS, initial_wait_seconds * 2 ** (i - 1)
                         )
                         time.sleep(wait_interval)
                     return func(*args, **kwargs)
-                except no_retry_on_exception_types or ():
-                    raise
-                except retriable_exceptions as err:  # Exceptions is a tuple.
-                    if suppress_errors or i < retries - 1:
-                        # We are either explicitly asked to suppress the error
-                        # or we have retries left.
-                        if logger is not None:
-                            logger.exception(err)
-                        continue
-                    err_msg = getattr(err, "message", repr(err))
-                    if check_message_contains is not None and any(
-                        message in err_msg for message in check_message_contains
-                    ):
-                        # In this case, the error is just logged, suppressed and default
-                        # value returned
-                        if logger is not None:
-                            logger.exception(
-                                wrap_error_message_in
-                            )  # Automatically logs `err` and its stack trace.
-                        continue
-                    if not wrap_error_message_in:
-                        raise
-                    else:
-                        msg = (
-                            f"{wrap_error_message_in}: {type(err).__name__}: {str(err)}"
-                        )
-                    raise type(err)(msg).with_traceback(err.__traceback__)
+
             # If we are here, it means the retries were finished but
-            # The error was somehow suppressed. Hence return the default value provided
+            # The error was suppressed. Hence return the default value provided.
             return default_return_on_suppression
 
         return actual_wrapper
 
     return func_wrapper
+
+
+@contextmanager
+def handle_exceptions_in_retries(
+    no_retry_exceptions: Tuple[Type[Exception], ...],
+    retry_exceptions: Tuple[Type[Exception], ...],
+    suppress_errors: bool,
+    check_message_contains: Optional[str],
+    last_retry: bool,
+    logger: Optional[Logger],
+    wrap_error_message_in: Optional[str],
+) -> Generator[None, None, None]:
+    try:
+        yield  # Perform action within the context manager.
+    except no_retry_exceptions:
+        raise
+    except retry_exceptions as err:  # Exceptions is a tuple.
+        err_msg = getattr(err, "message", repr(err))
+
+        if not last_retry or suppress_errors:
+            # We are either explicitly asked to suppress the error
+            # or we have retries left.
+            if logger is not None:
+                # `logger.exception` automatically logs `err` and its stack trace.
+                logger.exception(err)
+
+        elif (
+            not last_retry
+            and check_message_contains is not None
+            and any(message in err_msg for message in check_message_contains)
+        ):
+            # In this case, the error is just logged, suppressed and default
+            # value returned
+            if logger is not None:
+                logger.exception(wrap_error_message_in)
+
+        elif not wrap_error_message_in:
+            raise
+
+        else:
+            msg = f"{wrap_error_message_in}: {type(err).__name__}: {str(err)}"
+            raise type(err)(msg).with_traceback(err.__traceback__)
+
+
+def _validate_and_fill_defaults(
+    retry_on_exception_types: Optional[Tuple[Type[Exception], ...]],
+    no_retry_on_exception_types: Optional[Tuple[Type[Exception], ...]],
+    suppress_errors: bool,
+    **kwargs: Any,
+) -> Tuple[Tuple[Type[Exception], ...], Tuple[Type[Exception], ...], bool]:
+    if retry_on_exception_types is None:
+        # If no exception type provided, we catch all errors.
+        retry_on_exception_types = (Exception,)
+    if not isinstance(retry_on_exception_types, tuple):
+        raise ValueError("Expected a tuple of exception types.")
+
+    if no_retry_on_exception_types is not None:
+        if not isinstance(no_retry_on_exception_types, tuple):
+            raise ValueError("Expected a tuple of non-retriable exception types.")
+        if set(no_retry_on_exception_types).intersection(set(retry_on_exception_types)):
+            raise ValueError(
+                "Same exception type cannot appear in both "
+                "`exception_types` and `no_retry_on_exception_types`."
+            )
+
+    # `suppress_all_errors` could be a flag to the underlying function
+    # when used on instance methods.
+    suppress_errors = suppress_errors or kwargs.get("suppress_all_errors", False)
+    return retry_on_exception_types, no_retry_on_exception_types or (), suppress_errors

--- a/ax/utils/common/tests/test_executils.py
+++ b/ax/utils/common/tests/test_executils.py
@@ -6,6 +6,7 @@
 
 import logging
 import time
+from asyncio import iscoroutinefunction
 from unittest.mock import Mock
 
 from ax.utils.common.executils import retry_on_exception
@@ -66,7 +67,7 @@ class TestRetryDecorator(TestCase):
                 check_message_contains=["Hello", "World"],
                 exception_types=(RuntimeError,),
                 logger=logger,
-                suppress_all_errors=False,
+                suppress_all_errors=True,
             )
             def error_throwing_function(self):
                 # The exception thrown below should be caught and handled since it
@@ -259,6 +260,9 @@ class TestRetryDecorator(TestCase):
         def error_throwing_function():
             mock()
             raise RuntimeError("I failed")
+
+        # Check that the function remains non-async.
+        self.assertFalse(iscoroutinefunction(error_throwing_function))
 
         with self.assertRaisesRegex(
             RuntimeError, "Wrapper error message: RuntimeError: I failed"


### PR DESCRIPTION
Summary: To enable use of `retry_on_exception` on async methods and functions, extending it to cover that case

Differential Revision: D27777794

