### PR TITLE
Make it possible to infer noise

### DIFF
--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -25,7 +25,10 @@ except ModuleNotFoundError:
 class PyTorchCNNTorchvisionBenchmarkProblem(PyTorchCNNBenchmarkProblem):
     @classmethod
     def from_dataset_name(
-        cls, name: str, num_trials: int
+        cls,
+        name: str,
+        num_trials: int,
+        infer_noise: bool = True,
     ) -> "PyTorchCNNTorchvisionBenchmarkProblem":
         if name not in _REGISTRY:
             raise UserInputError(
@@ -49,7 +52,11 @@ class PyTorchCNNTorchvisionBenchmarkProblem(PyTorchCNNBenchmarkProblem):
         )
 
         problem = cls.from_datasets(
-            name=name, num_trials=num_trials, train_set=train_set, test_set=test_set
+            name=name,
+            num_trials=num_trials,
+            train_set=train_set,
+            test_set=test_set,
+            infer_noise=infer_noise,
         )
         runner = PyTorchCNNTorchvisionRunner(
             name=name, train_set=train_set, test_set=test_set
@@ -61,6 +68,7 @@ class PyTorchCNNTorchvisionBenchmarkProblem(PyTorchCNNBenchmarkProblem):
             optimization_config=problem.optimization_config,
             runner=runner,
             num_trials=num_trials,
+            infer_noise=infer_noise,
             optimal_value=problem.optimal_value,
         )
 

--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -31,6 +31,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
             "test_problem_class": Ackley,
             "test_problem_kwargs": {},
             "num_trials": 50,
+            "infer_noise": True,
         },
     ),
     "branin": BenchmarkProblemRegistryEntry(
@@ -39,6 +40,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
             "test_problem_class": Branin,
             "test_problem_kwargs": {},
             "num_trials": 30,
+            "infer_noise": True,
         },
     ),
     "branin_currin": BenchmarkProblemRegistryEntry(
@@ -47,12 +49,16 @@ BENCHMARK_PROBLEM_REGISTRY = {
             "test_problem_class": BraninCurrin,
             "test_problem_kwargs": {},
             "num_trials": 30,
+            "infer_noise": True,
         },
     ),
     "branin_currin30": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n: embed_higher_dimension(
             problem=MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
-                test_problem_class=BraninCurrin, test_problem_kwargs={}, num_trials=100
+                test_problem_class=BraninCurrin,
+                test_problem_kwargs={},
+                num_trials=100,
+                infer_noise=True,
             ),
             total_dimensionality=n,
         ),
@@ -64,6 +70,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
             "test_problem_class": Hartmann,
             "test_problem_kwargs": {"dim": 6},
             "num_trials": 50,
+            "infer_noise": True,
         },
     ),
     "hartmann30": BenchmarkProblemRegistryEntry(
@@ -72,6 +79,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
                 test_problem_class=Hartmann,
                 test_problem_kwargs={"dim": 6},
                 num_trials=100,
+                infer_noise=True,
             ),
             total_dimensionality=n,
         ),
