### PR TITLE
Refactor transforms to work on observations

### DIFF
--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -532,3 +532,15 @@ def separate_observations(
         observation_features = [obs.features for obs in observations]
         observation_data = [obs.data for obs in observations]
     return observation_features, observation_data
+
+
+def recombine_observations(
+    observation_features: List[ObservationFeatures],
+    observation_data: List[ObservationData],
+) -> List[Observation]:
+    if len(observation_features) != len(observation_data):
+        raise ValueError("Got features and data of different lengths")
+    return [
+        Observation(features=observation_features[i], data=obsd)
+        for i, obsd in enumerate(observation_data)
+    ]

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -412,7 +412,8 @@ class HierarchicalSearchSpace(SearchSpace):
         }
         obs_feats = observation_features.clone(
             replace_parameters=self._cast_parameterization(
-                parameters=observation_features.parameters
+                parameters=observation_features.parameters,
+                check_all_parameters_present=False,
             )
         )
         if not obs_feats.metadata:
@@ -586,7 +587,9 @@ class HierarchicalSearchSpace(SearchSpace):
             return applicable
 
         applicable_paramers = _find_applicable_parameters(root=self.root)
-        if not all(k in parameters for k in applicable_paramers):
+        if check_all_parameters_present and not all(
+            k in parameters for k in applicable_paramers
+        ):
             raise RuntimeError(
                 f"Parameters {applicable_paramers- set(parameters.keys())} "
                 "missing from the arm."

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -21,6 +21,7 @@ from ax.core.observation import (
     ObservationFeatures,
     observations_from_data,
     observations_from_map_data,
+    recombine_observations,
     separate_observations,
 )
 from ax.core.trial import Trial
@@ -693,6 +694,11 @@ class ObservationsTest(TestCase):
                 means=np.array([1]), covariance=np.array([[2]]), metric_names=["a"]
             ),
         )
+        with self.assertRaises(ValueError):
+            recombine_observations(observation_features=obs_feats, observation_data=[])
+        new_obs = recombine_observations(obs_feats, obs_data)[0]
+        self.assertEqual(new_obs.features, obs.features)
+        self.assertEqual(new_obs.data, obs.data)
         obs_feats, obs_data = separate_observations(observations=[obs], copy=True)
         self.assertEqual(obs.features, ObservationFeatures(parameters={"x": 20}))
         self.assertEqual(

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -17,7 +17,7 @@ from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
 from ax.modelbridge.map_torch import MapTorchModelBridge
 from ax.modelbridge.modelbridge_utils import (
-    _get_modelbridge_training_data,
+    _unpack_observations,
     observation_data_to_array,
     observation_features_to_array,
 )
@@ -416,16 +416,14 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         transform_model = get_transform_helper_model(
             experiment=experiment, data=map_data
         )
-        obs_feats_raw, obs_data_raw, arm_names = _get_modelbridge_training_data(
-            transform_model
-        )
-        obs_features, obs_data, _ = transform_model._transform_data(
-            obs_feats=obs_feats_raw,
-            obs_data=obs_data_raw,
+        observations_raw = transform_model.get_training_data()
+        observations, _ = transform_model._transform_data(
+            observations=observations_raw,
             search_space=transform_model._model_space,
             transforms=transform_model._raw_transforms,
             transform_configs=None,
         )
+        obs_features, obs_data, arm_names = _unpack_observations(observations)
         X = observation_features_to_array(parameters=parameters, obsf=obs_features)
         Y, Yvar = observation_data_to_array(
             outcomes=list(outcomes), observation_data=obs_data

--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -20,6 +20,7 @@ from ax.core.observation import (
     ObservationData,
     ObservationFeatures,
     observations_from_data,
+    recombine_observations,
     separate_observations,
 )
 from ax.core.optimization_config import OptimizationConfig
@@ -154,7 +155,7 @@ class ModelBridge(ABC):
         # Convert Data to Observations
         observations = self._prepare_observations(experiment=experiment, data=data)
 
-        obs_feats_raw, obs_data_raw = self._set_training_data(
+        observations_raw = self._set_training_data(
             observations=observations, search_space=search_space
         )
         # Set model status quo
@@ -164,9 +165,8 @@ class ModelBridge(ABC):
             status_quo_name=status_quo_name,
             status_quo_features=status_quo_features,
         )
-        obs_feats, obs_data, search_space = self._transform_data(
-            obs_feats=obs_feats_raw,
-            obs_data=obs_data_raw,
+        observations, search_space = self._transform_data(
+            observations=observations_raw,
             search_space=search_space,
             transforms=transforms,
             transform_configs=transform_configs,
@@ -178,8 +178,7 @@ class ModelBridge(ABC):
             self._fit(
                 model=model,
                 search_space=search_space,
-                observation_features=obs_feats,
-                observation_data=obs_data,
+                observations=observations,
             )
             # pyre-fixme[4]: Attribute must be annotated.
             self.fit_time = time.time() - t_fit_start
@@ -200,12 +199,11 @@ class ModelBridge(ABC):
 
     def _transform_data(
         self,
-        obs_feats: List[ObservationFeatures],
-        obs_data: List[ObservationData],
+        observations: List[Observation],
         search_space: SearchSpace,
         transforms: Optional[List[Type[Transform]]],
         transform_configs: Optional[Dict[str, TConfig]],
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData], SearchSpace]:
+    ) -> Tuple[List[Observation], SearchSpace]:
         """Initialize transforms and apply them to provided data."""
         # Initialize transforms
         search_space = search_space.clone()
@@ -216,53 +214,48 @@ class ModelBridge(ABC):
             for t in transforms:
                 t_instance = t(
                     search_space=search_space,
-                    observation_features=obs_feats,
-                    observation_data=obs_data,
+                    observations=observations,
                     modelbridge=self,
                     config=transform_configs.get(t.__name__, None),
                 )
                 search_space = t_instance.transform_search_space(search_space)
-                obs_feats = t_instance.transform_observation_features(obs_feats)
-                obs_data = t_instance.transform_observation_data(obs_data, obs_feats)
+                observations = t_instance.transform_observations(observations)
                 self.transforms[t.__name__] = t_instance
 
-        return obs_feats, obs_data, search_space
+        return observations, search_space
 
     def _prepare_training_data(
         self, observations: List[Observation]
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData]]:
+    ) -> List[Observation]:
         observation_features, observation_data = separate_observations(observations)
         if len(observation_features) != len(set(observation_features)):
             raise ValueError(
                 "Observation features not unique."
                 "Something went wrong constructing training data..."
             )
-        return observation_features, observation_data
+        return observations
 
     def _set_training_data(
         self, observations: List[Observation], search_space: SearchSpace
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData]]:
+    ) -> List[Observation]:
         """Store training data, not-transformed.
 
         If the modelbridge specifies _fit_out_of_design, all training data is
         returned. Otherwise, only in design points are returned.
         """
-        observation_features, observation_data = self._prepare_training_data(
-            observations=observations
-        )
+        observations = self._prepare_training_data(observations=observations)
         self._training_data = deepcopy(observations)
         self._metric_names: Set[str] = set()
-        for obsd in observation_data:
-            self._metric_names.update(obsd.metric_names)
+        for obs in observations:
+            self._metric_names.update(obs.data.metric_names)
         return self._process_in_design(
             search_space=search_space,
-            observation_features=observation_features,
-            observation_data=observation_data,
+            observations=observations,
         )
 
     def _extend_training_data(
         self, observations: List[Observation]
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData]]:
+    ) -> List[Observation]:
         """Extend and return training data, not-transformed.
 
         If the modelbridge specifies _fit_out_of_design, all training data is
@@ -271,15 +264,11 @@ class ModelBridge(ABC):
         Args:
             observations: New observations.
 
-        Returns:
-            observation_features: New + old observation features.
-            observation_data: New + old observation data.
+        Returns: New + old observations.
         """
-        observation_features, observation_data = self._prepare_training_data(
-            observations=observations
-        )
-        for obsd in observation_data:
-            for metric_name in obsd.metric_names:
+        observations = self._prepare_training_data(observations=observations)
+        for obs in observations:
+            for metric_name in obs.data.metric_names:
                 if metric_name not in self._metric_names:
                     raise ValueError(
                         f"Unrecognised metric {metric_name}; cannot update "
@@ -288,46 +277,42 @@ class ModelBridge(ABC):
                     )
         # Initialize with all points in design.
         self._training_data.extend(deepcopy(observations))
-        all_observation_features, all_observation_data = separate_observations(
-            self.get_training_data()
-        )
+        all_observations = self.get_training_data()
         return self._process_in_design(
             search_space=self._model_space,
-            observation_features=all_observation_features,
-            observation_data=all_observation_data,
+            observations=all_observations,
         )
 
     def _process_in_design(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
-    ) -> Tuple[List[ObservationFeatures], List[ObservationData]]:
+        observations: List[Observation],
+    ) -> List[Observation]:
         """Set training_in_design, and decide whether to filter out of design points."""
         # Don't filter points.
         if self._fit_out_of_design:
             # Use all data for training
             # Set training_in_design to True for all observations so that
             # all observations are used in CV and plotting
-            self.training_in_design = [True] * len(observation_features)
-            return observation_features, observation_data
+            self.training_in_design = [True] * len(observations)
+            return observations
         in_design = self._compute_in_design(
-            search_space=search_space, observation_features=observation_features
+            search_space=search_space, observations=observations
         )
         self.training_in_design = in_design
-        in_design_indices = [i for i, in_design in enumerate(in_design) if in_design]
-        in_design_features = [observation_features[i] for i in in_design_indices]
-        in_design_data = [observation_data[i] for i in in_design_indices]
-        return in_design_features, in_design_data
+        in_design_obs = [
+            observations[i] for i, is_in_design in enumerate(in_design) if is_in_design
+        ]
+        return in_design_obs
 
     def _compute_in_design(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
+        observations: List[Observation],
     ) -> List[bool]:
         return [
-            search_space.check_membership(obsf.parameters)
-            for obsf in observation_features
+            search_space.check_membership(obs.features.parameters)
+            for obs in observations
         ]
 
     def _set_status_quo(
@@ -442,8 +427,7 @@ class ModelBridge(ABC):
         # pyre-fixme[2]: Parameter annotation cannot be `Any`.
         model: Any,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
     ) -> None:
         """Apply terminal transform and fit model."""
         raise NotImplementedError  # pragma: no cover
@@ -464,14 +448,13 @@ class ModelBridge(ABC):
         observation_data = self._predict(observation_features)
 
         # Apply reverse transforms, in reverse order
+        pred_observations = recombine_observations(
+            observation_features=observation_features, observation_data=observation_data
+        )
+
         for t in reversed(list(self.transforms.values())):
-            observation_features = t.untransform_observation_features(
-                observation_features
-            )
-            observation_data = t.untransform_observation_data(
-                observation_data, observation_features
-            )
-        return observation_data
+            pred_observations = t.untransform_observations(pred_observations)
+        return [obs.data for obs in pred_observations]
 
     def _single_predict(
         self, observation_features: List[ObservationFeatures]
@@ -561,20 +544,16 @@ class ModelBridge(ABC):
         """
         t_update_start = time.time()
         observations = self._prepare_observations(experiment=experiment, data=new_data)
-        obs_feats_raw, obs_data_raw = self._extend_training_data(
-            observations=observations
-        )
-        obs_feats, obs_data, search_space = self._transform_data(
-            obs_feats=obs_feats_raw,
-            obs_data=obs_data_raw,
+        obs_raw = self._extend_training_data(observations=observations)
+        observations, search_space = self._transform_data(
+            observations=obs_raw,
             search_space=self._model_space,
             transforms=self._raw_transforms,
             transform_configs=self._transform_configs,
         )
         self._update(
             search_space=search_space,
-            observation_features=obs_feats,
-            observation_data=obs_data,
+            observations=observations,
         )
         self.fit_time += time.time() - t_update_start
         self.fit_time_since_gen += time.time() - t_update_start
@@ -582,8 +561,7 @@ class ModelBridge(ABC):
     def _update(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
     ) -> None:
         """Apply terminal transform and update model.
 
@@ -784,36 +762,34 @@ class ModelBridge(ABC):
         """
         # Apply transforms to cv_training_data and cv_test_points
         cv_test_points = deepcopy(cv_test_points)
-        obs_feats, obs_data = separate_observations(
-            observations=cv_training_data, copy=True
-        )
+        cv_training_data = deepcopy(cv_training_data)
         search_space = self._model_space.clone()
         for t in self.transforms.values():
-            obs_feats = t.transform_observation_features(obs_feats)
-            obs_data = t.transform_observation_data(obs_data, obs_feats)
+            cv_training_data = t.transform_observations(cv_training_data)
             cv_test_points = t.transform_observation_features(cv_test_points)
             search_space = t.transform_search_space(search_space)
 
+        obs_feats, obs_data = separate_observations(observations=cv_training_data)
         # Apply terminal transform, and get predictions.
         cv_predictions = self._cross_validate(
             search_space=search_space,
-            observation_features=obs_feats,
-            observation_data=obs_data,
+            cv_training_data=cv_training_data,
             cv_test_points=cv_test_points,
         )
         # Apply reverse transforms, in reverse order
+        cv_test_observations = [
+            Observation(features=obsf, data=cv_predictions[i])
+            for i, obsf in enumerate(cv_test_points)
+        ]
+
         for t in reversed(list(self.transforms.values())):
-            cv_test_points = t.untransform_observation_features(cv_test_points)
-            cv_predictions = t.untransform_observation_data(
-                cv_predictions, cv_test_points
-            )
-        return cv_predictions
+            cv_test_observations = t.untransform_observations(cv_test_observations)
+        return [obs.data for obs in cv_test_observations]
 
     def _cross_validate(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        cv_training_data: List[Observation],
         cv_test_points: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Apply the terminal transform, make predictions on the test points,
@@ -855,9 +831,7 @@ class ModelBridge(ABC):
         )
 
     # pyre-fixme[3]: Return annotation cannot be `Any`.
-    def transform_observation_data(
-        self, observation_data: List[ObservationData]
-    ) -> Any:
+    def transform_observations(self, observations: List[Observation]) -> Any:
         """Applies transforms to given observation features and returns them in the
         model space.
 
@@ -868,17 +842,15 @@ class ModelBridge(ABC):
             Transformed values. This could be e.g. a torch Tensor, depending
             on the ModelBridge subclass.
         """
-        obsd = deepcopy(observation_data)
+        observations = deepcopy(observations)
         for t in self.transforms.values():
-            obsd = t.transform_observation_data(obsd, [])
+            observations = t.transform_observations(observations)
         # Apply terminal transform and return
-        return self._transform_observation_data(obsd)
+        return self._transform_observations(observations)
 
     # pyre-fixme[3]: Return annotation cannot be `Any`.
-    def _transform_observation_data(
-        self, observation_data: List[ObservationData]
-    ) -> Any:
-        """Apply terminal transform to given observation features and return result."""
+    def _transform_observations(self, observations: List[Observation]) -> Any:
+        """Apply terminal transform to given observations and return result."""
         raise NotImplementedError  # pragma: no cover
 
     # pyre-fixme[3]: Return annotation cannot be `Any`.

--- a/ax/modelbridge/discrete.py
+++ b/ax/modelbridge/discrete.py
@@ -6,7 +6,12 @@
 
 from typing import Dict, List, Optional, Set, Tuple
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import (
+    Observation,
+    ObservationData,
+    ObservationFeatures,
+    separate_observations,
+)
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ChoiceParameter, FixedParameter
 from ax.core.search_space import SearchSpace
@@ -44,13 +49,13 @@ class DiscreteModelBridge(ModelBridge):
         self,
         model: DiscreteModel,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
     ) -> None:
         self.model = model
         # Convert observations to arrays
         self.parameters = list(search_space.parameters.keys())
         all_metric_names: Set[str] = set()
+        observation_features, observation_data = separate_observations(observations)
         for od in observation_data:
             all_metric_names.update(od.metric_names)
         self.outcomes = list(all_metric_names)
@@ -163,13 +168,13 @@ class DiscreteModelBridge(ModelBridge):
     def _cross_validate(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        cv_training_data: List[Observation],
         cv_test_points: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Make predictions at cv_test_points using only the data in obs_feats
         and obs_data.
         """
+        observation_features, observation_data = separate_observations(cv_training_data)
         Xs_train, Ys_train, Yvars_train = self._convert_observations(
             observation_data=observation_data,
             observation_features=observation_features,

--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -16,6 +16,7 @@ from ax.core.observation import (
     ObservationData,
     ObservationFeatures,
     observations_from_map_data,
+    separate_observations,
 )
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
@@ -159,8 +160,7 @@ class MapTorchModelBridge(TorchModelBridge):
         self,
         model: TorchModel,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
         parameters: Optional[List[str]] = None,
     ) -> None:
         """The difference from `TorchModelBridge._fit(...)` is that we use
@@ -172,8 +172,7 @@ class MapTorchModelBridge(TorchModelBridge):
         super()._fit(
             model=model,
             search_space=search_space,
-            observation_features=observation_features,
-            observation_data=observation_data,
+            observations=observations,
             parameters=parameters,
         )
 
@@ -215,8 +214,7 @@ class MapTorchModelBridge(TorchModelBridge):
     def _update(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
         parameters: Optional[List[str]] = None,
     ) -> None:
         """The difference b/t this method and TorchModelBridge._update(...) is
@@ -224,8 +222,7 @@ class MapTorchModelBridge(TorchModelBridge):
         """
         return super()._update(
             search_space=search_space,
-            observation_features=observation_features,
-            observation_data=observation_data,
+            observations=observations,
             parameters=self.parameters_with_map_keys,
         )
 
@@ -246,7 +243,7 @@ class MapTorchModelBridge(TorchModelBridge):
         )
 
     def _compute_in_design(
-        self, search_space: SearchSpace, observation_features: List[ObservationFeatures]
+        self, search_space: SearchSpace, observations: List[Observation]
     ) -> List[bool]:
         """The difference b/t this method and ModelBridge._compute_in_design(...)
         is that this one correctly excludes map_keys when checking membership in
@@ -257,18 +254,17 @@ class MapTorchModelBridge(TorchModelBridge):
                 # Exclude map key features when checking
                 {
                     p: v
-                    for p, v in obsf.parameters.items()
+                    for p, v in obs.features.parameters.items()
                     if p not in self._map_key_features
                 }
             )
-            for obsf in observation_features
+            for obs in observations
         ]
 
     def _cross_validate(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        cv_training_data: List[Observation],
         cv_test_points: List[ObservationFeatures],
         parameters: Optional[List[str]] = None,
     ) -> List[ObservationData]:
@@ -282,11 +278,11 @@ class MapTorchModelBridge(TorchModelBridge):
             parameters = self.parameters_with_map_keys
         cv_test_data = super()._cross_validate(
             search_space=search_space,
-            observation_features=observation_features,
-            observation_data=observation_data,
+            cv_training_data=cv_training_data,
             cv_test_points=cv_test_points,
             parameters=parameters,  # we pass the map_keys too by default
         )
