### PR TITLE
Make import mocking error if module was already imported

### DIFF
--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -235,6 +235,8 @@ def _build_comparison_str(
 
 def setup_import_mocks(mocked_import_paths: List[str]) -> None:
     for import_path in mocked_import_paths:
+        if import_path in sys.modules:
+            raise Exception(f"{import_path} has already been imported!")
         sys.modules[import_path] = MagicMock()
 
 


### PR DESCRIPTION
Summary: checks if module is in sys.modules.  This gives certainty it has worked.

Differential Revision: D42805958

