### PR TITLE
Let all tutorials execute so we can see all errors

### DIFF
--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -201,10 +201,10 @@ def gen_tutorials(
             with tarfile.open(tar_path, "w:gz") as tar:
                 tar.add(tutorial_dir, arcname=os.path.basename(tutorial_dir))
 
-        if has_errors:
-            raise Exception(
-                "There are errors in tutorials, will not continue to publish"
-            )
+    if has_errors:
+        raise Exception(
+            "There are errors in tutorials, will not continue to publish"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -202,9 +202,7 @@ def gen_tutorials(
                 tar.add(tutorial_dir, arcname=os.path.basename(tutorial_dir))
 
     if has_errors:
-        raise Exception(
-            "There are errors in tutorials, will not continue to publish"
-        )
+        raise Exception("There are errors in tutorials, will not continue to publish")
 
 
 if __name__ == "__main__":

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -68,6 +68,7 @@ def gen_tutorials(
     Also create ipynb and py versions of tutorial in Docusaurus site for
     download.
     """
+    has_errors = False
     with open(os.path.join(repo_dir, "website", "tutorials.json"), "r") as infile:
         tutorial_config = json.loads(infile.read())
 
@@ -134,14 +135,22 @@ def gen_tutorials(
             ep = ExecutePreprocessor(timeout=timeout, **kwargs)
             start_time = time.time()
 
-            # execute notebook, using `tutorial_dir` as working directory
-            ep.preprocess(nb, {"metadata": {"path": tutorial_dir}})
-            total_time = time.time() - start_time
-            print(
-                "Done executing tutorial {}. Took {:.2f} seconds.".format(
-                    tid, total_time
+            # try / catch failures for now
+            # will re-raise at the end
+            try:
+                # execute notebook, using `tutorial_dir` as working directory
+                ep.preprocess(nb, {"metadata": {"path": tutorial_dir}})
+                total_time = time.time() - start_time
+                print(
+                    "Done executing tutorial {}. Took {:.2f} seconds.".format(
+                        tid, total_time
+                    )
                 )
-            )
+            except Exception as exc:
+                has_errors = True
+                print("Couldn't execute tutorial {}!".format(tid))
+                print(exc)
+                total_time = None
 
         # convert notebook to HTML
         exporter = HTMLExporter()
@@ -191,6 +200,11 @@ def gen_tutorials(
         if t_dir is not None:
             with tarfile.open(tar_path, "w:gz") as tar:
                 tar.add(tutorial_dir, arcname=os.path.basename(tutorial_dir))
+
+        if has_errors:
+            raise Exception(
+                "There are errors in tutorials, will not continue to publish"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sample output from running locally
```
...
----------------------------------
Generating tutorials
-----------------------------------
Generating gpei_hartmann_loop tutorial
Executing tutorial gpei_hartmann_loop
Couldn't execute tutorial gpei_hartmann_loop!
An error occurred while executing the following cell:
------------------
raise Exception('just `cause')
import numpy as np

from ax.plot.contour import plot_contour
from ax.plot.trace import optimization_trace_single_method
from ax.service.managed_loop import optimize
from ax.metrics.branin import branin
from ax.utils.measurement.synthetic_functions import hartmann6
from ax.utils.notebook.plotting import render, init_notebook_plotting

init_notebook_plotting()
------------------

---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-1-14760b80d3c8> in <module>
----> 1 raise Exception('just `cause')
      2 import numpy as np
      3 
      4 from ax.plot.contour import plot_contour
      5 from ax.plot.trace import optimization_trace_single_method

Exception: just `cause
Exception: just `cause

/Users/danielcohennyc/workspace/Ax/venv/lib/python3.8/site-packages/nbconvert/filters/highlight.py:138: UserWarning: IPython3 lexer unavailable, falling back on Python 3
  warn("IPython3 lexer unavailable, falling back on Python 3")
Generating gpei_hartmann_service tutorial
Executing tutorial gpei_hartmann_service
...
```