### PR TITLE
Fix flaky test test_transform_status_quos_always_zero

### DIFF
--- a/ax/modelbridge/tests/test_relativize_transform.py
+++ b/ax/modelbridge/tests/test_relativize_transform.py
@@ -128,15 +128,14 @@ class RelativizeDataTest(TestCase):
         st.floats(min_value=-10.0, max_value=10.0),
         st.floats(min_value=0, max_value=10.0),
     )
-    @settings(max_examples=1000)
-    # pyre-fixme[3]: Return type must be annotated.
+    @settings(max_examples=1000, deadline=None)
     def test_transform_status_quos_always_zero(
         self,
         sq_mean: float,
         sq_sem: float,
         mean: float,
         sem: float,
-    ):
+    ) -> None:
         assume(abs(sq_mean) >= 1e-10)
         assume(abs(sq_mean) != sq_sem)
 


### PR DESCRIPTION
Summary:
Addresses https://github.com/facebook/Ax/issues/1207.  Failure examples are https://fburl.com/testinfra/8s0bfrgm and https://github.com/facebook/Ax/actions/runs/3217066168/jobs/5259618955#step:9:179.  Both failures say:
```
Unreliable test timings! On an initial run, this test took <some number of>ms, which exceeded the deadline of 200.00ms, but on a subsequent run it took <some lower number of> ms, which did not. If you expect this sort of variability in your test timings, consider turning deadlines off for this test by setting deadline=None.
```
So I'm setting `deadline=None`.  I don't think the tests will time out and on average it should be fine.

Differential Revision: D40391710

