### PR TITLE
Fix tutorial failure

### DIFF
--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -92,6 +92,7 @@ def _get_objective_trace_plot(
 
     optimization_config = experiment.optimization_config
     if optimization_config is None:
+        raise RuntimeError("No optimization config")
         return []
 
     metric_names = (
@@ -278,7 +279,7 @@ def get_standard_plots(
 
     objective = not_none(experiment.optimization_config).objective
     if isinstance(objective, ScalarizedObjective):
-        logger.warning(
+        raise RuntimeError(
             "get_standard_plots does not currently support ScalarizedObjective "
             "optimization experiments. Returning an empty list."
         )
@@ -288,25 +289,20 @@ def get_standard_plots(
         data = experiment.fetch_data()
 
     if data.df.empty:
-        logger.info(f"Experiment {experiment} does not yet have data, nothing to plot.")
+        raise RuntimeError(f"Experiment {experiment} does not yet have data, nothing to plot.")
         return []
 
     output_plot_list = []
-    try:
-        output_plot_list.extend(
-            _get_objective_trace_plot(
-                experiment=experiment,
-                data=data,
-                model_transitions=model_transitions
-                if model_transitions is not None
-                else [],
-                true_objective_metric_name=true_objective_metric_name,
-            )
+    output_plot_list.extend(
+        _get_objective_trace_plot(
+            experiment=experiment,
+            data=data,
+            model_transitions=model_transitions
+            if model_transitions is not None
+            else [],
+            true_objective_metric_name=true_objective_metric_name,
         )
-    except Exception as e:
-        # Allow model-based plotting to proceed if objective_trace plotting fails.
-        logger.exception(f"Plotting `objective_trace` failed with error {e}")
-        pass
+    )
 
     # Objective vs. parameter plot requires a `Model`, so add it only if model
     # is alrady available. In cases where initially custom trials are attached,

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -83,8 +83,6 @@ def gen_tutorials(
 
     for config in tutorial_configs:
         tid = config["id"]
-        if 'scheduler' not in tid:
-            continue
         t_dir = config.get("dir")
         exec_on_build = config.get("exec_on_build", True)
 

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -83,6 +83,8 @@ def gen_tutorials(
 
     for config in tutorial_configs:
         tid = config["id"]
+        if 'scheduler' not in tid:
+            continue
         t_dir = config.get("dir")
         exec_on_build = config.get("exec_on_build", True)
 

--- a/tutorials/scheduler.ipynb
+++ b/tutorials/scheduler.ipynb
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "code_folding": [],
     "executionStartTime": 1646325042150,
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "code_folding": [],
     "executionStartTime": 1646325042214,
@@ -236,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "executionStartTime": 1646325042364,
     "executionStopTime": 1646325042596,
@@ -290,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "executionStartTime": 1646325042616,
     "executionStopTime": 1646325042623,
@@ -302,7 +302,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-11 15:31:25] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+      "[INFO 08-17 12:08:05] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
      ]
     }
    ],
@@ -368,20 +368,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "executionStartTime": 1646325042632,
     "executionStopTime": 1646325042699,
     "originalKey": "d699d3e9-85d3-40f3-822f-ece6a6cc58e3",
-    "requestMsgId": "d699d3e9-85d3-40f3-822f-ece6a6cc58e3"
+    "requestMsgId": "d699d3e9-85d3-40f3-822f-ece6a6cc58e3",
+    "scrolled": true
    },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-11 15:31:27] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n",
-      "[INFO 08-11 15:31:27] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
+      "[INFO 08-17 12:08:05] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n",
+      "[INFO 08-17 12:08:05] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n"
      ]
     }
    ],
@@ -406,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "code_folding": [],
     "executionStartTime": 1646325042718,
@@ -420,7 +421,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-11 15:31:28] Scheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
+      "[INFO 08-17 12:08:06] Scheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n"
      ]
     }
    ],
@@ -444,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,8 +453,10 @@
     "\n",
     "\n",
     "def make_plot(scheduler: Scheduler):\n",
-    "    fig = get_standard_plots(scheduler.experiment, None)[0]\n",
-    "    return fig\n",
+    "    standard_plots = get_standard_plots(scheduler.experiment, None)\n",
+    "    if len(standard_plots) == 0:\n",
+    "        raise RuntimeError(\"Nothing to plot.\")\n",
+    "    return standard_plots[0]\n",
     "\n",
     "fig, callback = get_figure_and_callback(make_plot)"
    ]
