### PR TITLE
Refactor transforms to enable using data as features

### DIFF
--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -530,3 +530,15 @@ def separate_observations(
         observation_features = [obs.features for obs in observations]
         observation_data = [obs.data for obs in observations]
     return observation_features, observation_data
+
+
+def recombine_observations(
+    observation_features: List[ObservationFeatures],
+    observation_data: List[ObservationData],
+) -> List[Observation]:
+    if len(observation_features) != len(observation_data):
+        raise ValueError("Got features and data of different lengths")
+    return [
+        Observation(features=observation_features[i], data=obsd)
+        for i, obsd in enumerate(observation_data)
+    ]

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -412,7 +412,8 @@ class HierarchicalSearchSpace(SearchSpace):
         }
         obs_feats = observation_features.clone(
             replace_parameters=self._cast_parameterization(
-                parameters=observation_features.parameters
+                parameters=observation_features.parameters,
+                check_all_parameters_present=False,
             )
         )
         if not obs_feats.metadata:
@@ -586,7 +587,9 @@ class HierarchicalSearchSpace(SearchSpace):
             return applicable
 
         applicable_paramers = _find_applicable_parameters(root=self.root)
-        if not all(k in parameters for k in applicable_paramers):
+        if check_all_parameters_present and not all(
+            k in parameters for k in applicable_paramers
+        ):
             raise RuntimeError(
                 f"Parameters {applicable_paramers- set(parameters.keys())} "
                 "missing from the arm."

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -21,6 +21,7 @@ from ax.core.observation import (
     ObservationFeatures,
     observations_from_data,
     observations_from_map_data,
+    recombine_observations,
     separate_observations,
 )
 from ax.core.trial import Trial
@@ -601,6 +602,11 @@ class ObservationsTest(TestCase):
                 means=np.array([1]), covariance=np.array([[2]]), metric_names=["a"]
             ),
         )
+        with self.assertRaises(ValueError):
+            recombine_observations(observation_features=obs_feats, observation_data=[])
+        new_obs = recombine_observations(obs_feats, obs_data)[0]
+        self.assertEqual(new_obs.features, obs.features)
+        self.assertEqual(new_obs.data, obs.data)
         obs_feats, obs_data = separate_observations(observations=[obs], copy=True)
         self.assertEqual(obs.features, ObservationFeatures(parameters={"x": 20}))
         self.assertEqual(

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -17,7 +17,7 @@ from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
 from ax.modelbridge.map_torch import MapTorchModelBridge
 from ax.modelbridge.modelbridge_utils import (
-    _get_modelbridge_training_data,
+    _unpack_observations,
     observation_data_to_array,
     observation_features_to_array,
 )
@@ -415,16 +415,14 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         transform_model = get_transform_helper_model(
             experiment=experiment, data=map_data
         )
-        obs_feats_raw, obs_data_raw, arm_names = _get_modelbridge_training_data(
-            transform_model
-        )
-        obs_features, obs_data, _ = transform_model._transform_data(
-            obs_feats=obs_feats_raw,
-            obs_data=obs_data_raw,
+        observations_raw = transform_model.get_training_data()
+        observations, _ = transform_model._transform_data(
+            observations=observations_raw,
             search_space=transform_model._model_space,
             transforms=transform_model._raw_transforms,
             transform_configs=None,
         )
+        obs_features, obs_data, arm_names = _unpack_observations(observations)
         X = observation_features_to_array(parameters=parameters, obsf=obs_features)
         Y, Yvar = observation_data_to_array(
             outcomes=list(outcomes), observation_data=obs_data

--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -20,6 +20,7 @@ from ax.core.observation import (
     ObservationData,
     ObservationFeatures,
     observations_from_data,
+    recombine_observations,
     separate_observations,
 )
 from ax.core.optimization_config import OptimizationConfig
@@ -150,7 +151,7 @@ class ModelBridge(ABC):
         # Convert Data to Observations
         observations = self._prepare_observations(experiment=experiment, data=data)
 
-        obs_feats_raw, obs_data_raw = self._set_training_data(
+        observations_raw = self._set_training_data(
             observations=observations, search_space=search_space
         )
         # Set model status quo
@@ -160,9 +161,8 @@ class ModelBridge(ABC):
             status_quo_name=status_quo_name,
             status_quo_features=status_quo_features,
         )
-        obs_feats, obs_data, search_space = self._transform_data(
-            obs_feats=obs_feats_raw,
-            obs_data=obs_data_raw,
+        observations, search_space = self._transform_data(
+            observations=observations_raw,
             search_space=search_space,
             transforms=transforms,
             transform_configs=transform_configs,
@@ -174,8 +174,7 @@ class ModelBridge(ABC):
             self._fit(
                 model=model,
                 search_space=search_space,
-                observation_features=obs_feats,
-                observation_data=obs_data,
+                observations=observations,
             )
             self.fit_time = time.time() - t_fit_start
             self.fit_time_since_gen = float(self.fit_time)
@@ -194,12 +193,11 @@ class ModelBridge(ABC):
 
     def _transform_data(
         self,
-        obs_feats: List[ObservationFeatures],
-        obs_data: List[ObservationData],
+        observations: List[Observation],
         search_space: SearchSpace,
         transforms: Optional[List[Type[Transform]]],
         transform_configs: Optional[Dict[str, TConfig]],
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData], SearchSpace]:
+    ) -> Tuple[List[Observation], SearchSpace]:
         """Initialize transforms and apply them to provided data."""
         # Initialize transforms
         search_space = search_space.clone()
@@ -210,53 +208,48 @@ class ModelBridge(ABC):
             for t in transforms:
                 t_instance = t(
                     search_space=search_space,
-                    observation_features=obs_feats,
-                    observation_data=obs_data,
+                    observations=observations,
                     modelbridge=self,
                     config=transform_configs.get(t.__name__, None),
                 )
                 search_space = t_instance.transform_search_space(search_space)
-                obs_feats = t_instance.transform_observation_features(obs_feats)
-                obs_data = t_instance.transform_observation_data(obs_data, obs_feats)
+                observations = t_instance.transform_observations(observations)
                 self.transforms[t.__name__] = t_instance
 
-        return obs_feats, obs_data, search_space
+        return observations, search_space
 
     def _prepare_training_data(
         self, observations: List[Observation]
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData]]:
+    ) -> List[Observation]:
         observation_features, observation_data = separate_observations(observations)
         if len(observation_features) != len(set(observation_features)):
             raise ValueError(
                 "Observation features not unique."
                 "Something went wrong constructing training data..."
             )
-        return observation_features, observation_data
+        return observations
 
     def _set_training_data(
         self, observations: List[Observation], search_space: SearchSpace
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData]]:
+    ) -> List[Observation]:
         """Store training data, not-transformed.
 
         If the modelbridge specifies _fit_out_of_design, all training data is
         returned. Otherwise, only in design points are returned.
         """
-        observation_features, observation_data = self._prepare_training_data(
-            observations=observations
-        )
+        observations = self._prepare_training_data(observations=observations)
         self._training_data = deepcopy(observations)
         self._metric_names: Set[str] = set()
-        for obsd in observation_data:
-            self._metric_names.update(obsd.metric_names)
+        for obs in observations:
+            self._metric_names.update(obs.data.metric_names)
         return self._process_in_design(
             search_space=search_space,
-            observation_features=observation_features,
-            observation_data=observation_data,
+            observations=observations,
         )
 
     def _extend_training_data(
         self, observations: List[Observation]
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData]]:
+    ) -> List[Observation]:
         """Extend and return training data, not-transformed.
 
         If the modelbridge specifies _fit_out_of_design, all training data is
@@ -265,15 +258,11 @@ class ModelBridge(ABC):
         Args:
             observations: New observations.
 
-        Returns:
-            observation_features: New + old observation features.
-            observation_data: New + old observation data.
+        Returns: New + old observations.
         """
-        observation_features, observation_data = self._prepare_training_data(
-            observations=observations
-        )
-        for obsd in observation_data:
-            for metric_name in obsd.metric_names:
+        observations = self._prepare_training_data(observations=observations)
+        for obs in observations:
+            for metric_name in obs.data.metric_names:
                 if metric_name not in self._metric_names:
                     raise ValueError(
                         f"Unrecognised metric {metric_name}; cannot update "
@@ -282,46 +271,42 @@ class ModelBridge(ABC):
                     )
         # Initialize with all points in design.
         self._training_data.extend(deepcopy(observations))
-        all_observation_features, all_observation_data = separate_observations(
-            self.get_training_data()
-        )
+        all_observations = self.get_training_data()
         return self._process_in_design(
             search_space=self._model_space,
-            observation_features=all_observation_features,
-            observation_data=all_observation_data,
+            observations=all_observations,
         )
 
     def _process_in_design(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData]]:
+        observations: List[Observation],
+    ) -> List[Observation]:
         """Set training_in_design, and decide whether to filter out of design points."""
         # Don't filter points.
         if self._fit_out_of_design:
             # Use all data for training
             # Set training_in_design to True for all observations so that
             # all observations are used in CV and plotting
-            self.training_in_design = [True] * len(observation_features)
-            return observation_features, observation_data
+            self.training_in_design = [True] * len(observations)
+            return observations
         in_design = self._compute_in_design(
-            search_space=search_space, observation_features=observation_features
+            search_space=search_space, observations=observations
         )
         self.training_in_design = in_design
-        in_design_indices = [i for i, in_design in enumerate(in_design) if in_design]
-        in_design_features = [observation_features[i] for i in in_design_indices]
-        in_design_data = [observation_data[i] for i in in_design_indices]
-        return in_design_features, in_design_data
+        in_design_obs = [
+            observations[i] for i, is_in_design in enumerate(in_design) if is_in_design
+        ]
+        return in_design_obs
 
     def _compute_in_design(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
+        observations: List[Observation],
     ) -> List[bool]:
         return [
-            search_space.check_membership(obsf.parameters)
-            for obsf in observation_features
+            search_space.check_membership(obs.features.parameters)
+            for obs in observations
         ]
 
     def _set_status_quo(
@@ -435,8 +420,7 @@ class ModelBridge(ABC):
         self,
         model: Any,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
     ) -> None:
         """Apply terminal transform and fit model."""
         raise NotImplementedError  # pragma: no cover
@@ -457,14 +441,13 @@ class ModelBridge(ABC):
         observation_data = self._predict(observation_features)
 
         # Apply reverse transforms, in reverse order
+        pred_observations = recombine_observations(
+            observation_features=observation_features, observation_data=observation_data
+        )
+
         for t in reversed(list(self.transforms.values())):
-            observation_features = t.untransform_observation_features(
-                observation_features
-            )
-            observation_data = t.untransform_observation_data(
-                observation_data, observation_features
-            )
-        return observation_data
+            pred_observations = t.untransform_observations(pred_observations)
+        return [obs.data for obs in pred_observations]
 
     def _single_predict(
         self, observation_features: List[ObservationFeatures]
@@ -554,20 +537,16 @@ class ModelBridge(ABC):
         """
         t_update_start = time.time()
         observations = self._prepare_observations(experiment=experiment, data=new_data)
-        obs_feats_raw, obs_data_raw = self._extend_training_data(
-            observations=observations
-        )
-        obs_feats, obs_data, search_space = self._transform_data(
-            obs_feats=obs_feats_raw,
-            obs_data=obs_data_raw,
+        obs_raw = self._extend_training_data(observations=observations)
+        observations, search_space = self._transform_data(
+            observations=obs_raw,
             search_space=self._model_space,
             transforms=self._raw_transforms,
             transform_configs=self._transform_configs,
         )
         self._update(
             search_space=search_space,
-            observation_features=obs_feats,
-            observation_data=obs_data,
+            observations=observations,
         )
         self.fit_time += time.time() - t_update_start
         self.fit_time_since_gen += time.time() - t_update_start
@@ -575,8 +554,7 @@ class ModelBridge(ABC):
     def _update(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
     ) -> None:
         """Apply terminal transform and update model.
 
@@ -777,36 +755,34 @@ class ModelBridge(ABC):
         """
         # Apply transforms to cv_training_data and cv_test_points
         cv_test_points = deepcopy(cv_test_points)
-        obs_feats, obs_data = separate_observations(
-            observations=cv_training_data, copy=True
-        )
+        cv_training_data = deepcopy(cv_training_data)
         search_space = self._model_space.clone()
         for t in self.transforms.values():
-            obs_feats = t.transform_observation_features(obs_feats)
-            obs_data = t.transform_observation_data(obs_data, obs_feats)
+            cv_training_data = t.transform_observations(cv_training_data)
             cv_test_points = t.transform_observation_features(cv_test_points)
             search_space = t.transform_search_space(search_space)
 
+        obs_feats, obs_data = separate_observations(observations=cv_training_data)
         # Apply terminal transform, and get predictions.
         cv_predictions = self._cross_validate(
             search_space=search_space,
-            observation_features=obs_feats,
-            observation_data=obs_data,
+            cv_training_data=cv_training_data,
             cv_test_points=cv_test_points,
         )
         # Apply reverse transforms, in reverse order
+        cv_test_observations = [
+            Observation(features=obsf, data=cv_predictions[i])
+            for i, obsf in enumerate(cv_test_points)
+        ]
+
         for t in reversed(list(self.transforms.values())):
-            cv_test_points = t.untransform_observation_features(cv_test_points)
-            cv_predictions = t.untransform_observation_data(
-                cv_predictions, cv_test_points
-            )
-        return cv_predictions
+            cv_test_observations = t.untransform_observations(cv_test_observations)
+        return [obs.data for obs in cv_test_observations]
 
     def _cross_validate(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        cv_training_data: List[Observation],
         cv_test_points: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Apply the terminal transform, make predictions on the test points,
@@ -847,9 +823,7 @@ class ModelBridge(ABC):
             "Feature importance not available for this model type"
         )
 
-    def transform_observation_data(
-        self, observation_data: List[ObservationData]
-    ) -> Any:
+    def transform_observations(self, observations: List[Observation]) -> Any:
         """Applies transforms to given observation features and returns them in the
         model space.
 
@@ -860,16 +834,14 @@ class ModelBridge(ABC):
             Transformed values. This could be e.g. a torch Tensor, depending
             on the ModelBridge subclass.
         """
-        obsd = deepcopy(observation_data)
+        observations = deepcopy(observations)
         for t in self.transforms.values():
-            obsd = t.transform_observation_data(obsd, [])
+            observations = t.transform_observations(observations)
         # Apply terminal transform and return
-        return self._transform_observation_data(obsd)
+        return self._transform_observations(observations)
 
-    def _transform_observation_data(
-        self, observation_data: List[ObservationData]
-    ) -> Any:
-        """Apply terminal transform to given observation features and return result."""
+    def _transform_observations(self, observations: List[Observation]) -> Any:
+        """Apply terminal transform to given observations and return result."""
         raise NotImplementedError  # pragma: no cover
 
     def transform_observation_features(

--- a/ax/modelbridge/discrete.py
+++ b/ax/modelbridge/discrete.py
@@ -6,7 +6,12 @@
 
 from typing import Dict, List, Optional, Set, Tuple
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import (
+    Observation,
+    ObservationData,
+    ObservationFeatures,
+    separate_observations,
+)
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ChoiceParameter, FixedParameter
 from ax.core.search_space import SearchSpace
@@ -44,13 +49,13 @@ class DiscreteModelBridge(ModelBridge):
         self,
         model: DiscreteModel,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
     ) -> None:
         self.model = model
         # Convert observations to arrays
         self.parameters = list(search_space.parameters.keys())
         all_metric_names: Set[str] = set()
+        observation_features, observation_data = separate_observations(observations)
         for od in observation_data:
             all_metric_names.update(od.metric_names)
         self.outcomes = list(all_metric_names)
@@ -163,13 +168,13 @@ class DiscreteModelBridge(ModelBridge):
     def _cross_validate(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        cv_training_data: List[Observation],
         cv_test_points: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Make predictions at cv_test_points using only the data in obs_feats
         and obs_data.
         """
+        observation_features, observation_data = separate_observations(cv_training_data)
         Xs_train, Ys_train, Yvars_train = self._convert_observations(
             observation_data=observation_data,
             observation_features=observation_features,

--- a/ax/modelbridge/random.py
+++ b/ax/modelbridge/random.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional
 
 from ax.core.data import Data
 from ax.core.experiment import Experiment
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.base import GenResults, ModelBridge
@@ -48,8 +48,7 @@ class RandomModelBridge(ModelBridge):
         self,
         model: RandomModel,
         search_space: SearchSpace,
-        observation_features: Optional[List[ObservationFeatures]] = None,
-        observation_data: Optional[List[ObservationData]] = None,
+        observations: Optional[List[Observation]] = None,
     ) -> None:
         self.model = model
         # Extract and fix parameters from initial search space.
@@ -103,8 +102,7 @@ class RandomModelBridge(ModelBridge):
     def _cross_validate(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        cv_training_data: List[Observation],
         cv_test_points: List[ObservationFeatures],
     ) -> List[ObservationData]:
         raise NotImplementedError

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -88,8 +88,7 @@ class BaseModelBridgeTest(TestCase):
         )
         fit_args = mock_fit.mock_calls[0][2]
         self.assertTrue(fit_args["search_space"] == get_search_space_for_value(8.0))
