### PR TITLE
Add missing `digits` parameter option to docstring

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -208,6 +208,7 @@ class AxClient(WithDBSettingsBase):
                 parameters,
                 4. "is_ordered" (bool) for choice parameters, and
                 5. "is_task" (bool) for task parameters.
+                6. "digits" (int) for float-valued range parameters.
             name: Name of the experiment to be created.
             objective_name[DEPRECATED]: Name of the metric used as objective
                 in this experiment. This metric must be present in `raw_data`


### PR DESCRIPTION
Hello again :)

I've found this small detail missing from a docstring. I think it should match the parameters of `make_experiment`.

Revising the docs, I wanted to bring to your attention that the [Service API tutorial code](https://ax.dev/tutorials/gpei_hartmann_service.html) still makes use of `objective_name` and `minimize`. I find it important given that #616 [deprecates](https://github.com/facebook/Ax/blob/main/ax/service/ax_client.py#L212) `objective_name` and `minimize`. I guess the objective (pun intended) is to deprecate single objective optimization in favor of MOO?