### PR TITLE
extend plot limitations to include number of metrics and slice plots

### DIFF
--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -233,4 +233,11 @@ class ReportUtilsTest(TestCase):
         )
         with self.assertLogs(logger="ax", level=WARN) as log:
             _get_objective_v_param_plots(experiment=exp, model=model)
-            self.assertIn("Contour plotting skipped", log.output[0])
+            self.assertEqual(len(log.output), 1)
+            self.assertIn("Skipping creation of 2450 contour plots", log.output[0])
+            _get_objective_v_param_plots(
+                experiment=exp, model=model, max_num_slice_plots=10
+            )
+            # Adds two more warnings.
+            self.assertEqual(len(log.output), 3)
+            self.assertIn("Skipping creation of 50 slice plots", log.output[1])


### PR DESCRIPTION
Summary:
* changes yes/no plotting criterion to be the number of plots to be created rather than the number of range params
* accounts for the number of metrics in that plotting criterion
* applies similar logic to the creation of slice plots (which i don't think are very costly but still probably better to have covered).

Differential Revision: D39784878

