### PR TITLE
Add pyro as a dependency for publishing

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -70,6 +70,7 @@ jobs:
         pip install tabulate  # Required for building RayTune tutorial notebook.
         pip install tensorboardX  # Required for building RayTune tutorial notebook.
         pip install matplotlib  # Required for building Multi-objective tutorial notebook.
+        pip install pyro  # Required for to call run_inference
     - name: Publish latest website
       env:
         DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ jobs:
         pip install tabulate  # Required for building RayTune tutorial notebook.
         pip install tensorboardX  # Required for building RayTune tutorial notebook.
         pip install matplotlib  # Required for building Multi-objective tutorial notebook.
+        pip install pyro  # Required for to call run_inference
     - name: Publish latest website
       env:
         DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}


### PR DESCRIPTION
See https://github.com/facebook/Ax/runs/3100756828?check_suite_focus=true#step:5:878.  We are getting tutorial build failures because `pyro` is a dependency.
I'm assuming this is also needed in `deploy.yml`.  See internal diff for more details on why