### PR TITLE
Add create_moo_experiment method

### DIFF
--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from ax.core.objective import MultiObjective
+from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.modelbridge.dispatch_utils import (
     DEFAULT_BAYESIAN_PARALLELISM,
     choose_generation_strategy,
@@ -22,40 +24,54 @@ class TestDispatchUtils(TestCase):
     """Tests that dispatching utilities correctly select generation strategies."""
 
     def test_choose_generation_strategy(self):
-        # GPEI
-        sobol_gpei = choose_generation_strategy(search_space=get_branin_search_space())
-        self.assertEqual(sobol_gpei._steps[0].model.value, "Sobol")
-        self.assertEqual(sobol_gpei._steps[0].num_trials, 5)
-        self.assertEqual(sobol_gpei._steps[1].model.value, "GPEI")
-        # Sobol (we can try every option)
-        sobol = choose_generation_strategy(
-            search_space=get_factorial_search_space(), num_trials=1000
-        )
-        self.assertEqual(sobol._steps[0].model.value, "Sobol")
-        self.assertEqual(len(sobol._steps), 1)
-        # Sobol (because of too many categories)
-        sobol_large = choose_generation_strategy(
-            search_space=get_large_factorial_search_space()
-        )
-        self.assertEqual(sobol_large._steps[0].model.value, "Sobol")
-        self.assertEqual(len(sobol_large._steps), 1)
-        # GPEI-Batched
-        sobol_gpei_batched = choose_generation_strategy(
-            search_space=get_branin_search_space(), use_batch_trials=3
-        )
-        self.assertEqual(sobol_gpei_batched._steps[0].num_trials, 1)
-        # BO_MIXED (purely categorical)
-        bo_mixed = choose_generation_strategy(search_space=get_factorial_search_space())
-        self.assertEqual(bo_mixed._steps[0].model.value, "Sobol")
-        self.assertEqual(bo_mixed._steps[0].num_trials, 5)
-        self.assertEqual(bo_mixed._steps[1].model.value, "BO_MIXED")
-        # BO_MIXED (mixed search space)
-        bo_mixed_2 = choose_generation_strategy(
-            search_space=get_branin_search_space(with_choice_parameter=True)
-        )
-        self.assertEqual(bo_mixed_2._steps[0].model.value, "Sobol")
-        self.assertEqual(bo_mixed_2._steps[0].num_trials, 5)
-        self.assertEqual(bo_mixed_2._steps[1].model.value, "BO_MIXED")
+        with self.subTest("GPEI"):
+            sobol_gpei = choose_generation_strategy(
+                search_space=get_branin_search_space()
+            )
+            self.assertEqual(sobol_gpei._steps[0].model.value, "Sobol")
+            self.assertEqual(sobol_gpei._steps[0].num_trials, 5)
+            self.assertEqual(sobol_gpei._steps[1].model.value, "GPEI")
+        with self.subTest("MOO"):
+            sobol_gpei = choose_generation_strategy(
+                search_space=get_branin_search_space(),
+                optimization_config=MultiObjectiveOptimizationConfig(
+                    objective=MultiObjective(objectives=[])
+                ),
+            )
+            self.assertEqual(sobol_gpei._steps[0].model.value, "Sobol")
+            self.assertEqual(sobol_gpei._steps[0].num_trials, 5)
+            self.assertEqual(sobol_gpei._steps[1].model.value, "MOO")
+        with self.subTest("Sobol (we can try every option)"):
+            sobol = choose_generation_strategy(
+                search_space=get_factorial_search_space(), num_trials=1000
+            )
+            self.assertEqual(sobol._steps[0].model.value, "Sobol")
+            self.assertEqual(len(sobol._steps), 1)
+        with self.subTest("Sobol (because of too many categories)"):
+            sobol_large = choose_generation_strategy(
+                search_space=get_large_factorial_search_space()
+            )
+            self.assertEqual(sobol_large._steps[0].model.value, "Sobol")
+            self.assertEqual(len(sobol_large._steps), 1)
+        with self.subTest("GPEI-Batched"):
+            sobol_gpei_batched = choose_generation_strategy(
+                search_space=get_branin_search_space(), use_batch_trials=3
+            )
+            self.assertEqual(sobol_gpei_batched._steps[0].num_trials, 1)
+        with self.subTest("BO_MIXED (purely categorical)"):
+            bo_mixed = choose_generation_strategy(
+                search_space=get_factorial_search_space()
+            )
+            self.assertEqual(bo_mixed._steps[0].model.value, "Sobol")
+            self.assertEqual(bo_mixed._steps[0].num_trials, 5)
+            self.assertEqual(bo_mixed._steps[1].model.value, "BO_MIXED")
+        with self.subTest("BO_MIXED (mixed search space)"):
+            bo_mixed_2 = choose_generation_strategy(
+                search_space=get_branin_search_space(with_choice_parameter=True)
+            )
+            self.assertEqual(bo_mixed_2._steps[0].model.value, "Sobol")
+            self.assertEqual(bo_mixed_2._steps[0].num_trials, 5)
+            self.assertEqual(bo_mixed_2._steps[1].model.value, "BO_MIXED")
 
     def test_setting_random_seed(self):
         sobol = choose_generation_strategy(

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -18,6 +18,8 @@ from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import BatchTrial
 from ax.core.experiment import DataType, Experiment
 from ax.core.generator_run import GeneratorRun
+from ax.core.objective import MultiObjective
+from ax.core.objective import Objective
 from ax.core.trial import Trial
 from ax.core.types import (
     TEvaluationOutcome,
@@ -26,7 +28,7 @@ from ax.core.types import (
     TParamValue,
 )
 from ax.exceptions.constants import CHOLESKY_ERROR_ANNOTATION
-from ax.exceptions.core import UnsupportedPlotError
+from ax.exceptions.core import UnsupportedPlotError, UnsupportedError
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.modelbridge_utils import get_pending_observation_features
@@ -39,6 +41,8 @@ from ax.service.utils.instantiation import (
     data_from_evaluations,
     make_experiment,
     raw_data_to_evaluation,
+    ObjectiveProperties,
+    build_objective_threshold,
 )
 from ax.service.utils.report_utils import exp_to_df
 from ax.service.utils.with_db_settings_base import DBSettings, WithDBSettingsBase
@@ -163,7 +167,8 @@ class AxClient(WithDBSettingsBase):
         parameters: List[Dict[str, Union[TParamValue, List[TParamValue]]]],
         name: Optional[str] = None,
         objective_name: Optional[str] = None,
-        minimize: bool = False,
+        minimize: Optional[bool] = None,
+        objectives: Optional[Dict[str, ObjectiveProperties]] = None,
         parameter_constraints: Optional[List[str]] = None,
         outcome_constraints: Optional[List[str]] = None,
         status_quo: Optional[TParameterization] = None,
@@ -196,10 +201,15 @@ class AxClient(WithDBSettingsBase):
                 parameters,
                 4. "is_ordered" (bool) for choice parameters, and
                 5. "is_task" (bool) for task parameters.
-            objective: Name of the metric used as objective in this experiment.
-                This metric must be present in `raw_data` argument to `complete_trial`.
             name: Name of the experiment to be created.
-            minimize: Whether this experiment represents a minimization problem.
+            objective_name[DEPRECATED]: Name of the metric used as objective
+                in this experiment. This metric must be present in `raw_data`
+                argument to `complete_trial`.
+            minimize[DEPRECATED]: Whether this experiment represents a minimization
+                 problem.
+            objectives: Mapping from an objective name to object containing:
+                minimize: Whether this experiment represents a minimization problem.
+                threshold: The bound in the objective's threshold constraint.
             parameter_constraints: List of string representation of parameter
                 constraints, such as "x3 >= x4" or "-x3 + 2*x4 - 3.5*x5 >= 2". For
                 the latter constraints, any number of arguments is accepted, and
@@ -232,11 +242,36 @@ class AxClient(WithDBSettingsBase):
             is_test: Whether this experiment will be a test experiment (useful for
                 marking test experiments in storage etc). Defaults to False.
         """
+        objective_kwargs = {}
+        if (objective_name or minimize is not None) and objectives:
+            raise UnsupportedError(
+                "You may either pass an an objective object "
+                "or an objective_name and minimize param, but not both"
+            )
+        elif objectives and len(objectives.keys()) == 1:
+            objective = next(iter(objectives.keys()))
+            objective_kwargs["objective_name"] = objective
+            objective_kwargs["minimize"] = objectives[objective].minimize
+        elif objectives:
+            objective_kwargs["objectives"] = {
+                objective: ("minimize" if properties.minimize else "maximize")
+                for objective, properties in objectives.items()
+            }
+            objective_kwargs["objective_thresholds"] = [
+                build_objective_threshold(objective, properties)
+                for objective, properties in objectives.items()
+            ]
+        elif objective_name or minimize is not None:
+            objective_kwargs["objective_name"] = objective_name
+            objective_kwargs["minimize"] = minimize or False
+            warnings.warn(
+                "objective_name and minimize are deprecated",
+                category=DeprecationWarning,
+            )
+
         experiment = make_experiment(
             name=name,
             parameters=parameters,
-            objective_name=objective_name,
-            minimize=minimize,
             parameter_constraints=parameter_constraints,
             outcome_constraints=outcome_constraints,
             status_quo=status_quo,
@@ -245,6 +280,7 @@ class AxClient(WithDBSettingsBase):
             support_intermediate_data=support_intermediate_data,
             immutable_search_space_and_opt_config=immutable_search_space_and_opt_config,
             is_test=is_test,
+            **objective_kwargs,
         )
         self._set_experiment(
             experiment=experiment,
@@ -569,8 +605,15 @@ class AxClient(WithDBSettingsBase):
         """
         if not self.experiment.trials:
             raise ValueError("Cannot generate plot as there are no trials.")
-        # pyre-fixme[16]: `Optional` has no attribute `objective`.
-        objective_name = self.experiment.optimization_config.objective.metric.name
+
+        objective = self.objective
+        if isinstance(objective, MultiObjective):
+            raise UnsupportedError(
+                "`get_optimization_trace` is not supported "
+                "for multi-objective experiments"
+            )
+
+        objective_name = self.objective_name
         best_objectives = np.array(
             [
                 [
@@ -588,7 +631,7 @@ class AxClient(WithDBSettingsBase):
         return optimization_trace_single_method(
             y=(
                 np.minimum.accumulate(best_objectives, axis=1)
-                if self.experiment.optimization_config.objective.minimize
+                if objective.minimize
                 else np.maximum.accumulate(best_objectives, axis=1)
             ),
             optimum=objective_optimum,
@@ -631,9 +674,15 @@ class AxClient(WithDBSettingsBase):
                 "If `param_x` is provided, `param_y` is "
                 "required as well, and vice-versa."
             )
-        objective_name = self.objective_name
+
         if not metric_name:
-            metric_name = objective_name
+            if isinstance(self.objective, MultiObjective):
+                raise UnsupportedError(
+                    "`get_contour_plot` requires a `metric_name` "
+                    "for multi-objective experiments"
+                )
+
+            metric_name = self.objective_name
 
         if not param_x or not param_y:
             parameter_names = list(self.experiment.parameters.keys())
@@ -881,10 +930,24 @@ class AxClient(WithDBSettingsBase):
         return not_none(self._generation_strategy)
 
     @property
+    def objective(self) -> Objective:
+        return not_none(self.experiment.optimization_config).objective
+
+    @property
     def objective_name(self) -> str:
         """Returns the name of the objective in this optimization."""
-        opt_config = not_none(self.experiment.optimization_config)
-        return opt_config.objective.metric.name
+        objective = self.objective
+        if isinstance(objective, MultiObjective):
+            raise UnsupportedError(
+                "Multi-objective experiments contain multiple objectives"
+            )
+        return objective.metric.name
+
+    @property
+    def objective_names(self) -> List[str]:
+        """Returns the name of the objective in this optimization."""
+        objective = self.objective
+        return [m.name for m in objective.metrics]
 
     def _update_trial_with_raw_data(
         self,
@@ -999,6 +1062,7 @@ class AxClient(WithDBSettingsBase):
         if self._generation_strategy is None:
             self._generation_strategy = choose_generation_strategy(
                 search_space=self.experiment.search_space,
+                optimization_config=self.experiment.optimization_config,
                 enforce_sequential_optimization=enforce_sequential_optimization,
                 random_seed=random_seed,
                 **choose_generation_strategy_kwargs,
@@ -1085,9 +1149,10 @@ class AxClient(WithDBSettingsBase):
             raise ValueError(
                 f"Arms {not_trial_arm_names} are not part of trial #{trial.index}."
             )
+
         evaluations = {
             arm_name: raw_data_to_evaluation(
-                raw_data=raw_data[arm_name], objective_name=self.objective_name
+                raw_data=raw_data[arm_name], objective=self.objective
             )
             for arm_name in raw_data
         }


### PR DESCRIPTION
Summary:
This differs from the format of the `make_experiment` arguments, which we talked about and decided to consolidate `objectives` and `objective_thresholds` into a single argument to minimize the need for validation code.  It is an intermediate step in that direction if we choose to.

Also related to T92282450

Differential Revision: D29488210

