### PR TITLE
Remove @cached_property (does not exist in python3.7)

### DIFF
--- a/ax/storage/registry_bundle.py
+++ b/ax/storage/registry_bundle.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import abstractproperty, ABC
-from functools import cached_property
 from typing import Any, Callable, Optional, Type, Dict
 
 from ax.core.metric import Metric
@@ -136,10 +135,7 @@ class RegistryBundle(RegistryBundleBase):
             json_decoder_registry=json_decoder_registry,
             json_class_decoder_registry=json_class_decoder_registry,
         )
-
-    @cached_property
-    def sqa_config(self) -> SQAConfig:
-        return SQAConfig(
+        self._sqa_config = SQAConfig(
             json_encoder_registry={**self.encoder_registry, **CORE_ENCODER_REGISTRY},
             json_decoder_registry={**self.decoder_registry, **CORE_DECODER_REGISTRY},
             metric_registry=self.metric_registry,
@@ -148,10 +144,18 @@ class RegistryBundle(RegistryBundleBase):
             json_class_decoder_registry=self.class_decoder_registry,
         )
 
-    @cached_property
-    def encoder(self) -> Encoder:
-        return Encoder(self.sqa_config)
+        self._encoder = Encoder(self._sqa_config)
+        self._decoder = Decoder(self._sqa_config)
 
-    @cached_property
+    # TODO[mpolson64] change @property to @cached_property once we deprecate 3.7
+    @property
+    def sqa_config(self) -> SQAConfig:
+        return self._sqa_config
+
+    @property
+    def encoder(self) -> Encoder:
+        return self._encoder
+
+    @property
     def decoder(self) -> Decoder:
-        return Decoder(self.sqa_config)
+        return self._decoder

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -24,6 +24,7 @@ from ax.modelbridge.dispatch_utils import choose_generation_strategy
 from ax.modelbridge.registry import Models
 from ax.runners.synthetic import SyntheticRunner
 from ax.storage.metric_registry import register_metric, CORE_METRIC_REGISTRY
+from ax.storage.registry_bundle import RegistryBundle
 from ax.storage.runner_registry import register_runner, CORE_RUNNER_REGISTRY
 from ax.storage.sqa_store.db import (
     get_engine,
@@ -1054,6 +1055,28 @@ class SQAStoreTest(TestCase):
         experiment.add_tracking_metric(MyMetric(name="my_metric"))
         save_experiment(experiment, config=sqa_config)
         loaded_experiment = load_experiment(experiment.name, config=sqa_config)
+        self.assertEqual(loaded_experiment, experiment)
+
+    def testRegistryBundle(self):
+        class MyRunner(Runner):
+            def run():
+                pass
+
+            def staging_required():
+                return False
+
+        class MyMetric(Metric):
+            pass
+
+        bundle = RegistryBundle(
+            metric_clss={MyMetric: 1998}, runner_clss={MyRunner: None}
+        )
+
+        experiment = get_experiment_with_batch_trial()
+        experiment.runner = MyRunner()
+        experiment.add_tracking_metric(MyMetric(name="my_metric"))
+        save_experiment(experiment, config=bundle.sqa_config)
+        loaded_experiment = load_experiment(experiment.name, config=bundle.sqa_config)
         self.assertEqual(loaded_experiment, experiment)
 
     def testEncodeDecodeGenerationStrategy(self):


### PR DESCRIPTION
Summary: Unfortunately, cached_property doesnt exist in python3.7 so it must be removed from the OSS RegistryBundle. Not sure how the unit tests didnt catch this (I exported from phabricator to gh) so I've added some new unit tests to make sure this cant happen again.

Reviewed By: EugenHotaj

Differential Revision: D34753355

