### PR TITLE
make reference point optional

### DIFF
--- a/ax/modelbridge/transforms/trial_as_task.py
+++ b/ax/modelbridge/transforms/trial_as_task.py
@@ -97,7 +97,7 @@ class TrialAsTask(Transform):
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         for p_name, level_dict in self.trial_level_map.items():
-            level_values = list(set(level_dict.values()))
+            level_values = sorted(set(level_dict.values()))
             if len(level_values) == 1:
                 raise ValueError(
                     "TrialAsTask transform expects 2+ task params, "

--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
+import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch_base import TorchModel
 from ax.utils.common.testutils import TestCase
@@ -64,3 +65,8 @@ class TorchModelTest(TestCase):
                 search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
                 metric_names=[],
             )
+
+    def testTorchModelInferObjectiveThresholds(self):
+        torch_model = TorchModel()
+        with self.assertRaises(NotImplementedError):
+            torch_model.infer_objective_thresholds(torch.zeros(2))

--- a/ax/models/torch/botorch_moo.py
+++ b/ax/models/torch/botorch_moo.py
@@ -36,6 +36,7 @@ from ax.models.torch.utils import (
     randomize_objective_weights,
     subset_model,
 )
+from ax.models.torch.utils import get_outcome_constraint_transforms
 from ax.models.torch_base import TorchModel
 from ax.utils.common.constants import Keys
 from ax.utils.common.docutils import copy_doc
@@ -43,6 +44,8 @@ from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast, not_none
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.models.model import Model
+from botorch.utils.multi_objective.hypervolume import infer_reference_point
+from botorch.utils.multi_objective.pareto import is_non_dominated
 from torch import Tensor
 
 
@@ -229,6 +232,80 @@ class MultiObjectiveBotorchModel(BotorchModel):
         self.fidelity_features: List[int] = []
         self.metric_names: List[str] = []
 
