### PR TITLE
Let Pyre know that `AcquisitionFunction.model` is a `Model` (#1452)

### DIFF
--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -338,8 +338,6 @@ class KnowledgeGradientTest(TestCase):
             X_pending=self.X_dummy,
         )
         self.assertIsNone(acq_function.inner_sampler)
-        # pyre-fixme[6]: For 1st param expected `Tensor` but got `Union[Tensor,
-        #  Module]`.
         self.assertTrue(torch.equal(acq_function.X_pending, self.X_dummy))
 
         # test _get_best_point_acqf


### PR DESCRIPTION
Summary:
## Motivation

Pyre is not smart enough to understand that calling `self.add_module('model', model)` makes `self.model` have the type of `model`, which is true due to some fairly complex underlying logic inherited from `torch.nn.Module`. However, PyTorch is smart enough to properly `add_module` if we just do `self.model = model`. This also works for tensors, but only if the tensor is explicitly registered as a buffer (by name, not necessarily by value) before assignment.

### Have you read the [Contributing Guidelines on pull requests]
Yes

X-link: https://github.com/pytorch/botorch/pull/1452

Differential Revision: D40469725

Pulled By: esantorella

