### PR TITLE
Introduce a `skip_fit_gpytorch_mll` for faster testing

### DIFF
--- a/ax/utils/testing/mock.py
+++ b/ax/utils/testing/mock.py
@@ -101,3 +101,34 @@ def fast_botorch_optimize(f: Callable) -> Callable:
             return f(*args, **kwargs)
 
     return inner
+
+
+@contextmanager
+def skip_fit_gpytorch_mll_context_manager() -> Generator[None, None, None]:
+    """A context manager that makes `fit_gpytorch_mll` a no-op.
+
+    This should only be used to speed up slow tests.
+    """
+    with mock.patch(
+        "botorch.fit.FitGPyTorchMLL", side_effect=lambda *args, **kwargs: args[0]
+    ) as mock_fit:
+        yield
+    if mock_fit.call_count < 1:
+        raise AssertionError(
+            "No mocks were called in the context manager. Please remove unused "
+            "skip_fit_gpytorch_mll_context_manager()."
+        )
+
+
+# pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
+def skip_fit_gpytorch_mll(f: Callable) -> Callable:
+    """Wraps f in the skip_fit_gpytorch_mll_context_manager for use as a decorator."""
+
+    @wraps(f)
+    # pyre-fixme[3]: Return type must be annotated.
+    # pyre-fixme[2]: Parameter must be annotated.
+    def inner(*args, **kwargs):
+        with skip_fit_gpytorch_mll_context_manager():
+            return f(*args, **kwargs)
+
+    return inner


### PR DESCRIPTION
Summary: Similar to `fast_botorch_optimize`, this can be used to speed up tests by skipping model fitting.

Reviewed By: mpolson64

Differential Revision: D42557155

