### PR TITLE
Remove catch_warnings from AxClient._gen_new_generator_run

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1602,9 +1602,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         # so if we just set the seed without the context manager, it can have
         # serious negative impact on the performance of the models that employ
         # stochasticity.
-        with manual_seed(seed=self._random_seed) and warnings.catch_warnings():
-            # Filter out GPYTorch warnings to avoid confusing users.
-            warnings.simplefilter("ignore")
+        with manual_seed(seed=self._random_seed):
             return not_none(self.generation_strategy).gen(
                 experiment=self.experiment,
                 n=n,


### PR DESCRIPTION
Summary: This masks some important upstream warnings, and is no longer needed. In addition, the `and` between the two context managers was effectively disabling the `manual_seed` context, thus leading to reproducibility issues.

Differential Revision: D39473176

