### PR TITLE
Propagate Result through metric fetching pipeline

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -12,9 +12,8 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from ax.core.arm import Arm
-from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun
-from ax.core.metric import Metric
+from ax.core.metric import Metric, MetricFetchResult
 from ax.core.runner import Runner
 from ax.core.types import TCandidateMetadata
 from ax.utils.common.base import SortableBase
@@ -464,7 +463,9 @@ class BaseTrial(ABC, SortableBase):
             self.mark_completed()
         return self
 
-    def fetch_data(self, metrics: Optional[List[Metric]] = None, **kwargs: Any) -> Data:
+    def fetch_data(
+        self, metrics: Optional[List[Metric]] = None, **kwargs: Any
+    ) -> Dict[str, MetricFetchResult]:
         """Fetch data for this trial for all metrics on experiment.
 
         Args:
@@ -482,7 +483,7 @@ class BaseTrial(ABC, SortableBase):
 
     def lookup_data(
         self,
-    ) -> Data:
+    ) -> Dict[str, MetricFetchResult]:
         """Lookup cached data on experiment for this trial.
 
         Returns:
@@ -490,9 +491,11 @@ class BaseTrial(ABC, SortableBase):
             associated with the trial. If merging, all data for trial, merged.
 
         """
-        return self.experiment.lookup_data_for_trial(
-            trial_index=self.index,
-        )[0]
+        return Metric._wrap_trial_data_multi(
+            data=self.experiment.lookup_data_for_trial(
+                trial_index=self.index,
+            )[0]
+        )
 
     def _check_existing_and_name_arm(self, arm: Arm) -> None:
         """Sets name for given arm; if this arm is already in the

--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -12,6 +12,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from ax.core.arm import Arm
+from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric, MetricFetchResult
 from ax.core.runner import Runner
@@ -483,7 +484,7 @@ class BaseTrial(ABC, SortableBase):
 
     def lookup_data(
         self,
-    ) -> Dict[str, MetricFetchResult]:
+    ) -> Data:
         """Lookup cached data on experiment for this trial.
 
         Returns:
@@ -491,11 +492,9 @@ class BaseTrial(ABC, SortableBase):
             associated with the trial. If merging, all data for trial, merged.
 
         """
-        return Metric._wrap_trial_data_multi(
-            data=self.experiment.lookup_data_for_trial(
-                trial_index=self.index,
-            )[0]
-        )
+        return self.experiment.lookup_data_for_trial(
+            trial_index=self.index,
+        )[0]
 
     def _check_existing_and_name_arm(self, arm: Arm) -> None:
         """Sets name for given arm; if this arm is already in the

--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -6,10 +6,16 @@
 
 from __future__ import annotations
 
-from typing import Type
+from typing import Dict, Type
+
+from ax.core.data import Data
 
 from ax.core.map_data import MapData
-from ax.core.metric import Metric
+from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
+from ax.utils.common.result import Ok, Result
+from ax.utils.common.typeutils import checked_cast
+
+MapMetricFetchResult = Result[MapData, MetricFetchE]
 
 
 class MapMetric(Metric):
@@ -27,3 +33,48 @@ class MapMetric(Metric):
     """
 
     data_constructor: Type[MapData] = MapData
+
+    @classmethod
+    def _wrap_experiment_data(cls, data: Data) -> Dict[int, MetricFetchResult]:
+        return {
+            trial_index: Ok(
+                value=MapData(
+                    df=data.true_df.loc[data.true_df["trial_index"] == trial_index],
+                    map_key_infos=checked_cast(MapData, data).map_key_infos,
+                )
+            )
+            for trial_index in data.true_df["trial_index"]
+        }
+
+    @classmethod
+    def _wrap_trial_data_multi(cls, data: Data) -> Dict[str, MetricFetchResult]:
+        return {
+            metric_name: Ok(
+                value=MapData(
+                    df=data.true_df.loc[data.true_df["metric_name"] == metric_name],
+                    map_key_infos=checked_cast(MapData, data).map_key_infos,
+                )
+            )
+            for metric_name in data.true_df["metric_name"]
+        }
+
+    @classmethod
+    def _wrap_experiment_data_multi(
+        cls, data: Data
+    ) -> Dict[int, Dict[str, MetricFetchResult]]:
+        # pyre-fixme[7]
+        return {
+            trial_index: {
+                metric_name: Ok(
+                    value=MapData(
+                        df=data.true_df.loc[
+                            (data.true_df["trial_index"] == trial_index)
+                            & (data.true_df["metric_name"] == metric_name)
+                        ],
+                        map_key_infos=checked_cast(MapData, data).map_key_infos,
+                    )
+                )
+                for metric_name in data.true_df["metric_name"]
+            }
+            for trial_index in data.true_df["trial_index"]
+        }

