### PR TITLE
Add a `num_samples` attribute to `RobustSearchSpace`, introduce `RobustSearchSpaceDigest`

### DIFF
--- a/ax/core/__init__.py
+++ b/ax/core/__init__.py
@@ -35,6 +35,7 @@ from ax.core.parameter_constraint import (
     SumConstraint,
 )
 from ax.core.parameter_distribution import ParameterDistribution
+from ax.core.risk_measures import RiskMeasure
 from ax.core.runner import Runner
 from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
@@ -63,6 +64,7 @@ __all__ = [
     "ParameterDistribution",
     "ParameterType",
     "RangeParameter",
+    "RiskMeasure",
     "Runner",
     "SearchSpace",
     "SimpleExperiment",

--- a/ax/core/risk_measures.py
+++ b/ax/core/risk_measures.py
@@ -17,6 +17,7 @@ from botorch.acquisition.multi_objective.multi_output_risk_measures import (
     IndependentVaR,
     IndependentCVaR,
     MultiOutputExpectation,
+    MultiOutputRiskMeasureMCObjective,
 )
 from botorch.acquisition.risk_measures import (
     CVaR,
@@ -73,6 +74,10 @@ class RiskMeasure(Base):
         self.options = options
         # Check that the risk measure is valid.
         self.module
+
+    @property
+    def is_multi_output(self) -> bool:
+        return isinstance(self.module, MultiOutputRiskMeasureMCObjective)
 
     @property
     @functools.lru_cache()

--- a/ax/core/risk_measures.py
+++ b/ax/core/risk_measures.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import functools
+from copy import deepcopy
+from typing import Dict, List, Type, Union
+
+from ax.exceptions.core import UserInputError
+from ax.utils.common.base import Base
+from botorch.acquisition.multi_objective.multi_output_risk_measures import (
+    MVaR,
+    IndependentVaR,
+    IndependentCVaR,
+    MultiOutputExpectation,
+)
+from botorch.acquisition.risk_measures import (
+    CVaR,
+    VaR,
+    Expectation,
+    RiskMeasureMCObjective,
+    WorstCase,
+)
+
+
+"""A mapping of risk measure names to the corresponding classes.
+
+NOTE: This can be extended with user-defined risk measure classes by
+importing the dictionary and adding the new risk measure class as
+`RISK_MEASURE_NAME_TO_CLASS["my_risk_measure"] = MyRiskMeasure`.
+An example of this is found in `tests/test_risk_measure`.
+"""
+RISK_MEASURE_NAME_TO_CLASS: Dict[str, Type[RiskMeasureMCObjective]] = {
+    "Expectation": Expectation,
+    "CVaR": CVaR,
+    "MVaR": MVaR,
+    "IndependentCVaR": IndependentCVaR,
+    "IndependentVaR": IndependentVaR,
+    "MultiOutputExpectation": MultiOutputExpectation,
+    "VaR": VaR,
+    "WorstCase": WorstCase,
+}
+
+
+class RiskMeasure(Base):
+    """A class for defining risk measures.
+
+    This can be used with a `RobustSearchSpace`, to convert the predictions over
+    `ParameterDistribution`s to robust metrics, which then get used in candidate
+    generation to recommend robust candidates.
+    """
+
+    def __init__(
+        self,
+        risk_measure: str,
+        options: Dict[str, Union[int, float, bool, List[float]]],
+    ) -> None:
+        """Initialize a risk measure.
+
+        Args:
+            risk_measure: The name of the risk measure to use. This should have a
+                corresponding entry in `RISK_MEASURE_NAME_TO_CLASS`.
+            options: A dictionary of keyword arguments for initializing the risk
+                measure. The risk measure will be initialized as
+                `RISK_MEASURE_NAME_TO_CLASS[risk_measure](**options)`.
+        """
+        super().__init__()
+        self.risk_measure = risk_measure
+        self.options = options
+        # Check that the risk measure is valid.
+        self.module
+
+    @property
+    @functools.lru_cache()
+    def module(self) -> RiskMeasureMCObjective:
+        """Get the risk measure objective."""
+        try:
+            # pyre-ignore Incompatible parameter type [6]
+            return RISK_MEASURE_NAME_TO_CLASS[self.risk_measure](**self.options)
+        except (KeyError, RuntimeError, ValueError):
+            raise UserInputError(
+                "Got an error while constructing the risk measure. "
+                f"Make sure that {self.risk_measure} exists in  "
+                f"`RISK_MEASURE_NAME_TO_CLASS` and accepts arguments {self.options}."
+            )
+
+    def clone(self) -> RiskMeasure:
+        """Clone."""
+        return RiskMeasure(
+            risk_measure=self.risk_measure,
+            options=deepcopy(self.options),
+        )
+
+    def __hash__(self) -> int:
+        """Make the class hashable to support the use of `lru_cache` above.
+
+        NOTE: The hash of two `RiskMeasures`s with identical attributes
+        will be the same. This is compatible with the use in `lru_cache` above,
+        since the resulting risk measures will be the same.
+        """
+        return hash(repr(self))
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            "risk_measure=" + self.risk_measure + ", "
+            "options=" + repr(self.options) + ")"
+        )

--- a/ax/core/tests/test_risk_measures.py
+++ b/ax/core/tests/test_risk_measures.py
@@ -21,6 +21,7 @@ class TestRiskMeasure(TestCase):
         self.assertIsInstance(rm_module, VaR)
         self.assertEqual(rm_module.alpha, 0.8)
         self.assertEqual(rm_module.n_w, 5)
+        self.assertFalse(rm.is_multi_output)
 
         # Test repr.
         expected_repr = (

--- a/ax/core/tests/test_risk_measures.py
+++ b/ax/core/tests/test_risk_measures.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.core.risk_measures import RiskMeasure, VaR, RISK_MEASURE_NAME_TO_CLASS
+from ax.exceptions.core import UserInputError
+from ax.utils.common.testutils import TestCase
+
+
+class TestRiskMeasure(TestCase):
+    def test_risk_measure(self):
+        rm = RiskMeasure(
+            risk_measure="VaR",
+            options={"alpha": 0.8, "n_w": 5},
+        )
+        self.assertEqual(rm.risk_measure, "VaR")
+        self.assertEqual(rm.options, {"alpha": 0.8, "n_w": 5})
+        rm_module = rm.module
+        self.assertIsInstance(rm_module, VaR)
+        self.assertEqual(rm_module.alpha, 0.8)
+        self.assertEqual(rm_module.n_w, 5)
+
+        # Test repr.
+        expected_repr = (
+            "RiskMeasure(risk_measure=VaR, options={'alpha': 0.8, 'n_w': 5})"
+        )
+        self.assertEqual(str(rm), expected_repr)
+
+        # Test clone.
+        rm_clone = rm.clone()
+        self.assertEqual(str(rm), str(rm_clone))
+
+        # Test unknown risk measure.
+        with self.assertRaisesRegex(UserInputError, "constructing"):
+            RiskMeasure(
+                risk_measure="VVar",
+                options={},
+            )
+        # Test invalid options.
+        with self.assertRaisesRegex(UserInputError, "constructing"):
+            RiskMeasure(
+                risk_measure="VaR",
+                options={"alpha": 5, "n_w": 5},
+            )
+
+    def test_custom_risk_measure(self):
+        # Test using user-defined risk measures.
+
+        class CustomRM(VaR):
+            pass
+
+        RISK_MEASURE_NAME_TO_CLASS["custom"] = CustomRM
+
+        rm = RiskMeasure(
+            risk_measure="custom",
+            options={"alpha": 0.8, "n_w": 5},
+        )
+        self.assertEqual(rm.risk_measure, "custom")
+        self.assertIsInstance(rm.module, CustomRM)

--- a/ax/modelbridge/tests/test_choice_encode_transform.py
+++ b/ax/modelbridge/tests/test_choice_encode_transform.py
@@ -153,6 +153,7 @@ class ChoiceEncodeTransformTest(TestCase):
         rss = RobustSearchSpace(
             parameters=all_params[2:],
             parameter_distributions=rss.parameter_distributions,
+            num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
         t = self.t_class(

--- a/ax/modelbridge/tests/test_int_range_to_choice_transform.py
+++ b/ax/modelbridge/tests/test_int_range_to_choice_transform.py
@@ -68,6 +68,7 @@ class IntRangeToChoiceTransformTest(TestCase):
         rss = RobustSearchSpace(
             parameters=all_params[2:],
             parameter_distributions=rss.parameter_distributions,
+            num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
         t = IntRangeToChoice(

--- a/ax/modelbridge/tests/test_int_to_float_transform.py
+++ b/ax/modelbridge/tests/test_int_to_float_transform.py
@@ -185,6 +185,7 @@ class IntToFloatTransformTest(TestCase):
         rss = RobustSearchSpace(
             parameters=all_params[2:],
             parameter_distributions=rss.parameter_distributions,
+            num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
         t = IntToFloat(

--- a/ax/modelbridge/tests/test_modelbridge_utils.py
+++ b/ax/modelbridge/tests/test_modelbridge_utils.py
@@ -6,63 +6,56 @@
 
 import numpy as np
 from ax.core.search_space import RobustSearchSpace
-from ax.modelbridge.modelbridge_utils import extract_parameter_distribution_samplers
+from ax.modelbridge.modelbridge_utils import extract_robust_digest
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_robust_search_space
 from ax.utils.testing.core_stubs import get_search_space
 
 
 class TestModelBridgeUtils(TestCase):
-    def test_extract_parameter_distribution_samplers(self):
+    def test_extract_robust_digest(self):
         # Test with non-robust search space.
         ss = get_search_space()
-        self.assertEqual(
-            extract_parameter_distribution_samplers(ss, list(ss.parameters)),
-            (None, False),
-        )
+        self.assertIsNone(extract_robust_digest(ss, list(ss.parameters)))
         # Test with non-environmental search space.
         for multiplicative in (True, False):
-            rss = get_robust_search_space()
+            rss = get_robust_search_space(num_samples=8)
             if multiplicative:
                 for p in rss.parameter_distributions:
                     p.multiplicative = True
-            sampler, mul_ = extract_parameter_distribution_samplers(
-                rss, list(rss.parameters)
-            )
-            self.assertEqual(mul_, multiplicative)
-            samples = sampler(5)
-            self.assertEqual(samples.shape, (5, 4))
+            robust_digest = extract_robust_digest(rss, list(rss.parameters))
+            self.assertEqual(robust_digest.multiplicative, multiplicative)
+            self.assertEqual(robust_digest.environmental_variables, [])
+            samples = robust_digest.distribution_sampler()
+            self.assertEqual(samples.shape, (8, 4))
             constructor = np.ones if multiplicative else np.zeros
-            self.assertTrue(np.equal(samples[:, 2:], constructor((5, 2))).all())
+            self.assertTrue(np.equal(samples[:, 2:], constructor((8, 2))).all())
             # Exponential distribution is non-negative, so we can check for that.
             self.assertTrue(np.all(samples[:, 1] > 0))
             # Check that it works as expected if param_names is missing some
             # non-distributional parameters.
-            sampler, mul_ = extract_parameter_distribution_samplers(
-                rss, list(rss.parameters)[:-1]
-            )
-            samples = sampler(5)
-            self.assertEqual(samples.shape, (5, 3))
-            self.assertTrue(np.equal(samples[:, 2:], constructor((5, 1))).all())
+            robust_digest = extract_robust_digest(rss, list(rss.parameters)[:-1])
+            samples = robust_digest.distribution_sampler()
+            self.assertEqual(samples.shape, (8, 3))
+            self.assertTrue(np.equal(samples[:, 2:], constructor((8, 1))).all())
             self.assertTrue(np.all(samples[:, 1] > 0))
             # Check that it errors if we're missing distributional parameters.
             with self.assertRaisesRegex(RuntimeError, "All distributional"):
-                extract_parameter_distribution_samplers(rss, list(rss.parameters)[1:])
+                extract_robust_digest(rss, list(rss.parameters)[1:])
         # Test with environmental search space.
         all_params = list(rss.parameters.values())
         rss = RobustSearchSpace(
             parameters=all_params[2:],
             parameter_distributions=rss.parameter_distributions,
+            num_samples=8,
             environmental_variables=all_params[:2],
         )
-        sampler, mul_ = extract_parameter_distribution_samplers(
-            rss, list(rss.parameters)
-        )
-        self.assertFalse(mul_)
-        samples = sampler(5)
-        self.assertEqual(samples.shape, (5, 2))
+        robust_digest = extract_robust_digest(rss, list(rss.parameters))
+        self.assertFalse(robust_digest.multiplicative)
+        samples = robust_digest.distribution_sampler()
+        self.assertEqual(samples.shape, (8, 2))
         # Both are continuous distributions, should be non-zero.
         self.assertTrue(np.all(samples != 0))
         # Check for error if environmental variables are not at the end.
         with self.assertRaisesRegex(RuntimeError, "last entries"):
-            extract_parameter_distribution_samplers(rss, list(rss.parameters)[::-1])
+            extract_robust_digest(rss, list(rss.parameters)[::-1])

--- a/ax/modelbridge/tests/test_one_hot_transform.py
+++ b/ax/modelbridge/tests/test_one_hot_transform.py
@@ -171,6 +171,7 @@ class OneHotTransformTest(TestCase):
         rss = RobustSearchSpace(
             parameters=all_params[2:],
             parameter_distributions=rss.parameter_distributions,
+            num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
         t = OneHot(

--- a/ax/modelbridge/tests/test_remove_fixed_transform.py
+++ b/ax/modelbridge/tests/test_remove_fixed_transform.py
@@ -90,6 +90,7 @@ class RemoveFixedTransformTest(TestCase):
         rss = RobustSearchSpace(
             parameters=all_params[2:],
             parameter_distributions=rss.parameter_distributions,
+            num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
         rss.add_parameter(

--- a/ax/modelbridge/tests/test_task_encode_transform.py
+++ b/ax/modelbridge/tests/test_task_encode_transform.py
@@ -113,6 +113,7 @@ class TaskEncodeTransformTest(TestCase):
         rss = RobustSearchSpace(
             parameters=all_params[2:],
             parameter_distributions=rss.parameter_distributions,
+            num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
         t = TaskEncode(

--- a/ax/modelbridge/tests/test_unit_x_transform.py
+++ b/ax/modelbridge/tests/test_unit_x_transform.py
@@ -199,6 +199,7 @@ class UnitXTransformTest(TestCase):
         rss = RobustSearchSpace(
             parameters=all_parameters[1:],
             parameter_distributions=rss.parameter_distributions[:1],
+            num_samples=rss.num_samples,
             environmental_variables=all_parameters[:1],
         )
         t.transform_search_space(rss)

--- a/ax/modelbridge/transforms/utils.py
+++ b/ax/modelbridge/transforms/utils.py
@@ -118,4 +118,5 @@ def construct_new_search_space(
             new_kwargs["environmental_variables"] = env_vars
             new_kwargs["parameters"] = [p for p in parameters if p not in env_vars]
         new_kwargs["parameter_distributions"] = search_space.parameter_distributions
+        new_kwargs["num_samples"] = search_space.num_samples
     return search_space.__class__(**new_kwargs)

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -645,6 +645,7 @@ def get_robust_search_space(
     ub: float = 5.0,
     multivariate: bool = False,
     use_discrete: bool = False,
+    num_samples: int = 4,  # dummy
 ) -> RobustSearchSpace:
 
     parameters = [
@@ -694,6 +695,7 @@ def get_robust_search_space(
         # pyre-ignore Incompatible parameter type [6]
         parameters=parameters,
         parameter_distributions=distributions,
+        num_samples=num_samples,
     )
 
 

--- a/sphinx/source/core.rst
+++ b/sphinx/source/core.rst
@@ -104,7 +104,7 @@ Core Classes
     :undoc-members:
     :show-inheritance:
 
-Objective
+`Objective`
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.core.objective
@@ -158,6 +158,14 @@ Objective
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.core.parameter_distribution
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`RiskMeasure`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.core.risk_measures
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Summary: Adds a `num_samples` attribute to `RobustSearchSpace`, since it is quite inconvenient to extract it from `RiskMeasure.options` otherwise. Also introduces a `RobustSearchSpaceDigest` container for the robust-only arguments in `SearchSpaceDigest`, and refactors `extract_parameter_distribution_samplers` into `extract_robust_digest`.

Reviewed By: mpolson64

Differential Revision: D35913001

