### PR TITLE
keep custom arm names on warm-start

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -491,13 +491,18 @@ class BaseTrial(ABC, SortableBase):
         """Sets name for given arm; if this arm is already in the
         experiment, uses the existing arm name.
         """
-        proposed_name = f"{self.index}_{self._num_arms_created}"
+        proposed_name = self._get_default_name()
         self.experiment._name_and_store_arm_if_not_exists(
             arm=arm, proposed_name=proposed_name
         )
         # If arm was named using given name, incremement the count
         if arm.name == proposed_name:
             self._num_arms_created += 1
+
+    def _get_default_name(self, arm_index: Optional[int] = None) -> str:
+        if arm_index is None:
+            arm_index = self._num_arms_created
+        return f"{self.index}_{arm_index}"
 
     def _set_generation_step_index(self, generation_step_index: Optional[int]) -> None:
         """Sets the `generation_step_index` property of the trial, to reflect which

--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -148,6 +148,14 @@ class TrialStatus(int, Enum):
         return f"{self!s}"
 
 
+DEFAULT_STATUSES_TO_WARM_START = [
+    TrialStatus.RUNNING,
+    TrialStatus.COMPLETED,
+    TrialStatus.ABANDONED,
+    TrialStatus.EARLY_STOPPED,
+]
+
+
 def immutable_once_run(func: Callable) -> Callable:
     """Decorator for methods that should throw Error when
     trial is running or has ever run and immutable.

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -732,9 +732,10 @@ class ExperimentTest(TestCase):
 
     def testWarmStartFromOldExperiment(self):
         # create old_experiment
-        len_old_trials = 5
+        len_old_trials = 7
         i_failed_trial = 1
         i_abandoned_trial = 3
+        i_running_trial = 5
         old_experiment = get_branin_experiment()
         for i_old_trial in range(len_old_trials):
             sobol_run = get_sobol(search_space=old_experiment.search_space).gen(n=1)
@@ -744,6 +745,8 @@ class ExperimentTest(TestCase):
                 trial.mark_failed()
             elif i_old_trial == i_abandoned_trial:
                 trial.mark_abandoned(reason=DUMMY_ABANDONED_REASON)
+            elif i_old_trial == i_running_trial:
+                pass
             else:
                 trial.mark_completed()
         # make metric noiseless for exact reproducibility
@@ -803,7 +806,7 @@ class ExperimentTest(TestCase):
             copy_run_metadata=True,
             trial_statuses_to_copy=[TrialStatus.COMPLETED],
         )
-        self.assertEqual(len(new_experiment.trials), len(old_experiment.trials) - 2)
+        self.assertEqual(len(new_experiment.trials), len(old_experiment.trials) - 3)
 
         # Warm start from an experiment with only a subset of metrics
         map_data_experiment = get_branin_experiment_with_timestamp_map_metric()
@@ -966,9 +969,10 @@ class ExperimentWithMapDataTest(TestCase):
 
     def testWarmStartMapData(self):
         # create old_experiment
-        len_old_trials = 5
+        len_old_trials = 7
         i_failed_trial = 1
         i_abandoned_trial = 3
+        i_running_trial = 5
         old_experiment = get_branin_experiment_with_timestamp_map_metric()
         for i_old_trial in range(len_old_trials):
             sobol_run = get_sobol(search_space=old_experiment.search_space).gen(n=1)
@@ -978,6 +982,8 @@ class ExperimentWithMapDataTest(TestCase):
                 trial.mark_failed()
             elif i_old_trial == i_abandoned_trial:
                 trial.mark_abandoned(reason=DUMMY_ABANDONED_REASON)
+            elif i_old_trial == i_running_trial:
+                pass
             else:
                 trial.mark_completed()
         # make metric noiseless for exact reproducibility
@@ -1011,7 +1017,10 @@ class ExperimentWithMapDataTest(TestCase):
         old_df = old_experiment.fetch_data().df
         new_df = new_experiment.fetch_data().df
 