@@ -79,15 +87,15 @@ BENCHMARK_PROBLEM_REGISTRY = {
     ),
     "hpo_pytorch_cnn_MNIST": BenchmarkProblemRegistryEntry(
         factory_fn=PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name,
-        factory_kwargs={"name": "MNIST", "num_trials": 50},
+        factory_kwargs={"name": "MNIST", "num_trials": 50, "infer_noise": True},
     ),
     "hpo_pytorch_cnn_FashionMNIST": BenchmarkProblemRegistryEntry(
         factory_fn=PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name,
-        factory_kwargs={"name": "FashionMNIST", "num_trials": 50},
+        factory_kwargs={"name": "FashionMNIST", "num_trials": 50, "infer_noise": True},
     ),
     "jenatton": BenchmarkProblemRegistryEntry(
         factory_fn=get_jenatton_benchmark_problem,
-        factory_kwargs={"num_trials": 50},
+        factory_kwargs={"num_trials": 50, "infer_noise": True},
     ),
     "powell": BenchmarkProblemRegistryEntry(
         factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
@@ -95,7 +103,64 @@ BENCHMARK_PROBLEM_REGISTRY = {
             "test_problem_class": Powell,
             "test_problem_kwargs": {},
             "num_trials": 50,
+            "infer_noise": True,
         },
+    ),
+    # Problems without inferred noise
+    "branin_fixed_noise": BenchmarkProblemRegistryEntry(
+        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_kwargs={
+            "test_problem_class": Branin,
+            "test_problem_kwargs": {},
+            "num_trials": 30,
+            "infer_noise": False,
+        },
+    ),
+    "branin_currin_fixed_noise": BenchmarkProblemRegistryEntry(
+        factory_fn=MultiObjectiveBenchmarkProblem.from_botorch_multi_objective,
+        factory_kwargs={
+            "test_problem_class": BraninCurrin,
+            "test_problem_kwargs": {},
+            "num_trials": 30,
+            "infer_noise": False,
+        },
+    ),
+    "branin_currin30_fixed_noise": BenchmarkProblemRegistryEntry(
+        factory_fn=lambda n: embed_higher_dimension(
+            problem=MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
+                test_problem_class=BraninCurrin,
+                test_problem_kwargs={},
+                num_trials=100,
+                infer_noise=False,
+            ),
+            total_dimensionality=n,
+        ),
+        factory_kwargs={"n": 30},
+    ),
+    "hartmann6_fixed_noise": BenchmarkProblemRegistryEntry(
+        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_kwargs={
+            "test_problem_class": Hartmann,
+            "test_problem_kwargs": {"dim": 6},
+            "num_trials": 50,
+            "infer_noise": False,
+        },
+    ),
+    "hartmann30_fixed_noise": BenchmarkProblemRegistryEntry(
+        factory_fn=lambda n: embed_higher_dimension(
+            problem=SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
+                test_problem_class=Hartmann,
+                test_problem_kwargs={"dim": 6},
+                num_trials=100,
+                infer_noise=False,
+            ),
+            total_dimensionality=n,
+        ),
+        factory_kwargs={"n": 30},
+    ),
+    "jenatton_fixed_noise": BenchmarkProblemRegistryEntry(
+        factory_fn=get_jenatton_benchmark_problem,
+        factory_kwargs={"num_trials": 50, "infer_noise": False},
     ),
 }
 

--- a/ax/benchmark/problems/surrogate.py
+++ b/ax/benchmark/problems/surrogate.py
@@ -5,8 +5,6 @@
 
 from typing import Any, Dict, Iterable, List, Set
 
-import numpy as np
-
 import pandas as pd
 import torch
 from ax.benchmark.benchmark_problem import SingleObjectiveBenchmarkProblem
@@ -45,6 +43,7 @@ class SurrogateBenchmarkProblem(SingleObjectiveBenchmarkProblem):
         minimize: bool,
         optimal_value: float,
         num_trials: int,
+        infer_noise: bool = True,
     ) -> "SurrogateBenchmarkProblem":
         return SurrogateBenchmarkProblem(
             name=name,
@@ -63,12 +62,14 @@ class SurrogateBenchmarkProblem(SingleObjectiveBenchmarkProblem):
             ),
             optimal_value=optimal_value,
             num_trials=num_trials,
+            infer_noise=infer_noise,
         )
 
 
 class SurrogateMetric(Metric):
-    def __init__(self) -> None:
+    def __init__(self, infer_noise: bool = True) -> None:
         super().__init__(name="prediction")
+        self.infer_noise = infer_noise
 
     # pyre-fixme[2]: Parameter must be annotated.
     def fetch_trial_data(self, trial: BaseTrial, **kwargs) -> MetricFetchResult:
@@ -82,7 +83,7 @@ class SurrogateMetric(Metric):
                     "arm_name": [name for name, _ in trial.arms_by_name.items()],
                     "metric_name": self.name,
                     "mean": prediction,
