### PR TITLE
Add dry run tutorial builds on pinned botorch

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -28,7 +28,6 @@ jobs:
       run: |
         # will automatically install latest stable Botorch (pinned in setup.py)
         pip install -e .[dev,mysql,notebook]
-        pip list | grep botorch
       if: matrix.botorch == 'stable'
     - name: Install dependencies (Botorch master)
       env:
@@ -37,7 +36,6 @@ jobs:
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
-        pip list | grep botorch
       if: matrix.botorch == 'latest'
     - name: Import Ax
       run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -46,6 +46,31 @@ jobs:
       run: |
         pytest -ra
 
+  build-tutorials-with-pinned-botorch:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        # will automatically install latest stable Botorch (pinned in setup.py)
+        pip install -e .[dev,mysql,notebook]
+        pip install psycopg2  # Used in example DBSettings in a tutorial (as part of postgres).
+        pip install torchvision  # required for tutorials
+        pip install ray  # Required for building RayTune tutorial notebook.
+        pip install tabulate  # Required for building RayTune tutorial notebook.
+        pip install tensorboardX  # Required for building RayTune tutorial notebook.
+        pip install matplotlib  # Required for building Multi-objective tutorial notebook.
+        pip install pyro-ppl  # Required for to call run_inference
+    - name: Publish latest website
+      run: |
+        python scripts/make_tutorials.py -w (pwd) -e
+
   publish-latest-website:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         # will automatically install latest stable Botorch (pinned in setup.py)
         pip install -e .[dev,mysql,notebook]
+        pip list | grep botorch
       if: matrix.botorch == 'stable'
     - name: Install dependencies (Botorch master)
       env:
@@ -36,6 +37,7 @@ jobs:
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
+        pip list | grep botorch
       if: matrix.botorch == 'latest'
     - name: Import Ax
       run: |
@@ -100,6 +102,7 @@ jobs:
       env:
         DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}
       run: |
+        pip list | grep botorch
         bash scripts/publish_site.sh -d
 
   deploy-test-pypi:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -69,7 +69,7 @@ jobs:
         pip install pyro-ppl  # Required for to call run_inference
     - name: Publish latest website
       run: |
-        python scripts/make_tutorials.py -w (pwd) -e
+        python scripts/make_tutorials.py -w $(pwd) -e
 
   publish-latest-website:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,13 +23,14 @@ jobs:
         python-version: 3.7
     - name: Install dependencies (stable Botorch)
       run: |
-        # will automatically install latest stable Botorch
+        # use master Botorch
+        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
       if: matrix.botorch == 'stable'
     - name: Install dependencies (pinned Botorch)
       run: |
-        # TODO: read pinned Botorch version from a shared source
-        pip install botorch==0.5.0
+        # will automatically install latest stable Botorch (pinned in setup.py)
         pip install -e .[dev,mysql,notebook]
       if: matrix.botorch == 'pinned'
     - name: Import Ax

--- a/website/tutorials.json
+++ b/website/tutorials.json
@@ -47,6 +47,14 @@
     {
       "id": "multiobjective_optimization",
       "title": "Multi-Objective Optimization"
+    },
+    {
+      "id": "saasbo",
+      "title": "High-Dimensional Bayesian Optimization with Sparse Axis-Aligned Subspaces (SAASBO)"
+    },
+    {
+      "id": "saasbo_nehvi",
+      "title": "Fully Bayesian, High-Dimensional, Multi-Objective Optimization"
     }
   ],
   "Field Experiments": [


### PR DESCRIPTION
To prevent failures from being caught on deploy.  See [nightly cron on branch](https://github.com/facebook/Ax/runs/3294419943?check_suite_focus=true#step:4:251) to validate this is correctly installing the botorch version we intend to
