### PR TITLE
PairwiseModelBridge for PL in Ax using RankingDataset

### DIFF
--- a/ax/modelbridge/pairwise.py
+++ b/ax/modelbridge/pairwise.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.types import TCandidateMetadata
+from ax.modelbridge.modelbridge_utils import detect_duplicates
+from ax.modelbridge.torch import TorchModelBridge
+from botorch.utils.containers import SliceContainer
+from botorch.utils.datasets import RankingDataset, SupervisedDataset
+from torch import Tensor
+
+
+class PairwiseModelBridge(TorchModelBridge):
+    def _convert_observations(
+        self,
+        observation_data: List[ObservationData],
+        observation_features: List[ObservationFeatures],
+        outcomes: List[str],
+        parameters: List[str],
+    ) -> Tuple[
+        List[Optional[SupervisedDataset]], Optional[List[List[TCandidateMetadata]]]
+    ]:
+        """Converts observations to a dictionary of `Dataset` containers and (optional)
+        candidate metadata.
+        """
+        if len(observation_features) != len(observation_data):
+            raise ValueError("Observation features and data must have the same length!")
+        ordered_idx = np.argsort([od.trial_index for od in observation_features])
+        observation_features = [observation_features[i] for i in ordered_idx]
+        observation_data = [observation_data[i] for i in ordered_idx]
+
+        (
+            Xs,
+            Ys,
+            Yvars,
+            candidate_metadata_dict,
+            any_candidate_metadata_is_not_none,
+        ) = self._extract_observation_data(
+            observation_data, observation_features, parameters
+        )
+
+        datasets: List[Optional[SupervisedDataset]] = []
+        candidate_metadata = []
+        for outcome in outcomes:
+            X = torch.stack(Xs[outcome], dim=0)
+            Y = torch.tensor(Ys[outcome], dtype=torch.long).unsqueeze(-1)
+
+            # Update Xs and Ys shapes for PairwiseGP
+            Y = _binary_pref_to_comp_pair(Y=Y)
+            X, Y = _consolidate_comparisons(X=X, Y=Y)
+
+            datapoints, comparisons = X, Y.long()
+            event_shape = torch.Size([2 * datapoints.shape[-1]])
+            dataset_X = SliceContainer(datapoints, comparisons, event_shape=event_shape)
+            dataset_Y = torch.tensor([[0, 1]]).expand(comparisons.shape)
+            dataset = RankingDataset(X=dataset_X, Y=dataset_Y)
+
+            datasets.append(dataset)
+            candidate_metadata.append(candidate_metadata_dict[outcome])
+
+        if not any_candidate_metadata_is_not_none:
+            return datasets, None
+
+        return datasets, candidate_metadata
+
+
+def _binary_pref_to_comp_pair(Y: Tensor) -> Tensor:
+    """Convert Y from binary indicator pair to index pair comparisons
+
+    Convert Y from binary indicator pair such as [[0, 1], [1, 0], ...]
+    to index comparisons like [[1, 0], [2, 3], ...]
+    """
+    Y_shape = Y.shape[:-2] + (-1, 2)
+    Y = Y.reshape(Y_shape)
+
+    _validate_Y_values(Y)
+
+    idx_shift = (torch.arange(0, Y.shape[-2]) * 2).unsqueeze(-1).expand_as(Y)
+    comparison_pairs = idx_shift + (1 - Y)
+    return comparison_pairs
+
+
+def _consolidate_comparisons(X: Tensor, Y: Tensor) -> Tuple[Tensor, Tensor]:
+    """Drop duplicated Xs and update the indices in Ys accordingly"""
+    if len(X.shape) != 2:
+        raise ValueError("X must have 2 dimensions.")
+    if len(Y.shape) != 2:
+        raise ValueError("Y must have 2 dimensions.")
+    if Y.shape[-1] != 2:
+        raise ValueError(
+            "The last dimension of Y must contain 2 elements "
+            "representing the pairwise comparison."
+        )
+
+    n = X.shape[-2]
+    dupplicates = list(detect_duplicates(X=X))
+    if len(dupplicates) != 0:
+        dup_indices, kept_indices = zip(*dupplicates)
+        unique_indices = set(range(n)) - set(dup_indices)
+
+        # After dropping the duplicates,
+        # the kept ones' indices may also change by being shifted up
+        new_idx_map = dict(zip(unique_indices, range(len(unique_indices))))
+        new_indices_for_dup = (new_idx_map[idx] for idx in kept_indices)
+        new_idx_map.update(dict(zip(dup_indices, new_indices_for_dup)))
+
+        consolidated_X = X[list(unique_indices), :]
+        consolidated_Y = torch.tensor(
+            [(new_idx_map[y1.item()], new_idx_map[y2.item()]) for y1, y2 in Y],
+            dtype=torch.long,
+        )
+        return consolidated_X, consolidated_Y
+    else:
+        return X, Y
+
+
+def _validate_Y_values(Y: Tensor) -> None:
+    """Check if Ys have valid values"""
+    # Y must have even number of elements
+    if Y.shape[-1] != 2:
+        raise ValueError(
+            f"Trailing dimension of `Y` should be size 2 but is {Y.shape[-1]}"
+        )
+
+    # all adjacent pairs must have exactly a 0 and a 1
+    if not (Y.min(dim=-1).values.eq(0).all() and Y.max(dim=-1).values.eq(1).all()):
+        raise ValueError("`Y` values must be `{0, 1}.`")

