### PR TITLE
Make `RnadomModel` subclasses deduplicate by default

### DIFF
--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -203,7 +203,7 @@ class ModelRegistryTest(TestCase):
             (
                 {
                     "seed": None,
-                    "deduplicate": False,
+                    "deduplicate": True,
                     "init_position": 0,
                     "scramble": True,
                     "generated_points": None,

--- a/ax/models/random/alebo_initializer.py
+++ b/ax/models/random/alebo_initializer.py
@@ -47,7 +47,7 @@ class ALEBOInitializer(UniformGenerator):
         self.Q = np.linalg.pinv(B) @ B  # Projects down to B and then back up
         self.nsamp = nsamp
         self.init_bound = init_bound
-        super().__init__(seed=seed)
+        super().__init__(seed=seed, deduplicate=False)
 
     @copy_doc(UniformGenerator.gen)
     def gen(

--- a/ax/models/random/rembo_initializer.py
+++ b/ax/models/random/rembo_initializer.py
@@ -35,7 +35,7 @@ class REMBOInitializer(UniformGenerator):
         self.A = A
         # pyre-fixme[4]: Attribute must be annotated.
         self.X_d_gen = []  # Store points in low-d space generated here
-        super().__init__(seed=seed)
+        super().__init__(seed=seed, deduplicate=False)
 
     def project_up(self, X: np.ndarray) -> np.ndarray:
         """Project to high-dimensional space."""

--- a/ax/models/random/sobol.py
+++ b/ax/models/random/sobol.py
@@ -39,7 +39,7 @@ class SobolGenerator(RandomModel):
     def __init__(
         self,
         seed: Optional[int] = None,
-        deduplicate: bool = False,
+        deduplicate: bool = True,
         init_position: int = 0,
         scramble: bool = True,
         generated_points: Optional[np.ndarray] = None,

--- a/ax/models/random/uniform.py
+++ b/ax/models/random/uniform.py
@@ -22,7 +22,7 @@ class UniformGenerator(RandomModel):
 
     """
 
-    def __init__(self, deduplicate: bool = False, seed: Optional[int] = None) -> None:
+    def __init__(self, deduplicate: bool = True, seed: Optional[int] = None) -> None:
         super().__init__(deduplicate=deduplicate, seed=seed)
         self._rs = np.random.RandomState(seed=seed)
 

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -211,10 +211,9 @@ class SQAStoreTest(TestCase):
         f"{Decoder.__module__}.Decoder.experiment_from_sqa",
         side_effect=Decoder(SQAConfig()).experiment_from_sqa,
     )
-    # pyre-fixme[3]: Return type must be annotated.
     def testExperimentSaveAndLoadReducedState(
         self, _mock_exp_from_sqa, _mock_trial_from_sqa, _mock_gr_from_sqa
-    ):
+    ) -> None:
         # 1. No abandoned arms + no trials case, reduced state should be the
         # same as non-reduced state.
         exp = get_experiment_with_multi_objective()
@@ -250,18 +249,18 @@ class SQAStoreTest(TestCase):
         # Expecting model kwargs to have 6 fields (seed, deduplicate, init_position,
         # scramble, generated_points, fallback_to_sample_polytope)
         # and the rest of model-state info on generator run to have values too.
-        # pyre-fixme[6]: For 1st param expected `Sized` but got `Optional[Dict[str,
-        #  typing.Any]]`.
-        self.assertEqual(len(gr._model_kwargs), 6)
-        # pyre-fixme[6]: For 1st param expected `Sized` but got `Optional[Dict[str,
-        #  typing.Any]]`.
-        self.assertEqual(len(gr._bridge_kwargs), 7)
-        # pyre-fixme[6]: For 1st param expected `Sized` but got `Optional[Dict[str,
-        #  typing.Any]]`.
-        self.assertEqual(len(gr._model_state_after_gen), 1)
-        # pyre-fixme[6]: For 1st param expected `Sized` but got `Optional[Dict[str,
-        #  typing.Any]]`.
-        self.assertEqual(len(gr._gen_metadata), 0)
+        mkw = gr._model_kwargs
+        self.assertIsNotNone(mkw)
+        self.assertEqual(len(mkw), 6)
+        bkw = gr._bridge_kwargs
+        self.assertIsNotNone(bkw)
+        self.assertEqual(len(bkw), 7)
+        ms = gr._model_state_after_gen
+        self.assertIsNotNone(ms)
+        self.assertEqual(len(ms), 2)
+        gm = gr._gen_metadata
+        self.assertIsNotNone(gm)
+        self.assertEqual(len(gm), 0)
         self.assertIsNotNone(gr._search_space, gr.optimization_config)
         exp.new_trial(generator_run=gr)
         save_experiment(exp)


### PR DESCRIPTION
Summary: As titled; we updated the base class years ago, but forgot to update the subclasses.

Reviewed By: Balandat, mpolson64

Differential Revision: D39736772

