### PR TITLE
add optional `arm_name` arg to attach_trial

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -823,6 +823,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         parameters: TParameterization,
         ttl_seconds: Optional[int] = None,
         run_metadata: Optional[Dict[str, Any]] = None,
+        arm_name: Optional[str] = None,
     ) -> Tuple[TParameterization, int]:
         """Attach a new trial with the given parameterization to the experiment.
 
@@ -852,7 +853,8 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
             ).metadata
 
         trial = self.experiment.new_trial(ttl_seconds=ttl_seconds).add_arm(
-            Arm(parameters=parameters), candidate_metadata=candidate_metadata
+            Arm(parameters=parameters, name=arm_name),
+            candidate_metadata=candidate_metadata,
         )
         trial.mark_running(no_runner_required=True)
         logger.info(

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1462,6 +1462,11 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
             for m in self.experiment.metrics.values()
         }
 
+    @property
+    def metric_names(self) -> Set[str]:
+        """Returns the names of all metrics on the attached experiment."""
+        return set(self.experiment.metrics)
+
     @copy_doc(BestPointMixin.get_best_trial)
     def get_best_trial(
         self,
@@ -1750,7 +1755,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
 
         evaluations, data = self.data_and_evaluations_from_raw_data(
             raw_data=raw_data_by_arm,
-            metric_names=self.objective_names,
+            metric_names=list(self.metric_names),
             trial_index=trial.index,
             sample_sizes=sample_sizes or {},
             start_time=(

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -70,6 +70,7 @@ DUMMY_RUN_METADATA = {
     "TEST_KEY": "TEST_VALUE",
     "abc": {123: 456},
 }
+ARM_NAME = "test_arm_name"
 
 
 def run_trials_using_recommended_parallelism(
@@ -1661,13 +1662,18 @@ class TestAxClient(TestCase):
             minimize=True,
         )
         params, idx = ax_client.attach_trial(
-            parameters={"x": 0.0, "y": 1.0}, run_metadata=DUMMY_RUN_METADATA
+            parameters={"x": 0.0, "y": 1.0},
+            run_metadata=DUMMY_RUN_METADATA,
+            arm_name=ARM_NAME,
         )
         ax_client.complete_trial(trial_index=idx, raw_data=5)
         # pyre-fixme[16]: `Optional` has no attribute `__getitem__`.
         self.assertEqual(ax_client.get_best_parameters()[0], params)
         self.assertEqual(
             ax_client.get_trial_parameters(trial_index=idx), {"x": 0, "y": 1}
+        )
+        self.assertEqual(
+            not_none(ax_client.get_trial(trial_index=idx).arm).name, ARM_NAME
         )
         with self.assertRaises(KeyError):
             ax_client.get_trial_parameters(

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -817,6 +817,12 @@ class TestAxClient(TestCase):
         with self.subTest("objective_names"):
             self.assertEqual(ax_client.objective_names, ["test_objective"])
 
+        with self.subTest("metric_names"):
+            self.assertEqual(
+                ax_client.metric_names,
+                {"test_objective", "some_metric", "test_tracking_metric"},
+            )
+
     def test_create_single_objective_experiment_with_objectives_dict(self) -> None:
         """Test basic experiment creation."""
         ax_client = AxClient(


### PR DESCRIPTION
Summary: Allows user to specify the name of the arm in the newly attached trial

Differential Revision: D40526695

