### PR TITLE
Fix scheduler db init

### DIFF
--- a/tutorials/scheduler.ipynb
+++ b/tutorials/scheduler.ipynb
@@ -3,7 +3,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "45253a91-ecf5-4669-b2b0-94b7206ef403"
+        "originalKey": "a87a01c2-c344-46a6-b70c-d4961b3b5273"
       },
       "source": [
         "# Configurable closed-loop optimization with Ax `Scheduler`\n",
@@ -28,7 +28,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "0c53b147-32c8-4f2d-9a7a-bc58cca61d9c"
+        "originalKey": "987f8249-e45f-4464-89a9-87bae587a459"
       },
       "source": [
         "## 1. `Scheduler` and external systems for trial evaluation\n",
@@ -45,7 +45,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "002c780f-5066-4538-83f2-8f5174ca2db5"
+        "originalKey": "f41175cc-1a95-4761-957a-a94f69336c1f"
       },
       "source": [
         "This scheme summarizes how the scheduler interacts with any external system used to run trial evaluations:\n",
@@ -61,7 +61,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "dcc3ad8d-10d4-41aa-9393-186d789356e4"
+        "originalKey": "7552ca86-4081-432f-93b6-122b3c7fe480"
       },
       "source": [
         "## 2. Set up a mock external execution system "
@@ -70,7 +70,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "61826502-296b-42f0-bb06-ebd67d05fbb4"
+        "originalKey": "a35cbe77-f3e6-46af-8c49-e906a6710959"
       },
       "source": [
         "An example of an 'external system' running trial evaluations could be a remote server executing scheduled jobs, a subprocess conducting ML training runs, an engine running physics simulations, etc. For the sake of example here, let us assume a dummy external system with the following client:"
@@ -79,11 +79,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "65486bdf-52a4-4f7e-a8ad-d17a1a8b0cbb",
+        "originalKey": "b63015f2-5426-4cb8-bf30-4a9d6962b7c2",
         "collapsed": false,
-        "requestMsgId": "c6ca75a2-7c5b-4143-8f27-555301a13924",
-        "executionStartTime": 1627310495103,
-        "executionStopTime": 1627310496658
+        "requestMsgId": "0c28fca2-3ced-4cd4-8289-ce8cff67fb6d",
+        "executionStartTime": 1627414193750,
+        "executionStopTime": 1627414194981
       },
       "source": [
         "from typing import Any, Dict, NamedTuple, List, Union\n",
@@ -151,7 +151,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "cbfe1f5a-dc61-4209-bb38-1fdded7d7654"
+        "originalKey": "4741d8e2-5ea3-4827-88e6-eb7c74956faf"
       },
       "source": [
         "## 3. Set up an experiment according to the mock external system\n",
@@ -164,11 +164,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "4571fe89-2205-4f94-a4a1-1fc7617506bf",
+        "originalKey": "febb6790-864d-404c-b9c7-bfc097514072",
         "collapsed": false,
-        "requestMsgId": "4e40f846-75d0-4700-86d6-5a597baf3fda",
-        "executionStartTime": 1627310500952,
-        "executionStopTime": 1627310500962
+        "requestMsgId": "d6a35c1e-a54e-4100-8b0c-21672cc9648d",
+        "executionStartTime": 1627414196894,
+        "executionStopTime": 1627414196928
       },
       "source": [
         "from ax.core.runner import Runner\n",
@@ -196,11 +196,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "574ccfb4-d94b-4fc4-92aa-c1053fc8ad1f",
+        "originalKey": "2da78e8c-de67-403b-9ba3-194e309ac00a",
         "collapsed": false,
-        "requestMsgId": "c5c080fd-47b9-4ee5-a4f9-7923c62452fd",
-        "executionStartTime": 1627310504157,
-        "executionStopTime": 1627310504189
+        "requestMsgId": "2654bdca-31f5-4849-85f3-14c7b22962f1",
+        "executionStartTime": 1627414202599,
+        "executionStopTime": 1627414202643
       },
       "source": [
         "import pandas as pd\n",
@@ -241,7 +241,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "fcc43a47-f153-4682-9ba9-69f536194bff"
+        "originalKey": "12c13e97-a368-442e-a7c7-34ef05c6667d"
       },
       "source": [
         "Now we can set up the experiment using the runner and metric we defined. This experiment will have a single-objective optimization config, minimizing the Branin function, and the search space that corresponds to that function."
@@ -250,11 +250,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "717b5d75-9a16-40bb-833b-350a6457b94b",
+        "originalKey": "6099a777-c44b-4d52-a872-9cf2f21e0119",
         "collapsed": false,
-        "requestMsgId": "030a5549-0c91-4794-b4fa-04b914c0f14a",
-        "executionStartTime": 1627310509570,
-        "executionStopTime": 1627310509648
+        "requestMsgId": "ff1c1ef7-40f9-424c-9209-89c8c9efc226",
+        "executionStartTime": 1627414205594,
+        "executionStopTime": 1627414205632
       },
       "source": [
         "from ax import *\n",
@@ -293,7 +293,7 @@
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:41:49] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+            "[INFO 07-27 12:30:05] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
           ]
         }
       ]
