### PR TITLE
warm_start_from_old_experiment copies RUNNING trials by default in addition to those mentioned

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1107,8 +1107,8 @@ class Experiment(Base):
             copy_run_metadata_keys: A list of keys denoting which items to copy over
                 from each trial's run_metadata.
             trial_statuses_to_copy: All trials with a status in this list will be
-                copied. By default, copies all ``COMPLETED``, ``ABANDONED``, and
-                ``EARLY_STOPPED`` trials.
+                copied. By default, copies all ``RUNNING``, ``COMPLETED``,
+                ``ABANDONED``, and ``EARLY_STOPPED`` trials.
 
         Returns:
             List of trials successfully copied from old_experiment to this one


### PR DESCRIPTION
Summary:
see https://fburl.com/code/2wlij4e4

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: saitcakmak

Differential Revision: D41439963

