### PR TITLE
Update pinned BoTorch version to 0.6.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from setuptools import find_packages, setup
 
 # TODO: read pinned Botorch version from a shared source
-PINNED_BOTORCH_VERSION = "0.6.2"
+PINNED_BOTORCH_VERSION = "0.6.3.1"
 
 if os.environ.get("ALLOW_BOTORCH_LATEST"):
     # allows a more recent previously installed version of botorch to remain


### PR DESCRIPTION
Summary: D35164979 (https://github.com/facebook/Ax/commit/3f99a1a7857e72ed67f3bb1bfc09595a094cdf52) added SAASBO to BotAx, but SAASBO isn't available in the pinned BoTorch version which causes a flurry of CI test failures. Bumping the pinned BoTorch version should fix the issue.

Reviewed By: mpolson64

Differential Revision: D35207530

