### PR TITLE
Ensure client's generation strategy is attached to experiment

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1522,6 +1522,8 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
                 experiment=self.experiment,
                 **choose_generation_strategy_kwargs,
             )
+        elif self._experiment:
+            self._generation_strategy.experiment = self.experiment
 
     def _save_generation_strategy_to_db_if_possible(
         self,


### PR DESCRIPTION
Summary:
Pointed out in https://github.com/facebook/Ax/issues/923
If GS is set on the client, it is not saved with a reference to the created experiment

Differential Revision: D35854210

