### PR TITLE
Scheduler + MapMetric test case that somewhat resembles IGML setup

### DIFF
--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -94,7 +94,14 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         for i in range(5):
             trial = exp.new_trial().add_arm(arm=get_branin_arms(n=1, seed=i)[0])
             trial.run()
+
+        for _ in range(3):
+            # each time we call fetch, we grab another timestamp
+            exp.fetch_data()
+
+        for i in range(5):
             # only mark the first 4 complete
+            trial = exp.trials[i]
             if i < 4:
                 trial.mark_as(status=TrialStatus.COMPLETED)
 
@@ -183,6 +190,12 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         for i in range(5):
             trial = exp.new_trial().add_arm(arm=get_branin_arms(n=1, seed=i)[0])
             trial.run()
+
+        for _ in range(3):
+            # each time we call fetch, we grab another timestamp
+            exp.fetch_data()
+
+        for trial in exp.trials.values():
             trial.mark_as(status=TrialStatus.COMPLETED)
 
         # manually "unalign" timestamps to simulate real-world scenario
@@ -191,7 +204,7 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
 
         unaligned_timestamps = [0, 1, 4, 1, 2, 3, 1, 3, 4, 0, 1, 2, 0, 2, 4]
         data.map_df.loc[
-            data.map_df["metric_name"] == "branin", "timestamp"
+            data.map_df["metric_name"] == "branin_map", "timestamp"
         ] = unaligned_timestamps
         exp.attach_data(data=data)
 
@@ -227,6 +240,12 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         for i in range(5):
             trial = exp.new_trial().add_arm(arm=get_branin_arms(n=1, seed=i)[0])
             trial.run()
+
+        for _ in range(3):
+            # each time we call fetch, we grab another timestamp
+            exp.fetch_data()
+
+        for trial in exp.trials.values():
             trial.mark_as(status=TrialStatus.COMPLETED)
 
         # manually "unalign" timestamps to simulate real-world scenario
@@ -235,11 +254,11 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
 
         unaligned_timestamps = [0, 1, 4, 1, 2, 3, 1, 3, 4, 0, 1, 2, 0, 2, 4]
         data.map_df.loc[
-            data.map_df["metric_name"] == "branin", "timestamp"
+            data.map_df["metric_name"] == "branin_map", "timestamp"
         ] = unaligned_timestamps
         # manually remove timestamps 1 and 2 for arm 3
         data.map_df.drop(
-            [22, 23], inplace=True
+            [15, 16], inplace=True
         )  # TODO this wont work once we make map_df immutable (which we should)
         exp.attach_data(data=data)
 
@@ -278,6 +297,13 @@ class TestThresholdEarlyStoppingStrategy(TestCase):
         for i in range(5):
             trial = exp.new_trial().add_arm(arm=get_branin_arms(n=1, seed=i)[0])
             trial.run()
+
+        for _ in range(3):
+            # each time we call fetch, we grab another timestamp
+            exp.fetch_data()
+
+        for trial in exp.trials.values():
+            trial.mark_as(status=TrialStatus.COMPLETED)
 
         exp.attach_data(data=exp.fetch_data())
 
@@ -345,9 +371,9 @@ def _evaluate_early_stopping_with_df(
     metric_to_aligned_means, _ = align_partial_results(
         df=df,
         progr_key="timestamp",
-        metrics=["branin"],
+        metrics=["branin_map"],
     )
-    aligned_means = metric_to_aligned_means["branin"]
+    aligned_means = metric_to_aligned_means["branin_map"]
     decisions = {
         trial_index: early_stopping_strategy.should_stop_trial_early(
             trial_index=trial_index,

--- a/ax/metrics/noisy_function_map.py
+++ b/ax/metrics/noisy_function_map.py
@@ -100,23 +100,6 @@ class NoisyFunctionMapMetric(MapMetric):
 
         return MapData(df=df, map_key_infos=self.map_key_infos)
 
-    def _cached_f(self, x: np.ndarray, noisy: bool) -> Mapping[str, Any]:
-        noise_sd = self.noise_sd if noisy else 0.0
-        x_tuple = tuple(x)  # works since x is 1-d array
-
-        if not self.cache_evaluations:
-            res = {**self.f(x)}
-            res["mean"] += np.random.randn() * noise_sd
-            return res
-
-        if x_tuple in self.cache:
-            return self.cache[x_tuple]
-
-        res = {**self.f(x)}
-        res["mean"] += np.random.randn() * noise_sd
-        self.cache[x_tuple] = res
-        return res
-
     def f(self, x: np.ndarray) -> Mapping[str, Any]:
         """The deterministic function that produces the metric outcomes."""
         raise NotImplementedError

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -275,13 +275,13 @@ class ReportUtilsTest(TestCase):
         plots = get_standard_plots(
             experiment=exp,
             model=Models.BOTORCH(experiment=exp, data=exp.fetch_data()),
-            true_objective_metric_name="b",
+            true_objective_metric_name="branin",
         )
 
         self.assertEqual(len(plots), 9)
         self.assertTrue(all(isinstance(plot, go.Figure) for plot in plots))
         self.assertIn(
-            "Objective branin vs. True Objective Metric b",
+            "Objective branin_map vs. True Objective Metric branin",
             [p.layout.title.text for p in plots],
         )
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -171,7 +171,6 @@ def get_branin_experiment(
 def get_branin_experiment_with_timestamp_map_metric(
     with_status_quo: bool = False,
     rate: Optional[float] = None,
-    incremental: Optional[bool] = False,
 ) -> Experiment:
     exp = Experiment(
         name="branin_with_timestamp_map_metric",
@@ -179,12 +178,12 @@ def get_branin_experiment_with_timestamp_map_metric(
         optimization_config=OptimizationConfig(
             objective=Objective(
                 metric=BraninTimestampMapMetric(
-                    name="branin", param_names=["x1", "x2"], rate=rate
+                    name="branin_map", param_names=["x1", "x2"], rate=rate
                 ),
                 minimize=True,
             )
         ),
-        tracking_metrics=[BraninTimestampMapMetric(name="b", param_names=["x1", "x2"])],
+        tracking_metrics=[BraninMetric(name="branin", param_names=["x1", "x2"])],
         runner=SyntheticRunner(),
         default_data_type=DataType.MAP_DATA,
     )


### PR DESCRIPTION
Summary:
We didn't have any unit tests in our codebase that came close to mimicking the behavior of an IGML early stopping run. The behavior we want is:
* A unit test that uses the Scheduler + EarlyStoppingStrategy
* An experiment with two metrics: a MapMetric and non-MapMetric
* The MapMetric should report incrementally increasing partial results, starting with t = 1, then t = 1.. n, then t = 1 ... n+1, etc

I've made several adjustments so that `test_scheduler_with_odd_index_early_stopping_strategy` in `test_scheduler.py` should now have these desired properties. This should enable better testing of all subsequent diffs in this stack!

Differential Revision: D33279696

