### PR TITLE
Extend Posterior API to support torch distributions & overhaul MCSampler API (#1486)

### DIFF
--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -23,7 +23,7 @@ from botorch.acquisition.objective import (
 )
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.transforms.input import Warp
-from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
+from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.datasets import FixedNoiseDataset
 
 

--- a/ax/models/tests/test_botorch_mes.py
+++ b/ax/models/tests/test_botorch_mes.py
@@ -19,7 +19,7 @@ from botorch.acquisition.max_value_entropy_search import (
 )
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.transforms.input import Warp
-from botorch.sampling.samplers import SobolQMCNormalSampler
+from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils.datasets import FixedNoiseDataset
 
 

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from contextlib import ExitStack
-from typing import Tuple
+from typing import Any, Dict, Tuple
 from unittest import mock
 
 import numpy as np
@@ -219,7 +219,11 @@ class BotorchMOODefaultsTest(TestCase):
                 objective_thresholds=objective_thresholds,
             )
 
-    def test_get_ehvi(self) -> None:
+    @mock.patch(  # pyre-ignore
+        "ax.models.torch.botorch_moo_defaults.checked_cast",
+        wraps=lambda x, y: y,
+    )
+    def test_get_ehvi(self, _) -> None:
         weights = torch.tensor([0.0, 1.0, 1.0])
         X_observed = torch.rand(4, 3)
         X_pending = torch.rand(1, 3)
@@ -264,61 +268,26 @@ class BotorchMOODefaultsTest(TestCase):
             )
 
     # test infer objective thresholds alone
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def test_infer_objective_thresholds(self, cuda=False):
+    @mock.patch(  # pyre-ignore
+        "ax.models.torch.botorch_moo_defaults.checked_cast",
+        wraps=lambda x, y: y,
+    )
+    def test_infer_objective_thresholds(self, _, cuda: bool = False) -> None:
         for dtype in (torch.float, torch.double):
-
-            tkwargs = {
+            tkwargs: Dict[str, Any] = {
                 "device": torch.device("cuda") if cuda else torch.device("cpu"),
                 "dtype": dtype,
             }
-            # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-            #  `Union[device, dtype]`.
-            # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but
-            #  got `Union[device, dtype]`.
-            # pyre-fixme[6]: For 2nd param expected `bool` but got `Union[device,
-            #  dtype]`.
             Xs = [torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **tkwargs)]
             bounds = [(0.0, 1.0), (1.0, 4.0), (2.0, 5.0)]
             outcome_constraints = (
-                # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-                #  `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]`
-                #  but got `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `bool` but got
-                #  `Union[device, dtype]`.
                 torch.tensor([[1.0, 0.0, 0.0]], **tkwargs),
-                # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-                #  `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]`
-                #  but got `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `bool` but got
-                #  `Union[device, dtype]`.
                 torch.tensor([[10.0]], **tkwargs),
             )
             linear_constraints = (
-                # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-                #  `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]`
-                #  but got `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `bool` but got
-                #  `Union[device, dtype]`.
                 torch.tensor([1.0, 0.0, 0.0], **tkwargs),
-                # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-                #  `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]`
-                #  but got `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `bool` but got
-                #  `Union[device, dtype]`.
                 torch.tensor([2.0], **tkwargs),
             )
-            # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-            #  `Union[device, dtype]`.
-            # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but
-            #  got `Union[device, dtype]`.
-            # pyre-fixme[6]: For 2nd param expected `bool` but got `Union[device,
-            #  dtype]`.
             objective_weights = torch.tensor([-1.0, -1.0, 0.0], **tkwargs)
             with ExitStack() as es:
                 _mock_get_X_pending_and_observed = es.enter_context(
@@ -350,12 +319,6 @@ class BotorchMOODefaultsTest(TestCase):
                                 [11.0, 2.0],
                                 [9.0, 3.0],
                             ],
-                            # pyre-fixme[6]: For 2nd param expected
-                            #  `Optional[dtype]` but got `Union[device, dtype]`.
-                            # pyre-fixme[6]: For 2nd param expected `Union[None,
-                            #  str, device]` but got `Union[device, dtype]`.
-                            # pyre-fixme[6]: For 2nd param expected `bool` but got
-                            #  `Union[device, dtype]`.
                             **tkwargs,
                         )
                     )
