### PR TITLE
Add logit parameter transform

### DIFF
--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -29,6 +29,7 @@ from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
 from ax.modelbridge.transforms.int_to_float import IntToFloat
 from ax.modelbridge.transforms.ivw import IVW
 from ax.modelbridge.transforms.log import Log
+from ax.modelbridge.transforms.logit import Logit
 from ax.modelbridge.transforms.one_hot import OneHot
 from ax.modelbridge.transforms.remove_fixed import RemoveFixed
 from ax.modelbridge.transforms.search_space_to_choice import SearchSpaceToChoice
@@ -83,6 +84,7 @@ Cont_X_trans: List[Type[Transform]] = [
     OneHot,
     IntToFloat,
     Log,
+    Logit,
     UnitX,
 ]
 
@@ -93,6 +95,7 @@ Mixed_transforms: List[Type[Transform]] = [
     ChoiceEncode,
     IntToFloat,
     Log,
+    Logit,
     UnitX,
 ]
 

--- a/ax/modelbridge/tests/test_logit_transform.py
+++ b/ax/modelbridge/tests/test_logit_transform.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from copy import deepcopy
+
+from ax.core.observation import ObservationFeatures
+from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
+from ax.core.search_space import SearchSpace
+from ax.exceptions.core import UserInputError
+from ax.modelbridge.transforms.logit import Logit
+from ax.utils.common.testutils import TestCase
+from scipy.special import logit, expit
+
+
+class LogitTransformTest(TestCase):
+    def setUp(self):
+        self.search_space = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    "x",
+                    lower=0.9,
+                    upper=0.999,
+                    parameter_type=ParameterType.FLOAT,
+                    logit_scale=True,
+                ),
+                RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),
+                ChoiceParameter(
+                    "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
+                ),
+            ]
+        )
+        self.t = Logit(
+            search_space=self.search_space,
+            observation_features=None,
+            observation_data=None,
+        )
+        self.search_space_with_target = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    "x",
+                    lower=0.1,
+                    upper=0.3,
+                    parameter_type=ParameterType.FLOAT,
+                    logit_scale=True,
+                    is_fidelity=True,
+                    target_value=0.123,
+                )
+            ]
+        )
+
+    def _create_logit_parameter(self, lower, upper, log_scale=False):
+        return RangeParameter(
+            "x",
+            lower=lower,
+            upper=upper,
+            parameter_type=ParameterType.FLOAT,
+            log_scale=log_scale,
+            logit_scale=True,
+        )
+
+    def testInit(self):
+        self.assertEqual(self.t.transform_parameters, {"x"})
+
+    def testTransformObservationFeatures(self):
+        observation_features = [
+            ObservationFeatures(parameters={"x": 0.95, "a": 2, "b": "c"})
+        ]
+        obs_ft2 = deepcopy(observation_features)
+        obs_ft2 = self.t.transform_observation_features(obs_ft2)
+        self.assertEqual(
+            obs_ft2,
+            [ObservationFeatures(parameters={"x": logit(0.95), "a": 2, "b": "c"})],
+        )
+        # Untransform
+        obs_ft2 = self.t.untransform_observation_features(obs_ft2)
+        x_true = expit(logit(0.95))
+        self.assertAlmostEqual(x_true, 0.95)  # Need to be careful with rounding here
+        self.assertEqual(
+            obs_ft2,
+            [ObservationFeatures(parameters={"x": x_true, "a": 2, "b": "c"})],
+        )
+
+    def testInvalidSettings(self):
+        with self.assertRaises(UserInputError) as cm:
+            self._create_logit_parameter(lower=0.1, upper=0.9, log_scale=True)
+        self.assertEqual("Can't use both log and logit.", str(cm.exception))
+
+        str_exc = "Logit requires lower > 0 and upper < 1"
+        with self.assertRaises(UserInputError) as cm:
+            self._create_logit_parameter(lower=0.0, upper=0.5)
+        self.assertEqual(str_exc, str(cm.exception))
+        with self.assertRaises(UserInputError) as cm:
+            self._create_logit_parameter(lower=0.3, upper=1.0)
+        self.assertEqual(str_exc, str(cm.exception))
+        with self.assertRaises(UserInputError) as cm:
+            self._create_logit_parameter(lower=0.5, upper=10.0)
+        self.assertEqual(str_exc, str(cm.exception))
+
+    def testTransformSearchSpace(self):
+        ss2 = deepcopy(self.search_space)
+        ss2 = self.t.transform_search_space(ss2)
+        self.assertEqual(ss2.parameters["x"].lower, logit(0.9))
+        self.assertEqual(ss2.parameters["x"].upper, logit(0.999))
+        t2 = Logit(
+            search_space=self.search_space_with_target,
+            observation_features=None,
+            observation_data=None,
+        )
+        ss_target = deepcopy(self.search_space_with_target)
+        t2.transform_search_space(ss_target)
+        self.assertEqual(ss_target.parameters["x"].target_value, logit(0.123))
+        self.assertEqual(ss_target.parameters["x"].lower, logit(0.1))
+        self.assertEqual(ss_target.parameters["x"].upper, logit(0.3))

