### PR TITLE
Fix italics

### DIFF
--- a/tutorials/scheduler.ipynb
+++ b/tutorials/scheduler.ipynb
@@ -6,7 +6,7 @@
       "source": [
         "# Configurable closed-loop optimization with Ax `Scheduler`\n",
         "\n",
-        "*We recommend reading through the [\"Building Blocks of Ax\" tutorial](https://ax.dev/tutorials/building_blocks.html) before getting started with the `Scheduler`, as using it in this tutorial will require an Ax `Experiment` and an undertstanding of the experiment's subcomponents like the search space and the runner.*\n",
+        "*We recommend reading through the [\"Building Blocks of Ax\" tutorial](https://ax.dev/tutorials/building_blocks.html) before getting started with the `Scheduler`, as using it in this tutorial will require an Ax `Experiment` and an understanding of the experiment's subcomponents like the search space and the runner.*\n",
         "\n",
         "### Contents:\n",
         "1. **Scheduler and external systems for trial evalution** –– overview of how scheduler works with an external system to run a closed-loop optimization.\n",

--- a/tutorials/scheduler.ipynb
+++ b/tutorials/scheduler.ipynb
@@ -6,7 +6,7 @@
       "source": [
         "# Configurable closed-loop optimization with Ax `Scheduler`\n",
         "\n",
-        "_We recommend reading through the [\"Building Blocks of Ax\" tutorial](https://ax.dev/tutorials/building_blocks.html) before getting started with the `Scheduler`, as using it in this tutorial will require an Ax `Experiment` and an undertstanding of the experiment's subcomponents like the search space and the runner._\n",
+        "*We recommend reading through the [\"Building Blocks of Ax\" tutorial](https://ax.dev/tutorials/building_blocks.html) before getting started with the `Scheduler`, as using it in this tutorial will require an Ax `Experiment` and an undertstanding of the experiment's subcomponents like the search space and the runner.*\n",
         "\n",
         "### Contents:\n",
         "1. **Scheduler and external systems for trial evalution** –– overview of how scheduler works with an external system to run a closed-loop optimization.\n",


### PR DESCRIPTION
For whatever reason, the underscore way of doing italics isn't working https://ax.dev/tutorials/scheduler.html#Configurable-closed-loop-optimization-with-Ax-Scheduler though it [should be supported](https://www.markdownguide.org/basic-syntax/#italic)
![image](https://user-images.githubusercontent.com/6516020/125958581-767c3ed9-510e-4965-9b4c-40b58f74be6c.png)
Using an asterisk seems to do it
![image](https://user-images.githubusercontent.com/6516020/125958656-076b49c2-6710-40de-88b8-be57f0cd966c.png)
