### PR TITLE
Combine data fetching for analyzers

### DIFF
--- a/ax/exceptions/data_provider.py
+++ b/ax/exceptions/data_provider.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Iterable
+from typing import Any
 
 
 class DataProviderError(Exception):
@@ -35,16 +35,3 @@ class DataProviderError(Exception):
             message=self.message,
             dp_error=self.data_provider_error,
         )
-
-
-class MissingDataError(Exception):
-    def __init__(self, missing_trial_indexes: Iterable[int]) -> None:
-        missing_trial_str = ", ".join([str(index) for index in missing_trial_indexes])
-        self.message: str = (
-            f"Unable to find data for the following trials: {missing_trial_str} "
-            "consider updating the data fetching kwargs or manually fetching "
-            "data via `refetch_data()`"
-        )
-
-    def __str__(self) -> str:
-        return self.message


### PR DESCRIPTION
Summary:
This change is for the scenario where all of our data has been prefetched in a nightly job.  Unless the user explicitly distrusts that data enough to use `refetch_data()` or adds new metrics, we want it to use attached data.

Before this, PTSAnalyzer works as we'd want except for the current and any other running trials, where it always fetches.  QuickBOAnalyzer never fetches for completed trials and always fetches for running trials.  Both analyzers would cache results after the first fetch.

Now it tries to use lookup data for everything, fetching metrics it can't find, unless you specify refetch and then it will set "use_attached_data" false (by calling refetch).  Then it will ignore attached data.

After fetching data it always sets "use_attached_data" back to true.

NOTE: if the user wants to refetch one metric they'd have to refetch them all because the refetched data would include and attach only the metrics they fetched.

Differential Revision: D39219018

