### PR TITLE
fix posterior type check for SEBO

### DIFF
--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -220,8 +220,8 @@ class BotorchMOODefaultsTest(TestCase):
             )
 
     @mock.patch(  # pyre-ignore
-        "ax.models.torch.botorch_moo_defaults.checked_cast",
-        wraps=lambda x, y: y,
+        "ax.models.torch.botorch_moo_defaults._check_posterior_type",
+        wraps=lambda y: y,
     )
     def test_get_ehvi(self, _) -> None:
         weights = torch.tensor([0.0, 1.0, 1.0])
@@ -269,8 +269,8 @@ class BotorchMOODefaultsTest(TestCase):
 
     # test infer objective thresholds alone
     @mock.patch(  # pyre-ignore
-        "ax.models.torch.botorch_moo_defaults.checked_cast",
-        wraps=lambda x, y: y,
+        "ax.models.torch.botorch_moo_defaults._check_posterior_type",
+        wraps=lambda y: y,
     )
     def test_infer_objective_thresholds(self, _, cuda: bool = False) -> None:
         for dtype in (torch.float, torch.double):

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -449,8 +449,8 @@ class BotorchMOOModelTest(TestCase):
             )
             es.enter_context(
                 mock.patch(
-                    "ax.models.torch.botorch_moo_defaults.checked_cast",
-                    wraps=lambda x, y: y,
+                    "ax.models.torch.botorch_moo_defaults._check_posterior_type",
+                    wraps=lambda y: y,
                 )
             )
             _mock_model_infer_objective_thresholds = es.enter_context(

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -514,8 +514,8 @@ class AcquisitionTest(TestCase):
         mock_evaluate.assert_called_with(X=self.X)
 
     @mock.patch(  # pyre-ignore
-        "ax.models.torch.botorch_moo_defaults.checked_cast",
-        wraps=lambda x, y: y,
+        "ax.models.torch.botorch_moo_defaults._check_posterior_type",
+        wraps=lambda y: y,
     )
     @mock.patch(f"{ACQUISITION_PATH}._get_X_pending_and_observed")
     def test_init_moo(


### PR DESCRIPTION
Summary: The check of posterior type in  `MultiObjectiveBotorchModel` breaks the SEBO-L0/L1's candidate generation, because this model includes the DeterministicMetric and the posterior type is `PosteriorList`.  The fix adds  `PosteriorList` into posterior type check.

Reviewed By: saitcakmak

Differential Revision: D41831762

