### PR TITLE
Skip contour plots when too many range parameters

### DIFF
--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import namedtuple
+from logging import WARN
 from typing import List
 from unittest.mock import patch
 
@@ -14,6 +15,7 @@ from ax.core.outcome_constraint import ObjectiveThreshold
 from ax.core.types import ComparisonOp
 from ax.modelbridge.registry import Models
 from ax.service.utils.report_utils import (
+    _get_objective_v_param_plots,
     _get_shortest_unique_suffix_dict,
     exp_to_df,
     Experiment,
@@ -24,6 +26,7 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_branin_experiment_with_multi_objective,
     get_branin_experiment_with_timestamp_map_metric,
+    get_high_dimensional_branin_experiment,
     get_multi_type_experiment,
 )
 from ax.utils.testing.mock import fast_botorch_optimize
@@ -216,3 +219,18 @@ class ReportUtilsTest(TestCase):
                 model=Models.BOTORCH(experiment=exp, data=exp.fetch_data()),
                 true_objective_metric_name="not_present",
             )
+
+    @fast_botorch_optimize
+    def test_skip_contour_high_dimensional(self) -> None:
+        exp = get_high_dimensional_branin_experiment()
+        # Initial Sobol points
+        sobol = Models.SOBOL(search_space=exp.search_space)
+        for _ in range(10):
+            exp.new_trial(sobol.gen(1)).run()
+        model = Models.GPEI(
+            experiment=exp,
+            data=exp.fetch_data(),
+        )
+        with self.assertLogs(logger="ax", level=WARN) as log:
+            _get_objective_v_param_plots(experiment=exp, model=model)
+            self.assertIn("Contour plotting skipped", log.output[0])

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -135,6 +135,7 @@ def _get_objective_trace_plot(
 def _get_objective_v_param_plots(
     experiment: Experiment,
     model: ModelBridge,
+    max_range_params_contour: int = 10,
 ) -> List[go.Figure]:
     search_space = experiment.search_space
 
@@ -152,7 +153,7 @@ def _get_objective_v_param_plots(
             model=model,
         )
     ]
-    if len(range_params) > 1:
+    if len(range_params) > 1 and len(range_params) <= max_range_params_contour:
         # contour plots
         try:
             with gpytorch.settings.max_eager_kernel_size(float("inf")):
@@ -167,6 +168,22 @@ def _get_objective_v_param_plots(
         # https://github.com/cornellius-gp/gpytorch/issues/1853
         except RuntimeError as e:
             logger.warning(f"Contour plotting failed with error: {e}.")
+    elif len(range_params) > max_range_params_contour:
+        warning_msg = (
+            "Contour plotting skipped since there are more than "
+            f"<br>`max_range_params_contour = {max_range_params_contour}` range "
+            "params. <br>Users can plot individual contour plots with the <br>python "
+            "function ax.plot.contour.plot_contour_plotly."
+        )
+        logger.warning(warning_msg)
+        # TODO: return a warning here then convert to a plot/message/etc. downstream.
+        warning_plot = (
+            go.Figure()
+            .add_annotation(text=warning_msg, showarrow=False, font={"size": 20})
+            .update_xaxes(showgrid=False, showticklabels=False, zeroline=False)
+            .update_yaxes(showgrid=False, showticklabels=False, zeroline=False)
+        )
+        output_plots.append(warning_plot)
     return output_plots
 
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -585,6 +585,48 @@ def get_experiment_with_observations(
     return exp
 
 
+def get_high_dimensional_branin_experiment() -> Experiment:
+    search_space = SearchSpace(
+        # pyre-fixme[6]: In call `SearchSpace.__init__`, for 1st parameter `parameters`
+        # expected `List[Parameter]` but got `List[RangeParameter]`.
+        parameters=[
+            RangeParameter(
+                name=f"x{i}",
+                parameter_type=ParameterType.FLOAT,
+                lower=-5.0,
+                upper=10.0,
+            )
+            for i in range(25)
+        ]
+        + [
+            RangeParameter(
+                name=f"x{i + 25}",
+                parameter_type=ParameterType.FLOAT,
+                lower=0.0,
+                upper=15.0,
+            )
+            for i in range(25)
+        ],
+    )
+
+    optimization_config = OptimizationConfig(
+        objective=Objective(
+            metric=BraninMetric(
+                name="objective",
+                param_names=["x19", "x44"],
+            ),
+            minimize=True,
+        )
+    )
+
+    return Experiment(
+        name="high_dimensional_branin_experiment",
+        search_space=search_space,
+        optimization_config=optimization_config,
+        runner=SyntheticRunner(),
+    )
+
+
 ##############################
 # Search Spaces
 ##############################


### PR DESCRIPTION
Summary: sets a default max number of range params (10) for which to create contour plots in report_results. above this default max, contour plotting is skipped. without this change, users can request arbitrarily many contour plots, which can effectively crash the sweep.

Reviewed By: dme65, lena-kashtelyan

Differential Revision: D39734951

