### PR TITLE
Create class for compound GenerationStep completion critera

### DIFF
--- a/ax/modelbridge/completion_criterion.py
+++ b/ax/modelbridge/completion_criterion.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import abstractmethod
+
+from ax.core.base_trial import TrialStatus
+
+from ax.core.experiment import Experiment
+from ax.utils.common.base import Base
+from ax.utils.common.serialization import SerializationMixin
+
+
+class CompletionCriterion(Base, SerializationMixin):
+    """
+    Simple class to descibe a condition which must be met for a GenerationStraytegy
+    to move to its next GenerationStep.
+    """
+
+    def __init__(self) -> None:
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def is_met(self, experiment: Experiment) -> bool:
+        pass  # pragma: no cover
+
+
+class MinimumTrialsInStatus(CompletionCriterion):
+    def __init__(self, status: TrialStatus, threshold: int) -> None:
+        self.status = status
+        self.threshold = threshold
+
+    def is_met(self, experiment: Experiment) -> bool:
+        return len(experiment.trial_indices_by_status[self.status]) >= self.threshold
+
+
+class MinimumPreferenceOccurances(CompletionCriterion):
+    def __init__(self, metric_name: str, threshold: int) -> None:
+        self.metric_name = metric_name
+        self.threshold = threshold
+
+    def is_met(self, experiment: Experiment) -> bool:
+        data = experiment.fetch_data(metrics=[experiment.metrics[self.metric_name]])
+
+        count_no = (data.df["mean"] == 0).sum()
+        count_yes = (data.df["mean"] != 0).sum()
+
+        return count_no >= self.threshold and count_yes >= self.threshold

--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -6,8 +6,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Union
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from ax.core.data import Data  # Perhaps need to use `AbstractDataFrameData`?
 from ax.core.experiment import Experiment
@@ -17,6 +17,7 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.base import ModelBridge
+from ax.modelbridge.completion_criterion import CompletionCriterion
 from ax.modelbridge.cross_validation import BestModelSelector, CVDiagnostics, CVResult
 from ax.modelbridge.model_spec import FactoryFunctionModelSpec, ModelSpec
 from ax.modelbridge.registry import ModelRegistryBase
@@ -250,6 +251,8 @@ class GenerationStep(GenerationNode, SortableBase):
         model_gen_kwargs: Each call to `generation_strategy.gen` performs a call to the
             step's model's `gen` under the hood; `model_gen_kwargs` will be passed to
             the model's `gen` like so: `model.gen(**model_gen_kwargs)`.
+        completion_criteria: List of CompletionCriterion. All `is_met` must evaluate
+            True for the GenerationStrategy to move on to the next Step
         index: Index of this generation step, for use internally in `Generation
             Strategy`. Do not assign as it will be reassigned when instantiating
             `GenerationStrategy` with a list of its steps.
@@ -275,6 +278,7 @@ class GenerationStep(GenerationNode, SortableBase):
     model_gen_kwargs: Optional[Dict[str, Any]] = None
 
     # Optional specifications for use in generation strategy:
+    completion_criteria: Sequence[CompletionCriterion] = field(default_factory=list)
     min_trials_observed: int = 0
     max_parallelism: Optional[int] = None
     use_update: bool = False