@@ -472,13 +475,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3c7e5c54a0a84233b9540b8f7e76b651",
+       "model_id": "9ea9ca5028464fd593558774e5341ccf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -495,14 +498,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-11 15:31:30] Scheduler: Running trials [0]...\n",
-      "[INFO 08-11 15:31:31] Scheduler: Running trials [1]...\n",
-      "[INFO 08-11 15:31:32] Scheduler: Running trials [2]...\n",
-      "[INFO 08-11 15:31:33] Scheduler: Retrieved COMPLETED trials: 0 - 1.\n",
-      "[INFO 08-11 15:31:33] Scheduler: Fetching data for trials: 0 - 1.\n",
-      "[INFO 08-11 15:31:33] Scheduler: Done submitting trials, waiting for remaining 1 running trials...\n",
-      "[INFO 08-11 15:31:33] Scheduler: Retrieved COMPLETED trials: [2].\n",
-      "[INFO 08-11 15:31:33] Scheduler: Fetching data for trials: [2].\n"
+      "[INFO 08-17 12:08:06] Scheduler: Running trials [0]...\n",
+      "[INFO 08-17 12:08:06] Scheduler: Running trials [1]...\n",
+      "[INFO 08-17 12:08:07] Scheduler: Running trials [2]...\n",
+      "[INFO 08-17 12:08:08] Scheduler: Retrieved COMPLETED trials: [2].\n",
+      "[INFO 08-17 12:08:08] Scheduler: Fetching data for trials: [2].\n",
+      "[INFO 08-17 12:08:08] Scheduler: Done submitting trials, waiting for remaining 2 running trials...\n",
+      "[INFO 08-17 12:08:08] Scheduler: Retrieved COMPLETED trials: 0 - 1.\n",
+      "[INFO 08-17 12:08:08] Scheduler: Fetching data for trials: 0 - 1.\n"
      ]
     },
     {
@@ -511,7 +514,7 @@
        "OptimizationResult()"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -533,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "executionStartTime": 1646325045492,
     "executionStopTime": 1646325045752,
@@ -574,31 +577,31 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>48.830532</td>\n",
+       "      <td>67.168046</td>\n",
        "      <td>0</td>\n",
        "      <td>0_0</td>\n",
-       "      <td>8.537585</td>\n",
-       "      <td>8.528700</td>\n",
+       "      <td>1.565389</td>\n",
+       "      <td>11.382686</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>55.212038</td>\n",
+       "      <td>31.823387</td>\n",
        "      <td>1</td>\n",
        "      <td>1_0</td>\n",
-       "      <td>-1.279781</td>\n",
-       "      <td>1.732519</td>\n",
+       "      <td>0.577258</td>\n",
+       "      <td>8.836075</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>3.164134</td>\n",
+       "      <td>0.845907</td>\n",
        "      <td>2</td>\n",
        "      <td>2_0</td>\n",
-       "      <td>9.143289</td>\n",
-       "      <td>0.702370</td>\n",
+       "      <td>-2.911514</td>\n",
+       "      <td>11.287328</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
        "    </tr>\n",
@@ -607,10 +610,10 @@
        "</div>"
       ],
       "text/plain": [
-       "      branin  trial_index arm_name        x1        x2 trial_status  \\\n",
-       "0  48.830532            0      0_0  8.537585  8.528700    COMPLETED   \n",
-       "1  55.212038            1      1_0 -1.279781  1.732519    COMPLETED   \n",
-       "2   3.164134            2      2_0  9.143289  0.702370    COMPLETED   \n",
+       "      branin  trial_index arm_name        x1         x2 trial_status  \\\n",
+       "0  67.168046            0      0_0  1.565389  11.382686    COMPLETED   \n",
+       "1  31.823387            1      1_0  0.577258   8.836075    COMPLETED   \n",
+       "2   0.845907            2      2_0 -2.911514  11.287328    COMPLETED   \n",
        "\n",
        "  generation_method  \n",
        "0             Sobol  \n",
@@ -618,7 +621,7 @@
        "2             Sobol  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -641,7 +644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "executionStartTime": 1646325045788,
     "executionStopTime": 1646325048325,
@@ -653,14 +656,14 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3c7e5c54a0a84233b9540b8f7e76b651",
+       "model_id": "5807cf462a284577abec71ac188f510b",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
        "FigureWidget({\n",
-       "    'data': [{'error_y': {'array': array([0., 0., 0.]), 'type': 'data', 'visible': True},\n",
-       "     …"
+       "    'data': [], 'layout': {'template': '...'}\n",
+       "})"
       ]
      },
      "metadata": {},
