### PR TITLE
Pass around empty fixed_features as None

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -44,7 +44,7 @@ class BaseGenArgs:
     search_space: SearchSpace
     optimization_config: Optional[OptimizationConfig]
     pending_observations: Dict[str, List[ObservationFeatures]]
-    fixed_features: ObservationFeatures
+    fixed_features: Optional[ObservationFeatures]
 
 
 @dataclass(frozen=True)
@@ -607,8 +607,6 @@ class ModelBridge(ABC):
     ) -> BaseGenArgs:
         if pending_observations is None:
             pending_observations = {}
-        if fixed_features is None:
-            fixed_features = ObservationFeatures({})
         if optimization_config is None:
             optimization_config = (
                 self._optimization_config.clone()
@@ -633,7 +631,11 @@ class ModelBridge(ABC):
                 )
             for metric, po in pending_observations.items():
                 pending_observations[metric] = t.transform_observation_features(po)
-            fixed_features = t.transform_observation_features([fixed_features])[0]
+            fixed_features = (
+                t.transform_observation_features([fixed_features])[0]
+                if fixed_features is not None
+                else None
+            )
         return BaseGenArgs(
             search_space=search_space,
             optimization_config=optimization_config,
@@ -795,7 +797,7 @@ class ModelBridge(ABC):
         search_space: SearchSpace,
         optimization_config: Optional[OptimizationConfig],
         pending_observations: Dict[str, List[ObservationFeatures]],
-        fixed_features: ObservationFeatures,
+        fixed_features: Optional[ObservationFeatures],
         model_gen_options: Optional[TConfig],
     ) -> GenResults:
         """Apply terminal transform, gen, and reverse terminal transform on

--- a/ax/modelbridge/discrete.py
+++ b/ax/modelbridge/discrete.py
@@ -18,7 +18,10 @@ from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValueList
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.base import GenResults, ModelBridge
-from ax.modelbridge.modelbridge_utils import array_to_observation_data
+from ax.modelbridge.modelbridge_utils import (
+    array_to_observation_data,
+    get_fixed_features,
+)
 from ax.modelbridge.torch import (
     extract_objective_weights,
     extract_outcome_constraints,
@@ -113,7 +116,7 @@ class DiscreteModelBridge(ModelBridge):
         n: int,
         search_space: SearchSpace,
         pending_observations: Dict[str, List[ObservationFeatures]],
-        fixed_features: ObservationFeatures,
+        fixed_features: Optional[ObservationFeatures],
         model_gen_options: Optional[TConfig] = None,
         optimization_config: Optional[OptimizationConfig] = None,
     ) -> GenResults:
@@ -142,12 +145,8 @@ class DiscreteModelBridge(ModelBridge):
             )
 
         # Get fixed features
-        fixed_features_dict = {
-            self.parameters.index(p_name): val
-            for p_name, val in fixed_features.parameters.items()
-        }
-        fixed_features_dict = (
-            fixed_features_dict if len(fixed_features_dict) > 0 else None
+        fixed_features_dict = get_fixed_features(
+            fixed_features=fixed_features, param_names=self.parameters
         )
 
         # Pending observations
@@ -166,7 +165,7 @@ class DiscreteModelBridge(ModelBridge):
             parameter_values=parameter_values,
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
-            fixed_features=fixed_features_dict,
+            fixed_features=fixed_features_dict,  # pyre-ignore
             pending_observations=pending_array,
             model_gen_options=model_gen_options,
         )

--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -185,7 +185,7 @@ class MapTorchModelBridge(TorchModelBridge):
         n: int,
         search_space: SearchSpace,
         pending_observations: Dict[str, List[ObservationFeatures]],
-        fixed_features: ObservationFeatures,
+        fixed_features: Optional[ObservationFeatures],
         model_gen_options: Optional[TConfig] = None,
         optimization_config: Optional[OptimizationConfig] = None,
     ) -> GenResults:

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -503,9 +503,11 @@ def validate_and_apply_final_transform(
 
 
 def get_fixed_features(
-    fixed_features: ObservationFeatures, param_names: List[str]
+    fixed_features: Optional[ObservationFeatures], param_names: List[str]
 ) -> Optional[Dict[int, float]]:
     """Reformat a set of fixed_features."""
+    if fixed_features is None:
+        return None
     fixed_features_dict = {}
     for p_name, val in fixed_features.parameters.items():
         # These all need to be floats at this point.

--- a/ax/modelbridge/random.py
+++ b/ax/modelbridge/random.py
@@ -63,7 +63,7 @@ class RandomModelBridge(ModelBridge):
         n: int,
         search_space: SearchSpace,
         pending_observations: Dict[str, List[ObservationFeatures]],
-        fixed_features: ObservationFeatures,
+        fixed_features: Optional[ObservationFeatures],
         optimization_config: Optional[OptimizationConfig],
         model_gen_options: Optional[TConfig],
     ) -> GenResults:

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -190,7 +190,7 @@ class BaseModelBridgeTest(TestCase):
             search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
             optimization_config=None,
             pending_observations={},
-            fixed_features=ObservationFeatures({}),
+            fixed_features=None,
             model_gen_options=None,
         )
 
@@ -208,7 +208,7 @@ class BaseModelBridgeTest(TestCase):
             search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
             optimization_config=oc2,
             pending_observations={},
-            fixed_features=ObservationFeatures({}),
+            fixed_features=None,
             model_gen_options=None,
         )
 
@@ -551,9 +551,7 @@ class BaseModelBridgeTest(TestCase):
     @mock.patch(
         "ax.modelbridge.base.ModelBridge.predict", autospec=True, return_value=None
     )
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def testGenWithDefaults(self, _, mock_gen):
+    def testGenWithDefaults(self, _, mock_gen: Mock) -> None:
         exp = get_experiment_for_value()
         exp.optimization_config = get_optimization_config_no_constraints()
         ss = get_search_space_for_range_value()
@@ -565,7 +563,7 @@ class BaseModelBridgeTest(TestCase):
             modelbridge,
             n=1,
             search_space=ss,
-            fixed_features=ObservationFeatures(parameters={}),
+            fixed_features=None,
             model_gen_options=None,
             optimization_config=OptimizationConfig(
                 objective=Objective(metric=Metric("test_metric"), minimize=False),

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -520,7 +520,7 @@ class TorchModelBridge(ModelBridge):
         n: int,
         search_space: SearchSpace,
         pending_observations: Dict[str, List[ObservationFeatures]],
-        fixed_features: ObservationFeatures,
+        fixed_features: Optional[ObservationFeatures],
         model_gen_options: Optional[TConfig] = None,
         optimization_config: Optional[OptimizationConfig] = None,
     ) -> GenResults:
@@ -645,7 +645,7 @@ class TorchModelBridge(ModelBridge):
         self,
         search_space: SearchSpace,
         pending_observations: Dict[str, List[ObservationFeatures]],
-        fixed_features: ObservationFeatures,
+        fixed_features: Optional[ObservationFeatures],
         model_gen_options: Optional[TConfig] = None,
         optimization_config: Optional[OptimizationConfig] = None,
     ) -> Tuple[SearchSpaceDigest, TorchOptConfig]:


### PR DESCRIPTION
Summary: Prior to this, we would make this into a dummy `ObservationFeatures({})` which would lead to warnings with HSS.

Differential Revision: D42809755