@@ -399,22 +362,10 @@ class BotorchMOODefaultsTest(TestCase):
                 self.assertTrue(
                     torch.equal(
                         ckwargs["pareto_Y"],
-                        # pyre-fixme[6]: For 2nd param expected `Optional[dtype]`
-                        #  but got `Union[device, dtype]`.
-                        # pyre-fixme[6]: For 2nd param expected `Union[None, str,
-                        #  device]` but got `Union[device, dtype]`.
-                        # pyre-fixme[6]: For 2nd param expected `bool` but got
-                        #  `Union[device, dtype]`.
                         torch.tensor([[-9.0, -3.0]], **tkwargs),
                     )
                 )
                 self.assertTrue(
-                    # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but
-                    #  got `Union[device, dtype]`.
-                    # pyre-fixme[6]: For 2nd param expected `Union[None, str,
-                    #  device]` but got `Union[device, dtype]`.
-                    # pyre-fixme[6]: For 2nd param expected `bool` but got
-                    #  `Union[device, dtype]`.
                     torch.equal(obj_thresholds[:2], torch.tensor([9.9, 3.3], **tkwargs))
                 )
                 self.assertTrue(np.isnan(obj_thresholds[2].item()))
@@ -440,12 +391,6 @@ class BotorchMOODefaultsTest(TestCase):
                                 [11.0, 2.0],
                                 [9.0, 3.0],
                             ],
-                            # pyre-fixme[6]: For 2nd param expected
-                            #  `Optional[dtype]` but got `Union[device, dtype]`.
-                            # pyre-fixme[6]: For 2nd param expected `Union[None,
-                            #  str, device]` but got `Union[device, dtype]`.
-                            # pyre-fixme[6]: For 2nd param expected `bool` but got
-                            #  `Union[device, dtype]`.
                             **tkwargs,
                         )
                     )
@@ -460,12 +405,6 @@ class BotorchMOODefaultsTest(TestCase):
                 )
                 _mock_get_X_pending_and_observed.assert_not_called()
                 self.assertTrue(
-                    # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but
-                    #  got `Union[device, dtype]`.
-                    # pyre-fixme[6]: For 2nd param expected `Union[None, str,
-                    #  device]` but got `Union[device, dtype]`.
-                    # pyre-fixme[6]: For 2nd param expected `bool` but got
-                    #  `Union[device, dtype]`.
                     torch.equal(obj_thresholds[:2], torch.tensor([9.9, 3.3], **tkwargs))
                 )
                 self.assertTrue(np.isnan(obj_thresholds[2].item()))
@@ -491,12 +430,6 @@ class BotorchMOODefaultsTest(TestCase):
                             [11.0, 2.0],
                             [9.0, 3.0],
                         ],
-                        # pyre-fixme[6]: For 2nd param expected `Optional[dtype]`
-                        #  but got `Union[device, dtype]`.
-                        # pyre-fixme[6]: For 2nd param expected `Union[None, str,
-                        #  device]` but got `Union[device, dtype]`.
-                        # pyre-fixme[6]: For 2nd param expected `bool` but got
-                        #  `Union[device, dtype]`.
                         **tkwargs,
                     )
                 )
@@ -508,12 +441,6 @@ class BotorchMOODefaultsTest(TestCase):
                 X_observed=Xs[0],
             )
             self.assertTrue(
-                # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-                #  `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]`
-                #  but got `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `bool` but got
-                #  `Union[device, dtype]`.
                 torch.equal(obj_thresholds[:2], torch.tensor([9.9, 3.3], **tkwargs))
             )
             self.assertTrue(np.isnan(obj_thresholds[2].item()))
