### PR TITLE
Fix tutorials which required register_{runner, metric}

### DIFF
--- a/tutorials/gpei_hartmann_developer.ipynb
+++ b/tutorials/gpei_hartmann_developer.ipynb
@@ -1,4 +1,24 @@
 {
+  "metadata": {
+    "kernelspec": {
+      "display_name": "ae",
+      "language": "python",
+      "name": "bento_kernel_ae",
+      "metadata": {
+        "kernel_name": "bento_kernel_ae",
+        "nightly_builds": false,
+        "fbpkg_supported": true,
+        "is_prebuilt": true
+      }
+    },
+    "last_server_session_id": "4585396d-6a4f-4e7e-810e-b573c53f88ad",
+    "last_kernel_id": "203f6c0c-94e0-4612-9b41-0f84d3ff089d",
+    "last_base_url": "https://37766.od.fbinfra.net:443/",
+    "last_msg_id": "68286049-d1af2be2484e85dea135d81d_518",
+    "outputWidgetContext": {}
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2,
   "cells": [
     {
       "cell_type": "markdown",
@@ -17,11 +37,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "e45e47fa-35d2-4a1a-86db-1cf5fa0c8a62",
+        "originalKey": "c0fdff2d-6317-4b7e-9056-a064c5d2e650",
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "c0fdff2d-6317-4b7e-9056-a064c5d2e650"
+        "requestMsgId": "7b98b243-30da-468b-82c7-7e22dbce6b57",
+        "executionStartTime": 1646323252842,
+        "executionStopTime": 1646323256492
       },
       "source": [
         "from ax import (\n",
@@ -56,7 +78,7 @@
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 07-21 12:55:30] ax.utils.notebook.plotting: Injecting Plotly library into cell. Do not overwrite or delete cell.\n"
+            "[INFO 03-03 08:00:54] ax.utils.notebook.plotting: Injecting Plotly library into cell. Do not overwrite or delete cell.\n"
           ]
         },
         {
@@ -86,8 +108,10 @@
       "cell_type": "code",
       "metadata": {
         "collapsed": false,
-        "originalKey": "38418604-f280-4cec-ba3f-a8d987680a96",
-        "requestMsgId": "d7ccd747-2096-4254-84f3-a619b7c3b473"
+        "originalKey": "d7ccd747-2096-4254-84f3-a619b7c3b473",
+        "requestMsgId": "9b782d53-f9e2-4b13-a8ba-b7941aba802e",
+        "executionStartTime": 1646323256533,
+        "executionStopTime": 1646323256546
       },
       "source": [
         "hartmann_search_space = SearchSpace(\n",
@@ -118,13 +142,15 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "09fd4723-021f-4569-9b5c-fe5aa5ab6835",
+        "originalKey": "45f10ccd-2318-4674-8017-9f0e2b5bfcf1",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "45f10ccd-2318-4674-8017-9f0e2b5bfcf1"
+        "requestMsgId": "e29cbb8f-9045-4d9c-8a57-aeff1cd91da6",
+        "executionStartTime": 1646323256562,
+        "executionStopTime": 1646323256584
       },
       "source": [
         "choice_param = ChoiceParameter(name=\"choice\", values=[\"foo\", \"bar\"], parameter_type=ParameterType.STRING)\n",
@@ -149,13 +175,15 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "fe8edcef-6b44-4db8-ba7d-9a3e60ed5896",
+        "originalKey": "6175df8e-0376-41db-a96e-e1dd0dd46544",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "6175df8e-0376-41db-a96e-e1dd0dd46544"
+        "requestMsgId": "b782e8cf-c11c-4f4e-a416-2577a56b4100",
+        "executionStartTime": 1646323256616,
+        "executionStopTime": 1646323256621
       },
       "source": [
         "sum_constraint = SumConstraint(\n",
@@ -194,10 +222,12 @@
       "cell_type": "code",
       "metadata": {
         "collapsed": false,
-        "originalKey": "692b9ecc-9c67-42d8-ab08-c7108293b043",
+        "originalKey": "44682533-bb98-40fd-add2-ec0abd643568",
         "code_folding": [],
         "hidden_ranges": [],
-        "requestMsgId": "44682533-bb98-40fd-add2-ec0abd643568"
+        "requestMsgId": "d0e2b580-bfb5-4a73-8db1-34a3c43c3ef2",
+        "executionStartTime": 1646323256629,
+        "executionStopTime": 1646323256633
       },
       "source": [
         "from ax.metrics.l2norm import L2NormMetric\n",
@@ -245,13 +275,15 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "2e2aca22-d04f-468a-a3a2-cb99115d8998",
+        "originalKey": "03408af3-c7d7-41b1-b220-00d795c9e40f",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "03408af3-c7d7-41b1-b220-00d795c9e40f"
+        "requestMsgId": "c9862804-4c0c-4691-be2c-5cb0eb778460",
+        "executionStartTime": 1646323256641,
+        "executionStopTime": 1646323256645
       },
       "source": [
         "from ax import Runner\n",
@@ -281,13 +313,15 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "7618dd5f-bba2-4c3c-8d6c-f281ec6aae80",
+        "originalKey": "c61e7d66-e9be-439c-a471-b680d81b375d",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "c61e7d66-e9be-439c-a471-b680d81b375d"
+        "requestMsgId": "18ce7d69-d556-48f5-9945-c75bedb362bb",
+        "executionStartTime": 1646323256653,
+        "executionStopTime": 1646323256658
       },
       "source": [
         "exp = Experiment(\n",
@@ -297,7 +331,7 @@
         "    runner=MyRunner(),\n",
         ")"
       ],
-      "execution_count": 82,
+      "execution_count": 7,
       "outputs": []
     },
     {
@@ -319,11 +353,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "981eff70-2598-40e8-a850-49d188c82cfa",
+        "originalKey": "b7a41ce7-1b33-4b06-add9-83c6516410cd",
         "collapsed": false,
-        "requestMsgId": "b7a41ce7-1b33-4b06-add9-83c6516410cd",
+        "requestMsgId": "b48e26da-57e7-4b81-baf0-122a71f0bb72",
         "code_folding": [],
-        "hidden_ranges": []
+        "hidden_ranges": [],
+        "executionStartTime": 1646323256665,
+        "executionStopTime": 1646323714923
       },
       "source": [
         "from ax.modelbridge.registry import Models\n",
@@ -360,20 +396,13 @@
         "    \n",
         "print(\"Done!\")"
       ],
-      "execution_count": 83,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "Running Sobol initialization trials...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Running GP+EI optimization trial 6/20...\n"
+            "Running Sobol initialization trials...\nRunning GP+EI optimization trial 6/20...\n"
           ]
         },
         {
@@ -506,23 +535,25 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "8887b621-efff-4dec-9109-1480db461b4e",
+        "originalKey": "9ce39f1b-7e3f-4388-a729-8fb6c83d7cf7",
         "collapsed": false,
-        "requestMsgId": "9ce39f1b-7e3f-4388-a729-8fb6c83d7cf7",
+        "requestMsgId": "65113ac3-956a-4fcc-abf7-a9d45f8ecb72",
         "code_folding": [],
-        "hidden_ranges": []
+        "hidden_ranges": [],
+        "executionStartTime": 1646323714950,
+        "executionStopTime": 1646323715210
       },
       "source": [
         "trial_data = exp.fetch_trials_data([NUM_SOBOL_TRIALS + NUM_BOTORCH_TRIALS - 1])\n",
         "trial_data.df"
       ],
-      "execution_count": 84,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "  arm_name metric_name      mean  sem  trial_index      n  frac_nonnull\n0     19_0      l2norm  1.557466  0.2           19  10000      1.557466\n1     19_0   hartmann6 -2.920944  0.0           19  10000     -2.920944",
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>arm_name</th>\n      <th>metric_name</th>\n      <th>mean</th>\n      <th>sem</th>\n      <th>trial_index</th>\n      <th>n</th>\n      <th>frac_nonnull</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>19_0</td>\n      <td>l2norm</td>\n      <td>1.557466</td>\n      <td>0.2</td>\n      <td>19</td>\n      <td>10000</td>\n      <td>1.557466</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>19_0</td>\n      <td>hartmann6</td>\n      <td>-2.920944</td>\n      <td>0.0</td>\n      <td>19</td>\n      <td>10000</td>\n      <td>-2.920944</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+            "text/plain": "  arm_name metric_name      mean  sem  trial_index      n  frac_nonnull\n0     19_0      l2norm  1.284402  0.2           19  10000      1.284402\n1     19_0   hartmann6 -2.675499  0.0           19  10000     -2.675499",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>arm_name</th>\n      <th>metric_name</th>\n      <th>mean</th>\n      <th>sem</th>\n      <th>trial_index</th>\n      <th>n</th>\n      <th>frac_nonnull</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>19_0</td>\n      <td>l2norm</td>\n      <td>1.284402</td>\n      <td>0.2</td>\n      <td>19</td>\n      <td>10000</td>\n      <td>1.284402</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>19_0</td>\n      <td>hartmann6</td>\n      <td>-2.675499</td>\n      <td>0.0</td>\n      <td>19</td>\n      <td>10000</td>\n      <td>-2.675499</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
             "application/vnd.dataresource+json": {
               "schema": {
                 "fields": [
@@ -569,29 +600,29 @@
                   "index": 0,
                   "arm_name": "19_0",
                   "metric_name": "l2norm",
-                  "mean": 1.5574657622,
+                  "mean": 1.2844019287,
                   "sem": 0.2,
                   "trial_index": 19,
                   "n": 10000,
-                  "frac_nonnull": 1.5574657622
+                  "frac_nonnull": 1.2844019287
                 },
                 {
                   "index": 1,
                   "arm_name": "19_0",
                   "metric_name": "hartmann6",
-                  "mean": -2.920944359,
+                  "mean": -2.6754986543,
                   "sem": 0,
                   "trial_index": 19,
                   "n": 10000,
-                  "frac_nonnull": -2.920944359
+                  "frac_nonnull": -2.6754986543
                 }
               ]
             }
           },
           "metadata": {
-            "bento_obj_id": "139815296314000"
+            "bento_obj_id": "139699853652896"
           },
-          "execution_count": 84
+          "execution_count": 9
         }
       ]
     },
@@ -611,26 +642,26 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "753afdcb-4c20-4a9f-aa10-90b85cf0fbcd",
+        "originalKey": "4aa093dd-d81d-40bb-9931-517bad31bdcb",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "4aa093dd-d81d-40bb-9931-517bad31bdcb",
-        "executionStartTime": 1626971528112,
-        "executionStopTime": 1626971529427
+        "requestMsgId": "88fb1408-0965-48f9-a211-140ea57f46a6",
+        "executionStartTime": 1646323715232,
+        "executionStopTime": 1646323715950
       },
       "source": [
         "exp.fetch_data().df"
       ],