-                    "sem": np.nan,
+                    "sem": None if self.infer_noise else 0,
                     "trial_index": trial.index,
                 }
             )

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -14,6 +14,7 @@ from ax.runners.synthetic import SyntheticRunner
 
 def get_jenatton_benchmark_problem(
     num_trials: int = 50,
+    infer_noise: bool = True,
 ) -> SingleObjectiveBenchmarkProblem:
     search_space = HierarchicalSearchSpace(
         parameters=[
@@ -54,7 +55,9 @@ def get_jenatton_benchmark_problem(
     )
 
     optimization_config = OptimizationConfig(
-        objective=Objective(metric=JenattonMetric(), minimize=True)
+        objective=Objective(
+            metric=JenattonMetric(infer_noise=infer_noise), minimize=True
+        )
     )
 
     return SingleObjectiveBenchmarkProblem(
@@ -63,5 +66,6 @@ def get_jenatton_benchmark_problem(
         optimization_config=optimization_config,
         runner=SyntheticRunner(),
         num_trials=num_trials,
+        infer_noise=infer_noise,
         optimal_value=0.1,
     )

--- a/ax/metrics/botorch_test_problem.py
+++ b/ax/metrics/botorch_test_problem.py
@@ -19,7 +19,9 @@ class BotorchTestProblemMetric(Metric):
     proper value from the resulting tensor given its index.
     """
 
-    def __init__(self, name: str, noise_sd: float, index: Optional[int] = None) -> None:
+    def __init__(
+        self, name: str, noise_sd: Optional[float] = None, index: Optional[int] = None
+    ) -> None:
         super().__init__(name=name)
         self.noise_sd = noise_sd
         self.index = index

--- a/ax/metrics/jenatton.py
+++ b/ax/metrics/jenatton.py
@@ -17,8 +17,10 @@ class JenattonMetric(Metric):
     def __init__(
         self,
         name: str = "jenatton",
+        infer_noise: bool = True,
     ) -> None:
         super().__init__(name=name)
+        self.infer_noise = infer_noise
 
     @staticmethod
     def _f(
@@ -52,7 +54,7 @@ class JenattonMetric(Metric):
                     "arm_name": [name for name, _ in trial.arms_by_name.items()],
                     "metric_name": self.name,
                     "mean": mean,
-                    "sem": 0,
+                    "sem": None if self.infer_noise else 0,
                     "trial_index": trial.index,
                 }
             )

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -205,7 +205,9 @@ def object_from_json(
             )
         elif _class == TorchvisionBenchmarkProblem:
             return TorchvisionBenchmarkProblem.from_dataset_name(  # pragma: no cover
-                name=object_json["name"], num_trials=object_json["num_trials"]
+                name=object_json["name"],
+                num_trials=object_json["num_trials"],
+                infer_noise=object_json["infer_noise"],
             )
         elif issubclass(_class, SerializationMixin):
             return _class(**_class.deserialize_init_args(args=object_json))

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -575,6 +575,7 @@ def pytorch_cnn_torchvision_benchmark_problem_to_dict(
         "__type": problem.__class__.__name__,
         "name": not_none(re.compile("(?<=::).*").search(problem.name)).group(),
         "num_trials": problem.num_trials,
+        "infer_noise": problem.infer_noise,
     }
 
 

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -19,7 +19,7 @@ from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.service.scheduler import SchedulerOptions
 from ax.utils.common.constants import Keys
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
-from botorch.models.gp_regression import FixedNoiseGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.test_functions.multi_objective import BraninCurrin
 from botorch.test_functions.synthetic import Branin
 
@@ -66,7 +66,7 @@ def get_sobol_gpei_benchmark_method() -> BenchmarkMethod:
                     model=Models.BOTORCH_MODULAR,
                     num_trials=-1,
                     model_kwargs={
-                        "surrogate": Surrogate(FixedNoiseGP),
+                        "surrogate": Surrogate(SingleTaskGP),
                         "botorch_acqf_class": qNoisyExpectedImprovement,
                     },
                     model_gen_kwargs={


### PR DESCRIPTION
Summary: We currently set the noise to 0 for all benchmark problems even though we often infer the noise in practice. This diff adds an `infer_noise` flag that we can use to control whether different problems should set the noise to a fixed value or `None`, where the latter will trigger inferring the noise in the model. I'm setting `infer_noise=True` by default for all problems.

Reviewed By: Balandat

Differential Revision: D39413742

