### PR TITLE
Use GPyTorch==1.8.1 in workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         # use latest Botorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install tensorboard  # For tensorboard unit tests.
@@ -81,7 +81,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         # use latest Botorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install tensorboard  # For generating Sphinx docs for TensorboardCurveMetric.

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -46,7 +46,7 @@ jobs:
       env:
         ALLOW_BOTORCH_LATEST: true
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install tensorboard  # For tensorboard unit tests
@@ -58,7 +58,7 @@ jobs:
       env:
         ALLOW_BOTORCH_LATEST: true
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .
         pip install tensorboard  # For tensorboard unit tests
@@ -116,7 +116,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         # use latest BoTorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install psycopg2  # Used in example DBSettings in a tutorial (as part of postgres).
@@ -152,7 +152,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         # use latest BoTorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install wheel

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
       run: |
         # use latest Botorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install "gpytorch==1.8.1"
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e .[dev,mysql,notebook]
         pip install tensorboard  # For tensorboard unit tests


### PR DESCRIPTION
Summary:
Echoing pytorch/botorch#1362:
> cornellius-gp/gpytorch#2027 was a massive change to gpytorch and broke our CI (and other things).
This PR pins gpytorch to the release made right prior to this being merged in to give us some time to fix these.

Differential Revision: D38952803

