### PR TITLE
Store detailed generator runs on trials

### DIFF
--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -229,6 +229,10 @@ class OptimizationConfig(Base):
             end_repr = ", risk_measure=" + repr(self.risk_measure) + ")"
         return base_repr + end_repr
 
+    def __hash__(self) -> int:
+        """Make the class hashable to support grouping of GeneratorRuns."""
+        return hash(repr(self))
+
 
 class MultiObjectiveOptimizationConfig(OptimizationConfig):
     """An optimization configuration for multi-objective optimization,

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -371,6 +371,10 @@ class SearchSpace(Base):
             "parameter_constraints=" + repr(self._parameter_constraints) + ")"
         )
 
+    def __hash__(self) -> int:
+        """Make the class hashable to support grouping of GeneratorRuns."""
+        return hash(repr(self))
+
 
 class HierarchicalSearchSpace(SearchSpace):
     def __init__(


### PR DESCRIPTION
Summary: By detailed generator runs, I mean that they have opt config and search space.  Because candidates are often generated using multiple opt configs, there may be multiple GRs that get attached to the trial with the same model key.  However, we do not want this reflected in plots, so we still have the option to create GRs without opt config and search space for plotting.  None of this is exposed in the top level API.

Differential Revision: D39712619

