### PR TITLE
NotImplementedError for relative objective thresholds in Pareto plots

### DIFF
--- a/ax/plot/pareto_frontier.py
+++ b/ax/plot/pareto_frontier.py
@@ -843,6 +843,13 @@ def _validate_experiment_and_maybe_get_objective_thresholds(
         objective_thresholds = checked_cast(
             MultiObjectiveOptimizationConfig, optimization_config
         ).objective_thresholds
+        if any(
+            ot.relative for ot in objective_thresholds if ot.metric.name in metric_names
+        ):
+            raise NotImplementedError(
+                "Pareto plotting not supported for experiments with relative objective "
+                "thresholds."
+            )
         constraint_metric_names = {
             objective_threshold.metric.name
             for objective_threshold in objective_thresholds

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -209,6 +209,19 @@ class ReportUtilsTest(TestCase):
             ),
         ]
         exp.trials[0].run()
+        with self.assertLogs(logger="ax", level=WARN) as log:
+            plots = get_standard_plots(
+                experiment=exp, model=Models.MOO(experiment=exp, data=exp.fetch_data())
+            )
+            self.assertEqual(len(log.output), 1)
+            self.assertIn(
+                "Pareto plotting not supported for experiments with relative objective "
+                "thresholds.",
+                log.output[0],
+            )
+        self.assertEqual(len(plots), 6)
+        for ot in exp.optimization_config._objective_thresholds:
+            ot.relative = False
         plots = get_standard_plots(
             experiment=exp, model=Models.MOO(experiment=exp, data=exp.fetch_data())
         )


### PR DESCRIPTION
Summary: This is a quick fix so users don't see nonsensical plots (i.e., plots that conflate relative for absolute values).

Differential Revision: D41734958