-        self.assertTrue(fit_args["observation_features"] == [])
-        self.assertTrue(fit_args["observation_data"] == [])
+        self.assertTrue(fit_args["observations"] == [])
         self.assertTrue(mock_observations_from_data.called)
 
         # Test prediction on out of design features.
@@ -212,8 +211,7 @@ class BaseModelBridgeTest(TestCase):
         )
         modelbridge._cross_validate.assert_called_with(
             search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
-            observation_features=[get_observation2trans().features],
-            observation_data=[get_observation2trans().data],
+            cv_training_data=[get_observation2trans()],
             cv_test_points=[get_observation1().features],  # untransformed after
         )
         self.assertTrue(cv_predictions == [get_observation1().data])
@@ -553,7 +551,7 @@ class BaseModelBridgeTest(TestCase):
     def test_update(self, _mock_update, _mock_gen):
         exp = get_experiment_for_value()
         exp.optimization_config = get_optimization_config_no_constraints()
-        ss = get_search_space_for_range_values()
+        ss = get_search_space_for_range_values(min=0, max=1000)
         exp.search_space = ss
         modelbridge = ModelBridge(
             search_space=ss, model=Model(), transforms=[Log], experiment=exp

--- a/ax/modelbridge/tests/test_base_transform.py
+++ b/ax/modelbridge/tests/test_base_transform.py
@@ -4,8 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from copy import deepcopy
 from unittest.mock import MagicMock
 
+import numpy as np
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.modelbridge.transforms.base import Transform
 from ax.utils.common.testutils import TestCase
 
@@ -13,15 +16,39 @@ from ax.utils.common.testutils import TestCase
 class TransformsTest(TestCase):
     def testIdentityTransform(self):
         # Test that the identity transform does not mutate anything
-        t = Transform(MagicMock(), MagicMock(), MagicMock())
+        t = Transform(MagicMock(), MagicMock())
         x = MagicMock()
         ys = []
         ys.append(t.transform_search_space(x))
         ys.append(t.transform_optimization_config(x, x, x))
         ys.append(t.transform_observation_features(x))
-        ys.append(t.transform_observation_data(x, x))
+        ys.append(t._transform_observation_data(x))
         ys.append(t.untransform_observation_features(x))
-        ys.append(t.untransform_observation_data(x, x))
+        ys.append(t._untransform_observation_data(x))
         self.assertEqual(len(x.mock_calls), 0)
         for y in ys:
             self.assertEqual(y, x)
+
+    def testTransformObservations(self):
+        # Test that this is an identity transform
+        means = np.array([3.0, 4.0])
+        metric_names = ["a", "b"]
+        covariance = np.array([[1.0, 2.0], [3.0, 4.0]])
+        parameters = {"x": 1.0, "y": "cat"}
+        arm_name = "armmy"
+        observation = Observation(
+            features=ObservationFeatures(parameters=parameters),
+            data=ObservationData(
+                metric_names=metric_names, means=means, covariance=covariance
+            ),
+            arm_name=arm_name,
+        )
+        t = Transform(None, [])
+        obs1 = t.transform_observations([deepcopy(observation)])[0]
+        obs2 = t.untransform_observations([deepcopy(obs1)])[0]
+        for obs in [obs1, obs2]:
+            self.assertTrue(np.array_equal(obs.data.means, means))
+            self.assertTrue(np.array_equal(obs.data.covariance, covariance))
+            self.assertEqual(obs.data.metric_names, metric_names)
+            self.assertEqual(obs.features.parameters, parameters)
+            self.assertEqual(obs.arm_name, arm_name)

--- a/ax/modelbridge/tests/test_cap_parameter_transform.py
+++ b/ax/modelbridge/tests/test_cap_parameter_transform.py
@@ -28,16 +28,14 @@ class CapParameterTest(TestCase):
     def test_transform_search_space(self):
         t = CapParameter(
             search_space=self.search_space,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             config={"a": "2"},
         )
         t.transform_search_space(self.search_space)
         self.assertEqual(self.search_space.parameters.get("a").upper, 2)
         t2 = CapParameter(
             search_space=self.search_space,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             config={"b": "2"},
         )
         with self.assertRaises(NotImplementedError):
@@ -48,8 +46,7 @@ class CapParameterTest(TestCase):
         # Transform a non-distributional parameter.
         t = CapParameter(
             search_space=rss,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             config={"z": "2"},
         )
         t.transform_search_space(rss)
@@ -57,8 +54,7 @@ class CapParameterTest(TestCase):
         # Error with distributional parameter.
         t = CapParameter(
             search_space=rss,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             config={"x": "2"},
         )
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):

--- a/ax/modelbridge/tests/test_cast_transform.py
+++ b/ax/modelbridge/tests/test_cast_transform.py
@@ -42,9 +42,9 @@ class CastTransformTest(TestCase):
             ],
             parameter_constraints=[],
         )
-        self.t = Cast(search_space=self.search_space)
+        self.t = Cast(search_space=self.search_space, observations=[])
         self.hss = get_hierarchical_search_space()
-        self.t_hss = Cast(search_space=self.hss)
+        self.t_hss = Cast(search_space=self.hss, observations=[])
         self.obs_feats_hss = ObservationFeatures(
             parameters={
                 "model": "Linear",
@@ -92,9 +92,9 @@ class CastTransformTest(TestCase):
         )
 
     def test_flatten_hss_setting(self):
-        t = Cast(search_space=self.hss)
+        t = Cast(search_space=self.hss, observations=[])
         self.assertTrue(t.flatten_hss)
-        t = Cast(search_space=self.hss, config={"flatten_hss": False})
+        t = Cast(search_space=self.hss, config={"flatten_hss": False}, observations=[])
         self.assertFalse(t.flatten_hss)
         self.assertFalse(self.t.flatten_hss)  # `self.t` does not have HSS
         self.assertTrue(self.t_hss.flatten_hss)  # `self.t_hss` does have HSS

--- a/ax/modelbridge/tests/test_choice_encode_transform.py
+++ b/ax/modelbridge/tests/test_choice_encode_transform.py
@@ -48,8 +48,7 @@ class ChoiceEncodeTransformTest(TestCase):
         )
         self.t = self.t_class(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         self.observation_features = [
             ObservationFeatures(
@@ -127,9 +126,7 @@ class ChoiceEncodeTransformTest(TestCase):
                 )
             ]
         )
-        t = OrderedChoiceEncode(
-            search_space=ss3, observation_features=None, observation_data=None
-        )
+        t = OrderedChoiceEncode(search_space=ss3, observations=[])
         with self.assertRaises(ValueError):
             t.transform_search_space(ss3)
 
@@ -139,8 +136,7 @@ class ChoiceEncodeTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = self.t_class(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -158,8 +154,7 @@ class ChoiceEncodeTransformTest(TestCase):
         )
         t = self.t_class(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -219,9 +214,7 @@ class OrderedChoiceEncodeTransformTest(ChoiceEncodeTransformTest):
                 )
             ]
         )
-        t = OrderedChoiceEncode(
-            search_space=ss3, observation_features=None, observation_data=None
-        )
+        t = OrderedChoiceEncode(search_space=ss3, observations=[])
         with self.assertRaises(ValueError):
             t.transform_search_space(ss3)
 

--- a/ax/modelbridge/tests/test_convert_metric_names.py
+++ b/ax/modelbridge/tests/test_convert_metric_names.py
@@ -27,30 +27,27 @@ class ConvertMetricNamesTest(TestCase):
 
     def testConvertMetricNames(self):
         transform = ConvertMetricNames(
-            None, self.observation_features, self.observation_data, config=self.tconfig
+            None, observations=self.observations, config=self.tconfig
         )
 
         transformed_observations = convert_mt_observations(
             self.observations, self.experiment
         )
         transformed_observation_data = [o.data for o in transformed_observations]
-        transformed_observation_features = [
-            o.features for o in transformed_observations
-        ]
 
         # All trials should have canonical name "m1"
         for obsd in transformed_observation_data:
             self.assertEqual(obsd.metric_names[0], "m1")
 
         # By default untransform does nothing
-        untransformed_observation_data = transform.untransform_observation_data(
-            transformed_observation_data, transformed_observation_features
+        untransformed_observations = transform.untransform_observations(
+            transformed_observations
         )
-        self.assertEqual(transformed_observation_data, untransformed_observation_data)
+        self.assertEqual(transformed_observations, untransformed_observations)
 
         transform.perform_untransform = True
-        untransformed_observation_data = transform.untransform_observation_data(
-            transformed_observation_data, transformed_observation_features
+        untransformed_observations = transform.untransform_observations(
+            transformed_observations
         )
 
         # Should have original metric_name
@@ -59,22 +56,19 @@ class ConvertMetricNamesTest(TestCase):
                 "m1" if self.observation_features[i].trial_index == 0 else "m2"
             )
             self.assertEqual(
-                untransformed_observation_data[i].metric_names[0], metric_name
+                untransformed_observations[i].data.metric_names[0], metric_name
             )
 
     def testBadInputs(self):
         with self.assertRaises(ValueError):
-            ConvertMetricNames(
-                None, self.observation_features, self.observation_data, config=None
-            )
+            ConvertMetricNames(None, observations=self.observations, config=None)
 
         with self.assertRaises(ValueError):
             tconfig_copy = dict(self.tconfig)
             tconfig_copy.pop("metric_name_map")
             ConvertMetricNames(
                 None,
-                self.observation_features,
-                self.observation_data,
+                observations=self.observations,
                 config=tconfig_copy,
             )
 
@@ -83,8 +77,7 @@ class ConvertMetricNamesTest(TestCase):
             tconfig_copy.pop("trial_index_to_type")
             ConvertMetricNames(
                 None,
-                self.observation_features,
-                self.observation_data,
+                observations=self.observations,
                 config=tconfig_copy,
             )
 
@@ -93,8 +86,7 @@ class ConvertMetricNamesTest(TestCase):
             tconfig_copy.pop("metric_name_to_trial_type")
             ConvertMetricNames(
                 None,
-                self.observation_features,
-                self.observation_data,
+                observations=self.observations,
                 config=tconfig_copy,
             )
 
@@ -103,8 +95,7 @@ class ConvertMetricNamesTest(TestCase):
             tconfig_copy["trial_index_to_type"].pop(0)
             ConvertMetricNames(
                 None,
-                self.observation_features,
-                self.observation_data,
+                observations=self.observations,
                 config=tconfig_copy,
             )
 
@@ -114,6 +105,4 @@ class ConvertMetricNamesTest(TestCase):
         online_metric._name = "m3"
         self.experiment.add_tracking_metric(online_metric, "type2", "m4")
         tconfig = tconfig_from_mt_experiment(self.experiment)
-        ConvertMetricNames(
-            None, self.observation_features, self.observation_data, config=tconfig
-        )
+        ConvertMetricNames(None, observations=self.observations, config=tconfig)

--- a/ax/modelbridge/tests/test_derelativize_transform.py
+++ b/ax/modelbridge/tests/test_derelativize_transform.py
@@ -77,7 +77,8 @@ class DerelativizeTransformTest(TestCase):
         self, mock_predict, mock_fit, mock_observations_from_data
     ):
         t = Derelativize(
-            search_space=None, observation_features=None, observation_data=None
+            search_space=None,
+            observations=[],
         )
 
         # ModelBridge with in-design status quo
@@ -233,8 +234,7 @@ class DerelativizeTransformTest(TestCase):
         # Bypasses error if use_raw_sq
         t2 = Derelativize(
             search_space=None,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
             config={"use_raw_status_quo": True},
         )
         oc2 = t2.transform_optimization_config(deepcopy(oc), g, None)