--- a/ax/modelbridge/tests/test_pairwise_modelbridge.py
+++ b/ax/modelbridge/tests/test_pairwise_modelbridge.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import mock
+
+import numpy as np
+import torch
+from ax.core.observation import ObservationData, ObservationFeatures
+from ax.modelbridge.base import ModelBridge
+from ax.modelbridge.pairwise import (
+    _binary_pref_to_comp_pair,
+    _consolidate_comparisons,
+    PairwiseModelBridge,
+)
+from ax.utils.common.testutils import TestCase
+from botorch.utils.datasets import RankingDataset
+
+
+class PairwiseModelBridgeTest(TestCase):
+    @mock.patch(
+        f"{ModelBridge.__module__}.ModelBridge.__init__",
+        autospec=True,
+        return_value=None,
+    )
+    def testPairwiseModelBridge(self, mock_init):
+        # Test _convert_observations
+        pmb = PairwiseModelBridge(
+            experiment=None,
+            search_space=None,
+            data=None,
+            model=None,
+            transforms=[],
+            torch_dtype=None,
+            torch_device=None,
+        )
+
+        observation_data = [
+            ObservationData(
+                metric_names=["pairwise_pref_query"],
+                means=np.array([0]),
+                covariance=np.array([[np.nan]]),
+            ),
+            ObservationData(
+                metric_names=["pairwise_pref_query"],
+                means=np.array([1]),
+                covariance=np.array([[np.nan]]),
+            ),
+        ]
+        observation_features = [
+            ObservationFeatures(parameters={"y1": 0.1, "y2": 0.2}, trial_index=0),
+            ObservationFeatures(parameters={"y1": 0.3, "y2": 0.4}, trial_index=0),
+        ]
+        observation_features_with_metadata = [
+            ObservationFeatures(parameters={"y1": 0.1, "y2": 0.2}, trial_index=0),
+            ObservationFeatures(
+                parameters={"y1": 0.3, "y2": 0.4},
+                trial_index=0,
+                metadata={"metadata_key": "metadata_val"},
+            ),
+        ]
+        parameters = ["y1", "y2"]
+        outcomes = ["pairwise_pref_query"]
+
+        datasets, candidate_metadata = pmb._convert_observations(
+            observation_data=observation_data,
+            observation_features=observation_features,
+            outcomes=outcomes,
+            parameters=parameters,
+        )
+        self.assertTrue(len(datasets) == 1)
+        self.assertTrue(isinstance(datasets[0], RankingDataset))
+        self.assertTrue(candidate_metadata is None)
+
+        datasets, candidate_metadata = pmb._convert_observations(
+            observation_data=observation_data,
+            observation_features=observation_features_with_metadata,
+            outcomes=outcomes,
+            parameters=parameters,
+        )
+        self.assertTrue(len(datasets) == 1)
+        self.assertTrue(isinstance(datasets[0], RankingDataset))
+        self.assertTrue(candidate_metadata is not None)
+
+        # Test individual helper methods
+        X = torch.tensor(
+            [[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [1.0, 2.0, 3.0], [2.1, 3.1, 4.1]]
+        )
+        Y = torch.tensor([[1, 0, 0, 1]])
+        expected_X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [2.1, 3.1, 4.1]])
+        ordered_Y = torch.tensor([[0, 1], [3, 2]])
+        expected_Y = torch.tensor([[0, 1], [2, 0]])
+
+        # `_binary_pref_to_comp_pair`.
+        comp_pair_Y = _binary_pref_to_comp_pair(Y=Y)
+        self.assertTrue(torch.equal(comp_pair_Y, ordered_Y))
+
+        # test `_binary_pref_to_comp_pair` with invalid data
+        bad_Y = torch.tensor([[1, 1, 0, 0]])
+        with self.assertRaises(ValueError):
+            _binary_pref_to_comp_pair(Y=bad_Y)
+
+        # `_consolidate_comparisons`.
+        consolidated_X, consolidated_Y = _consolidate_comparisons(X=X, Y=comp_pair_Y)
+        self.assertTrue(torch.equal(consolidated_X, expected_X))
+        self.assertTrue(torch.equal(consolidated_Y, expected_Y))

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -282,32 +282,17 @@ class TorchModelBridge(ModelBridge):
         """Converts observations to a dictionary of `Dataset` containers and (optional)
         candidate metadata.
         """
