### PR TITLE
Pass bounds to optimize_acqf in Alebo

### DIFF
--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -521,7 +521,7 @@ def alebo_acqf_optimizer(
             # Optimize the acquisition function, separately for each random restart.
             candidate, acq_value = optimize_acqf(
                 acq_function=acq_function,
-                bounds=[None, None],  # pyre-ignore
+                bounds=torch.tensor([[-1.0], [1.0]]).to(Yinit).expand(2, Yinit.shape[-1]),
                 q=1,
                 num_restarts=num_restarts,
                 raw_samples=0,


### PR DESCRIPTION
Addresses part of #953. The main issue here is that the unit tests are fully mocking optimize_acqf and so the recent added validation of the bounds didn't trigger any failures. This should be reworked to actually run a couple of optimization steps so thithings are tested e2e.