@@ -256,7 +256,8 @@ class DerelativizeTransformTest(TestCase):
 
     def testErrors(self):
         t = Derelativize(
-            search_space=None, observation_features=None, observation_data=None
+            search_space=None,
+            observations=[],
         )
         oc = OptimizationConfig(
             objective=Objective(Metric("c")),

--- a/ax/modelbridge/tests/test_discrete_modelbridge.py
+++ b/ax/modelbridge/tests/test_discrete_modelbridge.py
@@ -75,9 +75,7 @@ class DiscreteModelBridgeTest(TestCase):
         ma = DiscreteModelBridge()
         ma._training_data = self.observations
         model = mock.create_autospec(DiscreteModel, instance=True)
-        ma._fit(
-            model, self.search_space, self.observation_features, self.observation_data
-        )
+        ma._fit(model, self.search_space, self.observations)
         self.assertEqual(ma.parameters, ["x", "y", "z"])
         self.assertEqual(sorted(ma.outcomes), ["a", "b"])
         Xs = {
@@ -96,15 +94,11 @@ class DiscreteModelBridgeTest(TestCase):
             self.assertEqual(v, Yvars[ma.outcomes[i]])
         self.assertEqual(model_fit_args["parameter_values"], parameter_values)
 
-        sq_feat = ObservationFeatures({})
-        sq_data = self.observation_data[0]
+        sq_obs = Observation(
+            features=ObservationFeatures({}), data=self.observation_data[0]
+        )
         with self.assertRaises(ValueError):
-            ma._fit(
-                model,
-                self.search_space,
-                self.observation_features + [sq_feat],
-                self.observation_data + [sq_data],
-            )
+            ma._fit(model, self.search_space, self.observations + [sq_obs])
 
     @mock.patch(
         "ax.modelbridge.discrete.DiscreteModelBridge.__init__", return_value=None
@@ -230,8 +224,7 @@ class DiscreteModelBridgeTest(TestCase):
         ma.outcomes = ["a", "b"]
         observation_data = ma._cross_validate(
             search_space=self.search_space,
-            observation_features=self.observation_features,
-            observation_data=self.observation_data,
+            cv_training_data=self.observations,
             cv_test_points=self.observation_features,
         )
         Xs = [

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -705,7 +705,7 @@ class TestGenerationStrategy(TestCase):
             ) as mock_model_fit, patch.object(RandomModelBridge, "gen"):
                 self.sobol_GS.gen(experiment=experiment)
                 mock_model_fit.assert_called_once()
-                obs_feats = mock_model_fit.call_args[1].get("observation_features")
+                observations = mock_model_fit.call_args[1].get("observations")
                 all_parameter_names = (
                     experiment.search_space._all_parameter_names.copy()
                 )
@@ -713,9 +713,9 @@ class TestGenerationStrategy(TestCase):
                 # one-hot encoded).
                 all_parameter_names.remove("model")
                 all_parameter_names.add("model_OH_PARAM_")
-                for obsf in obs_feats:
+                for obs in observations:
                     for p_name in all_parameter_names:
-                        self.assertIn(p_name, obsf.parameters)
+                        self.assertIn(p_name, obs.features.parameters)
 
             trial = (
                 experiment.new_trial(

--- a/ax/modelbridge/tests/test_int_range_to_choice_transform.py
+++ b/ax/modelbridge/tests/test_int_range_to_choice_transform.py
@@ -28,8 +28,7 @@ class IntRangeToChoiceTransformTest(TestCase):
         )
         self.t = IntRangeToChoice(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
 
     def testInit(self):
@@ -54,8 +53,7 @@ class IntRangeToChoiceTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = IntRangeToChoice(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -73,8 +71,7 @@ class IntRangeToChoiceTransformTest(TestCase):
         )
         t = IntRangeToChoice(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -86,8 +83,7 @@ class IntRangeToChoiceTransformTest(TestCase):
         rss = get_robust_search_space(use_discrete=True)
         t = IntRangeToChoice(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)

--- a/ax/modelbridge/tests/test_int_to_float_transform.py
+++ b/ax/modelbridge/tests/test_int_to_float_transform.py
@@ -36,13 +36,11 @@ class IntToFloatTransformTest(TestCase):
         )
         self.t = IntToFloat(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         self.t2 = IntToFloat(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
             config={"rounding": "randomized"},
         )
 
@@ -124,8 +122,7 @@ class IntToFloatTransformTest(TestCase):
         )
         t = IntToFloat(
             search_space=constrained_int_search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         self.assertEqual(t.rounding, "randomized")
         observation_features = [ObservationFeatures(parameters={"x": 2.6, "y": 2.6})]
@@ -150,8 +147,7 @@ class IntToFloatTransformTest(TestCase):
         )
         t = IntToFloat(
             search_space=constrained_int_search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         self.assertEqual(t.rounding, "randomized")
         observation_features = [ObservationFeatures(parameters={"x": 2.6, "y": 2.6})]
@@ -168,8 +164,7 @@ class IntToFloatTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = IntToFloat(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -189,8 +184,7 @@ class IntToFloatTransformTest(TestCase):
         )
         t = IntToFloat(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -204,8 +198,7 @@ class IntToFloatTransformTest(TestCase):
         rss = get_robust_search_space(use_discrete=True)
         t = IntToFloat(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)

--- a/ax/modelbridge/tests/test_inverse_gaussian_cdf_y.py
+++ b/ax/modelbridge/tests/test_inverse_gaussian_cdf_y.py
@@ -32,12 +32,13 @@ class InverseGaussianCdfYTransformTest(TestCase):
             ),
         )
         self.t = InverseGaussianCdfY(
-            search_space=None, observation_features=None, observation_data=None
+            search_space=None,
+            observations=[],
         )
 
     def testTransformObservations(self):
-        transformed_obsd_mid = self.t.transform_observation_data(
-            [deepcopy(self.obsd_mid)], []
+        transformed_obsd_mid = self.t._transform_observation_data(
+            [deepcopy(self.obsd_mid)]
         )[0]
         # Approximate assertion for robustness.
         mean_results = np.array(list(transformed_obsd_mid.means))
@@ -56,11 +57,11 @@ class InverseGaussianCdfYTransformTest(TestCase):
 
         # Fail with extreme values.
         with self.assertRaises(ValueError):
-            self.t.transform_observation_data([deepcopy(self.obsd_extreme)], [])[0]
+            self.t._transform_observation_data([deepcopy(self.obsd_extreme)])[0]
 
         # NaN covar values remain as NaNs
-        transformed_obsd_nan_covars = self.t.transform_observation_data(
-            [deepcopy(self.obsd_nan_covars)], []
+        transformed_obsd_nan_covars = self.t._transform_observation_data(
+            [deepcopy(self.obsd_nan_covars)]
         )[0]
         cov_results = np.array(transformed_obsd_nan_covars.covariance)
         self.assertTrue(

--- a/ax/modelbridge/tests/test_ivw_transform.py
+++ b/ax/modelbridge/tests/test_ivw_transform.py
@@ -93,8 +93,8 @@ class IVWTransformTest(TestCase):
             covariance=np.array([[0.5, 0.14], [0.14, 1.584]]),
         )
         observation_data = [obsd1_0, obsd1_1]
-        t = IVW(None, None, None)
-        observation_data2 = t.transform_observation_data(observation_data, [])
+        t = IVW(None, [])
+        observation_data2 = t._transform_observation_data(observation_data)
         observation_data2_true = [obsd2_0, obsd2_1]
         for i, obsd in enumerate(observation_data2_true):
             self.assertEqual(observation_data2[i].metric_names, obsd.metric_names)

--- a/ax/modelbridge/tests/test_log_transform.py
+++ b/ax/modelbridge/tests/test_log_transform.py
@@ -35,8 +35,7 @@ class LogTransformTest(TestCase):
         )
         self.t = Log(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         self.search_space_with_target = SearchSpace(
             parameters=[
@@ -76,8 +75,7 @@ class LogTransformTest(TestCase):
         self.assertEqual(ss2.parameters["x"].upper, math.log10(3))
         t2 = Log(
             search_space=self.search_space_with_target,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         t2.transform_search_space(self.search_space_with_target)
         self.assertEqual(
@@ -90,8 +88,7 @@ class LogTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = Log(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(rss)
         self.assertFalse(rss.parameters.get("y").log_scale)
@@ -99,8 +96,7 @@ class LogTransformTest(TestCase):
         rss.parameters["x"].set_log_scale(True)
         t = Log(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)

--- a/ax/modelbridge/tests/test_logit_transform.py
+++ b/ax/modelbridge/tests/test_logit_transform.py
@@ -35,8 +35,7 @@ class LogitTransformTest(TestCase):
         )
         self.t = Logit(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         self.search_space_with_target = SearchSpace(
             parameters=[
@@ -107,8 +106,7 @@ class LogitTransformTest(TestCase):
         self.assertEqual(ss2.parameters["x"].upper, logit(0.999))
         t2 = Logit(
             search_space=self.search_space_with_target,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         ss_target = deepcopy(self.search_space_with_target)
         t2.transform_search_space(ss_target)
@@ -122,8 +120,7 @@ class LogitTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = Logit(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(rss)
         self.assertFalse(rss.parameters.get("y").logit_scale)
@@ -131,8 +128,7 @@ class LogitTransformTest(TestCase):
         rss.parameters["x"].set_logit_scale(True)
         t = Logit(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)

--- a/ax/modelbridge/tests/test_map_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_map_torch_modelbridge.py
@@ -10,10 +10,12 @@ import numpy as np
 
 import torch
 
-from ax.core import ObservationFeatures
-
 from ax.core.base_trial import TrialStatus
-from ax.core.observation import ObservationData
+from ax.core.observation import (
+    ObservationData,
+    ObservationFeatures,
+    recombine_observations,
+)
 from ax.modelbridge.map_torch import MapTorchModelBridge
 from ax.models.torch_base import TorchGenResults, TorchModel
 from ax.utils.common.constants import Keys
@@ -136,14 +138,14 @@ class MapTorchModelBridgeTest(TestCase):
                 covariance=np.array([[1.0, 0.0], [0.0, 1.0]]),
             ),
         ]
+        cv_training_data = recombine_observations(features, data)
         with mock.patch(
             "ax.modelbridge.torch.TorchModelBridge._cross_validate",
             return_value=test_data,
         ):
             cv_obs_data = modelbridge._cross_validate(
                 search_space=experiment.search_space,
-                observation_features=features,
-                observation_data=data,
+                cv_training_data=cv_training_data,
                 cv_test_points=test_features,
             )
             # check that the out-of-design metric is deleted

--- a/ax/modelbridge/tests/test_map_unit_x_transform.py
+++ b/ax/modelbridge/tests/test_map_unit_x_transform.py
@@ -6,7 +6,8 @@
 
 from copy import deepcopy
 
-from ax.core.observation import ObservationFeatures
+import numpy as np
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.map_unit_x import MapUnitX
@@ -45,10 +46,15 @@ class MapUnitXTransformTest(TestCase):
                 parameters={"x": 2, "a": 2, "b": "b", "step_1": 7.0, "step_2": 3.0}
             ),
         ]
+        self.observations = [
+            Observation(
+                data=ObservationData([], np.array([]), np.empty((0, 0))), features=obsf
+            )
+            for obsf in self.observation_features
+        ]
         self.t = MapUnitX(
             search_space=self.search_space,
-            observation_features=self.observation_features,
-            observation_data=[],
+            observations=self.observations,
         )
 
     def testInit(self):

--- a/ax/modelbridge/tests/test_metrics_as_task_transform.py
+++ b/ax/modelbridge/tests/test_metrics_as_task_transform.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from copy import deepcopy
+
+import numpy as np
+
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.parameter import ChoiceParameter
+from ax.modelbridge.transforms.metrics_as_task import MetricsAsTask
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_search_space_for_range_values
+
+
+class MetricsAsTaskTransformTest(TestCase):
+    def setUp(self):
+        self.metric_task_map = {
+            "metric1": ["metric2", "metric3"],
+            "metric2": ["metric3"],
+        }
+        self.observations = [
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric1", "metric2", "metric3"],
+                    means=np.array([1.0, 2.0, 3.0]),
+                    covariance=np.diag([1.0, 2.0, 3.0]),
+                ),
+                features=ObservationFeatures(parameters={"x": 5.0, "y": 2.0}),
+                arm_name="0_0",
+            ),
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric3"],
+                    means=np.array([30.0]),
+                    covariance=np.array([[30.0]]),
+                ),
+                features=ObservationFeatures(parameters={"x": 10.0, "y": 4.0}),
+            ),
+        ]
+        self.search_space = get_search_space_for_range_values(min=0.0, max=20.0)
+        self.expected_new_observations = [
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric1", "metric2", "metric3"],
+                    means=np.array([1.0, 2.0, 3.0]),
+                    covariance=np.diag([1.0, 2.0, 3.0]),
+                ),
+                features=ObservationFeatures(
+                    parameters={"x": 5.0, "y": 2.0, "METRIC_TASK": "TARGET"}
+                ),
+                arm_name="0_0",
+            ),
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric2", "metric3"],
+                    means=np.array([1.0, 1.0]),
+                    covariance=np.diag([1.0, 1.0]),
+                ),
+                features=ObservationFeatures(
+                    parameters={"x": 5.0, "y": 2.0, "METRIC_TASK": "metric1"}
+                ),
+                arm_name="0_0",
+            ),
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric3"],
+                    means=np.array([2.0]),
+                    covariance=np.array([[2.0]]),
+                ),
+                features=ObservationFeatures(
+                    parameters={"x": 5.0, "y": 2.0, "METRIC_TASK": "metric2"}
+                ),
+                arm_name="0_0",
+            ),
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric3"],
+                    means=np.array([30.0]),
+                    covariance=np.array([[30.0]]),
+                ),
+                features=ObservationFeatures(
+                    parameters={"x": 10.0, "y": 4.0, "METRIC_TASK": "TARGET"}
+                ),
+            ),
+        ]
+        self.t = MetricsAsTask(
+            search_space=self.search_space,
+            observations=self.observations,
+            config={"metric_task_map": self.metric_task_map},
+        )
+
+    def testInit(self):
+        with self.assertRaises(ValueError):
+            MetricsAsTask(
+                search_space=self.search_space, observations=self.observations
+            )
+
+    def testTransformObservations(self):
+        new_obs = self.t.transform_observations(deepcopy(self.observations))
+        self.assertEqual(new_obs, self.expected_new_observations)
+
+        new_obs = self.t.untransform_observations(new_obs)
+        self.assertEqual(new_obs, self.observations)
+
+    def testTransformObservationFeatures(self):
+        obsfs_t = self.t.transform_observation_features(
+            deepcopy([obs.features for obs in self.observations])
+        )
+        for obsf in obsfs_t:
+            assert obsf.parameters["METRIC_TASK"] == "TARGET"
+
+        obsfs_t = self.t.untransform_observation_features(obsfs_t)
+        for obsf in obsfs_t:
+            assert "METRIC_TASK" not in obsf.parameters
+
+        with self.assertRaises(ValueError):
+            self.t.untransform_observation_features(
+                deepcopy([obs.features for obs in self.expected_new_observations])
+            )
+
+    def testTransformSearchSpace(self):
+        new_ss = self.t._transform_search_space(deepcopy(self.search_space))
+        self.assertEqual(len(new_ss.parameters), 3)
+        new_param = new_ss.parameters["METRIC_TASK"]
+        self.assertIsInstance(new_param, ChoiceParameter)
+        self.assertEqual(new_param.values, ["TARGET", "metric1", "metric2"])
+        self.assertTrue(new_param.is_task)

--- a/ax/modelbridge/tests/test_one_hot_transform.py
+++ b/ax/modelbridge/tests/test_one_hot_transform.py
@@ -48,13 +48,11 @@ class OneHotTransformTest(TestCase):
         )
         self.t = OneHot(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         self.t2 = OneHot(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
             config={"rounding": "randomized"},
         )
 
@@ -148,7 +146,7 @@ class OneHotTransformTest(TestCase):
                 )
             ]
         )
-        t = OneHot(search_space=ss3, observation_features=None, observation_data=None)
+        t = OneHot(search_space=ss3, observations=[])
         with self.assertRaises(ValueError):
             t.transform_search_space(ss3)
 
@@ -157,8 +155,7 @@ class OneHotTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = OneHot(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -176,8 +173,7 @@ class OneHotTransformTest(TestCase):
         )
         t = OneHot(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)

--- a/ax/modelbridge/tests/test_percentile_y_transform.py
+++ b/ax/modelbridge/tests/test_percentile_y_transform.py
@@ -7,7 +7,7 @@
 from copy import deepcopy
 
 import numpy as np
-from ax.core.observation import ObservationData
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.exceptions.core import DataRequiredError
 from ax.modelbridge.transforms.percentile_y import PercentileY
 from ax.utils.common.testutils import TestCase
@@ -45,39 +45,32 @@ class PercentileYTransformTest(TestCase):
             means=np.array([-1.0, 126.0]),
             covariance=np.array([[1.0, 0.0], [0.0, 1.0]]),
         )
+
+        self.observations = [
+            Observation(features=ObservationFeatures({}), data=deepcopy(obsd))
+            for obsd in [self.obsd1, self.obsd2, self.obsd3, self.obsd4]
+        ]
         self.t = PercentileY(
             search_space=None,
-            observation_features=None,
-            observation_data=[
-                deepcopy(self.obsd1),
-                deepcopy(self.obsd2),
-                deepcopy(self.obsd3),
-                deepcopy(self.obsd4),
-            ],
+            observations=self.observations,
         )
         self.t_with_winsorization = PercentileY(
             search_space=None,
-            observation_features=None,
-            observation_data=[
-                deepcopy(self.obsd1),
-                deepcopy(self.obsd2),
-                deepcopy(self.obsd3),
-                deepcopy(self.obsd4),
-            ],
+            observations=self.observations,
             config={"winsorize": True},
         )
 
     def testInit(self):
         with self.assertRaises(DataRequiredError):
