### PR TITLE
Update ax/models/torch/alebo.py to use torch.linalg.qr

### DIFF
--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -74,7 +74,7 @@ class ALEBOKernel(Kernel):
         self.B = B
         # Initialize U
         Arnd = torch.randn(D, D, dtype=B.dtype, device=B.device)
-        Arnd = torch.qr(Arnd)[0]
+        Arnd = torch.linalg.qr(Arnd)[0]
         ABinv = Arnd[: self.d, :] @ torch.pinverse(B)
         # U is the upper Cholesky decomposition of Gamma, the Mahalanobis
         # matrix. Uvec is the upper triangular portion of U squeezed out into


### PR DESCRIPTION
Summary:
torch.qr is deprecated for a long time and is being removed by https://github.com/pytorch/pytorch/pull/70989

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: Balandat

Differential Revision: D39079315

