### PR TITLE
Kill `restore_model_from_generator_run` as it's no longer needed!

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from copy import deepcopy
 
 from logging import Logger
-from typing import Any, Dict, List, Optional, Set, Tuple, Type
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import pandas as pd
 from ax.core.base_trial import BaseTrial, TrialStatus
@@ -29,7 +29,7 @@ from ax.modelbridge.modelbridge_utils import extend_pending_observations
 from ax.modelbridge.registry import _extract_model_state_after_gen, ModelRegistryBase
 from ax.utils.common.base import Base
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
-from ax.utils.common.typeutils import not_none
+from ax.utils.common.typeutils import checked_cast, not_none
 
 logger: Logger = get_logger(__name__)
 
@@ -664,18 +664,35 @@ class GenerationStrategy(Base):
         # Potential solution: store generator runs on `GenerationStep`-s and
         # split them per-model there.
         model_state_on_lgr = {}
+        model_on_curr = self._curr.model
         if (
             lgr is not None
             and lgr._generation_step_index == self._curr.index
             and lgr._model_state_after_gen
-            and self.model
         ):
-            # TODO[drfreund]: Consider moving this to `GenerationStep` or
-            # `GenerationNode`.
-            model_state_on_lgr = _extract_model_state_after_gen(
-                generator_run=lgr,
-                model_class=not_none(self.model).model.__class__,
-            )
+            if self.model or isinstance(model_on_curr, ModelRegistryBase):
+                # TODO[drfreund]: Consider moving this to `GenerationStep` or
+                # `GenerationNode`.
+                model_cls = (
+                    self.model.model.__class__
+                    if self.model is not None
+                    # NOTE: This checked cast is save per the OR-statement in last line
+                    # of the IF-check above.
+                    else checked_cast(ModelRegistryBase, model_on_curr).model_class
+                )
+                model_state_on_lgr = _extract_model_state_after_gen(
+                    generator_run=lgr,
+                    model_class=model_cls,
+                )
+            else:
+                logger.warn(
+                    "While model state after last call to `gen` was recorded on the "
+                    "las generator run produced by this generation strategy, it could"
+                    " not be applied because model for this generation step is defined"
+                    f" via factory function: {self._curr.model}. Generation strategies"
+                    " with factory functions do not support reloading from a stored "
+                    "state."
+                )
 
         if not data.df.empty:
             trial_indices_in_data = sorted(data.df["trial_index"].unique())
@@ -780,19 +797,6 @@ class GenerationStrategy(Base):
             df=passed_in_data.df[
                 passed_in_data.df.trial_index.isin(newly_completed_trials)
             ]
-        )
-
-    def _restore_model_from_generator_run(
-        self, models_enum: Optional[Type[ModelRegistryBase]] = None
-    ) -> None:
-        """Reinstantiates the most recent model on this generation strategy
-        from the last generator run it produced.
-
-        NOTE: Uses model and model bridge kwargs stored on the generator run, as well
-        as the model state attributes stored on the generator run.
-        """
-        self._fit_or_update_current_model(
-            data=self._get_data_for_fit(passed_in_data=None)
         )
 
     # ------------------------- State-tracking helpers. -------------------------

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -221,35 +221,6 @@ class TestGenerationStrategy(TestCase):
         gs3 = gs1.clone_reset()
         self.assertEqual(gs1, gs3)
 
