### PR TITLE
Remove note that status quo is automatically attached to arms

### DIFF
--- a/tutorials/building_blocks.ipynb
+++ b/tutorials/building_blocks.ipynb
@@ -403,13 +403,6 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Note that the arms attached to the trial are the same as those in the generator run above, except for the status quo, which is automatically added to each trial."
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": 14,
       "metadata": {},


### PR DESCRIPTION
This is no longer true