### PR TITLE
Robust candidate generation via MBM

### DIFF
--- a/ax/modelbridge/tests/test_robust.py
+++ b/ax/modelbridge/tests/test_robust.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+from ax.core import Objective, OptimizationConfig
+from ax.core.objective import MultiObjective
+from ax.core.observation import ObservationFeatures
+from ax.core.optimization_config import (
+    MultiObjectiveOptimizationConfig,
+    ObjectiveThreshold,
+)
+from ax.core.risk_measures import RiskMeasure
+from ax.core.types import ComparisonOp
+from ax.exceptions.core import UnsupportedError
+from ax.metrics.branin import BraninMetric
+from ax.modelbridge.registry import Models
+from ax.models.torch.botorch_modular.list_surrogate import ListSurrogate
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_robust_branin_experiment
+from ax.utils.testing.mock import fast_botorch_optimize
+from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
+from botorch.acquisition.multi_objective.monte_carlo import (
+    qNoisyExpectedHypervolumeImprovement,
+)
+from botorch.models.gp_regression import FixedNoiseGP
+
+
+class TestRobust(TestCase):
+    @fast_botorch_optimize
+    def test_robust(
+        self,
+        risk_measure: Optional[RiskMeasure] = None,
+        optimization_config: Optional[OptimizationConfig] = None,
+        acqf_class: Optional[str] = None,
+        use_list_surrogate: bool = False,
+    ) -> None:
+        exp = get_robust_branin_experiment(
+            risk_measure=risk_measure,
+            optimization_config=optimization_config,
+        )
+
+        for _ in range(5):
+            if use_list_surrogate:
+                surrogate = ListSurrogate(botorch_submodel_class=FixedNoiseGP)
+            else:
+                surrogate = Surrogate(botorch_model_class=FixedNoiseGP)
+            modelbridge = Models.BOTORCH_MODULAR(
+                experiment=exp,
+                data=exp.fetch_data(),
+                surrogate=surrogate,
+                botorch_acqf_class=acqf_class or qNoisyExpectedImprovement,
+            )
+            trial = (
+                exp.new_trial(generator_run=modelbridge.gen(1)).run().mark_completed()
+            )
+
+        obs = ObservationFeatures(parameters=trial.arm.parameters)
+        modelbridge.predict([obs])
+
+    def test_robust_multi_objective(self) -> None:
+        risk_measure = RiskMeasure(
+            risk_measure="MultiOutputExpectation",
+            options={"n_w": 16},
+        )
+        metrics = [
+            BraninMetric(
+                name=f"branin_{i}", param_names=["x1", "x2"], lower_is_better=True
+            )
+            for i in range(2)
+        ]
+        optimization_config = MultiObjectiveOptimizationConfig(
+            objective=MultiObjective(
+                [
+                    Objective(
+                        metric=m,
+                        minimize=True,
+                    )
+                    for m in metrics
+                ]
+            ),
+            objective_thresholds=[
+                ObjectiveThreshold(metric=m, bound=10.0, relative=False)
+                for m in metrics
+            ],
+            risk_measure=risk_measure,
+        )
+        for use_list_surrogate in (True, False):
+            with self.subTest(use_list_surrogate=use_list_surrogate):
+                self.test_robust(
+                    risk_measure,
+                    optimization_config,
+                    acqf_class=qNoisyExpectedHypervolumeImprovement,
+                    use_list_surrogate=use_list_surrogate,
+                )
+
+    def test_mars(self) -> None:
+        risk_measure = RiskMeasure(
+            risk_measure="MARS",
+            options={"n_w": 16, "alpha": 0.8},
+        )
+        metrics = [
+            BraninMetric(
+                name=f"branin_{i}", param_names=["x1", "x2"], lower_is_better=False
+            )
+            for i in range(2)
+        ]
+        optimization_config = MultiObjectiveOptimizationConfig(
+            objective=MultiObjective(
+                [
+                    Objective(
+                        metric=m,
+                        minimize=False,
+                    )
+                    for m in metrics
+                ]
+            ),
+            objective_thresholds=[
+                ObjectiveThreshold(
+                    metric=m, bound=10.0, relative=False, op=ComparisonOp.GEQ
+                )
+                for m in metrics
+            ],
+            risk_measure=risk_measure,
+        )
+        self.test_robust(
+            risk_measure,
+            optimization_config,
+            acqf_class=qNoisyExpectedImprovement,
+        )
+
+    def test_unsupported_model(self) -> None:
+        exp = get_robust_branin_experiment()
+        with self.assertRaisesRegex(UnsupportedError, "support robust"):
+            Models.GPEI(
+                experiment=exp,
+                data=exp.fetch_data(),
+            ).gen(n=1)

