### PR TITLE
Expose timeout option in higher-level optimziation wrappers (#1598)

### DIFF
--- a/ax/utils/testing/mock.py
+++ b/ax/utils/testing/mock.py
@@ -58,7 +58,7 @@ def fast_botorch_optimize_context_manager() -> Generator[None, None, None]:
 
         mock_fit = es.enter_context(
             mock.patch(
-                "botorch.optim.core.minimize",
+                "botorch.optim.core.minimize_with_timeout",
                 wraps=one_iteration_minimize,
             )
         )


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/1598

Now that we have the ability to time out the optimization in `scipy.optimize.minimize` at a lower-level, we can expose it also in the higher-level optimization wrappers.

Reviewed By: esantorella

Differential Revision: D42254406

