### PR TITLE
Raise an error if trying to generate less than 1 candidate

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -29,6 +29,7 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import TCandidateMetadata, TModelCov, TModelMean, TModelPredict
+from ax.exceptions.core import UserInputError
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.cast import Cast
 from ax.models.types import TConfig
@@ -640,6 +641,25 @@ class ModelBridge(ABC):
             fixed_features=fixed_features,
         )
 
+    def _validate_gen_inputs(
+        self,
+        n: int,
+        search_space: Optional[SearchSpace] = None,
+        optimization_config: Optional[OptimizationConfig] = None,
+        pending_observations: Optional[Dict[str, List[ObservationFeatures]]] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
+        model_gen_options: Optional[TConfig] = None,
+    ) -> None:
+        """Validate inputs to `ModelBridge.gen`.
+
+        Currently, this is only used to ensure that `n` is a positive integer.
+        """
+        if n < 1:
+            raise UserInputError(
+                f"Attempted to generate n={n} points. Number of points to generate "
+                "must be a positive integer."
+            )
+
     def gen(
         self,
         n: int,
@@ -668,6 +688,14 @@ class ModelBridge(ABC):
         Returns:
             A GeneratorRun object that contains the generated points and other metadata.
         """
+        self._validate_gen_inputs(
+            n=n,
+            search_space=search_space,
+            optimization_config=optimization_config,
+            pending_observations=pending_observations,
+            fixed_features=fixed_features,
+            model_gen_options=model_gen_options,
+        )
         t_gen_start = time.monotonic()
         # Get modifiable versions
         if search_space is None:

--- a/ax/modelbridge/discrete.py
+++ b/ax/modelbridge/discrete.py
@@ -16,6 +16,7 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ChoiceParameter, FixedParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValueList
+from ax.exceptions.core import UserInputError
 from ax.modelbridge.base import GenResults, ModelBridge
 from ax.modelbridge.modelbridge_utils import array_to_observation_data
 from ax.modelbridge.torch import (
@@ -87,6 +88,25 @@ class DiscreteModelBridge(ModelBridge):
         f, cov = self.model.predict(X=X)
         # Convert arrays to observations
         return array_to_observation_data(f=f, cov=cov, outcomes=self.outcomes)
+
+    def _validate_gen_inputs(
+        self,
+        n: int,
+        search_space: Optional[SearchSpace] = None,
+        optimization_config: Optional[OptimizationConfig] = None,
+        pending_observations: Optional[Dict[str, List[ObservationFeatures]]] = None,
+        fixed_features: Optional[ObservationFeatures] = None,
+        model_gen_options: Optional[TConfig] = None,
+    ) -> None:
+        """Validate inputs to `ModelBridge.gen`.
+
+        Currently, this is only used to ensure that `n` is a positive integer or -1.
+        """
+        if n < 1 and n != -1:
+            raise UserInputError(
+                f"Attempted to generate n={n} points. Number of points to generate "
+                "must be either a positive integer or -1."
+            )
 
     def _gen(
         self,

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -6,6 +6,7 @@
 
 import warnings
 from unittest import mock
+from unittest.mock import Mock
 
 import numpy as np
 import pandas as pd
@@ -21,6 +22,7 @@ from ax.core.observation import (
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import FixedParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
+from ax.exceptions.core import UserInputError
 from ax.modelbridge.base import (
     clamp_observation_features,
     gen_arms,
@@ -69,9 +71,9 @@ class BaseModelBridgeTest(TestCase):
         return_value=([Arm(parameters={})], None),
     )
     @mock.patch("ax.modelbridge.base.ModelBridge._fit", autospec=True)
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def testModelBridge(self, mock_fit, mock_gen_arms, mock_observations_from_data):
+    def test_ModelBridge(
+        self, mock_fit: Mock, mock_gen_arms: Mock, mock_observations_from_data: Mock
+    ) -> None:
         # Test that on init transforms are stored and applied in the correct order
         transforms = [transform_1, transform_2]
         exp = get_experiment_for_value()
@@ -155,6 +157,9 @@ class BaseModelBridgeTest(TestCase):
         modelbridge._set_kwargs_to_save(
             model_key="TestModel", model_kwargs={}, bridge_kwargs={}
         )
+        # Test input error when generating 0 candidates.
+        with self.assertRaisesRegex(UserInputError, "Attempted to generate"):
+            modelbridge.gen(n=0)
         gr = modelbridge.gen(
             n=1,
             search_space=get_search_space_for_value(),
@@ -258,8 +263,7 @@ class BaseModelBridgeTest(TestCase):
         autospec=True,
         return_value=([get_observation1(), get_observation2()]),
     )
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_ood_gen(self, _):
+    def test_ood_gen(self, _) -> None:
         # Test fit_out_of_design by returning OOD candidats
         exp = get_experiment_for_value()
         ss = SearchSpace([RangeParameter("x", ParameterType.FLOAT, 0.0, 1.0)])

--- a/ax/modelbridge/tests/test_discrete_modelbridge.py
+++ b/ax/modelbridge/tests/test_discrete_modelbridge.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from unittest import mock
+from unittest.mock import Mock
 
 import numpy as np
 from ax.core.metric import Metric
@@ -19,6 +20,7 @@ from ax.core.parameter import (
     RangeParameter,
 )
 from ax.core.search_space import SearchSpace
+from ax.exceptions.core import UserInputError
 from ax.modelbridge.discrete import _get_parameter_values, DiscreteModelBridge
 from ax.models.discrete_base import DiscreteModel
 from ax.utils.common.testutils import TestCase
@@ -73,9 +75,7 @@ class DiscreteModelBridgeTest(TestCase):
     @mock.patch(
         "ax.modelbridge.discrete.DiscreteModelBridge.__init__", return_value=None
     )
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def testFit(self, mock_init):
+    def test_fit(self, mock_init: Mock) -> None:
         # pyre-fixme[20]: Argument `model` expected.
         ma = DiscreteModelBridge()
         ma._training_data = self.observations
@@ -108,9 +108,7 @@ class DiscreteModelBridgeTest(TestCase):
     @mock.patch(
         "ax.modelbridge.discrete.DiscreteModelBridge.__init__", return_value=None
     )
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def testPredict(self, mock_init):
+    def test_predict(self, mock_init: Mock) -> None:
         # pyre-fixme[20]: Argument `model` expected.
         ma = DiscreteModelBridge()
         model = mock.MagicMock(DiscreteModel, autospec=True, instance=True)
@@ -132,9 +130,7 @@ class DiscreteModelBridgeTest(TestCase):
     @mock.patch(
         "ax.modelbridge.discrete.DiscreteModelBridge.__init__", return_value=None
     )
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def testGen(self, mock_init):
+    def test_gen(self, mock_init: Mock) -> None:
         # Test with constraints
         optimization_config = OptimizationConfig(
             objective=Objective(Metric("a"), minimize=True),
@@ -144,6 +140,11 @@ class DiscreteModelBridgeTest(TestCase):
         )
         # pyre-fixme[20]: Argument `model` expected.
         ma = DiscreteModelBridge()
+        # Test validation.
+        with self.assertRaisesRegex(UserInputError, "positive integer or -1."):
+            ma._validate_gen_inputs(n=0)
+        ma._validate_gen_inputs(n=-1)
+        # Test rest of gen.
         model = mock.MagicMock(DiscreteModel, autospec=True, instance=True)
         model.gen.return_value = ([[0.0, 2.0, 3.0], [1.0, 1.0, 3.0]], [1.0, 2.0], {})
         ma.model = model
@@ -226,9 +227,7 @@ class DiscreteModelBridgeTest(TestCase):
     @mock.patch(
         "ax.modelbridge.discrete.DiscreteModelBridge.__init__", return_value=None
     )
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def testCrossValidate(self, mock_init):
+    def test_cross_validate(self, mock_init: Mock) -> None:
         # pyre-fixme[20]: Argument `model` expected.
         ma = DiscreteModelBridge()
         model = mock.MagicMock(DiscreteModel, autospec=True, instance=True)
@@ -266,7 +265,7 @@ class DiscreteModelBridgeTest(TestCase):
         for i, od in enumerate(observation_data):
             self.assertEqual(od, self.observation_data[i])
 
-    def testGetParameterValues(self) -> None:
+    def test_get_parameter_values(self) -> None:
         parameter_values = _get_parameter_values(self.search_space, ["x", "y", "z"])
         self.assertEqual(parameter_values, [[0.0, 1.0], ["foo", "bar"], [True]])
         # pyre-fixme[6]: For 1st param expected `List[Parameter]` but got


### PR DESCRIPTION
Summary: Without this, we go deep into BoTorch before the `SobolEngine` raises a cryptic error message.~

Differential Revision: D40944087