--- a/ax/models/model_utils.py
+++ b/ax/models/model_utils.py
@@ -18,6 +18,7 @@ from ax.core.types import TParamCounter
 from ax.exceptions.core import SearchSpaceExhausted
 from ax.models.torch_base import TorchModel
 from ax.models.types import TConfig
+from botorch.acquisition.risk_measures import RiskMeasureMCObjective
 
 
 Tensoray = Union[torch.Tensor, np.ndarray]
@@ -234,6 +235,7 @@ def best_observed_point(
     outcome_constraints: Optional[Tuple[Tensoray, Tensoray]] = None,
     linear_constraints: Optional[Tuple[Tensoray, Tensoray]] = None,
     fixed_features: Optional[Dict[int, float]] = None,
+    risk_measure: Optional[RiskMeasureMCObjective] = None,
     options: Optional[TConfig] = None,
 ) -> Optional[Tensoray]:
     """Select the best point that has been observed.
@@ -279,6 +281,7 @@ def best_observed_point(
             A x <= b.
         fixed_features: A map {feature_index: value} for features that
             should be fixed to a particular value in the best point.
+        risk_measure: An optional risk measure for reporting best robust point.
         options: A config dictionary with settings described above.
 
     Returns:
@@ -294,6 +297,7 @@ def best_observed_point(
         outcome_constraints=outcome_constraints,
         linear_constraints=linear_constraints,
         fixed_features=fixed_features,
+        risk_measure=risk_measure,
         options=options,
     )
     return None if best_point_and_value is None else best_point_and_value[0]
@@ -307,6 +311,7 @@ def best_in_sample_point(
     outcome_constraints: Optional[Tuple[Tensoray, Tensoray]] = None,
     linear_constraints: Optional[Tuple[Tensoray, Tensoray]] = None,
     fixed_features: Optional[Dict[int, float]] = None,
+    risk_measure: Optional[RiskMeasureMCObjective] = None,
     options: Optional[TConfig] = None,
 ) -> Optional[Tuple[Tensoray, float]]:
     """Select the best point that has been observed.
