### PR TITLE
Get rid of torchvision req in tests

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -30,12 +30,14 @@ jobs:
         # will install the version of Botorch that is pinned in setup.py
         pip install -e .[dev,mysql,notebook]
         pip install tensorboard  # For tensorboard unit tests
+        pip install torchvision # For torchvision unit tests
         pip install torchx  # For torchx unit tests.
       if: matrix.botorch == 'pinned' && matrix.requirements == 'full'
     - name: Install dependencies (minimal requirements, stable Botorch)
       run: |
         pip install -e .
         pip install tensorboard  # For tensorboard unit tests
+        pip install torchvision # For torchvision unit tests
         pip install torchx  # For torchx unit tests.
       if: matrix.botorch == 'pinned' && matrix.requirements == 'minimal'
     - name: Install dependencies (full requirements, Botorch main)
@@ -46,6 +48,7 @@ jobs:
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install tensorboard  # For tensorboard unit tests
+        pip install torchvision # For torchvision unit tests
         pip install torchx  # For torchx unit tests.
       if: matrix.botorch == 'latest' && matrix.requirements == 'full'
     - name: Install dependencies (minimal requirements, Botorch main)
@@ -56,6 +59,7 @@ jobs:
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .
         pip install tensorboard  # For tensorboard unit tests
+        pip install torchvision # For torchvision unit tests
         pip install torchx  # For torchx unit tests.
       if: matrix.botorch == 'latest' && matrix.requirements == 'minimal'
     - name: Import Ax

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -12,9 +12,15 @@ from ax.benchmark.problems.hpo.pytorch_cnn import (
 from ax.core.runner import Runner
 from ax.exceptions.core import UserInputError
 from ax.utils.common.typeutils import checked_cast
-from torchvision import transforms, datasets
 
-_REGISTRY = {"MNIST": datasets.MNIST, "FashionMNIST": datasets.FashionMNIST}
+try:  # We don't require TorchVision by default.
+    from torchvision import transforms, datasets
+
+    _REGISTRY = {"MNIST": datasets.MNIST, "FashionMNIST": datasets.FashionMNIST}
+except ModuleNotFoundError:
+    transforms = None
+    datasets = None
+    _REGISTRY = {}
 
 
 class PyTorchCNNTorchvisionBenchmarkProblem(PyTorchCNNBenchmarkProblem):

--- a/ax/benchmark/tests/test_torchvision_problem_storage.py
+++ b/ax/benchmark/tests/test_torchvision_problem_storage.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.benchmark.problems.hpo.torchvision import PyTorchCNNTorchvisionBenchmarkProblem
+from ax.storage.json_store.decoder import object_from_json
+from ax.storage.json_store.encoder import object_to_json
+from ax.utils.common.testutils import TestCase
+
+
+class TestProblems(TestCase):
+    def test_encode_decode(self):
+        original_object = PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name(
+            name="MNIST"
+        )
+
+        json_object = object_to_json(
+            original_object,
+        )
+        converted_object = object_from_json(
+            json_object,
+        )
+
+        self.assertEqual(original_object, converted_object)

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -197,7 +197,7 @@ def object_from_json(
                 class_decoder_registry=class_decoder_registry,
             )
         elif _class == PyTorchCNNTorchvisionBenchmarkProblem:
-            return PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name(
+            return PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name(  # noqa (unit tests in benchmark suite)
                 object_json["name"]
             )
         elif issubclass(_class, Runner):

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -537,4 +537,7 @@ def winsorization_config_to_dict(config: WinsorizationConfig) -> Dict[str, Any]:
 def pytorch_cnn_torchvision_benchmark_problem_to_dict(
     problem: PyTorchCNNTorchvisionBenchmarkProblem,
 ) -> Dict[str, Any]:
-    return {"__type": problem.__class__.__name__, "name": problem.name}
+    return {
+        "__type": problem.__class__.__name__,
+        "name": problem.name,
+    }  # noqa (unit tests in benchmark suite)

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -38,7 +38,6 @@ from ax.storage.json_store.save import save_experiment
 from ax.storage.registry_bundle import RegistryBundle
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import (
-    get_torchvision_problem,
     get_scored_benchmark_result,
     get_single_objective_benchmark_problem,
     get_multi_objective_benchmark_problem,
@@ -168,7 +167,6 @@ TEST_CASES = [
         get_percentile_early_stopping_strategy_with_non_objective_metric_name,
     ),
     ("ParameterConstraint", get_parameter_constraint),
-    ("PyTorchCNNTorchvisionBenchmarkProblem", get_torchvision_problem),
     ("RangeParameter", get_range_parameter),
     ("ScalarizedObjective", get_scalarized_objective),
     ("SchedulerOptions", get_default_scheduler_options),

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -16,9 +16,6 @@ from ax.benchmark.benchmark_result import (
     BenchmarkResult,
     ScoredBenchmarkResult,
 )
-from ax.benchmark.problems.hpo.torchvision import (
-    PyTorchCNNTorchvisionBenchmarkProblem,
-)
 from ax.core.experiment import Experiment
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
@@ -57,10 +54,6 @@ def get_sobol_benchmark_method() -> BenchmarkMethod:
             total_trials=4, init_seconds_between_polls=0
         ),
     )
-
-
-def get_torchvision_problem() -> PyTorchCNNTorchvisionBenchmarkProblem:
-    return PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name(name="MNIST")
 
 
 def get_sobol_gpei_benchmark_method() -> BenchmarkMethod:


### PR DESCRIPTION
Summary:
We dont require torchvision by default (nor should we) so make it possible to build ax without it installed. This pattern is similar to what we do for SQA

PyTorchCNNTorchvisionBenchmarkProblem will break if you try and run it without torchvision installed, but it will not break at build time which is what matters

Reviewed By: Balandat

Differential Revision: D35723850

