### PR TITLE
Move timeout_hours to SchedulerOptions, add to benchmark

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -72,8 +72,15 @@ def benchmark_replication(
         BestPointMixin.get_trace(experiment=scheduler.experiment)
     )
 
+    # Use the first GenerationStep's best found point as baseline. Sometimes (ex. in
+    # a timeout) the first GenerationStep will not have not completed and we will not
+    # have enough trials; in this case we do not score.
     num_sobol_trials = scheduler.generation_strategy._steps[0].num_trials
-    baseline = optimization_trace[num_sobol_trials - 1]
+    baseline = (
+        optimization_trace[num_sobol_trials - 1]
+        if len(optimization_trace) > num_sobol_trials
+        else None
+    )
 
     if isinstance(problem, SingleObjectiveBenchmarkProblem):
         optimum = problem.optimal_value
@@ -85,7 +92,7 @@ def benchmark_replication(
 
     score_trace = (
         (100 * (1 - (optimization_trace - optimum) / (baseline - optimum))).clip(min=0)
-        if optimum is not None
+        if optimum is not None and baseline is not None
         else np.full(len(optimization_trace), np.nan)
     )
 

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -30,4 +30,6 @@ def get_sequential_optimization_scheduler_options() -> SchedulerOptions:
         # Do not throttle, as is often necessary when polling real endpoints
         init_seconds_between_polls=0,
         min_seconds_before_poll=0,
+        # Time the experiment out after 4 hours
+        timeout_hours=4,
     )

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -9,6 +9,11 @@ from ax.benchmark.benchmark import (
     benchmark_replication,
     benchmark_test,
 )
+from ax.benchmark.benchmark_method import BenchmarkMethod
+from ax.benchmark.benchmark_problem import SingleObjectiveBenchmarkProblem
+from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.registry import Models
+from ax.service.utils.scheduler_options import SchedulerOptions
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import (
     get_multi_objective_benchmark_problem,
@@ -17,6 +22,7 @@ from ax.utils.testing.benchmark_stubs import (
     get_sobol_gpei_benchmark_method,
 )
 from ax.utils.testing.mock import fast_botorch_optimize
+from botorch.test_functions.synthetic import Branin
 
 
 class TestBenchmark(TestCase):
@@ -85,3 +91,41 @@ class TestBenchmark(TestCase):
         for agg in aggs:
             for col in ["mean", "P10", "P25", "P50", "P75", "P90"]:
                 self.assertTrue((agg.score_trace[col] <= 100).all())
+
+    @fast_botorch_optimize
+    def test_timeout(self):
+        problem = SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
+            test_problem=Branin(), num_trials=1000  # Unachievable num_trials
+        )
+
+        generation_strategy = GenerationStrategy(
+            name="SOBOL+GPEI::default",
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5, min_trials_observed=5),
+                GenerationStep(
+                    model=Models.GPEI,
+                    num_trials=-1,
+                    max_parallelism=1,
+                ),
+            ],
+        )
+
+        method = BenchmarkMethod(
+            name=generation_strategy.name,
+            generation_strategy=generation_strategy,
+            scheduler_options=SchedulerOptions(
+                max_pending_trials=1,
+                init_seconds_between_polls=0,
+                min_seconds_before_poll=0,
+                timeout_hours=0.001,  # Strict timeout of 3.6 seconds
+            ),
+        )
+
+        # Each replication will have a different number of trials
+        result = benchmark_test(problem=problem, method=method, seeds=(0, 1, 2, 3))
+
+        # Test the traces get composited correctly. The AggregatedResult's traces
+        # should be the length of the shortest trace in the BenchmarkResults
+        min_num_trials = min([len(res.optimization_trace) for res in result.results])
+        self.assertEqual(len(result.optimization_trace), min_num_trials)
+        self.assertEqual(len(result.score_trace), min_num_trials)

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -163,7 +163,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
     # recorded in each `run_n_trials`.
     _latest_optimization_start_timestamp: Optional[int] = None
     # Timeout setting for current optimization.
-    _timeout_hours: Optional[int] = None
+    _timeout_hours: Optional[float] = None
     # Timestamp of when the last deployed trial started running.
     _latest_trial_start_timestamp: Optional[float] = None
     # Will be set to `True` if generation strategy signals that the optimization
@@ -227,6 +227,8 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         self.markdown_messages["Generation strategy"] = GS_TYPE_MSG.format(
             gs_name=generation_strategy.name
         )
+
+        self._timeout_hours = options.timeout_hours
 
     @classmethod
     def get_default_db_settings(cls) -> DBSettings:

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -282,7 +282,7 @@ class TestAxScheduler(TestCase):
                 "min_failed_trials_for_failure_rate_check=5, log_filepath=None, "
                 "logging_level=20, ttl_seconds_for_trials=None, init_seconds_between_"
                 "polls=10, min_seconds_before_poll=1.0, seconds_between_polls_backoff_"
-                "factor=1.5, run_trials_in_batches=False, "
+                "factor=1.5, timeout_hours=None, run_trials_in_batches=False, "
                 "debug_log_run_metadata=False, early_stopping_strategy=None, "
                 "suppress_storage_errors_after_retries=False))"
             ),

--- a/ax/service/utils/scheduler_options.py
+++ b/ax/service/utils/scheduler_options.py
@@ -76,6 +76,7 @@ class SchedulerOptions:
         min_seconds_before_poll: Minimum number of seconds between
             beginning to run a trial and the first poll to check
             trial status.
+        timeout_hours: Number of hours after which the optimization will abort
         seconds_between_polls_backoff_factor: The rate at which the poll
             interval increases.
         run_trials_in_batches: If True and ``poll_available_capacity`` is
@@ -110,6 +111,7 @@ class SchedulerOptions:
     init_seconds_between_polls: Optional[int] = 1
     min_seconds_before_poll: float = 1.0
     seconds_between_polls_backoff_factor: float = 1.5
+    timeout_hours: Optional[float] = None
     run_trials_in_batches: bool = False
     debug_log_run_metadata: bool = False
     early_stopping_strategy: Optional[BaseEarlyStoppingStrategy] = None


### PR DESCRIPTION
Summary:
As titled. Users may want to abort benchmark early if it is taking too long.

Note: AggregatedBenchmarkResult has been changed to only take into account the number of trials completed for all replications in its aggregation calculations (ex if a problem is specified for 50 iterations but the underlying experiments are only able to finish `[28, 28, 31, 39, 35, 34, 31, 29, 29, 38]` trials respectively, the AggregatedBenchmarkResult will calculate its traces to be len 28 to ensure each index represents the same number of replications).

Differential Revision: D38081887