+        observation_features, observation_data = separate_observations(cv_training_data)
         # Since map_keys are used as features, there can be the possibility that
         # models for different outcomes were fit on different ranges of map_key
         # values; for example, this is the case if we (1) mix learning curve data with

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from copy import deepcopy
 from functools import partial
 from typing import (
     Callable,
@@ -27,7 +28,12 @@ from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.observation import (
+    Observation,
+    ObservationData,
+    ObservationFeatures,
+    recombine_observations,
+)
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
@@ -743,7 +749,11 @@ def get_pareto_frontier_and_configs(
         )
     if observation_data is not None:
         if transform_outcomes_and_configs:
-            Y, Yvar = modelbridge.transform_observation_data(observation_data)
+            observations = recombine_observations(
+                observation_features=observation_features,
+                observation_data=observation_data,
+            )
+            _, Y, Yvar = modelbridge.transform_observations(observations)
         else:
             Y, Yvar = observation_data_to_array(
                 outcomes=modelbridge.outcomes, observation_data=observation_data
@@ -771,11 +781,10 @@ def get_pareto_frontier_and_configs(
         )
     else:
         # de-relativize outcome constraints and objective thresholds
-        obs_feats, obs_data, _ = _get_modelbridge_training_data(modelbridge=modelbridge)
+        observations = modelbridge.get_training_data()
         tf = Derelativize(
             search_space=modelbridge.model_space.clone(),
-            observation_data=obs_data,
-            observation_features=obs_feats,
+            observations=observations,
             config={"use_raw_status_quo": True},
         )
         # pyre-ignore [9]
@@ -822,28 +831,28 @@ def get_pareto_frontier_and_configs(
     frontier_observation_data = array_to_observation_data(
         f=f.numpy(), cov=cov.numpy(), outcomes=not_none(modelbridge.outcomes)
     )
+    # Construct observations
+    frontier_observations = []
+    for i, obsd in enumerate(frontier_observation_data):
+        frontier_observations.append(
+            Observation(
+                features=deepcopy(observation_features[indx[i]]),
+                data=deepcopy(obsd),
+                arm_name=arm_names[indx[i]],
+            )
+        )
 
     if use_model_predictions:
         # Untransform observations
         for t in reversed(list(modelbridge.transforms.values())):
-            frontier_observation_data = t.untransform_observation_data(
-                frontier_observation_data, []
+            frontier_observations = t.untransform_observations(
+                frontier_observations,
             )
         # reconstruct tensor representation of untransformed predictions
         Y_arr, _ = observation_data_to_array(
             outcomes=modelbridge.outcomes, observation_data=frontier_observation_data
         )
         f = _array_to_tensor(Y_arr)
-    # Construct observations
-    frontier_observations = []
-    for i, obsd in enumerate(frontier_observation_data):
-        frontier_observations.append(
-            Observation(
-                features=observation_features[indx[i]],
-                data=obsd,
-                arm_name=arm_names[indx[i]],
-            )
-        )
     return frontier_observations, f, obj_w.cpu(), obj_t.cpu()
 
 

--- a/ax/modelbridge/random.py
+++ b/ax/modelbridge/random.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional
 
 from ax.core.data import Data
 from ax.core.experiment import Experiment
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.base import GenResults, ModelBridge
@@ -48,8 +48,7 @@ class RandomModelBridge(ModelBridge):
         self,
         model: RandomModel,
         search_space: SearchSpace,
-        observation_features: Optional[List[ObservationFeatures]] = None,
-        observation_data: Optional[List[ObservationData]] = None,
+        observations: Optional[List[Observation]] = None,
     ) -> None:
         self.model = model
         # Extract and fix parameters from initial search space.
@@ -103,8 +102,7 @@ class RandomModelBridge(ModelBridge):
     def _cross_validate(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        cv_training_data: List[Observation],
         cv_test_points: List[ObservationFeatures],
     ) -> List[ObservationData]:
         raise NotImplementedError

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -94,8 +94,7 @@ class BaseModelBridgeTest(TestCase):
         )
         fit_args = mock_fit.mock_calls[0][2]
         self.assertTrue(fit_args["search_space"] == get_search_space_for_value(8.0))
-        self.assertTrue(fit_args["observation_features"] == [])
-        self.assertTrue(fit_args["observation_data"] == [])
+        self.assertTrue(fit_args["observations"] == [])
         self.assertTrue(mock_observations_from_data.called)
 
         # Test prediction on out of design features.
@@ -222,8 +221,7 @@ class BaseModelBridgeTest(TestCase):
         #  `assert_called_with`.
         modelbridge._cross_validate.assert_called_with(
             search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
-            observation_features=[get_observation2trans().features],
-            observation_data=[get_observation2trans().data],
+            cv_training_data=[get_observation2trans()],
             cv_test_points=[get_observation1().features],  # untransformed after
         )
         self.assertTrue(cv_predictions == [get_observation1().data])
@@ -602,7 +600,7 @@ class BaseModelBridgeTest(TestCase):
     def test_update(self, _mock_update, _mock_gen):
         exp = get_experiment_for_value()
         exp.optimization_config = get_optimization_config_no_constraints()
-        ss = get_search_space_for_range_values()
+        ss = get_search_space_for_range_values(min=0, max=1000)
         exp.search_space = ss
         modelbridge = ModelBridge(
             search_space=ss, model=Model(), transforms=[Log], experiment=exp

--- a/ax/modelbridge/tests/test_base_transform.py
+++ b/ax/modelbridge/tests/test_base_transform.py
@@ -4,8 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from copy import deepcopy
 from unittest.mock import MagicMock
 
+import numpy as np
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.modelbridge.transforms.base import Transform
 from ax.utils.common.testutils import TestCase
 
@@ -14,15 +17,39 @@ class TransformsTest(TestCase):
     # pyre-fixme[3]: Return type must be annotated.
     def testIdentityTransform(self):
         # Test that the identity transform does not mutate anything
-        t = Transform(MagicMock(), MagicMock(), MagicMock())
+        t = Transform(MagicMock(), MagicMock())
         x = MagicMock()
         ys = []
         ys.append(t.transform_search_space(x))
         ys.append(t.transform_optimization_config(x, x, x))
         ys.append(t.transform_observation_features(x))
-        ys.append(t.transform_observation_data(x, x))
+        ys.append(t._transform_observation_data(x))
         ys.append(t.untransform_observation_features(x))
-        ys.append(t.untransform_observation_data(x, x))
+        ys.append(t._untransform_observation_data(x))
         self.assertEqual(len(x.mock_calls), 0)
         for y in ys:
             self.assertEqual(y, x)
+
+    def testTransformObservations(self) -> None:
+        # Test that this is an identity transform
+        means = np.array([3.0, 4.0])
+        metric_names = ["a", "b"]
+        covariance = np.array([[1.0, 2.0], [3.0, 4.0]])
+        parameters = {"x": 1.0, "y": "cat"}
+        arm_name = "armmy"
+        observation = Observation(
+            features=ObservationFeatures(parameters=parameters),  # pyre-ignore
+            data=ObservationData(
+                metric_names=metric_names, means=means, covariance=covariance
+            ),
+            arm_name=arm_name,
+        )
+        t = Transform(None, [])
+        obs1 = t.transform_observations([deepcopy(observation)])[0]
+        obs2 = t.untransform_observations([deepcopy(obs1)])[0]
+        for obs in [obs1, obs2]:
+            self.assertTrue(np.array_equal(obs.data.means, means))
+            self.assertTrue(np.array_equal(obs.data.covariance, covariance))
+            self.assertEqual(obs.data.metric_names, metric_names)
+            self.assertEqual(obs.features.parameters, parameters)
+            self.assertEqual(obs.arm_name, arm_name)

--- a/ax/modelbridge/tests/test_cap_parameter_transform.py
+++ b/ax/modelbridge/tests/test_cap_parameter_transform.py
@@ -30,8 +30,7 @@ class CapParameterTest(TestCase):
     def test_transform_search_space(self):
         t = CapParameter(
             search_space=self.search_space,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             config={"a": "2"},
         )
         t.transform_search_space(self.search_space)
@@ -39,8 +38,7 @@ class CapParameterTest(TestCase):
         self.assertEqual(self.search_space.parameters.get("a").upper, 2)
         t2 = CapParameter(
             search_space=self.search_space,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             config={"b": "2"},
         )
         with self.assertRaises(NotImplementedError):
@@ -52,8 +50,7 @@ class CapParameterTest(TestCase):
         # Transform a non-distributional parameter.
         t = CapParameter(
             search_space=rss,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             config={"z": "2"},
         )
         t.transform_search_space(rss)
@@ -62,8 +59,7 @@ class CapParameterTest(TestCase):
         # Error with distributional parameter.
         t = CapParameter(
             search_space=rss,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             config={"x": "2"},
         )
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):

--- a/ax/modelbridge/tests/test_cast_transform.py
+++ b/ax/modelbridge/tests/test_cast_transform.py
@@ -43,9 +43,9 @@ class CastTransformTest(TestCase):
             ],
             parameter_constraints=[],
         )
-        self.t = Cast(search_space=self.search_space)
+        self.t = Cast(search_space=self.search_space, observations=[])
         self.hss = get_hierarchical_search_space()
-        self.t_hss = Cast(search_space=self.hss)
+        self.t_hss = Cast(search_space=self.hss, observations=[])
         self.obs_feats_hss = ObservationFeatures(
             parameters={
                 "model": "Linear",
@@ -98,9 +98,9 @@ class CastTransformTest(TestCase):
 
     # pyre-fixme[3]: Return type must be annotated.
     def test_flatten_hss_setting(self):
-        t = Cast(search_space=self.hss)
+        t = Cast(search_space=self.hss, observations=[])
         self.assertTrue(t.flatten_hss)
-        t = Cast(search_space=self.hss, config={"flatten_hss": False})
+        t = Cast(search_space=self.hss, config={"flatten_hss": False}, observations=[])
         self.assertFalse(t.flatten_hss)
         self.assertFalse(self.t.flatten_hss)  # `self.t` does not have HSS
         self.assertTrue(self.t_hss.flatten_hss)  # `self.t_hss` does have HSS
@@ -129,7 +129,7 @@ class CastTransformTest(TestCase):
         with patch.object(
             self.t_hss.search_space,
             "flatten_observation_features",
-            wraps=self.t_hss.search_space.flatten_observation_features,
+            wraps=self.t_hss.search_space.flatten_observation_features,  # pyre-ignore
         ) as mock_flatten_obsf:
             transformed_obs_feats = self.t_hss.transform_observation_features(
                 observation_features=obs_feats
@@ -170,7 +170,7 @@ class CastTransformTest(TestCase):
         with patch.object(
             self.t_hss.search_space,
             "cast_observation_features",
-            wraps=self.t_hss.search_space.cast_observation_features,
+            wraps=self.t_hss.search_space.cast_observation_features,  # pyre-ignore
         ) as mock_cast_obsf:
             obs_feats = self.t_hss.untransform_observation_features(
                 observation_features=[self.obs_feats_hss]

--- a/ax/modelbridge/tests/test_choice_encode_transform.py
+++ b/ax/modelbridge/tests/test_choice_encode_transform.py
@@ -49,12 +49,7 @@ class ChoiceEncodeTransformTest(TestCase):
         )
         self.t = self.t_class(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         self.observation_features = [
             ObservationFeatures(
@@ -135,15 +130,7 @@ class ChoiceEncodeTransformTest(TestCase):
                 )
             ]
         )
-        t = OrderedChoiceEncode(
-            search_space=ss3,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
-        )
+        t = OrderedChoiceEncode(search_space=ss3, observations=[])
         with self.assertRaises(ValueError):
             t.transform_search_space(ss3)
 
@@ -155,12 +142,7 @@ class ChoiceEncodeTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = self.t_class(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -180,12 +162,7 @@ class ChoiceEncodeTransformTest(TestCase):
         )
         t = self.t_class(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -249,15 +226,7 @@ class OrderedChoiceEncodeTransformTest(ChoiceEncodeTransformTest):
                 )
             ]
         )
-        t = OrderedChoiceEncode(
-            search_space=ss3,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
-        )
+        t = OrderedChoiceEncode(search_space=ss3, observations=[])
         with self.assertRaises(ValueError):
             t.transform_search_space(ss3)
 

--- a/ax/modelbridge/tests/test_convert_metric_names.py
+++ b/ax/modelbridge/tests/test_convert_metric_names.py
@@ -29,30 +29,27 @@ class ConvertMetricNamesTest(TestCase):
     # pyre-fixme[3]: Return type must be annotated.
     def testConvertMetricNames(self):
         transform = ConvertMetricNames(
-            None, self.observation_features, self.observation_data, config=self.tconfig
+            None, observations=self.observations, config=self.tconfig
         )
 
         transformed_observations = convert_mt_observations(
             self.observations, self.experiment
         )
         transformed_observation_data = [o.data for o in transformed_observations]
-        transformed_observation_features = [
-            o.features for o in transformed_observations
-        ]
 
         # All trials should have canonical name "m1"
         for obsd in transformed_observation_data:
             self.assertEqual(obsd.metric_names[0], "m1")
 
         # By default untransform does nothing
-        untransformed_observation_data = transform.untransform_observation_data(
-            transformed_observation_data, transformed_observation_features
+        untransformed_observations = transform.untransform_observations(
+            transformed_observations
         )
-        self.assertEqual(transformed_observation_data, untransformed_observation_data)
+        self.assertEqual(transformed_observations, untransformed_observations)
 
         transform.perform_untransform = True
-        untransformed_observation_data = transform.untransform_observation_data(
-            transformed_observation_data, transformed_observation_features
+        untransformed_observations = transform.untransform_observations(
+            transformed_observations
         )
 
         # Should have original metric_name
@@ -61,23 +58,20 @@ class ConvertMetricNamesTest(TestCase):
                 "m1" if self.observation_features[i].trial_index == 0 else "m2"
             )
             self.assertEqual(
-                untransformed_observation_data[i].metric_names[0], metric_name
+                untransformed_observations[i].data.metric_names[0], metric_name
             )
 
     # pyre-fixme[3]: Return type must be annotated.
     def testBadInputs(self):
         with self.assertRaises(ValueError):
-            ConvertMetricNames(
-                None, self.observation_features, self.observation_data, config=None
-            )
+            ConvertMetricNames(None, observations=self.observations, config=None)
 
         with self.assertRaises(ValueError):
             tconfig_copy = dict(self.tconfig)
             tconfig_copy.pop("metric_name_map")
             ConvertMetricNames(
                 None,
-                self.observation_features,
-                self.observation_data,
+                observations=self.observations,
                 config=tconfig_copy,
             )
 
@@ -86,8 +80,7 @@ class ConvertMetricNamesTest(TestCase):
             tconfig_copy.pop("trial_index_to_type")
             ConvertMetricNames(
                 None,
-                self.observation_features,
-                self.observation_data,
+                observations=self.observations,
                 config=tconfig_copy,
             )
 
@@ -96,8 +89,7 @@ class ConvertMetricNamesTest(TestCase):
             tconfig_copy.pop("metric_name_to_trial_type")
             ConvertMetricNames(
                 None,
-                self.observation_features,
-                self.observation_data,
+                observations=self.observations,
                 config=tconfig_copy,
             )
 
@@ -106,8 +98,7 @@ class ConvertMetricNamesTest(TestCase):
             tconfig_copy["trial_index_to_type"].pop(0)
             ConvertMetricNames(
                 None,
-                self.observation_features,
-                self.observation_data,
+                observations=self.observations,
                 config=tconfig_copy,
             )
 
@@ -118,6 +109,4 @@ class ConvertMetricNamesTest(TestCase):
         online_metric._name = "m3"
         self.experiment.add_tracking_metric(online_metric, "type2", "m4")
         tconfig = tconfig_from_mt_experiment(self.experiment)
-        ConvertMetricNames(
-            None, self.observation_features, self.observation_data, config=tconfig
-        )
+        ConvertMetricNames(None, observations=self.observations, config=tconfig)

--- a/ax/modelbridge/tests/test_derelativize_transform.py
+++ b/ax/modelbridge/tests/test_derelativize_transform.py
@@ -86,12 +86,7 @@ class DerelativizeTransformTest(TestCase):
     ):
         t = Derelativize(
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
 
         # ModelBridge with in-design status quo
@@ -127,7 +122,6 @@ class DerelativizeTransformTest(TestCase):
                 ),
             ],
         )
-        # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got `None`.
         oc2 = t.transform_optimization_config(oc, g, None)
         self.assertTrue(oc == oc2)
 
@@ -150,7 +144,6 @@ class DerelativizeTransformTest(TestCase):
                 ),
             ],
         )
-        # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got `None`.
         oc = t.transform_optimization_config(oc, g, None)
         self.assertTrue(
             oc.outcome_constraints
@@ -202,7 +195,6 @@ class DerelativizeTransformTest(TestCase):
                 ),
             ],
         )
-        # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got `None`.
         oc = t.transform_optimization_config(oc, g, None)
         self.assertTrue(
             oc.outcome_constraints
@@ -245,22 +237,15 @@ class DerelativizeTransformTest(TestCase):
             ],
         )
         with self.assertRaises(RuntimeError):
-            # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got
             #  `None`.
             oc = t.transform_optimization_config(oc, g, None)
 
         # Bypasses error if use_raw_sq
         t2 = Derelativize(
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
             config={"use_raw_status_quo": True},
         )
-        # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got `None`.
         oc2 = t2.transform_optimization_config(deepcopy(oc), g, None)
 
         # Raises error with relative constraint, no status quo
@@ -272,26 +257,18 @@ class DerelativizeTransformTest(TestCase):
             data=Data(),
         )
         with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got
             #  `None`.
             oc = t.transform_optimization_config(oc, g, None)
 
         # Raises error with relative constraint, no modelbridge
         with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got
             #  `None`.
             oc = t.transform_optimization_config(oc, None, None)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def testErrors(self):
