### PR TITLE
Add a warning when using float dtype (#1445)

### DIFF
--- a/ax/models/tests/test_cbo_lcea.py
+++ b/ax/models/tests/test_cbo_lcea.py
@@ -22,7 +22,7 @@ class LCEABOTest(TestCase):
             [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]]
         )
         train_Y = torch.tensor([[1.0], [2.0], [3.0]])
-        train_Yvar = 0.1 * torch.ones(3, 1, dtype=torch.double)
+        train_Yvar = 0.1 * torch.ones(3, 1)
         training_data = [FixedNoiseDataset(X=train_X, Y=train_Y, Yvar=train_Yvar)]
 
         # Test setting attributes

--- a/ax/models/tests/test_cbo_sac.py
+++ b/ax/models/tests/test_cbo_sac.py
@@ -21,7 +21,7 @@ class SACBOTest(TestCase):
             [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]]
         )
         train_Y = torch.tensor([[1.0], [2.0], [3.0]])
-        train_Yvar = 0.1 * torch.ones(3, 1, dtype=torch.double)
+        train_Yvar = 0.1 * torch.ones(3, 1)
         dataset = FixedNoiseDataset(X=train_X, Y=train_Y, Yvar=train_Yvar)
 
         # test setting attributes


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/1445

We commonly see issues with users running into numerical errors when using float inputs. This adds a dtype check in `_validate_tensor_args`, which is used in the constructor of a large number of models, warning the users if they're not using double, and pointing them to https://github.com/pytorch/botorch/discussions/1444. Feel free to edit & add more details / examples to the discussion!

Reviewed By: Balandat

Differential Revision: D40199087

