### PR TITLE
Use cache for sqlalchemy TypeDecorator

### DIFF
--- a/ax/storage/sqa_store/json.py
+++ b/ax/storage/sqa_store/json.py
@@ -24,6 +24,8 @@ class JSONEncodedObject(TypeDecorator):
 
     impl: VARCHAR = VARCHAR(JSON_FIELD_LENGTH)
 
+    cache_ok = True
+
     def __init__(
         self, object_pairs_hook: Any = None, *args: List[Any], **kwargs: Dict[Any, Any]
     ) -> None:

--- a/ax/storage/sqa_store/sqa_enum.py
+++ b/ax/storage/sqa_store/sqa_enum.py
@@ -12,6 +12,8 @@ from sqlalchemy import types
 
 
 class BaseNullableEnum(types.TypeDecorator):
+    cache_ok = True
+
     def __init__(self, enum: Any, *arg: List[Any], **kw: Dict[Any, Any]) -> None:
         types.TypeDecorator.__init__(self, *arg, **kw)
         self._member_map = enum._member_map_

--- a/ax/storage/sqa_store/timestamp.py
+++ b/ax/storage/sqa_store/timestamp.py
@@ -13,6 +13,7 @@ from sqlalchemy.types import Integer, TypeDecorator
 
 class IntTimestamp(TypeDecorator):
     impl = Integer
+    cache_ok = True
 
     # pyre-fixme[15]: `process_bind_param` overrides method defined in
     #  `TypeDecorator` inconsistently.


### PR DESCRIPTION
Summary: This is a test to see what breaks if we were to set `cache_ok = True` on some of our sqlalchemy types.  It may be causing significant slowness when used with RDS

Differential Revision: D35150874

