### PR TITLE
Fix issue with calling reversed on a dict_values in py3.7

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -451,7 +451,7 @@ class ModelBridge(ABC):
         observation_data = self._predict(observation_features)
 
         # Apply reverse transforms, in reverse order
-        for t in reversed(self.transforms.values()):  # noqa T484
+        for t in reversed(list(self.transforms.values())):
             observation_features = t.untransform_observation_features(
                 observation_features
             )
@@ -682,7 +682,7 @@ class ModelBridge(ABC):
         observation_features = gen_results.observation_features
         best_obsf = gen_results.best_observation_features
         # Apply reverse transforms
-        for t in reversed(self.transforms.values()):  # noqa T484
+        for t in reversed(list(self.transforms.values())):
             observation_features = t.untransform_observation_features(
                 observation_features
             )
@@ -797,7 +797,7 @@ class ModelBridge(ABC):
             cv_test_points=cv_test_points,
         )
         # Apply reverse transforms, in reverse order
-        for t in reversed(self.transforms.values()):
+        for t in reversed(list(self.transforms.values())):
             cv_test_points = t.untransform_observation_features(cv_test_points)
             cv_predictions = t.untransform_observation_data(
                 cv_predictions, cv_test_points

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -506,7 +506,7 @@ def transform_callback(
             )
         ]
         # reverse loop through the transforms and do untransform
-        for t in reversed(transforms.values()):
+        for t in reversed(list(transforms.values())):
             observation_features = t.untransform_observation_features(
                 observation_features
             )
@@ -789,7 +789,7 @@ def get_pareto_frontier_and_configs(
 
     if use_model_predictions:
         # Untransform observations
-        for t in reversed(modelbridge.transforms.values()):  # noqa T484
+        for t in reversed(list(modelbridge.transforms.values())):
             frontier_observation_data = t.untransform_observation_data(
                 frontier_observation_data, []
             )

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -260,7 +260,7 @@ class TorchModelBridge(ModelBridge):
             parameters={p: float(xbest[i]) for i, p in enumerate(self.parameters)}
         )
 
-        for t in reversed(self.transforms.values()):  # noqa T484
+        for t in reversed(list(self.transforms.values())):
             best_obsf = t.untransform_observation_features([best_obsf])[0]
 
         best_point_predictions = extract_arm_predictions(
@@ -760,7 +760,7 @@ class TorchModelBridge(ModelBridge):
         ]
 
         # Untransform ObjectiveThresholds along with the dummy ObservationFeatures.
-        for t in reversed(self.transforms.values()):
+        for t in reversed(list(self.transforms.values())):
             thresholds = t.untransform_objective_thresholds(
                 objective_thresholds=thresholds,
                 observation_features=observation_features,


### PR DESCRIPTION
This will work in py3.8. Not sure why this didn't cause issues in the past.