-            PercentileY(search_space=None, observation_features=[], observation_data=[])
+            PercentileY(search_space=None, observations=[])
 
     def testTransformObservations(self):
         self.assertListEqual(self.t.percentiles["m1"], [0.0, 1.0, 2.0, 3.0])
         self.assertListEqual(self.t.percentiles["m2"], [0.0, 5.0, 25.0, 125.0])
 
         # Mid-range value transformation
-        transformed_obsd_mid = self.t.transform_observation_data(
-            [deepcopy(self.obsd_mid)], []
+        transformed_obsd_mid = self.t._transform_observation_data(
+            [deepcopy(self.obsd_mid)]
         )[0]
         mean_results = np.array(list(transformed_obsd_mid.means))
         expected = np.array([0.5, 0.75])
@@ -92,8 +85,8 @@ class PercentileYTransformTest(TestCase):
         )
 
         # Extreme value transformation
-        transformed_obsd_extreme = self.t.transform_observation_data(
-            [deepcopy(self.obsd_extreme)], []
+        transformed_obsd_extreme = self.t._transform_observation_data(
+            [deepcopy(self.obsd_extreme)]
         )[0]
         mean_results = np.array(list(transformed_obsd_extreme.means))
         expected = np.array([0.0, 1.0])
@@ -110,8 +103,8 @@ class PercentileYTransformTest(TestCase):
     def testTransformObservationsWithWinsorization(self):
         self.assertListEqual(self.t.percentiles["m1"], [0.0, 1.0, 2.0, 3.0])
         self.assertListEqual(self.t.percentiles["m2"], [0.0, 5.0, 25.0, 125.0])
-        transformed_obsd_mid = self.t_with_winsorization.transform_observation_data(
-            [deepcopy(self.obsd_mid)], []
+        transformed_obsd_mid = self.t_with_winsorization._transform_observation_data(
+            [deepcopy(self.obsd_mid)]
         )[0]
         mean_results = np.array(list(transformed_obsd_mid.means))
         expected = np.array([0.5, 0.75])
@@ -119,9 +112,11 @@ class PercentileYTransformTest(TestCase):
             np.allclose(mean_results, expected),
             msg=f"Unexpected mean Results: {mean_results}. Expected: {expected}.",
         )
-        transformed_obsd_extreme = self.t_with_winsorization.transform_observation_data(
-            [deepcopy(self.obsd_extreme)], []
-        )[0]
+        transformed_obsd_extreme = (
+            self.t_with_winsorization._transform_observation_data(
+                [deepcopy(self.obsd_extreme)]
+            )[0]
+        )
         mean_results = np.array(list(transformed_obsd_extreme.means))
         expected = np.array([0.0847075, 0.9152924])
         self.assertTrue(

--- a/ax/modelbridge/tests/test_power_transform_y.py
+++ b/ax/modelbridge/tests/test_power_transform_y.py
@@ -12,7 +12,7 @@ from math import isfinite, isnan
 import numpy as np
 from ax.core.metric import Metric
 from ax.core.objective import Objective
-from ax.core.observation import ObservationData
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.types import ComparisonOp
@@ -56,12 +56,15 @@ class PowerTransformYTest(TestCase):
             means=np.array([0.3, 0.2]),
             covariance=np.array([[float("nan"), 0.0], [0.0, float("nan")]]),
         )
+        self.observations = [
+            Observation(features=ObservationFeatures({}), data=obsd)
+            for obsd in [self.obsd1, self.obsd2, self.obsd3, self.obsd_nan]
+        ]
 
     def testInit(self):
         shared_init_args = {
             "search_space": None,
-            "observation_features": None,
-            "observation_data": [self.obsd1, self.obsd2],
+            "observations": self.observations[:2],
         }
         # Test error for not specifying a config
         with self.assertRaises(ValueError):
@@ -161,16 +164,16 @@ class PowerTransformYTest(TestCase):
         self.assertTrue(isfinite(new_mean_2) and isfinite(new_var_2))
 
     def testTransformAndUntransformOneMetric(self):
-        observation_data = [deepcopy(self.obsd1), deepcopy(self.obsd2)]
         pt = PowerTransformY(
             search_space=None,
-            observation_features=None,
-            observation_data=observation_data,
+            observations=deepcopy(self.observations[:2]),
             config={"metrics": ["m1"]},
         )
 
         # Transform the data and make sure we don't touch m1
-        observation_data_tf = pt.transform_observation_data(observation_data, [])
+        observation_data_tf = pt._transform_observation_data(
+            deepcopy([self.obsd1, self.obsd2])
+        )
         for obsd, obsd_orig in zip(observation_data_tf, [self.obsd1, self.obsd2]):
             self.assertNotAlmostEqual(obsd.means[0], obsd_orig.means[0])
             self.assertNotAlmostEqual(obsd.covariance[0][0], obsd_orig.covariance[0][0])
@@ -178,28 +181,28 @@ class PowerTransformYTest(TestCase):
             self.assertAlmostEqual(obsd.covariance[1][1], obsd_orig.covariance[1][1])
 
         # Untransform the data and make sure the means are the same
-        observation_data_untf = pt.untransform_observation_data(observation_data_tf, [])
+        observation_data_untf = pt._untransform_observation_data(observation_data_tf)
         for obsd, obsd_orig in zip(observation_data_untf, [self.obsd1, self.obsd2]):
             self.assertAlmostEqual(obsd.means[0], obsd_orig.means[0], places=4)
             self.assertAlmostEqual(obsd.means[1], obsd_orig.means[1], places=4)
 
         # NaN covar values remain as NaNs
-        transformed_obsd_nan = pt.transform_observation_data(
-            [deepcopy(self.obsd_nan)], []
+        transformed_obsd_nan = pt._transform_observation_data(
+            [deepcopy(self.obsd_nan)]
         )[0]
         cov_results = np.array(transformed_obsd_nan.covariance)
         self.assertTrue(np.all(np.isnan(np.diag(cov_results))))
 
     def testTransformAndUntransformAllMetrics(self):
-        observation_data = [deepcopy(self.obsd1), deepcopy(self.obsd2)]
         pt = PowerTransformY(
             search_space=None,
-            observation_features=None,
-            observation_data=observation_data,
+            observations=deepcopy(self.observations[:2]),
             config={"metrics": ["m1", "m2"]},
         )
 
-        observation_data_tf = pt.transform_observation_data(observation_data, [])
+        observation_data_tf = pt._transform_observation_data(
+            deepcopy([self.obsd1, self.obsd2])
+        )
         for obsd, obsd_orig in zip(observation_data_tf, [self.obsd1, self.obsd2]):
             for i in range(2):  # Both metrics should be transformed
                 self.assertNotAlmostEqual(obsd.means[i], obsd_orig.means[i])
@@ -208,14 +211,14 @@ class PowerTransformYTest(TestCase):
                 )
 
         # Untransform the data and make sure the means are the same
-        observation_data_untf = pt.untransform_observation_data(observation_data_tf, [])
+        observation_data_untf = pt._untransform_observation_data(observation_data_tf)
         for obsd, obsd_orig in zip(observation_data_untf, [self.obsd1, self.obsd2]):
             for i in range(2):  # Both metrics should be transformed
                 self.assertAlmostEqual(obsd.means[i], obsd_orig.means[i])
 
         # NaN covar values remain as NaNs
-        transformed_obsd_nan = pt.transform_observation_data(
-            [deepcopy(self.obsd_nan)], []
+        transformed_obsd_nan = pt._transform_observation_data(
+            [deepcopy(self.obsd_nan)]
         )[0]
         cov_results = np.array(transformed_obsd_nan.covariance)
         self.assertTrue(np.all(np.isnan(np.diag(cov_results))))
@@ -229,11 +232,10 @@ class PowerTransformYTest(TestCase):
 
         pt = PowerTransformY(
             search_space=None,
-            observation_features=None,
-            observation_data=deepcopy(observation_data),
+            observations=deepcopy(self.observations[:3]),
             config={"metrics": ["m1"]},
         )
-        observation_data_tf = pt.transform_observation_data(observation_data, [])
+        observation_data_tf = pt._transform_observation_data(observation_data)
         y2 = [data.means[0] for data in observation_data_tf]
         for y1_, y2_ in zip(y1, y2):
             self.assertAlmostEqual(y1_, y2_)
@@ -245,8 +247,7 @@ class PowerTransformYTest(TestCase):
         oc = OptimizationConfig(objective=objective_m1, outcome_constraints=[])
         tf = PowerTransformY(
             search_space=None,
-            observation_features=None,
-            observation_data=[self.obsd1, self.obsd2],
+            observations=self.observations[:2],
             config={"metrics": ["m1"]},
         )
         oc_tf = tf.transform_optimization_config(deepcopy(oc), None, None)
@@ -278,6 +279,11 @@ class PowerTransformYTest(TestCase):
             )
             oc_true.outcome_constraints[0].bound = tf_bound
             self.assertEqual(oc_tf, oc_true)
+        # Check untransform of outcome constraint
+        cons = tf.untransform_outcome_constraints(
+            outcome_constraints=oc_tf.outcome_constraints, fixed_features=None
+        )
+        self.assertEqual(cons, oc.outcome_constraints)
         # Relative constraints aren't supported
         oc = OptimizationConfig(
             objective=objective_m2,
@@ -289,6 +295,12 @@ class PowerTransformYTest(TestCase):
             "subject to a relative constraint.",
         ):
             tf.transform_optimization_config(oc, None, None)
+        # Untransform doesn't work if relative
+        with self.assertRaises(ValueError):
+            tf.untransform_outcome_constraints(
+                outcome_constraints=oc.outcome_constraints,
+                fixed_features=None,
+            )
         # Support for scalarized outcome constraints isn't implemented
         m3 = Metric(name="m3")
         oc = OptimizationConfig(

--- a/ax/modelbridge/tests/test_random_modelbridge.py
+++ b/ax/modelbridge/tests/test_random_modelbridge.py
@@ -40,7 +40,7 @@ class RandomModelBridgeTest(TestCase):
     def testFit(self, mock_init):
         modelbridge = RandomModelBridge()
         model = mock.create_autospec(RandomModel, instance=True)
-        modelbridge._fit(model, self.search_space, None, None)
+        modelbridge._fit(model, self.search_space, None)
         self.assertEqual(modelbridge.parameters, ["x", "y", "z"])
         self.assertTrue(isinstance(modelbridge.model, RandomModel))
 
@@ -58,7 +58,7 @@ class RandomModelBridgeTest(TestCase):
         modelbridge.transforms = OrderedDict()
         modelbridge.parameters = ["x", "y", "z"]
         with self.assertRaises(NotImplementedError):
-            modelbridge._cross_validate(None, [], [], [])
+            modelbridge._cross_validate(None, [], [])
 
     @mock.patch(
         "ax.models.random.base.RandomModel.gen",

--- a/ax/modelbridge/tests/test_remove_fixed_transform.py
+++ b/ax/modelbridge/tests/test_remove_fixed_transform.py
@@ -34,8 +34,7 @@ class RemoveFixedTransformTest(TestCase):
         )
         self.t = RemoveFixed(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
 
     def testInit(self):
@@ -76,8 +75,7 @@ class RemoveFixedTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = RemoveFixed(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -98,8 +96,7 @@ class RemoveFixedTransformTest(TestCase):
         )
         t = RemoveFixed(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss = t.transform_search_space(rss)
         self.assertIsInstance(rss, RobustSearchSpace)

--- a/ax/modelbridge/tests/test_search_space_to_choice_transform.py
+++ b/ax/modelbridge/tests/test_search_space_to_choice_transform.py
@@ -6,8 +6,9 @@
 
 from copy import deepcopy
 
+import numpy as np
 from ax.core.arm import Arm
-from ax.core.observation import ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.parameter import (
     ChoiceParameter,
     FixedParameter,
@@ -53,20 +54,23 @@ class SearchSpaceToChoiceTest(TestCase):
                 parameters={"arms": Arm(parameters={"a": 3, "b": "c"}).signature}
             ),
         ]
+        self.observations = [
+            Observation(
+                data=ObservationData([], np.array([]), np.empty((0, 0))), features=obsf
+            )
+            for obsf in self.observation_features
+        ]
         self.t = SearchSpaceToChoice(
             search_space=self.search_space,
-            observation_features=self.observation_features,
-            observation_data=None,
+            observations=self.observations,
         )
         self.t2 = SearchSpaceToChoice(
             search_space=self.search_space,
-            observation_features=[self.observation_features[0]],
-            observation_data=None,
+            observations=self.observations[:1],
         )
         self.t3 = SearchSpaceToChoice(
             search_space=self.search_space,
-            observation_features=self.observation_features,
-            observation_data=None,
+            observations=self.observations,
             config={"use_ordered": True},
         )
 
@@ -109,8 +113,7 @@ class SearchSpaceToChoiceTest(TestCase):
         with self.assertRaises(ValueError):
             SearchSpaceToChoice(
                 search_space=ss3,
-                observation_features=self.observation_features,
-                observation_data=None,
+                observations=[],
             )
 
     def testTransformSearchSpaceWithFixedParam(self):
@@ -137,6 +140,5 @@ class SearchSpaceToChoiceTest(TestCase):
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             SearchSpaceToChoice(
                 search_space=rss,
-                observation_features=None,
-                observation_data=None,
+                observations=[],
             )

--- a/ax/modelbridge/tests/test_standardize_y_transform.py
+++ b/ax/modelbridge/tests/test_standardize_y_transform.py
@@ -10,7 +10,7 @@ from math import sqrt
 import numpy as np
 from ax.core.metric import Metric
 from ax.core.objective import Objective
-from ax.core.observation import ObservationData
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.types import ComparisonOp
@@ -38,10 +38,11 @@ class StandardizeYTransformTest(TestCase):
                 ]
             ),
         )
+        obs1 = Observation(features=ObservationFeatures({}), data=self.obsd1)
+        obs2 = Observation(features=ObservationFeatures({}), data=self.obsd2)
         self.t = StandardizeY(
             search_space=None,
-            observation_features=None,
-            observation_data=[self.obsd1, self.obsd2],
+            observations=[obs1, obs2],
         )
 
     def testInit(self):
@@ -49,7 +50,8 @@ class StandardizeYTransformTest(TestCase):
         self.assertEqual(self.t.Ystd, {"m1": 1.0, "m2": sqrt(1 / 3)})
         with self.assertRaises(DataRequiredError):
             StandardizeY(
-                search_space=None, observation_features=None, observation_data=[]
+                search_space=None,
+                observations=[],
             )
 
     def testTransformObservations(self):
@@ -65,9 +67,9 @@ class StandardizeYTransformTest(TestCase):
             ),
         )
         obsd2 = [deepcopy(self.obsd1)]
-        obsd2 = self.t.transform_observation_data(obsd2, [])
+        obsd2 = self.t._transform_observation_data(obsd2)
         self.assertTrue(osd_allclose(obsd2[0], obsd1_t))
-        obsd2 = self.t.untransform_observation_data(obsd2, [])
+        obsd2 = self.t._untransform_observation_data(obsd2)
         self.assertTrue(osd_allclose(obsd2[0], self.obsd1))
 
     def testTransformOptimizationConfig(self):

--- a/ax/modelbridge/tests/test_task_encode_transform.py
+++ b/ax/modelbridge/tests/test_task_encode_transform.py
@@ -37,8 +37,7 @@ class TaskEncodeTransformTest(TestCase):
         )
         self.t = TaskEncode(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
 
     def testInit(self):
@@ -90,7 +89,8 @@ class TaskEncodeTransformTest(TestCase):
         )
         with self.assertRaises(ValueError):
             TaskEncode(
-                search_space=ss3, observation_features=None, observation_data=None
+                search_space=ss3,
+                observations=[],
             )
 
     def test_w_parameter_distributions(self):
