### PR TITLE
Update transforms to support RobustSearchSpace / ParameterDistribution

### DIFF
--- a/ax/core/parameter_distribution.py
+++ b/ax/core/parameter_distribution.py
@@ -30,6 +30,7 @@ class ParameterDistribution(Base):
         parameters: List[TParamName],
         distribution_class: TDistribution,
         distribution_parameters: Optional[Dict[str, Any]],
+        multiplicative: bool = False,
     ) -> None:
         """Initialize a parameter distribution.
 
@@ -42,11 +43,15 @@ class ParameterDistribution(Base):
             distribution_parameters: A dictionary of keyword arguments for initializing
                 the distribution class. The distribution will be initialized as
                 `distribution = distribution_class(**distribution_parameters)`.
+            multiplicative: A boolean denoting whether the distribution will be used as
+                a multiplicative input perturbation. Should be `False` for the
+                distributions of environmental variables.
         """
         super().__init__()
         self.parameters = parameters
         self.distribution_class = distribution_class
         self.distribution_parameters = distribution_parameters or {}
+        self.multiplicative = multiplicative
 
     @property
     @functools.lru_cache()
@@ -69,6 +74,7 @@ class ParameterDistribution(Base):
             parameters=self.parameters.copy(),
             distribution_class=self.distribution_class,
             distribution_parameters=deepcopy(self.distribution_parameters),
+            multiplicative=self.multiplicative,
         )
 
     def __hash__(self) -> int:
@@ -85,5 +91,6 @@ class ParameterDistribution(Base):
             f"{self.__class__.__name__}("
             "parameters=" + repr(self.parameters) + ", "
             "distribution_class=" + self.distribution_class + ", "