-      "execution_count": 93,
+      "execution_count": 10,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "   arm_name metric_name      mean  sem  trial_index      n  frac_nonnull\n0       0_0      l2norm  1.563932  0.2            0  10000      1.563932\n1       1_0      l2norm  0.980516  0.2            1  10000      0.980516\n2       2_0      l2norm  1.463128  0.2            2  10000      1.463128\n3       3_0      l2norm  1.465579  0.2            3  10000      1.465579\n4       4_0      l2norm  1.618146  0.2            4  10000      1.618146\n5       5_0      l2norm  1.365054  0.2            5  10000      1.365054\n6       6_0      l2norm  1.275449  0.2            6  10000      1.275449\n7       7_0      l2norm  1.182169  0.2            7  10000      1.182169\n8       8_0      l2norm  1.410753  0.2            8  10000      1.410753\n9       9_0      l2norm  1.495001  0.2            9  10000      1.495001\n10     10_0      l2norm  1.141756  0.2           10  10000      1.141756\n11     11_0      l2norm  1.428378  0.2           11  10000      1.428378\n12     12_0      l2norm  1.378171  0.2           12  10000      1.378171\n13     13_0      l2norm  1.289432  0.2           13  10000      1.289432\n14     14_0      l2norm  1.659345  0.2           14  10000      1.659345\n15     15_0      l2norm  1.634820  0.2           15  10000      1.634820\n16     16_0      l2norm  1.267591  0.2           16  10000      1.267591\n17     17_0      l2norm  1.574375  0.2           17  10000      1.574375\n18     18_0      l2norm  1.488781  0.2           18  10000      1.488781\n19     19_0      l2norm  1.276863  0.2           19  10000      1.276863\n20      0_0   hartmann6 -0.165818  0.0            0  10000     -0.165818\n21      1_0   hartmann6 -0.204664  0.0            1  10000     -0.204664\n22      2_0   hartmann6 -0.371105  0.0            2  10000     -0.371105\n23      3_0   hartmann6 -0.010540  0.0            3  10000     -0.010540\n24      4_0   hartmann6 -0.008968  0.0            4  10000     -0.008968\n25      5_0   hartmann6 -0.264002  0.0            5  10000     -0.264002\n26      6_0   hartmann6 -0.734002  0.0            6  10000     -0.734002\n27      7_0   hartmann6 -0.519209  0.0            7  10000     -0.519209\n28      8_0   hartmann6 -0.706598  0.0            8  10000     -0.706598\n29      9_0   hartmann6 -1.349966  0.0            9  10000     -1.349966\n30     10_0   hartmann6 -1.562996  0.0           10  10000     -1.562996\n31     11_0   hartmann6 -2.356175  0.0           11  10000     -2.356175\n32     12_0   hartmann6 -2.724168  0.0           12  10000     -2.724168\n33     13_0   hartmann6 -2.952578  0.0           13  10000     -2.952578\n34     14_0   hartmann6 -2.524413  0.0           14  10000     -2.524413\n35     15_0   hartmann6 -1.901949  0.0           15  10000     -1.901949\n36     16_0   hartmann6 -2.851597  0.0           16  10000     -2.851597\n37     17_0   hartmann6 -2.212761  0.0           17  10000     -2.212761\n38     18_0   hartmann6 -2.878421  0.0           18  10000     -2.878421\n39     19_0   hartmann6 -2.920944  0.0           19  10000     -2.920944",
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>arm_name</th>\n      <th>metric_name</th>\n      <th>mean</th>\n      <th>sem</th>\n      <th>trial_index</th>\n      <th>n</th>\n      <th>frac_nonnull</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0_0</td>\n      <td>l2norm</td>\n      <td>1.563932</td>\n      <td>0.2</td>\n      <td>0</td>\n      <td>10000</td>\n      <td>1.563932</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1_0</td>\n      <td>l2norm</td>\n      <td>0.980516</td>\n      <td>0.2</td>\n      <td>1</td>\n      <td>10000</td>\n      <td>0.980516</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2_0</td>\n      <td>l2norm</td>\n      <td>1.463128</td>\n      <td>0.2</td>\n      <td>2</td>\n      <td>10000</td>\n      <td>1.463128</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3_0</td>\n      <td>l2norm</td>\n      <td>1.465579</td>\n      <td>0.2</td>\n      <td>3</td>\n      <td>10000</td>\n      <td>1.465579</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4_0</td>\n      <td>l2norm</td>\n      <td>1.618146</td>\n      <td>0.2</td>\n      <td>4</td>\n      <td>10000</td>\n      <td>1.618146</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>5_0</td>\n      <td>l2norm</td>\n      <td>1.365054</td>\n      <td>0.2</td>\n      <td>5</td>\n      <td>10000</td>\n      <td>1.365054</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>6_0</td>\n      <td>l2norm</td>\n      <td>1.275449</td>\n      <td>0.2</td>\n      <td>6</td>\n      <td>10000</td>\n      <td>1.275449</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>7_0</td>\n      <td>l2norm</td>\n      <td>1.182169</td>\n      <td>0.2</td>\n      <td>7</td>\n      <td>10000</td>\n      <td>1.182169</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>8_0</td>\n      <td>l2norm</td>\n      <td>1.410753</td>\n      <td>0.2</td>\n      <td>8</td>\n      <td>10000</td>\n      <td>1.410753</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>9_0</td>\n      <td>l2norm</td>\n      <td>1.495001</td>\n      <td>0.2</td>\n      <td>9</td>\n      <td>10000</td>\n      <td>1.495001</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>10_0</td>\n      <td>l2norm</td>\n      <td>1.141756</td>\n      <td>0.2</td>\n      <td>10</td>\n      <td>10000</td>\n      <td>1.141756</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>11_0</td>\n      <td>l2norm</td>\n      <td>1.428378</td>\n      <td>0.2</td>\n      <td>11</td>\n      <td>10000</td>\n      <td>1.428378</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>12_0</td>\n      <td>l2norm</td>\n      <td>1.378171</td>\n      <td>0.2</td>\n      <td>12</td>\n      <td>10000</td>\n      <td>1.378171</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>13_0</td>\n      <td>l2norm</td>\n      <td>1.289432</td>\n      <td>0.2</td>\n      <td>13</td>\n      <td>10000</td>\n      <td>1.289432</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>14_0</td>\n      <td>l2norm</td>\n      <td>1.659345</td>\n      <td>0.2</td>\n      <td>14</td>\n      <td>10000</td>\n      <td>1.659345</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>15_0</td>\n      <td>l2norm</td>\n      <td>1.634820</td>\n      <td>0.2</td>\n      <td>15</td>\n      <td>10000</td>\n      <td>1.634820</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>16_0</td>\n      <td>l2norm</td>\n      <td>1.267591</td>\n      <td>0.2</td>\n      <td>16</td>\n      <td>10000</td>\n      <td>1.267591</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>17_0</td>\n      <td>l2norm</td>\n      <td>1.574375</td>\n      <td>0.2</td>\n      <td>17</td>\n      <td>10000</td>\n      <td>1.574375</td>\n    </tr>\n    <tr>\n      <th>18</th>\n      <td>18_0</td>\n      <td>l2norm</td>\n      <td>1.488781</td>\n      <td>0.2</td>\n      <td>18</td>\n      <td>10000</td>\n      <td>1.488781</td>\n    </tr>\n    <tr>\n      <th>19</th>\n      <td>19_0</td>\n      <td>l2norm</td>\n      <td>1.276863</td>\n      <td>0.2</td>\n      <td>19</td>\n      <td>10000</td>\n      <td>1.276863</td>\n    </tr>\n    <tr>\n      <th>20</th>\n      <td>0_0</td>\n      <td>hartmann6</td>\n      <td>-0.165818</td>\n      <td>0.0</td>\n      <td>0</td>\n      <td>10000</td>\n      <td>-0.165818</td>\n    </tr>\n    <tr>\n      <th>21</th>\n      <td>1_0</td>\n      <td>hartmann6</td>\n      <td>-0.204664</td>\n      <td>0.0</td>\n      <td>1</td>\n      <td>10000</td>\n      <td>-0.204664</td>\n    </tr>\n    <tr>\n      <th>22</th>\n      <td>2_0</td>\n      <td>hartmann6</td>\n      <td>-0.371105</td>\n      <td>0.0</td>\n      <td>2</td>\n      <td>10000</td>\n      <td>-0.371105</td>\n    </tr>\n    <tr>\n      <th>23</th>\n      <td>3_0</td>\n      <td>hartmann6</td>\n      <td>-0.010540</td>\n      <td>0.0</td>\n      <td>3</td>\n      <td>10000</td>\n      <td>-0.010540</td>\n    </tr>\n    <tr>\n      <th>24</th>\n      <td>4_0</td>\n      <td>hartmann6</td>\n      <td>-0.008968</td>\n      <td>0.0</td>\n      <td>4</td>\n      <td>10000</td>\n      <td>-0.008968</td>\n    </tr>\n    <tr>\n      <th>25</th>\n      <td>5_0</td>\n      <td>hartmann6</td>\n      <td>-0.264002</td>\n      <td>0.0</td>\n      <td>5</td>\n      <td>10000</td>\n      <td>-0.264002</td>\n    </tr>\n    <tr>\n      <th>26</th>\n      <td>6_0</td>\n      <td>hartmann6</td>\n      <td>-0.734002</td>\n      <td>0.0</td>\n      <td>6</td>\n      <td>10000</td>\n      <td>-0.734002</td>\n    </tr>\n    <tr>\n      <th>27</th>\n      <td>7_0</td>\n      <td>hartmann6</td>\n      <td>-0.519209</td>\n      <td>0.0</td>\n      <td>7</td>\n      <td>10000</td>\n      <td>-0.519209</td>\n    </tr>\n    <tr>\n      <th>28</th>\n      <td>8_0</td>\n      <td>hartmann6</td>\n      <td>-0.706598</td>\n      <td>0.0</td>\n      <td>8</td>\n      <td>10000</td>\n      <td>-0.706598</td>\n    </tr>\n    <tr>\n      <th>29</th>\n      <td>9_0</td>\n      <td>hartmann6</td>\n      <td>-1.349966</td>\n      <td>0.0</td>\n      <td>9</td>\n      <td>10000</td>\n      <td>-1.349966</td>\n    </tr>\n    <tr>\n      <th>30</th>\n      <td>10_0</td>\n      <td>hartmann6</td>\n      <td>-1.562996</td>\n      <td>0.0</td>\n      <td>10</td>\n      <td>10000</td>\n      <td>-1.562996</td>\n    </tr>\n    <tr>\n      <th>31</th>\n      <td>11_0</td>\n      <td>hartmann6</td>\n      <td>-2.356175</td>\n      <td>0.0</td>\n      <td>11</td>\n      <td>10000</td>\n      <td>-2.356175</td>\n    </tr>\n    <tr>\n      <th>32</th>\n      <td>12_0</td>\n      <td>hartmann6</td>\n      <td>-2.724168</td>\n      <td>0.0</td>\n      <td>12</td>\n      <td>10000</td>\n      <td>-2.724168</td>\n    </tr>\n    <tr>\n      <th>33</th>\n      <td>13_0</td>\n      <td>hartmann6</td>\n      <td>-2.952578</td>\n      <td>0.0</td>\n      <td>13</td>\n      <td>10000</td>\n      <td>-2.952578</td>\n    </tr>\n    <tr>\n      <th>34</th>\n      <td>14_0</td>\n      <td>hartmann6</td>\n      <td>-2.524413</td>\n      <td>0.0</td>\n      <td>14</td>\n      <td>10000</td>\n      <td>-2.524413</td>\n    </tr>\n    <tr>\n      <th>35</th>\n      <td>15_0</td>\n      <td>hartmann6</td>\n      <td>-1.901949</td>\n      <td>0.0</td>\n      <td>15</td>\n      <td>10000</td>\n      <td>-1.901949</td>\n    </tr>\n    <tr>\n      <th>36</th>\n      <td>16_0</td>\n      <td>hartmann6</td>\n      <td>-2.851597</td>\n      <td>0.0</td>\n      <td>16</td>\n      <td>10000</td>\n      <td>-2.851597</td>\n    </tr>\n    <tr>\n      <th>37</th>\n      <td>17_0</td>\n      <td>hartmann6</td>\n      <td>-2.212761</td>\n      <td>0.0</td>\n      <td>17</td>\n      <td>10000</td>\n      <td>-2.212761</td>\n    </tr>\n    <tr>\n      <th>38</th>\n      <td>18_0</td>\n      <td>hartmann6</td>\n      <td>-2.878421</td>\n      <td>0.0</td>\n      <td>18</td>\n      <td>10000</td>\n      <td>-2.878421</td>\n    </tr>\n    <tr>\n      <th>39</th>\n      <td>19_0</td>\n      <td>hartmann6</td>\n      <td>-2.920944</td>\n      <td>0.0</td>\n      <td>19</td>\n      <td>10000</td>\n      <td>-2.920944</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+            "text/plain": "   arm_name metric_name      mean  sem  trial_index      n  frac_nonnull\n0       0_0      l2norm  0.507579  0.2            0  10000      0.507579\n1       1_0      l2norm  1.883702  0.2            1  10000      1.883702\n2       2_0      l2norm  1.032996  0.2            2  10000      1.032996\n3       3_0      l2norm  1.916155  0.2            3  10000      1.916155\n4       4_0      l2norm  1.365540  0.2            4  10000      1.365540\n5       5_0      l2norm  1.375043  0.2            5  10000      1.375043\n6       6_0      l2norm  1.500577  0.2            6  10000      1.500577\n7       7_0      l2norm  0.731745  0.2            7  10000      0.731745\n8       8_0      l2norm  1.183251  0.2            8  10000      1.183251\n9       9_0      l2norm  1.334056  0.2            9  10000      1.334056\n10     10_0      l2norm  1.651445  0.2           10  10000      1.651445\n11     11_0      l2norm  1.457749  0.2           11  10000      1.457749\n12     12_0      l2norm  1.672653  0.2           12  10000      1.672653\n13     13_0      l2norm  1.262552  0.2           13  10000      1.262552\n14     14_0      l2norm  0.993675  0.2           14  10000      0.993675\n15     15_0      l2norm  1.271348  0.2           15  10000      1.271348\n16     16_0      l2norm  1.349642  0.2           16  10000      1.349642\n17     17_0      l2norm  1.486440  0.2           17  10000      1.486440\n18     18_0      l2norm  1.348229  0.2           18  10000      1.348229\n19     19_0      l2norm  1.197649  0.2           19  10000      1.197649\n20      0_0   hartmann6 -0.384000  0.0            0  10000     -0.384000\n21      1_0   hartmann6 -0.443456  0.0            1  10000     -0.443456\n22      2_0   hartmann6 -0.398283  0.0            2  10000     -0.398283\n23      3_0   hartmann6 -0.632983  0.0            3  10000     -0.632983\n24      4_0   hartmann6 -0.076013  0.0            4  10000     -0.076013\n25      5_0   hartmann6 -0.901104  0.0            5  10000     -0.901104\n26      6_0   hartmann6 -2.128343  0.0            6  10000     -2.128343\n27      7_0   hartmann6 -2.617726  0.0            7  10000     -2.617726\n28      8_0   hartmann6 -2.384470  0.0            8  10000     -2.384470\n29      9_0   hartmann6 -1.718234  0.0            9  10000     -1.718234\n30     10_0   hartmann6 -2.658890  0.0           10  10000     -2.658890\n31     11_0   hartmann6 -1.565920  0.0           11  10000     -1.565920\n32     12_0   hartmann6 -2.675189  0.0           12  10000     -2.675189\n33     13_0   hartmann6 -2.150674  0.0           13  10000     -2.150674\n34     14_0   hartmann6 -2.774178  0.0           14  10000     -2.774178\n35     15_0   hartmann6 -2.613163  0.0           15  10000     -2.613163\n36     16_0   hartmann6 -2.756064  0.0           16  10000     -2.756064\n37     17_0   hartmann6 -2.708216  0.0           17  10000     -2.708216\n38     18_0   hartmann6 -3.031849  0.0           18  10000     -3.031849\n39     19_0   hartmann6 -2.675499  0.0           19  10000     -2.675499",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>arm_name</th>\n      <th>metric_name</th>\n      <th>mean</th>\n      <th>sem</th>\n      <th>trial_index</th>\n      <th>n</th>\n      <th>frac_nonnull</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0_0</td>\n      <td>l2norm</td>\n      <td>0.507579</td>\n      <td>0.2</td>\n      <td>0</td>\n      <td>10000</td>\n      <td>0.507579</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1_0</td>\n      <td>l2norm</td>\n      <td>1.883702</td>\n      <td>0.2</td>\n      <td>1</td>\n      <td>10000</td>\n      <td>1.883702</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2_0</td>\n      <td>l2norm</td>\n      <td>1.032996</td>\n      <td>0.2</td>\n      <td>2</td>\n      <td>10000</td>\n      <td>1.032996</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3_0</td>\n      <td>l2norm</td>\n      <td>1.916155</td>\n      <td>0.2</td>\n      <td>3</td>\n      <td>10000</td>\n      <td>1.916155</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4_0</td>\n      <td>l2norm</td>\n      <td>1.365540</td>\n      <td>0.2</td>\n      <td>4</td>\n      <td>10000</td>\n      <td>1.365540</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>5_0</td>\n      <td>l2norm</td>\n      <td>1.375043</td>\n      <td>0.2</td>\n      <td>5</td>\n      <td>10000</td>\n      <td>1.375043</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>6_0</td>\n      <td>l2norm</td>\n      <td>1.500577</td>\n      <td>0.2</td>\n      <td>6</td>\n      <td>10000</td>\n      <td>1.500577</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>7_0</td>\n      <td>l2norm</td>\n      <td>0.731745</td>\n      <td>0.2</td>\n      <td>7</td>\n      <td>10000</td>\n      <td>0.731745</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>8_0</td>\n      <td>l2norm</td>\n      <td>1.183251</td>\n      <td>0.2</td>\n      <td>8</td>\n      <td>10000</td>\n      <td>1.183251</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>9_0</td>\n      <td>l2norm</td>\n      <td>1.334056</td>\n      <td>0.2</td>\n      <td>9</td>\n      <td>10000</td>\n      <td>1.334056</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>10_0</td>\n      <td>l2norm</td>\n      <td>1.651445</td>\n      <td>0.2</td>\n      <td>10</td>\n      <td>10000</td>\n      <td>1.651445</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>11_0</td>\n      <td>l2norm</td>\n      <td>1.457749</td>\n      <td>0.2</td>\n      <td>11</td>\n      <td>10000</td>\n      <td>1.457749</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>12_0</td>\n      <td>l2norm</td>\n      <td>1.672653</td>\n      <td>0.2</td>\n      <td>12</td>\n      <td>10000</td>\n      <td>1.672653</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>13_0</td>\n      <td>l2norm</td>\n      <td>1.262552</td>\n      <td>0.2</td>\n      <td>13</td>\n      <td>10000</td>\n      <td>1.262552</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>14_0</td>\n      <td>l2norm</td>\n      <td>0.993675</td>\n      <td>0.2</td>\n      <td>14</td>\n      <td>10000</td>\n      <td>0.993675</td>\n    </tr>\n    <tr>\n      <th>15</th>\n      <td>15_0</td>\n      <td>l2norm</td>\n      <td>1.271348</td>\n      <td>0.2</td>\n      <td>15</td>\n      <td>10000</td>\n      <td>1.271348</td>\n    </tr>\n    <tr>\n      <th>16</th>\n      <td>16_0</td>\n      <td>l2norm</td>\n      <td>1.349642</td>\n      <td>0.2</td>\n      <td>16</td>\n      <td>10000</td>\n      <td>1.349642</td>\n    </tr>\n    <tr>\n      <th>17</th>\n      <td>17_0</td>\n      <td>l2norm</td>\n      <td>1.486440</td>\n      <td>0.2</td>\n      <td>17</td>\n      <td>10000</td>\n      <td>1.486440</td>\n    </tr>\n    <tr>\n      <th>18</th>\n      <td>18_0</td>\n      <td>l2norm</td>\n      <td>1.348229</td>\n      <td>0.2</td>\n      <td>18</td>\n      <td>10000</td>\n      <td>1.348229</td>\n    </tr>\n    <tr>\n      <th>19</th>\n      <td>19_0</td>\n      <td>l2norm</td>\n      <td>1.197649</td>\n      <td>0.2</td>\n      <td>19</td>\n      <td>10000</td>\n      <td>1.197649</td>\n    </tr>\n    <tr>\n      <th>20</th>\n      <td>0_0</td>\n      <td>hartmann6</td>\n      <td>-0.384000</td>\n      <td>0.0</td>\n      <td>0</td>\n      <td>10000</td>\n      <td>-0.384000</td>\n    </tr>\n    <tr>\n      <th>21</th>\n      <td>1_0</td>\n      <td>hartmann6</td>\n      <td>-0.443456</td>\n      <td>0.0</td>\n      <td>1</td>\n      <td>10000</td>\n      <td>-0.443456</td>\n    </tr>\n    <tr>\n      <th>22</th>\n      <td>2_0</td>\n      <td>hartmann6</td>\n      <td>-0.398283</td>\n      <td>0.0</td>\n      <td>2</td>\n      <td>10000</td>\n      <td>-0.398283</td>\n    </tr>\n    <tr>\n      <th>23</th>\n      <td>3_0</td>\n      <td>hartmann6</td>\n      <td>-0.632983</td>\n      <td>0.0</td>\n      <td>3</td>\n      <td>10000</td>\n      <td>-0.632983</td>\n    </tr>\n    <tr>\n      <th>24</th>\n      <td>4_0</td>\n      <td>hartmann6</td>\n      <td>-0.076013</td>\n      <td>0.0</td>\n      <td>4</td>\n      <td>10000</td>\n      <td>-0.076013</td>\n    </tr>\n    <tr>\n      <th>25</th>\n      <td>5_0</td>\n      <td>hartmann6</td>\n      <td>-0.901104</td>\n      <td>0.0</td>\n      <td>5</td>\n      <td>10000</td>\n      <td>-0.901104</td>\n    </tr>\n    <tr>\n      <th>26</th>\n      <td>6_0</td>\n      <td>hartmann6</td>\n      <td>-2.128343</td>\n      <td>0.0</td>\n      <td>6</td>\n      <td>10000</td>\n      <td>-2.128343</td>\n    </tr>\n    <tr>\n      <th>27</th>\n      <td>7_0</td>\n      <td>hartmann6</td>\n      <td>-2.617726</td>\n      <td>0.0</td>\n      <td>7</td>\n      <td>10000</td>\n      <td>-2.617726</td>\n    </tr>\n    <tr>\n      <th>28</th>\n      <td>8_0</td>\n      <td>hartmann6</td>\n      <td>-2.384470</td>\n      <td>0.0</td>\n      <td>8</td>\n      <td>10000</td>\n      <td>-2.384470</td>\n    </tr>\n    <tr>\n      <th>29</th>\n      <td>9_0</td>\n      <td>hartmann6</td>\n      <td>-1.718234</td>\n      <td>0.0</td>\n      <td>9</td>\n      <td>10000</td>\n      <td>-1.718234</td>\n    </tr>\n    <tr>\n      <th>30</th>\n      <td>10_0</td>\n      <td>hartmann6</td>\n      <td>-2.658890</td>\n      <td>0.0</td>\n      <td>10</td>\n      <td>10000</td>\n      <td>-2.658890</td>\n    </tr>\n    <tr>\n      <th>31</th>\n      <td>11_0</td>\n      <td>hartmann6</td>\n      <td>-1.565920</td>\n      <td>0.0</td>\n      <td>11</td>\n      <td>10000</td>\n      <td>-1.565920</td>\n    </tr>\n    <tr>\n      <th>32</th>\n      <td>12_0</td>\n      <td>hartmann6</td>\n      <td>-2.675189</td>\n      <td>0.0</td>\n      <td>12</td>\n      <td>10000</td>\n      <td>-2.675189</td>\n    </tr>\n    <tr>\n      <th>33</th>\n      <td>13_0</td>\n      <td>hartmann6</td>\n      <td>-2.150674</td>\n      <td>0.0</td>\n      <td>13</td>\n      <td>10000</td>\n      <td>-2.150674</td>\n    </tr>\n    <tr>\n      <th>34</th>\n      <td>14_0</td>\n      <td>hartmann6</td>\n      <td>-2.774178</td>\n      <td>0.0</td>\n      <td>14</td>\n      <td>10000</td>\n      <td>-2.774178</td>\n    </tr>\n    <tr>\n      <th>35</th>\n      <td>15_0</td>\n      <td>hartmann6</td>\n      <td>-2.613163</td>\n      <td>0.0</td>\n      <td>15</td>\n      <td>10000</td>\n      <td>-2.613163</td>\n    </tr>\n    <tr>\n      <th>36</th>\n      <td>16_0</td>\n      <td>hartmann6</td>\n      <td>-2.756064</td>\n      <td>0.0</td>\n      <td>16</td>\n      <td>10000</td>\n      <td>-2.756064</td>\n    </tr>\n    <tr>\n      <th>37</th>\n      <td>17_0</td>\n      <td>hartmann6</td>\n      <td>-2.708216</td>\n      <td>0.0</td>\n      <td>17</td>\n      <td>10000</td>\n      <td>-2.708216</td>\n    </tr>\n    <tr>\n      <th>38</th>\n      <td>18_0</td>\n      <td>hartmann6</td>\n      <td>-3.031849</td>\n      <td>0.0</td>\n      <td>18</td>\n      <td>10000</td>\n      <td>-3.031849</td>\n    </tr>\n    <tr>\n      <th>39</th>\n      <td>19_0</td>\n      <td>hartmann6</td>\n      <td>-2.675499</td>\n      <td>0.0</td>\n      <td>19</td>\n      <td>10000</td>\n      <td>-2.675499</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
             "application/vnd.dataresource+json": {
               "schema": {
                 "fields": [
@@ -677,409 +708,409 @@
                   "index": 0,
                   "arm_name": "0_0",
                   "metric_name": "l2norm",
-                  "mean": 1.5639316914,
+                  "mean": 0.5075788142,
                   "sem": 0.2,
                   "trial_index": 0,
                   "n": 10000,
-                  "frac_nonnull": 1.5639316914
+                  "frac_nonnull": 0.5075788142
                 },
                 {
                   "index": 1,
                   "arm_name": "1_0",
                   "metric_name": "l2norm",
-                  "mean": 0.9805157794,
+                  "mean": 1.88370227,
                   "sem": 0.2,
                   "trial_index": 1,
                   "n": 10000,
-                  "frac_nonnull": 0.9805157794
+                  "frac_nonnull": 1.88370227
                 },
                 {
                   "index": 2,
                   "arm_name": "2_0",
                   "metric_name": "l2norm",
-                  "mean": 1.4631275686,
+                  "mean": 1.0329964472,
                   "sem": 0.2,
                   "trial_index": 2,
                   "n": 10000,
-                  "frac_nonnull": 1.4631275686
+                  "frac_nonnull": 1.0329964472
                 },
                 {
                   "index": 3,
                   "arm_name": "3_0",
                   "metric_name": "l2norm",
-                  "mean": 1.4655789484,
+                  "mean": 1.9161551512,
                   "sem": 0.2,
                   "trial_index": 3,
                   "n": 10000,
-                  "frac_nonnull": 1.4655789484
+                  "frac_nonnull": 1.9161551512
                 },
                 {
                   "index": 4,
                   "arm_name": "4_0",
                   "metric_name": "l2norm",
-                  "mean": 1.6181464289,
+                  "mean": 1.3655401279,
                   "sem": 0.2,
                   "trial_index": 4,
                   "n": 10000,
-                  "frac_nonnull": 1.6181464289
+                  "frac_nonnull": 1.3655401279
                 },
                 {
                   "index": 5,
                   "arm_name": "5_0",
                   "metric_name": "l2norm",
-                  "mean": 1.3650535029,
+                  "mean": 1.3750430964,
                   "sem": 0.2,
                   "trial_index": 5,
                   "n": 10000,
-                  "frac_nonnull": 1.3650535029
+                  "frac_nonnull": 1.3750430964
                 },
                 {
                   "index": 6,
                   "arm_name": "6_0",
                   "metric_name": "l2norm",
-                  "mean": 1.2754489051,
+                  "mean": 1.5005770559,
                   "sem": 0.2,
                   "trial_index": 6,
                   "n": 10000,
-                  "frac_nonnull": 1.2754489051
+                  "frac_nonnull": 1.5005770559
                 },
                 {
                   "index": 7,
                   "arm_name": "7_0",
                   "metric_name": "l2norm",
-                  "mean": 1.1821690378,
+                  "mean": 0.7317451428,
                   "sem": 0.2,
                   "trial_index": 7,
                   "n": 10000,
-                  "frac_nonnull": 1.1821690378
+                  "frac_nonnull": 0.7317451428
                 },
                 {
                   "index": 8,
                   "arm_name": "8_0",
                   "metric_name": "l2norm",
-                  "mean": 1.410752626,
+                  "mean": 1.1832513855,
                   "sem": 0.2,
                   "trial_index": 8,
                   "n": 10000,
-                  "frac_nonnull": 1.410752626
+                  "frac_nonnull": 1.1832513855
                 },
                 {
                   "index": 9,
                   "arm_name": "9_0",
                   "metric_name": "l2norm",
-                  "mean": 1.495001434,
+                  "mean": 1.3340555445,
                   "sem": 0.2,
                   "trial_index": 9,
                   "n": 10000,
-                  "frac_nonnull": 1.495001434
+                  "frac_nonnull": 1.3340555445
                 },
                 {
                   "index": 10,
                   "arm_name": "10_0",
                   "metric_name": "l2norm",
-                  "mean": 1.141756005,
+                  "mean": 1.6514450959,
                   "sem": 0.2,
                   "trial_index": 10,
                   "n": 10000,
-                  "frac_nonnull": 1.141756005
+                  "frac_nonnull": 1.6514450959
                 },
                 {
                   "index": 11,
                   "arm_name": "11_0",
                   "metric_name": "l2norm",
-                  "mean": 1.4283780764,
+                  "mean": 1.4577490056,
                   "sem": 0.2,
                   "trial_index": 11,
                   "n": 10000,
-                  "frac_nonnull": 1.4283780764
+                  "frac_nonnull": 1.4577490056
                 },
                 {
                   "index": 12,
                   "arm_name": "12_0",
                   "metric_name": "l2norm",
-                  "mean": 1.3781713249,
+                  "mean": 1.6726526231,
                   "sem": 0.2,
                   "trial_index": 12,
                   "n": 10000,
-                  "frac_nonnull": 1.3781713249
+                  "frac_nonnull": 1.6726526231
                 },
                 {
                   "index": 13,
                   "arm_name": "13_0",
                   "metric_name": "l2norm",
-                  "mean": 1.2894321457,
+                  "mean": 1.2625518762,
                   "sem": 0.2,
                   "trial_index": 13,
                   "n": 10000,
-                  "frac_nonnull": 1.2894321457
+                  "frac_nonnull": 1.2625518762
                 },
                 {
                   "index": 14,
                   "arm_name": "14_0",
                   "metric_name": "l2norm",
-                  "mean": 1.6593451997,
+                  "mean": 0.9936750533,
                   "sem": 0.2,
                   "trial_index": 14,
                   "n": 10000,
-                  "frac_nonnull": 1.6593451997
+                  "frac_nonnull": 0.9936750533
                 },
                 {
                   "index": 15,
                   "arm_name": "15_0",
                   "metric_name": "l2norm",
-                  "mean": 1.6348201716,
+                  "mean": 1.2713475843,
                   "sem": 0.2,
                   "trial_index": 15,
                   "n": 10000,
-                  "frac_nonnull": 1.6348201716
+                  "frac_nonnull": 1.2713475843
                 },
                 {
                   "index": 16,
                   "arm_name": "16_0",
                   "metric_name": "l2norm",
-                  "mean": 1.2675905229,
+                  "mean": 1.3496418893,
                   "sem": 0.2,
                   "trial_index": 16,
                   "n": 10000,
-                  "frac_nonnull": 1.2675905229
+                  "frac_nonnull": 1.3496418893
                 },
                 {
                   "index": 17,
                   "arm_name": "17_0",
                   "metric_name": "l2norm",
-                  "mean": 1.5743746294,
+                  "mean": 1.486439752,
                   "sem": 0.2,
                   "trial_index": 17,
                   "n": 10000,
-                  "frac_nonnull": 1.5743746294
+                  "frac_nonnull": 1.486439752
                 },
                 {
                   "index": 18,
                   "arm_name": "18_0",
                   "metric_name": "l2norm",
-                  "mean": 1.4887812959,
+                  "mean": 1.3482293901,
                   "sem": 0.2,
                   "trial_index": 18,
                   "n": 10000,
-                  "frac_nonnull": 1.4887812959
+                  "frac_nonnull": 1.3482293901
                 },
                 {
                   "index": 19,
                   "arm_name": "19_0",
                   "metric_name": "l2norm",
-                  "mean": 1.2768631718,
+                  "mean": 1.1976492186,
                   "sem": 0.2,
                   "trial_index": 19,
                   "n": 10000,
-                  "frac_nonnull": 1.2768631718
+                  "frac_nonnull": 1.1976492186
                 },
                 {
                   "index": 20,
                   "arm_name": "0_0",
                   "metric_name": "hartmann6",
-                  "mean": -0.1658180515,
+                  "mean": -0.3839997145,
                   "sem": 0,
                   "trial_index": 0,
                   "n": 10000,
-                  "frac_nonnull": -0.1658180515
+                  "frac_nonnull": -0.3839997145
                 },
                 {
                   "index": 21,
                   "arm_name": "1_0",
                   "metric_name": "hartmann6",
-                  "mean": -0.204664385,
+                  "mean": -0.4434561127,
                   "sem": 0,
                   "trial_index": 1,
                   "n": 10000,
-                  "frac_nonnull": -0.204664385
+                  "frac_nonnull": -0.4434561127
                 },
                 {
                   "index": 22,
                   "arm_name": "2_0",
                   "metric_name": "hartmann6",
-                  "mean": -0.3711052831,
+                  "mean": -0.3982833375,
                   "sem": 0,
                   "trial_index": 2,
                   "n": 10000,
-                  "frac_nonnull": -0.3711052831
+                  "frac_nonnull": -0.3982833375
                 },
                 {
                   "index": 23,
                   "arm_name": "3_0",
                   "metric_name": "hartmann6",
-                  "mean": -0.0105396623,
+                  "mean": -0.6329826406,
                   "sem": 0,
                   "trial_index": 3,
                   "n": 10000,
-                  "frac_nonnull": -0.0105396623
+                  "frac_nonnull": -0.6329826406
                 },
                 {
                   "index": 24,
                   "arm_name": "4_0",
                   "metric_name": "hartmann6",
-                  "mean": -0.0089683056,
+                  "mean": -0.0760127228,
                   "sem": 0,
                   "trial_index": 4,
                   "n": 10000,
-                  "frac_nonnull": -0.0089683056
+                  "frac_nonnull": -0.0760127228
                 },
                 {
                   "index": 25,
                   "arm_name": "5_0",
                   "metric_name": "hartmann6",
-                  "mean": -0.2640016509,
+                  "mean": -0.9011038216,
                   "sem": 0,
                   "trial_index": 5,
                   "n": 10000,
-                  "frac_nonnull": -0.2640016509
+                  "frac_nonnull": -0.9011038216
                 },
                 {
                   "index": 26,
                   "arm_name": "6_0",
                   "metric_name": "hartmann6",
-                  "mean": -0.7340021495,
+                  "mean": -2.1283425536,
                   "sem": 0,
                   "trial_index": 6,
                   "n": 10000,
-                  "frac_nonnull": -0.7340021495
+                  "frac_nonnull": -2.1283425536
                 },
                 {
                   "index": 27,
                   "arm_name": "7_0",
                   "metric_name": "hartmann6",
-                  "mean": -0.5192086675,
+                  "mean": -2.6177259808,
                   "sem": 0,
                   "trial_index": 7,
                   "n": 10000,
-                  "frac_nonnull": -0.5192086675
+                  "frac_nonnull": -2.6177259808
                 },
                 {
                   "index": 28,
                   "arm_name": "8_0",
                   "metric_name": "hartmann6",
-                  "mean": -0.7065982058,
+                  "mean": -2.3844698081,
                   "sem": 0,
                   "trial_index": 8,
                   "n": 10000,
-                  "frac_nonnull": -0.7065982058
+                  "frac_nonnull": -2.3844698081
                 },
                 {
                   "index": 29,
                   "arm_name": "9_0",
                   "metric_name": "hartmann6",
-                  "mean": -1.3499655532,
+                  "mean": -1.7182341204,
                   "sem": 0,
                   "trial_index": 9,
                   "n": 10000,
-                  "frac_nonnull": -1.3499655532
+                  "frac_nonnull": -1.7182341204
                 },
                 {
                   "index": 30,
                   "arm_name": "10_0",
                   "metric_name": "hartmann6",
-                  "mean": -1.5629957722,
+                  "mean": -2.6588897749,
                   "sem": 0,
                   "trial_index": 10,
                   "n": 10000,
-                  "frac_nonnull": -1.5629957722
+                  "frac_nonnull": -2.6588897749
                 },
                 {
                   "index": 31,
                   "arm_name": "11_0",
                   "metric_name": "hartmann6",
-                  "mean": -2.3561748002,
+                  "mean": -1.5659201481,
                   "sem": 0,
                   "trial_index": 11,
                   "n": 10000,
-                  "frac_nonnull": -2.3561748002
+                  "frac_nonnull": -1.5659201481
                 },
                 {
                   "index": 32,
                   "arm_name": "12_0",
                   "metric_name": "hartmann6",
-                  "mean": -2.7241677074,
+                  "mean": -2.6751887106,
                   "sem": 0,
                   "trial_index": 12,
                   "n": 10000,
-                  "frac_nonnull": -2.7241677074
+                  "frac_nonnull": -2.6751887106
                 },
                 {
                   "index": 33,
                   "arm_name": "13_0",
                   "metric_name": "hartmann6",
-                  "mean": -2.9525777281,
+                  "mean": -2.1506739236,
                   "sem": 0,
                   "trial_index": 13,
                   "n": 10000,
-                  "frac_nonnull": -2.9525777281
+                  "frac_nonnull": -2.1506739236
                 },
                 {
                   "index": 34,
                   "arm_name": "14_0",
                   "metric_name": "hartmann6",
-                  "mean": -2.5244126454,
+                  "mean": -2.7741775101,
                   "sem": 0,
                   "trial_index": 14,
                   "n": 10000,
-                  "frac_nonnull": -2.5244126454
+                  "frac_nonnull": -2.7741775101
                 },
                 {
                   "index": 35,
                   "arm_name": "15_0",
                   "metric_name": "hartmann6",
-                  "mean": -1.9019486587,
+                  "mean": -2.6131625059,
                   "sem": 0,
                   "trial_index": 15,
                   "n": 10000,
-                  "frac_nonnull": -1.9019486587
+                  "frac_nonnull": -2.6131625059
                 },
                 {
                   "index": 36,
                   "arm_name": "16_0",
                   "metric_name": "hartmann6",
-                  "mean": -2.8515969655,
+                  "mean": -2.7560644937,
                   "sem": 0,
                   "trial_index": 16,
                   "n": 10000,
-                  "frac_nonnull": -2.8515969655
+                  "frac_nonnull": -2.7560644937
                 },
                 {
                   "index": 37,
                   "arm_name": "17_0",
                   "metric_name": "hartmann6",
-                  "mean": -2.2127606789,
+                  "mean": -2.708216491,
                   "sem": 0,
                   "trial_index": 17,
                   "n": 10000,
-                  "frac_nonnull": -2.2127606789
+                  "frac_nonnull": -2.708216491
                 },
                 {
                   "index": 38,
                   "arm_name": "18_0",
                   "metric_name": "hartmann6",
-                  "mean": -2.8784209126,
+                  "mean": -3.0318486996,
                   "sem": 0,
                   "trial_index": 18,
                   "n": 10000,
-                  "frac_nonnull": -2.8784209126
+                  "frac_nonnull": -3.0318486996
                 },
                 {
                   "index": 39,
                   "arm_name": "19_0",
                   "metric_name": "hartmann6",
-                  "mean": -2.920944359,
+                  "mean": -2.6754986543,
                   "sem": 0,
                   "trial_index": 19,
                   "n": 10000,
-                  "frac_nonnull": -2.920944359
+                  "frac_nonnull": -2.6754986543
                 }
               ]
             }
           },
           "metadata": {
-            "bento_obj_id": "139815225470784"
+            "bento_obj_id": "139700076315216"
           },
