### PR TITLE
Break off Trial.fetch_data_results from Trial.fetch_data

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -527,6 +527,9 @@ class Experiment(Base):
         available while trial is running is determined by the boolean returned from its
         `is_available_while_running` class method.
 
+        NOTE: This can be lossy (ex. a MapData could get implicitly cast to a Data and
+        lose rows) if Experiment.default_data_type is misconfigured!
+
         Args:
             metrics: If provided, fetch data for these metrics instead of the ones
                 defined on the experiment.
@@ -567,6 +570,9 @@ class Experiment(Base):
         via calls to `experiment.attach_data` and whetner a given metric class is
         available while trial is running is determined by the boolean returned from its
         `is_available_while_running` class method.
+
+        NOTE: This can be lossy (ex. a MapData could get implicitly cast to a Data and
+        lose rows) if Experiment.default_data_type is misconfigured!
 
         Args:
             trial_indices: Indices of trials, for which to fetch data.

--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -309,6 +309,10 @@ class Metric(SortableBase, SerializationMixin):
 
     @classmethod
     def _unwrap_experiment_data(cls, results: Mapping[int, MetricFetchResult]) -> Data:
+        # NOTE: This can be lossy (ex. a MapData could get implicitly cast to a Data and
+        # lose rows)if some MetricFetchResults contain Data not of type
+        # `cls.data_constructor`
+
         oks: List[Ok[Data, MetricFetchE]] = [
             result for result in results.values() if isinstance(result, Ok)
         ]
@@ -340,6 +344,10 @@ class Metric(SortableBase, SerializationMixin):
         # TODO[mpolson64] Add critical_metric_names to other unwrap methods
         critical_metric_names: Optional[Iterable[str]] = None,
     ) -> Data:
+        # NOTE: This can be lossy (ex. a MapData could get implicitly cast to a Data and
+        # lose rows)if some MetricFetchResults contain Data not of type
+        # `cls.data_constructor`
+
         oks: List[Ok[Data, MetricFetchE]] = [
             result for result in results.values() if isinstance(result, Ok)
         ]
@@ -391,6 +399,10 @@ class Metric(SortableBase, SerializationMixin):
         cls,
         results: Mapping[int, Mapping[str, MetricFetchResult]],
     ) -> Data:
+        # NOTE: This can be lossy (ex. a MapData could get implicitly cast to a Data and
+        # lose rows)if some MetricFetchResults contain Data not of type
+        # `cls.data_constructor`
+
         flattened = [
             result for sublist in results.values() for result in sublist.values()
         ]

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -194,9 +194,7 @@ class MultiTypeExperiment(Experiment):
     ) -> Data:
         return self.default_data_constructor.from_multiple_data(
             [
-                Metric._unwrap_trial_data_multi(
-                    results=trial.fetch_data(**kwargs, metrics=metrics)
-                )
+                trial.fetch_data(**kwargs, metrics=metrics)
                 if trial.status.expecting_data
                 else Data()
                 for trial in self.trials.values()

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -391,7 +391,7 @@ class ExperimentTest(TestCase):
         batch.mark_completed()
 
         # Test fetch data
-        batch_data = Metric._unwrap_trial_data_multi(results=batch.fetch_data())
+        batch_data = batch.fetch_data()
         self.assertEqual(len(batch_data.df), n)
 
         exp_data = exp.fetch_data()
@@ -470,9 +470,7 @@ class ExperimentTest(TestCase):
 
         # Verify we don't get the data if the trial is abandoned
         batch._status = TrialStatus.ABANDONED
-        self.assertEqual(
-            len(Metric._unwrap_trial_data_multi(results=batch.fetch_data()).df), 0
-        )
+        self.assertEqual(len(batch.fetch_data().df), 0)
         self.assertEqual(len(exp.fetch_data().df), 3 * n)
 
         # Verify we do get the stored data if there are an unimplemented metrics.
@@ -483,13 +481,9 @@ class ExperimentTest(TestCase):
         exp.add_tracking_metric(Metric(name="b"))  # Add unimplemented metric.
         batch._status = TrialStatus.COMPLETED
         # Data should be getting looked up now.
-        self.assertEqual(batch.fetch_data()["b"].ok, exp.lookup_data_for_ts(t1))
+        self.assertEqual(batch.fetch_data(), exp.lookup_data_for_ts(t1))
         self.assertEqual(exp.fetch_data(), exp.lookup_data_for_ts(t1))
-        metrics_in_data = set(
-            Metric._unwrap_trial_data_multi(results=batch.fetch_data())
-            .df["metric_name"]
-            .values
-        )
+        metrics_in_data = set(batch.fetch_data().df["metric_name"].values)
         # Data for metric "z" should no longer be present since we removed it.
         self.assertEqual(metrics_in_data, {"b"})
 

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -361,9 +361,7 @@ def compute_posterior_pareto_frontier(
     if not data:
         try:
             data = (
-                Metric._unwrap_trial_data_multi(
-                    results=experiment.trials[trial_index].fetch_data()
-                )
+                experiment.trials[trial_index].fetch_data()
                 if trial_index
                 else experiment.fetch_data()
             )

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -11,7 +11,6 @@ from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import LifecycleStage
 from ax.core.generator_run import GeneratorRun
-from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
 from ax.core.objective import Objective
 from ax.core.outcome_constraint import OutcomeConstraint
@@ -376,9 +375,7 @@ class SQAStoreTest(TestCase):
         save_experiment(exp)
         generator_run = Models.SOBOL(search_space=exp.search_space).gen(n=1)
         trial = exp.new_trial(generator_run=generator_run)
-        exp.attach_data(
-            MapMetric._unwrap_trial_data_multi(results=trial.run().fetch_data())
-        )
+        exp.attach_data(trial.run().fetch_data())
         save_or_update_trials(
             experiment=exp,
             trials=[trial],


### PR DESCRIPTION
Summary:
Break apart fetching into two distinct methods, the former getting the results as returned by the metrics and the latter (unsafely) unwrapping them into a Data object, raising errors.

Also added comments along the unwrap methods letting users know that if their experiment does not properly configure default_data_type then fetching may be lossy (this was always the case, even before the results refactor, but bears repeating now).

Differential Revision: D41348611

