### PR TITLE
Add method to dynamically created BenchmarkMethods via choose_generation_strategy

### DIFF
--- a/ax/benchmark/methods/choose_generation_strategy.py
+++ b/ax/benchmark/methods/choose_generation_strategy.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.benchmark.benchmark_method import BenchmarkMethod
+from ax.benchmark.benchmark_problem import BenchmarkProblem
+from ax.modelbridge.dispatch_utils import choose_generation_strategy
+from ax.service.scheduler import SchedulerOptions
+
+
+def get_choose_generation_strategy_method(
+    problem: BenchmarkProblem, num_trials: int = 30
+) -> BenchmarkMethod:
+    generation_strategy = choose_generation_strategy(
+        search_space=problem.search_space,
+        optimization_config=problem.optimization_config,
+        num_trials=num_trials,
+    )
+
+    return BenchmarkMethod(
+        name=f"ChooseGenerationStrategy::{problem.name}",
+        generation_strategy=generation_strategy,
+        scheduler_options=SchedulerOptions(total_trials=num_trials),
+    )

--- a/ax/benchmark/problems/hpo/__init__.py
+++ b/ax/benchmark/problems/hpo/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/benchmark/problems/hpo/pytorch_cnn.py
+++ b/ax/benchmark/problems/hpo/pytorch_cnn.py
@@ -1,0 +1,212 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Set, Iterable, Any, Dict
+
+import pandas as pd
+import torch
+from ax.benchmark.benchmark_problem import SingleObjectiveBenchmarkProblem
+from ax.core.base_trial import TrialStatus, BaseTrial
+from ax.core.data import Data
+from ax.core.metric import Metric
+from ax.core.objective import Objective
+from ax.core.optimization_config import OptimizationConfig
+from ax.core.parameter import RangeParameter, ParameterType
+from ax.core.runner import Runner
+from ax.core.search_space import SearchSpace
+from ax.utils.common.base import Base
+from ax.utils.common.equality import equality_typechecker
+from torch import optim, nn
+from torch.nn import functional as F
+from torch.utils.data import Dataset, DataLoader
+
+
+class PyTorchCNNBenchmarkProblem(SingleObjectiveBenchmarkProblem):
+    @equality_typechecker
+    def __eq__(self, other: Base) -> bool:
+        if not isinstance(other, PyTorchCNNBenchmarkProblem):
+            return False
+
+        # Checking the whole datasets' equality here would be too expensive to be
+        # worth it; just check names instead
+        return self.name == other.name
+
+    @classmethod
+    def from_datasets(
+        cls, name: str, train_set: Dataset, test_set: Dataset
+    ) -> "PyTorchCNNBenchmarkProblem":
+        optimal_value = 1
+
+        search_space = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="lr", parameter_type=ParameterType.FLOAT, lower=1e-6, upper=0.4
+                ),
+                RangeParameter(
+                    name="momentum",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0,
+                    upper=1,
+                ),
+                RangeParameter(
+                    name="weight_decay",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0,
+                    upper=1,
+                ),
+                RangeParameter(
+                    name="step_size",
+                    parameter_type=ParameterType.INT,
+                    lower=1,
+                    upper=100,
+                ),
+                RangeParameter(
+                    name="gamma",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0,
+                    upper=1,
+                ),
+            ]
+        )
+        optimization_config = OptimizationConfig(
+            objective=Objective(
+                metric=PyTorchCNNMetric(),
+                minimize=False,
+            )
+        )
+
+        runner = PyTorchCNNRunner(name=name, train_set=train_set, test_set=test_set)
+
+        return cls(
+            name=name,
+            optimal_value=optimal_value,
+            search_space=search_space,
+            optimization_config=optimization_config,
+            runner=runner,
+        )
+
+
+class PyTorchCNNMetric(Metric):
+    def __init__(self) -> None:
+        super().__init__(name="accuracy")
+
+    def fetch_trial_data(self, trial: BaseTrial, **kwargs) -> Data:
+        accuracy = [
+            trial.run_metadata["accuracy"][name]
+            for name, arm in trial.arms_by_name.items()
+        ]
+        df = pd.DataFrame(
+            {
+                "arm_name": [name for name, _ in trial.arms_by_name.items()],
+                "metric_name": self.name,
+                "mean": accuracy,
+                "sem": 0,
+                "trial_index": trial.index,
+            }
+        )
+
+        return Data(df=df)
+
+
+class PyTorchCNNRunner(Runner):
+    def __init__(self, name: str, train_set: Dataset, test_set: Dataset) -> None:
+        self.name = name
+
+        self.train_loader = DataLoader(train_set)
+        self.test_loader = DataLoader(test_set)
+
+        self.results: Dict[int, float] = {}
+        self.statuses: Dict[int, TrialStatus] = {}
+
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    class CNN(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv1 = nn.Conv2d(1, 20, kernel_size=5, stride=1)
+            self.fc1 = nn.Linear(8 * 8 * 20, 64)
+            self.fc2 = nn.Linear(64, 10)
+
+        def forward(self, x):
+            x = F.relu(self.conv1(x))
+            x = F.max_pool2d(x, 3, 3)
+            x = x.view(-1, 8 * 8 * 20)
+            x = F.relu(self.fc1(x))
+            x = self.fc2(x)
+            return F.log_softmax(x, dim=-1)
+
+    def train_and_evaluate(
+        self,
+        lr: float,
+        momentum: float,
+        weight_decay: float,
+        step_size: int,
+        gamma: float,
+    ) -> float:
+        net = self.CNN()
+        net.to(device=self.device)
+
+        # Train
+        net.train()
+        criterion = nn.NLLLoss(reduction="sum")
+        optimizer = optim.SGD(
+            net.parameters(),
+            lr=lr,
+            momentum=momentum,
+            weight_decay=weight_decay,
+        )
+
+        scheduler = optim.lr_scheduler.StepLR(
+            optimizer, step_size=step_size, gamma=gamma
+        )
+
+        for inputs, labels in self.train_loader:
+            inputs = inputs.to(device=self.device)
+            labels = labels.to(device=self.device)
+
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = net(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+            scheduler.step()
+
+        # Evaluate
+        net.eval()
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for inputs, labels in self.test_loader:
+                outputs = net(inputs)
+                _, predicted = torch.max(outputs.data, 1)
+                total += labels.size(0)
+                correct += (predicted == labels).sum().item()
+
+        return correct / total
+
+    def run(self, trial: BaseTrial) -> Dict[str, Any]:
+        self.statuses[trial.index] = TrialStatus.RUNNING
+
+        self.statuses[trial.index] = TrialStatus.COMPLETED
+        return {
+            "accuracy": {
+                arm.name: self.train_and_evaluate(
+                    lr=arm.parameters["lr"],  # pyre-ignore[6]
+                    momentum=arm.parameters["momentum"],  # pyre-ignore[6]
+                    weight_decay=arm.parameters["weight_decay"],  # pyre-ignore[6]
+                    step_size=arm.parameters["step_size"],  # pyre-ignore[6]
+                    gamma=arm.parameters["gamma"],  # pyre-ignore[6]
+                )
+                for arm in trial.arms
+            }
+        }
+
+    def poll_trial_status(
+        self, trials: Iterable[BaseTrial]
+    ) -> Dict[TrialStatus, Set[int]]:
+        return {TrialStatus.COMPLETED: {t.index for t in trials}}

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -1,0 +1,90 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+from ax.benchmark.problems.hpo.pytorch_cnn import (
+    PyTorchCNNRunner,
+    PyTorchCNNBenchmarkProblem,
+)
+from ax.core.runner import Runner
+from ax.exceptions.core import UserInputError
+from ax.utils.common.typeutils import checked_cast
+from torchvision import transforms, datasets
+
+_REGISTRY = {"MNIST": datasets.MNIST, "FashionMNIST": datasets.FashionMNIST}
+
+
+class PyTorchCNNTorchvisionBenchmarkProblem(PyTorchCNNBenchmarkProblem):
+    @classmethod
+    def from_dataset_name(cls, name: str) -> "PyTorchCNNTorchvisionBenchmarkProblem":
+        if name not in _REGISTRY:
+            raise UserInputError(
+                f"Unrecognized torchvision dataset {name}. Please ensure it is listed"
+                "in PyTorchCNNTorchvisionBenchmarkProblem registry."
+            )
+        dataset_fn = _REGISTRY[name]
+
+        train_set = dataset_fn(
+            root="./data",
+            train=True,
+            download=True,
+            transform=transforms.ToTensor(),
+        )
+
+        test_set = dataset_fn(
+            root="./data",
+            train=False,
+            download=True,
+            transform=transforms.ToTensor(),
+        )
+
+        problem = cls.from_datasets(name=name, train_set=train_set, test_set=test_set)
+        runner = PyTorchCNNTorchvisionRunner(
+            name=name, train_set=train_set, test_set=test_set
+        )
+
+        return cls(
+            name=problem.name,
+            search_space=problem.search_space,
+            optimization_config=problem.optimization_config,
+            runner=runner,
+            optimal_value=problem.optimal_value,
+        )
+
+
+class PyTorchCNNTorchvisionRunner(PyTorchCNNRunner):
+    """
+    A subclass to aid in serialization. This allows us to save only the name of the
+    dataset and reload it from TorchVision at deserialization time.
+    """
+
+    @classmethod
+    def serialize_init_args(cls, runner: Runner) -> Dict[str, Any]:
+        pytorch_cnn_runner = checked_cast(PyTorchCNNRunner, runner)
+
+        return {"name": pytorch_cnn_runner.name}
+
+    @classmethod
+    def deserialize_init_args(cls, args: Dict[str, Any]) -> Dict[str, Any]:
+        name = args["name"]
+
+        dataset_fn = _REGISTRY[name]
+
+        train_set = dataset_fn(
+            root="./data",
+            train=True,
+            download=True,
+            transform=transforms.ToTensor(),
+        )
+
+        test_set = dataset_fn(
+            root="./data",
+            train=False,
+            download=True,
+            transform=transforms.ToTensor(),
+        )
+
+        return {"name": name, "train_set": train_set, "test_set": test_set}

--- a/ax/benchmark/tests/test_problems.py
+++ b/ax/benchmark/tests/test_problems.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult
+from ax.benchmark.problems.hpo.torchvision import PyTorchCNNTorchvisionBenchmarkProblem
 from ax.benchmark.problems.synthetic import (
     get_problem_and_baseline_from_botorch,
     _REGISTRY,
@@ -21,3 +22,7 @@ class TestProblems(TestCase):
             )
 
             self.assertTrue(isinstance(baseline, AggregatedBenchmarkResult))
+
+    def test_pytorch_cnn(self):
+        # Just check data loading and construction succeeds
+        PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name(name="MNIST")

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -13,6 +13,7 @@ from typing import Callable, Any, Dict, List, Type, Optional
 import numpy as np
 import pandas as pd
 import torch
+from ax.benchmark.problems.hpo.torchvision import PyTorchCNNTorchvisionBenchmarkProblem
 from ax.core.base_trial import BaseTrial
 from ax.core.data import Data
 from ax.core.experiment import Experiment
@@ -194,6 +195,10 @@ def object_from_json(
                 search_space_json=object_json,
                 decoder_registry=decoder_registry,
                 class_decoder_registry=class_decoder_registry,
+            )
+        elif _class == PyTorchCNNTorchvisionBenchmarkProblem:
+            return PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name(
+                object_json["name"]
             )
         elif issubclass(_class, Runner):
             return runner_from_json(_class=_class, runner_json=object_json)

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -6,6 +6,9 @@
 
 from typing import Any, Dict, Type
 
+from ax.benchmark.problems.hpo.torchvision import (
+    PyTorchCNNTorchvisionBenchmarkProblem,
+)
 from ax.core import ObservationFeatures
 from ax.core.arm import Arm
 from ax.core.batch_trial import BatchTrial
@@ -529,3 +532,9 @@ def winsorization_config_to_dict(config: WinsorizationConfig) -> Dict[str, Any]:
         "lower_boundary": config.lower_boundary,
         "upper_boundary": config.upper_boundary,
     }
+
+
+def pytorch_cnn_torchvision_benchmark_problem_to_dict(
+    problem: PyTorchCNNTorchvisionBenchmarkProblem,
+) -> Dict[str, Any]:
+    return {"__type": problem.__class__.__name__, "name": problem.name}

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -14,6 +14,11 @@ from ax.benchmark.benchmark_problem import (
 )
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
 from ax.benchmark.benchmark_result import ScoredBenchmarkResult
+from ax.benchmark.problems.hpo.pytorch_cnn import PyTorchCNNMetric
+from ax.benchmark.problems.hpo.torchvision import (
+    PyTorchCNNTorchvisionRunner,
+    PyTorchCNNTorchvisionBenchmarkProblem,
+)
 from ax.core import ObservationFeatures
 from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
@@ -111,6 +116,7 @@ from ax.storage.json_store.encoders import (
     trial_to_dict,
     threshold_early_stopping_strategy_to_dict,
     winsorization_config_to_dict,
+    pytorch_cnn_torchvision_benchmark_problem_to_dict,
 )
 from ax.storage.json_store.encoders import logical_early_stopping_strategy_to_dict
 from ax.storage.utils import DomainType, ParameterConstraintType
@@ -166,6 +172,9 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     OrderConstraint: order_parameter_constraint_to_dict,
     OutcomeConstraint: outcome_constraint_to_dict,
     ParameterConstraint: parameter_constraint_to_dict,
+    PyTorchCNNTorchvisionBenchmarkProblem: pytorch_cnn_torchvision_benchmark_problem_to_dict,  # noqa
+    PyTorchCNNMetric: metric_to_dict,
+    PyTorchCNNTorchvisionRunner: runner_to_dict,
     RangeParameter: range_parameter_to_dict,
     ScalarizedObjective: scalarized_objective_to_dict,
     SearchSpace: search_space_to_dict,
@@ -250,6 +259,9 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "ParameterConstraintType": ParameterConstraintType,
     "ParameterType": ParameterType,
     "PercentileEarlyStoppingStrategy": PercentileEarlyStoppingStrategy,
+    "PyTorchCNNTorchvisionBenchmarkProblem": PyTorchCNNTorchvisionBenchmarkProblem,
+    "PyTorchCNNMetric": PyTorchCNNMetric,
+    "PyTorchCNNTorchvisionRunner": PyTorchCNNTorchvisionRunner,
     "RangeParameter": RangeParameter,
     "ScalarizedObjective": ScalarizedObjective,
     "SchedulerOptions": SchedulerOptions,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -38,6 +38,7 @@ from ax.storage.json_store.save import save_experiment
 from ax.storage.registry_bundle import RegistryBundle
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import (
+    get_torchvision_problem,
     get_scored_benchmark_result,
     get_single_objective_benchmark_problem,
     get_multi_objective_benchmark_problem,
@@ -167,6 +168,7 @@ TEST_CASES = [
         get_percentile_early_stopping_strategy_with_non_objective_metric_name,
     ),
     ("ParameterConstraint", get_parameter_constraint),
+    ("PyTorchCNNTorchvisionBenchmarkProblem", get_torchvision_problem),
     ("RangeParameter", get_range_parameter),
     ("ScalarizedObjective", get_scalarized_objective),
     ("SchedulerOptions", get_default_scheduler_options),

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -16,6 +16,9 @@ from ax.benchmark.benchmark_result import (
     BenchmarkResult,
     ScoredBenchmarkResult,
 )
+from ax.benchmark.problems.hpo.torchvision import (
+    PyTorchCNNTorchvisionBenchmarkProblem,
+)
 from ax.core.experiment import Experiment
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
@@ -54,6 +57,10 @@ def get_sobol_benchmark_method() -> BenchmarkMethod:
             total_trials=4, init_seconds_between_polls=0
         ),
     )