--- a/ax/modelbridge/transforms/logit.py
+++ b/ax/modelbridge/transforms/logit.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional, Set
+
+from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.parameter import ParameterType, RangeParameter
+from ax.core.search_space import SearchSpace
+from ax.core.types import TConfig
+from ax.modelbridge.transforms.base import Transform
+from scipy.special import logit, expit
+
+
+class Logit(Transform):
+    """Apply logit transfor to a float RangeParameter domain.
+
+    Transform is done in-place.
+    """
+
+    def __init__(
+        self,
+        search_space: SearchSpace,
+        observation_features: List[ObservationFeatures],
+        observation_data: List[ObservationData],
+        config: Optional[TConfig] = None,
+    ) -> None:
+        # Identify parameters that should be transformed
+        self.transform_parameters: Set[str] = {
+            p_name
+            for p_name, p in search_space.parameters.items()
+            if isinstance(p, RangeParameter)
+            and p.parameter_type == ParameterType.FLOAT
+            and p.logit_scale is True
+        }
+
+    def transform_observation_features(
+        self, observation_features: List[ObservationFeatures]
+    ) -> List[ObservationFeatures]:
+        for obsf in observation_features:
+            for p_name in self.transform_parameters:
+                if p_name in obsf.parameters:
+                    param: float = obsf.parameters[p_name]  # pyre-ignore [9]
+                    obsf.parameters[p_name] = logit(param).item()
+        return observation_features
+
+    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+        for p_name, p in search_space.parameters.items():
+            if p_name in self.transform_parameters and isinstance(p, RangeParameter):
+                p.set_logit_scale(False).update_range(
+                    lower=logit(p.lower).item(), upper=logit(p.upper).item()
+                )
+                if p.target_value is not None:
+                    p._target_value = logit(p.target_value).item()
+        return search_space
+
+    def untransform_observation_features(
+        self, observation_features: List[ObservationFeatures]
+    ) -> List[ObservationFeatures]:
+        for obsf in observation_features:
+            for p_name in self.transform_parameters:
+                if p_name in obsf.parameters:
+                    param: float = obsf.parameters[p_name]  # pyre-ignore [9]
+                    obsf.parameters[p_name] = expit(param).item()
+        return observation_features

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -143,6 +143,7 @@ def range_parameter_to_dict(parameter: RangeParameter) -> Dict[str, Any]:
         "lower": parameter.lower,
         "upper": parameter.upper,
         "log_scale": parameter.log_scale,
+        "logit_scale": parameter.logit_scale,
         "digits": parameter.digits,
         "is_fidelity": parameter.is_fidelity,
         "target_value": parameter.target_value,

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -15,6 +15,7 @@ from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
 from ax.modelbridge.transforms.int_to_float import IntToFloat
 from ax.modelbridge.transforms.ivw import IVW
 from ax.modelbridge.transforms.log import Log
+from ax.modelbridge.transforms.logit import Logit
 from ax.modelbridge.transforms.one_hot import OneHot
 from ax.modelbridge.transforms.power_transform_y import PowerTransformY
 from ax.modelbridge.transforms.remove_fixed import RemoveFixed
@@ -63,6 +64,7 @@ TRANSFORM_REGISTRY: Dict[Type[Transform], int] = {
     CapParameter: 17,
     PowerTransformY: 18,
     ChoiceEncode: 19,
+    Logit: 20,
 }
 
 

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -232,6 +232,14 @@ Transforms
     :undoc-members:
     :show-inheritance:
 
+`ax.modelbridge.transforms.logit`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.logit
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 `ax.modelbridge.transforms.one\_hot`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary: Logit is a parameter transform that is useful for parameters in the (0, 1) range that are very sensitive close to 0 and/or 1. It is commonly used when tuning the beta parameters for Adam where beta_2 is often very close to 1 (0.999 is a common choice).

Reviewed By: lena-kashtelyan

Differential Revision: D32150086

