### PR TITLE
Support discrete features in `Acquisition.optimize`

### DIFF
--- a/ax/models/torch/utils.py
+++ b/ax/models/torch/utils.py
@@ -231,7 +231,7 @@ def subset_model(
     objective_weights: Tensor,
     outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
     objective_thresholds: Optional[Tensor] = None,
-) -> Tuple[Model, Tensor, Optional[Tuple[Tensor, Tensor]], Optional[Tensor],]:
+) -> Tuple[Model, Tensor, Optional[Tuple[Tensor, Tensor]], Optional[Tensor]]:
     """Subset a botorch model to the outputs used in the optimization.
 
     Args:

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -11,6 +11,7 @@ from ax.models.torch.botorch_modular.acquisition import Acquisition
 
 # BoTorch `AcquisitionFunction` imports
 from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.analytic import ExpectedImprovement
 from botorch.acquisition.knowledge_gradient import (
     qKnowledgeGradient,
     qMultiFidelityKnowledgeGradient,
@@ -71,6 +72,7 @@ MODEL_REGISTRY: Dict[Type[Model], str] = {
 Mapping of Botorch `AcquisitionFunction` classes to class name strings.
 """
 ACQUISITION_FUNCTION_REGISTRY: Dict[Type[AcquisitionFunction], str] = {
+    ExpectedImprovement: "ExpectedImprovement",
     qExpectedImprovement: "qExpectedImprovement",
     qKnowledgeGradient: "qKnowledgeGradient",
     qMaxValueEntropy: "qMaxValueEntropy",


### PR DESCRIPTION
Summary:
Supports discrete (categorical & ordinal) features in the modular BoTorch model's `optimize` method. For now this just enumerates the discrete choices for optimization, which is not scalable.

We will deal with this the following way:
- For mixed spaces with a modest number of discrete choices, we will use the batched solver
- For purely discrete spaces with many choices, we will use a random init + local perturbation solver
- For mixed spaces with a high number of discrete choices, we still need to figure something out :)

Differential Revision: D28021532