--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -292,7 +292,10 @@ class Metric(SortableBase, SerializationMixin):
 
             # TODO[mpolson64] Raise all errors in a group via PEP 654
             exceptions = [
-                err.err.exception or Exception(err.err.message) for err in errs
+                err.err.exception
+                if err.err.exception is not None
+                else Exception(err.err.message)
+                for err in errs
             ]
             raise exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
 
@@ -315,7 +318,10 @@ class Metric(SortableBase, SerializationMixin):
 
             # TODO[mpolson64] Raise all errors in a group via PEP 654
             exceptions = [
-                err.err.exception or Exception(err.err.message) for err in errs
+                err.err.exception
+                if err.err.exception is not None
+                else Exception(err.err.message)
+                for err in errs
             ]
             raise exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
 
@@ -344,7 +350,10 @@ class Metric(SortableBase, SerializationMixin):
 
             # TODO[mpolson64] Raise all errors in a group via PEP 654
             exceptions = [
-                err.err.exception or Exception(err.err.message) for err in errs
+                err.err.exception
+                if err.err.exception is not None
+                else Exception(err.err.message)
+                for err in errs
             ]
             raise exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
 

--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -6,16 +6,37 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Optional, Tuple, Type, TYPE_CHECKING
+from dataclasses import dataclass
+
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    TYPE_CHECKING,
+)
 
 from ax.core.data import Data
 from ax.utils.common.base import SortableBase
+from ax.utils.common.result import Err, Ok, Result
 from ax.utils.common.serialization import SerializationMixin
-from ax.utils.common.typeutils import checked_cast
 
 if TYPE_CHECKING:  # pragma: no cover
     # import as module to make sphinx-autodoc-typehints happy
     from ax import core  # noqa F401
+
+
+@dataclass(frozen=True)
+class MetricFetchE:
+    message: str
+    exception: Optional[Exception]
+
+
+MetricFetchResult = Result[Data, MetricFetchE]
 
 
 class Metric(SortableBase, SerializationMixin):
@@ -84,7 +105,9 @@ class Metric(SortableBase, SerializationMixin):
         """
         return self.__class__
 
-    def fetch_trial_data(self, trial: core.base_trial.BaseTrial, **kwargs: Any) -> Data:
+    def fetch_trial_data(
+        self, trial: core.base_trial.BaseTrial, **kwargs: Any
+    ) -> MetricFetchResult:
         """Fetch data for one trial."""
         raise NotImplementedError(
             f"Metric {self.name} does not implement data-fetching logic."
@@ -92,36 +115,33 @@ class Metric(SortableBase, SerializationMixin):
 
     def fetch_experiment_data(
         self, experiment: core.experiment.Experiment, **kwargs: Any
-    ) -> Data:
+    ) -> Dict[int, MetricFetchResult]:
         """Fetch this metric's data for an experiment.
 
-        Default behavior is to fetch data from all trials expecting data
-        and concatenate the results.
+        Returns Dict of trial_index => Result
         """
-        return self.data_constructor.from_multiple_data(
-            [
-                checked_cast(
-                    self.data_constructor, self.fetch_trial_data(trial, **kwargs)
-                )
-                if trial.status.expecting_data
-                else self.data_constructor()
-                for trial in experiment.trials.values()
-            ],
-        )
+
+        return {
+            trial.index: self.fetch_trial_data(trial=trial, **kwargs)
+            for trial in experiment.trials.values()
+            if trial.status.expecting_data
+        }
 
     @classmethod
     def fetch_trial_data_multi(
         cls, trial: core.base_trial.BaseTrial, metrics: Iterable[Metric], **kwargs: Any
-    ) -> Data:
+    ) -> Dict[str, MetricFetchResult]:
         """Fetch multiple metrics data for one trial.
 
