### PR TITLE
avoid scheduler failure due to missing metric value

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -966,7 +966,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
                 f"Fetching data for trials: {idcs} because some metrics "
                 "on experiment are available while trials are running."
             )
-            self.experiment.fetch_trials_data(
+            self._fetch_trials_data(
                 trial_indices=running_trial_indices,
                 overwrite_existing_data=True,
             )
@@ -1012,7 +1012,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
                 # fetch it during candidate generation.
                 idcs = make_indices_str(indices=newly_completed)
                 self.logger.info(f"Fetching data for trials: {idcs}.")
-                self.experiment.fetch_trials_data(trial_indices=newly_completed)
+                self._fetch_trials_data(trial_indices=newly_completed)
 
             updated_trials.extend(trials)
 
@@ -1428,4 +1428,12 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
                 self.experiment._properties[prop] = [val_to_append]
         self._update_experiment_properties_in_db(
             experiment_with_updated_properties=self.experiment
+        )
+
+    def _fetch_trials_data(
+        self, trial_indices: Iterable[int], overwrite_existing_data: bool = False
+    ) -> None:
+        """Fetches data from experiment."""
+        self.experiment.fetch_trials_data(
+            trial_indices=trial_indices, overwrite_existing_data=overwrite_existing_data
         )


### PR DESCRIPTION
Summary: wrap results-fetching in try catch so as not to fail the scheduler when a single metric fails to fetch; instead mark the trial as "abandoned" and log a warning. if this works we can maybe do something similar for EarlyStopping metric fetching as well.

Reviewed By: lena-kashtelyan

Differential Revision: D38160234

