### PR TITLE
Add @fast_gpytorch decorator and change @fast_botorch_optimize -> @fast_mopdeling

### DIFF
--- a/ax/benchmark2/tests/test_benchmark.py
+++ b/ax/benchmark2/tests/test_benchmark.py
@@ -19,7 +19,7 @@ from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.service.scheduler import SchedulerOptions
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.models.gp_regression import FixedNoiseGP
 from botorch.test_functions.multi_objective import BraninCurrin
@@ -134,7 +134,7 @@ class TestBenchmark(TestCase):
                 agg.optimization_trace["mean"][i], agg.optimization_trace["mean"][i - 1]
             )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_full_run(self):
         aggs = benchmark_full_run(
             problems=[self.ackley],

--- a/ax/modelbridge/tests/test_factory.py
+++ b/ax/modelbridge/tests/test_factory.py
@@ -48,12 +48,12 @@ from ax.utils.testing.core_stubs import (
     get_factorial_experiment,
     get_multi_type_experiment,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.models.multitask import MultiTaskGP
 
 
 class ModelBridgeFactoryTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def test_sobol_GPEI(self):
         """Tests sobol + GPEI instantiation."""
         exp = get_branin_experiment()
@@ -78,7 +78,7 @@ class ModelBridgeFactoryTest(TestCase):
         gpei_run = gpei.gen(n=1)
         self.assertEqual(len(gpei_run.arms), 1)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_MTGP(self):
         """Tests MTGP instantiation."""
         # Test Multi-type MTGP
@@ -115,7 +115,7 @@ class ModelBridgeFactoryTest(TestCase):
         with self.assertRaises(ValueError):
             get_MTGP(experiment=exp, data=exp.fetch_data(), trial_index=0)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_GPKG(self):
         """Tests GPKG instantiation."""
         exp = get_branin_experiment(with_batch=True)
@@ -156,7 +156,7 @@ class ModelBridgeFactoryTest(TestCase):
         gpkg_mf = get_GPKG(experiment=exp, data=exp.fetch_data())
         self.assertIsInstance(gpkg_mf, TorchModelBridge)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_GPMES(self):
         """Tests GPMES instantiation."""
         exp = get_branin_experiment(with_batch=True)
@@ -252,7 +252,7 @@ class ModelBridgeFactoryTest(TestCase):
         uniform_run = uniform.gen(n=5)
         self.assertEqual(len(uniform_run.arms), 5)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_MOO_RS(self):
         single_obj_exp = get_branin_experiment(with_batch=True)
         with self.assertRaises(ValueError):
@@ -277,7 +277,7 @@ class ModelBridgeFactoryTest(TestCase):
         moo_rs_run = moo_rs.gen(n=2)
         self.assertEqual(len(moo_rs_run.arms), 2)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_MOO_PAREGO(self):
         single_obj_exp = get_branin_experiment(with_batch=True)
         with self.assertRaises(ValueError):
@@ -304,7 +304,7 @@ class ModelBridgeFactoryTest(TestCase):
         moo_parego_run = moo_parego.gen(n=2)
         self.assertEqual(len(moo_parego_run.arms), 2)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_MOO_EHVI(self):
         single_obj_exp = get_branin_experiment(with_batch=True)
         metrics = single_obj_exp.optimization_config.objective.metrics
@@ -348,7 +348,7 @@ class ModelBridgeFactoryTest(TestCase):
         moo_ehvi_run = moo_ehvi.gen(n=1)
         self.assertEqual(len(moo_ehvi_run.arms), 1)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_MTGP_PAREGO(self):
         """Tests MTGP ParEGO instantiation."""
         # Test Multi-type MTGP
@@ -424,7 +424,7 @@ class ModelBridgeFactoryTest(TestCase):
             objective_thresholds=multi_objective_thresholds,
         )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_MOO_NEHVI(self):
         single_obj_exp = get_branin_experiment(with_batch=True)
         metrics = single_obj_exp.optimization_config.objective.metrics
@@ -466,7 +466,7 @@ class ModelBridgeFactoryTest(TestCase):
         moo_ehvi_run = moo_ehvi.gen(n=1)
         self.assertEqual(len(moo_ehvi_run.arms), 1)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_MOO_with_more_outcomes_than_thresholds(self):
         experiment = get_branin_experiment_with_multi_objective(
             has_optimization_config=False
@@ -529,7 +529,7 @@ class ModelBridgeFactoryTest(TestCase):
                 self.assertEqual(obj_t[1], objective_thresholds[0])
                 self.assertEqual(len(obj_t), 2)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_MTGP_NEHVI(self):
         single_obj_exp = get_branin_experiment(with_batch=True)
         metrics = single_obj_exp.optimization_config.objective.metrics

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -21,7 +21,7 @@ from ax.modelbridge.model_spec import ModelSpec, FactoryFunctionModelSpec
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 
 
 class TestGenerationNode(TestCase):
@@ -84,7 +84,7 @@ class TestGenerationNode(TestCase):
         with self.assertRaises(NotImplementedError):
             generation_node.gen()
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_properties(self):
         node = GenerationNode(
             model_specs=[
@@ -192,7 +192,7 @@ class TestGenerationStep(TestCase):
 
 
 class TestGenerationNodeWithBestModelSelector(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def setUp(self):
         self.branin_experiment = get_branin_experiment()
         sobol = Models.SOBOL(search_space=self.branin_experiment.search_space)
@@ -219,7 +219,7 @@ class TestGenerationNodeWithBestModelSelector(TestCase):
             ),
         )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_gen(self):
         self.model_selection_node.fit(
             experiment=self.branin_experiment, data=self.branin_experiment.lookup_data()

--- a/ax/modelbridge/tests/test_model_spec.py
+++ b/ax/modelbridge/tests/test_model_spec.py
@@ -14,7 +14,7 @@ from ax.modelbridge.model_spec import ModelSpec, FactoryFunctionModelSpec
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 
 
 class BaseModelSpecTest(TestCase):
@@ -29,7 +29,7 @@ class BaseModelSpecTest(TestCase):
 
 
 class ModelSpecTest(BaseModelSpecTest):
-    @fast_botorch_optimize
+    @fast_modeling
     def test_construct(self):
         ms = ModelSpec(model_enum=Models.GPEI)
         with self.assertRaises(UserInputError):

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -41,14 +41,14 @@ from ax.utils.testing.core_stubs import (
     get_branin_optimization_config,
     get_factorial_experiment,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.models.gp_regression import FixedNoiseGP
 from torch import float64 as torch_float64
 
 
 class ModelRegistryTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def test_botorch_modular(self):
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()
@@ -70,7 +70,7 @@ class ModelRegistryTest(TestCase):
         # FixedNoiseGP should be picked since experiment data has fixed noise.
         self.assertIsInstance(gpei.model.surrogate.model, FixedNoiseGP)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_enum_sobol_GPEI(self):
         """Tests Sobol and GPEI instantiation through the Models enum."""
         exp = get_branin_experiment()
@@ -240,7 +240,7 @@ class ModelRegistryTest(TestCase):
             ),
         )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_get_model_from_generator_run(self):
         """Tests that it is possible to restore a model from a generator run it
         produced, if `Models` registry was used.
@@ -316,7 +316,7 @@ class ModelRegistryTest(TestCase):
             # Intersection of two sets should be empty
             self.assertEqual(model_args & bridge_args, set())
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_ST_MTGP(self):
         """Tests single type MTGP instantiation."""
         # Test Single-type MTGP
@@ -358,7 +358,7 @@ class ModelRegistryTest(TestCase):
                 status_quo_features=status_quo_features,
             )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_ALEBO(self):
         """Tests Alebo fitting and generations"""
         experiment = get_branin_experiment(with_batch=True)
@@ -398,7 +398,7 @@ class ModelRegistryTest(TestCase):
         gr = m.gen(n=2)
         self.assertEqual(len(gr.arms), 2)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_ST_MTGP_NEHVI(self):
         """Tests single type MTGP NEHVI instantiation."""
         multi_obj_exp = get_branin_experiment_with_multi_objective(

--- a/ax/modelbridge/tests/test_torch_modelbridge_moo.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge_moo.py
@@ -40,7 +40,7 @@ from ax.utils.testing.core_stubs import (
     get_non_monolithic_branin_moo_data,
     TEST_SOBOL_SEED,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.utils.multi_objective.pareto import is_non_dominated
 
 PARETO_FRONTIER_EVALUATOR_PATH = (
@@ -141,7 +141,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
         f"{STUBS_PATH}.BraninMetric.is_available_while_running",
         return_value=False,
     )
-    @fast_botorch_optimize
+    @fast_modeling
     def test_pareto_frontier(self, _):
         exp = get_branin_experiment_with_multi_objective(
             has_optimization_config=True, with_batch=True
@@ -397,7 +397,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
         f"{STUBS_PATH}.BraninMetric.is_available_while_running",
         return_value=False,
     )
-    @fast_botorch_optimize
+    @fast_modeling
     def test_infer_objective_thresholds(self, _, cuda=False):
         # lightweight test
         exp = get_branin_experiment_with_multi_objective(
@@ -578,7 +578,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             )
         )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_status_quo_for_non_monolithic_data(self):
         exp = get_branin_experiment_with_multi_objective(with_status_quo=True)
         sobol_generator = get_sobol(

--- a/ax/models/tests/test_alebo.py
+++ b/ax/models/tests/test_alebo.py
@@ -21,7 +21,7 @@ from ax.models.torch.alebo import (
     get_map_model,
 )
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.acquisition.analytic import ExpectedImprovement
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.models.model_list_gp_regression import ModelListGP
@@ -56,7 +56,7 @@ class ALEBOTest(TestCase):
         )
         self.assertTrue(torch.equal(K, Ktrue))
 
-    @fast_botorch_optimize
+    @fast_modeling
     def testALEBOGP(self):
         # First non-batch
         B = torch.tensor(
@@ -253,7 +253,7 @@ class ALEBOTest(TestCase):
         Z = (B @ torch.pinverse(B) @ X[:, 0, :].t()).t()
         self.assertTrue(torch.allclose(Z, X[:, 0, :]))
 
-    @fast_botorch_optimize
+    @fast_modeling
     def testALEBO(self):
         B = torch.tensor(
             [[1.0, 2.0, 3.0, 4.0, 5.0], [2.0, 3.0, 4.0, 5.0, 6.0]], dtype=torch.double

--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -14,7 +14,7 @@ from ax.models.torch.botorch_defaults import (
     get_warping_transform,
 )
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.acquisition.penalized import PenalizedMCObjective
 from botorch.models import FixedNoiseGP, SingleTaskGP
 from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
@@ -102,7 +102,7 @@ class BotorchDefaultsTest(TestCase):
             _get_model(X=x, Y=y, Yvar=partial_var.clone(), task_feature=1, **kwargs5)
 
     @mock.patch("ax.models.torch.botorch_defaults._get_model", wraps=_get_model)
-    @fast_botorch_optimize
+    @fast_modeling
     def test_task_feature(self, get_model_mock):
         x = [torch.zeros(2, 2)]
         y = [torch.zeros(2, 1)]

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -10,7 +10,7 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.botorch_kg import KnowledgeGradient, _instantiate_KG
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.acquisition.analytic import PosteriorMean
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
 from botorch.acquisition.knowledge_gradient import qMultiFidelityKnowledgeGradient
@@ -62,7 +62,7 @@ class KnowledgeGradientTest(TestCase):
         self.moo_objective_weights = torch.ones(2, dtype=self.dtype, device=self.device)
         self.objective_thresholds = torch.tensor([0.5, 1.5])
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_KnowledgeGradient(self):
         model = KnowledgeGradient()
         model.fit(
@@ -198,7 +198,7 @@ class KnowledgeGradientTest(TestCase):
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_KnowledgeGradient_multifidelity(self):
         model = KnowledgeGradient()
         model.fit(
@@ -299,7 +299,7 @@ class KnowledgeGradientTest(TestCase):
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_KnowledgeGradient_helpers(self):
         model = KnowledgeGradient()
         model.fit(

--- a/ax/models/tests/test_botorch_mes.py
+++ b/ax/models/tests/test_botorch_mes.py
@@ -10,7 +10,7 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.botorch_mes import MaxValueEntropySearch, _instantiate_MES
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.acquisition.max_value_entropy_search import (
     qMaxValueEntropy,
     qMultiFidelityMaxValueEntropy,
@@ -49,7 +49,7 @@ class MaxValueEntropySearchTest(TestCase):
         }
         self.optimize_acqf = "ax.models.torch.botorch_mes.optimize_acqf"
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_MaxValueEntropySearch(self):
 
         model = MaxValueEntropySearch()
@@ -167,7 +167,7 @@ class MaxValueEntropySearchTest(TestCase):
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_MaxValueEntropySearch_MultiFidelity(self):
         model = MaxValueEntropySearch()
         model.fit(
@@ -264,7 +264,7 @@ class MaxValueEntropySearchTest(TestCase):
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_instantiate_MES(self):
 
         model = MaxValueEntropySearch()

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -17,7 +17,7 @@ from ax.models.torch.botorch_defaults import (
 )
 from ax.models.torch.utils import sample_simplex
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition.utils import get_infeasible_cost
 from botorch.models import FixedNoiseGP, ModelListGP
@@ -118,7 +118,7 @@ class BotorchModelTest(TestCase):
                 0.6,
             )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_BotorchModel(self, dtype=torch.float, cuda=False):
         Xs1, Ys1, Yvars1, bounds, tfs, fns, mns = get_torch_test_data(
             dtype=dtype, cuda=cuda, constant_noise=True

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -22,7 +22,7 @@ from ax.models.torch.botorch_moo_defaults import (
 )
 from ax.models.torch.utils import HYPERSPHERE
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.acquisition.multi_objective import monte_carlo as moo_monte_carlo
 from botorch.models import ModelListGP
 from botorch.models.transforms.input import Warp
@@ -104,7 +104,7 @@ class BotorchMOOModelTest(TestCase):
                 dtype=dtype, use_qnehvi=True
             )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_BotorchMOOModel_with_random_scalarization(
         self, dtype=torch.float, cuda=False
     ):
@@ -217,7 +217,7 @@ class BotorchMOOModelTest(TestCase):
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_BotorchMOOModel_with_chebyshev_scalarization(
         self, dtype=torch.float, cuda=False
     ):
@@ -536,7 +536,7 @@ class BotorchMOOModelTest(TestCase):
             self.assertTrue(torch.equal(obj_t[:2], provided_obj_t[:2].cpu()))
             self.assertTrue(np.isnan(obj_t[2]))
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_BotorchMOOModel_with_random_scalarization_and_outcome_constraints(
         self, dtype=torch.float, cuda=False
     ):
@@ -590,7 +590,7 @@ class BotorchMOOModelTest(TestCase):
             )
             self.assertEqual(n, _mock_sample_simplex.call_count)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_BotorchMOOModel_with_chebyshev_scalarization_and_outcome_constraints(
         self, dtype=torch.float, cuda=False
     ):
@@ -643,7 +643,7 @@ class BotorchMOOModelTest(TestCase):
             # get_chebyshev_scalarization should be called once for generated candidate.
             self.assertEqual(n, _mock_chebyshev_scalarization.call_count)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_BotorchMOOModel_with_qehvi_and_outcome_constraints(
         self, dtype=torch.float, cuda=False, use_qnehvi=False
     ):

--- a/ax/models/tests/test_cbo_lcea.py
+++ b/ax/models/tests/test_cbo_lcea.py
@@ -9,13 +9,13 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.cbo_lcea import LCEABO
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.models.contextual import LCEAGP
 from botorch.models.model_list_gp_regression import ModelListGP
 
 
 class LCEABOTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def testLCEABO(self):
         train_X = torch.tensor(
             [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]]

--- a/ax/models/tests/test_cbo_lcem.py
+++ b/ax/models/tests/test_cbo_lcem.py
@@ -8,13 +8,13 @@ import numpy as np
 import torch
 from ax.models.torch.cbo_lcem import LCEMBO
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.models.contextual_multioutput import LCEMGP, FixedNoiseLCEMGP
 from botorch.models.model_list_gp_regression import ModelListGP
 
 
 class LCEMBOTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def testLCEMBO(self):
         d = 1
         train_x = torch.rand(10, d)

--- a/ax/models/tests/test_cbo_sac.py
+++ b/ax/models/tests/test_cbo_sac.py
@@ -9,12 +9,12 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.cbo_sac import SACBO, SACGP
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from botorch.models.model_list_gp_regression import ModelListGP
 
 
 class SACBOTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def test_SACBO(self):
         train_X = torch.tensor(
             [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]]

--- a/ax/models/tests/test_rembo.py
+++ b/ax/models/tests/test_rembo.py
@@ -10,11 +10,11 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.rembo import REMBO
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 
 
 class REMBOTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def testREMBOModel(self):
         A = torch.cat((torch.eye(2), -(torch.eye(2))))
         initial_X_d = torch.tensor([[0.25, 0.5], [1, 0], [0, -1]])

--- a/ax/plot/tests/test_contours.py
+++ b/ax/plot/tests/test_contours.py
@@ -15,11 +15,11 @@ from ax.plot.contour import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 
 
 class ContoursTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def testContours(self):
         exp = get_branin_experiment(with_str_choice_param=True, with_batch=True)
         exp.trials[0].run()

--- a/ax/plot/tests/test_diagnostic.py
+++ b/ax/plot/tests/test_diagnostic.py
@@ -14,11 +14,11 @@ from ax.plot.diagnostic import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 
 
 class DiagnosticTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def test_cross_validation(self):
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()

--- a/ax/plot/tests/test_feature_importances.py
+++ b/ax/plot/tests/test_feature_importances.py
@@ -17,7 +17,7 @@ from ax.plot.feature_importances import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from plotly import graph_objects as go
 
 DUMMY_CAPTION = "test_caption"
@@ -34,7 +34,7 @@ def get_modelbridge() -> ModelBridge:
 
 
 class FeatureImportancesTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def testFeatureImportances(self):
         model = get_modelbridge()
         # Assert that each type of plot can be constructed successfully

--- a/ax/plot/tests/test_fitted_scatter.py
+++ b/ax/plot/tests/test_fitted_scatter.py
@@ -13,11 +13,11 @@ from ax.plot.scatter import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 
 
 class FittedScatterTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def test_fitted_scatter(self):
         exp = get_branin_experiment(with_str_choice_param=True, with_batch=True)
         exp.trials[0].run()

--- a/ax/plot/tests/test_slices.py
+++ b/ax/plot/tests/test_slices.py
@@ -15,11 +15,11 @@ from ax.plot.slice import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 
 
 class SlicesTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def testSlices(self):
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()

--- a/ax/plot/tests/test_traces.py
+++ b/ax/plot/tests/test_traces.py
@@ -14,11 +14,11 @@ from ax.plot.trace import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 
 
 class TracesTest(TestCase):
-    @fast_botorch_optimize
+    @fast_modeling
     def testTraces(self):
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -48,7 +48,7 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.common.timeutils import current_timestamp_in_millis
 from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.testing.core_stubs import DummyEarlyStoppingStrategy
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from ax.utils.testing.modeling_stubs import get_observation1, get_observation1trans
 from botorch.test_functions.multi_objective import BraninCurrin
 from botorch.utils.sampling import manual_seed
@@ -154,7 +154,7 @@ def get_branin_optimization(
 class TestAxClient(TestCase):
     """Tests service-like API functionality."""
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_interruption(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
@@ -207,7 +207,7 @@ class TestAxClient(TestCase):
         autospec=True,
         return_value={"x": 0.9, "y": 1.1},
     )
-    @fast_botorch_optimize
+    @fast_modeling
     def test_default_generation_strategy_continuous(self, _a, _b, _c, _d) -> None:
         """Test that Sobol+GPEI is used if no GenerationStrategy is provided."""
         ax_client = get_branin_optimization()
@@ -254,7 +254,7 @@ class TestAxClient(TestCase):
         autospec=True,
         return_value=([get_observation1(first_metric_name="branin")]),
     )
-    @fast_botorch_optimize
+    @fast_modeling
     def test_default_generation_strategy_continuous_gen_trials_in_batches(
         self, _
     ) -> None:
@@ -324,7 +324,7 @@ class TestAxClient(TestCase):
         autospec=True,
         return_value={"x": 0.9, "y": 1.1},
     )
-    @fast_botorch_optimize
+    @fast_modeling
     def test_default_generation_strategy_continuous_for_moo(
         self, _a, _b, _c, _d
     ) -> None:
@@ -824,7 +824,7 @@ class TestAxClient(TestCase):
                 outcome_constraints=["test_objective >= 3"],
             )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_raw_data_format(self):
         ax_client = AxClient()
         ax_client.create_experiment(
@@ -843,7 +843,7 @@ class TestAxClient(TestCase):
         ):
             ax_client.update_trial_data(trial_index, raw_data="invalid_data")
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_raw_data_format_with_map_results(self):
         ax_client = AxClient()
         ax_client.create_experiment(
@@ -1173,7 +1173,7 @@ class TestAxClient(TestCase):
                 outcome_constraints=["some_metric <= 4.0%"],
             )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_recommended_parallelism(self):
         ax_client = AxClient()
         with self.assertRaisesRegex(ValueError, "No generation strategy"):
@@ -1555,7 +1555,7 @@ class TestAxClient(TestCase):
         f"{get_pareto_optimal_parameters.__module__}.observed_pareto",
         wraps=observed_pareto,
     )
-    @fast_botorch_optimize
+    @fast_modeling
     def test_get_pareto_optimal_points(
         self, mock_observed_pareto, mock_predicted_pareto
     ):
@@ -1580,7 +1580,7 @@ class TestAxClient(TestCase):
             ax_client.get_best_trial()
 
         # Check model-predicted Pareto frontier using model on GS.
-        # NOTE: model predictions are very poor due to `fast_botorch_optimize`.
+        # NOTE: model predictions are very poor due to `fast_modeling`.
         # This overwrites the `predict` call to return the original observations,
         # while testing the rest of the code as if we're using predictions.
         model = ax_client.generation_strategy.model.model
@@ -1633,7 +1633,7 @@ class TestAxClient(TestCase):
         f"{get_pareto_optimal_parameters.__module__}.observed_pareto",
         wraps=observed_pareto,
     )
-    @fast_botorch_optimize
+    @fast_modeling
     def test_get_pareto_optimal_points_objective_threshold_inference(
         self, mock_observed_pareto, mock_predicted_pareto
     ):
@@ -1669,7 +1669,7 @@ class TestAxClient(TestCase):
         mock_predicted_pareto.assert_not_called()
         self.assertGreater(len(observed_pareto), 0)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_get_hypervolume(self):
         # First check that hypervolume gets returned for observed data
         ax_client, branin_currin = get_branin_currin_optimization_with_N_sobol_trials(

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -21,14 +21,14 @@ from ax.service.utils.best_point import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment, get_branin_metric
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 
 
 class TestBestPointUtils(TestCase):
     """Testing the best point utilities functionality that is not tested in
     main `AxClient` testing suite (`TestServiceAPI`)."""
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_best_from_model_prediction(self):
         exp = get_branin_experiment()
 

--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -13,7 +13,7 @@ from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrateg
 from ax.modelbridge.registry import Models
 from ax.service.managed_loop import OptimizationLoop, optimize
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 
 
 def _branin_evaluation_function(parameterization, weight=None):
@@ -80,7 +80,7 @@ class TestManagedLoop(TestCase):
                 len(loop.experiment.search_space.parameter_constraints) == 0
             )
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_branin(self) -> None:
         """Basic async synthetic function managed loop case."""
         loop = OptimizationLoop.with_evaluation_function(
@@ -108,7 +108,7 @@ class TestManagedLoop(TestCase):
         with self.assertRaisesRegex(ValueError, "Optimization is complete"):
             loop.run_trial()
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_branin_with_active_parameter_constraints(self) -> None:
         """Basic async synthetic function managed loop case."""
         loop = OptimizationLoop.with_evaluation_function(
@@ -137,7 +137,7 @@ class TestManagedLoop(TestCase):
         with self.assertRaisesRegex(ValueError, "Optimization is complete"):
             loop.run_trial()
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_branin_without_objective_name(self) -> None:
         loop = OptimizationLoop.with_evaluation_function(
             parameters=[
@@ -159,7 +159,7 @@ class TestManagedLoop(TestCase):
         self.assertIn("x1", bp)
         self.assertIn("x2", bp)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_branin_with_unknown_sem(self) -> None:
         loop = OptimizationLoop.with_evaluation_function(
             parameters=[
@@ -181,7 +181,7 @@ class TestManagedLoop(TestCase):
         self.assertIn("x1", bp)
         self.assertIn("x2", bp)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_branin_batch(self) -> None:
         """Basic async synthetic function managed loop case."""
 
@@ -252,7 +252,7 @@ class TestManagedLoop(TestCase):
         autospec=True,
         return_value=({"x1": 2.0, "x2": 3.0}, ({"a": 9.0}, {"a": {"a": 3.0}})),
     )
-    @fast_botorch_optimize
+    @fast_modeling
     def test_optimize_with_predictions(self, _) -> None:
         """Tests optimization as a single call."""
         best, vals, exp, model = optimize(
@@ -274,7 +274,7 @@ class TestManagedLoop(TestCase):
         self.assertIn("a", vals[1])
         self.assertIn("a", vals[1]["a"])
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_optimize_unknown_sem(self) -> None:
         """Tests optimization as a single call."""
         best, vals, exp, model = optimize(

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -25,7 +25,7 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_multi_type_experiment,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import fast_modeling
 from ax.utils.testing.modeling_stubs import get_generation_strategy
 from plotly import graph_objects as go
 
@@ -142,7 +142,7 @@ class ReportUtilsTest(TestCase):
         )
         self.assertDictEqual(expected_output, actual_output)
 
-    @fast_botorch_optimize
+    @fast_modeling
     def test_get_standard_plots(self):
         exp = get_branin_experiment()
         self.assertEqual(


### PR DESCRIPTION
Summary:
Add a context manager to speed up gpytorch via their provided gpt_settings object. We utilize 3 of their contexts: fast_computations, fast_pred_samples, and fast_pred_var which you can read more about here https://docs.gpytorch.ai/en/stable/settings.html

Also added a new context manager to apply both fast_botorch and fast_gpytorch at the same time, and replaced calls to fast_botorch_optimize with the new fast_modeling.

Differential Revision: D35010410

