### PR TITLE
Remove botorch imports from RiskMeasure

### DIFF
--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -181,11 +181,6 @@ class OptimizationConfig(Base):
             unconstrainable_metrics=unconstrainable_metrics,
             outcome_constraints=outcome_constraints,
         )
-        # Ensure that the risk measure is single-output.
-        if risk_measure is not None and risk_measure.is_multi_output:
-            raise UserInputError(
-                "Received a multi-output risk measure for a single objective problem."
-            )
 
     @staticmethod
     def _validate_outcome_constraints(
@@ -416,18 +411,6 @@ class MultiObjectiveOptimizationConfig(OptimizationConfig):
             unconstrainable_metrics=unconstrainable_metrics,
             outcome_constraints=outcome_constraints,
         )
-        if risk_measure is not None:
-            if isinstance(objective, MultiObjective):
-                if not risk_measure.is_multi_output:
-                    raise UserInputError(
-                        "A multi-output risk measure must be used with a "
-                        "`MultiObjective`."
-                    )
-            elif risk_measure.is_multi_output:
-                raise UserInputError(
-                    "A single-output risk measure must be used with a "
-                    "`ScalarizedObjective`"
-                )
 
     def __repr__(self) -> str:
         base_repr = (

--- a/ax/core/tests/test_optimization_config.py
+++ b/ax/core/tests/test_optimization_config.py
@@ -39,8 +39,7 @@ MOOC_STR = (
 
 
 class OptimizationConfigTest(TestCase):
-    # pyre-fixme[3]: Return type must be annotated.
-    def setUp(self):
+    def setUp(self) -> None:
         self.metrics = {
             "m1": Metric(name="m1"),
             "m2": Metric(name="m2"),
@@ -81,8 +80,7 @@ class OptimizationConfigTest(TestCase):
             options={"n_w": 2},
         )
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def testInit(self):
+    def testInit(self) -> None:
         config1 = OptimizationConfig(
             objective=self.objective, outcome_constraints=self.outcome_constraints
         )
@@ -117,16 +115,8 @@ class OptimizationConfigTest(TestCase):
         )
         self.assertEqual(str(config3), expected_str)
         self.assertIs(config3.risk_measure, self.single_output_risk_measure)
-        # Error with multi-output risk measure.
-        with self.assertRaisesRegex(UserInputError, "multi-output risk"):
-            OptimizationConfig(
-                objective=self.objective,
-                outcome_constraints=self.outcome_constraints,
-                risk_measure=self.multi_output_risk_measure,
-            )
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def testEq(self):
+    def testEq(self) -> None:
         config1 = OptimizationConfig(
             objective=self.objective,
             outcome_constraints=self.outcome_constraints,
@@ -148,8 +138,7 @@ class OptimizationConfigTest(TestCase):
         )
         self.assertNotEqual(config1, config3)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def testConstraintValidation(self):
+    def testConstraintValidation(self) -> None:
         # Can build OptimizationConfig with MultiObjective
         with self.assertRaises(ValueError):
             OptimizationConfig(objective=self.multi_objective)
@@ -227,8 +216,7 @@ class OptimizationConfigTest(TestCase):
             config.outcome_constraints, [self.outcome_constraint, opposing_constraint]
         )
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def testClone(self):
+    def testClone(self) -> None:
         config1 = OptimizationConfig(
             objective=self.objective,
             outcome_constraints=self.outcome_constraints,
@@ -238,8 +226,7 @@ class OptimizationConfigTest(TestCase):
 
 
 class MultiObjectiveOptimizationConfigTest(TestCase):
-    # pyre-fixme[3]: Return type must be annotated.
-    def setUp(self):
+    def setUp(self) -> None:
         self.metrics = {
             "m1": Metric(name="m1", lower_is_better=True),
             "m2": Metric(name="m2", lower_is_better=False),
@@ -298,8 +285,7 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
             options={"n_w": 2},
         )
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def testInit(self):
+    def testInit(self) -> None:
         config1 = MultiObjectiveOptimizationConfig(
             objective=self.multi_objective, outcome_constraints=self.outcome_constraints
         )
@@ -371,25 +357,14 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
             "MultiOutputExpectation, options={'n_w': 2}))"
         )
         self.assertEqual(str(config6), expected_str)
