### PR TITLE
Update PyPA "publish to PyPi" github action

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -160,7 +160,7 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Deploy to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: lilidworkin
         password: ${{ secrets.test_pypi_password }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,7 +101,7 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Deploy to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: drfreund
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Summary:
Uh oh! On our actions page it tells us we are using an old version of the PyPA "publish to PyPi" github action. It looks like they sunset the "master" brand (ie no more updates, not even security) and want us to use this new one instead. Screenshot attached.

https://pxl.cl/2b87z

Differential Revision: D38784031

