### PR TITLE
Use Scheduler.best_point in param_sweep_scheduler

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -21,6 +21,7 @@ from ax.core.experiment import DataType, Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.objective import MultiObjective, Objective
 from ax.core.observation import ObservationFeatures
+from ax.core.optimization_config import OptimizationConfig
 from ax.core.trial import Trial
 from ax.core.types import (
     TModelPredictArm,
@@ -1150,7 +1151,9 @@ class AxClient(WithDBSettingsBase, BestPointMixin):
 
     @copy_doc(BestPointMixin.get_best_trial)
     def get_best_trial(
-        self, use_model_predictions: bool = True
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        use_model_predictions: bool = True,
     ) -> Optional[Tuple[int, TParameterization, Optional[TModelPredictArm]]]:
         return self._get_best_trial(
             experiment=self.experiment,
@@ -1160,7 +1163,9 @@ class AxClient(WithDBSettingsBase, BestPointMixin):
 
     @copy_doc(BestPointMixin.get_best_parameters)
     def get_best_parameters(
-        self, use_model_predictions: bool = True
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        use_model_predictions: bool = True,
     ) -> Optional[Tuple[TParameterization, Optional[TModelPredictArm]]]:
         return self._get_best_parameters(
             experiment=self.experiment,
@@ -1170,7 +1175,9 @@ class AxClient(WithDBSettingsBase, BestPointMixin):
 
     @copy_doc(BestPointMixin.get_pareto_optimal_parameters)
     def get_pareto_optimal_parameters(
-        self, use_model_predictions: bool = True
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        use_model_predictions: bool = True,
     ) -> Optional[Dict[int, Tuple[TParameterization, TModelPredictArm]]]:
         return self._get_pareto_optimal_parameters(
             experiment=self.experiment,

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -34,6 +34,7 @@ from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.observation import ObservationFeatures
+from ax.core.optimization_config import OptimizationConfig
 from ax.core.runner import Runner
 from ax.core.trial import Trial
 from ax.core.types import TModelPredictArm, TParameterization
@@ -508,7 +509,9 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
 
     @copy_doc(BestPointMixin.get_best_trial)
     def get_best_trial(
-        self, use_model_predictions: bool = True
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        use_model_predictions: bool = True,
     ) -> Optional[Tuple[int, TParameterization, Optional[TModelPredictArm]]]:
         return self._get_best_trial(
             experiment=self.experiment,
@@ -518,7 +521,9 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
 
     @copy_doc(BestPointMixin.get_best_parameters)
     def get_best_parameters(
-        self, use_model_predictions: bool = True
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        use_model_predictions: bool = True,
     ) -> Optional[Tuple[TParameterization, Optional[TModelPredictArm]]]:
         return self._get_best_parameters(
             experiment=self.experiment,
@@ -528,7 +533,9 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
 
     @copy_doc(BestPointMixin.get_pareto_optimal_parameters)
     def get_pareto_optimal_parameters(
-        self, use_model_predictions: bool = True
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        use_model_predictions: bool = True,
     ) -> Optional[Dict[int, Tuple[TParameterization, TModelPredictArm]]]:
         return self._get_pareto_optimal_parameters(
             experiment=self.experiment,

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -57,29 +57,30 @@ def get_best_raw_objective_point_with_trial_index(
 
     Args:
         experiment: Experiment, on which to identify best raw objective arm.
-        optimization_config: Optimization config to use in absence or in place of
-            the one stored on the experiment.
+        optimization_config: Optimization config to use in place of the one stored
+        on the experiment.
 
     Returns:
         Tuple of parameterization and a mapping from metric name to a tuple of
             the corresponding objective mean and SEM.
     """
-    # pyre-ignore [16]
-    if isinstance(experiment.optimization_config.objective, MultiObjective):
+    optimization_config = optimization_config or experiment.optimization_config
+    if optimization_config is None:
+        raise ValueError(
+            "Cannot identify the best point without an optimization config, but no "
+            "optimization config was provided on the experiment or as an argument."
+        )
+    if isinstance(optimization_config.objective, MultiObjective):
         logger.warning(
             "get_best_raw_objective_point is deprecated for multi-objective "
             "optimization. This method will return an arbitrary point on the "
             "pareto frontier."
         )
-    opt_config = optimization_config or experiment.optimization_config
-    assert opt_config is not None, (
-        "Cannot identify the best point without an optimization config, but no "
-        "optimization config was provided on the experiment or as an argument."
-    )
+
     dat = experiment.fetch_data()
     if dat.df.empty:
         raise ValueError("Cannot identify best point if experiment contains no data.")
-    objective = opt_config.objective
+    objective = optimization_config.objective
     if isinstance(objective, ScalarizedObjective):
         best_row = _get_best_row_for_scalarized_objective(
             df=dat.df, objective=objective
@@ -87,7 +88,7 @@ def get_best_raw_objective_point_with_trial_index(
     else:
         best_row = _get_best_feasible_row_for_single_objective(
             df=dat.df,
-            optimization_config=opt_config,
+            optimization_config=optimization_config,
             status_quo=experiment.status_quo,
         )
     best_arm = experiment.arms_by_name[best_row["arm_name"]]
@@ -138,7 +139,9 @@ def _raw_values_to_model_predict_arm(
 
 
 def get_best_parameters_from_model_predictions_with_trial_index(
-    experiment: Experiment, models_enum: Type[ModelRegistryBase]
+    experiment: Experiment,
+    models_enum: Type[ModelRegistryBase],
+    optimization_config: Optional[OptimizationConfig] = None,
 ) -> Optional[Tuple[int, TParameterization, Optional[TModelPredictArm]]]:
     """Given an experiment, returns the best predicted parameterization and corresponding
     prediction based on the most recent Trial with predictions. If no trials have
@@ -151,12 +154,21 @@ def get_best_parameters_from_model_predictions_with_trial_index(
 
     Args:
         experiment: Experiment, on which to identify best raw objective arm.
+        models_enum: Registry of all models that may be in the experiment's
+            generation strategy.
+        optimization_config: Optimization config to use in place of the one stored
+            on the experiment.
 
     Returns:
         Tuple of trial index, parameterization, and model predictions for it.
     """
-    # pyre-ignore [16]
-    if isinstance(experiment.optimization_config.objective, MultiObjective):
+    optimization_config = optimization_config or experiment.optimization_config
+    if optimization_config is None:
+        raise ValueError(
+            "Cannot identify the best point without an optimization config, but no "
+            "optimization config was provided on the experiment or as an argument."
+        )
+    if isinstance(optimization_config.objective, MultiObjective):
         logger.warning(
             "get_best_parameters_from_model_predictions is deprecated for "
             "multi-objective optimization configs. This method will return an "
@@ -195,7 +207,7 @@ def get_best_parameters_from_model_predictions_with_trial_index(
             cv_results = cross_validate(model=model)
             diagnostics = compute_diagnostics(result=cv_results)
             assess_model_fit_results = assess_model_fit(diagnostics=diagnostics)
-            objective_name = experiment.optimization_config.objective.metric.name
+            objective_name = optimization_config.objective.metric.name
             # If model fit is bad use raw results
             if (
                 objective_name
@@ -212,7 +224,9 @@ def get_best_parameters_from_model_predictions_with_trial_index(
                         + "results carefully."
                     )
 
-                return get_best_by_raw_objective_with_trial_index(experiment=experiment)
+                return get_best_by_raw_objective_with_trial_index(
+                    experiment=experiment, optimization_config=optimization_config
+                )
 
             res = model.model_best_point()
             if res is None:
@@ -239,6 +253,10 @@ def get_best_parameters_from_model_predictions(
 
     Args:
         experiment: Experiment, on which to identify best raw objective arm.
+        models_enum: Registry of all models that may be in the experiment's
+            generation strategy.
+        optimization_config: Optimization config to use in place of the one stored
+            on the experiment.
 
     Returns:
         Tuple of parameterization and model predictions for it.
@@ -257,6 +275,7 @@ def get_best_parameters_from_model_predictions(
 
 def get_best_by_raw_objective_with_trial_index(
     experiment: Experiment,
+    optimization_config: Optional[OptimizationConfig] = None,
 ) -> Optional[Tuple[int, TParameterization, Optional[TModelPredictArm]]]:
     """Given an experiment, identifies the arm that had the best raw objective,
     based on the data fetched from the experiment.
@@ -266,6 +285,8 @@ def get_best_by_raw_objective_with_trial_index(
 
     Args:
         experiment: Experiment, on which to identify best raw objective arm.
+        optimization_config: Optimization config to use in place of the one stored
+            on the experiment.
 
     Returns:
         Tuple of trial index, parameterization, and model predictions for it.
@@ -275,7 +296,9 @@ def get_best_by_raw_objective_with_trial_index(
             trial_index,
             parameterization,
             values,
-        ) = get_best_raw_objective_point_with_trial_index(experiment=experiment)
+        ) = get_best_raw_objective_point_with_trial_index(
+            experiment=experiment, optimization_config=optimization_config
+        )
     except ValueError as err:
         logger.error(
             f"Encountered error while trying to identify the best point: {err}"
@@ -290,6 +313,7 @@ def get_best_by_raw_objective_with_trial_index(
 
 def get_best_by_raw_objective(
     experiment: Experiment,
+    optimization_config: Optional[OptimizationConfig] = None,
 ) -> Optional[Tuple[TParameterization, Optional[TModelPredictArm]]]:
     """Given an experiment, identifies the arm that had the best raw objective,
     based on the data fetched from the experiment.
@@ -299,11 +323,15 @@ def get_best_by_raw_objective(
 
     Args:
         experiment: Experiment, on which to identify best raw objective arm.
+        optimization_config: Optimization config to use in place of the one stored
+            on the experiment.
 
     Returns:
         Tuple of parameterization, and model predictions for it.
     """
-    res = get_best_by_raw_objective_with_trial_index(experiment=experiment)
+    res = get_best_by_raw_objective_with_trial_index(
+        experiment=experiment, optimization_config=optimization_config
+    )
 
     if res is None:
         return None
@@ -315,6 +343,7 @@ def get_best_by_raw_objective(
 def get_best_parameters_with_trial_index(
     experiment: Experiment,
     models_enum: Type[ModelRegistryBase],
+    optimization_config: Optional[OptimizationConfig] = None,
 ) -> Optional[Tuple[int, TParameterization, Optional[TModelPredictArm]]]:
     """Given an experiment, identifies the best arm.
 
@@ -327,12 +356,22 @@ def get_best_parameters_with_trial_index(
 
     Args:
         experiment: Experiment, on which to identify best raw objective arm.
+        models_enum: Registry of all models that may be in the experiment's
+            generation strategy.
+        optimization_config: Optimization config to use in place of the one stored
+            on the experiment.
 
     Returns:
         Tuple of trial index, parameterization, and model predictions for it.
     """
-    # pyre-ignore [16]
-    if isinstance(experiment.optimization_config.objective, MultiObjective):
+    optimization_config = optimization_config or experiment.optimization_config
+    if optimization_config is None:
+        raise ValueError(
+            "Cannot identify the best point without an optimization config, but no "
+            "optimization config was provided on the experiment or as an argument."
+        )
+
+    if isinstance(optimization_config.objective, MultiObjective):
         logger.warning(
             "get_best_parameters is deprecated for multi-objective optimization. "
             "This method will return an arbitrary point on the pareto frontier."
@@ -340,18 +379,23 @@ def get_best_parameters_with_trial_index(
 
     # Find latest trial which has a generator_run attached and get its predictions
     res = get_best_parameters_from_model_predictions_with_trial_index(
-        experiment=experiment, models_enum=models_enum
+        experiment=experiment,
+        models_enum=models_enum,
+        optimization_config=optimization_config,
     )
 
     if res is not None:
         return res
 
-    return get_best_by_raw_objective_with_trial_index(experiment=experiment)
+    return get_best_by_raw_objective_with_trial_index(
+        experiment=experiment, optimization_config=optimization_config
+    )
 
 
 def get_best_parameters(
     experiment: Experiment,
     models_enum: Type[ModelRegistryBase],
+    optimization_config: Optional[OptimizationConfig] = None,
 ) -> Optional[Tuple[TParameterization, Optional[TModelPredictArm]]]:
     """Given an experiment, identifies the best arm.
 
@@ -364,6 +408,10 @@ def get_best_parameters(
 
     Args:
         experiment: Experiment, on which to identify best raw objective arm.
+        models_enum: Registry of all models that may be in the experiment's
+            generation strategy.
+        optimization_config: Optimization config to use in place of the one stored
+            on the experiment.
 
     Returns:
         Tuple of parameterization and model predictions for it.
@@ -371,6 +419,7 @@ def get_best_parameters(
     res = get_best_parameters_with_trial_index(
         experiment=experiment,
         models_enum=models_enum,
+        optimization_config=optimization_config,
     )
 
     if res is None:
@@ -383,6 +432,7 @@ def get_best_parameters(
 def get_pareto_optimal_parameters(
     experiment: Experiment,
     generation_strategy: GenerationStrategy,
+    optimization_config: Optional[OptimizationConfig] = None,
     use_model_predictions: bool = True,
 ) -> Optional[Dict[int, Tuple[TParameterization, TModelPredictArm]]]:
     """Identifies the best parameterizations tried in the experiment so far,
@@ -399,6 +449,8 @@ def get_pareto_optimal_parameters(
     Args:
         experiment: Experiment, from which to find Pareto-optimal arms.
         generation_strategy: Generation strategy containing the modelbridge.
+        optimization_config: Optimization config to use in place of the one stored
+            on the experiment.
         use_model_predictions: Whether to extract the Pareto frontier using
             model predictions or directly observed values. If ``True``,
             the metric means and covariances in this method's output will
@@ -413,15 +465,22 @@ def get_pareto_optimal_parameters(
             (model-predicted if ``use_model_predictions=True`` and observed
             otherwise).
     """
+    optimization_config = optimization_config or experiment.optimization_config
+    if optimization_config is None:
+        raise ValueError(
+            "Cannot identify the best point without an optimization config, but no "
+            "optimization config was provided on the experiment or as an argument."
+        )
+
     # Validate aspects of the experiment: that it is a MOO experiment and
     # that the current model can be used to produce the Pareto frontier.
-    if not not_none(experiment.optimization_config).is_moo_problem:
+    if not optimization_config.is_moo_problem:
         raise UnsupportedError(
             "Please use `get_best_parameters` for single-objective problems."
         )
 
     moo_optimization_config = checked_cast(
-        MultiObjectiveOptimizationConfig, experiment.optimization_config
+        MultiObjectiveOptimizationConfig, optimization_config
     )
     if moo_optimization_config.outcome_constraints:
         # TODO[drfreund]: Test this flow and remove error.
@@ -454,7 +513,7 @@ def get_pareto_optimal_parameters(
             objective_thresholds_override = lgr.gen_metadata["objective_thresholds"]
         objective_thresholds_override = modelbridge.infer_objective_thresholds(
             search_space=experiment.search_space,
-            optimization_config=experiment.optimization_config,
+            optimization_config=optimization_config,
             fixed_features=None,
         )
         logger.info(

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -8,6 +8,7 @@ from abc import abstractmethod, ABCMeta
 from typing import Dict, Tuple, Optional
 
 from ax.core.experiment import Experiment
+from ax.core.optimization_config import OptimizationConfig
 from ax.core.types import TModelPredictArm, TParameterization
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.registry import ModelRegistryBase
@@ -18,7 +19,9 @@ from ax.utils.common.typeutils import not_none
 class BestPointMixin(metaclass=ABCMeta):
     @abstractmethod
     def get_best_trial(
-        self, use_model_predictions: bool = True
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        use_model_predictions: bool = True,
     ) -> Optional[Tuple[int, TParameterization, Optional[TModelPredictArm]]]:
         """Identifies the best parameterization tried in the experiment so far.
 
@@ -30,6 +33,8 @@ class BestPointMixin(metaclass=ABCMeta):
             ({metric_name: mean}, {metric_name_1: {metric_name_2: cov_1_2}})
 
         Args:
+            optimization_config: Optimization config to use in place of the one stored
+                on the experiment.
             use_model_predictions: Whether to extract the best point using
                 model predictions or directly observed values. If ``True``,
                 the metric means and covariances in this method's output will
@@ -43,7 +48,9 @@ class BestPointMixin(metaclass=ABCMeta):
 
     @abstractmethod
     def get_best_parameters(
-        self, use_model_predictions: bool = True
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        use_model_predictions: bool = True,
     ) -> Optional[Tuple[TParameterization, Optional[TModelPredictArm]]]:
         """Identifies the best parameterization tried in the experiment so far.
 
@@ -55,6 +62,8 @@ class BestPointMixin(metaclass=ABCMeta):
             ({metric_name: mean}, {metric_name_1: {metric_name_2: cov_1_2}})
 
         Args:
+            optimization_config: Optimization config to use in place of the one stored
+                on the experiment.
             use_model_predictions: Whether to extract the best point using
                 model predictions or directly observed values. If ``True``,
                 the metric means and covariances in this method's output will
@@ -68,7 +77,9 @@ class BestPointMixin(metaclass=ABCMeta):
 
     @abstractmethod
     def get_pareto_optimal_parameters(
-        self, use_model_predictions: bool = True
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        use_model_predictions: bool = True,
     ) -> Optional[Dict[int, Tuple[TParameterization, TModelPredictArm]]]:
         """Identifies the best parameterizations tried in the experiment so far,
         using model predictions if ``use_model_predictions`` is true and using
@@ -82,6 +93,8 @@ class BestPointMixin(metaclass=ABCMeta):
         { one_metric_name --> { another_metric_name: covariance } }.
 
         Args:
+            optimization_config: Optimization config to use in place of the one stored
+                on the experiment.
             use_model_predictions: Whether to extract the Pareto frontier using
                 model predictions or directly observed values. If ``True``,
                 the metric means and covariances in this method's output will
@@ -102,6 +115,7 @@ class BestPointMixin(metaclass=ABCMeta):
     def _get_best_trial(
         experiment: Experiment,
         generation_strategy: GenerationStrategy,
+        optimization_config: Optional[OptimizationConfig] = None,
         use_model_predictions: bool = True,
     ) -> Optional[Tuple[int, TParameterization, Optional[TModelPredictArm]]]:
         if not_none(experiment.optimization_config).is_moo_problem:
@@ -124,23 +138,25 @@ class BestPointMixin(metaclass=ABCMeta):
             )
 
             if models_enum is not None:
-
                 res = best_point_utils.get_best_parameters_from_model_predictions_with_trial_index(  # noqa
                     experiment=experiment,
                     models_enum=models_enum,
+                    optimization_config=optimization_config,
                 )
 
                 if res is not None:
                     return res  # pragma: no cover
 
         return best_point_utils.get_best_by_raw_objective_with_trial_index(
-            experiment=experiment
+            experiment=experiment,
+            optimization_config=optimization_config,
         )
 
     @staticmethod
     def _get_best_parameters(
         experiment: Experiment,
         generation_strategy: GenerationStrategy,
+        optimization_config: Optional[OptimizationConfig] = None,
         use_model_predictions: bool = True,
     ) -> Optional[Tuple[TParameterization, Optional[TModelPredictArm]]]:
         if not_none(experiment.optimization_config).is_moo_problem:
@@ -152,6 +168,7 @@ class BestPointMixin(metaclass=ABCMeta):
         res = BestPointMixin._get_best_trial(
             experiment=experiment,
             generation_strategy=generation_strategy,
+            optimization_config=optimization_config,
             use_model_predictions=use_model_predictions,
         )
 
@@ -165,6 +182,7 @@ class BestPointMixin(metaclass=ABCMeta):
     def _get_pareto_optimal_parameters(
         experiment: Experiment,
         generation_strategy: GenerationStrategy,
+        optimization_config: Optional[OptimizationConfig] = None,
         use_model_predictions: bool = True,
     ) -> Optional[Dict[int, Tuple[TParameterization, TModelPredictArm]]]:
         if not not_none(experiment.optimization_config).is_moo_problem:
@@ -174,5 +192,6 @@ class BestPointMixin(metaclass=ABCMeta):
         return best_point_utils.get_pareto_optimal_parameters(
             experiment=experiment,
             generation_strategy=generation_strategy,
+            optimization_config=optimization_config,
             use_model_predictions=use_model_predictions,
         )

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -558,7 +558,9 @@ def get_best_trial(
     true_objective_minimize: Optional[bool] = None,
     **kwargs: Any,
 ) -> Optional[pd.DataFrame]:
-    """Finds the optimal trial given an experiment, based on raw objective value.
+    """DEPRECATED! Please use Scheduler.get_best_trial or AxClient.get_best_trial
+
+    Finds the optimal trial given an experiment, based on raw objective value.
 
     Returns a 1-row dataframe. Should match the row of ``exp_to_df`` with the best
     raw objective value, given the same arguments.


### PR DESCRIPTION
Summary:
This diff is a step towards deprecating the best point extraction from report utils.

In Ax we have two ways of extracting the best point from an experiment, one in the report utils and another in the BestPointMixin. The latter is much better supported, notably having the ability to find the best point based on model predictions and respect outcome constraints, and ideally we should stop using the one in report utils.

This diff removes the call to ax.service.utils.report_utils.get_best_trial and replaces it with Scheudler.get_best trial and some glue code. AFAIK ax.service.utils.report_utils.get_best_trial is only called in some tests now so it should be safe to delete, but just in case I have only marked it as deprecated.

Differential Revision: D34420658

