### PR TITLE
Change botorch benchmark problems to take in TestProblem class and kwargs

### DIFF
--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -27,20 +27,32 @@ class BenchmarkProblemRegistryEntry:
 BENCHMARK_PROBLEM_REGISTRY = {
     "ackley": BenchmarkProblemRegistryEntry(
         factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
-        factory_kwargs={"test_problem": Ackley(), "num_trials": 50},
+        factory_kwargs={
+            "test_problem_class": Ackley,
+            "test_problem_kwargs": {},
+            "num_trials": 50,
+        },
     ),
     "branin": BenchmarkProblemRegistryEntry(
         factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
-        factory_kwargs={"test_problem": Branin(), "num_trials": 30},
+        factory_kwargs={
+            "test_problem_class": Branin,
+            "test_problem_kwargs": {},
+            "num_trials": 30,
+        },
     ),
     "branin_currin": BenchmarkProblemRegistryEntry(
         factory_fn=MultiObjectiveBenchmarkProblem.from_botorch_multi_objective,
-        factory_kwargs={"test_problem": BraninCurrin(), "num_trials": 30},
+        factory_kwargs={
+            "test_problem_class": BraninCurrin,
+            "test_problem_kwargs": {},
+            "num_trials": 30,
+        },
     ),
     "branin_currin30": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n: embed_higher_dimension(
             problem=MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
-                test_problem=BraninCurrin(), num_trials=100
+                test_problem_class=BraninCurrin, test_problem_kwargs={}, num_trials=100
             ),
             total_dimensionality=n,
         ),
@@ -48,12 +60,18 @@ BENCHMARK_PROBLEM_REGISTRY = {
     ),
     "hartmann6": BenchmarkProblemRegistryEntry(
         factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
-        factory_kwargs={"test_problem": Hartmann(dim=6), "num_trials": 50},
+        factory_kwargs={
+            "test_problem_class": Hartmann,
+            "test_problem_kwargs": {"dim": 6},
+            "num_trials": 50,
+        },
     ),
     "hartmann30": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n: embed_higher_dimension(
             problem=SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
-                test_problem=Hartmann(dim=6), num_trials=100
+                test_problem_class=Hartmann,
+                test_problem_kwargs={"dim": 6},
+                num_trials=100,
             ),
             total_dimensionality=n,
         ),
@@ -73,7 +91,11 @@ BENCHMARK_PROBLEM_REGISTRY = {
     ),
     "powell": BenchmarkProblemRegistryEntry(
         factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
-        factory_kwargs={"test_problem": Powell(), "num_trials": 50},
+        factory_kwargs={
+            "test_problem_class": Powell,
+            "test_problem_kwargs": {},
+            "num_trials": 50,
+        },
     ),
 }
 

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -95,7 +95,9 @@ class TestBenchmark(TestCase):
     @fast_botorch_optimize
     def test_timeout(self) -> None:
         problem = SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
-            test_problem=Branin(), num_trials=1000  # Unachievable num_trials
+            test_problem_class=Branin,
+            test_problem_kwargs={},
+            num_trials=1000,  # Unachievable num_trials
         )
 
         generation_strategy = GenerationStrategy(

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -16,7 +16,9 @@ class TestBenchmarkProblem(TestCase):
     def test_single_objective_from_botorch(self) -> None:
         test_problem = Ackley()
         ackley_problem = SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
-            test_problem=test_problem, num_trials=1
+            test_problem_class=test_problem.__class__,
+            test_problem_kwargs={},
+            num_trials=1,
         )
 
         # Test search space
@@ -51,7 +53,9 @@ class TestBenchmarkProblem(TestCase):
         test_problem = BraninCurrin()
         branin_currin_problem = (
             MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
-                test_problem=test_problem, num_trials=1
+                test_problem_class=test_problem.__class__,
+                test_problem_kwargs={},
+                num_trials=1,
             )
         )
 

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -25,18 +25,20 @@ from botorch.test_functions.synthetic import Branin
 
 
 def get_benchmark_problem() -> BenchmarkProblem:
-    return BenchmarkProblem.from_botorch(test_problem=Branin(), num_trials=4)
+    return BenchmarkProblem.from_botorch(
+        test_problem_class=Branin, test_problem_kwargs={}, num_trials=4
+    )
 
 
 def get_single_objective_benchmark_problem() -> SingleObjectiveBenchmarkProblem:
     return SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
-        test_problem=Branin(), num_trials=4
+        test_problem_class=Branin, test_problem_kwargs={}, num_trials=4
     )
 
 
 def get_multi_objective_benchmark_problem() -> MultiObjectiveBenchmarkProblem:
     return MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
-        test_problem=BraninCurrin(), num_trials=4
+        test_problem_class=BraninCurrin, test_problem_kwargs={}, num_trials=4
     )
 
 


### PR DESCRIPTION
Summary:
David ran into a bug when trying to run Hartmann3 benchmarks on fbl -- this turned out to be an issue with our serialization of botorch benchmark problems. Previously we were passing in an instantiated TestProblem, extracting its class and module name, saving those strings, and reinstantiating at load time. If a problem had args passed in (ex. `dim=3` in David's case) they were lost.

Now we pass in a class and kwargs so we always have those to instantiate with whenever we need, like we do for other botorch components.

Reviewed By: dme65

Differential Revision: D39706491