+        Returns Dict of metric_name => Result
         Default behavior calls `fetch_trial_data` for each metric.
         Subclasses should override this to trial data computation for multiple metrics.
         """
-        dat = cls.data_constructor.from_multiple_data(
-            [metric.fetch_trial_data(trial, **kwargs) for metric in metrics]
-        )
-        return dat
+
+        return {
+            metric.name: metric.fetch_trial_data(trial=trial, **kwargs)
+            for metric in metrics
+        }
 
     @classmethod
     def fetch_experiment_data_multi(
@@ -130,12 +150,22 @@ class Metric(SortableBase, SerializationMixin):
         metrics: Iterable[Metric],
         trials: Optional[Iterable[core.base_trial.BaseTrial]] = None,
         **kwargs: Any,
-    ) -> Data:
+    ) -> Dict[int, Dict[str, MetricFetchResult]]:
         """Fetch multiple metrics data for an experiment.
 
+        Returns Dict of trial_index => (metric_name => Result)
         Default behavior calls `fetch_trial_data_multi` for each trial.
         Subclasses should override to batch data computation across trials + metrics.
         """
+
+        return {
+            trial.index: cls.fetch_trial_data_multi(
+                trial=trial, metrics=metrics, **kwargs
+            )
+            for trial in (trials if trials is not None else experiment.trials.values())
+            if trial.status.expecting_data
+        }
+
         return cls.data_constructor.from_multiple_data(
             [
                 cls.fetch_trial_data_multi(trial, metrics, **kwargs)
@@ -152,7 +182,7 @@ class Metric(SortableBase, SerializationMixin):
         metrics: Iterable[Metric],
         trials: Optional[Iterable[core.base_trial.BaseTrial]] = None,
         **kwargs: Any,
-    ) -> Tuple[Data, bool]:
+    ) -> Tuple[Dict[int, Dict[str, MetricFetchResult]], bool]:
         """Fetch or lookup (with fallback to fetching) data for given metrics,
         depending on whether they are available while running. Return a tuple
         containing the data, along with a boolean that will be True if new
@@ -186,9 +216,9 @@ class Metric(SortableBase, SerializationMixin):
             completed_trials = [t for t in trials if t.status.is_completed]
 
         if not completed_trials:
-            return cls.data_constructor(), False
+            return {}, False
 
-        trials_data = []
+        trials_results = {}
         contains_new_data = False
         for trial in completed_trials:
             cached_trial_data = experiment.lookup_data_for_trial(
@@ -200,7 +230,9 @@ class Metric(SortableBase, SerializationMixin):
             if not metrics_to_fetch:
                 # If all needed data fetched from cache, no need to fetch any other data
                 # for trial.
-                trials_data.append(cached_trial_data)
+                trials_results[trial.index] = cls._wrap_trial_data_multi(
+                    data=cached_trial_data
+                )
                 continue
 
             try:
@@ -209,21 +241,26 @@ class Metric(SortableBase, SerializationMixin):
                     metrics=metrics_to_fetch,
                     trials=[trial],
                     **kwargs,
-                )
+                )[trial.index]
                 contains_new_data = True
             except NotImplementedError:
                 # Metric does not implement fetching logic and only uses lookup.
-                fetched_trial_data = cls.data_constructor()
+                fetched_trial_data = {}
 
-            final_data = cls.data_constructor.from_multiple_data(
-                [cached_trial_data, fetched_trial_data]
-            )
+            trials_results[trial.index] = {
+                **cls._wrap_trial_data_multi(data=cached_trial_data),
+                **fetched_trial_data,
+            }
 
-            trials_data.append(final_data)
         return (
-            cls.data_constructor.from_multiple_data(
-                trials_data, subset_metrics=[m.name for m in metrics]
-            ),
+            {
+                trial_index: {
+                    metric_name: results
+                    for metric_name, results in results_by_metric_name.items()
+                    if metric_name in [metric.name for metric in metrics]
+                }
+                for trial_index, results_by_metric_name in trials_results.items()
+            },
             contains_new_data,
         )
 
@@ -242,3 +279,120 @@ class Metric(SortableBase, SerializationMixin):
     @property
     def _unique_id(self) -> str:
         return str(self)