-          "execution_count": 93
+          "execution_count": 10
         }
       ]
     },
@@ -1099,11 +1130,13 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "6732e438-ba5a-46a4-b1c9-8d5789fa8dd8",
+        "originalKey": "2f5e4110-a5f4-418c-9308-43226426816a",
         "collapsed": false,
-        "requestMsgId": "2f5e4110-a5f4-418c-9308-43226426816a",
+        "requestMsgId": "5a4d2c4d-756a-492a-8938-d080a499b66c",
         "code_folding": [],
-        "hidden_ranges": []
+        "hidden_ranges": [],
+        "executionStartTime": 1646323715983,
+        "executionStopTime": 1646323716634
       },
       "source": [
         "import numpy as np\n",
@@ -1118,7 +1151,7 @@
         ")\n",
         "render(best_objective_plot)"
       ],
-      "execution_count": 86,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1162,26 +1195,26 @@
                     20
                   ],
                   "y": [
-                    -0.16581805147758324,
-                    -0.20466438502312354,
-                    -0.3711052831214975,
-                    -0.3711052831214975,
-                    -0.3711052831214975,
-                    -0.3711052831214975,
-                    -0.7340021494695315,
-                    -0.7340021494695315,
-                    -0.7340021494695315,
-                    -1.3499655532159853,
-                    -1.562995772216956,
-                    -2.3561748002192684,
-                    -2.7241677074035326,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844
+                    -0.3839997145314064,
+                    -0.4434561127063069,
+                    -0.4434561127063069,
+                    -0.6329826406109733,
+                    -0.6329826406109733,
+                    -0.9011038216280288,
+                    -2.1283425536050182,
+                    -2.6177259808397837,
+                    -2.6177259808397837,
+                    -2.6177259808397837,
+                    -2.658889774937316,
+                    -2.658889774937316,
+                    -2.6751887105826926,
+                    -2.6751887105826926,
+                    -2.7741775101023047,
+                    -2.7741775101023047,
+                    -2.7741775101023047,
+                    -2.7741775101023047,
+                    -3.031848699625884,
+                    -3.031848699625884
                   ]
                 },
                 {
@@ -1217,26 +1250,26 @@
                     20
                   ],
                   "y": [
-                    -0.16581805147758324,
-                    -0.20466438502312354,
-                    -0.3711052831214975,
-                    -0.3711052831214975,
-                    -0.3711052831214975,
-                    -0.3711052831214975,
-                    -0.7340021494695315,
-                    -0.7340021494695315,
-                    -0.7340021494695315,
-                    -1.3499655532159853,
-                    -1.562995772216956,
-                    -2.3561748002192684,
-                    -2.7241677074035326,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844
+                    -0.3839997145314064,
+                    -0.4434561127063069,
+                    -0.4434561127063069,
+                    -0.6329826406109733,
+                    -0.6329826406109733,
+                    -0.9011038216280288,
+                    -2.1283425536050182,
+                    -2.6177259808397837,
+                    -2.6177259808397837,
+                    -2.6177259808397837,
+                    -2.658889774937316,
+                    -2.658889774937316,
+                    -2.6751887105826926,
+                    -2.6751887105826926,
+                    -2.7741775101023047,
+                    -2.7741775101023047,
+                    -2.7741775101023047,
+                    -2.7741775101023047,
+                    -3.031848699625884,
+                    -3.031848699625884
                   ]
                 },
                 {
@@ -1273,26 +1306,26 @@
                     20
                   ],
                   "y": [
-                    -0.16581805147758324,
-                    -0.20466438502312354,
-                    -0.3711052831214975,
-                    -0.3711052831214975,
-                    -0.3711052831214975,
-                    -0.3711052831214975,
-                    -0.7340021494695315,
-                    -0.7340021494695315,
-                    -0.7340021494695315,
-                    -1.3499655532159853,
-                    -1.562995772216956,
-                    -2.3561748002192684,
-                    -2.7241677074035326,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844,
-                    -2.9525777281284844
+                    -0.3839997145314064,
+                    -0.4434561127063069,
+                    -0.4434561127063069,
+                    -0.6329826406109733,
+                    -0.6329826406109733,
+                    -0.9011038216280288,
+                    -2.1283425536050182,
+                    -2.6177259808397837,
+                    -2.6177259808397837,
+                    -2.6177259808397837,
+                    -2.658889774937316,
+                    -2.658889774937316,
+                    -2.6751887105826926,
+                    -2.6751887105826926,
+                    -2.7741775101023047,
+                    -2.7741775101023047,
+                    -2.7741775101023047,
+                    -2.7741775101023047,
+                    -3.031848699625884,
+                    -3.031848699625884
                   ]
                 },
                 {
@@ -2141,14 +2174,14 @@
                   },
                   "type": "linear",
                   "range": [
-                    -3.497733997140134,
-                    0.009545945662551014
+                    -3.4856127936371437,
+                    -0.22075692089426233
                   ],
                   "autorange": true
                 }
               }
             },