@@ -301,7 +301,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "8d208f1f-2632-41f7-817c-0109b3ac91bd"
+        "originalKey": "8fa33228-92f7-40e8-b7a4-10529c61fa22"
       },
       "source": [
         "## 4. Setting up a `Scheduler`\n",
@@ -314,11 +314,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "fabf46fc-69e9-47f9-95fd-f3d44ed7cb6d",
+        "originalKey": "18722c77-fb22-4414-aa67-294b172aa4b9",
         "collapsed": false,
-        "requestMsgId": "f2f520f3-c7e8-42f3-be58-359174b7131a",
-        "executionStartTime": 1627310513891,
-        "executionStopTime": 1627310514120
+        "requestMsgId": "4953e65c-f856-47b0-ae9d-468c4f0c51e4",
+        "executionStartTime": 1627414208419,
+        "executionStopTime": 1627414208624
       },
       "source": [
         "from typing import Dict, Set\n",
@@ -348,7 +348,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "202720bd-7d7a-4c84-8b1f-8759b859798f"
+        "originalKey": "d354e66c-96be-40db-a5dc-446e7ba57898"
       },
       "source": [
         "### 4B. Auto-selecting a generation strategy\n",
@@ -361,11 +361,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "f47311e8-8446-4e9e-8120-10c67c7cac7c",
+        "originalKey": "17d5680f-8ce7-475a-8a7a-1130254df680",
         "collapsed": false,
-        "requestMsgId": "70b59445-931b-4fec-bdab-880169456fb8",
-        "executionStartTime": 1627310519129,
-        "executionStopTime": 1627310519191
+        "requestMsgId": "01b963a3-cf48-48fc-b05b-cfa04e00c136",
+        "executionStartTime": 1627414211632,
+        "executionStopTime": 1627414211704
       },
       "source": [
         "from ax.modelbridge.dispatch_utils import choose_generation_strategy\n",
@@ -381,14 +381,14 @@
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:41:59] ax.modelbridge.dispatch_utils: Using GPEI (Bayesian optimization) since there are more continuous parameters than there are categories for the unordered categorical parameters.\n"
+            "[INFO 07-27 12:30:11] ax.modelbridge.dispatch_utils: Using GPEI (Bayesian optimization) since there are more continuous parameters than there are categories for the unordered categorical parameters.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:41:59] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
+            "[INFO 07-27 12:30:11] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
           ]
         }
       ]
@@ -396,7 +396,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "a79cb68c-c9cd-4495-9954-1c0b7fb4d916"
+        "originalKey": "d27ec254-d46e-433a-ba28-b87bad37c1de"
       },
       "source": [
         "Now we have all the components needed to start the scheduler:"
@@ -405,11 +405,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "9be74da1-c6e1-4c0e-955b-8dfd44526315",
+        "originalKey": "0e125b29-63f8-449b-a91e-5b599664318a",
         "collapsed": false,
-        "requestMsgId": "10687e68-f60a-47c8-8f54-ba2e7657d91b",
-        "executionStartTime": 1627310522711,
-        "executionStopTime": 1627310522772
+        "requestMsgId": "2ab3aea0-374c-4f80-9357-a75e960c3242",
+        "executionStartTime": 1627414213948,
+        "executionStopTime": 1627414214000
       },
       "source": [
         "scheduler = MockJobQueueScheduler(\n",
@@ -424,7 +424,7 @@
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:02] MockJobQueueScheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
+            "[INFO 07-27 12:30:14] MockJobQueueScheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
           ]
         }
       ]
@@ -432,7 +432,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "f83d0af0-6854-4b41-ac4f-d518fc617e42"
+        "originalKey": "c160240e-bc0e-4b6b-aa5e-f18fcef629ce"
       },
       "source": [
         "## 5. Running the optimization\n",
@@ -443,11 +443,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "d5966dfc-e37a-4889-9ff7-0e0b593550df",
+        "originalKey": "8764c6b0-4a38-4aa0-becd-8432901daf06",
         "collapsed": false,
-        "requestMsgId": "b230a84a-df81-4ebe-a24b-a399713d3e8d",
-        "executionStartTime": 1627310526122,
-        "executionStopTime": 1627310528358
+        "requestMsgId": "85427438-cedd-4df7-8fdd-ef2dc2748baa",
+        "executionStartTime": 1627414216886,
+        "executionStopTime": 1627414219256
       },
       "source": [
         "scheduler.run_n_trials(max_trials=3)"
@@ -458,35 +458,49 @@
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:06] MockJobQueueScheduler: Running trials [0]...\n"
+            "[INFO 07-27 12:30:17] MockJobQueueScheduler: Running trials [0]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:06] MockJobQueueScheduler: Running trials [1]...\n"
+            "[INFO 07-27 12:30:18] MockJobQueueScheduler: Running trials [1]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:07] MockJobQueueScheduler: Running trials [2]...\n"
+            "[INFO 07-27 12:30:19] MockJobQueueScheduler: Running trials [2]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:08] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
+            "[INFO 07-27 12:30:19] MockJobQueueScheduler: Retrieved COMPLETED trials: {1, 2}.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:08] MockJobQueueScheduler: Retrieved COMPLETED trials: {0, 1, 2}.\n"
+            "[INFO 07-27 12:30:19] MockJobQueueScheduler: Done submitting trials, waiting for remaining 1 running trials...\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 07-27 12:30:19] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 07-27 12:30:19] MockJobQueueScheduler: Retrieved COMPLETED trials: {0}.\n"
           ]
         },
         {
@@ -495,7 +509,7 @@
             "text/plain": "OptimizationResult()"
           },
           "metadata": {
-            "bento_obj_id": "140576941710736"
+            "bento_obj_id": "139990948326176"
           },
           "execution_count": 8
         }