+
+    @classmethod
+    def _unwrap_experiment_data(cls, results: Mapping[int, MetricFetchResult]) -> Data:
+        oks: List[Ok[Data, MetricFetchE]] = [
+            result for result in results.values() if isinstance(result, Ok)
+        ]
+        if len(oks) < len(results):
+            errs: List[Err[Data, MetricFetchE]] = [
+                result for result in results.values() if isinstance(result, Err)
+            ]
+
+            # TODO[mpolson64] Raise all errors in a group via PEP 654
+            exceptions = [
+                err.err.exception or Exception(err.err.message) for err in errs
+            ]
+            raise exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+
+        data = [ok.ok for ok in oks]
+        return (
+            cls.data_constructor.from_multiple_data(data=data)
+            if len(data) > 0
+            else cls.data_constructor()
+        )
+
+    @classmethod
+    def _unwrap_trial_data_multi(cls, results: Mapping[str, MetricFetchResult]) -> Data:
+        oks: List[Ok[Data, MetricFetchE]] = [
+            result for result in results.values() if isinstance(result, Ok)
+        ]
+        if len(oks) < len(results):
+            errs: List[Err[Data, MetricFetchE]] = [
+                result for result in results.values() if isinstance(result, Err)
+            ]
+
+            # TODO[mpolson64] Raise all errors in a group via PEP 654
+            exceptions = [
+                err.err.exception or Exception(err.err.message) for err in errs
+            ]
+            raise exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+
+        data = [ok.ok for ok in oks]
+        return (
+            cls.data_constructor.from_multiple_data(data=data)
+            if len(data) > 0
+            else cls.data_constructor()
+        )
+
+    @classmethod
+    def _unwrap_experiment_data_multi(
+        cls,
+        results: Mapping[int, Mapping[str, MetricFetchResult]],
+    ) -> Data:
+        flattened = [
+            result for sublist in results.values() for result in sublist.values()
+        ]
+        oks: List[Ok[Data, MetricFetchE]] = [
+            result for result in flattened if isinstance(result, Ok)
+        ]
+        if len(oks) < len(flattened):
+            errs: List[Err[Data, MetricFetchE]] = [
+                result for result in flattened if isinstance(result, Err)
+            ]
+
+            # TODO[mpolson64] Raise all errors in a group via PEP 654
+            exceptions = [
+                err.err.exception or Exception(err.err.message) for err in errs
+            ]
+            raise exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+
+        data = [ok.ok for ok in oks]
+        return (
+            cls.data_constructor.from_multiple_data(data=data)
+            if len(data) > 0
+            else cls.data_constructor()
+        )
+
+    @classmethod
+    def _wrap_experiment_data(cls, data: Data) -> Dict[int, MetricFetchResult]:
+        return {
+            trial_index: Ok(
+                value=Data(
+                    df=data.true_df.loc[data.true_df["trial_index"] == trial_index]
+                )
+            )
+            for trial_index in data.true_df["trial_index"]
+        }
+
+    @classmethod
+    def _wrap_trial_data_multi(cls, data: Data) -> Dict[str, MetricFetchResult]:
+        return {
+            metric_name: Ok(
+                value=Data(
+                    df=data.true_df.loc[data.true_df["metric_name"] == metric_name]
+                )
+            )
+            for metric_name in data.true_df["metric_name"]
+        }
+
+    @classmethod
+    def _wrap_experiment_data_multi(
+        cls, data: Data
+    ) -> Dict[int, Dict[str, MetricFetchResult]]:
+        # pyre-fixme[7]
+        return {
+            trial_index: {
+                metric_name: Ok(
+                    value=Data(
+                        df=data.true_df.loc[
+                            (data.true_df["trial_index"] == trial_index)
+                            & (data.true_df["metric_name"] == metric_name)
+                        ]
+                    )
+                )
+                for metric_name in data.true_df["metric_name"]
+            }
+            for trial_index in data.true_df["trial_index"]
+        }

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -11,7 +11,7 @@ from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial
 from ax.core.data import Data
 from ax.core.experiment import DataType, Experiment
-from ax.core.metric import Metric
+from ax.core.metric import Metric, MetricFetchResult
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.runner import Runner
 from ax.core.search_space import SearchSpace
