### PR TITLE
Use Ax plotting functions instead of Plotly in the Scheduler tutorial

### DIFF
--- a/tutorials/scheduler.ipynb
+++ b/tutorials/scheduler.ipynb
@@ -421,7 +421,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4C. Optional: Defining a plotting function and a callback to update plots during optimization"
+    "### 4C. Optional: Defining a plotting function"
    ]
   },
   {
@@ -430,16 +430,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ax.service.utils.report_utils import get_figure_and_callback, get_standard_plots\n",
+    "import numpy as np\n",
+    "from ax.plot.trace import optimization_trace_single_method\n",
+    "from ax.utils.notebook.plotting import render, init_notebook_plotting\n",
+    "\n",
+    "init_notebook_plotting()\n",
     "\n",
     "\n",
-    "def make_plot(scheduler: Scheduler):\n",
-    "    standard_plots = get_standard_plots(scheduler.experiment, None)\n",
-    "    if len(standard_plots) == 0:\n",
-    "        raise RuntimeError(\"Nothing to plot.\")\n",
-    "    return standard_plots[0]\n",
-    "\n",
-    "fig, callback = get_figure_and_callback(make_plot)"
+    "def get_plot():\n",
+    "    best_objectives = np.array(\n",
+    "        [[trial.objective_mean for trial in scheduler.experiment.trials.values()]]\n",
+    "    )\n",
+    "    best_objective_plot = optimization_trace_single_method(\n",
+    "        y=np.minimum.accumulate(best_objectives, axis=1),\n",
+    "        title=\"Model performance vs. # of iterations\",\n",
+    "        ylabel=\"Y\",\n",
+    "    )\n",
+    "    return best_objective_plot"
    ]
   },
   {
@@ -460,8 +467,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(fig)\n",
-    "scheduler.run_n_trials(max_trials=3, idle_callback=callback)"
+    "scheduler.run_n_trials(max_trials=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_objective_plot = get_plot()\n",
+    "render(best_objective_plot)"
    ]
   },
   {
@@ -512,11 +528,17 @@
    },
    "outputs": [],
    "source": [
-    "# create a new figure to prevent overwriting the first one\n",
-    "# this isn't necessary if you just care about the final results\n",
-    "second_fig, callback = get_figure_and_callback(make_plot)\n",
-    "display(second_fig)\n",
-    "scheduler.run_n_trials(max_trials=3, idle_callback=callback)"
+    "scheduler.run_n_trials(max_trials=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_objective_plot = get_plot()\n",
+    "render(best_objective_plot)"
    ]
   },
   {
@@ -564,9 +586,17 @@
    },
    "outputs": [],
    "source": [
-    "third_fig, callback = get_figure_and_callback(make_plot)\n",
-    "display(third_fig)\n",
-    "scheduler.run_n_trials(max_trials=3, timeout_hours=0.00001, idle_callback=callback)"
+    "scheduler.run_n_trials(max_trials=3, timeout_hours=0.00001)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_objective_plot = get_plot()\n",
+    "render(best_objective_plot)"
    ]
   },
   {


### PR DESCRIPTION
Figures in the scheduler tutorial are not showing up because Plotly figures don't just automatically render properly with html. Instead we need to use the plotting functionality in Ax written for this.

Currently on the website on v:latest (stable is even more broken):
![image](https://user-images.githubusercontent.com/9137425/207741241-aaecd6a3-80f4-47a6-8d15-fb3cce8cc440.png)

After this fix:
![image](https://user-images.githubusercontent.com/9137425/207898976-2eefb6c5-a563-47da-81b3-e15a4d0c456d.png)
