### PR TITLE
Require keyword-only arguments for choose_generation_strategy

### DIFF
--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -216,6 +216,7 @@ def _suggest_gp_model(
 
 def choose_generation_strategy(
     search_space: SearchSpace,
+    *,
     use_batch_trials: bool = False,
     enforce_sequential_optimization: bool = True,
     random_seed: Optional[int] = None,


### PR DESCRIPTION
Summary:
Require keyword-only arguments for choose_generation_strategy.

With recent changes already modifying the function signature, we can require that callers to choose_generation_strategy use keywords for all optional parameters (e.g. everything but the first parameter of search_space).

Reviewed By: bernardbeckerman

Differential Revision: D41344197