-            "distribution_parameters=" + repr(self.distribution_parameters) + ")"
+            "distribution_parameters=" + repr(self.distribution_parameters) + ", "
+            "multiplicative=" + repr(self.multiplicative) + ")"
         )

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -687,6 +687,11 @@ class RobustSearchSpace(SearchSpace):
                 distributions.
             parameter_constraints: List of parameter constraints.
         """
+        if len(parameter_distributions) == 0:
+            raise UserInputError(
+                "RobustSearchSpace requires at least one distributional parameter. "
+                "Use SearchSpace instead."
+            )
         self.parameter_distributions = parameter_distributions
         # Make sure that there is at most one distribution per parameter.
         distributional_parameters_list = []
@@ -729,6 +734,11 @@ class RobustSearchSpace(SearchSpace):
                 raise UserInputError(
                     "All environmental variables must be range parameters."
                 )
+            if any(d.multiplicative for d in parameter_distributions):
+                raise UserInputError(
+                    "Distributions of environmental variables must have "
+                    "`multiplicative=False`."
+                )
         else:
             if not all(
                 isinstance(self.parameters[p], RangeParameter)
@@ -745,9 +755,12 @@ class RobustSearchSpace(SearchSpace):
 
     @property
     def parameters(self) -> Dict[str, Parameter]:
-        # NOTE: We include environmental variables here to support
-        # `transform_search_space` and other similar functionality.
-        # It also helps avoid having to overwrite a bunch of parent methods.
+        """Get all parameters and environmental variables.
+
+        We include environmental variables here to support `transform_search_space`
+        and other similar functionality. It also helps avoid having to overwrite a
+        bunch of parent methods.
+        """
         return {**self._parameters, **self._environmental_variables}
 
     def update_parameter(self, parameter: Parameter) -> None:

--- a/ax/core/tests/test_parameter_distribution.py
+++ b/ax/core/tests/test_parameter_distribution.py
@@ -17,7 +17,9 @@ class ParameterDistributionTest(TestCase):
             parameters=["x1"],
             distribution_class="norm",
             distribution_parameters={"loc": 0.0, "scale": 1.0},
+            multiplicative=True,
         )
+        self.assertTrue(dist.multiplicative)
         dist_obj = dist.distribution
         self.assertEqual(dist.parameters, ["x1"])
         self.assertIsInstance(dist_obj, rv_frozen)
@@ -31,7 +33,8 @@ class ParameterDistributionTest(TestCase):
             "ParameterDistribution("
             "parameters=['x1'], "
             "distribution_class=norm, "
-            "distribution_parameters={'loc': 0.0, 'scale': 1.0})"
+            "distribution_parameters={'loc': 0.0, 'scale': 1.0}, "
+            "multiplicative=True)"
         )
         self.assertEqual(str(dist), expected_repr)
 
@@ -41,5 +44,6 @@ class ParameterDistributionTest(TestCase):
             distribution_class="dummy_dist",
             distribution_parameters={},
         )
+        self.assertFalse(dist.multiplicative)
         with self.assertRaises(UserInputError):
             dist.distribution

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -703,6 +703,12 @@ class TestRobustSearchSpace(TestCase):
             distribution_class="norm",
             distribution_parameters={"loc": 0.0, "scale": 1.0},
         )
+        env1_dist_mul = ParameterDistribution(
+            parameters=["env1"],
+            distribution_class="norm",
+            distribution_parameters={"loc": 0.0, "scale": 1.0},
+            multiplicative=True,
+        )
         env2_dist = ParameterDistribution(
             parameters=["env2"],
             distribution_class="binom",
@@ -714,6 +720,8 @@ class TestRobustSearchSpace(TestCase):
             distribution_parameters={"n": 2, "p": 0.3},
         )
         # Error handling.
+        with self.assertRaisesRegex(UserInputError, "Use SearchSpace instead."):
+            RobustSearchSpace(parameters=self.parameters, parameter_distributions=[])
         with self.assertRaisesRegex(UserInputError, "must be unique"):
             RobustSearchSpace(
                 parameters=self.parameters,
@@ -733,6 +741,14 @@ class TestRobustSearchSpace(TestCase):
                 parameters=self.parameters,
                 parameter_distributions=[env1_dist, env_choice_dist],
                 environmental_variables=[env1, env_choice],
+            )
+        with self.assertRaisesRegex(
+            UserInputError, "Distributions of environmental variables"
+        ):
+            RobustSearchSpace(
+                parameters=self.parameters,
+                parameter_distributions=[env1_dist_mul],
+                environmental_variables=[env1],
             )
         with self.assertRaisesRegex(UserInputError, "multiple parameter distributions"):
             RobustSearchSpace(
@@ -842,7 +858,8 @@ class TestRobustSearchSpace(TestCase):
             "values=['foo', 'bar', 'baz'], is_ordered=False, sort_values=False)], "
             "parameter_distributions=["
             "ParameterDistribution(parameters=['a', 'b'], "
-            "distribution_class=multivariate_normal, distribution_parameters={})], "
+            "distribution_class=multivariate_normal, distribution_parameters={}, "
+            "multiplicative=False)], "
             "environmental_variables=[], "
             "parameter_constraints=[OrderConstraint(a <= b)])"
         )

--- a/ax/modelbridge/tests/test_cap_parameter_transform.py
+++ b/ax/modelbridge/tests/test_cap_parameter_transform.py
@@ -6,8 +6,10 @@
 
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
+from ax.exceptions.core import UnsupportedError
 from ax.modelbridge.transforms.cap_parameter import CapParameter
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_robust_search_space
 
 
 class CapParameterTest(TestCase):
@@ -40,3 +42,24 @@ class CapParameterTest(TestCase):
         )
         with self.assertRaises(NotImplementedError):
             t2.transform_search_space(self.search_space)
+
+    def test_w_parameter_distributions(self):
+        rss = get_robust_search_space()
+        # Transform a non-distributional parameter.
+        t = CapParameter(
+            search_space=rss,
+            observation_features=[],
+            observation_data=[],
+            config={"z": "2"},
+        )
+        t.transform_search_space(rss)
+        self.assertEqual(rss.parameters.get("z").upper, 2)
+        # Error with distributional parameter.
+        t = CapParameter(
+            search_space=rss,
+            observation_features=[],
+            observation_data=[],
+            config={"x": "2"},
+        )
+        with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
+            t.transform_search_space(rss)

--- a/ax/modelbridge/tests/test_centered_unit_x_transform.py
+++ b/ax/modelbridge/tests/test_centered_unit_x_transform.py
@@ -4,115 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from copy import deepcopy
-
-from ax.core.observation import ObservationFeatures
-from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
-from ax.core.parameter_constraint import ParameterConstraint
-from ax.core.search_space import SearchSpace
+from ax.modelbridge.tests.test_unit_x_transform import UnitXTransformTest
 from ax.modelbridge.transforms.centered_unit_x import CenteredUnitX
-from ax.utils.common.testutils import TestCase
 
 
-class CenteredUnitXTransformTest(TestCase):
-    def setUp(self):
-        self.search_space = SearchSpace(
-            parameters=[
-                RangeParameter(
-                    "x", lower=1, upper=3, parameter_type=ParameterType.FLOAT
-                ),
-                RangeParameter(
-                    "y", lower=1, upper=2, parameter_type=ParameterType.FLOAT
-                ),
-                RangeParameter(
-                    "z",
-                    lower=1,
-                    upper=2,
-                    parameter_type=ParameterType.FLOAT,
-                    log_scale=True,
-                ),
-                RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),
-                ChoiceParameter(
-                    "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
-                ),
-            ],
-            parameter_constraints=[],
-        )
-        self.search_space_with_target = SearchSpace(
-            parameters=[
-                RangeParameter(
-                    "x",
-                    lower=1,
-                    upper=3,
-                    parameter_type=ParameterType.FLOAT,
-                    is_fidelity=True,
-                    target_value=3,
-                )
-            ]
-        )
-        self.t = CenteredUnitX(
-            search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
-        )
+class CenteredUnitXTransformTest(UnitXTransformTest):
 
-    def testInit(self):
-        self.assertEqual(self.t.bounds, {"x": (1.0, 3.0), "y": (1.0, 2.0)})
-
-    def testTransformObservationFeatures(self):
-        observation_features = [
-            ObservationFeatures(parameters={"x": 2, "y": 2, "z": 2, "a": 2, "b": "b"})
-        ]
-        obs_ft2 = deepcopy(observation_features)
-        obs_ft2 = self.t.transform_observation_features(obs_ft2)
-        self.assertEqual(
-            obs_ft2,
-            [
-                ObservationFeatures(
-                    parameters={"x": 0.0, "y": 1.0, "z": 2, "a": 2, "b": "b"}
-                )
-            ],
-        )
-        obs_ft2 = self.t.untransform_observation_features(obs_ft2)
-        self.assertEqual(obs_ft2, observation_features)
-        # Test transform partial observation
-        obs_ft3 = [ObservationFeatures(parameters={"x": 1.0, "z": 2})]
-        obs_ft3 = self.t.transform_observation_features(obs_ft3)
-        self.assertEqual(
-            obs_ft3[0], ObservationFeatures(parameters={"x": -1.0, "z": 2})
-        )
-        obs_ft5 = self.t.transform_observation_features([ObservationFeatures({})])
-        self.assertEqual(obs_ft5[0], ObservationFeatures({}))
-
-    def testTransformSearchSpace(self):
-        ss2 = deepcopy(self.search_space)
-        ss2 = self.t.transform_search_space(ss2)
-
-        # Parameters transformed
-        true_bounds = {
-            "x": (-1.0, 1.0),
-            "y": (-1.0, 1.0),
-            "z": (1.0, 2.0),
-            "a": (1.0, 2.0),
-        }
-        for p_name, (l, u) in true_bounds.items():
-            self.assertEqual(ss2.parameters[p_name].lower, l)
-            self.assertEqual(ss2.parameters[p_name].upper, u)
-        self.assertEqual(ss2.parameters["b"].values, ["a", "b", "c"])
-        self.assertEqual(len(ss2.parameters), 5)
-        # Constraints error
-        ss2 = deepcopy(self.search_space)
-        ss2.add_parameter_constraints(
-            [ParameterConstraint(constraint_dict={"x": -0.5, "y": 1}, bound=0.5)]
-        )
-        with self.assertRaises(ValueError):
-            ss2 = self.t.transform_search_space(ss2)
-        t = CenteredUnitX(
-            search_space=self.search_space_with_target,
-            observation_features=None,
-            observation_data=None,
-        )
-        t.transform_search_space(self.search_space_with_target)
-        self.assertEqual(
-            self.search_space_with_target.parameters["x"].target_value, 1.0
-        )
+    transform_class = CenteredUnitX
+    expected_c_dicts = [{"x": -0.5, "y": 0.5}, {"x": -0.5, "a": 1.0}]
+    expected_c_bounds = [0.0, 1.5]

--- a/ax/modelbridge/tests/test_search_space_to_choice_transform.py
+++ b/ax/modelbridge/tests/test_search_space_to_choice_transform.py
@@ -15,8 +15,10 @@ from ax.core.parameter import (
     RangeParameter,
 )
 from ax.core.search_space import SearchSpace
+from ax.exceptions.core import UnsupportedError
 from ax.modelbridge.transforms.search_space_to_choice import SearchSpaceToChoice
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_robust_search_space
 
 
 class SearchSpaceToChoiceTest(TestCase):
@@ -128,3 +130,13 @@ class SearchSpaceToChoiceTest(TestCase):
         self.assertEqual(obs_ft2, self.transformed_features)
         obs_ft2 = self.t.untransform_observation_features(obs_ft2)
         self.assertEqual(obs_ft2, self.observation_features)
+
+    def test_w_robust_search_space(self):
+        rss = get_robust_search_space()
+        # Raises an error in __init__.
+        with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
+            SearchSpaceToChoice(
+                search_space=rss,
+                observation_features=None,
+                observation_data=None,
+            )

--- a/ax/modelbridge/tests/test_trial_as_task_transform.py
+++ b/ax/modelbridge/tests/test_trial_as_task_transform.py
@@ -9,8 +9,10 @@ from copy import deepcopy
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
+from ax.exceptions.core import UnsupportedError
 from ax.modelbridge.transforms.trial_as_task import TrialAsTask
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_robust_search_space
 
 
 class TrialAsTaskTransformTest(TestCase):
@@ -123,3 +125,13 @@ class TrialAsTaskTransformTest(TestCase):
         self.assertEqual(p.parameter_type, ParameterType.STRING)
         self.assertEqual(set(p.values), {"u1", "u2"})
         self.assertTrue(p.is_task)
+
+    def test_w_robust_search_space(self):
+        rss = get_robust_search_space()
+        # Raises an error in __init__.
+        with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
+            TrialAsTask(
+                search_space=rss,
+                observation_features=[],
+                observation_data=None,
+            )

--- a/ax/modelbridge/transforms/base.py
+++ b/ax/modelbridge/transforms/base.py
@@ -12,7 +12,8 @@ import numpy as np
 from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import ObjectiveThreshold
-from ax.core.search_space import SearchSpace
+from ax.core.search_space import SearchSpace, RobustSearchSpace
+from ax.exceptions.core import UnsupportedError
 from ax.models.types import TConfig
 
 
@@ -73,6 +74,22 @@ class Transform:
         self.modelbridge = modelbridge
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+        """Transform search space.
+
+        The transforms are typically done in-place. This calls two private methods,
+        `_transform_search_space`, which transforms the core search space attributes,
+        and `_transform_parameter_distributions`, which transforms the distributions
+        when using a `RobustSearchSpace`.
+
+        Args:
+            search_space: The search space
+
+        Returns: transformed search space.
+        """
+        self._transform_parameter_distributions(search_space=search_space)
+        return self._transform_search_space(search_space=search_space)
+
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         """Transform search space.
 
         This is typically done in-place. This class implements the identity
