### PR TITLE
Fix equality check for np arrays with NaNs

### DIFF
--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -183,7 +183,7 @@ def object_attribute_dicts_find_unequal_fields(
                 list(one_val.values()), list(other_val.values())
             )
         elif isinstance(one_val, np.ndarray):
-            equal = np.array_equal(one_val, other_val)
+            equal = np.array_equal(one_val, other_val, equal_nan=True)
         elif isinstance(one_val, datetime):
             equal = datetime_equals(one_val, other_val)
         elif isinstance(one_val, float):


### PR DESCRIPTION
Summary: Prior to this change, having NaN in a field would lead to the equality check failing. This is a real issue with observation data with multi-objective as the non-diagonal entries of covariance matrix get populated with NaNs.

Differential Revision: D42254565

