### PR TITLE
Readd run override

### DIFF
--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -239,6 +239,9 @@ class TestCase(unittest.TestCase):
         self, result: Optional[unittest.result.TestResult] = ...
     ) -> Optional[unittest.result.TestResult]:
         result = super().run(result)
+        self.assertTrue(
+            self.setUp_called, "`_callSetUp` must call `super()._callSetUp()`"
+        )
         return result
 
     def _callTearDown(self) -> None:

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -235,15 +235,6 @@ class TestCase(unittest.TestCase):
         self.setUp_called = True
         super()._callSetUp()  # pyre-ignore[16]... it does
 
-    def run(
-        self, result: Optional[unittest.result.TestResult] = ...
-    ) -> Optional[unittest.result.TestResult]:
-        result = super().run(result)
-        self.assertTrue(
-            self.setUp_called, "`_callSetUp` must call `super()._callSetUp()`"
-        )
-        return result
-
     def _callTearDown(self) -> None:
         # When seconds argument to alarm is zero, any pending alarm is canceled.
         signal.alarm(0)

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -235,6 +235,12 @@ class TestCase(unittest.TestCase):
         self.setUp_called = True
         super()._callSetUp()  # pyre-ignore[16]... it does
 
+    def run(
+        self, result: Optional[unittest.result.TestResult] = ...
+    ) -> Optional[unittest.result.TestResult]:
+        result = super().run(result)
+        return result
+
     def _callTearDown(self) -> None:
         # When seconds argument to alarm is zero, any pending alarm is canceled.
         signal.alarm(0)

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -226,28 +226,18 @@ class TestCase(unittest.TestCase):
 
         super().__init__(methodName=methodName)
         signal.signal(signal.SIGALRM, signal_handler)
-        self.setUp_called = False
-
-    def _callSetUp(self) -> None:
-        # Arrange for a SIGALRM signal to be delivered to the calling process
-        # in specified number of seconds.
-        signal.alarm(self.MAX_TEST_SECONDS)
-        self.setUp_called = True
-        super()._callSetUp()  # pyre-ignore[16]... it does
 
     def run(
         self, result: Optional[unittest.result.TestResult] = ...
     ) -> Optional[unittest.result.TestResult]:
-        result = super().run(result)
-        self.assertTrue(
-            self.setUp_called, "`_callSetUp` must call `super()._callSetUp()`"
-        )
+        # Arrange for a SIGALRM signal to be delivered to the calling process
+        # in specified number of seconds.
+        signal.alarm(self.MAX_TEST_SECONDS)
+        try:
+            result = super().run(result)
+        finally:
+            signal.alarm(0)
         return result
-
-    def _callTearDown(self) -> None:
-        # When seconds argument to alarm is zero, any pending alarm is canceled.
-        signal.alarm(0)
-        super()._callTearDown()  # pyre-ignore[16]... it does
 
     def assertEqual(
         self,


### PR DESCRIPTION
in order to support python 3.7, which has no `unittest.TestCase._callSetUp()` or `unittest.TestCase._callTearDown()` method, we add and remove alarms in the override of `unittest.TestCase.run()`