-            "text/html": "<div>                            <div id=\"4d20cfe7-170c-4b57-b2df-ceb50fef47a4\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"4d20cfe7-170c-4b57-b2df-ceb50fef47a4\")) {                    Plotly.newPlot(                        \"4d20cfe7-170c-4b57-b2df-ceb50fef47a4\",                        [{\"hoverinfo\": \"none\", \"legendgroup\": \"\", \"line\": {\"width\": 0}, \"mode\": \"lines\", \"showlegend\": false, \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], \"y\": [-0.16581805147758324, -0.20466438502312354, -0.3711052831214975, -0.3711052831214975, -0.3711052831214975, -0.3711052831214975, -0.7340021494695315, -0.7340021494695315, -0.7340021494695315, -1.3499655532159853, -1.562995772216956, -2.3561748002192684, -2.7241677074035326, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844]}, {\"fill\": \"tonexty\", \"fillcolor\": \"rgba(128,177,211,0.3)\", \"legendgroup\": \"objective value\", \"line\": {\"color\": \"rgba(128,177,211,1)\"}, \"mode\": \"lines\", \"name\": \"objective value\", \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], \"y\": [-0.16581805147758324, -0.20466438502312354, -0.3711052831214975, -0.3711052831214975, -0.3711052831214975, -0.3711052831214975, -0.7340021494695315, -0.7340021494695315, -0.7340021494695315, -1.3499655532159853, -1.562995772216956, -2.3561748002192684, -2.7241677074035326, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844]}, {\"fill\": \"tonexty\", \"fillcolor\": \"rgba(128,177,211,0.3)\", \"hoverinfo\": \"none\", \"legendgroup\": \"\", \"line\": {\"width\": 0}, \"mode\": \"lines\", \"showlegend\": false, \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], \"y\": [-0.16581805147758324, -0.20466438502312354, -0.3711052831214975, -0.3711052831214975, -0.3711052831214975, -0.3711052831214975, -0.7340021494695315, -0.7340021494695315, -0.7340021494695315, -1.3499655532159853, -1.562995772216956, -2.3561748002192684, -2.7241677074035326, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844, -2.9525777281284844]}, {\"line\": {\"color\": \"rgba(253,180,98,1)\", \"dash\": \"dash\"}, \"mode\": \"lines\", \"name\": \"Optimum\", \"type\": \"scatter\", \"x\": [1, 20], \"y\": [-3.32237, -3.32237]}],                        {\"showlegend\": true, \"template\": {\"data\": {\"bar\": [{\"error_x\": {\"color\": \"#2a3f5f\"}, \"error_y\": {\"color\": \"#2a3f5f\"}, \"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"bar\"}], \"barpolar\": [{\"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"barpolar\"}], \"carpet\": [{\"aaxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"baxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"type\": \"carpet\"}], \"choropleth\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"choropleth\"}], \"contour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"contour\"}], \"contourcarpet\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"contourcarpet\"}], \"heatmap\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmap\"}], \"heatmapgl\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmapgl\"}], \"histogram\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"histogram\"}], \"histogram2d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2d\"}], \"histogram2dcontour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2dcontour\"}], \"mesh3d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"mesh3d\"}], \"parcoords\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"parcoords\"}], \"pie\": [{\"automargin\": true, \"type\": \"pie\"}], \"scatter\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter\"}], \"scatter3d\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter3d\"}], \"scattercarpet\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattercarpet\"}], \"scattergeo\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergeo\"}], \"scattergl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergl\"}], \"scattermapbox\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattermapbox\"}], \"scatterpolar\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolar\"}], \"scatterpolargl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolargl\"}], \"scatterternary\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterternary\"}], \"surface\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"surface\"}], \"table\": [{\"cells\": {\"fill\": {\"color\": \"#EBF0F8\"}, \"line\": {\"color\": \"white\"}}, \"header\": {\"fill\": {\"color\": \"#C8D4E3\"}, \"line\": {\"color\": \"white\"}}, \"type\": \"table\"}]}, \"layout\": {\"annotationdefaults\": {\"arrowcolor\": \"#2a3f5f\", \"arrowhead\": 0, \"arrowwidth\": 1}, \"autotypenumbers\": \"strict\", \"coloraxis\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"colorscale\": {\"diverging\": [[0, \"#8e0152\"], [0.1, \"#c51b7d\"], [0.2, \"#de77ae\"], [0.3, \"#f1b6da\"], [0.4, \"#fde0ef\"], [0.5, \"#f7f7f7\"], [0.6, \"#e6f5d0\"], [0.7, \"#b8e186\"], [0.8, \"#7fbc41\"], [0.9, \"#4d9221\"], [1, \"#276419\"]], \"sequential\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"sequentialminus\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]]}, \"colorway\": [\"#636efa\", \"#EF553B\", \"#00cc96\", \"#ab63fa\", \"#FFA15A\", \"#19d3f3\", \"#FF6692\", \"#B6E880\", \"#FF97FF\", \"#FECB52\"], \"font\": {\"color\": \"#2a3f5f\"}, \"geo\": {\"bgcolor\": \"white\", \"lakecolor\": \"white\", \"landcolor\": \"#E5ECF6\", \"showlakes\": true, \"showland\": true, \"subunitcolor\": \"white\"}, \"hoverlabel\": {\"align\": \"left\"}, \"hovermode\": \"closest\", \"mapbox\": {\"style\": \"light\"}, \"paper_bgcolor\": \"white\", \"plot_bgcolor\": \"#E5ECF6\", \"polar\": {\"angularaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"radialaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"scene\": {\"xaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"yaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"zaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}}, \"shapedefaults\": {\"line\": {\"color\": \"#2a3f5f\"}}, \"ternary\": {\"aaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"baxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"caxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"title\": {\"x\": 0.05}, \"xaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}, \"yaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}}}, \"title\": {\"text\": \"\"}, \"xaxis\": {\"title\": {\"text\": \"Iteration\"}}, \"yaxis\": {\"title\": {\"text\": \"\"}}},                        {\"responsive\": true}                    ).then(function(){\n                            \nvar gd = document.getElementById('4d20cfe7-170c-4b57-b2df-ceb50fef47a4');\nvar x = new MutationObserver(function (mutations, observer) {{\n        var display = window.getComputedStyle(gd).display;\n        if (!display || display === 'none') {{\n            console.log([gd, 'removed!']);\n            Plotly.purge(gd);\n            observer.disconnect();\n        }}\n}});\n\n// Listen for the removal of the full notebook cells\nvar notebookContainer = gd.closest('#notebook-container');\nif (notebookContainer) {{\n    x.observe(notebookContainer, {childList: true});\n}}\n\n// Listen for the clearing of the current output cell\nvar outputEl = gd.closest('.output');\nif (outputEl) {{\n    x.observe(outputEl, {childList: true});\n}}\n\n                        })                };                });            </script>        </div>"
+            "text/html": "<div>                            <div id=\"6f9d1020-77c5-4e11-b6e6-d98dba19d3fc\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"6f9d1020-77c5-4e11-b6e6-d98dba19d3fc\")) {                    Plotly.newPlot(                        \"6f9d1020-77c5-4e11-b6e6-d98dba19d3fc\",                        [{\"hoverinfo\": \"none\", \"legendgroup\": \"\", \"line\": {\"width\": 0}, \"mode\": \"lines\", \"showlegend\": false, \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], \"y\": [-0.3839997145314064, -0.4434561127063069, -0.4434561127063069, -0.6329826406109733, -0.6329826406109733, -0.9011038216280288, -2.1283425536050182, -2.6177259808397837, -2.6177259808397837, -2.6177259808397837, -2.658889774937316, -2.658889774937316, -2.6751887105826926, -2.6751887105826926, -2.7741775101023047, -2.7741775101023047, -2.7741775101023047, -2.7741775101023047, -3.031848699625884, -3.031848699625884]}, {\"fill\": \"tonexty\", \"fillcolor\": \"rgba(128,177,211,0.3)\", \"legendgroup\": \"objective value\", \"line\": {\"color\": \"rgba(128,177,211,1)\"}, \"mode\": \"lines\", \"name\": \"objective value\", \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], \"y\": [-0.3839997145314064, -0.4434561127063069, -0.4434561127063069, -0.6329826406109733, -0.6329826406109733, -0.9011038216280288, -2.1283425536050182, -2.6177259808397837, -2.6177259808397837, -2.6177259808397837, -2.658889774937316, -2.658889774937316, -2.6751887105826926, -2.6751887105826926, -2.7741775101023047, -2.7741775101023047, -2.7741775101023047, -2.7741775101023047, -3.031848699625884, -3.031848699625884]}, {\"fill\": \"tonexty\", \"fillcolor\": \"rgba(128,177,211,0.3)\", \"hoverinfo\": \"none\", \"legendgroup\": \"\", \"line\": {\"width\": 0}, \"mode\": \"lines\", \"showlegend\": false, \"type\": \"scatter\", \"x\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], \"y\": [-0.3839997145314064, -0.4434561127063069, -0.4434561127063069, -0.6329826406109733, -0.6329826406109733, -0.9011038216280288, -2.1283425536050182, -2.6177259808397837, -2.6177259808397837, -2.6177259808397837, -2.658889774937316, -2.658889774937316, -2.6751887105826926, -2.6751887105826926, -2.7741775101023047, -2.7741775101023047, -2.7741775101023047, -2.7741775101023047, -3.031848699625884, -3.031848699625884]}, {\"line\": {\"color\": \"rgba(253,180,98,1)\", \"dash\": \"dash\"}, \"mode\": \"lines\", \"name\": \"Optimum\", \"type\": \"scatter\", \"x\": [1, 20], \"y\": [-3.32237, -3.32237]}],                        {\"showlegend\": true, \"template\": {\"data\": {\"bar\": [{\"error_x\": {\"color\": \"#2a3f5f\"}, \"error_y\": {\"color\": \"#2a3f5f\"}, \"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"bar\"}], \"barpolar\": [{\"marker\": {\"line\": {\"color\": \"#E5ECF6\", \"width\": 0.5}}, \"type\": \"barpolar\"}], \"carpet\": [{\"aaxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"baxis\": {\"endlinecolor\": \"#2a3f5f\", \"gridcolor\": \"white\", \"linecolor\": \"white\", \"minorgridcolor\": \"white\", \"startlinecolor\": \"#2a3f5f\"}, \"type\": \"carpet\"}], \"choropleth\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"choropleth\"}], \"contour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"contour\"}], \"contourcarpet\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"contourcarpet\"}], \"heatmap\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmap\"}], \"heatmapgl\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"heatmapgl\"}], \"histogram\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"histogram\"}], \"histogram2d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2d\"}], \"histogram2dcontour\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"histogram2dcontour\"}], \"mesh3d\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"type\": \"mesh3d\"}], \"parcoords\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"parcoords\"}], \"pie\": [{\"automargin\": true, \"type\": \"pie\"}], \"scatter\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter\"}], \"scatter3d\": [{\"line\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatter3d\"}], \"scattercarpet\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattercarpet\"}], \"scattergeo\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergeo\"}], \"scattergl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattergl\"}], \"scattermapbox\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scattermapbox\"}], \"scatterpolar\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolar\"}], \"scatterpolargl\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterpolargl\"}], \"scatterternary\": [{\"marker\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"type\": \"scatterternary\"}], \"surface\": [{\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}, \"colorscale\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"type\": \"surface\"}], \"table\": [{\"cells\": {\"fill\": {\"color\": \"#EBF0F8\"}, \"line\": {\"color\": \"white\"}}, \"header\": {\"fill\": {\"color\": \"#C8D4E3\"}, \"line\": {\"color\": \"white\"}}, \"type\": \"table\"}]}, \"layout\": {\"annotationdefaults\": {\"arrowcolor\": \"#2a3f5f\", \"arrowhead\": 0, \"arrowwidth\": 1}, \"autotypenumbers\": \"strict\", \"coloraxis\": {\"colorbar\": {\"outlinewidth\": 0, \"ticks\": \"\"}}, \"colorscale\": {\"diverging\": [[0, \"#8e0152\"], [0.1, \"#c51b7d\"], [0.2, \"#de77ae\"], [0.3, \"#f1b6da\"], [0.4, \"#fde0ef\"], [0.5, \"#f7f7f7\"], [0.6, \"#e6f5d0\"], [0.7, \"#b8e186\"], [0.8, \"#7fbc41\"], [0.9, \"#4d9221\"], [1, \"#276419\"]], \"sequential\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]], \"sequentialminus\": [[0.0, \"#0d0887\"], [0.1111111111111111, \"#46039f\"], [0.2222222222222222, \"#7201a8\"], [0.3333333333333333, \"#9c179e\"], [0.4444444444444444, \"#bd3786\"], [0.5555555555555556, \"#d8576b\"], [0.6666666666666666, \"#ed7953\"], [0.7777777777777778, \"#fb9f3a\"], [0.8888888888888888, \"#fdca26\"], [1.0, \"#f0f921\"]]}, \"colorway\": [\"#636efa\", \"#EF553B\", \"#00cc96\", \"#ab63fa\", \"#FFA15A\", \"#19d3f3\", \"#FF6692\", \"#B6E880\", \"#FF97FF\", \"#FECB52\"], \"font\": {\"color\": \"#2a3f5f\"}, \"geo\": {\"bgcolor\": \"white\", \"lakecolor\": \"white\", \"landcolor\": \"#E5ECF6\", \"showlakes\": true, \"showland\": true, \"subunitcolor\": \"white\"}, \"hoverlabel\": {\"align\": \"left\"}, \"hovermode\": \"closest\", \"mapbox\": {\"style\": \"light\"}, \"paper_bgcolor\": \"white\", \"plot_bgcolor\": \"#E5ECF6\", \"polar\": {\"angularaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"radialaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"scene\": {\"xaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"yaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}, \"zaxis\": {\"backgroundcolor\": \"#E5ECF6\", \"gridcolor\": \"white\", \"gridwidth\": 2, \"linecolor\": \"white\", \"showbackground\": true, \"ticks\": \"\", \"zerolinecolor\": \"white\"}}, \"shapedefaults\": {\"line\": {\"color\": \"#2a3f5f\"}}, \"ternary\": {\"aaxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"baxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}, \"bgcolor\": \"#E5ECF6\", \"caxis\": {\"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\"}}, \"title\": {\"x\": 0.05}, \"xaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}, \"yaxis\": {\"automargin\": true, \"gridcolor\": \"white\", \"linecolor\": \"white\", \"ticks\": \"\", \"title\": {\"standoff\": 15}, \"zerolinecolor\": \"white\", \"zerolinewidth\": 2}}}, \"title\": {\"text\": \"\"}, \"xaxis\": {\"title\": {\"text\": \"Iteration\"}}, \"yaxis\": {\"title\": {\"text\": \"\"}}},                        {\"responsive\": true}                    ).then(function(){\n                            \nvar gd = document.getElementById('6f9d1020-77c5-4e11-b6e6-d98dba19d3fc');\nvar x = new MutationObserver(function (mutations, observer) {{\n        var display = window.getComputedStyle(gd).display;\n        if (!display || display === 'none') {{\n            console.log([gd, 'removed!']);\n            Plotly.purge(gd);\n            observer.disconnect();\n        }}\n}});\n\n// Listen for the removal of the full notebook cells\nvar notebookContainer = gd.closest('#notebook-container');\nif (notebookContainer) {{\n    x.observe(notebookContainer, {childList: true});\n}}\n\n// Listen for the clearing of the current output cell\nvar outputEl = gd.closest('.output');\nif (outputEl) {{\n    x.observe(outputEl, {childList: true});\n}}\n\n                        })                };                });            </script>        </div>"
           },
           "metadata": {}
         }
