### PR TITLE
Change default seconds between polls to 5 minutes across the board

### DIFF
--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -57,7 +57,7 @@ class BaseEarlyStoppingStrategy(ABC, Base):
     def __init__(
         self,
         metric_names: Optional[Iterable[str]] = None,
-        seconds_between_polls: int = 60,
+        seconds_between_polls: int = 300,
         min_progression: Optional[float] = None,
         min_curves: Optional[int] = None,
         trial_indices_to_ignore: Optional[List[int]] = None,

--- a/ax/early_stopping/strategies/logical.py
+++ b/ax/early_stopping/strategies/logical.py
@@ -16,7 +16,7 @@ class LogicalEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         self,
         left: BaseEarlyStoppingStrategy,
         right: BaseEarlyStoppingStrategy,
-        seconds_between_polls: int = 60,
+        seconds_between_polls: int = 300,
         true_objective_metric_name: Optional[str] = None,
     ) -> None:
         super().__init__(

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -25,7 +25,7 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
     def __init__(
         self,
         metric_names: Optional[Iterable[str]] = None,
-        seconds_between_polls: int = 60,
+        seconds_between_polls: int = 300,
         percentile_threshold: float = 50.0,
         min_progression: Optional[float] = 10,
         min_curves: Optional[int] = 5,

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -22,7 +22,7 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
     def __init__(
         self,
         metric_names: Optional[Iterable[str]] = None,
-        seconds_between_polls: int = 60,
+        seconds_between_polls: int = 300,
         metric_threshold: float = 0.2,
         min_progression: Optional[float] = 10,
         min_curves: Optional[int] = 5,


### PR DESCRIPTION
Summary: Neural code search `seconds_between_polls: int = 60` => `seconds_between_polls: int = 300`

Differential Revision: D38630353

