### PR TITLE
Change nan-policy to propagate in benchmarking suite

### DIFF
--- a/ax/benchmark/benchmark_result.py
+++ b/ax/benchmark/benchmark_result.py
@@ -102,7 +102,7 @@ class AggregatedBenchmarkResult(Base):
         """
         # Extract average wall times and standard errors thereof
         fit_time, gen_time = map(
-            lambda Ts: [nanmean(Ts), float(sem(Ts, ddof=1, nan_policy="omit"))],
+            lambda Ts: [nanmean(Ts), float(sem(Ts, ddof=1, nan_policy="propagate"))],
             zip(*((res.fit_time, res.gen_time) for res in results)),
         )
 
@@ -159,7 +159,7 @@ def _get_stats(
         stats.update({"progression": []})
     for i, step_vals in enumerate(step_data):
         stats["mean"].append(nanmean(step_vals))
-        stats["sem"].append(sem(step_vals, ddof=1, nan_policy="omit"))
+        stats["sem"].append(sem(step_vals, ddof=1, nan_policy="propagate"))
         quantiles.append(nanquantile(step_vals, q=percentiles))
         if progressions is not None:
             stats["progression"].append(progressions[i])


### PR DESCRIPTION
Summary:
Sometimes the figures used to calculate the sem column on either the optimization trace or score trace may be malformed and contain/produce nans. In current behavior (omit policy) we would omit the nans from the trace, possibly leaving traces of different lengths between replications. When these traces were concatenated into dataframes at aggregation time we would get masked values due to the shape mismatch, which cause serialization issues.

In this diff we allow the nans to propagate through -- while we may wind up with nans in the traces they will at least serialize properly and we wont run into this strange class of bug again.

Reviewed By: saitcakmak

Differential Revision: D38802608

