### PR TITLE
Make Benchmark objects json storable

### DIFF
--- a/ax/benchmark2/__init__.py
+++ b/ax/benchmark2/__init__.py
@@ -3,28 +3,3 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
-from ax.benchmark2.benchmark import (
-    benchmark_full_run,
-    benchmark_replication,
-    benchmark_test,
-)
-from ax.benchmark2.benchmark_method import BenchmarkMethod
-from ax.benchmark2.benchmark_problem import (
-    BenchmarkProblem,
-    SingleObjectiveBenchmarkProblem,
-    MultiObjectiveBenchmarkProblem,
-)
-from ax.benchmark2.benchmark_result import BenchmarkResult, AggregatedBenchmarkResult
-
-__all__ = [
-    "BenchmarkMethod",
-    "BenchmarkProblem",
-    "SingleObjectiveBenchmarkProblem",
-    "MultiObjectiveBenchmarkProblem",
-    "BenchmarkResult",
-    "AggregatedBenchmarkResult",
-    "benchmark_replication",
-    "benchmark_test",
-    "benchmark_full_run",
-]

--- a/ax/benchmark2/benchmark.py
+++ b/ax/benchmark2/benchmark.py
@@ -19,11 +19,14 @@ Key terms used:
 from time import time
 from typing import List, Iterable
 
+import numpy as np
 from ax.benchmark2.benchmark_method import BenchmarkMethod
 from ax.benchmark2.benchmark_problem import BenchmarkProblem
 from ax.benchmark2.benchmark_result import BenchmarkResult, AggregatedBenchmarkResult
 from ax.core.experiment import Experiment
+from ax.core.utils import get_model_times
 from ax.service.scheduler import Scheduler