@@ -215,3 +232,26 @@ class Transform:
                     )
                 )
         return untransformed_thresholds
+
+    def _transform_parameter_distributions(self, search_space: SearchSpace) -> None:
+        """Transform the parameter distributions of the given search space, in-place.
+
+        This method should be called in transform_search_space before parameters
+        are transformed.
+
+        The base implementation is a no-op for most transforms, except for those
+        that have a `transform_parameters` attribute, in which case this will
+        raise an `UnsupportedError` if a parameter with an associated distribution
+        is being transformed.
+        """
+        if isinstance(search_space, RobustSearchSpace) and hasattr(
+            self, "transform_parameters"
+        ):
+            # pyre-ignore Undefined attribute [16]
+            for p_name in self.transform_parameters:
+                if p_name in search_space._distributional_parameters:
+                    raise UnsupportedError(
+                        f"{self.__class__.__name__} transform is not supported for "
+                        "parameters with an associated distribution. Consider updating "
+                        "the transform config."
+                    )

--- a/ax/modelbridge/transforms/cap_parameter.py
+++ b/ax/modelbridge/transforms/cap_parameter.py
@@ -38,7 +38,7 @@ class CapParameter(Transform):
             p_name for p_name in search_space.parameters if p_name in self.config
         }
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         for p_name, p in search_space.parameters.items():
             if p_name in self.transform_parameters:
                 if not isinstance(p, RangeParameter):