@@ -521,8 +448,6 @@ class BotorchMOODefaultsTest(TestCase):
             subset_idcs = torch.tensor(
                 [0, 1],
                 dtype=torch.long,
-                # pyre-fixme[6]: For 3rd param expected `Union[None, str, device]`
-                #  but got `Union[device, dtype]`.
                 device=tkwargs["device"],
             )
             obj_thresholds = infer_objective_thresholds(
@@ -533,31 +458,13 @@ class BotorchMOODefaultsTest(TestCase):
                 subset_idcs=subset_idcs,
             )
             self.assertTrue(
-                # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-                #  `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]`
-                #  but got `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `bool` but got
-                #  `Union[device, dtype]`.
                 torch.equal(obj_thresholds[:2], torch.tensor([9.9, 3.3], **tkwargs))
             )
             self.assertTrue(np.isnan(obj_thresholds[2].item()))
             # test without subsetting (e.g. if there are
             # 3 metrics for 2 objectives + 1 outcome constraint)
             outcome_constraints = (
-                # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-                #  `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]`
-                #  but got `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `bool` but got
-                #  `Union[device, dtype]`.
                 torch.tensor([[0.0, 0.0, 1.0]], **tkwargs),
-                # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-                #  `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]`
-                #  but got `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `bool` but got
-                #  `Union[device, dtype]`.
                 torch.tensor([[5.0]], **tkwargs),
             )
             with ExitStack() as es:
@@ -581,12 +488,6 @@ class BotorchMOODefaultsTest(TestCase):
                                 [11.0, 2.0, 6.0],
                                 [9.0, 3.0, 4.0],
                             ],
-                            # pyre-fixme[6]: For 2nd param expected
-                            #  `Optional[dtype]` but got `Union[device, dtype]`.
-                            # pyre-fixme[6]: For 2nd param expected `Union[None,
-                            #  str, device]` but got `Union[device, dtype]`.
-                            # pyre-fixme[6]: For 2nd param expected `bool` but got
-                            #  `Union[device, dtype]`.
                             **tkwargs,
                         )
                     )
@@ -602,12 +503,6 @@ class BotorchMOODefaultsTest(TestCase):
                     Xs=Xs + Xs + Xs,
                 )
                 self.assertTrue(
-                    # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but
-                    #  got `Union[device, dtype]`.
-                    # pyre-fixme[6]: For 2nd param expected `Union[None, str,
-                    #  device]` but got `Union[device, dtype]`.
-                    # pyre-fixme[6]: For 2nd param expected `bool` but got
-                    #  `Union[device, dtype]`.
                     torch.equal(obj_thresholds[:2], torch.tensor([9.9, 3.3], **tkwargs))
                 )
                 self.assertTrue(np.isnan(obj_thresholds[2].item()))

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -29,6 +29,7 @@ from botorch.acquisition.multi_objective import monte_carlo as moo_monte_carlo
 from botorch.models import ModelListGP
 from botorch.models.transforms.input import Warp
 from botorch.optim.optimize import optimize_acqf_list
+from botorch.sampling.normal import IIDNormalSampler
 from botorch.utils.datasets import FixedNoiseDataset
 from botorch.utils.multi_objective.hypervolume import infer_reference_point
 from botorch.utils.multi_objective.scalarization import get_chebyshev_scalarization
@@ -446,6 +447,12 @@ class BotorchMOOModelTest(TestCase):
                 metric_names=["y1", "y2", "dummy_metric"],
                 search_space_digest=search_space_digest,
             )
