### PR TITLE
Make disable_logger compatible with whole classes

### DIFF
--- a/ax/modelbridge/random.py
+++ b/ax/modelbridge/random.py
@@ -112,3 +112,11 @@ class RandomModelBridge(ModelBridge):
         cv_test_points: List[ObservationFeatures],
     ) -> List[ObservationData]:
         raise NotImplementedError
+
+    def _set_status_quo(
+        self,
+        experiment: Optional[Experiment],
+        status_quo_name: Optional[str],
+        status_quo_features: Optional[ObservationFeatures],
+    ) -> None:
+        pass

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -371,9 +371,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         self._set_generation_strategy(
             choose_generation_strategy_kwargs=choose_generation_strategy_kwargs
         )
-        self._save_generation_strategy_to_db_if_possible(
-            generation_strategy=self.generation_strategy,
-        )
+        self._save_generation_strategy_to_db_if_possible()
 
     @property
     def status_quo(self) -> TParameterization:
@@ -1022,9 +1020,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
             self._set_generation_strategy(
                 choose_generation_strategy_kwargs=choose_generation_strategy_kwargs
             )
-            self._save_generation_strategy_to_db_if_possible(
-                generation_strategy=self.generation_strategy,
-            )
+            self._save_generation_strategy_to_db_if_possible()
         else:
             self._generation_strategy = generation_strategy
             logger.info(
@@ -1526,6 +1522,16 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
                 experiment=self.experiment,
                 **choose_generation_strategy_kwargs,
             )
+
+    def _save_generation_strategy_to_db_if_possible(
+        self,
+        generation_strategy: Optional[GenerationStrategy] = None,
+        suppress_all_errors: bool = False,
+    ) -> bool:
+        return super()._save_generation_strategy_to_db_if_possible(
+            generation_strategy=generation_strategy or self.generation_strategy,
+            suppress_all_errors=suppress_all_errors,
+        )
 
     def _gen_new_generator_run(self, n: int = 1) -> GeneratorRun:
         """Generate new generator run for this experiment.

--- a/ax/service/utils/with_db_settings_base.py
+++ b/ax/service/utils/with_db_settings_base.py
@@ -355,7 +355,9 @@ class WithDBSettingsBase:
         return False
 
     def _save_generation_strategy_to_db_if_possible(
-        self, generation_strategy: GenerationStrategy, suppress_all_errors: bool = False
+        self,
+        generation_strategy: Optional[GenerationStrategy] = None,
+        suppress_all_errors: bool = False,
     ) -> bool:
         """Saves given generation strategy if DB settings are set on this
         `WithDBSettingsBase` instance.
@@ -366,7 +368,7 @@ class WithDBSettingsBase:
         Returns:
             bool: Whether the generation strategy was saved.
         """
-        if self.db_settings_set:
+        if self.db_settings_set and generation_strategy is not None:
             _save_generation_strategy_to_db_if_possible(
                 generation_strategy=generation_strategy,
                 encoder=self.db_settings.encoder,

--- a/ax/utils/common/logger.py
+++ b/ax/utils/common/logger.py
@@ -136,27 +136,49 @@ def set_stderr_log_level(level: int) -> None:
 
 
 # pyre-ignore[3] Supports generic callables
-def disable_logger(
-    name: str, level: int = logging.ERROR
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Disables a specific logger by name (e.g. module path) by setting the
-    log level at the given one for the duration of the decorated function's call
-    """
+class disable_logger:
+    def __init__(
+        self, name: str, level: int = logging.ERROR
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Disables a specific logger by name (e.g. module path) by setting the
+        log level at the given one for the duration of the decorated function's call
+        """
+        self.name = name
+        self.level = level
 
-    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+    def decorate_class(self, klass: T) -> T:
+        for attr in dir(klass):
+            attr_value = getattr(klass, attr)
+            if (
+                not callable(attr_value)
+                or isinstance(attr_value, type)
+                or attr in ("__class__", "__repr__", "__str__")
+            ):
+                continue
+
+            setattr(klass, attr, self.decorate_callable(attr_value))
+        return klass
+
+    def decorate_callable(self, func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         def inner(*args: Any, **kwargs: Any) -> T:
-            logger = get_logger(name)
+            logger = get_logger(self.name)
             prev_level = logger.getEffectiveLevel()
-            logger.setLevel(level)
+            logger.setLevel(self.level)
             try:
                 return func(*args, **kwargs)
+            except TypeError:
+                # static functions
+                return func(*args[1:], **kwargs)
             finally:
                 logger.setLevel(prev_level)
 
         return inner
 
-    return decorator
+    def __call__(self, func):
+        if isinstance(func, type):
+            return self.decorate_class(func)
+        return self.decorate_callable(func)
 
 
 """Sets up Ax's root logger to not propogate to Python's root logger and


### PR DESCRIPTION
Summary: Based on [`mock.patch`](https://github.com/python/cpython/blob/3.10/Lib/unittest/mock.py#L1266).  I'm primarily doing this so I can remove db.py and mysql.py logs from N1662794

Differential Revision: D35646267

