### PR TITLE
Remove non-determinism in test_timeout

### DIFF
--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -92,7 +92,6 @@ class TestBenchmark(TestCase):
             for col in ["mean", "P10", "P25", "P50", "P75", "P90"]:
                 self.assertTrue((agg.score_trace[col] <= 100).all())
 
-    @fast_botorch_optimize
     def test_timeout(self) -> None:
         problem = SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
             test_problem_class=Branin,


### PR DESCRIPTION
Summary: Because of how strict the timeout was in this case, sometimes we wouldnt make it to the GPEI step which would cause fast_botorch_optimize to be unused (which throws an error and asks you to remove the decorator). Since these replications are so short we don't really need to use the decorator anyway, so I am removing it.

Differential Revision: D42557139

