### PR TITLE
Update readme with https instead of ssh github install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ We recommend installing Ax via pip (even if using Conda environment):
 
 ```
 conda install pytorch torchvision -c pytorch  # OSX only (details below)
-pip3 install ax-platform
+pip install ax-platform
 ```
 
 Installation will use Python wheels from PyPI, available for [OSX, Linux, and Windows](https://pypi.org/project/ax-platform/#files).
 
-*Note*: Make sure the `pip3` being used to install `ax-platform` is actually the one from the newly created Conda environment.
-If you're using a Unix-based OS, you can use `which pip3` to check.
+*Note*: Make sure the `pip` being used to install `ax-platform` is actually the one from the newly created Conda environment.
+If you're using a Unix-based OS, you can use `which pip` to check.
 
 *Recommendation for MacOS users*: PyTorch is a required dependency of BoTorch, and can be automatically installed via pip.
 However, **we recommend you [install PyTorch manually](https://pytorch.org/get-started/locally/#anaconda-1) before installing Ax, using the Anaconda package manager**.
@@ -100,12 +100,12 @@ If you need CUDA on MacOS, you will need to build PyTorch from source. Please co
 
 To use Ax with a notebook environment, you will need Jupyter. Install it first:
 ```
-pip3 install jupyter
+pip install jupyter
 ```
 
 If you want to store the experiments in MySQL, you will need SQLAlchemy:
 ```
-pip3 install SQLAlchemy
+pip install SQLAlchemy
 ```
 
 ### Latest Version
@@ -122,8 +122,8 @@ See recommendation for installing PyTorch for MacOS users above.
 
 At times, the bleeding edge for Ax can depend on bleeding edge versions of BoTorch (or GPyTorch). We therefore recommend installing those from Git as well:
 ```
-pip3 install git+https://github.com/cornellius-gp/gpytorch.git
-pip3 install git+https://github.com/pytorch/botorch.git
+pip install git+https://github.com/cornellius-gp/gpytorch.git
+pip install git+https://github.com/pytorch/botorch.git
 ```
 
 #### Optional Dependencies
@@ -161,12 +161,12 @@ When contributing to Ax, we recommend cloning the [repository](https://github.co
 
 ```
 # bleeding edge versions of GPyTorch + BoTorch are recommended
-pip3 install git+https://github.com/cornellius-gp/gpytorch.git
-pip3 install git+https://github.com/pytorch/botorch.git
+pip install git+https://github.com/cornellius-gp/gpytorch.git
+pip install git+https://github.com/pytorch/botorch.git
 
 git clone https://github.com/facebook/ax.git --depth 1
 cd ax
-pip3 install -e .[notebook,mysql,dev]
+pip install -e .[notebook,mysql,dev]
 ```
 
 See recommendation for installing PyTorch for MacOS users above.


### PR DESCRIPTION
This caused some confusion for users in #984.
This PR also renames `pip3` -> `pip`, since we've long been living in a post-py2 world for long enough.