### PR TITLE
Add a BO_MIXED model

### DIFF
--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -225,6 +225,12 @@ MODEL_KEY_TO_MODEL_SETUP: Dict[str, ModelSetup] = {
         model_class=ALEBO,
         transforms=ALEBO_X_trans + ALEBO_Y_trans,
     ),
+    "BO_MIXED": ModelSetup(
+        bridge_class=TorchModelBridge,
+        model_class=ModularBoTorchModel,
+        transforms=Mixed_transforms + Y_trans,
+        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
+    ),
 }
 
 
@@ -393,6 +399,7 @@ class Models(ModelRegistryBase):
     MOO_MODULAR = "MOO_Modular"
     ST_MTGP = "ST_MTGP"
     ALEBO = "ALEBO"
+    BO_MIXED = "BO_MIXED"
 
 
 def get_model_from_generator_run(

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -169,25 +169,6 @@ class TestAxClient(TestCase):
         self.assertIn("a", trials_df)
         self.assertEqual(len(trials_df), 6)
 
-    def test_default_generation_strategy_discrete(self) -> None:
-        """Test that Sobol is used if no GenerationStrategy is provided and
-        the search space is discrete.
-        """
-        # Test that Sobol is chosen when all parameters are choice.
-        ax_client = AxClient()
-        ax_client.create_experiment(
-            parameters=[  # pyre-fixme[6]: expected union that should include
-                {"name": "x", "type": "choice", "values": [1, 2, 3]},
-                {"name": "y", "type": "choice", "values": [1, 2, 3]},
-            ]
-        )
-        self.assertEqual(
-            [s.model for s in not_none(ax_client.generation_strategy)._steps],
-            [Models.SOBOL],
-        )
-        self.assertEqual(ax_client.get_max_parallelism(), [(-1, -1)])
-        self.assertTrue(ax_client.get_trials_data_frame().empty)
-
     def test_create_experiment(self) -> None:
         """Test basic experiment creation."""
         ax_client = AxClient(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -454,36 +454,38 @@ def get_branin_search_space(
 
 def get_factorial_search_space() -> SearchSpace:
     return SearchSpace(
-        # Expected `List[ax.core.parameter.Parameter]` for 2nd parameter
-        # `parameters` to call `ax.core.search_space.SearchSpace.__init__` but
-        # got `List[ChoiceParameter]`.
         parameters=[
             ChoiceParameter(
                 name="factor1",
                 parameter_type=ParameterType.STRING,
-                # Expected `List[typing.Optional[typing.Union[bool, float, str]]]` for
-                # 4th parameter `values` to call
-                # `ax.core.parameter.ChoiceParameter.__init__` but got
-                # `List[str]`.
                 values=["level11", "level12", "level13"],
             ),
             ChoiceParameter(
                 name="factor2",
                 parameter_type=ParameterType.STRING,
-                # Expected `List[typing.Optional[typing.Union[bool, float, str]]]` for
-                # 4th parameter `values` to call
-                # `ax.core.parameter.ChoiceParameter.__init__` but got
-                # `List[str]`.
                 values=["level21", "level22"],
             ),
             ChoiceParameter(
                 name="factor3",
                 parameter_type=ParameterType.STRING,
-                # Expected `List[typing.Optional[typing.Union[bool, float, str]]]` for
-                # 4th parameter `values` to call
-                # `ax.core.parameter.ChoiceParameter.__init__` but got
-                # `List[str]`.
                 values=["level31", "level32", "level33", "level34"],
+            ),
+        ]
+    )
+
+
+def get_large_factorial_search_space() -> SearchSpace:
+    return SearchSpace(
+        parameters=[
+            ChoiceParameter(
+                name="factor1",
+                parameter_type=ParameterType.STRING,
+                values=[f"level1{i}" for i in range(7)],
+            ),
+            ChoiceParameter(
+                name="factor2",
+                parameter_type=ParameterType.STRING,
+                values=[f"level2{i}" for i in range(10)],
             ),
         ]
     )


### PR DESCRIPTION
Summary: Add a `BO_MIXED` model and choose it in `choose_generation_strategy` when there are more discrete options than continuous variables. If we can enumerate the search space we still use Sobol.

Reviewed By: lena-kashtelyan

Differential Revision: D29322210

