### PR TITLE
Standardize Ax logging level

### DIFF
--- a/ax/utils/common/logger.py
+++ b/ax/utils/common/logger.py
@@ -30,7 +30,7 @@ class AxOutputNameFilter(logging.Filter):
         return True
 
 
-def get_logger(name: str) -> logging.Logger:
+def get_logger(name: str, level: int = DEFAULT_LOG_LEVEL) -> logging.Logger:
     """Get an Axlogger.
 
     To set a human-readable "output_name" that appears in logger outputs,
@@ -48,6 +48,7 @@ def get_logger(name: str) -> logging.Logger:
         The logging.Logger object.
     """
     logger = logging.getLogger(name)
+    logger.setLevel(level)
     logger.addFilter(AxOutputNameFilter())
     return logger
 


### PR DESCRIPTION
Summary:
Pythons default log level [is warning](https://docs.python.org/3.8/howto/logging.html#a-simple-example).  Somehow it's different in bento, but that means for fb loggers, and the scuba logger its warning outside of bento, the logger itself will filter before the handler filters (see [docs logger flow section](https://docs.python.org/3.8/howto/logging.html#logging-flow)).  So we need to set the default level for the loggers as well to avoid unwanted filtering that the handlers wouldn't do.

I'm being cautious because of [steve's advice](https://www.internalfb.com/diff/D37554330?dst_version_fbid=707649733657236&transaction_fbid=769816974160262).

Reviewed By: lena-kashtelyan

Differential Revision: D37559225

