### PR TITLE
Handle refetching when all metrics are not Deltoid3Metrics

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1456,7 +1456,8 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         """
         return {
             m.serialize_init_args(m)["name"]: {
-                k: v for k, v in m.serialize_init_args(m).items() if k != "name"
+                "metric_class": m.__class__,
+                **{k: v for k, v in m.serialize_init_args(m).items() if k != "name"},
             }
             for m in self.experiment.metrics.values()
         }


### PR DESCRIPTION
Summary:
I noticed this error in the nightly notifications job: P536681688.  This situation was created because Jerry created plain `Metric`s to handle metrics with attribute filters.  We may or may not want to do things this way, *but* we don't want to throw errors in the nightly job!
It still won't correctly fetch that specific metric, and may not correctly notify if the metric is in the opt config, but we'll handle that by fully supporting attribute filters at the metric level.

Differential Revision: D40192042

