### PR TITLE
GenericNoisyFunctionMetric

### DIFF
--- a/ax/metrics/tests/test_noisy_function.py
+++ b/ax/metrics/tests/test_noisy_function.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+from ax.metrics.noisy_function import GenericNoisyFunctionMetric
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_trial
+
+
+class GenericNoisyFunctionMetricTest(TestCase):
+    def testGenericNoisyFunctionMetric(self):
+        def f(params):
+            return params["x"] + 1.0
+
+        # noiseless
+        metric = GenericNoisyFunctionMetric(
+            name="test_metric",
+            f=f,
+        )
+        trial = get_trial()
+        df = metric.fetch_trial_data(trial).df
+        self.assertEqual(df["arm_name"].tolist(), ["0_0"])
+        self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
+        self.assertEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
+        self.assertEqual(df["sem"].tolist(), [0.0])
+
+        # noisy
+        metric = GenericNoisyFunctionMetric(
+            name="test_metric",
+            f=f,
+            noise_sd=1.0,
+        )
+        trial = get_trial()
+        df = metric.fetch_trial_data(trial).df
+        self.assertEqual(df["arm_name"].tolist(), ["0_0"])
+        self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
+        self.assertNotEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
+        self.assertEqual(df["sem"].tolist(), [1.0])
+        df = metric.fetch_trial_data(trial, noisy=False).df
+        self.assertEqual(df["arm_name"].tolist(), ["0_0"])
+        self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
+        self.assertEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
+        self.assertEqual(df["sem"].tolist(), [0.0])
+
+        # unknown noise level
+        metric = GenericNoisyFunctionMetric(
+            name="test_metric",
+            f=f,
+            noise_sd=None,
+        )
+        trial = get_trial()
+        df = metric.fetch_trial_data(trial).df
+        self.assertEqual(df["arm_name"].tolist(), ["0_0"])
+        self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
+        self.assertEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
+        self.assertEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
+        self.assertTrue(math.isnan(df["sem"].tolist()[0]))

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -16,7 +16,7 @@ from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.runner import Runner
 from ax.core.types import ComparisonOp
-from ax.exceptions.storage import ImmutabilityError, SQADecodeError, SQAEncodeError
+from ax.exceptions.storage import SQADecodeError, SQAEncodeError
 from ax.metrics.branin import BraninMetric
 from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
@@ -25,7 +25,6 @@ from ax.runners.synthetic import SyntheticRunner
 from ax.storage.metric_registry import METRIC_REGISTRY, register_metric
 from ax.storage.runner_registry import RUNNER_REGISTRY, register_runner
 from ax.storage.sqa_store.db import (
-    SQABase,
     get_engine,
     get_session,
     init_engine_and_session_factory,
@@ -71,7 +70,6 @@ from ax.utils.common.serialization import serialize_init_args
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_arm,
-    get_batch_trial,
     get_branin_data,
     get_branin_experiment,
     get_branin_metric,


### PR DESCRIPTION
Summary:
Defines a `GenericNoisyFunctionMetric` that can be instatiated with a
simple callable that takes in parameter dicts. Makes it much easier to set up
metrics in scenarios where this is a natural way of working with callables.

Reviewed By: sdaulton

Differential Revision: D27495205

