### PR TITLE
replace pyro Uniform priors in fully bayesian models

### DIFF
--- a/ax/models/tests/test_fully_bayesian.py
+++ b/ax/models/tests/test_fully_bayesian.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
 from abc import ABC
 from contextlib import ExitStack
 from itertools import product
@@ -47,7 +48,6 @@ def _get_dummy_mcmc_samples(
     dtype: torch.dtype,
     device: torch.device,
     perturb_sd: float = 1e-5,
-    use_saas: bool = False,
 ) -> Dict[str, torch.Tensor]:
     tkwargs = {"dtype": dtype, "device": device}
     dummy_sample_list = []
@@ -63,11 +63,10 @@ def _get_dummy_mcmc_samples(
             "mean": torch.tensor([3.5000], **tkwargs)
             + perturb_sd * torch.randn(num_samples, **tkwargs),
         }
-        if use_saas:
-            dummy_samples["kernel_tausq"] = torch.tensor(0.5, **tkwargs)
-            dummy_samples["_kernel_inv_length_sq"] = (
-                1.0 / dummy_samples["lengthscale"].sqrt()
-            )
+        dummy_samples["kernel_tausq"] = torch.tensor(0.5, **tkwargs)
+        dummy_samples["_kernel_inv_length_sq"] = (
+            1.0 / dummy_samples["lengthscale"].sqrt()
+        )
         dummy_sample_list.append(dummy_samples)
     return dummy_sample_list
 
@@ -83,6 +82,19 @@ try:
         model_cls: Type[FullyBayesianBotorchModel]
 
         def test_FullyBayesianBotorchModel(self, dtype=torch.float, cuda=False):
+            # test deprecation warning
+            warnings.simplefilter("always", append=True)
+            with warnings.catch_warnings(record=True) as ws:
+                self.model_cls(use_saas=True)
+                self.assertTrue(
+                    any(issubclass(w.category, DeprecationWarning) for w in ws)
+                )
+                self.assertTrue(
+                    any(
+                        "Passing `use_saas` is no longer supported" in str(w.message)
+                        for w in ws
+                    )
+                )
             Xs1, Ys1, Yvars1, bounds, tfs, fns, mns = get_torch_test_data(
                 dtype=dtype, cuda=cuda, constant_noise=True
             )
@@ -98,15 +110,12 @@ try:
             Xs = Xs1 + Xs2_diff
             Ys = Ys1 + Ys2
 
-            for inferred_noise, use_input_warping, use_saas in product(
-                (True, False), repeat=3
-            ):
+            for inferred_noise, use_input_warping in product((True, False), repeat=2):
                 Yvars = Yvars_inferred_noise if inferred_noise else Yvars1 + Yvars2
                 model = self.model_cls(
                     use_input_warping=use_input_warping,
                     thinning=1,
                     num_samples=4,
-                    use_saas=use_saas,
                     disable_progbar=True,
                     max_tree_depth=1,
                 )
@@ -167,7 +176,6 @@ try:
                         self.assertEqual(
                             ckwargs["use_input_warping"], use_input_warping
                         )
-                        self.assertEqual(ckwargs["use_saas"], use_saas)
 
                         # Check attributes
                         self.assertTrue(torch.equal(model.Xs[i], Xs[i]))
@@ -302,7 +310,6 @@ try:
                     use_input_warping=use_input_warping,
                     thinning=1,
                     num_samples=4,
-                    use_saas=use_saas,
                     disable_progbar=True,
                     max_tree_depth=1,
                 )
@@ -504,7 +511,7 @@ try:
                     unfit_model.feature_importances()
 
         def test_saasbo_sample(self):
-            for use_saas, use_input_warping in product((False, True), repeat=2):
+            for use_input_warping in (False, True):
                 with torch.random.fork_rng():
                     torch.manual_seed(0)
                     X = torch.randn(3, 2)
@@ -517,17 +524,11 @@ try:
                         Y,
                         Yvar,
                         use_input_warping=use_input_warping,
-                        use_saas=use_saas,
                     )
                     samples = mcmc.get_samples()