@@ -2180,13 +2213,15 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "21bbb0ae-f3e3-4a5a-ac62-53934c3f1a4b",
+        "originalKey": "78b8c7d4-3915-4cd2-9bd9-dde0ddeaa65f",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "78b8c7d4-3915-4cd2-9bd9-dde0ddeaa65f"
+        "requestMsgId": "7ec75ae4-1d7f-4ff4-8d9d-b77fdf28ccfe",
+        "executionStartTime": 1646323716638,
+        "executionStopTime": 1646323716697
       },
       "source": [
         "from ax import Data\n",
@@ -2212,7 +2247,7 @@
         "    def is_available_while_running(self) -> bool:\n",
         "        return True"
       ],
-      "execution_count": 15,
+      "execution_count": 12,
       "outputs": []
     },
     {
@@ -2232,46 +2267,59 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "a2202ebe-b6fa-4bb9-91a5-6b505ce2d3fc",
+        "originalKey": "d9f25a3b-ca8b-4283-86de-f7ec537723ab",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "d9f25a3b-ca8b-4283-86de-f7ec537723ab"
+        "requestMsgId": "f57e11d7-cc68-4323-a0cd-ff6f464dcd97",
+        "executionStartTime": 1646324682655,
+        "executionStopTime": 1646324682796
       },
       "source": [
-        "from ax.storage.metric_registry import register_metric\n",
+        "from ax.storage.metric_registry import register_metrics\n",
         "from ax.storage.runner_registry import register_runner\n",
         "\n",
-        "register_metric(BoothMetric)\n",
-        "register_metric(L2NormMetric)\n",
-        "register_metric(Hartmann6Metric)\n",
-        "register_runner(MyRunner)\n",
+        "# register_metric(BoothMetric)\n",
+        "# register_metric(L2NormMetric)\n",
+        "# register_metric(Hartmann6Metric)\n",
+        "# register_runner(MyRunner)\n",
+        "\n",
+        "metric_registry, _encoder_registry, _decoder_registry = register_metrics(\n",
+        "    {BoothMetric: None, L2NormMetric: None, Hartmann6Metric: None},\n",
+        ")\n",
+        "runner_registry, encoder_registry, decoder_registry = register_runner(\n",
+        "    MyRunner,\n",
+        "    encoder_registry=_encoder_registry,\n",
+        "    decoder_registry=_decoder_registry,\n",
+        ")\n",
         "\n",
         "from ax.storage.json_store.load import load_experiment\n",
         "from ax.storage.json_store.save import save_experiment\n",
         "\n",
-        "save_experiment(exp, \"experiment.json\")"
+        "save_experiment(exp, \"experiment.json\", encoder_registry=encoder_registry)"
       ],
-      "execution_count": 16,
+      "execution_count": 19,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "be389a75-f37f-446b-aeeb-3bd647a457fc",
+        "originalKey": "82385488-d4ec-4052-869f-792c4606bcec",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "82385488-d4ec-4052-869f-792c4606bcec"
+        "requestMsgId": "e19ec7fb-f266-417e-ad17-5662a53a9ae3",
+        "executionStopTime": 1646324720104,
+        "executionStartTime": 1646324718153
       },
       "source": [
-        "loaded_experiment = load_experiment(\"experiment.json\")"
+        "loaded_experiment = load_experiment(\"experiment.json\", decoder_registry=decoder_registry)"
       ],
-      "execution_count": 17,
+      "execution_count": 26,
       "outputs": []
     },
     {
@@ -2290,16 +2338,18 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "b9cb7a42-972b-43b6-832b-8c08137a403e",
+        "originalKey": "502a1d87-43a8-4c91-bf04-3b72d10e8fd6",
         "showInput": true,
         "customInput": null,
         "collapsed": false,
-        "requestMsgId": "502a1d87-43a8-4c91-bf04-3b72d10e8fd6",
+        "requestMsgId": "a0376ade-9a26-430b-b08b-0b93e890539c",
         "code_folding": [],
-        "hidden_ranges": []
+        "hidden_ranges": [],
+        "executionStopTime": 1646324835293,
+        "executionStartTime": 1646324834810
       },
       "source": [
-        "from ax.storage.sqa_store.db import init_engine_and_session_factory,get_engine, create_all_tables\n",
+        "from ax.storage.sqa_store.db import init_engine_and_session_factory, get_engine, create_all_tables\n",
         "from ax.storage.sqa_store.load import load_experiment\n",
         "from ax.storage.sqa_store.save import save_experiment\n",
         "\n",
@@ -2308,63 +2358,73 @@
         "engine = get_engine()\n",
         "create_all_tables(engine)"
       ],
-      "execution_count": 24,
+      "execution_count": 28,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "61282918-fc05-4a33-9877-bfe49e3fc934",
+        "originalKey": "c01febf4-1f6d-49a9-b647-0405949e232b",
         "showInput": true,
         "customInput": null,
         "code_folding": [],
         "hidden_ranges": [],
         "collapsed": false,
-        "requestMsgId": "c01febf4-1f6d-49a9-b647-0405949e232b"
+        "requestMsgId": "484af38c-8b3b-4edb-ac4a-dac792cf9bd6",
+        "executionStopTime": 1646324837193,
+        "executionStartTime": 1646324836782
       },
       "source": [
+        "from ax.storage.sqa_store.decoder import Decoder\n",
+        "from ax.storage.sqa_store.encoder import Encoder\n",
+        "from ax.storage.sqa_store.sqa_config import SQAConfig\n",
+        "\n",
         "exp.name = \"new\"\n",
-        "save_experiment(exp)"
+        "\n",
+        "sqa_config = SQAConfig(\n",
+        "    json_encoder_registry=encoder_registry,\n",
+        "    json_decoder_registry=decoder_registry,\n",
+        "    metric_registry=metric_registry,\n",
+        "    runner_registry=runner_registry,\n",
+        ")\n",
+        "\n",
+        "save_experiment(\n",
+        "    exp,\n",
+        "    config=sqa_config,\n",
+        ")"
       ],