@@ -670,8 +673,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-11 15:31:41] Scheduler: Running trials [3]...\n",
-      "[INFO 08-11 15:31:42] Scheduler: Running trials [4]...\n",
+      "[INFO 08-17 12:08:08] Scheduler: Running trials [3]...\n",
+      "[INFO 08-17 12:08:09] Scheduler: Running trials [4]...\n",
       "/Users/santorella/opt/anaconda3/envs/axdev/lib/python3.10/site-packages/gpytorch/lazy/lazy_tensor.py:1811: UserWarning:\n",
       "\n",
       "torch.triangular_solve is deprecated in favor of torch.linalg.solve_triangularand will be removed in a future PyTorch release.\n",
@@ -680,9 +683,12 @@
       "should be replaced with\n",
       "X = torch.linalg.solve_triangular(A, B). (Triggered internally at  /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/native/BatchLinearAlgebra.cpp:2189.)\n",
       "\n",
-      "[INFO 08-11 15:31:43] Scheduler: Running trials [5]...\n",
-      "[INFO 08-11 15:31:44] Scheduler: Retrieved COMPLETED trials: 3 - 5.\n",
-      "[INFO 08-11 15:31:44] Scheduler: Fetching data for trials: 3 - 5.\n"
+      "[INFO 08-17 12:08:11] Scheduler: Running trials [5]...\n",
+      "[INFO 08-17 12:08:12] Scheduler: Retrieved COMPLETED trials: [4].\n",
+      "[INFO 08-17 12:08:12] Scheduler: Fetching data for trials: [4].\n",
+      "[INFO 08-17 12:08:12] Scheduler: Done submitting trials, waiting for remaining 2 running trials...\n",
+      "[INFO 08-17 12:08:12] Scheduler: Retrieved COMPLETED trials: [3, 5].\n",
+      "[INFO 08-17 12:08:12] Scheduler: Fetching data for trials: [3, 5].\n"
      ]
     },
     {
@@ -691,13 +697,16 @@
        "OptimizationResult()"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "display(fig)\n",
+    "# create a new figure to prevent overwriting the first one\n",
+    "# this isn't necessary if you just care about the final results\n",
+    "second_fig, callback = get_figure_and_callback(make_plot)\n",
+    "display(second_fig)\n",
     "scheduler.run_n_trials(max_trials=3, idle_callback=callback)"
    ]
   },
@@ -713,7 +722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "executionStartTime": 1646325048364,
     "executionStopTime": 1646325048529,
@@ -754,61 +763,61 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>48.830532</td>\n",
+       "      <td>67.168046</td>\n",
        "      <td>0</td>\n",
        "      <td>0_0</td>\n",
-       "      <td>8.537585</td>\n",
-       "      <td>8.528700</td>\n",
+       "      <td>1.565389</td>\n",
+       "      <td>11.382686</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>55.212038</td>\n",
+       "      <td>31.823387</td>\n",
        "      <td>1</td>\n",
        "      <td>1_0</td>\n",
-       "      <td>-1.279781</td>\n",
-       "      <td>1.732519</td>\n",
+       "      <td>0.577258</td>\n",
+       "      <td>8.836075</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>3.164134</td>\n",
+       "      <td>0.845907</td>\n",
        "      <td>2</td>\n",
        "      <td>2_0</td>\n",
-       "      <td>9.143289</td>\n",
-       "      <td>0.702370</td>\n",
+       "      <td>-2.911514</td>\n",
+       "      <td>11.287328</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>93.629914</td>\n",
+       "      <td>36.096419</td>\n",
        "      <td>3</td>\n",
        "      <td>3_0</td>\n",
-       "      <td>9.879896</td>\n",
-       "      <td>12.490587</td>\n",
+       "      <td>-4.741787</td>\n",
+       "      <td>11.370676</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>16.603565</td>\n",
+       "      <td>112.880196</td>\n",
        "      <td>4</td>\n",
        "      <td>4_0</td>\n",
