### PR TITLE
Move SchedulerOptions so they can be stored

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -8,10 +8,9 @@ from __future__ import annotations
 
 import warnings
 from collections import defaultdict
-from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from logging import INFO, LoggerAdapter
+from logging import LoggerAdapter
 from time import sleep
 from typing import (
     Any,
@@ -39,9 +38,7 @@ from ax.core.optimization_config import (
     OptimizationConfig,
 )
 from ax.core.runner import Runner
-from ax.core.trial import Trial
 from ax.core.types import TModelPredictArm, TParameterization
-from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
 from ax.exceptions.core import (
     UserInputError,
     AxError,
@@ -55,6 +52,7 @@ from ax.modelbridge.modelbridge_utils import (
     get_pending_observation_features_based_on_trial_status,
 )
 from ax.service.utils.best_point_mixin import BestPointMixin
+from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.service.utils.with_db_settings_base import DBSettings, WithDBSettingsBase
 from ax.utils.common.constants import Keys
 from ax.utils.common.docutils import copy_doc
@@ -106,6 +104,9 @@ NO_RETRY_EXCEPTIONS: Tuple[Type[Exception], ...] = (
     cast(Type[Exception], UnsupportedError),
 )
 
+# TODO[mpolson64] Remove this eventually
+SchedulerOptions = SchedulerOptions
+
 
 class ExperimentStatusProperties(str, Enum):
     """Enum for keys in experiment properties that represent status of
@@ -131,103 +132,6 @@ class RunTrialsStatus(str, Enum):
     STARTED = "started"
     SUCCESS = "success"
     ABORTED = "aborted"
-
-
-@dataclass(frozen=True)
-class SchedulerOptions:
-    """Settings for a scheduler instance.
-
-    Attributes:
-        max_pending_trials: Maximum number of pending trials the scheduler
-            can have ``STAGED`` or ``RUNNING`` at once, required. If looking
-            to use ``Runner.poll_available_capacity`` as a primary guide for
-            how many trials should be pending at a given time, set this limit
-            to a high number, as an upper bound on number of trials that
-            should not be exceeded.
-        trial_type: Type of trials (1-arm ``Trial`` or multi-arm ``Batch
-            Trial``) that will be deployed using the scheduler. Defaults
-            to 1-arm `Trial`. NOTE: use ``BatchTrial`` only if need to
-            evaluate multiple arms *together*, e.g. in an A/B-test
-            influenced by data nonstationarity. For cases where just
-            deploying multiple arms at once is beneficial but the trials
-            are evaluated *independently*, implement ``run_trials`` method
-            in scheduler subclass, to deploy multiple 1-arm trials at
-            the same time.
-        total_trials: Limit on number of trials a given ``Scheduler``
-            should run. If no stopping criteria are implemented on
-            a given scheduler, exhaustion of this number of trials
-            will be used as default stopping criterion in
-            ``Scheduler.run_all_trials``. Required to be non-null if
-            using ``Scheduler.run_all_trials`` (not required for
-            ``Scheduler.run_n_trials``).
-        tolerated_trial_failure_rate: Fraction of trials in this
-            optimization that are allowed to fail without the whole
-            optimization ending. Expects value between 0 and 1.
-            NOTE: Failure rate checks begin once
-            min_failed_trials_for_failure_rate_check trials have
-            failed; after that point if the ratio of failed trials
-            to total trials ran so far exceeds the failure rate,
-            the optimization will halt.
-        min_failed_trials_for_failure_rate_check: The minimum number
-            of trials that must fail in `Scheduler` in order to start
-            checking failure rate.
-        log_filepath: File, to which to write optimization logs.
-        logging_level: Minimum level of logging statements to log,
-            defaults to ``logging.INFO``.
-        ttl_seconds_for_trials: Optional TTL for all trials created
-            within this ``Scheduler``, in seconds. Trials that remain
-            ``RUNNING`` for more than their TTL seconds will be marked
-            ``FAILED`` once the TTL elapses and may be re-suggested by
-            the Ax optimization models.
-        init_seconds_between_polls: Initial wait between rounds of
-            polling, in seconds. Relevant if using the default wait-
-            for-completed-runs functionality of the base ``Scheduler``
-            (if ``wait_for_completed_trials_and_report_results`` is not
-            overridden). With the default waiting, every time a poll
-            returns that no trial evaluations completed, wait
-            time will increase; once some completed trial evaluations
-            are found, it will reset back to this value. Specify 0
-            to not introduce any wait between polls.
-        min_seconds_before_poll: Minimum number of seconds between
-            beginning to run a trial and the first poll to check
-            trial status.
-        seconds_between_polls_backoff_factor: The rate at which the poll
-            interval increases.
-        run_trials_in_batches: If True and ``poll_available_capacity`` is
-            implemented to return non-null results, trials will be dispatched
-            in groups via `run_trials` instead of one-by-one via ``run_trial``.
-            This allows to save time, IO calls or computation in cases where
-            dispatching trials in groups is more efficient then sequential
-            deployment. The size of the groups will be determined as
-            the minimum of ``self.poll_available_capacity()`` and the number
-            of generator runs that the generation strategy is able to produce
-            without more data or reaching its allowed max paralellism limit.
-        debug_log_run_metadata: Whether to log run_metadata for debugging purposes.
-        early_stopping_strategy: A ``BaseEarlyStoppingStrategy`` that determines
-            whether a trial should be stopped given the current state of
-            the experiment. Used in ``should_stop_trials_early``.
-        suppress_storage_errors_after_retries: Whether to fully suppress SQL
-            storage-related errors if encounted, after retrying the call
-            multiple times. Only use if SQL storage is not important for the given
-            use case, since this will only log, but not raise, an exception if
-            it's encountered while saving to DB or loading from it.
-    """
-
-    max_pending_trials: int = 10
-    trial_type: Type[BaseTrial] = Trial
-    total_trials: Optional[int] = None
-    tolerated_trial_failure_rate: float = 0.5
-    min_failed_trials_for_failure_rate_check: int = 5
-    log_filepath: Optional[str] = None
-    logging_level: int = INFO
-    ttl_seconds_for_trials: Optional[int] = None
-    init_seconds_between_polls: Optional[int] = 1
-    min_seconds_before_poll: float = 1.0
-    seconds_between_polls_backoff_factor: float = 1.5
-    run_trials_in_batches: bool = False
-    debug_log_run_metadata: bool = False
-    early_stopping_strategy: Optional[BaseEarlyStoppingStrategy] = None
-    suppress_storage_errors_after_retries: bool = False
 
 
 class Scheduler(WithDBSettingsBase, BestPointMixin):
@@ -1201,7 +1105,9 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         """Validates `SchedulerOptions` for compatibility with given
         `Scheduler` class.
         """
-        if options.trial_type is BatchTrial:  # TODO[T61776778]: support batches
+        if (
+            options.trial_type == TrialType.BATCH_TRIAL
+        ):  # TODO[T61776778]: support batches
             raise NotImplementedError("Support for batched trials coming soon.")
 
         if not (0.0 <= options.tolerated_trial_failure_rate < 1.0):
@@ -1323,7 +1229,10 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             self.logger.debug(f"Message from generation strategy: {err}")
             return []
 
-        if self.options.trial_type is Trial and len(generator_runs[0].arms) > 1:
+        if (
+            self.options.trial_type == TrialType.TRIAL
+            and len(generator_runs[0].arms) > 1
+        ):
             raise SchedulerInternalError(
                 "Generation strategy produced multiple arms when only one was expected."
             )

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -281,7 +281,7 @@ class TestAxScheduler(TestCase):
                 "generation_strategy=GenerationStrategy(name='Sobol+GPEI', "
                 "steps=[Sobol for 5 trials, GPEI for subsequent trials]), "
                 "options=SchedulerOptions(max_pending_trials=10, "
-                "trial_type=<class 'ax.core.trial.Trial'>, "
+                "trial_type=<TrialType.TRIAL: 0>, "
                 "total_trials=0, tolerated_trial_failure_rate=0.2, "
                 "min_failed_trials_for_failure_rate_check=5, log_filepath=None, "
                 "logging_level=20, ttl_seconds_for_trials=None, init_seconds_between_"

--- a/ax/service/utils/scheduler_options.py
+++ b/ax/service/utils/scheduler_options.py
@@ -1,0 +1,113 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from enum import Enum
+from logging import INFO
+from typing import Optional
+
+from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
+
+
+class TrialType(Enum):
+    TRIAL = 0
+    BATCH_TRIAL = 1
+
+
+@dataclass(frozen=True)
+class SchedulerOptions:
+    """Settings for a scheduler instance.
+
+    Attributes:
+        max_pending_trials: Maximum number of pending trials the scheduler
+            can have ``STAGED`` or ``RUNNING`` at once, required. If looking
+            to use ``Runner.poll_available_capacity`` as a primary guide for
+            how many trials should be pending at a given time, set this limit
+            to a high number, as an upper bound on number of trials that
+            should not be exceeded.
+        trial_type: Type of trials (1-arm ``Trial`` or multi-arm ``Batch
+            Trial``) that will be deployed using the scheduler. Defaults
+            to 1-arm `Trial`. NOTE: use ``BatchTrial`` only if need to
+            evaluate multiple arms *together*, e.g. in an A/B-test
+            influenced by data nonstationarity. For cases where just
+            deploying multiple arms at once is beneficial but the trials
+            are evaluated *independently*, implement ``run_trials`` method
+            in scheduler subclass, to deploy multiple 1-arm trials at
+            the same time.
+        total_trials: Limit on number of trials a given ``Scheduler``
+            should run. If no stopping criteria are implemented on
+            a given scheduler, exhaustion of this number of trials
+            will be used as default stopping criterion in
+            ``Scheduler.run_all_trials``. Required to be non-null if
+            using ``Scheduler.run_all_trials`` (not required for
+            ``Scheduler.run_n_trials``).
+        tolerated_trial_failure_rate: Fraction of trials in this
+            optimization that are allowed to fail without the whole
+            optimization ending. Expects value between 0 and 1.
+            NOTE: Failure rate checks begin once
+            min_failed_trials_for_failure_rate_check trials have
+            failed; after that point if the ratio of failed trials
+            to total trials ran so far exceeds the failure rate,
+            the optimization will halt.
+        min_failed_trials_for_failure_rate_check: The minimum number
+            of trials that must fail in `Scheduler` in order to start
+            checking failure rate.
+        log_filepath: File, to which to write optimization logs.
+        logging_level: Minimum level of logging statements to log,
+            defaults to ``logging.INFO``.
+        ttl_seconds_for_trials: Optional TTL for all trials created
+            within this ``Scheduler``, in seconds. Trials that remain
+            ``RUNNING`` for more than their TTL seconds will be marked
+            ``FAILED`` once the TTL elapses and may be re-suggested by
+            the Ax optimization models.
+        init_seconds_between_polls: Initial wait between rounds of
+            polling, in seconds. Relevant if using the default wait-
+            for-completed-runs functionality of the base ``Scheduler``
+            (if ``wait_for_completed_trials_and_report_results`` is not
+            overridden). With the default waiting, every time a poll
+            returns that no trial evaluations completed, wait
+            time will increase; once some completed trial evaluations
+            are found, it will reset back to this value. Specify 0
+            to not introduce any wait between polls.
+        min_seconds_before_poll: Minimum number of seconds between
+            beginning to run a trial and the first poll to check
+            trial status.
+        seconds_between_polls_backoff_factor: The rate at which the poll
+            interval increases.
+        run_trials_in_batches: If True and ``poll_available_capacity`` is
+            implemented to return non-null results, trials will be dispatched
+            in groups via `run_trials` instead of one-by-one via ``run_trial``.
+            This allows to save time, IO calls or computation in cases where
+            dispatching trials in groups is more efficient then sequential
+            deployment. The size of the groups will be determined as
+            the minimum of ``self.poll_available_capacity()`` and the number
+            of generator runs that the generation strategy is able to produce
+            without more data or reaching its allowed max paralellism limit.
+        debug_log_run_metadata: Whether to log run_metadata for debugging purposes.
+        early_stopping_strategy: A ``BaseEarlyStoppingStrategy`` that determines
+            whether a trial should be stopped given the current state of
+            the experiment. Used in ``should_stop_trials_early``.
+        suppress_storage_errors_after_retries: Whether to fully suppress SQL
+            storage-related errors if encounted, after retrying the call
+            multiple times. Only use if SQL storage is not important for the given
+            use case, since this will only log, but not raise, an exception if
+            it's encountered while saving to DB or loading from it.
+    """
+
+    max_pending_trials: int = 10
+    trial_type: TrialType = TrialType.TRIAL
+    total_trials: Optional[int] = None
+    tolerated_trial_failure_rate: float = 0.5
+    min_failed_trials_for_failure_rate_check: int = 5
+    log_filepath: Optional[str] = None
+    logging_level: int = INFO
+    ttl_seconds_for_trials: Optional[int] = None
+    init_seconds_between_polls: Optional[int] = 1
+    min_seconds_before_poll: float = 1.0
+    seconds_between_polls_backoff_factor: float = 1.5
+    run_trials_in_batches: bool = False
+    debug_log_run_metadata: bool = False
+    early_stopping_strategy: Optional[BaseEarlyStoppingStrategy] = None
+    suppress_storage_errors_after_retries: bool = False

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -60,6 +60,7 @@ from ax.models.torch.botorch_modular.list_surrogate import ListSurrogate
 from ax.models.torch.botorch_modular.model import BoTorchModel
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.runners.synthetic import SyntheticRunner
+from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.storage.json_store.decoders import (
     class_from_json,
     transform_type_from_json,
@@ -232,6 +233,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "PercentileEarlyStoppingStrategy": PercentileEarlyStoppingStrategy,
     "RangeParameter": RangeParameter,
     "ScalarizedObjective": ScalarizedObjective,
+    "SchedulerOptions": SchedulerOptions,
     "SearchSpace": SearchSpace,
     "SimpleBenchmarkProblem": SimpleBenchmarkProblem,
     "SklearnDataset": SklearnDataset,
@@ -241,6 +243,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "Surrogate": Surrogate,
     "SyntheticRunner": SyntheticRunner,
     "Trial": Trial,
+    "TrialType": TrialType,
     "TrialStatus": TrialStatus,
     "ThresholdEarlyStoppingStrategy": ThresholdEarlyStoppingStrategy,
     "ObservationFeatures": ObservationFeatures,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -98,6 +98,8 @@ from ax.utils.testing.core_stubs import (
     get_threshold_early_stopping_strategy,
     get_trial,
     get_winsorization_config,
+    get_default_scheduler_options,
+    get_scheduler_options_batch_trial,
 )
 from ax.utils.testing.modeling_stubs import (
     get_generation_strategy,
@@ -154,6 +156,8 @@ TEST_CASES = [
     ("ParameterConstraint", get_parameter_constraint),
     ("RangeParameter", get_range_parameter),
     ("ScalarizedObjective", get_scalarized_objective),
+    ("SchedulerOptions", get_default_scheduler_options),
+    ("SchedulerOptions", get_scheduler_options_batch_trial),
     ("SearchSpace", get_search_space),
     ("SimpleBenchmarkProblem", get_mult_simple_benchmark_problem),
     ("SimpleBenchmarkProblem", get_branin_simple_benchmark_problem),

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -74,6 +74,7 @@ from ax.models.torch.botorch_modular.list_surrogate import ListSurrogate
 from ax.models.torch.botorch_modular.model import BoTorchModel
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.runners.synthetic import SyntheticRunner
+from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.measurement.synthetic_functions import branin
@@ -1556,3 +1557,16 @@ def get_gamma_prior() -> GammaPrior:
 
 def get_interval() -> Interval:
     return Interval(lower_bound=1e-6, upper_bound=0.1)
+
+
+##############################
+# Scheduler
+##############################
+
+
+def get_default_scheduler_options() -> SchedulerOptions:
+    return SchedulerOptions()
+
+
+def get_scheduler_options_batch_trial() -> SchedulerOptions:
+    return SchedulerOptions(trial_type=TrialType.BATCH_TRIAL)


### PR DESCRIPTION
Summary:
Unfortunately, adding SchedulerOptions to the json registry created a circular dependency because of things imported by the Scheduler. Since it is a pretty lightweight dataclass there is no need for it to necessarily have to live in the same module as the Scheduler so I have popped it out into its own module in util. I have done some aliasing in Scheduler so users can still import it from there.

Also, changed trial_type to use an enum instead of the raw class. This makes serialization much easier and has the added benefit of not forcing us to carry around the Trial import wherever the SchedulerOptions goes.

Differential Revision: D35147597

