### PR TITLE
Introduce a class for specifying parameter distributions

### DIFF
--- a/ax/core/__init__.py
+++ b/ax/core/__init__.py
@@ -34,6 +34,7 @@ from ax.core.parameter_constraint import (
     ParameterConstraint,
     SumConstraint,
 )
+from ax.core.parameter_distribution import ParameterDistribution
 from ax.core.runner import Runner
 from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
@@ -59,6 +60,7 @@ __all__ = [
     "OutcomeConstraint",
     "Parameter",
     "ParameterConstraint",
+    "ParameterDistribution",
     "ParameterType",
     "RangeParameter",
     "Runner",

--- a/ax/core/parameter_distribution.py
+++ b/ax/core/parameter_distribution.py
@@ -1,0 +1,65 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+from importlib import import_module
+from typing import List, Any, Dict, Optional
+
+from ax.exceptions.core import UserInputError
+from ax.utils.common.base import Base
+from scipy.stats._distn_infrastructure import rv_generic
+
+TDistribution = str
+TParamName = str
+
+
+class ParameterDistribution(Base):
+    """A class for defining parameter distributions.
+
+    Intended for robust optimization use cases. This could be used to specify the
+    distribution of an environmental variable or the distribution of the input noise.
+    """
+
+    def __init__(
+        self,
+        parameters: List[TParamName],
+        distribution_class: TDistribution,
+        distribution_parameters: Optional[Dict[str, Any]],
+    ) -> None:
+        """Initialize a parameter distribution.
+
+        Args:
+            parameters: A list of parameters, which the distribution belongs to. If
+                this represents the joint input noise distribution of the parameters
+                `x1` and `x2`, pass in `parameters = ["x1", "x2"]`, etc.
+            distribution_class: The name of the scipy distribution class. This must be
+                importable as `from scipy.stats import <distribution_class>`.
+            distribution_parameters: A dictionary of keyword arguments for initializing
+                the distribution class. The distribution will be initialized as
+                `distribution = distribution_class(**distribution_parameters)`.
+        """
+        super().__init__()
+        self.parameters = parameters
+        self.distribution_class = distribution_class
+        self.distribution_parameters = distribution_parameters or {}
+
+    @property
+    @functools.lru_cache()
+    def distribution(self) -> rv_generic:
+        """Get the distribution object."""
+        stats = import_module("scipy.stats")
+        try:
+            dist_class = getattr(stats, self.distribution_class)
+        except AttributeError:
+            raise UserInputError(
+                "Got an error while importing the distribution "
+                f"{self.distribution_class}. Make sure that the "
+                "`distribution_class` is importable from `scipy.stats`."
+            )
+        return dist_class(**self.distribution_parameters)
+
+    def __hash__(self) -> int:
+        """Make the class hashable to support the use of `lru_cache` above."""
+        return hash(repr(self))

--- a/ax/core/tests/test_parameter_distribution.py
+++ b/ax/core/tests/test_parameter_distribution.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.core.parameter_distribution import ParameterDistribution
+from ax.exceptions.core import UserInputError
+from ax.utils.common.testutils import TestCase
+from scipy.stats._continuous_distns import norm_gen
+from scipy.stats._distn_infrastructure import rv_frozen
+
+
+class ParameterDistributionTest(TestCase):
+    def test_parameter_distribution(self):
+        dist = ParameterDistribution(
+            parameters=["x1"],
+            distribution_class="norm",
+            distribution_parameters={"loc": 0.0, "scale": 1.0},
+        )
+        dist_obj = dist.distribution
+        self.assertEqual(dist.parameters, ["x1"])
+        self.assertIsInstance(dist_obj, rv_frozen)
+        self.assertIsInstance(dist_obj.dist, norm_gen)
+        dist_kwds = dist_obj.kwds
+        self.assertEqual(dist_kwds["loc"], 0.0)
+        self.assertEqual(dist_kwds["scale"], 1.0)
+
+        # Test weird distribution name.
+        dist = ParameterDistribution(
+            parameters=["x1"],
+            distribution_class="dummy_dist",
+            distribution_parameters={},
+        )
+        with self.assertRaises(UserInputError):
+            dist.distribution

--- a/sphinx/source/core.rst
+++ b/sphinx/source/core.rst
@@ -154,6 +154,14 @@ Objective
     :undoc-members:
     :show-inheritance:
 
+`ParameterDistribution`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.core.parameter_distribution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 `Runner`
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary:
Introduces a `ParameterDistribution` class for specifying a parameter distribution. This takes in a `scipy` distribution name and the arguments needed to construct the distribution. The distribution is imported and constructed dynamically.

The overall idea is to use this to specify the parameter distributions, which we would sample from and use in constructing the `InputPerturbation` or `AppendFeatures` input transforms, which would be passed onto the BoTorch model.

Reviewed By: Balandat

Differential Revision: D34943939