-        Xs: Dict[str, List[Tensor]] = defaultdict(list)
-        Ys: Dict[str, List[np.ndarray]] = defaultdict(list)
-        Yvars: Dict[str, List[np.ndarray]] = defaultdict(list)
+        (
+            Xs,
+            Ys,
+            Yvars,
+            candidate_metadata_dict,
+            any_candidate_metadata_is_not_none,
+        ) = self._extract_observation_data(
+            observation_data, observation_features, parameters
+        )
+
         datasets: List[Optional[SupervisedDataset]] = []
-        candidate_metadata_dict: Dict[str, List[TCandidateMetadata]] = defaultdict(list)
-        any_candidate_metadata_is_not_none = False
-
-        for obsd, obsf in zip(observation_data, observation_features):
-            try:
-                x = torch.tensor(
-                    [obsf.parameters[p] for p in parameters],
-                    dtype=self.dtype,
-                    device=self.device,
-                )
-            except (KeyError, TypeError):
-                raise ValueError("Out of design points cannot be converted.")
-            for metric_name, mean, var in zip(
-                obsd.metric_names, obsd.means, obsd.covariance.diagonal()
-            ):
-                Xs[metric_name].append(x)
-                Ys[metric_name].append(mean)
-                Yvars[metric_name].append(var)
-                if obsf.metadata is not None:
-                    any_candidate_metadata_is_not_none = True
-                candidate_metadata_dict[metric_name].append(obsf.metadata)
-
         candidate_metadata = []
         for outcome in outcomes:
             if outcome not in Xs:
@@ -806,6 +791,45 @@ class TorchModelBridge(ModelBridge):
                 "or data being excluded because it is out-of-design. Try setting "
                 "`fit_out_of_design`=True during construction to fix the latter."
             )
+
+    def _extract_observation_data(
+        self,
+        observation_data: List[ObservationData],
+        observation_features: List[ObservationFeatures],
+        parameters: List[str],
+    ) -> Tuple[Dict, Dict, Dict, Dict, bool]:
+        Xs: Dict[str, List[Tensor]] = defaultdict(list)
+        Ys: Dict[str, List[Tensor]] = defaultdict(list)
+        Yvars: Dict[str, List[Tensor]] = defaultdict(list)
+        candidate_metadata_dict: Dict[str, List[TCandidateMetadata]] = defaultdict(list)
+        any_candidate_metadata_is_not_none = False
+
+        for obsd, obsf in zip(observation_data, observation_features):
+            try:
+                x = torch.tensor(
+                    [obsf.parameters[p] for p in parameters],
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+            except (KeyError, TypeError):
+                raise ValueError("Out of design points cannot be converted.")
+            for metric_name, mean, var in zip(
+                obsd.metric_names, obsd.means, obsd.covariance.diagonal()
+            ):
+                Xs[metric_name].append(x)
+                Ys[metric_name].append(mean)
+                Yvars[metric_name].append(var)
+                if obsf.metadata is not None:
+                    any_candidate_metadata_is_not_none = True
+                candidate_metadata_dict[metric_name].append(obsf.metadata)
+
+        return (
+            Xs,
+            Ys,
+            Yvars,
+            candidate_metadata_dict,
+            any_candidate_metadata_is_not_none,
+        )
 
 
 def validate_optimization_config(

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -31,9 +31,10 @@ from ax.utils.common.typeutils import checked_cast, checked_cast_optional, not_n
 from botorch.fit import fit_fully_bayesian_model_nuts, fit_gpytorch_model
 from botorch.models import SaasFullyBayesianSingleTaskGP
 from botorch.models.model import Model
+from botorch.models.pairwise_gp import PairwiseGP
 from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
-from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
+from botorch.utils.datasets import FixedNoiseDataset, RankingDataset, SupervisedDataset
 from gpytorch.kernels import Kernel
 from gpytorch.likelihoods.likelihood import Likelihood
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
@@ -147,7 +148,12 @@ class Surrogate(Base):
         training_data = self.training_data
         Xs = []
         for dataset in training_data:
-            Xi = dataset.X()
+            if self.botorch_model_class == PairwiseGP and isinstance(
+                dataset, RankingDataset
+            ):
+                Xi = dataset.X.values
+            else:
+                Xi = dataset.X()
             for _ in range(dataset.Y.shape[-1]):
                 Xs.append(Xi)
         return Xs

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -82,6 +82,15 @@ Torch Model Bridge
     :undoc-members:
     :show-inheritance:
 
+
+Pairwise Model Bridge
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.pairwise
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Utilities
 ---------------
 


### PR DESCRIPTION
Summary:
Added `PairwiseModelBridge` and updated `PairwiseGP` to support preference learning in Ax using the newly added `RankingDataset`.
We expect to receive experiments with batch trials consisting of 2 arms each with one outcome metric. That metric being 1 indicates the arm is preferred among the two arms within the batch trial and 0 otherwise.

Differential Revision: D33913421

