### PR TITLE
adding a safeguard for stopping strategy

### DIFF
--- a/ax/global_stopping/strategies/improvement.py
+++ b/ax/global_stopping/strategies/improvement.py
@@ -76,6 +76,11 @@ class ImprovementGlobalStoppingStrategy(BaseGlobalStoppingStrategy):
             message = "There are pending trials in the experiment."
             return False, message
 
+        if len(experiment.trials_by_status[TrialStatus.COMPLETED]) == 0:
+            message = "There are no completed trials yet."
+            return False, message
+            max_completed_trial = 0
+
         max_completed_trial = max(
             experiment.trial_indices_by_status[TrialStatus.COMPLETED]
         )
@@ -198,6 +203,9 @@ class ImprovementGlobalStoppingStrategy(BaseGlobalStoppingStrategy):
 
         # Computing the interquartile for scaling the difference
         feasible_objectives = np.array(objectives)[is_feasible]
+        if len(feasible_objectives) <= 1:
+            message = "There are not enough feasible arms tried yet."
+            return False, message
 
         q3, q1 = np.percentile(feasible_objectives, [75, 25])
         iqr = q3 - q1

--- a/ax/global_stopping/tests/tests_strategies.py
+++ b/ax/global_stopping/tests/tests_strategies.py
@@ -25,7 +25,7 @@ from ax.global_stopping.strategies.improvement import (
     constraint_satisfaction,
 )
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_experiment_with_data
+from ax.utils.testing.core_stubs import get_experiment, get_experiment_with_data
 
 
 class TestImprovementGlobalStoppingStrategy(TestCase):
@@ -273,6 +273,17 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
             message,
             "The improvement in best objective in the past 3 trials (=0.000) is "
             "less than 0.1.",
+        )
+
+    def test_safety_check(self):
+        experiment = get_experiment()
+        gss = ImprovementGlobalStoppingStrategy(min_trials=2, window_size=3)
+
+        stop, message = gss.should_stop_optimization(experiment=experiment)
+        self.assertFalse(stop)
+        self.assertEqual(
+            message,
+            "There are no completed trials yet.",
         )
 
     def test_constraint_satisfaction(self):


### PR DESCRIPTION
Summary: The stopping strategy at first call to get_next_trial() raises error since there are no compleleted trials yet to call max() function on. This fixes that.

Reviewed By: danielrjiang

Differential Revision: D35274315