@@ -504,7 +518,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "eed6a9f5-b3d4-4353-a988-3834111a157a"
+        "originalKey": "3e681099-b35a-420f-aa68-f2db59d655c6"
       },
       "source": [
         "We can examine `experiment` to see that it now has three trials:"
@@ -513,11 +527,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "0ff213d1-925f-4d54-80a8-6a16d50e7417",
+        "originalKey": "29356b75-0ad4-496a-94e6-455aa994d187",
         "collapsed": false,
-        "requestMsgId": "9a7d984f-1a6f-4f8d-a339-7033835d7092",
-        "executionStartTime": 1627310555371,
-        "executionStopTime": 1627310555504
+        "requestMsgId": "b965ea55-6223-4ceb-98c7-2b32d92c6138",
+        "executionStartTime": 1627414221485,
+        "executionStopTime": 1627414221596
       },
       "source": [
         "from ax.service.utils.report_utils import exp_to_df\n",
@@ -529,8 +543,8 @@
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "      branin  trial_index arm_name  ...        x2  trial_status generator_model\n0  27.889713            0      0_0  ...  0.974036     COMPLETED           Sobol\n1  27.889713            1      1_0  ...  4.032652     COMPLETED           Sobol\n2  32.415946            2      2_0  ...  7.690536     COMPLETED           Sobol\n\n[3 rows x 7 columns]",
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>branin</th>\n      <th>trial_index</th>\n      <th>arm_name</th>\n      <th>x1</th>\n      <th>x2</th>\n      <th>trial_status</th>\n      <th>generator_model</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>27.889713</td>\n      <td>0</td>\n      <td>0_0</td>\n      <td>7.572295</td>\n      <td>0.974036</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>27.889713</td>\n      <td>1</td>\n      <td>1_0</td>\n      <td>6.504650</td>\n      <td>4.032652</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>32.415946</td>\n      <td>2</td>\n      <td>2_0</td>\n      <td>3.423225</td>\n      <td>7.690536</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+            "text/plain": "      branin  trial_index arm_name  ...        x2  trial_status generator_model\n0  10.769584            0      0_0  ...  0.941264     COMPLETED           Sobol\n1   3.973548            1      1_0  ...  2.705769     COMPLETED           Sobol\n2   6.475534            2      2_0  ...  4.752174     COMPLETED           Sobol\n\n[3 rows x 7 columns]",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>branin</th>\n      <th>trial_index</th>\n      <th>arm_name</th>\n      <th>x1</th>\n      <th>x2</th>\n      <th>trial_status</th>\n      <th>generator_model</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>10.769584</td>\n      <td>0</td>\n      <td>0_0</td>\n      <td>4.775549</td>\n      <td>0.941264</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>3.973548</td>\n      <td>1</td>\n      <td>1_0</td>\n      <td>3.905883</td>\n      <td>2.705769</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>6.475534</td>\n      <td>2</td>\n      <td>2_0</td>\n      <td>2.332745</td>\n      <td>4.752174</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
             "application/vnd.dataresource+json": {
               "schema": {
                 "fields": [
@@ -575,31 +589,31 @@
               "data": [
                 {
                   "index": 0,
-                  "branin": 27.8897131508,
+                  "branin": 10.7695843106,
                   "trial_index": 0,
                   "arm_name": "0_0",
-                  "x1": 7.5722950697,
-                  "x2": 0.9740355983,
+                  "x1": 4.7755485773,
+                  "x2": 0.9412643686,
                   "trial_status": "COMPLETED",
                   "generator_model": "Sobol"
                 },
                 {
                   "index": 1,
-                  "branin": 27.8897131508,
+                  "branin": 3.9735477044,
                   "trial_index": 1,
                   "arm_name": "1_0",
-                  "x1": 6.504650237,
-                  "x2": 4.0326518146,
+                  "x1": 3.9058831101,
+                  "x2": 2.7057687286,
                   "trial_status": "COMPLETED",
                   "generator_model": "Sobol"
                 },
                 {
                   "index": 2,
-                  "branin": 32.415945599,
+                  "branin": 6.4755337177,
                   "trial_index": 2,
                   "arm_name": "2_0",
-                  "x1": 3.4232249763,
-                  "x2": 7.690536431,
+                  "x1": 2.3327453528,
+                  "x2": 4.7521744017,
                   "trial_status": "COMPLETED",
                   "generator_model": "Sobol"
                 }
@@ -607,7 +621,7 @@
             }
           },
           "metadata": {
-            "bento_obj_id": "140576638301184"
+            "bento_obj_id": "139990946542544"
           },
           "execution_count": 9
         }
@@ -616,7 +630,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "177d65ef-1b26-45f8-8992-c80cd38fe5aa"
+        "originalKey": "5b743c06-b118-4aba-9903-2f397c87428d"
       },
       "source": [
         "Now we can run `run_n_trials` again to add three more trials to the experiment."
@@ -626,50 +640,64 @@
       "cell_type": "code",
       "metadata": {
         "scrolled": true,
-        "originalKey": "7fc61d87-5ee5-4a46-b522-4da1f9178bf8",
+        "originalKey": "5aa6249c-e28c-4789-8ead-f936e6c92831",
         "collapsed": false,
-        "requestMsgId": "d55cf1d4-bda1-4dad-b777-b7a4931b7477",
-        "executionStartTime": 1627310559064,
-        "executionStopTime": 1627310562515
+        "requestMsgId": "58827fee-62b4-40f7-b100-6ded49ac9653",
+        "executionStartTime": 1627414225840,
+        "executionStopTime": 1627414231051
       },
       "source": [
         "scheduler.run_n_trials(max_trials=3)"
       ],
-      "execution_count": 10,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:39] MockJobQueueScheduler: Running trials [3]...\n"
+            "[INFO 07-27 12:30:26] MockJobQueueScheduler: Running trials [3]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:40] MockJobQueueScheduler: Running trials [4]...\n"
+            "[INFO 07-27 12:30:27] MockJobQueueScheduler: Running trials [4]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:41] MockJobQueueScheduler: Running trials [5]...\n"
+            "[INFO 07-27 12:30:30] MockJobQueueScheduler: Running trials [5]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:42] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
+            "[INFO 07-27 12:30:31] MockJobQueueScheduler: Retrieved COMPLETED trials: {4, 5}.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:42:42] MockJobQueueScheduler: Retrieved COMPLETED trials: {3, 4, 5}.\n"
+            "[INFO 07-27 12:30:31] MockJobQueueScheduler: Done submitting trials, waiting for remaining 1 running trials...\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 07-27 12:30:31] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 07-27 12:30:31] MockJobQueueScheduler: Retrieved COMPLETED trials: {3}.\n"
           ]
         },
         {
@@ -678,16 +706,16 @@
             "text/plain": "OptimizationResult()"
           },
           "metadata": {
-            "bento_obj_id": "140582076766144"
+            "bento_obj_id": "139990948325936"
           },
