### PR TITLE
Install tensorboard in GHA workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,8 @@ jobs:
         # use latest Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
+        pip install tensorboard  # For tensorboard unit tests
     - name: Tests and coverage
       run: |
         pytest -ra --cov=ax
@@ -77,7 +78,8 @@ jobs:
         # use latest Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
+        pip install tensorboard  # For generating Sphinx docs for TensorboardCurveMetric
     - name: Validate Sphinx
       run: |
         python scripts/validate_sphinx.py -p "${pwd}"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -28,11 +28,13 @@ jobs:
     - name: Install dependencies (full requirements, stable Botorch)
       run: |
         # will install the version of Botorch that is pinned in setup.py
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
+        pip install tensorboard  # For tensorboard unit tests
       if: matrix.botorch == 'pinned' && matrix.requirements == 'full'
     - name: Install dependencies (minimal requirements, stable Botorch)
       run: |
         pip install -e .
+        pip install tensorboard  # For tensorboard unit tests
       if: matrix.botorch == 'pinned' && matrix.requirements == 'minimal'
     - name: Install dependencies (full requirements, Botorch main)
       env:
@@ -40,7 +42,8 @@ jobs:
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
+        pip install tensorboard  # For tensorboard unit tests
       if: matrix.botorch == 'latest' && matrix.requirements == 'full'
     - name: Install dependencies (minimal requirements, Botorch main)
       env:
@@ -49,6 +52,7 @@ jobs:
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .
+        pip install tensorboard  # For tensorboard unit tests
       if: matrix.botorch == 'latest' && matrix.requirements == 'minimal'
     - name: Import Ax
       run: |
@@ -72,7 +76,7 @@ jobs:
     - name: Install dependencies
       run: |
         # will install the version of Botorch that is pinned in setup.py
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
         pip install psycopg2  # Used in example DBSettings in a tutorial (as part of postgres).
         pip install torchvision  # required for tutorials
         pip install ray  # Required for building RayTune tutorial notebook.
@@ -101,7 +105,7 @@ jobs:
         # use latest BoTorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
         pip install psycopg2  # Used in example DBSettings in a tutorial (as part of postgres).
         pip install torchvision  # required for tutorials
         pip install ray  # Required for building RayTune tutorial notebook.
@@ -109,6 +113,7 @@ jobs:
         pip install tensorboardX  # Required for building RayTune tutorial notebook.
         pip install matplotlib  # Required for building Multi-objective tutorial notebook.
         pip install pyro-ppl  # Required for to call run_inference
+        pip install tensorboard  # For generating Sphinx docs for TensorboardCurveMetric
     - name: Publish latest website
       env:
         DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}
@@ -134,7 +139,7 @@ jobs:
         # use latest BoTorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
         pip install wheel
     - name: Build wheel
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,15 +25,17 @@ jobs:
       env:
         ALLOW_BOTORCH_LATEST: true
       run: |
+        pip install tensorboard  # For unit tests
         # use latest Botorch
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
       if: matrix.botorch == 'latest'
     - name: Install dependencies (pinned Botorch)
       run: |
+        pip install tensorboard  # For unit tests
         # will install the version of Botorch that is pinned in setup.py
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
       if: matrix.botorch == 'pinned'
     - name: Import Ax
       run: |
@@ -56,7 +58,7 @@ jobs:
     - name: Install dependencies
       run: |
         # use stable Botorch
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
         pip install psycopg2  # Used in example DBSettings in a tutorial (as part of postgres).
         pip install torchvision  # required for tutorials
         pip install ray  # Required for building RayTune tutorial notebook.
@@ -64,6 +66,7 @@ jobs:
         pip install tensorboardX  # Required for building RayTune tutorial notebook.
         pip install matplotlib  # Required for building Multi-objective tutorial notebook.
         pip install pyro-ppl  # Required for to call run_inference
+        pip install tensorboard  # For generating Sphinx docs for TensorboardCurveMetric
     - name: Publish latest website
       env:
         DOCUSAURUS_PUBLISH_TOKEN: ${{ secrets.DOCUSAURUS_PUBLISH_TOKEN }}
@@ -84,7 +87,7 @@ jobs:
     - name: Install dependencies
       run: |
         # use stable Botorch
-        pip install -e .[dev,mysql,notebook,tensorboard]
+        pip install -e .[dev,mysql,notebook]
         pip install wheel
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,6 @@ MYSQL_REQUIRES = ["SQLAlchemy>=1.1.13"]
 
 NOTEBOOK_REQUIRES = ["jupyter"]
 
-TENSORBOARD_REQUIRES = ["tensorboard"]
-
 
 def local_version(version):
     """
@@ -86,7 +84,6 @@ def setup_package() -> None:
             "dev": DEV_REQUIRES,
             "mysql": MYSQL_REQUIRES,
             "notebook": NOTEBOOK_REQUIRES,
-            "tensorboard": TENSORBOARD_REQUIRES,
         },
         use_scm_version={
             "write_to": "ax/version.py",


### PR DESCRIPTION
tensorboard is a dependency used in TensorboardCurveMetric and is required for its unit tests. This PR makes sure tensorboard is installed where needed in GHA CI