### PR TITLE
Update handling of seeds for benchmark runs

### DIFF
--- a/ax/benchmark/benchmark_result.py
+++ b/ax/benchmark/benchmark_result.py
@@ -27,6 +27,7 @@ class BenchmarkResult(Base):
     """
 
     name: str
+    seed: int
     experiment: Experiment
 
     # Tracks best point if single-objective problem, max hypervolume if MOO

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -23,7 +23,7 @@ class TestBenchmark(TestCase):
     def test_replication_synthetic(self):
         method = get_sobol_benchmark_method()
         res = benchmark_replication(
-            problem=get_single_objective_benchmark_problem(), method=method
+            problem=get_single_objective_benchmark_problem(), method=method, seed=0
         )
 
         self.assertEqual(
@@ -37,7 +37,7 @@ class TestBenchmark(TestCase):
         method = get_sobol_benchmark_method()
 
         res = benchmark_replication(
-            problem=get_multi_objective_benchmark_problem(), method=method
+            problem=get_multi_objective_benchmark_problem(), method=method, seed=0
         )
 
         self.assertEqual(
@@ -55,7 +55,7 @@ class TestBenchmark(TestCase):
         agg = benchmark_test(
             problem=get_single_objective_benchmark_problem(),
             method=get_sobol_benchmark_method(),
-            num_replications=2,
+            seeds=(0, 1),
         )
 
         self.assertEqual(len(agg.results), 2)
@@ -72,7 +72,7 @@ class TestBenchmark(TestCase):
         aggs = benchmark_full_run(
             problems=[get_single_objective_benchmark_problem()],
             methods=[get_sobol_benchmark_method(), get_sobol_gpei_benchmark_method()],
-            num_replications=2,
+            seeds=(0, 1),
         )
 
         self.assertEqual(len(aggs), 2)

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -91,7 +91,8 @@ def get_benchmark_result() -> BenchmarkResult:
     problem = get_single_objective_benchmark_problem()
 
     return BenchmarkResult(
-        name="test_benchmrking_result",
+        name="test_benchmarking_result",
+        seed=0,
         experiment=Experiment(
             name="test_benchmarking_experiment",
             search_space=problem.search_space,


### PR DESCRIPTION
Summary: Replace interally generated seeds with user generated ones and add `seed` to `BenchmarkResult`

Reviewed By: mpolson64

Differential Revision: D37043698

