### PR TITLE
Adding ELI5 video to the home page

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -190,6 +190,29 @@ class Index extends React.Component {
         </Block>
       </div>
     );
+          
+    const VideoContainer = () => {
+      return (
+        <div className="container text--center margin-bottom--xl">
+          <div className="row">
+            <div className="col" style={{textAlign: 'center'}}>
+              <h2>Check it out in the intro video</h2>
+              <div>
+                <iframe
+                  width="560"
+                  height="315"
+                  src="https://www.youtube.com/embed/L1IPnaKjIWg"
+                  title="Explain Like I'm 5: Ax"
+                  frameBorder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
 
     const Showcase = () => {
       if ((siteConfig.users || []).length === 0) {
@@ -224,6 +247,7 @@ class Index extends React.Component {
       <div>
         <HomeSplash siteConfig={siteConfig} language={language} />
         <div className="landingPage mainContainer">
+          <VideoContainer />
           <Features />
           <QuickStart />
         </div>


### PR DESCRIPTION
## Summary

Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/12485205/154572824-bf05f10a-f8e1-406c-aeb6-de464a3b74ba.png">
