### PR TITLE
Allow passing label dict to cross validation plot

### DIFF
--- a/ax/plot/tests/test_diagnostic.py
+++ b/ax/plot/tests/test_diagnostic.py
@@ -29,7 +29,8 @@ class DiagnosticTest(TestCase):
         )
         cv = cross_validate(model)
         # Assert that each type of plot can be constructed successfully
-        plot = interact_cross_validation_plotly(cv)
+        label_dict = {"branin": "BrAnIn"}
+        plot = interact_cross_validation_plotly(cv, label_dict=label_dict)
         self.assertIsInstance(plot, go.Figure)
-        plot = interact_cross_validation(cv)
+        plot = interact_cross_validation(cv, label_dict=label_dict)
         self.assertIsInstance(plot, AxPlotConfig)


### PR DESCRIPTION
Summary:
Allows specifying a label dict to pass along to the cross validation plot to handle really long metric names.

This is consistent with how the label_dict kwarg has been added to other plots like the trade-off plot.

Allows for the label dict to be a partial listing, and modifies only the names that are in the dict while leaving the others as original.

Differential Revision: D38863101

