### PR TITLE
Bump black version to 22.3.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install dependencies
       # Pin ufmt deps so they match intermal pyfmt.
       run: |
-        pip install black==21.4b2
+        pip install black==22.3.0
         pip install usort==0.6.4
         pip install libcst==0.3.19
         pip install ufmt

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIRES = [
 # pytest-cov requires pytest >= 3.6
 DEV_REQUIRES = [
     "beautifulsoup4",
-    "black",
+    "black==22.3.0",
     "flake8",
     "hypothesis",
     "Jinja2",


### PR DESCRIPTION
fd6f5220aa5180a9007ed9cc3cdab585856bb000 introduced black 22.3.0 formatting and with that lint failures, this bumps black to that version.