+            es.enter_context(
+                mock.patch(
+                    "ax.models.torch.botorch_moo_defaults.checked_cast",
+                    wraps=lambda x, y: y,
+                )
+            )
             _mock_model_infer_objective_thresholds = es.enter_context(
                 mock.patch(
                     "ax.models.torch.botorch_moo.infer_objective_thresholds",
@@ -490,6 +497,12 @@ class BotorchMOOModelTest(TestCase):
                     model.model,
                     "subset_output",
                     return_value=subset_mock_model,
+                )
+            )
+            es.enter_context(
+                mock.patch(
+                    "botorch.acquisition.utils.get_sampler",
+                    return_value=IIDNormalSampler(sample_shape=torch.Size([2])),
                 )
             )
             outcome_constraints = (

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -253,7 +253,7 @@ def _get_acquisition_func(
     # construct Objective module
     if kwargs.get("chebyshev_scalarization", False):
         with torch.no_grad():
-            Y = model.posterior(X_observed).mean
+            Y = model.posterior(X_observed).mean  # pyre-ignore [16]
         obj_tf = get_chebyshev_scalarization(weights=objective_weights, Y=Y)
     else:
         obj_tf = get_objective_weights_transform(objective_weights)

--- a/ax/models/torch/botorch_kg.py
+++ b/ax/models/torch/botorch_kg.py
@@ -36,7 +36,7 @@ from botorch.models.cost import AffineFidelityCostModel
 from botorch.models.model import Model
 from botorch.optim.initializers import gen_one_shot_kg_initial_conditions
 from botorch.optim.optimize import optimize_acqf
-from botorch.sampling.samplers import IIDNormalSampler, SobolQMCNormalSampler
+from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from torch import Tensor
 
 
@@ -286,9 +286,13 @@ def _instantiate_KG(
     acquisition function depending on whether `target_fidelities` is defined.
     """
     sampler_cls = SobolQMCNormalSampler if qmc else IIDNormalSampler
-    fantasy_sampler = sampler_cls(num_samples=n_fantasies, seed=seed_outer)
+    fantasy_sampler = sampler_cls(
+        sample_shape=torch.Size([n_fantasies]), seed=seed_outer
+    )
     if isinstance(objective, MCAcquisitionObjective):
-        inner_sampler = sampler_cls(num_samples=mc_samples, seed=seed_inner)
+        inner_sampler = sampler_cls(
+            sample_shape=torch.Size([mc_samples]), seed=seed_inner
+        )
     else:
         inner_sampler = None
     if target_fidelities:

--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -34,13 +34,14 @@ from ax.models.torch.utils import (  # noqa F40
 )
 from ax.models.torch_base import TorchModel
 from ax.utils.common.constants import Keys
-from ax.utils.common.typeutils import not_none
+from ax.utils.common.typeutils import checked_cast, not_none
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.multi_objective.objective import WeightedMCMultiOutputObjective
 from botorch.acquisition.multi_objective.utils import get_default_partitioning_alpha
 from botorch.acquisition.utils import get_acquisition_function
 from botorch.models.model import Model
 from botorch.optim.optimize import optimize_acqf_list
+from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.utils.multi_objective.hypervolume import infer_reference_point
 from botorch.utils.multi_objective.pareto import is_non_dominated
 from torch import Tensor
@@ -215,7 +216,7 @@ def get_EHVI(
         objective_weights=objective_weights, objective_thresholds=objective_thresholds
     )
     with torch.no_grad():
-        Y = model.posterior(X_observed).mean
+        Y = checked_cast(GPyTorchPosterior, model.posterior(X_observed)).mean
     # For EHVI acquisition functions we pass the constraint transform directly.
     if outcome_constraints is None:
         cons_tfs = None
@@ -505,7 +506,9 @@ def infer_objective_thresholds(
                 outcome_constraints[1],
             )
     with torch.no_grad():
-        pred = not_none(model).posterior(not_none(X_observed)).mean
+        pred = checked_cast(
+            GPyTorchPosterior, not_none(model).posterior(not_none(X_observed))
+        ).mean
     if outcome_constraints is not None:
         cons_tfs = get_outcome_constraint_transforms(outcome_constraints)
         # pyre-ignore [16]

--- a/ax/models/torch/fully_bayesian.py
+++ b/ax/models/torch/fully_bayesian.py
@@ -65,10 +65,12 @@ from ax.models.torch.fully_bayesian_model_utils import (
 )
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.logger import get_logger
+from ax.utils.common.typeutils import checked_cast
 from botorch.acquisition import AcquisitionFunction
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model import Model
 from botorch.models.model_list_gp_regression import ModelListGP
+from botorch.posteriors.gpytorch import GPyTorchPosterior
 from torch import Tensor
 
 logger: Logger = get_logger(__name__)
@@ -97,7 +99,7 @@ def predict_from_model_mcmc(model: Model, X: Tensor) -> Tuple[Tensor, Tensor]:
     """
     with torch.no_grad():
         # compute the batch (independent posterior over the inputs)
-        posterior = model.posterior(X.unsqueeze(-3))
+        posterior = checked_cast(GPyTorchPosterior, model.posterior(X.unsqueeze(-3)))
     # the mean and variance both have shape: n x num_samples x m (after squeezing)
     mean = posterior.mean.cpu().detach()
     # TODO: Allow Posterior to (optionally) return the full covariance matrix

--- a/ax/models/torch/posterior_mean.py
+++ b/ax/models/torch/posterior_mean.py
@@ -8,11 +8,13 @@
 from typing import Any, Optional, Tuple
 
 import torch
+from ax.utils.common.typeutils import checked_cast
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.monte_carlo import qSimpleRegret
 from botorch.acquisition.objective import ConstrainedMCObjective, GenericMCObjective
 from botorch.acquisition.utils import get_infeasible_cost
 from botorch.models.model import Model
+from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.utils import (
     get_objective_weights_transform,
     get_outcome_constraint_transforms,
@@ -57,7 +59,7 @@ def get_PosteriorMean(
     # construct Objective module
     if kwargs.get("chebyshev_scalarization", False):
         with torch.no_grad():
-            Y = model.posterior(X_observed).mean
+            Y = checked_cast(GPyTorchPosterior, model.posterior(X_observed)).mean
         obj_tf = get_chebyshev_scalarization(weights=objective_weights, Y=Y)
     else:
         obj_tf = get_objective_weights_transform(objective_weights)

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -513,10 +513,15 @@ class AcquisitionTest(TestCase):
         acquisition.evaluate(X=self.X)
         mock_evaluate.assert_called_with(X=self.X)
 
+    @mock.patch(  # pyre-ignore
+        "ax.models.torch.botorch_moo_defaults.checked_cast",
+        wraps=lambda x, y: y,
+    )
     @mock.patch(f"{ACQUISITION_PATH}._get_X_pending_and_observed")
     def test_init_moo(
         self,
         mock_get_X: Mock,
+        _,
     ) -> None:
         moo_training_data = [SupervisedDataset(X=self.X, Y=self.Y.repeat(1, 3))]
         moo_objective_weights = torch.tensor([-1.0, -1.0, 0.0], **self.tkwargs)

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -37,7 +37,7 @@ from botorch.acquisition.multi_objective.objective import WeightedMCMultiOutputO
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
 from botorch.models.gp_regression_fidelity import FixedNoiseMultiFidelityGP
 from botorch.models.model_list_gp_regression import ModelListGP
-from botorch.sampling.samplers import SobolQMCNormalSampler
+from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
 
 
@@ -50,7 +50,7 @@ LIST_SURROGATE_PATH: str = ListSurrogate.__module__
 NEHVI_PATH: str = qNoisyExpectedHypervolumeImprovement.__module__
 
 ACQ_OPTIONS: Dict[Keys, SobolQMCNormalSampler] = {
-    Keys.SAMPLER: SobolQMCNormalSampler(1024)
+    Keys.SAMPLER: SobolQMCNormalSampler(sample_shape=torch.Size([1024]))
 }
 
 

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -27,7 +27,7 @@ from botorch.models import SaasFullyBayesianSingleTaskGP, SingleTaskGP
 from botorch.models.model import Model
 from botorch.models.transforms.input import InputPerturbation, Normalize
 from botorch.models.transforms.outcome import Standardize
-from botorch.sampling.samplers import SobolQMCNormalSampler
+from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils.datasets import SupervisedDataset
 from gpytorch.constraints import Interval
 from gpytorch.kernels import Kernel, RBFKernel, ScaleKernel  # noqa: F401

--- a/ax/utils/sensitivity/sobol_measures.py
+++ b/ax/utils/sensitivity/sobol_measures.py
@@ -7,8 +7,10 @@ from copy import deepcopy
 from typing import Callable, List, Optional
 
 import torch
+from ax.utils.common.typeutils import checked_cast
 from botorch.models.model import Model
-from botorch.sampling.samplers import SobolQMCNormalSampler
+from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils.sampling import draw_sobol_samples
 from botorch.utils.transforms import unnormalize
 from torch._tensor import Tensor
@@ -397,10 +399,8 @@ class SobolSensitivityGPMean(object):
         self.num_bootstrap_samples = num_bootstrap_samples
         self.num_mc_samples = num_mc_samples
 
-        # pyre-fixme[3]: Return type must be annotated.
-        # pyre-fixme[2]: Parameter must be annotated.
-        def input_function(x):
-            return self.model.posterior(x).mean
+        def input_function(x: Tensor) -> Tensor:
+            return checked_cast(GPyTorchPosterior, self.model.posterior(x)).mean
 
         self.sensitivity = SobolSensitivity(
             dim=self.dim,
@@ -498,11 +498,14 @@ class SobolSensitivityGPSampling(object):
         )
         posterior = self.model.posterior(self.sensitivity.A_B_ABi)
         if self.gp_sample_qmc:
-            sampler = SobolQMCNormalSampler(num_samples=self.num_gp_samples, seed=0)
+            sampler = SobolQMCNormalSampler(
+                sample_shape=torch.Size([self.num_gp_samples]), seed=0
+            )
             # pyre-fixme[4]: Attribute must be annotated.
             self.samples = sampler(posterior)
         else:
-            self.samples = posterior.sample(torch.Size([self.num_gp_samples]))
+            with torch.no_grad():
+                self.samples = posterior.rsample(torch.Size([self.num_gp_samples]))
 
     def first_order_indices(self) -> Tensor:
         r"""Computes the first order Sobol indices:


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/1486

The main goal here is to broadly support non-Gaussian posteriors.
- Adds a generic `TorchPosterior` which wraps a Torch `Distribution`. This defines a few properties that we commonly expect, and calls the `distribution` for the rest.
- For a unified plotting API, this shifts away from mean & variance to a quantile function. Most torch distributions implement inverse CDF, which is used as quantile. For others, the user should implement it either at distribution or posterior level.
- Hands off the burden of base sample handling from the posterior to the samplers. Using a dispatcher based `get_sampler` method, we can support SAA with mixed posteriors without having to shuffle base samples in a `PosteriorList`, as long as all base distributions have a corresponding sampler and support base samples.
- Adds `ListSampler` for sampling from `PosteriorList`.
- Adds `ForkedRNGSampler` and `StochasticSampler` for sampling from posteriors without base samples.
- Adds `rsample_from_base_samples` for sampling with `base_samples` / with a `sampler`.
- Absorbs `FullyBayesianPosteriorList` into `PosteriorList`.
- For MC acqfs, introduces a `get_posterior_samples` for sampling from the posterior with base samples / a sampler. If a sampler was not specified, this constructs the appropriate sampler for the posterior using `get_sampler`, eliminating the need to construct a sampler in `__init__`, which we used to do under the assumption of Gaussian posteriors.

TODOs:
- Relax the Gaussian assumption in acquisition functions & utilities. Some of this might be addressed in a follow-up diff.
- Updates to website / docs & tutorials to clear up some of the Gaussian assumption, introduce the new relaxed API. Likely a follow-up diff.
- Some more listed in T134364907
- Test fixes and new units

Other notables:
- See D39760855 for usage of TorchDistribution in SkewGP.
- TransformedPosterior could serve as the fallback option for derived posteriors.
- MC samplers no longer support resample or collapse_batch_dims(=False). These can be handled by i) not using base samples, ii) just using torch.fork_rng and sampling without base samples from that. Samplers are only meant to support SAA. Introduces `ForkedRNGSampler` and `StochasticSampler` as convenience samplers for these use cases.
- Introduced `batch_range_override` for the sampler to support edge cases where we may want to override `posterior.batch_range` (needed in `qMultiStepLookahead`)
- Removes unused sampling utilities `construct_base_samples(_from_posterior)`, which assume Gaussian posterior.
- Moves the main logic of `_set_sampler` method of CachedCholesky subclasses to a `_update_base_samples` method on samplers, and simplifies these classes a bit more.

Reviewed By: Balandat

Differential Revision: D39759489

