### PR TITLE
Force refit on final report_results call

### DIFF
--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -83,7 +83,9 @@ class TestScheduler(Scheduler):
 
     # pyre-fixme[15]: `report_results` overrides method defined in `Scheduler`
     #  inconsistently.
-    def report_results(self) -> Tuple[bool, Dict[str, Set[int]]]:
+    def report_results(
+        self, force_refit: bool = False
+    ) -> Tuple[bool, Dict[str, Set[int]]]:
         # pyre-fixme[7]: Expected `Tuple[bool, Dict[str, Set[int]]]` but got
         #  `Dict[str, Set[int]]`.
         return {


### PR DESCRIPTION
Summary: Followup on recent diff disabling refitting unless there are newly completed trials. It is possible that we may want to refit the model in other cases as well before reporting, e.g., a trial is EarlyStopped and has some updated data. For this reason, we force a refit once right before scheduler termination.

Differential Revision: D40986262

