### PR TITLE
Assert repository (hg) status doesn't change during test runs

### DIFF
--- a/ax/core/tests/test_arm.py
+++ b/ax/core/tests/test_arm.py
@@ -9,9 +9,6 @@ from ax.utils.common.testutils import TestCase
 
 
 class ArmTest(TestCase):
-    def setUp(self):
-        pass
-
     def testInit(self):
         arm = Arm(parameters={"y": 0.25, "x": 0.75, "z": 75})
         self.assertEqual(str(arm), "Arm(parameters={'y': 0.25, 'x': 0.75, 'z': 75})")

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -32,6 +32,7 @@ from ax.utils.testing.core_stubs import (
 
 class BatchTrialTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.experiment = get_experiment()
         self.experiment.status_quo = None
         self.batch = self.experiment.new_batch_trial()

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -19,6 +19,7 @@ from ax.utils.common.timeutils import current_timestamp_in_millis
 
 class DataTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.df_hash = "3dd7ab8c67942d43c78ea4af05bbb1c4"
         self.df = pd.DataFrame(
             [

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -48,6 +48,7 @@ DUMMY_ABANDONED_REASON = "test abandoned reason"
 
 class ExperimentTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.experiment = get_experiment()
 
     def _setupBraninExperiment(self, n: int) -> Experiment:
@@ -863,6 +864,7 @@ class ExperimentTest(TestCase):
 
 class ExperimentWithMapDataTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.experiment = get_experiment_with_map_data_type()
 
     def _setupBraninExperiment(self, n: int, incremental: bool = False) -> Experiment:

--- a/ax/core/tests/test_generator_run.py
+++ b/ax/core/tests/test_generator_run.py
@@ -22,6 +22,7 @@ GENERATOR_RUN_STR_PLUS_1 = "GeneratorRun(3 arms, total weight 4.0)"
 
 class GeneratorRunTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.model_predictions = get_model_predictions()
         self.optimization_config = get_optimization_config()
         self.search_space = get_search_space()

--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -12,6 +12,7 @@ from ax.utils.common.testutils import TestCase
 
 class MapDataTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.df = pd.DataFrame(
             [
                 {

--- a/ax/core/tests/test_map_metric.py
+++ b/ax/core/tests/test_map_metric.py
@@ -12,9 +12,6 @@ METRIC_STRING = "MapMetric('m1')"
 
 
 class MapMetricTest(TestCase):
-    def setUp(self):
-        pass
-
     def testInit(self):
         metric = MapMetric(name="m1", lower_is_better=False)
         self.assertEqual(str(metric), METRIC_STRING)

--- a/ax/core/tests/test_metric.py
+++ b/ax/core/tests/test_metric.py
@@ -13,9 +13,6 @@ METRIC_STRING = "Metric('m1')"
 
 
 class MetricTest(TestCase):
-    def setUp(self):
-        pass
-
     def testInit(self):
         metric = Metric(name="m1", lower_is_better=False)
         self.assertEqual(str(metric), METRIC_STRING)

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -12,6 +12,7 @@ from ax.utils.testing.core_stubs import get_branin_arms, get_multi_type_experime
 
 class MultiTypeExperimentTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.experiment = get_multi_type_experiment()
 
     def testMTExperimentFlow(self):

--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -20,6 +20,7 @@ Objective(metric_name="m3", minimize=False)])
 
 class ObjectiveTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.metrics = {
             "m1": Metric(name="m1"),
             "m2": Metric(name="m2", lower_is_better=True),

--- a/ax/core/tests/test_optimization_config.py
+++ b/ax/core/tests/test_optimization_config.py
@@ -40,6 +40,7 @@ MOOC_STR = (
 
 class OptimizationConfigTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.metrics = {
             "m1": Metric(name="m1"),
             "m2": Metric(name="m2"),
@@ -231,6 +232,7 @@ class OptimizationConfigTest(TestCase):
 
 class MultiObjectiveOptimizationConfigTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.metrics = {
             "m1": Metric(name="m1", lower_is_better=True),
             "m2": Metric(name="m2", lower_is_better=False),

--- a/ax/core/tests/test_outcome_constraint.py
+++ b/ax/core/tests/test_outcome_constraint.py
@@ -24,6 +24,7 @@ OUTCOME_CONSTRAINT_PATH = "ax.core.outcome_constraint"
 
 class OutcomeConstraintTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.minimize_metric = Metric(name="bar", lower_is_better=True)
         self.maximize_metric = Metric(name="baz", lower_is_better=False)
         self.bound = 0
@@ -81,6 +82,7 @@ class OutcomeConstraintTest(TestCase):
 
 class ObjectiveThresholdTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.minimize_metric = Metric(name="bar", lower_is_better=True)
         self.maximize_metric = Metric(name="baz", lower_is_better=False)
         self.ambiguous_metric = Metric(name="buz")
@@ -153,6 +155,7 @@ class ObjectiveThresholdTest(TestCase):
 
 class ScalarizedOutcomeConstraintTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.metrics = [
             Metric(name="m1", lower_is_better=True),
             Metric(name="m2", lower_is_better=True),

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -17,6 +17,7 @@ from ax.utils.common.testutils import TestCase
 
 class RangeParameterTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.param1 = RangeParameter(
             name="x",
             parameter_type=ParameterType.FLOAT,
@@ -163,6 +164,7 @@ class RangeParameterTest(TestCase):
 
 class ChoiceParameterTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.param1 = ChoiceParameter(
             name="x", parameter_type=ParameterType.STRING, values=["foo", "bar", "baz"]
         )
@@ -331,6 +333,7 @@ class ChoiceParameterTest(TestCase):
 
 class FixedParameterTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.param1 = FixedParameter(
             name="x", parameter_type=ParameterType.BOOL, value=True
         )
@@ -415,6 +418,7 @@ class FixedParameterTest(TestCase):
 
 class ParameterEqualityTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.fixed_parameter = FixedParameter(
             name="x", parameter_type=ParameterType.BOOL, value=True
         )

--- a/ax/core/tests/test_parameter_constraint.py
+++ b/ax/core/tests/test_parameter_constraint.py
@@ -21,6 +21,7 @@ from ax.utils.common.testutils import TestCase
 
 class ParameterConstraintTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.constraint = ParameterConstraint(
             constraint_dict={"x": 2.0, "y": -3.0}, bound=6.0
         )
@@ -92,6 +93,7 @@ class ParameterConstraintTest(TestCase):
 
 class OrderConstraintTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.x = RangeParameter("x", ParameterType.INT, lower=0, upper=1)
         self.y = RangeParameter("y", ParameterType.INT, lower=0, upper=1)
         self.constraint = OrderConstraint(
@@ -147,6 +149,7 @@ class OrderConstraintTest(TestCase):
 
 class SumConstraintTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.x = RangeParameter("x", ParameterType.INT, lower=-5, upper=5)
         self.y = RangeParameter("y", ParameterType.INT, lower=-5, upper=5)
         self.constraint1 = SumConstraint(

--- a/ax/core/tests/test_runner.py
+++ b/ax/core/tests/test_runner.py
@@ -19,6 +19,7 @@ class DummyRunner(Runner):
 
 class RunnerTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.dummy_runner = DummyRunner()
         self.trials = [get_trial(), get_batch_trial()]
 

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -46,6 +46,7 @@ RANGE_PARAMS = 3
 
 class SearchSpaceTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.a = RangeParameter(
             name="a", parameter_type=ParameterType.FLOAT, lower=0.5, upper=5.5
         )
@@ -347,6 +348,7 @@ class SearchSpaceTest(TestCase):
 
 class SearchSpaceDigestTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.kwargs = {
             "feature_names": ["a", "b", "c"],
             "bounds": [(0.0, 1.0), (0, 2), (0, 4)],
@@ -379,6 +381,7 @@ class SearchSpaceDigestTest(TestCase):
 
 class RobustSearchSpaceDigestTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.kwargs = {
             "distribution_sampler": lambda X: X,
             "environmental_variables": ["a"],
@@ -403,6 +406,7 @@ class RobustSearchSpaceDigestTest(TestCase):
 
 class HierarchicalSearchSpaceTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.model_parameter = get_model_parameter()
         self.lr_parameter = get_lr_parameter()
         self.l2_reg_weight_parameter = get_l2_reg_weight_parameter()
@@ -672,6 +676,7 @@ class HierarchicalSearchSpaceTest(TestCase):
 
 class TestRobustSearchSpace(TestCase):
     def setUp(self):
+        super().setUp()
         self.a = RangeParameter(
             name="a", parameter_type=ParameterType.FLOAT, lower=0.5, upper=5.5
         )

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -33,6 +33,7 @@ TEST_DATA = Data(
 
 class TrialTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.experiment = get_experiment()
         self.trial = self.experiment.new_trial()
         self.arm = get_arms()[0]

--- a/ax/core/tests/test_types.py
+++ b/ax/core/tests/test_types.py
@@ -10,6 +10,7 @@ from ax.utils.common.testutils import TestCase
 
 class TypesTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.num_arms = 2
         mu = {"m1": [0.0, 0.5], "m2": [0.1, 0.6]}
         cov = {

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -27,6 +27,7 @@ from ax.utils.common.testutils import TestCase
 
 class UtilsTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.df = pd.DataFrame(
             [
                 {

--- a/ax/modelbridge/tests/test_cap_parameter_transform.py
+++ b/ax/modelbridge/tests/test_cap_parameter_transform.py
@@ -14,6 +14,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class CapParameterTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/tests/test_cast_transform.py
+++ b/ax/modelbridge/tests/test_cast_transform.py
@@ -23,6 +23,7 @@ from ax.utils.testing.core_stubs import get_hierarchical_search_space
 
 class CastTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/tests/test_choice_encode_transform.py
+++ b/ax/modelbridge/tests/test_choice_encode_transform.py
@@ -20,6 +20,7 @@ class ChoiceEncodeTransformTest(TestCase):
     t_class = ChoiceEncode
 
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/tests/test_convert_metric_names.py
+++ b/ax/modelbridge/tests/test_convert_metric_names.py
@@ -18,6 +18,7 @@ from ax.utils.testing.core_stubs import get_multi_type_experiment
 
 class ConvertMetricNamesTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.experiment = get_multi_type_experiment(add_trials=True)
         self.data = self.experiment.fetch_data()
         self.observations = observations_from_data(self.experiment, self.data)

--- a/ax/modelbridge/tests/test_cross_validation.py
+++ b/ax/modelbridge/tests/test_cross_validation.py
@@ -34,6 +34,7 @@ from ax.utils.testing.core_stubs import get_branin_experiment
 
 class CrossValidationTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.training_data = [
             Observation(
                 features=ObservationFeatures(parameters={"x": 2.0}, trial_index=0),

--- a/ax/modelbridge/tests/test_derelativize_transform.py
+++ b/ax/modelbridge/tests/test_derelativize_transform.py
@@ -25,6 +25,7 @@ from ax.utils.common.testutils import TestCase
 
 class DerelativizeTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         m = mock.patch.object(ModelBridge, "__abstractmethods__", frozenset())
         self.addCleanup(m.stop)
         m.start()

--- a/ax/modelbridge/tests/test_discrete_modelbridge.py
+++ b/ax/modelbridge/tests/test_discrete_modelbridge.py
@@ -26,6 +26,7 @@ from ax.utils.common.testutils import TestCase
 
 class DiscreteModelBridgeTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.parameters = [
             ChoiceParameter("x", ParameterType.FLOAT, values=[0, 1]),
             ChoiceParameter("y", ParameterType.STRING, values=["foo", "bar"]),

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -23,6 +23,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 
 class TestGenerationNode(TestCase):
     def setUp(self):
+        super().setUp()
         self.sobol_model_spec = ModelSpec(
             model_enum=Models.SOBOL,
             model_kwargs={"init_position": 3},
@@ -151,6 +152,7 @@ class TestGenerationNode(TestCase):
 
 class TestGenerationStep(TestCase):
     def setUp(self):
+        super().setUp()
         self.model_kwargs = ({"init_position": 5},)
         self.sobol_generation_step = GenerationStep(
             model=Models.SOBOL,
@@ -191,6 +193,7 @@ class TestGenerationStep(TestCase):
 class TestGenerationNodeWithBestModelSelector(TestCase):
     @fast_botorch_optimize
     def setUp(self):
+        super().setUp()
         self.branin_experiment = get_branin_experiment()
         sobol = Models.SOBOL(search_space=self.branin_experiment.search_space)
         sobol_run = sobol.gen(n=20)

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -44,6 +44,7 @@ from ax.utils.testing.core_stubs import (
 
 class TestGenerationStrategy(TestCase):
     def setUp(self):
+        super().setUp()
         self.gr = GeneratorRun(arms=[Arm(parameters={"x1": 1, "x2": 2})])
 
         # Mock out slow GPEI.
@@ -108,6 +109,7 @@ class TestGenerationStrategy(TestCase):
         )
 
     def tearDown(self):
+        super().tearDown()
         self.torch_model_bridge_patcher.stop()
         self.discrete_model_bridge_patcher.stop()
         self.registry_setup_dict_patcher.stop()

--- a/ax/modelbridge/tests/test_int_range_to_choice_transform.py
+++ b/ax/modelbridge/tests/test_int_range_to_choice_transform.py
@@ -17,6 +17,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class IntRangeToChoiceTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter("a", lower=1, upper=5, parameter_type=ParameterType.INT),

--- a/ax/modelbridge/tests/test_int_to_float_transform.py
+++ b/ax/modelbridge/tests/test_int_to_float_transform.py
@@ -18,6 +18,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class IntToFloatTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         parameters = [
             RangeParameter("x", lower=1, upper=3, parameter_type=ParameterType.FLOAT),
             RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),

--- a/ax/modelbridge/tests/test_inverse_gaussian_cdf_y.py
+++ b/ax/modelbridge/tests/test_inverse_gaussian_cdf_y.py
@@ -14,6 +14,7 @@ from ax.utils.common.testutils import TestCase
 
 class InverseGaussianCdfYTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.obsd_mid = ObservationData(
             metric_names=["m1", "m2"],
             means=np.array([0.5, 0.9]),

--- a/ax/modelbridge/tests/test_log_transform.py
+++ b/ax/modelbridge/tests/test_log_transform.py
@@ -18,6 +18,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class LogTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/tests/test_log_y_transform.py
+++ b/ax/modelbridge/tests/test_log_y_transform.py
@@ -28,6 +28,7 @@ from ax.utils.common.testutils import TestCase
 
 class LogYTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2", "m3"],
             means=np.array([0.5, 1.0, 1.0]),

--- a/ax/modelbridge/tests/test_logit_transform.py
+++ b/ax/modelbridge/tests/test_logit_transform.py
@@ -18,6 +18,7 @@ from scipy.special import expit, logit
 
 class LogitTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/tests/test_model_spec.py
+++ b/ax/modelbridge/tests/test_model_spec.py
@@ -19,6 +19,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 
 class BaseModelSpecTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.experiment = get_branin_experiment()
         sobol = Models.SOBOL(search_space=self.experiment.search_space)
         sobol_run = sobol.gen(n=20)

--- a/ax/modelbridge/tests/test_one_hot_transform.py
+++ b/ax/modelbridge/tests/test_one_hot_transform.py
@@ -17,6 +17,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class OneHotTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/tests/test_percentile_y_transform.py
+++ b/ax/modelbridge/tests/test_percentile_y_transform.py
@@ -15,6 +15,7 @@ from ax.utils.common.testutils import TestCase
 
 class PercentileYTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2"],
             means=np.array([0.0, 0.0]),

--- a/ax/modelbridge/tests/test_power_transform_y.py
+++ b/ax/modelbridge/tests/test_power_transform_y.py
@@ -36,6 +36,7 @@ def get_constraint(metric, bound, relative):
 
 class PowerTransformYTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2"],
             means=np.array([0.5, 0.9]),

--- a/ax/modelbridge/tests/test_random_modelbridge.py
+++ b/ax/modelbridge/tests/test_random_modelbridge.py
@@ -23,6 +23,7 @@ from ax.utils.testing.core_stubs import get_small_discrete_search_space
 
 class RandomModelBridgeTest(TestCase):
     def setUp(self):
+        super().setUp()
         x = RangeParameter("x", ParameterType.FLOAT, lower=0, upper=1)
         y = RangeParameter("y", ParameterType.FLOAT, lower=1, upper=2)
         z = RangeParameter("z", ParameterType.FLOAT, lower=0, upper=5)

--- a/ax/modelbridge/tests/test_remove_fixed_transform.py
+++ b/ax/modelbridge/tests/test_remove_fixed_transform.py
@@ -21,6 +21,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class RemoveFixedTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/tests/test_rounding.py
+++ b/ax/modelbridge/tests/test_rounding.py
@@ -13,9 +13,6 @@ from ax.utils.common.testutils import TestCase
 
 
 class RoundingTest(TestCase):
-    def setUp(self):
-        pass
-
     def testOneHotRound(self):
         self.assertTrue(
             np.allclose(

--- a/ax/modelbridge/tests/test_search_space_to_choice_transform.py
+++ b/ax/modelbridge/tests/test_search_space_to_choice_transform.py
@@ -23,6 +23,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class SearchSpaceToChoiceTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/tests/test_standardize_y_transform.py
+++ b/ax/modelbridge/tests/test_standardize_y_transform.py
@@ -21,6 +21,7 @@ from ax.utils.common.testutils import TestCase
 
 class StandardizeYTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2", "m2"],
             means=np.array([1.0, 2.0, 1.0]),

--- a/ax/modelbridge/tests/test_stratified_standardize_y.py
+++ b/ax/modelbridge/tests/test_stratified_standardize_y.py
@@ -24,6 +24,7 @@ from .test_standardize_y_transform import osd_allclose
 
 class StratifiedStandardizeYTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2", "m2"],
             means=np.array([1.0, 2.0, 8.0]),

--- a/ax/modelbridge/tests/test_task_encode_transform.py
+++ b/ax/modelbridge/tests/test_task_encode_transform.py
@@ -16,6 +16,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class TaskEncodeTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/tests/test_trial_as_task_transform.py
+++ b/ax/modelbridge/tests/test_trial_as_task_transform.py
@@ -17,6 +17,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class TrialAsTaskTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/tests/test_unit_x_transform.py
+++ b/ax/modelbridge/tests/test_unit_x_transform.py
@@ -23,6 +23,7 @@ class UnitXTransformTest(TestCase):
     expected_c_bounds = [0.0, 1.0]
 
     def setUp(self):
+        super().setUp()
         self.target_lb = self.transform_class.target_lb
         self.target_range = self.transform_class.target_range
         self.target_ub = self.target_lb + self.target_range

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -40,6 +40,7 @@ from ax.utils.testing.core_stubs import (
 
 class TestModelbridgeUtils(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.experiment = get_experiment()
         self.arm = Arm({"x": 1, "y": "foo", "z": True, "w": 4})
         self.trial = self.experiment.new_trial(GeneratorRun([self.arm]))

--- a/ax/modelbridge/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/tests/test_winsorize_transform.py
@@ -36,6 +36,7 @@ from ax.utils.testing.core_stubs import get_optimization_config
 
 class WinsorizeTransformTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2", "m2"],
             means=np.array([0.0, 0.0, 1.0]),

--- a/ax/modelbridge/tests/test_winsorize_transform_legacy.py
+++ b/ax/modelbridge/tests/test_winsorize_transform_legacy.py
@@ -16,6 +16,7 @@ from ax.utils.common.testutils import TestCase
 
 class WinsorizeTransformTestLegacy(TestCase):
     def setUp(self):
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2", "m2"],
             means=np.array([0.0, 0.0, 1.0]),

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -33,6 +33,7 @@ def dummy_func(X: torch.Tensor) -> torch.Tensor:
 
 class KnowledgeGradientTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.tkwargs = {"device": torch.device("cpu"), "dtype": torch.double}
         self.dataset = FixedNoiseDataset(
             X=torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **self.tkwargs),

--- a/ax/models/tests/test_botorch_mes.py
+++ b/ax/models/tests/test_botorch_mes.py
@@ -25,6 +25,7 @@ from botorch.utils.datasets import FixedNoiseDataset
 
 class MaxValueEntropySearchTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.tkwargs = {"device": torch.device("cpu"), "dtype": torch.double}
         self.training_data = [
             FixedNoiseDataset(

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -48,6 +48,7 @@ def dummy_predict(model, X):
 
 class FrontierEvaluatorTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.X = torch.tensor(
             [[1.0, 0.0], [1.0, 1.0], [1.0, 3.0], [2.0, 2.0], [3.0, 1.0]]
         )

--- a/ax/models/tests/test_discrete.py
+++ b/ax/models/tests/test_discrete.py
@@ -10,9 +10,6 @@ from ax.utils.common.testutils import TestCase
 
 
 class DiscreteModelTest(TestCase):
-    def setUp(self):
-        pass
-
     def test_discrete_model_get_state(self):
         discrete_model = DiscreteModel()
         self.assertEqual(discrete_model._get_state(), {})

--- a/ax/models/tests/test_eb_thompson.py
+++ b/ax/models/tests/test_eb_thompson.py
@@ -13,6 +13,7 @@ from ax.utils.common.testutils import TestCase
 
 class EmpiricalBayesThompsonSamplerTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.Xs = [
             [[1, 1], [2, 2], [3, 3], [4, 4]],
             [[1, 1], [2, 2], [3, 3], [4, 4]],

--- a/ax/models/tests/test_model_utils.py
+++ b/ax/models/tests/test_model_utils.py
@@ -19,9 +19,6 @@ from ax.utils.common.testutils import TestCase
 
 
 class ModelUtilsTest(TestCase):
-    def setUp(self):
-        pass
-
     def testBestObservedPoint(self):
         model = MagicMock()
 

--- a/ax/models/tests/test_posterior_mean.py
+++ b/ax/models/tests/test_posterior_mean.py
@@ -17,6 +17,7 @@ from botorch.utils.datasets import FixedNoiseDataset
 # TODO (jej): Streamline testing for a simple acquisition function.
 class PosteriorMeanTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.tkwargs = {"device": torch.device("cpu"), "dtype": torch.double}
         self.X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **self.tkwargs)
         self.Y = torch.tensor([[3.0], [4.0]], **self.tkwargs)

--- a/ax/models/tests/test_random.py
+++ b/ax/models/tests/test_random.py
@@ -12,6 +12,7 @@ from ax.utils.common.testutils import TestCase
 
 class RandomModelTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.random_model = RandomModel()
 
     def testRandomModelGenSamples(self):

--- a/ax/models/tests/test_sobol.py
+++ b/ax/models/tests/test_sobol.py
@@ -13,6 +13,7 @@ from ax.utils.common.testutils import TestCase
 
 class SobolGeneratorTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.tunable_param_bounds = (0, 1)
         self.fixed_param_bounds = (1, 100)
 

--- a/ax/models/tests/test_thompson.py
+++ b/ax/models/tests/test_thompson.py
@@ -13,6 +13,7 @@ from ax.utils.common.testutils import TestCase
 
 class ThompsonSamplerTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.Xs = [[[1, 1], [2, 2], [3, 3], [4, 4]]]  # 4 arms, each of dimensionality 2
         self.Ys = [[1, 2, 3, 4]]
         self.Yvars = [[1, 1, 1, 1]]

--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -13,6 +13,7 @@ from botorch.utils.datasets import FixedNoiseDataset
 
 class TorchModelTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.dataset = FixedNoiseDataset(
             X=torch.zeros(1), Y=torch.zeros(1), Yvar=torch.ones(1)
         )

--- a/ax/models/tests/test_torch_utils.py
+++ b/ax/models/tests/test_torch_utils.py
@@ -23,6 +23,7 @@ from botorch.models.model import Model
 
 class TorchUtilsTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.device = torch.device("cpu")
         self.dtype = torch.double
         self.mock_botorch_model = MagicMock(Model)

--- a/ax/models/tests/test_uniform.py
+++ b/ax/models/tests/test_uniform.py
@@ -12,6 +12,7 @@ from ax.utils.common.testutils import TestCase
 
 class UniformGeneratorTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.tunable_param_bounds = (0, 1)
         self.fixed_param_bounds = (1, 100)
 

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -66,6 +66,7 @@ class DummyAcquisitionFunction(AcquisitionFunction):
 
 class AcquisitionTest(TestCase):
     def setUp(self):
+        super().setUp()
         qNEI_input_constructor = get_acqf_input_constructor(qNoisyExpectedImprovement)
         self.mock_input_constructor = mock.MagicMock(
             qNEI_input_constructor, side_effect=qNEI_input_constructor

--- a/ax/models/torch/tests/test_list_surrogate.py
+++ b/ax/models/torch/tests/test_list_surrogate.py
@@ -41,6 +41,7 @@ RANK = "rank"
 
 class ListSurrogateTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.outcomes = ["outcome_1", "outcome_2"]
         self.mll_class = ExactMarginalLogLikelihood
         self.dtype = torch.float

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -53,6 +53,7 @@ ACQ_OPTIONS = {Keys.SAMPLER: SobolQMCNormalSampler(1024)}
 
 class BoTorchModelTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.botorch_model_class = SingleTaskGP
         self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
         self.acquisition_class = Acquisition

--- a/ax/models/torch/tests/test_multi_fidelity.py
+++ b/ax/models/torch/tests/test_multi_fidelity.py
@@ -29,6 +29,7 @@ MFKG_PATH = (
 
 class MultiFidelityAcquisitionTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.botorch_model_class = SingleTaskGP
         self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
         self.X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -49,6 +49,7 @@ class SingleTaskGPWithDifferentConstructor(SingleTaskGP):
 
 class SurrogateTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.device = torch.device("cpu")
         self.dtype = torch.float
         self.Xs, self.Ys, self.Yvars, self.bounds, _, _, _ = get_torch_test_data(

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -37,6 +37,7 @@ from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
 
 class BoTorchModelUtilsTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.dtype = torch.float
         self.Xs, self.Ys, self.Yvars, _, _, _, _ = get_torch_test_data(dtype=self.dtype)
         self.Xs2, self.Ys2, self.Yvars2, _, _, _, _ = get_torch_test_data(

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -30,6 +30,7 @@ from ax.utils.testing.core_stubs import (
 
 class ParetoUtilsTest(TestCase):
     def setUp(self):
+        super().setUp()
         experiment = get_branin_experiment()
         experiment.add_tracking_metric(
             BraninMetric(name="m2", param_names=["x1", "x2"])

--- a/ax/runners/tests/test_torchx.py
+++ b/ax/runners/tests/test_torchx.py
@@ -30,6 +30,7 @@ from torchx.components import utils
 
 class TorchXRunnerTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.test_dir = tempfile.mkdtemp("torchx_runtime_hpo_ax_test")
 
         self.old_cwd = os.getcwd()
@@ -66,6 +67,7 @@ class TorchXRunnerTest(TestCase):
         )
 
     def tearDown(self) -> None:
+        super().tearDown()
         shutil.rmtree(self.test_dir)
         os.chdir(self.old_cwd)
 

--- a/ax/service/tests/test_early_stopping.py
+++ b/ax/service/tests/test_early_stopping.py
@@ -16,6 +16,7 @@ class TestEarlyStoppingUtils(TestCase):
     main `AxClient` testing suite (`TestServiceAPI`)."""
 
     def setUp(self):
+        super().setUp()
         self.branin_experiment = get_branin_experiment()
 
     def test_should_stop_trials_early(self):

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -181,6 +181,7 @@ class TestAxScheduler(TestCase):
     """Tests base `Scheduler` functionality."""
 
     def setUp(self):
+        super().setUp()
         self.branin_experiment = get_branin_experiment()
         self.branin_timestamp_map_metric_experiment = (
             get_branin_experiment_with_timestamp_map_metric()

--- a/ax/service/tests/test_with_db_settings_base.py
+++ b/ax/service/tests/test_with_db_settings_base.py
@@ -34,6 +34,7 @@ class TestWithDBSettingsBase(TestCase):
     """Tests saving/loading functionality of WithDBSettingsBase class."""
 
     def setUp(self):
+        super().setUp()
         self.generation_strategy = get_generation_strategy(with_experiment=True)
         self.experiment = self.generation_strategy.experiment
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -199,6 +199,7 @@ TEST_CASES = [
 
 class JSONStoreTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.experiment = get_experiment_with_batch_and_single_trial()
 
     def testJSONEncodeFailure(self):

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -107,6 +107,7 @@ GET_GS_SQA_IMM_FUNC = _get_generation_strategy_sqa_immutable_opt_config_and_sear
 
 class SQAStoreTest(TestCase):
     def setUp(self):
+        super().setUp()
         init_test_engine_and_session_factory(force_init=True)
         self.config = SQAConfig()
         self.encoder = Encoder(config=self.config)

--- a/ax/storage/sqa_store/tests/test_utils.py
+++ b/ax/storage/sqa_store/tests/test_utils.py
@@ -23,6 +23,7 @@ class DummyClassWithBaseline(Base):
 
 class SQAStoreUtilsTest(TestCase):
     def setUp(self):
+        super().setUp()
         init_test_engine_and_session_factory(force_init=True)
 
     def testCopyDBIDsBatchTrialExp(self):

--- a/ax/utils/common/tests/test_logger.py
+++ b/ax/utils/common/tests/test_logger.py
@@ -17,6 +17,7 @@ BASE_LOGGER_NAME = f"ax.{__name__}"
 
 class LoggerTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.warning_string = "Test warning"
 
     def testLogger(self):


### PR DESCRIPTION
Summary:
I believe this will work better than D37865277 because it will tell us specifically which test failed.  D37865277 will tell us all tests that ran after the file was created.  The offending test might also be left out if it overrode `tearDown()`, which makes it very tough to debug!

This compares `hg status` on `setUp()` to `hg status` on `tearDown()`, asserting that `setUp()` was called, and that they are the same.

Differential Revision: D37901914