--- a/ax/modelbridge/tests/test_completion_criterion.py
+++ b/ax/modelbridge/tests/test_completion_criterion.py
@@ -1,0 +1,138 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import patch
+
+import pandas as pd
+from ax.core.base_trial import TrialStatus
+from ax.core.data import Data
+from ax.modelbridge.completion_criterion import (
+    MinimumPreferenceOccurances,
+    MinimumTrialsInStatus,
+)
+from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.registry import Models
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_experiment
+
+
+class TestCompletionCritereon(TestCase):
+    def test_single_criterion(self) -> None:
+        criterion = MinimumPreferenceOccurances(metric_name="m1", threshold=3)
+
+        experiment = get_experiment()
+
+        generation_strategy = GenerationStrategy(
+            name="SOBOL+GPEI::default",
+            steps=[
+                GenerationStep(
+                    model=Models.SOBOL, num_trials=-1, completion_criteria=[criterion]
+                ),
+                GenerationStep(
+                    model=Models.GPEI,
+                    num_trials=-1,
+                    max_parallelism=1,
+                ),
+            ],
+        )
+        generation_strategy.experiment = experiment
+
+        # Has not seen enough of each preference
+        self.assertFalse(
+            generation_strategy._maybe_move_to_next_step(
+                raise_data_required_error=False
+            )
+        )
+
+        data = Data(
+            df=pd.DataFrame(
+                {
+                    "trial_index": range(6),
+                    "arm_name": [f"{i}_0" for i in range(6)],
+                    "metric_name": ["m1" for _ in range(6)],
+                    "mean": [0, 0, 0, 1, 1, 1],
+                    "sem": [0 for _ in range(6)],
+                }
+            )
+        )
+        with patch.object(experiment, "fetch_data", return_value=data):
+            # We have seen three "yes" and three "no"
+            self.assertTrue(
+                generation_strategy._maybe_move_to_next_step(
+                    raise_data_required_error=False
+                )
+            )
+
+            self.assertEqual(generation_strategy._curr.model, Models.GPEI)
+
+    def test_many_criteria(self) -> None:
+        criteria = [
+            MinimumPreferenceOccurances(metric_name="m1", threshold=3),
+            MinimumTrialsInStatus(status=TrialStatus.COMPLETED, threshold=5),
+        ]
+
+        experiment = get_experiment()
+
+        generation_strategy = GenerationStrategy(
+            name="SOBOL+GPEI::default",
+            steps=[
+                GenerationStep(
+                    model=Models.SOBOL, num_trials=-1, completion_criteria=criteria
+                ),
+                GenerationStep(
+                    model=Models.GPEI,
+                    num_trials=-1,
+                    max_parallelism=1,
+                ),
+            ],
+        )
+        generation_strategy.experiment = experiment
+
+        # Has not seen enough of each preference
+        self.assertFalse(
+            generation_strategy._maybe_move_to_next_step(
+                raise_data_required_error=False
+            )
+        )
+
+        data = Data(
+            df=pd.DataFrame(
+                {
+                    "trial_index": range(6),
+                    "arm_name": [f"{i}_0" for i in range(6)],
+                    "metric_name": ["m1" for _ in range(6)],
+                    "mean": [0, 0, 0, 1, 1, 1],
+                    "sem": [0 for _ in range(6)],
+                }
+            )
+        )
+        with patch.object(experiment, "fetch_data", return_value=data):
+            # We have seen three "yes" and three "no", but not enough trials
+            # are completed
+            self.assertFalse(
+                generation_strategy._maybe_move_to_next_step(
+                    raise_data_required_error=False
+                )
+            )
+
+        experiment._trial_indices_by_status = {TrialStatus.COMPLETED: {*range(6)}}
+        # Enough trials are completed but we have not seen three "yes" and three
+        # "no"
+        self.assertFalse(
+            generation_strategy._maybe_move_to_next_step(
+                raise_data_required_error=False
+            )
+        )
+
+        with patch.object(experiment, "fetch_data", return_value=data):
+            # Enough trials are completed but we have not seen three "yes" and three
+            # "no"
+            self.assertTrue(
+                generation_strategy._maybe_move_to_next_step(
+                    raise_data_required_error=False
+                )
+            )
+
+            self.assertEqual(generation_strategy._curr.model, Models.GPEI)

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -620,6 +620,11 @@ def generation_step_from_json(
         ),
         num_trials=generation_step_json.pop("num_trials"),
         min_trials_observed=generation_step_json.pop("min_trials_observed", 0),
+        completion_criteria=object_from_json(
+            generation_step_json.pop("completion_criteria")
+        )
+        if "completion_criteria" in generation_step_json.keys()
+        else [],
         max_parallelism=(generation_step_json.pop("max_parallelism", None)),
         use_update=generation_step_json.pop("use_update", False),
         enforce_num_trials=generation_step_json.pop("enforce_num_trials", True),

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -39,6 +39,7 @@ from ax.early_stopping.strategies import (
     PercentileEarlyStoppingStrategy,
     ThresholdEarlyStoppingStrategy,
 )
+from ax.modelbridge.completion_criterion import CompletionCriterion
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import _encode_callables_as_references
 from ax.modelbridge.transforms.base import Transform
@@ -398,6 +399,7 @@ def generation_step_to_dict(generation_step: GenerationStep) -> Dict[str, Any]:
         "model": generation_step.model,
         "num_trials": generation_step.num_trials,
         "min_trials_observed": generation_step.min_trials_observed,
+        "completion_criteria": generation_step.completion_criteria,
         "max_parallelism": generation_step.max_parallelism,
         "use_update": generation_step.use_update,
         "enforce_num_trials": generation_step.enforce_num_trials,
@@ -431,6 +433,13 @@ def generation_strategy_to_dict(
         "had_initialized_model": generation_strategy.model is not None,
         "experiment": generation_strategy._experiment,
     }