+    def testErrors(self) -> None:
         t = Derelativize(
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         oc = OptimizationConfig(
             objective=Objective(Metric("c")),
@@ -304,10 +281,8 @@ class DerelativizeTransformTest(TestCase):
         )
         g = ModelBridge(search_space, None, [])
         with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got
             #  `None`.
             t.transform_optimization_config(oc, None, None)
         with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got
             #  `None`.
             t.transform_optimization_config(oc, g, None)

--- a/ax/modelbridge/tests/test_discrete_modelbridge.py
+++ b/ax/modelbridge/tests/test_discrete_modelbridge.py
@@ -81,9 +81,7 @@ class DiscreteModelBridgeTest(TestCase):
         ma = DiscreteModelBridge()
         ma._training_data = self.observations
         model = mock.create_autospec(DiscreteModel, instance=True)
-        ma._fit(
-            model, self.search_space, self.observation_features, self.observation_data
-        )
+        ma._fit(model, self.search_space, self.observations)
         self.assertEqual(ma.parameters, ["x", "y", "z"])
         self.assertEqual(sorted(ma.outcomes), ["a", "b"])
         Xs = {
@@ -102,15 +100,11 @@ class DiscreteModelBridgeTest(TestCase):
             self.assertEqual(v, Yvars[ma.outcomes[i]])
         self.assertEqual(model_fit_args["parameter_values"], parameter_values)
 
-        sq_feat = ObservationFeatures({})
-        sq_data = self.observation_data[0]
+        sq_obs = Observation(
+            features=ObservationFeatures({}), data=self.observation_data[0]
+        )
         with self.assertRaises(ValueError):
-            ma._fit(
-                model,
-                self.search_space,
-                self.observation_features + [sq_feat],
-                self.observation_data + [sq_data],
-            )
+            ma._fit(model, self.search_space, self.observations + [sq_obs])
 
     @mock.patch(
         "ax.modelbridge.discrete.DiscreteModelBridge.__init__", return_value=None
@@ -250,8 +244,7 @@ class DiscreteModelBridgeTest(TestCase):
         ma.outcomes = ["a", "b"]
         observation_data = ma._cross_validate(
             search_space=self.search_space,
-            observation_features=self.observation_features,
-            observation_data=self.observation_data,
+            cv_training_data=self.observations,
             cv_test_points=self.observation_features,
         )
         Xs = [

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -741,7 +741,7 @@ class TestGenerationStrategy(TestCase):
             ) as mock_model_fit, patch.object(RandomModelBridge, "gen"):
                 self.sobol_GS.gen(experiment=experiment)
                 mock_model_fit.assert_called_once()
-                obs_feats = mock_model_fit.call_args[1].get("observation_features")
+                observations = mock_model_fit.call_args[1].get("observations")
                 all_parameter_names = (
                     # pyre-fixme[16]: `SearchSpace` has no attribute
                     #  `_all_parameter_names`.
@@ -751,9 +751,9 @@ class TestGenerationStrategy(TestCase):
                 # one-hot encoded).
                 all_parameter_names.remove("model")
                 all_parameter_names.add("model_OH_PARAM_")
-                for obsf in obs_feats:
+                for obs in observations:
                     for p_name in all_parameter_names:
-                        self.assertIn(p_name, obsf.parameters)
+                        self.assertIn(p_name, obs.features.parameters)
 
             trial = (
                 experiment.new_trial(

--- a/ax/modelbridge/tests/test_int_range_to_choice_transform.py
+++ b/ax/modelbridge/tests/test_int_range_to_choice_transform.py
@@ -29,12 +29,7 @@ class IntRangeToChoiceTransformTest(TestCase):
         )
         self.t = IntRangeToChoice(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -64,12 +59,7 @@ class IntRangeToChoiceTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = IntRangeToChoice(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -88,12 +78,7 @@ class IntRangeToChoiceTransformTest(TestCase):
         )
         t = IntRangeToChoice(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -106,12 +91,7 @@ class IntRangeToChoiceTransformTest(TestCase):
         rss = get_robust_search_space(use_discrete=True)
         t = IntRangeToChoice(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)

--- a/ax/modelbridge/tests/test_int_to_float_transform.py
+++ b/ax/modelbridge/tests/test_int_to_float_transform.py
@@ -39,21 +39,11 @@ class IntToFloatTransformTest(TestCase):
         )
         self.t = IntToFloat(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         self.t2 = IntToFloat(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
             config={"rounding": "randomized"},
         )
 
@@ -144,12 +134,7 @@ class IntToFloatTransformTest(TestCase):
         )
         t = IntToFloat(
             search_space=constrained_int_search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         self.assertEqual(t.rounding, "randomized")
         observation_features = [ObservationFeatures(parameters={"x": 2.6, "y": 2.6})]
@@ -179,12 +164,7 @@ class IntToFloatTransformTest(TestCase):
         )
         t = IntToFloat(
             search_space=constrained_int_search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         self.assertEqual(t.rounding, "randomized")
         observation_features = [ObservationFeatures(parameters={"x": 2.6, "y": 2.6})]
@@ -202,12 +182,7 @@ class IntToFloatTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = IntToFloat(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -230,12 +205,7 @@ class IntToFloatTransformTest(TestCase):
         )
         t = IntToFloat(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -250,12 +220,7 @@ class IntToFloatTransformTest(TestCase):
         rss = get_robust_search_space(use_discrete=True)
         t = IntToFloat(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)

--- a/ax/modelbridge/tests/test_inverse_gaussian_cdf_y.py
+++ b/ax/modelbridge/tests/test_inverse_gaussian_cdf_y.py
@@ -33,24 +33,14 @@ class InverseGaussianCdfYTransformTest(TestCase):
             ),
         )
         self.t = InverseGaussianCdfY(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
 
     # pyre-fixme[3]: Return type must be annotated.
     def testTransformObservations(self):
-        transformed_obsd_mid = self.t.transform_observation_data(
-            [deepcopy(self.obsd_mid)], []
+        transformed_obsd_mid = self.t._transform_observation_data(
+            [deepcopy(self.obsd_mid)]
         )[0]
         # Approximate assertion for robustness.
         mean_results = np.array(list(transformed_obsd_mid.means))
@@ -69,11 +59,11 @@ class InverseGaussianCdfYTransformTest(TestCase):
 
         # Fail with extreme values.
         with self.assertRaises(ValueError):
-            self.t.transform_observation_data([deepcopy(self.obsd_extreme)], [])[0]
+            self.t._transform_observation_data([deepcopy(self.obsd_extreme)])[0]
 
         # NaN covar values remain as NaNs
-        transformed_obsd_nan_covars = self.t.transform_observation_data(
-            [deepcopy(self.obsd_nan_covars)], []
+        transformed_obsd_nan_covars = self.t._transform_observation_data(
+            [deepcopy(self.obsd_nan_covars)]
         )[0]
         cov_results = np.array(transformed_obsd_nan_covars.covariance)
         self.assertTrue(

--- a/ax/modelbridge/tests/test_ivw_transform.py
+++ b/ax/modelbridge/tests/test_ivw_transform.py
@@ -97,11 +97,8 @@ class IVWTransformTest(TestCase):
             covariance=np.array([[0.5, 0.14], [0.14, 1.584]]),
         )
         observation_data = [obsd1_0, obsd1_1]
-        # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but got
-        #  `None`.
-        # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got `None`.
-        t = IVW(None, None, None)
-        observation_data2 = t.transform_observation_data(observation_data, [])
+        t = IVW(None, [])
+        observation_data2 = t._transform_observation_data(observation_data)
         observation_data2_true = [obsd2_0, obsd2_1]
         for i, obsd in enumerate(observation_data2_true):
             self.assertEqual(observation_data2[i].metric_names, obsd.metric_names)

--- a/ax/modelbridge/tests/test_log_transform.py
+++ b/ax/modelbridge/tests/test_log_transform.py
@@ -36,12 +36,7 @@ class LogTransformTest(TestCase):
         )
         self.t = Log(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         self.search_space_with_target = SearchSpace(
             parameters=[
@@ -86,12 +81,7 @@ class LogTransformTest(TestCase):
         self.assertEqual(ss2.parameters["x"].upper, math.log10(3))
         t2 = Log(
             search_space=self.search_space_with_target,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         t2.transform_search_space(self.search_space_with_target)
         self.assertEqual(
@@ -106,12 +96,7 @@ class LogTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = Log(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(rss)
         # pyre-fixme[16]: Optional type has no attribute `log_scale`.
@@ -120,12 +105,7 @@ class LogTransformTest(TestCase):
         rss.parameters["x"].set_log_scale(True)
         t = Log(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)

--- a/ax/modelbridge/tests/test_logit_transform.py
+++ b/ax/modelbridge/tests/test_logit_transform.py
@@ -36,12 +36,7 @@ class LogitTransformTest(TestCase):
         )
         self.t = Logit(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         self.search_space_with_target = SearchSpace(
             parameters=[
@@ -120,12 +115,7 @@ class LogitTransformTest(TestCase):
         self.assertEqual(ss2.parameters["x"].upper, logit(0.999))
         t2 = Logit(
             search_space=self.search_space_with_target,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         ss_target = deepcopy(self.search_space_with_target)
         t2.transform_search_space(ss_target)
@@ -141,12 +131,7 @@ class LogitTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = Logit(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(rss)
         # pyre-fixme[16]: Optional type has no attribute `logit_scale`.
@@ -155,12 +140,7 @@ class LogitTransformTest(TestCase):
         rss.parameters["x"].set_logit_scale(True)
         t = Logit(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)

--- a/ax/modelbridge/tests/test_map_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_map_torch_modelbridge.py
@@ -10,10 +10,12 @@ import numpy as np
 
 import torch
 
-from ax.core import ObservationFeatures
-
 from ax.core.base_trial import TrialStatus
-from ax.core.observation import ObservationData
+from ax.core.observation import (
+    ObservationData,
+    ObservationFeatures,
+    recombine_observations,
+)
 from ax.modelbridge.map_torch import MapTorchModelBridge
 from ax.models.torch_base import TorchGenResults, TorchModel
 from ax.utils.common.constants import Keys
@@ -137,14 +139,14 @@ class MapTorchModelBridgeTest(TestCase):
                 covariance=np.array([[1.0, 0.0], [0.0, 1.0]]),
             ),
         ]
+        cv_training_data = recombine_observations(features, data)
         with mock.patch(
             "ax.modelbridge.torch.TorchModelBridge._cross_validate",
             return_value=test_data,
         ):
             cv_obs_data = modelbridge._cross_validate(
                 search_space=experiment.search_space,
-                observation_features=features,
-                observation_data=data,
+                cv_training_data=cv_training_data,
                 cv_test_points=test_features,
             )
             # check that the out-of-design metric is deleted

--- a/ax/modelbridge/tests/test_map_unit_x_transform.py
+++ b/ax/modelbridge/tests/test_map_unit_x_transform.py
@@ -6,7 +6,8 @@
 
 from copy import deepcopy
 
-from ax.core.observation import ObservationFeatures
+import numpy as np
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.map_unit_x import MapUnitX
@@ -46,10 +47,15 @@ class MapUnitXTransformTest(TestCase):
                 parameters={"x": 2, "a": 2, "b": "b", "step_1": 7.0, "step_2": 3.0}
             ),
         ]
+        self.observations = [
+            Observation(
+                data=ObservationData([], np.array([]), np.empty((0, 0))), features=obsf
+            )
+            for obsf in self.observation_features
+        ]
         self.t = MapUnitX(
             search_space=self.search_space,
-            observation_features=self.observation_features,
-            observation_data=[],
+            observations=self.observations,
         )
 
     # pyre-fixme[3]: Return type must be annotated.

--- a/ax/modelbridge/tests/test_metrics_as_task_transform.py
+++ b/ax/modelbridge/tests/test_metrics_as_task_transform.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from copy import deepcopy
+
+import numpy as np
+
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.parameter import ChoiceParameter
+from ax.modelbridge.transforms.metrics_as_task import MetricsAsTask
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_search_space_for_range_values
+
+
+class MetricsAsTaskTransformTest(TestCase):
+    def setUp(self) -> None:
+        self.metric_task_map = {
+            "metric1": ["metric2", "metric3"],
+            "metric2": ["metric3"],
+        }
+        self.observations = [
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric1", "metric2", "metric3"],
+                    means=np.array([1.0, 2.0, 3.0]),
+                    covariance=np.diag([1.0, 2.0, 3.0]),
+                ),
+                features=ObservationFeatures(parameters={"x": 5.0, "y": 2.0}),
+                arm_name="0_0",
+            ),
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric3"],
+                    means=np.array([30.0]),
+                    covariance=np.array([[30.0]]),
+                ),
+                features=ObservationFeatures(parameters={"x": 10.0, "y": 4.0}),
+            ),
+        ]
+        self.search_space = get_search_space_for_range_values(min=0.0, max=20.0)
+        self.expected_new_observations = [
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric1", "metric2", "metric3"],
+                    means=np.array([1.0, 2.0, 3.0]),
+                    covariance=np.diag([1.0, 2.0, 3.0]),
+                ),
+                features=ObservationFeatures(
+                    parameters={"x": 5.0, "y": 2.0, "METRIC_TASK": "TARGET"}
+                ),
+                arm_name="0_0",
+            ),
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric2", "metric3"],
+                    means=np.array([1.0, 1.0]),
+                    covariance=np.diag([1.0, 1.0]),
+                ),
+                features=ObservationFeatures(
+                    parameters={"x": 5.0, "y": 2.0, "METRIC_TASK": "metric1"}
+                ),
+                arm_name="0_0",
+            ),
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric3"],
+                    means=np.array([2.0]),
+                    covariance=np.array([[2.0]]),
+                ),
+                features=ObservationFeatures(
+                    parameters={"x": 5.0, "y": 2.0, "METRIC_TASK": "metric2"}
+                ),
+                arm_name="0_0",
+            ),
+            Observation(
+                data=ObservationData(
+                    metric_names=["metric3"],
+                    means=np.array([30.0]),
+                    covariance=np.array([[30.0]]),
+                ),
+                features=ObservationFeatures(
+                    parameters={"x": 10.0, "y": 4.0, "METRIC_TASK": "TARGET"}
+                ),
+            ),
+        ]
+        self.t = MetricsAsTask(
+            search_space=self.search_space,
+            observations=self.observations,
+            config={"metric_task_map": self.metric_task_map},
+        )
+
+    def testInit(self) -> None:
+        with self.assertRaises(ValueError):
+            MetricsAsTask(
+                search_space=self.search_space, observations=self.observations
+            )
+
+    def testTransformObservations(self) -> None:
+        new_obs = self.t.transform_observations(deepcopy(self.observations))
+        self.assertEqual(new_obs, self.expected_new_observations)
+
+        new_obs = self.t.untransform_observations(new_obs)
+        self.assertEqual(new_obs, self.observations)
+
+    def testTransformObservationFeatures(self) -> None:
+        obsfs_t = self.t.transform_observation_features(
+            deepcopy([obs.features for obs in self.observations])
+        )
+        for obsf in obsfs_t:
+            assert obsf.parameters["METRIC_TASK"] == "TARGET"
+
+        obsfs_t = self.t.untransform_observation_features(obsfs_t)
+        for obsf in obsfs_t:
+            assert "METRIC_TASK" not in obsf.parameters
+
+        with self.assertRaises(ValueError):
+            self.t.untransform_observation_features(
+                deepcopy([obs.features for obs in self.expected_new_observations])
+            )
+
+    def testTransformSearchSpace(self) -> None:
+        new_ss = self.t._transform_search_space(deepcopy(self.search_space))
+        self.assertEqual(len(new_ss.parameters), 3)
+        new_param = new_ss.parameters["METRIC_TASK"]
+        self.assertIsInstance(new_param, ChoiceParameter)
+        self.assertEqual(
+            new_param.values, ["TARGET", "metric1", "metric2"]  # pyre-ignore
+        )
+        self.assertTrue(new_param.is_task)  # pyre-ignore

--- a/ax/modelbridge/tests/test_one_hot_transform.py
+++ b/ax/modelbridge/tests/test_one_hot_transform.py
@@ -49,21 +49,11 @@ class OneHotTransformTest(TestCase):
         )
         self.t = OneHot(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         self.t2 = OneHot(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
             config={"rounding": "randomized"},
         )
 
@@ -163,10 +153,7 @@ class OneHotTransformTest(TestCase):
                 )
             ]
         )
-        # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but got
-        #  `None`.
-        # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got `None`.
-        t = OneHot(search_space=ss3, observation_features=None, observation_data=None)
+        t = OneHot(search_space=ss3, observations=[])
         with self.assertRaises(ValueError):
             t.transform_search_space(ss3)
 
@@ -176,12 +163,7 @@ class OneHotTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = OneHot(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -200,12 +182,7 @@ class OneHotTransformTest(TestCase):
         )
         t = OneHot(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)

--- a/ax/modelbridge/tests/test_power_transform_y.py
+++ b/ax/modelbridge/tests/test_power_transform_y.py
@@ -12,7 +12,7 @@ from math import isfinite, isnan
 import numpy as np
 from ax.core.metric import Metric
 from ax.core.objective import Objective
-from ax.core.observation import ObservationData
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.types import ComparisonOp
@@ -59,38 +59,22 @@ class PowerTransformYTest(TestCase):
             means=np.array([0.3, 0.2]),
             covariance=np.array([[float("nan"), 0.0], [0.0, float("nan")]]),
         )
+        self.observations = [
+            Observation(features=ObservationFeatures({}), data=obsd)
+            for obsd in [self.obsd1, self.obsd2, self.obsd3, self.obsd_nan]
+        ]
 
     # pyre-fixme[3]: Return type must be annotated.
     def testInit(self):
         shared_init_args = {
             "search_space": None,
-            "observation_features": None,
-            "observation_data": [self.obsd1, self.obsd2],
+            "observations": self.observations[:2],
         }
         # Test error for not specifying a config
         with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 1st param expected `List[ObservationData]` but got
-            #  `Optional[List[ObservationData]]`.
-            # pyre-fixme[6]: For 1st param expected `List[ObservationFeatures]` but
-            #  got `Optional[List[ObservationData]]`.
-            # pyre-fixme[6]: For 1st param expected `Optional[Dict[str, Union[None,
-            #  Dict[str, typing.Any], OptimizationConfig, AcquisitionFunction, float,
-            #  int, str]]]` but got `Optional[List[ObservationData]]`.
-            # pyre-fixme[6]: For 1st param expected `Optional[ModelBridge]` but got
-            #  `Optional[List[ObservationData]]`.
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got
-            #  `Optional[List[ObservationData]]`.
             PowerTransformY(**shared_init_args)
         # Test error for not specifying at least one metric
         with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 1st param expected `List[ObservationData]` but got
-            #  `Optional[List[ObservationData]]`.
-            # pyre-fixme[6]: For 1st param expected `List[ObservationFeatures]` but
-            #  got `Optional[List[ObservationData]]`.
-            # pyre-fixme[6]: For 1st param expected `Optional[ModelBridge]` but got
-            #  `Optional[List[ObservationData]]`.
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got
-            #  `Optional[List[ObservationData]]`.
             PowerTransformY(**shared_init_args, config={})
         # Test default init
         for m in ["m1", "m2"]:
@@ -204,22 +188,16 @@ class PowerTransformYTest(TestCase):
 
     # pyre-fixme[3]: Return type must be annotated.
     def testTransformAndUntransformOneMetric(self):
-        observation_data = [deepcopy(self.obsd1), deepcopy(self.obsd2)]
         pt = PowerTransformY(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=observation_data,
-            # pyre-fixme[6]: For 4th param expected `Optional[Dict[str, Union[None,
-            #  Dict[str, typing.Any], OptimizationConfig, AcquisitionFunction, float,
-            #  int, str]]]` but got `Dict[str, List[str]]`.
-            config={"metrics": ["m1"]},
+            observations=deepcopy(self.observations[:2]),
+            config={"metrics": ["m1"]},  # pyre-ignore
         )
 
         # Transform the data and make sure we don't touch m1
