### PR TITLE
Add missing init file so test stops yelling at us

### DIFF
--- a/ax/utils/testing/test_init_files.py
+++ b/ax/utils/testing/test_init_files.py
@@ -11,6 +11,7 @@ from ax.utils.common.testutils import TestCase
 
 class InitTest(TestCase):
     def testInitFiles(self) -> None:
+        """__init__.py files are necessary when not using buck targets"""
         for root, _dirs, files in os.walk("./ax/ax", topdown=False):
             self.assertTrue(
                 "__init__.py" in files,


### PR DESCRIPTION
Summary: We don't need __init__.py's for buck, but OSS doesn't use buck targets, so we need it there.  I think that's what this test is getting at.

Differential Revision: D35078275

