### PR TITLE
Botorch closures (#1439)

### DIFF
--- a/ax/utils/testing/mock.py
+++ b/ax/utils/testing/mock.py
@@ -29,7 +29,6 @@ def fast_botorch_optimize_context_manager() -> Generator[None, None, None]:
             kwargs["options"] = {}
 
         kwargs["options"]["maxiter"] = 1
-
         return minimize(*args, **kwargs)
 
     # pyre-fixme[3]: Return type must be annotated.
@@ -58,7 +57,7 @@ def fast_botorch_optimize_context_manager() -> Generator[None, None, None]:
 
         mock_fit = es.enter_context(
             mock.patch(
-                "botorch.optim.fit.minimize",
+                "botorch.optim.core.minimize",
                 wraps=one_iteration_minimize,
             )
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/1439

This diff acts as follow-up to the recent model fitting refactor. The previous update focused on the high-level logic used to determine which fitting routines to use for which MLLs. This diff refactors the internal machinery used to evaluate forward-backward passes (producing losses and gradients, respectively) during optimization.

The solution we have opted for is to abstract away the evaluation process by relying on closures. In most cases, these closures are automatically constructed by composing simpler, multiply-dispatched base functions.

Differential Revision: D39101211

