### PR TITLE
Unpin sphinx, jinja and nbconvert

### DIFF
--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -153,7 +153,7 @@ def gen_tutorials(
                 total_time = None
 
         # convert notebook to HTML
-        exporter = HTMLExporter()
+        exporter = HTMLExporter(template_name="classic")
         html, meta = exporter.from_notebook_node(nb)
 
         # pull out html div for notebook

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,13 @@ DEV_REQUIRES = [
     "black",
     "flake8",
     "hypothesis",
-    "Jinja2<3.1.0",
+    "Jinja2",
     "pytest>=4.6",
     "pytest-cov",
-    "sphinx<4.0",
+    "sphinx",
     "sphinx-autodoc-typehints",
     "torchvision>=0.5.0",
-    "nbconvert<=5.6.1",
+    "nbconvert",
     "jupyter-client==6.1.12",
 ]
 


### PR DESCRIPTION
Summary: The pinned version of `nbconvert` has been leading to errors due to newer versions of its dependencies deprecating functions it relies on. This unpins `sphinx`, `jinja2` and `nbconvert`, and updates the `make_tutorials` script to work with the new version.

Reviewed By: Balandat, lena-kashtelyan

Differential Revision: D35158268

