### PR TITLE
Update pinned BoTorch version to 0.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from setuptools import find_packages, setup
 
 # TODO: read pinned Botorch version from a shared source
-PINNED_BOTORCH_VERSION = "0.6.0"
+PINNED_BOTORCH_VERSION = "0.6.1"
 
 if os.environ.get("ALLOW_BOTORCH_LATEST"):
     # allows a more recent previously installed version of botorch to remain


### PR DESCRIPTION
Summary: In preparation for the next OSS release

Differential Revision: D34617314

