### PR TITLE
set init_batch_limit for SAASBO models to prevent OOM

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         # use latest Botorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install tensorboard  # For tensorboard unit tests.
@@ -81,7 +81,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         # use latest Botorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install tensorboard  # For generating Sphinx docs for TensorboardCurveMetric.

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -46,7 +46,7 @@ jobs:
       env:
         ALLOW_BOTORCH_LATEST: true
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install tensorboard  # For tensorboard unit tests
@@ -58,7 +58,7 @@ jobs:
       env:
         ALLOW_BOTORCH_LATEST: true
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .
         pip install tensorboard  # For tensorboard unit tests
@@ -116,7 +116,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         # use latest BoTorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install psycopg2  # Used in example DBSettings in a tutorial (as part of postgres).
@@ -152,7 +152,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         # use latest BoTorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install wheel

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         # use latest Botorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install tensorboard  # For tensorboard unit tests

--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -134,6 +134,10 @@ class TestDispatchUtils(TestCase):
             self.assertEqual(sobol_fullybayesian._steps[0].num_trials, 3)
             self.assertEqual(sobol_fullybayesian._steps[1].model.value, "FullyBayesian")
             self.assertTrue(sobol_fullybayesian._steps[1].model_kwargs["verbose"])
+            self.assertDictEqual(
+                sobol_fullybayesian._steps[1].model_gen_kwargs,
+                {"optimizer_kwargs": {"init_batch_limit": 128}},
+            )
         with self.subTest("SAASBO MOO"):
             sobol_fullybayesianmoo = choose_generation_strategy(
                 search_space=get_branin_search_space(),
@@ -150,6 +154,10 @@ class TestDispatchUtils(TestCase):
                 sobol_fullybayesianmoo._steps[1].model.value, "FullyBayesianMOO"
             )
             self.assertTrue(sobol_fullybayesianmoo._steps[1].model_kwargs["verbose"])
+            self.assertDictEqual(
+                sobol_fullybayesian._steps[1].model_gen_kwargs,
+                {"optimizer_kwargs": {"init_batch_limit": 128}},
+            )
         with self.subTest("SAASBO"):
             sobol_fullybayesian_large = choose_generation_strategy(
                 search_space=get_large_ordinal_search_space(


### PR DESCRIPTION
Summary: Sets init_batch_limit to avoid OOM during highly parallel candidate generation (~32 candidates).

Differential Revision: D38502990

