### PR TITLE
Don't require any inputs other than `observation_features` in `ModelBridge.evaluate_acquisition_function`

### DIFF
--- a/ax/modelbridge/array.py
+++ b/ax/modelbridge/array.py
@@ -483,8 +483,8 @@ class ArrayModelBridge(ModelBridge):
     def _evaluate_acquisition_function(
         self,
         observation_features: List[ObservationFeatures],
-        search_space_digest: SearchSpaceDigest,
-        objective_weights: np.ndarray,
+        search_space: SearchSpace,
+        optimization_config: OptimizationConfig,
         objective_thresholds: Optional[np.ndarray] = None,
         outcome_constraints: Optional[Tuple[np.ndarray, np.ndarray]] = None,
         linear_constraints: Optional[Tuple[np.ndarray, np.ndarray]] = None,
@@ -492,6 +492,12 @@ class ArrayModelBridge(ModelBridge):
         pending_observations: Optional[List[np.ndarray]] = None,
         acq_options: Optional[Dict[str, Any]] = None,
     ) -> List[float]:
+        search_space_digest = extract_search_space_digest(
+            search_space=search_space, param_names=self.parameters
+        )
+        objective_weights = extract_objective_weights(
+            objective=optimization_config.objective, outcomes=self.outcomes
+        )
         return self._model_evaluate_acquisition_function(
             X=observation_features_to_array(self.parameters, observation_features),
             search_space_digest=search_space_digest,

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -86,7 +86,7 @@ def extract_parameter_constraints(
 def extract_search_space_digest(
     search_space: SearchSpace, param_names: List[str]
 ) -> SearchSpaceDigest:
-    """Extract basic parameter prpoerties from a search space."""
+    """Extract basic parameter properties from a search space."""
     bounds: List[Tuple[Union[int, float], Union[int, float]]] = []
     ordinal_features: List[int] = []
     categorical_features: List[int] = []


### PR DESCRIPTION
Summary:
Change the signatures of `ModelBridge.evaluate_acquisition_function` and `ModelBridge._evaluate_acquisition_function` to accept a SearchSpace and an OptimizationConfig (instead of SearchSpaceDigest and objective_weights). The arguments are required for the private method and are optional for the public method.

See the linked task for more details.

Differential Revision: D34316208

