### PR TITLE
Infer SEM as None when not provided

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -260,8 +260,9 @@ class Data(Base):
         Convert dict of evaluations to Ax data object.
 
         Args:
-            evaluations: Map from arm name to metric outcomes (itself a mapping
-                of metric names to tuples of mean and optionally a SEM).
+            evaluations: Map from arm name to metric outcomes, which itself is  a
+                mapping of metric names to means or tuples of mean and an SEM). If
+                SEM is not specified, it will be set to None and inferred from data.
             trial_index: Trial index to which this data belongs.
             sample_sizes: Number of samples collected for each arm.
             start_time: Optional start time of run of the trial that produced this
@@ -277,7 +278,7 @@ class Data(Base):
                 "arm_name": name,
                 "metric_name": metric_name,
                 "mean": value[0] if isinstance(value, tuple) else value,
-                "sem": value[1] if isinstance(value, tuple) else 0.0,
+                "sem": value[1] if isinstance(value, tuple) else None,
                 "trial_index": trial_index,
             }
             for name, evaluation in evaluations.items()
@@ -304,8 +305,9 @@ class Data(Base):
 
         Args:
             evaluations: Map from arm name to list of (fidelity, metric outcomes)
-                (where metric outcomes is itself a mapping of metric names to
-                tuples of mean and SEM).
+                where metric outcomes is itself a mapping of metric names to means
+                or tuples of mean and SEM. If SEM is not specified, it will be set
+                to None and inferred from data.
             trial_index: Trial index to which this data belongs.
             sample_sizes: Number of samples collected for each arm.
             start_time: Optional start time of run of the trial that produced this
@@ -321,7 +323,7 @@ class Data(Base):
                 "arm_name": name,
                 "metric_name": metric_name,
                 "mean": value[0] if isinstance(value, tuple) else value,
-                "sem": value[1] if isinstance(value, tuple) else 0.0,
+                "sem": value[1] if isinstance(value, tuple) else None,
                 "trial_index": trial_index,
                 "fidelities": json.dumps(fidelity),
             }

--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -181,7 +181,7 @@ class MapData(Data):
                 "arm_name": name,
                 "metric_name": metric_name,
                 "mean": value[0] if isinstance(value, tuple) else value,
-                "sem": value[1] if isinstance(value, tuple) else 0.0,
+                "sem": value[1] if isinstance(value, tuple) else None,
                 "trial_index": trial_index,
                 **map_dict,
             }

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -151,34 +151,41 @@ class DataTest(TestCase):
             Data(df=pd.DataFrame([data_entry2]))
 
     def testFromEvaluations(self):
-        data = Data.from_evaluations(
-            evaluations={"0_1": {"b": (3.7, 0.5)}},
-            trial_index=0,
-            sample_sizes={"0_1": 2},
-            start_time=current_timestamp_in_millis(),
-            end_time=current_timestamp_in_millis(),
-        )
-        self.assertEqual(len(data.df), 1)
-        self.assertNotEqual(data, Data(self.df))
-        self.assertIn("start_time", data.df)
-        self.assertIn("end_time", data.df)
+        for sem in (0.5, None):
+            eval1 = (3.7, sem) if sem is not None else 3.7
+            data = Data.from_evaluations(
+                evaluations={"0_1": {"b": eval1}},
+                trial_index=0,
+                sample_sizes={"0_1": 2},
+                start_time=current_timestamp_in_millis(),
+                end_time=current_timestamp_in_millis(),
+            )
+            self.assertEqual(data.df["sem"].isnull()[0], sem is None)
+            self.assertEqual(len(data.df), 1)
+            self.assertNotEqual(data, Data(self.df))
+            self.assertIn("start_time", data.df)
+            self.assertIn("end_time", data.df)
 
     def testFromFidelityEvaluations(self):
-        data = Data.from_fidelity_evaluations(
-            evaluations={
-                "0_1": [
-                    ({"f1": 1.0, "f2": 0.5}, {"b": (3.7, 0.5)}),
-                    ({"f1": 1.0, "f2": 0.75}, {"b": (3.8, 0.5)}),
-                ]
-            },
-            trial_index=0,
-            sample_sizes={"0_1": 2},
-            start_time=current_timestamp_in_millis(),
-            end_time=current_timestamp_in_millis(),
-        )
-        self.assertEqual(len(data.df), 2)
-        self.assertIn("start_time", data.df)
-        self.assertIn("end_time", data.df)
+        for sem in (0.5, None):
+            eval1 = (3.7, sem) if sem is not None else 3.7
+            eval2 = (3.8, sem) if sem is not None else 3.8
+            data = Data.from_fidelity_evaluations(
+                evaluations={
+                    "0_1": [
+                        ({"f1": 1.0, "f2": 0.5}, {"b": eval1}),
+                        ({"f1": 1.0, "f2": 0.75}, {"b": eval2}),
+                    ]
+                },
+                trial_index=0,
+                sample_sizes={"0_1": 2},
+                start_time=current_timestamp_in_millis(),
+                end_time=current_timestamp_in_millis(),
+            )
+            self.assertEqual(data.df["sem"].isnull().all(), sem is None)
+            self.assertEqual(len(data.df), 2)
+            self.assertIn("start_time", data.df)
+            self.assertIn("end_time", data.df)
 
     def testCloneWithoutMetrics(self):
         data = Data(df=self.df)

