### PR TITLE
Improve a hack in BoTorchModel.fit() where outcome metrics names are forced through concatenation

### DIFF
--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -171,7 +171,7 @@ class BoTorchModel(TorchModel, Base):
                 metric_names=metric_names,
                 search_space_digest=search_space_digest,
             )
-
+        original_metric_names = deepcopy(metric_names)
         if len(datasets) > 1 and not isinstance(self.surrogate, ListSurrogate):
             # Note: If the datasets do not confirm to a block design then this
             # will filter the data and drop observations to make sure that it does.
@@ -189,6 +189,7 @@ class BoTorchModel(TorchModel, Base):
             candidate_metadata=candidate_metadata,
             state_dict=state_dict,
             refit=refit,
+            original_metric_names=original_metric_names,
         )
 
     @copy_doc(TorchModel.update)

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -203,6 +203,7 @@ class BoTorchModelTest(TestCase):
             candidate_metadata=self.candidate_metadata,
             state_dict=None,
             refit=True,
+            original_metric_names=self.metric_names,
         )
         # ensure that error is raised when len(metric_names) != len(datasets)
         with self.assertRaisesRegex(

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -65,7 +65,8 @@ class SurrogateTest(TestCase):
             bounds=self.bounds,
             target_fidelities={1: 1.0},
         )
-        self.metric_names = ["y"]
+        self.metric_names = ["x_y"]
+        self.original_metric_names = ["x", "y"]
         self.fixed_features = {1: 2.0}
         self.refit = True
         self.objective_weights = torch.tensor(
@@ -319,6 +320,19 @@ class SurrogateTest(TestCase):
             )
             mock_state_dict.assert_not_called()
             mock_fit.assert_called_once()
+            mock_state_dict.reset_mock()
+            mock_MLL.reset_mock()
+            mock_fit.reset_mock()
+            # Check that the optional original_metric_names arg propagates
+            # through surrogate._outcomes.
+            surrogate.fit(
+                datasets=self.training_data,
+                metric_names=self.metric_names,
+                search_space_digest=self.search_space_digest,
+                refit=self.refit,
+                original_metric_names=self.original_metric_names,
+            )
+            self.assertEqual(surrogate._outcomes, self.original_metric_names)
             mock_state_dict.reset_mock()
             mock_MLL.reset_mock()
             mock_fit.reset_mock()


### PR DESCRIPTION
Summary: We preserve the original list of metric_names and pass it down into surrogate.fit() before it got mangled in convert_to_block_design()

Differential Revision: D39982867