-        with self.assertRaisesRegex(UserInputError, "multi-output risk"):
-            MultiObjectiveOptimizationConfig(
-                objective=self.multi_objective,
-                risk_measure=self.single_output_risk_measure,
-            )
         # With scalarized objective.
         config7 = MultiObjectiveOptimizationConfig(
             objective=self.scalarized_objective,
             risk_measure=self.single_output_risk_measure,
         )
         self.assertIs(config7.risk_measure, self.single_output_risk_measure)
-        with self.assertRaisesRegex(UserInputError, "single-output risk"):
-            MultiObjectiveOptimizationConfig(
-                objective=self.scalarized_objective,
-                risk_measure=self.multi_output_risk_measure,
-            )
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def testEq(self):
+    def testEq(self) -> None:
         config1 = MultiObjectiveOptimizationConfig(
             objective=self.multi_objective, outcome_constraints=self.outcome_constraints
         )
@@ -407,8 +382,7 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
         )
         self.assertNotEqual(config1, config3)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def testConstraintValidation(self):
+    def testConstraintValidation(self) -> None:
         # Cannot build with non-MultiObjective
         with self.assertRaises(TypeError):
             MultiObjectiveOptimizationConfig(objective=self.objective)
@@ -481,8 +455,7 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
             config.outcome_constraints, [self.outcome_constraint, opposing_constraint]
         )
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def testClone(self):
+    def testClone(self) -> None:
         config1 = MultiObjectiveOptimizationConfig(
             objective=self.multi_objective, outcome_constraints=self.outcome_constraints
         )
