### PR TITLE
`fit_gyptorch_model` refactor (#1371)

### DIFF
--- a/ax/modelbridge/tests/test_rembo_strategy.py
+++ b/ax/modelbridge/tests/test_rembo_strategy.py
@@ -29,10 +29,10 @@ class REMBOStrategyTest(TestCase):
             torch.randn((2, 6), dtype=torch.double),
         ),
     )
-    @patch("ax.models.torch.botorch_defaults.fit_gpytorch_model", autospec=True)
+    @patch("ax.models.torch.botorch_defaults.fit_gpytorch_mll", autospec=True)
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
-    def test_REMBOStrategy(self, mock_fit_gpytorch_model, mock_optimize_acqf):
+    def test_REMBOStrategy(self, mock_fit_gpytorch_mll, mock_optimize_acqf):
         # Construct a high-D test experiment with multiple metrics
         hartmann_search_space = SearchSpace(
             parameters=[
@@ -88,7 +88,7 @@ class REMBOStrategyTest(TestCase):
         # Iterate until the first projection fits a GP
         for _ in range(4):
             exp.new_batch_trial(generator_run=gs.gen(experiment=exp, n=2)).run()
-            mock_fit_gpytorch_model.assert_not_called()
+            mock_fit_gpytorch_mll.assert_not_called()
 
         self.assertEqual(len(gs.arms_by_proj[0]), 4)
         self.assertEqual(len(gs.arms_by_proj[1]), 4)
@@ -105,11 +105,11 @@ class REMBOStrategyTest(TestCase):
 
             exp.new_batch_trial(generator_run=gs.gen(experiment=exp, n=2)).run()
             if i < 2:
-                mock_fit_gpytorch_model.assert_not_called()
+                mock_fit_gpytorch_mll.assert_not_called()
             else:
                 # After all proj. have > 4 arms' worth of data, GP can be fit.
                 self.assertFalse(any(len(x) < 4 for x in gs.arms_by_proj.values()))
-                mock_fit_gpytorch_model.assert_called()
+                mock_fit_gpytorch_mll.assert_called()
 
         self.assertTrue(len(gs.model_transitions) > 0)
         gs2 = gs.clone_reset()

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -33,7 +33,7 @@ from gpytorch.priors import GammaPrior
 from gpytorch.priors.lkj_prior import LKJCovariancePrior
 
 
-FIT_MODEL_MO_PATH = f"{get_and_fit_model.__module__}.fit_gpytorch_model"
+FIT_MODEL_MO_PATH = f"{get_and_fit_model.__module__}.fit_gpytorch_mll"
 SAMPLE_SIMPLEX_UTIL_PATH = f"{sample_simplex.__module__}.sample_simplex"
 SAMPLE_HYPERSPHERE_UTIL_PATH = f"{sample_simplex.__module__}.sample_hypersphere"
 CHEBYSHEV_SCALARIZATION_PATH = (

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -36,7 +36,7 @@ GET_OBJ_PATH = (
     "get_weighted_mc_objective_and_objective_thresholds"
 )
 
-FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_gpytorch_model"
+FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_gpytorch_mll"
 
 
 # pyre-fixme[3]: Return type must be annotated.

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -34,7 +34,7 @@ from botorch.utils.multi_objective.scalarization import get_chebyshev_scalarizat
 from botorch.utils.testing import MockModel, MockPosterior
 
 
-FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_gpytorch_model"
+FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_gpytorch_mll"
 SAMPLE_SIMPLEX_UTIL_PATH = "ax.models.torch.utils.sample_simplex"
 SAMPLE_HYPERSPHERE_UTIL_PATH = "ax.models.torch.utils.sample_hypersphere"
 CHEBYSHEV_SCALARIZATION_PATH = (

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -18,7 +18,7 @@ from botorch.acquisition.objective import ConstrainedMCObjective, GenericMCObjec
 from botorch.acquisition.penalized import PenalizedMCObjective
 from botorch.acquisition.utils import get_acquisition_function, get_infeasible_cost
 from botorch.exceptions.errors import UnsupportedError
-from botorch.fit import fit_gpytorch_model
+from botorch.fit import fit_gpytorch_mll
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
 from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.gpytorch import GPyTorchModel
@@ -174,7 +174,7 @@ def get_and_fit_model(
             mll = SumMarginalLogLikelihood(model.likelihood, model, mll_cls=mll_cls)
         else:
             mll = mll_cls(model.likelihood, model)
-        mll = fit_gpytorch_model(mll, bounds=bounds)
+        mll = fit_gpytorch_mll(mll, optimizer_kwargs={"bounds": bounds})
     return model
 
 

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -20,8 +20,7 @@ from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
     qNoisyExpectedHypervolumeImprovement,
 )
-from botorch.fit import fit_fully_bayesian_model_nuts, fit_gpytorch_model
-from botorch.models import ModelListGP
+from botorch.fit import fit_fully_bayesian_model_nuts, fit_gpytorch_mll
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
 from botorch.models.gp_regression_fidelity import (
     FixedNoiseMultiFidelityGP,
@@ -30,6 +29,7 @@ from botorch.models.gp_regression_fidelity import (
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel, GPyTorchModel
 from botorch.models.model import Model, ModelList
+from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
 from botorch.models.pairwise_gp import PairwiseGP
 from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
@@ -272,7 +272,7 @@ def fit_botorch_model(
         elif isinstance(m, (GPyTorchModel, PairwiseGP)):
             mll_options = mll_options or {}
             mll = mll_class(likelihood=m.likelihood, model=m, **mll_options)
-            fit_gpytorch_model(mll)
+            fit_gpytorch_mll(mll)
         else:
             raise NotImplementedError(
                 f"Model of type {m.__class__.__name__} is currently not supported."

--- a/ax/models/torch/cbo_lcea.py
+++ b/ax/models/torch/cbo_lcea.py
@@ -15,7 +15,7 @@ from ax.models.torch.cbo_sac import generate_model_space_decomposition
 from ax.models.torch_base import TorchModel, TorchOptConfig
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.logger import get_logger
-from botorch.fit import fit_gpytorch_model
+from botorch.fit import fit_gpytorch_mll
 from botorch.models.contextual import LCEAGP
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model_list_gp_regression import ModelListGP
@@ -60,7 +60,7 @@ def get_map_model(
         context_weight_dict=context_weight_dict,
     )
     mll = ExactMarginalLogLikelihood(model.likelihood, model)
-    fit_gpytorch_model(mll)
+    fit_gpytorch_mll(mll)
     return model, mll
 
 

--- a/ax/models/torch/cbo_lcem.py
+++ b/ax/models/torch/cbo_lcem.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 import torch
 from ax.models.torch.botorch import BotorchModel
-from botorch.fit import fit_gpytorch_model
+from botorch.fit import fit_gpytorch_mll
 from botorch.models.contextual_multioutput import FixedNoiseLCEMGP, LCEMGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
@@ -92,5 +92,5 @@ class LCEMBO(BotorchModel):
         model = ModelListGP(*models)
         model.to(Xs[0])
         mll = SumMarginalLogLikelihood(model.likelihood, model)
-        fit_gpytorch_model(mll)
+        fit_gpytorch_mll(mll)
         return model

--- a/ax/models/torch/cbo_sac.py
+++ b/ax/models/torch/cbo_sac.py
@@ -13,7 +13,7 @@ from ax.models.torch.botorch import BotorchModel
 from ax.models.torch_base import TorchModel
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.logger import get_logger
-from botorch.fit import fit_gpytorch_model
+from botorch.fit import fit_gpytorch_mll
 from botorch.models.contextual import SACGP
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model_list_gp_regression import ModelListGP
@@ -92,7 +92,7 @@ class SACBO(BotorchModel):
             Yvar = Yvars[i].clamp_min_(MIN_OBSERVED_NOISE_LEVEL)
             gp_m = SACGP(X, Ys[i], Yvar, decomp_index)
             mll = ExactMarginalLogLikelihood(gp_m.likelihood, gp_m)
-            fit_gpytorch_model(mll)
+            fit_gpytorch_mll(mll)
             models.append(gp_m)
 
         if len(models) == 1:

--- a/ax/models/torch/tests/test_list_surrogate.py
+++ b/ax/models/torch/tests/test_list_surrogate.py
@@ -269,7 +269,7 @@ class ListSurrogateTest(TestCase):
 
     @patch(f"{CURRENT_PATH}.ModelListGP.load_state_dict", return_value=None)
     @patch(f"{CURRENT_PATH}.ExactMarginalLogLikelihood")
-    @patch(f"{UTILS_PATH}.fit_gpytorch_model")
+    @patch(f"{UTILS_PATH}.fit_gpytorch_mll")
     @patch(f"{UTILS_PATH}.fit_fully_bayesian_model_nuts")
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
@@ -287,7 +287,7 @@ class ListSurrogateTest(TestCase):
         for i, surrogate in enumerate(surrogates):
             # Checking that model is None before `fit` (and `construct`) calls.
             self.assertIsNone(surrogate._model)
-            # Should instantiate mll and `fit_gpytorch_model` when `state_dict`
+            # Should instantiate mll and `fit_gpytorch_mll` when `state_dict`
             # is `None`.
             surrogate.fit(
                 datasets=self.fixed_noise_training_data,

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -101,7 +101,7 @@ class SurrogateTest(TestCase):
             self.assertEqual(surrogate.botorch_model_class, botorch_model_class)
             self.assertEqual(surrogate.mll_class, self.mll_class)
 
-    @patch(f"{UTILS_PATH}.fit_gpytorch_model")
+    @patch(f"{UTILS_PATH}.fit_gpytorch_mll")
     # pyre-fixme[3]: Return type must be annotated.
     def test_mll_options(self, _):
         mock_mll = MagicMock(self.mll_class)
@@ -284,7 +284,7 @@ class SurrogateTest(TestCase):
     )
     @patch(f"{CURRENT_PATH}.SingleTaskGP.load_state_dict", return_value=None)
     @patch(f"{UTILS_PATH}.fit_fully_bayesian_model_nuts")
-    @patch(f"{UTILS_PATH}.fit_gpytorch_model")
+    @patch(f"{UTILS_PATH}.fit_gpytorch_mll")
     @patch(f"{CURRENT_PATH}.ExactMarginalLogLikelihood")
     # pyre-fixme[3]: Return type must be annotated.
     def test_fit(
@@ -305,7 +305,7 @@ class SurrogateTest(TestCase):
             )
             # Checking that model is None before `fit` (and `construct`) calls.
             self.assertIsNone(surrogate._model)
-            # Should instantiate mll and `fit_gpytorch_model` when `state_dict`
+            # Should instantiate mll and `fit_gpytorch_mll` when `state_dict`
             # is `None`.
             surrogate.fit(
                 datasets=self.training_data,
@@ -460,7 +460,7 @@ class SurrogateTest(TestCase):
     )
     @patch(f"{CURRENT_PATH}.SingleTaskGP.load_state_dict", return_value=None)
     @patch(f"{UTILS_PATH}.fit_fully_bayesian_model_nuts")
-    @patch(f"{UTILS_PATH}.fit_gpytorch_model")
+    @patch(f"{UTILS_PATH}.fit_gpytorch_mll")
     @patch(f"{CURRENT_PATH}.ExactMarginalLogLikelihood")
     # pyre-fixme[3]: Return type must be annotated.
     def test_update(


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/1371

This commit updates `fit_gpytorch_model` and related methods, with the aim of fixing existing issues and improving extensibility. Key changes are as follow:

- Replace `fit_gpytorch_model` with `fit_gpytorch_mll`, a `Dispatcher` backed reimplementation of the original model fitting pipeline. Note that `fit_gpytorch_mll` does **not** pass `kwargs` to `optimizer` and instead introduces an optional `optimizer_kwargs` argument.

- Convert `fit_gpytorch_model` into a convenience method for calling `fit_gpytorch_mll` with (limited) support for legacy API.

- Add validation for multioutput GP fitting routines based on decomposing a single model into a list of independent models.

- Updated unit tests for relevant code paths.

Differential Revision: D38692173

