### PR TITLE
Fix human_in_the_loop tutorial on the website

### DIFF
--- a/tutorials/human_in_the_loop/human_in_the_loop.ipynb
+++ b/tutorials/human_in_the_loop/human_in_the_loop.ipynb
@@ -133,7 +133,6 @@
         "from ax.modelbridge.factory import get_GPEI\n",
         "from ax.plot.diagnostic import tile_cross_validation\n",
         "from ax.plot.scatter import plot_multiple_metrics, tile_fitted\n",
-        "from ax.storage.json_store.registry import DEPRECATED_DECODER_REGISTRY, DEPRECATED_CLASS_DECODER_REGISTRY\n",
         "from ax.utils.notebook.plotting import render, init_notebook_plotting\n",
         "\n",
         "import pandas as pd\n",
@@ -147,7 +146,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "experiment = json_load.load_experiment('hitl_exp.json', DEPRECATED_DECODER_REGISTRY, DEPRECATED_CLASS_DECODER_REGISTRY)"
+        "experiment = json_load.load_experiment('hitl_exp.json')"
       ]
     },
     {


### PR DESCRIPTION
Summary: This tutorial had a load_experiment call that needed to be changed after the metric/runner registry changes went through. Now, the propper json encoders (the CORE encoders) get passed in by default.

Reviewed By: EugenHotaj

Differential Revision: D34347491

