### PR TITLE
Add num_completed_initialization_trials to choose_generation_strategy

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1158,6 +1158,12 @@ class Experiment(Base):
                 f"Warm start from Experiment: `{old_experiment._name}`, "
                 f"trial: `{trial.index}`"
             )
+            # Associates a generation_model_key to the new trial.
+            generation_model_key = trial._properties.get("generation_model_key")
+            if generation_model_key is None and trial.generator_run is not None:
+                generation_model_key = trial.generator_run._model_key or "Manual"
+            new_trial._properties["generation_model_key"] = generation_model_key
+
             if copy_run_metadata_keys is not None:
                 for run_metadata_field in copy_run_metadata_keys:
                     new_trial.update_run_metadata(

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -20,6 +20,7 @@ from ax.core.parameter import FixedParameter, ParameterType
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UnsupportedError
 from ax.metrics.branin import BraninMetric
+from ax.modelbridge.registry import Models
 from ax.runners.synthetic import SyntheticRunner
 from ax.service.ax_client import AxClient
 from ax.utils.common.constants import EXPERIMENT_IS_TEST_WARNING, Keys
@@ -1051,6 +1052,9 @@ class ExperimentWithMapDataTest(TestCase):
             )
             self.assertRegex(
                 trial._properties["source"], "Warm start.*Experiment.*trial"
+            )
+            self.assertEqual(
+                trial._properties["generation_model_key"], Models.SOBOL.value
             )
             self.assertDictEqual(trial.run_metadata, DUMMY_RUN_METADATA)
             i_old_trial += 1