@@ -99,8 +99,7 @@ class TaskEncodeTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = TaskEncode(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -118,8 +117,7 @@ class TaskEncodeTransformTest(TestCase):
         )
         t = TaskEncode(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -14,7 +14,11 @@ from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.metric import Metric
 from ax.core.objective import Objective
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import (
+    ObservationData,
+    ObservationFeatures,
+    recombine_observations,
+)
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
 from ax.core.search_space import SearchSpace, SearchSpaceDigest
@@ -30,85 +34,8 @@ from ax.utils.testing.core_stubs import (
     get_branin_search_space,
     get_search_space_for_range_value,
 )
-from ax.utils.testing.modeling_stubs import get_observation1
+from ax.utils.testing.modeling_stubs import get_observation1, transform_1, transform_2
 from botorch.utils.datasets import FixedNoiseDataset
-
-
-# Prepare mock transforms
-class TestTransform1(Transform):
-    def transform_search_space(self, ss):
-        new_ss = ss.clone()
-        new_ss.parameters["x"]._lower += 1.0
-        new_ss.parameters["x"]._upper += 1.0
-        return new_ss
-
-    def transform_optimization_config(
-        self, optimization_config, modelbridge, fixed_features
-    ):
-        return (
-            optimization_config + 1
-            if isinstance(optimization_config, int)
-            else optimization_config
-        )
-
-    def transform_observation_features(self, x):
-        for obsf in x:
-            if "x" in obsf.parameters:
-                obsf.parameters["x"] += 1
-        return x
-
-    def transform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means += 1
-        return x
-
-    def untransform_observation_features(self, x):
-        for obsf in x:
-            obsf.parameters["x"] -= 1
-        return x
-
-    def untransform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means -= 1
-        return x
-
-
-class TestTransform2(Transform):
-    def transform_search_space(self, ss):
-        new_ss = ss.clone()
-        new_ss.parameters["x"]._lower *= 2
-        new_ss.parameters["x"]._upper *= 2
-        return new_ss
-
-    def transform_optimization_config(
-        self, optimization_config, modelbridge, fixed_features
-    ):
-        return (
-            optimization_config**2
-            if isinstance(optimization_config, int)
-            else optimization_config
-        )
-
-    def transform_observation_features(self, x):
-        for obsf in x:
-            if "x" in obsf.parameters:
-                obsf.parameters["x"] = obsf.parameters["x"] ** 2
-        return x
-
-    def transform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means = obsd.means**2
-        return x
-
-    def untransform_observation_features(self, x):
-        for obsf in x:
-            obsf.parameters["x"] = np.sqrt(obsf.parameters["x"])
-        return x
-
-    def untransform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means = np.sqrt(obsd.means)
-        return x
 
 
 class TorchModelBridgeTest(TestCase):
@@ -169,6 +96,7 @@ class TorchModelBridgeTest(TestCase):
                 datasets["y2"].Yvar().tolist(),
             )
         ]
+        observations = recombine_observations(observation_features, observation_data)
         ssd = SearchSpaceDigest(feature_names=feature_names, bounds=[(0, 1)] * 3)
 
         with mock.patch(
@@ -178,8 +106,7 @@ class TorchModelBridgeTest(TestCase):
             ma._fit(
                 model=model,
                 search_space=search_space,
-                observation_features=observation_features,
-                observation_data=observation_data,
+                observations=observations,
             )
         model_fit_args = model.fit.mock_calls[0][2]
         self.assertEqual(model_fit_args["datasets"], list(datasets.values()))
@@ -194,8 +121,7 @@ class TorchModelBridgeTest(TestCase):
         ):
             ma._update(
                 search_space=search_space,
-                observation_features=observation_features,
-                observation_data=observation_data,
+                observations=observations,
             )
         model_update_args = model.update.mock_calls[0][2]
         self.assertEqual(model_update_args["datasets"], list(datasets.values()))
@@ -328,8 +254,7 @@ class TorchModelBridgeTest(TestCase):
         ):
             cv_obs_data = ma._cross_validate(
                 search_space=search_space,
-                observation_features=observation_features,
-                observation_data=observation_data,
+                cv_training_data=observations,
                 cv_test_points=cv_test_points,
             )
         model_cv_args = model.cross_validate.mock_calls[0][2]
@@ -521,7 +446,7 @@ class TorchModelBridgeTest(TestCase):
         modelbridge = TorchModelBridge(
             search_space=search_space,
             model=TorchModel(),
-            transforms=[TestTransform1, TestTransform2],
+            transforms=[transform_1, transform_2],
             experiment=exp,
             data=Data(),
             optimization_config=oc,
@@ -529,7 +454,7 @@ class TorchModelBridgeTest(TestCase):
 
         self.assertEqual(
             list(modelbridge.transforms.keys()),
-            ["Cast", "TestTransform1", "TestTransform2"],
+            ["Cast", "transform_1", "transform_2"],
         )
 
         # _fit is mocked, which sets these
@@ -616,7 +541,7 @@ class TorchModelBridgeTest(TestCase):
         modelbridge = TorchModelBridge(
             search_space=search_space,
             model=TorchModel(),
-            transforms=[TestTransform1, TestTransform2],
+            transforms=[transform_1, transform_2],
             experiment=exp,
             data=Data(),
         )

--- a/ax/modelbridge/tests/test_torch_modelbridge_moo.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge_moo.py
@@ -23,7 +23,6 @@ from ax.modelbridge.modelbridge_utils import (
 )
 from ax.modelbridge.registry import Cont_X_trans, ST_MTGP_trans, Y_trans
 from ax.modelbridge.torch import TorchModelBridge
-from ax.modelbridge.transforms.base import Transform
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.botorch_moo_defaults import (
     infer_objective_thresholds,
@@ -38,97 +37,13 @@ from ax.utils.testing.core_stubs import (
     TEST_SOBOL_SEED,
 )
 from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.modeling_stubs import transform_1, transform_2
 from botorch.utils.multi_objective.pareto import is_non_dominated
 
 PARETO_FRONTIER_EVALUATOR_PATH = (
     f"{pareto_frontier_evaluator.__module__}.pareto_frontier_evaluator"
 )
 STUBS_PATH = get_branin_experiment_with_multi_objective.__module__
-
-
-# Prepare mock transforms
-class t1(Transform):
-    def transform_search_space(self, ss):
-        new_ss = ss.clone()
-        for param_name in new_ss.parameters:
-            new_ss.parameters[param_name]._lower += 1.0
-            new_ss.parameters[param_name]._upper += 1.0
-        return new_ss
-
-    def transform_optimization_config(
-        self, optimization_config, modelbridge, fixed_features
-    ):
-        return (
-            optimization_config + 1
-            if isinstance(optimization_config, int)
-            else optimization_config
-        )
-
-    def transform_observation_features(self, x):
-        for obsf in x:
-            for param_name in obsf.parameters:
-                obsf.parameters[param_name] += 1
-        return x
-
-    def transform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means += 1
-        return x
-
-    def untransform_observation_features(self, x):
-        for obsf in x:
-            for param_name in obsf.parameters:
-                obsf.parameters[param_name] -= 1
-        return x
-
-    def untransform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means -= 1
-        return x
-
-
-class t2(Transform):
-    def transform_search_space(self, ss):
-        new_ss = ss.clone()
-        for param_name in new_ss.parameters:
-            new_ss.parameters[param_name]._lower = (
-                new_ss.parameters[param_name]._lower ** 2
-            )
-            new_ss.parameters[param_name]._upper = (
-                new_ss.parameters[param_name]._upper ** 2
-            )
-        return new_ss
-
-    def transform_optimization_config(
-        self, optimization_config, modelbridge, fixed_features
-    ):
-        return (
-            optimization_config**2
-            if isinstance(optimization_config, int)
-            else optimization_config
-        )
-
-    def transform_observation_features(self, x):
-        for obsf in x:
-            for param_name in obsf.parameters:
-                obsf.parameters[param_name] = obsf.parameters[param_name] ** 2
-        return x
-
-    def transform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means = obsd.means**2
-        return x
-
-    def untransform_observation_features(self, x):
-        for obsf in x:
-            for param_name in obsf.parameters:
-                obsf.parameters[param_name] = np.sqrt(obsf.parameters[param_name])
-        return x
-
-    def untransform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means = np.sqrt(obsd.means)
-        return x
 
 
 class MultiObjectiveTorchModelBridgeTest(TestCase):
@@ -170,7 +85,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             search_space=exp.search_space,
             model=MultiObjectiveBotorchModel(),
             optimization_config=exp.optimization_config,
-            transforms=[t1, t2],
+            transforms=[transform_1, transform_2],
             experiment=exp,
             data=exp.fetch_data(),
         )

--- a/ax/modelbridge/tests/test_unit_x_transform.py
+++ b/ax/modelbridge/tests/test_unit_x_transform.py
@@ -54,8 +54,7 @@ class UnitXTransformTest(TestCase):
         )
         self.t = self.transform_class(
             search_space=self.search_space,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         self.search_space_with_target = SearchSpace(
             parameters=[
@@ -134,8 +133,7 @@ class UnitXTransformTest(TestCase):
         # Test transform of target value
         t = self.transform_class(
             search_space=self.search_space_with_target,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(self.search_space_with_target)
         self.assertEqual(
@@ -153,8 +151,7 @@ class UnitXTransformTest(TestCase):
             expected = str(rss)
             t = self.transform_class(
                 search_space=rss,
-                observation_features=None,
-                observation_data=None,
+                observations=[],
             )
             self.assertEqual(expected, str(t.transform_search_space(rss)))
         # Error if distribution is multiplicative.
@@ -162,8 +159,7 @@ class UnitXTransformTest(TestCase):
         rss.parameter_distributions[0].multiplicative = True
         t = self.transform_class(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(NotImplementedError, "multiplicative"):
             t.transform_search_space(rss)
@@ -171,8 +167,7 @@ class UnitXTransformTest(TestCase):
         rss = get_robust_search_space(lb=5.0, ub=10.0)
         t = self.transform_class(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(rss)
         dists = rss.parameter_distributions
@@ -205,8 +200,7 @@ class UnitXTransformTest(TestCase):
         rss.parameters["z"]._parameter_type = ParameterType.FLOAT
         t = self.transform_class(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "`loc` and `scale`"):
             t.transform_search_space(rss)
@@ -217,8 +211,7 @@ class UnitXTransformTest(TestCase):
         rss.parameter_distributions[0].distribution_class = "multivariate_t"
         t = self.transform_class(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "multivariate"):
             t.transform_search_space(rss)
@@ -227,8 +220,7 @@ class UnitXTransformTest(TestCase):
         old_params = deepcopy(rss.parameter_distributions[0].distribution_parameters)
         t = self.transform_class(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(rss)
         new_params = rss.parameter_distributions[0].distribution_parameters
@@ -257,8 +249,7 @@ class UnitXTransformTest(TestCase):
         )
         t = self.transform_class(
             search_space=rss,
-            observation_features=None,
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(rss)
         new_params = rss.parameter_distributions[0].distribution_parameters

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -13,7 +13,7 @@ from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.outcome_constraint import (
     ObjectiveThreshold,
     OutcomeConstraint,
@@ -184,17 +184,22 @@ class TestModelbridgeUtils(TestCase):
         # is applying `Cast` transform, it should inject full parameterization into
         # resulting obs.feats.). Therefore, transforming the extracted pending features
         #  and observation features made from full parameterization should be the same.
+        obsd = ObservationData(
+            metric_names=["m1"], means=np.array([1.0]), covariance=np.array([[1.0]])
+        )
         self.assertEqual(
             self.hss_sobol._transform_data(
-                obs_feats=pending["m1"],
-                obs_data=[],
+                observations=[Observation(data=obsd, features=pending["m1"][0])],
                 search_space=self.hss_exp.search_space,
                 transforms=self.hss_sobol._raw_transforms,
                 transform_configs=None,
             ),
             self.hss_sobol._transform_data(
-                obs_feats=[self.hss_obs_feat_all_params.clone()],
-                obs_data=[],
+                observations=[
+                    Observation(
+                        data=obsd, features=self.hss_obs_feat_all_params.clone()
+                    )
+                ],
                 search_space=self.hss_exp.search_space,
                 transforms=self.hss_sobol._raw_transforms,
                 transform_configs=None,
@@ -260,15 +265,17 @@ class TestModelbridgeUtils(TestCase):
             # Check that candidate metadata is property propagated for abandoned arm.
             self.assertEqual(
                 self.hss_sobol._transform_data(
-                    obs_feats=pending["m1"],
-                    obs_data=[],
+                    observations=[Observation(data=obsd, features=pending["m1"][0])],
                     search_space=hss_exp.search_space,
                     transforms=self.hss_sobol._raw_transforms,
                     transform_configs=None,
                 ),
                 self.hss_sobol._transform_data(
-                    obs_feats=[self.hss_obs_feat_all_params.clone()],
-                    obs_data=[],
+                    observations=[
+                        Observation(
+                            data=obsd, features=self.hss_obs_feat_all_params.clone()
+                        )
+                    ],
                     search_space=hss_exp.search_space,
                     transforms=self.hss_sobol._raw_transforms,
                     transform_configs=None,
@@ -393,17 +400,22 @@ class TestModelbridgeUtils(TestCase):
         # is applying `Cast` transform, it should inject full parameterization into
         # resulting obs.feats.). Therefore, transforming the extracted pending features
         #  and observation features made from full parameterization should be the same.
+        obsd = ObservationData(
+            metric_names=["m1"], means=np.array([1.0]), covariance=np.array([[1.0]])
+        )
         self.assertEqual(
             self.hss_sobol._transform_data(
-                obs_feats=pending["m1"],
-                obs_data=[],
+                observations=[Observation(data=obsd, features=pending["m1"][0])],
                 search_space=self.hss_exp.search_space,
                 transforms=self.hss_sobol._raw_transforms,
                 transform_configs=None,
             ),
             self.hss_sobol._transform_data(
-                obs_feats=[self.hss_obs_feat_all_params],
-                obs_data=[],
+                observations=[
+                    Observation(
+                        data=obsd, features=self.hss_obs_feat_all_params.clone()
+                    )
+                ],
                 search_space=self.hss_exp.search_space,
                 transforms=self.hss_sobol._raw_transforms,
                 transform_configs=None,

--- a/ax/modelbridge/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/tests/test_winsorize_transform.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 import numpy as np
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
-from ax.core.observation import ObservationData
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
@@ -53,34 +53,34 @@ class WinsorizeTransformTest(TestCase):
                 ]
             ),
         )
+        self.observations = [
+            Observation(features=ObservationFeatures({}), data=obsd)
+            for obsd in [self.obsd1, self.obsd2]
+        ]
         self.t = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_config": WinsorizationConfig(upper_quantile_margin=0.2)
             },
         )
         self.t1 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_config": WinsorizationConfig(upper_quantile_margin=0.8)
             },
         )
         self.t2 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_config": WinsorizationConfig(lower_quantile_margin=0.2)
             },
         )
         self.t3 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(upper_quantile_margin=0.6),
@@ -92,8 +92,7 @@ class WinsorizeTransformTest(TestCase):
         )
         self.t4 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(lower_quantile_margin=0.8),
@@ -109,14 +108,10 @@ class WinsorizeTransformTest(TestCase):
             means=np.array([0.0, 1.0, 5.0, 3.0]),
             covariance=np.eye(4),
         )
+        self.obs3 = Observation(features=ObservationFeatures({}), data=self.obsd3)
         self.t5 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[
-                deepcopy(self.obsd1),
-                deepcopy(self.obsd2),
-                deepcopy(self.obsd3),
-            ],
+            observations=deepcopy(self.observations) + deepcopy([self.obs3]),
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(upper_quantile_margin=0.6),
@@ -126,8 +121,7 @@ class WinsorizeTransformTest(TestCase):
         )
         self.t6 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(upper_quantile_margin=0.6),
@@ -147,10 +141,9 @@ class WinsorizeTransformTest(TestCase):
         self.assertEqual(self.t2.cutoffs["m2"], (0.0, float("inf")))
         with self.assertRaisesRegex(
             DataRequiredError,
-            "`Winsorize` transform requires non-empty observation data.",
+            "`Winsorize` transform requires non-empty data.",
         ):
-            Winsorize(search_space=None, observation_features=[], observation_data=[])
-        obsd = [deepcopy(self.obsd1)]
+            Winsorize(search_space=None, observations=[])
         with self.assertRaisesRegex(
             ValueError,
             "Transform config for `Winsorize` transform must be specified and "
@@ -158,8 +151,7 @@ class WinsorizeTransformTest(TestCase):
         ):
             Winsorize(
                 search_space=None,
-                observation_features=[],
-                observation_data=obsd,
+                observations=deepcopy(self.observations[:1]),
             )
         with self.assertRaisesRegex(
             UserInputError,
@@ -168,27 +160,26 @@ class WinsorizeTransformTest(TestCase):
         ):
             Winsorize(
                 search_space=None,
-                observation_features=[],
-                observation_data=obsd,
+                observations=deepcopy(self.observations[:1]),
                 config={"optimization_config": 1234},
             )
 
     def testTransformObservations(self):
-        observation_data = self.t1.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t1._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t1.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t1._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 1.0, 1.0])
-        observation_data = self.t2.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t2._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t2.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t2._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
 
     def testInitPercentileBounds(self):
@@ -198,40 +189,40 @@ class WinsorizeTransformTest(TestCase):
         self.assertEqual(self.t4.cutoffs["m2"], (0.3, float("inf")))
 
     def testTransformObservationsPercentileBounds(self):
-        observation_data = self.t3.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t3._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t3.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t3._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 1.9, 1.0])
-        observation_data = self.t4.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t4._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 0.3, 1.0])
-        observation_data = self.t4.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t4._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
 
     def testTransformObservationsDifferentLowerUpper(self):
