### PR TITLE
Explain what ModelBridge.gen() does and what it returns in the docstring

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -627,6 +627,9 @@ class ModelBridge(ABC):
         model_gen_options: Optional[TConfig] = None,
     ) -> GeneratorRun:
         """
+        Generate new points from the underlying model according to
+        search_space, optimization_config and other parameters.
+
         Args:
             n: Number of points to generate
             search_space: Search space
@@ -638,6 +641,9 @@ class ModelBridge(ABC):
                 generation.
             model_gen_options: A config dictionary that is passed along to the
                 model.
+
+        Returns:
+            A GeneratorRun object that contains the generated points and other metadata.
         """
         t_gen_start = time.monotonic()
         # Get modifiable versions


### PR DESCRIPTION
Summary: ModelBridge.gen() is a core piece of the AX API and existing documentation doesn't say anything about what it does. This change plugs this hole.

Differential Revision: D39593366

