### PR TITLE
Implement QuickBO

### DIFF
--- a/ax/exceptions/data_provider.py
+++ b/ax/exceptions/data_provider.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any
+from typing import Iterable, Any
 
 
 class DataProviderError(Exception):
@@ -31,3 +31,16 @@ class DataProviderError(Exception):
             message=self.message,
             dp_error=self.data_provider_error,
         )
+
+
+class MissingDataError(Exception):
+    def __init__(self, missing_trial_indexes: Iterable[int]) -> None:
+        missing_trial_str = ", ".join([str(index) for index in missing_trial_indexes])
+        self.message: str = (
+            f"Unable to find data for the following trials: {missing_trial_str} "
+            "consider updating the data fetching kwargs or manually fetching "
+            "data via `refetch_data()`"
+        )
+
+    def __str__(self) -> str:
+        return self.message


### PR DESCRIPTION
Summary:
This is just a bare bones, no change in interface, just if the user adds a long run trial, the client treats it as the experiement as quickbo as long as the long run trial is running.
We've upstreamed `instagram.igml.assistant.qe_lib.utils.analyzer.QELibQuickBOAnalyzer` to `ax.fb.utils.pts.QuickBOAnalyzer`, minus the `QELibTrialBuilderMixIn`.  I'm going to leave the tests on `QELibQuickBOAnalyzer` to make sure the contract is preserved as there are users using that one, and for PTS I eventually want to de-differentiate the sequential and quickbo analyzers.

Reviewed By: lena-kashtelyan

Differential Revision: D35293585