--- a/ax/modelbridge/transforms/cast.py
+++ b/ax/modelbridge/transforms/cast.py
@@ -50,7 +50,7 @@ class Cast(Transform):
             config is None or checked_cast(bool, config.get("flatten_hss", True))
         ) and isinstance(search_space, HierarchicalSearchSpace)
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         """Flattens the hierarchical search space and returns the flat
         ``SearchSpace`` if this transform is configured to flatten hierarchical
         search spaces. Does nothing if the search space is not hierarchical.

--- a/ax/modelbridge/transforms/centered_unit_x.py
+++ b/ax/modelbridge/transforms/centered_unit_x.py
@@ -4,85 +4,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
-from ax.core.observation import ObservationData, ObservationFeatures
-from ax.core.parameter import ParameterType, RangeParameter
-from ax.core.search_space import SearchSpace
-from ax.modelbridge.transforms.base import Transform
-from ax.models.types import TConfig
-from ax.utils.common.docutils import copy_doc
-
-if TYPE_CHECKING:
-    # import as module to make sphinx-autodoc-typehints happy
-    from ax import modelbridge as modelbridge_module  # noqa F401  # pragma: no cover
+from ax.modelbridge.transforms.unit_x import UnitX
 
 
-class CenteredUnitX(Transform):
+class CenteredUnitX(UnitX):
     """Map X to [-1, 1]^d for RangeParameter of type float and not log scale.