-        observation_data_tf = pt.transform_observation_data(observation_data, [])
+        observation_data_tf = pt._transform_observation_data(
+            deepcopy([self.obsd1, self.obsd2])
+        )
         for obsd, obsd_orig in zip(observation_data_tf, [self.obsd1, self.obsd2]):
             self.assertNotAlmostEqual(obsd.means[0], obsd_orig.means[0])
             self.assertNotAlmostEqual(obsd.covariance[0][0], obsd_orig.covariance[0][0])
@@ -227,35 +205,29 @@ class PowerTransformYTest(TestCase):
             self.assertAlmostEqual(obsd.covariance[1][1], obsd_orig.covariance[1][1])
 
         # Untransform the data and make sure the means are the same
-        observation_data_untf = pt.untransform_observation_data(observation_data_tf, [])
+        observation_data_untf = pt._untransform_observation_data(observation_data_tf)
         for obsd, obsd_orig in zip(observation_data_untf, [self.obsd1, self.obsd2]):
             self.assertAlmostEqual(obsd.means[0], obsd_orig.means[0], places=4)
             self.assertAlmostEqual(obsd.means[1], obsd_orig.means[1], places=4)
 
         # NaN covar values remain as NaNs
-        transformed_obsd_nan = pt.transform_observation_data(
-            [deepcopy(self.obsd_nan)], []
+        transformed_obsd_nan = pt._transform_observation_data(
+            [deepcopy(self.obsd_nan)]
         )[0]
         cov_results = np.array(transformed_obsd_nan.covariance)
         self.assertTrue(np.all(np.isnan(np.diag(cov_results))))
 
     # pyre-fixme[3]: Return type must be annotated.
     def testTransformAndUntransformAllMetrics(self):
-        observation_data = [deepcopy(self.obsd1), deepcopy(self.obsd2)]
         pt = PowerTransformY(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=observation_data,
-            # pyre-fixme[6]: For 4th param expected `Optional[Dict[str, Union[None,
-            #  Dict[str, typing.Any], OptimizationConfig, AcquisitionFunction, float,
-            #  int, str]]]` but got `Dict[str, List[str]]`.
-            config={"metrics": ["m1", "m2"]},
+            observations=deepcopy(self.observations[:2]),
+            config={"metrics": ["m1", "m2"]},  # pyre-ignore
         )
 
-        observation_data_tf = pt.transform_observation_data(observation_data, [])
+        observation_data_tf = pt._transform_observation_data(
+            deepcopy([self.obsd1, self.obsd2])
+        )
         for obsd, obsd_orig in zip(observation_data_tf, [self.obsd1, self.obsd2]):
             for i in range(2):  # Both metrics should be transformed
                 self.assertNotAlmostEqual(obsd.means[i], obsd_orig.means[i])
@@ -264,14 +236,14 @@ class PowerTransformYTest(TestCase):
                 )
 
         # Untransform the data and make sure the means are the same
-        observation_data_untf = pt.untransform_observation_data(observation_data_tf, [])
+        observation_data_untf = pt._untransform_observation_data(observation_data_tf)
         for obsd, obsd_orig in zip(observation_data_untf, [self.obsd1, self.obsd2]):
             for i in range(2):  # Both metrics should be transformed
                 self.assertAlmostEqual(obsd.means[i], obsd_orig.means[i])
 
         # NaN covar values remain as NaNs
-        transformed_obsd_nan = pt.transform_observation_data(
-            [deepcopy(self.obsd_nan)], []
+        transformed_obsd_nan = pt._transform_observation_data(
+            [deepcopy(self.obsd_nan)]
         )[0]
         cov_results = np.array(transformed_obsd_nan.covariance)
         self.assertTrue(np.all(np.isnan(np.diag(cov_results))))
@@ -285,18 +257,11 @@ class PowerTransformYTest(TestCase):
         y1 = PowerTransformer("yeo-johnson").fit(y_orig).transform(y_orig).ravel()
 
         pt = PowerTransformY(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=deepcopy(observation_data),
-            # pyre-fixme[6]: For 4th param expected `Optional[Dict[str, Union[None,
-            #  Dict[str, typing.Any], OptimizationConfig, AcquisitionFunction, float,
-            #  int, str]]]` but got `Dict[str, List[str]]`.
-            config={"metrics": ["m1"]},
+            observations=deepcopy(self.observations[:3]),
+            config={"metrics": ["m1"]},  # pyre-ignore
         )
-        observation_data_tf = pt.transform_observation_data(observation_data, [])
+        observation_data_tf = pt._transform_observation_data(observation_data)
         y2 = [data.means[0] for data in observation_data_tf]
         for y1_, y2_ in zip(y1, y2):
             self.assertAlmostEqual(y1_, y2_)
@@ -308,18 +273,10 @@ class PowerTransformYTest(TestCase):
         objective_m1 = Objective(metric=m1, minimize=False)
         oc = OptimizationConfig(objective=objective_m1, outcome_constraints=[])
         tf = PowerTransformY(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[self.obsd1, self.obsd2],
-            # pyre-fixme[6]: For 4th param expected `Optional[Dict[str, Union[None,
-            #  Dict[str, typing.Any], OptimizationConfig, AcquisitionFunction, float,
-            #  int, str]]]` but got `Dict[str, List[str]]`.
-            config={"metrics": ["m1"]},
+            observations=self.observations[:2],
+            config={"metrics": ["m1"]},  # pyre-ignore
         )
-        # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got `None`.
         oc_tf = tf.transform_optimization_config(deepcopy(oc), None, None)
         self.assertEqual(oc_tf, oc)
         # Output constraint on a different metric should not transform the bound
@@ -331,8 +288,6 @@ class PowerTransformYTest(TestCase):
                     metric=m2, bound=bound, relative=False
                 ),
             )
-            # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got
-            #  `None`.
             oc_tf = tf.transform_optimization_config(deepcopy(oc), None, None)
             self.assertEqual(oc_tf, oc)
         # Output constraint on the same metric should transform the bound
@@ -344,8 +299,6 @@ class PowerTransformYTest(TestCase):
                     metric=m1, bound=bound, relative=False
                 ),
             )
-            # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got
-            #  `None`.
             oc_tf = tf.transform_optimization_config(deepcopy(oc), None, None)
             oc_true = deepcopy(oc)
             tf_bound = (
@@ -353,6 +306,11 @@ class PowerTransformYTest(TestCase):
             )
             oc_true.outcome_constraints[0].bound = tf_bound
             self.assertEqual(oc_tf, oc_true)
+        # Check untransform of outcome constraint
+        cons = tf.untransform_outcome_constraints(
+            outcome_constraints=oc_tf.outcome_constraints, fixed_features=None
+        )
+        self.assertEqual(cons, oc.outcome_constraints)
         # Relative constraints aren't supported
         oc = OptimizationConfig(
             objective=objective_m2,
@@ -363,9 +321,13 @@ class PowerTransformYTest(TestCase):
             "PowerTransformY cannot be applied to metric m1 since it is "
             "subject to a relative constraint.",
         ):
-            # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got
-            #  `None`.
             tf.transform_optimization_config(oc, None, None)
+        # Untransform doesn't work if relative
+        with self.assertRaises(ValueError):
+            tf.untransform_outcome_constraints(
+                outcome_constraints=oc.outcome_constraints,
+                fixed_features=None,
+            )
         # Support for scalarized outcome constraints isn't implemented
         m3 = Metric(name="m3")
         oc = OptimizationConfig(
@@ -377,8 +339,6 @@ class PowerTransformYTest(TestCase):
             ],
         )
         with self.assertRaises(NotImplementedError) as cm:
-            # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got
-            #  `None`.
             tf.transform_optimization_config(oc, None, None)
         self.assertEqual(
             "PowerTransformY cannot be used for metric(s) {'m1'} "

--- a/ax/modelbridge/tests/test_random_modelbridge.py
+++ b/ax/modelbridge/tests/test_random_modelbridge.py
@@ -47,7 +47,7 @@ class RandomModelBridgeTest(TestCase):
         # pyre-fixme[20]: Argument `model` expected.
         modelbridge = RandomModelBridge()
         model = mock.create_autospec(RandomModel, instance=True)
-        modelbridge._fit(model, self.search_space, None, None)
+        modelbridge._fit(model, self.search_space, None)
         self.assertEqual(modelbridge.parameters, ["x", "y", "z"])
         self.assertTrue(isinstance(modelbridge.model, RandomModel))
 
@@ -71,8 +71,7 @@ class RandomModelBridgeTest(TestCase):
         modelbridge.transforms = OrderedDict()
         modelbridge.parameters = ["x", "y", "z"]
         with self.assertRaises(NotImplementedError):
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
-            modelbridge._cross_validate(None, [], [], [])
+            modelbridge._cross_validate(self.search_space, [], [])
 
     @mock.patch(
         "ax.models.random.base.RandomModel.gen",

--- a/ax/modelbridge/tests/test_relativize_transform.py
+++ b/ax/modelbridge/tests/test_relativize_transform.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from copy import deepcopy
 from unittest.mock import Mock
 
 import numpy as np
@@ -11,6 +12,7 @@ from ax.core.observation import (
     ObservationData,
     ObservationFeatures,
     observations_from_data,
+    recombine_observations,
 )
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.types import ComparisonOp
@@ -34,8 +36,7 @@ class RelativizeDataTest(TestCase):
         with self.assertRaisesRegex(ValueError, "modelbridge"):
             Relativize(
                 search_space=None,
-                observation_features=[],
-                observation_data=[],
+                observations=[],
             )
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -45,22 +46,22 @@ class RelativizeDataTest(TestCase):
         with self.assertRaisesRegex(ValueError, "status quo data"):
             Relativize(
                 search_space=None,
-                observation_features=[],
-                observation_data=[],
+                observations=[],
                 modelbridge=sobol,
-            ).transform_observation_data(
-                observation_data=[
-                    ObservationData(
-                        metric_names=["foo"],
-                        means=np.array([2]),
-                        covariance=np.array([[0.1]]),
+            ).transform_observations(
+                observations=[
+                    Observation(
+                        data=ObservationData(
+                            metric_names=["foo"],
+                            means=np.array([2]),
+                            covariance=np.array([[0.1]]),
+                        ),
+                        features=ObservationFeatures(parameters={"x": 1}),
                     )
                 ],
-                observation_features=[ObservationFeatures(parameters={"x": 1})],
             )
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_relativize_transform_observation_data(self):
+    def test_relativize_transform_observations(self) -> None:
         obs_data = [
             ObservationData(
                 metric_names=["foobar", "foobaz"],
@@ -79,36 +80,43 @@ class RelativizeDataTest(TestCase):
             # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures(parameters={"x": 2}, trial_index=0),
         ]
+        observations = recombine_observations(obs_features, obs_data)
         modelbridge = Mock(
             status_quo=Mock(
                 data=obs_data[0],
                 features=obs_features[0],
             )
         )
-        results = Relativize(
+        tf = Relativize(
             search_space=None,
-            observation_features=obs_features,
-            observation_data=obs_data,
+            observations=observations,
             modelbridge=modelbridge,
-        ).transform_observation_data(obs_data, obs_features)
-        self.assertEqual(results[0].metric_names, ["foobar", "foobaz"])
+        )
+        results = tf.transform_observations(observations)
+        self.assertEqual(results[0].data.metric_names, ["foobar", "foobaz"])
         # status quo means must always be zero
         self.assertTrue(
-            np.allclose(results[0].means, np.array([0.0, 0.0])), results[0].means
+            np.allclose(results[0].data.means, np.array([0.0, 0.0])),
+            results[0].data.means,
         )
         # status quo covariances must always be zero
         self.assertTrue(
-            np.allclose(results[0].covariance, np.array([[0.0, 0.0], [0.0, 0.0]])),
-            results[0].covariance,
+            np.allclose(results[0].data.covariance, np.array([[0.0, 0.0], [0.0, 0.0]])),
+            results[0].data.covariance,
         )
-        self.assertEqual(results[1].metric_names, ["foobar", "foobaz"])
+        self.assertEqual(results[1].data.metric_names, ["foobar", "foobaz"])
         self.assertTrue(
-            np.allclose(results[1].means, np.array([-51.25, 98.4])), results[1].means
+            np.allclose(results[1].data.means, np.array([-51.25, 98.4])),
+            results[1].data.means,
         )
         self.assertTrue(
-            np.allclose(results[1].covariance, np.array([[812.5, 0.0], [0.0, 480.0]])),
-            results[1].covariance,
+            np.allclose(
+                results[1].data.covariance, np.array([[812.5, 0.0], [0.0, 480.0]])
+            ),
+            results[1].data.covariance,
         )
+        obsd_t = tf._untransform_observation_data(obs_data)
+        self.assertEqual(obsd_t, obs_data)
 
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     #  `hypothesis.strategies.floats($parameter$min_value = - 10.000000,
@@ -155,16 +163,16 @@ class RelativizeDataTest(TestCase):
                 features=obs_features[0],
             )
         )
+        observations = recombine_observations(obs_features, obs_data)
         transform = Relativize(
             search_space=None,
-            observation_features=obs_features,
-            observation_data=obs_data,
+            observations=observations,
             modelbridge=modelbridge,
         )
-        relative_data = transform.transform_observation_data(obs_data, obs_features)
-        self.assertEqual(relative_data[0].metric_names, ["foo"])
-        self.assertEqual(relative_data[0].means[0], 0)
-        self.assertEqual(relative_data[0].covariance[0][0], 0)
+        relative_obs = transform.transform_observations(observations)
+        self.assertEqual(relative_obs[0].data.metric_names, ["foo"])
+        self.assertAlmostEqual(relative_obs[0].data.means[0], 0, places=4)
+        self.assertAlmostEqual(relative_obs[0].data.covariance[0][0], 0, places=4)
 
     # pyre-fixme[3]: Return type must be annotated.
     def test_multitask_data(self):
@@ -199,27 +207,23 @@ class RelativizeDataTest(TestCase):
                 ),
             )
         )
-        obs_features = [obs.features for obs in observations]
-        obs_data = [obs.data for obs in observations]
-        expected_obs_data = [obs.data for obs in relative_observations]
 
         transform = Relativize(
             search_space=None,
-            observation_features=obs_features,
-            observation_data=obs_data,
+            observations=observations,
             modelbridge=modelbridge,
         )
-        relative_obs_data = transform.transform_observation_data(obs_data, obs_features)
+        relative_obs_t = transform.transform_observations(observations)
         self.maxDiff = None
         # this assertion just checks that order is the same, which
         # is only important for the purposes of this test
         self.assertEqual(
-            [datum.metric_names for datum in relative_obs_data],
-            [datum.metric_names for datum in expected_obs_data],
+            [datum.data.metric_names for datum in relative_obs_t],
+            [datum.data.metric_names for datum in relative_observations],
         )
         means = [
-            np.array([datum.means for datum in relative_obs_data]),
-            np.array([datum.means for datum in expected_obs_data]),
+            np.array([datum.data.means for datum in relative_obs_t]),
+            np.array([datum.data.means for datum in relative_observations]),
         ]
         # `self.assertAlmostEqual(relative_obs_data, expected_obs_data)`
         # fails 1% of the time, so we check with numpy.
@@ -228,8 +232,8 @@ class RelativizeDataTest(TestCase):
             means,
         )
         covariances = [
-            np.array([datum.covariance for datum in expected_obs_data]),
-            np.array([datum.covariance for datum in relative_obs_data]),
+            np.array([datum.data.covariance for datum in relative_observations]),
+            np.array([datum.data.covariance for datum in relative_obs_t]),
         ]
         self.assertTrue(
             all(np.isclose(covariances[0], covariances[1])),
@@ -254,8 +258,7 @@ class RelativizeDataOptConfigTest(TestCase):
     def test_transform_optimization_config_without_constraints(self):
         relativize = Relativize(
             search_space=None,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             modelbridge=self.model,
         )
         optimization_config = get_branin_optimization_config()
@@ -270,8 +273,7 @@ class RelativizeDataOptConfigTest(TestCase):
     def test_transform_optimization_config_with_relative_constraints(self):
         relativize = Relativize(
             search_space=None,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             modelbridge=self.model,
         )
         optimization_config = get_branin_optimization_config()
@@ -284,7 +286,7 @@ class RelativizeDataOptConfigTest(TestCase):
             )
         ]
         new_config = relativize.transform_optimization_config(
-            optimization_config=optimization_config,
+            optimization_config=deepcopy(optimization_config),
             modelbridge=None,
             fixed_features=Mock(),
         )
@@ -294,13 +296,17 @@ class RelativizeDataOptConfigTest(TestCase):
             optimization_config.outcome_constraints[0].bound,
         )
         self.assertFalse(new_config.outcome_constraints[0].relative)
+        # Untransform the constraints
+        cons = relativize.untransform_outcome_constraints(
+            outcome_constraints=new_config.outcome_constraints, fixed_features=Mock()
+        )
+        self.assertEqual(cons, optimization_config.outcome_constraints)
 
     # pyre-fixme[3]: Return type must be annotated.
     def test_transform_optimization_config_with_non_relative_constraints(self):
         relativize = Relativize(
             search_space=None,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             modelbridge=self.model,
         )
         optimization_config = get_branin_optimization_config()
@@ -323,8 +329,7 @@ class RelativizeDataOptConfigTest(TestCase):
     def test_transform_optimization_config_with_relative_thresholds(self):
         relativize = Relativize(
             search_space=None,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             modelbridge=self.model,
         )
         optimization_config = get_branin_multi_objective_optimization_config(
@@ -356,8 +361,7 @@ class RelativizeDataOptConfigTest(TestCase):
     def test_transform_optimization_config_with_non_relative_thresholds(self):
         relativize = Relativize(
             search_space=None,
-            observation_features=[],
-            observation_data=[],
+            observations=[],
             modelbridge=self.model,
         )
         optimization_config = get_branin_multi_objective_optimization_config(

--- a/ax/modelbridge/tests/test_remove_fixed_transform.py
+++ b/ax/modelbridge/tests/test_remove_fixed_transform.py
@@ -35,12 +35,7 @@ class RemoveFixedTransformTest(TestCase):
         )
         self.t = RemoveFixed(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -85,12 +80,7 @@ class RemoveFixedTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = RemoveFixed(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -113,12 +103,7 @@ class RemoveFixedTransformTest(TestCase):
         )
         t = RemoveFixed(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss = t.transform_search_space(rss)
         self.assertIsInstance(rss, RobustSearchSpace)

--- a/ax/modelbridge/tests/test_search_space_to_choice_transform.py
+++ b/ax/modelbridge/tests/test_search_space_to_choice_transform.py
@@ -6,8 +6,9 @@
 
 from copy import deepcopy
 
+import numpy as np
 from ax.core.arm import Arm
-from ax.core.observation import ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.parameter import (
     ChoiceParameter,
     FixedParameter,
@@ -54,26 +55,23 @@ class SearchSpaceToChoiceTest(TestCase):
                 parameters={"arms": Arm(parameters={"a": 3, "b": "c"}).signature}
             ),
         ]
+        self.observations = [
+            Observation(
+                data=ObservationData([], np.array([]), np.empty((0, 0))), features=obsf
+            )
+            for obsf in self.observation_features
+        ]
         self.t = SearchSpaceToChoice(
             search_space=self.search_space,
-            observation_features=self.observation_features,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=self.observations,
         )
         self.t2 = SearchSpaceToChoice(
             search_space=self.search_space,
-            observation_features=[self.observation_features[0]],
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=self.observations[:1],
         )
         self.t3 = SearchSpaceToChoice(
             search_space=self.search_space,
-            observation_features=self.observation_features,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=self.observations,
             config={"use_ordered": True},
         )
 
@@ -117,10 +115,7 @@ class SearchSpaceToChoiceTest(TestCase):
         with self.assertRaises(ValueError):
             SearchSpaceToChoice(
                 search_space=ss3,
-                observation_features=self.observation_features,
-                # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but
-                #  got `None`.
-                observation_data=None,
+                observations=[],
             )
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -150,10 +145,5 @@ class SearchSpaceToChoiceTest(TestCase):
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             SearchSpaceToChoice(
                 search_space=rss,
-                # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]`
-                #  but got `None`.
-                observation_features=None,
-                # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but
-                #  got `None`.
-                observation_data=None,
+                observations=[],
             )

--- a/ax/modelbridge/tests/test_standardize_y_transform.py
+++ b/ax/modelbridge/tests/test_standardize_y_transform.py
@@ -10,7 +10,7 @@ from math import sqrt
 import numpy as np
 from ax.core.metric import Metric
 from ax.core.objective import Objective
-from ax.core.observation import ObservationData
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.types import ComparisonOp
@@ -39,13 +39,11 @@ class StandardizeYTransformTest(TestCase):
                 ]
             ),
         )
