### PR TITLE
Mock SQLAlchemy imports when using autodoc

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -254,7 +254,7 @@ set_type_checking_flag = True
 # class (with same table) multiple times through autodocs
 # Also mock Pandas to avoid circular imports due to TYPE_CHECKING = True
 autodoc_mock_imports = [
-    "sqlalchemy.ext.declarative",
+    "sqlalchemy",
     "pandas",
     "__test_modules__",
 ]


### PR DESCRIPTION
Fixes #1319 

When docs are built, we import decorated functions that call SQLAlchemy code. Since decorators are evaluated at import time, this code is executed even when importing modules for the purposes of building documentation. For reasons I don't fully understand, this isn't working (see #1319 ). However, mocking SQLAlchemy imports seems to fix the problem.

Test plan:
[ ] Make sure `make_docs` runs without so many errors on this PR (there will still be some)
[x] Build the website locally and make sure that the documentation that was missing before has reappeared

<img width="920" alt="image" src="https://user-images.githubusercontent.com/9137425/207723807-bf71a75b-eb9b-4b16-9334-28da3a2c8733.png">
