### PR TITLE
Remove use of `_set_transformed_inputs` from `fully_bayesian`

### DIFF
--- a/ax/models/tests/test_fully_bayesian.py
+++ b/ax/models/tests/test_fully_bayesian.py
@@ -179,7 +179,8 @@ try:
                         # Note each model in the model list is a batched model, where
                         # the batch dim corresponds to the MCMC samples
                         model_list = model.model.models
-                        m = model_list[i]
+                        # Put model in `eval` mode to transform the train inputs.
+                        m = model_list[i].eval()
                         # check mcmc samples
                         dummy_samples = dummy_samples_list[i]
                         expected_train_inputs = Xs[i].expand(4, *Xs[i].shape)

--- a/ax/models/torch/fully_bayesian.py
+++ b/ax/models/torch/fully_bayesian.py
@@ -54,7 +54,6 @@ from ax.models.torch.frontier_utils import TFrontierEvaluator
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.logger import get_logger
 from botorch.acquisition import AcquisitionFunction
-from botorch.fit import _set_transformed_inputs
 from botorch.models.gp_regression import MIN_INFERRED_NOISE_LEVEL
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model import Model
@@ -184,7 +183,6 @@ def get_and_fit_model_mcmc(
                     .clone()
                     .view(m.input_transform.concentration1.shape),
                 )
-    _set_transformed_inputs(model=model)
     return model
 
 


### PR DESCRIPTION
Summary: pytorch/botorch#894 absorbs `_set_transformed_inputs` into the `model.eval` call. This removes its explicit use in `fully_bayesian`.

Differential Revision: D30047502