+        obs1 = Observation(features=ObservationFeatures({}), data=self.obsd1)
+        obs2 = Observation(features=ObservationFeatures({}), data=self.obsd2)
         self.t = StandardizeY(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[self.obsd1, self.obsd2],
+            observations=[obs1, obs2],
         )
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -54,14 +52,8 @@ class StandardizeYTransformTest(TestCase):
         self.assertEqual(self.t.Ystd, {"m1": 1.0, "m2": sqrt(1 / 3)})
         with self.assertRaises(DataRequiredError):
             StandardizeY(
-                # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
-                # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]`
-                #  but got `None`.
                 search_space=None,
-                # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]`
-                #  but got `None`.
-                observation_features=None,
-                observation_data=[],
+                observations=[],
             )
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -78,9 +70,9 @@ class StandardizeYTransformTest(TestCase):
             ),
         )
         obsd2 = [deepcopy(self.obsd1)]
-        obsd2 = self.t.transform_observation_data(obsd2, [])
+        obsd2 = self.t._transform_observation_data(obsd2)
         self.assertTrue(osd_allclose(obsd2[0], obsd1_t))
-        obsd2 = self.t.untransform_observation_data(obsd2, [])
+        obsd2 = self.t._untransform_observation_data(obsd2)
         self.assertTrue(osd_allclose(obsd2[0], self.obsd1))
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -105,7 +97,6 @@ class StandardizeYTransformTest(TestCase):
             ),
         ]
         oc = OptimizationConfig(objective=objective, outcome_constraints=cons)
-        # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got `None`.
         oc = self.t.transform_optimization_config(oc, None, None)
         cons_t = [
             OutcomeConstraint(
@@ -134,8 +125,6 @@ class StandardizeYTransformTest(TestCase):
         )
         oc = OptimizationConfig(objective=objective, outcome_constraints=[con])
         with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 3rd param expected `ObservationFeatures` but got
-            #  `None`.
             oc = self.t.transform_optimization_config(oc, None, None)
 
 

--- a/ax/modelbridge/tests/test_stratified_standardize_y.py
+++ b/ax/modelbridge/tests/test_stratified_standardize_y.py
@@ -10,7 +10,7 @@ from math import sqrt
 import numpy as np
 from ax.core.metric import Metric
 from ax.core.objective import Objective
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
@@ -54,10 +54,11 @@ class StratifiedStandardizeYTransformTest(TestCase):
         )
         self.obsf1 = ObservationFeatures({"x": 2, "z": "a"})
         self.obsf2 = ObservationFeatures({"x": 5, "z": "b"})
+        self.obs1 = Observation(features=self.obsf1, data=self.obsd1)
+        self.obs2 = Observation(features=self.obsf2, data=self.obsd2)
         self.t = StratifiedStandardizeY(
             search_space=self.search_space,
-            observation_features=[self.obsf1, self.obsf2],
-            observation_data=[self.obsd1, self.obsd2],
+            observations=[self.obs1, self.obs2],
             config={"parameter_name": "z"},
         )
 
@@ -86,15 +87,13 @@ class StratifiedStandardizeYTransformTest(TestCase):
             # No parameter specified
             StratifiedStandardizeY(
                 search_space=self.search_space,
-                observation_features=[self.obsf1, self.obsf2],
-                observation_data=[self.obsd1, self.obsd2],
+                observations=[self.obs1, self.obs2],
             )
         with self.assertRaises(ValueError):
             # Wrong parameter type
             StratifiedStandardizeY(
                 search_space=self.search_space,
-                observation_features=[self.obsf1, self.obsf2],
-                observation_data=[self.obsd1, self.obsd2],
+                observations=[self.obs1, self.obs2],
                 config={"parameter_name": "x"},
             )
         # Multiple tasks parameters
@@ -120,8 +119,7 @@ class StratifiedStandardizeYTransformTest(TestCase):
         with self.assertRaises(ValueError):
             StratifiedStandardizeY(
                 search_space=ss3,
-                observation_features=[self.obsf1, self.obsf2],
-                observation_data=[self.obsd1, self.obsd2],
+                observations=[self.obs1, self.obs2],
             )
 
         # Grab from task feature
@@ -140,8 +138,7 @@ class StratifiedStandardizeYTransformTest(TestCase):
         )
         t2 = StratifiedStandardizeY(
             search_space=ss2,
-            observation_features=[self.obsf1, self.obsf2],
-            observation_data=[self.obsd1, self.obsd2],
+            observations=[self.obs1, self.obs2],
         )
         self.assertEqual(
             t2.Ymean,
@@ -177,24 +174,24 @@ class StratifiedStandardizeYTransformTest(TestCase):
                 ]
             ),
         )
-        obsd2 = [deepcopy(self.obsd1)]
-        obsd2 = self.t.transform_observation_data(
-            obsd2, [ObservationFeatures({"z": "a"})]
-        )
-        self.assertTrue(osd_allclose(obsd2[0], obsd1_ta))
-        obsd2 = self.t.untransform_observation_data(
-            obsd2, [ObservationFeatures({"z": "a"})]
-        )
-        self.assertTrue(osd_allclose(obsd2[0], self.obsd1))
-        obsd2 = [deepcopy(self.obsd1)]
-        obsd2 = self.t.transform_observation_data(
-            obsd2, [ObservationFeatures({"z": "b"})]
-        )
-        self.assertTrue(osd_allclose(obsd2[0], obsd1_tb))
-        obsd2 = self.t.untransform_observation_data(
-            obsd2, [ObservationFeatures({"z": "b"})]
-        )
-        self.assertTrue(osd_allclose(obsd2[0], self.obsd1))
+        obsd2 = deepcopy(self.obsd1)
+        obsd2 = self.t.transform_observations(
+            [Observation(data=obsd2, features=ObservationFeatures({"z": "a"}))]
+        )[0].data
+        self.assertTrue(osd_allclose(obsd2, obsd1_ta))
+        obsd2 = self.t.untransform_observations(
+            [Observation(data=obsd2, features=ObservationFeatures({"z": "a"}))]
+        )[0].data
+        self.assertTrue(osd_allclose(obsd2, self.obsd1))
+        obsd2 = deepcopy(self.obsd1)
+        obsd2 = self.t.transform_observations(
+            [Observation(data=obsd2, features=ObservationFeatures({"z": "b"}))]
+        )[0].data
+        self.assertTrue(osd_allclose(obsd2, obsd1_tb))
+        obsd2 = self.t.untransform_observations(
+            [Observation(data=obsd2, features=ObservationFeatures({"z": "b"}))]
+        )[0].data
+        self.assertTrue(osd_allclose(obsd2, self.obsd1))
 
     # pyre-fixme[3]: Return type must be annotated.
     def testTransformOptimizationConfig(self):

