### PR TITLE
Modify transforms to support `RobustSearchSpace`, part 2

### DIFF
--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -725,6 +725,14 @@ class RobustSearchSpace(SearchSpace):
         self._environmental_variables: Dict[str, Parameter] = {
             p.name: p for p in environmental_variables
         }
+        # Make sure that the environmental variables and parameters are distinct.
+        param_names = {p.name for p in parameters}
+        for p_name in self._environmental_variables:
+            if p_name in param_names:
+                raise UserInputError(
+                    f"Environmental variable {p_name} should not be repeated "
+                    "in parameters."
+                )
         # NOTE: We need `_environmental_variables` set before calling `__init__`.
         super().__init__(
             parameters=parameters, parameter_constraints=parameter_constraints

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -743,6 +743,12 @@ class TestRobustSearchSpace(TestCase):
                 parameter_distributions=[env1_dist],
                 environmental_variables=[env1, env2],
             )
+        with self.assertRaisesRegex(UserInputError, "should not be repeated"):
+            RobustSearchSpace(
+                parameters=self.parameters,
+                parameter_distributions=[a_dist],
+                environmental_variables=[self.a],
+            )
         with self.assertRaisesRegex(
             UserInputError, "environmental variables must be range parameters"
         ):

--- a/ax/modelbridge/tests/test_int_range_to_choice_transform.py
+++ b/ax/modelbridge/tests/test_int_range_to_choice_transform.py
@@ -63,6 +63,24 @@ class IntRangeToChoiceTransformTest(TestCase):
         self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
         self.assertEqual(rss.parameter_distributions, rss_new.parameter_distributions)
         self.assertIsInstance(rss_new.parameters.get("z"), ChoiceParameter)
