### PR TITLE
apply import merging for fbcode/ax/ax (1 of 3)

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -47,10 +47,7 @@ from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 from ax.utils.measurement.synthetic_functions import SyntheticFunction
 from ax.utils.testing.backend_scheduler import AsyncSimulatedBackendScheduler
-from ax.utils.testing.backend_simulator import (
-    BackendSimulator,
-    BackendSimulatorOptions,
-)
+from ax.utils.testing.backend_simulator import BackendSimulator, BackendSimulatorOptions
 
 logger = get_logger(__name__)
 

--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -5,11 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 from types import FunctionType
-from typing import List, Optional, Tuple, Union, cast
+from typing import cast, List, Optional, Tuple, Union
 
 from ax.core.optimization_config import (
-    OptimizationConfig,
     MultiObjectiveOptimizationConfig,
+    OptimizationConfig,
 )
 from ax.core.search_space import SearchSpace
 from ax.service.utils.instantiation import TParameterRepresentation

--- a/ax/benchmark/benchmark_result.py
+++ b/ax/benchmark/benchmark_result.py
@@ -20,10 +20,7 @@ from ax.core.trial import Trial
 from ax.core.utils import best_feasible_objective, feasible_hypervolume, get_model_times
 from ax.plot.base import AxPlotConfig
 from ax.plot.pareto_frontier import plot_multiple_pareto_frontiers
