### PR TITLE
Remove unnecessary method from MOOModelBridge.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,8 +48,11 @@ jobs:
       with:
         python-version: 3.7
     - name: Install dependencies
+      # Pin ufmt deps so they match intermal pyfmt.
       run: |
         pip install black==21.4b2
+        pip install usort==0.6.4
+        pip install libcst==0.3.19
         pip install ufmt
         pip install flake8
     - name: ufmt

--- a/ax/modelbridge/multi_objective_torch.py
+++ b/ax/modelbridge/multi_objective_torch.py
@@ -194,25 +194,6 @@ class MultiObjectiveTorchModelBridge(TorchModelBridge):
             candidate_metadata,
         )
 
-    def _transform_data(
-        self,
-        obs_feats: List[ObservationFeatures],
-        obs_data: List[ObservationData],
-        search_space: SearchSpace,
-        transforms: Optional[List[Type[Transform]]],
-        transform_configs: Optional[Dict[str, TConfig]],
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData], SearchSpace]:
-        """Initialize transforms and apply them to provided data."""
-        # Run superclass version to fit transforms to observations
-        obs_feats, obs_data, search_space = super()._transform_data(
-            obs_feats=obs_feats,
-            obs_data=obs_data,
-            search_space=search_space,
-            transforms=transforms,
-            transform_configs=transform_configs,
-        )
-        return obs_feats, obs_data, search_space
-
     @copy_doc(TorchModelBridge.gen)
     def gen(
         self,


### PR DESCRIPTION
Summary: `_trasform_data` just delegates to the super so the override is not necessary.

Differential Revision: D33238305

