### PR TITLE
Fix flake8 issues in OSS

### DIFF
--- a/ax/core/generator_run.py
+++ b/ax/core/generator_run.py
@@ -231,8 +231,8 @@ class GeneratorRun(SortableBase):
 
     @property
     def index(self) -> Optional[int]:
-        """The index of this generator run within a trial's list of generator run structs.
-        This field is set when the generator run is added to a trial.
+        """The index of this generator run within a trial's list of generator run
+        structs. This field is set when the generator run is added to a trial.
         """
         return self._index
 

--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -72,9 +72,10 @@ class Metric(SortableBase, SerializationMixin):
 
     @property
     def fetch_multi_group_by_metric(self) -> Type[Metric]:
-        """Metric class, with which to group this metric in `Experiment._metrics_by_class`,
-        which is used to combine metrics on experiment into groups and then fetch their
-        data via `Metric.fetch_trial_data_multi` for each group.
+        """Metric class, with which to group this metric in
+        `Experiment._metrics_by_class`, which is used to combine metrics on experiment
+        into groups and then fetch their data via `Metric.fetch_trial_data_multi` for
+        each group.
 
         NOTE: By default, this property will just return the class on which it is
         defined; however, in some cases it is useful to group metrics by their

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -595,8 +595,8 @@ class HierarchicalSearchSpace(SearchSpace):
         return {k: v for k, v in parameters.items() if k in applicable_paramers}
 
     def _find_root(self) -> Parameter:
-        """Find the root of hierarchical search space: a parameter that does not depend on
-        other parameters.
+        """Find the root of hierarchical search space: a parameter that does not depend
+        on other parameters.
         """
         dependent_parameter_names = set()
         for parameter in self.parameters.values():

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -496,8 +496,8 @@ class GenerationStrategy(Base):
     # ------------------------- Model selection logic helpers. -------------------------
 
     def _fit_or_update_current_model(self, data: Optional[Data]) -> None:
-        """Fits or update the model on the current generation step (does not move between
-        generation steps).
+        """Fits or update the model on the current generation step (does not move
+        between generation steps).
 
         Args:
             data: Optional ``Data`` to fit or update with; if not specified, generation

--- a/ax/modelbridge/transforms/convert_metric_names.py
+++ b/ax/modelbridge/transforms/convert_metric_names.py
@@ -20,7 +20,8 @@ if TYPE_CHECKING:
 
 
 class ConvertMetricNames(Transform):
-    """Convert all metric names to canonical name as specified on a multi_type_experiment.
+    """Convert all metric names to canonical name as specified on a
+    multi_type_experiment.
 
     For example, a multi-type experiment may have an offline simulator which attempts to
     approximate observations from some online system. We want to map the offline

--- a/ax/plot/pareto_frontier.py
+++ b/ax/plot/pareto_frontier.py
@@ -582,8 +582,8 @@ def interact_multiple_pareto_frontier(
     CI_level: float = DEFAULT_CI_LEVEL,
     show_parameterization_on_hover: bool = True,
 ) -> AxPlotConfig:
-    """Plot a Pareto frontiers from a list of lists of NamedParetoFrontierResults objects
-    that we want to compare.
+    """Plot a Pareto frontiers from a list of lists of NamedParetoFrontierResults
+    objects that we want to compare.
 
     Args:
         frontier_lists (Dict[List[ParetoFrontierResults]]): A dictionary of multiple

--- a/ax/runners/botorch_test_problem.py
+++ b/ax/runners/botorch_test_problem.py
@@ -74,8 +74,8 @@ class BotorchTestProblemRunner(Runner):
 
     @classmethod
     def deserialize_init_args(cls, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Given a dictionary, deserialize the properties needed to initialize the runner.
-        Used for storage.
+        """Given a dictionary, deserialize the properties needed to initialize the
+        runner. Used for storage.
         """
         module = importlib.import_module(args["test_problem_module"])
 

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -786,9 +786,9 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         return self.summarize_final_result()
 
     def run_all_trials(self, timeout_hours: Optional[int] = None) -> OptimizationResult:
-        """Run all trials until ``completion_criterion`` is reached (by default, completion
-        criterion is reaching the ``num_trials`` setting, passed to scheduler on
-        instantiation as part of ``SchedulerOptions``).
+        """Run all trials until ``completion_criterion`` is reached (by default,
+        completion criterion is reaching the ``num_trials`` setting, passed to
+        scheduler on instantiation as part of ``SchedulerOptions``).
 
         NOTE: This function is available only when ``SchedulerOptions.num_trials`` is
         specified.
@@ -1338,8 +1338,8 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             )
 
     def _validate_runner_and_implemented_metrics(self, experiment: Experiment) -> None:
-        """Ensure that the experiment specifies runner and metrics; check that metrics are
-        not base ``Metric``-s, which do not implement fetching logic.
+        """Ensure that the experiment specifies runner and metrics; check that metrics
+        are not base ``Metric``-s, which do not implement fetching logic.
         """
         if experiment.runner is None:
             raise UnsupportedError(

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -152,9 +152,9 @@ def get_best_parameters_from_model_predictions_with_trial_index(
     optimization_config: Optional[OptimizationConfig] = None,
     trial_indices: Optional[Iterable[int]] = None,
 ) -> Optional[Tuple[int, TParameterization, Optional[TModelPredictArm]]]:
-    """Given an experiment, returns the best predicted parameterization and corresponding
-    prediction based on the most recent Trial with predictions. If no trials have
-    predictions returns None.
+    """Given an experiment, returns the best predicted parameterization and
+    corresponding prediction based on the most recent Trial with predictions. If no
+    trials have predictions returns None.
 
     Only some models return predictions. For instance GPEI does while Sobol does not.
 
@@ -257,9 +257,9 @@ def get_best_parameters_from_model_predictions(
     models_enum: Type[ModelRegistryBase],
     trial_indices: Optional[Iterable[int]] = None,
 ) -> Optional[Tuple[TParameterization, Optional[TModelPredictArm]]]:
-    """Given an experiment, returns the best predicted parameterization and corresponding
-    prediction based on the most recent Trial with predictions. If no trials have
-    predictions returns None.
+    """Given an experiment, returns the best predicted parameterization and
+    corresponding prediction based on the most recent Trial with predictions. If no
+    trials have predictions returns None.
 
     Only some models return predictions. For instance GPEI does while Sobol does not.
 

--- a/ax/utils/common/serialization.py
+++ b/ax/utils/common/serialization.py
@@ -121,7 +121,7 @@ class SerializationMixin(ABC):
 
     @classmethod
     def deserialize_init_args(cls, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Given a dictionary, deserialize the properties needed to initialize the object.
-        Used for storage.
+        """Given a dictionary, deserialize the properties needed to initialize the
+        object. Used for storage.
         """
         return extract_init_args(args=args, class_=cls)


### PR DESCRIPTION
Summary: The linter we have running on github must have updated/changed settings or something bc OSS started failing out of the blue. Maybe we should consider disabling this (or disabling the internal linter, though that seems bad) rather than trying to keep both linters in sync. Thoughts?

Differential Revision: D38355972

