### PR TITLE
Implement Interactive Loop with candidate pregeneration

### DIFF
--- a/ax/service/interactive_loop.py
+++ b/ax/service/interactive_loop.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+from logging import Logger
+from queue import Queue
+from threading import Event, Lock, Thread
+from typing import Callable, Tuple
+
+from ax.core.types import TEvaluationOutcome, TParameterization
+
+from ax.exceptions.core import DataRequiredError
+from ax.exceptions.generation_strategy import MaxParallelismReachedException
+from ax.service.ax_client import AxClient
+from ax.utils.common.logger import get_logger
+
+logger: Logger = get_logger(__name__)
+
+IDLE_SLEEP_SEC = 0.1
+
+
+# TODO[mpolson64] Create `optimize` method that constructs its own ax_client
+def optimize_with_client(
+    ax_client: AxClient,
+    num_trials: int,
+    candidate_queue_maxsize: int,
+    elicitation_function: Callable[[TParameterization], TEvaluationOutcome],
+) -> None:
+    """
+    Function to facilitate running Ax experiments with candidate pregeneration (the
+    generation of candidate points while waiting for trial evaluation). This can be
+    useful in many contexts, especially in interactive experiments in which trial
+    evaluation entails eliciting a response from a human. Candidate pregeneration
+    uses the time waiting for trail evaluation to generate new candidates from the
+    data available. Note that this is a tradeoff -- a larger pregeneration queue
+    will result in more trials being generated with less data compared to a smaller
+    pregeneration queue (or no pregeneration as in conventional Ax usage) and should
+    only be used in contexts where it is necessary for the user to not experience any
+    "lag" while candidates are being generated.
+
+    Extract results of the experiment from the AxClient passed in.
+
+    The basic structure is as follows: One thread tries for a lock on the AxClient,
+    generates a candidate, and enqueues it to a candidate queue. Another thread tries
+    for the same lock, takes all the trial outcomes in the outcome queue, and attaches
+    them to the AxClient. The main thread pops a candidate off the candidate queue,
+    elicits response from the user, and puts the response onto the outcome queue.
+
+    Args:
+        ax_client: An AxClient properly configured for the experiment intended to be
+            run. Construct and configure this before passing in.
+        num_trials: The total number of trials to be run.
+        candidate_queue_maxsize: The maximum number of candidates to pregenerate.
+        elicitation_function: Function from parameterization (as returned by
+        `AxClient.get_next_trial`) to outcome (as expected by
+        `AxClient.complete_trial`).
+    """
+
+    # Construct a lock to ensure only one thread my access the AxClient at any moment
+    ax_client_lock = Lock()
+
+    # Construct queues to buffer inputs and outputs of the AxClient
+    candidate_queue: "Queue[Tuple[TParameterization, int]]" = Queue(
+        maxsize=candidate_queue_maxsize
+    )
+    data_queue: "Queue[Tuple[int, TEvaluationOutcome]]" = Queue()
+
+    # Construct events to allow us to stop the generator and attacher threads
+    candidate_generator_stop_event = Event()
+    data_attacher_stop_event = Event()
+
+    # Construct threads to run candidate thread-safe pregeneration and thread-safe
+    # data attaching respectively
+    candidate_generator_thread = Thread(
+        target=_candidate_generator,
+        args=(
+            ax_client,
+            ax_client_lock,
+            candidate_generator_stop_event,
+            candidate_queue,
+            num_trials,
+        ),
+    )
+    data_attacher_thread = Thread(
+        target=_data_attacher,
+        args=(ax_client, ax_client_lock, data_attacher_stop_event, data_queue),
+    )
+
+    candidate_generator_thread.start()
+    data_attacher_thread.start()
+
+    for _i in range(num_trials):
+        parametrization, trial_index = candidate_queue.get()
+
+        raw_data = elicitation_function(parametrization)
+
+        data_queue.put((trial_index, raw_data))
+        candidate_queue.task_done()
+
+    # Clean up threads (if they have not been stopped already)
+    candidate_generator_stop_event.set()
+    data_queue.join()
+    data_attacher_stop_event.set()
+
+
+def _candidate_generator(
+    ax_client: AxClient,
+    lock: Lock,
+    stop_event: Event,
+    queue: "Queue[Tuple[TParameterization, int]]",
+    num_trials: int,
+) -> None:
+    """Thread-safe method for generating the next trial from the AxClient and
+    enqueueing it to the candidate queue. The number of candidates pre-generated is
+    controlled by the maximum size of the queue. Generation stops when num_trials
+    trials are attached to the AxClient's experiment.
+    """
+    while not stop_event.is_set():
+        if not queue.full():
+            with lock:
+                try:
+                    parameterization_with_trial_index = ax_client.get_next_trial()
+                    queue.put(parameterization_with_trial_index)
+
+                    # Check if candidate generation can end
+                    if len(ax_client.experiment.arms_by_name) >= num_trials:
+                        stop_event.set()
+
+                except (MaxParallelismReachedException, DataRequiredError) as e:
+                    logger.warning(
+                        f"Encountered error {e}, sleeping for {IDLE_SLEEP_SEC} "
+                        "seconds and trying again."
+                    )
+                    pass  # Try again later
+
+        time.sleep(IDLE_SLEEP_SEC)
+
+
+def _data_attacher(
+    ax_client: AxClient,
+    lock: Lock,
+    stop_event: Event,
+    queue: "Queue[Tuple[int, TEvaluationOutcome]]",
+) -> None:
+    """Thread-safe method for attaching evaluation outcomes to the AxClient from the
+    outcome queue. If the AxClient's lock is acquired all data in the outcome queue
+    is attached at once, then the lock released. Stops when the event is set.
+    """
+
+    while not stop_event.is_set():
+        if not queue.empty():
+            with lock:
+                while not queue.empty():
+                    trial_index, raw_data = queue.get()
+
+                    ax_client.complete_trial(
+                        trial_index=trial_index,
+                        raw_data=raw_data,
+                    )
+
+                    queue.task_done()
+
+        time.sleep(IDLE_SLEEP_SEC)

