### PR TITLE
Adds derelativization to Winsorization (only when using raw status quo value)

### DIFF
--- a/ax/modelbridge/tests/test_transform_utils.py
+++ b/ax/modelbridge/tests/test_transform_utils.py
@@ -4,8 +4,33 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ax.modelbridge.transforms.utils import ClosestLookupDict
+from unittest import mock
+
+import numpy as np
+from ax.core.data import Data
+from ax.core.experiment import Experiment
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.parameter import ParameterType, RangeParameter
+from ax.core.search_space import SearchSpace
+from ax.modelbridge.base import ModelBridge
+from ax.modelbridge.transforms.utils import (
+    ClosestLookupDict,
+    derelativize_optimization_config_with_raw_sq,
+)
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_multi_objective_optimization_config
+
+OBSERVATION_DATA = [
+    Observation(
+        features=ObservationFeatures(parameters={"x": 2.0, "y": 10.0}),
+        data=ObservationData(
+            means=np.array([1.0, 2.0, 6.0]),
+            covariance=np.array([[1.0, 2.0, 0.0], [3.0, 4.0, 0.0], [0.0, 0.0, 4.0]]),
+            metric_names=["m1", "m2", "m3"],
+        ),
+        arm_name="1_1",
+    )
+]
 
 
 class TransformUtilsTest(TestCase):
@@ -26,3 +51,36 @@ class TransformUtilsTest(TestCase):
         with self.assertRaises(ValueError):
             # pyre-fixme[6]: For 1st param expected `Number` but got `str`.
             d["str_key"] = 3
+
+    @mock.patch(
+        "ax.modelbridge.base.observations_from_data",
+        autospec=True,
+        return_value=(OBSERVATION_DATA),
+    )
+    def test_derelativize_optimization_config_with_raw_sq(self, _) -> None:
+        optimization_config = get_multi_objective_optimization_config()
+        dummy_search_space = SearchSpace(
+            parameters=[
+                RangeParameter("x", ParameterType.FLOAT, 0, 20),
+                RangeParameter("y", ParameterType.FLOAT, 0, 20),
+            ]
+        )
+        modelbridge = ModelBridge(
+            search_space=dummy_search_space,
+            model=None,
+            transforms=[],
+            experiment=Experiment(dummy_search_space, "test"),
+            data=Data(),
+            optimization_config=optimization_config,
+            status_quo_name="1_1",
+        )
+        new_opt_config = derelativize_optimization_config_with_raw_sq(
+            optimization_config=optimization_config,
+            modelbridge=modelbridge,
+            observations=OBSERVATION_DATA,
+        )
+        expected_bound_values = {"m1": 0.9975, "m2": 1.995, "m3": 5.985}
+        for oc in new_opt_config.all_constraints:
+            self.assertFalse(oc.relative)
+            expected_bound_value = expected_bound_values[oc.metric.name]
+            self.assertEqual(oc.bound, expected_bound_value)

