### PR TITLE
Move `get_default_partitioning_alpha` to BoTorch from Ax

### DIFF
--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import warnings
 from contextlib import ExitStack
 from unittest import mock
 
@@ -14,7 +13,6 @@ from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.botorch_moo_defaults import (
     get_EHVI,
     pareto_frontier_evaluator,
-    get_default_partitioning_alpha,
     get_weighted_mc_objective_and_objective_thresholds,
     get_outcome_constraint_transforms,
 )
@@ -183,14 +181,6 @@ class BotorchMOODefaultsTest(TestCase):
                 objective_weights=weights,
                 objective_thresholds=objective_thresholds,
             )
-
-    def test_get_default_partitioning_alpha(self):
-        self.assertEqual(0.0, get_default_partitioning_alpha(2))
-        self.assertEqual(1e-5, get_default_partitioning_alpha(3))
-        self.assertEqual(1e-4, get_default_partitioning_alpha(4))
-        with warnings.catch_warnings(record=True) as ws:
-            self.assertEqual(0.1, get_default_partitioning_alpha(7))
-        self.assertEqual(len(ws), 1)
 
     def test_get_weighted_mc_objective_and_objective_thresholds(self):
         objective_weights = torch.tensor([0.0, 1.0, 0.0, 1.0])

--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -14,11 +14,9 @@ References
 
 """
 
-import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
-from ax.exceptions.core import AxWarning
 from ax.models.torch.utils import (  # noqa F40
     _to_inequality_constraints,
     get_outcome_constraint_transforms,
@@ -27,7 +25,10 @@ from ax.models.torch.utils import (  # noqa F40
 from ax.models.torch_base import TorchModel
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.multi_objective.objective import WeightedMCMultiOutputObjective
-from botorch.acquisition.utils import get_acquisition_function
+from botorch.acquisition.multi_objective.utils import get_default_partitioning_alpha
+from botorch.acquisition.utils import (
+    get_acquisition_function,
+)
 from botorch.models.model import Model
 from botorch.optim.optimize import optimize_acqf_list
 from botorch.utils.multi_objective.pareto import is_non_dominated
@@ -308,17 +309,3 @@ def pareto_frontier_evaluator(
     Yvar_frontier = Yvar[frontier_mask]
     indx_frontier = indx_frontier[frontier_mask]
     return Y_frontier, Yvar_frontier, indx_frontier
-
-
-def get_default_partitioning_alpha(num_objectives: int) -> float:
-    """Adaptively selects a reasonable partitioning based on the number of objectives.
-
-    This strategy is derived from the results in [Daulton2020qehvi]_, which suggest
-    that this heuristic provides a reasonable trade-off between the closed-loop
-    performance and the wall time required for the partitioning.
-    """
-    if num_objectives == 2:
-        return 0.0
-    elif num_objectives > 6:
-        warnings.warn("EHVI works best for less than 7 objectives.", AxWarning)
-    return 10 ** (-8 + num_objectives)


### PR DESCRIPTION
Summary: Ax counterpart for D28368337

Reviewed By: Balandat

Differential Revision: D28371536

