### PR TITLE
support selected_metrics in hypervolume evaluation

### DIFF
--- a/ax/modelbridge/tests/test_multi_objective_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_multi_objective_torch_modelbridge.py
@@ -336,6 +336,14 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             expected_hv = 25  # (5 - 0) * (5 - 0)
             wrapped_frontier_evaluator.assert_called_once()
             self.assertEqual(expected_hv, hv)
+            # Test selected_metrics
+            hv = observed_hypervolume(
+                modelbridge=modelbridge,
+                objective_thresholds=objective_thresholds,
+                selected_metrics=["branin_a"],
+            )
+            expected_hv = 5  # (5 - 0)
+            self.assertEqual(expected_hv, hv)
 
         with self.assertRaises(ValueError):
             predicted_hypervolume(
@@ -352,6 +360,14 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             modelbridge=modelbridge,
             objective_thresholds=objective_thresholds,
             observation_features=observation_features,
+        )
+        self.assertTrue(predicted_hv >= 0)
+        # Test selected_metrics
+        predicted_hv = predicted_hypervolume(
+            modelbridge=modelbridge,
+            objective_thresholds=objective_thresholds,
+            observation_features=observation_features,
+            selected_metrics=["branin_a"],
         )
         self.assertTrue(predicted_hv >= 0)
 


### PR DESCRIPTION
Summary:
In some cases, we want to only calculate the hypervolume of the given subset of metrics (of interest).

`hypervolume`, `observed_hypervolume` and `predicted_hypervolume` in `ax/modelbridge/modelbridge_utils.py` are modified to take `selected_metrics` as argument to support evaluation of hypervolume on a subset of metrics.

Reviewed By: bletham

Differential Revision: D30221140