+        # Test with environmental variables.
+        all_params = list(rss.parameters.values())
+        rss = RobustSearchSpace(
+            parameters=all_params[2:],
+            parameter_distributions=rss.parameter_distributions,
+            environmental_variables=all_params[:2],
+        )
+        t = IntRangeToChoice(
+            search_space=rss,
+            observation_features=None,
+            observation_data=None,
+        )
+        rss_new = t.transform_search_space(rss)
+        self.assertIsInstance(rss_new, RobustSearchSpace)
+        self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
+        self.assertEqual(rss.parameter_distributions, rss_new.parameter_distributions)
+        self.assertEqual(rss._environmental_variables, rss_new._environmental_variables)
+        self.assertIsInstance(rss_new.parameters.get("z"), ChoiceParameter)
         # Error with distributional parameter.
         rss = get_robust_search_space(use_discrete=True)
         t = IntRangeToChoice(

--- a/ax/modelbridge/tests/test_int_to_float_transform.py
+++ b/ax/modelbridge/tests/test_int_to_float_transform.py
@@ -180,6 +180,26 @@ class IntToFloatTransformTest(TestCase):
         self.assertEqual(
             rss_new.parameters.get("z").parameter_type, ParameterType.FLOAT
         )
+        # Test with environmental variables.
+        all_params = list(rss.parameters.values())
+        rss = RobustSearchSpace(
+            parameters=all_params[2:],
+            parameter_distributions=rss.parameter_distributions,
+            environmental_variables=all_params[:2],
+        )
+        t = IntToFloat(
+            search_space=rss,
+            observation_features=None,
+            observation_data=None,
+        )
+        rss_new = t.transform_search_space(rss)
+        self.assertIsInstance(rss_new, RobustSearchSpace)
+        self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
+        self.assertEqual(rss.parameter_distributions, rss_new.parameter_distributions)
+        self.assertEqual(rss._environmental_variables, rss_new._environmental_variables)
+        self.assertEqual(
+            rss_new.parameters.get("z").parameter_type, ParameterType.FLOAT
+        )
         # Error with distributional parameter.
         rss = get_robust_search_space(use_discrete=True)
         t = IntToFloat(

--- a/ax/modelbridge/transforms/choice_encode.py
+++ b/ax/modelbridge/transforms/choice_encode.py
@@ -12,7 +12,10 @@ from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangePa
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
 from ax.modelbridge.transforms.base import Transform
-from ax.modelbridge.transforms.utils import ClosestLookupDict
+from ax.modelbridge.transforms.utils import (
+    construct_new_search_space,
+    ClosestLookupDict,
+)
 from ax.models.types import TConfig
 
 if TYPE_CHECKING:
@@ -92,7 +95,8 @@ class ChoiceEncode(Transform):
                 )
             else:
                 transformed_parameters[p.name] = p
-        return SearchSpace(
+        return construct_new_search_space(
+            search_space=search_space,
             parameters=list(transformed_parameters.values()),
             parameter_constraints=[
                 pc.clone_with_transformed_parameters(
@@ -170,7 +174,8 @@ class OrderedChoiceEncode(ChoiceEncode):
                 )
             else:
                 transformed_parameters[p.name] = p
-        return SearchSpace(
+        return construct_new_search_space(
+            search_space=search_space,
             parameters=list(transformed_parameters.values()),
             parameter_constraints=[
                 pc.clone_with_transformed_parameters(

--- a/ax/modelbridge/transforms/int_range_to_choice.py
+++ b/ax/modelbridge/transforms/int_range_to_choice.py
@@ -8,8 +8,9 @@ from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
 from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
-from ax.core.search_space import RobustSearchSpace, SearchSpace
+from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.utils import construct_new_search_space
 from ax.models.types import TConfig
 
 if TYPE_CHECKING:
@@ -64,20 +65,13 @@ class IntRangeToChoice(Transform):
                 )
             else:
                 transformed_parameters[p.name] = p
-        new_kwargs = {
-            "parameters": list(transformed_parameters.values()),
-            "parameter_constraints": [
+        return construct_new_search_space(
+            search_space=search_space,
+            parameters=list(transformed_parameters.values()),
+            parameter_constraints=[
                 pc.clone_with_transformed_parameters(
                     transformed_parameters=transformed_parameters
                 )
                 for pc in search_space.parameter_constraints
             ],
-        }
-        if isinstance(search_space, RobustSearchSpace):
-            new_kwargs["environmental_variables"] = list(
-                search_space._environmental_variables.values()
-            )
-            # pyre-ignore Incompatible parameter type [6]
-            new_kwargs["parameter_distributions"] = search_space.parameter_distributions
-        # pyre-ignore Incompatible parameter type [6]
-        return search_space.__class__(**new_kwargs)
+        )

--- a/ax/modelbridge/transforms/one_hot.py
+++ b/ax/modelbridge/transforms/one_hot.py
@@ -16,6 +16,7 @@ from ax.modelbridge.transforms.rounding import (
     randomized_onehot_round,
     strict_onehot_round,
 )
+from ax.modelbridge.transforms.utils import construct_new_search_space
 from ax.models.types import TConfig
 from sklearn.preprocessing import LabelBinarizer, LabelEncoder
 
@@ -141,7 +142,8 @@ class OneHot(Transform):
                     )
             else:
                 transformed_parameters[p_name] = p
-        return SearchSpace(
+        return construct_new_search_space(
+            search_space=search_space,
             parameters=list(transformed_parameters.values()),
             parameter_constraints=[
                 pc.clone_with_transformed_parameters(

--- a/ax/modelbridge/transforms/remove_fixed.py
+++ b/ax/modelbridge/transforms/remove_fixed.py
@@ -10,6 +10,7 @@ from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, FixedParameter, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.utils import construct_new_search_space
 from ax.models.types import TConfig
 
 if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class RemoveFixed(Transform):
     Fixed parameters should not be included in the SearchSpace.
     This transform removes these parameters, leaving only tunable parameters.
 
-    Transform is done in-place.
+    Transform is done in-place for observation features.
     """
 
     def __init__(
@@ -65,11 +66,9 @@ class RemoveFixed(Transform):
                 # pyre-fixme[9]: parameter.Parameter`.
                 p_: Union[ChoiceParameter, RangeParameter] = p
                 tunable_parameters.append(p_)
-        return SearchSpace(
-            # Expected `List[ax.core.parameter.Parameter]` for 2nd parameter
-            # `parameters` to call `ax.core.search_space.SearchSpace.__init__`
-            # but got `List[Union[ChoiceParameter, RangeParameter]]`.
-            # pyre-fixme[6]:
+        return construct_new_search_space(
+            search_space=search_space,
+            # pyre-ignore Incompatible parameter type [6]
             parameters=tunable_parameters,
             parameter_constraints=[
                 pc.clone() for pc in search_space.parameter_constraints

--- a/ax/modelbridge/transforms/task_encode.py
+++ b/ax/modelbridge/transforms/task_encode.py
@@ -11,6 +11,7 @@ from ax.core.parameter import ChoiceParameter, Parameter, ParameterType
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
 from ax.modelbridge.transforms.choice_encode import OrderedChoiceEncode
+from ax.modelbridge.transforms.utils import construct_new_search_space
 from ax.models.types import TConfig
 
 if TYPE_CHECKING:
@@ -78,7 +79,8 @@ class TaskEncode(OrderedChoiceEncode):
                 )
             else:
                 transformed_parameters[p.name] = p
-        return SearchSpace(
+        return construct_new_search_space(
+            search_space=search_space,
             parameters=list(transformed_parameters.values()),
             parameter_constraints=[
                 pc.clone_with_transformed_parameters(


### PR DESCRIPTION
Summary:
This fixes the ones I originally marked as ignore / no-op and left untouched. Seeing my `RobustSearchSpace` mysteriously being converted to `SearchSpace` made me realize that these needed modifications to respect the original search space class.

Also removes a few pyre-ignore comments.

I also noticed that `RobustSearchSpace` did not complain if we included the environmental variables in both the `environmental_variables` and the `parameters`, which we were doing with some of the modified transforms. This did not seem like a great idea, so it also got fixed.

Differential Revision: D35797496

