### PR TITLE
Lower bound noise in SaasPyroModel

### DIFF
--- a/ax/models/torch/fully_bayesian.py
+++ b/ax/models/torch/fully_bayesian.py
@@ -209,7 +209,7 @@ def single_task_pyro_model(
     mean = pyro_sample_mean(**tkwargs)
     if torch.isnan(Yvar).all():
         # infer noise level
-        noise = pyro_sample_noise(**tkwargs)
+        noise = MIN_OBSERVED_NOISE_LEVEL + pyro_sample_noise(**tkwargs)
     else:
         noise = Yvar.clamp_min(MIN_OBSERVED_NOISE_LEVEL)
     # pyre-fixme[6]: For 2nd param expected `float` but got `Union[device, dtype]`.


### PR DESCRIPTION
Summary: Inspecting some models where we get the Cholesky errors, I found that the noise is around 1e-14 - 1e-15, which is very small. Adding a lower bound to the noise seems to let the model fit without errors.

Reviewed By: dme65

Differential Revision: D42177954

