### PR TITLE
Add annotation to logger

### DIFF
--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -10,6 +10,7 @@ from collections import defaultdict, OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from logging import Logger
 from typing import (
     DefaultDict,
     Dict,
@@ -34,8 +35,7 @@ from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast, not_none
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 if TYPE_CHECKING:

--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from logging import Logger
 from typing import Any, Dict, Generic, Iterable, List, Optional, Type, TypeVar
 
 import numpy as np
@@ -19,8 +20,7 @@ from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import serialize_init_args
 from ax.utils.common.typeutils import checked_cast
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 T = TypeVar("T")

--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import warnings
+from logging import Logger
 from typing import Any, Iterable, List, Optional, Tuple
 
 from ax.core.metric import Metric
@@ -14,9 +15,7 @@ from ax.utils.common.base import SortableBase
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class Objective(SortableBase):

--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from itertools import groupby
+from logging import Logger
 from typing import Dict, List, Optional
 
 from ax.core.metric import Metric
@@ -20,9 +21,7 @@ from ax.exceptions.core import UserInputError
 from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 TRefPoint = List[ObjectiveThreshold]
 

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -7,6 +7,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from logging import Logger
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type
 
 import numpy as np
@@ -30,8 +31,7 @@ from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast, not_none
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 @dataclass

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import numpy as np
@@ -15,8 +16,7 @@ from ax.exceptions.core import UnsupportedError
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import pandas as pd
@@ -12,8 +13,7 @@ from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.logger import get_logger
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):