+
+
+def completion_criterion_to_dict(criterion: CompletionCriterion) -> Dict[str, Any]:
+    """Convert Ax CompletionCriterion to a dictionary."""
+    properties = criterion.serialize_init_args(obj=criterion)
+    properties["__type"] = criterion.__class__.__name__
+    return properties
 
 
 def observation_features_to_dict(obs_features: ObservationFeatures) -> Dict[str, Any]:

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -72,6 +72,10 @@ from ax.metrics.jenatton import JenattonMetric
 from ax.metrics.l2norm import L2NormMetric
 from ax.metrics.noisy_function import NoisyFunctionMetric
 from ax.metrics.sklearn import SklearnDataset, SklearnMetric, SklearnModelType
+from ax.modelbridge.completion_criterion import (
+    MinimumPreferenceOccurances,
+    MinimumTrialsInStatus,
+)
 from ax.modelbridge.factory import Models
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.transforms.base import Transform
@@ -91,6 +95,7 @@ from ax.storage.json_store.encoders import (
     botorch_model_to_dict,
     botorch_modular_to_dict,
     choice_parameter_to_dict,
+    completion_criterion_to_dict,
     data_to_dict,
     experiment_to_dict,
     fixed_parameter_to_dict,
@@ -167,6 +172,8 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     MapKeyInfo: map_key_info_to_dict,
     MapMetric: metric_to_dict,
     Metric: metric_to_dict,
+    MinimumTrialsInStatus: completion_criterion_to_dict,
+    MinimumPreferenceOccurances: completion_criterion_to_dict,
     MultiObjective: multi_objective_to_dict,
     MultiObjectiveOptimizationConfig: multi_objective_optimization_config_to_dict,
     MultiTypeExperiment: multi_type_experiment_to_dict,
@@ -263,6 +270,8 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "MapMetric": MapMetric,
     "MapKeyInfo": MapKeyInfo,
     "Metric": Metric,
+    "MinimumTrialsInStatus": MinimumTrialsInStatus,
+    "MinimumPreferenceOccurances": MinimumPreferenceOccurances,
     "Models": Models,
     "MultiObjective": MultiObjective,
     "MultiObjectiveBenchmarkProblem": MultiObjectiveBenchmarkProblem,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -142,6 +142,12 @@ TEST_CASES = [
     ("FixedParameter", get_fixed_parameter),
     ("GammaPrior", get_gamma_prior),
     ("GenerationStrategy", partial(get_generation_strategy, with_experiment=True)),
+    (
+        "GenerationStrategy",
+        partial(
+            get_generation_strategy, with_experiment=True, with_completion_criteria=3
+        ),
+    ),
     ("GeneratorRun", get_generator_run),
     ("Hartmann6Metric", get_hartmann_metric),
     ("HierarchicalSearchSpace", get_hierarchical_search_space),

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -14,6 +14,7 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import FixedParameter, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.base import ModelBridge
+from ax.modelbridge.completion_criterion import MinimumPreferenceOccurances
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.transforms.base import Transform
@@ -162,7 +163,9 @@ def get_observation2trans(
 
 
 def get_generation_strategy(
-    with_experiment: bool = False, with_callable_model_kwarg: bool = True
+    with_experiment: bool = False,
+    with_callable_model_kwarg: bool = True,
+    with_completion_criteria: int = 0,
 ) -> GenerationStrategy:
     gs = choose_generation_strategy(
         search_space=get_search_space(), should_deduplicate=True
@@ -174,6 +177,12 @@ def get_generation_strategy(
         # pyre-ignore[16]: testing hack to test serialization of callable kwargs
         # in generation steps.
         gs._steps[0].model_kwargs["model_constructor"] = fake_func
+
+    if with_completion_criteria > 0:
+        gs._steps[0].num_trials = -1
+        gs._steps[0].completion_criteria = [
+            MinimumPreferenceOccurances(metric_name="m1", threshold=3)
+        ] * with_completion_criteria
     return gs
 
 

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -25,6 +25,12 @@ Generation Node
     :undoc-members:
     :show-inheritance:
 
+Completion Criterion
+.. automodule:: ax.modelbridge.completion_criterion
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Registry
 ~~~~~~~~~~~~~~~~~~~~
 .. automodule:: ax.modelbridge.registry


### PR DESCRIPTION
Summary: Create a new system for telling the generation strategy when it is okay to move onto the next generation step. These can encode arbitrary checking logic via the `is_met` method which has access to the full experiment.

Reviewed By: lena-kashtelyan

Differential Revision: D40457981