-       "      <td>-4.095656</td>\n",
-       "      <td>11.198717</td>\n",
+       "      <td>1.025954</td>\n",
+       "      <td>14.397744</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>20.737134</td>\n",
+       "      <td>136.678800</td>\n",
        "      <td>5</td>\n",
        "      <td>5_0</td>\n",
-       "      <td>6.161786</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>-4.568516</td>\n",
+       "      <td>4.651111</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>GPEI</td>\n",
        "    </tr>\n",
@@ -817,13 +826,13 @@
        "</div>"
       ],
       "text/plain": [
-       "      branin  trial_index arm_name        x1         x2 trial_status  \\\n",
-       "0  48.830532            0      0_0  8.537585   8.528700    COMPLETED   \n",
-       "1  55.212038            1      1_0 -1.279781   1.732519    COMPLETED   \n",
-       "2   3.164134            2      2_0  9.143289   0.702370    COMPLETED   \n",
-       "3  93.629914            3      3_0  9.879896  12.490587    COMPLETED   \n",
-       "4  16.603565            4      4_0 -4.095656  11.198717    COMPLETED   \n",
-       "5  20.737134            5      5_0  6.161786   0.000000    COMPLETED   \n",
+       "       branin  trial_index arm_name        x1         x2 trial_status  \\\n",
+       "0   67.168046            0      0_0  1.565389  11.382686    COMPLETED   \n",
+       "1   31.823387            1      1_0  0.577258   8.836075    COMPLETED   \n",
+       "2    0.845907            2      2_0 -2.911514  11.287328    COMPLETED   \n",
+       "3   36.096419            3      3_0 -4.741787  11.370676    COMPLETED   \n",
+       "4  112.880196            4      4_0  1.025954  14.397744    COMPLETED   \n",
+       "5  136.678800            5      5_0 -4.568516   4.651111    COMPLETED   \n",
        "\n",
        "  generation_method  \n",
        "0             Sobol  \n",
@@ -834,7 +843,7 @@
        "5              GPEI  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -855,7 +864,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {
     "executionStartTime": 1646325048565,
     "executionStopTime": 1646325049269,
@@ -866,13 +875,14 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3c7e5c54a0a84233b9540b8f7e76b651",
+       "model_id": "10e103b963244c84b87d27ec01092c06",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
        "FigureWidget({\n",
-       "    'data': [{'error_y': {'array': array([0., 0., 0., 0., 0., 0.]), 'type': 'data', 'visible': …"
+       "    'data': [], 'layout': {'template': '...'}\n",
+       "})"
       ]
      },
      "metadata": {},
@@ -882,14 +892,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-11 15:31:49] Scheduler: Running trials [6]...\n",
-      "[ERROR 08-11 15:31:49] Scheduler: Optimization timed out (timeout hours: 1e-05)!\n",
-      "[INFO 08-11 15:31:49] Scheduler: `should_abort_optimization` is `True`, not running more trials.\n",
-      "[INFO 08-11 15:31:49] Scheduler: Waiting for completed trials (for 1 sec, currently running trials: 1).\n",
-      "[INFO 08-11 15:31:50] Scheduler: Waiting for completed trials (for 1.5 sec, currently running trials: 1).\n",
-      "[INFO 08-11 15:31:52] Scheduler: Retrieved COMPLETED trials: [6].\n",
-      "[INFO 08-11 15:31:52] Scheduler: Fetching data for trials: [6].\n",
-      "[ERROR 08-11 15:31:52] Scheduler: Optimization timed out (timeout hours: 1e-05)!\n"
+      "[INFO 08-17 12:08:12] Scheduler: Running trials [6]...\n",
+      "[ERROR 08-17 12:08:12] Scheduler: Optimization timed out (timeout hours: 1e-05)!\n",
+      "[INFO 08-17 12:08:12] Scheduler: `should_abort_optimization` is `True`, not running more trials.\n",
+      "[INFO 08-17 12:08:12] Scheduler: Retrieved COMPLETED trials: [6].\n",
+      "[INFO 08-17 12:08:12] Scheduler: Fetching data for trials: [6].\n",
+      "[ERROR 08-17 12:08:12] Scheduler: Optimization timed out (timeout hours: 1e-05)!\n"
      ]
     },
     {
@@ -898,13 +906,14 @@
        "OptimizationResult()"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "display(fig)\n",
+    "third_fig, callback = get_figure_and_callback(make_plot)\n",
+    "display(third_fig)\n",
     "scheduler.run_n_trials(max_trials=3, timeout_hours=0.00001, idle_callback=callback)"
    ]
   },