--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -5,13 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
+from logging import Logger
 from typing import Dict, List, Tuple
 
 import pandas as pd
 from ax.utils.common.logger import get_logger
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def align_partial_results(

--- a/ax/metrics/curve.py
+++ b/ax/metrics/curve.py
@@ -12,6 +12,8 @@ Typically used to retrieve partial learning curves of ML training jobs.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+
+from logging import Logger
 from typing import Any, Dict, Iterable, Optional, Union
 
 import numpy as np
@@ -27,8 +29,7 @@ from ax.early_stopping.utils import align_partial_results
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class AbstractCurveMetric(MapMetric, ABC):

--- a/ax/metrics/noisy_function_map.py
+++ b/ax/metrics/noisy_function_map.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from logging import Logger
+
 from typing import Any, Dict, Iterable, Mapping, Optional
 
 import numpy as np
@@ -17,8 +19,7 @@ from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import serialize_init_args
 from ax.utils.common.typeutils import checked_cast
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class NoisyFunctionMapMetric(MapMetric):

--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import logging
+
+from logging import Logger
 from typing import Dict, Iterable, List, NamedTuple, Union
 
 import pandas as pd
@@ -14,8 +16,7 @@ from ax.core.map_data import MapKeyInfo
 from ax.metrics.curve import AbstractCurveMetric
 from ax.utils.common.logger import get_logger
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 try:
     from tensorboard.backend.event_processing import (

--- a/ax/metrics/torchx.py
+++ b/ax/metrics/torchx.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, cast
 
 import pandas as pd
@@ -13,8 +14,7 @@ from ax.core.metric import Metric
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 try:
     from ax.runners.torchx import TORCHX_TRACKER_BASE

--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -9,6 +9,8 @@ from abc import ABC
 from collections import OrderedDict
 from copy import deepcopy
 from dataclasses import dataclass, field
+
+from logging import Logger
 from typing import Any, Dict, List, MutableMapping, Optional, Set, Tuple, Type
 
 from ax.core.arm import Arm
@@ -33,9 +35,7 @@ from ax.models.types import TConfig
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast, not_none
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)

--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -8,6 +8,8 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from enum import Enum
 from functools import partial
+
+from logging import Logger
 from numbers import Number
 from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
 
@@ -18,8 +20,7 @@ from ax.modelbridge.base import ModelBridge
 from ax.utils.common.logger import get_logger
 from scipy.stats import fisher_exact, norm, pearsonr, spearmanr
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 CVDiagnostics = Dict[str, Dict[str, float]]
 

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from collections import defaultdict
 from copy import deepcopy
+
+from logging import Logger
 from typing import Any, Dict, List, Optional, Set, Tuple, Type
 
 import pandas as pd
@@ -30,9 +32,7 @@ from ax.utils.common.base import Base
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
 from ax.utils.common.typeutils import not_none
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 MAX_CONDITIONS_GENERATED = 10000

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from collections import defaultdict
 from copy import deepcopy
 from functools import partial
+
+from logging import Logger
 from typing import (
     Callable,
     Dict,
@@ -88,8 +90,7 @@ from botorch.utils.multi_objective.box_decompositions.dominated import (
 )
 from torch import Tensor
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 if TYPE_CHECKING:

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from enum import Enum
 from inspect import isfunction, signature
+
+from logging import Logger
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Type
 
 import torch
@@ -76,9 +78,7 @@ from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import callable_from_reference, callable_to_reference
 from ax.utils.common.typeutils import checked_cast, not_none
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 Cont_X_trans: List[Type[Transform]] = [
     RemoveFixed,

--- a/ax/modelbridge/transforms/int_to_float.py
+++ b/ax/modelbridge/transforms/int_to_float.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
 from ax.core.observation import Observation, ObservationFeatures
@@ -24,8 +25,7 @@ if TYPE_CHECKING:
     from ax import modelbridge as modelbridge_module  # noqa F401  # pragma: no cover
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 DEFAULT_MAX_ROUND_ATTEMPTS = 10000

--- a/ax/modelbridge/transforms/inverse_gaussian_cdf_y.py
+++ b/ax/modelbridge/transforms/inverse_gaussian_cdf_y.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import List, Optional, TYPE_CHECKING
 
 from ax.core.observation import Observation, ObservationData
@@ -20,8 +21,7 @@ if TYPE_CHECKING:
     from ax.modelbridge import base as base_modelbridge  # noqa F401  # pragma: no cover
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 # TODO(jej): Add OptimizationConfig validation - can't transform outcome constraints.

--- a/ax/modelbridge/transforms/ivw.py
+++ b/ax/modelbridge/transforms/ivw.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Dict, List
 
 import numpy as np
@@ -11,9 +12,7 @@ from ax.core.observation import ObservationData
 from ax.modelbridge.transforms.base import Transform
 from ax.utils.common.logger import get_logger
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def ivw_metric_merge(

--- a/ax/modelbridge/transforms/log_y.py
+++ b/ax/modelbridge/transforms/log_y.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from logging import Logger
+
 from typing import Callable, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
@@ -24,8 +26,7 @@ if TYPE_CHECKING:
     from ax.modelbridge import base as base_modelbridge  # noqa F401  # pragma: no cover
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class LogY(Transform):

--- a/ax/modelbridge/transforms/percentile_y.py
+++ b/ax/modelbridge/transforms/percentile_y.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+from logging import Logger
 from typing import List, Optional, TYPE_CHECKING
 
 from ax.core.observation import Observation, ObservationData
@@ -23,8 +24,7 @@ if TYPE_CHECKING:
     from ax import modelbridge as modelbridge_module  # noqa F401  # pragma: no cover
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 # TODO(jej): Add OptimizationConfig validation - can't transform outcome constraints.

--- a/ax/modelbridge/transforms/power_transform_y.py
+++ b/ax/modelbridge/transforms/power_transform_y.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from logging import Logger
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
@@ -26,8 +27,7 @@ if TYPE_CHECKING:
     from ax import modelbridge as modelbridge_module  # noqa F401  # pragma: no cover
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class PowerTransformY(Transform):

--- a/ax/modelbridge/transforms/standardize_y.py
+++ b/ax/modelbridge/transforms/standardize_y.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import DefaultDict, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
@@ -24,8 +25,7 @@ if TYPE_CHECKING:
     from ax.modelbridge import base as base_modelbridge  # noqa F401  # pragma: no cover
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class StandardizeY(Transform):

--- a/ax/modelbridge/transforms/stratified_standardize_y.py
+++ b/ax/modelbridge/transforms/stratified_standardize_y.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import defaultdict
+from logging import Logger
 from typing import DefaultDict, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
@@ -24,8 +25,7 @@ if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
     from ax import modelbridge as modelbridge_module  # noqa F401  # pragma: no cover
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class StratifiedStandardizeY(Transform):

--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -6,6 +6,7 @@
 
 import warnings
 from dataclasses import dataclass
+from logging import Logger
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
@@ -33,8 +34,7 @@ if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
     from ax import modelbridge as modelbridge_module  # noqa F401  # pragma: no cover
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 @dataclass

--- a/ax/models/random/base.py
+++ b/ax/models/random/base.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -23,8 +24,7 @@ from botorch.utils.sampling import HitAndRunPolytopeSampler
 from torch import Tensor
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class RandomModel(Model):

--- a/ax/models/tests/test_alebo.py
+++ b/ax/models/tests/test_alebo.py
@@ -27,6 +27,7 @@ from botorch.acquisition.analytic import ExpectedImprovement
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.utils.datasets import FixedNoiseDataset
+from linear_operator.operators import LinearOperator
 
 
 class ALEBOTest(TestCase):
@@ -54,6 +55,9 @@ class ALEBOTest(TestCase):
         x2 = torch.tensor([[1.0, 1.0], [0.0, 0.0]], dtype=torch.double)
 
         K = k.forward(x1, x2)
+        if type(K) == LinearOperator:
+            K = K.to_dense()
+
         Ktrue = torch.tensor(
             [[np.exp(-0.5 * 18), 1.0], [1.0, np.exp(-0.5 * 18)]], dtype=torch.double
         )

--- a/ax/models/tests/test_fully_bayesian.py
+++ b/ax/models/tests/test_fully_bayesian.py
@@ -9,6 +9,7 @@ import warnings
 from abc import ABC
 from contextlib import ExitStack
 from itertools import product
+from logging import Logger
 from math import sqrt
 from typing import Dict, Type
 from unittest import mock
@@ -43,8 +44,7 @@ RUN_INFERENCE_PATH = "ax.models.torch.fully_bayesian.run_inference"
 NUTS_PATH = "pyro.infer.mcmc.NUTS"
 MCMC_PATH = "pyro.infer.mcmc.MCMC"
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def _get_dummy_mcmc_samples(

--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import dataclasses
 import re
 from collections import OrderedDict
+from logging import Logger
 from typing import Any, Callable, Dict, List, MutableMapping, Optional, Tuple, Union
 
 import gpytorch
@@ -46,8 +47,7 @@ from scipy.optimize import approx_fprime
 from torch import Tensor
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class ALEBOKernel(Kernel):

--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -41,6 +41,7 @@ from gpytorch.kernels.kernel import Kernel
 from gpytorch.kernels.rbf_kernel import postprocess_rbf
 from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from linear_operator.operators import LinearOperator
 from scipy.optimize import approx_fprime
 from torch import Tensor
 
@@ -94,7 +95,7 @@ class ALEBOKernel(Kernel):
         diag: bool = False,
         last_dim_is_batch: bool = False,
         **params: Any,
-    ) -> Tensor:
+    ) -> Union[Tensor, LinearOperator]:
         """Compute kernel distance."""
         # Unpack Uvec into an upper triangular matrix U
         shapeU = self.Uvec.shape[:-1] + torch.Size([self.d, self.d])

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 from copy import deepcopy
+
+from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -40,8 +42,7 @@ from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.utils.datasets import SupervisedDataset
 from torch import Tensor
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 # pyre-fixme[33]: Aliased annotation cannot contain `Any`.

--- a/ax/models/torch/botorch_modular/list_surrogate.py
+++ b/ax/models/torch/botorch_modular/list_surrogate.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import inspect
+
+from logging import Logger
 from typing import Any, Dict, List, Optional, Type
 
 from ax.models.torch.botorch_modular.surrogate import Surrogate
@@ -22,9 +24,7 @@ from gpytorch.likelihoods.likelihood import Likelihood
 from gpytorch.mlls import ExactMarginalLogLikelihood
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class ListSurrogate(Surrogate):

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import warnings
+from logging import Logger
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import torch
@@ -36,10 +37,8 @@ from botorch.utils.transforms import is_fully_bayesian
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from torch import Tensor
 
-
 MIN_OBSERVED_NOISE_LEVEL = 1e-7
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def use_model_list(

--- a/ax/models/torch/botorch_moo.py
+++ b/ax/models/torch/botorch_moo.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
@@ -47,8 +48,7 @@ from botorch.models.model import Model
 from torch import Tensor
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 # pyre-fixme[33]: Aliased annotation cannot contain `Any`.
 TOptimizerList = Callable[

--- a/ax/models/torch/cbo_lcea.py
+++ b/ax/models/torch/cbo_lcea.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, Dict, List, Optional, Tuple
 
 from ax.core.search_space import SearchSpaceDigest
@@ -24,8 +25,7 @@ from torch import Tensor
 
 
 MIN_OBSERVED_NOISE_LEVEL = 1e-7
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def get_map_model(

--- a/ax/models/torch/cbo_sac.py
+++ b/ax/models/torch/cbo_sac.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, Dict, List, Optional
 
 from ax.core.search_space import SearchSpaceDigest
@@ -22,8 +23,7 @@ from torch import Tensor
 
 
 MIN_OBSERVED_NOISE_LEVEL = 1e-7
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class SACBO(BotorchModel):

--- a/ax/models/torch/fully_bayesian.py
+++ b/ax/models/torch/fully_bayesian.py
@@ -29,6 +29,8 @@ import sys
 import time
 import types
 import warnings
+
+from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -69,9 +71,7 @@ from botorch.models.model import Model
 from botorch.models.model_list_gp_regression import ModelListGP
 from torch import Tensor
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 SAAS_DEPRECATION_MSG = (
@@ -431,7 +431,7 @@ def run_inference(
     # this prints the summary
     if verbose:
         orig_std_out = sys.stdout.write
-        sys.stdout.write = logger.info
+        sys.stdout.write = logger.info  # pyre-fixme[8]
         print_summary(samples, prob=0.9, group_by_chain=False)
         sys.stdout.write = orig_std_out
         logger.info(f"MCMC elapsed time: {time.time() - start}")

--- a/ax/models/torch/utils.py
+++ b/ax/models/torch/utils.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
+
+from logging import Logger
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Type
 
 import numpy as np
@@ -38,9 +40,7 @@ from botorch.utils.objective import get_objective_weights_transform
 from botorch.utils.sampling import sample_hypersphere, sample_simplex
 from torch import Tensor
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 NOISELESS_MODELS = {SingleTaskGP}

--- a/ax/plot/feature_importances.py
+++ b/ax/plot/feature_importances.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, Dict, Optional, Union
 
 import numpy as np
@@ -16,9 +17,7 @@ from ax.plot.helper import compose_annotation
 from ax.utils.common.logger import get_logger
 from plotly import subplots
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def plot_feature_importance_plotly(df: pd.DataFrame, title: str) -> go.Figure:

--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -6,6 +6,8 @@
 
 import math
 from collections import Counter
+
+from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -20,9 +22,7 @@ from ax.plot.base import DECIMALS, PlotData, PlotInSampleArm, PlotOutOfSampleArm
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 # Typing alias
 RawData = List[Dict[str, Union[str, float]]]

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -7,6 +7,7 @@
 import copy
 from copy import deepcopy
 from itertools import combinations
+from logging import Logger
 from typing import Dict, List, NamedTuple, Optional, Tuple, Union
 
 import numpy as np
@@ -39,14 +40,12 @@ from ax.utils.stats.statstools import relativize
 from botorch.utils.multi_objective import is_non_dominated
 from botorch.utils.multi_objective.hypervolume import infer_reference_point
 
-
 # type aliases
 Mu = Dict[str, List[float]]
 Cov = Dict[str, Dict[str, List[float]]]
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def _extract_observed_pareto_2d(

--- a/ax/plot/scatter.py
+++ b/ax/plot/scatter.py
@@ -7,6 +7,8 @@
 import numbers
 import warnings
 from collections import OrderedDict
+
+from logging import Logger
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -43,8 +45,7 @@ from ax.utils.common.typeutils import checked_cast_optional
 from ax.utils.stats.statstools import relativize
 from plotly import subplots
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 # type aliases
 Traces = List[Dict[str, Any]]

--- a/ax/runners/torchx.py
+++ b/ax/runners/torchx.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import inspect
+
+from logging import Logger
 from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Set
 
 from ax.core import Trial
@@ -13,8 +15,7 @@ from ax.core.runner import Runner
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 try:

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -8,6 +8,8 @@ import json
 import logging
 import warnings
 from functools import partial
+
+from logging import Logger
 from typing import (
     Any,
     Callable,
@@ -93,9 +95,7 @@ from ax.utils.common.typeutils import (
 )
 from botorch.utils.sampling import manual_seed
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 AxClientSubclass = TypeVar("AxClientSubclass", bound="AxClient")

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from functools import reduce
+
+from logging import Logger
 from typing import Dict, Iterable, Optional, Tuple, Type
 
 import pandas as pd
@@ -43,9 +45,7 @@ from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.stats.statstools import relativize_data
 from numpy import NaN
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def get_best_raw_objective_point_with_trial_index(

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -6,6 +6,8 @@
 
 import enum
 from dataclasses import dataclass
+
+from logging import Logger
 from typing import Any, cast, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
@@ -52,8 +54,7 @@ from ax.utils.common.typeutils import (
     numpy_type_to_python_type,
 )
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 """Utilities for RESTful-like instantiation of Ax classes needed in AxClient."""

--- a/ax/service/utils/with_db_settings_base.py
+++ b/ax/service/utils/with_db_settings_base.py
@@ -5,7 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import time
-from logging import INFO
+
+from logging import INFO, Logger
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 from ax.core.base_trial import BaseTrial
@@ -16,7 +17,6 @@ from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.utils.common.executils import retry_on_exception
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
 from ax.utils.common.typeutils import not_none
-
 
 RETRY_EXCEPTION_TYPES: Tuple[Type[Exception], ...] = ()
 
@@ -54,8 +54,7 @@ except ModuleNotFoundError:  # pragma: no cover
 STORAGE_MINI_BATCH_SIZE = 50
 LOADING_MINI_BATCH_SIZE = 10000
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class WithDBSettingsBase:

--- a/ax/storage/metric_registry.py
+++ b/ax/storage/metric_registry.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, Callable, Dict, Optional, Tuple, Type
 
 from ax.core.map_metric import MapMetric
@@ -19,8 +20,7 @@ from ax.storage.json_store.encoders import metric_to_dict
 from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
 from ax.utils.common.logger import get_logger
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 """
 Mapping of Metric classes to ints.

--- a/ax/storage/runner_registry.py
+++ b/ax/storage/runner_registry.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, Callable, Dict, Optional, Tuple, Type
 
 from ax.core.runner import Runner
@@ -12,8 +13,7 @@ from ax.storage.json_store.encoders import runner_to_dict
 from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
 from ax.utils.common.logger import get_logger
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 # """
 # Mapping of Runner classes to ints.

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from enum import Enum
+
+from logging import Logger
 from typing import Any, cast, Dict, List, Optional, Tuple, Type
 
 from ax.core.arm import Arm
@@ -60,9 +62,7 @@ from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import serialize_init_args
 from ax.utils.common.typeutils import checked_cast, not_none
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class Encoder:

--- a/ax/storage/sqa_store/save.py
+++ b/ax/storage/sqa_store/save.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+
+from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from ax.core.base_trial import BaseTrial
@@ -28,9 +30,7 @@ from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast, not_none
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def save_experiment(experiment: Experiment, config: Optional[SQAConfig] = None) -> None:

--- a/ax/storage/sqa_store/validation.py
+++ b/ax/storage/sqa_store/validation.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import Any, Callable, List, TypeVar
 
 from ax.storage.sqa_store.db import SQABase
@@ -23,12 +24,10 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm.base import NO_VALUE
 from sqlalchemy.orm.mapper import Mapper
 
-
 T = TypeVar("T")
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 def listens_for_multiple(

--- a/ax/utils/common/kwargs.py
+++ b/ax/utils/common/kwargs.py
@@ -5,14 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 from inspect import Parameter, signature
+
+from logging import Logger
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from ax.utils.common.logger import get_logger
 from typeguard import check_type
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 TKwargs = Dict[str, Any]
 

--- a/ax/utils/notebook/plotting.py
+++ b/ax/utils/notebook/plotting.py
@@ -4,15 +4,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
+
 from ax.plot.base import AxPlotConfig, AxPlotTypes
 from ax.plot.render import _js_requires, _wrap_js, plot_config_to_html
 from ax.utils.common.logger import get_logger
 from IPython.display import display
 from plotly.offline import init_notebook_mode, iplot
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 # pyre-fixme[3]: Return type must be annotated.

--- a/ax/utils/stats/statstools.py
+++ b/ax/utils/stats/statstools.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import List, Tuple, Union
 
 import numpy as np
@@ -11,9 +12,7 @@ import pandas as pd
 from ax.core.data import Data
 from ax.utils.common.logger import get_logger
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 num_mixed = Union[np.ndarray, List[float]]
 
 

--- a/ax/utils/testing/backend_scheduler.py
+++ b/ax/utils/testing/backend_scheduler.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 from dataclasses import replace as dataclass_replace
+
+from logging import Logger
 from typing import Dict, Optional, Set
 
 from ax.core.experiment import Experiment
@@ -16,9 +18,7 @@ from ax.service.scheduler import Scheduler, SchedulerOptions
 from ax.utils.common.logger import get_logger
 from ax.utils.testing.backend_simulator import BackendSimulator
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 class AsyncSimulatedBackendScheduler(Scheduler):

--- a/ax/utils/testing/backend_simulator.py
+++ b/ax/utils/testing/backend_simulator.py
@@ -8,14 +8,14 @@ import logging
 import random
 import time
 from dataclasses import dataclass
+
+from logging import Logger
 from typing import Dict, List, Optional
 
 from ax.core.base_trial import TrialStatus
 from ax.utils.common.logger import get_logger
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 @dataclass

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -7,6 +7,8 @@
 
 from collections import OrderedDict
 from datetime import datetime, timedelta
+
+from logging import Logger
 from typing import (
     Any,
     cast,
@@ -102,8 +104,7 @@ from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikeliho
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from gpytorch.priors.torch_priors import GammaPrior
 
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 TEST_SOBOL_SEED = 1234
 

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from logging import Logger
 from typing import List, Optional, Type
 
 import numpy as np
@@ -24,9 +25,7 @@ from ax.utils.testing.core_stubs import (
     get_search_space_for_value,
 )
 
-
-# pyre-fixme[5]: Global expression must be annotated.
-logger = get_logger(__name__)
+logger: Logger = get_logger(__name__)
 
 
 # Observations


### PR DESCRIPTION
Summary:
Address one of the easiest and most common (~250!) pyre-fixmes in our codebase.

```
# pyre-fixme[5]: Global expression must be annotated.
logger = get_logger(__name__)
```
becomes
```
from logger import Logger
logger: Logger = get_logger(__name__)
```
then arc lint is applied.

Differential Revision: D39547946

