### PR TITLE
allow plotting when the pareto frontier is of length 0

### DIFF
--- a/ax/plot/pareto_frontier.py
+++ b/ax/plot/pareto_frontier.py
@@ -105,7 +105,11 @@ def scatter_plot_with_pareto_frontier_plotly(
     ]
     # No Pareto frontier is drawn if none is provided, or if the frontier consists of
     # a single point and no reference points are provided.
-    if Y_pareto is None or (len(Y_pareto) == 1 and reference_point is None):
+    if (
+        Y_pareto is None
+        or len(Y_pareto) == 0
+        or (len(Y_pareto) == 1 and reference_point is None)
+    ):
         # `Y_pareto` input was not specified
         range_x = extend_range(lower=min(Y[:, 0]), upper=max(Y[:, 0]))
         range_y = extend_range(lower=min(Y[:, 1]), upper=max(Y[:, 1]))

--- a/ax/plot/pareto_frontier.py
+++ b/ax/plot/pareto_frontier.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import warnings
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import plotly.graph_objs as go
@@ -54,6 +54,7 @@ def scatter_plot_with_pareto_frontier_plotly(
     metric_y: Optional[str],
     reference_point: Optional[Tuple[float, float]],
     minimize: Optional[Union[bool, Tuple[bool, bool]]] = True,
+    hovertext: Optional[Iterable[str]] = None,
 ) -> go.Figure:
     """Plots a scatter of all points in ``Y`` for ``metric_x`` and ``metric_y``
     with a reference point and Pareto frontier from ``Y_pareto``.
@@ -98,6 +99,8 @@ def scatter_plot_with_pareto_frontier_plotly(
                 },
             },
             name="Experimental points",
+            hovertemplate="%{text}",
+            text=hovertext,
         )
     ]
     # No Pareto frontier is drawn if none is provided, or if the frontier consists of

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -682,6 +682,8 @@ def _pareto_frontier_scatter_2d_plotly(
         else None
     )
 
+    hovertext = [f"Arm name: {arm_name}" for arm_name in df["arm_name"]]
+
     return scatter_plot_with_pareto_frontier_plotly(
         Y=Y,
         Y_pareto=Y_pareto,
@@ -689,6 +691,7 @@ def _pareto_frontier_scatter_2d_plotly(
         metric_y=metric_names[1],
         reference_point=reference_point,
         minimize=minimize,
+        hovertext=hovertext,
     )
 
 


### PR DESCRIPTION
Summary: we have a default behavior for if the pareto curve is None but this needs to be extended as well to if the pareto curve is of length 0, or else we get a plotting failure when, e.g., taking the `min` or `max` of the pareto curve.

Differential Revision: D40354768

