### PR TITLE
Pass in required columns to pd.Dataframe as List instead of Set

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -55,6 +55,8 @@ class Data(Base, SerializationMixin):
         "fidelities": str,  # Dictionary stored as json
     }
 
+    _df: pd.DataFrame
+
     def __init__(
         self,
         df: Optional[pd.DataFrame] = None,
@@ -69,8 +71,7 @@ class Data(Base, SerializationMixin):
         """
         # Initialize with barebones DF.
         if df is None:
-            # pyre-fixme[4]: Attribute must be annotated.
-            self._df = pd.DataFrame(columns=self.required_columns())
+            self._df = pd.DataFrame(columns=list(self.required_columns()))
         else:
             columns = set(df.columns)
             missing_columns = self.required_columns() - columns

--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -83,6 +83,11 @@ class MapData(Data):
 
     DEDUPLICATE_BY_COLUMNS = ["arm_name", "metric_name"]
 
+    _map_df: pd.DataFrame
+
+    # pyre-fixme[24]: Generic type `MapKeyInfo` expects 1 type parameter.
+    _map_key_infos: List[MapKeyInfo]
+
     def __init__(
         self,
         df: Optional[pd.DataFrame] = None,
@@ -94,12 +99,11 @@ class MapData(Data):
             raise ValueError("map_key_infos may be `None` iff `df` is None.")
 
         # pyre-fixme[4]: Attribute must be annotated.
-        self._map_key_infos = map_key_infos or []
+        self._map_key_infos = list(map_key_infos) if map_key_infos is not None else []
 
         if df is None:  # If df is None create an empty dataframe with appropriate cols
-            # pyre-fixme[4]: Attribute must be annotated.
             self._map_df = pd.DataFrame(
-                columns=self.required_columns().union(self.map_keys)
+                columns=list(self.required_columns().union(self.map_keys))
             )
         else:
             columns = set(df.columns)


### PR DESCRIPTION
Summary:
The new version of Pandas being used by gh actions unit tests does not allow us to pass in columns as a Set anymore.

In this diff I grepped for all df initializations that specified columns as a Set and wrapped with a call to `list`.

Differential Revision: D39654724

