### PR TITLE
use local .flake8 config in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,8 +64,7 @@ jobs:
       # run even if previous step (ufmt) failed
       if: ${{ always() }}
       run: |
-        # don't use .flake8 config for now, since don't need custom plugin
-        flake8 --isolated --ignore=T484,T499,W503,E704,E231,E203 --max-line-length=88
+        flake8
 
   docs:
 


### PR DESCRIPTION
Summary:
This is the same config that internal linter uses, and doesn't
have any local plugins configured, so dropping the arguments and
comments, and just letting flake8 use the real config.

detective_pikachu

Differential Revision: D37765021

