### PR TITLE
Pin SQA version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ DEV_REQUIRES = [
     "yappi",
 ]
 
-MYSQL_REQUIRES = ["SQLAlchemy>=1.1.13"]
+MYSQL_REQUIRES = ["SQLAlchemy==1.4.17"]
 
 NOTEBOOK_REQUIRES = ["jupyter"]
 


### PR DESCRIPTION
Summary: SQA updated to 2.0.0 yesterday -- pin to v1.4.17 until we plan on porting to 2.0.0

Reviewed By: saitcakmak, esantorella

Differential Revision: D42812050

