### PR TITLE
cast objective constraint bound to float before comparison

### DIFF
--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -6,6 +6,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import torch
+
 from ax.core.arm import Arm
 from ax.core.generator_run import GeneratorRun
 from ax.core.objective import ScalarizedObjective
@@ -130,6 +132,15 @@ class TestBestPointUtils(TestCase):
             constrained=True,
             minimize=False,
         )
+        _, best_prediction = not_none(get_best_parameters(exp, Models))
+        best_metrics = not_none(best_prediction)[0]
+        self.assertDictEqual(best_metrics, {"m1": 3.0, "m2": 4.0})
+
+        # Tensor bounds are accepted.
+        constraint = not_none(exp.optimization_config).all_constraints[0]
+        # pyre-fixme[8]: Attribute `bound` declared in class `OutcomeConstraint`
+        # has type `float` but is used as type `Tensor`.
+        constraint.bound = torch.tensor(constraint.bound)
         _, best_prediction = not_none(get_best_parameters(exp, Models))
         best_metrics = not_none(best_prediction)[0]
         self.assertDictEqual(best_metrics, {"m1": 3.0, "m2": 4.0})

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -701,9 +701,9 @@ def _is_row_feasible(
         # Return True if metrics are different, or whether the confidence
         # interval is entirely not within the bound
         if oc.op == ComparisonOp.GEQ:
-            return ~name_match_mask | (observed_upper_bound > oc.bound)
+            return ~name_match_mask | (observed_upper_bound > float(oc.bound))
         else:
-            return ~name_match_mask | (observed_lower_bound < oc.bound)
+            return ~name_match_mask | (observed_lower_bound < float(oc.bound))
 
     mask = reduce(
         lambda left, right: left & right,


### PR DESCRIPTION
Summary: Constraint bounds can be of type tensor (e.g. in the [OSS MOO tutorial](https://ax.dev/versions/latest/tutorials/multiobjective_optimization.html)), which produces [an error](https://github.com/facebook/Ax/actions/runs/3737655087/jobs/6343042139) prior to this diff.

Reviewed By: lena-kashtelyan

Differential Revision: D42171519

