### PR TITLE
Fix pyre error in Alebo

### DIFF
--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -103,7 +103,7 @@ class ALEBOKernel(Kernel):
         # Compute kernel distance
         z1 = torch.matmul(x1, U_t)
         z2 = torch.matmul(x2, U_t)
-        # pyre-fixme[7]: Expected `Tensor` but got `Union[LinearOperator, Tensor]`.
+
         return self.covar_dist(
             z1,
             z2,


### PR DESCRIPTION
Summary: Max's GPyTorch upgrade yesterday "broke" some pyre annotations in Ax by fixing annotations in GPytorch and making a pyre-fixme irrelevant. This removes the fixme

Differential Revision: D39654865