+
+
+def get_torchvision_problem() -> PyTorchCNNTorchvisionBenchmarkProblem:
+    return PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name(name="MNIST")
 
 
 def get_sobol_gpei_benchmark_method() -> BenchmarkMethod:

--- a/ax/utils/tutorials/cnn_utils.py
+++ b/ax/utils/tutorials/cnn_utils.py
@@ -209,7 +209,7 @@ def train(
         nn.Module: trained CNN.
     """
     # Initialize network
-    net.to(dtype=dtype, device=device)  # pyre-ignore [28]
+    net.to(dtype=dtype, device=device)
     net.train()
     # Define loss and optimizer
     criterion = nn.NLLLoss(reduction="sum")

--- a/sphinx/source/benchmark.rst
+++ b/sphinx/source/benchmark.rst
@@ -51,10 +51,34 @@ Benchmark Methods Modular BoTorch
     :undoc-members:
     :show-inheritance:
 
+Benchmark Methods Choose Generation Strategy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.benchmark.methods.choose_generation_strategy
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Benchmark Problems Synthetic
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.benchmark.problems.synthetic
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Benchmark Problems PyTorchCNN
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.benchmark.problems.hpo.pytorch_cnn
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Benchmark Problems PyTorchCNN TorchVision
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.benchmark.problems.hpo.torchvision
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Summary: Of course it is very important that we are able to observe the performance of choose_generation_strategy over time, but it is a bit of a special case: It is dynamic on aspects of the BenchmarkProblem. This is not a prohibative problem, we can pass in the problem and generate the method using its search space and optimization config, but some special casing needs to be done for full_run. This diff should cover all that special casing.

Reviewed By: lena-kashtelyan

Differential Revision: D35686636

