### PR TITLE
update `fit_botorch_model` for SaasFullyBayesianMultiTaskGP

### DIFF
--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -20,7 +20,7 @@ from botorch.acquisition.multi_objective.monte_carlo import (
     qNoisyExpectedHypervolumeImprovement,
 )
 from botorch.fit import fit_fully_bayesian_model_nuts, fit_gpytorch_model
-from botorch.models import ModelListGP, SaasFullyBayesianSingleTaskGP
+from botorch.models import ModelListGP
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
 from botorch.models.gp_regression_fidelity import (
     FixedNoiseMultiFidelityGP,
@@ -32,6 +32,7 @@ from botorch.models.model import Model, ModelList
 from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
 from botorch.models.pairwise_gp import PairwiseGP
 from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
+from botorch.utils.transforms import is_fully_bayesian
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from torch import Tensor
 
@@ -267,7 +268,7 @@ def fit_botorch_model(
     models = model.models if isinstance(model, (ModelListGP, ModelList)) else [model]
     for m in models:
         # TODO: Support deterministic models when we support `ModelList`
-        if isinstance(m, SaasFullyBayesianSingleTaskGP):
+        if is_fully_bayesian(m):
             fit_fully_bayesian_model_nuts(m, disable_progbar=True)
         elif isinstance(m, (GPyTorchModel, PairwiseGP)):
             mll_options = mll_options or {}

--- a/ax/models/torch/tests/test_list_surrogate.py
+++ b/ax/models/torch/tests/test_list_surrogate.py
@@ -16,7 +16,11 @@ from ax.models.torch.botorch_modular.utils import choose_model_class
 from ax.models.torch.tests.test_surrogate import SingleTaskGPWithDifferentConstructor
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.torch_stubs import get_torch_test_data
-from botorch.models import SaasFullyBayesianSingleTaskGP, SingleTaskGP
+from botorch.models import (
+    SaasFullyBayesianMultiTaskGP,
+    SaasFullyBayesianSingleTaskGP,
+    SingleTaskGP,
+)
 from botorch.models.deterministic import GenericDeterministicModel
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
@@ -277,6 +281,7 @@ class ListSurrogateTest(TestCase):
                 mll_class=ExactMarginalLogLikelihood,
             ),
             ListSurrogate(botorch_submodel_class=SaasFullyBayesianSingleTaskGP),
+            ListSurrogate(botorch_submodel_class=SaasFullyBayesianMultiTaskGP),
         ]
 
         for i, surrogate in enumerate(surrogates):


### PR DESCRIPTION
Summary: Update the `fit_botorch_model` util so that we can run MCMC to fit each SaasFullyBayesianMultiTaskGP independently

Reviewed By: dme65, lena-kashtelyan

Differential Revision: D36151097

