### PR TITLE
Add hypervolume trace to `get_standard_plots`

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -34,7 +34,6 @@ from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkRe
 from ax.core.experiment import Experiment
 from ax.core.utils import get_model_times
 from ax.service.scheduler import Scheduler
-from ax.service.utils.best_point_mixin import BestPointMixin
 from botorch.utils.sampling import manual_seed
 
 
@@ -69,9 +68,7 @@ def benchmark_replication(
     with manual_seed(seed=seed):
         scheduler.run_n_trials(max_trials=problem.num_trials)
 
-    optimization_trace = np.array(
-        BestPointMixin.get_trace(experiment=scheduler.experiment)
-    )
+    optimization_trace = np.array(scheduler.get_trace())
 
     # Use the first GenerationStep's best found point as baseline. Sometimes (ex. in
     # a timeout) the first GenerationStep will not have not completed and we will not

--- a/ax/benchmark/benchmark_result.py
+++ b/ax/benchmark/benchmark_result.py
@@ -46,7 +46,7 @@ class BenchmarkResult(Base):
         self, final_progression_only: bool = False
     ) -> Tuple[ndarray, ndarray]:  # (y-values, x-values)
         if isinstance(self.experiment.lookup_data(), MapData):
-            by_progression_result = BestPointMixin.get_trace_by_progression(
+            by_progression_result = BestPointMixin._get_trace_by_progression(
                 experiment=self.experiment,
                 final_progression_only=final_progression_only,
             )
@@ -59,7 +59,7 @@ class BenchmarkResult(Base):
             # if not MapData, set this to standard optimization_trace
             # with a default x-values
             optimization_trace = np.array(
-                BestPointMixin.get_trace(
+                BestPointMixin._get_trace(
                     experiment=self.experiment,
                 )
             )

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1545,6 +1545,30 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
             use_model_predictions=use_model_predictions,
         )
 
+    @copy_doc(BestPointMixin.get_trace)
+    def get_trace(
+        self,
+        optimization_config: Optional[MultiObjectiveOptimizationConfig] = None,
+    ) -> List[float]:
+        return BestPointMixin._get_trace(
+            experiment=self.experiment,
+            optimization_config=optimization_config,
+        )
+
+    @copy_doc(BestPointMixin.get_trace_by_progression)
+    def get_trace_by_progression(
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        bins: Optional[List[float]] = None,
+        final_progression_only: bool = False,
+    ) -> Tuple[List[float], List[float]]:
+        return BestPointMixin._get_trace_by_progression(
+            experiment=self.experiment,
+            optimization_config=optimization_config,
+            bins=bins,
+            final_progression_only=final_progression_only,
+        )
+
     def _update_trial_with_raw_data(
         self,
         trial_index: int,

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -470,6 +470,30 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             use_model_predictions=use_model_predictions,
         )
 
+    @copy_doc(BestPointMixin.get_trace)
+    def get_trace(
+        self,
+        optimization_config: Optional[MultiObjectiveOptimizationConfig] = None,
+    ) -> List[float]:
+        return BestPointMixin._get_trace(
+            experiment=self.experiment,
+            optimization_config=optimization_config,
+        )
+
+    @copy_doc(BestPointMixin.get_trace_by_progression)
+    def get_trace_by_progression(
+        self,
+        optimization_config: Optional[OptimizationConfig] = None,
+        bins: Optional[List[float]] = None,
+        final_progression_only: bool = False,
+    ) -> Tuple[List[float], List[float]]:
+        return BestPointMixin._get_trace_by_progression(
+            experiment=self.experiment,
+            optimization_config=optimization_config,
+            bins=bins,
+            final_progression_only=final_progression_only,
+        )
+
     def report_results(self, force_refit: bool = False) -> Dict[str, Any]:
         """Optional user-defined function for reporting intermediate
         and final optimization results (e.g. make some API call, write to some

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -19,7 +19,7 @@ from ax.utils.testing.core_stubs import (
 class TestBestPointMixin(TestCase):
     def test_get_trace(self) -> None:
         # Alias for easier access.
-        get_trace = BestPointMixin.get_trace
+        get_trace = BestPointMixin._get_trace
 
         # Single objective, minimize.
         exp = get_experiment_with_observations(

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -5,9 +5,11 @@
 
 from unittest.mock import Mock
 
+from ax.core.optimization_config import MultiObjectiveOptimizationConfig
+
 from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.utils.common.testutils import TestCase
-from ax.utils.common.typeutils import not_none
+from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.testing.core_stubs import (
     get_experiment_with_observations,
     get_experiment_with_trial,
@@ -41,6 +43,12 @@ class TestBestPointMixin(TestCase):
             observations=[[1, 1], [-1, 100], [1, 2], [3, 3], [2, 4], [2, 1]],
         )
         self.assertEqual(get_trace(exp), [1, 1, 2, 9, 11, 11])
+
+        # W/o ObjectiveThresholds (infering ObjectiveThresholds from nadir point)
+        checked_cast(
+            MultiObjectiveOptimizationConfig, exp.optimization_config
+        ).objective_thresholds = []
+        self.assertEqual(get_trace(exp), [0.0, 0.0, 2.0, 8.0, 11.0, 11.0])
 
         # W/ constraints.
         exp = get_experiment_with_observations(

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -287,14 +287,14 @@ class ReportUtilsTest(TestCase):
         plots = get_standard_plots(
             experiment=exp, model=Models.MOO(experiment=exp, data=exp.fetch_data())
         )
-        self.assertEqual(len(plots), 7)
+        self.assertEqual(len(plots), 8)
 
         # All plots are successfully created when objective thresholds are absent
         exp.optimization_config._objective_thresholds = []
         plots = get_standard_plots(
             experiment=exp, model=Models.MOO(experiment=exp, data=exp.fetch_data())
         )
-        self.assertEqual(len(plots), 7)
+        self.assertEqual(len(plots), 8)
 
         exp = get_branin_experiment_with_timestamp_map_metric(with_status_quo=True)
         exp.new_trial().add_arm(exp.status_quo)

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -185,6 +185,66 @@ class BestPointMixin(metaclass=ABCMeta):
         """
         pass
 
+    @abstractmethod
+    def get_trace(
+        optimization_config: Optional[OptimizationConfig] = None,
+    ) -> List[float]:
+        """Get the optimization trace of the given experiment.
+
+        The output is equivalent to calling `_get_hypervolume` or `_get_best_trial`
+        repeatedly, with an increasing sequence of `trial_indices` and with
+        `use_model_predictions = False`, though this does it more efficiently.
+
+        Args:
+            experiment: The experiment to get the trace for.
+            optimization_config: An optional optimization config to use for computing
+                the trace. This allows computing the traces under different objectives
+                or constraints without having to modify the experiment.
+
+        Returns:
+            A list of observed hypervolumes or best values.
+        """
+        pass
+
+    @abstractmethod
+    def get_trace_by_progression(
+        optimization_config: Optional[OptimizationConfig] = None,
+        bins: Optional[List[float]] = None,
+        final_progression_only: bool = False,
+    ) -> Tuple[List[float], List[float]]:
+        """Get the optimization trace with respect to trial progressions instead of
+        `trial_indices` (which is the behavior used in `get_trace`). Note that this
+        method does not take into account the parallelism of trials and essentially
+        assumes that trials are run one after another, in the sense that it considers
+        the total number of progressions "used" at the end of trial k to be the
+        cumulative progressions "used" in trials 0,...,k. This method assumes that the
+        final value of a particular trial is used and does not take the best value
+        of a trial over its progressions.
+
+        The best observed value is computed at each value in `bins` (see below for
+        details). If `bins` is not supplied, the method defaults to a heuristic of
+        approximately `NUM_BINS_PER_TRIAL` per trial, where each trial is assumed to
+        run until maximum progression (inferred from the data).
+
+        Args:
+            experiment: The experiment to get the trace for.
+            optimization_config: An optional optimization config to use for computing
+                the trace. This allows computing the traces under different objectives
+                or constraints without having to modify the experiment.
+            bins: A list progression values at which to calculate the best observed
+                value. The best observed value at bins[i] is defined as the value
+                observed in trials 0,...,j where j = largest trial such that the total
+                progression in trials 0,...,j is less than bins[i].
+            final_progression_only: If True, considers the value of the last step to be
+                the value of the trial. If False, considers the best along the curve to
+                be the value of the trial.
+
+        Returns:
+            A tuple containing (1) the list of observed hypervolumes or best values and
+            (2) a list of associated x-values (i.e., progressions) useful for plotting.
+        """
+        pass
+
     @staticmethod
     def _get_best_trial(
         experiment: Experiment,
@@ -309,25 +369,10 @@ class BestPointMixin(metaclass=ABCMeta):
         )
 
     @staticmethod
-    def get_trace(
+    def _get_trace(
         experiment: Experiment,
         optimization_config: Optional[OptimizationConfig] = None,
     ) -> List[float]:
-        """Get the optimization trace of the given experiment.
-
-        The output is equivalent to calling `_get_hypervolume` or `_get_best_trial`
-        repeatedly, with an increasing sequence of `trial_indices` and with
-        `use_model_predictions = False`, though this does it more efficiently.
-
-        Args:
-            experiment: The experiment to get the trace for.
-            optimization_config: An optional optimization config to use for computing
-                the trace. This allows computing the traces under different objectives
-                or constraints without having to modify the experiment.
-
-        Returns:
-            A list of observed hypervolumes or best values.
-        """
         optimization_config = optimization_config or not_none(
             experiment.optimization_config
         )
@@ -456,43 +501,12 @@ class BestPointMixin(metaclass=ABCMeta):
             return raw_maximum.tolist()
 
     @staticmethod
-    def get_trace_by_progression(
+    def _get_trace_by_progression(
         experiment: Experiment,
         optimization_config: Optional[OptimizationConfig] = None,
         bins: Optional[List[float]] = None,
         final_progression_only: bool = False,
     ) -> Tuple[List[float], List[float]]:
-        """Get the optimization trace with respect to trial progressions instead of
-        `trial_indices` (which is the behavior used in `get_trace`). Note that this
-        method does not take into account the parallelism of trials and essentially
-        assumes that trials are run one after another, in the sense that it considers
-        the total number of progressions "used" at the end of trial k to be the
-        cumulative progressions "used" in trials 0,...,k. This method assumes that the
-        final value of a particular trial is used and does not take the best value
-        of a trial over its progressions.
-
-        The best observed value is computed at each value in `bins` (see below for
-        details). If `bins` is not supplied, the method defaults to a heuristic of
-        approximately `NUM_BINS_PER_TRIAL` per trial, where each trial is assumed to
-        run until maximum progression (inferred from the data).
-
-        Args:
-            experiment: The experiment to get the trace for.
-            optimization_config: An optional optimization config to use for computing
-                the trace. This allows computing the traces under different objectives
-                or constraints without having to modify the experiment.
-            bins: A list progression values at which to calculate the best observed
-                value. The best observed value at bins[i] is defined as the value
-                observed in trials 0,...,j where j = largest trial such that the total
-                progression in trials 0,...,j is less than bins[i].
-            final_progression_only: If True, considers the value of the last step to be
-                the value of the trial. If False, considers the best along the curve to
-                be the value of the trial.
-
-        Returns:
-            A tuple containing (1) the list of observed hypervolumes or best values and
-            (2) a list of associated x-values (i.e., progressions) useful for plotting.
-        """
         optimization_config = optimization_config or not_none(
             experiment.optimization_config
         )

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -42,6 +42,7 @@ from ax.plot.helper import get_range_parameters_from_list
 from ax.plot.pareto_frontier import (
     _pareto_frontier_plot_input_processing,
     _validate_experiment_and_get_optimization_config,
+    scatter_plot_with_hypervolume_trace_plotly,
     scatter_plot_with_pareto_frontier_plotly,
 )
 from ax.plot.pareto_utils import _extract_observed_pareto_2d
@@ -70,13 +71,6 @@ CROSS_VALIDATION_CAPTION = (
 FEASIBLE_COL_NAME = "is_feasible"
 
 
-def _get_hypervolume_trace() -> None:
-    logger.warning(
-        "Objective trace plots not yet implemented for multi-objective optimization. "
-        "Returning `None`."
-    )
-
-
 # pyre-ignore[11]: Annotation `go.Figure` is not defined as a type.
 def _get_cross_validation_plots(model: ModelBridge) -> List[go.Figure]:
     cv = cross_validate(model=model)
@@ -94,8 +88,10 @@ def _get_objective_trace_plot(
     true_objective_metric_name: Optional[str] = None,
 ) -> Iterable[go.Figure]:
     if experiment.is_moo_problem:
-        # TODO: implement `_get_hypervolume_trace()`
-        return _pairwise_pareto_plotly_scatter(experiment=experiment)
+        return [
+            scatter_plot_with_hypervolume_trace_plotly(experiment=experiment),
+            *_pairwise_pareto_plotly_scatter(experiment=experiment),
+        ]
 
     optimization_config = experiment.optimization_config
     if optimization_config is None:


### PR DESCRIPTION
Summary: Add a new plot for MOO experiments that shows the hypervolume plotted against the iteration num. This is useful for understanding if the pareto frontier is expanding or if the optimization has stalled out.

Differential Revision: D42725693