-from ax.plot.pareto_utils import (
-    get_observed_pareto_frontiers,
-    ParetoFrontierResults,
-)
+from ax.plot.pareto_utils import get_observed_pareto_frontiers, ParetoFrontierResults
 from ax.plot.render import plot_config_to_html
 from ax.plot.trace import (
     optimization_times,

--- a/ax/benchmark/utils.py
+++ b/ax/benchmark/utils.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional, Tuple, Union, cast
+from typing import cast, List, Optional, Tuple, Union
 
 from ax.benchmark.benchmark_problem import BenchmarkProblem
 from ax.modelbridge.generation_strategy import GenerationStrategy

--- a/ax/benchmark2/benchmark.py
+++ b/ax/benchmark2/benchmark.py
@@ -17,26 +17,26 @@ Key terms used:
 
 """
 from time import time
-from typing import Tuple, List, Iterable
+from typing import Iterable, List, Tuple
 
 import numpy as np
 from ax.benchmark2.benchmark_method import BenchmarkMethod
 from ax.benchmark2.benchmark_problem import (
+    BenchmarkProblem,
     MultiObjectiveBenchmarkProblem,
     SingleObjectiveBenchmarkProblem,
-    BenchmarkProblem,
 )
 from ax.benchmark2.benchmark_result import (
-    ScoredBenchmarkResult,
-    BenchmarkResult,
     AggregatedBenchmarkResult,
+    BenchmarkResult,
+    ScoredBenchmarkResult,
 )
 from ax.core.experiment import Experiment
 from ax.core.utils import get_model_times
 from ax.exceptions.core import UnsupportedError
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
-from ax.service.scheduler import SchedulerOptions, Scheduler
+from ax.service.scheduler import Scheduler, SchedulerOptions
 from ax.utils.common.typeutils import not_none
 
 

--- a/ax/benchmark2/benchmark_problem.py
+++ b/ax/benchmark2/benchmark_problem.py
@@ -9,8 +9,8 @@ from typing import List
 
 from ax.core.objective import MultiObjective, Objective
 from ax.core.optimization_config import (
-    ObjectiveThreshold,
     MultiObjectiveOptimizationConfig,
+    ObjectiveThreshold,
     OptimizationConfig,
 )
 from ax.core.parameter import ParameterType, RangeParameter

--- a/ax/benchmark2/tests/test_benchmark.py
+++ b/ax/benchmark2/tests/test_benchmark.py
@@ -4,18 +4,18 @@
 # LICENSE file in the root directory of this source tree.
 
 from ax.benchmark2.benchmark import (
-    benchmark_scored_full_run,
-    get_sobol_baseline,
-    benchmark_replication,
-    benchmark_test,
     benchmark_full_run,
+    benchmark_replication,
+    benchmark_scored_full_run,
+    benchmark_test,
+    get_sobol_baseline,
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import (
-    get_sobol_gpei_benchmark_method,
-    get_single_objective_benchmark_problem,
     get_multi_objective_benchmark_problem,
+    get_single_objective_benchmark_problem,
     get_sobol_benchmark_method,
+    get_sobol_gpei_benchmark_method,
 )
 from ax.utils.testing.mock import fast_botorch_optimize
 

--- a/ax/benchmark2/tests/test_benchmark_method.py
+++ b/ax/benchmark2/tests/test_benchmark_method.py
@@ -5,7 +5,7 @@
 
 from ax.benchmark2.benchmark_method import BenchmarkMethod
 from ax.exceptions.core import UserInputError
-from ax.modelbridge.generation_strategy import GenerationStrategy, GenerationStep
+from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
 from ax.service.scheduler import SchedulerOptions
 from ax.utils.common.testutils import TestCase

--- a/ax/benchmark2/tests/test_benchmark_problem.py
+++ b/ax/benchmark2/tests/test_benchmark_problem.py
@@ -4,8 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from ax.benchmark2.benchmark_problem import (
-    SingleObjectiveBenchmarkProblem,
     MultiObjectiveBenchmarkProblem,
+    SingleObjectiveBenchmarkProblem,
 )
 from ax.utils.common.testutils import TestCase
 from botorch.test_functions.multi_objective import BraninCurrin

--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod, abstractproperty
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from ax.core.arm import Arm
 from ax.core.data import Data

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -6,18 +6,18 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict, OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import (
-    TYPE_CHECKING,
     DefaultDict,
     Dict,
     List,
     MutableMapping,
     Optional,
     Set,
+    TYPE_CHECKING,
     Union,
 )
 

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -15,7 +15,7 @@ import pandas as pd
 from ax.core.types import TFidelityTrialEvaluation, TTrialEvaluation
 from ax.utils.common.base import Base
 from ax.utils.common.serialization import extract_init_args, serialize_init_args
-from ax.utils.common.typeutils import not_none, checked_cast
+from ax.utils.common.typeutils import checked_cast, not_none
 
 
 class Data(Base):

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import logging
-from collections import OrderedDict, defaultdict
+from collections import defaultdict, OrderedDict
 from datetime import datetime
 from enum import Enum
 from functools import reduce
@@ -29,7 +29,7 @@ from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.base import Base
-from ax.utils.common.constants import Keys, EXPERIMENT_IS_TEST_WARNING
+from ax.utils.common.constants import EXPERIMENT_IS_TEST_WARNING, Keys
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.logger import get_logger
 from ax.utils.common.timeutils import current_timestamp_in_millis

--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Type, TypeVar, Generic, Iterable, Optional
+from typing import Any, Dict, Generic, Iterable, Optional, Type, TypeVar
 
 import pandas as pd
 from ax.core.data import Data

--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Tuple, Type
+from typing import Any, Dict, Iterable, Optional, Tuple, Type, TYPE_CHECKING
 
 from ax.core.data import Data
 from ax.utils.common.base import SortableBase

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import warnings
 from copy import deepcopy
-from typing import Iterable, List, Optional, Tuple, Dict
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd

--- a/ax/core/outcome_constraint.py
+++ b/ax/core/outcome_constraint.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Optional, List, Iterable, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from ax.core.metric import Metric
 from ax.core.types import ComparisonOp

--- a/ax/core/parameter_distribution.py
+++ b/ax/core/parameter_distribution.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import functools
 from copy import deepcopy
 from importlib import import_module
-from typing import List, Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ax.exceptions.core import UserInputError
 from ax.utils.common.base import Base

--- a/ax/core/runner.py
+++ b/ax/core/runner.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Iterable
+from typing import Any, Dict, Iterable, Optional, Set, TYPE_CHECKING
 
 from ax.utils.common.base import Base
 from ax.utils.common.serialization import extract_init_args, serialize_init_args

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -12,7 +12,7 @@ import warnings
 from dataclasses import dataclass, field
 from functools import reduce
 from logging import Logger
-from typing import Dict, List, Optional, Tuple, Union, Set
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from ax import core
 from ax.core.arm import Arm

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -6,7 +6,7 @@
 
 import math
 from time import sleep
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch, PropertyMock
 
 import numpy as np
 from ax.core.arm import Arm

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -8,9 +8,9 @@ import random
 
 import pandas as pd
 from ax.core.data import (
-    Data,
     clone_without_metrics,
     custom_data_class,
+    Data,
     set_single_trial,
 )
 from ax.utils.common.testutils import TestCase

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -22,24 +22,24 @@ from ax.exceptions.core import UnsupportedError
 from ax.metrics.branin import BraninMetric
 from ax.runners.synthetic import SyntheticRunner
 from ax.service.ax_client import AxClient
-from ax.utils.common.constants import Keys, EXPERIMENT_IS_TEST_WARNING
+from ax.utils.common.constants import EXPERIMENT_IS_TEST_WARNING, Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
-    get_branin_experiment_with_multi_objective,
     get_arm,
     get_branin_arms,
+    get_branin_experiment,
+    get_branin_experiment_with_multi_objective,
+    get_branin_experiment_with_timestamp_map_metric,
     get_branin_optimization_config,
     get_branin_search_space,
-    get_branin_experiment,
-    get_branin_experiment_with_timestamp_map_metric,
     get_data,
     get_experiment,
     get_experiment_with_map_data_type,
     get_optimization_config,
+    get_scalarized_outcome_constraint,
     get_search_space,
     get_sobol,
     get_status_quo,
-    get_scalarized_outcome_constraint,
 )
 
 DUMMY_RUN_METADATA = {"test_run_metadata_key": "test_run_metadata_value"}

--- a/ax/core/tests/test_outcome_constraint.py
+++ b/ax/core/tests/test_outcome_constraint.py
@@ -10,10 +10,10 @@ from ax.core.metric import Metric
 from ax.core.outcome_constraint import (
     CONSTRAINT_WARNING_MESSAGE,
     LOWER_BOUND_MISMATCH,
-    UPPER_BOUND_MISMATCH,
     ObjectiveThreshold,
     OutcomeConstraint,
     ScalarizedOutcomeConstraint,
+    UPPER_BOUND_MISMATCH,
 )
 from ax.core.types import ComparisonOp
 from ax.utils.common.testutils import TestCase

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -5,11 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 from ax.core.parameter import (
+    _get_parameter_type,
     ChoiceParameter,
     FixedParameter,
     ParameterType,
     RangeParameter,
-    _get_parameter_type,
 )
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase

--- a/ax/core/tests/test_runner.py
+++ b/ax/core/tests/test_runner.py
@@ -9,7 +9,7 @@ from unittest import mock
 from ax.core.base_trial import BaseTrial
 from ax.core.runner import Runner
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_trial, get_batch_trial
+from ax.utils.testing.core_stubs import get_batch_trial, get_trial
 
 
 class DummyRunner(Runner):

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -21,22 +21,22 @@ from ax.core.parameter_constraint import (
 )
 from ax.core.parameter_distribution import ParameterDistribution
 from ax.core.search_space import (
+    HierarchicalSearchSpace,
     RobustSearchSpace,
     SearchSpace,
     SearchSpaceDigest,
-    HierarchicalSearchSpace,
 )
 from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
-    get_model_parameter,
-    get_lr_parameter,
-    get_l2_reg_weight_parameter,
-    get_num_boost_rounds_parameter,
     get_hierarchical_search_space,
+    get_l2_reg_weight_parameter,
+    get_lr_parameter,
+    get_model_parameter,
+    get_num_boost_rounds_parameter,
+    get_parameter_constraint,
 )
-from ax.utils.testing.core_stubs import get_parameter_constraint
 
 TOTAL_PARAMS = 6
 TUNABLE_PARAMS = 4

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -8,19 +8,19 @@ import numpy as np
 import pandas as pd
 from ax.core.data import Data
 from ax.core.metric import Metric
-from ax.core.objective import Objective, MultiObjective
+from ax.core.objective import MultiObjective, Objective
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
 )
-from ax.core.outcome_constraint import OutcomeConstraint, ObjectiveThreshold
+from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.types import ComparisonOp
 from ax.core.utils import (
-    MissingMetrics,
     best_feasible_objective,
+    feasible_hypervolume,
     get_missing_metrics,
     get_missing_metrics_by_name,
-    feasible_hypervolume,
+    MissingMetrics,
 )
 from ax.utils.common.testutils import TestCase
 

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, immutable_once_run

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -6,8 +6,8 @@
 
 import enum
 from typing import (
-    Callable,
     Any,
+    Callable,
     DefaultDict,
     Dict,
     Hashable,

--- a/ax/early_stopping/strategies/__init__.py
+++ b/ax/early_stopping/strategies/__init__.py
@@ -11,8 +11,8 @@ from ax.early_stopping.strategies.base import (
 )
 from ax.early_stopping.strategies.logical import (
     AndEarlyStoppingStrategy,
-    OrEarlyStoppingStrategy,
     LogicalEarlyStoppingStrategy,
+    OrEarlyStoppingStrategy,
 )
 from ax.early_stopping.strategies.percentile import PercentileEarlyStoppingStrategy
 from ax.early_stopping.strategies.threshold import ThresholdEarlyStoppingStrategy

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -7,7 +7,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Any, Dict, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import numpy as np
 from ax.core.experiment import Experiment
@@ -15,9 +15,9 @@ from ax.core.map_data import MapData
 from ax.core.observation import observations_from_map_data
 from ax.exceptions.core import UnsupportedError
 from ax.modelbridge.modelbridge_utils import (
+    _unpack_observations,
     observation_data_to_array,
     observation_features_to_array,
-    _unpack_observations,
 )
 from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger

--- a/ax/early_stopping/strategies/logical.py
+++ b/ax/early_stopping/strategies/logical.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Set, Optional
+from typing import Any, Dict, Optional, Set
 
 from ax.core.experiment import Experiment
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Any, Dict, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import numpy as np
 import pandas as pd

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Any, Dict, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import pandas as pd
 from ax.core.experiment import Experiment

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -8,9 +8,11 @@ import pandas as pd
 from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
-from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
-from ax.early_stopping.strategies import PercentileEarlyStoppingStrategy
-from ax.early_stopping.strategies import ThresholdEarlyStoppingStrategy
+from ax.early_stopping.strategies import (
+    BaseEarlyStoppingStrategy,
+    PercentileEarlyStoppingStrategy,
+    ThresholdEarlyStoppingStrategy,
+)
 from ax.early_stopping.strategies.logical import (
     AndEarlyStoppingStrategy,
     OrEarlyStoppingStrategy,

--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
-from typing import List, Dict, Tuple
+from typing import Dict, List, Tuple
 
 import pandas as pd
 from ax.utils.common.logger import get_logger

--- a/ax/exceptions/data_provider.py
+++ b/ax/exceptions/data_provider.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Iterable, Any
+from typing import Any, Iterable
 
 
 class DataProviderError(Exception):

--- a/ax/global_stopping/strategies/improvement.py
+++ b/ax/global_stopping/strategies/improvement.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from logging import Logger
-from typing import Any, Dict, Tuple, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 from ax.core.base_trial import TrialStatus

--- a/ax/global_stopping/tests/tests_strategies.py
+++ b/ax/global_stopping/tests/tests_strategies.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple, List
+from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -12,17 +12,19 @@ from ax.core.arm import Arm
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.metric import Metric
-from ax.core.objective import Objective, MultiObjective
-from ax.core.optimization_config import MultiObjectiveOptimizationConfig
-from ax.core.optimization_config import OptimizationConfig
-from ax.core.outcome_constraint import OutcomeConstraint, ObjectiveThreshold
-from ax.core.parameter import RangeParameter, ParameterType
+from ax.core.objective import MultiObjective, Objective
+from ax.core.optimization_config import (
+    MultiObjectiveOptimizationConfig,
+    OptimizationConfig,
+)
+from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
+from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
 from ax.core.types import ComparisonOp
 from ax.global_stopping.strategies.improvement import (
-    ImprovementGlobalStoppingStrategy,
     constraint_satisfaction,
+    ImprovementGlobalStoppingStrategy,
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_experiment, get_experiment_with_data

--- a/ax/metrics/botorch_test_problem.py
+++ b/ax/metrics/botorch_test_problem.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, Any
+from typing import Any, Optional
 
 import pandas as pd
 from ax.core.base_trial import BaseTrial

--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 from random import random
-from typing import Mapping, Iterable, Any, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 import numpy as np
 import pandas as pd
 from ax.core.base_trial import BaseTrial
-from ax.core.map_data import MapKeyInfo, MapData
+from ax.core.map_data import MapData, MapKeyInfo
 from ax.metrics.noisy_function_map import NoisyFunctionMapMetric
 from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.measurement.synthetic_functions import branin

--- a/ax/metrics/curve.py
+++ b/ax/metrics/curve.py
@@ -11,7 +11,7 @@ Typically used to retrieve partial learning curves of ML training jobs.
 
 from __future__ import annotations
 
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterable, Optional, Union
 
 import numpy as np
@@ -19,7 +19,7 @@ import pandas as pd
 from ax.core.base_trial import BaseTrial
 from ax.core.data import Data
 from ax.core.experiment import Experiment
-from ax.core.map_data import MapKeyInfo, MapData
+from ax.core.map_data import MapData, MapKeyInfo
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
 from ax.core.trial import Trial

--- a/ax/metrics/noisy_function.py
+++ b/ax/metrics/noisy_function.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Callable
+from typing import Any, Callable, List, Optional
 
 import numpy as np
 import pandas as pd

--- a/ax/metrics/noisy_function_map.py
+++ b/ax/metrics/noisy_function_map.py
@@ -6,12 +6,12 @@
 
 from __future__ import annotations
 
-from typing import Mapping, Iterable, Any, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 import numpy as np
 import pandas as pd
 from ax.core.base_trial import BaseTrial
-from ax.core.map_data import MapKeyInfo, MapData
+from ax.core.map_data import MapData, MapKeyInfo
 from ax.core.map_metric import MapMetric
 from ax.utils.common.logger import get_logger
 

--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Iterable, Dict, List, NamedTuple, Union
+from typing import Dict, Iterable, List, NamedTuple, Union
 
 import pandas as pd
 from ax.core.map_data import MapKeyInfo

--- a/ax/metrics/tests/test_sklearn.py
+++ b/ax/metrics/tests/test_sklearn.py
@@ -12,11 +12,7 @@ from unittest import mock
 import numpy as np
 from ax.core.arm import Arm
 from ax.core.generator_run import GeneratorRun
-from ax.metrics.sklearn import (
-    SklearnMetric,
-    SklearnDataset,
-    SklearnModelType,
-)
+from ax.metrics.sklearn import SklearnDataset, SklearnMetric, SklearnModelType
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_trial
 from sklearn.ensemble import RandomForestClassifier

--- a/ax/modelbridge/__init__.py
+++ b/ax/modelbridge/__init__.py
@@ -8,12 +8,12 @@
 from ax.modelbridge import transforms
 from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.factory import (
-    Models,
     get_factorial,
     get_GPEI,
     get_sobol,
     get_thompson,
     get_uniform,
+    Models,
 )
 from ax.modelbridge.numpy import NumpyModelBridge
 from ax.modelbridge.torch import TorchModelBridge

--- a/ax/modelbridge/array.py
+++ b/ax/modelbridge/array.py
@@ -14,7 +14,7 @@ from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
 from ax.core.search_space import SearchSpace
-from ax.core.types import TModelPredictArm, TCandidateMetadata, TGenMetadata
+from ax.core.types import TCandidateMetadata, TGenMetadata, TModelPredictArm
 from ax.modelbridge.base import gen_arms, ModelBridge
 from ax.modelbridge.modelbridge_utils import (
     array_to_observation_data,
@@ -27,8 +27,8 @@ from ax.modelbridge.modelbridge_utils import (
     observation_features_to_array,
     parse_observation_features,
     pending_observations_as_array,
-    transform_callback,
     SearchSpaceDigest,
+    transform_callback,
 )
 from ax.models.types import TConfig
 from ax.utils.common.typeutils import not_none

--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -15,7 +15,7 @@ import numpy as np
 from ax.core.arm import Arm
 from ax.core.data import Data
 from ax.core.experiment import Experiment
-from ax.core.generator_run import GeneratorRun, extract_arm_predictions
+from ax.core.generator_run import extract_arm_predictions, GeneratorRun
 from ax.core.observation import (
     Observation,
     ObservationData,

--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -8,14 +8,14 @@ from collections import defaultdict
 from enum import Enum
 from functools import partial
 from numbers import Number
-from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, Any
+from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
 
 import numpy as np
 from ax.core.observation import Observation, ObservationData
 from ax.core.optimization_config import OptimizationConfig
 from ax.modelbridge.base import ModelBridge
 from ax.utils.common.logger import get_logger
-from scipy.stats import fisher_exact, pearsonr, spearmanr, norm
+from scipy.stats import fisher_exact, norm, pearsonr, spearmanr
 
 logger = get_logger(__name__)
 

--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -7,7 +7,7 @@
 import logging
 import warnings
 from math import ceil
-from typing import Any, Dict, cast, Optional, Type, Union
+from typing import Any, cast, Dict, Optional, Type, Union
 
 import torch
 from ax.core.experiment import Experiment

--- a/ax/modelbridge/factory.py
+++ b/ax/modelbridge/factory.py
@@ -41,9 +41,7 @@ from ax.models.torch.botorch_defaults import (
     predict_from_model,
     scipy_optimizer,
 )
-from ax.models.torch.botorch_moo_defaults import (
-    get_EHVI,
-)
+from ax.models.torch.botorch_moo_defaults import get_EHVI
 from ax.models.types import TConfig
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast

--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, List, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from ax.core.data import Data  # Perhaps need to use `AbstractDataFrameData`?
 from ax.core.experiment import Experiment
@@ -17,11 +17,9 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.base import ModelBridge
-from ax.modelbridge.cross_validation import CVResult, CVDiagnostics, BestModelSelector
-from ax.modelbridge.model_spec import ModelSpec, FactoryFunctionModelSpec
-from ax.modelbridge.registry import (
-    ModelRegistryBase,
-)
+from ax.modelbridge.cross_validation import BestModelSelector, CVDiagnostics, CVResult
+from ax.modelbridge.model_spec import FactoryFunctionModelSpec, ModelSpec
+from ax.modelbridge.registry import ModelRegistryBase
 from ax.utils.common.base import SortableBase
 from ax.utils.common.typeutils import not_none
 

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Set, Type, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple, Type
 
 import pandas as pd
 from ax.core.arm import Arm
@@ -25,10 +25,7 @@ from ax.exceptions.generation_strategy import (
 )
 from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.generation_node import GenerationStep
-from ax.modelbridge.registry import (
-    ModelRegistryBase,
-    _extract_model_state_after_gen,
-)
+from ax.modelbridge.registry import _extract_model_state_after_gen, ModelRegistryBase
 from ax.utils.common.base import Base
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
 from ax.utils.common.typeutils import not_none

--- a/ax/modelbridge/model_spec.py
+++ b/ax/modelbridge/model_spec.py
@@ -10,7 +10,7 @@ import json
 import warnings
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Tuple, List, Any, Dict, Optional, Callable
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ax.core.data import Data
 from ax.core.experiment import Experiment
@@ -30,8 +30,8 @@ from ax.modelbridge.registry import ModelRegistryBase
 from ax.utils.common.base import Base
 from ax.utils.common.kwargs import (
     consolidate_kwargs,
-    get_function_argument_names,
     filter_kwargs,
+    get_function_argument_names,
 )
 from ax.utils.common.typeutils import not_none
 

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 from collections import defaultdict
 from functools import partial
 from typing import (
-    TYPE_CHECKING,
     Callable,
     Dict,
     List,
     MutableMapping,
     Optional,
     Tuple,
+    TYPE_CHECKING,
     Union,
 )
 
@@ -28,8 +28,8 @@ from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
-    TRefPoint,
     OptimizationConfig,
+    TRefPoint,
 )
 from ax.core.outcome_constraint import (
     ComparisonOp,
@@ -44,14 +44,14 @@ from ax.core.types import TBounds, TCandidateMetadata
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.derelativize import Derelativize
 from ax.models.torch.frontier_utils import (
-    get_weighted_mc_objective_and_objective_thresholds,
     get_default_frontier_evaluator,
+    get_weighted_mc_objective_and_objective_thresholds,
 )
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import (
     checked_cast_optional,
-    not_none,
     checked_cast_to_tuple,
+    not_none,
 )
 from botorch.utils.multi_objective.box_decompositions.dominated import (
     DominatedPartitioning,

--- a/ax/modelbridge/prediction_utils.py
+++ b/ax/modelbridge/prediction_utils.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Set, Dict, Tuple
+from typing import Dict, Set, Tuple
 
 import numpy as np
 from ax.core.observation import ObservationFeatures

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -31,7 +31,7 @@ from ax.modelbridge.random import RandomModelBridge
 from ax.modelbridge.torch import TorchModelBridge
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.centered_unit_x import CenteredUnitX
-from ax.modelbridge.transforms.choice_encode import OrderedChoiceEncode, ChoiceEncode
+from ax.modelbridge.transforms.choice_encode import ChoiceEncode, OrderedChoiceEncode
 from ax.modelbridge.transforms.convert_metric_names import ConvertMetricNames
 from ax.modelbridge.transforms.derelativize import Derelativize
 from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -22,10 +22,10 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import FixedParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.base import (
-    ModelBridge,
-    gen_arms,
-    unwrap_observation_data,
     clamp_observation_features,
+    gen_arms,
+    ModelBridge,
+    unwrap_observation_data,
 )
 from ax.modelbridge.registry import Models
 from ax.modelbridge.transforms.log import Log
@@ -35,10 +35,8 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_branin_experiment_with_multi_objective,
     get_experiment,
-    get_non_monolithic_branin_moo_data,
-)
-from ax.utils.testing.core_stubs import (
     get_experiment_with_repeated_arms,
+    get_non_monolithic_branin_moo_data,
     get_optimization_config_no_constraints,
     get_search_space_for_range_value,
     get_search_space_for_range_values,

--- a/ax/modelbridge/tests/test_cast_transform.py
+++ b/ax/modelbridge/tests/test_cast_transform.py
@@ -14,7 +14,7 @@ from ax.core.parameter import (
     ParameterType,
     RangeParameter,
 )
-from ax.core.search_space import SearchSpace, HierarchicalSearchSpace
+from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
 from ax.modelbridge.transforms.cast import Cast
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase

--- a/ax/modelbridge/tests/test_convert_metric_names.py
+++ b/ax/modelbridge/tests/test_convert_metric_names.py
@@ -8,8 +8,8 @@ from copy import copy
 
 from ax.core.observation import observations_from_data
 from ax.modelbridge.transforms.convert_metric_names import (
-    ConvertMetricNames,
     convert_mt_observations,
+    ConvertMetricNames,
     tconfig_from_mt_experiment,
 )
 from ax.utils.common.testutils import TestCase

--- a/ax/modelbridge/tests/test_cross_validation.py
+++ b/ax/modelbridge/tests/test_cross_validation.py
@@ -12,20 +12,20 @@ from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
-    OptimizationConfig,
     MultiObjectiveOptimizationConfig,
+    OptimizationConfig,
 )
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.types import ComparisonOp
 from ax.modelbridge.cross_validation import (
-    CVResult,
     assess_model_fit,
     compute_diagnostics,
     cross_validate,
     cross_validate_by_trial,
+    CVDiagnostics,
+    CVResult,
     has_good_opt_config_model_fit,
     SingleDiagnosticBestModelSelector,
-    CVDiagnostics,
 )
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase

--- a/ax/modelbridge/tests/test_discrete_modelbridge.py
+++ b/ax/modelbridge/tests/test_discrete_modelbridge.py
@@ -19,7 +19,7 @@ from ax.core.parameter import (
     RangeParameter,
 )
 from ax.core.search_space import SearchSpace
-from ax.modelbridge.discrete import DiscreteModelBridge, _get_parameter_values
+from ax.modelbridge.discrete import _get_parameter_values, DiscreteModelBridge
 from ax.models.discrete_base import DiscreteModel
 from ax.utils.common.testutils import TestCase
 

--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -8,8 +8,8 @@ import torch
 from ax.core.objective import MultiObjective
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.modelbridge.dispatch_utils import (
-    DEFAULT_BAYESIAN_PARALLELISM,
     choose_generation_strategy,
+    DEFAULT_BAYESIAN_PARALLELISM,
 )
 from ax.modelbridge.transforms.winsorize import WinsorizationConfig
 from ax.utils.common.testutils import TestCase

--- a/ax/modelbridge/tests/test_factory.py
+++ b/ax/modelbridge/tests/test_factory.py
@@ -10,9 +10,7 @@ from ax.core.data import Data
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
 from ax.core.observation import ObservationFeatures
-from ax.core.optimization_config import (
-    MultiObjectiveOptimizationConfig,
-)
+from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.outcome_constraint import ComparisonOp, ObjectiveThreshold
 from ax.core.parameter import RangeParameter
 from ax.modelbridge.discrete import DiscreteModelBridge
@@ -25,11 +23,11 @@ from ax.modelbridge.factory import (
     get_GPMES,
     get_MOO_EHVI,
     get_MOO_NEHVI,
-    get_MTGP_NEHVI,
     get_MOO_PAREGO,
-    get_MTGP_PAREGO,
     get_MOO_RS,
     get_MTGP,
+    get_MTGP_NEHVI,
+    get_MTGP_PAREGO,
     get_sobol,
     get_thompson,
     get_uniform,
@@ -43,10 +41,10 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_branin_experiment_with_multi_objective,
-    get_multi_type_experiment_with_multi_objective,
     get_branin_optimization_config,
     get_factorial_experiment,
     get_multi_type_experiment,
+    get_multi_type_experiment_with_multi_objective,
 )
 from ax.utils.testing.mock import fast_botorch_optimize
 from botorch.models.multitask import MultiTaskGP

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -8,16 +8,13 @@ from unittest.mock import patch
 
 from ax.core.observation import ObservationFeatures
 from ax.modelbridge.cross_validation import (
-    SingleDiagnosticBestModelSelector,
-    MetricAggregation,
     DiagnosticCriterion,
+    MetricAggregation,
+    SingleDiagnosticBestModelSelector,
 )
 from ax.modelbridge.factory import get_sobol
-from ax.modelbridge.generation_node import (
-    GenerationNode,
-    GenerationStep,
-)
-from ax.modelbridge.model_spec import ModelSpec, FactoryFunctionModelSpec
+from ax.modelbridge.generation_node import GenerationNode, GenerationStep
+from ax.modelbridge.model_spec import FactoryFunctionModelSpec, ModelSpec
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -4,14 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, cast
+from typing import cast, List
 from unittest.mock import patch
 
 from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
-from ax.core.parameter import FixedParameter, Parameter, ParameterType, ChoiceParameter
+from ax.core.parameter import ChoiceParameter, FixedParameter, Parameter, ParameterType
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.exceptions.generation_strategy import (
@@ -29,7 +29,7 @@ from ax.modelbridge.modelbridge_utils import (
     get_pending_observation_features_based_on_trial_status as get_pending,
 )
 from ax.modelbridge.random import RandomModelBridge
-from ax.modelbridge.registry import MODEL_KEY_TO_MODEL_SETUP, Cont_X_trans, Models
+from ax.modelbridge.registry import Cont_X_trans, MODEL_KEY_TO_MODEL_SETUP, Models
 from ax.modelbridge.torch import TorchModelBridge
 from ax.models.random.sobol import SobolGenerator
 from ax.utils.common.testutils import TestCase

--- a/ax/modelbridge/tests/test_log_y_transform.py
+++ b/ax/modelbridge/tests/test_log_y_transform.py
@@ -18,8 +18,8 @@ from ax.core.optimization_config import (
 from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.types import ComparisonOp
 from ax.modelbridge.transforms.log_y import (
-    LogY,
     lognorm_to_norm,
+    LogY,
     match_ci_width,
     norm_to_lognorm,
 )

--- a/ax/modelbridge/tests/test_logit_transform.py
+++ b/ax/modelbridge/tests/test_logit_transform.py
@@ -9,12 +9,11 @@ from copy import deepcopy
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
-from ax.exceptions.core import UnsupportedError
-from ax.exceptions.core import UserInputError
+from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.modelbridge.transforms.logit import Logit
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_robust_search_space
-from scipy.special import logit, expit
+from scipy.special import expit, logit
 
 
 class LogitTransformTest(TestCase):

--- a/ax/modelbridge/tests/test_model_spec.py
+++ b/ax/modelbridge/tests/test_model_spec.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch
 from ax.core.observation import ObservationFeatures
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.factory import get_sobol
-from ax.modelbridge.model_spec import ModelSpec, FactoryFunctionModelSpec
+from ax.modelbridge.model_spec import FactoryFunctionModelSpec, ModelSpec
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment

--- a/ax/modelbridge/tests/test_power_transform_y.py
+++ b/ax/modelbridge/tests/test_power_transform_y.py
@@ -17,9 +17,9 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.types import ComparisonOp
 from ax.modelbridge.transforms.power_transform_y import (
-    PowerTransformY,
-    _compute_power_transforms,
     _compute_inverse_bounds,
+    _compute_power_transforms,
+    PowerTransformY,
 )
 from ax.modelbridge.transforms.utils import get_data, match_ci_width_truncated
 from ax.utils.common.testutils import TestCase

--- a/ax/modelbridge/tests/test_prediction_utils.py
+++ b/ax/modelbridge/tests/test_prediction_utils.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import numpy as np
 from ax.core.observation import ObservationFeatures
-from ax.modelbridge.prediction_utils import predict_by_features, predict_at_point
+from ax.modelbridge.prediction_utils import predict_at_point, predict_by_features
 from ax.service.ax_client import AxClient
 from ax.utils.common.testutils import TestCase
 

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -16,11 +16,11 @@ from ax.core.types import ComparisonOp
 from ax.modelbridge.discrete import DiscreteModelBridge
 from ax.modelbridge.random import RandomModelBridge
 from ax.modelbridge.registry import (
-    MODEL_KEY_TO_MODEL_SETUP,
     Cont_X_trans,
+    get_model_from_generator_run,
+    MODEL_KEY_TO_MODEL_SETUP,
     Models,
     Y_trans,
-    get_model_from_generator_run,
 )
 from ax.modelbridge.torch import TorchModelBridge
 from ax.models.base import Model
@@ -35,9 +35,9 @@ from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.utils.common.kwargs import get_function_argument_names
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
-    get_branin_experiment_with_multi_objective,
     get_branin_data,
     get_branin_experiment,
+    get_branin_experiment_with_multi_objective,
     get_branin_optimization_config,
     get_factorial_experiment,
 )

--- a/ax/modelbridge/tests/test_relativize_transform.py
+++ b/ax/modelbridge/tests/test_relativize_transform.py
@@ -7,10 +7,10 @@ from unittest.mock import Mock
 
 import numpy as np
 from ax.core.observation import (
-    observations_from_data,
     Observation,
-    ObservationFeatures,
     ObservationData,
+    ObservationFeatures,
+    observations_from_data,
 )
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.types import ComparisonOp
@@ -20,12 +20,12 @@ from ax.modelbridge.transforms.relativize import Relativize
 from ax.utils.common.testutils import TestCase
 from ax.utils.stats.statstools import relativize_data
 from ax.utils.testing.core_stubs import (
-    get_branin_with_multi_task,
     get_branin_multi_objective_optimization_config,
     get_branin_optimization_config,
+    get_branin_with_multi_task,
     get_search_space,
 )
-from hypothesis import assume, settings, strategies as st, given
+from hypothesis import assume, given, settings, strategies as st
 
 
 class RelativizeDataTest(TestCase):

--- a/ax/modelbridge/tests/test_torch_modelbridge_moo.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge_moo.py
@@ -9,29 +9,26 @@ from unittest.mock import patch
 
 import numpy as np
 import torch
-from ax.core.observation import ObservationFeatures, ObservationData
-from ax.core.outcome_constraint import (
-    ComparisonOp,
-    ObjectiveThreshold,
-)
+from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.outcome_constraint import ComparisonOp, ObjectiveThreshold
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.modelbridge.factory import get_sobol
 from ax.modelbridge.modelbridge_utils import (
     get_pareto_frontier_and_configs,
+    observed_hypervolume,
+    observed_pareto_frontier,
     pareto_frontier,
     predicted_hypervolume,
     predicted_pareto_frontier,
-    observed_hypervolume,
-    observed_pareto_frontier,
 )
-from ax.modelbridge.registry import Cont_X_trans, Y_trans, ST_MTGP_trans
+from ax.modelbridge.registry import Cont_X_trans, ST_MTGP_trans, Y_trans
 from ax.modelbridge.torch import TorchModelBridge
 from ax.modelbridge.transforms.base import Transform
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.botorch_moo_defaults import (
     infer_objective_thresholds,
+    pareto_frontier_evaluator,
 )
-from ax.models.torch.botorch_moo_defaults import pareto_frontier_evaluator
 from ax.service.utils.report_utils import exp_to_df
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -12,21 +12,21 @@ from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
-from ax.core.objective import Objective, MultiObjective
-from ax.core.observation import ObservationFeatures, ObservationData
+from ax.core.objective import MultiObjective, Objective
+from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.outcome_constraint import (
+    ObjectiveThreshold,
     OutcomeConstraint,
     ScalarizedOutcomeConstraint,
-    ObjectiveThreshold,
 )
 from ax.core.types import ComparisonOp
 from ax.modelbridge.modelbridge_utils import (
+    extract_objective_thresholds,
+    extract_outcome_constraints,
     get_pending_observation_features,
     get_pending_observation_features_based_on_trial_status as get_pending_status,
-    pending_observations_as_array,
-    extract_outcome_constraints,
-    extract_objective_thresholds,
     observation_data_to_array,
+    pending_observations_as_array,
 )
 from ax.modelbridge.registry import Models
 from ax.utils.common.constants import Keys

--- a/ax/modelbridge/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/tests/test_winsorize_transform.py
@@ -23,12 +23,12 @@ from ax.core.outcome_constraint import (
 )
 from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.modelbridge.transforms.winsorize import (
-    AUTO_WINS_QUANTILE,
-    WinsorizationConfig,
-    Winsorize,
     _get_auto_winsorization_cutoffs_outcome_constraint,
     _get_auto_winsorization_cutoffs_single_objective,
     _get_tukey_cutoffs,
+    AUTO_WINS_QUANTILE,
+    WinsorizationConfig,
+    Winsorize,
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_optimization_config

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -12,18 +12,18 @@ from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
-    TRefPoint,
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
+    TRefPoint,
 )
 from ax.core.outcome_constraint import ComparisonOp, ObjectiveThreshold
 from ax.core.search_space import SearchSpace
 from ax.core.types import TCandidateMetadata, TGenMetadata
-from ax.modelbridge.array import FIT_MODEL_ERROR, ArrayModelBridge
+from ax.modelbridge.array import ArrayModelBridge, FIT_MODEL_ERROR
 from ax.modelbridge.modelbridge_utils import (
     extract_objective_thresholds,
-    validate_and_apply_final_transform,
     SearchSpaceDigest,
+    validate_and_apply_final_transform,
 )
 from ax.modelbridge.transforms.base import Transform
 from ax.models.torch.botorch_modular.model import BoTorchModel


### PR DESCRIPTION
Summary:
Applies new import merging and sorting from µsort v1.0.

When merging imports, µsort will make a best-effort to move associated
comments to match merged elements, but there are known limitations due to
the diynamic nature of Python and developer tooling. These changes should
not produce any dangerous runtime changes, but may require touch-ups to
satisfy linters and other tooling.

Note that µsort uses case-insensitive, lexicographical sorting, which
results in a different ordering compared to isort. This provides a more
consistent sorting order, matching the case-insensitive order used when
sorting import statements by module name, and ensures that "frog", "FROG",
and "Frog" always sort next to each other.

For details on µsort's sorting and merging semantics, see the user guide:
https://usort.readthedocs.io/en/stable/guide.html#sorting

Reviewed By: lena-kashtelyan

Differential Revision: D35566187