-      "execution_count": 26,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "originalKey": "e8ea6d47-a91e-47f6-b48a-63f60c11b7bc",
-        "showInput": true,
-        "customInput": null,
-        "code_folding": [],
-        "hidden_ranges": [],
-        "collapsed": false,
-        "requestMsgId": "2e8c6e5d-b206-497e-8675-0768105e678d"
-      },
-      "source": [
-        "load_experiment(exp.name)"
-      ],
-      "execution_count": 27,
+      "execution_count": 29,
       "outputs": [
         {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "Experiment(new)"
-          },
-          "metadata": {
-            "bento_obj_id": "139815333551504"
-          },
-          "execution_count": 27
+          "output_type": "error",
+          "ename": "TypeError",
+          "evalue": "save_experiment() got an unexpected keyword argument 'encoder'",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+            "\u001b[0;32m<ipython-input-29-bbf2110c597c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     12\u001b[0m )\n\u001b[1;32m     13\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 14\u001b[0;31m save_experiment(\n\u001b[0m\u001b[1;32m     15\u001b[0m     \u001b[0mexp\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m     \u001b[0mencoder\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mEncoder\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msqa_config\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;31mTypeError\u001b[0m: save_experiment() got an unexpected keyword argument 'encoder'"
+          ]
         }
       ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "2e8c6e5d-b206-497e-8675-0768105e678d",
+        "showInput": true,
+        "customInput": null,
+        "code_folding": [],
+        "hidden_ranges": [],
+        "collapsed": false,
+        "requestMsgId": "bf6ff7fd-b7a5-4b39-a770-e1b909a9060c",
+        "executionStopTime": 1646323717340
+      },
+      "source": [
+        "load_experiment(exp.name, decoder=Decoder(sqa_config))"
+      ],
+      "execution_count": null,
+      "outputs": []
     }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "python3",
-      "language": "python",
-      "name": "python3"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  ]
 }

--- a/tutorials/scheduler.ipynb
+++ b/tutorials/scheduler.ipynb
@@ -1,9 +1,9 @@
 {
   "metadata": {
     "kernelspec": {
-      "display_name": "python3",
+      "display_name": "ae",
       "language": "python",
-      "name": "python3",
+      "name": "bento_kernel_ae",
       "metadata": {
         "kernel_name": "bento_kernel_ae",
         "nightly_builds": false,
@@ -11,10 +11,10 @@
         "is_prebuilt": true
       }
     },
-    "last_server_session_id": "f69f0901-efdd-4230-86a6-08d17f806aa5",
-    "last_kernel_id": "22fd970c-2dde-4c1f-a439-66bbfbbb43b9",
-    "last_base_url": "https://devvm3002.frc0.facebook.com:8090/",
-    "last_msg_id": "b1d49dc1-9824bf694d4896bac87b2d67_177",
+    "last_server_session_id": "c173d8ef-377f-4847-af67-fda8ed534e9f",
+    "last_kernel_id": "13557944-0201-40d5-895f-aac9ed79bccc",
+    "last_base_url": "https://37766.od.fbinfra.net:443/",
+    "last_msg_id": "b89074ef-b8f0ec93b2eb18c03654d89a_887",
     "captumWidgetMessage": {},
     "outputWidgetContext": {}
   },
@@ -100,11 +100,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "924ba133-d791-4a19-bb7a-99863d82a0bf",
+        "originalKey": "326c94b3-be22-43bb-b123-0ab5638f37de",
         "collapsed": false,
-        "requestMsgId": "326c94b3-be22-43bb-b123-0ab5638f37de",
-        "executionStartTime": 1639600338857,
-        "executionStopTime": 1639600340240,
+        "requestMsgId": "b29baae5-9b62-4298-aa22-ce8fb8701137",
+        "executionStartTime": 1646324521594,
+        "executionStopTime": 1646324521669,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -167,7 +167,7 @@
         "    \"\"\"Obtain the singleton job queue instance.\"\"\"\n",
         "    return MOCK_JOB_QUEUE_CLIENT"
       ],
-      "execution_count": 1,
+      "execution_count": 21,
       "outputs": []
     },
     {
@@ -187,11 +187,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "786dc582-ffb1-4d5e-a6a2-f8d74bf525d2",
+        "originalKey": "822348ed-5127-41cd-82f0-5b1991f6c50e",
         "collapsed": false,
-        "requestMsgId": "822348ed-5127-41cd-82f0-5b1991f6c50e",
-        "executionStartTime": 1639600340270,
-        "executionStopTime": 1639600340356,
+        "requestMsgId": "17a45120-860b-41c6-913c-90ec4e63b52d",
+        "executionStartTime": 1646324521710,
+        "executionStopTime": 1646324522025,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -254,17 +254,17 @@
         "\n",
         "        return status_dict"
       ],
-      "execution_count": 2,
+      "execution_count": 22,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "4c7975c6-fc54-4c9c-969c-f72bd4e212a9",
+        "originalKey": "8b4f86c6-2032-4374-b324-7196f9aacad5",
         "collapsed": false,
-        "requestMsgId": "8b4f86c6-2032-4374-b324-7196f9aacad5",
-        "executionStartTime": 1639600340385,
-        "executionStopTime": 1639600340426
+        "requestMsgId": "11e5e1d7-c163-4433-9f95-49e1b23345ff",
+        "executionStartTime": 1646324522033,
+        "executionStopTime": 1646324522055
       },
       "source": [
         "import pandas as pd\n",
@@ -299,7 +299,7 @@
         "        }\n",
         "        return Data(df=pd.DataFrame.from_records([df_dict]))"
       ],
-      "execution_count": 3,
+      "execution_count": 23,
       "outputs": []
     },
     {
@@ -315,11 +315,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "1dd68568-6ce2-493a-a717-5c1e4e633e53",
+        "originalKey": "b65ebc40-7a77-4e63-a80b-886cc9b136a8",
         "collapsed": false,
-        "requestMsgId": "b65ebc40-7a77-4e63-a80b-886cc9b136a8",
-        "executionStartTime": 1639600340542,
-        "executionStopTime": 1639600340955
+        "requestMsgId": "59b4be37-0309-4e4d-8bb0-ef2586077652",
+        "executionStartTime": 1646324522063,
+        "executionStopTime": 1646324522101
       },
       "source": [
         "from ax import *\n",
@@ -352,13 +352,13 @@
         "\n",
         "experiment = make_branin_experiment_with_runner_and_metric()"
       ],
-      "execution_count": 4,
+      "execution_count": 24,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:20] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+            "[INFO 03-03 08:22:02] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
           ]
         }
       ]
@@ -394,11 +394,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "3f2d1052-29d6-4cf6-b0ee-1dd5c866b45c",
+        "originalKey": "4a17bb2e-b74e-4b0c-8d68-6d89e4351bae",
         "collapsed": false,
-        "requestMsgId": "4a17bb2e-b74e-4b0c-8d68-6d89e4351bae",
-        "executionStartTime": 1639600340969,
-        "executionStopTime": 1639600341029
+        "requestMsgId": "38842552-4a57-4d57-b9dc-43bba81de461",
+        "executionStartTime": 1646324522111,
+        "executionStopTime": 1646324522135
       },
       "source": [
         "from ax.modelbridge.dispatch_utils import choose_generation_strategy\n",
@@ -408,20 +408,20 @@
         "    max_parallelism_cap=3,\n",
         ")"
       ],
-      "execution_count": 5,
+      "execution_count": 25,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:20] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n"
+            "[INFO 03-03 08:22:02] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:20] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
+            "[INFO 03-03 08:22:02] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
           ]
         }
       ]
@@ -439,11 +439,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "3fd42376-4487-485d-8d14-2af1e2780153",
+        "originalKey": "fb1016fa-6e79-4bb5-8a68-4dd8fc82c955",
         "collapsed": false,
-        "requestMsgId": "fb1016fa-6e79-4bb5-8a68-4dd8fc82c955",
-        "executionStartTime": 1639600341052,
-        "executionStopTime": 1639600341062,
+        "requestMsgId": "7f379d50-effd-4af5-9c36-b7777694ac17",
+        "executionStartTime": 1646324522152,
+        "executionStopTime": 1646324522245,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -457,13 +457,13 @@
         "    options=SchedulerOptions(),\n",
         ")"
       ],
-      "execution_count": 6,
+      "execution_count": 26,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:20] Scheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
+            "[INFO 03-03 08:22:02] Scheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
           ]
         }
       ]
@@ -483,50 +483,85 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "886a04c1-792c-4a98-ab81-ee8bca3ba5f9",
+        "originalKey": "a9fb4890-0c48-4d43-b788-26c3163b8bb9",
         "collapsed": false,
-        "requestMsgId": "a9fb4890-0c48-4d43-b788-26c3163b8bb9",
-        "executionStartTime": 1639600341077,
-        "executionStopTime": 1639600344167
+        "requestMsgId": "3539060c-e019-4d5d-b357-0ed0ab5e9f12",
+        "executionStartTime": 1646324522552,
+        "executionStopTime": 1646324524633
       },
       "source": [
         "scheduler.run_n_trials(max_trials=3)"
       ],
-      "execution_count": 7,
+      "execution_count": 27,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:21] Scheduler: Running trials [0]...\n"
+            "[INFO 03-03 08:22:02] Scheduler: Running trials [0]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:22] Scheduler: Running trials [1]...\n"
+            "[INFO 03-03 08:22:03] Scheduler: Running trials [1]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:23] Scheduler: Running trials [2]...\n"
+            "[INFO 03-03 08:22:03] Scheduler: Running trials [2]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:24] Scheduler: Retrieved COMPLETED trials: 0 - 2.\n"
+            "[INFO 03-03 08:22:04] Scheduler: Retrieved COMPLETED trials: [2].\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:24] Scheduler: Fetching data for trials: 0 - 2.\n"
+            "[INFO 03-03 08:22:04] Scheduler: Fetching data for trials: [2].\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-03 08:22:04] Scheduler: Done submitting trials, waiting for remaining 2 running trials...\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-03 08:22:04] Scheduler: Retrieved COMPLETED trials: [0].\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-03 08:22:04] Scheduler: Fetching data for trials: [0].\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-03 08:22:04] Scheduler: Retrieved COMPLETED trials: [1].\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 03-03 08:22:04] Scheduler: Fetching data for trials: [1].\n"
           ]
         },
         {
@@ -535,9 +570,9 @@
             "text/plain": "OptimizationResult()"
           },
           "metadata": {
-            "bento_obj_id": "140204204742256"
+            "bento_obj_id": "140047084072576"
           },
-          "execution_count": 7
+          "execution_count": 27
         }
       ]
     },
@@ -554,24 +589,24 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "c96fd413-2806-4f12-babe-e77f2c0570c5",
+        "originalKey": "65efb7ad-39c0-4c29-97c8-b784f72a8335",
         "collapsed": false,
-        "requestMsgId": "65efb7ad-39c0-4c29-97c8-b784f72a8335",
-        "executionStartTime": 1639600345584,
-        "executionStopTime": 1639600345605
+        "requestMsgId": "789e225e-d147-4537-a9ee-cba19815dcd6",
+        "executionStartTime": 1646324524645,
+        "executionStopTime": 1646324524747
       },
       "source": [
         "from ax.service.utils.report_utils import exp_to_df\n",
         "\n",
         "exp_to_df(experiment)"
       ],
-      "execution_count": 8,
+      "execution_count": 28,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "      branin  trial_index arm_name  ...         x2  trial_status generation_method\n0  20.718698            0      0_0  ...  13.339543     COMPLETED             Sobol\n1  95.178358            1      1_0  ...   2.004153     COMPLETED             Sobol\n2  14.662899            2      2_0  ...   4.833436     COMPLETED             Sobol\n\n[3 rows x 7 columns]",
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>branin</th>\n      <th>trial_index</th>\n      <th>arm_name</th>\n      <th>x1</th>\n      <th>x2</th>\n      <th>trial_status</th>\n      <th>generation_method</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>20.718698</td>\n      <td>0</td>\n      <td>0_0</td>\n      <td>-4.769288</td>\n      <td>13.339543</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>95.178358</td>\n      <td>1</td>\n      <td>1_0</td>\n      <td>-2.910515</td>\n      <td>2.004153</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>14.662899</td>\n      <td>2</td>\n      <td>2_0</td>\n      <td>1.083257</td>\n      <td>4.833436</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+            "text/plain": "       branin  trial_index arm_name  ...         x2  trial_status generation_method\n0   20.896003            0      0_0  ...   3.928219     COMPLETED             Sobol\n1  102.237330            1      1_0  ...  10.971986     COMPLETED             Sobol\n2  102.237330            2      2_0  ...  14.245586     COMPLETED             Sobol\n\n[3 rows x 7 columns]",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>branin</th>\n      <th>trial_index</th>\n      <th>arm_name</th>\n      <th>x1</th>\n      <th>x2</th>\n      <th>trial_status</th>\n      <th>generation_method</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>20.896003</td>\n      <td>0</td>\n      <td>0_0</td>\n      <td>5.105530</td>\n      <td>3.928219</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>102.237330</td>\n      <td>1</td>\n      <td>1_0</td>\n      <td>6.207874</td>\n      <td>10.971986</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>102.237330</td>\n      <td>2</td>\n      <td>2_0</td>\n      <td>0.624864</td>\n      <td>14.245586</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
             "application/vnd.dataresource+json": {
               "schema": {
                 "fields": [
@@ -616,31 +651,31 @@
               "data": [
                 {
                   "index": 0,
-                  "branin": 20.7186978537,
+                  "branin": 20.8960027366,
                   "trial_index": 0,
                   "arm_name": "0_0",
-                  "x1": -4.7692875983,
-                  "x2": 13.3395427465,
+                  "x1": 5.1055300236,
+                  "x2": 3.928219378,
                   "trial_status": "COMPLETED",
                   "generation_method": "Sobol"
                 },
                 {
                   "index": 1,
-                  "branin": 95.1783580525,
+                  "branin": 102.2373297538,
                   "trial_index": 1,
                   "arm_name": "1_0",
-                  "x1": -2.9105149349,
-                  "x2": 2.0041533513,
+                  "x1": 6.2078739377,
+                  "x2": 10.9719859762,
                   "trial_status": "COMPLETED",
                   "generation_method": "Sobol"
                 },
                 {
                   "index": 2,
-                  "branin": 14.6628992273,
+                  "branin": 102.2373297538,
                   "trial_index": 2,
                   "arm_name": "2_0",
-                  "x1": 1.083256891,
-                  "x2": 4.8334363382,
+                  "x1": 0.6248635845,
+                  "x2": 14.2455859669,
                   "trial_status": "COMPLETED",
                   "generation_method": "Sobol"
                 }
@@ -648,9 +683,9 @@
             }
           },
           "metadata": {
-            "bento_obj_id": "140204043733408"
+            "bento_obj_id": "140047099498992"
           },
-          "execution_count": 8
+          "execution_count": 28
         }
       ]
     },
@@ -668,71 +703,50 @@
       "cell_type": "code",
       "metadata": {
         "scrolled": true,
-        "originalKey": "8b5fbd5e-98fc-4ef4-a555-410d338b29e7",
+        "originalKey": "be5d99d4-8562-4a65-8aa9-36f138c1727d",
         "collapsed": false,
-        "requestMsgId": "be5d99d4-8562-4a65-8aa9-36f138c1727d",
-        "executionStartTime": 1639600345620,
-        "executionStopTime": 1639600348173
+        "requestMsgId": "3a20d166-3056-4d62-8411-cbe48a934a72",
+        "executionStartTime": 1646324524773,
+        "executionStopTime": 1646324528301
       },
       "source": [
         "scheduler.run_n_trials(max_trials=3)"
       ],
