### PR TITLE
fix shape mismatch in MOO with constraints

### DIFF
--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -528,5 +528,6 @@ def infer_objective_thresholds(
         dtype=objective_weights.dtype,
         device=objective_weights.device,
     )
-    full_objective_thresholds[subset_idcs] = objective_thresholds.clone()
+    obj_idcs = subset_idcs[obj_mask]
+    full_objective_thresholds[obj_idcs] = objective_thresholds.clone()
     return full_objective_thresholds


### PR DESCRIPTION
Summary: see title. This fixes a shape mismatch when there are outcome constraints

Differential Revision: D30529951

