### PR TITLE
Remove `objective_thresholds` argument from `TorchModelBridge` and factory functions

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import BatchTrial
+from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
@@ -69,6 +70,21 @@ logger = get_logger(__name__)
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
     from ax import modelbridge as modelbridge_module  # noqa F401  # pragma: no cover
+
+
+def check_has_multi_objective_and_data(
+    experiment: Experiment,
+    data: Data,
+    optimization_config: Optional[OptimizationConfig] = None,
+) -> None:
+    """Raise an error if not using a `MultiObjective` or if the data is empty."""
+    optimization_config = not_none(
+        optimization_config or experiment.optimization_config
+    )
+    if not isinstance(optimization_config.objective, MultiObjective):
+        raise ValueError("Multi-objective optimization requires multiple objectives.")
+    if data.df.empty:
+        raise ValueError("MultiObjectiveOptimization requires non-empty data.")
 
 
 def extract_parameter_constraints(

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -133,7 +133,6 @@ class ModelRegistryTest(TestCase):
                 "transforms": Cont_X_trans + Y_trans,
                 "fit_out_of_design": False,
                 "default_model_gen_options": None,
-                "objective_thresholds": None,
             },
         )
         gpei = Models.GPEI(
@@ -428,11 +427,14 @@ class ModelRegistryTest(TestCase):
             parameters=multi_obj_exp.trials[0].status_quo.parameters,
             trial_index=0,
         )
+        optimization_config = multi_obj_exp.optimization_config.clone_with_args(
+            objective_thresholds=multi_objective_thresholds
+        )
         mtgp = Models.ST_MTGP_NEHVI(
             experiment=multi_obj_exp,
             data=multi_obj_exp.fetch_data(),
             status_quo_features=status_quo_features,
-            objective_thresholds=multi_objective_thresholds,
+            optimization_config=optimization_config,
         )
         self.assertIsInstance(mtgp, TorchModelBridge)
         self.assertIsInstance(mtgp.model, MultiObjectiveBotorchModel)

--- a/ax/modelbridge/tests/test_torch_modelbridge_moo.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge_moo.py
@@ -173,7 +173,6 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             transforms=[t1, t2],
             experiment=exp,
             data=exp.fetch_data(),
-            objective_thresholds=objective_thresholds,
         )
         with patch(
             PARETO_FRONTIER_EVALUATOR_PATH, wraps=pareto_frontier_evaluator
@@ -332,7 +331,6 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
                 experiment=exp,
                 data=exp.fetch_data(),
                 torch_device=torch.device("cuda" if cuda else "cpu"),
-                objective_thresholds=objective_thresholds,
             )
             with patch(
                 PARETO_FRONTIER_EVALUATOR_PATH, wraps=pareto_frontier_evaluator

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -21,7 +21,6 @@ from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
-    TRefPoint,
 )
 from ax.core.outcome_constraint import (
     ComparisonOp,
@@ -96,7 +95,6 @@ class TorchModelBridge(ModelBridge):
         status_quo_features: Optional[ObservationFeatures] = None,
         optimization_config: Optional[OptimizationConfig] = None,
         fit_out_of_design: bool = False,
-        objective_thresholds: Optional[TRefPoint] = None,
         default_model_gen_options: Optional[TConfig] = None,
     ) -> None:
         self.dtype = torch.double if torch_dtype is None else torch_dtype
@@ -110,18 +108,6 @@ class TorchModelBridge(ModelBridge):
                 optimization_config or experiment.optimization_config
             )
             self.is_moo_problem = optimization_config.is_moo_problem
-        if objective_thresholds:
-            if not self.is_moo_problem:
-                raise ValueError(
-                    "objective_thresholds are only supported for multi objective "
-                    "optimization."
-                )
-            optimization_config = checked_cast(
-                MultiObjectiveOptimizationConfig, optimization_config
-            )
-            optimization_config = optimization_config.clone_with_args(
-                objective_thresholds=objective_thresholds
-            )
 
         super().__init__(
             experiment=experiment,


### PR DESCRIPTION
Summary:
Removes `objective_threshold` argument from `TorchModelBridge`. In current design, this is a duplicate argument since it can be supplied via `optimization_config`. Also cleans up its usage within the factory functions. I made sure to include `optimization_config` as an argument where `objective_threshold` was previously accepted to make sure anyone that was using this to change things between generation steps can still do.

This also consolidates some common error handling in these factory functions into a small utility function.

Reviewed By: lena-kashtelyan

Differential Revision: D36483947

