### PR TITLE
Objectives should never be subject to an outcome_contraint

### DIFF
--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -176,10 +176,6 @@ class MultiObjective(Objective):
     def __repr__(self) -> str:
         return f"MultiObjective(objectives={self.objectives})"
 
-    def get_unconstrainable_metrics(self) -> List[Metric]:
-        """Return a list of metrics that are incompatible with OutcomeConstraints."""
-        return []
-
 
 class ScalarizedObjective(Objective):
     """Class for an objective composed of a linear scalarization of metrics.
@@ -244,7 +240,3 @@ class ScalarizedObjective(Objective):
         return "ScalarizedObjective(metric_names={}, weights={}, minimize={})".format(
             [metric.name for metric in self.metrics], self.weights, self.minimize
         )
-
-    def get_unconstrainable_metrics(self) -> List[Metric]:
-        """Return a list of metrics that are incompatible with OutcomeConstraints."""
-        return []

--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -84,7 +84,10 @@ class ObjectiveTest(TestCase):
                 'Objective(metric_name="m3", minimize=False)])'
             ),
         )
-        self.assertEqual(self.multi_objective.get_unconstrainable_metrics(), [])
+        self.assertEqual(
+            self.multi_objective.get_unconstrainable_metrics(),
+            [self.metrics["m1"], self.metrics["m2"], self.metrics["m3"]],
+        )
 
     def testMultiObjectiveBackwardsCompatibility(self):
         multi_objective = MultiObjective(
@@ -118,4 +121,7 @@ class ObjectiveTest(TestCase):
                 "minimize=False)"
             ),
         )
-        self.assertEqual(self.scalarized_objective.get_unconstrainable_metrics(), [])
+        self.assertEqual(
+            self.scalarized_objective.get_unconstrainable_metrics(),
+            [self.metrics["m1"], self.metrics["m2"]],
+        )


### PR DESCRIPTION
Summary: It was previously possible to add outcome constraints to an objective in a `MultiObjective` or `ScalarizedObjective`. This is a bit confusing since the only setting where constraints make sense is for MOO where we already have a notion of objective thresholds, so there is no need for additional outcome constraints.

Reviewed By: bernardbeckerman

Differential Revision: D32409183