@@ -924,7 +933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "metadata": {
     "code_folding": [],
     "executionStartTime": 1646325049292,
@@ -938,13 +947,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-11 15:32:14] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n",
-      "[INFO 08-11 15:32:14] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n",
-      "[INFO 08-11 15:32:14] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n",
-      "[INFO 08-11 15:32:14] Scheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n",
-      "[INFO 08-11 15:32:14] ax.service.utils.with_db_settings_base: Experiment branin_test_experiment is not yet in DB, storing it.\n",
-      "[INFO 08-11 15:32:14] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n",
-      "[INFO 08-11 15:32:14] ax.service.utils.with_db_settings_base: Generation strategy Sobol+GPEI is not yet in DB, storing it.\n"
+      "[INFO 08-17 12:08:12] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n",
+      "[INFO 08-17 12:08:12] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n",
+      "[INFO 08-17 12:08:12] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n",
+      "[INFO 08-17 12:08:12] Scheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n",
+      "[INFO 08-17 12:08:12] ax.service.utils.with_db_settings_base: Experiment branin_test_experiment is not yet in DB, storing it.\n",
+      "[INFO 08-17 12:08:12] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n",
+      "[INFO 08-17 12:08:12] ax.service.utils.with_db_settings_base: Generation strategy Sobol+GPEI is not yet in DB, storing it.\n"
      ]
     }
    ],
@@ -998,7 +1007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 14,
    "metadata": {
     "code_folding": [],
     "executionStartTime": 1646325049666,
@@ -1012,10 +1021,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-11 15:32:16] ax.service.utils.with_db_settings_base: Loading experiment and generation strategy (with reduced state: True)...\n",
-      "[INFO 08-11 15:32:16] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n",
-      "[INFO 08-11 15:32:16] ax.service.utils.with_db_settings_base: Loaded experiment branin_test_experiment in 0.01 seconds, loading trials in mini-batches of 10000.\n",
-      "[INFO 08-11 15:32:16] ax.service.utils.with_db_settings_base: Loaded generation strategy for experiment branin_test_experiment in 0.01 seconds.\n",
+      "[INFO 08-17 12:08:12] ax.service.utils.with_db_settings_base: Loading experiment and generation strategy (with reduced state: True)...\n",
+      "[INFO 08-17 12:08:12] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n",
+      "[INFO 08-17 12:08:12] ax.service.utils.with_db_settings_base: Loaded experiment branin_test_experiment in 0.02 seconds, loading trials in mini-batches of 10000.\n",
+      "[INFO 08-17 12:08:12] ax.service.utils.with_db_settings_base: Loaded generation strategy for experiment branin_test_experiment in 0.01 seconds.\n",
       "/Users/santorella/repos/ax/ax/storage/sqa_store/save.py:389: SAWarning:\n",
       "\n",
       "TypeDecorator JSONEncodedText() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)\n",
