### PR TITLE
Run cron job if a PR modifies tutorials

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -6,6 +6,9 @@ on:
     - cron:  '0 5 * * *'
   # allow this to be scheduled manually in addition to cron
   workflow_dispatch:
+  push:
+    paths:
+      - "tutorials/**"
 
 
 jobs:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,6 +7,11 @@ on:
   # allow this to be scheduled manually in addition to cron
   workflow_dispatch:
   push:
+    branches: [ main ]
+    paths:
+      - "tutorials/**"
+  pull_request:
+    branches: [ main ]
     paths:
       - "tutorials/**"
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -105,6 +105,7 @@ jobs:
         pip install matplotlib  # Required for building Multi-objective tutorial notebook.
         pip install pyro-ppl  # Required for to call run_inference
         pip install torchx  # For torchx unit tests.
+        pip install pytorch-lightning # For the early stopping tutorial
         pip install "protobuf<4"  # Temporary fix for tensorboard / ray import errors.
     - name: Build tutorials
       run: |
@@ -137,6 +138,7 @@ jobs:
         pip install pyro-ppl  # Required for to call run_inference
         pip install tensorboard  # For generating Sphinx docs for TensorboardCurveMetric
         pip install torchx  # For generating Sphinx docs for TorchXMetric.
+        pip install pytorch-lightning # For the early stopping tutorial
         pip install "protobuf<4"  # Temporary fix for tensorboard / ray import errors.
     - name: Publish latest website
       env:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -104,6 +104,7 @@ jobs:
         pip install tensorboardX  # Required for building RayTune tutorial notebook.
         pip install matplotlib  # Required for building Multi-objective tutorial notebook.
         pip install pyro-ppl  # Required for to call run_inference
+        pip install torchx  # For torchx unit tests.
         pip install "protobuf<4"  # Temporary fix for tensorboard / ray import errors.
     - name: Build tutorials
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,7 @@ jobs:
         pip install pyro-ppl  # Required for to call run_inference
         pip install tensorboard  # For generating Sphinx docs for TensorboardCurveMetric
         pip install torchx  # For generating Sphinx docs for TorchXMetric.
+        pip install pytorch-lightning # For the early stopping tutorial
         pip install "protobuf<4"  # Temporary fix for tensorboard / ray import errors.
     - name: Publish latest website
       env:


### PR DESCRIPTION
This should help catch tutorial failures. Also fixes the failures due to missing dependencies in the early stopping tutorial.