-      "execution_count": 9,
+      "execution_count": 29,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:24] Scheduler: Running trials [3]...\n"
+            "[INFO 03-03 08:22:04] Scheduler: Running trials [3]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:25] Scheduler: Running trials [4]...\n"
+            "[INFO 03-03 08:22:05] Scheduler: Running trials [4]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:27] Scheduler: Running trials [5]...\n"
+            "[INFO 03-03 08:22:07] Scheduler: Running trials [5]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:28] Scheduler: Retrieved COMPLETED trials: 4 - 5.\n"
+            "[INFO 03-03 08:22:08] Scheduler: Retrieved COMPLETED trials: 3 - 5.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:28] Scheduler: Fetching data for trials: 4 - 5.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:28] Scheduler: Done submitting trials, waiting for remaining 1 running trials...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:28] Scheduler: Retrieved COMPLETED trials: [3].\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:28] Scheduler: Fetching data for trials: [3].\n"
+            "[INFO 03-03 08:22:08] Scheduler: Fetching data for trials: 3 - 5.\n"
           ]
         },
         {
@@ -741,9 +755,9 @@
             "text/plain": "OptimizationResult()"
           },
           "metadata": {
-            "bento_obj_id": "140204043956384"
+            "bento_obj_id": "140047099550592"
           },
-          "execution_count": 9
+          "execution_count": 29
         }
       ]
     },
@@ -760,22 +774,22 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "d9f4f093-36af-43ed-802e-9c98fceec80e",
+        "originalKey": "99c7eb14-f57d-454b-9026-4bc351391cc6",
         "collapsed": false,
-        "requestMsgId": "99c7eb14-f57d-454b-9026-4bc351391cc6",
-        "executionStartTime": 1639600348210,
-        "executionStopTime": 1639600348343
+        "requestMsgId": "224b617e-c0c8-4996-a166-fc31c9654435",
+        "executionStartTime": 1646324528334,
+        "executionStopTime": 1646324528486
       },
       "source": [
         "exp_to_df(experiment)"
       ],
-      "execution_count": 10,
+      "execution_count": 30,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
-            "text/plain": "       branin  trial_index arm_name  ...         x2  trial_status generation_method\n0   20.718698            0      0_0  ...  13.339543     COMPLETED             Sobol\n1   95.178358            1      1_0  ...   2.004153     COMPLETED             Sobol\n2   14.662899            2      2_0  ...   4.833436     COMPLETED             Sobol\n3   43.134658            3      3_0  ...   8.214753     COMPLETED             Sobol\n4    5.157093            4      4_0  ...   2.623648     COMPLETED             Sobol\n5  135.130320            5      5_0  ...  15.000000     COMPLETED              GPEI\n\n[6 rows x 7 columns]",
-            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>branin</th>\n      <th>trial_index</th>\n      <th>arm_name</th>\n      <th>x1</th>\n      <th>x2</th>\n      <th>trial_status</th>\n      <th>generation_method</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>20.718698</td>\n      <td>0</td>\n      <td>0_0</td>\n      <td>-4.769288</td>\n      <td>13.339543</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>95.178358</td>\n      <td>1</td>\n      <td>1_0</td>\n      <td>-2.910515</td>\n      <td>2.004153</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>14.662899</td>\n      <td>2</td>\n      <td>2_0</td>\n      <td>1.083257</td>\n      <td>4.833436</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>43.134658</td>\n      <td>3</td>\n      <td>3_0</td>\n      <td>3.785722</td>\n      <td>8.214753</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>5.157093</td>\n      <td>4</td>\n      <td>4_0</td>\n      <td>4.068357</td>\n      <td>2.623648</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>135.130320</td>\n      <td>5</td>\n      <td>5_0</td>\n      <td>1.577302</td>\n      <td>15.000000</td>\n      <td>COMPLETED</td>\n      <td>GPEI</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+            "text/plain": "       branin  trial_index arm_name  ...         x2  trial_status generation_method\n0   20.896003            0      0_0  ...   3.928219     COMPLETED             Sobol\n1  102.237330            1      1_0  ...  10.971986     COMPLETED             Sobol\n2  102.237330            2      2_0  ...  14.245586     COMPLETED             Sobol\n3   49.645475            3      3_0  ...   4.598523     COMPLETED             Sobol\n4   73.257804            4      4_0  ...   0.892040     COMPLETED             Sobol\n5    3.844261            5      5_0  ...   0.978783     COMPLETED              GPEI\n\n[6 rows x 7 columns]",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>branin</th>\n      <th>trial_index</th>\n      <th>arm_name</th>\n      <th>x1</th>\n      <th>x2</th>\n      <th>trial_status</th>\n      <th>generation_method</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>20.896003</td>\n      <td>0</td>\n      <td>0_0</td>\n      <td>5.105530</td>\n      <td>3.928219</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>102.237330</td>\n      <td>1</td>\n      <td>1_0</td>\n      <td>6.207874</td>\n      <td>10.971986</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>102.237330</td>\n      <td>2</td>\n      <td>2_0</td>\n      <td>0.624864</td>\n      <td>14.245586</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>49.645475</td>\n      <td>3</td>\n      <td>3_0</td>\n      <td>-2.850953</td>\n      <td>4.598523</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>73.257804</td>\n      <td>4</td>\n      <td>4_0</td>\n      <td>-1.589961</td>\n      <td>0.892040</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>3.844261</td>\n      <td>5</td>\n      <td>5_0</td>\n      <td>8.676005</td>\n      <td>0.978783</td>\n      <td>COMPLETED</td>\n      <td>GPEI</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
             "application/vnd.dataresource+json": {
               "schema": {
                 "fields": [
@@ -820,61 +834,61 @@
               "data": [
                 {
                   "index": 0,
-                  "branin": 20.7186978537,
+                  "branin": 20.8960027366,
                   "trial_index": 0,
                   "arm_name": "0_0",
-                  "x1": -4.7692875983,
-                  "x2": 13.3395427465,
+                  "x1": 5.1055300236,
+                  "x2": 3.928219378,
                   "trial_status": "COMPLETED",
                   "generation_method": "Sobol"
                 },
                 {
                   "index": 1,
-                  "branin": 95.1783580525,
+                  "branin": 102.2373297538,
                   "trial_index": 1,
                   "arm_name": "1_0",
-                  "x1": -2.9105149349,
-                  "x2": 2.0041533513,
+                  "x1": 6.2078739377,
+                  "x2": 10.9719859762,
                   "trial_status": "COMPLETED",
                   "generation_method": "Sobol"
                 },
                 {
                   "index": 2,
-                  "branin": 14.6628992273,
+                  "branin": 102.2373297538,
                   "trial_index": 2,
                   "arm_name": "2_0",
-                  "x1": 1.083256891,
-                  "x2": 4.8334363382,
+                  "x1": 0.6248635845,
+                  "x2": 14.2455859669,
                   "trial_status": "COMPLETED",
                   "generation_method": "Sobol"
                 },
                 {
                   "index": 3,
-                  "branin": 43.1346584696,
+                  "branin": 49.6454752966,
                   "trial_index": 3,
                   "arm_name": "3_0",
-                  "x1": 3.7857216829,
-                  "x2": 8.2147531025,
+                  "x1": -2.8509525303,
+                  "x2": 4.598523248,
                   "trial_status": "COMPLETED",
                   "generation_method": "Sobol"
                 },
                 {
                   "index": 4,
-                  "branin": 5.1570926602,
+                  "branin": 73.2578040801,
                   "trial_index": 4,
                   "arm_name": "4_0",
-                  "x1": 4.0683565103,
-                  "x2": 2.623648122,
+                  "x1": -1.5899611637,
+                  "x2": 0.8920401055,
                   "trial_status": "COMPLETED",
                   "generation_method": "Sobol"
                 },
                 {
                   "index": 5,
-                  "branin": 135.1303202461,
+                  "branin": 3.8442611279,
                   "trial_index": 5,
                   "arm_name": "5_0",
-                  "x1": 1.5773019609,
-                  "x2": 15,
+                  "x1": 8.6760045436,
+                  "x2": 0.978783074,
                   "trial_status": "COMPLETED",
                   "generation_method": "GPEI"
                 }
@@ -882,9 +896,9 @@
             }
           },
           "metadata": {
-            "bento_obj_id": "140205700846880"
+            "bento_obj_id": "140047083250016"
           },
-          "execution_count": 10
+          "execution_count": 30
         }
       ]
     },
@@ -901,64 +915,57 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "c6c718cf-fa6a-46e8-ac03-aca101b45e43",
+        "originalKey": "7c6c9c28-a7b7-4d69-b07b-911e9c7b3d44",
         "collapsed": false,
-        "requestMsgId": "7c6c9c28-a7b7-4d69-b07b-911e9c7b3d44",
-        "executionStartTime": 1639600348420,
-        "executionStopTime": 1639600350175
+        "requestMsgId": "16b53f94-897b-4149-8059-e2b5b2e68344",
+        "executionStartTime": 1646324528526,
+        "executionStopTime": 1646324528961
       },
       "source": [
         "scheduler.run_n_trials(max_trials=3, timeout_hours=0.00001)"
       ],
-      "execution_count": 11,
+      "execution_count": 31,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:28] Scheduler: Running trials [6]...\n"
+            "[INFO 03-03 08:22:08] Scheduler: Running trials [6]...\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[ERROR 12-15 12:32:28] Scheduler: Optimization timed out (timeout hours: 1e-05)!\n"
+            "[ERROR 03-03 08:22:08] Scheduler: Optimization timed out (timeout hours: 1e-05)!\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:28] Scheduler: `should_abort_optimization` is `True`, not running more trials.\n"
+            "[INFO 03-03 08:22:08] Scheduler: `should_abort_optimization` is `True`, not running more trials.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:28] Scheduler: Waiting for completed trials (for 1 sec, currently running trials: 1).\n"
+            "[INFO 03-03 08:22:08] Scheduler: Retrieved COMPLETED trials: [6].\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:29] Scheduler: Retrieved COMPLETED trials: [6].\n"
+            "[INFO 03-03 08:22:08] Scheduler: Fetching data for trials: [6].\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:29] Scheduler: Fetching data for trials: [6].\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[ERROR 12-15 12:32:30] Scheduler: Optimization timed out (timeout hours: 1e-05)!\n"
+            "[ERROR 03-03 08:22:08] Scheduler: Optimization timed out (timeout hours: 1e-05)!\n"
           ]
         },
         {
@@ -967,9 +974,9 @@
             "text/plain": "OptimizationResult()"
           },
           "metadata": {
-            "bento_obj_id": "140205700475296"
+            "bento_obj_id": "140047083332416"
           },
-          "execution_count": 11
+          "execution_count": 31
         }
       ]
     },
@@ -990,31 +997,47 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "c42b34c1-fa1b-4971-af57-22c1a3056612",
+        "originalKey": "fa485a79-fad5-46c0-b991-1524fa39efb6",
         "collapsed": false,
-        "requestMsgId": "fa485a79-fad5-46c0-b991-1524fa39efb6",
-        "executionStartTime": 1639600350199,
-        "executionStopTime": 1639600350270,
+        "requestMsgId": "31947b4c-25f0-4f04-99fa-ce8fc95aa8b0",
+        "executionStartTime": 1646324528986,
+        "executionStopTime": 1646324529171,
         "code_folding": [],
         "hidden_ranges": []
       },
       "source": [
         "from ax.storage.metric_registry import register_metric\n",
         "from ax.storage.runner_registry import register_runner\n",
-        "from ax.storage.sqa_store.db import (\n",
-        "    create_all_tables,\n",
-        "    get_engine,\n",
-        "    init_engine_and_session_factory,\n",
-        ")\n",
+        "from ax.storage.sqa_store.db import create_all_tables, get_engine, init_engine_and_session_factory\n",
+        "from ax.storage.sqa_store.decoder import Decoder\n",
+        "from ax.storage.sqa_store.encoder import Encoder\n",
+        "from ax.storage.sqa_store.sqa_config import SQAConfig\n",
         "from ax.storage.sqa_store.structs import DBSettings\n",
         "\n",
         "\n",
-        "register_metric(BraninForMockJobMetric)\n",
-        "register_runner(MockJobRunner)\n",
+        "metric_registry, _encoder_registry, _decoder_registry = register_metric(\n",
+        "    BraninForMockJobMetric,\n",
+        ")\n",
+        "runner_registry, encoder_registry, decoder_registry = register_runner(\n",
+        "    MockJobRunner,\n",
+        "    encoder_registry=_encoder_registry,\n",
+        "    decoder_registry=_decoder_registry,\n",
+        ")\n",
+        "\n",
+        "sqa_config = SQAConfig(\n",
+        "    json_encoder_registry=encoder_registry,\n",
+        "    json_decoder_registry=decoder_registry,\n",
+        "    metric_registry=metric_registry,\n",
+        "    runner_registry=runner_registry,\n",
+        ")\n",
         "\n",
         "# URL is of the form \"dialect+driver://username:password@host:port/database\".\n",
         "# Instead of URL, can provide a `creator function`; can specify custom encoders/decoders if necessary.\n",
-        "db_settings = DBSettings(url=\"sqlite:///foo.db\")\n",
+        "db_settings = DBSettings(\n",
+        "    url=\"sqlite:///foo.db\",\n",
+        "    encoder=Encoder(sqa_config),\n",
+        "    decoder=Decoder(sqa_config),\n",
+        ")\n",
         "\n",
         "# The following lines are only necessary because it is the first time we are using this database\n",
         "# in practice, you will not need to run these lines every time you initialize your scheduler\n",
@@ -1032,55 +1055,59 @@
         "    db_settings=db_settings,\n",
         ")"
       ],
-      "execution_count": 12,
+      "execution_count": 32,
       "outputs": [
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:30] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+            "[INFO 03-03 08:22:09] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:30] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n"
+            "[INFO 03-03 08:22:09] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:30] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
+            "[INFO 03-03 08:22:09] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:30] Scheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
+            "[INFO 03-03 08:22:09] Scheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
           ]
         },
         {
           "output_type": "stream",
           "name": "stderr",
           "text": [
-            "[INFO 12-15 12:32:30] ax.service.utils.with_db_settings_base: Experiment branin_test_experiment is not yet in DB, storing it.\n"
+            "[INFO 03-03 08:22:09] ax.service.utils.with_db_settings_base: Experiment branin_test_experiment is in DB, updating it.\n"
           ]
         },
         {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] ax.service.utils.with_db_settings_base: Generation strategy Sobol+GPEI is not yet in DB, storing it.\n"
