### PR TITLE
Make `metric_names` a required input in `Surrogate.construct`

### DIFF
--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -197,14 +197,17 @@ class Surrogate(Base):
     def construct(
         self,
         datasets: List[SupervisedDataset],
-        metric_names: Optional[List[str]] = None,
+        metric_names: List[str],
         search_space_digest: Optional[SearchSpaceDigest] = None,
         **kwargs: Any,
     ) -> None:
         """Constructs the underlying BoTorch ``Model`` using the training data.
 
         Args:
-            datasets: Training data for the model.
+            datasets: A list of ``SupervisedDataset`` containers, each
+                corresponding to the data of one metric (outcome).
+            metric_names: A list of metric names, with the i-th metric
+                corresponding to the i-th dataset.
             search_space_digest: Information about the search space used for
                 inferring suitable botorch model class.
             **kwargs: Optional keyword arguments, expects any of:
@@ -216,10 +219,6 @@ class Surrogate(Base):
                 "seach_space_digest may not be None if surrogate.botorch_model_class "
                 "is None. The SearchSpaceDigest is used to choose and appropriate "
                 "model class automatically."
-            )
-        if len(datasets) > 1 and metric_names is None:
-            raise UserInputError(
-                "metric_names must be provided if using using multiple datasets."
             )
 
         if self._constructed_manually:
@@ -242,7 +241,7 @@ class Surrogate(Base):
             if len(datasets) > 1:
                 datasets, metric_names = convert_to_block_design(
                     datasets=datasets,
-                    metric_names=not_none(metric_names),
+                    metric_names=metric_names,
                     force=True,
                 )
                 kwargs["metric_names"] = metric_names
@@ -254,7 +253,7 @@ class Surrogate(Base):
         else:
             self._construct_model_list(
                 datasets=datasets,
-                metric_names=not_none(metric_names),
+                metric_names=metric_names,
                 search_space_digest=search_space_digest,
                 **kwargs,
             )

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -92,25 +92,18 @@ class AcquisitionTest(TestCase):
             acqf_cls=DummyOneShotAcquisitionFunction,
             input_constructor=self.mock_input_constructor,
         )
-        tkwargs = {"dtype": torch.double}
+        tkwargs: Dict[str, Any] = {"dtype": torch.double}
         self.botorch_model_class = SingleTaskGP
         self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
-        # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but got
-        #  `dtype`.
-        # pyre-fixme[6]: For 2nd param expected `bool` but got `dtype`.
         self.X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **tkwargs)
-        # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but got
-        #  `dtype`.
-        # pyre-fixme[6]: For 2nd param expected `bool` but got `dtype`.
         self.Y = torch.tensor([[3.0], [4.0]], **tkwargs)
-        # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but got
-        #  `dtype`.
-        # pyre-fixme[6]: For 2nd param expected `bool` but got `dtype`.
         self.Yvar = torch.tensor([[0.0], [2.0]], **tkwargs)
         self.training_data = [SupervisedDataset(X=self.X, Y=self.Y)]
         self.fidelity_features = [2]
         self.surrogate.construct(
-            datasets=self.training_data, fidelity_features=self.fidelity_features
+            datasets=self.training_data,
+            metric_names=["metric"],
+            fidelity_features=self.fidelity_features,
         )
         self.search_space_digest = SearchSpaceDigest(
             feature_names=["a", "b", "c"],
@@ -120,27 +113,15 @@ class AcquisitionTest(TestCase):
         self.botorch_acqf_class = DummyAcquisitionFunction
         self.objective_weights = torch.tensor([1.0])
         self.objective_thresholds = None
-        # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but got
-        #  `dtype`.
-        # pyre-fixme[6]: For 2nd param expected `bool` but got `dtype`.
         self.pending_observations = [torch.tensor([[1.0, 3.0, 4.0]], **tkwargs)]
         self.outcome_constraints = (
-            # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but
-            #  got `dtype`.
-            # pyre-fixme[6]: For 2nd param expected `bool` but got `dtype`.
             torch.tensor([[1.0]], **tkwargs),
-            # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but
-            #  got `dtype`.
-            # pyre-fixme[6]: For 2nd param expected `bool` but got `dtype`.
             torch.tensor([[0.5]], **tkwargs),
         )
         self.linear_constraints = None
         self.fixed_features = {1: 2.0}
         self.options = {"best_f": 0.0}
         self.inequality_constraints = [
-            # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but
-            #  got `dtype`.
-            # pyre-fixme[6]: For 2nd param expected `bool` but got `dtype`.
             (torch.tensor([0, 1], **tkwargs), torch.tensor([-1.0, 1.0], **tkwargs), 1)
         ]
         self.rounding_func = lambda x: x
@@ -528,7 +509,9 @@ class AcquisitionTest(TestCase):
         moo_objective_thresholds = torch.tensor(
             [0.5, 1.5, float("nan")], **self.tkwargs
         )
-        self.surrogate.construct(datasets=moo_training_data)
+        self.surrogate.construct(
+            datasets=moo_training_data, metric_names=["m1", "m2", "m3"]
+        )
         mock_get_X.return_value = (self.pending_observations[0], self.X[:1])
         outcome_constraints = (
             torch.tensor([[1.0, 0.0, 0.0]], **self.tkwargs),

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -498,6 +498,7 @@ class BoTorchModelTest(TestCase):
         )
         model.surrogates[Keys.ONLY_SURROGATE].construct(
             datasets=self.block_design_training_data,
+            metric_names=["metric"],
             fidelity_features=self.mf_search_space_digest.fidelity_features,
         )
         model._botorch_acqf_class = None
@@ -587,6 +588,7 @@ class BoTorchModelTest(TestCase):
         )
         model.surrogates[Keys.ONLY_SURROGATE].construct(
             datasets=self.block_design_training_data,
+            metric_names=["metric"],
             search_space_digest=SearchSpaceDigest(
                 feature_names=[],
                 bounds=[],

--- a/ax/models/torch/tests/test_multi_fidelity.py
+++ b/ax/models/torch/tests/test_multi_fidelity.py
@@ -37,7 +37,9 @@ class MultiFidelityAcquisitionTest(TestCase):
         self.training_data = [SupervisedDataset(X=self.X, Y=self.Y)]
         self.fidelity_features = [2]
         self.surrogate.construct(
-            datasets=self.training_data, fidelity_features=self.fidelity_features
+            datasets=self.training_data,
+            metric_names=["metric"],
+            fidelity_features=self.fidelity_features,
         )
         self.acquisition_options = {Keys.NUM_FANTASIES: 64}
         self.search_space_digest = SearchSpaceDigest(

--- a/ax/utils/testing/torch_stubs.py
+++ b/ax/utils/testing/torch_stubs.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 
@@ -30,33 +30,20 @@ def get_torch_test_data(
     List[str],
     List[str],
 ]:
-    tkwargs = {"device": torch.device("cuda" if cuda else "cpu"), "dtype": dtype}
+    tkwargs: Dict[str, Any] = {
+        "device": torch.device("cuda" if cuda else "cpu"),
+        "dtype": dtype,
+    }
     Xs = [
         torch.tensor(
             [
                 [1.0 + offset, 2.0 + offset, 3.0 + offset],
                 [2.0 + offset, 3.0 + offset, 4.0 + offset],
             ],
-            # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-            #  `Union[dtype, device]`.
-            # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but
-            #  got `Union[dtype, device]`.
-            # pyre-fixme[6]: For 2nd param expected `bool` but got `Union[dtype,
-            #  device]`.
             **tkwargs,
         )
     ]
-    # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got `Union[dtype,
-    #  device]`.
-    # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but got
-    #  `Union[dtype, device]`.
-    # pyre-fixme[6]: For 2nd param expected `bool` but got `Union[dtype, device]`.
     Ys = [torch.tensor([[3.0 + offset], [4.0 + offset]], **tkwargs)]
-    # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got `Union[dtype,
-    #  device]`.
-    # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but got
-    #  `Union[dtype, device]`.
-    # pyre-fixme[6]: For 2nd param expected `bool` but got `Union[dtype, device]`.
     Yvars = [torch.tensor([[0.0 + offset], [2.0 + offset]], **tkwargs)]
     if constant_noise:
         Yvars[0].fill_(1.0)


### PR DESCRIPTION
Summary:
`Surrogate.construct` is only called in `Surrogate.fit`, where `metric_names` is a required input. The usage within `Surrogate.construct` also assumes it to be not-None in many cases, so this update makes sense to me.

These changes also eliminate the test failures in D42687367v1 due to missing metric names in `Surrogate.construct` calls.

Differential Revision: D42699205

