### PR TITLE
fix ListSurrogate.construct for constructing MTGP

### DIFF
--- a/ax/models/torch/botorch_modular/list_surrogate.py
+++ b/ax/models/torch/botorch_modular/list_surrogate.py
@@ -126,6 +126,21 @@ class ListSurrogate(Surrogate):
         """
         fidelity_features = kwargs.get(Keys.FIDELITY_FEATURES, [])
         task_features = kwargs.get(Keys.TASK_FEATURES, [])
+
+        if len(fidelity_features) > 0 and len(task_features) > 0:
+            raise NotImplementedError(
+                "Multi-Fidelity GP models with task_features are "
+                "currently not supported."
+            )
+        # TODO: Allow each metric having different task_features or fidelity_features
+        # TODO: Need upstream change in the modelbrdige
+        if len(task_features) > 1:
+            raise NotImplementedError("This model only supports 1 task feature!")
+        elif len(task_features) == 1:
+            task_feature = task_features[0]
+        else:
+            task_feature = None
+
         self._training_data = datasets
 
         submodels = []
@@ -152,7 +167,7 @@ class ListSurrogate(Surrogate):
             formatted_model_inputs = model_cls.construct_inputs(
                 training_data=dataset,
                 fidelity_features=fidelity_features,
-                task_features=task_features,
+                task_feature=task_feature,
                 **submodel_options,
             )
             # Add input / outcome transforms.


### PR DESCRIPTION
Summary:
We see an error in CV when using ListSurrogate (a list of MTGP) in Models.BOTORCH_MODULAR. See N2054031 for the full error trace.

The error happens when loading state_dict. The reason is that a wrong task_feature is passed to MTGP (use default value = 0) and thus, the task_covar_module has a wrong shape.

The proposed the fix is
1.  ListSurrogate.construct. Pass task_feature to contruct MTGP. Also add checks to make sure that len(task_features) = 1
2. Make task_feature as required input in the MultiTaskGP.construct_inputs

Differential Revision: D36925653

