### PR TITLE
Update clone_with_args to respect empty arguments

### DIFF
--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -25,6 +25,13 @@ logger: Logger = get_logger(__name__)
 
 TRefPoint = List[ObjectiveThreshold]
 
+# Sentinels for default arguments when None is a valid input
+_NO_OUTCOME_CONSTRAINTS = [
+    OutcomeConstraint(Metric("", lower_is_better=True), ComparisonOp.GEQ, 0)
+]
+_NO_OBJECTIVE_THRESHOLDS = [ObjectiveThreshold(Metric("", lower_is_better=True), 0)]
+_NO_RISK_MEASURE = RiskMeasure("", {})
+
 
 class OptimizationConfig(Base):
     """An optimization configuration, which comprises an objective,
@@ -68,15 +75,22 @@ class OptimizationConfig(Base):
     def clone_with_args(
         self,
         objective: Optional[Objective] = None,
-        outcome_constraints: Optional[List[OutcomeConstraint]] = None,
-        risk_measure: Optional[RiskMeasure] = None,
+        outcome_constraints: Optional[
+            List[OutcomeConstraint]
+        ] = _NO_OUTCOME_CONSTRAINTS,
+        risk_measure: Optional[RiskMeasure] = _NO_RISK_MEASURE,
     ) -> "OptimizationConfig":
         """Make a copy of this optimization config."""
-        objective = objective or self.objective.clone()
-        outcome_constraints = outcome_constraints or [
-            constraint.clone() for constraint in self.outcome_constraints
-        ]
-        risk_measure = risk_measure or self.risk_measure
+        objective = self.objective.clone() if objective is None else objective
+        outcome_constraints = (
+            [constraint.clone() for constraint in self.outcome_constraints]
+            if outcome_constraints is _NO_OUTCOME_CONSTRAINTS
+            else outcome_constraints
+        )
+        risk_measure = (
+            self.risk_measure if risk_measure is _NO_RISK_MEASURE else risk_measure
+        )
+
         return OptimizationConfig(
             objective=objective,
             outcome_constraints=outcome_constraints,
@@ -284,19 +298,30 @@ class MultiObjectiveOptimizationConfig(OptimizationConfig):
     def clone_with_args(
         self,
         objective: Optional[Objective] = None,
-        outcome_constraints: Optional[List[OutcomeConstraint]] = None,
-        objective_thresholds: Optional[List[ObjectiveThreshold]] = None,
-        risk_measure: Optional[RiskMeasure] = None,
+        outcome_constraints: Optional[
+            List[OutcomeConstraint]
+        ] = _NO_OUTCOME_CONSTRAINTS,
+        objective_thresholds: Optional[
+            List[ObjectiveThreshold]
+        ] = _NO_OBJECTIVE_THRESHOLDS,
+        risk_measure: Optional[RiskMeasure] = _NO_RISK_MEASURE,
     ) -> "MultiObjectiveOptimizationConfig":
         """Make a copy of this optimization config."""
-        objective = objective or self.objective.clone()
-        outcome_constraints = outcome_constraints or [
-            constraint.clone() for constraint in self.outcome_constraints
-        ]
-        objective_thresholds = objective_thresholds or [
-            ot.clone() for ot in self.objective_thresholds
-        ]
-        risk_measure = risk_measure or self.risk_measure
+        objective = self.objective.clone() if objective is None else objective
+        outcome_constraints = (
+            [constraint.clone() for constraint in self.outcome_constraints]
+            if outcome_constraints is _NO_OUTCOME_CONSTRAINTS
+            else outcome_constraints
+        )
+        objective_thresholds = (
+            [ot.clone() for ot in self.objective_thresholds]
+            if objective_thresholds is _NO_OBJECTIVE_THRESHOLDS
+            else objective_thresholds
+        )
+        risk_measure = (
+            self.risk_measure if risk_measure is _NO_RISK_MEASURE else risk_measure
+        )
+
         return MultiObjectiveOptimizationConfig(
             objective=objective,
             outcome_constraints=outcome_constraints,

--- a/ax/core/tests/test_optimization_config.py
+++ b/ax/core/tests/test_optimization_config.py
@@ -7,6 +7,7 @@
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.optimization_config import (
+    _NO_RISK_MEASURE,
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
 )
@@ -223,6 +224,43 @@ class OptimizationConfigTest(TestCase):
             risk_measure=self.single_output_risk_measure,
         )
         self.assertEqual(config1, config1.clone())
+
+    def testCloneWithArgs(self) -> None:
+        config1 = OptimizationConfig(
+            objective=self.objective,
+            outcome_constraints=self.outcome_constraints,
+            risk_measure=self.single_output_risk_measure,
+        )
+        config2 = OptimizationConfig(
+            objective=self.objective,
+        )
+        config3 = OptimizationConfig(
+            objective=self.objective, risk_measure=_NO_RISK_MEASURE.clone()
+        )
+
+        # Empty args produce exact clone
+        self.assertEqual(
+            config1.clone_with_args(),
+            config1,
+        )
+
+        # None args not treated as default
+        self.assertEqual(
+            config1.clone_with_args(
+                outcome_constraints=None,
+                risk_measure=None,
+            ),
+            config2,
+        )
+
+        # Arguments that has same value with default won't be treated as default
+        self.assertEqual(
+            config1.clone_with_args(
+                outcome_constraints=None,
+                risk_measure=config3.risk_measure,
+            ),
+            config3,
+        )
 
 
 class MultiObjectiveOptimizationConfigTest(TestCase):
@@ -469,17 +507,40 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
 
     def testCloneWithArgs(self) -> None:
         config1 = MultiObjectiveOptimizationConfig(
-            objective=self.multi_objective_just_m2,
-            outcome_constraints=[self.m1_constraint],
+            objective=self.multi_objective,
+            objective_thresholds=self.objective_thresholds,
+            outcome_constraints=self.outcome_constraints,
+            risk_measure=self.multi_output_risk_measure,
         )
         config2 = MultiObjectiveOptimizationConfig(
-            objective=self.multi_objective_just_m2,
-            objective_thresholds=[self.objective_thresholds[1]],
-            outcome_constraints=[self.m1_constraint],
+            objective=self.multi_objective,
         )
+        config3 = MultiObjectiveOptimizationConfig(
+            objective=self.multi_objective, risk_measure=_NO_RISK_MEASURE.clone()
+        )
+
+        # Empty args produce exact clone
+        self.assertEqual(
+            config1.clone_with_args(),
+            config1,
+        )
+
+        # None args not treated as default
         self.assertEqual(
             config1.clone_with_args(
-                objective_thresholds=[self.objective_thresholds[1]]
+                outcome_constraints=None,
+                objective_thresholds=None,
+                risk_measure=None,
             ),
             config2,
+        )
+
+        # Arguments that has same value with default won't be treated as default
+        self.assertEqual(
+            config1.clone_with_args(
+                outcome_constraints=None,
+                objective_thresholds=None,
+                risk_measure=config3.risk_measure,
+            ),
+            config3,
         )


### PR DESCRIPTION
Summary: Change `None` to sentinel variables as default argument to differentiate user input `None` from default argument

Differential Revision: D40911185