-          "execution_count": 10
+          "execution_count": 11
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "5a1afeec-1a27-4f6a-bb7c-cd915e906e55"
+        "originalKey": "11b91bc8-3746-42b0-a2c8-049cd47b30e1"
       },
       "source": [
         "Examiniming the experiment, we now see 6 trials, one of which is produced by Bayesian optimization (GPEI):"
@@ -696,22 +724,22 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "9d38a002-0784-408a-b260-aaf776418fe6",
+        "originalKey": "b71ed370-1471-4be7-9050-b43f0b327457",
         "collapsed": false,
-        "requestMsgId": "2fb63700-5bf1-4ca1-9e15-01c7aef1392c",
-        "executionStartTime": 1627310566575,
-        "executionStopTime": 1627310566687
+        "requestMsgId": "d8db331c-a2e2-41e4-9408-687bca0bd9b7",
+        "executionStartTime": 1627414232819,
+        "executionStopTime": 1627414232928
       },
       "source": [
         "exp_to_df(experiment)"
       ],
-      "execution_count": 11,
+      "execution_count": 12,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "       branin  trial_index arm_name  ...         x2  trial_status generator_model\n0   27.889713            0      0_0  ...   0.974036     COMPLETED           Sobol\n1   27.889713            1      1_0  ...   4.032652     COMPLETED           Sobol\n2   32.415946            2      2_0  ...   7.690536     COMPLETED           Sobol\n3  163.435087            3      3_0  ...  13.302217     COMPLETED           Sobol\n4   82.693721            4      4_0  ...   2.288735     COMPLETED           Sobol\n5    3.865690            5      5_0  ...   4.389517     COMPLETED            GPEI\n\n[6 rows x 7 columns]",
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>branin</th>\n      <th>trial_index</th>\n      <th>arm_name</th>\n      <th>x1</th>\n      <th>x2</th>\n      <th>trial_status</th>\n      <th>generator_model</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>27.889713</td>\n      <td>0</td>\n      <td>0_0</td>\n      <td>7.572295</td>\n      <td>0.974036</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>27.889713</td>\n      <td>1</td>\n      <td>1_0</td>\n      <td>6.504650</td>\n      <td>4.032652</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>32.415946</td>\n      <td>2</td>\n      <td>2_0</td>\n      <td>3.423225</td>\n      <td>7.690536</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>163.435087</td>\n      <td>3</td>\n      <td>3_0</td>\n      <td>7.044616</td>\n      <td>13.302217</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>82.693721</td>\n      <td>4</td>\n      <td>4_0</td>\n      <td>-2.734029</td>\n      <td>2.288735</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>3.865690</td>\n      <td>5</td>\n      <td>5_0</td>\n      <td>10.000000</td>\n      <td>4.389517</td>\n      <td>COMPLETED</td>\n      <td>GPEI</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+            "text/plain": "      branin  trial_index arm_name  ...         x2  trial_status generator_model\n0  10.769584            0      0_0  ...   0.941264     COMPLETED           Sobol\n1   3.973548            1      1_0  ...   2.705769     COMPLETED           Sobol\n2   6.475534            2      2_0  ...   4.752174     COMPLETED           Sobol\n3   1.921628            3      3_0  ...   1.592081     COMPLETED           Sobol\n4   2.985589            4      4_0  ...   2.611647     COMPLETED           Sobol\n5  19.778603            5      5_0  ...  14.531264     COMPLETED            GPEI\n\n[6 rows x 7 columns]",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>branin</th>\n      <th>trial_index</th>\n      <th>arm_name</th>\n      <th>x1</th>\n      <th>x2</th>\n      <th>trial_status</th>\n      <th>generator_model</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>10.769584</td>\n      <td>0</td>\n      <td>0_0</td>\n      <td>4.775549</td>\n      <td>0.941264</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>3.973548</td>\n      <td>1</td>\n      <td>1_0</td>\n      <td>3.905883</td>\n      <td>2.705769</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>6.475534</td>\n      <td>2</td>\n      <td>2_0</td>\n      <td>2.332745</td>\n      <td>4.752174</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>1.921628</td>\n      <td>3</td>\n      <td>3_0</td>\n      <td>9.677308</td>\n      <td>1.592081</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2.985589</td>\n      <td>4</td>\n      <td>4_0</td>\n      <td>8.740622</td>\n      <td>2.611647</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>19.778603</td>\n      <td>5</td>\n      <td>5_0</td>\n      <td>-5.000000</td>\n      <td>14.531264</td>\n      <td>COMPLETED</td>\n      <td>GPEI</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
             "application/vnd.dataresource+json": {
               "schema": {
                 "fields": [
@@ -756,61 +784,61 @@
               "data": [
                 {
                   "index": 0,
-                  "branin": 27.8897131508,
+                  "branin": 10.7695843106,
                   "trial_index": 0,
                   "arm_name": "0_0",
-                  "x1": 7.5722950697,
-                  "x2": 0.9740355983,
+                  "x1": 4.7755485773,
+                  "x2": 0.9412643686,
                   "trial_status": "COMPLETED",
                   "generator_model": "Sobol"
                 },
                 {
                   "index": 1,
-                  "branin": 27.8897131508,
+                  "branin": 3.9735477044,
                   "trial_index": 1,
                   "arm_name": "1_0",
-                  "x1": 6.504650237,
-                  "x2": 4.0326518146,
+                  "x1": 3.9058831101,
+                  "x2": 2.7057687286,
                   "trial_status": "COMPLETED",
                   "generator_model": "Sobol"
                 },
                 {
                   "index": 2,
-                  "branin": 32.415945599,
+                  "branin": 6.4755337177,
                   "trial_index": 2,
                   "arm_name": "2_0",
-                  "x1": 3.4232249763,
-                  "x2": 7.690536431,
+                  "x1": 2.3327453528,
+                  "x2": 4.7521744017,
                   "trial_status": "COMPLETED",
                   "generator_model": "Sobol"
                 },
                 {
                   "index": 3,
-                  "branin": 163.4350870143,
+                  "branin": 1.9216278556,
                   "trial_index": 3,
                   "arm_name": "3_0",
-                  "x1": 7.044615848,
-                  "x2": 13.3022174891,
+                  "x1": 9.6773079177,
+                  "x2": 1.5920814034,
                   "trial_status": "COMPLETED",
                   "generator_model": "Sobol"
                 },
                 {
                   "index": 4,
-                  "branin": 82.6937210339,
+                  "branin": 2.9855894646,
                   "trial_index": 4,
                   "arm_name": "4_0",
-                  "x1": -2.7340292698,
-                  "x2": 2.2887349594,
+                  "x1": 8.7406220939,
+                  "x2": 2.6116466196,
                   "trial_status": "COMPLETED",
                   "generator_model": "Sobol"
                 },
                 {
                   "index": 5,
-                  "branin": 3.8656896017,
+                  "branin": 19.7786028573,
                   "trial_index": 5,
                   "arm_name": "5_0",
-                  "x1": 10,
-                  "x2": 4.3895167153,
+                  "x1": -5,
+                  "x2": 14.5312637629,
                   "trial_status": "COMPLETED",
                   "generator_model": "GPEI"
                 }
@@ -818,84 +846,7 @@
             }
           },
           "metadata": {
-            "bento_obj_id": "140576761070160"
-          },
-          "execution_count": 11
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "originalKey": "036a595d-d4a7-40c4-afae-3535769436e2"
-      },
-      "source": [
-        "For each call to `run_n_trials`, one can specify a timeout; if `run_n_trials` has been running for too long without finishing its `max_trials`, the operation will exit gracefully:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "fe628ed3-795d-4412-a701-663c44cd89b4",
-        "collapsed": false,
-        "requestMsgId": "f488cd5c-1c12-48f5-8d2e-f8904a977227",
-        "executionStartTime": 1627310570062,
-        "executionStopTime": 1627310570746
-      },
-      "source": [
-        "scheduler.run_n_trials(max_trials=3, timeout_hours=0.00001)"
-      ],
-      "execution_count": 12,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 07-26 07:42:50] MockJobQueueScheduler: Running trials [6]...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[ERROR 07-26 07:42:50] MockJobQueueScheduler: Optimization timed out (timeout hours: 1e-05)!\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 07-26 07:42:50] MockJobQueueScheduler: `should_abort` is `True`, not running more trials.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 07-26 07:42:50] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 07-26 07:42:50] MockJobQueueScheduler: Retrieved COMPLETED trials: {6}.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[ERROR 07-26 07:42:50] MockJobQueueScheduler: Optimization timed out (timeout hours: 1e-05)!\n"
-          ]
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "OptimizationResult()"
-          },
-          "metadata": {
-            "bento_obj_id": "140576761072800"
+            "bento_obj_id": "139990922882736"
           },
           "execution_count": 12
         }