@@ -353,6 +358,7 @@ def best_in_sample_point(
             A x <= b.
         fixed_features: A map {feature_index: value} for features that
             should be fixed to a particular value in the best point.
+        risk_measure: An optional risk measure for reporting best robust point.
         options: A config dictionary with settings described above.
 
     Returns:
@@ -360,6 +366,11 @@ def best_in_sample_point(
         - d-array of the best point,
         - utility at the best point.
     """
+    if risk_measure is not None:
+        # TODO[T131759268]: We need to apply the risk measure. Instead of doing obj_w @,
+        # we could use `get_botorch_objective_and_transform` to get the objective
+        # then apply it, though we also need to decide how to deal with constraints.
+        raise NotImplementedError  # pragma: no cover
     # Parse options
     if options is None:
         options = {}

--- a/ax/models/tests/test_torch_utils.py
+++ b/ax/models/tests/test_torch_utils.py
@@ -4,26 +4,32 @@
 # LICENSE file in the root directory of this source tree.
 
 from typing import Set, Tuple
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import torch
+from ax.exceptions.core import UnsupportedError
 from ax.models.torch.utils import (
     _get_X_pending_and_observed,
     get_botorch_objective_and_transform,
 )
 from ax.utils.common.testutils import TestCase
+from ax.utils.common.typeutils import checked_cast, not_none
+from botorch.acquisition.multi_objective.multi_output_risk_measures import (
+    MARS,
+    MultiOutputExpectation,
+)
 from botorch.acquisition.multi_objective.objective import WeightedMCMultiOutputObjective
 from botorch.acquisition.objective import (
     ConstrainedMCObjective,
     ScalarizedPosteriorTransform,
 )
+from botorch.acquisition.risk_measures import Expectation
 from botorch.exceptions.errors import BotorchTensorDimensionError
 from botorch.models.model import Model
 
 
 class TorchUtilsTest(TestCase):
-    # pyre-fixme[3]: Return type must be annotated.
-    def setUp(self):
+    def setUp(self) -> None:
         self.device = torch.device("cpu")
         self.dtype = torch.double
         self.mock_botorch_model = MagicMock(Model)
@@ -37,8 +43,7 @@ class TorchUtilsTest(TestCase):
         self.moo_objective_weights = torch.ones(2, **tkwargs)
         self.objective_thresholds = torch.tensor([0.5, 1.5], **tkwargs)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_get_X_pending_and_observed(self):
+    def test_get_X_pending_and_observed(self) -> None:
         def _to_obs_set(X: torch.Tensor) -> Set[Tuple[float]]:
             return {tuple(float(x_i) for x_i in x) for x in X}
 
@@ -54,8 +59,7 @@ class TorchUtilsTest(TestCase):
             fixed_features=fixed_features,
         )
         expected = Xs[0][1:]
-        # pyre-fixme[6]: For 1st param expected `Tensor` but got `Optional[Tensor]`.
-        self.assertEqual(_to_obs_set(expected), _to_obs_set(X_observed))
+        self.assertEqual(_to_obs_set(expected), _to_obs_set(not_none(X_observed)))
 
         # Filter too strict; return unfiltered X_observed
         fixed_features = {0: 1.0}
@@ -66,15 +70,13 @@ class TorchUtilsTest(TestCase):
             fixed_features=fixed_features,
         )
         expected = Xs[0]
-        # pyre-fixme[6]: For 1st param expected `Tensor` but got `Optional[Tensor]`.
-        self.assertEqual(_to_obs_set(expected), _to_obs_set(X_observed))
+        self.assertEqual(_to_obs_set(expected), _to_obs_set(not_none(X_observed)))
 
     @patch(
         f"{get_botorch_objective_and_transform.__module__}.get_infeasible_cost",
         return_value=1.0,
     )
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_get_botorch_objective(self, _):
+    def test_get_botorch_objective(self, _) -> None:
         # If there are outcome constraints, use a ConstrainedMCObjective
         obj, tf = get_botorch_objective_and_transform(
             model=self.mock_botorch_model,
@@ -112,3 +114,100 @@ class TorchUtilsTest(TestCase):
         )
         self.assertIsInstance(obj, WeightedMCMultiOutputObjective)
         self.assertIsNone(tf)
+
+    @patch(f"{MARS.__module__}.MARS.set_baseline_Y")
+    def test_get_botorch_objective_w_risk_measures(
+        self, mock_set_baseline_Y: Mock
+    ) -> None:
+        # Test outcome constraint error.
+        with self.assertRaisesRegex(NotImplementedError, "Outcome constraints"):
+            get_botorch_objective_and_transform(
+                model=self.mock_botorch_model,
+                objective_weights=self.objective_weights,
+                outcome_constraints=self.outcome_constraints,
+                risk_measure=Expectation(n_w=5),
+            )
+        # Test user supplied preprocessing function error.
+        with self.assertRaisesRegex(UnsupportedError, "User supplied"):
+            get_botorch_objective_and_transform(
+                model=self.mock_botorch_model,
+                objective_weights=self.objective_weights,
+                risk_measure=Expectation(
+                    n_w=5,
+                    preprocessing_function=WeightedMCMultiOutputObjective(
+                        weights=torch.tensor([1.0, 1.0])
+                    ),
+                ),
+            )
+        # Test MARS errors.
+        with self.assertRaisesRegex(UnsupportedError, "X_observed"):
+            get_botorch_objective_and_transform(
+                model=self.mock_botorch_model,
+                objective_weights=self.moo_objective_weights,
+                risk_measure=MARS(alpha=0.8, n_w=5, chebyshev_weights=[]),
+            )
+        # Test single objective case.
+        risk_measure, _ = get_botorch_objective_and_transform(
+            model=self.mock_botorch_model,
+            objective_weights=torch.tensor([-1.0]),
+            risk_measure=Expectation(n_w=2),
+        )
+        self.assertTrue(
+            torch.allclose(
+                not_none(risk_measure)(torch.tensor([[1.0], [2.0]])),
+                torch.tensor([-1.5]),
+            )
+        )
+        # Test scalarized objective with single objective risk measure.
+        risk_measure, _ = get_botorch_objective_and_transform(
+            model=self.mock_botorch_model,
+            objective_weights=torch.tensor([-1.0, 1.0, 0.0]),
+            risk_measure=Expectation(n_w=2),
+        )
+        Y = torch.tensor([[1.0, -1.0, 3.0], [2.0, -2.0, 3.0]])
+        self.assertTrue(
+            torch.allclose(
+                not_none(risk_measure)(Y),
+                torch.tensor([-3.0]),
+            )
+        )
+        # Test MO risk measure.
+        risk_measure, _ = get_botorch_objective_and_transform(
+            model=self.mock_botorch_model,
+            objective_weights=torch.tensor([-1.0, 2.0, 0.0]),
+            risk_measure=MultiOutputExpectation(n_w=2),
+        )
+        self.assertTrue(
+            torch.allclose(
+                not_none(risk_measure)(Y),
+                torch.tensor([-1.5, -3.0]),
+            )
+        )
+        # Test MARS.
+        risk_measure, _ = get_botorch_objective_and_transform(
+            model=self.mock_botorch_model,
+            objective_weights=torch.tensor([-1.0, 2.0, 0.0]),
+            risk_measure=MARS(
+                alpha=0.8,
+                n_w=2,
+                chebyshev_weights=[],
+                baseline_Y=torch.tensor([[0.0, 1.0], [1.0, 0.0]]),
+            ),
+            X_observed=torch.ones(2, 2),  # dummy
+        )
+        mock_set_baseline_Y.assert_called_once()
+        risk_measure = checked_cast(MARS, risk_measure)
+        self.assertIsInstance(
+            risk_measure.preprocessing_function, WeightedMCMultiOutputObjective
+        )
+        ch_weights = risk_measure.chebyshev_weights
+        self.assertEqual(ch_weights.shape, torch.Size([2]))
+        self.assertTrue(torch.allclose(ch_weights.sum(), torch.tensor(1.0)))
+        # Overwrite ch weights to simplify the test.
+        risk_measure.chebyshev_weights = [0.0, 1.0]
+        self.assertTrue(
+            torch.allclose(
+                not_none(risk_measure)(Y),
+                torch.tensor([-4.0]),
+            )
+        )

--- a/ax/models/torch/botorch_modular/multi_fidelity.py
+++ b/ax/models/torch/botorch_modular/multi_fidelity.py
@@ -7,6 +7,7 @@
 from typing import Any, Dict, Optional
 
 from ax.core.search_space import SearchSpaceDigest
+from ax.exceptions.core import UnsupportedError
 from ax.models.torch.botorch_modular.acquisition import Acquisition
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.models.torch_base import TorchOptConfig
@@ -31,6 +32,10 @@ class MultiFidelityAcquisition(Acquisition):
         torch_opt_config: TorchOptConfig,
         options: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
+        if torch_opt_config.risk_measure is not None:  # pragma: no cover
+            raise UnsupportedError(
+                f"{self.__class__.__name__} does not support risk measures."
+            )
         target_fidelities = search_space_digest.target_fidelities
         if not target_fidelities:
             raise ValueError(  # pragma: no cover

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -15,6 +15,7 @@ from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
 from ax.models.base import Model as BaseModel
 from ax.models.types import TConfig
+from botorch.acquisition.risk_measures import RiskMeasureMCObjective
 from botorch.utils.datasets import SupervisedDataset
 from torch import Tensor
 
@@ -52,6 +53,7 @@ class TorchOptConfig:
         opt_config_metrics: A dictionary of metrics that are included in
             the optimization config.
         is_moo: A boolean denoting whether this is for an MOO problem.
+        risk_measure: An optional risk measure, used for robust optimization.
     """
 
     objective_weights: Tensor
@@ -64,6 +66,7 @@ class TorchOptConfig:
     rounding_func: Optional[Callable[[Tensor], Tensor]] = None
     opt_config_metrics: Optional[Dict[str, Metric]] = None
     is_moo: bool = False
+    risk_measure: Optional[RiskMeasureMCObjective] = None
 
 
 @dataclass(frozen=True)
@@ -92,6 +95,7 @@ class TorchModel(BaseModel):
 
     dtype: Optional[torch.dtype] = None
     device: Optional[torch.device] = None
+    _supports_robust_optimization: bool = False
 
     def fit(
         self,

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -11,6 +11,7 @@ from ax.core.data import Data
 from ax.core.objective import MultiObjective, Objective
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.outcome_constraint import ObjectiveThreshold
+from ax.core.search_space import SearchSpace
 from ax.core.types import ComparisonOp
 from ax.exceptions.core import UnsupportedError
 from ax.metrics.branin import BraninMetric, NegativeBraninMetric
@@ -21,6 +22,7 @@ from ax.plot.pareto_utils import (
     compute_posterior_pareto_frontier,
     get_observed_pareto_frontiers,
     infer_reference_point_from_experiment,
+    to_nonrobust_search_space,
 )
 
 from ax.utils.common.testutils import TestCase
@@ -28,6 +30,8 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_branin_experiment_with_multi_objective,
     get_experiment_with_observations,
+    get_robust_search_space_environmental,
+    get_search_space,
 )
 
 
@@ -201,6 +205,20 @@ class ParetoUtilsTest(TestCase):
         )
         self.assertTrue(
             np.array_equal(pareto, np.array([[3.0, 0.0], [2.1, 1.0], [2.0, 2.0]]))
+        )
+
+    def test_to_nonrobust_search_space(self) -> None:
+        # Return non-robust search space as is.
+        search_space = get_search_space()
+        self.assertIs(to_nonrobust_search_space(search_space), search_space)
+        # Prune environmental variables and distributions from RSS.
+        rss = get_robust_search_space_environmental()
+        transformed_ss = to_nonrobust_search_space(rss)
+        # Can't use isinstance here since RSS is also a SearchSpace.
+        self.assertEqual(transformed_ss.__class__, SearchSpace)
+        self.assertEqual(transformed_ss.parameters, rss._parameters)
+        self.assertEqual(
+            transformed_ss.parameter_constraints, rss.parameter_constraints
         )
 
 


### PR DESCRIPTION
Summary:
This implements the core parts of robust optimization support within the MBM setup. There are still a bunch of TODOs and `NotImplementedError`s around the place that needs cleaning up for full support of constrained optimization etc. Also, the support for environmental variables is lacking in this diff.

Some other features that we may want to support in a follow up diff:
- best point utilities
- infer_objective_thresholds
- support mixing with user supplied input transforms in ListSurrogate/Surrogate
- risk measure info in MBM candidate metadata?
- robust opt support in choose_botorch_acqf_class

Reviewed By: Balandat

Differential Revision: D35767912

