### PR TITLE
Remove run override for now

### DIFF
--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -235,15 +235,6 @@ class TestCase(unittest.TestCase):
         self.setUp_called = True
         super()._callSetUp()  # pyre-ignore[16]... it does
 
-    def run(
-        self, result: Optional[unittest.result.TestResult] = ...
-    ) -> Optional[unittest.result.TestResult]:
-        result = super().run(result)
-        self.assertTrue(
-            self.setUp_called, "`_callSetUp` must call `super()._callSetUp()`"
-        )
-        return result
-
     def _callTearDown(self) -> None:
         # When seconds argument to alarm is zero, any pending alarm is canceled.
         signal.alarm(0)


### PR DESCRIPTION
- it fails in python 3.7