### PR TITLE
Automatic winsorization

### DIFF
--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -176,10 +176,6 @@ class MultiObjective(Objective):
     def __repr__(self) -> str:
         return f"MultiObjective(objectives={self.objectives})"
 
-    def get_unconstrainable_metrics(self) -> List[Metric]:
-        """Return a list of metrics that are incompatible with OutcomeConstraints."""
-        return []
-
 
 class ScalarizedObjective(Objective):
     """Class for an objective composed of a linear scalarization of metrics.
@@ -244,7 +240,3 @@ class ScalarizedObjective(Objective):
         return "ScalarizedObjective(metric_names={}, weights={}, minimize={})".format(
             [metric.name for metric in self.metrics], self.weights, self.minimize
         )
-
-    def get_unconstrainable_metrics(self) -> List[Metric]:
-        """Return a list of metrics that are incompatible with OutcomeConstraints."""
-        return []

--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -84,7 +84,10 @@ class ObjectiveTest(TestCase):
                 'Objective(metric_name="m3", minimize=False)])'
             ),
         )
-        self.assertEqual(self.multi_objective.get_unconstrainable_metrics(), [])
+        self.assertEqual(
+            self.multi_objective.get_unconstrainable_metrics(),
+            [self.metrics["m1"], self.metrics["m2"], self.metrics["m3"]],
+        )
 
     def testMultiObjectiveBackwardsCompatibility(self):
         multi_objective = MultiObjective(
@@ -118,4 +121,7 @@ class ObjectiveTest(TestCase):
                 "minimize=False)"
             ),
         )
-        self.assertEqual(self.scalarized_objective.get_unconstrainable_metrics(), [])
+        self.assertEqual(
+            self.scalarized_objective.get_unconstrainable_metrics(),
+            [self.metrics["m1"], self.metrics["m2"]],
+        )

--- a/ax/modelbridge/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/tests/test_winsorize_transform.py
@@ -4,17 +4,34 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
 from copy import deepcopy
 
 import numpy as np
+from ax.core.metric import Metric
+from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.observation import ObservationData
-from ax.exceptions.core import UserInputError
-from ax.modelbridge.transforms.winsorize import Winsorize, WinsorizationConfig
-from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import (
-    get_optimization_config,
-    get_multi_objective_optimization_config,
+from ax.core.optimization_config import (
+    MultiObjectiveOptimizationConfig,
+    OptimizationConfig,
 )
+from ax.core.outcome_constraint import (
+    ComparisonOp,
+    ObjectiveThreshold,
+    OutcomeConstraint,
+    ScalarizedOutcomeConstraint,
+)
+from ax.exceptions.core import UnsupportedError, UserInputError
+from ax.modelbridge.transforms.winsorize import (
+    AUTO_WINS_QUANTILE,
+    WinsorizationConfig,
+    Winsorize,
+    _get_auto_winsorization_cutoffs_outcome_constraint,
+    _get_auto_winsorization_cutoffs_single_objective,
+    _get_tukey_cutoffs,
+)
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_optimization_config
 
 
 class WinsorizeTransformTest(TestCase):
@@ -122,14 +139,38 @@ class WinsorizeTransformTest(TestCase):
         )
 
     def testInit(self):
-        self.assertEqual(self.t.percentiles["m1"], (0.0, 2.0))
-        self.assertEqual(self.t.percentiles["m2"], (0.0, 2.0))
-        self.assertEqual(self.t1.percentiles["m1"], (0.0, 1.0))
-        self.assertEqual(self.t1.percentiles["m2"], (0.0, 1.0))
-        self.assertEqual(self.t2.percentiles["m1"], (0.0, 2.0))
-        self.assertEqual(self.t2.percentiles["m2"], (0.0, 2.0))
-        with self.assertRaises(ValueError):
+        self.assertEqual(self.t.cutoffs["m1"], (-float("inf"), 2.0))
+        self.assertEqual(self.t.cutoffs["m2"], (-float("inf"), 2.0))
+        self.assertEqual(self.t1.cutoffs["m1"], (-float("inf"), 1.0))
+        self.assertEqual(self.t1.cutoffs["m2"], (-float("inf"), 1.0))
+        self.assertEqual(self.t2.cutoffs["m1"], (0.0, float("inf")))
+        self.assertEqual(self.t2.cutoffs["m2"], (0.0, float("inf")))
+        with self.assertRaisesRegex(
+            ValueError, "Winsorize transform requires non-empty observation data."
+        ):
             Winsorize(search_space=None, observation_features=[], observation_data=[])
+        obsd = [deepcopy(self.obsd1)]
+        with self.assertRaisesRegex(
+            ValueError,
+            "Transform config for `Winsorize` transform must be specified and "
+            "non-empty when using winsorization.",
+        ):
+            Winsorize(
+                search_space=None,
+                observation_features=[],
+                observation_data=obsd,
+            )
+        with self.assertRaisesRegex(
+            UserInputError,
+            "Expected `optimization_config` of type `OptimizationConfig` "
+            "but got type `<class 'int'>.",
+        ):
+            Winsorize(
+                search_space=None,
+                observation_features=[],
+                observation_data=obsd,
+                config={"optimization_config": 1234},
+            )
 
     def testTransformObservations(self):
         observation_data = self.t1.transform_observation_data(
@@ -150,10 +191,10 @@ class WinsorizeTransformTest(TestCase):
         self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
 
     def testInitPercentileBounds(self):
-        self.assertEqual(self.t3.percentiles["m1"], (0.0, 1.0))
-        self.assertEqual(self.t3.percentiles["m2"], (0.0, 1.9))
-        self.assertEqual(self.t4.percentiles["m1"], (1.0, 2.0))
-        self.assertEqual(self.t4.percentiles["m2"], (0.3, 2.0))
+        self.assertEqual(self.t3.cutoffs["m1"], (-float("inf"), 1.0))
+        self.assertEqual(self.t3.cutoffs["m2"], (-float("inf"), 1.9))
+        self.assertEqual(self.t4.cutoffs["m1"], (1.0, float("inf")))
+        self.assertEqual(self.t4.cutoffs["m2"], (0.3, float("inf")))
 
     def testTransformObservationsPercentileBounds(self):
         observation_data = self.t3.transform_observation_data(
@@ -177,9 +218,9 @@ class WinsorizeTransformTest(TestCase):
         observation_data = self.t5.transform_observation_data(
             [deepcopy(self.obsd2)], []
         )[0]
-        self.assertEqual(self.t5.percentiles["m1"], (0.0, 1.0))
-        self.assertEqual(self.t5.percentiles["m2"], (1.0, 2.0))
-        self.assertEqual(self.t5.percentiles["m3"], (-float("inf"), float("inf")))
+        self.assertEqual(self.t5.cutoffs["m1"], (-float("inf"), 1.0))
+        self.assertEqual(self.t5.cutoffs["m2"], (1.0, float("inf")))
+        self.assertEqual(self.t5.cutoffs["m3"], (-float("inf"), float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
         # Nothing should happen to m3
         observation_data = self.t5.transform_observation_data(
@@ -190,24 +231,18 @@ class WinsorizeTransformTest(TestCase):
         observation_data = self.t6.transform_observation_data(
             [deepcopy(self.obsd2)], []
         )[0]
-        self.assertEqual(self.t6.percentiles["m1"], (0.0, 1.0))
-        self.assertEqual(self.t6.percentiles["m2"], (0.0, 2.0))
+        self.assertEqual(self.t6.cutoffs["m1"], (-float("inf"), 1.0))
+        self.assertEqual(self.t6.cutoffs["m2"], (0.0, float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
 
     def test_optimization_config_default(self):
-        # 20% winsorization by default
+        # Specify the winsorization
         optimization_config = get_optimization_config()
-        percentiles = get_default_transform_percentiles(
-            optimization_config=optimization_config
+        percentiles = get_default_transform_cutoffs(
+            optimization_config=optimization_config,
+            winsorization_config={"m1": WinsorizationConfig(0.2, 0.0)},
         )
-        self.assertDictEqual(percentiles, {"m1": (1, 5)})
-
-        # Don't winsorize by default for MOO problems
-        optimization_config = get_multi_objective_optimization_config()
-        percentiles = get_default_transform_percentiles(
-            optimization_config=optimization_config
-        )
-        self.assertDictEqual(percentiles, {"m1": (-float("inf"), float("inf"))})
+        self.assertDictEqual(percentiles, {"m1": (1, float("inf"))})
 
         # Don't winsorize if optimization_config is mistyped
         optimization_config = "not an optimization config"
@@ -215,10 +250,309 @@ class WinsorizeTransformTest(TestCase):
             UserInputError,
             "Expected `optimization_config` of type `OptimizationConfig`",
         ):
-            get_default_transform_percentiles(optimization_config=optimization_config)
+            get_default_transform_cutoffs(optimization_config=optimization_config)
+
+    def test_tukey_cutoffs(self):
+        Y = np.array([-100, 0, 1, 2, 50])
+        self.assertEqual(_get_tukey_cutoffs(Y=Y, lower=True), -3.0)
+        self.assertEqual(_get_tukey_cutoffs(Y=Y, lower=False), 5.0)
+
+    def test_winsorize_outcome_constraints(self):
+        metric_values = [-100, 0, 1, 2, 3, 4, 5, 6, 7, 50]
+        ma, mb = Metric(name="a"), Metric(name="b")
+        outcome_constraint_leq = OutcomeConstraint(
+            metric=ma, op=ComparisonOp.LEQ, bound=10, relative=False
+        )
+        outcome_constraint_geq = OutcomeConstraint(
+            metric=mb, op=ComparisonOp.GEQ, bound=-9, relative=False
+        )
+        # From above with a loose bound
+        cutoffs = _get_auto_winsorization_cutoffs_outcome_constraint(
+            metric_values=metric_values,
+            outcome_constraints=[outcome_constraint_leq],
+        )
+        self.assertEqual(cutoffs, (-float("inf"), 23.5))
+        # From above with a tight bound
+        outcome_constraint_leq.bound = 2
+        cutoffs = _get_auto_winsorization_cutoffs_outcome_constraint(
+            metric_values=metric_values,
+            outcome_constraints=[outcome_constraint_leq],
+        )
+        self.assertEqual(cutoffs, (-float("inf"), 13.5))
+        # From below with a loose bound
+        cutoffs = _get_auto_winsorization_cutoffs_outcome_constraint(
+            metric_values=metric_values,
+            outcome_constraints=[outcome_constraint_geq],
+        )
+        self.assertEqual(cutoffs, (-31.5, float("inf")))
+        # From below with a tight bound
+        outcome_constraint_geq.bound = 5
+        cutoffs = _get_auto_winsorization_cutoffs_outcome_constraint(
+            metric_values=metric_values,
+            outcome_constraints=[outcome_constraint_geq],
+        )
+        self.assertEqual(cutoffs, (-6.5, float("inf")))
+        # Both with the tight bounds
+        outcome_constraint_geq.bound = 5
+        cutoffs = _get_auto_winsorization_cutoffs_outcome_constraint(
+            metric_values=metric_values,
+            outcome_constraints=[outcome_constraint_leq, outcome_constraint_geq],
+        )
+        self.assertEqual(cutoffs, (-6.5, 13.5))
+
+    def test_winsorization_single_objective(self):
+        metric_values = [-100, 0, 1, 2, 3, 4, 5, 6, 7, 50]
+        cutoffs = _get_auto_winsorization_cutoffs_single_objective(
+            metric_values=metric_values,
+            minimize=True,
+        )
+        self.assertEqual(cutoffs, (-float("inf"), 13.5))
+        cutoffs = _get_auto_winsorization_cutoffs_single_objective(
+            metric_values=metric_values,
+            minimize=False,
+        )
+        self.assertEqual(cutoffs, (-6.5, float("inf")))
+
+    def test_winsorization_without_optimization_config(self):
+        means = np.array([-100, 0, 1, 2, 3, 4, 5, 6, 7, 50])
+        obsd = ObservationData(
+            metric_names=["m1"] * 10,
+            means=means,
+            covariance=np.eye(10),
+        )
+        config = {
+            "winsorization_config": {
+                "m1": WinsorizationConfig(None, None),
+            }
+        }
+        transform = get_transform(observation_data=[deepcopy(obsd)], config=config)
+        self.assertEqual(transform.cutoffs["m1"], (-float("inf"), float("inf")))
+        # None and 0.0 should be treated the same way
+        config["winsorization_config"]["m1"] = WinsorizationConfig(0.0, 0.0)
+        transform = get_transform(observation_data=[deepcopy(obsd)], config=config)
+        self.assertEqual(transform.cutoffs["m1"], (-float("inf"), float("inf")))
+        # From above
+        config["winsorization_config"]["m1"] = WinsorizationConfig(0.0, 0.2)
+        transform = get_transform(observation_data=[deepcopy(obsd)], config=config)
+        self.assertEqual(transform.cutoffs["m1"], (-float("inf"), 7))
+        # From below
+        config["winsorization_config"]["m1"] = WinsorizationConfig(0.2, 0.0)
+        transform = get_transform(observation_data=[deepcopy(obsd)], config=config)
+        self.assertEqual(transform.cutoffs["m1"], (0, float("inf")))
+        # Do both automatically
+        config["winsorization_config"]["m1"] = WinsorizationConfig(
+            AUTO_WINS_QUANTILE, AUTO_WINS_QUANTILE
+        )
+        transform = get_transform(observation_data=[deepcopy(obsd)], config=config)
+        self.assertEqual(transform.cutoffs["m1"], (-6.5, 13.5))
+        # Add a second metric that shouldn't be winsorized
+        config["winsorization_config"]["m1"] = WinsorizationConfig(
+            0.0, AUTO_WINS_QUANTILE
+        )
+        obsd2 = ObservationData(
+            metric_names=["m2"] * 10,
+            means=means,
+            covariance=np.eye(10),
+        )
+        transform = get_transform(
+            observation_data=[deepcopy(obsd), deepcopy(obsd2)], config=config
+        )
+        self.assertEqual(transform.cutoffs["m1"], (-float("inf"), 13.5))
+        self.assertEqual(transform.cutoffs["m2"], (-float("inf"), float("inf")))
+        # Winsorize both
+        config["winsorization_config"]["m2"] = WinsorizationConfig(0.2, 0.0)
+        transform = get_transform(
+            observation_data=[deepcopy(obsd), deepcopy(obsd2)], config=config
+        )
+        self.assertEqual(transform.cutoffs["m1"], (-float("inf"), 13.5))
+        self.assertEqual(transform.cutoffs["m2"], (0.0, float("inf")))
+
+    def test_winsorization_with_optimization_config(self):
+        obsd_1 = ObservationData(
+            metric_names=["m1"] * 10,
+            means=np.array([-100, 0, 1, 2, 3, 4, 5, 6, 7, 50]),
+            covariance=np.eye(10),
+        )
+        obsd_2 = ObservationData(
+            metric_names=["m2"] * 7,
+            means=np.array([-10, 0, 1, 2, 3, 4, 47]),
+            covariance=np.eye(7),
+        )
+        obsd_3 = ObservationData(
+            metric_names=["m3"] * 6,
+            means=np.array([-456, 1, 2, 3, 4, 9]),
+            covariance=np.eye(6),
+        )
+        all_obsd = [obsd_1, obsd_2, obsd_3]
+        m1 = Metric(name="m1", lower_is_better=False)
+        m2 = Metric(name="m2", lower_is_better=True)
+        m3 = Metric(name="m3")
+        # Scalarized objective shouldn't be winsorized but should print a warning
+        config = {
+            "optimization_config": OptimizationConfig(
+                objective=ScalarizedObjective(metrics=[m1, m2])
+            )
+        }
+        warnings.simplefilter("always", append=True)
+        with warnings.catch_warnings(record=True) as ws:
+            transform = get_transform(
+                observation_data=deepcopy(all_obsd), config=config
+            )
+            self.assertEqual(len(ws), 2)  # One warning per objective
+            for i in range(2):
+                self.assertEqual(
+                    "Automatic winsorization isn't supported for ScalarizedObjective. "
+                    "Specify the winsorization settings manually if you want to "
+                    f"winsorize metric m{i + 1}.",
+                    str(ws[i].message),
+                )
+        self.assertEqual(transform.cutoffs["m1"], (-float("inf"), float("inf")))
+        self.assertEqual(transform.cutoffs["m2"], (-float("inf"), float("inf")))
+        self.assertEqual(transform.cutoffs["m3"], (-float("inf"), float("inf")))
+        # Simple single-objective problem
+        config["optimization_config"].objective = Objective(metric=m2, minimize=True)
+        transform = get_transform(observation_data=deepcopy(all_obsd), config=config)
+        self.assertEqual(transform.cutoffs["m1"], (-float("inf"), float("inf")))
+        self.assertEqual(transform.cutoffs["m2"], (-float("inf"), 10.0))  # 4 + 1.5 * 4
+        self.assertEqual(transform.cutoffs["m3"], (-float("inf"), float("inf")))
+        # Add a relative constraint, which should raise an error
+        outcome_constraint = OutcomeConstraint(
+            metric=m1, op=ComparisonOp.LEQ, bound=3, relative=True
+        )
+        config = {
+            "optimization_config": OptimizationConfig(
+                objective=Objective(metric=m2, minimize=True),
+                outcome_constraints=[outcome_constraint],
+            )
+        }
+        with self.assertRaisesRegex(
+            UnsupportedError,
+            "Automatic winsorization doesn't support relative outcome constraints. "
+            "Make sure a `Derelativize` transform is applied first.",
+        ):
+            get_transform(observation_data=deepcopy(all_obsd), config=config)
+        # Make the constraint absolute, which should trigger winsorization
+        config["optimization_config"].outcome_constraints[0].relative = False
+        transform = get_transform(observation_data=deepcopy(all_obsd), config=config)
+        self.assertEqual(transform.cutoffs["m1"], (-float("inf"), 13.5))  # 6 + 1.5 * 5
+        self.assertEqual(transform.cutoffs["m2"], (-float("inf"), 10.0))  # 4 + 1.5 * 4
+        self.assertEqual(transform.cutoffs["m3"], (-float("inf"), float("inf")))
+        # Change to a GEQ constraint
+        config["optimization_config"].outcome_constraints[0].op = ComparisonOp.GEQ
+        transform = get_transform(observation_data=deepcopy(all_obsd), config=config)
+        self.assertEqual(transform.cutoffs["m1"], (-6.5, float("inf")))  # 1 - 1.5 * 5
+        self.assertEqual(transform.cutoffs["m2"], (-float("inf"), 10.0))  # 4 + 1.5 * 4
+        self.assertEqual(transform.cutoffs["m3"], (-float("inf"), float("inf")))
+        # Add a scalarized outcome constraint which should print a warning
+        config["optimization_config"].outcome_constraints = [
+            ScalarizedOutcomeConstraint(
+                metrics=[m1, m3], op=ComparisonOp.GEQ, bound=3, relative=False
+            )
+        ]
+        warnings.simplefilter("always", append=True)
+        with warnings.catch_warnings(record=True) as ws:
+            transform = get_transform(
+                observation_data=deepcopy(all_obsd), config=config
+            )
+            self.assertEqual(len(ws), 2)  # One warning per metric
+            for i in range(2):
+                self.assertEqual(
+                    "Automatic winsorization isn't supported for a "
+                    "`ScalarizedOutcomeConstraint`. Specify the winsorization settings "
+                    f"manually if you want to winsorize metric m{['1', '3'][i]}.",
+                    str(ws[i].message),
+                )
+        # Making the constraint relative should print the same warning
+        config["optimization_config"].outcome_constraints[0].relative = True
+        with warnings.catch_warnings(record=True) as ws:
+            transform = get_transform(
+                observation_data=deepcopy(all_obsd), config=config
+            )
+            self.assertEqual(len(ws), 2)  # One warning per metric
+            for i in range(2):
+                self.assertEqual(
+                    "Automatic winsorization isn't supported for a "
+                    "`ScalarizedOutcomeConstraint`. Specify the winsorization settings "
+                    f"manually if you want to winsorize metric m{['1', '3'][i]}.",
+                    str(ws[i].message),
+                )
+        # Multi-objective without objective thresholds (should print a warning)
+        moo_objective = MultiObjective(
+            [Objective(m1, minimize=False), Objective(m2, minimize=True)]
+        )
+        moo_config = {
+            "optimization_config": MultiObjectiveOptimizationConfig(
+                objective=moo_objective
+            )
+        }
+        warnings.simplefilter("always", append=True)
+        with warnings.catch_warnings(record=True) as ws:
+            transform = get_transform(
+                observation_data=deepcopy(all_obsd), config=moo_config
+            )
+            self.assertEqual(len(ws), 2)  # One warning per objective
+            for i in range(2):
+                self.assertEqual(
+                    "Automatic winsorization isn't supported for an objective in "
+                    "`MultiObjective` without objective thresholds. Specify the "
+                    "winsorization settings manually if you want to winsorize "
+                    f"metric m{i + 1}.",
+                    str(ws[i].message),
+                )
+        self.assertEqual(transform.cutoffs["m1"], (-float("inf"), float("inf")))
+        self.assertEqual(transform.cutoffs["m2"], (-float("inf"), float("inf")))
+        self.assertEqual(transform.cutoffs["m3"], (-float("inf"), float("inf")))
+        # Add relative objective thresholds (should raise an error)
+        objective_thresholds = [
+            ObjectiveThreshold(m1, 3, relative=True),
+            ObjectiveThreshold(m2, 4, relative=True),
+        ]
+        moo_config = {
+            "optimization_config": MultiObjectiveOptimizationConfig(
+                objective=moo_objective,
+                objective_thresholds=objective_thresholds,
+                outcome_constraints=[],
+            )
+        }
+        with self.assertRaisesRegex(
+            UnsupportedError,
+            "Automatic winsorization doesn't support relative objective thresholds. "
+            "Make sure a `Derelevatize` transform is applied first.",
+        ):
+            get_transform(observation_data=deepcopy(all_obsd), config=moo_config)
+        # Make the objective thresholds absolute (should trigger winsorization)
+        moo_config["optimization_config"].objective_thresholds[0].relative = False
+        moo_config["optimization_config"].objective_thresholds[1].relative = False
+        transform = get_transform(
+            observation_data=deepcopy(all_obsd), config=moo_config
+        )
+        self.assertEqual(transform.cutoffs["m1"], (-6.5, float("inf")))  # 1 - 1.5 * 5
+        self.assertEqual(transform.cutoffs["m2"], (-float("inf"), 10.0))  # 4 + 1.5 * 4
+        self.assertEqual(transform.cutoffs["m3"], (-float("inf"), float("inf")))
+        # Add an absolute outcome constraint
+        moo_config["optimization_config"].outcome_constraints = [
+            OutcomeConstraint(metric=m3, op=ComparisonOp.GEQ, bound=3, relative=False)
+        ]
+        transform = get_transform(
+            observation_data=deepcopy(all_obsd), config=moo_config
+        )
+        self.assertEqual(transform.cutoffs["m1"], (-6.5, float("inf")))  # 1 - 1.5 * 5
+        self.assertEqual(transform.cutoffs["m2"], (-float("inf"), 10.0))  # 4 + 1.5 * 4
+        self.assertEqual(transform.cutoffs["m3"], (-3.5, float("inf")))  # 1 - 1.5 * 3
 
 
-def get_default_transform_percentiles(optimization_config, obs_data_len=6):
+def get_transform(observation_data, config):
+    return Winsorize(
+        search_space=None,
+        observation_features=None,
+        observation_data=observation_data,
+        config=config,
+    )
+
+
+def get_default_transform_cutoffs(
+    optimization_config, winsorization_config=None, obs_data_len=6
+):
     obsd = ObservationData(
         metric_names=["m1"] * obs_data_len,
         means=np.array(range(obs_data_len)),
@@ -228,6 +562,9 @@ def get_default_transform_percentiles(optimization_config, obs_data_len=6):
         search_space=None,
         observation_features=None,
         observation_data=[deepcopy(obsd)],
-        config={"optimization_config": optimization_config},
+        config={
+            "optimization_config": optimization_config,
+            "winsorization_config": winsorization_config,
+        },
     )
-    return transform.percentiles
+    return transform.cutoffs

--- a/ax/modelbridge/tests/test_winsorize_transform_legacy.py
+++ b/ax/modelbridge/tests/test_winsorize_transform_legacy.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import warnings
 from copy import deepcopy
 
 import numpy as np
@@ -106,13 +107,31 @@ class WinsorizeTransformTestLegacy(TestCase):
             },
         )
 
+    def testPrintDeprectationWarning(self):
+        warnings.simplefilter("always", append=True)
+        with warnings.catch_warnings(record=True) as ws:
+            Winsorize(
+                search_space=None,
+                observation_features=None,
+                observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+                config={"winsorization_upper": 0.2},
+            )
+            self.assertEqual(len(ws), 1)
+            self.assertEqual(
+                "Winsorization received an out-of-date `transform_config`, containing "
+                "the following deprecated keys: {'winsorization_upper'}. Please "
+                "update the config according to the docs of "
+                "`ax.modelbridge.transforms.winsorize.Winsorize`.",
+                str(ws[0].message),
+            )
+
     def testInit(self):
-        self.assertEqual(self.t.percentiles["m1"], (0.0, 2.0))
-        self.assertEqual(self.t.percentiles["m2"], (0.0, 2.0))
-        self.assertEqual(self.t1.percentiles["m1"], (0.0, 1.0))
-        self.assertEqual(self.t1.percentiles["m2"], (0.0, 1.0))
-        self.assertEqual(self.t2.percentiles["m1"], (0.0, 2.0))
-        self.assertEqual(self.t2.percentiles["m2"], (0.0, 2.0))
+        self.assertEqual(self.t.cutoffs["m1"], (-float("inf"), 2.0))
+        self.assertEqual(self.t.cutoffs["m2"], (-float("inf"), 2.0))
+        self.assertEqual(self.t1.cutoffs["m1"], (-float("inf"), 1.0))
+        self.assertEqual(self.t1.cutoffs["m2"], (-float("inf"), 1.0))
+        self.assertEqual(self.t2.cutoffs["m1"], (0.0, float("inf")))
+        self.assertEqual(self.t2.cutoffs["m2"], (0.0, float("inf")))
         with self.assertRaises(ValueError):
             Winsorize(search_space=None, observation_features=[], observation_data=[])
 
@@ -135,10 +154,10 @@ class WinsorizeTransformTestLegacy(TestCase):
         self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
 
     def testInitPercentileBounds(self):
-        self.assertEqual(self.t3.percentiles["m1"], (0.0, 1.0))
-        self.assertEqual(self.t3.percentiles["m2"], (0.0, 1.9))
-        self.assertEqual(self.t4.percentiles["m1"], (1.0, 2.0))
-        self.assertEqual(self.t4.percentiles["m2"], (0.3, 2.0))
+        self.assertEqual(self.t3.cutoffs["m1"], (-float("inf"), 1.0))
+        self.assertEqual(self.t3.cutoffs["m2"], (-float("inf"), 1.9))
+        self.assertEqual(self.t4.cutoffs["m1"], (1.0, float("inf")))
+        self.assertEqual(self.t4.cutoffs["m2"], (0.3, float("inf")))
 
     def testValueError(self):
         with self.assertRaises(ValueError):
@@ -174,9 +193,9 @@ class WinsorizeTransformTestLegacy(TestCase):
         observation_data = self.t5.transform_observation_data(
             [deepcopy(self.obsd2)], []
         )[0]
-        self.assertEqual(self.t5.percentiles["m1"], (0.0, 1.0))
-        self.assertEqual(self.t5.percentiles["m2"], (1.0, 2.0))
-        self.assertEqual(self.t5.percentiles["m3"], (0.0, 5.0))
+        self.assertEqual(self.t5.cutoffs["m1"], (-float("inf"), 1.0))
+        self.assertEqual(self.t5.cutoffs["m2"], (1.0, float("inf")))
+        self.assertEqual(self.t5.cutoffs["m3"], (-float("inf"), float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
         # Nothing should happen to m3
         observation_data = self.t5.transform_observation_data(
@@ -187,6 +206,6 @@ class WinsorizeTransformTestLegacy(TestCase):
         observation_data = self.t6.transform_observation_data(
             [deepcopy(self.obsd2)], []
         )[0]
-        self.assertEqual(self.t6.percentiles["m1"], (0.0, 1.0))
-        self.assertEqual(self.t6.percentiles["m2"], (0.0, 2.0))
+        self.assertEqual(self.t6.cutoffs["m1"], (-float("inf"), 1.0))
+        self.assertEqual(self.t6.cutoffs["m2"], (0.0, float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])


### PR DESCRIPTION
Summary:
This adds support for automatically inferring the winsorization settings based on the observed data and the optimization config, which is useful for outcome constraints and MOO. The main idea is to winsorize in a similar way to how outliers are defined in a Tukey box plot, but while also taking the constraint boundaries into account. For users fitting models in a notebook where there is no optimization config it is also possible to use automatic winsorization by specifying, e.g., `WinsorizationConfig(0.0, AUTO_WINS_QUANTILE)`, which will automatically winsorize from above and apply no winsorization from below.

When an optimization config is supplied, the following logic is used:
- **Single objective:** We automatically winsorize from above for minimization and from below for maximization. For minimization the cutoff is `q3 + 1.5 (q3 - q1)`  and for maximization it is `q1 + 1.5 (q3 - q1)`  where `q1` is the first quartile and `q3` is the third quartile.
- **Outcome constraint:** For a leq constraint, we will winsorize from above but need to be careful so we don't make infeasible points feasible. Thus, instead of using the cutoff `q3 + 1.5 (q3 - q1)` we instead use `max(q3, bnd) + 1.5 (max(q3, bnd) - q1)`. Using the max of the 3rd quartile and the bound guarantees that infeasible points remain infeasible.
- **Multi objective:** If an objective threshold is specified, we deal with this in the same way as an outcome constraint. If no objective threshold is specified we don't winsorize (since outliers may be on the Pareto frontier).

Automatically infering winsorization from the optimization config doesn't support:
- Relative outcome constraints (including relative objective thresholds)
- Scalarized objectives
- Scalarized outcome constraints.

Reviewed By: bernardbeckerman

Differential Revision: D32306496

