### PR TITLE
Implement `BestPointMixin.get_trace` and use it in benchmarks

### DIFF
--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.service.utils.best_point_mixin import BestPointMixin
+from ax.utils.common.testutils import TestCase
+from ax.utils.common.typeutils import not_none
+from ax.utils.testing.core_stubs import get_experiment_with_observations
+
+
+class TestBestPointMixin(TestCase):
+    def test_get_trace(self):
+        # Alias for easier access.
+        get_trace = BestPointMixin.get_trace
+
+        # Single objective, minimize.
+        exp = get_experiment_with_observations(
+            observations=[[11], [10], [9], [15], [5]], minimize=True
+        )
+        self.assertEqual(get_trace(exp), [11, 10, 9, 9, 5])
+        # Same experiment with maximize via new optimization config.
+        opt_conf = not_none(exp.optimization_config).clone()
+        opt_conf.objective.minimize = False
+        self.assertEqual(get_trace(exp, opt_conf), [11, 11, 11, 15, 15])
+
+        # Scalarized.
+        exp = get_experiment_with_observations(
+            observations=[[1, 1], [2, 2], [3, 3]],
+            scalarized=True,
+        )
+        self.assertEqual(get_trace(exp), [2, 4, 6])
+
+        # Multi objective.
+        exp = get_experiment_with_observations(
+            observations=[[1, 1], [1, 2], [3, 3], [2, 4], [2, 1]],
+        )
+        self.assertEqual(get_trace(exp), [1, 2, 9, 11, 11])
+
+        # W/ constraints.
+        exp = get_experiment_with_observations(
+            observations=[[1, 1, 1], [1, 2, -1], [3, 3, -1], [2, 4, 1], [2, 1, 1]],
+            constrained=True,
+        )
+        self.assertEqual(get_trace(exp), [1, 1, 1, 8, 8])
+
+        # W/ first objective being minimized.
+        exp = get_experiment_with_observations(
+            observations=[[1, 1], [-1, 2], [3, 3], [-2, 4], [2, 1]], minimize=True
+        )
+        self.assertEqual(get_trace(exp), [0, 2, 2, 8, 8])


### PR DESCRIPTION
Summary:
The current `_get_trace` method we have in `ax/benchmark/benchmark.py` loops over `scheduler.get_hypervolume` or `scheduler.get_best_trial`, which is quite slow due to all the overhead of repeatedly getting and trasforming data it has to go through. This implements a `BestPointMixin.get_trace` method that gathers the experiment data once, parses it, and computes the whole optimization trace in one go.

Timing comparison w/ 2 objectives:
With 100 data points, old approach takes 6.23s, new one takes 230ms.
With 200 data points, old approach takes 29.2s, new one takes 548ms.

While digging through the code, I also noticed that `get_best_raw_objective_point_with_trial_index` was not taking into account feasibility for `ScalarizedObjective`s. Modified the code a bit to fix that as well.

Differential Revision: D36025215

