### PR TITLE
Turnoff buggy lazy tensor computations in benchmarks

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -17,10 +17,13 @@ Key terms used:
 
 """
 
+from contextlib import ExitStack
 from functools import partial
 from itertools import product
 from time import time
 from typing import Any, Iterable, List
+
+import gpytorch
 
 import numpy as np
 
@@ -36,6 +39,8 @@ from ax.core.utils import get_model_times
 from ax.service.scheduler import Scheduler
 from ax.service.utils.best_point_mixin import BestPointMixin
 from botorch.utils.sampling import manual_seed
+
+MAX_EAGER_KERNEL_SIZE = 4096
 
 
 def benchmark_replication(
@@ -65,7 +70,19 @@ def benchmark_replication(
         generation_strategy=method.generation_strategy.clone_reset(),
         options=method.scheduler_options,
     )
-    with manual_seed(seed=seed):
+    # Set the seed and turn of all the GPyTorch tricks to prevent
+    # issues with large evaluation budgets.
+    with ExitStack() as es:
+        es.enter_context(manual_seed(seed=seed))
+        es.enter_context(gpytorch.settings.max_eager_kernel_size(MAX_EAGER_KERNEL_SIZE))
+        es.enter_context(
+            gpytorch.settings.fast_computations(
+                log_prob=False,
+                covar_root_decomposition=False,
+                solves=False,
+            )
+        )
+        es.enter_context(gpytorch.settings.cholesky_max_tries(6))
         scheduler.run_n_trials(max_trials=problem.num_trials)
 
     optimization_trace = np.array(


### PR DESCRIPTION
Summary: This ensures that we can run benchmarks for many iterations without running into lazy tensor related bugs with SAAS models.

Reviewed By: Balandat

Differential Revision: D41569569

