### PR TITLE
Fix MBM tutorial on website

### DIFF
--- a/tutorials/modular_botax.ipynb
+++ b/tutorials/modular_botax.ipynb
@@ -14,7 +14,6 @@
     "# Ax wrappers for BoTorch components\n",
     "from ax.models.torch.botorch_modular.model import BoTorchModel\n",
     "from ax.models.torch.botorch_modular.surrogate import Surrogate\n",
-    "from ax.models.torch.botorch_modular.list_surrogate import ListSurrogate\n",
     "from ax.models.torch.botorch_modular.acquisition import Acquisition\n",
     "\n",
     "# Ax data tranformation layer\n",
@@ -348,7 +347,7 @@
    },
    "source": [
     "### 3a. Making a `Surrogate` from BoTorch `Model`:\n",
-    "Most models should work with base `Surrogate` in Ax, except for BoTorch `ModelListGP`, which works with `ListSurrogate`. `ModelListGP` is a special case because its purpose is to combine multiple sub-models into a single `Model` in BoTorch. It is most commonly used for multi-objective and constrained optimization.\n",
+    "Most models should work with base `Surrogate` in Ax, except for BoTorch `ModelListGP`. `ModelListGP` is a special case because its purpose is to combine multiple sub-models into a single `Model` in BoTorch. It is most commonly used for multi-objective and constrained optimization. Whether or not `ModelListGP` is used is determined automatically based on the `Model` class and the data being used via the `ax.models.torch.botorch_modular.utils.use_model_list` function.\n",
     "\n",
     "If your `Model` is not a `ModelListGP`, the steps to set it up as a `Surrogate` are:\n",
     "1. Implement a [`construct_inputs` class method](https://github.com/pytorch/botorch/blob/main/botorch/models/model.py#L143). The purpose of this method is to produce arguments to a particular model from a standardized set of inputs passed to BoTorch `Model`-s from [`Surrogate.construct`](https://github.com/facebook/Ax/blob/main/ax/models/torch/botorch_modular/surrogate.py#L148) in Ax. It should accept training data in form of a `SupervisedDataset` container and optionally other keyword arguments and produce a dictionary of arguments to `__init__` of the `Model`. See [`SingleTaskMultiFidelityGP.construct_inputs`](https://github.com/pytorch/botorch/blob/5b3172f3daa22f6ea2f6f4d1d0a378a9518dcd8d/botorch/models/gp_regression_fidelity.py#L131) for an example.\n",
@@ -388,54 +387,6 @@
     "    botorch_model_class=MyModelClass,  # Must implement `construct_inputs`\n",
     "    # Optional dict of additional keyword arguments to `MyModelClass`\n",
     "    model_options={},\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "professional-welcome",
-   "metadata": {
-    "originalKey": "74b44b1f-fd2f-4a5a-a643-50c3a553f0c7"
-   },
-   "source": [
-    "For a `ModelListGP`, the setup is similar, except that the surrogate is defined in terms of sub-models rather than one model. Both of the following options will work:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "liberal-surveillance",
-   "metadata": {
-    "originalKey": "ed49dbd9-6065-4bee-9240-71fa374172bc"
-   },
-   "outputs": [],
-   "source": [
-    "class MyOtherModelClass(MyModelClass):\n",
-    "    pass\n",
-    "\n",
-    "surrogate = ListSurrogate(\n",
-    "    botorch_submodel_class_per_outcome={\n",
-    "        \"metric_a\": MyModelClass, \n",
-    "        \"metric_b\": MyOtherModelClass,\n",
-    "    },\n",
-    "    submodel_options_per_outcome={\"metric_a\": {}, \"metric_b\": {}},\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "sunrise-weekend",
-   "metadata": {
-    "originalKey": "1f3e14c4-7774-4c3e-9af1-3f1b3e258def"
-   },
-   "outputs": [],
-   "source": [
-    "surrogate = ListSurrogate(\n",
-    "    # Shortcut if all submodels are the same type\n",
-    "    botorch_submodel_class=MyModelClass,\n",
-    "    # Shortcut if all submodel options are the same\n",
-    "    submodel_options={},\n",
     ")"
    ]
   },
@@ -1182,7 +1133,7 @@
    "source": [
     "## 6. Customizing a `Surrogate` or `Acquisition`\n",
     "\n",
-    "We expect the base `Surrogate`, `ListSurrogate`, and `Acquisition` classes to work with most BoTorch components, but there could be a case where you would need to subclass one of aforementioned abstractions to handle a given BoTorch component. If you run into a case like this, feel free to open an issue on our [Github issues page](https://github.com/facebook/Ax/issues) –– it would be very useful for us to know \n",
+    "We expect the base `Surrogate` and `Acquisition` classes to work with most BoTorch components, but there could be a case where you would need to subclass one of aforementioned abstractions to handle a given BoTorch component. If you run into a case like this, feel free to open an issue on our [Github issues page](https://github.com/facebook/Ax/issues) –– it would be very useful for us to know \n",
     "\n",
     "One such example would be a need for a custom `AcquisitionObjective` or for a custom acquisition function optimization utility. To subclass `Acquisition` accordingly, one would override the `get_botorch_objective` method:"
    ]


### PR DESCRIPTION
Summary:
The recent MBM refactor that deprecated ListSurrogate broke OSS tutorials.

This whole tutorial should be updated to reflect the new abilities of the MBM stack. I will file a follow up task, but this fix should get out ASAP.

Differential Revision: D42386836