--- a/ax/service/tests/test_interactive_loop.py
+++ b/ax/service/tests/test_interactive_loop.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import functools
+import time
+from logging import WARN
+
+import numpy as np
+from ax.core.types import TEvaluationOutcome
+from ax.service.ax_client import AxClient, TParameterization
+from ax.service.interactive_loop import optimize_with_client
+from ax.utils.common.testutils import TestCase
+from ax.utils.measurement.synthetic_functions import hartmann6
+from ax.utils.testing.mock import fast_botorch_optimize
+
+
+class TestInteractiveLoop(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+    @fast_botorch_optimize
+    def test_interactive_loop(self) -> None:
+        def _elicit(parameterization: TParameterization) -> TEvaluationOutcome:
+            x = np.array([parameterization.get(f"x{i+1}") for i in range(6)])
+
+            return {
+                "hartmann6": (hartmann6(x), 0.0),
+                "l2norm": (np.sqrt((x**2).sum()), 0.0),
+            }
+
+        ax_client = AxClient()
+        ax_client.create_experiment(
+            name="hartmann_test_experiment",
+            # pyre-fixme[6]
+            parameters=[
+                {
+                    "name": f"x{i}",
+                    "type": "range",
+                    "bounds": [0.0, 1.0],
+                }
+                for i in range(1, 7)
+            ],
+            objective_name="hartmann6",
+            tracking_metric_names=["l2norm"],
+            minimize=True,
+        )
+
+        optimize_with_client(
+            ax_client=ax_client,
+            num_trials=15,
+            candidate_queue_maxsize=3,
+            elicitation_function=_elicit,
+        )
+
+        self.assertEqual(len(ax_client.experiment.trials), 15)
+
+    def test_candidate_pregeneration_errors_raised(self) -> None:
+        def _elicit(parameterization: TParameterization) -> TEvaluationOutcome:
+            time.sleep(0.15)  # Sleep to induce MaxParallelismException in loop
+
+            x = np.array([parameterization.get(f"x{i+1}") for i in range(6)])
+
+            return {
+                "hartmann6": (hartmann6(x), 0.0),
+                "l2norm": (np.sqrt((x**2).sum()), 0.0),
+            }
+
+        ax_client = AxClient()
+        ax_client.create_experiment(
+            name="hartmann_test_experiment",
+            # pyre-fixme[6]
+            parameters=[
+                {
+                    "name": f"x{i}",
+                    "type": "range",
+                    "bounds": [0.0, 1.0],
+                }
+                for i in range(1, 7)
+            ],
+            objective_name="hartmann6",
+            tracking_metric_names=["l2norm"],
+            minimize=True,
+        )
+
+        # Lower max parallelism to induce MaxParallelismException
+        ax_client.generation_strategy._steps[0].max_parallelism = 1
+
+        with self.assertLogs(logger="ax", level=WARN) as logger:
+            optimize_with_client(
+                ax_client=ax_client,
+                num_trials=3,
+                candidate_queue_maxsize=3,
+                elicitation_function=_elicit,
+            )
+
+            # Assert sleep and retry warning is somewhere in the logs
+            self.assertIn(
+                "sleeping for 0.1 seconds and trying again.",
+                functools.reduce(lambda left, right: left + right, logger.output),
+            )

--- a/sphinx/source/service.rst
+++ b/sphinx/source/service.rst
@@ -24,6 +24,14 @@ Managed Loop
     :undoc-members:
     :show-inheritance:
 
+Interactive Loop
+~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.service.interactive_loop
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Scheduler
 ~~~~~~~~~~


### PR DESCRIPTION
Summary: In this diff we create an interactive loop API (based loosely off the existing Loop API) in order to facilitate candidate pregeneration. This can be useful in many contexts, espcially interactive experiments in which trial evaluation entails eliciting a response from a real human. Candidate pregeneration uses the time waiting for trail evaluation to generate new candidates from the data available. Note that this is a tradeoff -- a larger lookahead will result in more trials being generated with less data compared to a smaller lookahead (or no lookahead as in conventional Ax usage) and should only be used in contexts where it is necessary for the user to not experience any "lag" while candidates are being generated.

Reviewed By: lena-kashtelyan

Differential Revision: D39505104

