### PR TITLE
Update default_data_type on tracking metric addition

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -311,14 +311,11 @@ class Experiment(Base):
                 self.remove_tracking_metric(metric_name)
         self._optimization_config = optimization_config
 
-        self._default_data_type = (
-            DataType.MAP_DATA
-            if any(
-                isinstance(metric, MapMetric)
-                for metric in optimization_config.metrics.values()
-            )
-            else DataType.DATA
-        )
+        if any(
+            isinstance(metric, MapMetric)
+            for metric in optimization_config.metrics.values()
+        ):
+            self._default_data_type = DataType.MAP_DATA
 
     @property
     def data_by_trial(self) -> Dict[int, OrderedDict]:
@@ -366,6 +363,9 @@ class Experiment(Base):
                 "OptimizationConfig. Set a new OptimizationConfig without this metric "
                 "before adding it to tracking metrics."
             )
+
+        if isinstance(metric, MapMetric):
+            self._default_data_type = DataType.MAP_DATA
 
         self._tracking_metrics[metric.name] = metric
         return self


### PR DESCRIPTION
Summary:
A user was running into a bug loading their vanilla Data experiment after adding a tracking metric that used MapData. This was because the default_data_type gets used as a constructor in data reconstruction during loading, and calling Data(map_df) was resulting in an extra_columns error.

With this fix, the experiment will update its default_data_type properly on calls to add_tracking_metric, thus fixing loading.

I've also fixed some logic for doing the same updating on the optimization_config setter.

Reviewed By: ldworkin

Differential Revision: D33892321