@@ -194,7 +194,9 @@ class MultiTypeExperiment(Experiment):
     ) -> Data:
         return self.default_data_constructor.from_multiple_data(
             [
-                trial.fetch_data(**kwargs, metrics=metrics)
+                Metric._unwrap_trial_data_multi(
+                    results=trial.fetch_data(**kwargs, metrics=metrics)
+                )
                 if trial.status.expecting_data
                 else Data()
                 for trial in self.trials.values()
@@ -204,7 +206,7 @@ class MultiTypeExperiment(Experiment):
     @copy_doc(Experiment._fetch_trial_data)
     def _fetch_trial_data(
         self, trial_index: int, metrics: Optional[List[Metric]] = None, **kwargs: Any
-    ) -> Data:
+    ) -> Dict[str, MetricFetchResult]:
         trial = self.trials[trial_index]
         metrics = [
             metric

--- a/ax/core/tests/test_map_metric.py
+++ b/ax/core/tests/test_map_metric.py
@@ -6,6 +6,7 @@
 
 from ax.core.map_metric import MapMetric
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_map_data
 
 
 METRIC_STRING = "MapMetric('m1')"
@@ -35,3 +36,21 @@ class MapMetricTest(TestCase):
         metric1 = MapMetric(name="m1", lower_is_better=False)
         metric2 = MapMetric(name="m2", lower_is_better=False)
         self.assertTrue(metric1 < metric2)
+
+    def testWrapUnwrap(self) -> None:
+        data = get_map_data()
+
+        trial_multi = MapMetric._unwrap_trial_data_multi(
+            results=MapMetric._wrap_trial_data_multi(data=data)
+        )
+        self.assertEqual(trial_multi, data)
+
+        experiment = MapMetric._unwrap_experiment_data(
+            results=MapMetric._wrap_experiment_data(data=data)
+        )
+        self.assertEqual(experiment, data)
+
+        experiment_multi = MapMetric._unwrap_experiment_data_multi(
+            results=MapMetric._wrap_experiment_data_multi(data=data)
+        )
+        self.assertEqual(experiment_multi, data)

--- a/ax/core/tests/test_metric.py
+++ b/ax/core/tests/test_metric.py
@@ -4,9 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ax.core.metric import Metric
+from ax.core.metric import Metric, MetricFetchE
+from ax.utils.common.result import Err
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_branin_metric, get_factorial_metric
+from ax.utils.testing.core_stubs import (
+    get_branin_metric,
+    get_data,
+    get_factorial_metric,
+)
 
 
 METRIC_STRING = "Metric('m1')"
@@ -42,3 +47,33 @@ class MetricTest(TestCase):
         metric1 = Metric(name="m1", lower_is_better=False)
         metric2 = Metric(name="m2", lower_is_better=False)
         self.assertTrue(metric1 < metric2)
+
+    def testWrapUnwrap(self) -> None:
+        data = get_data()
+
+        trial_multi = Metric._unwrap_trial_data_multi(
+            results=Metric._wrap_trial_data_multi(data=data)
+        )
+        self.assertEqual(trial_multi, data)
+
+        experiment = Metric._unwrap_experiment_data(
+            results=Metric._wrap_experiment_data(data=data)
+        )
+        self.assertEqual(experiment, data)
+
+        experiment_multi = Metric._unwrap_experiment_data_multi(
+            results=Metric._wrap_experiment_data_multi(data=data)
+        )
+        self.assertEqual(experiment_multi, data)
+
+    def testWrapErr(self) -> None:
+        err = Err(MetricFetchE(message="failed!", exception=Exception("panic!")))
+
+        with self.assertRaisesRegex(Exception, "panic"):
+            Metric._unwrap_experiment_data_multi(results={0: {"foo": err}})
+
+        with self.assertRaisesRegex(Exception, "panic"):
+            Metric._unwrap_experiment_data(results={0: err})
+
+        with self.assertRaisesRegex(Exception, "panic"):
+            Metric._unwrap_trial_data_multi(results={"foo": err})

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -5,37 +5,30 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
-from typing import Dict
 from unittest.mock import patch
 
 import pandas as pd
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun, GeneratorRunType
-from ax.core.metric import MetricFetchResult
 from ax.core.runner import Runner
-from ax.utils.common.result import Ok
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_arms, get_experiment, get_objective
 
 
-TEST_DATA: Dict[str, MetricFetchResult] = {
-    get_objective().metric.name: Ok(
-        value=Data(
-            df=pd.DataFrame(
-                [
-                    {
-                        "arm_name": "0_0",
-                        "metric_name": get_objective().metric.name,
-                        "mean": 1.0,
-                        "sem": 2.0,
-                        "trial_index": 0,
-                    }
-                ]
-            )
-        )
+TEST_DATA = Data(
+    df=pd.DataFrame(
+        [
+            {
+                "arm_name": "0_0",
+                "metric_name": get_objective().metric.name,
+                "mean": 1.0,
+                "sem": 2.0,
+                "trial_index": 0,
+            }
+        ]
     )
-}
+)
 
 
 class TrialTest(TestCase):
@@ -205,8 +198,7 @@ class TrialTest(TestCase):
         self.assertEqual(self.trial.objective_mean, 1.0)
 
     @patch(
-        f"{BaseTrial.__module__}.{BaseTrial.__name__}.lookup_data",
-        return_value={"m1": Ok(Data())},
+        f"{BaseTrial.__module__}.{BaseTrial.__name__}.lookup_data", return_value=Data()
     )
     # pyre-fixme[3]: Return type must be annotated.
     def test_objective_mean_empty_df(self, _mock):

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -202,11 +202,10 @@ class Trial(BaseTrial):
         latest data available for the metric for the trial.
         """
 
-        fetch_result = self.lookup_data()[metric_name]
+        fetch_result = self.lookup_data()
 
         try:
-            # TODO[mpolson64] Decide how to handle this more elegantly
-            df = fetch_result.unwrap().df
+            df = fetch_result.df
             return df.loc[df["metric_name"] == metric_name].iloc[0]["mean"]
         except IndexError:  # pragma: no cover
             raise ValueError(f"Metric {metric_name} not yet in data for trial.")

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -189,9 +189,7 @@ class Trial(BaseTrial):
         objective that was set at the time the trial was created or ran.
         """
         # For SimpleExperiment, fetch_data just executes eval_trial.
-        df = self.lookup_data().df
-        if df.empty:
-            raise ValueError(f"No data was retrieved for trial {self.index}.")
+
         opt_config = self.experiment.optimization_config
         if opt_config is None:
             raise ValueError(  # pragma: no cover
@@ -203,9 +201,12 @@ class Trial(BaseTrial):
         """Metric mean for the arm attached to this trial, retrieved from the
         latest data available for the metric for the trial.
         """
-        # For SimpleExperiment, fetch_data just executes eval_trial.
-        df = self.lookup_data().df
+
+        fetch_result = self.lookup_data()[metric_name]
+
         try:
+            # TODO[mpolson64] Decide how to handle this more elegantly
+            df = fetch_result.unwrap().df
             return df.loc[df["metric_name"] == metric_name].iloc[0]["mean"]
         except IndexError:  # pragma: no cover
             raise ValueError(f"Metric {metric_name} not yet in data for trial.")

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -422,6 +422,8 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         # manually "unalign" timestamps to simulate real-world scenario
         # where each curve reports results at different steps
         data = checked_cast(MapData, exp.fetch_data())
+        data.map_df.sort_values(by=["metric_name", "arm_name"], inplace=True)
+        data.map_df.reset_index(drop=True, inplace=True)
 
         unaligned_timestamps = [0, 1, 4, 1, 2, 3, 1, 3, 4, 0, 1, 2, 0, 2, 4]
         data.map_df.loc[

--- a/ax/metrics/tests/test_chemistry.py
+++ b/ax/metrics/tests/test_chemistry.py
@@ -79,7 +79,7 @@ class ChemistryMetricTest(TestCase):
                 trial._generator_run = GeneratorRun(
                     arms=[Arm(name="0_0", parameters=params)]
                 )
-                df = metric.fetch_trial_data(trial).df
+                df = metric.fetch_trial_data(trial).unwrap().df
                 self.assertEqual(mock_read_csv.call_count, 1)
                 self.assertEqual(df["mean"].values[0], obj)
                 self.assertTrue(np.isnan(df["sem"].values[0]))
@@ -91,5 +91,5 @@ class ChemistryMetricTest(TestCase):
                 metric = ChemistryMetric(
                     name="test_metric", problem_type=problem_type, noiseless=True
                 )
-                df = metric.fetch_trial_data(trial).df
+                df = metric.fetch_trial_data(trial).unwrap().df
                 self.assertEqual(df["sem"].values[0], 0.0)

--- a/ax/metrics/tests/test_noisy_function.py
+++ b/ax/metrics/tests/test_noisy_function.py
@@ -24,7 +24,7 @@ class GenericNoisyFunctionMetricTest(TestCase):
             f=f,
         )
         trial = get_trial()
-        df = metric.fetch_trial_data(trial).df
+        df = metric.fetch_trial_data(trial).unwrap().df
         self.assertEqual(df["arm_name"].tolist(), ["0_0"])
         self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
         # pyre-fixme[16]: Optional type has no attribute `parameters`.
@@ -38,12 +38,12 @@ class GenericNoisyFunctionMetricTest(TestCase):
             noise_sd=1.0,
         )
         trial = get_trial()
-        df = metric.fetch_trial_data(trial).df
+        df = metric.fetch_trial_data(trial).unwrap().df
         self.assertEqual(df["arm_name"].tolist(), ["0_0"])
         self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
         self.assertNotEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
         self.assertEqual(df["sem"].tolist(), [1.0])
-        df = metric.fetch_trial_data(trial, noisy=False).df
+        df = metric.fetch_trial_data(trial, noisy=False).unwrap().df
         self.assertEqual(df["arm_name"].tolist(), ["0_0"])
         self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
         self.assertEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
@@ -56,7 +56,7 @@ class GenericNoisyFunctionMetricTest(TestCase):
             noise_sd=None,
         )
         trial = get_trial()
-        df = metric.fetch_trial_data(trial).df
+        df = metric.fetch_trial_data(trial).unwrap().df
         self.assertEqual(df["arm_name"].tolist(), ["0_0"])
         self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
         self.assertEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])