@@ -904,7 +855,84 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "6d26e468-6e03-4ba5-af10-de086646a5d8",
+        "originalKey": "77bc0747-99ab-4c6a-99ce-6d35e15543b3"
+      },
+      "source": [
+        "For each call to `run_n_trials`, one can specify a timeout; if `run_n_trials` has been running for too long without finishing its `max_trials`, the operation will exit gracefully:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "639590c5-dc5e-4a7f-970e-cca3abbae74c",
+        "collapsed": false,
+        "requestMsgId": "0b8c2c62-5c20-4ea0-a011-f8af3422fc75",
+        "executionStartTime": 1627414236297,
+        "executionStopTime": 1627414236719
+      },
+      "source": [
+        "scheduler.run_n_trials(max_trials=3, timeout_hours=0.00001)"
+      ],
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 07-27 12:30:36] MockJobQueueScheduler: Running trials [6]...\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[ERROR 07-27 12:30:36] MockJobQueueScheduler: Optimization timed out (timeout hours: 1e-05)!\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 07-27 12:30:36] MockJobQueueScheduler: `should_abort` is `True`, not running more trials.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 07-27 12:30:36] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 07-27 12:30:36] MockJobQueueScheduler: Retrieved COMPLETED trials: {6}.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[ERROR 07-27 12:30:36] MockJobQueueScheduler: Optimization timed out (timeout hours: 1e-05)!\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "OptimizationResult()"
+          },
+          "metadata": {
+            "bento_obj_id": "139990946544320"
+          },
+          "execution_count": 13
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "originalKey": "d376f489-01af-4c7a-9307-d116021df3d9",
         "showInput": false
       },
       "source": [
@@ -918,26 +946,27 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "a310602d-6bd7-4187-890b-6893f3b9f243",
+        "originalKey": "61a5588e-7ba9-4189-8b98-534485331a7f",
         "collapsed": false,
-        "requestMsgId": "058b3753-f102-4d80-a09c-35bf51ce2095",
-        "executionStartTime": 1627310791157,
-        "executionStopTime": 1627310791248,
+        "requestMsgId": "d5bfea13-7c2b-4ba6-af39-f76dd568cb37",
+        "executionStartTime": 1627414240596,
+        "executionStopTime": 1627414240749,
         "code_folding": [],
         "hidden_ranges": []
       },
       "source": [
         "from ax.storage.sqa_store.structs import DBSettings\n",
-        "from ax.storage.sqa_store.db import get_engine, create_all_tables\n",
+        "from ax.storage.sqa_store.db import init_engine_and_session_factory, get_engine, create_all_tables\n",
         "from ax.storage.metric_registry import register_metric\n",
         "from ax.storage.runner_registry import register_runner\n",
         "\n",
         "# URL is of the form \"dialect+driver://username:password@host:port/database\".\n",
         "# Instead of URL, can provide a `creator function`; can specify custom encoders/decoders if necessary.\n",
         "db_settings = DBSettings(url=\"sqlite:///foo.db\")\n",
+        "init_engine_and_session_factory(url=db_settings.url)\n",
+        "\n",
         "engine = get_engine()\n",
         "create_all_tables(engine)\n",
-        "\n",
         "register_metric(BraninForMockJobMetric)\n",
         "register_runner(MockJobRunner)\n",
         "\n",
@@ -951,55 +980,55 @@
         "    db_settings=db_settings,\n",
         ")"
       ],
