### PR TITLE
Support early stopping on non-objective metrics

### DIFF
--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -514,6 +514,7 @@ def percentile_early_stopping_strategy_to_dict(
     """Convert Ax percentile early stopping strategy to a dictionary."""
     return {
         "__type": strategy.__class__.__name__,
+        "metric_names": strategy.metric_names,
         "percentile_threshold": strategy.percentile_threshold,
         "min_progression": strategy.min_progression,
         "min_curves": strategy.min_curves,
@@ -529,6 +530,7 @@ def threshold_early_stopping_strategy_to_dict(
     """Convert Ax metric-threshold early stopping strategy to a dictionary."""
     return {
         "__type": strategy.__class__.__name__,
+        "metric_names": strategy.metric_names,
         "metric_threshold": strategy.metric_threshold,
         "min_progression": strategy.min_progression,
         "trial_indices_to_ignore": strategy.trial_indices_to_ignore,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -52,6 +52,7 @@ from ax.utils.testing.benchmark_stubs import (
     get_benchmark_result,
 )
 from ax.utils.testing.core_stubs import (
+    get_percentile_early_stopping_strategy_with_non_objective_metric_name,
     get_or_early_stopping_strategy,
     get_and_early_stopping_strategy,
     get_abandoned_arm,
@@ -166,6 +167,10 @@ TEST_CASES = [
     (
         "PercentileEarlyStoppingStrategy",
         get_percentile_early_stopping_strategy_with_true_objective_metric_name,
+    ),
+    (
+        "PercentileEarlyStoppingStrategy",
+        get_percentile_early_stopping_strategy_with_non_objective_metric_name,
     ),
     ("ParameterConstraint", get_parameter_constraint),
     ("RangeParameter", get_range_parameter),

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -188,7 +188,10 @@ def get_branin_experiment_with_timestamp_map_metric(
         optimization_config=OptimizationConfig(
             objective=Objective(
                 metric=BraninTimestampMapMetric(
-                    name="branin_map", param_names=["x1", "x2"], rate=rate
+                    name="branin_map",
+                    param_names=["x1", "x2"],
+                    rate=rate,
+                    lower_is_better=True,
                 ),
                 minimize=True,
             )
@@ -1467,6 +1470,16 @@ def get_percentile_early_stopping_strategy_with_true_objective_metric_name() -> 
     strategy = get_percentile_early_stopping_strategy()
     strategy.true_objective_metric_name = "true_objective"
     return strategy
+
+
+def get_percentile_early_stopping_strategy_with_non_objective_metric_name() -> PercentileEarlyStoppingStrategy:  # noqa
+    return PercentileEarlyStoppingStrategy(
+        metric_names=["foo"],
+        percentile_threshold=0.25,
+        min_progression=0.2,
+        min_curves=10,
+        trial_indices_to_ignore=[0, 1, 2],
+    )
 
 
 def get_threshold_early_stopping_strategy() -> ThresholdEarlyStoppingStrategy:


### PR DESCRIPTION
Summary:
It is not hard to imagine wanting to early stop on some non-objective metric, say a guardrail metric. This, along with the new LogicalEarlyStoppingStrategy, will allow users to create extremely expressive early stopping strategies that capture all their preferences for a worthwhile solution.

Metric names are passed in as an iterable for compatibility with some ideas Daniel had for future strategies that may early stop on multiple metrics in more complex ways than LogicalEarlyStoppingStrategies provide, talk to him for more details

Differential Revision: D35549557

