### PR TITLE
Restrict max_parallelism to 1 for all methods

### DIFF
--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -38,6 +38,7 @@ def get_sobol_botorch_modular_fixed_noise_gp_qnei() -> BenchmarkMethod:
             GenerationStep(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
+                max_parallelism=1,
                 model_kwargs={
                     "surrogate": Surrogate(FixedNoiseGP),
                     "botorch_acqf_class": qNoisyExpectedImprovement,
@@ -78,6 +79,7 @@ def get_sobol_botorch_modular_fixed_noise_gp_qnehvi() -> BenchmarkMethod:
             GenerationStep(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
+                max_parallelism=1,
                 model_kwargs={
                     "surrogate": Surrogate(FixedNoiseGP),
                     "botorch_acqf_class": qNoisyExpectedHypervolumeImprovement,
@@ -96,7 +98,7 @@ def get_sobol_botorch_modular_fixed_noise_gp_qnehvi() -> BenchmarkMethod:
     )
 
 
-def get_sobol_botorch_modular_default():
+def get_sobol_botorch_modular_default() -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name="SOBOL+BOTORCH_MODULAR::default",
         steps=[
@@ -104,6 +106,7 @@ def get_sobol_botorch_modular_default():
             GenerationStep(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
+                max_parallelism=1,
             ),
         ],
     )

--- a/ax/benchmark/methods/saasbo.py
+++ b/ax/benchmark/methods/saasbo.py
@@ -17,6 +17,7 @@ def get_saasbo_default() -> BenchmarkMethod:
             GenerationStep(
                 model=Models.FULLYBAYESIAN,
                 num_trials=-1,
+                max_parallelism=1,
             ),
         ],
     )
@@ -38,6 +39,7 @@ def get_saasbo_moo_default() -> BenchmarkMethod:
             GenerationStep(
                 model=Models.FULLYBAYESIANMOO,
                 num_trials=-1,
+                max_parallelism=1,
             ),
         ],
     )


### PR DESCRIPTION
Summary: Thank you Bernie and David for debugging the supposedly flagging SAASBO performance. Turns out it was running at 10 parallelism (which is way too much for just 30 trials)

Reviewed By: bernardbeckerman

Differential Revision: D36108210

