### PR TITLE
Add optional run_metadata arg to attach_trial

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -818,7 +818,10 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         )
 
     def attach_trial(
-        self, parameters: TParameterization, ttl_seconds: Optional[int] = None
+        self,
+        parameters: TParameterization,
+        ttl_seconds: Optional[int] = None,
+        run_metadata: Optional[Dict[str, Any]] = None,
     ) -> Tuple[TParameterization, int]:
         """Attach a new trial with the given parameterization to the experiment.
 
@@ -855,6 +858,8 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
             "Attached custom parameterization "
             f"{round_floats_for_logging(item=parameters)} as trial {trial.index}."
         )
+        if run_metadata is not None:
+            trial.update_run_metadata(metadata=run_metadata)
         self._save_or_update_trial_in_db_if_possible(
             experiment=self.experiment,
             trial=trial,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -64,6 +64,10 @@ if TYPE_CHECKING:
 
 
 RANDOM_SEED = 239
+DUMMY_RUN_METADATA = {
+    "TEST_KEY": "TEST_VALUE",
+    "abc": {123: 456},
+}
 
 
 def run_trials_using_recommended_parallelism(
@@ -1635,7 +1639,9 @@ class TestAxClient(TestCase):
             ],
             minimize=True,
         )
-        params, idx = ax_client.attach_trial(parameters={"x": 0.0, "y": 1.0})
+        params, idx = ax_client.attach_trial(
+            parameters={"x": 0.0, "y": 1.0}, run_metadata=DUMMY_RUN_METADATA
+        )
         ax_client.complete_trial(trial_index=idx, raw_data=5)
         # pyre-fixme[16]: `Optional` has no attribute `__getitem__`.
         self.assertEqual(ax_client.get_best_parameters()[0], params)


### PR DESCRIPTION
Summary: Allows run_metadata to added during attach_trial.

Reviewed By: lena-kashtelyan

Differential Revision: D40075619

