### PR TITLE
Use upload token for pypi / test.pypi instead of user/pw

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -136,7 +136,8 @@ jobs:
     - name: Deploy to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: lilidworkin
-        password: ${{ secrets.test_pypi_password }}
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
         skip_existing: true
+        verbose: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,5 +87,6 @@ jobs:
     - name: Deploy to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: drfreund
-        password: ${{ secrets.pypi_password }}
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
+        verbose: true


### PR DESCRIPTION
`PYPI_TOKEN` is in the secrets, this is ready to be merged once `TEST_PYPI_TOKEN` is added as well. 