### PR TITLE
Always clear "data/MNIST/raw" in test tearDowns

### DIFF
--- a/ax/benchmark/tests/test_problem_storage.py
+++ b/ax/benchmark/tests/test_problem_storage.py
@@ -3,9 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import glob
-import os
-
 from ax.benchmark.problems.hpo.torchvision import PyTorchCNNTorchvisionBenchmarkProblem
 from ax.storage.json_store.decoder import object_from_json
 from ax.storage.json_store.encoder import object_to_json
@@ -13,14 +10,6 @@ from ax.utils.common.testutils import TestCase
 
 
 class TestProblems(TestCase):
-    def tearDown(self) -> None:
-        mnist_dir_path = "data/MNIST/raw"
-        files = glob.glob(mnist_dir_path + "/*")
-        for f in files:
-            os.remove(f)
-        os.rmdir(mnist_dir_path)
-        super().tearDown()
-
     def test_torchvision_encode_decode(self) -> None:
         original_object = PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name(
             name="MNIST", num_trials=50

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -13,6 +13,7 @@ import contextlib
 import io
 import linecache
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -243,6 +244,7 @@ class TestCase(unittest.TestCase):
 
     # try to remove these files on tearDown
     FILES_TO_CLEAN: List[str] = []
+    FOLDERS_TO_CLEAN: List[str] = []
 
     MAX_TEST_SECONDS = 540
     MIN_TTOT = 1.0
@@ -273,6 +275,13 @@ class TestCase(unittest.TestCase):
         signal.signal(signal.SIGALRM, signal_handler)
 
     def tearDown(self) -> None:
+        # just always clean "data/MNIST/raw"
+        for folder in self.FOLDERS_TO_CLEAN + ["data/MNIST/raw"]:
+            try:
+                shutil.rmtree(folder)
+            except OSError:
+                pass
+
         for f in self.FILES_TO_CLEAN:
             if os.path.exists(f):
                 os.remove(f)


### PR DESCRIPTION
Summary: this is the fully automatic solution.  It only takes `0.0003138110041618347s`...

Reviewed By: mpolson64

Differential Revision: D42387374