-
-    Currently does not support linear constraints, but could in the future be
-    adjusted to transform them too, since this is a linear operation.
 
     Transform is done in-place.
     """
 
-    def __init__(
-        self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
-        modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
-        config: Optional[TConfig] = None,
-    ) -> None:
-        # Identify parameters that should be transformed
-        self.bounds: Dict[str, Tuple[float, float]] = {}
-        for p_name, p in search_space.parameters.items():
-            if (
-                isinstance(p, RangeParameter)
-                and p.parameter_type == ParameterType.FLOAT
-                and not p.log_scale
-            ):
-                self.bounds[p_name] = (p.lower, p.upper)
-
-    @copy_doc(Transform.transform_observation_features)
-    def transform_observation_features(
-        self, observation_features: List[ObservationFeatures]
-    ) -> List[ObservationFeatures]:
-        for obsf in observation_features:
-            for p_name, (l, u) in self.bounds.items():
-                if p_name in obsf.parameters:
-                    # pyre: param is declared to have type `float` but is used
-                    # pyre-fixme[9]: as type `Optional[typing.Union[bool, float, str]]`.
-                    param: float = obsf.parameters[p_name]
-                    obsf.parameters[p_name] = -1 + 2 * (param - l) / (u - l)
-        return observation_features
-
-    @copy_doc(Transform.transform_search_space)
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
-        for p_name, p in search_space.parameters.items():
-            if p_name in self.bounds and isinstance(p, RangeParameter):
-                p.update_range(lower=-1.0, upper=1.0)
-            if p.target_value is not None:
-                l, u = self.bounds[p_name]
-                # pyre-fixme[58]: `-` is not supported for operand types
-                #  `Union[None, bool, float, int, str]` and `float`.
-                new_tval = -1 + 2 * (p.target_value - l) / (u - l)
-                p._target_value = new_tval
-        for c in search_space.parameter_constraints:
-            for p_name in c.constraint_dict:
-                if p_name in self.bounds:
-                    raise ValueError("Does not support parameter constraints")
-        return search_space
-
-    @copy_doc(Transform.untransform_observation_features)
-    def untransform_observation_features(
-        self, observation_features: List[ObservationFeatures]
-    ) -> List[ObservationFeatures]:
-        for obsf in observation_features:
-            for p_name, (l, u) in self.bounds.items():
-                # pyre: param is declared to have type `float` but is used as
-                # pyre-fixme[9]: type `Optional[typing.Union[bool, float, str]]`.
-                param: float = obsf.parameters[p_name]
-                obsf.parameters[p_name] = ((param + 1) / 2) * (u - l) + l
-        return observation_features
+    target_lb: float = -1.0
+    target_range: float = 2.0

--- a/ax/modelbridge/transforms/choice_encode.py
+++ b/ax/modelbridge/transforms/choice_encode.py
@@ -75,7 +75,7 @@ class ChoiceEncode(Transform):
                     ]
         return observation_features
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         transformed_parameters: Dict[str, Parameter] = {}
         for p_name, p in search_space.parameters.items():
             if p_name in self.encoded_parameters and isinstance(p, ChoiceParameter):
@@ -153,7 +153,7 @@ class OrderedChoiceEncode(ChoiceEncode):
             for p_name, transforms in self.encoded_parameters.items()
         }
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         transformed_parameters: Dict[str, Parameter] = {}
         for p_name, p in search_space.parameters.items():
             if p_name in self.encoded_parameters and isinstance(p, ChoiceParameter):

--- a/ax/modelbridge/transforms/int_range_to_choice.py
+++ b/ax/modelbridge/transforms/int_range_to_choice.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set
 
 from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
-from ax.core.search_space import SearchSpace
+from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.models.types import TConfig
 
@@ -38,7 +38,7 @@ class IntRangeToChoice(Transform):
             if isinstance(p, RangeParameter) and p.parameter_type == ParameterType.INT
         }
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         transformed_parameters: Dict[str, Parameter] = {}
         for p_name, p in search_space.parameters.items():
             if p_name in self.transform_parameters and isinstance(p, RangeParameter):
@@ -64,12 +64,20 @@ class IntRangeToChoice(Transform):
                 )
             else:
                 transformed_parameters[p.name] = p
-        return SearchSpace(
-            parameters=list(transformed_parameters.values()),
-            parameter_constraints=[
+        new_kwargs = {
+            "parameters": list(transformed_parameters.values()),
+            "parameter_constraints": [
                 pc.clone_with_transformed_parameters(
                     transformed_parameters=transformed_parameters
                 )
                 for pc in search_space.parameter_constraints
             ],
-        )
+        }
+        if isinstance(search_space, RobustSearchSpace):
+            new_kwargs["environmental_variables"] = list(
+                search_space._environmental_variables.values()
+            )
+            # pyre-ignore Incompatible parameter type [6]
+            new_kwargs["parameter_distributions"] = search_space.parameter_distributions
+        # pyre-ignore Incompatible parameter type [6]
+        return search_space.__class__(**new_kwargs)

--- a/ax/modelbridge/transforms/log.py
+++ b/ax/modelbridge/transforms/log.py
@@ -53,7 +53,7 @@ class Log(Transform):
                     obsf.parameters[p_name] = math.log10(param)
         return observation_features
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         for p_name, p in search_space.parameters.items():
             if p_name in self.transform_parameters and isinstance(p, RangeParameter):
                 p.set_log_scale(False).update_range(

--- a/ax/modelbridge/transforms/logit.py
+++ b/ax/modelbridge/transforms/logit.py
@@ -51,7 +51,7 @@ class Logit(Transform):
                     obsf.parameters[p_name] = logit(param).item()
         return observation_features
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         for p_name, p in search_space.parameters.items():
             if p_name in self.transform_parameters and isinstance(p, RangeParameter):
                 p.set_logit_scale(False).update_range(

--- a/ax/modelbridge/transforms/one_hot.py
+++ b/ax/modelbridge/transforms/one_hot.py
@@ -124,7 +124,7 @@ class OneHot(Transform):
                     obsf.parameters.update(updated_parameters)
         return observation_features
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         transformed_parameters: Dict[str, Parameter] = {}
         for p_name, p in search_space.parameters.items():
             if p_name in self.encoded_parameters:

--- a/ax/modelbridge/transforms/remove_fixed.py
+++ b/ax/modelbridge/transforms/remove_fixed.py
@@ -55,7 +55,7 @@ class RemoveFixed(Transform):
                     obsf.parameters.pop(p_name)
         return observation_features
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         tunable_parameters: List[Union[ChoiceParameter, RangeParameter]] = []
         for p in search_space.parameters.values():
             if p.name not in self.fixed_parameters:

--- a/ax/modelbridge/transforms/task_encode.py
+++ b/ax/modelbridge/transforms/task_encode.py
@@ -59,7 +59,7 @@ class TaskEncode(OrderedChoiceEncode):
             for p_name, transforms in self.encoded_parameters.items()
         }
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         transformed_parameters: Dict[str, Parameter] = {}
         for p_name, p in search_space.parameters.items():
             if p_name in self.encoded_parameters and isinstance(p, ChoiceParameter):

--- a/ax/modelbridge/transforms/trial_as_task.py
+++ b/ax/modelbridge/transforms/trial_as_task.py
@@ -9,7 +9,8 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 import numpy as np
 from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType
-from ax.core.search_space import SearchSpace
+from ax.core.search_space import SearchSpace, RobustSearchSpace
+from ax.exceptions.core import UnsupportedError
 from ax.modelbridge.transforms.base import Transform
 from ax.models.types import TConfig
 
@@ -54,6 +55,10 @@ class TrialAsTask(Transform):
     ) -> None:
         # Identify values of trial.
         trials = {obsf.trial_index for obsf in observation_features}
+        if isinstance(search_space, RobustSearchSpace):
+            raise UnsupportedError(
+                "TrialAsTask transform is not supported for RobustSearchSpace."
+            )
         if None in trials:
             raise ValueError(
                 "Unable to use trial as task since not all observations have "
@@ -100,7 +105,7 @@ class TrialAsTask(Transform):
                 obsf.trial_index = None
         return observation_features
 
-    def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         for p_name, level_dict in self.trial_level_map.items():
             level_values = sorted(set(level_dict.values()))
             if len(level_values) < 2:

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -45,7 +45,8 @@ from ax.core.parameter_constraint import (
     ParameterConstraint,
     SumConstraint,
 )
-from ax.core.search_space import SearchSpace, HierarchicalSearchSpace
+from ax.core.parameter_distribution import ParameterDistribution
+from ax.core.search_space import SearchSpace, HierarchicalSearchSpace, RobustSearchSpace
 from ax.core.trial import Trial
 from ax.core.types import (
     ComparisonOp,
@@ -64,6 +65,7 @@ from ax.early_stopping.strategies.logical import (
     OrEarlyStoppingStrategy,
     AndEarlyStoppingStrategy,
 )
+from ax.exceptions.core import UserInputError
 from ax.global_stopping.strategies.base import BaseGlobalStoppingStrategy
 from ax.metrics.branin import AugmentedBraninMetric, BraninMetric
 from ax.metrics.branin_map import (
@@ -635,6 +637,63 @@ def get_hierarchical_search_space() -> HierarchicalSearchSpace:
             get_l2_reg_weight_parameter(),
             get_num_boost_rounds_parameter(),
         ]
+    )
+
+
+def get_robust_search_space(
+    lb: float = 0.0,
+    ub: float = 5.0,
+    multivariate: bool = False,
+    use_discrete: bool = False,
+) -> RobustSearchSpace:
+
+    parameters = [
+        RangeParameter("x", ParameterType.FLOAT, lb, ub),
+        RangeParameter("y", ParameterType.FLOAT, lb, ub),
+        RangeParameter("z", ParameterType.INT, lb, ub),
+        ChoiceParameter("c", ParameterType.STRING, ["red", "panda"]),
+    ]
+    if multivariate:
+        if use_discrete:
+            raise UserInputError(
+                "`multivariate` and `use_discrete` are not supported together."
+            )
+        distributions = [
+            ParameterDistribution(
+                parameters=["x", "y"],
+                distribution_class="multivariate_normal",
+                distribution_parameters={"loc": 1.0, "scale": ub - lb},
+            )
+        ]
+    else:
+        distributions = []
+        distributions.append(
+            ParameterDistribution(
+                parameters=["x"],
+                distribution_class="norm",
+                distribution_parameters={"loc": 1.0, "scale": ub - lb},
+            )
+        )
+        if use_discrete:
+            distributions.append(
+                ParameterDistribution(
+                    parameters=["z"],
+                    distribution_class="binom",
+                    distribution_parameters={"n": 20, "p": 0.5},
+                )
+            )
+        else:
+            distributions.append(
+                ParameterDistribution(
+                    parameters=["y"],
+                    distribution_class="expon",
+                    distribution_parameters={},
+                )
+            )
+    return RobustSearchSpace(
+        # pyre-ignore Incompatible parameter type [6]
+        parameters=parameters,
+        parameter_distributions=distributions,
     )
 
 


### PR DESCRIPTION
Summary:
This adds support for transforming `ParameterDistribution`s to `UnitX` and `CenteredUnitX`, and raises errors in a number of other transforms if they attempt to transform a parameter with an attached distribution.

This makes `CenteredUnitX` a subclass of `UnitX` with added support for constraints.

Also addresses a couple minor comments on `RobustSearchSpace`.

Reviewed By: Balandat

Differential Revision: D35439048

