### PR TITLE
De-duplicate best point utilities in MBM

### DIFF
--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -26,10 +26,8 @@ from ax.models.torch.utils import (
     subset_model,
 )
 from ax.models.torch_base import TorchOptConfig
-from ax.models.types import TConfig
 from ax.utils.common.base import Base
 from ax.utils.common.constants import Keys
-from ax.utils.common.docutils import copy_doc
 from ax.utils.common.typeutils import not_none
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.input_constructors import get_acqf_input_constructor
@@ -377,19 +375,6 @@ class Acquisition(Base):
         # NOTE: `AcquisitionFunction.__call__` calls `forward`,
         # so below is equivalent to `self.acqf.forward(X=X)`.
         return self.acqf(X=X)
-
-    @copy_doc(Surrogate.best_in_sample_point)
-    def best_point(
-        self,
-        search_space_digest: SearchSpaceDigest,
-        torch_opt_config: TorchOptConfig,
-        options: Optional[TConfig] = None,
-    ) -> Tuple[Tensor, float]:
-        return self.surrogate.best_in_sample_point(
-            search_space_digest=search_space_digest,
-            torch_opt_config=torch_opt_config,
-            options=options,
-        )
 
     def compute_model_dependencies(
         self,

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -356,7 +356,10 @@ class Surrogate(Base):
         if best_point_and_observed_value is None:
             raise ValueError("Could not obtain best in-sample point.")
         best_point, observed_value = best_point_and_observed_value
-        return checked_cast(Tensor, best_point), observed_value
+        return (
+            best_point.to(dtype=self.dtype, device=torch.device("cpu")),
+            observed_value,
+        )
 
     def best_out_of_sample_point(
         self,

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -438,20 +438,6 @@ class AcquisitionTest(TestCase):
             )
         )
 
-    @mock.patch(f"{SURROGATE_PATH}.Surrogate.best_in_sample_point")
-    def test_best_point(self, mock_best_point):
-        acquisition = self.get_acquisition_function(self.fixed_features)
-        acquisition.best_point(
-            search_space_digest=self.search_space_digest,
-            torch_opt_config=self.torch_opt_config,
-            options=self.options,
-        )
-        mock_best_point.assert_called_with(
-            search_space_digest=self.search_space_digest,
-            torch_opt_config=self.torch_opt_config,
-            options=self.options,
-        )
-
     @mock.patch(
         f"{DummyAcquisitionFunction.__module__}.DummyAcquisitionFunction.__call__",
         return_value=None,

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -471,7 +471,7 @@ class BoTorchModelTest(TestCase):
                 torch_opt_config=self.torch_opt_config,
             )
         )
-        with mock.patch(f"{MODEL_PATH}.best_observed_point", return_value=None):
+        with mock.patch(f"{SURROGATE_PATH}.best_in_sample_point", return_value=None):
             self.assertIsNone(
                 self.model.best_point(
                     search_space_digest=self.mf_search_space_digest,


### PR DESCRIPTION
Summary: We currently have three best (observed) point utilities in MBM, each leading to the same utility under the hood. This removes `Acquisition.best_point` and modifies `BoTorchModel.best_point` to use `Surrogate.best_in_sample_point`.

Reviewed By: mpolson64

Differential Revision: D36482056

