### PR TITLE
Use correct pyro package

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -70,7 +70,7 @@ jobs:
         pip install tabulate  # Required for building RayTune tutorial notebook.
         pip install tensorboardX  # Required for building RayTune tutorial notebook.
         pip install matplotlib  # Required for building Multi-objective tutorial notebook.
-        pip install pyro  # Required for to call run_inference
+        pip install pyro-ppl  # Required for to call run_inference
     - name: Publish latest website
       env:
         DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         pip install tabulate  # Required for building RayTune tutorial notebook.
         pip install tensorboardX  # Required for building RayTune tutorial notebook.
         pip install matplotlib  # Required for building Multi-objective tutorial notebook.
-        pip install pyro  # Required for to call run_inference
+        pip install pyro-ppl  # Required for to call run_inference
     - name: Publish latest website
       env:
         DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}


### PR DESCRIPTION
There is also a pypi package [pyro](https://pypi.org/project/Pyro/3.16/) but it's deprecated and fails to install.  I installed [pyro-ppl](https://pypi.org/project/pyro-ppl/) one locally and verified I can run
```
from pyro.mcmc import NUTS, MCMC
```
which is where [the failure](https://github.com/facebook/Ax/runs/3100756828?check_suite_focus=true#step:5:914) was happening 