-    def test_restore_from_generator_run(self) -> None:
-        gs = GenerationStrategy(
-            steps=[GenerationStep(model=Models.SOBOL, num_trials=5)]
-        )
-        # No generator runs on GS, so can't restore from one.
-        with self.assertRaises(ValueError):
-            gs._restore_model_from_generator_run()
-        exp = get_branin_experiment(with_batch=True)
-        gs.gen(experiment=exp)
-        model = gs.model
-        # Create a copy of the generation strategy and check that when
-        # we restore from last generator run, the model will be set
-        # correctly and that `_seen_trial_indices_by_status` is filled.
-        new_gs = GenerationStrategy(
-            steps=[GenerationStep(model=Models.SOBOL, num_trials=5)]
-        )
-        new_gs._experiment = exp
-        new_gs._generator_runs = gs._generator_runs
-        self.assertIsNone(new_gs._seen_trial_indices_by_status)
-        new_gs._restore_model_from_generator_run()
-        self.assertEqual(gs._seen_trial_indices_by_status, exp.trial_indices_by_status)
-        # Model should be reset, but it should be the same model with same data.
-        self.assertIsNot(model, new_gs.model)
-        self.assertEqual(model.__class__, new_gs.model.__class__)  # Model bridge.
-        # pyre-fixme[16]: Optional type has no attribute `model`.
-        self.assertEqual(model.model.__class__, new_gs.model.model.__class__)  # Model.
-        # pyre-fixme[16]: Optional type has no attribute `_training_data`.
-        self.assertEqual(model._training_data, new_gs.model._training_data)
-
     def test_min_observed(self) -> None:
         # We should fail to transition the next model if there is not
         # enough data observed.

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -1917,13 +1917,11 @@ class TestAxClient(TestCase):
         gs = ax_client.generation_strategy
         ax_client = AxClient(db_settings=db_settings)
         ax_client.load_experiment_from_database("test_experiment")
-        # Trial #4 was completed after the last time the generation strategy
-        # generated candidates, so pre-save generation strategy was not
-        # "aware" of completion of trial #4. Post-restoration generation
-        # strategy is aware of it, however, since it gets restored with most
-        # up-to-date experiment data. Do adding trial #4 to the seen completed
-        # trials of pre-storage GS to check their equality otherwise.
-        gs._seen_trial_indices_by_status[TrialStatus.COMPLETED].add(4)
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        gs._seen_trial_indices_by_status = None
+        gs._model = None
         self.assertEqual(gs, ax_client.generation_strategy)
         with self.assertRaises(ValueError):
             # Overwriting existing experiment.
@@ -2052,8 +2050,7 @@ class TestAxClient(TestCase):
             ax_client = AxClient.from_json_snapshot(serialized)
             with self.subTest(ax=ax_client, params=params, idx=idx):
                 new_params, new_idx = ax_client.get_next_trial()
-                self.assertEqual(params, new_params)
-                self.assertEqual(idx, new_idx)
+                # Sobol "init_position" setting should be saved on the generator run.
                 self.assertEqual(
                     # pyre-fixme[16]: `BaseTrial` has no attribute `_generator_run`.
                     ax_client.experiment.trials[
@@ -2061,6 +2058,8 @@ class TestAxClient(TestCase):
                     ]._generator_run._model_state_after_gen["init_position"],
                     idx + 1,
                 )
+                self.assertEqual(params, new_params)
+                self.assertEqual(idx, new_idx)
             # pyre-fixme[6]: For 2nd param expected `Union[List[Tuple[Dict[str, Union...
             ax_client.complete_trial(idx, branin(params.get("x"), params.get("y")))
 

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -700,18 +700,7 @@ def generation_strategy_from_json(
         decoder_registry=decoder_registry,
         class_decoder_registry=class_decoder_registry,
     )
-    if generation_strategy_json.pop("had_initialized_model"):  # pragma: no cover
-        # If model in the current step was not directly from the `Models` enum,
-        # pass its type to `restore_model_from_generator_run`, which will then
-        # attempt to use this type to recreate the model.
-        if type(gs._curr.model) != Models:
-            models_enum = type(gs._curr.model)
-            assert issubclass(models_enum, ModelRegistryBase)
-            # pyre-ignore[6]: `models_enum` typing hackiness
-            gs._restore_model_from_generator_run(models_enum=models_enum)
-            return gs
 
