### PR TITLE
support inferred objective thresholds in modular botorch

### DIFF
--- a/ax/modelbridge/tests/test_multi_objective_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_multi_objective_torch_modelbridge.py
@@ -29,6 +29,9 @@ from ax.modelbridge.multi_objective_torch import MultiObjectiveTorchModelBridge
 from ax.modelbridge.registry import Cont_X_trans, Y_trans, ST_MTGP_trans
 from ax.modelbridge.transforms.base import Transform
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
+from ax.models.torch.botorch_moo_defaults import (
+    infer_objective_thresholds,
+)
 from ax.models.torch.botorch_moo_defaults import pareto_frontier_evaluator
 from ax.service.utils.report_utils import exp_to_df
 from ax.utils.common.testutils import TestCase
@@ -408,10 +411,9 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
         )
         with ExitStack() as es:
             mock_model_infer_obj_t = es.enter_context(
-                patch.object(
-                    modelbridge.model,
-                    "infer_objective_thresholds",
-                    wraps=modelbridge.model.infer_objective_thresholds,
+                patch(
+                    "ax.modelbridge.multi_objective_torch.infer_objective_thresholds",
+                    wraps=infer_objective_thresholds,
                 )
             )
             mock_get_transformed_gen_args = es.enter_context(
@@ -518,10 +520,9 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             )
         with ExitStack() as es:
             mock_model_infer_obj_t = es.enter_context(
-                patch.object(
-                    modelbridge.model,
-                    "infer_objective_thresholds",
-                    wraps=modelbridge.model.infer_objective_thresholds,
+                patch(
+                    "ax.modelbridge.multi_objective_torch.infer_objective_thresholds",
+                    wraps=infer_objective_thresholds,
                 )
             )
             mock_untransform_objective_thresholds = es.enter_context(

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -15,15 +15,19 @@ from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import AxError
 from ax.models.torch.botorch_defaults import get_NEI
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
-from ax.models.torch.botorch_moo_defaults import get_NEHVI, get_EHVI
-from ax.models.torch.utils import HYPERSPHERE, _get_X_pending_and_observed
+from ax.models.torch.botorch_moo_defaults import (
+    get_NEHVI,
+    get_EHVI,
+    infer_objective_thresholds,
+)
+from ax.models.torch.utils import HYPERSPHERE
 from ax.utils.common.testutils import TestCase
 from botorch.acquisition.multi_objective import monte_carlo as moo_monte_carlo
-from botorch.models import ModelListGP, FixedNoiseGP
+from botorch.models import ModelListGP
 from botorch.models.transforms.input import Warp
 from botorch.utils.multi_objective.hypervolume import infer_reference_point
 from botorch.utils.multi_objective.scalarization import get_chebyshev_scalarization
-from botorch.utils.testing import MockPosterior
+from botorch.utils.testing import MockModel, MockPosterior
 
 FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_gpytorch_model"
 SAMPLE_SIMPLEX_UTIL_PATH = "ax.models.torch.utils.sample_simplex"
@@ -412,33 +416,49 @@ class BotorchMOOModelTest(TestCase):
                 metric_names=mns + ["dummy_metric"],
             )
             _mock_model_infer_objective_thresholds = es.enter_context(
-                mock.patch.object(
-                    model,
-                    "infer_objective_thresholds",
-                    wraps=model.infer_objective_thresholds,
+                mock.patch(
+                    "ax.models.torch.botorch_moo.infer_objective_thresholds",
+                    wraps=infer_objective_thresholds,
                 )
             )
             _mock_infer_reference_point = es.enter_context(
                 mock.patch(
-                    "ax.models.torch.botorch_moo.infer_reference_point",
+                    "ax.models.torch.botorch_moo_defaults.infer_reference_point",
                     wraps=infer_reference_point,
                 )
             )
+            # after subsetting, the model will only have two outputs
+            _mock_num_outputs = es.enter_context(
+                mock.patch(
+                    "botorch.utils.testing.MockModel.num_outputs",
+                    new_callable=mock.PropertyMock,
+                )
+            )
+            _mock_num_outputs.return_value = 3
             preds = torch.tensor(
                 [
-                    [11.0, 2.0, 0.0],
-                    [9.0, 3.0, 0.0],
+                    [11.0, 2.0],
+                    [9.0, 3.0],
                 ],
                 **tkwargs,
             )
-            _mock_posterior = es.enter_context(
+            model.model = MockModel(
+                MockPosterior(
+                    mean=preds,
+                    samples=preds,
+                ),
+            )
+            subset_mock_model = MockModel(
+                MockPosterior(
+                    mean=preds,
+                    samples=preds,
+                ),
+            )
+            es.enter_context(
                 mock.patch.object(
                     model.model,
-                    "posterior",
-                    return_value=MockPosterior(
-                        mean=preds,
-                        samples=preds,
-                    ),
+                    "subset_output",
+                    return_value=subset_mock_model,
                 )
             )
             outcome_constraints = (
@@ -476,7 +496,7 @@ class BotorchMOOModelTest(TestCase):
             oc = ckwargs["outcome_constraints"]
             self.assertTrue(torch.equal(oc[0], outcome_constraints[0]))
             self.assertTrue(torch.equal(oc[1], outcome_constraints[1]))
-            self.assertIsInstance(ckwargs["model"], FixedNoiseGP)
+            self.assertIs(ckwargs["model"], subset_mock_model)
             self.assertTrue(
                 torch.equal(
                     ckwargs["subset_idcs"],
@@ -497,68 +517,6 @@ class BotorchMOOModelTest(TestCase):
                 torch.equal(obj_t[:2], torch.tensor([9.9, 3.3], dtype=tkwargs["dtype"]))
             )
             self.assertTrue(np.isnan(obj_t[2]))
-
-            # test infer objective thresholds alone
-            # include an extra 3rd outcome
-            outcome_constraints = (
-                torch.tensor([[1.0, 0.0, 0.0]], **tkwargs),
-                torch.tensor([[10.0]], **tkwargs),
-            )
-            _mock_get_X_pending_and_observed = es.enter_context(
-                mock.patch(
-                    "ax.models.torch.botorch_moo._get_X_pending_and_observed",
-                    wraps=_get_X_pending_and_observed,
-                )
-            )
-            _mock_posterior.return_value = MockPosterior(
-                mean=torch.tensor(
-                    [
-                        [11.0, 2.0, 0.0],
-                        [9.0, 3.0, 0.0],
-                    ],
-                    **tkwargs,
-                )
-            )
-            linear_constraints = (
-                torch.tensor([1.0, 0.0, 0.0], **tkwargs),
-                torch.tensor([2.0], **tkwargs),
-            )
-            objective_weights = torch.tensor([-1.0, -1.0, 0.0], **tkwargs)
-            obj_thresholds = model.infer_objective_thresholds(
-                bounds=bounds,
-                objective_weights=objective_weights,
-                outcome_constraints=outcome_constraints,
-                fixed_features={},
-                linear_constraints=linear_constraints,
-            )
-            _mock_get_X_pending_and_observed.assert_called_once()
-            ckwargs = _mock_get_X_pending_and_observed.call_args[1]
-            actual_Xs = ckwargs["Xs"]
-            for X in actual_Xs:
-                self.assertTrue(torch.equal(X, Xs1[0]))
-            self.assertEqual(ckwargs["bounds"], bounds)
-            self.assertTrue(
-                torch.equal(ckwargs["objective_weights"], objective_weights)
-            )
-            oc = ckwargs["outcome_constraints"]
-            self.assertTrue(torch.equal(oc[0], outcome_constraints[0]))
-            self.assertTrue(torch.equal(oc[1], outcome_constraints[1]))
-            self.assertEqual(ckwargs["fixed_features"], {})
-            lc = ckwargs["linear_constraints"]
-            self.assertTrue(torch.equal(lc[0], linear_constraints[0]))
-            self.assertTrue(torch.equal(lc[1], linear_constraints[1]))
-            self.assertEqual(_mock_infer_reference_point.call_count, 2)
-            ckwargs = _mock_infer_reference_point.call_args[1]
-            self.assertEqual(ckwargs["scale"], 0.1)
-            self.assertTrue(
-                torch.equal(
-                    ckwargs["pareto_Y"], torch.tensor([[-9.0, -3.0]], **tkwargs)
-                )
-            )
-            self.assertTrue(
-                torch.equal(obj_thresholds[:2], torch.tensor([9.9, 3.3], **tkwargs))
-            )
-            self.assertTrue(np.isnan(obj_thresholds[2].item()))
 
     def test_BotorchMOOModel_with_random_scalarization_and_outcome_constraints(
         self, dtype=torch.float, cuda=False

--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
-import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch_base import TorchModel
 from ax.utils.common.testutils import TestCase
@@ -65,8 +64,3 @@ class TorchModelTest(TestCase):
                 search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
                 metric_names=[],
             )
-
-    def testTorchModelInferObjectiveThresholds(self):
-        torch_model = TorchModel()
-        with self.assertRaises(NotImplementedError):
-            torch_model.infer_objective_thresholds(torch.zeros(2))

--- a/ax/models/tests/test_torch_model_utils.py
+++ b/ax/models/tests/test_torch_model_utils.py
@@ -73,6 +73,7 @@ class TorchUtilsTest(TestCase):
         self.assertIsNone(obj_t_sub)
         self.assertIs(model_sub, model)  # check identity
         self.assertIs(obj_weights_sub, obj_weights)  # check identity
+        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
         # test w/ outcome constraints, can subset
         obj_weights = torch.tensor([1.0, 0.0])
         ocs = (torch.tensor([[1.0, 0.0]]), torch.tensor([1.0]))
@@ -86,6 +87,7 @@ class TorchUtilsTest(TestCase):
         self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
         self.assertTrue(torch.equal(ocs_sub[0], torch.tensor([[1.0]])))
         self.assertTrue(torch.equal(ocs_sub[1], torch.tensor([1.0])))
+        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0])))
         # test w/ outcome constraints, cannot subset
         obj_weights = torch.tensor([1.0, 0.0])
         ocs = (torch.tensor([[0.0, 1.0]]), torch.tensor([1.0]))
@@ -98,6 +100,7 @@ class TorchUtilsTest(TestCase):
         self.assertIsNone(obj_t_sub)
         self.assertIs(obj_weights_sub, obj_weights)  # check identity
         self.assertIs(ocs_sub, ocs)  # check identity
+        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
         # test w/ objective thresholds, cannot subset
         obj_weights = torch.tensor([1.0, 0.0])
         ocs = (torch.tensor([[0.0, 1.0]]), torch.tensor([1.0]))
@@ -136,6 +139,7 @@ class TorchUtilsTest(TestCase):
         self.assertIsNone(ocs_sub)
         self.assertIs(model_sub, model)  # check identity
         self.assertIs(obj_weights_sub, obj_weights)  # check identity
+        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
         # test error on size inconsistency
         obj_weights = torch.ones(3)
         with self.assertRaises(RuntimeError):

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -227,6 +227,7 @@ class BotorchModel(TorchModel):
     Xs: List[Tensor]
     Ys: List[Tensor]
     Yvars: List[Tensor]
+    model: Optional[Model]
 
     def __init__(
         self,

--- a/ax/models/torch/utils.py
+++ b/ax/models/torch/utils.py
@@ -275,7 +275,10 @@ def subset_model(
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
             objective_thresholds=objective_thresholds,
-            indices=idcs_t,
+            indices=torch.arange(
+                model.num_outputs,
+                device=objective_weights.device,
+            ),
         )
     elif len(idcs) > model.num_outputs:
         raise RuntimeError(
@@ -291,7 +294,10 @@ def subset_model(
         if objective_thresholds is not None:
             objective_thresholds = objective_thresholds[nonzero]
     except NotImplementedError:
-        pass
+        idcs_t = torch.arange(
+            model.num_outputs,
+            device=objective_weights.device,
+        )
     return SubsetModelData(
         model=model,
         objective_weights=objective_weights,

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -10,7 +10,6 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata, TConfig, TGenMetadata
 from ax.models.base import Model as BaseModel
-from botorch.models.model import Model
 from torch import Tensor
 
 
@@ -229,35 +228,3 @@ class TorchModel(BaseModel):
             A single-element tensor with the acquisition value for these points.
         """
         raise NotImplementedError  # pragma: nocover
-
-    def infer_objective_thresholds(
-        self,
-        objective_weights: Tensor,  # objective_directions
-        bounds: Optional[List[Tuple[float, float]]] = None,
-        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,
-        linear_constraints: Optional[Tuple[Tensor, Tensor]] = None,
-        fixed_features: Optional[Dict[int, float]] = None,
-        X_observed: Optional[Tensor] = None,
-        model: Optional[Model] = None,
-        subset_idcs: Optional[Tensor] = None,
-    ) -> Tensor:
-        """Infer objective thresholds.
-
-        Args:
-            objective_weights: The objective is to maximize a weighted sum of
-                the columns of f(x). These are the weights.
-            bounds: A list of (lower, upper) tuples for each column of X.
-            outcome_constraints: A tuple of (A, b). For k outcome constraints
-                and m outputs at f(x), A is (k x m) and b is (k x 1) such that
-                A f(x) <= b.
-            linear_constraints: A tuple of (A, b). For k linear constraints on
-                d-dimensional x, A is (k x d) and b is (k x 1) such that
-                A x <= b.
-            fixed_features: A map {feature_index: value} for features that
-                should be fixed to a particular value during generation.
-            X_observed: A `n x d`-dim tensor of observed in-sample points
-            model: The model
-            subset_idcs: The indices of the outcomes are that are used in the
-                optimization config (if the model has been subset'd).
-        """
-        raise NotImplementedError


### PR DESCRIPTION
Summary: Refactor `TorchModel.infer_objective_thresholds` into a utility function and use it in both the old Ax model and the modular botorch model

Differential Revision: D29783247

