### PR TITLE
Add missing __init__ file in runners/tests.

### DIFF
--- a/ax/runners/tests/__init__.py
+++ b/ax/runners/tests/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
`tests/` was added in D34928063 (https://github.com/facebook/Ax/commit/8e2e68f21155e918996bda0b7d97b5b9ef4e0cba). Unclear why the missing `__init__`
file did not stop the land.

Differential Revision: D35078137

