### PR TITLE
pass customized prior to fit GP models

### DIFF
--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -4,11 +4,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from copy import deepcopy
 from unittest import mock
 
 import torch
 from ax.models.torch.botorch_defaults import (
     _get_acquisition_func,
+    _get_customized_covar_module,
     _get_model,
     get_and_fit_model,
     get_warping_transform,
@@ -20,6 +22,8 @@ from botorch.models import FixedNoiseGP, SingleTaskGP
 from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
 from botorch.models.transforms.input import Warp
+from gpytorch.kernels import MaternKernel, ScaleKernel
+from gpytorch.module import Module
 from gpytorch.priors import GammaPrior
 from gpytorch.priors.lkj_prior import LKJCovariancePrior
 from gpytorch.priors.prior import Prior
@@ -37,6 +41,13 @@ class BotorchDefaultsTest(TestCase):
 
         model = _get_model(X=x, Y=y, Yvar=var)
         self.assertIsInstance(model, FixedNoiseGP)
+        self.assertEqual(
+            # pyre-ignore
+            model.covar_module.base_kernel.lengthscale_prior.concentration,
+            3.0,
+        )
+        # pyre-ignore
+        self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 6.0)
         model = _get_model(X=x, Y=y, Yvar=unknown_var, task_feature=1)
         self.assertTrue(type(model) == MultiTaskGP)  # Don't accept subclasses.
         model = _get_model(X=x, Y=y, Yvar=var, task_feature=1)
@@ -142,6 +153,70 @@ class BotorchDefaultsTest(TestCase):
             # pyre-fixme[6]: For 5th param expected `bool` but got `Dict[str,
             #  Union[Type[Prior], float, GammaPrior]]`.
             _get_model(X=x, Y=y, Yvar=partial_var.clone(), task_feature=1, **kwargs5)
+        # test passing customized prior
+        kwargs6 = {
+            "prior": {
+                "covar_module_prior": {"lengthscale_prior": GammaPrior(12.0, 2.0)},
+                "type": LKJCovariancePrior,
+            }
+        }
+        model = _get_model(X=x, Y=y, Yvar=var, **deepcopy(kwargs6))  # pyre-ignore
+        self.assertIsInstance(model, FixedNoiseGP)
+        self.assertEqual(
+            # pyre-ignore
+            model.covar_module.base_kernel.lengthscale_prior.concentration,
+            12.0,
+        )
+        # pyre-ignore
+        self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
+        model = _get_model(
+            X=x,
+            Y=y,
+            Yvar=unknown_var,
+            task_feature=1,
+            **deepcopy(kwargs6),  # pyre-ignore
+        )
+        self.assertTrue(type(model) == MultiTaskGP)
+        self.assertEqual(
+            model.covar_module.base_kernel.lengthscale_prior.concentration, 12.0
+        )
+        self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
+        self.assertIsInstance(
+            model.task_covar_module.IndexKernelPrior,
+            LKJCovariancePrior,
+        )
+        model = _get_model(
+            X=x, Y=y, Yvar=var, task_feature=1, **deepcopy(kwargs6)  # pyre-ignore
+        )
+        self.assertIsInstance(model, FixedNoiseMultiTaskGP)
+        self.assertEqual(
+            # pyre-ignore
+            model.covar_module.base_kernel.lengthscale_prior.concentration,
+            12.0,
+        )
+        # pyre-ignore
+        self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
+        self.assertIsInstance(
+            # pyre-ignore
+            model.task_covar_module.IndexKernelPrior,
+            LKJCovariancePrior,
+        )
+        # test passing customized prior
+        kwargs7 = {
+            "prior": {
+                "covar_module_prior": {"lengthscale_prior": GammaPrior(12.0, 2.0)},
+            }
+        }
+        covar_module = MaternKernel(
+            nu=2.5,
+            ard_num_dims=2,
+            lengthscale_prior=GammaPrior(6.0, 6.0),
+        )
+        model = _get_model(
+            X=x, Y=y, Yvar=var, covar_module=covar_module, **kwargs7  # pyre-ignore
+        )
+        self.assertIsInstance(model, FixedNoiseGP)
+        self.assertEqual(covar_module, model.covar_module)
 
     @mock.patch("ax.models.torch.botorch_defaults._get_model", wraps=_get_model)
     @fast_botorch_optimize
@@ -203,6 +278,65 @@ class BotorchDefaultsTest(TestCase):
                 refit_model=False,
             )
 
