### PR TITLE
Support mixing environmental and perturbation parameters in `RobustSearchSpace`

### DIFF
--- a/ax/core/parameter_distribution.py
+++ b/ax/core/parameter_distribution.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 import functools
 from copy import deepcopy
 from importlib import import_module
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from ax.exceptions.core import UserInputError
 from ax.utils.common.base import SortableBase
 from scipy.stats._distn_infrastructure import rv_generic
+
+if TYPE_CHECKING:
+    from ax.core.search_space import RobustSearchSpace
 
 TDistribution = str
 TParamName = str
@@ -67,6 +70,18 @@ class ParameterDistribution(SortableBase):
                 "`distribution_class` is importable from `scipy.stats`."
             )
         return dist_class(**self.distribution_parameters)
+
+    def is_environmental(self, search_space: RobustSearchSpace) -> bool:
+        r"""Check if the parameters are environmental variables of the given
+        search space.
+
+        Args:
+            search_space: The search space to check.
+
+        Returns:
+            A boolean denoting whether the parameters are environmental variables.
+        """
+        return any(search_space.is_environmental_variable(p) for p in self.parameters)
 
     def clone(self) -> ParameterDistribution:
         """Clone."""

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -697,38 +697,15 @@ class RobustSearchSpace(SearchSpace):
                 "RobustSearchSpace requires at least one distributional parameter. "
                 "Use SearchSpace instead."
             )
-        if num_samples < 1:
+        if num_samples < 1 or int(num_samples) != num_samples:
             raise UserInputError("`num_samples` must be a positive integer!")
         self.num_samples = num_samples
-        # Make sure that the distributions are all multiplicative or additive.
-        mul_flags = [d.multiplicative for d in parameter_distributions]
-        if not (all(mul_flags) or not any(mul_flags)):
-            raise UnsupportedError(
-                "Parameter distributions must be either all multiplicative "
-                "or all additive (not multiplicative)."
-            )
         self.parameter_distributions = parameter_distributions
-        # Make sure that there is at most one distribution per parameter.
-        distributional_parameters_list = []
-        for param_dist in parameter_distributions:
-            distributional_parameters_list.extend(param_dist.parameters)
-        self._distributional_parameters: Set[str] = set(distributional_parameters_list)
-        if len(self._distributional_parameters) != len(distributional_parameters_list):
-            raise UserInputError(
-                "Received multiple parameter distributions for at least one parameter. "
-                "Make sure that there is at most one distribution specified for any "
-                "given parameter / environmental variable."
-            )
-        # Make sure that all env vars have distributions specified,
-        # and the names are unique.
+        # Make sure that the env var names are unique.
         environmental_variables = environmental_variables or []
         all_env_vars: Set[str] = {p.name for p in environmental_variables}
         if len(all_env_vars) < len(environmental_variables):
             raise UserInputError("Environmental variable names must be unique!")
-        if not all_env_vars.issubset(self._distributional_parameters):
-            raise UserInputError(
-                "All environmental variables must have a distribution specified."
-            )
         self._environmental_variables: Dict[str, Parameter] = {
             p.name: p for p in environmental_variables
         }
@@ -744,37 +721,95 @@ class RobustSearchSpace(SearchSpace):
         super().__init__(
             parameters=parameters, parameter_constraints=parameter_constraints
         )
-        # NOTE: We do not support env var and input noise together since the existing
-        # acqfs are designed to work with only one of these.
+        self._validate_distributions()
+
+    def _validate_distributions(self) -> None:
+        r"""Validate the parameter distributions.
+
+        * All distributional parameters must be range parameters.
+        * All environmental variables must have a non-multiplicative distribution.
+        * Either all or none of the perturbation distributions must be
+        multiplicative.
+        * Each parameter can have at most one distribution associated with it.
+        """
+        distributions = self.parameter_distributions
+        # Make sure that there is at most one distribution per parameter.
+        self._distributional_parameters: Set[str] = set()
+        for dist in distributions:
+            duplicates = self._distributional_parameters.intersection(dist.parameters)
+            if duplicates:
+                raise UserInputError(
+                    "Received multiple parameter distributions for parameters "
+                    f"{duplicates}. Make sure that there is at most one distribution "
+                    "specified for any given parameter / environmental variable."
+                )
+            self._distributional_parameters.update(dist.parameters)
+
+        all_env_vars = set(self._environmental_variables.keys())
+        if not all_env_vars.issubset(self._distributional_parameters):
+            raise UserInputError(
+                "All environmental variables must have a distribution specified."
+            )
+
+        self._environmental_distributions: List[ParameterDistribution] = []
+        self._perturbation_distributions: List[ParameterDistribution] = []
         if len(all_env_vars) > 0:
             if all_env_vars != self._distributional_parameters:
-                raise UnsupportedError(
-                    "Environmental variables and input noise are currently not "
-                    "supported together. Use either environmental variables or "
-                    "input noise on the parameters, not both."
-                )
-            if not all(isinstance(p, RangeParameter) for p in environmental_variables):
-                raise UserInputError(
-                    "All environmental variables must be range parameters."
-                )
-            if any(d.multiplicative for d in parameter_distributions):
+                # NOTE: We do not support mixing env var and input noise together
+                # in a single `ParameterDistribuion`.
+                for dist in distributions:
+                    is_env = [p in all_env_vars for p in dist.parameters]
+                    if not all(is_env) and any(is_env):
+                        raise UnsupportedError(
+                            "A `ParameterDistribution` must represent either the "
+                            "distribution of a set of environmental variables or "
+                            "a set of parameter perturbations. Mixing the distribution "
+                            "of both types in a single `ParameterDistribution` is "
+                            f"not supported. Offending distribution: {dist}."
+                        )
+                    if any(is_env):
+                        self._environmental_distributions.append(dist)
+                    else:
+                        self._perturbation_distributions.append(dist)
+            else:
+                self._environmental_distributions = distributions
+            if any(d.multiplicative for d in self._environmental_distributions):
                 raise UserInputError(
                     "Distributions of environmental variables must have "
                     "`multiplicative=False`."
                 )
         else:
