### PR TITLE
Pin jinja version to avoid import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ DEV_REQUIRES = [
     "black",
     "flake8",
     "hypothesis",
+    "Jinja2<3.1.0",
     "pytest>=4.6",
     "pytest-cov",
     "sphinx<4.0",


### PR DESCRIPTION
see https://github.com/sphinx-doc/sphinx/issues/10291
I believe because we're on an older version of sphinx we need to pin the
version of Jinja2 to avoid this import error. https://github.com/facebook/Ax/runs/5693784066?check_suite_focus=true

Also, can we update sphinx?  It's pinned to "<4.0" right now