--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -216,6 +216,7 @@ def _suggest_gp_model(
 
 def choose_generation_strategy(
     search_space: SearchSpace,
+    *,
     use_batch_trials: bool = False,
     enforce_sequential_optimization: bool = True,
     random_seed: Optional[int] = None,

--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -249,6 +249,7 @@ def choose_generation_strategy(
     no_bayesian_optimization: bool = False,
     num_trials: Optional[int] = None,
     num_initialization_trials: Optional[int] = None,
+    num_completed_initialization_trials: int = 0,
     max_initialization_trials: Optional[int] = None,
     max_parallelism_cap: Optional[int] = None,
     max_parallelism_override: Optional[int] = None,
@@ -297,6 +298,10 @@ def choose_generation_strategy(
         max_initialization_trials: If ``num_initialization_trials`` unspecified, it
             will be determined automatically. This arg provides a cap on that
             automatically determined number.
+        num_completed_initialization_trials: The final calculated number of
+            initialization trials is reduced by this number. This is useful when
+            warm-starting an experiment, to specify what number of completed trials
+            can be used to satisfy the initialization_trial requirement.
         max_parallelism_cap: Integer cap on parallelism in this generation strategy.
             If specified, ``max_parallelism`` setting in each generation step will be
             set to the minimum of the default setting for that step and the value of
@@ -382,17 +387,36 @@ def choose_generation_strategy(
             )
 
         # If number of initialization trials is not specified, estimate it.
+        logger.info(
+            "Calculating the number of remaining initialization trials based on "
+            f"num_initialization_trials={num_initialization_trials} "
+            f"max_initialization_trials={max_initialization_trials} "
+            f"num_tunable_parameters={len(search_space.tunable_parameters)} "
+            f"num_trials={num_trials} "
+            f"use_batch_trials={use_batch_trials}"
+        )
         if num_initialization_trials is None:
             num_initialization_trials = calculate_num_initialization_trials(
                 num_tunable_parameters=len(search_space.tunable_parameters),
                 num_trials=num_trials,
                 use_batch_trials=use_batch_trials,
             )
+            logger.info(
+                f"calculated num_initialization_trials={num_initialization_trials}"
+            )
         if max_initialization_trials is not None:
             num_initialization_trials = min(
                 num_initialization_trials, max_initialization_trials
             )
-
+        num_remaining_initialization_trials = max(
+            0, num_initialization_trials - max(0, num_completed_initialization_trials)
+        )
+        logger.info(
+            "num_completed_initialization_trials="
+            f"{num_completed_initialization_trials} "
+            f"num_remaining_initialization_trials={num_remaining_initialization_trials}"
+        )
+        steps = []
         # `verbose` and `disable_progbar` defaults and overrides
         model_is_saasbo = is_saasbo(suggested_model)
         if verbose is None and model_is_saasbo:
@@ -410,12 +434,11 @@ def choose_generation_strategy(
             disable_progbar = None
 
         # Create `generation_strategy`, adding first Sobol step
-        # if `num_initialization_trials` is > 0.
-        steps = []
-        if num_initialization_trials is None or num_initialization_trials > 0:
+        # if `num_remaining_initialization_trials` is > 0.
+        if num_remaining_initialization_trials > 0:
             steps.append(
                 _make_sobol_step(
-                    num_trials=num_initialization_trials,
+                    num_trials=num_remaining_initialization_trials,
                     enforce_num_trials=enforce_sequential_optimization,
                     seed=random_seed,
                     max_parallelism=sobol_parallelism,
@@ -438,8 +461,8 @@ def choose_generation_strategy(
         gs = GenerationStrategy(steps=steps)
         logger.info(
             f"Using Bayesian Optimization generation strategy: {gs}. Iterations after"
-            f" {num_initialization_trials} will take longer to generate due to "
-            " model-fitting."
+            f" {num_remaining_initialization_trials} will take longer to generate due"
+            " to model-fitting."
         )
     else:  # `no_bayesian_optimization` is True or we could not suggest BO model
         if verbose is not None:

--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -560,6 +560,25 @@ class TestDispatchUtils(TestCase):
         gs = choose_generation_strategy(search_space=exp.search_space, experiment=exp)
         self.assertEqual(gs._experiment, exp)
 
+    def test_setting_num_completed_initialization_trials(self) -> None:
+        default_initialization_num_trials = 5
+        sobol_gpei = choose_generation_strategy(search_space=get_branin_search_space())
+
+        self.assertEqual(
+            sobol_gpei._steps[0].num_trials, default_initialization_num_trials
+        )
+
+        num_completed_initialization_trials = 2
+        sobol_gpei = choose_generation_strategy(
+            search_space=get_branin_search_space(),
+            num_completed_initialization_trials=num_completed_initialization_trials,
+        )
+
+        self.assertEqual(
+            sobol_gpei._steps[0].num_trials,
+            default_initialization_num_trials - num_completed_initialization_trials,
+        )
+
     def test_calculate_num_initialization_trials(self) -> None:
 
         with self.subTest("one trial for batch trials"):

--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -11,6 +11,7 @@ import torch
 from ax.core.objective import MultiObjective
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.modelbridge.dispatch_utils import (
+    calculate_num_initialization_trials,
     choose_generation_strategy,
     DEFAULT_BAYESIAN_PARALLELISM,
 )
@@ -558,3 +559,65 @@ class TestDispatchUtils(TestCase):
         exp = get_experiment()
         gs = choose_generation_strategy(search_space=exp.search_space, experiment=exp)
         self.assertEqual(gs._experiment, exp)
+
+    def test_calculate_num_initialization_trials(self) -> None:
+
+        with self.subTest("one trial for batch trials"):
+            self.assertEqual(
+                calculate_num_initialization_trials(
+                    num_tunable_parameters=2,
+                    num_trials=None,
+                    use_batch_trials=True,
+                ),
+                1,
+            )
+
+        with self.subTest("num_trials is unset, small exp"):
+            self.assertEqual(
+                calculate_num_initialization_trials(
+                    num_tunable_parameters=2,
+                    num_trials=None,
+                    use_batch_trials=False,
+                ),
+                5,
+            )
+
+        with self.subTest("num_trials is unset, large exp"):
+            self.assertEqual(
+                calculate_num_initialization_trials(
+                    num_tunable_parameters=10,
+                    num_trials=None,
+                    use_batch_trials=False,
+                ),
+                20,
+            )
+
+        with self.subTest("many trials"):
+            self.assertEqual(
+                calculate_num_initialization_trials(
+                    num_tunable_parameters=10,
+                    num_trials=200,
+                    use_batch_trials=False,
+                ),
+                20,
+            )
+
+        with self.subTest("limited trials"):
+            self.assertEqual(
+                calculate_num_initialization_trials(
+                    num_tunable_parameters=10,
+                    num_trials=50,
+                    use_batch_trials=False,
+                ),
+                10,
+            )
+
+        with self.subTest("few trials"):
+            self.assertEqual(
+                calculate_num_initialization_trials(
+                    num_tunable_parameters=10,
+                    num_trials=10,
+                    use_batch_trials=False,
+                ),
+                5,
+            )


### PR DESCRIPTION
Summary:
Adds a parameter to choose_generation_strategy

        num_completed_initialization_trials: The final calculated number of
            initialization trials is reduced by this number. This is useful when
            warm-starting an experiment, to specify what number of completed trials
            can be used to satisfy the initialization_trial requirement.

Reviewed By: bernardbeckerman

Differential Revision: D41375608