-        observation_data = self.t5.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t5._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertEqual(self.t5.cutoffs["m1"], (-float("inf"), 1.0))
         self.assertEqual(self.t5.cutoffs["m2"], (1.0, float("inf")))
         self.assertEqual(self.t5.cutoffs["m3"], (-float("inf"), float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
         # Nothing should happen to m3
-        observation_data = self.t5.transform_observation_data(
-            [deepcopy(self.obsd3)], []
-        )[0]
+        observation_data = self.t5._transform_observation_data([deepcopy(self.obsd3)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 1.0, 5.0, 3.0])
         # With winsorization boundaries
-        observation_data = self.t6.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t6._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertEqual(self.t6.cutoffs["m1"], (-float("inf"), 1.0))
         self.assertEqual(self.t6.cutoffs["m2"], (0.0, float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
@@ -538,10 +529,13 @@ class WinsorizeTransformTest(TestCase):
 
 
 def get_transform(observation_data, config):
+    observations = [
+        Observation(features=ObservationFeatures({}), data=obsd)
+        for obsd in observation_data
+    ]
     return Winsorize(
         search_space=None,
-        observation_features=None,
-        observation_data=observation_data,
+        observations=observations,
         config=config,
     )
 
@@ -554,10 +548,10 @@ def get_default_transform_cutoffs(
         means=np.array(range(obs_data_len)),
         covariance=np.eye(obs_data_len),
     )
+    obs = Observation(features=ObservationFeatures({}), data=obsd)
     transform = Winsorize(
         search_space=None,
-        observation_features=None,
-        observation_data=[deepcopy(obsd)],
+        observations=[deepcopy(obs)],
         config={
             "optimization_config": optimization_config,
             "winsorization_config": winsorization_config,

--- a/ax/modelbridge/tests/test_winsorize_transform_legacy.py
+++ b/ax/modelbridge/tests/test_winsorize_transform_legacy.py
@@ -8,7 +8,7 @@ import warnings
 from copy import deepcopy
 
 import numpy as np
-from ax.core.observation import ObservationData
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.exceptions.core import DataRequiredError
 from ax.modelbridge.transforms.winsorize import Winsorize
 from ax.utils.common.testutils import TestCase
@@ -33,28 +33,28 @@ class WinsorizeTransformTestLegacy(TestCase):
                 ]
             ),
         )
+        self.observations = [
+            Observation(features=ObservationFeatures({}), data=obsd)
+            for obsd in [self.obsd1, self.obsd2]
+        ]
         self.t = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={"winsorization_upper": 0.2},
         )
         self.t1 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={"winsorization_upper": 0.8},
         )
         self.t2 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={"winsorization_lower": 0.2},
         )
         self.t3 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_upper": 0.6,
                 "percentile_bounds": {
@@ -65,8 +65,7 @@ class WinsorizeTransformTestLegacy(TestCase):
         )
         self.t4 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_lower": 0.8,
                 "percentile_bounds": {
@@ -76,19 +75,17 @@ class WinsorizeTransformTestLegacy(TestCase):
             },
         )
 
-        self.obsd3 = ObservationData(
-            metric_names=["m3", "m3", "m3", "m3"],
-            means=np.array([0.0, 1.0, 5.0, 3.0]),
-            covariance=np.eye(4),
+        self.obs3 = Observation(
+            features=ObservationFeatures({}),
+            data=ObservationData(
+                metric_names=["m3", "m3", "m3", "m3"],
+                means=np.array([0.0, 1.0, 5.0, 3.0]),
+                covariance=np.eye(4),
+            ),
         )
         self.t5 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[
-                deepcopy(self.obsd1),
-                deepcopy(self.obsd2),
-                deepcopy(self.obsd3),
-            ],
+            observations=deepcopy(self.observations) + [deepcopy(self.obs3)],
             config={
                 "winsorization_lower": {"m2": 0.4},
                 "winsorization_upper": {"m1": 0.6},
@@ -96,8 +93,7 @@ class WinsorizeTransformTestLegacy(TestCase):
         )
         self.t6 = Winsorize(
             search_space=None,
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_lower": {"m2": 0.4},
                 "winsorization_upper": {"m1": 0.6},
@@ -113,8 +109,7 @@ class WinsorizeTransformTestLegacy(TestCase):
         with warnings.catch_warnings(record=True) as ws:
             Winsorize(
                 search_space=None,
-                observation_features=None,
-                observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+                observations=deepcopy(self.observations),
                 config={"winsorization_upper": 0.2},
             )
             self.assertTrue(
@@ -133,24 +128,24 @@ class WinsorizeTransformTestLegacy(TestCase):
         self.assertEqual(self.t2.cutoffs["m1"], (0.0, float("inf")))
         self.assertEqual(self.t2.cutoffs["m2"], (0.0, float("inf")))
         with self.assertRaises(DataRequiredError):
-            Winsorize(search_space=None, observation_features=[], observation_data=[])
+            Winsorize(search_space=None, observations=[])
 
     def testTransformObservations(self):
-        observation_data = self.t1.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t1._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t1.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t1._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 1.0, 1.0])
-        observation_data = self.t2.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t2._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t2.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t2._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
 
     def testInitPercentileBounds(self):
@@ -163,8 +158,7 @@ class WinsorizeTransformTestLegacy(TestCase):
         with self.assertRaises(ValueError):
             Winsorize(
                 search_space=None,
-                observation_features=None,
-                observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+                observations=deepcopy(self.observations),
                 config={
                     "winsorization_lower": 0.8,
                     "percentile_bounds": {"m1": (0.1, 0.2, 0.3)},  # Too many inputs..
@@ -172,40 +166,38 @@ class WinsorizeTransformTestLegacy(TestCase):
             )
 
     def testTransformObservationsPercentileBounds(self):
-        observation_data = self.t3.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t3._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t3.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t3._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 1.9, 1.0])
-        observation_data = self.t4.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t4._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 0.3, 1.0])
-        observation_data = self.t4.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t4._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
 
     def testTransformObservationsDifferentLowerUpper(self):
