### PR TITLE
Small change in documentation of 'Total raw effect'

### DIFF
--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -186,8 +186,8 @@ def compute_diagnostics(result: List[CVResult]) -> CVDiagnostics:
       predictions, relative to the observed mean.
     - 'MAPE': mean absolute percentage error of the estimated mean relative
       to the observed mean.
-    - 'Total raw effect': the percent change from the smallest observed
-      mean to the largest observed mean.
+    - 'Total raw effect': the multiple change from the smallest observed
+      mean to the largest observed mean, i.e. `(max - min) / min`.
     - 'Correlation coefficient': the Pearson correlation of the estimated
       and observed means.
     - 'Rank correlation': the Spearman correlation of the estimated
@@ -353,7 +353,8 @@ def _mape(y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray) -> float:
 def _total_raw_effect(
     y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
 ) -> float:
-    return float((np.max(y_obs) - np.min(y_obs)) / np.min(y_obs))
+    min_y_obs = np.min(y_obs)
+    return float((np.max(y_obs) - min_y_obs) / min_y_obs)
 
 
 def _correlation_coefficient(


### PR DESCRIPTION
Summary: 'Total raw effect' was previously described as a percentage, but it is actually the raw multiple factor between the largest and smallest mean. I adjusted the docs, which should not impact any code relying on this field. I also made a small change to `_total_raw_effect` that avoids computing the minium twice.

Reviewed By: lena-kashtelyan

Differential Revision: D39030553

