### PR TITLE
Return AxPlotConfigs instead of rendering in PTSClient and PTSAnalyzer

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -60,8 +60,6 @@ from ax.plot.base import AxPlotConfig
 from ax.plot.contour import plot_contour
 from ax.plot.feature_importances import plot_feature_importance_by_feature
 from ax.plot.helper import _format_dict, _get_in_sample_arms
-from ax.plot.pareto_frontier import plot_pareto_frontier
-from ax.plot.pareto_utils import compute_posterior_pareto_frontier
 from ax.plot.trace import optimization_trace_single_method
 from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.service.utils.instantiation import ObjectiveProperties, InstantiationBase
@@ -88,7 +86,6 @@ from ax.utils.common.typeutils import (
     checked_cast_optional,
     not_none,
 )
-from ax.utils.notebook.plotting import render
 from botorch.utils.sampling import manual_seed
 
 
@@ -1251,22 +1248,6 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
             trial_indices=trial_indices,
             use_model_predictions=use_model_predictions,
         )
-
-    def view_pareto_frontier_plot(
-        self, primary_metric_name: str, secondary_metric_name: str
-    ) -> None:
-        metrics = self.experiment.metrics.values()
-        frontier = compute_posterior_pareto_frontier(
-            experiment=self.experiment,
-            data=self.experiment.fetch_data(),
-            primary_objective=next(
-                metric for metric in metrics if metric.name == primary_metric_name
-            ),
-            secondary_objective=next(
-                metric for metric in metrics if metric.name == secondary_metric_name
-            ),
-        )
-        render(plot_pareto_frontier(frontier, CI_level=0.9000))
 
     def _update_trial_with_raw_data(
         self,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -8,8 +8,8 @@ import math
 import sys
 import time
 from math import ceil
-from typing import List, Tuple, Optional
-from unittest.mock import patch
+from typing import Any, List, Tuple, Optional
+from unittest.mock import Mock, patch
 
 import numpy as np
 import torch
@@ -93,7 +93,7 @@ def get_branin_currin_optimization_with_N_sobol_trials(
     minimize: bool = False,
     include_objective_thresholds: bool = True,
     random_seed: int = RANDOM_SEED,
-) -> AxClient:
+) -> Tuple[AxClient, BraninCurrin]:
     branin_currin = get_branin_currin(minimize=minimize)
     ax_client = AxClient()
     ax_client.create_experiment(
@@ -1691,6 +1691,34 @@ class TestAxClient(TestCase):
         )
 
         self.assertGreaterEqual(ax_client.get_hypervolume(), 0)
+
+    @patch(
+        "ax.service.ax_client.render"
+    )  # it will error if it tries to render the mock plot
+    @patch(
+        "ax.service.ax_client.plot_pareto_frontier"
+    )  # it will error if it tries to plot the mock
+    @patch("ax.service.ax_client.compute_posterior_pareto_frontier")
+    def test_view_pareto_frontier_plot(self, mock_plot: Mock, *args: Any) -> None:
+        primary_metric_name, secondary_metric_name = "branin", "currin"
+        ax_client, branin_currin = get_branin_currin_optimization_with_N_sobol_trials(
+            num_trials=20
+        )
+        ax_client.view_pareto_frontier_plot(
+            primary_metric_name=primary_metric_name,
+            secondary_metric_name=secondary_metric_name,
+        )
+        kwargs = mock_plot.mock_calls[0][2]
+        self.assertEqual(
+            kwargs["experiment"],
+            ax_client.experiment,
+        )
+        self.assertEqual(
+            kwargs["data"],
+            ax_client.experiment.fetch_data(),
+        )
+        self.assertEqual(kwargs["primary_objective"].name, primary_metric_name)
+        self.assertEqual(kwargs["secondary_objective"].name, secondary_metric_name)
 
     def test_with_hss(self):
         ax_client = AxClient()

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -8,8 +8,8 @@ import math
 import sys
 import time
 from math import ceil
-from typing import Any, List, Tuple, Optional
-from unittest.mock import Mock, patch
+from typing import List, Tuple, Optional
+from unittest.mock import patch
 
 import numpy as np
 import torch
@@ -1691,34 +1691,6 @@ class TestAxClient(TestCase):
         )
 
         self.assertGreaterEqual(ax_client.get_hypervolume(), 0)
-
-    @patch(
-        "ax.service.ax_client.render"
-    )  # it will error if it tries to render the mock plot
-    @patch(
-        "ax.service.ax_client.plot_pareto_frontier"
-    )  # it will error if it tries to plot the mock
-    @patch("ax.service.ax_client.compute_posterior_pareto_frontier")
-    def test_view_pareto_frontier_plot(self, mock_plot: Mock, *args: Any) -> None:
-        primary_metric_name, secondary_metric_name = "branin", "currin"
-        ax_client, branin_currin = get_branin_currin_optimization_with_N_sobol_trials(
-            num_trials=20
-        )
-        ax_client.view_pareto_frontier_plot(
-            primary_metric_name=primary_metric_name,
-            secondary_metric_name=secondary_metric_name,
-        )
-        kwargs = mock_plot.mock_calls[0][2]
-        self.assertEqual(
-            kwargs["experiment"],
-            ax_client.experiment,
-        )
-        self.assertEqual(
-            kwargs["data"],
-            ax_client.experiment.fetch_data(),
-        )
-        self.assertEqual(kwargs["primary_objective"].name, primary_metric_name)
-        self.assertEqual(kwargs["secondary_objective"].name, secondary_metric_name)
 
     def test_with_hss(self):
         ax_client = AxClient()


### PR DESCRIPTION
Summary: I didn't alter the contract in qe_lib's QuickBO analyzer because it currently has a tutorial and we'll be rewriting it soon

Reviewed By: lena-kashtelyan

Differential Revision: D34932892