-      "execution_count": 20,
+      "execution_count": 14,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:31] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+            "[INFO 07-27 12:30:40] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:31] ax.modelbridge.dispatch_utils: Using GPEI (Bayesian optimization) since there are more continuous parameters than there are categories for the unordered categorical parameters.\n"
+            "[INFO 07-27 12:30:40] ax.modelbridge.dispatch_utils: Using GPEI (Bayesian optimization) since there are more continuous parameters than there are categories for the unordered categorical parameters.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:31] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
+            "[INFO 07-27 12:30:40] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:31] MockJobQueueScheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
+            "[INFO 07-27 12:30:40] MockJobQueueScheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:31] ax.service.utils.with_db_settings_base: Experiment branin_test_experiment is not yet in DB, storing it.\n"
+            "[INFO 07-27 12:30:40] ax.service.utils.with_db_settings_base: Experiment branin_test_experiment is not yet in DB, storing it.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:31] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+            "[INFO 07-27 12:30:40] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:31] ax.service.utils.with_db_settings_base: Generation strategy Sobol+GPEI is not yet in DB, storing it.\n"
+            "[INFO 07-27 12:30:40] ax.service.utils.with_db_settings_base: Generation strategy Sobol+GPEI is not yet in DB, storing it.\n"
           ]
         }
       ]
@@ -1007,16 +1036,16 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "b94fc83c-2f04-4617-89bf-d83d2f89d7ce",
+        "originalKey": "b46aa812-dc9f-43a6-8242-f1df6c325924",
         "collapsed": false,
-        "requestMsgId": "87960a38-1714-4507-8bff-796e91d82ee8",
-        "executionStartTime": 1627310795061,
-        "executionStopTime": 1627310795120
+        "requestMsgId": "5d565e4f-e946-4270-b4e6-db250ba6638d",
+        "executionStartTime": 1627414244132,
+        "executionStopTime": 1627414244160
       },
       "source": [
         "stored_experiment.name"
       ],
-      "execution_count": 22,
+      "execution_count": 15,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1024,16 +1053,16 @@
             "text/plain": "'branin_test_experiment'"
           },
           "metadata": {
-            "bento_obj_id": "140576752429776"
+            "bento_obj_id": "139991257100736"
           },
-          "execution_count": 22
+          "execution_count": 15
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "c3ff1927-9acb-4d51-a0e6-b83cb9800bbe"
+        "originalKey": "c72c037e-1111-4ba3-944a-cba9c6405143"
       },
       "source": [
         "To resume a stored experiment:"
@@ -1042,11 +1071,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "82aafa2f-6ee3-4b48-95c6-826bae61d97c",
+        "originalKey": "4422c1e9-1d21-440c-99b4-2db2f9d6b881",
         "collapsed": false,
-        "requestMsgId": "59d80ccf-0498-4d6d-ae34-579b0d043dbe",
-        "executionStartTime": 1627310797321,
-        "executionStopTime": 1627310797428
+        "requestMsgId": "fd1f42d7-9b8b-4caa-98da-bfb18894da92",
+        "executionStartTime": 1627414246073,
+        "executionStopTime": 1627414246173
       },
       "source": [
         "reloaded_experiment_scheduler = MockJobQueueScheduler.from_stored_experiment(\n",
@@ -1057,34 +1086,34 @@
         "    db_settings=db_settings,\n",
         ")"
       ],
