### PR TITLE
incorporate MAX_INITIALIZATION_TRIALS override into choose_generation_strategy

### DIFF
--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -227,6 +227,7 @@ def choose_generation_strategy(
     no_bayesian_optimization: bool = False,
     num_trials: Optional[int] = None,
     num_initialization_trials: Optional[int] = None,
+    max_initialization_trials: Optional[int] = None,
     max_parallelism_cap: Optional[int] = None,
     max_parallelism_override: Optional[int] = None,
     optimization_config: Optional[OptimizationConfig] = None,
@@ -271,6 +272,9 @@ def choose_generation_strategy(
             known in advance.
         num_initialization_trials: Specific number of initialization trials, if wanted.
             Typically, initialization trials are generated quasi-randomly.
+        max_initialization_trials: If ``num_initialization_trials`` unspecified, it
+            will be determined automatically. This arg provides a cap on that
+            automatically determined number.
         max_parallelism_cap: Integer cap on parallelism in this generation strategy.
             If specified, ``max_parallelism`` setting in each generation step will be
             set to the minimum of the default setting for that step and the value of
@@ -370,6 +374,10 @@ def choose_generation_strategy(
             else:  # 1-arm trials.
                 num_initialization_trials = max(
                     5, 2 * len(search_space.tunable_parameters)
+                )
+            if max_initialization_trials is not None:
+                num_initialization_trials = min(
+                    num_initialization_trials, max_initialization_trials
                 )
 
         # `verbose` and `disable_progbar` defaults and overrides

--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -54,6 +54,18 @@ class TestDispatchUtils(TestCase):
             self.assertEqual(
                 sobol_gpei._steps[1].model_kwargs, {"torch_device": device}
             )
+        with self.subTest("max initialization trials"):
+            sobol_gpei = choose_generation_strategy(
+                search_space=get_branin_search_space(),
+                max_initialization_trials=2,
+            )
+            # pyre-fixme[16]: Item `Callable` of `Union[(...) -> ModelBridge,
+            #  ModelRegistryBase]` has no attribute `value`.
+            self.assertEqual(sobol_gpei._steps[0].model.value, "Sobol")
+            self.assertEqual(sobol_gpei._steps[0].num_trials, 2)
+            # pyre-fixme[16]: Item `Callable` of `Union[(...) -> ModelBridge,
+            #  ModelRegistryBase]` has no attribute `value`.
+            self.assertEqual(sobol_gpei._steps[1].model.value, "GPEI")
         with self.subTest("MOO"):
             optimization_config = MultiObjectiveOptimizationConfig(
                 objective=MultiObjective(objectives=[])


### PR DESCRIPTION
Summary: bug reported [here](https://fb.workplace.com/groups/automl/permalink/5773131776059109/), introduced in D40196130. I overlooked that num_initialization_trials is also important for determining min_trials_observed for the initialization step, and when changing one but not the other in choose_gs_wrapper, we can end up in a state where the sweep is expecting to see more trials in a step than that step's total number of trials. Incorporating the trial cap into `choose_generation_strategy` mitigates this issue.

Differential Revision: D41339501

