### PR TITLE
Consider only .py files as modules

### DIFF
--- a/ax/utils/testing/manifest.py
+++ b/ax/utils/testing/manifest.py
@@ -82,6 +82,7 @@ def list_modules():
         _LIST_MODULES = [
             ModuleInfo(local_path=f, base_path=__ae__manifest__.BASE_PATH)
             for f in __ae__manifest__.FILES
+            if f.endswith(".py")
         ]
     return _LIST_MODULES
 


### PR DESCRIPTION
Summary: Without this all hell breaks lose with doctests etc when having non-python files in the repo

Reviewed By: sdaulton

Differential Revision: D28079411