--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -25,7 +25,10 @@ from ax.core.outcome_constraint import (
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import DataRequiredError, UnsupportedError, UserInputError
 from ax.modelbridge.transforms.base import Transform
-from ax.modelbridge.transforms.utils import get_data
+from ax.modelbridge.transforms.utils import (
+    derelativize_optimization_config_with_raw_sq,
+    get_data,
+)
 from ax.models.types import TConfig
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast
@@ -74,6 +77,12 @@ class Winsorize(Transform):
         ``WinsorizationConfig``, which, if provided will be used for all metrics; or
         a mapping ``Dict[str, WinsorizationConfig]`` between each metric name and its
         ``WinsorizationConfig``.
+    - ``"derelativize_with_raw_sq"``, indicating whether to use the raw status-quo
+        value for any derelativization. Note this defaults to ``False``, which is
+        unsupported and simply fails if derelativization is necessary. The user must
+        specify ``derelativize_using_raw_sq = True`` in order for derelativization to
+        succeed. Note that this must match the `use_raw_status_quo` value in the
+        ``Derelativize`` config if used.
     For example,
     ``{"winsorization_config": WinsorizationConfig(lower_quantile_margin=0.3)}``
     will specify the same 30% winsorization from below for all metrics, whereas
@@ -103,6 +112,8 @@ class Winsorize(Transform):
     the optimization config.
     """
 
+    cutoffs: Dict[str, Tuple[float, float]]
+
     def __init__(
         self,
         search_space: Optional[SearchSpace] = None,
@@ -112,7 +123,6 @@ class Winsorize(Transform):
     ) -> None:
         if observations is None or len(observations) == 0:
             raise DataRequiredError("`Winsorize` transform requires non-empty data.")
-        optimization_config = modelbridge._optimization_config if modelbridge else None
         if config is not None and config.get("optimization_config") is not None:
             warnings.warn(
                 "Winsorization received an out-of-date `transform_config`, containing "
@@ -120,6 +130,7 @@ class Winsorize(Transform):
                 "to the docs of `ax.modelbridge.transforms.winsorize.Winsorize`.",
                 DeprecationWarning,
             )
+        optimization_config = modelbridge._optimization_config if modelbridge else None
         if config is None and optimization_config is None:
             raise ValueError(
                 "Transform config for `Winsorize` transform must be specified and "
@@ -129,7 +140,6 @@ class Winsorize(Transform):
         if config is None:
             config = {}
         observation_data = [obs.data for obs in observations]
-        all_metric_values = get_data(observation_data=observation_data)
 
         # Check for legacy config
         use_legacy = False
@@ -144,10 +154,11 @@ class Winsorize(Transform):
             )
             use_legacy = True
 
-        # Get winsorization and optimization configs
+        # Get config settings.
         winsorization_config = config.get("winsorization_config", {})
-        # pyre-fixme[4]: Attribute must be annotated.
+        use_raw_sq = _get_and_validate_use_raw_sq(config=config)
         self.cutoffs = {}
+        all_metric_values = get_data(observation_data=observation_data)
         for metric_name, metric_values in all_metric_values.items():
             if use_legacy:
                 self.cutoffs[metric_name] = _get_cutoffs_from_legacy_transform_config(
@@ -156,11 +167,14 @@ class Winsorize(Transform):
                     transform_config=config,
                 )
             else:
-                self.cutoffs[metric_name] = _get_cutoffs_from_transform_config(
+                self.cutoffs[metric_name] = _get_cutoffs(
                     metric_name=metric_name,
                     metric_values=metric_values,
                     winsorization_config=winsorization_config,
+                    modelbridge=modelbridge,
+                    observations=observations,
                     optimization_config=optimization_config,
+                    use_raw_sq=use_raw_sq,
                 )
 
     def _transform_observation_data(
@@ -178,11 +192,14 @@ class Winsorize(Transform):
         return observation_data
 
 
-def _get_cutoffs_from_transform_config(
+def _get_cutoffs(
     metric_name: str,
     metric_values: List[float],
     winsorization_config: Union[WinsorizationConfig, Dict[str, WinsorizationConfig]],
+    modelbridge: Optional["modelbridge_module.base.ModelBridge"],
+    observations: Optional[List[Observation]],
     optimization_config: Optional[OptimizationConfig],
+    use_raw_sq: bool,
 ) -> Tuple[float, float]:
     # (1) Use the same config for all metrics if one WinsorizationConfig was specified
     if isinstance(winsorization_config, WinsorizationConfig):
@@ -210,61 +227,90 @@ def _get_cutoffs_from_transform_config(
 
     # (3) For constraints and objectives that don't have a pre-specified config we
     # choose the cutoffs automatically using the optimization config (if supplied).
-    # We ignore ScalarizedOutcomeConstraint and ScalarizedObjective for now. An
-    # exception is raised if we encounter relative constraints.
-    if optimization_config:
-        if metric_name in optimization_config.objective.metric_names:
-            if isinstance(optimization_config.objective, ScalarizedObjective):
-                warnings.warn(
-                    "Automatic winsorization isn't supported for ScalarizedObjective. "
-                    "Specify the winsorization settings manually if you want to "
-                    f"winsorize metric {metric_name}."
-                )
-                return DEFAULT_CUTOFFS  # Don't winsorize a ScalarizedObjective
-            elif optimization_config.is_moo_problem:
-                # We deal with a multi-objective function the same way as we deal
-                # with an output constraint. It may be worth investigating setting
-                # the winsorization cutoffs based on the Pareto frontier in the future.
-                optimization_config = checked_cast(
-                    MultiObjectiveOptimizationConfig, optimization_config
-                )
-                objective_threshold = _get_objective_threshold_from_moo_config(
-                    optimization_config=optimization_config, metric_name=metric_name
-                )
-                if objective_threshold:
-                    return _get_auto_winsorization_cutoffs_outcome_constraint(
-                        metric_values=metric_values,
-                        outcome_constraints=objective_threshold,
-                    )
-                warnings.warn(
-                    "Automatic winsorization isn't supported for an objective in "
-                    "`MultiObjective` without objective thresholds. Specify the "
-                    "winsorization settings manually if you want to winsorize "
-                    f"metric {metric_name}."
-                )
-                return DEFAULT_CUTOFFS  # Don't winsorize if there is no threshold
-            else:  # Single objective
-                return _get_auto_winsorization_cutoffs_single_objective(
-                    metric_values=metric_values,
-                    minimize=optimization_config.objective.minimize,
-                )
-        # Get all outcome constraints for metric_name that aren't relative or scalarized
-        outcome_constraints = _get_outcome_constraints_from_config(
-            optimization_config=optimization_config, metric_name=metric_name
-        )
-        if outcome_constraints:
-            return _get_auto_winsorization_cutoffs_outcome_constraint(
-                metric_values=metric_values,
-                outcome_constraints=outcome_constraints,
+    # We ignore ScalarizedOutcomeConstraint and ScalarizedObjective for now, and
+    # derelativize relative constraints if possible.
+
+    # When no optimization config is available, return defaults.
+    if modelbridge is None or optimization_config is None:
+        return DEFAULT_CUTOFFS
+    if any(oc.relative for oc in optimization_config.all_constraints):
+        if not use_raw_sq:
+            raise UnsupportedError(
+                "Automatic winsorization doesn't support relative outcome constraints "
+                "or objective thresholds when `derelativize_with_raw_sq` is not set "
+                "to `True`."
             )
+        optimization_config = derelativize_optimization_config_with_raw_sq(
+            optimization_config=optimization_config,
+            modelbridge=modelbridge,
+            observations=observations,
+        )
 
-    # If none of the above, we don't winsorize.
-    return DEFAULT_CUTOFFS
+    # Non-objective metrics - obtain cutoffs from outcome_constraints.
+    if metric_name not in optimization_config.objective.metric_names:
+        # Get all outcome constraints for `metric_name`` that aren't scalarized.
+        return _obtain_cutoffs_from_outcome_constraints(
+            optimization_config=optimization_config,
+            metric_name=metric_name,
+            metric_values=metric_values,
+        )
+
+    # Don't winsorize a ScalarizedObjective
+    if isinstance(optimization_config.objective, ScalarizedObjective):
+        warnings.warn(
+            "Automatic winsorization isn't supported for ScalarizedObjective. "
+            "Specify the winsorization settings manually if you want to "
+            f"winsorize metric {metric_name}."
+        )
+        return DEFAULT_CUTOFFS
+
+    # Single-objective
+    if not optimization_config.is_moo_problem:
+        return _get_auto_winsorization_cutoffs_single_objective(
+            metric_values=metric_values,
+            minimize=optimization_config.objective.minimize,
+        )
+
+    # Multi-objective
+    return _get_auto_winsorization_cutoffs_multi_objective(
+        optimization_config=optimization_config,
+        metric_name=metric_name,
+        metric_values=metric_values,
+    )
 
 
-def _get_outcome_constraints_from_config(
-    optimization_config: OptimizationConfig, metric_name: str
-) -> List[OutcomeConstraint]:
+def _get_auto_winsorization_cutoffs_multi_objective(
+    optimization_config: OptimizationConfig,
+    metric_name: str,
+    metric_values: List[float],
+) -> Tuple[float, float]:
+    # We approach a multi-objective metric the same as output constraints. It may be
+    # worth investigating setting the winsorization cutoffs based on the Pareto
+    # frontier in the future.
+    optimization_config = checked_cast(
+        MultiObjectiveOptimizationConfig, optimization_config
+    )
+    objective_threshold = _get_objective_threshold_from_moo_config(
+        optimization_config=optimization_config, metric_name=metric_name
+    )
+    if objective_threshold:
+        return _get_auto_winsorization_cutoffs_outcome_constraint(
+            metric_values=metric_values,
+            outcome_constraints=objective_threshold,
+        )
+    warnings.warn(
+        "Automatic winsorization isn't supported for an objective in `MultiObjective` "
+        "without objective thresholds. Specify the winsorization settings manually if "
+        f"you want to winsorize metric {metric_name}."
+    )
+    return DEFAULT_CUTOFFS  # Don't winsorize if there is no threshold
+
+
+def _obtain_cutoffs_from_outcome_constraints(
+    optimization_config: OptimizationConfig,
+    metric_name: str,
+    metric_values: List[float],
+) -> Tuple[float, float]:
     """Get all outcome constraints (non-scalarized) for a given metric."""
     # Check for scalarized outcome constraints for the given metric
     if any(
@@ -277,37 +323,37 @@ def _get_outcome_constraints_from_config(
             "`ScalarizedOutcomeConstraint`. Specify the winsorization settings "
             f"manually if you want to winsorize metric {metric_name}."
         )
-    # Filter scalarized outcome constraints
-    outcome_constraints = [
+    outcome_constraints = _get_non_scalarized_outcome_constraints(
+        optimization_config=optimization_config, metric_name=metric_name
+    )
+    if outcome_constraints:
+        return _get_auto_winsorization_cutoffs_outcome_constraint(
+            metric_values=metric_values,
+            outcome_constraints=outcome_constraints,
+        )
+    return DEFAULT_CUTOFFS
+
+
+def _get_non_scalarized_outcome_constraints(
+    optimization_config: OptimizationConfig, metric_name: str
+) -> List[OutcomeConstraint]:
+    return [
         oc
         for oc in optimization_config.outcome_constraints
         if not isinstance(oc, ScalarizedOutcomeConstraint)
         and oc.metric.name == metric_name
     ]
-    # Raise an error if there are relative constraints
-    if any(oc.relative for oc in outcome_constraints):
-        raise UnsupportedError(
-            "Automatic winsorization doesn't support relative outcome constraints. "
-            "Make sure a `Derelativize` transform is applied first."
-        )
-    return outcome_constraints
 
 
 def _get_objective_threshold_from_moo_config(
     optimization_config: MultiObjectiveOptimizationConfig, metric_name: str
 ) -> List[ObjectiveThreshold]:
     """Get the non-relative objective threshold for a given metric."""
-    objective_thresholds = [
+    return [
         ot
         for ot in optimization_config.objective_thresholds
         if ot.metric.name == metric_name
     ]
-    if any(oc.relative for oc in objective_thresholds):
-        raise UnsupportedError(
-            "Automatic winsorization doesn't support relative objective thresholds. "
-            "Make sure a `Derelevatize` transform is applied first."
-        )
-    return objective_thresholds
 
 
 def _get_tukey_cutoffs(Y: np.ndarray, lower: bool) -> float:
@@ -454,4 +500,13 @@ def _get_cutoffs_from_legacy_transform_config(
         metric_name=metric_name,
         metric_values=metric_values,
         metric_config=winsorization_config,
+    )
+
+
+def _get_and_validate_use_raw_sq(config: TConfig) -> bool:
+    use_raw_sq = config.get("derelativize_with_raw_sq", False)
+    if isinstance(use_raw_sq, bool):
+        return use_raw_sq
+    raise UserInputError(
+        f"`derelativize_with_raw_sq` must be a boolean. Got {use_raw_sq}."
     )


### PR DESCRIPTION
Summary: Allows derelativization using raw status quo metric values during winsorization. This should only be used with a Derelativize transform that also uses raw status quo metric values, however there is no enforcement of this as of now.

Differential Revision: D41348332

