### PR TITLE
Standardize SchedulerOptions on benchmark methods

### DIFF
--- a/ax/benchmark/methods/choose_generation_strategy.py
+++ b/ax/benchmark/methods/choose_generation_strategy.py
@@ -19,5 +19,7 @@ def get_choose_generation_strategy_method(problem: BenchmarkProblem) -> Benchmar
     return BenchmarkMethod(
         name=f"ChooseGenerationStrategy::{problem.name}",
         generation_strategy=generation_strategy,
-        scheduler_options=SchedulerOptions(),
+        scheduler_options=SchedulerOptions(
+            init_seconds_between_polls=0, max_pending_trials=1
+        ),
     )

--- a/ax/benchmark/methods/gpei_and_moo.py
+++ b/ax/benchmark/methods/gpei_and_moo.py
@@ -13,7 +13,7 @@ def get_gpei_default() -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name="SOBOL+GPEI::default",
         steps=[
-            GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=3),
+            GenerationStep(model=Models.SOBOL, num_trials=5),
             GenerationStep(
                 model=Models.GPEI,
                 num_trials=-1,
@@ -22,7 +22,9 @@ def get_gpei_default() -> BenchmarkMethod:
         ],
     )
 
-    scheduler_options = SchedulerOptions(total_trials=30)
+    scheduler_options = SchedulerOptions(
+        init_seconds_between_polls=0, max_pending_trials=1
+    )
 
     return BenchmarkMethod(
         name=generation_strategy.name,
@@ -35,7 +37,7 @@ def get_moo_default() -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name="SOBOL+MOO::default",
         steps=[
-            GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=3),
+            GenerationStep(model=Models.SOBOL, num_trials=5),
             GenerationStep(
                 model=Models.MOO,
                 num_trials=-1,
@@ -44,7 +46,9 @@ def get_moo_default() -> BenchmarkMethod:
         ],
     )
 