+    def infer_objective_thresholds(
+        self,
+        objective_weights: Tensor,  # objective_directions
+        bounds: Optional[List[Tuple[float, float]]] = None,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        X_observed: Optional[Tensor] = None,
+        model: Optional[Model] = None,
+        subset_idcs: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Infer objective thresholds.
+
+        Returns:
+            A `m`-dim tensor of objective thresholds, where the objective
+                threshold is `nan` if the outcome is not an objective.
+        """
+        if X_observed is None:
+            if bounds is None:
+                raise ValueError("bounds is required if X_observed is None.")
+            _, X_observed = _get_X_pending_and_observed(
+                Xs=self.Xs,
+                objective_weights=objective_weights,
+                outcome_constraints=outcome_constraints,
+                bounds=bounds,
+                linear_constraints=linear_constraints,
+                fixed_features=fixed_features,
+            )
+        if model is not None:
+            if subset_idcs is None:
+                raise ValueError(
+                    "subset_idcs must be provided if the model is provided."
+                )
+        else:
+            # subset the model
+            subset_model_results = subset_model(
+                model=self.model,  # pyre-ignore [6]
+                objective_weights=objective_weights,
+                outcome_constraints=outcome_constraints,
+            )
+            model = subset_model_results.model
+            objective_weights = subset_model_results.objective_weights
+            outcome_constraints = subset_model_results.outcome_constraints
+            subset_idcs = subset_model_results.indices
+        with torch.no_grad():
+            pred = not_none(model).posterior(not_none(X_observed)).mean
+        if outcome_constraints is not None:
+            cons_tfs = get_outcome_constraint_transforms(outcome_constraints)
+            # pyre-ignore [16]
+            feas = torch.stack([c(pred) <= 0 for c in cons_tfs], dim=-1).all(dim=-1)
+            pred = pred[feas]
+        if pred.shape[0] == 0:
+            raise AxError("There are no feasible observed points.")
+        # pyre-ignore [16]
+        obj_mask = objective_weights.nonzero().view(-1)
+        obj_weights_subset = objective_weights[obj_mask]
+        obj = pred[..., obj_mask] * obj_weights_subset
+        pareto_obj = obj[is_non_dominated(obj)]
+        objective_thresholds = infer_reference_point(
+            pareto_Y=pareto_obj,
+            scale=0.1,
+        )
+        # multiply by objective weights to return objective thresholds in the
+        # unweighted space
+        objective_thresholds = objective_thresholds * obj_weights_subset
+        full_objective_thresholds = torch.full(
+            (len(self.metric_names),),
+            float("nan"),
+            dtype=objective_weights.dtype,
+            device=objective_weights.device,
+        )
+        full_objective_thresholds[subset_idcs] = objective_thresholds.clone()
+        return full_objective_thresholds
+
     @copy_doc(TorchModel.gen)
     def gen(
         self,
@@ -272,7 +349,7 @@ class MultiObjectiveBotorchModel(BotorchModel):
         )
 
         model = not_none(self.model)
-
+        full_objective_thresholds = objective_thresholds
         # subset model only to the outcomes we need for the optimization
         if options.get(Keys.SUBSET_MODEL, True):
             subset_model_results = subset_model(
@@ -285,6 +362,26 @@ class MultiObjectiveBotorchModel(BotorchModel):
             objective_weights = subset_model_results.objective_weights
             outcome_constraints = subset_model_results.outcome_constraints
             objective_thresholds = subset_model_results.objective_thresholds
+            idcs = subset_model_results.indices
+        else:
+            idcs = torch.arange(
+                objective_weights.shape[0],
+                dtype=objective_weights.dtype,
+                device=objective_weights.device,
+            )
+        if objective_thresholds is None:
+            full_objective_thresholds = self.infer_objective_thresholds(
+                X_observed=not_none(X_observed),
+                objective_weights=objective_weights,
+                outcome_constraints=outcome_constraints,
+                model=model,
+                subset_idcs=idcs,
+            )
+
+            # subset the objective thresholds
+            objective_thresholds = full_objective_thresholds[idcs].clone()
+        else:
+            full_objective_thresholds = objective_thresholds
 
         bounds_ = torch.tensor(bounds, dtype=self.dtype, device=self.device)
         bounds_ = bounds_.transpose(0, 1)
@@ -351,9 +448,13 @@ class MultiObjectiveBotorchModel(BotorchModel):
                 rounding_func=botorch_rounding_func,
                 **optimizer_options,
             )
+        gen_metadata = {
+            "expected_acquisition_value": expected_acquisition_value.tolist(),
+            "objective_thresholds": full_objective_thresholds.cpu(),
+        }
         return (
             candidates.detach().cpu(),
             torch.ones(n, dtype=self.dtype),
-            {"expected_acquisition_value": expected_acquisition_value.tolist()},
+            gen_metadata,
             None,
         )

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -9,13 +9,14 @@ from typing import Callable, Dict, List, Optional, Tuple
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata, TConfig, TGenMetadata
-from ax.models.base import Model
+from ax.models.base import Model as BaseModel
+from botorch.models.model import Model
 from torch import Tensor
 
 
 # pyre-fixme[13]: Attribute `device` is never initialized.
 # pyre-fixme[13]: Attribute `dtype` is never initialized.
-class TorchModel(Model):
+class TorchModel(BaseModel):
     """This class specifies the interface for a torch-based model.
 
     These methods should be implemented to have access to all of the features
@@ -226,5 +227,37 @@ class TorchModel(Model):
 
         Returns:
             A single-element tensor with the acquisition value for these points.
+        """
+        raise NotImplementedError
+
+    def infer_objective_thresholds(
+        self,
+        objective_weights: Tensor,  # objective_directions
+        bounds: Optional[List[Tuple[float, float]]] = None,
+        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
+        fixed_features: Optional[Dict[int, float]] = None,
+        X_observed: Optional[Tensor] = None,
+        model: Optional[Model] = None,
+        subset_idcs: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Infer objective thresholds.
+
+        Args:
+            objective_weights: The objective is to maximize a weighted sum of
+                the columns of f(x). These are the weights.
+            bounds: A list of (lower, upper) tuples for each column of X.
+            outcome_constraints: A tuple of (A, b). For k outcome constraints
+                and m outputs at f(x), A is (k x m) and b is (k x 1) such that
+                A f(x) <= b.
+            linear_constraints: A tuple of (A, b). For k linear constraints on
+                d-dimensional x, A is (k x d) and b is (k x 1) such that
+                A x <= b.
+            fixed_features: A map {feature_index: value} for features that
+                should be fixed to a particular value during generation.
+            X_observed: A `n x d`-dim tensor of observed in-sample points
+            model: The model
+            subset_idcs: The indices of the outcomes are that are used in the
+                optimization config (if the model has been subset'd).
         """
         raise NotImplementedError


### PR DESCRIPTION
Summary:
This diff does two things: 1) if a user creates a `MultiObjectiveTorchModelbridge` and calls `gen` without specifying objective thresholds, then we infer the objective thresholds within the `MultiObjectiveBotorchModel`, generate candidates, and return the inferred objective thresholds in `gen_metadata`. 2) it adds a `infer_objective_thresholds` method to the `MultiObjectiveTorchModelbridge`, which can be used to infer objective thresholds without generating candidates.

This refactors the Base `Modelbridge.gen` and `ArrayModelbridge._gen` methods and to apply transformations within a utility function.

Note that this method returns ObservationData. If the user wants to plot outcomes with objective thresholds, the user would have to create the ObjectiveThresholds and set the objective thresholds on the optimization config.

Reviewed By: Balandat

Differential Revision: D28163744