--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -177,18 +177,21 @@ class MapDataTest(TestCase):
         )
 
     def test_from_map_evaluations(self):
-        map_data = MapData.from_map_evaluations(
-            evaluations={
-                "0_1": [
-                    ({"f1": 1.0, "f2": 0.5}, {"b": (3.7, 0.5)}),
-                    ({"f1": 1.0, "f2": 0.75}, {"b": (3.8, 0.5)}),
-                ]
-            },
-            trial_index=0,
-        )
-
-        self.assertEqual(len(map_data.map_df), 2)
-        self.assertEqual(set(map_data.map_keys), {"f1", "f2"})
+        for sem in (0.5, None):
+            eval1 = (3.7, sem) if sem is not None else 3.7
+            eval2 = (3.8, sem) if sem is not None else 3.8
+            map_data = MapData.from_map_evaluations(
+                evaluations={
+                    "0_1": [
+                        ({"f1": 1.0, "f2": 0.5}, {"b": eval1}),
+                        ({"f1": 1.0, "f2": 0.75}, {"b": eval2}),
+                    ]
+                },
+                trial_index=0,
+            )
+            self.assertEqual(map_data.map_df["sem"].isnull().all(), sem is None)
+            self.assertEqual(len(map_data.map_df), 2)
+            self.assertEqual(set(map_data.map_keys), {"f1", "f2"})
 
         with self.assertRaisesRegex(
             ValueError, "Inconsistent map_key sets in evaluations"

--- a/docs/trial-evaluation.md
+++ b/docs/trial-evaluation.md
@@ -26,9 +26,9 @@ The data can be in the form of:
 - A single (mean, SEM) tuple
 - A single mean
 
-In the second case, Ax will assume that the mean and the SEM are for the experiment objective (if the evaluations are noiseless, simply provide a SEM of 0.0). In the third case, Ax will assume that observations are corrupted by Gaussian noise with zero mean and unknown SEM, and infer the SEM from the data. Note that if the observation noise is non-zero (either provided or inferred), the "best arm" suggested by Ax may not always be the one whose evaluation returned the best observed value (as the "best arm" is selected based on the model-predicted mean).
+In the second case, Ax will assume that the mean and the SEM are for the experiment objective (if the evaluations are noiseless, simply provide an SEM of 0.0). In the third case, Ax will assume that observations are corrupted by Gaussian noise with zero mean and unknown SEM, and infer the SEM from the data (this is equivalent to specifying an SEM of None). Note that if the observation noise is non-zero (either provided or inferred), the "best arm" suggested by Ax may not always be the one whose evaluation returned the best observed value (as the "best arm" is selected based on the model-predicted mean).
 
-For example, this evaluation function computes mean and SEM for [Hartmann6](https://www.sfu.ca/~ssurjano/hart6.html) function and for the L2-norm:
+For example, this evaluation function computes mean and SEM for [Hartmann6](https://www.sfu.ca/~ssurjano/hart6.html) function and for the L2-norm. We return `0.0` for SEM since the observations are noiseless:
 
 ```python
 from ax.utils.measurement.synthetic_functions import hartmann6
@@ -47,10 +47,19 @@ def branin_evaluation_function(parameterization):
     return (branin(parameterization.get("x1"), parameterization.get("x2")), 0.0)
 ```
 
-This form would be equivalent to the above, since SEM is 0:
+Alternatively, if the SEM is unknown, we could use the following form:
 
 ```python
 lambda parameterization: branin(parameterization.get("x1"), parameterization.get("x2"))
+```
+
+This is equivalent to returning `None` for the SEM:
+
+```python
+from ax.utils.measurement.synthetic_functions import branin
+def branin_evaluation_function_unknown_sem(parameterization):
+    # Standard error is 0, since we are computing a synthetic function.
+    return (branin(parameterization.get("x1"), parameterization.get("x2")), None)
 ```
 
 ## Loop API


### PR DESCRIPTION
Summary:
This fixes slight inconsistency in the code (believed to be a non-issue since None is added in Service API while adding new data).
This also updates the documentation for Trial Evaluation to clear a conflicting statement regarding SEMs.

Differential Revision: D34533271