-        # Factor 2 comes from 2 MapData rows per trial in this test experiment
+        old_df = old_df.sort_values(by=["arm_name", "metric_name"], ignore_index=True)
+        new_df = new_df.sort_values(by=["arm_name", "metric_name"], ignore_index=True)
+
+        # Factor 2 comes from 2 rows per trial in this test experiment
         self.assertEqual(len(new_df), (len_old_trials - 2) * 2)
         pd.testing.assert_frame_equal(
             old_df.drop(["arm_name", "trial_index"], axis=1),

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -42,7 +42,9 @@ from ax.utils.testing.core_stubs import (
     get_status_quo,
 )
 
-DUMMY_RUN_METADATA = {"test_run_metadata_key": "test_run_metadata_value"}
+DUMMY_RUN_METADATA_KEY = "test_run_metadata_key"
+DUMMY_RUN_METADATA_VALUE = "test_run_metadata_value"
+DUMMY_RUN_METADATA = {DUMMY_RUN_METADATA_KEY: DUMMY_RUN_METADATA_VALUE}
 DUMMY_ABANDONED_REASON = "test abandoned reason"
 
 
@@ -771,7 +773,8 @@ class ExperimentTest(TestCase):
         for _, trial in old_experiment.trials.items():
             trial._run_metadata = DUMMY_RUN_METADATA
         new_experiment.warm_start_from_old_experiment(
-            old_experiment=old_experiment, copy_run_metadata=True
+            old_experiment=old_experiment,
+            copy_run_metadata_keys=[DUMMY_RUN_METADATA_KEY],
         )
         self.assertEqual(len(new_experiment.trials), len(old_experiment.trials) - 1)
         i_old_trial = 0
@@ -803,7 +806,7 @@ class ExperimentTest(TestCase):
         new_experiment.optimization_config.objective.metric.noise_sd = 0
         new_experiment.warm_start_from_old_experiment(
             old_experiment=old_experiment,
-            copy_run_metadata=True,
+            copy_run_metadata_keys=[DUMMY_RUN_METADATA_KEY],
             trial_statuses_to_copy=[TrialStatus.COMPLETED],
         )
         self.assertEqual(len(new_experiment.trials), len(old_experiment.trials) - 3)
@@ -997,7 +1000,8 @@ class ExperimentWithMapDataTest(TestCase):
         for _, trial in old_experiment.trials.items():
             trial._run_metadata = DUMMY_RUN_METADATA
         new_experiment.warm_start_from_old_experiment(
-            old_experiment=old_experiment, copy_run_metadata=True
+            old_experiment=old_experiment,
+            copy_run_metadata_keys=[DUMMY_RUN_METADATA_KEY],
         )
         self.assertEqual(len(new_experiment.trials), len(old_experiment.trials) - 1)
         i_old_trial = 0

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -46,6 +46,7 @@ DUMMY_RUN_METADATA_KEY = "test_run_metadata_key"
 DUMMY_RUN_METADATA_VALUE = "test_run_metadata_value"
 DUMMY_RUN_METADATA = {DUMMY_RUN_METADATA_KEY: DUMMY_RUN_METADATA_VALUE}
 DUMMY_ABANDONED_REASON = "test abandoned reason"
+DUMMY_ARM_NAME = "test_arm_name"
 
 
 class ExperimentTest(TestCase):
@@ -772,6 +773,8 @@ class ExperimentTest(TestCase):
         new_experiment.optimization_config.objective.metric.noise_sd = 0
         for _, trial in old_experiment.trials.items():
             trial._run_metadata = DUMMY_RUN_METADATA
+        # name one arm to test name-preserving logic.
+        old_experiment.trials[0].arm._name = DUMMY_ARM_NAME
         new_experiment.warm_start_from_old_experiment(
             old_experiment=old_experiment,
             copy_run_metadata_keys=[DUMMY_RUN_METADATA_KEY],
@@ -799,6 +802,9 @@ class ExperimentTest(TestCase):
             old_df.drop(["arm_name", "trial_index"], axis=1),
             new_df.drop(["arm_name", "trial_index"], axis=1),
         )
+
+        # Check name-preserving logic.
+        self.assertEqual(new_experiment.trials[0].arm.name, DUMMY_ARM_NAME)
 
         # check that all non-failed/abandoned trials are copied to new_experiment
         new_experiment = get_branin_experiment()


### PR DESCRIPTION
Summary: prevent overwrite of arm name if the name was specified by the user. here, whether the user specified the arm name is determined by whether the arm name matches the format of the auto-determined default arm name.

Reviewed By: lena-kashtelyan

Differential Revision: D38527195

