### PR TITLE
Relax check on parameter constraints

### DIFF
--- a/ax/core/parameter_constraint.py
+++ b/ax/core/parameter_constraint.py
@@ -75,7 +75,7 @@ class ParameterConstraint(SortableBase):
         )
         # Expected `int` for 2nd anonymous parameter to call `int.__le__` but got
         # `float`.
-        return weighted_sum <= self._bound
+        return weighted_sum <= self._bound + 1e-8  # allow for numerical imprecision
 
     def clone(self) -> ParameterConstraint:
         """Clone."""

--- a/ax/core/tests/test_parameter_constraint.py
+++ b/ax/core/tests/test_parameter_constraint.py
@@ -52,10 +52,16 @@ class ParameterConstraintTest(TestCase):
         with self.assertRaises(ValueError):
             self.constraint.check(parameters)
 
+        # check slack constraint
         parameters = {"x": 4, "y": 1}
         self.assertTrue(self.constraint.check(parameters))
 
-        self.constraint.bound = 4.0
+        # check tight constraint (within numerical tolerance)
+        parameters = {"x": 4, "y": (2 - 0.5e-8) / 3}
+        self.assertTrue(self.constraint.check(parameters))
+
+        # check violated constraint
+        parameters = {"x": 4, "y": (2 - 0.5e-6) / 3}
         self.assertFalse(self.constraint.check(parameters))
 
     def testClone(self):


### PR DESCRIPTION
Currently this will fail any violation. This adds minimal slack to tolerate violations from numerical inaccuracies if constraints are binding.