-    scheduler_options = SchedulerOptions(total_trials=30)
+    scheduler_options = SchedulerOptions(
+        init_seconds_between_polls=0, max_pending_trials=1
+    )
 
     return BenchmarkMethod(
         name=generation_strategy.name,

--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -21,9 +21,7 @@ from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.gp_regression import FixedNoiseGP
 
 
-def get_sobol_botorch_modular_fixed_noise_gp_qnei(
-    total_trials: int = 30,
-) -> BenchmarkMethod:
+def get_sobol_botorch_modular_fixed_noise_gp_qnei() -> BenchmarkMethod:
     model_gen_kwargs = {
         "model_gen_options": {
             Keys.OPTIMIZER_KWARGS: {
@@ -41,7 +39,7 @@ def get_sobol_botorch_modular_fixed_noise_gp_qnei(
     generation_strategy = GenerationStrategy(
         name="SOBOL+BOTORCH_MODULAR::FixedNoiseGP_qNoisyExpectedImprovement",
         steps=[
-            GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=3),
+            GenerationStep(model=Models.SOBOL, num_trials=5),
             GenerationStep(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
@@ -55,7 +53,9 @@ def get_sobol_botorch_modular_fixed_noise_gp_qnei(
         ],
     )
 
-    scheduler_options = SchedulerOptions(total_trials=total_trials)
+    scheduler_options = SchedulerOptions(
+        init_seconds_between_polls=0, max_pending_trials=1
+    )
 
     return BenchmarkMethod(
         name=generation_strategy.name,
@@ -64,9 +64,7 @@ def get_sobol_botorch_modular_fixed_noise_gp_qnei(
     )
 
 
-def get_sobol_botorch_modular_fixed_noise_gp_qnehvi(
-    total_trials: int = 30,
-) -> BenchmarkMethod:
+def get_sobol_botorch_modular_fixed_noise_gp_qnehvi() -> BenchmarkMethod:
     model_gen_kwargs = {
         "model_gen_options": {
             Keys.OPTIMIZER_KWARGS: {
@@ -84,7 +82,10 @@ def get_sobol_botorch_modular_fixed_noise_gp_qnehvi(
     generation_strategy = GenerationStrategy(
         name="SOBOL+BOTORCH_MODULAR::FixedNoiseGP_qNoisyExpectedHypervolumeImprovement",
         steps=[
-            GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=3),
+            GenerationStep(
+                model=Models.SOBOL,
+                num_trials=5,
+            ),
             GenerationStep(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
@@ -98,7 +99,9 @@ def get_sobol_botorch_modular_fixed_noise_gp_qnehvi(
         ],
     )
 
-    scheduler_options = SchedulerOptions(total_trials=total_trials)
+    scheduler_options = SchedulerOptions(
+        init_seconds_between_polls=0, max_pending_trials=1
+    )
 
     return BenchmarkMethod(
         name=generation_strategy.name,
@@ -111,7 +114,10 @@ def get_sobol_botorch_modular_saas_fully_bayesian_single_task_gp_qnei() -> Bench
     generation_strategy = GenerationStrategy(
         name="SOBOL+BOTORCH_MODULAR::SaasFullyBayesianSingleTaskGP_qNoisyExpectedImprovement",  # noqa
         steps=[
-            GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=3),
+            GenerationStep(
+                model=Models.SOBOL,
+                num_trials=5,
+            ),
             GenerationStep(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
@@ -126,7 +132,9 @@ def get_sobol_botorch_modular_saas_fully_bayesian_single_task_gp_qnei() -> Bench
         ],
     )
 
-    scheduler_options = SchedulerOptions(total_trials=30)
+    scheduler_options = SchedulerOptions(
+        init_seconds_between_polls=0, max_pending_trials=1
+    )
 
     return BenchmarkMethod(
         name=generation_strategy.name,
@@ -139,7 +147,10 @@ def get_sobol_botorch_modular_saas_fully_bayesian_single_task_gp_qnehvi() -> Ben
     generation_strategy = GenerationStrategy(
         name="SOBOL+BOTORCH_MODULAR::SaasFullyBayesianSingleTaskGP_qNoisyExpectedHypervolumeImprovement",  # noqa
         steps=[
-            GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=3),
+            GenerationStep(
+                model=Models.SOBOL,
+                num_trials=5,
+            ),
             GenerationStep(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
@@ -154,7 +165,9 @@ def get_sobol_botorch_modular_saas_fully_bayesian_single_task_gp_qnehvi() -> Ben
         ],
     )
 
-    scheduler_options = SchedulerOptions(total_trials=30)
+    scheduler_options = SchedulerOptions(
+        init_seconds_between_polls=0, max_pending_trials=1
+    )
 
     return BenchmarkMethod(
         name=generation_strategy.name,
@@ -167,7 +180,10 @@ def get_sobol_botorch_modular_default() -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name="SOBOL+BOTORCH_MODULAR::default",
         steps=[
-            GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=3),
+            GenerationStep(
+                model=Models.SOBOL,
+                num_trials=5,
+            ),
             GenerationStep(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
@@ -176,7 +192,9 @@ def get_sobol_botorch_modular_default() -> BenchmarkMethod:
         ],
     )
 
-    scheduler_options = SchedulerOptions(total_trials=30)
+    scheduler_options = SchedulerOptions(
+        init_seconds_between_polls=0, max_pending_trials=1
+    )
 
     return BenchmarkMethod(
         name=generation_strategy.name,
@@ -188,12 +206,14 @@ def get_sobol_botorch_modular_default() -> BenchmarkMethod:
 def get_sobol_botorch_modular_acquisition(
     acquisition_cls: Type[AcquisitionFunction],
     acquisition_options: Optional[Dict[str, Any]] = None,
-    total_trials: int = 30,
 ) -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name=f"SOBOL+BOTORCH_MODULAR::{acquisition_cls.__name__}",
         steps=[
-            GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=3),
+            GenerationStep(
+                model=Models.SOBOL,
+                num_trials=5,
+            ),
             GenerationStep(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
@@ -206,7 +226,9 @@ def get_sobol_botorch_modular_acquisition(
         ],
     )
 
-    scheduler_options = SchedulerOptions(total_trials=total_trials)
+    scheduler_options = SchedulerOptions(
+        init_seconds_between_polls=0, max_pending_trials=1
+    )
 
     return BenchmarkMethod(
         name=generation_strategy.name,

--- a/ax/benchmark/methods/saasbo.py
+++ b/ax/benchmark/methods/saasbo.py
@@ -13,7 +13,7 @@ def get_saasbo_default() -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name="SOBOL+FULLYBAYESIAN::default",
         steps=[
-            GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=3),
+            GenerationStep(model=Models.SOBOL, num_trials=5),
             GenerationStep(
                 model=Models.FULLYBAYESIAN,
                 num_trials=-1,
@@ -22,7 +22,9 @@ def get_saasbo_default() -> BenchmarkMethod:
         ],
     )
 
-    scheduler_options = SchedulerOptions(total_trials=30)
+    scheduler_options = SchedulerOptions(
+        init_seconds_between_polls=0, max_pending_trials=1
+    )
 
     return BenchmarkMethod(
         name=generation_strategy.name,
@@ -35,7 +37,7 @@ def get_saasbo_moo_default() -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name="SOBOL+FULLYBAYESIANMOO::default",
         steps=[
-            GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=3),
+            GenerationStep(model=Models.SOBOL, num_trials=5),
             GenerationStep(
                 model=Models.FULLYBAYESIANMOO,
                 num_trials=-1,
@@ -44,7 +46,9 @@ def get_saasbo_moo_default() -> BenchmarkMethod:
         ],
     )
 
-    scheduler_options = SchedulerOptions(total_trials=30)
+    scheduler_options = SchedulerOptions(
+        init_seconds_between_polls=0, max_pending_trials=1
+    )
 
     return BenchmarkMethod(
         name=generation_strategy.name,

--- a/ax/benchmark/tests/test_methods.py
+++ b/ax/benchmark/tests/test_methods.py
@@ -14,13 +14,10 @@ class TestMethods(TestCase):
         method = get_sobol_botorch_modular_acquisition(
             acquisition_cls=qKnowledgeGradient,
             acquisition_options={"num_fantasies": 16},
-            total_trials=50,
         )
-        self.assertEqual(method.scheduler_options.total_trials, 50)
         self.assertEqual(method.name, "SOBOL+BOTORCH_MODULAR::qKnowledgeGradient")
         gs = method.generation_strategy
         sobol, kg = gs._steps
-        self.assertEqual(sobol.num_trials, 5)
         self.assertEqual(kg.model, Models.BOTORCH_MODULAR)
         model_kwargs = kg.model_kwargs
         self.assertEqual(model_kwargs["botorch_acqf_class"], qKnowledgeGradient)


### PR DESCRIPTION
Summary:
This is mostly cleanup from moving the num_trials to BenchmarkProblem. In this diff we:
- Remove all references to total_trials in methods files
- Standardize SchedulerOptions to have no artificial delay on scheduling and force sequential execution.

This should simplify things for users and not confuse them by having multiple places for all sorts of different options.

Differential Revision: D37965032