--- a/ax/modelbridge/tests/test_task_encode_transform.py
+++ b/ax/modelbridge/tests/test_task_encode_transform.py
@@ -38,12 +38,7 @@ class TaskEncodeTransformTest(TestCase):
         )
         self.t = TaskEncode(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -100,12 +95,7 @@ class TaskEncodeTransformTest(TestCase):
         with self.assertRaises(ValueError):
             TaskEncode(
                 search_space=ss3,
-                # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]`
-                #  but got `None`.
-                observation_features=None,
-                # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but
-                #  got `None`.
-                observation_data=None,
+                observations=[],
             )
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -116,12 +106,7 @@ class TaskEncodeTransformTest(TestCase):
         # Transform a non-distributional parameter.
         t = TaskEncode(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
@@ -141,12 +126,7 @@ class TaskEncodeTransformTest(TestCase):
         )
         t = TaskEncode(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)

--- a/ax/modelbridge/tests/test_torch_modelbridge_moo.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge_moo.py
@@ -23,7 +23,6 @@ from ax.modelbridge.modelbridge_utils import (
 )
 from ax.modelbridge.registry import Cont_X_trans, ST_MTGP_trans, Y_trans
 from ax.modelbridge.torch import TorchModelBridge
-from ax.modelbridge.transforms.base import Transform
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.botorch_moo_defaults import (
     infer_objective_thresholds,
@@ -38,6 +37,7 @@ from ax.utils.testing.core_stubs import (
     TEST_SOBOL_SEED,
 )
 from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.modeling_stubs import transform_1, transform_2
 from botorch.utils.multi_objective.pareto import is_non_dominated
 
 PARETO_FRONTIER_EVALUATOR_PATH = (
@@ -45,145 +45,6 @@ PARETO_FRONTIER_EVALUATOR_PATH = (
 )
 # pyre-fixme[5]: Global expression must be annotated.
 STUBS_PATH = get_branin_experiment_with_multi_objective.__module__
-
-
-# Prepare mock transforms
-class t1(Transform):
-    # pyre-fixme[14]: `transform_search_space` overrides method defined in
-    #  `Transform` inconsistently.
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def transform_search_space(self, ss):
-        new_ss = ss.clone()
-        for param_name in new_ss.parameters:
-            new_ss.parameters[param_name]._lower += 1.0
-            new_ss.parameters[param_name]._upper += 1.0
-        return new_ss
-
-    # pyre-fixme[3]: Return type must be annotated.
-    def transform_optimization_config(
-        self,
-        # pyre-fixme[2]: Parameter must be annotated.
-        optimization_config,
-        # pyre-fixme[2]: Parameter must be annotated.
-        modelbridge,
-        # pyre-fixme[2]: Parameter must be annotated.
-        fixed_features,
-    ):
-        return (
-            optimization_config + 1
-            if isinstance(optimization_config, int)
-            else optimization_config
-        )
-
-    # pyre-fixme[14]: `transform_observation_features` overrides method defined in
-    #  `Transform` inconsistently.
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def transform_observation_features(self, x):
-        for obsf in x:
-            for param_name in obsf.parameters:
-                obsf.parameters[param_name] += 1
-        return x
-
-    # pyre-fixme[14]: `transform_observation_data` overrides method defined in
-    #  `Transform` inconsistently.
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def transform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means += 1
-        return x
-
-    # pyre-fixme[14]: `untransform_observation_features` overrides method defined in
-    #  `Transform` inconsistently.
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def untransform_observation_features(self, x):
-        for obsf in x:
-            for param_name in obsf.parameters:
-                obsf.parameters[param_name] -= 1
-        return x
-
-    # pyre-fixme[14]: `untransform_observation_data` overrides method defined in
-    #  `Transform` inconsistently.
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def untransform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means -= 1
-        return x
-
-
-class t2(Transform):
-    # pyre-fixme[14]: `transform_search_space` overrides method defined in
-    #  `Transform` inconsistently.
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def transform_search_space(self, ss):
-        new_ss = ss.clone()
-        for param_name in new_ss.parameters:
-            new_ss.parameters[param_name]._lower = (
-                new_ss.parameters[param_name]._lower ** 2
-            )
-            new_ss.parameters[param_name]._upper = (
-                new_ss.parameters[param_name]._upper ** 2
-            )
-        return new_ss
-
-    # pyre-fixme[3]: Return type must be annotated.
-    def transform_optimization_config(
-        self,
-        # pyre-fixme[2]: Parameter must be annotated.
-        optimization_config,
-        # pyre-fixme[2]: Parameter must be annotated.
-        modelbridge,
-        # pyre-fixme[2]: Parameter must be annotated.
-        fixed_features,
-    ):
-        return (
-            optimization_config**2
-            if isinstance(optimization_config, int)
-            else optimization_config
-        )
-
-    # pyre-fixme[14]: `transform_observation_features` overrides method defined in
-    #  `Transform` inconsistently.
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def transform_observation_features(self, x):
-        for obsf in x:
-            for param_name in obsf.parameters:
-                obsf.parameters[param_name] = obsf.parameters[param_name] ** 2
-        return x
-
-    # pyre-fixme[14]: `transform_observation_data` overrides method defined in
-    #  `Transform` inconsistently.
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def transform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means = obsd.means**2
-        return x
-
-    # pyre-fixme[14]: `untransform_observation_features` overrides method defined in
-    #  `Transform` inconsistently.
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def untransform_observation_features(self, x):
-        for obsf in x:
-            for param_name in obsf.parameters:
-                obsf.parameters[param_name] = np.sqrt(obsf.parameters[param_name])
-        return x
-
-    # pyre-fixme[14]: `untransform_observation_data` overrides method defined in
-    #  `Transform` inconsistently.
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def untransform_observation_data(self, x, y):
-        for obsd in x:
-            obsd.means = np.sqrt(obsd.means)
-        return x
 
 
 class MultiObjectiveTorchModelBridgeTest(TestCase):
@@ -228,7 +89,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             search_space=exp.search_space,
             model=MultiObjectiveBotorchModel(),
             optimization_config=exp.optimization_config,
-            transforms=[t1, t2],
+            transforms=[transform_1, transform_2],
             experiment=exp,
             data=exp.fetch_data(),
         )

--- a/ax/modelbridge/tests/test_trial_as_task_transform.py
+++ b/ax/modelbridge/tests/test_trial_as_task_transform.py
@@ -6,7 +6,8 @@
 
 from copy import deepcopy
 
-from ax.core.observation import ObservationFeatures
+import numpy as np
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UnsupportedError
@@ -35,12 +36,19 @@ class TrialAsTaskTransformTest(TestCase):
             # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures({"x": 4}, trial_index=2),
         ]
+        self.training_obs = [
+            Observation(
+                data=ObservationData(
+                    metric_names=[], means=np.array([]), covariance=np.empty((0, 0))
+                ),
+                features=obsf,
+            )
+            for obsf in self.training_feats
+        ]
+
         self.t = TrialAsTask(
             search_space=self.search_space,
-            observation_features=self.training_feats,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=self.training_obs,
         )
         self.bm = {
             "bp1": {0: "v1", 1: "v2", 2: "v3"},
@@ -49,18 +57,12 @@ class TrialAsTaskTransformTest(TestCase):
 
         self.t2 = TrialAsTask(
             search_space=self.search_space,
-            observation_features=self.training_feats,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=self.training_obs,
             config={"trial_level_map": self.bm},
         )
         self.t3 = TrialAsTask(
             search_space=self.search_space,
-            observation_features=self.training_feats,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=self.training_obs,
             config={"trial_level_map": {}},
         )
 
@@ -74,22 +76,19 @@ class TrialAsTaskTransformTest(TestCase):
         self.assertIsNone(self.t2.inverse_map)
         # Test validation
         obsf = ObservationFeatures({"x": 2})
+        obs = Observation(
+            data=ObservationData([], np.array([]), np.empty((0, 0))), features=obsf
+        )
         with self.assertRaises(ValueError):
             TrialAsTask(
                 search_space=self.search_space,
-                observation_features=self.training_feats + [obsf],
-                # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but
-                #  got `None`.
-                observation_data=None,
+                observations=self.training_obs + [obs],
             )
         bm = {"p": {0: "x1", 1: "x2"}}
         with self.assertRaises(ValueError):
             TrialAsTask(
                 search_space=self.search_space,
-                observation_features=self.training_feats,
-                # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but
-                #  got `None`.
-                observation_data=None,
+                observations=self.training_obs,
                 config={"trial_level_map": bm},
             )
 
@@ -153,8 +152,5 @@ class TrialAsTaskTransformTest(TestCase):
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             TrialAsTask(
                 search_space=rss,
-                observation_features=[],
-                # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but
-                #  got `None`.
-                observation_data=None,
+                observations=[],
             )

--- a/ax/modelbridge/tests/test_unit_x_transform.py
+++ b/ax/modelbridge/tests/test_unit_x_transform.py
@@ -56,12 +56,7 @@ class UnitXTransformTest(TestCase):
         )
         self.t = self.transform_class(
             search_space=self.search_space,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         self.search_space_with_target = SearchSpace(
             parameters=[
@@ -143,12 +138,7 @@ class UnitXTransformTest(TestCase):
         # Test transform of target value
         t = self.transform_class(
             search_space=self.search_space_with_target,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(self.search_space_with_target)
         self.assertEqual(
@@ -167,12 +157,7 @@ class UnitXTransformTest(TestCase):
             expected = str(rss)
             t = self.transform_class(
                 search_space=rss,
-                # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]`
-                #  but got `None`.
-                observation_features=None,
-                # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but
-                #  got `None`.
-                observation_data=None,
+                observations=[],
             )
             self.assertEqual(expected, str(t.transform_search_space(rss)))
         # Error if distribution is multiplicative.
@@ -180,12 +165,7 @@ class UnitXTransformTest(TestCase):
         rss.parameter_distributions[0].multiplicative = True
         t = self.transform_class(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(NotImplementedError, "multiplicative"):
             t.transform_search_space(rss)
@@ -193,12 +173,7 @@ class UnitXTransformTest(TestCase):
         rss = get_robust_search_space(lb=5.0, ub=10.0)
         t = self.transform_class(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(rss)
         dists = rss.parameter_distributions
@@ -231,12 +206,7 @@ class UnitXTransformTest(TestCase):
         rss.parameters["z"]._parameter_type = ParameterType.FLOAT
         t = self.transform_class(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "`loc` and `scale`"):
             t.transform_search_space(rss)
@@ -248,12 +218,7 @@ class UnitXTransformTest(TestCase):
         rss.parameter_distributions[0].distribution_class = "multivariate_t"
         t = self.transform_class(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         with self.assertRaisesRegex(UnsupportedError, "multivariate"):
             t.transform_search_space(rss)
@@ -262,12 +227,7 @@ class UnitXTransformTest(TestCase):
         old_params = deepcopy(rss.parameter_distributions[0].distribution_parameters)
         t = self.transform_class(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(rss)
         new_params = rss.parameter_distributions[0].distribution_parameters
@@ -296,12 +256,7 @@ class UnitXTransformTest(TestCase):
         )
         t = self.transform_class(
             search_space=rss,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            # pyre-fixme[6]: For 3rd param expected `List[ObservationData]` but got
-            #  `None`.
-            observation_data=None,
+            observations=[],
         )
         t.transform_search_space(rss)
         new_params = rss.parameter_distributions[0].distribution_parameters

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -13,7 +13,7 @@ from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.outcome_constraint import (
     ObjectiveThreshold,
     OutcomeConstraint,
@@ -186,18 +186,24 @@ class TestModelbridgeUtils(TestCase):
         # is applying `Cast` transform, it should inject full parameterization into
         # resulting obs.feats.). Therefore, transforming the extracted pending features
         #  and observation features made from full parameterization should be the same.
+        obsd = ObservationData(
+            metric_names=["m1"], means=np.array([1.0]), covariance=np.array([[1.0]])
+        )
         self.assertEqual(
             self.hss_sobol._transform_data(
-                # pyre-fixme[16]: Optional type has no attribute `__getitem__`.
-                obs_feats=pending["m1"],
-                obs_data=[],
+                observations=[
+                    Observation(data=obsd, features=pending["m1"][0])  # pyre-ignore
+                ],
                 search_space=self.hss_exp.search_space,
                 transforms=self.hss_sobol._raw_transforms,
                 transform_configs=None,
             ),
             self.hss_sobol._transform_data(
-                obs_feats=[self.hss_obs_feat_all_params.clone()],
-                obs_data=[],
+                observations=[
+                    Observation(
+                        data=obsd, features=self.hss_obs_feat_all_params.clone()
+                    )
+                ],
                 search_space=self.hss_exp.search_space,
                 transforms=self.hss_sobol._raw_transforms,
                 transform_configs=None,
@@ -263,15 +269,17 @@ class TestModelbridgeUtils(TestCase):
             # Check that candidate metadata is property propagated for abandoned arm.
             self.assertEqual(
                 self.hss_sobol._transform_data(
-                    obs_feats=pending["m1"],
-                    obs_data=[],
+                    observations=[Observation(data=obsd, features=pending["m1"][0])],
                     search_space=hss_exp.search_space,
                     transforms=self.hss_sobol._raw_transforms,
                     transform_configs=None,
                 ),
                 self.hss_sobol._transform_data(
-                    obs_feats=[self.hss_obs_feat_all_params.clone()],
-                    obs_data=[],
+                    observations=[
+                        Observation(
+                            data=obsd, features=self.hss_obs_feat_all_params.clone()
+                        )
+                    ],
                     search_space=hss_exp.search_space,
                     transforms=self.hss_sobol._raw_transforms,
                     transform_configs=None,
@@ -399,18 +407,24 @@ class TestModelbridgeUtils(TestCase):
         # is applying `Cast` transform, it should inject full parameterization into
         # resulting obs.feats.). Therefore, transforming the extracted pending features
         #  and observation features made from full parameterization should be the same.
+        obsd = ObservationData(
+            metric_names=["m1"], means=np.array([1.0]), covariance=np.array([[1.0]])
+        )
         self.assertEqual(
             self.hss_sobol._transform_data(
-                # pyre-fixme[16]: Optional type has no attribute `__getitem__`.
-                obs_feats=pending["m1"],
-                obs_data=[],
+                observations=[
+                    Observation(data=obsd, features=pending["m1"][0])  # pyre-ignore
+                ],
                 search_space=self.hss_exp.search_space,
                 transforms=self.hss_sobol._raw_transforms,
                 transform_configs=None,
             ),
             self.hss_sobol._transform_data(
-                obs_feats=[self.hss_obs_feat_all_params],
-                obs_data=[],
+                observations=[
+                    Observation(
+                        data=obsd, features=self.hss_obs_feat_all_params.clone()
+                    )
+                ],
                 search_space=self.hss_exp.search_space,
                 transforms=self.hss_sobol._raw_transforms,
                 transform_configs=None,

--- a/ax/modelbridge/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/tests/test_winsorize_transform.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 import numpy as np
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
-from ax.core.observation import ObservationData
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
@@ -54,55 +54,34 @@ class WinsorizeTransformTest(TestCase):
                 ]
             ),
         )
+        self.observations = [
+            Observation(features=ObservationFeatures({}), data=obsd)
+            for obsd in [self.obsd1, self.obsd2]
+        ]
         self.t = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
-            # pyre-fixme[6]: For 4th param expected `Optional[Dict[str, Union[None,
-            #  Dict[str, typing.Any], OptimizationConfig, AcquisitionFunction, float,
-            #  int, str]]]` but got `Dict[str, WinsorizationConfig]`.
-            config={
+            observations=deepcopy(self.observations),
+            config={  # pyre-ignore
                 "winsorization_config": WinsorizationConfig(upper_quantile_margin=0.2)
             },
         )
         self.t1 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
-            # pyre-fixme[6]: For 4th param expected `Optional[Dict[str, Union[None,
-            #  Dict[str, typing.Any], OptimizationConfig, AcquisitionFunction, float,
-            #  int, str]]]` but got `Dict[str, WinsorizationConfig]`.
-            config={
+            observations=deepcopy(self.observations),
+            config={  # pyre-ignore
                 "winsorization_config": WinsorizationConfig(upper_quantile_margin=0.8)
             },
         )
         self.t2 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
-            # pyre-fixme[6]: For 4th param expected `Optional[Dict[str, Union[None,
-            #  Dict[str, typing.Any], OptimizationConfig, AcquisitionFunction, float,
-            #  int, str]]]` but got `Dict[str, WinsorizationConfig]`.
-            config={
+            observations=deepcopy(self.observations),
+            config={  # pyre-ignore
                 "winsorization_config": WinsorizationConfig(lower_quantile_margin=0.2)
             },
         )
         self.t3 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(upper_quantile_margin=0.6),
@@ -113,12 +92,8 @@ class WinsorizeTransformTest(TestCase):
             },
         )
         self.t4 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(lower_quantile_margin=0.8),
@@ -134,17 +109,10 @@ class WinsorizeTransformTest(TestCase):
             means=np.array([0.0, 1.0, 5.0, 3.0]),
             covariance=np.eye(4),
         )
+        self.obs3 = Observation(features=ObservationFeatures({}), data=self.obsd3)
         self.t5 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[
-                deepcopy(self.obsd1),
-                deepcopy(self.obsd2),
-                deepcopy(self.obsd3),
-            ],
+            observations=deepcopy(self.observations) + deepcopy([self.obs3]),
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(upper_quantile_margin=0.6),
@@ -153,12 +121,8 @@ class WinsorizeTransformTest(TestCase):
             },
         )
         self.t6 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(upper_quantile_margin=0.6),
@@ -179,21 +143,17 @@ class WinsorizeTransformTest(TestCase):
         self.assertEqual(self.t2.cutoffs["m2"], (0.0, float("inf")))
         with self.assertRaisesRegex(
             DataRequiredError,
-            "`Winsorize` transform requires non-empty observation data.",
+            "`Winsorize` transform requires non-empty data.",
         ):
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
-            Winsorize(search_space=None, observation_features=[], observation_data=[])
-        obsd = [deepcopy(self.obsd1)]
+            Winsorize(search_space=None, observations=[])
         with self.assertRaisesRegex(
             ValueError,
             "Transform config for `Winsorize` transform must be specified and "
             "non-empty when using winsorization.",
         ):
             Winsorize(
-                # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
                 search_space=None,
-                observation_features=[],
-                observation_data=obsd,
+                observations=deepcopy(self.observations[:1]),
             )
         with self.assertRaisesRegex(
             UserInputError,
@@ -201,30 +161,28 @@ class WinsorizeTransformTest(TestCase):
             "but got type `<class 'int'>.",
         ):
             Winsorize(
-                # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
                 search_space=None,
-                observation_features=[],
-                observation_data=obsd,
+                observations=deepcopy(self.observations[:1]),
                 config={"optimization_config": 1234},
             )
 
     # pyre-fixme[3]: Return type must be annotated.
     def testTransformObservations(self):
-        observation_data = self.t1.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t1._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t1.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t1._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 1.0, 1.0])
-        observation_data = self.t2.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t2._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t2.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t2._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -236,41 +194,41 @@ class WinsorizeTransformTest(TestCase):
 
     # pyre-fixme[3]: Return type must be annotated.
     def testTransformObservationsPercentileBounds(self):
-        observation_data = self.t3.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t3._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t3.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t3._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 1.9, 1.0])
-        observation_data = self.t4.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t4._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 0.3, 1.0])
-        observation_data = self.t4.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t4._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
 
     # pyre-fixme[3]: Return type must be annotated.
     def testTransformObservationsDifferentLowerUpper(self):
-        observation_data = self.t5.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t5._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertEqual(self.t5.cutoffs["m1"], (-float("inf"), 1.0))
         self.assertEqual(self.t5.cutoffs["m2"], (1.0, float("inf")))
         self.assertEqual(self.t5.cutoffs["m3"], (-float("inf"), float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
         # Nothing should happen to m3
-        observation_data = self.t5.transform_observation_data(
-            [deepcopy(self.obsd3)], []
-        )[0]
+        observation_data = self.t5._transform_observation_data([deepcopy(self.obsd3)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 1.0, 5.0, 3.0])
         # With winsorization boundaries
-        observation_data = self.t6.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t6._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertEqual(self.t6.cutoffs["m1"], (-float("inf"), 1.0))
         self.assertEqual(self.t6.cutoffs["m2"], (0.0, float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
@@ -594,13 +552,13 @@ class WinsorizeTransformTest(TestCase):
 # pyre-fixme[3]: Return type must be annotated.
 # pyre-fixme[2]: Parameter must be annotated.
 def get_transform(observation_data, config):
+    observations = [
+        Observation(features=ObservationFeatures({}), data=obsd)
+        for obsd in observation_data
+    ]
     return Winsorize(
-        # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
         search_space=None,
-        # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but got
-        #  `None`.
-        observation_features=None,
-        observation_data=observation_data,
+        observations=observations,
         config=config,
     )
 
@@ -619,13 +577,10 @@ def get_default_transform_cutoffs(
         means=np.array(range(obs_data_len)),
         covariance=np.eye(obs_data_len),
     )
+    obs = Observation(features=ObservationFeatures({}), data=obsd)
     transform = Winsorize(
-        # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
         search_space=None,
-        # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but got
-        #  `None`.
-        observation_features=None,
-        observation_data=[deepcopy(obsd)],
+        observations=[deepcopy(obs)],
         config={
             "optimization_config": optimization_config,
             "winsorization_config": winsorization_config,

--- a/ax/modelbridge/tests/test_winsorize_transform_legacy.py
+++ b/ax/modelbridge/tests/test_winsorize_transform_legacy.py
@@ -8,7 +8,7 @@ import warnings
 from copy import deepcopy
 
 import numpy as np
-from ax.core.observation import ObservationData
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.exceptions.core import DataRequiredError
 from ax.modelbridge.transforms.winsorize import Winsorize
 from ax.utils.common.testutils import TestCase
@@ -34,40 +34,28 @@ class WinsorizeTransformTestLegacy(TestCase):
                 ]
             ),
         )
+        self.observations = [
+            Observation(features=ObservationFeatures({}), data=obsd)
+            for obsd in [self.obsd1, self.obsd2]
+        ]
         self.t = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={"winsorization_upper": 0.2},
         )
         self.t1 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={"winsorization_upper": 0.8},
         )
         self.t2 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={"winsorization_lower": 0.2},
         )
         self.t3 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_upper": 0.6,
                 "percentile_bounds": {
@@ -77,12 +65,8 @@ class WinsorizeTransformTestLegacy(TestCase):
             },
         )
         self.t4 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_lower": 0.8,
                 "percentile_bounds": {
@@ -92,34 +76,25 @@ class WinsorizeTransformTestLegacy(TestCase):
             },
         )
 