-        gs._restore_model_from_generator_run()
     return gs
 
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -373,11 +373,13 @@ class JSONStoreTest(TestCase):
             decoder_registry=CORE_DECODER_REGISTRY,
             class_decoder_registry=CORE_CLASS_DECODER_REGISTRY,
         )
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(generation_strategy, new_generation_strategy)
         self.assertIsInstance(new_generation_strategy._steps[0].model, Models)
-        # Since this GS has now generated one generator run, model should have
-        # been initialized and restored when decoding from JSON.
-        self.assertIsInstance(new_generation_strategy.model, ModelBridge)
 
         # Check that we can encode and decode the generation strategy after
         # it has generated some trials and been updated with some data.
@@ -395,9 +397,13 @@ class JSONStoreTest(TestCase):
             decoder_registry=CORE_DECODER_REGISTRY,
             class_decoder_registry=CORE_CLASS_DECODER_REGISTRY,
         )
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(generation_strategy, new_generation_strategy)
         self.assertIsInstance(new_generation_strategy._steps[0].model, Models)
-        self.assertIsInstance(new_generation_strategy.model, ModelBridge)
 
     def testEncodeDecodeNumpy(self) -> None:
         arr = np.array([[1, 2, 3], [4, 5, 6]])

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -41,7 +41,6 @@ from ax.core.search_space import HierarchicalSearchSpace, RobustSearchSpace, Sea
 from ax.core.trial import Trial
 from ax.exceptions.storage import SQADecodeError
 from ax.modelbridge.generation_strategy import GenerationStrategy
-from ax.modelbridge.registry import ModelRegistryBase, Models
 from ax.storage.json_store.decoder import object_from_json
 from ax.storage.sqa_store.db import session_scope
 from ax.storage.sqa_store.sqa_classes import (
@@ -770,6 +769,7 @@ class Decoder:
                 for gr in gs_sqa.generator_runs
             ]
         gs._experiment = experiment
+
         if len(gs._generator_runs) > 0:
             # Generation strategy had an initialized model.
             if experiment is None:
@@ -777,17 +777,9 @@ class Decoder:
                     "Cannot decode a generation strategy with a non-zero number of "
                     "generator runs without an experiment."
                 )
-            # If model in the current step was not directly from the `Models` enum,
-            # pass its type to `restore_model_from_generator_run`, which will then
-            # attempt to use this type to recreate the model.
-            if type(gs._curr.model) != Models:
-                models_enum = type(gs._curr.model)
-                assert issubclass(models_enum, ModelRegistryBase)
-                # pyre-ignore[6]: `models_enum` typing hackiness
-                gs._restore_model_from_generator_run(models_enum=models_enum)
-            else:
-                gs._restore_model_from_generator_run()
+
         gs.db_id = gs_sqa.id
+
         return gs
 
     def runner_from_sqa(

--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -166,8 +166,10 @@ def object_attribute_dicts_find_unequal_fields(
         elif field == "_model":  # pragma: no cover (tested in modelbridge)
             # TODO[T52643706]: replace with per-`ModelBridge` method like
             # `equivalent_models`, to compare models more meaningfully.
-            if not hasattr(one_val, "model"):
-                equal = not hasattr(other_val, "model")
+            if not hasattr(one_val, "model") or not hasattr(other_val, "model"):
+                equal = not hasattr(other_val, "model") and not hasattr(
+                    other_val, "model"
+                )
             else:
                 # If model bridges have a `model` attribute, the types of the
                 # values of those attributes should be equal if the model


### PR DESCRIPTION
Summary:
NOTE: Copied from D32605396 (too stale to rebase)

Now that we refactored generation strategy to use generation nodes, we no longer need to refit the model on generation strategy re-loading. Instead, we can just fit it next time generation_strategy.gen is called, which is great because re-fitting the model really does not belong in the deserialization call anyway –– it's kind of a big side effect and makes the deserialization heavy and slow...

Differential Revision: D41687258