-      "execution_count": 23,
+      "execution_count": 16,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:37] ax.service.utils.with_db_settings_base: Loading experiment and generation strategy (with reduced state: True)...\n"
+            "[INFO 07-27 12:30:46] ax.service.utils.with_db_settings_base: Loading experiment and generation strategy (with reduced state: True)...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:37] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+            "[INFO 07-27 12:30:46] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:37] ax.service.utils.with_db_settings_base: Loaded experiment branin_test_experiment in 0.03 seconds.\n"
+            "[INFO 07-27 12:30:46] ax.service.utils.with_db_settings_base: Loaded experiment branin_test_experiment in 0.03 seconds.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:37] ax.service.utils.with_db_settings_base: Loaded generation strategy for experiment branin_test_experiment in 0.01 seconds.\n"
+            "[INFO 07-27 12:30:46] ax.service.utils.with_db_settings_base: Loaded generation strategy for experiment branin_test_experiment in 0.01 seconds.\n"
           ]
         }
       ]
@@ -1092,7 +1121,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "030848af-aa15-4de8-b8a7-4c6035d2e16b"
+        "originalKey": "91afdf4c-5e0a-4cd6-b01b-078de1edfeca"
       },
       "source": [
         "With the newly reloaded experiment, the `Scheduler` can continue the optimization:"
@@ -1101,50 +1130,50 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "a7135166-6875-47f0-8f29-0113444970c3",
+        "originalKey": "ac6ccb7e-fb95-4a69-b7bd-4febe2e8731a",
         "collapsed": false,
-        "requestMsgId": "c2410bc8-7a91-4dca-9e87-29a28f5b1a5c",
-        "executionStartTime": 1627310800869,
-        "executionStopTime": 1627310801304
+        "requestMsgId": "133c538d-2a6a-4ec8-a32b-a6f8e7040bfe",
+        "executionStartTime": 1627414249019,
+        "executionStopTime": 1627414249569
       },
       "source": [
         "reloaded_experiment_scheduler.run_n_trials(max_trials=3)"
       ],
-      "execution_count": 24,
+      "execution_count": 18,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:41] MockJobQueueScheduler: Running trials [0]...\n"
+            "[INFO 07-27 12:30:49] MockJobQueueScheduler: Running trials [0]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:41] MockJobQueueScheduler: Running trials [1]...\n"
+            "[INFO 07-27 12:30:49] MockJobQueueScheduler: Running trials [1]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:41] MockJobQueueScheduler: Running trials [2]...\n"
+            "[INFO 07-27 12:30:49] MockJobQueueScheduler: Running trials [2]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:41] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
+            "[INFO 07-27 12:30:49] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:41] MockJobQueueScheduler: Retrieved COMPLETED trials: {0, 1, 2}.\n"
+            "[INFO 07-27 12:30:49] MockJobQueueScheduler: Retrieved COMPLETED trials: {0, 1, 2}.\n"
           ]
         },
         {
@@ -1153,16 +1182,16 @@
             "text/plain": "OptimizationResult()"
           },
           "metadata": {
-            "bento_obj_id": "140576773080256"
+            "bento_obj_id": "139991257094896"
           },
-          "execution_count": 24
+          "execution_count": 18
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "bbee1054-63a1-46ed-bf56-c9f2d1391ff9"
+        "originalKey": "381c0476-cbec-47ed-988c-b22450d5adb8"
       },
       "source": [
         "## 7. Configuring the scheduler\n",
@@ -1179,16 +1208,16 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "60387cee-5a4b-4518-a463-cf69a5417c3d",
+        "originalKey": "02a2ba93-c1aa-4cc4-85a3-89bb66389aa3",
         "collapsed": false,
-        "requestMsgId": "d36e832b-d139-49a2-be4e-63342f9c4581",
-        "executionStartTime": 1627310805003,
-        "executionStopTime": 1627310805043
+        "requestMsgId": "491c7ca7-f5ac-41a1-838a-adbbeff321d2",
+        "executionStartTime": 1627414251894,
+        "executionStopTime": 1627414252016
       },
       "source": [
         "print(SchedulerOptions.__doc__)"
       ],
-      "execution_count": 26,
+      "execution_count": 19,
       "outputs": [
         {
           "output_type": "stream",
@@ -1202,7 +1231,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "35ecb81e-100c-4073-a97d-8a51edb5e5c2"
+        "originalKey": "04173dec-3fa2-46c4-9702-311828aa708e"
       },
       "source": [
         "## 8. Advanced functionality\n",
@@ -1227,7 +1256,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "originalKey": "2e8b74fc-6d23-4e23-9d54-cb785d402963"
+        "originalKey": "0915c7eb-a351-43d5-8e6d-ad02793591ca"
       },
       "source": [
         "### 8b. Using `run_trials_and_yield_results` generator method\n",
@@ -1238,11 +1267,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "3196a94c-7560-40ec-858d-d9cbedbb0942",
+        "originalKey": "2963b2c1-cb3f-4145-9b20-4b96e860b55a",
         "collapsed": false,
-        "requestMsgId": "4071327e-df37-470f-8e66-8a142111a223",
-        "executionStartTime": 1627310812809,
-        "executionStopTime": 1627310812844
+        "requestMsgId": "e2950413-2b84-475a-b109-376854811cef",
+        "executionStartTime": 1627414258044,
+        "executionStopTime": 1627414258072
       },
       "source": [
         "class ResultReportingScheduler(MockJobQueueScheduler):\n",
@@ -1254,17 +1283,17 @@
         "            \"running trials\": [t.index for t in self.running_trials],\n",
         "        }"
       ],
-      "execution_count": 27,
+      "execution_count": 20,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "d88d3ee3-fe35-4df0-912b-3fcb8d9160b0",
+        "originalKey": "8212e338-3a6e-4bf0-88ad-c23aab3ce967",
         "collapsed": false,
-        "requestMsgId": "6e8c56eb-b3aa-4e74-afce-3e454bd1f0e6",
-        "executionStartTime": 1627310815853,
-        "executionStopTime": 1627310822684
+        "requestMsgId": "484be5c4-2b77-4903-9e9b-b0b4be3e3053",
+        "executionStartTime": 1627414260070,
+        "executionStopTime": 1627414267829
       },
       "source": [
         "experiment = make_branin_experiment_with_runner_and_metric()\n",
@@ -1280,139 +1309,132 @@
         "for reported_result in scheduler.run_trials_and_yield_results(max_trials=6):\n",
         "  print(\"Reported result: \", reported_result)"
       ],
