### PR TITLE
fast low-rank cholesky updates for NEHVI (#990)

### DIFF
--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -470,7 +470,12 @@ class BotorchMOOModelTest(TestCase):
                 bounds,
                 objective_weights=torch.tensor([-1.0, -1.0, 0.0], **tkwargs),
                 outcome_constraints=outcome_constraints,
-                model_gen_options={"optimizer_kwargs": _get_optimizer_kwargs()},
+                model_gen_options={
+                    "optimizer_kwargs": _get_optimizer_kwargs(),
+                    # do not used cached root decomposition since
+                    # MockPosterior does not have an mvn attribute
+                    "acquisition_function_kwargs": {"cache_root": False},
+                },
             )
             # the NEHVI acquisition function should be created only once.
             self.assertEqual(_mock_acqf.call_count, 3)
@@ -524,7 +529,12 @@ class BotorchMOOModelTest(TestCase):
                 bounds,
                 objective_weights=torch.tensor([-1.0, -1.0, 0.0], **tkwargs),
                 outcome_constraints=outcome_constraints,
-                model_gen_options={"optimizer_kwargs": _get_optimizer_kwargs()},
+                model_gen_options={
+                    "optimizer_kwargs": _get_optimizer_kwargs(),
+                    # do not used cached root decomposition since
+                    # MockPosterior does not have an mvn attribute
+                    "acquisition_function_kwargs": {"cache_root": False},
+                },
                 objective_thresholds=provided_obj_t,
             )
             self.assertIn("objective_thresholds", gen_metadata)

--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -169,6 +169,7 @@ def get_NEHVI(
         ref_point=objective_thresholds.tolist(),
         marginalize_dim=kwargs.get("marginalize_dim"),
         match_right_most_batch_dim=kwargs.get("match_right_most_batch_dim", False),
+        cache_root=kwargs.get("cache_root", True),
     )
 
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/botorch/pull/990

In NEI and NEHVI, we sample from the posterior of f(X_baseline, X) repeatedly for different X, but the same X_baseline. We can make the sampling more efficient by caching the cholesky decomposition for the posterior covariance matrix of f(X_baseline) and then only compute the bottom q new rows of the cholesky of the posterior covariance matrix f(X_baseline, X).

Using the cached cholesky is probably more important for NEHVI than NEI the pruned X_baseline for NEHVI will often be quite a bit larger than the pruned X_baseline for NEI.

Differential Revision: D25804787

