### PR TITLE
Deal with NaNs when setting plotting limits

### DIFF
--- a/ax/plot/diagnostic.py
+++ b/ax/plot/diagnostic.py
@@ -126,20 +126,33 @@ def _obs_vs_pred_dropdown_plot(
             else [0.0] * len(y_raw)
         )
 
+        min_, max_ = _get_min_max_with_errors(y_raw, y_hat, se_raw, se_hat)
         if autoset_axis_limits:
             y_raw_np = np.array(y_raw)
-            q1 = np.percentile(y_raw_np, q=25, interpolation="lower").min()
-            q3 = np.percentile(y_raw_np, q=75, interpolation="higher").max()
+            q1 = np.nanpercentile(y_raw_np, q=25, interpolation="lower").min()
+            q3 = np.nanpercentile(y_raw_np, q=75, interpolation="higher").max()
             y_lower = q1 - 1.5 * (q3 - q1)
             y_upper = q3 + 1.5 * (q3 - q1)
             y_raw_np = y_raw_np.clip(y_lower, y_upper).tolist()
+            min_robust, max_robust = _get_min_max_with_errors(
+                y_raw_np, y_hat, se_raw, se_hat
+            )
+            y_padding = 0.05 * (max_robust - min_robust)
+            # Use the min/max of the limits
             layout_axis_range.append(
-                _get_min_max_with_errors(y_raw_np, y_hat, se_raw, se_hat)
+                [max(min_robust, min_) - y_padding, min(max_robust, max_) + y_padding]
+            )
+            traces.append(
+                _diagonal_trace(
+                    min(min_robust, min_) - y_padding,
+                    max(max_robust, max_) + y_padding,
+                    visible=(i == 0),
+                )
             )
         else:
             layout_axis_range.append(None)
-        min_, max_ = _get_min_max_with_errors(y_raw, y_hat, se_raw, se_hat)
-        traces.append(_diagonal_trace(min_, max_, visible=(i == 0)))
+            traces.append(_diagonal_trace(min_, max_, visible=(i == 0)))
+
         traces.append(
             _error_scatter_trace(
                 arms=list(data.in_sample.values()),

--- a/ax/plot/trace.py
+++ b/ax/plot/trace.py
@@ -234,6 +234,7 @@ def optimization_trace_single_method_plotly(
             plotting trial points. Defaults to light purple.
         autoset_axis_limits: Automatically try to set the limit for each axis to focus
             on the region of interest.
+
     Returns:
         go.Figure: plot of the optimization trace with IQR
     """
@@ -367,6 +368,7 @@ def optimization_trace_single_method(
             plotting trial points. Defaults to light purple.
         autoset_axis_limits: Automatically try to set the limit for each axis to focus
             on the region of interest.
+
     Returns:
         AxPlotConfig: plot of the optimization trace with IQR
     """


### PR DESCRIPTION
Summary: It turns out we pass in `NaNs` for pending points when creating cv plots, which doesn't play well with `np.percentile`.

Reviewed By: bernardbeckerman

Differential Revision: D39975219

