### PR TITLE
Make MOO thresholds optional/inferable

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -267,6 +267,7 @@ class AxClient(WithDBSettingsBase):
             objective_kwargs["objective_thresholds"] = [
                 build_objective_threshold(objective, properties)
                 for objective, properties in objectives.items()
+                if properties.threshold is not None
             ]
         elif objective_name or minimize is not None:
             objective_kwargs["objective_name"] = objective_name

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -87,7 +87,7 @@ class MetricObjective(enum.Enum):
 @dataclass
 class ObjectiveProperties:
     minimize: bool
-    threshold: float
+    threshold: Optional[float] = None
 
 
 def _get_parameter_type(python_type: TParameterType) -> ParameterType:
@@ -433,10 +433,12 @@ def optimization_config_from_objectives(
         objective_names = {m.metric.name for m in objectives}
         threshold_names = {oc.metric.name for oc in objective_thresholds}
         if objective_names != threshold_names:
-            diff = objective_names.symmetric_difference(threshold_names)
-            raise ValueError(
-                "Multi-objective optimization requires one objective threshold "
-                f"per objective metric; unmatched names are {diff}"
+            logger.info(
+                (
+                    "Due to non-specification, we will use the heuristic for selecting "
+                    "thresholds for these metrics: %s"
+                ),
+                objective_names.symmetric_difference(threshold_names),
             )
 
         return MultiObjectiveOptimizationConfig(


### PR DESCRIPTION
Summary: Modify data class `ObjectiveProperties` and log instead of raising on null values

Differential Revision: D30165548

