### PR TITLE
plotting progressions

### DIFF
--- a/ax/plot/benchmark.py
+++ b/ax/plot/benchmark.py
@@ -13,14 +13,16 @@ from plotly import graph_objs as go
 
 
 def plot_modeling_times(
-    aggregated_results: Iterable[AggregatedBenchmarkResult],
+    aggregated_results: List[AggregatedBenchmarkResult],
+    labels: Optional[List[str]] = None,
 ) -> AxPlotConfig:
     """Plots wall times of each method's fit and gen calls as a stack bar chart."""
-
+    if labels is None:
+        labels = [result.name for result in aggregated_results]
     data = [
         go.Bar(
             name="fit",
-            x=[result.name for result in aggregated_results],
+            x=labels,
             y=[result.fit_time[0] for result in aggregated_results],
             text=["fit" for _ in aggregated_results],
             error_y={
@@ -32,7 +34,7 @@ def plot_modeling_times(
         ),
         go.Bar(
             name="gen",
-            x=[result.name for result in aggregated_results],
+            x=labels,
             y=[result.gen_time[0] for result in aggregated_results],
             text=["gen" for _ in aggregated_results],
             error_y={
@@ -62,6 +64,7 @@ def plot_optimization_trace(
     optimum: Optional[float] = None,
     by_progression: bool = False,
     final_progression_only: bool = False,
+    labels: Optional[List[str]] = None,
 ) -> AxPlotConfig:
     """Plots optimization trace for each aggregated result with mean and SEM. When
     `by_progression` is True, the results are plotted with progressions on the
@@ -72,7 +75,8 @@ def plot_optimization_trace(
     hypervolume in the case of multi-objective problems) it will be plotted as an
     orange dashed line as well.
     """
-
+    if labels is None:
+        labels = [result.name for result in aggregated_results]
     x_axes = []
     dfs = []
     for agg_res in aggregated_results:
@@ -95,7 +99,7 @@ def plot_optimization_trace(
                     "color": rgba(DISCRETE_COLOR_SCALE[i % len(DISCRETE_COLOR_SCALE)])
                 },
                 mode="lines",
-                name=r.name,
+                name=label,
                 customdata=df["sem"],
                 hovertemplate="<br><b>Mean:</b> %{y}<br><b>SEM</b>: %{customdata}",
             ),
@@ -124,7 +128,7 @@ def plot_optimization_trace(
                 hoverinfo="skip",
             ),
         ]
-        for i, (x_axis, df, r) in enumerate(zip(x_axes, dfs, aggregated_results))
+        for i, (x_axis, df, label) in enumerate(zip(x_axes, dfs, labels))
     ]
 
     optimum_scatter = (
@@ -156,4 +160,106 @@ def plot_optimization_trace(
             + optimum_scatter,
         ),
         plot_type=AxPlotTypes.GENERIC,
+    )
+
+
+def plot_progression_trace(
+    aggregated_results: List[AggregatedBenchmarkResult],
+    labels: Optional[List[str]] = None,
+) -> AxPlotConfig:
+    if labels is None:
+        labels = [result.name for result in aggregated_results]
+    x_axes = []
+    dfs = []
+    for agg_res in aggregated_results:
+        progression_trace = agg_res.progression_trace()
+        dfs.append(progression_trace)
+        x_axes.append([*range(len(progression_trace))])
+
+    mean_sem_scatters = [
+        [
+            go.Scatter(
+                x=x_axis,
+                y=df["mean"],
+                line={
+                    "color": rgba(DISCRETE_COLOR_SCALE[i % len(DISCRETE_COLOR_SCALE)])
+                },
+                mode="lines",
+                name=label,
+                customdata=df["sem"],
+                hovertemplate="<br><b>Mean:</b> %{y}<br><b>SEM</b>: %{customdata}",
+            ),
+            go.Scatter(
+                x=x_axis,
+                y=df["mean"] + df["sem"],
+                line={"width": 0},
+                mode="lines",
+                fillcolor=rgba(
+                    DISCRETE_COLOR_SCALE[i % len(DISCRETE_COLOR_SCALE)], 0.3
+                ),
+                fill="tonexty",
+                showlegend=False,
+                hoverinfo="skip",
+            ),
+            go.Scatter(
+                x=x_axis,
+                y=df["mean"] - df["sem"],
+                line={"width": 0},
+                mode="lines",
+                fillcolor=rgba(
+                    DISCRETE_COLOR_SCALE[i % len(DISCRETE_COLOR_SCALE)], 0.3
+                ),
+                fill="tonexty",
+                showlegend=False,
+                hoverinfo="skip",
+            ),
+        ]
+        for i, (x_axis, df, label) in enumerate(zip(x_axes, dfs, labels))
+    ]
+    layout = go.Layout(
+        title="Progression Traces",
+        yaxis={"title": "Steps Used"},
+        xaxis={"title": "Iteration"},
+        hovermode="x unified",
+    )
+    return AxPlotConfig(
+        data=go.Figure(
+            layout=layout,
+            data=[scatter for sublist in mean_sem_scatters for scatter in sublist],
+        ),
+        plot_type=AxPlotTypes.GENERIC,
+    )
+
+
+def plot_total_progressions(
+    aggregated_results: Iterable[AggregatedBenchmarkResult],
+    labels: Optional[List[str]] = None,
+) -> AxPlotConfig:
+    """Plots total progressions used by each method as a bar chart."""
+    if labels is None:
+        labels = [result.name for result in aggregated_results]
+    total_progressions = [result.total_progression() for result in aggregated_results]
+    data = [
+        go.Bar(
+            name="total progressions",
+            x=labels,
+            y=[result[0] for result in total_progressions],
+            error_y={
+                "type": "data",
+                "array": [result[1] for result in total_progressions],
+                "visible": True,
+            },
+            opacity=0.6,
+        ),
+    ]
+
+    layout = go.Layout(
+        title="Total Steps",
+        showlegend=False,
+        yaxis={"title": "Total Steps"},
+        xaxis={"title": "Method"},
+    )
+
+    return AxPlotConfig(
+        data=go.Figure(layout=layout, data=data), plot_type=AxPlotTypes.GENERIC
     )


### PR DESCRIPTION
Summary:
Some new features to plot results related to early stopping:
(1) Plot the # of progressions used in each trial on average (see first figure in test plan)
(2) Plot the total progressions as a bar chart
(3) Add ability to pass in labels instead of long autogenerated benchmark name
(4) Update the performance vs progression plots to be more flexible

Differential Revision: D40626737

