### PR TITLE
Exclude int range parameter with less than 5 possible values from slice and contour plots

### DIFF
--- a/ax/plot/contour.py
+++ b/ax/plot/contour.py
@@ -374,7 +374,7 @@ def interact_contour_plotly(
             slice_values = {}
         slice_values["TRIAL_PARAM"] = str(trial_index)
 
-    range_parameters = get_range_parameters(model)
+    range_parameters = get_range_parameters(model, min_num_values=5)
     plot_data, _, _ = get_plot_data(
         model, generator_runs_dict or {}, {metric_name}, fixed_features=fixed_features
     )

--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -13,7 +13,13 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 import numpy as np
 from ax.core.generator_run import GeneratorRun
 from ax.core.observation import Observation, ObservationFeatures
-from ax.core.parameter import ChoiceParameter, FixedParameter, RangeParameter
+from ax.core.parameter import (
+    ChoiceParameter,
+    FixedParameter,
+    Parameter,
+    ParameterType,
+    RangeParameter,
+)
 from ax.core.types import TParameterization
 from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.prediction_utils import predict_at_point
@@ -391,20 +397,45 @@ def get_range_parameter(model: ModelBridge, param_name: str) -> RangeParameter:
     return range_param
 
 
-def get_range_parameters(model: ModelBridge) -> List[RangeParameter]:
+def get_range_parameters_from_list(
+    parameters: List[Parameter], min_num_values: int = 0
+) -> List[RangeParameter]:
     """
     Get a list of range parameters from a model.
 
     Args:
-        model: The model.
+        parameters: List of parameters
+        min_num_values: Minimum number of values
 
     Returns: List of RangeParameters.
     """
     return [
         parameter
-        for parameter in model.model_space.parameters.values()
+        for parameter in parameters
         if isinstance(parameter, RangeParameter)
+        and (
+            parameter.parameter_type == ParameterType.FLOAT
+            or parameter.upper - parameter.lower + 1 >= min_num_values
+        )
     ]
+
+
+def get_range_parameters(
+    model: ModelBridge, min_num_values: int = 0
+) -> List[RangeParameter]:
+    """
+    Get a list of range parameters from a model.
+
+    Args:
+        model: The model.
+        min_num_values: Minimum number of values
+
+    Returns: List of RangeParameters.
+    """
+    return get_range_parameters_from_list(
+        parameters=list(model.model_space.parameters.values()),
+        min_num_values=min_num_values,
+    )
 
 
 def get_grid_for_parameter(parameter: RangeParameter, density: int) -> np.ndarray:

--- a/ax/plot/slice.py
+++ b/ax/plot/slice.py
@@ -323,7 +323,7 @@ def interact_slice_plotly(
 
     # Populate `pbuttons`, which allows the user to select 1D slices of parameter
     # space with the chosen parameter on the x-axis.
-    range_parameters = get_range_parameters(model)
+    range_parameters = get_range_parameters(model, min_num_values=5)
     param_names = [parameter.name for parameter in range_parameters]
     pbuttons = []
     init_traces = []

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -38,6 +38,7 @@ from ax.modelbridge.cross_validation import cross_validate
 from ax.plot.contour import interact_contour_plotly
 from ax.plot.diagnostic import interact_cross_validation_plotly
 from ax.plot.feature_importances import plot_feature_importance_by_feature_plotly
+from ax.plot.helper import get_range_parameters_from_list
 from ax.plot.pareto_frontier import (
     _pareto_frontier_plot_input_processing,
     _validate_experiment_and_get_optimization_config,
@@ -142,7 +143,9 @@ def _get_objective_v_param_plots(
 ) -> List[go.Figure]:
     search_space = experiment.search_space
 
-    range_params = list(search_space.range_parameters.keys())
+    range_params = get_range_parameters_from_list(
+        list(search_space.range_parameters.values()), min_num_values=5
+    )
     if len(range_params) < 1:
         # if search space contains no range params
         logger.warning(


### PR DESCRIPTION
Summary:
We currently include all integer range parameter in our contour plots, but this can be very misleading since they can in some cases only take on a few different values (e.g., binary parameters). This may also result in failures when certain transforms such as `IntRangeToChoice` are used.

As a short-term fix, this diff will exclude all integer range parameter with less than 5 possible values from slice and contour plots.

Reviewed By: bernardbeckerman

Differential Revision: D39871800

