### PR TITLE
Fix logging in Result fetching

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1702,5 +1702,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         trial: BaseTrial,
         metric_name: Optional[str] = None,
         metric_fetch_e: Optional[MetricFetchE] = None,
-    ) -> None:
+    ) -> TrialStatus:
         trial.mark_failed(unsafe=True)
+
+        return TrialStatus.FAILED

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -1175,4 +1175,11 @@ class TestAxScheduler(TestCase):
                     for warning in lg.output
                 )
             )
+            self.assertTrue(
+                any(
+                    "Because branin is an objective, marking trial 0 as "
+                    "TrialStatus.FAILED" in warning
+                    for warning in lg.output
+                )
+            )
             self.assertEqual(scheduler.experiment.trials[0].status, TrialStatus.FAILED)


### PR DESCRIPTION
Summary: Was logging `Marking trial ... as None` before because we forgot a return on `_mark_err_trial_status`

Reviewed By: saitcakmak

Differential Revision: D41856235

