### PR TITLE
Support BoTorch input & outcome transforms in MBM

### DIFF
--- a/ax/models/torch/botorch_modular/list_surrogate.py
+++ b/ax/models/torch/botorch_modular/list_surrogate.py
@@ -6,15 +6,19 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, Dict, Optional, Type
 
 import torch
+from ax.exceptions.core import UserInputError
 from ax.models.torch.botorch_modular.surrogate import NOT_YET_FIT_MSG, Surrogate
 from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 from botorch.models.model import Model, TrainingData
 from botorch.models.model_list_gp_regression import ModelListGP
+from botorch.models.transforms.input import InputTransform
+from botorch.models.transforms.outcome import OutcomeTransform
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
 
@@ -42,6 +46,17 @@ class ListSurrogate(Surrogate):
             NOTE: kwargs for submodel are ``submodel_options`` (shared) +
             ``submodel_outions_per_outcome[submodel_outcome]`` (individual).
         mll_class: ``MarginalLogLikelihood`` class to use for model-fitting.
+        mll_options: Dictionary of options / kwargs for the MLL.
+        submodel_outcome_transforms: A dictionary mapping each outcome to a
+            BoTorch outcome transform. Gets passed down to the BoTorch ``Model``s.
+            To use multiple outcome transforms on a submodel, chain them
+            together using ``ChainedOutcomeTransform``.
+        submodel_input_transforms: A dictionary mapping each outcome to a
+            BoTorch input transform. Gets passed down to the BoTorch ``Model``.
+            If sharing a single ``InputTransform`` object across submodels is
+            preferred, pass in a dictionary where each outcome key references the
+            same ``InputTransform`` object. To use multiple input transfroms on
+            a submodel, chain them together using ``ChainedInputTransform``.
     """
 
     botorch_submodel_class_per_outcome: Dict[str, Type[Model]]
@@ -49,6 +64,9 @@ class ListSurrogate(Surrogate):
     submodel_options_per_outcome: Dict[str, Dict[str, Any]]
     submodel_options: Dict[str, Any]
     mll_class: Type[MarginalLogLikelihood]
+    mll_options: Dict[str, Any]
+    submodel_outcome_transforms: Dict[str, OutcomeTransform]
+    submodel_input_transforms: Dict[str, InputTransform]
     # TODO: Allow passing down `covar_module_class`, `covar_module_options`,
     # `likelihood_class`, and `likelihood_options`.
     _training_data_per_outcome: Optional[Dict[str, TrainingData]] = None
@@ -66,6 +84,8 @@ class ListSurrogate(Surrogate):
         submodel_options: Optional[Dict[str, Any]] = None,
         mll_class: Type[MarginalLogLikelihood] = SumMarginalLogLikelihood,
         mll_options: Optional[Dict[str, Any]] = None,
+        submodel_outcome_transforms: Optional[Dict[str, OutcomeTransform]] = None,
+        submodel_input_transforms: Optional[Dict[str, InputTransform]] = None,
     ) -> None:
         if not bool(botorch_submodel_class_per_outcome) ^ bool(botorch_submodel_class):
             raise ValueError(  # pragma: no cover
@@ -79,6 +99,8 @@ class ListSurrogate(Surrogate):
         self.botorch_submodel_class = botorch_submodel_class
         self.submodel_options_per_outcome = submodel_options_per_outcome or {}
         self.submodel_options = submodel_options or {}
+        self.submodel_outcome_transforms = submodel_outcome_transforms or {}
+        self.submodel_input_transforms = submodel_input_transforms or {}
         super().__init__(
             botorch_model_class=ModelListGP,
             mll_class=mll_class,
@@ -162,6 +184,24 @@ class ListSurrogate(Surrogate):
                 task_features=task_features,
                 **submodel_options,
             )
+            # Add input / outcome transforms.
+            # TODO: The use of `inspect` here is not ideal. We should find a better
+            # way to filter the arguments. See the comment in `Surrogate.construct`
+            # regarding potential use of a `ModelFactory` in the future.
+            model_cls_args = inspect.getfullargspec(model_cls).args
+            outcome_transform = self.submodel_outcome_transforms.get(m)
+            input_transform = self.submodel_input_transforms.get(m)
+            for input_name, input_obj in (
+                ("outcome_transform", outcome_transform),
+                ("input_transform", input_transform),
+            ):
+                if input_obj is not None:
+                    if input_name not in model_cls_args:
+                        raise UserInputError(
+                            f"The model class {model_cls} does not support an "
+                            f"{input_name} argument."
+                        )
+                    formatted_model_inputs[input_name] = input_obj
             # pyre-ignore[45]: Py raises informative error if model is abstract.
             submodels.append(model_cls(**formatted_model_inputs))
         self._model = ModelListGP(*submodels)
@@ -178,4 +218,6 @@ class ListSurrogate(Surrogate):
             "submodel_options": self.submodel_options,
             "mll_class": self.mll_class,
             "mll_options": self.mll_options,
+            "submodel_outcome_transforms": self.submodel_outcome_transforms,
+            "submodel_input_transforms": self.submodel_input_transforms,
         }


### PR DESCRIPTION
Summary:
Adds `input_transform` and `outcome_transform` as kwargs to `Surrogate`. These are passed to the `botorch_model_class` constructor along with the other `formatted_model_inputs`.

This also changes the silently filtering of likelihood and covar module (for models that don't support the arguments) to an explicit error.

Differential Revision: D35051312