@@ -1045,7 +1054,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 15,
    "metadata": {
     "executionStartTime": 1646325049943,
     "executionStopTime": 1646325050416,
@@ -1057,16 +1066,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-11 15:32:18] Scheduler: Running trials [0]...\n",
-      "[INFO 08-11 15:32:18] Scheduler: Running trials [1]...\n",
-      "[INFO 08-11 15:32:18] Scheduler: Running trials [2]...\n",
-      "[INFO 08-11 15:32:18] Scheduler: Retrieved COMPLETED trials: [0, 2].\n",
-      "[INFO 08-11 15:32:18] Scheduler: Fetching data for trials: [0, 2].\n",
-      "[INFO 08-11 15:32:18] Scheduler: Done submitting trials, waiting for remaining 1 running trials...\n",
-      "[INFO 08-11 15:32:18] Scheduler: Waiting for completed trials (for 1 sec, currently running trials: 1).\n",
-      "[INFO 08-11 15:32:19] Scheduler: Waiting for completed trials (for 1.5 sec, currently running trials: 1).\n",
-      "[INFO 08-11 15:32:21] Scheduler: Retrieved COMPLETED trials: [1].\n",
-      "[INFO 08-11 15:32:21] Scheduler: Fetching data for trials: [1].\n",
+      "[INFO 08-17 12:08:12] Scheduler: Running trials [0]...\n",
+      "[INFO 08-17 12:08:12] Scheduler: Running trials [1]...\n",
+      "[INFO 08-17 12:08:12] Scheduler: Running trials [2]...\n",
+      "[INFO 08-17 12:08:12] Scheduler: Retrieved COMPLETED trials: [0].\n",
+      "[INFO 08-17 12:08:12] Scheduler: Fetching data for trials: [0].\n",
+      "[INFO 08-17 12:08:13] Scheduler: Done submitting trials, waiting for remaining 2 running trials...\n",
+      "[INFO 08-17 12:08:13] Scheduler: Retrieved COMPLETED trials: [1].\n",
+      "[INFO 08-17 12:08:13] Scheduler: Fetching data for trials: [1].\n",
+      "[INFO 08-17 12:08:13] Scheduler: Waiting for completed trials (for 1 sec, currently running trials: 1).\n",
+      "[INFO 08-17 12:08:14] Scheduler: Waiting for completed trials (for 1.5 sec, currently running trials: 1).\n",
+      "[INFO 08-17 12:08:15] Scheduler: Retrieved COMPLETED trials: [2].\n",
+      "[INFO 08-17 12:08:15] Scheduler: Fetching data for trials: [2].\n",
       "/Users/santorella/repos/ax/ax/storage/sqa_store/save.py:389: SAWarning:\n",
       "\n",
       "TypeDecorator JSONEncodedText() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)\n",
