### PR TITLE
add `sort_values` when encoding task

### DIFF
--- a/ax/modelbridge/transforms/task_encode.py
+++ b/ax/modelbridge/transforms/task_encode.py
@@ -68,6 +68,7 @@ class TaskEncode(OrderedChoiceEncode):
                     values=list(range(len(p.values))),  # pyre-ignore [6]
                     is_ordered=p.is_ordered,
                     is_task=True,
+                    sort_values=True,
                 )
             else:
                 transformed_parameters[p.name] = p

--- a/ax/modelbridge/transforms/trial_as_task.py
+++ b/ax/modelbridge/transforms/trial_as_task.py
@@ -116,6 +116,7 @@ class TrialAsTask(Transform):
                 values=level_values,
                 is_ordered=False,
                 is_task=True,
+                sort_values=True,
             )
             search_space.add_parameter(trial_param)
         return search_space


### PR DESCRIPTION
Summary:
`sort_values` is not passed when encoding trial index / task as ChoiceParameter. This will cause warning in the multi-task GP. The task features are encoded as integer and the values are sorted. Thus, let's add `sort_values=True` to remove the warning. (e.g. shown in N1249577 )

{F671397590}

Reviewed By: stevemandala

Differential Revision: D31731409

