### PR TITLE
Move NEHVI to OSS

### DIFF
--- a/ax/modelbridge/factory.py
+++ b/ax/modelbridge/factory.py
@@ -14,6 +14,7 @@ from ax.core.multi_type_experiment import MultiTypeExperiment
 from ax.core.objective import MultiObjective
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig, TRefPoint
+from ax.core.outcome_constraint import ObjectiveThreshold
 from ax.core.search_space import SearchSpace
 from ax.core.types import TConfig
 from ax.modelbridge.discrete import DiscreteModelBridge
@@ -42,6 +43,9 @@ from ax.models.torch.botorch_defaults import (
     predict_from_model,
     scipy_optimizer,
 )
+from ax.models.torch.botorch_moo_defaults import (
+    get_EHVI,
+)
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast
 
@@ -63,6 +67,124 @@ additional ``GenerationStrategy`` and is able to delegate work to multiple model
 optimization model for subsequent trials).
 
 """
+
+
+def get_MOO_NEHVI(
+    experiment: Experiment,
+    data: Data,
+    objective_thresholds: Optional[TRefPoint] = None,
+    search_space: Optional[SearchSpace] = None,
+    dtype: torch.dtype = torch.double,
+    device: torch.device = (
+        torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    ),
+    status_quo_features: Optional[ObservationFeatures] = None,
+    use_input_warping: bool = False,
+) -> MultiObjectiveTorchModelBridge:
+    """Instantiates a multi-objective model using qNEHVI."""
+    # pyre-ignore: [16] `Optional` has no attribute `objective`.
+    if not isinstance(experiment.optimization_config.objective, MultiObjective):
+        raise ValueError("Multi-objective optimization requires multiple objectives.")
+    if data.df.empty:  # pragma: no cover
+        raise ValueError("MultiObjectiveOptimization requires non-empty data.")
+    return checked_cast(
+        MultiObjectiveTorchModelBridge,
+        Models.MOO(
+            experiment=experiment,
+            data=data,
+            objective_thresholds=objective_thresholds,
+            search_space=search_space or experiment.search_space,
+            torch_dtype=dtype,
+            torch_device=device,
+            status_quo_features=status_quo_features,
+            default_model_gen_options={
+                "optimizer_kwargs": {
+                    # having a batch limit is very important for avoiding
+                    # memory issues in the initialization
+                    "batch_limit": DEFAULT_EHVI_BATCH_LIMIT,
+                    "sequential": True,
+                },
+            },
+            use_input_warping=use_input_warping,
+        ),
+    )
+
+
+def get_MTGP_NEHVI(
+    experiment: Experiment,
+    data: Data,
+    objective_thresholds: Optional[List[ObjectiveThreshold]] = None,
+    search_space: Optional[SearchSpace] = None,
+    dtype: torch.dtype = torch.double,
+    device: torch.device = DEFAULT_TORCH_DEVICE,
+    trial_index: Optional[int] = None,
+) -> TorchModelBridge:
+    """Instantiates a Multi-task Gaussian Process (MTGP) model that generates
+    points with qNEHVI.
+
+    If the input experiment is a MultiTypeExperiment then a
+    Multi-type Multi-task GP model will be instantiated.
+    Otherwise, the model will be a Single-type Multi-task GP.
+    """
+    # pyre-ignore: [16] `Optional` has no attribute `objective`.
+    if not isinstance(experiment.optimization_config.objective, MultiObjective):
+        raise ValueError("Multi-objective optimization requires multiple objectives.")
+    elif data.df.empty:  # pragma: no cover
+        raise ValueError("MultiObjectiveOptimization requires non-empty data.")
+
+    if isinstance(experiment, MultiTypeExperiment):
+        trial_index_to_type = {
+            t.index: t.trial_type for t in experiment.trials.values()
+        }
+        transforms = MT_MTGP_trans
+        transform_configs = {
+            "ConvertMetricNames": tconfig_from_mt_experiment(experiment),
+            "TrialAsTask": {"trial_level_map": {"trial_type": trial_index_to_type}},
+        }
+    else:
+        # Set transforms for a Single-type MTGP model.
+        transforms = ST_MTGP_trans
+        transform_configs = None
+
+    # Choose the status quo features for the experiment from the selected trial.
+    # If trial_index is None, we will look for a status quo from the last
+    # experiment trial to use as a status quo for the experiment.
+    if trial_index is None:
+        trial_index = len(experiment.trials) - 1
+    elif trial_index >= len(experiment.trials):
+        raise ValueError("trial_index is bigger than the number of experiment trials")
+
+    # pyre-fixme[16]: `ax.core.base_trial.BaseTrial` has no attribute `status_quo`.
+    status_quo = experiment.trials[trial_index].status_quo
+    if status_quo is None:
+        status_quo_features = None
+    else:
+        status_quo_features = ObservationFeatures(
+            parameters=status_quo.parameters, trial_index=trial_index
+        )
+
+    return checked_cast(
+        MultiObjectiveTorchModelBridge,
+        Models.MOO(
+            experiment=experiment,
+            data=data,
+            objective_thresholds=objective_thresholds,
+            search_space=search_space or experiment.search_space,
+            transforms=transforms,
+            transform_configs=transform_configs,
+            torch_dtype=dtype,
+            torch_device=device,
+            status_quo_features=status_quo_features,
+            default_model_gen_options={
+                "optimizer_kwargs": {
+                    # having a batch limit is very important for avoiding
+                    # memory issues in the initialization
+                    "batch_limit": DEFAULT_EHVI_BATCH_LIMIT,
+                    "sequential": True,
+                },
+            },
+        ),
+    )
 
 
 def get_sobol(
@@ -400,6 +522,7 @@ def get_MOO_EHVI(
             search_space=search_space or experiment.search_space,
             torch_dtype=dtype,
             torch_device=device,
+            acqf_constructor=get_EHVI,
             default_model_gen_options={
                 "acquisition_function_kwargs": {"sequential": True},
                 "optimizer_kwargs": {

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -11,6 +11,7 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.botorch_moo_defaults import (
+    get_NEHVI,
     get_EHVI,
     pareto_frontier_evaluator,
     get_weighted_mc_objective_and_objective_thresholds,
@@ -195,6 +196,19 @@ class BotorchMOODefaultsTest(TestCase):
         self.assertTrue(torch.equal(weighted_obj.weights, objective_weights[[1, 3]]))
         self.assertEqual(weighted_obj.outcomes.tolist(), [1, 3])
         self.assertTrue(torch.equal(new_obj_thresholds, objective_thresholds[[1, 3]]))
+
+    def test_get_NEHVI_input_validation_errors(self):
+        model = MultiObjectiveBotorchModel()
+        weights = torch.ones(2)
+        objective_thresholds = torch.zeros(2)
+        with self.assertRaisesRegex(
+            ValueError, "There are no feasible observed points."
+        ):
+            get_NEHVI(
+                model=model.model,
+                objective_weights=weights,
+                objective_thresholds=objective_thresholds,
+            )
 
     def test_get_ehvi(self):
         weights = torch.tensor([0.0, 1.0, 1.0])

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -14,7 +14,7 @@ from ax.utils.common.typeutils import checked_cast
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
-    qExpectedHypervolumeImprovement,
+    qNoisyExpectedHypervolumeImprovement,
 )
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
 from botorch.models.gp_regression_fidelity import (
@@ -114,9 +114,7 @@ def choose_botorch_acqf_class(
 ) -> Type[AcquisitionFunction]:
     """Chooses a BoTorch `AcquisitionFunction` class."""
     if objective_thresholds is not None:
-        # TODO: Use new qNEHVI just added to BoTorch once we have `construct_inputs`
-        # for it in BoTorch.
-        return qExpectedHypervolumeImprovement
+        return qNoisyExpectedHypervolumeImprovement
     return qNoisyExpectedImprovement
 
 

--- a/ax/models/torch/botorch_moo.py
+++ b/ax/models/torch/botorch_moo.py
@@ -25,7 +25,7 @@ from ax.models.torch.botorch_defaults import (
     scipy_optimizer,
 )
 from ax.models.torch.botorch_moo_defaults import (
-    get_EHVI,
+    get_NEHVI,
     pareto_frontier_evaluator,
     scipy_optimizer_list,
 )
@@ -193,7 +193,7 @@ class MultiObjectiveBotorchModel(BotorchModel):
         #  AcquisitionFunction]`; used as `Callable[[Model, Tensor,
         #  Optional[Tuple[Tensor, Tensor]], Optional[Tensor], Optional[Tensor],
         #  **(Any)], AcquisitionFunction]`.
-        acqf_constructor: TAcqfConstructor = get_EHVI,
+        acqf_constructor: TAcqfConstructor = get_NEHVI,
         # pyre-fixme[9]: acqf_optimizer has type `Callable[[AcquisitionFunction,
         #  Tensor, int, Optional[Dict[int, float]], Optional[Callable[[Tensor],
         #  Tensor]], Any], Tensor]`; used as `Callable[[AcquisitionFunction, Tensor,

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -23,7 +23,7 @@ from botorch.acquisition.input_constructors import (
 )
 from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
-    qExpectedHypervolumeImprovement,
+    qNoisyExpectedHypervolumeImprovement,
 )
 from botorch.acquisition.multi_objective.objective import WeightedMCMultiOutputObjective
 from botorch.models.gp_regression import SingleTaskGP, FixedNoiseGP
@@ -39,7 +39,7 @@ SURROGATE_PATH = Surrogate.__module__
 UTILS_PATH = choose_model_class.__module__
 ACQUISITION_PATH = Acquisition.__module__
 LIST_SURROGATE_PATH = ListSurrogate.__module__
-EHVI_PATH = qExpectedHypervolumeImprovement.__module__
+NEHVI_PATH = qNoisyExpectedHypervolumeImprovement.__module__
 
 ACQ_OPTIONS = {Keys.SAMPLER: SobolQMCNormalSampler(1024)}
 
@@ -492,15 +492,15 @@ class BoTorchModelTest(TestCase):
         return_value=(torch.tensor([[2.0]]), torch.tensor([1.0])),
     )
     def test_MOO(self, _):
-        # Add mock for qEHVI input constructor to catch arguments passed to it.
-        qEHVI_input_constructor = get_acqf_input_constructor(
-            qExpectedHypervolumeImprovement
+        # Add mock for qNEHVI input constructor to catch arguments passed to it.
+        qNEHVI_input_constructor = get_acqf_input_constructor(
+            qNoisyExpectedHypervolumeImprovement
         )
         mock_input_constructor = mock.MagicMock(
-            qEHVI_input_constructor, side_effect=qEHVI_input_constructor
+            qNEHVI_input_constructor, side_effect=qNEHVI_input_constructor
         )
         _register_acqf_input_constructor(
-            acqf_cls=qExpectedHypervolumeImprovement,
+            acqf_cls=qNoisyExpectedHypervolumeImprovement,
             input_constructor=mock_input_constructor,
         )
 
@@ -527,7 +527,7 @@ class BoTorchModelTest(TestCase):
             rounding_func=self.rounding_func,
             target_fidelities=self.mf_search_space_digest.target_fidelities,
         )
-        self.assertIs(model.botorch_acqf_class, qExpectedHypervolumeImprovement)
+        self.assertIs(model.botorch_acqf_class, qNoisyExpectedHypervolumeImprovement)
         mock_input_constructor.assert_called_once()
         mock_input_constructor.assert_called_with(
             model=model.surrogate.model,
@@ -563,8 +563,8 @@ class BoTorchModelTest(TestCase):
         )
 
         # Avoid polluting the registry for other tests; re-register correct input
-        # contructor for qEHVI.
+        # contructor for qNEHVI.
         _register_acqf_input_constructor(
-            acqf_cls=qExpectedHypervolumeImprovement,
-            input_constructor=qEHVI_input_constructor,
+            acqf_cls=qNoisyExpectedHypervolumeImprovement,
+            input_constructor=qNEHVI_input_constructor,
         )

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -18,7 +18,7 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
-    qExpectedHypervolumeImprovement,
+    qNoisyExpectedHypervolumeImprovement,
 )
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
 from botorch.models.gp_regression_fidelity import (
@@ -154,7 +154,7 @@ class BoTorchModelUtilsTest(TestCase):
     def test_choose_botorch_acqf_class(self):
         self.assertEqual(qNoisyExpectedImprovement, choose_botorch_acqf_class())
         self.assertEqual(
-            qExpectedHypervolumeImprovement,
+            qNoisyExpectedHypervolumeImprovement,
             choose_botorch_acqf_class(objective_thresholds=self.objective_thresholds),
         )
 


### PR DESCRIPTION
Summary: Move NEHVI to OSS and use this by default in modular botorch and MultiObjectiveBotorchModel

Differential Revision: D29350437

