### PR TITLE
Remove SimpleExperiment from API section

### DIFF
--- a/sphinx/source/core.rst
+++ b/sphinx/source/core.rst
@@ -171,14 +171,6 @@ Objective
     :show-inheritance:
     :noindex:
 
-`SimpleExperiment`
-~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: ax.core.simple_experiment
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 `Trial`
 ~~~~~~~~
 


### PR DESCRIPTION
Summary:
It current appears [here](https://ax.dev/api/core.html#module-ax.core.simple_experiment) but we're deprecating it.

Note: This still exists, but we can't delete it quite yet
```
property is_simple_experiment
Whether this experiment is a regular Experiment or the subclassing SimpleExperiment.
```

Reviewed By: stevemandala

Differential Revision: D29999252