+    @mock.patch("ax.models.torch.botorch_defaults._get_model", wraps=_get_model)
+    @fast_botorch_optimize
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def test_pass_customized_prior(self, get_model_mock):
+        x = [torch.zeros(2, 2)]
+        y = [torch.zeros(2, 1)]
+        yvars = [torch.ones(2, 1)]
+        kwarg = {
+            "prior": {
+                "covar_module_prior": {
+                    "lengthscale_prior": GammaPrior(12.0, 2.0),
+                    "outputscale_prior": GammaPrior(2.0, 12.0),
+                },
+            }
+        }
+        model = get_and_fit_model(
+            Xs=x,
+            Ys=y,
+            Yvars=yvars,
+            task_features=[],
+            fidelity_features=[],
+            metric_names=["L2NormMetric"],
+            state_dict=None,
+            refit_model=False,
+            **kwarg,  # pyre-ignore
+        )
+        self.assertTrue(type(model) == FixedNoiseGP)
+        self.assertEqual(
+            # pyre-ignore
+            model.covar_module.base_kernel.lengthscale_prior.concentration,
+            12.0,
+        )
+        self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
+        # pyre-ignore
+        self.assertEqual(model.covar_module.outputscale_prior.concentration, 2.0)
+        self.assertEqual(model.covar_module.outputscale_prior.rate, 12.0)
+
+        model = get_and_fit_model(
+            Xs=x + x,
+            Ys=y + y,
+            Yvars=yvars + yvars,
+            task_features=[1],
+            fidelity_features=[],
+            metric_names=["L2NormMetric", "L2NormMetric2"],
+            state_dict=None,
+            refit_model=False,
+            **kwarg,  # pyre-ignore
+        )
+        for m in model.models:  # pyre-ignore
+            self.assertTrue(type(m) == FixedNoiseMultiTaskGP)
+            self.assertEqual(
+                m.covar_module.base_kernel.lengthscale_prior.concentration,
+                12.0,
+            )
+            self.assertEqual(m.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
+            self.assertEqual(m.covar_module.outputscale_prior.concentration, 2.0)
+            self.assertEqual(m.covar_module.outputscale_prior.rate, 12.0)
+
     def test_get_acquisition_func(self) -> None:
         x = torch.zeros(2, 2)
         y = torch.zeros(2, 1)
@@ -237,6 +371,48 @@ class BotorchDefaultsTest(TestCase):
                 outcome_constraints=outcome_constraints,
                 X_observed=X_observed,
             )
