### PR TITLE
Bump BoTorch version prior to release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from setuptools import find_packages, setup
 
 # TODO: read pinned Botorch version from a shared source
-PINNED_BOTORCH_VERSION = "0.6.4"
+PINNED_BOTORCH_VERSION = "0.6.6"
 
 if os.environ.get("ALLOW_BOTORCH_LATEST"):
     # allows a more recent previously installed version of botorch to remain


### PR DESCRIPTION
Summary: Current Ax version is using botorch 0.6.4, causing errors. Bumping required version of botorch to the current botorc release. An Ax release is to be made after this commit.

Differential Revision: D38711411

