### PR TITLE
Update single_task_pyro_model to not use _psd_safe_pyro_mvn_sample

### DIFF
--- a/ax/models/torch/fully_bayesian_model_utils.py
+++ b/ax/models/torch/fully_bayesian_model_utils.py
@@ -5,7 +5,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple
 
-import pyro  # @manual=fbsource//third-party/pypi/pyro-ppl:pyro-ppl
+import pyro
 import torch
 from ax.models.torch.botorch_defaults import _get_model
 from botorch.models.gp_regression import MIN_INFERRED_NOISE_LEVEL


### PR DESCRIPTION
Summary: This method was removed in D42159791 since it's not necessary anymore (see that diff for details).

Differential Revision: D42336304

