### PR TITLE
Automatically set plotting limits

### DIFF
--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -59,9 +59,8 @@ FEATURE_IMPORTANCE_CAPTION = (
     "relatively low importance may still be important to tune."
 )
 CROSS_VALIDATION_CAPTION = (
-    '<b>NOTE:</b> Models that <a href="https://en.wikipedia.org/wiki/Winsorizing">'
-    "winsorize</a> may appear to plateau<br>far from the optimum. Remove outliers "
-    "using the<br>zoom tool before judging the fit."
+    "<b>NOTE:</b> We have tried out best to only plot the region of interest.<br>"
+    "This may hide outliers. You can autoscale the axes to see all trials."
 )
 
 


### PR DESCRIPTION
Summary: Our default plotting utilities don't handle outliers well and this makes it very hard to see the region of interest. This diff automatically sets the axes limits for our cv and trace plots using ideas similar to box-and-whisker plots. This will hopefully result in a much better user-experience when there are outliers.

Reviewed By: bernardbeckerman

Differential Revision: D39751755