-        observation_data = self.t5.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t5._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertEqual(self.t5.cutoffs["m1"], (-float("inf"), 1.0))
         self.assertEqual(self.t5.cutoffs["m2"], (1.0, float("inf")))
         self.assertEqual(self.t5.cutoffs["m3"], (-float("inf"), float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
         # Nothing should happen to m3
-        observation_data = self.t5.transform_observation_data(
-            [deepcopy(self.obsd3)], []
-        )[0]
+        observation_data = self.t5.transform_observations([deepcopy(self.obs3)])[0].data
         self.assertListEqual(list(observation_data.means), [0.0, 1.0, 5.0, 3.0])
         # With percentile_bounds
-        observation_data = self.t6.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t6._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertEqual(self.t6.cutoffs["m1"], (-float("inf"), 1.0))
         self.assertEqual(self.t6.cutoffs["m2"], (0.0, float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])

--- a/ax/modelbridge/transforms/cap_parameter.py
+++ b/ax/modelbridge/transforms/cap_parameter.py
@@ -6,7 +6,7 @@
 
 from typing import List, Optional, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation
 from ax.core.parameter import RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -27,13 +27,13 @@ class CapParameter(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
         self.config = config or {}
+        assert search_space is not None, "CapParameter requires search space"
         self.transform_parameters = {  # Only transform parameters in config.
             p_name for p_name in search_space.parameters if p_name in self.config
         }

--- a/ax/modelbridge/transforms/cast.py
+++ b/ax/modelbridge/transforms/cast.py
@@ -6,7 +6,7 @@
 
 from typing import List, Optional, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.models.types import TConfig
@@ -39,12 +39,12 @@ class Cast(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: Optional[List[ObservationFeatures]] = None,
-        observation_data: Optional[List[ObservationData]] = None,
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "Cast requires search space"
         self.search_space = search_space.clone()
         self.flatten_hss: bool = (
             config is None or checked_cast(bool, config.get("flatten_hss", True))

--- a/ax/modelbridge/transforms/choice_encode.py
+++ b/ax/modelbridge/transforms/choice_encode.py
@@ -7,7 +7,7 @@
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
@@ -48,12 +48,12 @@ class ChoiceEncode(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "ChoiceEncode requires search space"
         # Identify parameters that should be transformed
         self.encoded_parameters: Dict[str, Dict[TParamValue, TParamValue]] = {}
         self.encoded_parameters_inverse: Dict[str, ClosestLookupDict] = {}
@@ -136,8 +136,7 @@ class OrderedChoiceEncode(ChoiceEncode):
     def __init__(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:

--- a/ax/modelbridge/transforms/convert_metric_names.py
+++ b/ax/modelbridge/transforms/convert_metric_names.py
@@ -7,7 +7,7 @@
 from typing import Dict, List, Optional, TYPE_CHECKING
 
 from ax.core.multi_type_experiment import MultiTypeExperiment
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.models.types import TConfig
@@ -37,12 +37,12 @@ class ConvertMetricNames(Transform):
 
     def __init__(
         self,
-        search_space: Optional[SearchSpace],
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert observations is not None, "ConvertMetricNames requires observations"
         if config is None:
             raise ValueError("Config cannot be none.")
 
@@ -65,8 +65,8 @@ class ConvertMetricNames(Transform):
         if self.trial_index_to_type is None:
             raise ValueError("Config must contain trial_index_to_type")
 
-        for obsf in observation_features:
-            if obsf.trial_index not in self.trial_index_to_type:
+        for obs in observations:
+            if obs.features.trial_index not in self.trial_index_to_type:
                 raise ValueError("trial_index_to_type does not include all trials")
 
         # For each trial type, give a map from transformed name back to original
@@ -83,11 +83,10 @@ class ConvertMetricNames(Transform):
             else:
                 self.reverse_metric_name_map[trial_type] = {trans_name: orig_name}
 
-    @copy_doc(Transform.transform_observation_data)
-    def transform_observation_data(
+    @copy_doc(Transform._transform_observation_data)
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         for obsd in observation_data:
             for i in range(len(obsd.metric_names)):
@@ -95,26 +94,25 @@ class ConvertMetricNames(Transform):
                     obsd.metric_names[i] = self.metric_name_map[obsd.metric_names[i]]
         return observation_data
 
-    @copy_doc(Transform.untransform_observation_data)
-    def untransform_observation_data(
+    @copy_doc(Transform.untransform_observations)
+    def untransform_observations(
         self,
-        observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
-    ) -> List[ObservationData]:
+        observations: List[Observation],
+    ) -> List[Observation]:
         if not self.perform_untransform:
-            return observation_data
-        for i, obsd in enumerate(observation_data):
-            trial_index = int(not_none(observation_features[i].trial_index))
+            return observations
+        for obs in observations:
+            trial_index = int(not_none(obs.features.trial_index))
             trial_type = self.trial_index_to_type[trial_index]
             reverse_map = self.reverse_metric_name_map.get(trial_type)
 
             if not reverse_map:
                 continue
 
-            for j in range(len(obsd.metric_names)):
-                if obsd.metric_names[j] in reverse_map:
-                    obsd.metric_names[j] = reverse_map[obsd.metric_names[j]]
-        return observation_data
+            for j in range(len(obs.data.metric_names)):
+                if obs.data.metric_names[j] in reverse_map:
+                    obs.data.metric_names[j] = reverse_map[obs.data.metric_names[j]]
+        return observations
 
 
 def tconfig_from_mt_experiment(experiment: MultiTypeExperiment) -> TConfig:
@@ -139,22 +137,12 @@ def convert_mt_observations(
     observations: List[Observation], experiment: MultiTypeExperiment
 ) -> List[Observation]:
     """Apply ConvertMetricNames transform to observations for a MT experiment."""
-    observation_data = [o.data for o in observations]
-    observation_features = [o.features for o in observations]
     transform = ConvertMetricNames(
         search_space=None,
-        observation_data=observation_data,
-        observation_features=observation_features,
+        observations=observations,
         config=tconfig_from_mt_experiment(experiment),
     )
-    transformed_observations = transform.transform_observation_data(
-        observation_data=observation_data, observation_features=observation_features
+    transformed_observations = transform.transform_observations(
+        observations=observations
     )
-    return [
-        Observation(
-            features=obs.features,
-            data=transformed_observations[i],
-            arm_name=obs.arm_name,
-        )
-        for i, obs in enumerate(observations)
-    ]
+    return transformed_observations

--- a/ax/modelbridge/transforms/derelativize.py
+++ b/ax/modelbridge/transforms/derelativize.py
@@ -4,12 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 
 import numpy as np
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
-from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
+from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.modelbridge.base import unwrap_observation_data
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.ivw import ivw_metric_merge
@@ -38,8 +38,8 @@ class Derelativize(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        modelbridge: Optional["modelbridge_module.base.ModelBridge"],
-        fixed_features: ObservationFeatures,
+        modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
     ) -> OptimizationConfig:
         use_raw_sq = self.config.get("use_raw_status_quo", False)
         has_relative_constraint = any(
@@ -91,3 +91,12 @@ class Derelativize(Transform):
                 c.bound = (1 + c.bound / 100.0) * sq_val
                 c.relative = False
         return optimization_config
+
+    def untransform_outcome_constraints(
+        self,
+        outcome_constraints: List[OutcomeConstraint],
+        fixed_features: Optional[ObservationFeatures] = None,
+    ) -> List[OutcomeConstraint]:
+        # We intentionally leave outcome constraints derelativized when
+        # untransforming.
+        return outcome_constraints

--- a/ax/modelbridge/transforms/int_range_to_choice.py
+++ b/ax/modelbridge/transforms/int_range_to_choice.py
@@ -6,7 +6,7 @@
 
 from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -26,12 +26,12 @@ class IntRangeToChoice(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "IntRangeToChoice requires search space"
         # Identify parameters that should be transformed
         self.transform_parameters: Set[str] = {
             p_name

--- a/ax/modelbridge/transforms/int_to_float.py
+++ b/ax/modelbridge/transforms/int_to_float.py
@@ -6,7 +6,7 @@
 
 from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -17,6 +17,7 @@ from ax.modelbridge.transforms.rounding import (
 from ax.modelbridge.transforms.utils import construct_new_search_space
 from ax.models.types import TConfig
 from ax.utils.common.logger import get_logger
+from ax.utils.common.typeutils import not_none
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
@@ -40,13 +41,12 @@ class IntToFloat(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
-        self.search_space = search_space
+        self.search_space = not_none(search_space, "IntToFloat requires search space")
         self.rounding = "strict"
         if config is not None:
             self.rounding = config.get("rounding", "strict")
@@ -59,7 +59,7 @@ class IntToFloat(Transform):
         # Identify parameters that should be transformed
         self.transform_parameters: Set[str] = {
             p_name
-            for p_name, p in search_space.parameters.items()
+            for p_name, p in self.search_space.parameters.items()
             if isinstance(p, RangeParameter) and p.parameter_type == ParameterType.INT
         }
         if contains_constrained_integer(self.search_space, self.transform_parameters):

--- a/ax/modelbridge/transforms/inverse_gaussian_cdf_y.py
+++ b/ax/modelbridge/transforms/inverse_gaussian_cdf_y.py
@@ -6,7 +6,7 @@
 
 from typing import List, Optional, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.utils import match_ci_width_truncated
@@ -32,18 +32,16 @@ class InverseGaussianCdfY(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["base_modelbridge.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
         self.dist = norm(loc=0, scale=1)
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Map to inverse Gaussian CDF in place."""
         # TODO (jej): Transform covariances.

--- a/ax/modelbridge/transforms/ivw.py
+++ b/ax/modelbridge/transforms/ivw.py
@@ -7,7 +7,7 @@
 from typing import Dict, List
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import ObservationData
 from ax.modelbridge.transforms.base import Transform
 from ax.utils.common.logger import get_logger
 
@@ -110,10 +110,9 @@ class IVW(Transform):
     are combined using inverse variance weighting.
     """
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         # pyre: conflicting_noiseless is declared to have type `str` but is
         # pyre-fixme[9]: used as type `typing.Union[float, int, str]`.

--- a/ax/modelbridge/transforms/log.py
+++ b/ax/modelbridge/transforms/log.py
@@ -7,7 +7,7 @@
 import math
 from typing import List, Optional, Set, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -26,12 +26,12 @@ class Log(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "Log requires search space"
         # Identify parameters that should be transformed
         self.transform_parameters: Set[str] = {
             p_name

--- a/ax/modelbridge/transforms/log_y.py
+++ b/ax/modelbridge/transforms/log_y.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 from typing import Callable, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
+from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.models.types import TConfig
@@ -40,9 +41,8 @@ class LogY(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["base_modelbridge.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
@@ -56,8 +56,7 @@ class LogY(Transform):
             raise ValueError("Must specify at least one metric in the config.")
         super().__init__(
             search_space=search_space,
-            observation_features=observation_features,
-            observation_data=observation_data,
+            observations=observations,
             config=config,
         )
         self.metric_names = metric_names
@@ -73,8 +72,8 @@ class LogY(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        modelbridge: Optional[base_modelbridge.ModelBridge],
-        fixed_features: ObservationFeatures,
+        modelbridge: Optional[base_modelbridge.ModelBridge] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
     ) -> OptimizationConfig:
         for c in optimization_config.all_constraints:
             if c.metric.name in self.metric_names:
@@ -94,7 +93,6 @@ class LogY(Transform):
     def _tf_obs_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
         transform: Callable[[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray]],
     ) -> List[ObservationData]:
         for obsd in observation_data:
@@ -124,23 +122,29 @@ class LogY(Transform):
                 obsd.covariance = cov
         return observation_data
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
-        return self._tf_obs_data(
-            observation_data, observation_features, self._transform
-        )
+        return self._tf_obs_data(observation_data, self._transform)
 
-    def untransform_observation_data(
+    def _untransform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
-        return self._tf_obs_data(
-            observation_data, observation_features, self._untransform
-        )
+        return self._tf_obs_data(observation_data, self._untransform)
+
+    def untransform_outcome_constraints(
+        self,
+        outcome_constraints: List[OutcomeConstraint],
+        fixed_features: Optional[ObservationFeatures] = None,
+    ) -> List[OutcomeConstraint]:
+        for c in outcome_constraints:
+            if c.metric.name in self.metric_names:
+                if c.relative:
+                    raise ValueError("Unexpected relative transform.")
+                c.bound = np.exp(c.bound)
+        return outcome_constraints
 
 
 def match_ci_width(

--- a/ax/modelbridge/transforms/logit.py
+++ b/ax/modelbridge/transforms/logit.py
@@ -6,7 +6,7 @@
 
 from typing import List, Optional, Set, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -26,12 +26,12 @@ class Logit(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "Logit requires search space"
         # Identify parameters that should be transformed
         self.transform_parameters: Set[str] = {
             p_name

--- a/ax/modelbridge/transforms/map_unit_x.py
+++ b/ax/modelbridge/transforms/map_unit_x.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.unit_x import UnitX
 from ax.models.types import TConfig
@@ -32,20 +32,21 @@ class MapUnitX(UnitX):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional[modelbridge_module.base.ModelBridge] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert observations is not None, "MapUnitX requires observations"
+        assert search_space is not None, "MapUnitX requires search space"
         # Loop through observation features and identify parameters that
         # are not part of the search space. Store all observed values to
         # infer bounds
         map_values = defaultdict(list)
-        for obsf in observation_features:
-            for p in obsf.parameters:
+        for obs in observations:
+            for p in obs.features.parameters:
                 if p not in search_space.parameters:
-                    map_values[p].append(obsf.parameters[p])
+                    map_values[p].append(obs.features.parameters[p])
 
         def get_range(values: List) -> Tuple[float, float]:
             return (min(values), max(values))

--- a/ax/modelbridge/transforms/metrics_as_task.py
+++ b/ax/modelbridge/transforms/metrics_as_task.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+import numpy as np
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.parameter import ChoiceParameter, ParameterType
+from ax.core.search_space import SearchSpace
+from ax.modelbridge.transforms.base import Transform
+from ax.models.types import TConfig
+
+if TYPE_CHECKING:
+    # import as module to make sphinx-autodoc-typehints happy
+    from ax import modelbridge as modelbridge_module  # noqa F401  # pragma: no cover
+
+
+class MetricsAsTask(Transform):
+    """Convert metrics to a task parameter.
+
+    For each metric to be used as a task, the config must specify a list of the
+    target metrics for that particular task metric. So,
+
+    config = {
+        'metric_task_map': {
+            'metric1': ['metric2', 'metric3'],
+            'metric2': ['metric3'],
+        }
+    }
+
+    means that metric2 will be given additional task observations of metric1,
+    and metric3 will be given additional task observations of both metric1 and
+    metric2. Note here that metric2 and metric3 are the target tasks, and this
+    map is from base tasks to target tasks.
+    """
+
+    def __init__(
+        self,
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
+        modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
+        config: Optional[TConfig] = None,
+    ) -> None:
+        # Use config to specify metric task map
+        if config is None or "metric_task_map" not in config:
+            raise ValueError("config must specify metric_task_map")
+        self.metric_task_map: Dict[str, List[str]] = config[  # pyre-ignore
+            "metric_task_map"
+        ]
+        self.task_values: List[str] = list(self.metric_task_map.keys())
+        assert "TARGET" not in self.task_values
+        self.task_values.append("TARGET")
+
+    def transform_observations(
+        self,
+        observations: List[Observation],
+    ) -> List[Observation]:
+        new_observations = []
+        for obs in observations:
+            # For the original observation, all the metrics with the new task param
+            params = obs.features.parameters.copy()
+            params["METRIC_TASK"] = "TARGET"
+            new_observations.append(
+                Observation(
+                    features=obs.features.clone(replace_parameters=params),
+                    data=obs.data,
+                    arm_name=obs.arm_name,
+                )
+            )
+            # Split out observations for the task metrics
+            for task_metric, target_metrics in self.metric_task_map.items():
+                if task_metric in obs.data.metric_names:
+                    # Make an observation for this task metric.
+                    params = obs.features.parameters.copy()
+                    params["METRIC_TASK"] = task_metric
+                    new_obs_feats = obs.features.clone(replace_parameters=params)
+                    new_obs_data = ObservationData(
+                        metric_names=target_metrics,
+                        means=obs.data.means_dict[task_metric]  # pyre-ignore
+                        * np.ones(len(target_metrics)),
+                        covariance=np.diag(
+                            obs.data.covariance_matrix[task_metric][task_metric]
+                            * np.ones(len(target_metrics))
+                        ),
+                    )
+                    new_observations.append(
+                        Observation(
+                            features=new_obs_feats,
+                            data=new_obs_data,
+                            arm_name=obs.arm_name,
+                        )
+                    )
+        return new_observations
+
+    def transform_observation_features(
+        self, observation_features: List[ObservationFeatures]
+    ) -> List[ObservationFeatures]:
+        """
+        If transforming features without data, map them to the target.
+        """
+        for obsf in observation_features:
+            obsf.parameters["METRIC_TASK"] = "TARGET"
+        return observation_features
+
+    def untransform_observations(
+        self, observations: List[Observation]
+    ) -> List[Observation]:
+        # Drop any observations that are not TARGET, and remove the param.
+        new_observations = []
+        for obs in observations:
+            task = obs.features.parameters.pop("METRIC_TASK")
+            if task == "TARGET":
+                new_observations.append(
+                    Observation(
+                        features=obs.features, data=obs.data, arm_name=obs.arm_name
+                    )
+                )
+        return new_observations
+
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+        # Add task parameter
+        task_param = ChoiceParameter(
+            name="METRIC_TASK",
+            parameter_type=ParameterType.STRING,
+            values=self.task_values,  # pyre-ignore
+            is_ordered=False,
+            is_task=True,
+            sort_values=True,
+        )
+        search_space.add_parameter(task_param)
+        return search_space
+
+    def untransform_observation_features(
+        self, observation_features: List[ObservationFeatures]
+    ) -> List[ObservationFeatures]:
+        # This is called during gen. We shouldn't gen for any task other than
+        # the target task.
+        for obsf in observation_features:
+            task = obsf.parameters.pop("METRIC_TASK")
+            if task != "TARGET":
+                raise ValueError(f"Got point for task {task}. Something went wrong.")
+        return observation_features

--- a/ax/modelbridge/transforms/percentile_y.py
+++ b/ax/modelbridge/transforms/percentile_y.py
@@ -7,7 +7,7 @@
 import math
 from typing import List, Optional, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import DataRequiredError
 from ax.modelbridge.transforms.base import Transform
@@ -32,16 +32,15 @@ class PercentileY(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
-        if len(observation_data) == 0:
-            raise DataRequiredError(
-                "Percentile transform requires non-empty observation data."
-            )
+        assert observations is not None, "PercentileY requires observations"
+        if len(observations) == 0:
+            raise DataRequiredError("Percentile transform requires non-empty data.")
+        observation_data = [obs.data for obs in observations]
         metric_values = get_data(observation_data=observation_data)
         self.percentiles = {
             metric_name: vals for metric_name, vals in metric_values.items()
@@ -51,10 +50,9 @@ class PercentileY(Transform):
         else:
             self.winsorize = False
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Map observation data to empirical CDF quantiles in place."""
         # TODO (jej): Transform covariances.

--- a/ax/modelbridge/transforms/power_transform_y.py
+++ b/ax/modelbridge/transforms/power_transform_y.py
@@ -10,9 +10,9 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
-from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
+from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.utils import get_data, match_ci_width_truncated
@@ -49,12 +49,12 @@ class PowerTransformY(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional[modelbridge_module.base.ModelBridge] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert observations is not None, "PowerTransformY requires observations"
         if config is None:
             raise ValueError("PowerTransform requires a config.")
         # pyre-fixme[6]: Same issue as for LogY
@@ -63,14 +63,14 @@ class PowerTransformY(Transform):
             raise ValueError("Must specify at least one metric in the config.")
         self.clip_mean = config.get("clip_mean", True)
         self.metric_names = metric_names
+        observation_data = [obs.data for obs in observations]
         Ys = get_data(observation_data=observation_data, metric_names=metric_names)
         self.power_transforms = _compute_power_transforms(Ys=Ys)
         self.inv_bounds = _compute_inverse_bounds(self.power_transforms, tol=1e-10)
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Winsorize observation data in place."""
         for obsd in observation_data:
@@ -86,10 +86,9 @@ class PowerTransformY(Transform):
                     )
         return observation_data
 
-    def untransform_observation_data(
+    def _untransform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Winsorize observation data in place."""
         for obsd in observation_data:
@@ -114,8 +113,8 @@ class PowerTransformY(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        modelbridge: Optional[modelbridge_module.base.ModelBridge],
-        fixed_features: ObservationFeatures,
+        modelbridge: Optional[modelbridge_module.base.ModelBridge] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
     ) -> OptimizationConfig:
         for c in optimization_config.all_constraints:
             if isinstance(c, ScalarizedOutcomeConstraint):
@@ -136,6 +135,22 @@ class PowerTransformY(Transform):
                     transform = self.power_transforms[c.metric.name].transform
                     c.bound = transform(np.array(c.bound, ndmin=2)).item()
         return optimization_config
+
+    def untransform_outcome_constraints(
+        self,
+        outcome_constraints: List[OutcomeConstraint],
+        fixed_features: Optional[ObservationFeatures] = None,
+    ) -> List[OutcomeConstraint]:
+        for c in outcome_constraints:
+            if isinstance(c, ScalarizedOutcomeConstraint):
+                raise ValueError("ScalarizedOutcomeConstraint not supported here")
+            elif c.metric.name in self.metric_names:
+                if c.relative:
+                    raise ValueError("Relative constraints not supported here.")
+                else:
+                    transform = self.power_transforms[c.metric.name].inverse_transform
+                    c.bound = transform(np.array(c.bound, ndmin=2)).item()
+        return outcome_constraints
 
 
 def _compute_power_transforms(

--- a/ax/modelbridge/transforms/relativize.py
+++ b/ax/modelbridge/transforms/relativize.py
@@ -12,11 +12,12 @@ from math import sqrt
 from typing import Dict, List, Optional, TYPE_CHECKING
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
 )
+from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.models.types import TConfig
@@ -44,16 +45,15 @@ class Relativize(Transform):
 
     def __init__(
         self,
-        search_space: Optional[SearchSpace],
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional[modelbridge_module.base.ModelBridge] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert observations is not None, "Relativize requires observations"
         super().__init__(
             search_space=search_space,
-            observation_features=observation_features,
-            observation_data=observation_data,
+            observations=observations,
             modelbridge=modelbridge,
             config=config,
         )
@@ -62,8 +62,7 @@ class Relativize(Transform):
             modelbridge, "Relativize transform requires a modelbridge"
         )
         self.status_quo_by_trial = self._get_status_quo_by_trial(
-            observation_data=observation_data,
-            observation_features=observation_features,
+            observations=observations,
             status_quo_feature=not_none(
                 self.modelbridge.status_quo, self.MISSING_STATUS_QUO_ERROR
             ).features,
@@ -72,8 +71,8 @@ class Relativize(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        modelbridge: Optional[modelbridge_module.base.ModelBridge],
-        fixed_features: ObservationFeatures,
+        modelbridge: Optional[modelbridge_module.base.ModelBridge] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
     ) -> OptimizationConfig:
         r"""
         Change the relative flag of the given relative optimization configuration
@@ -129,29 +128,40 @@ class Relativize(Transform):
 
         return new_optimization_config
 
-    def transform_observation_data(
+    def untransform_outcome_constraints(
         self,
-        observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
-    ) -> List[ObservationData]:
+        outcome_constraints: List[OutcomeConstraint],
+        fixed_features: Optional[ObservationFeatures] = None,
+    ) -> List[OutcomeConstraint]:
+        for c in outcome_constraints:
+            c.relative = True
+        return outcome_constraints
+
+    def transform_observations(
+        self,
+        observations: List[Observation],
+    ) -> List[Observation]:
         return [
-            self._get_relative_data(
-                data=datum,
-                status_quo_data=not_none(
-                    self.status_quo_by_trial.get(obs_features.trial_index, None),
-                    self.MISSING_STATUS_QUO_ERROR,
+            Observation(
+                features=obs.features,
+                data=self._get_relative_data(
+                    data=obs.data,
+                    status_quo_data=not_none(
+                        self.status_quo_by_trial.get(obs.features.trial_index, None),
+                        self.MISSING_STATUS_QUO_ERROR,
+                    ),
                 ),
+                arm_name=obs.arm_name,
             )
-            for datum, obs_features in zip(observation_data, observation_features)
+            for obs in observations
         ]
 
-    def untransform_observation_data(
+    def _untransform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         warnings.warn(
-            "`Relativize.untransform_observation_data()` not yet implemented. "
+            "`Relativize._untransform_observation_data()` not yet implemented. "
             "Returning relative data."
         )
         return observation_data
@@ -200,13 +210,13 @@ class Relativize(Transform):
 
     @staticmethod
     def _get_status_quo_by_trial(
-        observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
+        observations: List[Observation],
         status_quo_feature: ObservationFeatures,
     ) -> Dict[int, ObservationData]:
         status_quo_signature = json.dumps(status_quo_feature.parameters, sort_keys=True)
         return {
-            obs_f.trial_index: obs_data
-            for obs_data, obs_f in zip(observation_data, observation_features)
-            if json.dumps(obs_f.parameters, sort_keys=True) == status_quo_signature
+            int(not_none(obs.features.trial_index)): obs.data
+            for obs in observations
+            if json.dumps(obs.features.parameters, sort_keys=True)
+            == status_quo_signature
         }

--- a/ax/modelbridge/transforms/remove_fixed.py
+++ b/ax/modelbridge/transforms/remove_fixed.py
@@ -6,7 +6,7 @@
 
 from typing import Dict, List, Optional, TYPE_CHECKING, Union
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, FixedParameter, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -29,12 +29,12 @@ class RemoveFixed(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "RemoveFixed requires search space"
         # Identify parameters that should be transformed
         self.fixed_parameters: Dict[str, FixedParameter] = {
             p_name: p

--- a/ax/modelbridge/transforms/search_space_to_choice.py
+++ b/ax/modelbridge/transforms/search_space_to_choice.py
@@ -7,7 +7,7 @@
 from typing import List, Optional, TYPE_CHECKING
 
 from ax.core.arm import Arm
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, FixedParameter, ParameterType
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.exceptions.core import UnsupportedError
@@ -34,16 +34,16 @@ class SearchSpaceToChoice(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "SearchSpaceToChoice requires search space"
+        assert observations is not None, "SeachSpaceToChoice requires observations"
         super().__init__(
             search_space=search_space,
-            observation_features=observation_features,
-            observation_data=observation_data,
+            observations=observations,
             config=config,
         )
         if any(p.is_fidelity for p in search_space.parameters.values()):
@@ -57,8 +57,8 @@ class SearchSpaceToChoice(Transform):
             )
         self.parameter_name = "arms"
         self.signature_to_parameterization = {
-            Arm(parameters=obsf.parameters).signature: obsf.parameters
-            for obsf in observation_features
+            Arm(parameters=obs.features.parameters).signature: obs.features.parameters
+            for obs in observations
         }
 
     def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:

--- a/ax/modelbridge/transforms/task_encode.py
+++ b/ax/modelbridge/transforms/task_encode.py
@@ -6,7 +6,7 @@
 
 from typing import Dict, List, Optional, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
@@ -33,12 +33,12 @@ class TaskEncode(OrderedChoiceEncode):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "TaskEncode requires search space"
         # Identify parameters that should be transformed
         self.encoded_parameters: Dict[str, Dict[TParamValue, int]] = {}
         for p in search_space.parameters.values():

--- a/ax/modelbridge/transforms/trial_as_task.py
+++ b/ax/modelbridge/transforms/trial_as_task.py
@@ -7,7 +7,7 @@
 from typing import Dict, List, Optional, TYPE_CHECKING
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.exceptions.core import UnsupportedError
@@ -47,14 +47,14 @@ class TrialAsTask(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert observations is not None, "TrialAskTask requires observations"
         # Identify values of trial.
-        trials = {obsf.trial_index for obsf in observation_features}
+        trials = {obs.features.trial_index for obs in observations}
         if isinstance(search_space, RobustSearchSpace):
             raise UnsupportedError(
                 "TrialAsTask transform is not supported for RobustSearchSpace."

--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 from ax.core.objective import ScalarizedObjective
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
@@ -107,21 +107,19 @@ class Winsorize(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
-        if len(observation_data) == 0:
-            raise DataRequiredError(
-                "`Winsorize` transform requires non-empty observation data."
-            )
+        if observations is None or len(observations) == 0:
+            raise DataRequiredError("`Winsorize` transform requires non-empty data.")
         if config is None:
             raise ValueError(
                 "Transform config for `Winsorize` transform must be specified and "
                 "non-empty when using winsorization."
             )
+        observation_data = [obs.data for obs in observations]
         all_metric_values = get_data(observation_data=observation_data)
 
         # Check for legacy config
@@ -164,10 +162,9 @@ class Winsorize(Transform):
                     optimization_config=opt_config,  # pyre-ignore[6]
                 )
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Winsorize observation data in place."""
         for obsd in observation_data:

--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -215,8 +215,8 @@ def _get_in_sample_arms(
 
     # Merge multiple measurements within each Observation with IVW to get
     # un-modeled prediction
-    t = IVW(None, [], [])
-    obs_data = t.transform_observation_data([obs.data for obs in observations], [])
+    t = IVW(None, [])
+    observations = t.transform_observations(observations)
     # Start filling in plot data
     in_sample_plot: Dict[str, PlotInSampleArm] = {}
     for i, obs in enumerate(observations):
@@ -226,11 +226,10 @@ def _get_in_sample_arms(
         # Extract raw measurement
         obs_y = {}  # Observed metric means.
         obs_se = {}  # Observed metric standard errors.
-        # Use the IVW data, not obs.data
-        for j, metric_name in enumerate(obs_data[i].metric_names):
+        for j, metric_name in enumerate(obs.data.metric_names):
             if metric_name in metric_names:
-                obs_y[metric_name] = obs_data[i].means[j]
-                obs_se[metric_name] = np.sqrt(obs_data[i].covariance[j, j])
+                obs_y[metric_name] = obs.data.means[j]
+                obs_se[metric_name] = np.sqrt(obs.data.covariance[j, j])
         if training_in_design[i]:
             # Update with the input fixed features
             features = obs.features

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -17,6 +17,7 @@ from ax.modelbridge.transforms.ivw import IVW
 from ax.modelbridge.transforms.log import Log
 from ax.modelbridge.transforms.logit import Logit
 from ax.modelbridge.transforms.map_unit_x import MapUnitX
+from ax.modelbridge.transforms.metrics_as_task import MetricsAsTask
 from ax.modelbridge.transforms.one_hot import OneHot
 from ax.modelbridge.transforms.power_transform_y import PowerTransformY
 from ax.modelbridge.transforms.remove_fixed import RemoveFixed
@@ -67,6 +68,7 @@ TRANSFORM_REGISTRY: Dict[Type[Transform], int] = {
     ChoiceEncode: 19,
     Logit: 20,
     MapUnitX: 21,
+    MetricsAsTask: 22,
 }
 
 

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -10,6 +10,7 @@ import numpy as np
 from ax.core.experiment import Experiment
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
+from ax.core.parameter import FixedParameter, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
@@ -17,7 +18,6 @@ from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.int_to_float import IntToFloat
 from ax.utils.common.logger import get_logger
-from ax.utils.common.typeutils import not_none
 from ax.utils.testing.core_stubs import (
     get_experiment,
     get_search_space,
@@ -108,7 +108,7 @@ def get_observation1trans(
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(
-            parameters={"x": 9.0, "y": 10.0}, trial_index=np.int64(0)
+            parameters={"x": 9.0, "y": 121.0}, trial_index=np.int64(0)
         ),
         data=ObservationData(
             means=np.array([9.0, 25.0]),
@@ -140,7 +140,7 @@ def get_observation2trans(
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(
-            parameters={"x": 16.0, "y": 2.0}, trial_index=np.int64(1)
+            parameters={"x": 16.0, "y": 9.0}, trial_index=np.int64(1)
         ),
         data=ObservationData(
             means=np.array([9.0, 4.0]),
@@ -181,14 +181,19 @@ def get_experiment_for_value() -> Experiment:
 class transform_1(Transform):
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         new_ss = search_space.clone()
-        new_ss.parameters["x"]._value += 1.0  # pyre-ignore[16]: testing hack.
+        for param in new_ss.parameters.values():
+            if isinstance(param, FixedParameter):
+                param._value += 1.0
+            elif isinstance(param, RangeParameter):
+                param._lower += 1.0
+                param._upper += 1.0
         return new_ss
 
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
         modelbridge: Optional[ModelBridge],
-        fixed_features: ObservationFeatures,
+        fixed_features: Optional[ObservationFeatures],
     ) -> OptimizationConfig:
         return (  # pyre-ignore[7]: pyre is right, this is a hack for testing.
             # pyre-fixme[58]: `+` is not supported for operand types
@@ -202,19 +207,13 @@ class transform_1(Transform):
         self, observation_features: List[ObservationFeatures]
     ) -> List[ObservationFeatures]:
         for obsf in observation_features:
-            if "x" in obsf.parameters:
-                obsf.parameters["x"] = (
-                    # pyre-fixme[58]: `+` is not supported for operand types
-                    #  `Union[float, str]` and `int`.
-                    not_none(obsf.parameters["x"])
-                    + 1
-                )
+            for p_name in obsf.parameters:
+                obsf.parameters[p_name] += 1  # pyre-ignore
         return observation_features
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         for obsd in observation_data:
             obsd.means += 1
@@ -224,13 +223,13 @@ class transform_1(Transform):
         self, observation_features: List[ObservationFeatures]
     ) -> List[ObservationFeatures]:
         for obsf in observation_features:
-            obsf.parameters["x"] = obsf.parameters["x"] - 1  # pyre-ignore
+            for p_name in obsf.parameters:
+                obsf.parameters[p_name] -= 1  # pyre-ignore
         return observation_features
 
-    def untransform_observation_data(
+    def _untransform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         for obsd in observation_data:
             obsd.means -= 1
@@ -240,14 +239,19 @@ class transform_1(Transform):
 class transform_2(Transform):
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         new_ss = search_space.clone()
-        new_ss.parameters["x"]._value *= 2.0  # pyre-ignore[16]: testing hack.
+        for param in new_ss.parameters.values():
+            if isinstance(param, FixedParameter):
+                param._value *= 2.0
+            elif isinstance(param, RangeParameter):
+                param._lower *= 2.0
+                param._upper *= 2.0
         return new_ss
 
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
         modelbridge: Optional[ModelBridge],
-        fixed_features: ObservationFeatures,
+        fixed_features: Optional[ObservationFeatures],
     ) -> OptimizationConfig:
         return (
             # pyre-fixme[58]: `**` is not supported for operand types
@@ -261,14 +265,13 @@ class transform_2(Transform):
         self, observation_features: List[ObservationFeatures]
     ) -> List[ObservationFeatures]:
         for obsf in observation_features:
-            if "x" in obsf.parameters:
-                obsf.parameters["x"] = obsf.parameters["x"] ** 2  # pyre-ignore
+            for pname in obsf.parameters:
+                obsf.parameters[pname] = obsf.parameters[pname] ** 2  # pyre-ignore
         return observation_features
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         for obsd in observation_data:
             obsd.means = obsd.means**2
@@ -278,13 +281,13 @@ class transform_2(Transform):
         self, observation_features: List[ObservationFeatures]
     ) -> List[ObservationFeatures]:
         for obsf in observation_features:
-            obsf.parameters["x"] = np.sqrt(obsf.parameters["x"])
+            for pname in obsf.parameters:
+                obsf.parameters[pname] = np.sqrt(obsf.parameters[pname])
         return observation_features
 
-    def untransform_observation_data(
+    def _untransform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         for obsd in observation_data:
             obsd.means = np.sqrt(obsd.means)

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -253,6 +253,14 @@ Transforms
     :undoc-members:
     :show-inheritance:
 
+`ax.modelbridge.transforms.metrics_as_task`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.metrics_as_task
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 `ax.modelbridge.transforms.one\_hot`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary:
Refactors the transforms to enable converting data, like metrics, to features, such as a task feature.

The main thing is just to leave features and data together as an Observation and transform that object directly rather than splitting it into features and data and transforming each separately.

There are a few other API changes that came out of that:
* `transform_observation_data` and `untransform_observation_data` do not need to be implemented if `transform_observations` and `untransform_observations` are implemented, so I gave them a `_` in the method name.
* Several places that previous had as inputs or outputs both observation features and observation data now take just observations.
* Previously `transform_observation_data` required passing in observation_features, because some transforms require them to be able to transform the data (e.g. `StratifiedStandardizeY`). Now that we anyway have the `transform_observations` method that takes both of them, it is much cleaner to remove that as an input to (now) `_transform_observation_data`, and we can let `StratifiedStandardizeY` just implement `transform_observations` so that it has access to the features when transforming the data.
* Previously there was a very hacky use of `untransform_observation_features` for converting fixed_features when untransforming objective thresholds, and an even hackier method `untransform_objective_thresholds` that relied on `untransform_observation_data`. I replaced that with an explicit `untransform_outcome_constraints` method that must be implemented by any transform that modifies outcome constraints in `transform_optimization_config`. This is because the way this was being handled made what I feel like are some dangerous assumptions in order to use existing methods (setting arbitrary values to observation_features) and it is better to ask the Transform to be explicit in how the outcome constraints should be untransformed.
* To clean up the way the fixed_features were being untransformed also required making it so that the transforms can handle incomplete feature sets on the untransform. Already all of the transforms can handle missing features on the forward transform (so that fixed_features can be forward transformed), and about half of them correctly handled missing features on the backwards transform so I had to update a few that didn't.
* The purpose of this was to be able to implement a transform to converts metrics into task features. You can see this transform, `MetricsAsTask`.

threethousandlinesdiff

Differential Revision: D38833175

