### PR TITLE
Custom reference point in GSS

### DIFF
--- a/ax/global_stopping/strategies/base.py
+++ b/ax/global_stopping/strategies/base.py
@@ -23,14 +23,19 @@ class BaseGlobalStoppingStrategy(ABC, Base):
     justify the cost of running these trials).
     """
 
-    def __init__(self, min_trials: int) -> None:
+    def __init__(
+        self, min_trials: int, inactive_when_pending_trials: bool = True
+    ) -> None:
         """
         Initiating a base stopping strategy.
 
         Args:
             min_trials: Minimum number of trials before the stopping strategy kicks in.
+            inactive_when_pending_trials: If set, the optimization will not stopped as
+                long as it has running trials.
         """
         self.min_trials = min_trials
+        self.inactive_when_pending_trials = inactive_when_pending_trials
 
     @abstractmethod
     def should_stop_optimization(


### PR DESCRIPTION
Summary: Currently, the refrerence point used to compute the hv in improvement-based stopping strategy is taken from the experiment's optimization config. This adds the possibility of specifying a custom referecne point for the improvement-based stopping strategy.

Reviewed By: Balandat

Differential Revision: D39023637

