### PR TITLE
Add timeout ability to gen_* functions (#1562)

### DIFF
--- a/ax/utils/testing/mock.py
+++ b/ax/utils/testing/mock.py
@@ -8,11 +8,12 @@ from functools import wraps
 from typing import Callable, Generator
 from unittest import mock
 
+from botorch.generation.gen import minimize_with_timeout
+
 from botorch.optim.initializers import (
     gen_batch_initial_conditions,
     gen_one_shot_kg_initial_conditions,
 )
-from scipy.optimize import minimize
 
 
 @contextmanager
@@ -29,7 +30,7 @@ def fast_botorch_optimize_context_manager() -> Generator[None, None, None]:
             kwargs["options"] = {}
 
         kwargs["options"]["maxiter"] = 1
-        return minimize(*args, **kwargs)
+        return minimize_with_timeout(*args, **kwargs)
 
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
@@ -50,7 +51,7 @@ def fast_botorch_optimize_context_manager() -> Generator[None, None, None]:
     with ExitStack() as es:
         mock_generation = es.enter_context(
             mock.patch(
-                "botorch.generation.gen.minimize",
+                "botorch.generation.gen.minimize_with_timeout",
                 wraps=one_iteration_minimize,
             )
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/1562

Exposes the ability to pass a `timeout_sec` kwarg to `gen_candidates_scipy` and `gen_candidates_torch` that allows to stop the optimization after running for more than `timeout_sec` seconds.

Reviewed By: esantorella

Differential Revision: D42024857

