### PR TITLE
Type-checking improvements

### DIFF
--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -151,9 +151,6 @@ class ExperimentTest(TestCase):
         # Create an experiment with valid parameter constraints
         ax_client.create_experiment(
             name="experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {
                     "name": "x1",
@@ -175,10 +172,6 @@ class ExperimentTest(TestCase):
         with self.assertRaises(UnsupportedError):
             ax_client.create_experiment(
                 name="experiment",
-                # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-                #  Dict[str, List[str]], List[Union[None, bool, float, int, str]],
-                #  bool, float, int, str]]]` but got `List[Dict[str, Union[List[float],
-                #  str]]]`.
                 parameters=[
                     {
                         "name": "x1",
@@ -200,10 +193,6 @@ class ExperimentTest(TestCase):
         with self.assertRaises(UnsupportedError):
             ax_client.create_experiment(
                 name="experiment",
-                # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-                #  Dict[str, List[str]], List[Union[None, bool, float, int, str]],
-                #  bool, float, int, str]]]` but got `List[Dict[str, Union[List[float],
-                #  float, str]]]`.
                 parameters=[
                     {"name": "x1", "type": "fixed", "value": 0.0},
                     {

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -61,8 +61,8 @@ from ax.core.types import TBounds, TCandidateMetadata
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.derelativize import Derelativize
+from ax.models.torch.botorch_moo_defaults import pareto_frontier_evaluator
 from ax.models.torch.frontier_utils import (
-    get_default_frontier_evaluator,
     get_weighted_mc_objective_and_objective_thresholds,
 )
 from ax.utils.common.logger import get_logger
@@ -884,9 +884,7 @@ def get_pareto_frontier_and_configs(
         pending_observations=None,
         final_transform=array_to_tensor,
     )
-    frontier_evaluator = get_default_frontier_evaluator()
-    # pyre-ignore[28]: Unexpected keyword `modelbridge` to anonymous call
-    f, cov, indx = frontier_evaluator(
+    f, cov, indx = pareto_frontier_evaluator(
         model=modelbridge.model,
         X=X,
         Y=Y,

--- a/ax/modelbridge/tests/test_prediction_utils.py
+++ b/ax/modelbridge/tests/test_prediction_utils.py
@@ -95,9 +95,6 @@ def _set_up_client_for_get_model_predictions_no_next_trial() -> AxClient:
     ax_client.create_experiment(
         name="test_experiment",
         choose_generation_strategy_kwargs={"num_initialization_trials": 0},
-        # pyre-fixme[6]: For 3rd param expected `List[Dict[str, Union[None,
-        #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool, float,
-        #  int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
         parameters=[
             {
                 "name": "x1",

--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -297,7 +297,7 @@ def scipy_optimizer_list(
 
 
 def pareto_frontier_evaluator(
-    model: TorchModel,
+    model: Optional[TorchModel],
     objective_weights: Tensor,
     objective_thresholds: Optional[Tensor] = None,
     X: Optional[Tensor] = None,
@@ -333,8 +333,10 @@ def pareto_frontier_evaluator(
             cov[j, m1, m2] is Cov[m1@j, m2@j].
         - A `j` tensor of the index of each frontier point in the input Y.
     """
+    # TODO: better input validation, making more explicit whether we are using
+    # model predictions or not
     if X is not None:
-        Y, Yvar = model.predict(X)
+        Y, Yvar = not_none(model).predict(X)
         # model.predict returns cpu tensors
         Y = Y.to(X.device)
         Yvar = Yvar.to(X.device)

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -17,6 +17,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -244,7 +245,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
     def create_experiment(
         self,
         parameters: List[
-            Dict[str, Union[TParamValue, List[TParamValue], Dict[str, List[str]]]],
+            Dict[str, Union[TParamValue, Sequence[TParamValue], Dict[str, List[str]]]]
         ],
         name: Optional[str] = None,
         description: Optional[str] = None,
@@ -437,7 +438,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
     def set_search_space(
         self,
         parameters: List[
-            Dict[str, Union[TParamValue, List[TParamValue], Dict[str, List[str]]]],
+            Dict[str, Union[TParamValue, Sequence[TParamValue], Dict[str, List[str]]]]
         ],
         parameter_constraints: Optional[List[str]] = None,
     ) -> None:

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -112,9 +112,6 @@ def get_branin_currin_optimization_with_N_sobol_trials(
     branin_currin = get_branin_currin(minimize=minimize)
     ax_client = AxClient()
     ax_client.create_experiment(
-        # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-        #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool, float,
-        #  int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
         parameters=[
             {"name": "x", "type": "range", "bounds": [0.0, 1.0]},
             {"name": "y", "type": "range", "bounds": [0.0, 1.0]},
@@ -166,9 +163,6 @@ def get_branin_optimization(
     )
     ax_client.create_experiment(
         name="test_experiment",
-        # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-        #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool, float,
-        #  int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
         parameters=[
             {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
             {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -186,7 +180,7 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test",
-            parameters=[  # pyre-fixme[6]: expected union that should include
+            parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
             ],
@@ -218,7 +212,7 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test",
-            parameters=[  # pyre-fixme[6]: expected union that should include
+            parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
             ],
@@ -239,7 +233,7 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test",
-            parameters=[  # pyre-fixme[6]: expected union that should include
+            parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
             ],
@@ -258,7 +252,7 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test",
-            parameters=[  # pyre-fixme[6]: expected union that should include
+            parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
             ],
@@ -320,7 +314,7 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test",
-            parameters=[  # pyre-fixme[6]: expected union that should include
+            parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
             ],
@@ -354,7 +348,7 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test",
-            parameters=[  # pyre-fixme[6]: expected union that should include
+            parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
             ],
@@ -479,7 +473,7 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test",
-            parameters=[  # pyre-fixme[6]: expected union that should include
+            parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
             ],
@@ -520,9 +514,6 @@ class TestAxClient(TestCase):
         )
         ax_client.create_experiment(
             name="unique_test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -559,7 +550,7 @@ class TestAxClient(TestCase):
         """Test that Sobol+MOO is used if no GenerationStrategy is provided."""
         ax_client = AxClient()
         ax_client.create_experiment(
-            parameters=[  # pyre-fixme[6]: expected union that should include
+            parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
             ],
@@ -630,10 +621,6 @@ class TestAxClient(TestCase):
             ax_client.experiment
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float],
-            #  List[int], List[str], bool, int, str]]]`.
             parameters=[
                 {
                     "name": "x",
@@ -765,10 +752,6 @@ class TestAxClient(TestCase):
             ax_client.experiment
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float],
-            #  List[int], List[str], bool, int, str]]]`.
             parameters=[
                 {
                     "name": "x",
@@ -841,9 +824,6 @@ class TestAxClient(TestCase):
         }
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {
                     "name": "x",
@@ -906,9 +886,6 @@ class TestAxClient(TestCase):
         }
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {
                     "name": "x",
@@ -958,10 +935,6 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float],
-            #  List[int], List[str], bool, int, str]]]`.
             parameters=[
                 {
                     "name": "x1",
@@ -982,7 +955,7 @@ class TestAxClient(TestCase):
             immutable_search_space_and_opt_config=False,
         )
         ax_client.set_search_space(
-            parameters=[  # pyre-ignore[6]
+            parameters=[
                 {
                     "name": "x1",
                     "type": "range",
@@ -1133,10 +1106,6 @@ class TestAxClient(TestCase):
             ax_client.experiment
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float],
-            #  List[int], List[str], bool, int, str]]]`.
             parameters=[
                 {
                     "name": "x",
@@ -1311,9 +1280,6 @@ class TestAxClient(TestCase):
     def test_raw_data_format(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1336,9 +1302,6 @@ class TestAxClient(TestCase):
     def test_raw_data_format_with_map_results(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 1.0]},
@@ -1370,9 +1333,6 @@ class TestAxClient(TestCase):
         # generating.
         ax_client = AxClient(enforce_sequential_optimization=False)
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1389,9 +1349,6 @@ class TestAxClient(TestCase):
     def test_update_running_trial_with_intermediate_data(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 1.0]},
@@ -1420,9 +1377,6 @@ class TestAxClient(TestCase):
 
         no_intermediate_data_ax_client = AxClient()
         no_intermediate_data_ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 1.0]},
@@ -1526,9 +1480,6 @@ class TestAxClient(TestCase):
     def test_ttl_trial(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1557,9 +1508,6 @@ class TestAxClient(TestCase):
         start_time = current_timestamp_in_millis()
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1581,9 +1529,6 @@ class TestAxClient(TestCase):
     def test_fail_on_batch(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1606,9 +1551,6 @@ class TestAxClient(TestCase):
     def test_log_failure(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1630,9 +1572,6 @@ class TestAxClient(TestCase):
     def test_attach_trial_and_get_trial_parameters(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1658,9 +1597,6 @@ class TestAxClient(TestCase):
     def test_attach_trial_ttl_seconds(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1693,9 +1629,6 @@ class TestAxClient(TestCase):
     def test_attach_trial_numpy(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1713,10 +1646,6 @@ class TestAxClient(TestCase):
         with self.assertRaises(ValueError):
             ax_client.create_experiment(
                 name="test_experiment",
-                # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-                #  List[Union[None, bool, float, int, str]], Dict[str, List[str]],
-                #  bool, float, int, str]]]` but got `List[Dict[str, Union[List[float],
-                #  str]]]`.
                 parameters=[
                     {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                     {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1732,9 +1661,6 @@ class TestAxClient(TestCase):
         with self.assertRaisesRegex(ValueError, "No generation strategy"):
             ax_client.get_max_parallelism()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1752,9 +1678,6 @@ class TestAxClient(TestCase):
         # still be raised.
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1801,9 +1724,6 @@ class TestAxClient(TestCase):
             ax_client.get_contour_plot()
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1838,9 +1758,6 @@ class TestAxClient(TestCase):
         ax_client = AxClient(db_settings=db_settings)
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1871,10 +1788,6 @@ class TestAxClient(TestCase):
             # Overwriting existing experiment.
             ax_client.create_experiment(
                 name="test_experiment",
-                # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-                #  List[Union[None, bool, float, int, str]], Dict[str, List[str]],
-                #  bool, float, int, str]]]` but got `List[Dict[str, Union[List[float],
-                #  str]]]`.
                 parameters=[
                     {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                     {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1887,10 +1800,6 @@ class TestAxClient(TestCase):
             # experiments stored in the DB.
             ax_client.create_experiment(
                 name="test_experiment",
-                # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-                #  List[Union[None, bool, float, int, str]], Dict[str, List[str]],
-                #  bool, float, int, str]]]` but got `List[Dict[str, Union[List[float],
-                #  str]]]`.
                 parameters=[{"name": "x", "type": "range", "bounds": [-5.0, 10.0]}],
                 overwrite_existing_experiment=True,
             )
@@ -1902,9 +1811,6 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1924,10 +1830,6 @@ class TestAxClient(TestCase):
             # Overwriting existing experiment.
             ax_client.create_experiment(
                 name="test_experiment",
-                # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-                #  List[Union[None, bool, float, int, str]], Dict[str, List[str]],
-                #  bool, float, int, str]]]` but got `List[Dict[str, Union[List[float],
-                #  str]]]`.
                 parameters=[
                     {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                     {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1937,9 +1839,6 @@ class TestAxClient(TestCase):
         # Overwriting existing experiment with overwrite flag.
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x1", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "x2", "type": "range", "bounds": [0.0, 15.0]},
@@ -1962,9 +1861,6 @@ class TestAxClient(TestCase):
     def test_fixed_random_seed_reproducibility(self) -> None:
         ax_client = AxClient(random_seed=RANDOM_SEED)
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -1981,9 +1877,6 @@ class TestAxClient(TestCase):
         ]
         ax_client = AxClient(random_seed=RANDOM_SEED)
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -2001,9 +1894,6 @@ class TestAxClient(TestCase):
     def test_init_position_saved(self) -> None:
         ax_client = AxClient(random_seed=RANDOM_SEED)
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -2036,9 +1926,6 @@ class TestAxClient(TestCase):
     def test_unnamed_experiment_snapshot(self) -> None:
         ax_client = AxClient(random_seed=RANDOM_SEED)
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -2155,9 +2042,6 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -2185,9 +2069,6 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -2223,9 +2104,6 @@ class TestAxClient(TestCase):
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -2419,10 +2297,6 @@ class TestAxClient(TestCase):
     def test_with_hss(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float],
-            #  List[int], List[str], Dict[str, List[str]], str]]]`.
             parameters=[
                 {
                     "name": "model",
@@ -2492,9 +2366,6 @@ class TestAxClient(TestCase):
             early_stopping_strategy=DummyEarlyStoppingStrategy(expected)
         )
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -2508,9 +2379,6 @@ class TestAxClient(TestCase):
     def test_stop_trial_early(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -2525,9 +2393,6 @@ class TestAxClient(TestCase):
     def test_max_parallelism_exception_when_early_stopping(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -2563,10 +2428,6 @@ class TestAxClient(TestCase):
         ax_client = AxClient(early_stopping_strategy=DummyEarlyStoppingStrategy())
         with self.assertRaisesRegex(ValueError, ".*`support_intermediate_data=True`.*"):
             ax_client.create_experiment(
-                # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-                #  List[Union[None, bool, float, int, str]], Dict[str, List[str]],
-                #  bool, float, int, str]]]` but got `List[Dict[str, Union[List[float],
-                #  str]]]`.
                 parameters=[
                     {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                     {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
@@ -2610,9 +2471,6 @@ def _set_up_client_for_get_model_predictions_no_next_trial() -> AxClient:
     ax_client.create_experiment(
         name="test_experiment",
         choose_generation_strategy_kwargs={"num_initialization_trials": 0},
-        # pyre-fixme[6]: For 3rd param expected `List[Dict[str, Union[None,
-        #  List[Union[None, bool, float, int, str]], Dict[str, List[str]], bool, float,
-        #  int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
         parameters=[
             {
                 "name": "x1",

--- a/ax/service/tests/test_global_stopping.py
+++ b/ax/service/tests/test_global_stopping.py
@@ -27,9 +27,6 @@ class TestGlobalStoppingIntegration(TestCase):
         ax_client = AxClient(global_stopping_strategy=global_stopping_strategy)
         ax_client.create_experiment(
             name="branin_test_experiment",
-            # pyre-fixme[6]: For 2nd param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], str]]]`.
             parameters=[
                 {
                     "name": "x1",

--- a/ax/service/tests/test_instantiation_utils.py
+++ b/ax/service/tests/test_instantiation_utils.py
@@ -124,9 +124,6 @@ class TestInstantiationtUtils(TestCase):
 
     def test_add_tracking_metrics(self) -> None:
         experiment = InstantiationBase.make_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[int], str]]]`.
             parameters=[{"name": "x", "type": "range", "bounds": [0, 1]}],
             tracking_metric_names=None,
         )
@@ -134,9 +131,6 @@ class TestInstantiationtUtils(TestCase):
 
         metrics_names = ["metric_1", "metric_2"]
         experiment = InstantiationBase.make_experiment(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[int], str]]]`.
             parameters=[{"name": "x", "type": "range", "bounds": [0, 1]}],
             tracking_metric_names=metrics_names,
         )

--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -92,10 +92,6 @@ class TestManagedLoop(TestCase):
     def test_branin(self) -> None:
         """Basic async synthetic function managed loop case."""
         loop = OptimizationLoop.with_evaluation_function(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], bool,
-            #  str]]]`.
             parameters=[
                 {
                     "name": "x1",
@@ -124,10 +120,6 @@ class TestManagedLoop(TestCase):
     def test_branin_with_active_parameter_constraints(self) -> None:
         """Basic async synthetic function managed loop case."""
         loop = OptimizationLoop.with_evaluation_function(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], bool,
-            #  str]]]`.
             parameters=[
                 {
                     "name": "x1",
@@ -158,10 +150,6 @@ class TestManagedLoop(TestCase):
     @fast_botorch_optimize
     def test_branin_without_objective_name(self) -> None:
         loop = OptimizationLoop.with_evaluation_function(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], bool,
-            #  str]]]`.
             parameters=[
                 {
                     "name": "x1",
@@ -184,10 +172,6 @@ class TestManagedLoop(TestCase):
     @fast_botorch_optimize
     def test_branin_with_unknown_sem(self) -> None:
         loop = OptimizationLoop.with_evaluation_function(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], bool,
-            #  str]]]`.
             parameters=[
                 {
                     "name": "x1",
@@ -214,10 +198,6 @@ class TestManagedLoop(TestCase):
         batch_branin = Mock(side_effect=_branin_evaluation_function)
 
         loop = OptimizationLoop.with_evaluation_function(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], bool,
-            #  str]]]`.
             parameters=[
                 {
                     "name": "x1",
@@ -263,7 +243,7 @@ class TestManagedLoop(TestCase):
     def test_optimize(self) -> None:
         """Tests optimization as a single call."""
         best, vals, exp, model = optimize(
-            parameters=[  # pyre-fixme[6]
+            parameters=[
                 {"name": "x1", "type": "range", "bounds": [-10.0, 10.0]},
                 {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
             ],
@@ -293,7 +273,7 @@ class TestManagedLoop(TestCase):
     def test_optimize_with_predictions(self, _) -> None:
         """Tests optimization as a single call."""
         best, vals, exp, model = optimize(
-            parameters=[  # pyre-fixme[6]
+            parameters=[
                 {"name": "x1", "type": "range", "bounds": [-10.0, 10.0]},
                 {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
             ],
@@ -319,7 +299,7 @@ class TestManagedLoop(TestCase):
     def test_optimize_unknown_sem(self) -> None:
         """Tests optimization as a single call."""
         best, vals, exp, model = optimize(
-            parameters=[  # pyre-fixme[6]
+            parameters=[
                 {"name": "x1", "type": "range", "bounds": [-10.0, 10.0]},
                 {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
             ],
@@ -345,7 +325,7 @@ class TestManagedLoop(TestCase):
     def test_optimize_propagates_random_seed(self) -> None:
         """Tests optimization as a single call."""
         _, _, _, model = optimize(
-            parameters=[  # pyre-fixme[6]
+            parameters=[
                 {"name": "x1", "type": "range", "bounds": [-10.0, 10.0]},
                 {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
             ],
@@ -363,7 +343,7 @@ class TestManagedLoop(TestCase):
     def test_optimize_search_space_exhausted(self) -> None:
         """Tests optimization as a single call."""
         best, vals, exp, model = optimize(
-            parameters=[  # pyre-fixme[6]
+            parameters=[
                 {"name": "x1", "type": "choice", "values": [1, 2]},
                 {"name": "x2", "type": "choice", "values": [1, 2]},
             ],
@@ -393,10 +373,6 @@ class TestManagedLoop(TestCase):
             name="Sobol", steps=[GenerationStep(model=Models.SOBOL, num_trials=-1)]
         )
         loop = OptimizationLoop.with_evaluation_function(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], bool,
-            #  str]]]`.
             parameters=[
                 {
                     "name": "x1",
@@ -423,7 +399,7 @@ class TestManagedLoop(TestCase):
         candidate generation.
         """
         best, vals, exp, model = optimize(
-            parameters=[  # pyre-fixme[6]
+            parameters=[
                 {"name": "x1", "type": "range", "bounds": [-10.0, 10.0]},
                 {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
             ],
@@ -461,10 +437,6 @@ class TestManagedLoop(TestCase):
             name="Sobol", steps=[GenerationStep(model=Models.SOBOL, num_trials=-1)]
         )
         loop = OptimizationLoop.with_evaluation_function(
-            # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-            #  Dict[str, List[str]], List[Union[None, bool, float, int, str]], bool,
-            #  float, int, str]]]` but got `List[Dict[str, Union[List[float], bool,
-            #  str]]]`.
             parameters=[
                 {
                     "name": "x1",
@@ -493,7 +465,7 @@ class TestManagedLoop(TestCase):
             UserInputError, "Invalid number of arms per trial: 0"
         ):
             loop = OptimizationLoop.with_evaluation_function(
-                parameters=[  # pyre-fixme[6]
+                parameters=[
                     {"name": "x1", "type": "range", "bounds": [-10.0, 10.0]},
                     {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
                 ],
@@ -510,7 +482,7 @@ class TestManagedLoop(TestCase):
     def test_eval_function_with_wrong_parameter_count_generates_error(self) -> None:
         with self.assertRaises(UserInputError):
             loop = OptimizationLoop.with_evaluation_function(
-                parameters=[  # pyre-fixme[6]
+                parameters=[
                     {"name": "x1", "type": "range", "bounds": [-10.0, 10.0]},
                     {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
                 ],

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -8,7 +8,7 @@ import enum
 from dataclasses import dataclass
 
 from logging import Logger
-from typing import Any, cast, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, cast, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 from ax.core.arm import Arm
@@ -61,7 +61,7 @@ logger: Logger = get_logger(__name__)
 
 
 TParameterRepresentation = Dict[
-    str, Union[TParamValue, List[TParamValue], Dict[str, List[str]]]
+    str, Union[TParamValue, Sequence[TParamValue], Dict[str, List[str]]]
 ]
 PARAM_CLASSES = ["range", "choice", "fixed"]
 PARAM_TYPES = {"int": int, "float": float, "bool": bool, "str": str}


### PR DESCRIPTION
Summary:
1) Make TParameterRepresentation contains a Sequence, not a List
See T132699458 for why this is necessary.
- In instantiation.py, changed signature of `TParameterRepresentation` from `Dict[str, Union[TParamValue, List[TParamValue], Dict[str, List[str]]]]` to `Dict[str, Union[TParamValue, Sequence[TParamValue], Dict[str, List[str]]]]`
- Changed ax_client parameters type from List[complicated signature] to List[TParameterRepresentation] wherever it wasn't already like that (e.g. in ax_batch_client.py and client.py)
- Removed a whole bunch of pyre-ignores and pyre-fixmes

2) Remove call to unnecessary function `get_default_frontier_evaluator` that just returns another function. It's now not used within Ax, so we might want to delete it, but I left it for now so as to not change the API.

Reviewed By: lena-kashtelyan

Differential Revision: D40269996

