### PR TITLE
Fix Sphinx docs for Ax early stopping.

### DIFF
--- a/sphinx/source/service.rst
+++ b/sphinx/source/service.rst
@@ -24,6 +24,16 @@ Managed Loop
     :undoc-members:
     :show-inheritance:
 
+
+Scheduler
+~~~~~~~~~~
+
+.. automodule:: ax.service.scheduler
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Utils
 ------
 
@@ -63,10 +73,10 @@ WithDBSettingsBase
     :show-inheritance:
 
 
-Scheduler
-~~~~~~~~~~
+EarlyStopping
+~~~~~~~~~~~~~
 
-.. automodule:: ax.service.scheduler
+.. automodule:: ax.service.utils.early_stopping
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Summary:
Broken in D32623549 (https://github.com/facebook/Ax/commit/c913e6f75d22fb0897a807b07c6dec5c4936e3fd).

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D32734293

