### PR TITLE
Fix fit_botorch_model support for PairwiseGP

### DIFF
--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -63,7 +63,7 @@ def fit_botorch_model(
         # TODO: Support deterministic models when we support `ModelList`
         if isinstance(m, SaasFullyBayesianSingleTaskGP):
             fit_fully_bayesian_model_nuts(m, disable_progbar=True)
-        elif isinstance(m, GPyTorchModel):
+        elif isinstance(m, GPyTorchModel) or isinstance(m, PairwiseGP):
             mll_options = mll_options or {}
             mll = not_none(mll_class)(likelihood=m.likelihood, model=m, **mll_options)
             fit_gpytorch_model(mll)

--- a/ax/models/torch/tests/test_list_surrogate.py
+++ b/ax/models/torch/tests/test_list_surrogate.py
@@ -20,6 +20,7 @@ from botorch.models import SaasFullyBayesianSingleTaskGP, SingleTaskGP
 from botorch.models.deterministic import GenericDeterministicModel
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
+from botorch.models.pairwise_gp import PairwiseGP, PairwiseLaplaceMarginalLogLikelihood
 from botorch.models.transforms.input import Normalize
 from botorch.models.transforms.outcome import Standardize
 from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
@@ -300,6 +301,13 @@ class ListSurrogateTest(TestCase):
             mock_fit_nuts.assert_not_called()
             mock_state_dict.reset_mock()
 
+        # Fitting with PairwiseGP should be ok
+        fit_botorch_model(
+            model=PairwiseGP(
+                datapoints=torch.rand(2, 2), comparisons=torch.tensor([[0, 1]])
+            ),
+            mll_class=PairwiseLaplaceMarginalLogLikelihood,
+        )
         # Fitting with unknown model should raise
         with self.assertRaisesRegex(
             ValueError,


### PR DESCRIPTION
Summary: `PairwiseGP` is not a `GPyTorchModel` here and will break here when trying to construct a `PairwiseModelBridge`.

Differential Revision: D37409026