-            if not all(
-                isinstance(self.parameters[p], RangeParameter)
-                for p in self._distributional_parameters
-            ):
-                raise UserInputError(
-                    "All parameters with an associated distribution must be "
-                    "range parameters."
-                )
+            self._perturbation_distributions = distributions
 
-    @property
-    def is_environmental(self) -> bool:
-        return len(self._environmental_variables) > 0
+        if not all(
+            isinstance(self.parameters[p], RangeParameter)
+            for p in self._distributional_parameters
+        ):
+            raise UserInputError(
+                "All parameters with an associated distribution must be "
+                "range parameters."
+            )
+
+        # Make sure that all or none of perturbation distributions are multiplicative.
+        mul_flags = [d.multiplicative for d in self._perturbation_distributions]
+        if not (all(mul_flags) or not any(mul_flags)):
+            raise UnsupportedError(
+                "Non-environmental parameter distributions must be either all "
+                "multiplicative or all additive (not multiplicative)."
+            )
+        self.multiplicative = any(mul_flags)
+
+    def is_environmental_variable(self, parameter_name: str) -> bool:
+        r"""Check if a given parameter is an environmental variable.
+
+        Args:
+            parameter: A string denoting the name of the parameter.
+
+        Returns:
+            A boolean denoting whether the given `parameter_name` corresponds
+            to an environmental variable of this search space.
+        """
+        return parameter_name in self._environmental_variables
 
     @property
     def parameters(self) -> Dict[str, Parameter]:
@@ -862,20 +897,36 @@ class RobustSearchSpaceDigest:
     """Container for lightweight representation of properties that are unique
     to the `RobustSearchSpace`. This is used to append the `SearchSpaceDigest`.
 
+    NOTE: Both `sample_param_perturbations` and `sample_environmental` should
+    require no inputs and return a `num_samples x d`-dim array of samples from
+    the corresponding parameter distributions, where `d` is the number of
+    non-environmental parameters for `distribution_sampler` and the number of
+    environmental variables for `environmental_sampler`.
+
     Attributes:
-        distribution_sampler: An optional callable for sampling from the
-            parameter distributions. This should require no arguments
-            and return a `num_samples x d`-dim array of samples from the
-            parameter distributions, where `d` is either the number of environmental
-            variables, if any, or the number of parameters.
+        sample_param_perturbations: An optional callable for sampling from the
+            parameter distributions representing input perturbations.
+        sample_environmental: An optional callable for sampling from the
+            distributions of the environmental variables.
         environmental_variables: A list of environmental variable names.
         multiplicative: Denotes whether the distribution is multiplicative.
             Only relevant if paired with a `distribution_sampler`.
     """
 
-    distribution_sampler: Callable[[], np.ndarray]
+    sample_param_perturbations: Optional[Callable[[], np.ndarray]] = None
+    sample_environmental: Optional[Callable[[], np.ndarray]] = None
     environmental_variables: List[str] = field(default_factory=list)
     multiplicative: bool = False
+
+    def __post_init__(self) -> None:
+        if (
+            self.sample_param_perturbations is None
+            and self.sample_environmental is None
+        ):
+            raise UserInputError(
+                "`RobustSearchSpaceDigest` must be initialized with at least one of "
+                "`distribution_sampler` and `environmental_sampler`."
+            )
 
 
 def _disjoint_union(set1: Set[str], set2: Set[str]) -> Set[str]:

--- a/ax/core/tests/test_parameter_distribution.py
+++ b/ax/core/tests/test_parameter_distribution.py
@@ -5,8 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 from ax.core.parameter_distribution import ParameterDistribution
+from ax.core.search_space import RobustSearchSpace
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_robust_search_space
 from scipy.stats._continuous_distns import norm_gen
 from scipy.stats._distn_infrastructure import rv_frozen
 
@@ -47,3 +49,15 @@ class ParameterDistributionTest(TestCase):
         self.assertFalse(dist.multiplicative)
         with self.assertRaises(UserInputError):
             dist.distribution
+
+        # Test `is_environmental`.
+        rss = get_robust_search_space()
+        self.assertFalse(rss.parameter_distributions[0].is_environmental(rss))
+        params = list(rss.parameters.values())
+        rss = RobustSearchSpace(
+            parameters=params[2:],
+            parameter_distributions=rss.parameter_distributions,
+            num_samples=4,
+            environmental_variables=params[:2],
+        )
+        self.assertTrue(rss.parameter_distributions[0].is_environmental(rss))


### PR DESCRIPTION
Summary: Updates `RobustSearchSpace` to support having input perturbations alongside of environmental variables. Updates `RobustSearchSpaceDigest` to have two fields for distribution samplers, one for perturbation distributions and one for environmental variables, and updates `extract_robust_digest` to construct the two samplers together.

Differential Revision: D38598604

