### PR TITLE
Improve traceback visibility in Metric._unwrap.*

### DIFF
--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -27,7 +27,7 @@ from typing import (
 from ax.core.data import Data
 from ax.utils.common.base import SortableBase
 from ax.utils.common.logger import get_logger
-from ax.utils.common.result import Err, Ok, Result
+from ax.utils.common.result import Err, Ok, Result, UnwrapError
 from ax.utils.common.serialization import SerializationMixin
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -324,7 +324,10 @@ class Metric(SortableBase, SerializationMixin):
                 else Exception(err.err.message)
                 for err in errs
             ]
-            raise exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+
+            raise UnwrapError(errs) from (
+                exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+            )
 
         data = [ok.ok for ok in oks]
         return (
@@ -376,7 +379,9 @@ class Metric(SortableBase, SerializationMixin):
                     else Exception(err.err.message)
                     for err in critical_errs
                 ]
-                raise exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+                raise UnwrapError(critical_errs) from (
+                    exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+                )
 
         data = [ok.ok for ok in oks]
 
@@ -409,7 +414,9 @@ class Metric(SortableBase, SerializationMixin):
                 else Exception(err.err.message)
                 for err in errs
             ]
-            raise exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+            raise UnwrapError(errs) from (
+                exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+            )
 
         data = [ok.ok for ok in oks]
         return (


### PR DESCRIPTION
Summary: Change exception raising in Metric._unwrap.* methods so the full MetricFetchE repr will be written to stderr, which includes the exceptions' tracebacks. This should make debuggging easier for users

Differential Revision: D41438869