-                    if use_saas:
-                        self.assertTrue("kernel_tausq" in samples)
-                        self.assertTrue("_kernel_inv_length_sq" in samples)
-                        self.assertTrue("lengthscale" not in samples)
-                    else:
-                        self.assertTrue("kernel_tausq" not in samples)
-                        self.assertTrue("_kernel_inv_length_sq" not in samples)
-                        self.assertTrue("lengthscale" in samples)
+                    self.assertTrue("kernel_tausq" in samples)
+                    self.assertTrue("_kernel_inv_length_sq" in samples)
+                    self.assertTrue("lengthscale" not in samples)
                     if use_input_warping:
                         self.assertIn("c0", samples)
                         self.assertIn("c1", samples)
@@ -596,15 +597,14 @@ try:
                 Xs2, Ys2, raw_Yvars2, _, _, _, _ = get_torch_test_data(
                     dtype=dtype, cuda=cuda, constant_noise=True
                 )
-                for inferred_noise, use_input_warping, use_saas in product(
-                    (False, True), repeat=3
+                for inferred_noise, use_input_warping in product(
+                    (False, True), repeat=2
                 ):
                     model = self.model_cls(
                         num_samples=4,
                         warmup_steps=0,
                         thinning=1,
                         use_input_warping=use_input_warping,
-                        use_saas=use_saas,
                         disable_progbar=True,
                         max_tree_depth=1,
                     )
@@ -620,7 +620,6 @@ try:
                         num_outputs=2,
                         dtype=dtype,
                         device=Xs1[0].device,
-                        use_saas=use_saas,
                     )
                     with ExitStack() as es:
                         _mock_fit_model = es.enter_context(
@@ -655,7 +654,6 @@ try:
                         self.assertEqual(
                             ckwargs["use_input_warping"], use_input_warping
                         )
-                        self.assertEqual(ckwargs["use_saas"], use_saas)
                     with ExitStack() as es:
                         _mock_mcmc = es.enter_context(mock.patch(MCMC_PATH))
                         _mock_mcmc.return_value.get_samples.side_effect = dummy_samples
@@ -767,12 +765,11 @@ try:
             Xs1, Ys1, Yvars1, bounds, tfs, fns, mns = get_torch_test_data(
                 dtype=torch.float, cuda=False, constant_noise=True
             )
-            for use_input_warping, use_saas in product((True, False), repeat=2):
+            for use_input_warping in (True, False):
                 model = self.model_cls(
                     use_input_warping=use_input_warping,
                     num_samples=4,
                     thinning=1,
-                    use_saas=use_saas,
                     disable_progbar=True,
                     max_tree_depth=1,
                 )

--- a/ax/models/torch/fully_bayesian.py
+++ b/ax/models/torch/fully_bayesian.py
@@ -28,6 +28,7 @@ import math
 import sys
 import time
 import types
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -63,6 +64,11 @@ from torch import Tensor
 logger = get_logger(__name__)
 
 MIN_OBSERVED_NOISE_LEVEL_MCMC = 1e-6
+SAAS_DEPRECATION_MSG = (
+    "Passing `use_saas` is no longer supported and has no effect. "
+    "SAAS priors are used by default. "
+    "This will become an error in the future."
+)
 
 
 def get_and_fit_model_mcmc(
@@ -80,7 +86,6 @@ def get_and_fit_model_mcmc(
     warmup_steps: int = 1024,
     thinning: int = 16,
     max_tree_depth: int = 6,
-    use_saas: bool = False,
     disable_progbar: bool = False,
     **kwargs: Any,
 ) -> GPyTorchModel:
@@ -141,7 +146,6 @@ def get_and_fit_model_mcmc(
                 warmup_steps=warmup_steps,
                 thinning=thinning,
                 use_input_warping=use_input_warping,
-                use_saas=use_saas,
                 max_tree_depth=max_tree_depth,
                 disable_progbar=disable_progbar,
             )
@@ -272,7 +276,6 @@ def pyro_model(
     Y: Tensor,
     Yvar: Tensor,
     use_input_warping: bool = False,
-    use_saas: bool = False,
     eps: float = 1e-7,
 ) -> None:
     try:
@@ -297,10 +300,10 @@ def pyro_model(
     )
     mean = pyro.sample(
         "mean",
-        pyro.distributions.Uniform(  # pyre-ignore [16]
+        pyro.distributions.Normal(  # pyre-ignore [16]
             # pyre-fixme[6]: Expected `Optional[torch.dtype]` for 2nd param but got
             #  `Union[torch.device, torch.dtype]`.
-            torch.tensor(-1.0, **tkwargs),
+            torch.tensor(0.0, **tkwargs),
             # pyre-fixme[6]: Expected `Optional[torch.dtype]` for 2nd param but got
             #  `Union[torch.device, torch.dtype]`.
             torch.tensor(1.0, **tkwargs),
@@ -322,45 +325,22 @@ def pyro_model(
     else:
         # pyre-ignore [16]
         noise = Yvar.clamp_min(MIN_OBSERVED_NOISE_LEVEL_MCMC)
-
-    if use_saas:
-        tausq = pyro.sample(
-            "kernel_tausq",
-            pyro.distributions.HalfCauchy(  # pyre-ignore [16]
-                # pyre-fixme[6]: Expected `Optional[torch.dtype]` for 2nd param but
-                #  got `Union[torch.device, torch.dtype]`.
-                torch.tensor(0.1, **tkwargs)
-            ),
-        )
-        inv_length_sq = pyro.sample(
-            "_kernel_inv_length_sq",
-            pyro.distributions.HalfCauchy(  # pyre-ignore [16]
-                torch.ones(dim, **tkwargs)
-            ),
-        )
-        inv_length_sq = pyro.deterministic(
-            "kernel_inv_length_sq", tausq * inv_length_sq
-        )
-        lengthscale = pyro.deterministic(
-            "lengthscale",
-            (1.0 / inv_length_sq).sqrt(),  # pyre-ignore [16]
-        )
-    else:
-        lengthscale = pyro.sample(
-            "lengthscale",
-            # pyro.distributions.Uniform does not jit-compile with
-            # vector parameters, so use expand() instead on a
-            # distribution with scalar parameters.
-            # https://github.com/pyro-ppl/pyro/issues/2810
-            pyro.distributions.Uniform(  # pyre-ignore [16]
-                # pyre-fixme[6]: Expected `Optional[torch.dtype]` for 2nd param but
-                #  got `Union[torch.device, torch.dtype]`.
-                torch.tensor(0.0, **tkwargs),
-                # pyre-fixme[6]: Expected `Optional[torch.dtype]` for 2nd param but
-                #  got `Union[torch.device, torch.dtype]`.
-                torch.tensor(10.0, **tkwargs),
-            ).expand(torch.Size([dim])),
-        )
+    # use SAAS priors
+    tausq = pyro.sample(
+        "kernel_tausq",
+        # pyre-fixme[6]: Expected `Optional[torch.dtype]` for 2nd param but
+        #  got `Union[torch.device, torch.dtype]`.
+        pyro.distributions.HalfCauchy(torch.tensor(0.1, **tkwargs)),  # pyre-ignore [16]
+    )
+    inv_length_sq = pyro.sample(
+        "_kernel_inv_length_sq",
+        pyro.distributions.HalfCauchy(torch.ones(dim, **tkwargs)),  # pyre-ignore [16]
+    )
+    inv_length_sq = pyro.deterministic("kernel_inv_length_sq", tausq * inv_length_sq)
+    lengthscale = pyro.deterministic(
+        "lengthscale",
+        (1.0 / inv_length_sq).sqrt(),  # pyre-ignore [16]
+    )
 
     # transform inputs through kumaraswamy cdf
     if use_input_warping:
@@ -399,7 +379,8 @@ def pyro_model(
     pyro.sample(
         "Y",
         pyro.distributions.MultivariateNormal(  # pyre-ignore [16]
-            loc=mean.view(-1).expand(X.shape[0]), covariance_matrix=k
+            loc=mean.view(-1).expand(X.shape[0]),
+            covariance_matrix=k,
         ),
         obs=Y,
     )
@@ -415,7 +396,6 @@ def run_inference(
     thinning: int = 16,
     use_input_warping: bool = False,
     max_tree_depth: int = 6,
-    use_saas: bool = False,
     disable_progbar: bool = False,
 ) -> Tensor:
     start = time.time()
@@ -437,13 +417,10 @@ def run_inference(
         disable_progbar=disable_progbar,
     )
     mcmc.run(
-        # there is an issue with jit-compilation and cuda
-        # for now, we run MCMC on the CPU.
-        X.cpu(),
-        Y.cpu(),
-        Yvar.cpu(),
+        X,
+        Y,
+        Yvar,
         use_input_warping=use_input_warping,
-        use_saas=use_saas,
     )
     # this prints the summary
     orig_std_out = sys.stdout.write
@@ -452,16 +429,14 @@ def run_inference(
     sys.stdout.write = orig_std_out
     logger.info(f"MCMC elapsed time: {time.time() - start}")
     samples = mcmc.get_samples()
-    if use_saas:  # compute the lengthscale for saas and throw away everything else
-        inv_length_sq = (
-            samples["kernel_tausq"].unsqueeze(-1) * samples["_kernel_inv_length_sq"]
-        )
-        samples["lengthscale"] = (1.0 / inv_length_sq).sqrt()  # pyre-ignore [16]
-        del samples["kernel_tausq"], samples["_kernel_inv_length_sq"]
-    # thin
+    inv_length_sq = (
+        samples["kernel_tausq"].unsqueeze(-1) * samples["_kernel_inv_length_sq"]
+    )
+    samples["lengthscale"] = (1.0 / inv_length_sq).sqrt()  # pyre-ignore [16]
+    del samples["kernel_tausq"], samples["_kernel_inv_length_sq"]
     for k, v in samples.items():
-        # apply thinning and move back to X's device
-        samples[k] = v[::thinning].to(device=X.device)
+        # apply thinning
+        samples[k] = v[::thinning]
     return samples
 
 
@@ -560,7 +535,8 @@ class FullyBayesianBotorchModel(FullyBayesianBotorchModelMixin, BotorchModel):
         refit_on_update: bool = True,
         warm_start_refitting: bool = True,
         use_input_warping: bool = False,
-        use_saas: bool = False,
+        # use_saas is deprecated. TODO: remove
+        use_saas: Optional[bool] = None,
         num_samples: int = 512,
         warmup_steps: int = 1024,
         thinning: int = 16,
@@ -588,7 +564,7 @@ class FullyBayesianBotorchModel(FullyBayesianBotorchModelMixin, BotorchModel):
             warm_start_refitting: If True, start model refitting from previous
                 model parameters in order to speed up the fitting process.
             use_input_warping: A boolean indicating whether to use input warping
-            use_saas: A boolean indicating whether to use the SAAS model
+            use_saas: [deprecated] A boolean indicating whether to use the SAAS model
             num_samples: The number of MCMC samples. Note that with thinning,
                 num_samples/thinning samples are retained.
             warmup_steps: The number of burn-in steps for NUTS.
@@ -597,6 +573,9 @@ class FullyBayesianBotorchModel(FullyBayesianBotorchModelMixin, BotorchModel):
             disable_progbar: A boolean indicating whether to print the progress
                 bar and diagnostics during MCMC.
         """
+        # use_saas is deprecated. TODO: remove
+        if use_saas is not None:
+            warnings.warn(SAAS_DEPRECATION_MSG, DeprecationWarning)
         BotorchModel.__init__(
             self,
             model_constructor=model_constructor,
@@ -608,7 +587,6 @@ class FullyBayesianBotorchModel(FullyBayesianBotorchModelMixin, BotorchModel):
             refit_on_update=refit_on_update,
             warm_start_refitting=warm_start_refitting,
             use_input_warping=use_input_warping,
-            use_saas=use_saas,
             num_samples=num_samples,
             warmup_steps=warmup_steps,
             thinning=thinning,
@@ -653,10 +631,14 @@ class FullyBayesianMOOBotorchModel(
         warmup_steps: int = 1024,
         thinning: int = 16,
         max_tree_depth: int = 6,
-        use_saas: bool = False,
+        # use_saas is deprecated. TODO: remove
+        use_saas: Optional[bool] = None,
         disable_progbar: bool = False,
         **kwargs: Any,
     ) -> None:
+        # use_saas is deprecated. TODO: remove
+        if use_saas is not None:
+            warnings.warn(SAAS_DEPRECATION_MSG, DeprecationWarning)
         MultiObjectiveBotorchModel.__init__(
             self,
             model_constructor=model_constructor,
@@ -673,6 +655,5 @@ class FullyBayesianMOOBotorchModel(
             warmup_steps=warmup_steps,
             thinning=thinning,
             max_tree_depth=max_tree_depth,
-            use_saas=use_saas,
             disable_progbar=disable_progbar,
         )

--- a/tutorials/saasbo.ipynb
+++ b/tutorials/saasbo.ipynb
@@ -9,7 +9,7 @@
         "# High-Dimensional Bayesian Optimization with SAASBO\n",
         "\n",
         "\n",
-        "This tutorial shows how to use the Sparse Axis-Aligned Subspace Bayesian Optimization (SAASBO) method for high-dimensional Bayesian optimization [1]. SAASBO uses sparse axis-aligned subspace priors to avoid overfitting. Specifically, SAASBO uses a hierarchical sparsity prior consisting of a global shrinkage parameter with a Half-Cauchy prior $\\tau \\sim \\mathcal{HC}(\\beta)$ and inverse lengthscales $\\rho_d \\sim \\mathcal{HC}(\\tau)$ for $d=1, ..., D$. See [1] for details. These priors are natively supported in Ax by using the `use_saas` argument.\n",
+        "This tutorial shows how to use the Sparse Axis-Aligned Subspace Bayesian Optimization (SAASBO) method for high-dimensional Bayesian optimization [1]. SAASBO uses sparse axis-aligned subspace priors to avoid overfitting. Specifically, SAASBO uses a hierarchical sparsity prior consisting of a global shrinkage parameter with a Half-Cauchy prior $\\tau \\sim \\mathcal{HC}(\\beta)$ and inverse lengthscales $\\rho_d \\sim \\mathcal{HC}(\\tau)$ for $d=1, ..., D$. See [1] for details.\n",
         "\n",
         "[1] D. Eriksson, M. Jankowiak. High-Dimensional Bayesian Optimization with Sparse Axis-Aligned Subspaces. Proceedings of the Thirty-Seventh Conference on Uncertainty in Artificial Intelligence, 2021."
       ]
@@ -81,7 +81,6 @@
         "            model=Models.FULLYBAYESIAN, \n",
         "            num_trials=-1, \n",
         "            model_kwargs={\n",
-        "                \"use_saas\": True, \n",
         "                \"num_samples\": 256,\n",
         "                \"warmup_steps\": 512,\n",
         "                \"disable_progbar\": True,\n",

--- a/tutorials/saasbo_nehvi.ipynb
+++ b/tutorials/saasbo_nehvi.ipynb
@@ -67,7 +67,7 @@
       "source": [
         "### SAAS Priors (SAASBO)\n",
         "\n",
-        "Recently Eriksson et al [2] propose using sparse axis-aligned subspace priors for Bayesian optimization over high-dimensional search spaces. Specifically, the authors propose using a hierarchical sparsity prior consisting of a global shrinkage parameter with a Half-Cauchy prior $\\tau \\sim \\mathcal{HC}(\\beta)$, and ARD lengthscales $\\rho_d \\sim \\mathcal{HC}(\\tau)$ for $d=1, ..., D$. See [2] for details. These priors are natively supported in Ax by using the `use_saas` argument. \n",
+        "Recently Eriksson et al [2] propose using sparse axis-aligned subspace priors for Bayesian optimization over high-dimensional search spaces. Specifically, the authors propose using a hierarchical sparsity prior consisting of a global shrinkage parameter with a Half-Cauchy prior $\\tau \\sim \\mathcal{HC}(\\beta)$, and ARD lengthscales $\\rho_d \\sim \\mathcal{HC}(\\tau)$ for $d=1, ..., D$. See [2] for details. \n",
         "\n",
         "[2] D. Eriksson, M. Janjowiak. High-Dimensional Bayesian Optimization with Sparse Axis-Aligned Subspaces. Proceedings of the Thirty-Seventh Conference on Uncertainty in Artificial Intelligence, 2021."
       ]
@@ -1912,7 +1912,6 @@
         "    model = Models.FULLYBAYESIANMOO(\n",
         "        experiment=experiment, \n",
         "        data=data,\n",
-        "        use_saas=True,  # use SAAS priors (SAASBO)\n",
         "        # use fewer num_samples and warmup_steps to speed up this tutorial\n",
         "        num_samples=256,\n",
         "        warmup_steps=512,\n",


### PR DESCRIPTION
Summary: pyro's Uniform priors don't play nicely with jit (e.g. https://github.com/pyro-ppl/pyro/issues/2810) and are having other compilation issues on fblearner. This uses SAAS priors by default (rather than uniform) and uses a Normal prior (rather than uniform) on the mean, which avoids the issue.

Differential Revision: D30248398