+          "output_type": "error",
+          "ename": "ValueError",
+          "evalue": "An experiment already exists with the name branin_test_experiment. If you need to override this existing experiment, first delete it via `delete_experiment` in ax/ax/storage/sqa_store/delete.py, and then resave.",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+            "\u001b[0;32m<ipython-input-32-666d496191c9>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     41\u001b[0m \u001b[0mgeneration_strategy\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mchoose_generation_strategy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msearch_space\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mexperiment\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msearch_space\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     42\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 43\u001b[0;31m scheduler_with_storage = Scheduler(\n\u001b[0m\u001b[1;32m     44\u001b[0m     \u001b[0mexperiment\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mstored_experiment\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     45\u001b[0m     \u001b[0mgeneration_strategy\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mgeneration_strategy\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/mnt/xarfuse/uid-28769/ba2f3c41-seed-nspid4026533082_cgpid6921913-ns-4026532988/ax/service/scheduler.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, experiment, generation_strategy, options, db_settings, _skip_experiment_save)\u001b[0m\n\u001b[1;32m    310\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    311\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdb_settings_set\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0m_skip_experiment_save\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 312\u001b[0;31m             self._maybe_save_experiment_and_generation_strategy(\n\u001b[0m\u001b[1;32m    313\u001b[0m                 \u001b[0mexperiment\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mexperiment\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgeneration_strategy\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mgeneration_strategy\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    314\u001b[0m             )\n",
+            "\u001b[0;32m/mnt/xarfuse/uid-28769/ba2f3c41-seed-nspid4026533082_cgpid6921913-ns-4026532988/ax/service/utils/with_db_settings_base.py\u001b[0m in \u001b[0;36m_maybe_save_experiment_and_generation_strategy\u001b[0;34m(self, experiment, generation_strategy)\u001b[0m\n\u001b[1;32m    143\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mexp_id\u001b[0m\u001b[0;34m:\u001b[0m  \u001b[0;31m# Experiment in DB.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    144\u001b[0m                 \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"Experiment {exp_name} is in DB, updating it.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 145\u001b[0;31m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_save_experiment_to_db_if_possible\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mexperiment\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mexperiment\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    146\u001b[0m                 \u001b[0msaved_exp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    147\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m  \u001b[0;31m# Experiment not yet in DB.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/mnt/xarfuse/uid-28769/ba2f3c41-seed-nspid4026533082_cgpid6921913-ns-4026532988/ax/service/utils/with_db_settings_base.py\u001b[0m in \u001b[0;36m_save_experiment_to_db_if_possible\u001b[0;34m(self, experiment)\u001b[0m\n\u001b[1;32m    255\u001b[0m         \"\"\"\n\u001b[1;32m    256\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdb_settings_set\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 257\u001b[0;31m             _save_experiment_to_db_if_possible(\n\u001b[0m\u001b[1;32m    258\u001b[0m                 \u001b[0mexperiment\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mexperiment\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    259\u001b[0m                 \u001b[0mencoder\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdb_settings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mencoder\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/mnt/xarfuse/uid-28769/ba2f3c41-seed-nspid4026533082_cgpid6921913-ns-4026532988/ax/utils/common/executils.py\u001b[0m in \u001b[0;36mactual_wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    145\u001b[0m                         )\n\u001b[1;32m    146\u001b[0m                         \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msleep\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mwait_interval\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 147\u001b[0;31m                     \u001b[0;32mreturn\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    148\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    149\u001b[0m             \u001b[0;31m# If we are here, it means the retries were finished but\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/mnt/xarfuse/uid-28769/ba2f3c41-seed-nspid4026533082_cgpid6921913-ns-4026532988/ax/service/utils/with_db_settings_base.py\u001b[0m in \u001b[0;36m_save_experiment_to_db_if_possible\u001b[0;34m(experiment, encoder, decoder, suppress_all_errors)\u001b[0m\n\u001b[1;32m    430\u001b[0m ) -> None:\n\u001b[1;32m    431\u001b[0m     \u001b[0mstart_time\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 432\u001b[0;31m     _save_experiment(\n\u001b[0m\u001b[1;32m    433\u001b[0m         \u001b[0mexperiment\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    434\u001b[0m         \u001b[0mencoder\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mencoder\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/mnt/xarfuse/uid-28769/ba2f3c41-seed-nspid4026533082_cgpid6921913-ns-4026532988/ax/storage/sqa_store/save.py\u001b[0m in \u001b[0;36m_save_experiment\u001b[0;34m(experiment, encoder, decoder, return_sqa, validation_kwargs)\u001b[0m\n\u001b[1;32m     73\u001b[0m         \u001b[0mexisting_sqa_experiment_id\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mexisting_sqa_experiment_id\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     74\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 75\u001b[0;31m     encoder.validate_experiment_metadata(\n\u001b[0m\u001b[1;32m     76\u001b[0m         \u001b[0mexperiment\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     77\u001b[0m         \u001b[0mexisting_sqa_experiment_id\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mexisting_sqa_experiment_id\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/mnt/xarfuse/uid-28769/ba2f3c41-seed-nspid4026533082_cgpid6921913-ns-4026532988/ax/storage/sqa_store/encoder.py\u001b[0m in \u001b[0;36mvalidate_experiment_metadata\u001b[0;34m(cls, experiment, existing_sqa_experiment_id)\u001b[0m\n\u001b[1;32m    101\u001b[0m             \u001b[0;31m# experiment.db_id is None\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    102\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mexisting_sqa_experiment_id\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 103\u001b[0;31m                 raise ValueError(\n\u001b[0m\u001b[1;32m    104\u001b[0m                     \u001b[0;34mf\"An experiment already exists with the name {experiment.name}. \"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    105\u001b[0m                     \u001b[0;34m\"If you need to override this existing experiment, first delete it \"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;31mValueError\u001b[0m: An experiment already exists with the name branin_test_experiment. If you need to override this existing experiment, first delete it via `delete_experiment` in ax/ax/storage/sqa_store/delete.py, and then resave."
           ]
         }
       ]
@@ -1088,28 +1115,17 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "2458256c-5369-4f90-b30e-beedf6ff40b6",
+        "originalKey": "595bab53-3bb6-4188-b0e3-7dd11ed505b8",
         "collapsed": false,
-        "requestMsgId": "595bab53-3bb6-4188-b0e3-7dd11ed505b8",
-        "executionStartTime": 1639600350284,
-        "executionStopTime": 1639600350340
+        "requestMsgId": "e0557ddd-a1a7-4483-9b6c-31bc8c576246",
+        "executionStartTime": 1646324503009,
+        "executionStopTime": 1646324529182
       },
       "source": [
         "stored_experiment.name"
       ],
-      "execution_count": 13,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "'branin_test_experiment'"
-          },
-          "metadata": {
-            "bento_obj_id": "140204204728032"
-          },
-          "execution_count": 13
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1124,11 +1140,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "4c56afcd-6244-4915-af2b-432b3514dbfd",
+        "originalKey": "4a69207a-a51f-4757-b28b-7e66efd9978c",
         "collapsed": false,
-        "requestMsgId": "4a69207a-a51f-4757-b28b-7e66efd9978c",
-        "executionStartTime": 1639600350353,
-        "executionStopTime": 1639600350425,
+        "requestMsgId": "e82a9d61-02a0-487f-9394-e1cd0af39f86",
+        "executionStartTime": 1646324506144,
+        "executionStopTime": 1646324529191,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -1141,37 +1157,8 @@
         "    db_settings=db_settings,\n",
         ")"
       ],
-      "execution_count": 14,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] ax.service.utils.with_db_settings_base: Loading experiment and generation strategy (with reduced state: True)...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] ax.service.utils.with_db_settings_base: Loaded experiment branin_test_experiment in 0.03 seconds, loading trials in mini-batches of 10000.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] ax.service.utils.with_db_settings_base: Loaded generation strategy for experiment branin_test_experiment in 0.01 seconds.\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1186,91 +1173,17 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "06b84c6c-627a-4094-946c-379c293bf1cb",
+        "originalKey": "849cc9b5-b9fa-4980-a727-b889eabcd1f6",
         "collapsed": false,
-        "requestMsgId": "849cc9b5-b9fa-4980-a727-b889eabcd1f6",
-        "executionStartTime": 1639600350496,
-        "executionStopTime": 1639600351940
+        "requestMsgId": "68d61fe2-d342-4aea-8863-039a69c4e83f",
+        "executionStartTime": 1646324510525,
+        "executionStopTime": 1646324529202
       },
       "source": [
         "reloaded_experiment_scheduler.run_n_trials(max_trials=3)"
       ],
-      "execution_count": 15,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] Scheduler: Running trials [0]...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] Scheduler: Running trials [1]...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] Scheduler: Running trials [2]...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] Scheduler: Retrieved COMPLETED trials: 0 - 1.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] Scheduler: Fetching data for trials: 0 - 1.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] Scheduler: Done submitting trials, waiting for remaining 1 running trials...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:30] Scheduler: Waiting for completed trials (for 1 sec, currently running trials: 1).\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:31] Scheduler: Retrieved COMPLETED trials: [2].\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:31] Scheduler: Fetching data for trials: [2].\n"
-          ]
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": "OptimizationResult()"
-          },
-          "metadata": {
-            "bento_obj_id": "140205692225376"
-          },
-          "execution_count": 15
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1293,25 +1206,17 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "0107b45f-e7ab-4309-aa59-ca8fa34cdfb5",
+        "originalKey": "eae9ab60-68fb-40ee-a389-2cba8281929d",
         "collapsed": false,
-        "requestMsgId": "eae9ab60-68fb-40ee-a389-2cba8281929d",
-        "executionStartTime": 1639600351989,
-        "executionStopTime": 1639600352040
+        "requestMsgId": "e481558e-1853-418d-988c-c46e5d796ae8",
+        "executionStartTime": 1646324515812,
+        "executionStopTime": 1646324529215
       },
       "source": [
         "print(SchedulerOptions.__doc__)"
       ],
-      "execution_count": 16,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Settings for a scheduler instance.\n\n    Attributes:\n        max_pending_trials: Maximum number of pending trials the scheduler\n            can have ``STAGED`` or ``RUNNING`` at once, required. If looking\n            to use ``Runner.poll_available_capacity`` as a primary guide for\n            how many trials should be pending at a given time, set this limit\n            to a high number, as an upper bound on number of trials that\n            should not be exceeded.\n        trial_type: Type of trials (1-arm ``Trial`` or multi-arm ``Batch\n            Trial``) that will be deployed using the scheduler. Defaults\n            to 1-arm `Trial`. NOTE: use ``BatchTrial`` only if need to\n            evaluate multiple arms *together*, e.g. in an A/B-test\n            influenced by data nonstationarity. For cases where just\n            deploying multiple arms at once is beneficial but the trials\n            are evaluated *independently*, implement ``run_trials`` method\n            in scheduler subclass, to deploy multiple 1-arm trials at\n            the same time.\n        total_trials: Limit on number of trials a given ``Scheduler``\n            should run. If no stopping criteria are implemented on\n            a given scheduler, exhaustion of this number of trials\n            will be used as default stopping criterion in\n            ``Scheduler.run_all_trials``. Required to be non-null if\n            using ``Scheduler.run_all_trials`` (not required for\n            ``Scheduler.run_n_trials``).\n        tolerated_trial_failure_rate: Fraction of trials in this\n            optimization that are allowed to fail without the whole\n            optimization ending. Expects value between 0 and 1.\n            NOTE: Failure rate checks begin once\n            min_failed_trials_for_failure_rate_check trials have\n            failed; after that point if the ratio of failed trials\n            to total trials ran so far exceeds the failure rate,\n            the optimization will halt.\n        min_failed_trials_for_failure_rate_check: The minimum number\n            of trials that must fail in `Scheduler` in order to start\n            checking failure rate.\n        log_filepath: File, to which to write optimization logs.\n        logging_level: Minimum level of logging statements to log,\n            defaults to ``logging.INFO``.\n        ttl_seconds_for_trials: Optional TTL for all trials created\n            within this ``Scheduler``, in seconds. Trials that remain\n            ``RUNNING`` for more than their TTL seconds will be marked\n            ``FAILED`` once the TTL elapses and may be re-suggested by\n            the Ax optimization models.\n        init_seconds_between_polls: Initial wait between rounds of\n            polling, in seconds. Relevant if using the default wait-\n            for-completed-runs functionality of the base ``Scheduler``\n            (if ``wait_for_completed_trials_and_report_results`` is not\n            overridden). With the default waiting, every time a poll\n            returns that no trial evaluations completed, wait\n            time will increase; once some completed trial evaluations\n            are found, it will reset back to this value. Specify 0\n            to not introduce any wait between polls.\n        min_seconds_before_poll: Minimum number of seconds between\n            beginning to run a trial and the first poll to check\n            trial status.\n        seconds_between_polls_backoff_factor: The rate at which the poll\n            interval increases.\n        run_trials_in_batches: If True and ``poll_available_capacity`` is\n            implemented to return non-null results, trials will be dispatched\n            in groups via `run_trials` instead of one-by-one via ``run_trial``.\n            This allows to save time, IO calls or computation in cases where\n            dispatching trials in groups is more efficient then sequential\n            deployment. The size of the groups will be determined as\n            the minimum of ``self.poll_available_capacity()`` and the number\n            of generator runs that the generation strategy is able to produce\n            without more data or reaching its allowed max paralellism limit.\n        debug_log_run_metadata: Whether to log run_metadata for debugging purposes.\n        early_stopping_strategy: A ``BaseEarlyStoppingStrategy`` that determines\n            whether a trial should be stopped given the current state of\n            the experiment. Used in ``should_stop_trials_early``.\n        suppress_storage_errors_after_retries: Whether to fully suppress SQL\n            storage-related errors if encounted, after retrying the call\n            multiple times. Only use if SQL storage is not important for the given\n            use case, since this will only log, but not raise, an exception if\n            it's encountered while saving to DB or loading from it.\n    \n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1354,11 +1259,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "3fc7cf43-c658-418f-8799-1f0b12b67048",
+        "originalKey": "250a3680-8c62-421e-86a6-0dcb3433a44c",
         "collapsed": false,
-        "requestMsgId": "250a3680-8c62-421e-86a6-0dcb3433a44c",
+        "requestMsgId": "a76e95da-9d18-470c-a36e-ee170ed0c943",
         "executionStartTime": 1639600352094,
-        "executionStopTime": 1639600352124,
+        "executionStopTime": 1646324529226,
         "code_folding": [],
         "hidden_ranges": []
       },
@@ -1371,17 +1276,17 @@
         "            \"running trials\": [t.index for t in self.running_trials],\n",
         "        }"
       ],
-      "execution_count": 17,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "originalKey": "445a7377-a139-4122-b4be-642703552851",
+        "originalKey": "ffb2c9cd-bcde-4070-81eb-405a4814179c",
         "collapsed": false,
-        "requestMsgId": "ffb2c9cd-bcde-4070-81eb-405a4814179c",
+        "requestMsgId": "226d96a4-c0c9-4510-913a-ba60441291f8",
         "executionStartTime": 1639600352149,
-        "executionStopTime": 1639600358105
+        "executionStopTime": 1646324529232
       },
       "source": [
         "experiment = make_branin_experiment_with_runner_and_metric()\n",
@@ -1397,156 +1302,8 @@
         "for reported_result in scheduler.run_trials_and_yield_results(max_trials=6):\n",
         "    print(\"Reported result: \", reported_result)"
       ],
-      "execution_count": 18,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:32] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:32] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:32] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:32] ResultReportingScheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:32] ResultReportingScheduler: Running trials [0]...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:33] ResultReportingScheduler: Running trials [1]...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:34] ResultReportingScheduler: Running trials [2]...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:35] ResultReportingScheduler: Generated all trials that can be generated currently. Max parallelism currently reached.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:35] ResultReportingScheduler: Retrieved COMPLETED trials: [2].\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:35] ResultReportingScheduler: Fetching data for trials: [2].\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:35] ResultReportingScheduler: Running trials [3]...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Reported result:  (True, {'trials so far': 3, 'currently producing trials from generation step': 'Sobol', 'running trials': [0, 1]})\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:36] ResultReportingScheduler: Generated all trials that can be generated currently. Max parallelism currently reached.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:36] ResultReportingScheduler: Retrieved COMPLETED trials: [0, 1, 3].\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:36] ResultReportingScheduler: Fetching data for trials: [0, 1, 3].\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:36] ResultReportingScheduler: Running trials [4]...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Reported result:  (True, {'trials so far': 4, 'currently producing trials from generation step': 'Sobol', 'running trials': []})\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:38] ResultReportingScheduler: Running trials [5]...\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:38] ResultReportingScheduler: Retrieved COMPLETED trials: 4 - 5.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[INFO 12-15 12:32:38] ResultReportingScheduler: Fetching data for trials: 4 - 5.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Reported result:  (True, {'trials so far': 6, 'currently producing trials from generation step': 'GPEI', 'running trials': []})\nReported result:  (True, {'trials so far': 6, 'currently producing trials from generation step': 'GPEI', 'running trials': []})\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     }
   ]
 }


### PR DESCRIPTION
Summary: A couple of our tutorials did not reflect recent changes to saving custom runners/metrics. This should clear things up for our users

Differential Revision: D34615005