+
+    def test_get_customized_covar_module(self) -> None:
+        ard_num_dims = 3
+        batch_shape = torch.Size([2])
+        covar_module = _get_customized_covar_module(
+            covar_module_prior_dict={},
+            ard_num_dims=ard_num_dims,
+            batch_shape=batch_shape,
+            task_feature=None,
+        )
+        self.assertIsInstance(covar_module, Module)
+        self.assertIsInstance(covar_module, ScaleKernel)
+        self.assertIsInstance(covar_module.outputscale_prior, GammaPrior)
+        self.assertEqual(covar_module.outputscale_prior.concentration, 2.0)
+        self.assertEqual(covar_module.outputscale_prior.rate, 0.15)
+        self.assertIsInstance(covar_module.base_kernel, MaternKernel)
+        self.assertIsInstance(covar_module.base_kernel.lengthscale_prior, GammaPrior)
+        self.assertEqual(covar_module.base_kernel.lengthscale_prior.concentration, 3.0)
+        self.assertEqual(covar_module.base_kernel.lengthscale_prior.rate, 6.0)
+        self.assertEqual(covar_module.base_kernel.ard_num_dims, ard_num_dims)
+        self.assertEqual(covar_module.base_kernel.batch_shape, batch_shape)
+
+        covar_module = _get_customized_covar_module(
+            covar_module_prior_dict={
+                "lengthscale_prior": GammaPrior(12.0, 2.0),
+                "outputscale_prior": GammaPrior(2.0, 12.0),
+            },
+            ard_num_dims=ard_num_dims,
+            batch_shape=batch_shape,
+            task_feature=3,
+        )
+        self.assertIsInstance(covar_module, Module)
+        self.assertIsInstance(covar_module, ScaleKernel)
+        self.assertIsInstance(covar_module.outputscale_prior, GammaPrior)
+        self.assertEqual(covar_module.outputscale_prior.concentration, 2.0)
+        self.assertEqual(covar_module.outputscale_prior.rate, 12.0)
+        self.assertIsInstance(covar_module.base_kernel, MaternKernel)
+        self.assertIsInstance(covar_module.base_kernel.lengthscale_prior, GammaPrior)
+        self.assertEqual(covar_module.base_kernel.lengthscale_prior.concentration, 12.0)
+        self.assertEqual(covar_module.base_kernel.lengthscale_prior.rate, 2.0)
+        self.assertEqual(covar_module.base_kernel.ard_num_dims, ard_num_dims - 1)
+        self.assertEqual(covar_module.base_kernel.batch_shape, batch_shape)
 
     def test_get_warping_transform(self) -> None:
         warp_tf = get_warping_transform(d=4)

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -91,6 +91,10 @@ class BotorchModelTest(TestCase):
         )
         kwargs = {
             "prior": {
+                "covar_module_prior": {
+                    "lengthscale_prior": GammaPrior(6.0, 3.0),
+                    "outputscale_prior": GammaPrior(3.0, 12.0),
+                },
                 "type": LKJCovariancePrior,
                 "sd_prior": GammaPrior(2.0, 0.44),
                 "eta": 0.6,
@@ -118,6 +122,22 @@ class BotorchModelTest(TestCase):
         # pyre-fixme[16]: Optional type has no attribute `models`.
         model_list = model.model.models
         for i in range(1):
+            self.assertEqual(
+                model_list[i].covar_module.base_kernel.lengthscale_prior.concentration,
+                6.0,
+            )
+            self.assertEqual(
+                model_list[i].covar_module.base_kernel.lengthscale_prior.rate,
+                3.0,
+            )
+            self.assertEqual(
+                model_list[i].covar_module.outputscale_prior.concentration,
+                3.0,
+            )
+            self.assertEqual(
+                model_list[i].covar_module.outputscale_prior.rate,
+                12.0,
+            )
             self.assertIsInstance(
                 model_list[i].task_covar_module.IndexKernelPrior, LKJCovariancePrior
             )

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -134,6 +134,14 @@ class BotorchModel(TorchModel):
             data using the `update` method.
         warm_start_refitting: If True, start model refitting from previous
             model parameters in order to speed up the fitting process.
+        prior: A optinal dictionary that contains the specification of GP model prior.
+            Currently, the keys include:
+            - covar_module_prior: prior on covariance matrix e.g.
+                {"lengthscale_prior": GammaPrior(3.0, 6.0)}.
+            - type: type of prior on task covariance matrix e.g.`LKJCovariancePrior`.
+            - sd_prior: A scalar prior over nonnegative numbers, which is used for the
+                default LKJCovariancePrior task_covar_prior.
+            - eta: The eta parameter on the default LKJ task_covar_prior.
 
 
     Call signatures:
@@ -256,6 +264,7 @@ class BotorchModel(TorchModel):
         warm_start_refitting: bool = True,
         use_input_warping: bool = False,
         use_loocv_pseudo_likelihood: bool = False,
+        prior: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         self.model_constructor = model_constructor
@@ -270,6 +279,7 @@ class BotorchModel(TorchModel):
         self.warm_start_refitting = warm_start_refitting
         self.use_input_warping = use_input_warping
         self.use_loocv_pseudo_likelihood = use_loocv_pseudo_likelihood
+        self.prior = prior
         self.model: Optional[Model] = None
         self.Xs = []
         self.Ys = []
@@ -310,6 +320,7 @@ class BotorchModel(TorchModel):
             metric_names=self.metric_names,
             use_input_warping=self.use_input_warping,
             use_loocv_pseudo_likelihood=self.use_loocv_pseudo_likelihood,
+            prior=self.prior,
             **self._kwargs,
         )
 

--- a/ax/models/torch/botorch_moo.py
+++ b/ax/models/torch/botorch_moo.py
@@ -208,6 +208,7 @@ class MultiObjectiveBotorchModel(BotorchModel):
         warm_start_refitting: bool = False,
         use_input_warping: bool = False,
         use_loocv_pseudo_likelihood: bool = False,
+        prior: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         self.model_constructor = model_constructor
@@ -223,6 +224,7 @@ class MultiObjectiveBotorchModel(BotorchModel):
         self.warm_start_refitting = warm_start_refitting
         self.use_input_warping = use_input_warping
         self.use_loocv_pseudo_likelihood = use_loocv_pseudo_likelihood
+        self.prior = prior
         self.model: Optional[Model] = None
         self.Xs = []
         self.Ys = []


### PR DESCRIPTION
Summary: Using customized GP prior can improve model fit and optimization performance. Follow upon the implementation design [here](https://docs.google.com/document/d/1L-13prgv3v3P5Z95ULjFULT4v0MRWl_0OS2FQyFA4qU/edit#), this diff allows to pass GP prior to model_constructor vis kwargs  when instantiating a modelbridge / botorch model.

Reviewed By: danielcohenlive

Differential Revision: D41443053

