### PR TITLE
num_initialization_trials trumps max_initialization_trials if both are specified.

### DIFF
--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -439,12 +439,12 @@ def choose_generation_strategy(
                 num_trials=num_trials,
                 use_batch_trials=use_batch_trials,
             )
+            if max_initialization_trials is not None:
+                num_initialization_trials = min(
+                    num_initialization_trials, max_initialization_trials
+                )
             logger.info(
                 f"calculated num_initialization_trials={num_initialization_trials}"
-            )
-        if max_initialization_trials is not None:
-            num_initialization_trials = min(
-                num_initialization_trials, max_initialization_trials
             )
         num_remaining_initialization_trials = max(
             0, num_initialization_trials - max(0, num_completed_initialization_trials)

--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -73,6 +73,24 @@ class TestDispatchUtils(TestCase):
             self.assertEqual(sobol_gpei._steps[0].model, Models.SOBOL)
             self.assertEqual(sobol_gpei._steps[0].num_trials, 2)
             self.assertEqual(sobol_gpei._steps[1].model, Models.GPEI)
+        with self.subTest("num_initialization_trials > max_initialization_trials"):
+            sobol_gpei = choose_generation_strategy(
+                search_space=get_branin_search_space(),
+                max_initialization_trials=2,
+                num_initialization_trials=3,
+            )
+            self.assertEqual(sobol_gpei._steps[0].model, Models.SOBOL)
+            self.assertEqual(sobol_gpei._steps[0].num_trials, 3)
+            self.assertEqual(sobol_gpei._steps[1].model, Models.GPEI)
+        with self.subTest("num_initialization_trials > max_initialization_trials"):
+            sobol_gpei = choose_generation_strategy(
+                search_space=get_branin_search_space(),
+                max_initialization_trials=2,
+                num_initialization_trials=3,
+            )
+            self.assertEqual(sobol_gpei._steps[0].model, Models.SOBOL)
+            self.assertEqual(sobol_gpei._steps[0].num_trials, 3)
+            self.assertEqual(sobol_gpei._steps[1].model, Models.GPEI)
         with self.subTest("MOO"):
             optimization_config = MultiObjectiveOptimizationConfig(
                 objective=MultiObjective(objectives=[])


### PR DESCRIPTION
Summary: Allows users to set any num_initialization_trials they like. Potentially introduces a footgun, but since this is not specified

Reviewed By: zcohn

Differential Revision: D42710044

