### PR TITLE
RFC: Pin ufmt dep versions to match internal ones.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,8 +48,11 @@ jobs:
       with:
         python-version: 3.7
     - name: Install dependencies
+      # Pin ufmt deps so they match intermal pyfmt.
       run: |
         pip install black==21.4b2
+        pip install usort==0.6.4
+        pip install libcst==0.3.19
         pip install ufmt
         pip install flake8
     - name: ufmt


### PR DESCRIPTION
Summary:
Our current deps are out of date which is causing ufmt checks to fail
externally.

Not sure if this is the best way or if the team has some other way of handling
version mismatches.

Differential Revision: D33240894

