### PR TITLE
consistency of `metric_names` usage across stoppers

### DIFF
--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -225,7 +225,7 @@ class MapDataTest(TestCase):
             [
                 {
                     "arm_name": arm_name,
-                    "epoch": epoch,
+                    "epoch": epoch + 1,
                     "mean": epoch * 0.1,
                     "sem": 0.1,
                     "trial_index": trial_index,
@@ -263,12 +263,22 @@ class MapDataTest(TestCase):
 
         # test limit_total_rows
         with self.assertRaises(ValueError):
-            large_map_data.subsample(limit_total_rows=5)
-        subsample = large_map_data.subsample(limit_total_rows=10)
-        self.assertEqual(len(subsample.map_df), 10)
+            large_map_data.subsample(limit_total_rows=1)
         subsample = large_map_data.subsample(limit_total_rows=50)
-        self.assertEqual(len(subsample.map_df), 50)
+        self.assertEqual(len(subsample.map_df), 100)
         subsample = large_map_data.subsample(limit_total_rows=65)
-        self.assertEqual(len(subsample.map_df), 60)
+        self.assertEqual(len(subsample.map_df), 128)
         subsample = large_map_data.subsample(limit_total_rows=1000)
         self.assertEqual(len(subsample.map_df), 500)
+
+        # test include_first_last
+        subsample = large_map_data.subsample(
+            limit_total_rows=20, include_first_last=True
+        )
+        self.assertEqual(len(subsample.map_df), 40)
+        self.assertEqual(subsample.map_df["epoch"].max(), 100)
+        subsample = large_map_data.subsample(
+            limit_total_rows=20, include_first_last=False
+        )
+        self.assertEqual(len(subsample.map_df), 40)
+        self.assertEqual(subsample.map_df["epoch"].max(), 92)

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -104,18 +104,15 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             (optional) messages with the associated reason. An empty dictionary
             means no suggested updates to any trial's status.
         """
-        data = self._check_validity_and_get_data(experiment=experiment)
+        metric_name, minimize = self._default_objective_and_direction(
+            experiment=experiment
+        )
+        data = self._check_validity_and_get_data(
+            experiment=experiment, metric_names=[metric_name]
+        )
         if data is None:
             # don't stop any trials if we don't get data back
             return {}
-
-        if self.metric_names is None:
-            optimization_config = not_none(experiment.optimization_config)
-            metric_name = optimization_config.objective.metric.name
-            minimize = optimization_config.objective.minimize
-        else:
-            metric_name = list(self.metric_names)[0]
-            minimize = experiment.metrics[metric_name].lower_is_better or False
 
         map_key = next(iter(data.map_keys))
         df = data.map_df

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -11,7 +11,6 @@ from ax.core.experiment import Experiment
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.logger import get_logger
-from ax.utils.common.typeutils import not_none
 
 logger = get_logger(__name__)
 
@@ -97,18 +96,15 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             (optional) messages with the associated reason. An empty dictionary
             means no suggested updates to any trial's status.
         """
-        data = self._check_validity_and_get_data(experiment=experiment)
+        metric_name, minimize = self._default_objective_and_direction(
+            experiment=experiment
+        )
+        data = self._check_validity_and_get_data(
+            experiment=experiment, metric_names=[metric_name]
+        )
         if data is None:
             # don't stop any trials if we don't get data back
             return {}
-
-        if self.metric_names is None:
-            optimization_config = not_none(experiment.optimization_config)
-            metric_name = optimization_config.objective.metric.name
-            minimize = optimization_config.objective.minimize
-        else:
-            metric_name = list(self.metric_names)[0]
-            minimize = experiment.metrics[metric_name].lower_is_better or False
 
         map_key = next(iter(data.map_keys))
         df = data.map_df


### PR DESCRIPTION
Summary: Some consolidation of code / make things more consistent across stoppers

Differential Revision: D38253541

