### PR TITLE
Make test_managed_loop assertions 3.7 friendly

### DIFF
--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -146,11 +146,11 @@ class TestManagedLoop(TestCase):
         bp, vals = loop.full_run().get_best_point()
         branin_calls = batch_branin.call_args_list
         self.assertTrue(
-            all(len(call.args) == 2 for call in branin_calls),
+            all(len(args) == 2 for args, _ in branin_calls),
             branin_calls,
         )
         self.assertTrue(
-            all(type(call.args[1]) is np.float64 for call in branin_calls),
+            all(type(args[1]) is np.float64 for args, _ in branin_calls),
             branin_calls,
         )
         self.assertIn("x1", bp)


### PR DESCRIPTION
Summary: call.args is not a thing in 3.7, but call decomposes to `(args, kwargs)`

Differential Revision: D30141917

