### PR TITLE
Bump botorch version in preparation for Ax release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from setuptools import find_packages, setup
 
 # TODO: read pinned Botorch version from a shared source
-PINNED_BOTORCH_VERSION = "0.7.1"
+PINNED_BOTORCH_VERSION = "0.7.2"
 
 if os.environ.get("ALLOW_BOTORCH_LATEST"):
     # allows a more recent previously installed version of botorch to remain


### PR DESCRIPTION
Summary: Need to release an Ax patch that includes D39654724 (https://github.com/facebook/Ax/commit/2d7500e5c3cba4f028f1a553195e07e753bc0d88) to address pandas update incompatibility

Reviewed By: pcanaran

Differential Revision: D39861608

