### PR TITLE
Update running trials only if trials are running

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1045,8 +1045,11 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
 
         # 2. If any experiment metrics are available while running,
         #    fetch data for running trials
-        if any(
-            m.is_available_while_running() for m in self.experiment.metrics.values()
+        if (
+            any(
+                m.is_available_while_running() for m in self.experiment.metrics.values()
+            )
+            and len(running_trial_indices) > 0
         ):
             # NOTE: Metrics that are *not* available_while_running will be skipped
             # in fetch_trials_data


### PR DESCRIPTION
Summary:
Noticed this line in the logs:

```
[INFO 08-24 10:29:41] ParamSweepScheduler: Fetching data for trials: [] because some metrics on experiment are available while trials are running.
```

which shows the scheduler is attempting fetch data for running trials even when no trials are running.

Differential Revision: D39019456

