### PR TITLE
Add warning for test experiments

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -30,7 +30,7 @@ from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.base import Base
-from ax.utils.common.constants import Keys
+from ax.utils.common.constants import Keys, EXPERIMENT_IS_TEST_WARNING
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.logger import get_logger
 from ax.utils.common.timeutils import current_timestamp_in_millis
@@ -86,6 +86,7 @@ class Experiment(Base):
         # appease pyre
         self._search_space: SearchSpace
         self._status_quo: Optional[Arm] = None
+        self._is_test: bool
 
         self._name = name
         self.description = description
@@ -144,6 +145,18 @@ class Experiment(Base):
     def name(self, name: str) -> None:
         """Set experiment name."""
         self._name = name
+
+    @property
+    def is_test(self) -> bool:
+        """Get whether the experiment is a test."""
+        return self._is_test
+
+    @is_test.setter
+    def is_test(self, is_test: bool) -> None:
+        """Set whether the experiment is a test."""
+        if is_test:
+            logger.info(EXPERIMENT_IS_TEST_WARNING)
+        self._is_test = is_test
 
     @property
     def is_simple_experiment(self):

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 from typing import Type
 from unittest.mock import patch
 
@@ -20,7 +21,7 @@ from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UnsupportedError
 from ax.metrics.branin import BraninMetric
 from ax.runners.synthetic import SyntheticRunner
-from ax.utils.common.constants import Keys
+from ax.utils.common.constants import Keys, EXPERIMENT_IS_TEST_WARNING
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_arm,
@@ -801,3 +802,49 @@ class ExperimentWithMapDataTest(TestCase):
             old_df.drop(["arm_name", "trial_index"], axis=1),
             new_df.drop(["arm_name", "trial_index"], axis=1),
         )
+
+    def test_is_test_warning(self):
+        experiments_module = "ax.core.experiment"
+        with self.subTest("it warns on construction for a test"):
+            with self.assertLogs(experiments_module, level=logging.INFO) as logger:
+                exp = Experiment(
+                    search_space=get_search_space(),
+                    is_test=True,
+                )
+                self.assertIn(
+                    f"INFO:{experiments_module}:{EXPERIMENT_IS_TEST_WARNING}",
+                    logger.output,
+                )
+
+        with self.subTest("it does not warn on construction for a non test"):
+            with self.assertLogs(experiments_module, level=logging.INFO) as logger:
+                logging.getLogger(experiments_module).info(
+                    "there must be at least one log or the assertLogs statement fails"
+                )
+                exp = Experiment(
+                    search_space=get_search_space(),
+                    is_test=False,
+                )
+                self.assertNotIn(
+                    f"INFO:{experiments_module}:{EXPERIMENT_IS_TEST_WARNING}",
+                    logger.output,
+                )
+
+        with self.subTest("it warns on setting is_test to True"):
+            with self.assertLogs(experiments_module, level=logging.INFO) as logger:
+                exp.is_test = True
+                self.assertIn(
+                    f"INFO:{experiments_module}:{EXPERIMENT_IS_TEST_WARNING}",
+                    logger.output,
+                )
+
+        with self.subTest("it does not warn on setting is_test to False"):
+            with self.assertLogs(experiments_module, level=logging.INFO) as logger:
+                logging.getLogger(experiments_module).info(
+                    "there must be at least one log or the assertLogs statement fails"
+                )
+                exp.is_test = False
+                self.assertNotIn(
+                    f"INFO:{experiments_module}:{EXPERIMENT_IS_TEST_WARNING}",
+                    logger.output,
+                )

--- a/ax/utils/common/constants.py
+++ b/ax/utils/common/constants.py
@@ -7,6 +7,16 @@
 from enum import Enum, unique
 
 
+# -------------------------- Warnings --------------------------
+
+
+EXPERIMENT_IS_TEST_WARNING = (
+    "The is_test flag has been set to True. "
+    "This flag is meant purely for development and integration testing purposes. "
+    "If you are running a live experiment, please set this flag to False"
+)
+
+
 # -------------------------- Error messages --------------------------
 
 


### PR DESCRIPTION
Summary: Adds a warning (INFO level as per ticket) when an experiment is set as a test, both on construction and by setting the property.

Differential Revision: D29641420

