### PR TITLE
Support outcome constraints for MOO

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1430,7 +1430,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         optimization_config: Optional[OptimizationConfig] = None,
         trial_indices: Optional[Iterable[int]] = None,
         use_model_predictions: bool = True,
-    ) -> Optional[Dict[int, Tuple[TParameterization, TModelPredictArm]]]:
+    ) -> Dict[int, Tuple[TParameterization, TModelPredictArm]]:
         return self._get_pareto_optimal_parameters(
             experiment=self.experiment,
             generation_strategy=self.generation_strategy,

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -471,7 +471,7 @@ def get_pareto_optimal_parameters(
     optimization_config: Optional[OptimizationConfig] = None,
     trial_indices: Optional[Iterable[int]] = None,
     use_model_predictions: bool = True,
-) -> Optional[Dict[int, Tuple[TParameterization, TModelPredictArm]]]:
+) -> Dict[int, Tuple[TParameterization, TModelPredictArm]]:
     """Identifies the best parameterizations tried in the experiment so far,
     using model predictions if ``use_model_predictions`` is true and using
     observed values from the experiment otherwise. By default, uses model
@@ -497,8 +497,7 @@ def get_pareto_optimal_parameters(
             observed values.
 
     Returns:
-        ``None`` if it was not possible to extract the Pareto frontier,
-        otherwise a mapping from trial index to the tuple of:
+        A mapping from trial index to the tuple of:
         - the parameterization of the arm in that trial,
         - two-item tuple of metric means dictionary and covariance matrix
             (model-predicted if ``use_model_predictions=True`` and observed
@@ -521,11 +520,6 @@ def get_pareto_optimal_parameters(
     moo_optimization_config = checked_cast(
         MultiObjectiveOptimizationConfig, optimization_config
     )
-    if moo_optimization_config.outcome_constraints:
-        # TODO[drfreund]: Test this flow and remove error.
-        raise NotImplementedError(
-            "Support for outcome constraints is currently under development."
-        )
 
     # Use existing modelbridge if it supports MOO otherwise create a new MOO modelbridge
     # to use for Pareto frontier extraction.

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -232,7 +232,7 @@ class BestPointMixin(metaclass=ABCMeta):
         optimization_config: Optional[OptimizationConfig] = None,
         trial_indices: Optional[Iterable[int]] = None,
         use_model_predictions: bool = True,
-    ) -> Optional[Dict[int, Tuple[TParameterization, TModelPredictArm]]]:
+    ) -> Dict[int, Tuple[TParameterization, TModelPredictArm]]:
         if not not_none(experiment.optimization_config).is_moo_problem:
             raise NotImplementedError(  # pragma: no cover
                 "Please use `get_best_parameters` for single-objective problems."


### PR DESCRIPTION
Summary:
[x] Removed `NotImplementedError` from `ax.service.utils.best_point_mixin.BestPointMixin._get_pareto_optimal_paramters`. This was all that was needed to get outcome constraints working.
[x] Fixed an incorrect type signature (`best_oint.get_pareto_optimal_parameters` never returns `None`), fixed type signatures downstream from that, and removed related pyre-fixmes.
[x] Added a few simple annotations
[ ] Expose MOO plots in service API
[ ] Improve documentation on how MOO differs from scalarized-objective optimization
[ ] Expand MOO tutorial to demonstrate plots and reference new documentation

Differential Revision: D39607704

