### PR TITLE
Add traceback to MetricFetchE __repr__

### DIFF
--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -6,7 +6,10 @@
 
 from __future__ import annotations
 
+import traceback
+
 from dataclasses import dataclass
+from functools import reduce
 from logging import Logger
 
 from typing import (
@@ -36,6 +39,26 @@ if TYPE_CHECKING:  # pragma: no cover
 class MetricFetchE:
     message: str
     exception: Optional[Exception]
+
+    def __repr__(self) -> str:
+        if self.exception is None:
+            return f'MetricFetchE(message="{self.message}")'
+
+        return (
+            f'MetricFetchE(message="{self.message}", exception={self.exception})\n'
+            f"with Traceback:\n {self.tb_str()}"
+        )
+
+    def tb_str(self) -> Optional[str]:
+        if self.exception is None:
+            return None
+
+        return reduce(
+            lambda left, right: left + right,
+            traceback.format_exception(
+                None, self.exception, self.exception.__traceback__
+            ),
+        )
 
 
 MetricFetchResult = Result[Data, MetricFetchE]

--- a/ax/core/tests/test_metric.py
+++ b/ax/core/tests/test_metric.py
@@ -77,3 +77,25 @@ class MetricTest(TestCase):
 
         with self.assertRaisesRegex(Exception, "panic"):
             Metric._unwrap_trial_data_multi(results={"foo": err})
+
+    def testMetricFetchE(self) -> None:
+        def foo() -> bool:
+            raise ValueError("bad value")
+
+        def bar() -> bool:
+            return foo()
+
+        exception = None
+        try:
+            bar()
+        except Exception as e:
+            print(e)
+            exception = e
+
+        metric_fetch_e = MetricFetchE(message="foo", exception=exception)
+
+        self.assertEqual(metric_fetch_e.message, "foo")
+
+        self.assertIn("in foo", metric_fetch_e.__repr__())
+        self.assertIn("in bar", metric_fetch_e.__repr__())
+        self.assertIn("ValueError: bad value", metric_fetch_e.__repr__())

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -30,7 +30,7 @@ import ax.service.utils.early_stopping as early_stopping_utils
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
-from ax.core.metric import Metric, MetricFetchResult
+from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
@@ -1654,7 +1654,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
                     status = self._mark_err_trial_status(
                         trial=self.experiment.trials[trial_index],
                         metric_name=metric_name,
-                        reason=metric_fetch_e.message,
+                        metric_fetch_e=metric_fetch_e,
                     )
                     self.logger.warning(
                         f"Because {metric_name} is an objective, marking trial "
@@ -1670,6 +1670,6 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         self,
         trial: BaseTrial,
         metric_name: Optional[str] = None,
-        reason: Optional[str] = None,
+        metric_fetch_e: Optional[MetricFetchE] = None,
     ) -> None:
         trial.mark_failed(unsafe=True)


### PR DESCRIPTION
Summary: When you print a MetricFetchE it will calculate and format the traceback of the associated Exception if available. This will help considerably with debugging!

Differential Revision: D41193445

