### PR TITLE
Add a `risk_measure` attribute to `OptimizationConfig`

### DIFF
--- a/ax/core/__init__.py
+++ b/ax/core/__init__.py
@@ -35,6 +35,7 @@ from ax.core.parameter_constraint import (
     SumConstraint,
 )
 from ax.core.parameter_distribution import ParameterDistribution
+from ax.core.risk_measures import RiskMeasure
 from ax.core.runner import Runner
 from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
@@ -63,6 +64,7 @@ __all__ = [
     "ParameterDistribution",
     "ParameterType",
     "RangeParameter",
+    "RiskMeasure",
     "Runner",
     "SearchSpace",
     "SimpleExperiment",

--- a/ax/core/risk_measures.py
+++ b/ax/core/risk_measures.py
@@ -17,6 +17,7 @@ from botorch.acquisition.multi_objective.multi_output_risk_measures import (
     IndependentVaR,
     IndependentCVaR,
     MultiOutputExpectation,
+    MultiOutputRiskMeasureMCObjective,
 )
 from botorch.acquisition.risk_measures import (
     CVaR,
@@ -73,6 +74,10 @@ class RiskMeasure(Base):
         self.options = options
         # Check that the risk measure is valid.
         self.module
+
+    @property
+    def is_multi_output(self) -> bool:
+        return isinstance(self.module, MultiOutputRiskMeasureMCObjective)
 
     @property
     @functools.lru_cache()

--- a/ax/core/risk_measures.py
+++ b/ax/core/risk_measures.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import functools
+from copy import deepcopy
+from typing import Dict, List, Type, Union
+
+from ax.exceptions.core import UserInputError
+from ax.utils.common.base import Base
+from botorch.acquisition.multi_objective.multi_output_risk_measures import (
+    MVaR,
+    IndependentVaR,
+    IndependentCVaR,
+    MultiOutputExpectation,
+)
+from botorch.acquisition.risk_measures import (
+    CVaR,
+    VaR,
+    Expectation,
+    RiskMeasureMCObjective,
+    WorstCase,
+)
+
+
+"""A mapping of risk measure names to the corresponding classes.
+
+NOTE: This can be extended with user-defined risk measure classes by
+importing the dictionary and adding the new risk measure class as
+`RISK_MEASURE_NAME_TO_CLASS["my_risk_measure"] = MyRiskMeasure`.
+An example of this is found in `tests/test_risk_measure`.
+"""
+RISK_MEASURE_NAME_TO_CLASS: Dict[str, Type[RiskMeasureMCObjective]] = {
+    "Expectation": Expectation,
+    "CVaR": CVaR,
+    "MVaR": MVaR,
+    "IndependentCVaR": IndependentCVaR,
+    "IndependentVaR": IndependentVaR,
+    "MultiOutputExpectation": MultiOutputExpectation,
+    "VaR": VaR,
+    "WorstCase": WorstCase,
+}
+
+
+class RiskMeasure(Base):
+    """A class for defining risk measures.
+
+    This can be used with a `RobustSearchSpace`, to convert the predictions over
+    `ParameterDistribution`s to robust metrics, which then get used in candidate
+    generation to recommend robust candidates.
+    """
+
+    def __init__(
+        self,
+        risk_measure: str,
+        options: Dict[str, Union[int, float, bool, List[float]]],
+    ) -> None:
+        """Initialize a risk measure.
+
+        Args:
+            risk_measure: The name of the risk measure to use. This should have a
+                corresponding entry in `RISK_MEASURE_NAME_TO_CLASS`.
+            options: A dictionary of keyword arguments for initializing the risk
+                measure. The risk measure will be initialized as
+                `RISK_MEASURE_NAME_TO_CLASS[risk_measure](**options)`.
+        """
+        super().__init__()
+        self.risk_measure = risk_measure
+        self.options = options
+        # Check that the risk measure is valid.
+        self.module
+
+    @property
+    @functools.lru_cache()
+    def module(self) -> RiskMeasureMCObjective:
+        """Get the risk measure objective."""
+        try:
+            # pyre-ignore Incompatible parameter type [6]
+            return RISK_MEASURE_NAME_TO_CLASS[self.risk_measure](**self.options)
+        except (KeyError, RuntimeError, ValueError):
+            raise UserInputError(
+                "Got an error while constructing the risk measure. "
+                f"Make sure that {self.risk_measure} exists in  "
+                f"`RISK_MEASURE_NAME_TO_CLASS` and accepts arguments {self.options}."
+            )
+
+    def clone(self) -> RiskMeasure:
+        """Clone."""
+        return RiskMeasure(
+            risk_measure=self.risk_measure,
+            options=deepcopy(self.options),
+        )
+
+    def __hash__(self) -> int:
+        """Make the class hashable to support the use of `lru_cache` above.
+
+        NOTE: The hash of two `RiskMeasures`s with identical attributes
+        will be the same. This is compatible with the use in `lru_cache` above,
+        since the resulting risk measures will be the same.
+        """
+        return hash(repr(self))
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            "risk_measure=" + self.risk_measure + ", "
+            "options=" + repr(self.options) + ")"
+        )

--- a/ax/core/tests/test_risk_measures.py
+++ b/ax/core/tests/test_risk_measures.py
@@ -21,6 +21,7 @@ class TestRiskMeasure(TestCase):
         self.assertIsInstance(rm_module, VaR)
         self.assertEqual(rm_module.alpha, 0.8)
         self.assertEqual(rm_module.n_w, 5)
+        self.assertFalse(rm.is_multi_output)
 
         # Test repr.
         expected_repr = (

--- a/ax/core/tests/test_risk_measures.py
+++ b/ax/core/tests/test_risk_measures.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.core.risk_measures import RiskMeasure, VaR, RISK_MEASURE_NAME_TO_CLASS
+from ax.exceptions.core import UserInputError
+from ax.utils.common.testutils import TestCase
+
+
+class TestRiskMeasure(TestCase):
+    def test_risk_measure(self):
+        rm = RiskMeasure(
+            risk_measure="VaR",
+            options={"alpha": 0.8, "n_w": 5},
+        )
+        self.assertEqual(rm.risk_measure, "VaR")
+        self.assertEqual(rm.options, {"alpha": 0.8, "n_w": 5})
+        rm_module = rm.module
+        self.assertIsInstance(rm_module, VaR)
+        self.assertEqual(rm_module.alpha, 0.8)
+        self.assertEqual(rm_module.n_w, 5)
+
+        # Test repr.
+        expected_repr = (
+            "RiskMeasure(risk_measure=VaR, options={'alpha': 0.8, 'n_w': 5})"
+        )
+        self.assertEqual(str(rm), expected_repr)
+
+        # Test clone.
+        rm_clone = rm.clone()
+        self.assertEqual(str(rm), str(rm_clone))
+
+        # Test unknown risk measure.
+        with self.assertRaisesRegex(UserInputError, "constructing"):
+            RiskMeasure(
+                risk_measure="VVar",
+                options={},
+            )
+        # Test invalid options.
+        with self.assertRaisesRegex(UserInputError, "constructing"):
+            RiskMeasure(
+                risk_measure="VaR",
+                options={"alpha": 5, "n_w": 5},
+            )
+
+    def test_custom_risk_measure(self):
+        # Test using user-defined risk measures.
+
+        class CustomRM(VaR):
+            pass
+
+        RISK_MEASURE_NAME_TO_CLASS["custom"] = CustomRM
+
+        rm = RiskMeasure(
+            risk_measure="custom",
+            options={"alpha": 0.8, "n_w": 5},
+        )
+        self.assertEqual(rm.risk_measure, "custom")
+        self.assertIsInstance(rm.module, CustomRM)

--- a/sphinx/source/core.rst
+++ b/sphinx/source/core.rst
@@ -104,7 +104,7 @@ Core Classes
     :undoc-members:
     :show-inheritance:
 
-Objective
+`Objective`
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.core.objective
@@ -158,6 +158,14 @@ Objective
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.core.parameter_distribution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`RiskMeasure`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.core.risk_measures
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Summary: Adds a `risk_measure` attribute to `OptimizationConfig` and `MultiObjectiveOptimizationConfig`. This will later be parsed in `Array/TorchModelBridge._get_transformed_model_gen_args` and passed into the `get_botorch_objective_and_transform`  helper, where it will be combined with the other botorch objectives arguments to construct a risk measure objective.

Reviewed By: Balandat

Differential Revision: D35732627

