### PR TITLE
Run `pyre infer` (and clean up)

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -148,8 +148,7 @@ class TrialStatus(int, Enum):
         return f"{self!s}"
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-DEFAULT_STATUSES_TO_WARM_START = [
+DEFAULT_STATUSES_TO_WARM_START: List[TrialStatus] = [
     TrialStatus.RUNNING,
     TrialStatus.COMPLETED,
     TrialStatus.ABANDONED,

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import warnings
 from copy import deepcopy
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import numpy as np
 import pandas as pd
@@ -26,11 +26,15 @@ from ax.utils.common.typeutils import not_none
 
 TIME_COLS = {"start_time", "end_time"}
 
-# pyre-fixme[5]: Global expression must be annotated.
-OBS_COLS = {"arm_name", "trial_index", "random_split", "fidelities", *TIME_COLS}
+OBS_COLS: Set[str] = {
+    "arm_name",
+    "trial_index",
+    "random_split",
+    "fidelities",
+    *TIME_COLS,
+}
 
-# pyre-fixme[5]: Global expression must be annotated.
-OBS_KWARGS = {"trial_index", "random_split", *TIME_COLS}
+OBS_KWARGS: Set[str] = {"trial_index", "random_split", *TIME_COLS}
 
 
 class ObservationFeatures(Base):

--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
 from warnings import warn
 
 from ax.core.types import TParamValue
@@ -47,8 +47,9 @@ PARAMETER_PYTHON_TYPE_MAP: Dict[ParameterType, TParameterType] = {
     ParameterType.BOOL: bool,
 }
 
-# pyre-fixme[5]: Global expression must be annotated.
-SUPPORTED_PARAMETER_TYPES = tuple(PARAMETER_PYTHON_TYPE_MAP.values())
+SUPPORTED_PARAMETER_TYPES: Tuple[
+    Union[Type[bool], Type[float], Type[int], Type[str]], ...
+] = tuple(PARAMETER_PYTHON_TYPE_MAP.values())
 
 
 # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use `typing.Type` to

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Type
+from typing import Dict, Type
 from unittest.mock import patch
 
 import pandas as pd
@@ -44,8 +44,7 @@ from ax.utils.testing.core_stubs import (
 
 DUMMY_RUN_METADATA_KEY = "test_run_metadata_key"
 DUMMY_RUN_METADATA_VALUE = "test_run_metadata_value"
-# pyre-fixme[5]: Global expression must be annotated.
-DUMMY_RUN_METADATA = {DUMMY_RUN_METADATA_KEY: DUMMY_RUN_METADATA_VALUE}
+DUMMY_RUN_METADATA: Dict[str, str] = {DUMMY_RUN_METADATA_KEY: DUMMY_RUN_METADATA_VALUE}
 DUMMY_ABANDONED_REASON = "test abandoned reason"
 DUMMY_ARM_NAME = "test_arm_name"
 

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -698,12 +698,11 @@ class TestLogicalEarlyStoppingStrategy(TestCase):
                 self.assertNotIn(idc, or_from_collection_should_stop.keys())
 
 
-# pyre-fixme[3]: Return type must be annotated.
 def _evaluate_early_stopping_with_df(
     early_stopping_strategy: PercentileEarlyStoppingStrategy,
     experiment: Experiment,
     df: pd.DataFrame,
-):
+) -> Dict[int, Optional[str]]:
     """Helper function for testing PercentileEarlyStoppingStrategy
     on an arbitrary (MapData) df."""
     metric_to_aligned_means, _ = align_partial_results(

--- a/ax/modelbridge/tests/test_choice_encode_transform.py
+++ b/ax/modelbridge/tests/test_choice_encode_transform.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from copy import deepcopy
+from typing import Sized
 
 import numpy as np
 from ax.core.observation import ObservationFeatures
@@ -224,8 +225,7 @@ class OrderedChoiceEncodeTransformTest(ChoiceEncodeTransformTest):
 
 
 # pyre-fixme[3]: Return type must be annotated.
-# pyre-fixme[2]: Parameter must be annotated.
-def normalize_values(values):
+def normalize_values(values: Sized):
     values = np.array(values, dtype=float)
     vmin, vmax = values.min(), values.max()
     if len(values) > 1:

--- a/ax/modelbridge/tests/test_power_transform_y.py
+++ b/ax/modelbridge/tests/test_power_transform_y.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from math import isfinite, isnan
+from typing import List
 
 import numpy as np
 from ax.core.metric import Metric
@@ -26,9 +27,8 @@ from ax.utils.common.testutils import TestCase
 from sklearn.preprocessing import PowerTransformer
 
 
-# pyre-fixme[3]: Return type must be annotated.
 # pyre-fixme[2]: Parameter must be annotated.
-def get_constraint(metric, bound, relative):
+def get_constraint(metric, bound, relative) -> List[OutcomeConstraint]:
     return [
         OutcomeConstraint(
             metric=metric, op=ComparisonOp.GEQ, bound=bound, relative=relative

--- a/ax/modelbridge/tests/test_prediction_utils.py
+++ b/ax/modelbridge/tests/test_prediction_utils.py
@@ -23,6 +23,8 @@ class TestPredictionUtils(TestCase):
 
         observation_features = ObservationFeatures(parameters={"x1": 0.3, "x2": 0.5})
         y_hat, se_hat = predict_at_point(
+            # pyre-fixme[6]: For 1st param expected `ModelBridge` but got
+            #  `Optional[ModelBridge]`.
             model=ax_client.generation_strategy.model,
             obsf=observation_features,
             # pyre-fixme[6]: For 3rd param expected `Set[str]` but got `List[str]`.
@@ -43,6 +45,8 @@ class TestPredictionUtils(TestCase):
             20: ObservationFeatures(parameters={"x1": 0.8, "x2": 0.5}),
         }
         predictions_map = predict_by_features(
+            # pyre-fixme[6]: For 1st param expected `ModelBridge` but got
+            #  `Optional[ModelBridge]`.
             model=ax_client.generation_strategy.model,
             label_to_feature_dict=observation_features_dict,
             # pyre-fixme[6]: For 3rd param expected `Set[str]` but got `List[str]`.
@@ -90,8 +94,7 @@ class TestPredictionUtils(TestCase):
 # num_initial_trials kwarg is zero. Note that this kwarg is
 # needed to be able to instantiate the model for the first time
 # without calling get_next_trial().
-# pyre-fixme[3]: Return type must be annotated.
-def _set_up_client_for_get_model_predictions_no_next_trial():
+def _set_up_client_for_get_model_predictions_no_next_trial() -> AxClient:
     ax_client = AxClient()
     ax_client.create_experiment(
         name="test_experiment",
@@ -118,9 +121,8 @@ def _set_up_client_for_get_model_predictions_no_next_trial():
     return ax_client
 
 
-# pyre-fixme[3]: Return type must be annotated.
 # pyre-fixme[2]: Parameter must be annotated.
-def _attach_completed_trials(ax_client):
+def _attach_completed_trials(ax_client) -> None:
     # Attach completed trials
     trial1 = {"x1": 0.1, "x2": 0.1}
     parameters, trial_index = ax_client.attach_trial(trial1)

--- a/ax/modelbridge/tests/test_torch_modelbridge_moo.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge_moo.py
@@ -43,8 +43,7 @@ from botorch.utils.multi_objective.pareto import is_non_dominated
 PARETO_FRONTIER_EVALUATOR_PATH = (
     f"{pareto_frontier_evaluator.__module__}.pareto_frontier_evaluator"
 )
-# pyre-fixme[5]: Global expression must be annotated.
-STUBS_PATH = get_branin_experiment_with_multi_objective.__module__
+STUBS_PATH: str = get_branin_experiment_with_multi_objective.__module__
 
 
 class MultiObjectiveTorchModelBridgeTest(TestCase):

--- a/ax/modelbridge/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/tests/test_winsorize_transform.py
@@ -32,6 +32,7 @@ from ax.modelbridge.transforms.winsorize import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_optimization_config
+from typing_extensions import SupportsIndex
 
 
 class WinsorizeTransformTest(TestCase):
@@ -537,9 +538,8 @@ class WinsorizeTransformTest(TestCase):
         self.assertEqual(transform.cutoffs["m3"], (-3.5, float("inf")))  # 1 - 1.5 * 3
 
 
-# pyre-fixme[3]: Return type must be annotated.
 # pyre-fixme[2]: Parameter must be annotated.
-def get_transform(observation_data, config):
+def get_transform(observation_data, config) -> Winsorize:
     observations = [
         Observation(features=ObservationFeatures({}), data=obsd)
         for obsd in observation_data
@@ -557,8 +557,7 @@ def get_default_transform_cutoffs(
     optimization_config,
     # pyre-fixme[2]: Parameter must be annotated.
     winsorization_config=None,
-    # pyre-fixme[2]: Parameter must be annotated.
-    obs_data_len=6,
+    obs_data_len: SupportsIndex = 6,
 ):
     obsd = ObservationData(
         metric_names=["m1"] * obs_data_len,

--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -64,8 +64,7 @@ class WinsorizationConfig:
 
 OLD_KEYS = ["winsorization_lower", "winsorization_upper", "percentile_bounds"]
 AUTO_WINS_QUANTILE = -1  # This shouldn't be in the [0, 1] range
-# pyre-fixme[5]: Global expression must be annotated.
-DEFAULT_CUTOFFS = (-float("inf"), float("inf"))
+DEFAULT_CUTOFFS: Tuple[float, float] = (-float("inf"), float("inf"))
 
 
 class Winsorize(Transform):

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from contextlib import ExitStack
+from typing import Tuple
 from unittest import mock
 
 import numpy as np
@@ -25,6 +26,7 @@ from botorch.utils.datasets import FixedNoiseDataset
 from botorch.utils.multi_objective.hypervolume import infer_reference_point
 from botorch.utils.sampling import manual_seed
 from botorch.utils.testing import MockModel, MockPosterior
+from torch._tensor import Tensor
 
 
 GET_ACQF_PATH = "ax.models.torch.botorch_moo_defaults.get_acquisition_function"
@@ -39,9 +41,8 @@ GET_OBJ_PATH = (
 FIT_MODEL_MO_PATH = "ax.models.torch.botorch_defaults.fit_gpytorch_mll"
 
 
-# pyre-fixme[3]: Return type must be annotated.
 # pyre-fixme[2]: Parameter must be annotated.
-def dummy_predict(model, X):
+def dummy_predict(model, X) -> Tuple[Tensor, Tensor]:
     # Add column to X that is a product of previous elements.
     mean = torch.cat([X, torch.prod(X, dim=1).reshape(-1, 1)], dim=1)
     cov = torch.zeros(mean.shape[0], mean.shape[1], mean.shape[1])

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -62,12 +62,9 @@ def _get_optimizer_kwargs() -> Dict[str, int]:
 
 # pyre-fixme[3]: Return type must be annotated.
 def _get_torch_test_data(
-    # pyre-fixme[2]: Parameter must be annotated.
-    dtype=torch.float,
-    # pyre-fixme[2]: Parameter must be annotated.
-    cuda=False,
-    # pyre-fixme[2]: Parameter must be annotated.
-    constant_noise=True,
+    dtype: torch.dtype = torch.float,
+    cuda: bool = False,
+    constant_noise: bool = True,
     # pyre-fixme[2]: Parameter must be annotated.
     task_features=None,
 ):

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -43,12 +43,9 @@ from botorch.utils.testing import MockPosterior
 from torch import Tensor
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-ACQUISITION_PATH = Acquisition.__module__
-# pyre-fixme[5]: Global expression must be annotated.
-CURRENT_PATH = __name__
-# pyre-fixme[5]: Global expression must be annotated.
-SURROGATE_PATH = Surrogate.__module__
+ACQUISITION_PATH: str = Acquisition.__module__
+CURRENT_PATH: str = __name__
+SURROGATE_PATH: str = Surrogate.__module__
 
 
 # Used to avoid going through BoTorch `Acquisition.__init__` which

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -7,6 +7,7 @@
 import dataclasses
 import warnings
 from contextlib import ExitStack
+from typing import Dict
 from unittest import mock
 
 import numpy as np
@@ -40,23 +41,17 @@ from botorch.sampling.samplers import SobolQMCNormalSampler
 from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-CURRENT_PATH = __name__
-# pyre-fixme[5]: Global expression must be annotated.
-MODEL_PATH = BoTorchModel.__module__
-# pyre-fixme[5]: Global expression must be annotated.
-SURROGATE_PATH = Surrogate.__module__
-# pyre-fixme[5]: Global expression must be annotated.
-UTILS_PATH = choose_model_class.__module__
-# pyre-fixme[5]: Global expression must be annotated.
-ACQUISITION_PATH = Acquisition.__module__
-# pyre-fixme[5]: Global expression must be annotated.
-LIST_SURROGATE_PATH = ListSurrogate.__module__
-# pyre-fixme[5]: Global expression must be annotated.
-NEHVI_PATH = qNoisyExpectedHypervolumeImprovement.__module__
+CURRENT_PATH: str = __name__
+MODEL_PATH: str = BoTorchModel.__module__
+SURROGATE_PATH: str = Surrogate.__module__
+UTILS_PATH: str = choose_model_class.__module__
+ACQUISITION_PATH: str = Acquisition.__module__
+LIST_SURROGATE_PATH: str = ListSurrogate.__module__
+NEHVI_PATH: str = qNoisyExpectedHypervolumeImprovement.__module__
 
-# pyre-fixme[5]: Global expression must be annotated.
-ACQ_OPTIONS = {Keys.SAMPLER: SobolQMCNormalSampler(1024)}
+ACQ_OPTIONS: Dict[Keys, SobolQMCNormalSampler] = {
+    Keys.SAMPLER: SobolQMCNormalSampler(1024)
+}
 
 
 class BoTorchModelTest(TestCase):
@@ -70,6 +65,8 @@ class BoTorchModelTest(TestCase):
             surrogate=self.surrogate,
             acquisition_class=self.acquisition_class,
             botorch_acqf_class=self.botorch_acqf_class,
+            # pyre-fixme[6]: For 4th param expected `Optional[Dict[str,
+            #  typing.Any]]` but got `Dict[Keys, SobolQMCNormalSampler]`.
             acquisition_options=self.acquisition_options,
         )
 

--- a/ax/models/torch/tests/test_multi_fidelity.py
+++ b/ax/models/torch/tests/test_multi_fidelity.py
@@ -20,10 +20,8 @@ from botorch.models.gp_regression import SingleTaskGP
 from botorch.utils.datasets import SupervisedDataset
 
 
-# pyre-fixme[5]: Global expression must be annotated.
-ACQUISITION_PATH = Acquisition.__module__
-# pyre-fixme[5]: Global expression must be annotated.
-MULTI_FIDELITY_PATH = MultiFidelityAcquisition.__module__
+ACQUISITION_PATH: str = Acquisition.__module__
+MULTI_FIDELITY_PATH: str = MultiFidelityAcquisition.__module__
 MFKG_PATH = (
     f"{qMultiFidelityKnowledgeGradient.__module__}.qMultiFidelityKnowledgeGradient"
 )

--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -128,8 +128,7 @@ def arm_name_to_sort_key(arm_name: str) -> Tuple[str, int, int]:
         return (arm_name, 0, 0)
 
 
-# pyre-fixme[3]: Return type must be annotated.
-def resize_subtitles(figure: Dict[str, Any], size: int):
+def resize_subtitles(figure: Dict[str, Any], size: int) -> Dict[str, Any]:
     for ant in figure["layout"]["annotations"]:
         ant["font"].update(size=size)
     return figure
@@ -485,9 +484,8 @@ def get_fixed_values(
 
 
 # Utility methods ported from JS
-# pyre-fixme[3]: Return type must be annotated.
 # pyre-fixme[2]: Parameter must be annotated.
-def contour_config_to_trace(config):
+def contour_config_to_trace(config) -> List[Dict[str, Any]]:
     # Load from config
     arm_data = config["arm_data"]
     density = config["density"]
@@ -751,33 +749,28 @@ def infer_is_relative(
     return relative
 
 
-# pyre-fixme[3]: Return type must be annotated.
 def slice_config_to_trace(
     # pyre-fixme[2]: Parameter must be annotated.
     arm_data,
     # pyre-fixme[2]: Parameter must be annotated.
     arm_name_to_parameters,
-    # pyre-fixme[2]: Parameter must be annotated.
-    f,
+    f: List[float],
     # pyre-fixme[2]: Parameter must be annotated.
     fit_data,
     # pyre-fixme[2]: Parameter must be annotated.
     grid,
-    # pyre-fixme[2]: Parameter must be annotated.
-    metric,
+    metric: str,
     # pyre-fixme[2]: Parameter must be annotated.
     param,
-    # pyre-fixme[2]: Parameter must be annotated.
-    rel,
+    rel: bool,
     # pyre-fixme[2]: Parameter must be annotated.
     setx,
-    # pyre-fixme[2]: Parameter must be annotated.
-    sd,
+    sd: List[float],
     # pyre-fixme[2]: Parameter must be annotated.
     is_log,
     # pyre-fixme[2]: Parameter must be annotated.
     visible,
-):
+) -> List[Dict[str, Any]]:
     # format data
     res = relativize_data(f, sd, rel, arm_data, metric)
     f_final = res[0]

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -499,7 +499,6 @@ def _validate_outcome_constraints(
                 )
 
 
-# pyre-fixme[3]: Return type must be annotated.
 def _build_new_optimization_config(
     # pyre-fixme[2]: Parameter must be annotated.
     weights,
@@ -509,7 +508,7 @@ def _build_new_optimization_config(
     secondary_objective,
     # pyre-fixme[2]: Parameter must be annotated.
     outcome_constraints=None,
-):
+) -> MultiObjectiveOptimizationConfig:
     obj = ScalarizedObjective(
         metrics=[primary_objective, secondary_objective],
         weights=weights,

--- a/ax/plot/table_view.py
+++ b/ax/plot/table_view.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+from typing import Tuple
 
 import pandas as pd
 import plotly.graph_objs as go
@@ -14,6 +15,7 @@ from ax.modelbridge.factory import get_empirical_bayes_thompson, get_thompson
 from ax.plot.base import AxPlotConfig, AxPlotTypes, PlotMetric, Z
 from ax.plot.helper import get_plot_data
 from ax.plot.scatter import _error_scatter_data
+from pandas.core.frame import DataFrame
 
 
 COLOR_SCALE = ["#ff3333", "#ff6666", "#ffffff", "#99ff99", "#33ff33"]
@@ -34,14 +36,13 @@ def get_color(x: float, ci: float, rel: bool, reverse: bool) -> str:
     return color_scale[index]
 
 
-# pyre-fixme[3]: Return type must be annotated.
 def table_view_plot(
     experiment: Experiment,
     data: Data,
     use_empirical_bayes: bool = True,
     only_data_frame: bool = False,
     arm_noun: str = "arm",
-):
+) -> Tuple[DataFrame]:
     """Table of means and confidence intervals.
 
     Table is of the form:
@@ -158,4 +159,5 @@ def table_view_plot(
         margin=go.layout.Margin(l=0, r=20, b=20, t=20, pad=4),  # noqa E741
     )
     fig = go.Figure(data=[trace], layout=layout)
+    # pyre-fixme[7]: Expected `Tuple[DataFrame]` but got `AxPlotConfig`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)

--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Dict, Tuple, Union
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -14,11 +15,12 @@ from ax.modelbridge.registry import Models
 from ax.service.managed_loop import OptimizationLoop, optimize
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import fast_botorch_optimize
+from numpy import ndarray
 
 
-# pyre-fixme[3]: Return type must be annotated.
-# pyre-fixme[2]: Parameter must be annotated.
-def _branin_evaluation_function(parameterization, weight=None):
+def _branin_evaluation_function(
+    parameterization, weight=None  # pyre-fixme[2]: Parameter must be annotated.
+) -> Dict[str, Tuple[Union[float, ndarray], float]]:
     if any(param_name not in parameterization.keys() for param_name in ["x1", "x2"]):
         raise ValueError("Parametrization does not contain x1 or x2")
     x1, x2 = parameterization["x1"], parameterization["x2"]
@@ -28,18 +30,18 @@ def _branin_evaluation_function(parameterization, weight=None):
     }
 
 
-# pyre-fixme[3]: Return type must be annotated.
-# pyre-fixme[2]: Parameter must be annotated.
-def _branin_evaluation_function_v2(parameterization, weight=None):
+def _branin_evaluation_function_v2(
+    parameterization, weight=None  # pyre-fixme[2]: Parameter must be annotated.
+) -> Tuple[Union[float, ndarray], float]:
     if any(param_name not in parameterization.keys() for param_name in ["x1", "x2"]):
         raise ValueError("Parametrization does not contain x1 or x2")
     x1, x2 = parameterization["x1"], parameterization["x2"]
     return (branin(x1, x2), 0.0)
 
 
-# pyre-fixme[3]: Return type must be annotated.
-# pyre-fixme[2]: Parameter must be annotated.
-def _branin_evaluation_function_with_unknown_sem(parameterization, weight=None):
+def _branin_evaluation_function_with_unknown_sem(
+    parameterization, weight=None  # pyre-fixme[2]: Parameter must be annotated.
+) -> Tuple[Union[float, ndarray], None]:
     if any(param_name not in parameterization.keys() for param_name in ["x1", "x2"]):
         raise ValueError("Parametrization does not contain x1 or x2")
     x1, x2 = parameterization["x1"], parameterization["x2"]

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import namedtuple
+from typing import List
 from unittest.mock import patch
 
 import pandas as pd
@@ -31,10 +32,8 @@ from plotly import graph_objects as go
 
 OBJECTIVE_NAME = "branin"
 PARAMETER_COLUMNS = ["x1", "x2"]
-# pyre-fixme[5]: Global expression must be annotated.
-FLOAT_COLUMNS = [OBJECTIVE_NAME] + PARAMETER_COLUMNS
-# pyre-fixme[5]: Global expression must be annotated.
-EXPECTED_COLUMNS = [
+FLOAT_COLUMNS: List[str] = [OBJECTIVE_NAME] + PARAMETER_COLUMNS
+EXPECTED_COLUMNS: List[str] = [
     "trial_index",
     "arm_name",
     "trial_status",

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -65,8 +65,10 @@ TParameterRepresentation = Dict[
 ]
 PARAM_CLASSES = ["range", "choice", "fixed"]
 PARAM_TYPES = {"int": int, "float": float, "bool": bool, "str": str}
-# pyre-fixme[5]: Global expression must be annotated.
-COMPARISON_OPS = {"<=": ComparisonOp.LEQ, ">=": ComparisonOp.GEQ}
+COMPARISON_OPS: Dict[str, ComparisonOp] = {
+    "<=": ComparisonOp.LEQ,
+    ">=": ComparisonOp.GEQ,
+}
 EXPECTED_KEYS_IN_PARAM_REPR = {
     "name",
     "type",

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -46,6 +46,7 @@ from ax.plot.slice import interact_slice_plotly
 from ax.plot.trace import optimization_trace_single_method_plotly
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
+from pandas.core.frame import DataFrame
 
 if TYPE_CHECKING:
     from ax.service.scheduler import Scheduler
@@ -395,13 +396,12 @@ def _get_generation_method_str(trial: BaseTrial) -> str:
     return ", ".join(generation_methods) if generation_methods else "Unknown"
 
 
-# pyre-fixme[3]: Return type must be annotated.
 def _merge_results_if_no_duplicates(
     arms_df: pd.DataFrame,
     data: Data,
     key_components: List[str],
     metrics: List[Metric],
-):
+) -> DataFrame:
     """Formats ``data.df`` and merges it with ``arms_df`` if all of the following are
     True:
         - ``data.df`` is not empty

--- a/ax/utils/common/tests/test_docutils.py
+++ b/ax/utils/common/tests/test_docutils.py
@@ -8,13 +8,11 @@ from ax.utils.common.docutils import copy_doc
 from ax.utils.common.testutils import TestCase
 
 
-# pyre-fixme[3]: Return type must be annotated.
-def has_doc():
+def has_doc() -> None:
     """I have a docstring"""
 
 
-# pyre-fixme[3]: Return type must be annotated.
-def has_no_doc():
+def has_no_doc() -> None:
     pass
 
 

--- a/ax/utils/common/tests/test_testutils.py
+++ b/ax/utils/common/tests/test_testutils.py
@@ -20,8 +20,7 @@ def _f():
 F_FAILURE_LINENO = 17  # Line # for the error in `_f`.
 
 
-# pyre-fixme[3]: Return type must be annotated.
-def _g():
+def _g() -> None:
     _f()  # Lines along the path are matched too
 
 

--- a/ax/utils/notebook/plotting.py
+++ b/ax/utils/notebook/plotting.py
@@ -15,9 +15,7 @@ from plotly.offline import init_notebook_mode, iplot
 logger: Logger = get_logger(__name__)
 
 
-# pyre-fixme[3]: Return type must be annotated.
-# pyre-fixme[2]: Parameter must be annotated.
-def init_notebook_plotting(offline=False):
+def init_notebook_plotting(offline: bool = False) -> None:
     """Initialize plotting in notebooks, either in online or offline mode."""
     display_bundle = {"text/html": _wrap_js(_js_requires(offline=offline))}
     display(display_bundle, raw=True)
@@ -25,8 +23,7 @@ def init_notebook_plotting(offline=False):
     init_notebook_mode()
 
 
-# pyre-fixme[2]: Parameter must be annotated.
-def render(plot_config: AxPlotConfig, inject_helpers=False) -> None:
+def render(plot_config: AxPlotConfig, inject_helpers: bool = False) -> None:
     """Render plot config."""
     if plot_config.plot_type == AxPlotTypes.GENERIC:
         iplot(plot_config.data)

--- a/ax/utils/sensitivity/derivative_gp.py
+++ b/ax/utils/sensitivity/derivative_gp.py
@@ -23,8 +23,7 @@ def get_KXX_inv(gp: Model) -> Tensor:
     return L_inv_upper @ L_inv_upper.transpose(0, 1)
 
 
-# pyre-fixme[2]: Parameter must be annotated.
-def get_KxX_dx(gp: Model, x: Tensor, kernel_type="rbf") -> Tensor:
+def get_KxX_dx(gp: Model, x: Tensor, kernel_type: str = "rbf") -> Tensor:
     """Computes the analytic derivative of the kernel K(x,X) w.r.t. x.
     Args:
         gp: Botorch model.
@@ -67,8 +66,7 @@ def get_KxX_dx(gp: Model, x: Tensor, kernel_type="rbf") -> Tensor:
     return total
 
 
-# pyre-fixme[2]: Parameter must be annotated.
-def get_Kxx_dx2(gp: Model, kernel_type="rbf") -> Tensor:
+def get_Kxx_dx2(gp: Model, kernel_type: str = "rbf") -> Tensor:
     r"""Computes the analytic second derivative of the kernel w.r.t. the training data
     Args:
         gp: Botorch model.

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -39,8 +39,7 @@ def get_observation_features() -> ObservationFeatures:
 
 def get_observation(
     first_metric_name: str = "a",
-    # pyre-fixme[2]: Parameter must be annotated.
-    second_metric_name="b",
+    second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(
@@ -57,8 +56,7 @@ def get_observation(
 
 def get_observation1(
     first_metric_name: str = "a",
-    # pyre-fixme[2]: Parameter must be annotated.
-    second_metric_name="b",
+    second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(
@@ -75,8 +73,7 @@ def get_observation1(
 
 def get_observation_status_quo0(
     first_metric_name: str = "a",
-    # pyre-fixme[2]: Parameter must be annotated.
-    second_metric_name="b",
+    second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(
@@ -94,8 +91,7 @@ def get_observation_status_quo0(
 
 def get_observation_status_quo1(
     first_metric_name: str = "a",
-    # pyre-fixme[2]: Parameter must be annotated.
-    second_metric_name="b",
+    second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(
@@ -113,8 +109,7 @@ def get_observation_status_quo1(
 
 def get_observation1trans(
     first_metric_name: str = "a",
-    # pyre-fixme[2]: Parameter must be annotated.
-    second_metric_name="b",
+    second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(
@@ -131,8 +126,7 @@ def get_observation1trans(
 
 def get_observation2(
     first_metric_name: str = "a",
-    # pyre-fixme[2]: Parameter must be annotated.
-    second_metric_name="b",
+    second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(
@@ -149,8 +143,7 @@ def get_observation2(
 
 def get_observation2trans(
     first_metric_name: str = "a",
-    # pyre-fixme[2]: Parameter must be annotated.
-    second_metric_name="b",
+    second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
         features=ObservationFeatures(

--- a/ax/utils/testing/torch_stubs.py
+++ b/ax/utils/testing/torch_stubs.py
@@ -17,8 +17,7 @@ def get_optimizer_kwargs() -> Dict[str, int]:
 
 # pyre-fixme[3]: Return type must be annotated.
 def get_torch_test_data(
-    # pyre-fixme[2]: Parameter must be annotated.
-    dtype=torch.float,
+    dtype: torch.dtype = torch.float,
     cuda: bool = False,
     constant_noise: bool = True,
     # pyre-fixme[2]: Parameter must be annotated.
@@ -32,10 +31,26 @@ def get_torch_test_data(
                 [1.0 + offset, 2.0 + offset, 3.0 + offset],
                 [2.0 + offset, 3.0 + offset, 4.0 + offset],
             ],
+            # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
+            #  `Union[dtype, device]`.
+            # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but
+            #  got `Union[dtype, device]`.
+            # pyre-fixme[6]: For 2nd param expected `bool` but got `Union[dtype,
+            #  device]`.
             **tkwargs,
         )
     ]
+    # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got `Union[dtype,
+    #  device]`.
+    # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but got
+    #  `Union[dtype, device]`.
+    # pyre-fixme[6]: For 2nd param expected `bool` but got `Union[dtype, device]`.
     Ys = [torch.tensor([[3.0 + offset], [4.0 + offset]], **tkwargs)]
+    # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got `Union[dtype,
+    #  device]`.
+    # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but got
+    #  `Union[dtype, device]`.
+    # pyre-fixme[6]: For 2nd param expected `bool` but got `Union[dtype, device]`.
     Yvars = [torch.tensor([[0.0 + offset], [2.0 + offset]], **tkwargs)]
     if constant_noise:
         Yvars[0].fill_(1.0)


### PR DESCRIPTION
Summary:
Infer pyre type hints: https://pyre-check.org/docs/pysa-coverage/#pyre-infer

```
pyre infer
pyre infer -i --annotate-from-existing-stubs
arc lint
```

Also some minor cleanup from where the infer imported weirdly wrong things due to name collisions + torch weirdness, where autodeps freaked out, and where arc lint moved pyre-fixme comments off they're intended line.

I tried to do this when I first enabled pyre strict throughout our codebase but there were way way too many places that needed manual cleanup. I think a combination of heroic manual annotating from Sait as well as the codemods here D39578735 (https://github.com/facebook/Ax/commit/2e6a9f2e9b28b92ca0b7c6bd564a43f8bc4249e7) and here D39579225 (https://github.com/facebook/Ax/commit/c9e56ee435cb81cf35f9eb3abdf4e7fb75875fc5) are what made the difference this time and there were only ~20 places that needed special attention.

Differential Revision: D39619891