-      "execution_count": 28,
+      "execution_count": 21,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:56] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+            "[INFO 07-27 12:31:00] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:56] ax.modelbridge.dispatch_utils: Using GPEI (Bayesian optimization) since there are more continuous parameters than there are categories for the unordered categorical parameters.\n"
+            "[INFO 07-27 12:31:00] ax.modelbridge.dispatch_utils: Using GPEI (Bayesian optimization) since there are more continuous parameters than there are categories for the unordered categorical parameters.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:56] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
+            "[INFO 07-27 12:31:00] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:56] ResultReportingScheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
+            "[INFO 07-27 12:31:00] ResultReportingScheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:56] ResultReportingScheduler: Running trials [0]...\n"
+            "[INFO 07-27 12:31:00] ResultReportingScheduler: Running trials [0]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:57] ResultReportingScheduler: Running trials [1]...\n"
+            "[INFO 07-27 12:31:01] ResultReportingScheduler: Running trials [1]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:58] ResultReportingScheduler: Running trials [2]...\n"
+            "[INFO 07-27 12:31:02] ResultReportingScheduler: Running trials [2]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:59] ResultReportingScheduler: Generated all trials that can be generated currently. Max parallelism currently reached.\n"
+            "[INFO 07-27 12:31:03] ResultReportingScheduler: Generated all trials that can be generated currently. Max parallelism currently reached.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:59] ResultReportingScheduler: Retrieved COMPLETED trials: {0, 2}.\n"
+            "[INFO 07-27 12:31:03] ResultReportingScheduler: Retrieved COMPLETED trials: {1, 2}.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:46:59] ResultReportingScheduler: Running trials [3]...\n"
+            "[INFO 07-27 12:31:03] ResultReportingScheduler: Running trials [3]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Reported result:  {'trials so far': 3, 'currently producing trials from generation step': 'Sobol', 'running trials': [1]}\n"
+            "Reported result:  {'trials so far': 3, 'currently producing trials from generation step': 'Sobol', 'running trials': [0]}\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:47:00] ResultReportingScheduler: Running trials [4]...\n"
+            "[INFO 07-27 12:31:04] ResultReportingScheduler: Running trials [4]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:47:01] ResultReportingScheduler: Generated all trials that can be generated currently. Model requires more data to generate more trials.\n"
+            "[INFO 07-27 12:31:05] ResultReportingScheduler: Generated all trials that can be generated currently. Model requires more data to generate more trials.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:47:01] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 07-26 07:47:01] ResultReportingScheduler: Retrieved COMPLETED trials: {1, 3, 4}.\n"
+            "[INFO 07-27 12:31:05] ResultReportingScheduler: Retrieved COMPLETED trials: {0, 4}.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Reported result:  {'trials so far': 5, 'currently producing trials from generation step': 'Sobol', 'running trials': []}\n"
+            "Reported result:  {'trials so far': 5, 'currently producing trials from generation step': 'Sobol', 'running trials': [3]}\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:47:01] ResultReportingScheduler: Running trials [5]...\n"
+            "[INFO 07-27 12:31:06] ResultReportingScheduler: Running trials [5]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:47:02] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
+            "[INFO 07-27 12:31:07] ax.core.experiment: No trials are in a state expecting data. Returning empty data\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-26 07:47:02] ResultReportingScheduler: Retrieved COMPLETED trials: {5}.\n"
+            "[INFO 07-27 12:31:07] ResultReportingScheduler: Retrieved COMPLETED trials: {3, 5}.\n"
           ]
         },
         {


### PR DESCRIPTION
Summary:
Looks like it needs `init_engine_and_session_factory`, because `DBSettings` is more for the service API.  It failed in the [gh actions cron](https://github.com/facebook/Ax/runs/3168378583?check_suite_focus=true#step:5:498).  The change is

minus:
```
from ax.storage.sqa_store.structs import DBSettings
from ax.storage.sqa_store.db import get_engine, create_all_tables
from ax.storage.metric_registry import register_metric
from ax.storage.runner_registry import register_runner

# URL is of the form "dialect+driver://username:password@host:port/database".
# Instead of URL, can provide a `creator function`; can specify custom encoders/decoders if necessary.
db_settings = DBSettings(url="sqlite:///foo.db")
```
plus:
```
from ax.storage.sqa_store.db import init_engine_and_session_factory, get_engine, create_all_tables
from ax.storage.metric_registry import register_metric
from ax.storage.runner_registry import register_runner

# URL is of the form "dialect+driver://username:password@host:port/database".
# Instead of URL, can provide a `creator function`; can specify custom encoders/decoders if necessary.
db_settings = init_engine_and_session_factory(url="sqlite:///foo.db")
```

Differential Revision: D29938764

