### PR TITLE
Fix Result wrapping in mixed MapMetric/Metric experiments

### DIFF
--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -15,6 +15,7 @@ from ax.core.data import Data
 from ax.core.types import TMapTrialEvaluation
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.base import SortableBase
+from ax.utils.common.docutils import copy_doc
 from ax.utils.common.equality import dataframe_equals
 from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import serialize_init_args
@@ -273,6 +274,20 @@ class MapData(Data):
         )
 
         return self._memo_df
+
+    @copy_doc(Data.filter)
+    def filter(
+        self,
+        trial_indices: Optional[Iterable[int]] = None,
+        metric_names: Optional[Iterable[str]] = None,
+    ) -> MapData:
+
+        return MapData(
+            df=self._filter_df(
+                df=self.map_df, trial_indices=trial_indices, metric_names=metric_names
+            ),
+            map_key_infos=self.map_key_infos,
+        )
 
     @classmethod
     # pyre-fixme[2]: Parameter annotation cannot be `Any`.

--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -6,14 +6,11 @@
 
 from __future__ import annotations
 
-from typing import Dict, Type
-
-from ax.core.data import Data
+from typing import Type
 
 from ax.core.map_data import MapData
-from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
-from ax.utils.common.result import Ok, Result
-from ax.utils.common.typeutils import checked_cast
+from ax.core.metric import Metric, MetricFetchE
+from ax.utils.common.result import Result
 
 MapMetricFetchResult = Result[MapData, MetricFetchE]
 
@@ -33,48 +30,3 @@ class MapMetric(Metric):
     """
 
     data_constructor: Type[MapData] = MapData
-
-    @classmethod
-    def _wrap_experiment_data(cls, data: Data) -> Dict[int, MetricFetchResult]:
-        return {
-            trial_index: Ok(
-                value=MapData(
-                    df=data.true_df.loc[data.true_df["trial_index"] == trial_index],
-                    map_key_infos=checked_cast(MapData, data).map_key_infos,
-                )
-            )
-            for trial_index in data.true_df["trial_index"]
-        }
-
-    @classmethod
-    def _wrap_trial_data_multi(cls, data: Data) -> Dict[str, MetricFetchResult]:
-        return {
-            metric_name: Ok(
-                value=MapData(
-                    df=data.true_df.loc[data.true_df["metric_name"] == metric_name],
-                    map_key_infos=checked_cast(MapData, data).map_key_infos,
-                )
-            )
-            for metric_name in data.true_df["metric_name"]
-        }
-
-    @classmethod
-    def _wrap_experiment_data_multi(
-        cls, data: Data
-    ) -> Dict[int, Dict[str, MetricFetchResult]]:
-        # pyre-fixme[7]
-        return {
-            trial_index: {
-                metric_name: Ok(
-                    value=MapData(
-                        df=data.true_df.loc[
-                            (data.true_df["trial_index"] == trial_index)
-                            & (data.true_df["metric_name"] == metric_name)
-                        ],
-                        map_key_infos=checked_cast(MapData, data).map_key_infos,
-                    )
-                )
-                for metric_name in data.true_df["metric_name"]
-            }
-            for trial_index in data.true_df["trial_index"]
-        }

--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -421,22 +421,14 @@ class Metric(SortableBase, SerializationMixin):
     @classmethod
     def _wrap_experiment_data(cls, data: Data) -> Dict[int, MetricFetchResult]:
         return {
-            trial_index: Ok(
-                value=Data(
-                    df=data.true_df.loc[data.true_df["trial_index"] == trial_index]
-                )
-            )
+            trial_index: Ok(value=data.filter(trial_indices=[trial_index]))
             for trial_index in data.true_df["trial_index"]
         }
 
     @classmethod
     def _wrap_trial_data_multi(cls, data: Data) -> Dict[str, MetricFetchResult]:
         return {
-            metric_name: Ok(
-                value=Data(
-                    df=data.true_df.loc[data.true_df["metric_name"] == metric_name]
-                )
-            )
+            metric_name: Ok(value=data.filter(metric_names=[metric_name]))
             for metric_name in data.true_df["metric_name"]
         }
 
@@ -448,11 +440,8 @@ class Metric(SortableBase, SerializationMixin):
         return {
             trial_index: {
                 metric_name: Ok(
-                    value=Data(
-                        df=data.true_df.loc[
-                            (data.true_df["trial_index"] == trial_index)
-                            & (data.true_df["metric_name"] == metric_name)
-                        ]
+                    value=data.filter(
+                        trial_indices=[trial_index], metric_names=[metric_name]
                     )
                 )
                 for metric_name in data.true_df["metric_name"]

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -944,6 +944,22 @@ class ExperimentWithMapDataTest(TestCase):
         actual_data = self.experiment.lookup_data()
         self.assertEqual(expected_data, actual_data)
 
+    def testFetchDataWithMixedData(self) -> None:
+        with patch(
+            f"{BraninMetric.__module__}.BraninMetric.is_available_while_running",
+            return_value=False,
+        ):
+            exp = self._setupBraninExperiment(n=5)
+            [exp.trials[i].mark_completed() for i in range(len(exp.trials))]
+
+            # Fill cache with MapData
+            map_data = exp.fetch_data(metrics=[exp.metrics["branin_map"]])
+
+            # Fetch other metrics and merge Data into the cached MapData
+            full_data = exp.fetch_data()
+
+            self.assertEqual(len(full_data.true_df), len(map_data.true_df) + 20)
+
     def testFetchTrialsData(self) -> None:
         exp = self._setupBraninExperiment(n=5)
         batch_0 = exp.trials[0]


### PR DESCRIPTION
Summary:
While rare, it was possible for an experiment to get into a weird state in which it woudl crash during metric fetching. The following sequence of events would have to happen:

1. The experiment fetches MapData from some MapMetric and caches it
2. A nonmap Metric's data is requested and data is available
3. Metric.lookup_or_fetch_experiment_data_multi is called and encounters the cached MapData
4. The Metric tries to wrap the cached MapData into a Data (since Data is the metric's default_data_type).

The solution is to always use MapMetric._wrap_trial_data when the experiment's default data constructor is MapData

Differential Revision: D41279558

