### PR TITLE
move salient columns to the left

### DIFF
--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -69,7 +69,7 @@ class ReportUtilsTest(TestCase):
             ]
         ),
     )
-    def test_exp_to_df_ordering(self, _) -> None:
+    def test_exp_to_df_row_ordering(self, _) -> None:
         """
         This test verifies that the returned data frame indexes are
         in the same order as trial index. It mocks _merge_results_if_no_duplicates
@@ -81,6 +81,49 @@ class ReportUtilsTest(TestCase):
         self.assertEqual(len(df), 3)
         for idx, row in df.iterrows():
             self.assertEqual(row["trial_index"], idx)
+
+    @patch(
+        "ax.service.utils.report_utils._merge_results_if_no_duplicates",
+        autospec=True,
+        return_value=pd.DataFrame(
+            [
+                # Trial indexes are out-of-order.
+                {
+                    "col1": 1,
+                    "arm_name": "a",
+                    "trial_status": "FAILED",
+                    "generation_method": "Manual",
+                    "trial_index": 1,
+                },
+                {
+                    "col1": 2,
+                    "arm_name": "b",
+                    "trial_status": "COMPLETED",
+                    "generation_method": "BO",
+                    "trial_index": 2,
+                },
+                {
+                    "col1": 3,
+                    "arm_name": "c",
+                    "trial_status": "COMPLETED",
+                    "generation_method": "Manual",
+                    "trial_index": 0,
+                },
+            ]
+        ),
+    )
+    def test_exp_to_df_col_ordering(self, _) -> None:
+        """
+        This test verifies that the returned data frame indexes are
+        in the same order as trial index. It mocks _merge_results_if_no_duplicates
+        to verify just the ordering of items in the final data frame.
+        """
+        exp = get_branin_experiment(with_trial=True)
+        df = exp_to_df(exp)
+        self.assertListEqual(
+            list(df.columns),
+            ["trial_index", "arm_name", "trial_status", "generation_method", "col1"],
+        )
 
     def test_exp_to_df(self) -> None:
         # MultiTypeExperiment should fail

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -643,6 +643,17 @@ def exp_to_df(
     )
 
     exp_df = not_none(not_none(exp_df).sort_values(["trial_index"]))
+    initial_column_order = (
+        ["trial_index", "arm_name", "trial_status", "generation_method"]
+        + (run_metadata_fields or [])
+        + (trial_properties_fields or [])
+    )
+    for column_name in reversed(initial_column_order):
+        if column_name in exp_df.columns:
+            # pyre-ignore[6]: In call `DataFrame.insert`, for 3rd positional argument,
+            # expected `Union[int, Series, Variable[ArrayLike <: [ExtensionArray,
+            # ndarray]]]` but got `Union[DataFrame, Series]`]
+            exp_df.insert(0, column_name, exp_df.pop(column_name))
     return exp_df.reset_index(drop=True)
 
 


### PR DESCRIPTION
Summary: Reorders columns of exp_df so that the first (leftmost) columns are (in order): "trial_index", "arm_name", "trial_status", "generation_method", then any run_metadata_fields, then any trial_properties_fields. If any of the above column names are missing, they are skipped, and any remaining columns are kept in the same order relative to one another. See [this request](https://fb.workplace.com/groups/822676228356687/posts/1170824650208508/?comment_id=1170862783538028&reply_comment_id=1173094703314836) for more context.

Reviewed By: zcohn

Differential Revision: D42547914

