### PR TITLE
Refactor BestPointMixin to be used as a mixin

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -34,7 +34,6 @@ from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkRe
 from ax.core.experiment import Experiment
 from ax.core.utils import get_model_times
 from ax.service.scheduler import Scheduler
-from ax.service.utils.best_point_mixin import BestPointMixin
 from botorch.utils.sampling import manual_seed
 
 
@@ -69,9 +68,7 @@ def benchmark_replication(
     with manual_seed(seed=seed):
         scheduler.run_n_trials(max_trials=problem.num_trials)
 
-    optimization_trace = np.array(
-        BestPointMixin.get_trace(experiment=scheduler.experiment)
-    )
+    optimization_trace = np.array(scheduler.get_trace())
 
     # Use the first GenerationStep's best found point as baseline. Sometimes (ex. in
     # a timeout) the first GenerationStep will not have not completed and we will not

--- a/ax/benchmark/benchmark_result.py
+++ b/ax/benchmark/benchmark_result.py
@@ -46,7 +46,7 @@ class BenchmarkResult(Base):
         self, final_progression_only: bool = False
     ) -> Tuple[ndarray, ndarray]:  # (y-values, x-values)
         if isinstance(self.experiment.lookup_data(), MapData):
-            by_progression_result = BestPointMixin.get_trace_by_progression(
+            by_progression_result = BestPointMixin._get_trace_by_progression(
                 experiment=self.experiment,
                 final_progression_only=final_progression_only,
             )
@@ -59,7 +59,7 @@ class BenchmarkResult(Base):
             # if not MapData, set this to standard optimization_trace
             # with a default x-values
             optimization_trace = np.array(
-                BestPointMixin.get_trace(
+                BestPointMixin._get_trace(
                     experiment=self.experiment,
                 )
             )

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1545,6 +1545,30 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
             use_model_predictions=use_model_predictions,
         )
 
+    @copy_doc(BestPointMixin.get_trace)
+    def get_trace(
+        self,
+        optimization_config: Optional[MultiObjectiveOptimizationConfig] = None,
+    ) -> List[float]:
+        return BestPointMixin._get_trace(
+            experiment=self.experiment,
+            optimization_config=optimization_config,
+        )
+
+    @copy_doc(BestPointMixin.get_trace_by_progression)
+    def get_trace_by_progression(
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        bins: Optional[List[float]] = None,
+        final_progression_only: bool = False,
+    ) -> Tuple[List[float], List[float]]:
+        return BestPointMixin._get_trace_by_progression(
+            experiment=self.experiment,
+            optimization_config=optimization_config,
+            bins=bins,
+            final_progression_only=final_progression_only,
+        )
+
     def _update_trial_with_raw_data(
         self,
         trial_index: int,

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -470,6 +470,30 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             use_model_predictions=use_model_predictions,
         )
 
+    @copy_doc(BestPointMixin.get_trace)
+    def get_trace(
+        self,
+        optimization_config: Optional[MultiObjectiveOptimizationConfig] = None,
+    ) -> List[float]:
+        return BestPointMixin._get_trace(
+            experiment=self.experiment,
+            optimization_config=optimization_config,
+        )
+
+    @copy_doc(BestPointMixin.get_trace_by_progression)
+    def get_trace_by_progression(
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        bins: Optional[List[float]] = None,
+        final_progression_only: bool = False,
+    ) -> Tuple[List[float], List[float]]:
+        return BestPointMixin._get_trace_by_progression(
+            experiment=self.experiment,
+            optimization_config=optimization_config,
+            bins=bins,
+            final_progression_only=final_progression_only,
+        )
+
     def report_results(self, force_refit: bool = False) -> Dict[str, Any]:
         """Optional user-defined function for reporting intermediate
         and final optimization results (e.g. make some API call, write to some

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -19,7 +19,7 @@ from ax.utils.testing.core_stubs import (
 class TestBestPointMixin(TestCase):
     def test_get_trace(self) -> None:
         # Alias for easier access.
-        get_trace = BestPointMixin.get_trace
+        get_trace = BestPointMixin._get_trace
 
         # Single objective, minimize.
         exp = get_experiment_with_observations(

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -5,9 +5,11 @@
 
 from unittest.mock import Mock
 
+from ax.core.optimization_config import MultiObjectiveOptimizationConfig
+
 from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.utils.common.testutils import TestCase
-from ax.utils.common.typeutils import not_none
+from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.testing.core_stubs import (
     get_experiment_with_observations,
     get_experiment_with_trial,
@@ -41,6 +43,12 @@ class TestBestPointMixin(TestCase):
             observations=[[1, 1], [-1, 100], [1, 2], [3, 3], [2, 4], [2, 1]],
         )
         self.assertEqual(get_trace(exp), [1, 1, 2, 9, 11, 11])
+
+        # W/o ObjectiveThresholds (infering ObjectiveThresholds from nadir point)
+        checked_cast(
+            MultiObjectiveOptimizationConfig, exp.optimization_config
+        ).objective_thresholds = []
+        self.assertEqual(get_trace(exp), [0.0, 0.0, 2.0, 8.0, 11.0, 11.0])
 
         # W/ constraints.
         exp = get_experiment_with_observations(


### PR DESCRIPTION
Summary:
The `get_trace` and `get_trace_by_progression` methods were being called directly as static methods when we really want methods on this mixin to be called by the classes that implement the mixin.

For example we used to call like this `BestPointMixin.get_trace(scheduler.experiment)` but what we really want is to be able to call like this `scheduler.get_trace()`.

After this diff each of these methods follow the same structure as the other best point abstract methods like `get_best_point` and `get_hypervolume`

Differential Revision: D42722280

