### PR TITLE
Fix MBM best point bug, raise NotImplementedError when best point is used with MOO

### DIFF
--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -299,6 +299,7 @@ class TorchModelBridgeTest(TestCase):
         )
         self.assertEqual(gen_opt_config.model_gen_options, {"option": "yes"})
         self.assertIs(gen_opt_config.rounding_func, torch.round)
+        self.assertFalse(gen_opt_config.is_moo)
         self.assertEqual(gen_args["search_space_digest"].target_fidelities, {})
         self.assertEqual(len(gen_run.arms), 1)
         self.assertEqual(gen_run.arms[0].parameters, {"x1": 1.0, "x2": 2.0, "x3": 3.0})

--- a/ax/modelbridge/tests/test_torch_modelbridge_moo.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge_moo.py
@@ -604,3 +604,22 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             transforms=[],
         )
         self.assertEqual(bridge.status_quo.arm_name, "status_quo")
+
+    def test_best_point(self):
+        exp = get_branin_experiment_with_multi_objective(
+            has_optimization_config=True, with_batch=True
+        )
+        for trial in exp.trials.values():
+            trial.mark_running(no_runner_required=True).mark_completed()
+        exp.attach_data(
+            get_branin_data_multi_objective(trial_indices=exp.trials.keys())
+        )
+        bridge = TorchModelBridge(
+            search_space=exp.search_space,
+            model=MultiObjectiveBotorchModel(),
+            optimization_config=exp.optimization_config,
+            transforms=[],
+            experiment=exp,
+            data=exp.fetch_data(),
+        )
+        self.assertIsNone(bridge.model_best_point())

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -675,6 +675,7 @@ class TorchModelBridge(ModelBridge):
             model_gen_options=model_gen_options or {},
             rounding_func=rounding_func,
             opt_config_metrics=opt_config_metrics,
+            is_moo=optimization_config.is_moo_problem,
         )
         return search_space_digest, torch_opt_config
 

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -153,7 +153,13 @@ class BotorchMOOModelTest(TestCase):
                 "optimizer_kwargs": _get_optimizer_kwargs(),
                 "subset_model": False,
             },
+            is_moo=True,
         )
+        with self.assertRaisesRegex(NotImplementedError, "Best observed"):
+            model.best_point(
+                search_space_digest=search_space_digest,
+                torch_opt_config=torch_opt_config,
+            )
         with mock.patch(
             SAMPLE_SIMPLEX_UTIL_PATH,
             autospec=True,

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -413,6 +413,10 @@ class BotorchModel(TorchModel):
         search_space_digest: SearchSpaceDigest,
         torch_opt_config: TorchOptConfig,
     ) -> Optional[Tensor]:
+        if torch_opt_config.is_moo:
+            raise NotImplementedError(
+                "Best observed point is incompatible with MOO problems."
+            )
         return self.best_point_recommender(  # pyre-ignore [28]
             model=self,
             bounds=search_space_digest.bounds,

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -344,8 +344,12 @@ class Surrogate(Base):
         """Finds the best observed point and the corresponding observed outcome
         values.
         """
+        if torch_opt_config.is_moo:
+            raise NotImplementedError(
+                "Best observed point is incompatible with MOO problems."
+            )
         best_point_and_observed_value = best_in_sample_point(
-            Xs=[self.training_data[0].X()],  # NOTE: This assumes a "block design"
+            Xs=self.Xs,
             # pyre-ignore[6]: `best_in_sample_point` currently expects a `TorchModel`
             # as `model` kwarg, but only uses them for `predict` function, the
             # signature for which is the same on this `Surrogate`.

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -478,6 +478,13 @@ class BoTorchModelTest(TestCase):
                     torch_opt_config=self.torch_opt_config,
                 )
             )
+        with self.assertRaisesRegex(NotImplementedError, "Best observed"):
+            self.model.best_point(
+                search_space_digest=self.mf_search_space_digest,
+                torch_opt_config=dataclasses.replace(
+                    self.torch_opt_config, is_moo=True
+                ),
+            )
 
     @mock.patch(
         f"{MODEL_PATH}.construct_acquisition_and_optimizer_options",

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -27,7 +27,9 @@ class TorchOptConfig:
     an ephemeral object and not meant to be stored / serialized.
 
     Attributes:
-        objective_weights: The objective is to maximize a weighted sum of
+        objective_weights: If doing multi-objective optimization, these denote
+            which objectives should be maximized and which should be minimized.
+            Otherwise, the objective is to maximize a weighted sum of
             the columns of f(x). These are the weights.
         outcome_constraints: A tuple of (A, b). For k outcome constraints
             and m outputs at f(x), A is (k x m) and b is (k x 1) such that
@@ -49,6 +51,7 @@ class TorchOptConfig:
             appropriately (i.e., according to `round-trip` transformations).
         opt_config_metrics: A dictionary of metrics that are included in
             the optimization config.
+        is_moo: A boolean denoting whether this is for an MOO problem.
     """
 
     objective_weights: Tensor
@@ -60,6 +63,7 @@ class TorchOptConfig:
     model_gen_options: TConfig = field(default_factory=dict)
     rounding_func: Optional[Callable[[Tensor], Tensor]] = None
     opt_config_metrics: Optional[Dict[str, Metric]] = None
+    is_moo: bool = False
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Summary: See title. Also adds an `is_moo` field to `TorchOptConfig`.

Reviewed By: mpolson64

Differential Revision: D36874319

