### PR TITLE
Make evaluation metadata accept iso formatted dates instead of ints in ms

### DIFF
--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -151,21 +151,41 @@ class DataTest(TestCase):
         with self.assertRaises(ValueError):
             Data(df=pd.DataFrame([data_entry2]))
 
-    def testFromEvaluations(self) -> None:
+    def testFromEvaluationsIsoFormat(self) -> None:
+        now = pd.Timestamp.now()
+        day = now.day
         for sem in (0.5, None):
             eval1 = (3.7, sem) if sem is not None else 3.7
             data = Data.from_evaluations(
                 evaluations={"0_1": {"b": eval1}},
                 trial_index=0,
                 sample_sizes={"0_1": 2},
-                start_time=current_timestamp_in_millis(),
-                end_time=current_timestamp_in_millis(),
+                start_time=now.isoformat(),
+                end_time=now.isoformat(),
             )
             self.assertEqual(data.df["sem"].isnull()[0], sem is None)
             self.assertEqual(len(data.df), 1)
             self.assertNotEqual(data, Data(self.df))
-            self.assertIn("start_time", data.df)
-            self.assertIn("end_time", data.df)
+            self.assertEqual(data.df["start_time"][0].day, day)
+            self.assertEqual(data.df["end_time"][0].day, day)
+
+    def testFromEvaluationsMillisecondFormat(self) -> None:
+        now_ms = current_timestamp_in_millis()
+        day = pd.Timestamp(now_ms, unit="ms").day
+        for sem in (0.5, None):
+            eval1 = (3.7, sem) if sem is not None else 3.7
+            data = Data.from_evaluations(
+                evaluations={"0_1": {"b": eval1}},
+                trial_index=0,
+                sample_sizes={"0_1": 2},
+                start_time=now_ms,
+                end_time=now_ms,
+            )
+            self.assertEqual(data.df["sem"].isnull()[0], sem is None)
+            self.assertEqual(len(data.df), 1)
+            self.assertNotEqual(data, Data(self.df))
+            self.assertEqual(data.df["start_time"][0].day, day)
+            self.assertEqual(data.df["end_time"][0].day, day)
 
     def testFromFidelityEvaluations(self) -> None:
         for sem in (0.5, None):

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -88,12 +88,7 @@ from ax.storage.json_store.registry import (
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.executils import retry_on_exception
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
-from ax.utils.common.typeutils import (
-    checked_cast,
-    checked_cast_complex,
-    checked_cast_optional,
-    not_none,
-)
+from ax.utils.common.typeutils import checked_cast, checked_cast_complex, not_none
 from botorch.utils.sampling import manual_seed
 
 logger: Logger = get_logger(__name__)
@@ -1792,22 +1787,15 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
                 a batched trial or a 1-arm trial.
         """
         raw_data_by_arm = self._raw_data_by_arm(trial=trial, raw_data=raw_data)
+        metadata = metadata if metadata is not None else {}
 
         evaluations, data = self.data_and_evaluations_from_raw_data(
             raw_data=raw_data_by_arm,
             metric_names=list(self.metric_names),
             trial_index=trial.index,
             sample_sizes=sample_sizes or {},
-            start_time=(
-                checked_cast_optional(int, metadata.get("start_time"))
-                if metadata is not None
-                else None
-            ),
-            end_time=(
-                checked_cast_optional(int, metadata.get("end_time"))
-                if metadata is not None
-                else None
-            ),
+            start_time=metadata.get("start_time"),
+            end_time=metadata.get("end_time"),
         )
         return evaluations, data
 

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -895,8 +895,6 @@ class InstantiationBase:
     def raw_data_to_evaluation(
         raw_data: TEvaluationOutcome,
         metric_names: List[str],
-        start_time: Optional[int] = None,
-        end_time: Optional[int] = None,
     ) -> TEvaluationOutcome:
         """Format the trial evaluation data to a standard `TTrialEvaluation`
         (mapping from metric names to a tuple of mean and SEM) representation, or
@@ -945,8 +943,8 @@ class InstantiationBase:
         metric_names: List[str],
         trial_index: int,
         sample_sizes: Dict[str, int],
-        start_time: Optional[int] = None,
-        end_time: Optional[int] = None,
+        start_time: Optional[Union[int, str]] = None,
+        end_time: Optional[Union[int, str]] = None,
     ) -> Tuple[Dict[str, TEvaluationOutcome], Data]:
         """Transforms evaluations into Ax Data.
 
@@ -961,16 +959,18 @@ class InstantiationBase:
             sample_sizes: Number of samples collected for each arm, may be empty
                 if unavailable.
             start_time: Optional start time of run of the trial that produced this
-                data, in milliseconds.
+                data, in milliseconds or iso format.  Milliseconds will eventually be
+                converted to iso format because iso format automatically works with the
+                pandas column type `Timestamp`.
             end_time: Optional end time of run of the trial that produced this
-                data, in milliseconds.
+                data, in milliseconds or iso format.  Milliseconds will eventually be
+                converted to iso format because iso format automatically works with the
+                pandas column type `Timestamp`.
         """
         evaluations = {
             arm_name: cls.raw_data_to_evaluation(
                 raw_data=raw_data[arm_name],
                 metric_names=metric_names,
-                start_time=start_time,
-                end_time=end_time,
             )
             for arm_name in raw_data
         }


### PR DESCRIPTION
Summary: Because ints in ms don't work with pd.Timestamp, which the models ultimately need (https://fburl.com/code/ci5ji3kr) and which render in data

Differential Revision: D42050451

