### PR TITLE
Do not download torchvision datasets during unit tests

### DIFF
--- a/ax/benchmark/tests/test_problem_storage.py
+++ b/ax/benchmark/tests/test_problem_storage.py
@@ -3,9 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import glob
-import os
-
 from ax.benchmark.problems.hpo.torchvision import PyTorchCNNTorchvisionBenchmarkProblem
 from ax.storage.json_store.decoder import object_from_json
 from ax.storage.json_store.encoder import object_to_json
@@ -13,14 +10,6 @@ from ax.utils.common.testutils import TestCase
 
 
 class TestProblems(TestCase):
-    def tearDown(self) -> None:
-        mnist_dir_path = "data/MNIST/raw"
-        files = glob.glob(mnist_dir_path + "/*")
-        for f in files:
-            os.remove(f)
-        os.rmdir(mnist_dir_path)
-        super().tearDown()
-
     def test_torchvision_encode_decode(self) -> None:
         original_object = PyTorchCNNTorchvisionBenchmarkProblem.from_dataset_name(
             name="MNIST", num_trials=50


### PR DESCRIPTION
Summary: Previously the benchmarking unit tests would download a copy of MNIST or FashionMNIST. This was not only slow, but could lead to files getting left behind if the test crashed out before the tearDown method was called. This should solve both those problems :)

Differential Revision: D42391584

