### PR TITLE
Cache analyzer on the client provided nothing changes

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -568,7 +568,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         Args:
             trial_index: Index of trial within the experiment.
         """
-        trial = self._get_trial(trial_index=trial_index)
+        trial = self.trials[trial_index]
         trial.mark_abandoned(reason=reason)
 
     def update_running_trial_with_intermediate_data(
@@ -678,7 +678,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
                 optional.
         """
         # Validate that trial can be completed.
-        trial = self._get_trial(trial_index=trial_index)
+        trial = self.trials[trial_index]
         self._validate_can_complete_trial(trial=trial)
         if not isinstance(trial_index, int):  # pragma: no cover
             raise ValueError(f"Trial index must be an int, got: {trial_index}.")
@@ -717,7 +717,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         """
         if not isinstance(trial_index, int):  # pragma: no cover
             raise ValueError(f"Trial index must be an int, got: {trial_index}.")
-        trial = self._get_trial(trial_index=trial_index)
+        trial = self.trials[trial_index]
         if not trial.status.is_completed:
             raise ValueError(
                 f"Trial {trial.index} has not yet been completed with data."
@@ -789,7 +789,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
 
     def get_trial_parameters(self, trial_index: int) -> TParameterization:
         """Retrieve the parameterization of the trial by the given index."""
-        return not_none(self._get_trial(trial_index).arm).parameters
+        return not_none(self.trials[trial_index].arm).parameters
 
     def get_trials_data_frame(self) -> pd.DataFrame:
         return exp_to_df(exp=self.experiment)
@@ -1186,10 +1186,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         """Whether the given parameterization matches that of the arm in the trial
         specified in the trial index.
         """
-        return (
-            not_none(self._get_trial(trial_index=trial_index).arm).parameters
-            == parameterization
-        )
+        return not_none(self.trials[trial_index].arm).parameters == parameterization
 
     def should_stop_trials_early(
         self, trial_indices: Set[int]
@@ -1215,7 +1212,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         )
 
     def stop_trial_early(self, trial_index: int) -> None:
-        trial = self._get_trial(trial_index)
+        trial = self.trials[trial_index]
         trial.mark_early_stopped()
         logger.info(f"Early stopped trial {trial_index}.")
 
@@ -1328,6 +1325,16 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         )
 
     @property
+    def trials(self) -> Dict[int, Trial]:
+        """Return trials on experiment cast as Trial"""
+        return {
+            i: checked_cast(Trial, t)
+            for i, t in not_none(
+                self.experiment, "Must set an experiment to access trials"
+            ).trials.items()
+        }
+
+    @property
     def generation_strategy(self) -> GenerationStrategy:
         """Returns the generation strategy, set on this experiment."""
         return not_none(
@@ -1409,7 +1416,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
     ) -> str:
         """Helper method attaches data to a trial, returns a str of update."""
         # Format the data to save.
-        trial = self._get_trial(trial_index=trial_index)
+        trial = self.trials[trial_index]
         sample_sizes = {not_none(trial.arm).name: sample_size} if sample_size else {}
         evaluations, data = self._make_evaluations_and_data(
             trial=trial, raw_data=raw_data, metadata=metadata, sample_sizes=sample_sizes
@@ -1556,17 +1563,6 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
                 ),
             )
 
-    def _get_trial(self, trial_index: int) -> Trial:
-        """Gets trial by given index or raises an error if it does not exist."""
-        if trial_index in self.experiment.trials:
-            trial = self.experiment.trials.get(trial_index)
-            if not isinstance(trial, Trial):
-                raise NotImplementedError(
-                    "`AxClient` only supports `Trial`, not `BatchTrial`."
-                )
-            return trial
-        raise ValueError(f"Trial {trial_index} does not yet exist.")
-
     def _find_last_trial_with_parameterization(
         self, parameterization: TParameterization
     ) -> int:
@@ -1574,7 +1570,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         contains an arm with that parameterization.
         """
         for trial_idx in sorted(self.experiment.trials.keys(), reverse=True):
-            if not_none(self._get_trial(trial_idx).arm).parameters == parameterization:
+            if not_none(self.trials[trial_idx].arm).parameters == parameterization:
                 return trial_idx
         raise ValueError(
             f"No trial on experiment matches parameterization {parameterization}."

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -1215,7 +1215,9 @@ class TestAxClient(TestCase):
                 ]
             )
         )
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaisesRegex(
+            ValueError, "Value was not of type <class 'ax.core.trial.Trial'>"
+        ):
             ax_client.complete_trial(batch_trial.index, 0)
 
     def test_log_failure(self):
@@ -1251,7 +1253,7 @@ class TestAxClient(TestCase):
         self.assertEqual(
             ax_client.get_trial_parameters(trial_index=idx), {"x": 0, "y": 1}
         )
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             ax_client.get_trial_parameters(
                 trial_index=10
             )  # No trial #10 in experiment.
@@ -1972,7 +1974,7 @@ class TestAxClient(TestCase):
         )
         _, idx = ax_client.get_next_trial()
         ax_client.stop_trial_early(idx)
-        trial = ax_client._get_trial(idx)
+        trial = ax_client.trials[idx]
         self.assertTrue(trial.status.is_early_stopped)
 
     def test_max_parallelism_exception_when_early_stopping(self):

--- a/ax/utils/common/logger.py
+++ b/ax/utils/common/logger.py
@@ -149,7 +149,8 @@ class disable_logger:
             if (
                 not callable(attr_value)
                 or isinstance(attr_value, type)
-                or attr in ("__class__", "__repr__", "__str__")
+                or attr
+                in ("__class__", "__repr__", "__str__", "__getattribute__", "__new__")
             ):
                 continue
 
@@ -164,9 +165,13 @@ class disable_logger:
             logger.setLevel(self.level)
             try:
                 return func(*args, **kwargs)
-            except TypeError:
+            except TypeError as e:
                 # static functions
-                return func(*args[1:], **kwargs)
+                try:
+                    return func(*args[1:], **kwargs)
+                except TypeError:
+                    # it wasn't that it was a static function
+                    raise e
             finally:
                 logger.setLevel(prev_level)
 


### PR DESCRIPTION
Summary: Without caching the analyzer we can't use the analyzers caches, so data pretty much always refetches.

Reviewed By: lena-kashtelyan

Differential Revision: D35730587