--- a/ax/metrics/tests/test_sklearn.py
+++ b/ax/metrics/tests/test_sklearn.py
@@ -78,7 +78,7 @@ class SklearnMetricTest(TestCase):
                 #  float, int, str]]` but got `Dict[str, float]`.
                 arms=[Arm(name="0_0", parameters=params)]
             )
-            df = metric.fetch_trial_data(trial).df
+            df = metric.fetch_trial_data(trial).unwrap().df
             mock_load_digits.assert_called_once()
             mock_cv.assert_called_once()
             cargs, ckwargs = mock_cv.call_args
@@ -98,13 +98,13 @@ class SklearnMetricTest(TestCase):
 
             # test observed noise
             metric = SklearnMetric(name="test_metric", observed_noise=True)
-            df = metric.fetch_trial_data(trial).df
+            df = metric.fetch_trial_data(trial).unwrap().df
             self.assertEqual(
                 df["sem"].values[0], cv_scores.std() / sqrt(cv_scores.shape[0])
             )
             # test num_folds
             mock_cv.reset_mock()
             metric = SklearnMetric(name="test_metric", num_folds=10)
-            df = metric.fetch_trial_data(trial).df
+            df = metric.fetch_trial_data(trial).unwrap().df
             _, ckwargs = mock_cv.call_args
             self.assertEqual(ckwargs["cv"], 10)

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -126,15 +126,17 @@ class TestModelbridgeUtils(TestCase):
         with patch.object(
             self.batch_trial,
             "fetch_data",
-            return_value=Data.from_evaluations(
-                {
-                    self.batch_trial.arms[0].name: {
-                        "m1": (1, 0),
-                        "m2": (1, 0),
-                        "tracking": (1, 0),
-                    }
-                },
-                trial_index=self.trial.index,
+            return_value=Metric._wrap_trial_data_multi(
+                data=Data.from_evaluations(
+                    {
+                        self.batch_trial.arms[0].name: {
+                            "m1": (1, 0),
+                            "m2": (1, 0),
+                            "tracking": (1, 0),
+                        }
+                    },
+                    trial_index=self.trial.index,
+                ),
             ),
         ):
             self.assertEqual(
@@ -151,9 +153,17 @@ class TestModelbridgeUtils(TestCase):
         with patch.object(
             self.trial,
             "fetch_data",
-            return_value=Data.from_evaluations(
-                {self.trial.arm.name: {"m1": (1, 0), "m2": (1, 0), "tracking": (1, 0)}},
-                trial_index=self.trial.index,
+            return_value=Metric._wrap_trial_data_multi(
+                data=Data.from_evaluations(
+                    {
+                        self.trial.arm.name: {
+                            "m1": (1, 0),
+                            "m2": (1, 0),
+                            "tracking": (1, 0),
+                        }
+                    },
+                    trial_index=self.trial.index,
+                ),
             ),
         ):
             self.assertEqual(
@@ -244,14 +254,16 @@ class TestModelbridgeUtils(TestCase):
         with patch.object(
             hss_batch_trial,
             "fetch_data",
-            return_value=Data.from_evaluations(
-                {
-                    hss_batch_trial.arms[0].name: {
-                        "m1": (1, 0),
-                        "m2": (1, 0),
-                    }
-                },
-                trial_index=hss_batch_trial.index,
+            return_value=Metric._wrap_trial_data_multi(
+                data=Data.from_evaluations(
+                    {
+                        hss_batch_trial.arms[0].name: {
+                            "m1": (1, 0),
+                            "m2": (1, 0),
+                        }
+                    },
+                    trial_index=hss_batch_trial.index,
+                ),
             ),
         ):
             pending = get_pending_observation_features(
@@ -287,14 +299,16 @@ class TestModelbridgeUtils(TestCase):
         with patch.object(
             hss_batch_trial,
             "fetch_data",
-            return_value=Data.from_evaluations(
-                {
-                    hss_batch_trial.arms[0].name: {
-                        "m1": (1, 0),
-                        "m2": (1, 0),
-                    }
-                },
-                trial_index=hss_batch_trial.index,
+            return_value=Metric._wrap_trial_data_multi(
+                data=Data.from_evaluations(
+                    {
+                        hss_batch_trial.arms[0].name: {
+                            "m1": (1, 0),
+                            "m2": (1, 0),
+                        }
+                    },
+                    trial_index=hss_batch_trial.index,
+                ),
             ),
         ):
             self.assertEqual(

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -361,7 +361,9 @@ def compute_posterior_pareto_frontier(
     if not data:
         try:
             data = (
-                experiment.trials[trial_index].fetch_data()
+                Metric._unwrap_trial_data_multi(
+                    results=experiment.trials[trial_index].fetch_data()
+                )
                 if trial_index
                 else experiment.fetch_data()
             )

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -11,6 +11,7 @@ from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import LifecycleStage
 from ax.core.generator_run import GeneratorRun
+from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
 from ax.core.objective import Objective
 from ax.core.outcome_constraint import OutcomeConstraint
@@ -375,7 +376,9 @@ class SQAStoreTest(TestCase):
         save_experiment(exp)
         generator_run = Models.SOBOL(search_space=exp.search_space).gen(n=1)
         trial = exp.new_trial(generator_run=generator_run)
-        exp.attach_data(trial.run().fetch_data())
+        exp.attach_data(
+            MapMetric._unwrap_trial_data_multi(results=trial.run().fetch_data())
+        )
         save_or_update_trials(
             experiment=exp,
             trials=[trial],

--- a/ax/utils/common/result.py
+++ b/ax/utils/common/result.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod, abstractproperty
 
-from typing import Any, Callable, cast, Generic, NoReturn, Optional, TypeVar
+from typing import Any, Callable, cast, Generic, NoReturn, Optional, TypeVar, Union
 
 
 T = TypeVar("T", covariant=True)
@@ -31,16 +31,16 @@ class Result(Generic[T, E], ABC):
     def is_err(self) -> bool:
         pass
 
-    @abstractmethod
+    @abstractproperty
     def ok(self) -> Optional[T]:
         pass
 
-    @abstractmethod
+    @abstractproperty
     def err(self) -> Optional[E]:
         pass
 
     @abstractproperty
-    def value(self) -> T:
+    def value(self) -> Union[T, E]:
         pass
 
     @abstractmethod
@@ -121,7 +121,7 @@ class Result(Generic[T, E], ABC):
         pass
 
 
-class Ok(Result[T, E]):
+class Ok(Generic[T, E], Result[T, E]):
     """
     Contains the success value.
     """
@@ -147,9 +147,11 @@ class Ok(Result[T, E]):
     def is_err(self) -> bool:
         return False
 
+    @property
     def ok(self) -> T:
         return self._value
 
+    @property
     def err(self) -> None:
         return None
 
@@ -182,7 +184,7 @@ class Ok(Result[T, E]):
         return self._value
 
 
-class Err(Result[T, E]):
+class Err(Generic[T, E], Result[T, E]):
     """
     Contains the error value.
     """
@@ -206,10 +208,11 @@ class Err(Result[T, E]):
     def is_err(self) -> bool:
         return True
 
+    @property
     def ok(self) -> None:
-
         return None
 
+    @property
     def err(self) -> E:
         return self._value
 

--- a/ax/utils/testing/metrics/backend_simulator_map.py
+++ b/ax/utils/testing/metrics/backend_simulator_map.py
@@ -7,7 +7,7 @@
 from typing import Any, List
 
 from ax.core.base_trial import BaseTrial
-from ax.core.map_data import MapData
+from ax.core.map_metric import MapMetricFetchResult
 from ax.metrics.noisy_function_map import NoisyFunctionMapMetric
 
 
@@ -17,7 +17,7 @@ class BackendSimulatorTimestampMapMetric(NoisyFunctionMapMetric):
 
     def fetch_trial_data(
         self, trial: BaseTrial, noisy: bool = True, **kwargs: Any
-    ) -> MapData:
+    ) -> MapMetricFetchResult:
         """Fetch data for one trial."""
         backend_simulator = trial.experiment.runner.simulator  # pyre-ignore[16]
         sim_trial = backend_simulator.get_sim_trial_by_index(trial.index)


### PR DESCRIPTION
Summary: Propagate changes to the metric fetching pipeline throughout the rest of fbcode. See discussion on the previous diff in the stack for implementation details

Differential Revision: D40528347