@@ -1079,7 +1090,7 @@
        "OptimizationResult()"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1108,7 +1119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {
     "executionStartTime": 1646325050451,
     "executionStopTime": 1646325050569,
@@ -1247,7 +1258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {
     "code_folding": [],
     "executionStartTime": 1646325050601,
@@ -1269,7 +1280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {
     "executionStartTime": 1646325050680,
     "executionStopTime": 1646325057409,
@@ -1281,77 +1292,45 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-10 13:28:17] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n",
-      "[INFO 08-10 13:28:17] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n",
-      "[INFO 08-10 13:28:17] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n",
-      "[INFO 08-10 13:28:17] ResultReportingScheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n",
-      "[INFO 08-10 13:28:17] ResultReportingScheduler: Running trials [0]...\n"
+      "[INFO 08-17 12:08:15] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n",
+      "[INFO 08-17 12:08:15] ax.modelbridge.dispatch_utils: Using Bayesian optimization since there are more ordered parameters than there are categories for the unordered categorical parameters.\n",
+      "[INFO 08-17 12:08:15] ax.modelbridge.dispatch_utils: Using Bayesian Optimization generation strategy: GenerationStrategy(name='Sobol+GPEI', steps=[Sobol for 5 trials, GPEI for subsequent trials]). Iterations after 5 will take longer to generate due to  model-fitting.\n",
+      "[INFO 08-17 12:08:15] ResultReportingScheduler: `Scheduler` requires experiment to have immutable search space and optimization config. Setting property immutable_search_space_and_opt_config to `True` on experiment.\n",
+      "[INFO 08-17 12:08:15] ResultReportingScheduler: Running trials [0]...\n",
+      "[INFO 08-17 12:08:16] ResultReportingScheduler: Running trials [1]...\n",
+      "[INFO 08-17 12:08:17] ResultReportingScheduler: Running trials [2]...\n",
+      "[INFO 08-17 12:08:18] ResultReportingScheduler: Generated all trials that can be generated currently. Max parallelism currently reached.\n",
+      "[INFO 08-17 12:08:18] ResultReportingScheduler: Retrieved COMPLETED trials: 0 - 2.\n",
+      "[INFO 08-17 12:08:18] ResultReportingScheduler: Fetching data for trials: 0 - 2.\n",
+      "[INFO 08-17 12:08:18] ResultReportingScheduler: Running trials [3]...\n",
+      "[INFO 08-17 12:08:18] ResultReportingScheduler: Running trials [4]...\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "In run_trials_and_yield_results\n",
-      "in run_trials_and_yield_results while loop\n"
+      "Reported result:  (True, {'trials so far': 3, 'currently producing trials from generation step': 'Sobol', 'running trials': []})\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 08-10 13:28:18] ResultReportingScheduler: Running trials [1]...\n",
-      "[INFO 08-10 13:28:19] ResultReportingScheduler: Running trials [2]...\n",
-      "[INFO 08-10 13:28:20] ResultReportingScheduler: Generated all trials that can be generated currently. Max parallelism currently reached.\n",
-      "[INFO 08-10 13:28:20] ResultReportingScheduler: Retrieved COMPLETED trials: 0 - 2.\n",
-      "[INFO 08-10 13:28:20] ResultReportingScheduler: Fetching data for trials: 0 - 2.\n",
-      "[INFO 08-10 13:28:20] ResultReportingScheduler: Running trials [3]...\n"
+      "[INFO 08-17 12:08:19] ResultReportingScheduler: Running trials [5]...\n",
+      "[INFO 08-17 12:08:20] ResultReportingScheduler: Retrieved COMPLETED trials: [5].\n",
+      "[INFO 08-17 12:08:20] ResultReportingScheduler: Fetching data for trials: [5].\n",
+      "[INFO 08-17 12:08:20] ResultReportingScheduler: Done submitting trials, waiting for remaining 2 running trials...\n",
+      "[INFO 08-17 12:08:20] ResultReportingScheduler: Retrieved COMPLETED trials: 3 - 4.\n",
+      "[INFO 08-17 12:08:20] ResultReportingScheduler: Fetching data for trials: 3 - 4.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "in wait_for_completed_trials_and_report_results\n",
-      "n pending trials 3\n",
-      "about to report results\n",
-      "Reported result:  (True, {'trials so far': 3, 'currently producing trials from generation step': 'Sobol', 'running trials': []})\n",
-      "in run_trials_and_yield_results while loop\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[INFO 08-10 13:28:21] ResultReportingScheduler: Running trials [4]...\n",
-      "[INFO 08-10 13:28:23] ResultReportingScheduler: Running trials [5]...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "in wait_for_completed_trials_and_report_results\n",
-      "n pending trials 3\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[INFO 08-10 13:28:24] ResultReportingScheduler: Retrieved COMPLETED trials: 3 - 5.\n",
-      "[INFO 08-10 13:28:24] ResultReportingScheduler: Fetching data for trials: 3 - 5.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "about to report results\n",
+      "Reported result:  (True, {'trials so far': 6, 'currently producing trials from generation step': 'GPEI', 'running trials': [3, 4]})\n",
       "Reported result:  (True, {'trials so far': 6, 'currently producing trials from generation step': 'GPEI', 'running trials': []})\n",
-      "in wait_for_completed_trials_and_report_results\n",
-      "n pending trials 0\n",
-      "about to report results\n",
       "Reported result:  (True, {'trials so far': 6, 'currently producing trials from generation step': 'GPEI', 'running trials': []})\n"
      ]
     }
@@ -1369,6 +1348,19 @@
     "\n",
     "for reported_result in scheduler.run_trials_and_yield_results(max_trials=6):\n",
     "    print(\"Reported result: \", reported_result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up to enable running the tutorial repeatedly with\n",
+    "# the same results. You wouldn't do this if you wanted to\n",
+    "# keep adding data to the same experiment.\n",
+    "from ax.storage.sqa_store.delete import delete_experiment\n",
+    "delete_experiment('branin_test_experiment')"
    ]
   },
   {


### PR DESCRIPTION
Fixes #1074 : 
* When we generate the callback [here](https://github.com/facebook/Ax/blob/40714956c1849ac11350fcbf7a72a2aa41f939a4/ax/service/utils/report_utils.py#L662), put the call to plot_fn inside of a try/except, catching RuntimeErrors. If it fails, log the warning and proceed without updating the plot. In general, we probably don't to kill optimization just because of an issue with plotting.
* In the plotting function defined in the tutorial notebook scheduler.ipynb, raise a RuntimeError if there is no data to plot with.

Other tutorial changes:
* Since we are showing a figure that updates in-place several times, the tutorial was previously propagating changes to previous cells (since multiple cells were displaying the same figure). I started making a new figure for each cell.
* Clean-up: Delete the experiment from sqa_store at the end. I was not able to run the tutorial repeatedly without doing that.