### PR TITLE
Move untransform_objective_thresholds into Transform.

### DIFF
--- a/ax/modelbridge/tests/test_torch_modelbridge_moo.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge_moo.py
@@ -490,8 +490,6 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             self.assertTrue(
                 torch.equal(ckwargs["objective_weights"], expected_obj_weights)
             )
-            self.assertEqual(ckwargs["bounds"], [(0.0, 1.0), (0.0, 1.0)])
-            self.assertEqual(ckwargs["fixed_features"], {0: 1.0 / 3.0})
         self.assertEqual(obj_thresholds[0].metric.name, "branin_a")
         self.assertEqual(obj_thresholds[1].metric.name, "branin_b")
         self.assertEqual(obj_thresholds[0].op, ComparisonOp.LEQ)
@@ -561,8 +559,6 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             ckwargs = mock_model_infer_obj_t.call_args[1]
             self.assertEqual(ckwargs["fixed_features"], {2: 1.0})
             mock_untransform_objective_thresholds.assert_called_once()
-            ckwargs = mock_untransform_objective_thresholds.call_args[1]
-            self.assertEqual(ckwargs["fixed_features"], {2: 1.0})
         self.assertEqual(obj_thresholds[0].metric.name, "branin_a")
         self.assertEqual(obj_thresholds[1].metric.name, "branin_b")
         self.assertEqual(obj_thresholds[0].op, ComparisonOp.GEQ)

--- a/ax/modelbridge/transforms/base.py
+++ b/ax/modelbridge/transforms/base.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
+import numpy as np
 from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
+from ax.core.outcome_constraint import ObjectiveThreshold
 from ax.core.search_space import SearchSpace
 from ax.core.types import TConfig
 
@@ -170,3 +172,46 @@ class Transform:
         Returns: observation data in original space.
         """
         return observation_data
+
+    def untransform_objective_thresholds(
+        self,
+        objective_thresholds: List[ObjectiveThreshold],
+        observation_features: List[ObservationFeatures],
+    ) -> List[ObjectiveThreshold]:
+        """Untransforms objective thresholds.
+
+        By default, we untransform objective thresholds in the same way as the
+        observation data.
+
+        Args:
+            objective_thresholds: Objective thresholds in transformed space.
+            observation_features: Observation features in transformed space. Required
+                to correctly untransform thresholds for stratified observation data.
+        """
+        # Create dummy ObservationData from objective_thresholds so we can easily
+        # untransform them using the existing Transform methods.
+        means = np.array([t.bound for t in objective_thresholds])
+        metric_names = [t.metric.name for t in objective_thresholds]
+        observation_data = [
+            ObservationData(
+                means=means,
+                metric_names=metric_names,
+                covariance=np.zeros((len(metric_names), len(metric_names))),
+            )
+        ]
+        observation_data = self.untransform_observation_data(
+            observation_data, observation_features
+        )[0]
+
+        untransformed_thresholds = []
+        for threshold, bound in zip(objective_thresholds, observation_data.means):
+            if not np.isnan(bound):
+                untransformed_thresholds.append(
+                    ObjectiveThreshold(
+                        metric=threshold.metric,
+                        bound=bound,
+                        relative=False,
+                        op=threshold.op,
+                    )
+                )
+        return untransformed_thresholds


### PR DESCRIPTION
Summary:
`TorchModelBridge` does some hacky things to untransform objective thresholds using the existing transform APIs. Move this logic into `Transform` and remove some of the hackiness.

There's still some weird coupling where `untransform_objective_thresholds` requires dummy `objective_features` to be passed in because they might be required by downstream transforms. Unfortunately, right now users need to manually ensure `observation_features` are in the same space as the `objective_thresholds` when calling `transform`.

Differential Revision: D33796091

