### PR TITLE
Raise an informative warning on call to register_{metric, runner}

### DIFF
--- a/ax/storage/metric_registry.py
+++ b/ax/storage/metric_registry.py
@@ -17,6 +17,15 @@ from ax.metrics.noisy_function import NoisyFunctionMetric
 from ax.metrics.sklearn import SklearnMetric
 from ax.storage.json_store.encoders import metric_to_dict
 from ax.storage.json_store.registry import CORE_ENCODER_REGISTRY, CORE_DECODER_REGISTRY
+from ax.utils.common.logger import get_logger
+
+# TODO[T113829027] Remove in a few months
+logger = get_logger(__name__)
+WARNING_MSG = (
+    "There have been some recent changes to `register_metric`. Please see "
+    "https://ax.dev/tutorials/gpei_hartmann_developer.html#9.-Save-to-JSON-or-SQL "
+    "for the most up-to-date information on saving custom metrics."
+)
 
 """
 Mapping of Metric classes to ints.
@@ -54,6 +63,7 @@ def register_metric(
     """Add a custom metric class to the SQA and JSON registries.
     For the SQA registry, if no int is specified, use a hash of the class name.
     """
+    logger.warn(WARNING_MSG)
 
     metric_registry = metric_registry or {Metric: 0}
 
@@ -81,6 +91,7 @@ def register_metrics(
     """Add custom metric classes to the SQA and JSON registries.
     For the SQA registry, if no int is specified, use a hash of the class name.
     """
+    logger.warn(WARNING_MSG)
 
     metric_registry = metric_registry or {Metric: 1}
 

--- a/ax/storage/runner_registry.py
+++ b/ax/storage/runner_registry.py
@@ -10,6 +10,15 @@ from ax.core.runner import Runner
 from ax.runners.synthetic import SyntheticRunner
 from ax.storage.json_store.encoders import runner_to_dict
 from ax.storage.json_store.registry import CORE_ENCODER_REGISTRY, CORE_DECODER_REGISTRY
+from ax.utils.common.logger import get_logger
+
+# TODO[T113829027] Remove in a few months
+logger = get_logger(__name__)
+WARNING_MSG = (
+    "There have been some recent changes to `register_metric`. Please see "
+    "https://ax.dev/tutorials/gpei_hartmann_developer.html#9.-Save-to-JSON-or-SQL "
+    "for the most up-to-date information on saving custom runners."
+)
 
 # """
 # Mapping of Runner classes to ints.
@@ -39,6 +48,7 @@ def register_runner(
     """Add a custom runner class to the SQA and JSON registries.
     For the SQA registry, if no int is specified, use a hash of the class name.
     """
+    logger.warn(WARNING_MSG)
 
     registered_val = val or abs(hash(runner_cls.__name__)) % (10 ** 5)
 
@@ -64,6 +74,7 @@ def register_runners(
     """Add custom runner classes to the SQA and JSON registries.
     For the SQA registry, if no int is specified, use a hash of the class name.
     """
+    logger.warn(WARNING_MSG)
 
     new_runner_registry = {
         **{

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -75,8 +75,13 @@ class Decoder:
     def __init__(self, config: SQAConfig) -> None:
         self.config = config
 
-        # TODO[mpolson64] Remove this in a couple months
-        self.EXTRA_REGISTRY_ERROR_NOTE = ""
+        # TODO[T113829027] Remove this in a couple months
+        self.EXTRA_REGISTRY_ERROR_NOTE = (
+            "ATTENTION: There have been some recent "
+            "changes to Metric/Runner registration in Ax. Please see "
+            "https://ax.dev/tutorials/gpei_hartmann_developer.html#9.-Save-to-JSON-or-SQL "  # noqa
+            "for the most up-to-date information on saving custom metrics."
+        )
 
     def get_enum_name(
         self, value: Optional[int], enum: Optional[Enum]

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -74,8 +74,13 @@ class Encoder:
     def __init__(self, config: SQAConfig) -> None:
         self.config = config
 
-        # TODO[mpolson64] Remove this in a couple months
-        self.EXTRA_REGISTRY_ERROR_NOTE = ""
+        # TODO[T113829027] Remove this in a couple months
+        self.EXTRA_REGISTRY_ERROR_NOTE = (
+            "ATTENTION: There have been some recent "
+            "changes to Metric/Runner registration in Ax. Please see "
+            "https://ax.dev/tutorials/gpei_hartmann_developer.html#9.-Save-to-JSON-or-SQL "  # noqa
+            "for the most up-to-date information on saving custom metrics."
+        )
 
     @classmethod
     def validate_experiment_metadata(


### PR DESCRIPTION
Summary: As we all know these methods have undergone a bug change that may not be intuitive to everybody. Because the methods retained the same name through the refactor but do relatively different things, we should log a warning whenever this method is used (at least for now) to help our OSS users. This message links to the appropriate section of a tutorial that they should find helpful (the same link is provided on metric/runner encoding/decoding failure.

Differential Revision: D34732470