+from ax.utils.common.typeutils import not_none
 
 
 def benchmark_replication(
@@ -52,7 +55,7 @@ def benchmark_replication(
 
     scheduler.run_all_trials()
 
-    return BenchmarkResult.from_scheduler(scheduler=scheduler)
+    return _result_from_scheduler(scheduler=scheduler)
 
 
 def benchmark_test(
@@ -80,3 +83,47 @@ def benchmark_full_run(
         for problem in problems
         for method in methods
     ]
+
+
+def _result_from_scheduler(scheduler: Scheduler) -> BenchmarkResult:
+    fit_time, gen_time = get_model_times(experiment=scheduler.experiment)
+
+    return BenchmarkResult(
+        name=scheduler.experiment.name,
+        experiment=scheduler.experiment,
+        optimization_trace=_get_trace(scheduler=scheduler),
+        fit_time=fit_time,
+        gen_time=gen_time,
+    )
+
+
+def _get_trace(scheduler: Scheduler) -> np.ndarray:
+    if scheduler.experiment.is_moo_problem:
+        return np.array(
+            [
+                scheduler.get_hypervolume(
+                    trial_indices=[*range(i + 1)], use_model_predictions=False
+                )
+                if i != 0
+                else 0
+                # TODO[mpolson64] on i=0 we get an error with SearchspaceToChoice
+                for i in range(len(scheduler.experiment.trials))
+            ],
+        )
+
+    best_trials = [
+        scheduler.get_best_trial(
+            trial_indices=[*range(i + 1)], use_model_predictions=False
+        )
+        for i in range(len(scheduler.experiment.trials))
+    ]
+
+    return np.array(
+        [
+            not_none(not_none(trial)[2])[0][
+                not_none(scheduler.experiment.optimization_config).objective.metric.name
+            ]
+            for trial in best_trials
+            if trial is not None and not_none(trial)[2] is not None
+        ]
+    )

--- a/ax/benchmark2/benchmark_method.py
+++ b/ax/benchmark2/benchmark_method.py
@@ -7,11 +7,12 @@ from dataclasses import dataclass
 
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.generation_strategy import GenerationStrategy
-from ax.service.scheduler import SchedulerOptions
+from ax.service.utils.scheduler_options import SchedulerOptions
+from ax.utils.common.base import Base
 
 
 @dataclass(frozen=True)
-class BenchmarkMethod:
+class BenchmarkMethod(Base):
     """Benchmark method, represented in terms of Ax generation strategy (which tells us
     which models to use when) and scheduler options (which tell us extra execution
     information like maximum parallelism, early stopping configuration, etc.)

--- a/ax/benchmark2/benchmark_problem.py
+++ b/ax/benchmark2/benchmark_problem.py
@@ -20,13 +20,14 @@ from ax.core.search_space import SearchSpace
 from ax.core.types import ComparisonOp
 from ax.metrics.botorch_test_problem import BotorchTestProblemMetric
 from ax.runners.botorch_test_problem import BotorchTestProblemRunner
+from ax.utils.common.base import Base
 from botorch.test_functions.base import BaseTestProblem
 from botorch.test_functions.multi_objective import MultiObjectiveTestProblem
 from botorch.test_functions.synthetic import SyntheticTestFunction
 
 
 @dataclass(frozen=True)
-class BenchmarkProblem:
+class BenchmarkProblem(Base):
     """Benchmark problem, represented in terms of Ax search space, optimization
     config, and runner.
     """

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -8,10 +8,9 @@ from __future__ import annotations
 
 import warnings
 from collections import defaultdict
-from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from logging import INFO, LoggerAdapter
+from logging import LoggerAdapter
 from time import sleep
 from typing import (
     Any,
@@ -39,9 +38,7 @@ from ax.core.optimization_config import (
     OptimizationConfig,
 )
 from ax.core.runner import Runner
-from ax.core.trial import Trial
 from ax.core.types import TModelPredictArm, TParameterization
-from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
 from ax.exceptions.core import (
     UserInputError,
     AxError,
@@ -55,6 +52,7 @@ from ax.modelbridge.modelbridge_utils import (
     get_pending_observation_features_based_on_trial_status,
 )
 from ax.service.utils.best_point_mixin import BestPointMixin
+from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.service.utils.with_db_settings_base import DBSettings, WithDBSettingsBase
 from ax.utils.common.constants import Keys
 from ax.utils.common.docutils import copy_doc
@@ -131,103 +129,6 @@ class RunTrialsStatus(str, Enum):
     STARTED = "started"
     SUCCESS = "success"
     ABORTED = "aborted"
-
-
-@dataclass(frozen=True)
-class SchedulerOptions:
-    """Settings for a scheduler instance.
-
-    Attributes:
-        max_pending_trials: Maximum number of pending trials the scheduler
-            can have ``STAGED`` or ``RUNNING`` at once, required. If looking
-            to use ``Runner.poll_available_capacity`` as a primary guide for
-            how many trials should be pending at a given time, set this limit
-            to a high number, as an upper bound on number of trials that
-            should not be exceeded.
-        trial_type: Type of trials (1-arm ``Trial`` or multi-arm ``Batch
-            Trial``) that will be deployed using the scheduler. Defaults
-            to 1-arm `Trial`. NOTE: use ``BatchTrial`` only if need to
-            evaluate multiple arms *together*, e.g. in an A/B-test
-            influenced by data nonstationarity. For cases where just
-            deploying multiple arms at once is beneficial but the trials
-            are evaluated *independently*, implement ``run_trials`` method
-            in scheduler subclass, to deploy multiple 1-arm trials at
-            the same time.
-        total_trials: Limit on number of trials a given ``Scheduler``
-            should run. If no stopping criteria are implemented on
-            a given scheduler, exhaustion of this number of trials
-            will be used as default stopping criterion in
-            ``Scheduler.run_all_trials``. Required to be non-null if
-            using ``Scheduler.run_all_trials`` (not required for
-            ``Scheduler.run_n_trials``).
-        tolerated_trial_failure_rate: Fraction of trials in this
-            optimization that are allowed to fail without the whole
-            optimization ending. Expects value between 0 and 1.
-            NOTE: Failure rate checks begin once
-            min_failed_trials_for_failure_rate_check trials have
-            failed; after that point if the ratio of failed trials
-            to total trials ran so far exceeds the failure rate,
-            the optimization will halt.
-        min_failed_trials_for_failure_rate_check: The minimum number
-            of trials that must fail in `Scheduler` in order to start
-            checking failure rate.
-        log_filepath: File, to which to write optimization logs.
-        logging_level: Minimum level of logging statements to log,
-            defaults to ``logging.INFO``.
-        ttl_seconds_for_trials: Optional TTL for all trials created
-            within this ``Scheduler``, in seconds. Trials that remain
-            ``RUNNING`` for more than their TTL seconds will be marked
-            ``FAILED`` once the TTL elapses and may be re-suggested by
-            the Ax optimization models.
-        init_seconds_between_polls: Initial wait between rounds of
-            polling, in seconds. Relevant if using the default wait-
-            for-completed-runs functionality of the base ``Scheduler``
-            (if ``wait_for_completed_trials_and_report_results`` is not
-            overridden). With the default waiting, every time a poll
-            returns that no trial evaluations completed, wait
-            time will increase; once some completed trial evaluations
-            are found, it will reset back to this value. Specify 0
-            to not introduce any wait between polls.
-        min_seconds_before_poll: Minimum number of seconds between
-            beginning to run a trial and the first poll to check
-            trial status.
-        seconds_between_polls_backoff_factor: The rate at which the poll
-            interval increases.
-        run_trials_in_batches: If True and ``poll_available_capacity`` is
-            implemented to return non-null results, trials will be dispatched
-            in groups via `run_trials` instead of one-by-one via ``run_trial``.
-            This allows to save time, IO calls or computation in cases where
-            dispatching trials in groups is more efficient then sequential
-            deployment. The size of the groups will be determined as
-            the minimum of ``self.poll_available_capacity()`` and the number
-            of generator runs that the generation strategy is able to produce
-            without more data or reaching its allowed max paralellism limit.
-        debug_log_run_metadata: Whether to log run_metadata for debugging purposes.
-        early_stopping_strategy: A ``BaseEarlyStoppingStrategy`` that determines
-            whether a trial should be stopped given the current state of
-            the experiment. Used in ``should_stop_trials_early``.
-        suppress_storage_errors_after_retries: Whether to fully suppress SQL
-            storage-related errors if encounted, after retrying the call
-            multiple times. Only use if SQL storage is not important for the given
-            use case, since this will only log, but not raise, an exception if
-            it's encountered while saving to DB or loading from it.
-    """
-
-    max_pending_trials: int = 10
-    trial_type: Type[BaseTrial] = Trial
-    total_trials: Optional[int] = None
-    tolerated_trial_failure_rate: float = 0.5
-    min_failed_trials_for_failure_rate_check: int = 5
-    log_filepath: Optional[str] = None
-    logging_level: int = INFO
-    ttl_seconds_for_trials: Optional[int] = None
-    init_seconds_between_polls: Optional[int] = 1
-    min_seconds_before_poll: float = 1.0
-    seconds_between_polls_backoff_factor: float = 1.5
-    run_trials_in_batches: bool = False
-    debug_log_run_metadata: bool = False
-    early_stopping_strategy: Optional[BaseEarlyStoppingStrategy] = None
-    suppress_storage_errors_after_retries: bool = False
 
 
 class Scheduler(WithDBSettingsBase, BestPointMixin):
@@ -1201,7 +1102,9 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         """Validates `SchedulerOptions` for compatibility with given
         `Scheduler` class.
         """
-        if options.trial_type is BatchTrial:  # TODO[T61776778]: support batches
+        if (
+            options.trial_type == TrialType.BATCH_TRIAL
+        ):  # TODO[T61776778]: support batches
             raise NotImplementedError("Support for batched trials coming soon.")
 
         if not (0.0 <= options.tolerated_trial_failure_rate < 1.0):
@@ -1323,7 +1226,10 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             self.logger.debug(f"Message from generation strategy: {err}")
             return []
 
-        if self.options.trial_type is Trial and len(generator_runs[0].arms) > 1:
+        if (
+            self.options.trial_type == TrialType.TRIAL
+            and len(generator_runs[0].arms) > 1
+        ):
             raise SchedulerInternalError(
                 "Generation strategy produced multiple arms when only one was expected."
             )

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -281,7 +281,7 @@ class TestAxScheduler(TestCase):
                 "generation_strategy=GenerationStrategy(name='Sobol+GPEI', "
                 "steps=[Sobol for 5 trials, GPEI for subsequent trials]), "
                 "options=SchedulerOptions(max_pending_trials=10, "
-                "trial_type=<class 'ax.core.trial.Trial'>, "
+                "trial_type=<TrialType.TRIAL: 0>, "
                 "total_trials=0, tolerated_trial_failure_rate=0.2, "
                 "min_failed_trials_for_failure_rate_check=5, log_filepath=None, "
                 "logging_level=20, ttl_seconds_for_trials=None, init_seconds_between_"

--- a/ax/service/utils/scheduler_options.py
+++ b/ax/service/utils/scheduler_options.py
@@ -1,0 +1,113 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from enum import Enum
+from logging import INFO
+from typing import Optional
+
+from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
+
+
+class TrialType(Enum):
+    TRIAL = 0
+    BATCH_TRIAL = 1
+
+
+@dataclass(frozen=True)
+class SchedulerOptions:
+    """Settings for a scheduler instance.
+
+    Attributes:
+        max_pending_trials: Maximum number of pending trials the scheduler
+            can have ``STAGED`` or ``RUNNING`` at once, required. If looking
+            to use ``Runner.poll_available_capacity`` as a primary guide for
+            how many trials should be pending at a given time, set this limit
+            to a high number, as an upper bound on number of trials that
+            should not be exceeded.
+        trial_type: Type of trials (1-arm ``Trial`` or multi-arm ``Batch
+            Trial``) that will be deployed using the scheduler. Defaults
+            to 1-arm `Trial`. NOTE: use ``BatchTrial`` only if need to
+            evaluate multiple arms *together*, e.g. in an A/B-test
+            influenced by data nonstationarity. For cases where just
+            deploying multiple arms at once is beneficial but the trials
+            are evaluated *independently*, implement ``run_trials`` method
+            in scheduler subclass, to deploy multiple 1-arm trials at
+            the same time.
+        total_trials: Limit on number of trials a given ``Scheduler``
+            should run. If no stopping criteria are implemented on
+            a given scheduler, exhaustion of this number of trials
+            will be used as default stopping criterion in
+            ``Scheduler.run_all_trials``. Required to be non-null if
+            using ``Scheduler.run_all_trials`` (not required for
+            ``Scheduler.run_n_trials``).
+        tolerated_trial_failure_rate: Fraction of trials in this
+            optimization that are allowed to fail without the whole
+            optimization ending. Expects value between 0 and 1.
+            NOTE: Failure rate checks begin once
+            min_failed_trials_for_failure_rate_check trials have
+            failed; after that point if the ratio of failed trials
+            to total trials ran so far exceeds the failure rate,
+            the optimization will halt.
+        min_failed_trials_for_failure_rate_check: The minimum number
+            of trials that must fail in `Scheduler` in order to start
+            checking failure rate.
+        log_filepath: File, to which to write optimization logs.
+        logging_level: Minimum level of logging statements to log,
+            defaults to ``logging.INFO``.
+        ttl_seconds_for_trials: Optional TTL for all trials created
+            within this ``Scheduler``, in seconds. Trials that remain
+            ``RUNNING`` for more than their TTL seconds will be marked
+            ``FAILED`` once the TTL elapses and may be re-suggested by
+            the Ax optimization models.
+        init_seconds_between_polls: Initial wait between rounds of
+            polling, in seconds. Relevant if using the default wait-
+            for-completed-runs functionality of the base ``Scheduler``
+            (if ``wait_for_completed_trials_and_report_results`` is not
+            overridden). With the default waiting, every time a poll
+            returns that no trial evaluations completed, wait
+            time will increase; once some completed trial evaluations
+            are found, it will reset back to this value. Specify 0
+            to not introduce any wait between polls.
+        min_seconds_before_poll: Minimum number of seconds between
+            beginning to run a trial and the first poll to check
+            trial status.
+        seconds_between_polls_backoff_factor: The rate at which the poll
+            interval increases.
+        run_trials_in_batches: If True and ``poll_available_capacity`` is
+            implemented to return non-null results, trials will be dispatched
+            in groups via `run_trials` instead of one-by-one via ``run_trial``.
+            This allows to save time, IO calls or computation in cases where
+            dispatching trials in groups is more efficient then sequential
+            deployment. The size of the groups will be determined as
+            the minimum of ``self.poll_available_capacity()`` and the number
+            of generator runs that the generation strategy is able to produce
+            without more data or reaching its allowed max paralellism limit.
+        debug_log_run_metadata: Whether to log run_metadata for debugging purposes.
+        early_stopping_strategy: A ``BaseEarlyStoppingStrategy`` that determines
+            whether a trial should be stopped given the current state of
+            the experiment. Used in ``should_stop_trials_early``.
+        suppress_storage_errors_after_retries: Whether to fully suppress SQL
+            storage-related errors if encounted, after retrying the call
+            multiple times. Only use if SQL storage is not important for the given
+            use case, since this will only log, but not raise, an exception if
+            it's encountered while saving to DB or loading from it.
+    """
+
+    max_pending_trials: int = 10
+    trial_type: TrialType = TrialType.TRIAL
+    total_trials: Optional[int] = None
+    tolerated_trial_failure_rate: float = 0.5
+    min_failed_trials_for_failure_rate_check: int = 5
+    log_filepath: Optional[str] = None
+    logging_level: int = INFO
+    ttl_seconds_for_trials: Optional[int] = None
+    init_seconds_between_polls: Optional[int] = 1
+    min_seconds_before_poll: float = 1.0
+    seconds_between_polls_backoff_factor: float = 1.5
+    run_trials_in_batches: bool = False
+    debug_log_run_metadata: bool = False
+    early_stopping_strategy: Optional[BaseEarlyStoppingStrategy] = None
+    suppress_storage_errors_after_retries: bool = False

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -26,6 +26,7 @@ from ax.core.parameter_constraint import (
     ParameterConstraint,
     SumConstraint,
 )
+from ax.core.runner import Runner
 from ax.core.search_space import SearchSpace
 from ax.exceptions.storage import JSONDecodeError
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
@@ -205,6 +206,8 @@ def object_from_json(
                 decoder_registry=decoder_registry,
                 class_decoder_registry=class_decoder_registry,
             )
+        elif issubclass(_class, Runner):
+            return runner_from_json(_class=_class, runner_json=object_json)
 
         return ax_class_from_json_dict(
             _class=_class,
@@ -691,3 +694,10 @@ def simple_benchmark_problem_from_json(
         domain=cast(List[Tuple[float, float]], domain),
         minimize=object_json.pop("minimize"),
     )
+
+
+def runner_from_json(
+    _class: Type[Runner],
+    runner_json: Dict[str, Any],
+) -> Runner:
+    return _class(**_class.deserialize_init_args(args=runner_json))  # pyre-ignore[45]

--- a/ax/storage/json_store/encoder.py
+++ b/ax/storage/json_store/encoder.py
@@ -62,6 +62,7 @@ def object_to_json(
                     )
                     for k, v in obj_dict.items()
                 }
+
         raise ValueError(
             f"{obj} is a class. Add it to the CLASS_ENCODER_REGISTRY "
             "(and remove it from the ENCODER_REGISTRY if needed)."
@@ -129,7 +130,7 @@ def object_to_json(
                     encoder_registry=encoder_registry,
                     class_encoder_registry=class_encoder_registry,
                 )
-                for k, v in dataclasses.asdict(obj).items()
+                for k, v in obj.__dict__.items()
             },
         }
 

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -29,6 +29,7 @@ from ax.core.parameter_constraint import (
     ParameterConstraint,
     SumConstraint,
 )
+from ax.core.runner import Runner
 from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
 from ax.early_stopping.strategies import (
@@ -41,7 +42,6 @@ from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.winsorize import WinsorizationConfig
 from ax.models.torch.botorch_modular.model import BoTorchModel
 from ax.models.torch.botorch_modular.surrogate import Surrogate
-from ax.runners.synthetic import SyntheticRunner
 from ax.storage.botorch_modular_registry import CLASS_TO_REGISTRY
 from ax.storage.transform_registry import TRANSFORM_REGISTRY
 from ax.utils.common.serialization import serialize_init_args
@@ -324,9 +324,10 @@ def generator_run_to_dict(generator_run: GeneratorRun) -> Dict[str, Any]:
     }
 
 
-def runner_to_dict(runner: SyntheticRunner) -> Dict[str, Any]:
-    """Convert Ax synthetic runner to a dictionary."""
-    properties = serialize_init_args(object=runner)
+def runner_to_dict(runner: Runner) -> Dict[str, Any]:
+    """Convert Ax runner to a dictionary."""
+    runner_cls = type(runner)
+    properties = runner_cls.serialize_init_args(runner=runner)
     properties["__type"] = runner.__class__.__name__
     return properties
 
@@ -445,10 +446,6 @@ def benchmark_problem_to_dict(benchmark_problem: BenchmarkProblem) -> Dict[str, 
             "evaluate_suggested": benchmark_problem.evaluate_suggested,
             "optimal_value": benchmark_problem.optimal_value,
         }
-    elif isinstance(benchmark_problem, BenchmarkProblem):
-        properties = serialize_init_args(object=benchmark_problem)
-        properties["__type"] = benchmark_problem.__class__.__name__
-        return properties
     else:  # pragma: no cover
         raise ValueError(f"Expected benchmark problem, got: {benchmark_problem}.")
 

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -60,6 +60,7 @@ from ax.models.torch.botorch_modular.list_surrogate import ListSurrogate
 from ax.models.torch.botorch_modular.model import BoTorchModel
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.runners.synthetic import SyntheticRunner
+from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.storage.json_store.decoders import (
     class_from_json,
     transform_type_from_json,
@@ -232,6 +233,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "PercentileEarlyStoppingStrategy": PercentileEarlyStoppingStrategy,
     "RangeParameter": RangeParameter,
     "ScalarizedObjective": ScalarizedObjective,
+    "SchedulerOptions": SchedulerOptions,
     "SearchSpace": SearchSpace,
     "SimpleBenchmarkProblem": SimpleBenchmarkProblem,
     "SklearnDataset": SklearnDataset,
@@ -241,6 +243,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "Surrogate": Surrogate,
     "SyntheticRunner": SyntheticRunner,
     "Trial": Trial,
+    "TrialType": TrialType,
     "TrialStatus": TrialStatus,
     "ThresholdEarlyStoppingStrategy": ThresholdEarlyStoppingStrategy,
     "ObservationFeatures": ObservationFeatures,

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -6,8 +6,14 @@
 
 from typing import Any, Callable, Dict, Type
 
-from ax.benchmark.benchmark_problem import BenchmarkProblem, SimpleBenchmarkProblem
-from ax.benchmark.benchmark_result import BenchmarkResult
+from ax.benchmark.benchmark_problem import SimpleBenchmarkProblem
+from ax.benchmark2.benchmark_method import BenchmarkMethod
+from ax.benchmark2.benchmark_problem import (
+    MultiObjectiveBenchmarkProblem,
+    SingleObjectiveBenchmarkProblem,
+    BenchmarkProblem,
+)
+from ax.benchmark2.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
 from ax.core import ObservationFeatures
 from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
@@ -43,6 +49,7 @@ from ax.early_stopping.strategies import (
     PercentileEarlyStoppingStrategy,
     ThresholdEarlyStoppingStrategy,
 )
+from ax.metrics.botorch_test_problem import BotorchTestProblemMetric
 from ax.metrics.branin import AugmentedBraninMetric, BraninMetric, NegativeBraninMetric
 from ax.metrics.branin_map import BraninTimestampMapMetric
 from ax.metrics.chemistry import ChemistryProblemType, ChemistryMetric
@@ -59,6 +66,7 @@ from ax.models.torch.botorch_modular.acquisition import Acquisition
 from ax.models.torch.botorch_modular.list_surrogate import ListSurrogate
 from ax.models.torch.botorch_modular.model import BoTorchModel
 from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.runners.botorch_test_problem import BotorchTestProblemRunner
 from ax.runners.synthetic import SyntheticRunner
 from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.storage.json_store.decoders import (
@@ -118,8 +126,9 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     AugmentedBraninMetric: metric_to_dict,
     AugmentedHartmann6Metric: metric_to_dict,
     BatchTrial: batch_to_dict,
-    BenchmarkProblem: benchmark_problem_to_dict,
     BoTorchModel: botorch_model_to_dict,
+    BotorchTestProblemMetric: metric_to_dict,
+    BotorchTestProblemRunner: runner_to_dict,
     BraninMetric: metric_to_dict,
     BraninTimestampMapMetric: metric_to_dict,
     ChoiceParameter: choice_parameter_to_dict,
@@ -187,9 +196,13 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "AugmentedHartmann6Metric": AugmentedHartmann6Metric,
     "Arm": Arm,
     "BatchTrial": BatchTrial,
+    "AggregatedBenchmarkResult": AggregatedBenchmarkResult,
+    "BenchmarkMethod": BenchmarkMethod,
     "BenchmarkProblem": BenchmarkProblem,
     "BenchmarkResult": BenchmarkResult,
     "BoTorchModel": BoTorchModel,
+    "BotorchTestProblemMetric": BotorchTestProblemMetric,
+    "BotorchTestProblemRunner": BotorchTestProblemRunner,
     "BraninMetric": BraninMetric,
     "BraninTimestampMapMetric": BraninTimestampMapMetric,
     "ChemistryMetric": ChemistryMetric,
@@ -218,6 +231,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "Metric": Metric,
     "Models": Models,
     "MultiObjective": MultiObjective,
+    "MultiObjectiveBenchmarkProblem": MultiObjectiveBenchmarkProblem,
     "MultiObjectiveOptimizationConfig": MultiObjectiveOptimizationConfig,
     "MultiTypeExperiment": MultiTypeExperiment,
     "NegativeBraninMetric": NegativeBraninMetric,
@@ -236,6 +250,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "SchedulerOptions": SchedulerOptions,
     "SearchSpace": SearchSpace,
     "SimpleBenchmarkProblem": SimpleBenchmarkProblem,
+    "SingleObjectiveBenchmarkProblem": SingleObjectiveBenchmarkProblem,
     "SklearnDataset": SklearnDataset,
     "SklearnMetric": SklearnMetric,
     "SklearnModelType": SklearnModelType,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -40,10 +40,15 @@ from ax.storage.registry_bundle import RegistryBundle
 from ax.utils.common.testutils import TestCase
 from ax.utils.measurement.synthetic_functions import ackley, branin, from_botorch
 from ax.utils.testing.benchmark_stubs import (
-    get_branin_benchmark_problem,
     get_branin_simple_benchmark_problem,
     get_mult_simple_benchmark_problem,
     get_sum_simple_benchmark_problem,
+    get_single_objective_benchmark_problem,
+    get_multi_objective_benchmark_problem,
+    get_benchmark_problem,
+    get_sobol_gpei_benchmark_method,
+    get_aggregated_benchmark_result,
+    get_benchmark_result,
 )
 from ax.utils.testing.core_stubs import (
     get_abandoned_arm,
@@ -112,11 +117,14 @@ from torch.nn import Module
 
 TEST_CASES = [
     ("AbandonedArm", get_abandoned_arm),
+    ("AggregatedBenchmarkResult", get_aggregated_benchmark_result),
     ("Arm", get_arm),
     ("AugmentedBraninMetric", get_augmented_branin_metric),
     ("AugmentedHartmannMetric", get_augmented_hartmann_metric),
     ("BatchTrial", get_batch_trial),
-    ("BenchmarkProblem", get_branin_benchmark_problem),
+    ("BenchmarkMethod", get_sobol_gpei_benchmark_method),
+    ("BenchmarkProblem", get_benchmark_problem),
+    ("BenchmarkResult", get_benchmark_result),
     ("BoTorchModel", get_botorch_model),
     ("BoTorchModel", get_botorch_model_with_default_acquisition_class),
     ("BraninMetric", get_branin_metric),
@@ -140,6 +148,7 @@ TEST_CASES = [
     ("MapData", get_map_data),
     ("Metric", get_metric),
     ("MultiObjective", get_multi_objective),
+    ("MultiObjectiveBenchmarkProblem", get_multi_objective_benchmark_problem),
     ("MultiObjectiveOptimizationConfig", get_multi_objective_optimization_config),
     ("MultiTypeExperiment", get_multi_type_experiment),
     ("ObservationFeatures", get_observation_features),
@@ -162,6 +171,7 @@ TEST_CASES = [
     ("SimpleBenchmarkProblem", get_mult_simple_benchmark_problem),
     ("SimpleBenchmarkProblem", get_branin_simple_benchmark_problem),
     ("SimpleBenchmarkProblem", get_sum_simple_benchmark_problem),
+    ("SingleObjectiveBenchmarkProblem", get_single_objective_benchmark_problem),
     ("SumConstraint", get_sum_constraint1),
     ("SumConstraint", get_sum_constraint2),
     ("Surrogate", get_surrogate),
@@ -254,6 +264,7 @@ class JSONStoreTest(TestCase):
                 continue
 
             original_object = fake_func()
+
             json_object = object_to_json(
                 original_object,
                 encoder_registry=CORE_ENCODER_REGISTRY,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -98,6 +98,8 @@ from ax.utils.testing.core_stubs import (
     get_threshold_early_stopping_strategy,
     get_trial,
     get_winsorization_config,
+    get_default_scheduler_options,
+    get_scheduler_options_batch_trial,
 )
 from ax.utils.testing.modeling_stubs import (
     get_generation_strategy,
@@ -154,6 +156,8 @@ TEST_CASES = [
     ("ParameterConstraint", get_parameter_constraint),
     ("RangeParameter", get_range_parameter),
     ("ScalarizedObjective", get_scalarized_objective),
+    ("SchedulerOptions", get_default_scheduler_options),
+    ("SchedulerOptions", get_scheduler_options_batch_trial),
     ("SearchSpace", get_search_space),
     ("SimpleBenchmarkProblem", get_mult_simple_benchmark_problem),
     ("SimpleBenchmarkProblem", get_branin_simple_benchmark_problem),

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -14,6 +14,7 @@ from ax.benchmark2.benchmark_method import BenchmarkMethod
 from ax.benchmark2.benchmark_problem import (
     MultiObjectiveBenchmarkProblem,
     SingleObjectiveBenchmarkProblem,
+    BenchmarkProblem as Benchmark2Problem,
 )
 from ax.benchmark2.benchmark_result import (
     AggregatedBenchmarkResult,
@@ -66,6 +67,10 @@ def get_branin_benchmark_problem() -> BenchmarkProblem:
 
 
 # Benchmark2
+def get_benchmark_problem() -> Benchmark2Problem:
+    return Benchmark2Problem.from_botorch(test_problem=Branin())
+
+
 def get_single_objective_benchmark_problem() -> SingleObjectiveBenchmarkProblem:
     return SingleObjectiveBenchmarkProblem.from_botorch_synthetic(test_problem=Branin())
 
@@ -144,4 +149,5 @@ def get_benchmark_result() -> BenchmarkResult:
 
 
 def get_aggregated_benchmark_result() -> AggregatedBenchmarkResult:
-    return AggregatedBenchmarkResult.from_benchmark_results([get_benchmark_result()])
+    result = get_benchmark_result()
+    return AggregatedBenchmarkResult.from_benchmark_results([result, result])

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -74,6 +74,7 @@ from ax.models.torch.botorch_modular.list_surrogate import ListSurrogate
 from ax.models.torch.botorch_modular.model import BoTorchModel
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.runners.synthetic import SyntheticRunner
+from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.measurement.synthetic_functions import branin
@@ -1556,3 +1557,16 @@ def get_gamma_prior() -> GammaPrior:
 
 def get_interval() -> Interval:
     return Interval(lower_bound=1e-6, upper_bound=0.1)
+
+
+##############################
+# Scheduler
+##############################
+
+
+def get_default_scheduler_options() -> SchedulerOptions:
+    return SchedulerOptions()
+
+
+def get_scheduler_options_batch_trial() -> SchedulerOptions:
+    return SchedulerOptions(trial_type=TrialType.BATCH_TRIAL)

--- a/sphinx/source/service.rst
+++ b/sphinx/source/service.rst
@@ -33,6 +33,10 @@ Scheduler
     :undoc-members:
     :show-inheritance:
 
+.. automodule:: ax.service.utils.scheduler_options
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Utils
 ------


### PR DESCRIPTION
Summary:
Add json storage support for the BenchmarkProblem, BenchmarkMethod, BenchmarkResult, and AggregatedBenchmarkResult so they can be passed around as parameters and results on fblearner.

This wound up requiring a little bit of TARGETS rewriting in the benchmarking suite to keep Scheduler dependencies out of the registry, since this would create a dependency loop.

Differential Revision: D35146551