-        self.obsd3 = ObservationData(
-            metric_names=["m3", "m3", "m3", "m3"],
-            means=np.array([0.0, 1.0, 5.0, 3.0]),
-            covariance=np.eye(4),
+        self.obs3 = Observation(
+            features=ObservationFeatures({}),
+            data=ObservationData(
+                metric_names=["m3", "m3", "m3", "m3"],
+                means=np.array([0.0, 1.0, 5.0, 3.0]),
+                covariance=np.eye(4),
+            ),
         )
         self.t5 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[
-                deepcopy(self.obsd1),
-                deepcopy(self.obsd2),
-                deepcopy(self.obsd3),
-            ],
+            observations=deepcopy(self.observations) + [deepcopy(self.obs3)],
             config={
                 "winsorization_lower": {"m2": 0.4},
                 "winsorization_upper": {"m1": 0.6},
             },
         )
         self.t6 = Winsorize(
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
             search_space=None,
-            # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]` but
-            #  got `None`.
-            observation_features=None,
-            observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+            observations=deepcopy(self.observations),
             config={
                 "winsorization_lower": {"m2": 0.4},
                 "winsorization_upper": {"m1": 0.6},
@@ -135,12 +110,8 @@ class WinsorizeTransformTestLegacy(TestCase):
         warnings.simplefilter("always", DeprecationWarning)
         with warnings.catch_warnings(record=True) as ws:
             Winsorize(
-                # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
                 search_space=None,
-                # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]`
-                #  but got `None`.
-                observation_features=None,
-                observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+                observations=deepcopy(self.observations),
                 config={"winsorization_upper": 0.2},
             )
             self.assertTrue(
@@ -160,26 +131,25 @@ class WinsorizeTransformTestLegacy(TestCase):
         self.assertEqual(self.t2.cutoffs["m1"], (0.0, float("inf")))
         self.assertEqual(self.t2.cutoffs["m2"], (0.0, float("inf")))
         with self.assertRaises(DataRequiredError):
-            # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
-            Winsorize(search_space=None, observation_features=[], observation_data=[])
+            Winsorize(search_space=None, observations=[])
 
     # pyre-fixme[3]: Return type must be annotated.
     def testTransformObservations(self):
-        observation_data = self.t1.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t1._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t1.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t1._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 1.0, 1.0])
-        observation_data = self.t2.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t2._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t2.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t2._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -193,12 +163,8 @@ class WinsorizeTransformTestLegacy(TestCase):
     def testValueError(self):
         with self.assertRaises(ValueError):
             Winsorize(
-                # pyre-fixme[6]: For 1st param expected `SearchSpace` but got `None`.
                 search_space=None,
-                # pyre-fixme[6]: For 2nd param expected `List[ObservationFeatures]`
-                #  but got `None`.
-                observation_features=None,
-                observation_data=[deepcopy(self.obsd1), deepcopy(self.obsd2)],
+                observations=deepcopy(self.observations),
                 config={
                     "winsorization_lower": 0.8,
                     "percentile_bounds": {"m1": (0.1, 0.2, 0.3)},  # Too many inputs..
@@ -207,41 +173,39 @@ class WinsorizeTransformTestLegacy(TestCase):
 
     # pyre-fixme[3]: Return type must be annotated.
     def testTransformObservationsPercentileBounds(self):
-        observation_data = self.t3.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t3._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t3.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t3._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 1.9, 1.0])
-        observation_data = self.t4.transform_observation_data(
-            [deepcopy(self.obsd1)], []
-        )[0]
+        observation_data = self.t4._transform_observation_data([deepcopy(self.obsd1)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 0.3, 1.0])
-        observation_data = self.t4.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t4._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
 
     # pyre-fixme[3]: Return type must be annotated.
     def testTransformObservationsDifferentLowerUpper(self):
-        observation_data = self.t5.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t5._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertEqual(self.t5.cutoffs["m1"], (-float("inf"), 1.0))
         self.assertEqual(self.t5.cutoffs["m2"], (1.0, float("inf")))
         self.assertEqual(self.t5.cutoffs["m3"], (-float("inf"), float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
         # Nothing should happen to m3
-        observation_data = self.t5.transform_observation_data(
-            [deepcopy(self.obsd3)], []
-        )[0]
+        observation_data = self.t5.transform_observations([deepcopy(self.obs3)])[0].data
         self.assertListEqual(list(observation_data.means), [0.0, 1.0, 5.0, 3.0])
         # With percentile_bounds
-        observation_data = self.t6.transform_observation_data(
-            [deepcopy(self.obsd2)], []
-        )[0]
+        observation_data = self.t6._transform_observation_data([deepcopy(self.obsd2)])[
+            0
+        ]
         self.assertEqual(self.t6.cutoffs["m1"], (-float("inf"), 1.0))
         self.assertEqual(self.t6.cutoffs["m2"], (0.0, float("inf")))
         self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -17,7 +17,12 @@ from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import extract_arm_predictions
 from ax.core.metric import Metric
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import (
+    Observation,
+    ObservationData,
+    ObservationFeatures,
+    separate_observations,
+)
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
@@ -310,8 +315,7 @@ class TorchModelBridge(ModelBridge):
     def _cross_validate(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        cv_training_data: List[Observation],
         cv_test_points: List[ObservationFeatures],
         parameters: Optional[List[str]] = None,
     ) -> List[ObservationData]:
@@ -322,6 +326,7 @@ class TorchModelBridge(ModelBridge):
             raise ValueError(FIT_MODEL_ERROR.format(action="_cross_validate"))
         if parameters is None:
             parameters = self.parameters
+        observation_features, observation_data = separate_observations(cv_training_data)
         datasets, candidate_metadata = self._convert_observations(
             observation_data=observation_data,
             observation_features=observation_features,
@@ -460,14 +465,14 @@ class TorchModelBridge(ModelBridge):
         self,
         model: TorchModel,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
         parameters: Optional[List[str]] = None,
     ) -> None:  # pragma: no cover
         self.parameters = list(search_space.parameters.keys())
         if parameters is None:
             parameters = self.parameters
         all_metric_names: Set[str] = set()
+        observation_features, observation_data = separate_observations(observations)
         for od in observation_data:
             all_metric_names.update(od.metric_names)
         self.outcomes = sorted(all_metric_names)  # Deterministic order
@@ -691,23 +696,25 @@ class TorchModelBridge(ModelBridge):
         )
         return search_space_digest, torch_opt_config
 
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
-    def _transform_observation_data(
-        self, observation_data: List[ObservationData]
-    ) -> Any:  # TODO(jej): Make return type parametric
+    def _transform_observations(
+        self, observations: List[Observation]
+    ) -> Tuple[Tensor, Tensor, Tensor]:
         """Apply terminal transform to given observation data and return result.
 
-        Converts a set of observation data to a tuple of
+        Converts a set of observations to a tuple of
+            - a (n x d) array of X
             - an (n x m) array of means
             - an (n x m x m) array of covariances
         """
+        observation_features, observation_data = separate_observations(observations)
         try:
             mean, cov = observation_data_to_array(
                 outcomes=self.outcomes, observation_data=observation_data
             )
         except (KeyError, TypeError):  # pragma: no cover
             raise ValueError("Invalid formatting of observation data.")
-        return self._array_to_tensor(mean), self._array_to_tensor(cov)
+        X = self._transform_observation_features(observation_features)
+        return X, self._array_to_tensor(mean), self._array_to_tensor(cov)
 
     def _untransform_objective_thresholds(
         self,
@@ -732,25 +739,22 @@ class TorchModelBridge(ModelBridge):
                     op=ComparisonOp.LEQ if sign < 0 else ComparisonOp.GEQ,
                 )
             )
+        fixed_features = fixed_features or {}
+        fixed_features_obs = ObservationFeatures(
+            parameters={
+                name: fixed_features[i]
+                for i, name in enumerate(self.parameters)
+                if i in fixed_features
+            }
+        )
 
-        # Create dummy ObservationFeatures from the fixed features.
-        fixed = fixed_features or {}
-        observation_features = [
-            ObservationFeatures(
-                parameters={
-                    name: fixed.get(i, 0.0) for i, name in enumerate(self.parameters)
-                }
-            )
-        ]
-
-        # Untransform ObjectiveThresholds along with the dummy ObservationFeatures.
         for t in reversed(list(self.transforms.values())):
-            thresholds = t.untransform_objective_thresholds(
-                objective_thresholds=thresholds,
-                observation_features=observation_features,
-            )
-            observation_features = t.untransform_observation_features(
-                observation_features
+            fixed_features_obs = t.untransform_observation_features(
+                [fixed_features_obs]
+            )[0]
+            thresholds = t.untransform_outcome_constraints(
+                outcome_constraints=thresholds,
+                fixed_features=fixed_features_obs,
             )
 
         return thresholds
@@ -758,13 +762,13 @@ class TorchModelBridge(ModelBridge):
     def _update(
         self,
         search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        observations: List[Observation],
         parameters: Optional[List[str]] = None,
     ) -> None:
         """Apply terminal transform for update data, and pass along to model."""
         if parameters is None:
             parameters = self.parameters
+        observation_features, observation_data = separate_observations(observations)
         datasets, candidate_metadata = self._convert_observations(
             observation_data=observation_data,
             observation_features=observation_features,

--- a/ax/modelbridge/transforms/cap_parameter.py
+++ b/ax/modelbridge/transforms/cap_parameter.py
@@ -6,7 +6,7 @@
 
 from typing import List, Optional, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation
 from ax.core.parameter import RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -27,14 +27,14 @@ class CapParameter(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
         # pyre-fixme[4]: Attribute must be annotated.
         self.config = config or {}
+        assert search_space is not None, "CapParameter requires search space"
         # pyre-fixme[4]: Attribute must be annotated.
         self.transform_parameters = {  # Only transform parameters in config.
             p_name for p_name in search_space.parameters if p_name in self.config

--- a/ax/modelbridge/transforms/cast.py
+++ b/ax/modelbridge/transforms/cast.py
@@ -6,11 +6,11 @@
 
 from typing import List, Optional, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.models.types import TConfig
-from ax.utils.common.typeutils import checked_cast
+from ax.utils.common.typeutils import checked_cast, not_none
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
@@ -39,14 +39,12 @@ class Cast(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: Optional[List[ObservationFeatures]] = None,
-        observation_data: Optional[List[ObservationData]] = None,
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
-        # pyre-fixme[4]: Attribute must be annotated.
-        self.search_space = search_space.clone()
+        self.search_space: SearchSpace = not_none(search_space).clone()
         self.flatten_hss: bool = (
             config is None or checked_cast(bool, config.get("flatten_hss", True))
         ) and isinstance(search_space, HierarchicalSearchSpace)

--- a/ax/modelbridge/transforms/derelativize.py
+++ b/ax/modelbridge/transforms/derelativize.py
@@ -4,12 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 
 import numpy as np
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
-from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
+from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.modelbridge.base import unwrap_observation_data
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.ivw import ivw_metric_merge
@@ -38,8 +38,8 @@ class Derelativize(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        modelbridge: Optional["modelbridge_module.base.ModelBridge"],
-        fixed_features: ObservationFeatures,
+        modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
     ) -> OptimizationConfig:
         use_raw_sq = self.config.get("use_raw_status_quo", False)
         has_relative_constraint = any(
@@ -91,3 +91,12 @@ class Derelativize(Transform):
                 c.bound = (1 + c.bound / 100.0) * sq_val
                 c.relative = False
         return optimization_config
+
+    def untransform_outcome_constraints(
+        self,
+        outcome_constraints: List[OutcomeConstraint],
+        fixed_features: Optional[ObservationFeatures] = None,
+    ) -> List[OutcomeConstraint]:
+        # We intentionally leave outcome constraints derelativized when
+        # untransforming.
+        return outcome_constraints

--- a/ax/modelbridge/transforms/int_range_to_choice.py
+++ b/ax/modelbridge/transforms/int_range_to_choice.py
@@ -6,7 +6,7 @@
 
 from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -26,12 +26,12 @@ class IntRangeToChoice(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "IntRangeToChoice requires search space"
         # Identify parameters that should be transformed
         self.transform_parameters: Set[str] = {
             p_name

--- a/ax/modelbridge/transforms/inverse_gaussian_cdf_y.py
+++ b/ax/modelbridge/transforms/inverse_gaussian_cdf_y.py
@@ -6,7 +6,7 @@
 
 from typing import List, Optional, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.utils import match_ci_width_truncated
@@ -33,19 +33,17 @@ class InverseGaussianCdfY(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["base_modelbridge.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
         # pyre-fixme[4]: Attribute must be annotated.
         self.dist = norm(loc=0, scale=1)
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Map to inverse Gaussian CDF in place."""
         # TODO (jej): Transform covariances.

--- a/ax/modelbridge/transforms/ivw.py
+++ b/ax/modelbridge/transforms/ivw.py
@@ -7,7 +7,7 @@
 from typing import Dict, List
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import ObservationData
 from ax.modelbridge.transforms.base import Transform
 from ax.utils.common.logger import get_logger
 
@@ -111,10 +111,9 @@ class IVW(Transform):
     are combined using inverse variance weighting.
     """
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         # pyre: conflicting_noiseless is declared to have type `str` but is
         # pyre-fixme[9]: used as type `typing.Union[float, int, str]`.

--- a/ax/modelbridge/transforms/log.py
+++ b/ax/modelbridge/transforms/log.py
@@ -7,7 +7,7 @@
 import math
 from typing import List, Optional, Set, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -26,12 +26,12 @@ class Log(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "Log requires search space"
         # Identify parameters that should be transformed
         self.transform_parameters: Set[str] = {
             p_name

--- a/ax/modelbridge/transforms/log_y.py
+++ b/ax/modelbridge/transforms/log_y.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 from typing import Callable, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
+from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.models.types import TConfig
@@ -41,9 +42,8 @@ class LogY(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["base_modelbridge.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
@@ -57,8 +57,7 @@ class LogY(Transform):
             raise ValueError("Must specify at least one metric in the config.")
         super().__init__(
             search_space=search_space,
-            observation_features=observation_features,
-            observation_data=observation_data,
+            observations=observations,
             config=config,
         )
         # pyre-fixme[4]: Attribute must be annotated.
@@ -77,8 +76,8 @@ class LogY(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        modelbridge: Optional[base_modelbridge.ModelBridge],
-        fixed_features: ObservationFeatures,
+        modelbridge: Optional[base_modelbridge.ModelBridge] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
     ) -> OptimizationConfig:
         for c in optimization_config.all_constraints:
             if c.metric.name in self.metric_names:
@@ -98,7 +97,6 @@ class LogY(Transform):
     def _tf_obs_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
         transform: Callable[[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray]],
     ) -> List[ObservationData]:
         for obsd in observation_data:
@@ -128,23 +126,29 @@ class LogY(Transform):
                 obsd.covariance = cov
         return observation_data
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
-        return self._tf_obs_data(
-            observation_data, observation_features, self._transform
-        )
+        return self._tf_obs_data(observation_data, self._transform)
 
-    def untransform_observation_data(
+    def _untransform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
-        return self._tf_obs_data(
-            observation_data, observation_features, self._untransform
-        )
+        return self._tf_obs_data(observation_data, self._untransform)
+
+    def untransform_outcome_constraints(
+        self,
+        outcome_constraints: List[OutcomeConstraint],
+        fixed_features: Optional[ObservationFeatures] = None,
+    ) -> List[OutcomeConstraint]:
+        for c in outcome_constraints:
+            if c.metric.name in self.metric_names:
+                if c.relative:
+                    raise ValueError("Unexpected relative transform.")
+                c.bound = np.exp(c.bound)
+        return outcome_constraints
 
 
 def match_ci_width(

--- a/ax/modelbridge/transforms/logit.py
+++ b/ax/modelbridge/transforms/logit.py
@@ -6,7 +6,7 @@
 
 from typing import List, Optional, Set, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -26,12 +26,12 @@ class Logit(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "Logit requires search space"
         # Identify parameters that should be transformed
         self.transform_parameters: Set[str] = {
             p_name

--- a/ax/modelbridge/transforms/map_unit_x.py
+++ b/ax/modelbridge/transforms/map_unit_x.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.unit_x import UnitX
 from ax.models.types import TConfig
@@ -32,20 +32,21 @@ class MapUnitX(UnitX):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional[modelbridge_module.base.ModelBridge] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert observations is not None, "MapUnitX requires observations"
+        assert search_space is not None, "MapUnitX requires search space"
         # Loop through observation features and identify parameters that
         # are not part of the search space. Store all observed values to
         # infer bounds
         map_values = defaultdict(list)
-        for obsf in observation_features:
-            for p in obsf.parameters:
+        for obs in observations:
+            for p in obs.features.parameters:
                 if p not in search_space.parameters:
-                    map_values[p].append(obsf.parameters[p])
+                    map_values[p].append(obs.features.parameters[p])
 
         # pyre-fixme[24]: Generic type `list` expects 1 type parameter, use
         #  `typing.List` to avoid runtime subscripting errors.

--- a/ax/modelbridge/transforms/metrics_as_task.py
+++ b/ax/modelbridge/transforms/metrics_as_task.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+import numpy as np
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.parameter import ChoiceParameter, ParameterType
+from ax.core.search_space import SearchSpace
+from ax.modelbridge.transforms.base import Transform
+from ax.models.types import TConfig
+
+if TYPE_CHECKING:
+    # import as module to make sphinx-autodoc-typehints happy
+    from ax import modelbridge as modelbridge_module  # noqa F401  # pragma: no cover
+
+
+class MetricsAsTask(Transform):
+    """Convert metrics to a task parameter.
+
+    For each metric to be used as a task, the config must specify a list of the
+    target metrics for that particular task metric. So,
+
+    config = {
+        'metric_task_map': {
+            'metric1': ['metric2', 'metric3'],
+            'metric2': ['metric3'],
+        }
+    }
+
+    means that metric2 will be given additional task observations of metric1,
+    and metric3 will be given additional task observations of both metric1 and
+    metric2. Note here that metric2 and metric3 are the target tasks, and this
+    map is from base tasks to target tasks.
+    """
+
+    def __init__(
+        self,
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
+        modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
+        config: Optional[TConfig] = None,
+    ) -> None:
+        # Use config to specify metric task map
+        if config is None or "metric_task_map" not in config:
+            raise ValueError("config must specify metric_task_map")
+        self.metric_task_map: Dict[str, List[str]] = config[  # pyre-ignore
+            "metric_task_map"
+        ]
+        self.task_values: List[str] = list(self.metric_task_map.keys())
+        assert "TARGET" not in self.task_values
+        self.task_values.append("TARGET")
+
+    def transform_observations(
+        self,
+        observations: List[Observation],
+    ) -> List[Observation]:
+        new_observations = []
+        for obs in observations:
+            # For the original observation, all the metrics with the new task param
+            params = obs.features.parameters.copy()
+            params["METRIC_TASK"] = "TARGET"
+            new_observations.append(
+                Observation(
+                    features=obs.features.clone(replace_parameters=params),
+                    data=obs.data,
+                    arm_name=obs.arm_name,
+                )
+            )
+            # Split out observations for the task metrics
+            for task_metric, target_metrics in self.metric_task_map.items():
+                if task_metric in obs.data.metric_names:
+                    # Make an observation for this task metric.
+                    params = obs.features.parameters.copy()
+                    params["METRIC_TASK"] = task_metric
+                    new_obs_feats = obs.features.clone(replace_parameters=params)
+                    new_obs_data = ObservationData(
+                        metric_names=target_metrics,
+                        means=obs.data.means_dict[task_metric]  # pyre-ignore
+                        * np.ones(len(target_metrics)),
+                        covariance=np.diag(
+                            obs.data.covariance_matrix[task_metric][task_metric]
+                            * np.ones(len(target_metrics))
+                        ),
+                    )
+                    new_observations.append(
+                        Observation(
+                            features=new_obs_feats,
+                            data=new_obs_data,
+                            arm_name=obs.arm_name,
+                        )
+                    )
+        return new_observations
+
+    def transform_observation_features(
+        self, observation_features: List[ObservationFeatures]
+    ) -> List[ObservationFeatures]:
+        """
+        If transforming features without data, map them to the target.
+        """
+        for obsf in observation_features:
+            obsf.parameters["METRIC_TASK"] = "TARGET"
+        return observation_features
+
+    def untransform_observations(
+        self, observations: List[Observation]
+    ) -> List[Observation]:
+        # Drop any observations that are not TARGET, and remove the param.
+        new_observations = []
+        for obs in observations:
+            task = obs.features.parameters.pop("METRIC_TASK")
+            if task == "TARGET":
+                new_observations.append(
+                    Observation(
+                        features=obs.features, data=obs.data, arm_name=obs.arm_name
+                    )
+                )
+        return new_observations
+
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+        # Add task parameter
+        task_param = ChoiceParameter(
+            name="METRIC_TASK",
+            parameter_type=ParameterType.STRING,
+            values=self.task_values,  # pyre-ignore
+            is_ordered=False,
+            is_task=True,
+            sort_values=True,
+        )
+        search_space.add_parameter(task_param)
+        return search_space
+
+    def untransform_observation_features(
+        self, observation_features: List[ObservationFeatures]
+    ) -> List[ObservationFeatures]:
+        # This is called during gen. We shouldn't gen for any task other than
+        # the target task.
+        for obsf in observation_features:
+            task = obsf.parameters.pop("METRIC_TASK")
+            if task != "TARGET":
+                raise ValueError(f"Got point for task {task}. Something went wrong.")
+        return observation_features

--- a/ax/modelbridge/transforms/one_hot.py
+++ b/ax/modelbridge/transforms/one_hot.py
@@ -7,7 +7,7 @@
 from typing import Dict, List, Optional, TYPE_CHECKING, TypeVar
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParameterization
@@ -87,12 +87,12 @@ class OneHot(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "OneHot requires search space"
         # Identify parameters that should be transformed
         # pyre-fixme[4]: Attribute must be annotated.
         self.rounding = "strict"
@@ -159,6 +159,13 @@ class OneHot(Transform):
     ) -> List[ObservationFeatures]:
         for obsf in observation_features:
             for p_name in self.encoder.keys():
+                has_params = [
+                    p in obsf.parameters for p in self.encoded_parameters[p_name]
+                ]
+                if not all(has_params):
+                    if any(has_params):
+                        raise ValueError(f"Missing some parameters for {p_name}")
+                    continue
                 x = np.array(
                     [obsf.parameters.pop(p) for p in self.encoded_parameters[p_name]]
                 )

--- a/ax/modelbridge/transforms/power_transform_y.py
+++ b/ax/modelbridge/transforms/power_transform_y.py
@@ -10,9 +10,9 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
-from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
+from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.utils import get_data, match_ci_width_truncated
@@ -50,12 +50,12 @@ class PowerTransformY(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional[modelbridge_module.base.ModelBridge] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert observations is not None, "PowerTransformY requires observations"
         if config is None:
             raise ValueError("PowerTransform requires a config.")
         # pyre-fixme[6]: Same issue as for LogY
@@ -66,16 +66,16 @@ class PowerTransformY(Transform):
         self.clip_mean = config.get("clip_mean", True)
         # pyre-fixme[4]: Attribute must be annotated.
         self.metric_names = metric_names
+        observation_data = [obs.data for obs in observations]
         Ys = get_data(observation_data=observation_data, metric_names=metric_names)
         # pyre-fixme[4]: Attribute must be annotated.
         self.power_transforms = _compute_power_transforms(Ys=Ys)
         # pyre-fixme[4]: Attribute must be annotated.
         self.inv_bounds = _compute_inverse_bounds(self.power_transforms, tol=1e-10)
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Winsorize observation data in place."""
         for obsd in observation_data:
@@ -91,10 +91,9 @@ class PowerTransformY(Transform):
                     )
         return observation_data
 
-    def untransform_observation_data(
+    def _untransform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Winsorize observation data in place."""
         for obsd in observation_data:
@@ -119,8 +118,8 @@ class PowerTransformY(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        modelbridge: Optional[modelbridge_module.base.ModelBridge],
-        fixed_features: ObservationFeatures,
+        modelbridge: Optional[modelbridge_module.base.ModelBridge] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
     ) -> OptimizationConfig:
         for c in optimization_config.all_constraints:
             if isinstance(c, ScalarizedOutcomeConstraint):
@@ -141,6 +140,22 @@ class PowerTransformY(Transform):
                     transform = self.power_transforms[c.metric.name].transform
                     c.bound = transform(np.array(c.bound, ndmin=2)).item()
         return optimization_config
+
+    def untransform_outcome_constraints(
+        self,
+        outcome_constraints: List[OutcomeConstraint],
+        fixed_features: Optional[ObservationFeatures] = None,
+    ) -> List[OutcomeConstraint]:
+        for c in outcome_constraints:
+            if isinstance(c, ScalarizedOutcomeConstraint):
+                raise ValueError("ScalarizedOutcomeConstraint not supported here")
+            elif c.metric.name in self.metric_names:
+                if c.relative:
+                    raise ValueError("Relative constraints not supported here.")
+                else:
+                    transform = self.power_transforms[c.metric.name].inverse_transform
+                    c.bound = transform(np.array(c.bound, ndmin=2)).item()
+        return outcome_constraints
 
 
 def _compute_power_transforms(

--- a/ax/modelbridge/transforms/remove_fixed.py
+++ b/ax/modelbridge/transforms/remove_fixed.py
@@ -6,7 +6,7 @@
 
 from typing import Dict, List, Optional, TYPE_CHECKING, Union
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, FixedParameter, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.base import Transform
@@ -29,12 +29,12 @@ class RemoveFixed(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "RemoveFixed requires search space"
         # Identify parameters that should be transformed
         self.fixed_parameters: Dict[str, FixedParameter] = {
             p_name: p

--- a/ax/modelbridge/transforms/search_space_to_choice.py
+++ b/ax/modelbridge/transforms/search_space_to_choice.py
@@ -7,7 +7,7 @@
 from typing import List, Optional, TYPE_CHECKING
 
 from ax.core.arm import Arm
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, FixedParameter, ParameterType
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.exceptions.core import UnsupportedError
@@ -34,16 +34,16 @@ class SearchSpaceToChoice(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "SearchSpaceToChoice requires search space"
+        assert observations is not None, "SeachSpaceToChoice requires observations"
         super().__init__(
             search_space=search_space,
-            observation_features=observation_features,
-            observation_data=observation_data,
+            observations=observations,
             config=config,
         )
         if any(p.is_fidelity for p in search_space.parameters.values()):
@@ -58,8 +58,8 @@ class SearchSpaceToChoice(Transform):
         self.parameter_name = "arms"
         # pyre-fixme[4]: Attribute must be annotated.
         self.signature_to_parameterization = {
-            Arm(parameters=obsf.parameters).signature: obsf.parameters
-            for obsf in observation_features
+            Arm(parameters=obs.features.parameters).signature: obs.features.parameters
+            for obs in observations
         }
 
     def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:

--- a/ax/modelbridge/transforms/standardize_y.py
+++ b/ax/modelbridge/transforms/standardize_y.py
@@ -7,9 +7,9 @@
 from typing import DefaultDict, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
-from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
+from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
 from ax.exceptions.core import DataRequiredError
@@ -36,26 +36,23 @@ class StandardizeY(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["base_modelbridge.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
-        if len(observation_data) == 0:
-            raise DataRequiredError(
-                "`StandardizeY` transform requires non-empty observation data."
-            )
+        if observations is None or len(observations) == 0:
+            raise DataRequiredError("`StandardizeY` transform requires non-empty data.")
+        observation_data = [obs.data for obs in observations]
         Ys = get_data(observation_data=observation_data)
         # Compute means and SDs
         # pyre-fixme[6]: Expected `DefaultDict[Union[str, Tuple[str, Optional[Union[b...
         # pyre-fixme[4]: Attribute must be annotated.
         self.Ymean, self.Ystd = compute_standardization_parameters(Ys)
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         # Transform observation data
         for obsd in observation_data:
@@ -68,8 +65,8 @@ class StandardizeY(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        modelbridge: Optional["base_modelbridge.ModelBridge"],
-        fixed_features: ObservationFeatures,
+        modelbridge: Optional["base_modelbridge.ModelBridge"] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
     ) -> OptimizationConfig:
         for c in optimization_config.all_constraints:
             if c.relative:
@@ -102,10 +99,9 @@ class StandardizeY(Transform):
                 )
         return optimization_config
 
-    def untransform_observation_data(
+    def _untransform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         for obsd in observation_data:
             means = np.array([self.Ymean[m] for m in obsd.metric_names])
@@ -113,6 +109,23 @@ class StandardizeY(Transform):
             obsd.means = obsd.means * stds + means
             obsd.covariance *= np.dot(stds[:, None], stds[:, None].transpose())
         return observation_data
+
+    def untransform_outcome_constraints(
+        self,
+        outcome_constraints: List[OutcomeConstraint],
+        fixed_features: Optional[ObservationFeatures] = None,
+    ) -> List[OutcomeConstraint]:
+        for c in outcome_constraints:
+            if c.relative:
+                raise ValueError(
+                    f"StandardizeY transform does not support relative constraint {c}"
+                )
+            if isinstance(c, ScalarizedOutcomeConstraint):
+                raise ValueError("ScalarizedOutcomeConstraint not supported")
+            c.bound = float(
+                c.bound * self.Ystd[c.metric.name] + self.Ymean[c.metric.name]
+            )
+        return outcome_constraints
 
 
 def compute_standardization_parameters(

--- a/ax/modelbridge/transforms/stratified_standardize_y.py
+++ b/ax/modelbridge/transforms/stratified_standardize_y.py
@@ -8,8 +8,9 @@ from collections import defaultdict
 from typing import DefaultDict, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures, separate_observations
 from ax.core.optimization_config import OptimizationConfig
+from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.parameter import ChoiceParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
@@ -45,12 +46,13 @@ class StratifiedStandardizeY(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "StratifiedStandardizeY requires search space"
+        assert observations is not None, "StratifiedStandardizeY requires observations"
         # Get parameter name for standardization.
         if config is not None and "parameter_name" in config:
             # pyre: Attribute `p_name` declared in class `ax.modelbridge.
@@ -79,6 +81,7 @@ class StratifiedStandardizeY(Transform):
                 )
             self.p_name = task_parameters[0]
         # Compute means and SDs
+        observation_features, observation_data = separate_observations(observations)
         Ys: DefaultDict[Tuple[str, TParamValue], List[float]] = defaultdict(list)
         for j, obsd in enumerate(observation_data):
             v = observation_features[j].parameters[self.p_name]
@@ -94,29 +97,28 @@ class StratifiedStandardizeY(Transform):
         # pyre-fixme[4]: Attribute must be annotated.
         self.Ymean, self.Ystd = compute_standardization_parameters(Ys)
 
-    def transform_observation_data(
+    def transform_observations(
         self,
-        observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
-    ) -> List[ObservationData]:
-        # Transform observation data
-        for j, obsd in enumerate(observation_data):
-            v = observation_features[j].parameters[self.p_name]
-            means = np.array([self.Ymean[(m, v)] for m in obsd.metric_names])
-            stds = np.array([self.Ystd[(m, v)] for m in obsd.metric_names])
-            obsd.means = (obsd.means - means) / stds
-            obsd.covariance /= np.dot(stds[:, None], stds[:, None].transpose())
-        return observation_data
+        observations: List[Observation],
+    ) -> List[Observation]:
+        # Transform observations
+        for obs in observations:
+            v = obs.features.parameters[self.p_name]
+            means = np.array([self.Ymean[(m, v)] for m in obs.data.metric_names])
+            stds = np.array([self.Ystd[(m, v)] for m in obs.data.metric_names])
+            obs.data.means = (obs.data.means - means) / stds
+            obs.data.covariance /= np.dot(stds[:, None], stds[:, None].transpose())
+        return observations
 
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        modelbridge: Optional["modelbridge_module.base.ModelBridge"],
-        fixed_features: ObservationFeatures,
+        modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
     ) -> OptimizationConfig:
         if len(optimization_config.all_constraints) == 0:
             return optimization_config
-        if self.p_name not in fixed_features.parameters:
+        if fixed_features is None or self.p_name not in fixed_features.parameters:
             raise ValueError(
                 f"StratifiedStandardizeY transform requires {self.p_name} to be fixed "
                 "during generation."
@@ -133,15 +135,34 @@ class StratifiedStandardizeY(Transform):
             ]
         return optimization_config
 
-    def untransform_observation_data(
+    def untransform_observations(
         self,
-        observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
-    ) -> List[ObservationData]:
-        for j, obsd in enumerate(observation_data):
-            v = observation_features[j].parameters[self.p_name]
-            means = np.array([self.Ymean[(m, v)] for m in obsd.metric_names])
-            stds = np.array([self.Ystd[(m, v)] for m in obsd.metric_names])
-            obsd.means = obsd.means * stds + means
-            obsd.covariance *= np.dot(stds[:, None], stds[:, None].transpose())
-        return observation_data
+        observations: List[Observation],
+    ) -> List[Observation]:
+        for obs in observations:
+            v = obs.features.parameters[self.p_name]
+            means = np.array([self.Ymean[(m, v)] for m in obs.data.metric_names])
+            stds = np.array([self.Ystd[(m, v)] for m in obs.data.metric_names])
+            obs.data.means = obs.data.means * stds + means
+            obs.data.covariance *= np.dot(stds[:, None], stds[:, None].transpose())
+        return observations
+
+    def untransform_outcome_constraints(
+        self,
+        outcome_constraints: List[OutcomeConstraint],
+        fixed_features: Optional[ObservationFeatures] = None,
+    ) -> List[OutcomeConstraint]:
+        if fixed_features is None or self.p_name not in fixed_features.parameters:
+            raise ValueError(
+                f"StratifiedStandardizeY requires {self.p_name} to be fixed here"
+            )
+        v = fixed_features.parameters[self.p_name]
+        for c in outcome_constraints:
+            if c.relative:
+                raise ValueError(
+                    "StratifiedStandardizeY does not support relative constraints"
+                )
+            c.bound = float(
+                c.bound * self.Ystd[(c.metric.name, v)] + self.Ymean[(c.metric.name, v)]
+            )
+        return outcome_constraints

--- a/ax/modelbridge/transforms/task_encode.py
+++ b/ax/modelbridge/transforms/task_encode.py
@@ -6,7 +6,7 @@
 
 from typing import Dict, List, Optional, TYPE_CHECKING
 
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
@@ -33,12 +33,12 @@ class TaskEncode(OrderedChoiceEncode):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert search_space is not None, "TaskEncode requires search space"
         # Identify parameters that should be transformed
         self.encoded_parameters: Dict[str, Dict[TParamValue, int]] = {}
         for p in search_space.parameters.values():

--- a/ax/modelbridge/transforms/trial_as_task.py
+++ b/ax/modelbridge/transforms/trial_as_task.py
@@ -7,7 +7,7 @@
 from typing import Dict, List, Optional, TYPE_CHECKING
 
 import numpy as np
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.exceptions.core import UnsupportedError
@@ -47,14 +47,14 @@ class TrialAsTask(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
+        assert observations is not None, "TrialAskTask requires observations"
         # Identify values of trial.
-        trials = {obsf.trial_index for obsf in observation_features}
+        trials = {obs.features.trial_index for obs in observations}
         if isinstance(search_space, RobustSearchSpace):
             raise UnsupportedError(
                 "TrialAsTask transform is not supported for RobustSearchSpace."

--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 from ax.core.objective import ScalarizedObjective
-from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
@@ -109,21 +109,19 @@ class Winsorize(Transform):
 
     def __init__(
         self,
-        search_space: SearchSpace,
-        observation_features: List[ObservationFeatures],
-        observation_data: List[ObservationData],
+        search_space: Optional[SearchSpace] = None,
+        observations: Optional[List[Observation]] = None,
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
-        if len(observation_data) == 0:
-            raise DataRequiredError(
-                "`Winsorize` transform requires non-empty observation data."
-            )
+        if observations is None or len(observations) == 0:
+            raise DataRequiredError("`Winsorize` transform requires non-empty data.")
         if config is None:
             raise ValueError(
                 "Transform config for `Winsorize` transform must be specified and "
                 "non-empty when using winsorization."
             )
+        observation_data = [obs.data for obs in observations]
         all_metric_values = get_data(observation_data=observation_data)
 
         # Check for legacy config
@@ -167,10 +165,9 @@ class Winsorize(Transform):
                     optimization_config=opt_config,  # pyre-ignore[6]
                 )
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         """Winsorize observation data in place."""
         for obsd in observation_data:

--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -217,8 +217,8 @@ def _get_in_sample_arms(
 
     # Merge multiple measurements within each Observation with IVW to get
     # un-modeled prediction
-    t = IVW(None, [], [])
-    obs_data = t.transform_observation_data([obs.data for obs in observations], [])
+    t = IVW(None, [])
+    observations = t.transform_observations(observations)
     # Start filling in plot data
     in_sample_plot: Dict[str, PlotInSampleArm] = {}
     for i, obs in enumerate(observations):
@@ -228,11 +228,10 @@ def _get_in_sample_arms(
         # Extract raw measurement
         obs_y = {}  # Observed metric means.
         obs_se = {}  # Observed metric standard errors.
-        # Use the IVW data, not obs.data
-        for j, metric_name in enumerate(obs_data[i].metric_names):
+        for j, metric_name in enumerate(obs.data.metric_names):
             if metric_name in metric_names:
-                obs_y[metric_name] = obs_data[i].means[j]
-                obs_se[metric_name] = np.sqrt(obs_data[i].covariance[j, j])
+                obs_y[metric_name] = obs.data.means[j]
+                obs_se[metric_name] = np.sqrt(obs.data.covariance[j, j])
         if training_in_design[i]:
             # Update with the input fixed features
             features = obs.features

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -17,6 +17,7 @@ from ax.modelbridge.transforms.ivw import IVW
 from ax.modelbridge.transforms.log import Log
 from ax.modelbridge.transforms.logit import Logit
 from ax.modelbridge.transforms.map_unit_x import MapUnitX
+from ax.modelbridge.transforms.metrics_as_task import MetricsAsTask
 from ax.modelbridge.transforms.one_hot import OneHot
 from ax.modelbridge.transforms.power_transform_y import PowerTransformY
 from ax.modelbridge.transforms.remove_fixed import RemoveFixed
@@ -67,6 +68,7 @@ TRANSFORM_REGISTRY: Dict[Type[Transform], int] = {
     ChoiceEncode: 19,
     Logit: 20,
     MapUnitX: 21,
+    MetricsAsTask: 22,
 }
 
 

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -10,6 +10,7 @@ import numpy as np
 from ax.core.experiment import Experiment
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
+from ax.core.parameter import FixedParameter, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
@@ -17,7 +18,6 @@ from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.int_to_float import IntToFloat
 from ax.utils.common.logger import get_logger
-from ax.utils.common.typeutils import not_none
 from ax.utils.testing.core_stubs import (
     get_experiment,
     get_search_space,
@@ -119,7 +119,7 @@ def get_observation1trans(
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(
-            parameters={"x": 9.0, "y": 10.0}, trial_index=np.int64(0)
+            parameters={"x": 9.0, "y": 121.0}, trial_index=np.int64(0)
         ),
         data=ObservationData(
             means=np.array([9.0, 25.0]),
@@ -155,7 +155,7 @@ def get_observation2trans(
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(
-            parameters={"x": 16.0, "y": 2.0}, trial_index=np.int64(1)
+            parameters={"x": 16.0, "y": 9.0}, trial_index=np.int64(1)
         ),
         data=ObservationData(
             means=np.array([9.0, 4.0]),
@@ -196,14 +196,19 @@ def get_experiment_for_value() -> Experiment:
 class transform_1(Transform):
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         new_ss = search_space.clone()
-        new_ss.parameters["x"]._value += 1.0  # pyre-ignore[16]: testing hack.
+        for param in new_ss.parameters.values():
+            if isinstance(param, FixedParameter):
+                param._value += 1.0
+            elif isinstance(param, RangeParameter):
+                param._lower += 1.0
+                param._upper += 1.0
         return new_ss
 
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
         modelbridge: Optional[ModelBridge],
-        fixed_features: ObservationFeatures,
+        fixed_features: Optional[ObservationFeatures],
     ) -> OptimizationConfig:
         return (  # pyre-ignore[7]: pyre is right, this is a hack for testing.
             # pyre-fixme[58]: `+` is not supported for operand types
@@ -217,19 +222,13 @@ class transform_1(Transform):
         self, observation_features: List[ObservationFeatures]
     ) -> List[ObservationFeatures]:
         for obsf in observation_features:
-            if "x" in obsf.parameters:
-                obsf.parameters["x"] = (
-                    # pyre-fixme[58]: `+` is not supported for operand types
-                    #  `Union[float, str]` and `int`.
-                    not_none(obsf.parameters["x"])
-                    + 1
-                )
+            for p_name in obsf.parameters:
+                obsf.parameters[p_name] += 1  # pyre-ignore
         return observation_features
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         for obsd in observation_data:
             obsd.means += 1
@@ -239,13 +238,13 @@ class transform_1(Transform):
         self, observation_features: List[ObservationFeatures]
     ) -> List[ObservationFeatures]:
         for obsf in observation_features:
-            obsf.parameters["x"] = obsf.parameters["x"] - 1  # pyre-ignore
+            for p_name in obsf.parameters:
+                obsf.parameters[p_name] -= 1  # pyre-ignore
         return observation_features
 
-    def untransform_observation_data(
+    def _untransform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         for obsd in observation_data:
             obsd.means -= 1
@@ -255,14 +254,19 @@ class transform_1(Transform):
 class transform_2(Transform):
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         new_ss = search_space.clone()
-        new_ss.parameters["x"]._value *= 2.0  # pyre-ignore[16]: testing hack.
+        for param in new_ss.parameters.values():
+            if isinstance(param, FixedParameter):
+                param._value *= 2.0
+            elif isinstance(param, RangeParameter):
+                param._lower *= 2.0
+                param._upper *= 2.0
         return new_ss
 
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
         modelbridge: Optional[ModelBridge],
-        fixed_features: ObservationFeatures,
+        fixed_features: Optional[ObservationFeatures],
     ) -> OptimizationConfig:
         return (
             # pyre-fixme[58]: `**` is not supported for operand types
@@ -276,14 +280,13 @@ class transform_2(Transform):
         self, observation_features: List[ObservationFeatures]
     ) -> List[ObservationFeatures]:
         for obsf in observation_features:
-            if "x" in obsf.parameters:
-                obsf.parameters["x"] = obsf.parameters["x"] ** 2  # pyre-ignore
+            for pname in obsf.parameters:
+                obsf.parameters[pname] = obsf.parameters[pname] ** 2  # pyre-ignore
         return observation_features
 
-    def transform_observation_data(
+    def _transform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         for obsd in observation_data:
             obsd.means = obsd.means**2
@@ -293,13 +296,13 @@ class transform_2(Transform):
         self, observation_features: List[ObservationFeatures]
     ) -> List[ObservationFeatures]:
         for obsf in observation_features:
-            obsf.parameters["x"] = np.sqrt(obsf.parameters["x"])
+            for pname in obsf.parameters:
+                obsf.parameters[pname] = np.sqrt(obsf.parameters[pname])
         return observation_features
 
-    def untransform_observation_data(
+    def _untransform_observation_data(
         self,
         observation_data: List[ObservationData],
-        observation_features: List[ObservationFeatures],
     ) -> List[ObservationData]:
         for obsd in observation_data:
             obsd.means = np.sqrt(obsd.means)

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -253,6 +253,14 @@ Transforms
     :undoc-members:
     :show-inheritance:
 
+`ax.modelbridge.transforms.metrics_as_task`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.metrics_as_task
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 `ax.modelbridge.transforms.one\_hot`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary:
This is a re-do of D38833175 (https://github.com/facebook/Ax/commit/aa952971e84b828584909f2a2f03254b88dd9649), which was reverted due to a test failure in f6 that wasn't caught by sandcastle.

The source of the test failure is the change to apply untransform_observation_features to a partially specified fixed_features. I adjusted most of the transforms to ensure that they worked correctly on partially specified observation features, but had missed OrderedChoiceEncode and IntToFloat. The particular f6 failure was from trying to compute a Pareto frontier on a model that had an integer parameter, which failed because the fixed feature for IntToFloat didn't work correctly.

This diff is exactly what was landed earlier, plus the changeset in P525514492 which fixes the two transforms.

Differential Revision: D39150552