@@ -494,8 +467,7 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
         )
         self.assertEqual(config2, config2.clone())
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def testCloneWithArgs(self):
+    def testCloneWithArgs(self) -> None:
         config1 = MultiObjectiveOptimizationConfig(
             objective=self.multi_objective_just_m2,
             outcome_constraints=[self.m1_constraint],

--- a/ax/core/tests/test_risk_measures.py
+++ b/ax/core/tests/test_risk_measures.py
@@ -4,25 +4,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ax.core.risk_measures import RISK_MEASURE_NAME_TO_CLASS, RiskMeasure, VaR
-from ax.exceptions.core import UserInputError
+from ax.core.risk_measures import RiskMeasure
 from ax.utils.common.testutils import TestCase
 
 
 class TestRiskMeasure(TestCase):
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_risk_measure(self):
+    def test_risk_measure(self) -> None:
         rm = RiskMeasure(
             risk_measure="VaR",
             options={"alpha": 0.8, "n_w": 5},
         )
         self.assertEqual(rm.risk_measure, "VaR")
         self.assertEqual(rm.options, {"alpha": 0.8, "n_w": 5})
-        rm_module = rm.module
-        self.assertIsInstance(rm_module, VaR)
-        self.assertEqual(rm_module.alpha, 0.8)
-        self.assertEqual(rm_module.n_w, 5)
-        self.assertFalse(rm.is_multi_output)
 
         # Test repr.
         expected_repr = (
@@ -33,32 +26,3 @@ class TestRiskMeasure(TestCase):
         # Test clone.
         rm_clone = rm.clone()
         self.assertEqual(str(rm), str(rm_clone))
-
-        # Test unknown risk measure.
-        with self.assertRaisesRegex(UserInputError, "constructing"):
-            RiskMeasure(
-                risk_measure="VVar",
-                options={},
-            )
-        # Test invalid options.
-        with self.assertRaisesRegex(UserInputError, "constructing"):
-            RiskMeasure(
-                risk_measure="VaR",
-                options={"alpha": 5, "n_w": 5},
-            )
-
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_custom_risk_measure(self):
-        # Test using user-defined risk measures.
-
-        class CustomRM(VaR):
-            pass
-
-        RISK_MEASURE_NAME_TO_CLASS["custom"] = CustomRM
-
-        rm = RiskMeasure(
-            risk_measure="custom",
-            options={"alpha": 0.8, "n_w": 5},
-        )
-        self.assertEqual(rm.risk_measure, "custom")
-        self.assertIsInstance(rm.module, CustomRM)

--- a/ax/modelbridge/tests/test_modelbridge_utils.py
+++ b/ax/modelbridge/tests/test_modelbridge_utils.py
@@ -9,16 +9,65 @@ from ax.core.metric import Metric
 from ax.core.objective import MultiObjective
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
+from ax.core.risk_measures import RiskMeasure
 from ax.core.search_space import RobustSearchSpace
 from ax.core.types import ComparisonOp
-from ax.modelbridge.modelbridge_utils import extract_robust_digest, feasible_hypervolume
+from ax.exceptions.core import UserInputError
+from ax.modelbridge.modelbridge_utils import (
+    extract_risk_measure,
+    extract_robust_digest,
+    feasible_hypervolume,
+    RISK_MEASURE_NAME_TO_CLASS,
+)
 from ax.utils.common.testutils import TestCase
+from ax.utils.common.typeutils import not_none
 from ax.utils.testing.core_stubs import get_robust_search_space, get_search_space
+from botorch.acquisition.risk_measures import VaR
 
 
 class TestModelBridgeUtils(TestCase):
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_extract_robust_digest(self):
+    def test_extract_risk_measure(self) -> None:
+        rm = RiskMeasure(
+            risk_measure="VaR",
+            options={"alpha": 0.8, "n_w": 5},
+        )
+        rm_module = extract_risk_measure(risk_measure=rm)
+        self.assertIsInstance(rm_module, VaR)
+        self.assertEqual(rm_module.alpha, 0.8)
+        self.assertEqual(rm_module.n_w, 5)
+
+        # Test unknown risk measure.
+        with self.assertRaisesRegex(UserInputError, "constructing"):
+            extract_risk_measure(
+                risk_measure=RiskMeasure(
+                    risk_measure="VVar",
+                    options={},
+                )
+            )
+        # Test invalid options.
+        with self.assertRaisesRegex(UserInputError, "constructing"):
+            extract_risk_measure(
+                risk_measure=RiskMeasure(
+                    risk_measure="VaR",
+                    options={"alpha": 5, "n_w": 5},
+                )
+            )
+
+        # Test using user-defined risk measures.
+
+        class CustomRM(VaR):
+            pass
+
+        RISK_MEASURE_NAME_TO_CLASS["custom"] = CustomRM
+
+        rm = RiskMeasure(
+            risk_measure="custom",
+            options={"alpha": 0.8, "n_w": 5},
+        )
+        self.assertEqual(rm.risk_measure, "custom")
+        self.assertIsInstance(extract_risk_measure(risk_measure=rm), CustomRM)
+
+    def test_extract_robust_digest(self) -> None:
         # Test with non-robust search space.
         ss = get_search_space()
         self.assertIsNone(extract_robust_digest(ss, list(ss.parameters)))
@@ -29,16 +78,11 @@ class TestModelBridgeUtils(TestCase):
                 for p in rss.parameter_distributions:
                     p.multiplicative = True
                 rss.multiplicative = True
-            robust_digest = extract_robust_digest(rss, list(rss.parameters))
-            # pyre-fixme[16]: Optional type has no attribute `multiplicative`.
+            robust_digest = not_none(extract_robust_digest(rss, list(rss.parameters)))
             self.assertEqual(robust_digest.multiplicative, multiplicative)
-            # pyre-fixme[16]: Optional type has no attribute `environmental_variables`.
             self.assertEqual(robust_digest.environmental_variables, [])
-            # pyre-fixme[16]: Optional type has no attribute `sample_environmental`.
             self.assertIsNone(robust_digest.sample_environmental)
-            # pyre-fixme[16]: Optional type has no attribute
-            #  `sample_param_perturbations`.
-            samples = robust_digest.sample_param_perturbations()
+            samples = not_none(robust_digest.sample_param_perturbations)()
             self.assertEqual(samples.shape, (8, 4))
             constructor = np.ones if multiplicative else np.zeros
             self.assertTrue(np.equal(samples[:, 2:], constructor((8, 2))).all())
@@ -46,8 +90,10 @@ class TestModelBridgeUtils(TestCase):
             self.assertTrue(np.all(samples[:, 1] > 0))
             # Check that it works as expected if param_names is missing some
             # non-distributional parameters.
-            robust_digest = extract_robust_digest(rss, list(rss.parameters)[:-1])
-            samples = robust_digest.sample_param_perturbations()
+            robust_digest = not_none(
+                extract_robust_digest(rss, list(rss.parameters)[:-1])
+            )
+            samples = not_none(robust_digest.sample_param_perturbations)()
             self.assertEqual(samples.shape, (8, 3))
             self.assertTrue(np.equal(samples[:, 2:], constructor((8, 1))).all())
             self.assertTrue(np.all(samples[:, 1] > 0))
@@ -62,11 +108,11 @@ class TestModelBridgeUtils(TestCase):
             num_samples=8,
             environmental_variables=all_params[:2],
         )
-        robust_digest = extract_robust_digest(rss, list(rss.parameters))
+        robust_digest = not_none(extract_robust_digest(rss, list(rss.parameters)))
         self.assertFalse(robust_digest.multiplicative)
         self.assertIsNone(robust_digest.sample_param_perturbations)
         self.assertEqual(robust_digest.environmental_variables, ["x", "y"])
-        samples = robust_digest.sample_environmental()
+        samples = not_none(robust_digest.sample_environmental)()
         self.assertEqual(samples.shape, (8, 2))
         # Both are continuous distributions, should be non-zero.
         self.assertTrue(np.all(samples != 0))
@@ -80,14 +126,15 @@ class TestModelBridgeUtils(TestCase):
             num_samples=8,
             environmental_variables=all_params[:1],
         )
