### PR TITLE
Add support for out-of-sample predictions to AxClient

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -139,6 +139,11 @@ class GenerationStrategy(Base):
         return [sum(gen_changes[: i + 1]) for i in range(len(gen_changes))][:-1]
 
     @property
+    def current_step(self) -> GenerationStep:
+        """Current generation step."""
+        return self._curr
+
+    @property
     def model(self) -> Optional[ModelBridge]:
         """Current model in this strategy. Returns None if no model has been set
         yet (i.e., if no generator runs have been produced from this GS).

--- a/ax/modelbridge/prediction_utils.py
+++ b/ax/modelbridge/prediction_utils.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Set, Dict, Tuple
+
+import numpy as np
+from ax.core.observation import ObservationFeatures
+from ax.modelbridge import ModelBridge
+
+
+def predict_at_point(
+    model: ModelBridge, obsf: ObservationFeatures, metric_names: Set[str]
+) -> Tuple[Dict[str, float], Dict[str, float]]:
+    """Make a prediction at a point.
+
+    Returns mean and standard deviation in format expected by plotting.
+
+    Args:
+        model: ModelBridge
+        obsf: ObservationFeatures for which to predict
+        metric_names: Limit predictions to these metrics.
+
+    Returns:
+        A tuple containing
+
+        - Map from metric name to prediction.
+        - Map from metric name to standard error.
+    """
+    y_hat = {}
+    se_hat = {}
+    f_pred, cov_pred = model.predict([obsf])
+    for metric_name in f_pred:
+        if metric_name in metric_names:
+            y_hat[metric_name] = f_pred[metric_name][0]
+            se_hat[metric_name] = np.sqrt(cov_pred[metric_name][metric_name][0])
+    return y_hat, se_hat
+
+
+def predict_by_features(
+    model: ModelBridge,
+    label_to_feature_dict: Dict[int, ObservationFeatures],
+    metric_names: Set[str],
+) -> Dict[int, Dict[str, Tuple[float, float]]]:
+    """Predict for given data points and model.
+
+    Args:
+        model: Model to be used for the prediction
+        metric_names: Names of the metrics, for which to retrieve predictions.
+        label_to_feature_dict: Mapping from an int label to
+            a Parameterization. These data points are predicted.
+
+    Returns:
+        A mapping from an int label to a mapping of metric names to tuples
+        of predicted metric mean and SEM, of form:
+        { trial_index -> { metric_name: ( mean, SEM ) } }.
+    """
+    predictions_dict = {}  # Store predictions to return
+    for label in label_to_feature_dict:
+        try:
+            y_hat, se_hat = predict_at_point(
+                model=model,
+                obsf=label_to_feature_dict[label],
+                metric_names=metric_names,
+            )
+        except NotImplementedError:
+            raise NotImplementedError(
+                "The model associated with the current generation strategy "
+                "step is not one that can be used for predicting values. "
+                "For example, this may be the Sobol generator associated with the "
+                "initialization step where quasi-random points are generated. "
+                "Try again by calling the `AxClient.create_experiment()` "
+                "method with the `choose_generation_strategy_kwargs="
+                '{"num_initialization_trials": 0}` parameter if you are looking '
+                "to use a generation strategy without an initialization step that "
+                "proceeds straight to the Bayesian optimization step, but note "
+                "that performance of Bayesian optimization can be suboptimal if "
+                "search space is not sampled well in the initialization phase."
+            )
+
+        predictions_dict[label] = {
+            metric: (
+                y_hat[metric],
+                se_hat[metric],
+            )
+            for metric in metric_names
+        }
+
+    return predictions_dict

--- a/ax/modelbridge/tests/test_prediction_utils.py
+++ b/ax/modelbridge/tests/test_prediction_utils.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import mock
+
+import numpy as np
+from ax.core.observation import ObservationFeatures
+from ax.modelbridge.prediction_utils import predict_by_features, predict_at_point
+from ax.service.ax_client import AxClient
+from ax.utils.common.testutils import TestCase
+
+
+class TestPredictionUtils(TestCase):
+    """Tests prediction utilities."""
+
+    def test_predict_at_point(self):
+        ax_client = _set_up_client_for_get_model_predictions_no_next_trial()
+        _attach_completed_trials(ax_client)
+        ax_client.get_model_predictions()  # Ensures model is instantiated
+
+        observation_features = ObservationFeatures(parameters={"x1": 0.3, "x2": 0.5})
+        y_hat, se_hat = predict_at_point(
+            model=ax_client.generation_strategy.model,
+            obsf=observation_features,
+            metric_names=["test_metric1"],
+        )
+
+        self.assertEqual(len(y_hat), 1)
+        self.assertEqual(len(se_hat), 1)
+
+    def test_predict_by_features(self):
+        ax_client = _set_up_client_for_get_model_predictions_no_next_trial()
+        _attach_completed_trials(ax_client)
+        ax_client.get_model_predictions()  # Ensures model is instantiated
+
+        observation_features_dict = {
+            18: ObservationFeatures(parameters={"x1": 0.3, "x2": 0.5}),
+            19: ObservationFeatures(parameters={"x1": 0.4, "x2": 0.5}),
+            20: ObservationFeatures(parameters={"x1": 0.8, "x2": 0.5}),
+        }
+        predictions_map = predict_by_features(
+            model=ax_client.generation_strategy.model,
+            label_to_feature_dict=observation_features_dict,
+            metric_names=["test_metric1"],
+        )
+        self.assertEqual(len(predictions_map), 3)
+
+    @mock.patch("ax.modelbridge.random.RandomModelBridge.predict")
+    @mock.patch("ax.modelbridge.random.RandomModelBridge")
+    def test_predict_by_features_with_non_predicting_model(
+        self, model_bridge_mock, predict_mock
+    ):
+        ax_client = _set_up_client_for_get_model_predictions_no_next_trial()
+        _attach_completed_trials(ax_client)
+
+        # Do not call get_next_trial or get_model_predictions.
+        # This test is for handling the use case where no model
+        # is instantiated.
+
+        observation_features_dict = {
+            18: ObservationFeatures(parameters={"x1": 0.3, "x2": 0.5}),
+            19: ObservationFeatures(parameters={"x1": 0.4, "x2": 0.5}),
+            20: ObservationFeatures(parameters={"x1": 0.8, "x2": 0.5}),
+        }
+
+        predict_mock.side_effect = NotImplementedError()
+        self.assertRaises(
+            NotImplementedError,
+            predict_by_features,
+            **{
+                "model": model_bridge_mock,
+                "label_to_feature_dict": observation_features_dict,
+                "metric_names": ["test_metric1"],
+            },
+        )
+
+
+# Utility functions for testing get_model_predictions without calling
+# get_next_trial. Create Ax Client with an experiment where
+# num_initial_trials kwarg is zero. Note that this kwarg is
+# needed to be able to instantiate the model for the first time
+# without calling get_next_trial().
+def _set_up_client_for_get_model_predictions_no_next_trial():
+    ax_client = AxClient()
+    ax_client.create_experiment(
+        name="test_experiment",
+        choose_generation_strategy_kwargs={"num_initialization_trials": 0},
+        parameters=[
+            {
+                "name": "x1",
+                "type": "range",
+                "bounds": [0.0, 1.0],
+            },
+            {
+                "name": "x2",
+                "type": "range",
+                "bounds": [0.1, 1.0],
+            },
+        ],
+        objective_name="test_metric1",
+        outcome_constraints=["test_metric2 <= 1.5"],
+    )
+
+    return ax_client
+
+
+def _attach_completed_trials(ax_client):
+    # Attach completed trials
+    trial1 = {"x1": 0.1, "x2": 0.1}
+    parameters, trial_index = ax_client.attach_trial(trial1)
+    ax_client.complete_trial(
+        trial_index=trial_index, raw_data=_evaluate_test_metrics(parameters)
+    )
+
+    trial2 = {"x1": 0.2, "x2": 0.1}
+    parameters, trial_index = ax_client.attach_trial(trial2)
+    ax_client.complete_trial(
+        trial_index=trial_index, raw_data=_evaluate_test_metrics(parameters)
+    )
+
+
+# Test metric evaluation method
+def _evaluate_test_metrics(parameters):
+    x = np.array([parameters.get(f"x{i+1}") for i in range(2)])
+    return {"test_metric1": (x[0] / x[1], 0.0), "test_metric2": (x[0] + x[1], 0.0)}

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -108,6 +108,13 @@ General Utilities
     :undoc-members:
     :show-inheritance:
 
+Prediction Utilities
+~~~~~~~~~~~~~~~~~~
+.. automodule:: ax.modelbridge.prediction_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Cross Validation
 ~~~~~~~~~~~~~~~~~
 .. automodule:: ax.modelbridge.cross_validation


### PR DESCRIPTION
Summary:
Add support for out-of-sample predictions to the AxClient.

With these changes, AxClient.get_model_predictions() can be called with attached data without the need to call get_next_trial(). get_model_predictions() now instantiates a model as needed and provides recommendations on what can be done to ensure model creation succeeds. Furthermore, it updates the model as needed to ensure any completed data is fit before making predictions. Prior to these changes, model update was tied to the get_next_trial() call.

These changes also expose a new AxClient method get_model_predictions_for_parameterizations() which enables predictions by arbitrary parameterizations.

Reviewed By: lena-kashtelyan

Differential Revision: D35262761