-        robust_digest = extract_robust_digest(rss, list(rss.parameters))
+        robust_digest = not_none(extract_robust_digest(rss, list(rss.parameters)))
         self.assertFalse(robust_digest.multiplicative)
-        self.assertEqual(robust_digest.sample_param_perturbations().shape, (8, 3))
-        self.assertEqual(robust_digest.sample_environmental().shape, (8, 1))
+        self.assertEqual(
+            not_none(robust_digest.sample_param_perturbations)().shape, (8, 3)
+        )
+        self.assertEqual(not_none(robust_digest.sample_environmental)().shape, (8, 1))
         self.assertEqual(robust_digest.environmental_variables, ["x"])
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_feasible_hypervolume(self):
+    def test_feasible_hypervolume(self) -> None:
         ma = Metric(name="a", lower_is_better=False)
         mb = Metric(name="b", lower_is_better=True)
         mc = Metric(name="c", lower_is_better=False)


### PR DESCRIPTION
Summary:
The last piece in the quest to purge torch dependencies from ax/core.

Removes the botorch imports from `ax/core/risk_measure.py` and moves the functionality that depends on these imports into `modelbridge_utils`. The `extract_risk_measure` utility will be used to construct the risk measure in `TorchModelBridge`, which will then be added to `TorchOptConfig`.

With this change, we had to sacrifice some of the validation logic in constructing the risk measure & the corresponding `optimization_config`.

Differential Revision: D39401259

