### PR TITLE
Do not count 2-level choice parameters as unordered in choose_generation_strategy

### DIFF
--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -137,7 +137,8 @@ def _suggest_gp_model(
     ``MAX_DISCRETE_ENUMERATIONS_MIXED``, or if there are only choice parameters and
     the number of choice combinations to enumerate is less than
     ``MAX_DISCRETE_ENUMERATIONS_CHOICE_ONLY``. ``BO_MIXED`` is not currently enabled
-    for multi-objective optimization.
+    for multi-objective optimization. Note that we do not count 2-level choice
+    parameters as unordered, since these do not affect the modeling choice.
     3. We use ``MOO`` if ``optimization_config`` has multiple objectives and
     ``use_saasbo is False``.
     4. We use ``FULLYBAYESIANMOO`` if ``optimization_config`` has multiple objectives
@@ -157,7 +158,7 @@ def _suggest_gp_model(
             should_enumerate_param = True
             num_param_discrete_values = len(parameter.values)
             num_possible_points *= num_param_discrete_values
-            if parameter.is_ordered is False:
+            if parameter.is_ordered is False and num_param_discrete_values > 2:
                 num_unordered_choices += num_param_discrete_values
             else:
                 num_ordered_parameters += 1

--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -115,14 +115,12 @@ class TestDispatchUtils(TestCase):
             self.assertEqual(sobol._steps[0].model, Models.SOBOL)
             self.assertEqual(len(sobol._steps), 1)
         with self.subTest("Sobol (because of too many categories)"):
-            ss = get_large_factorial_search_space()
             sobol_large = choose_generation_strategy(
                 search_space=get_large_factorial_search_space(), verbose=True
             )
             self.assertEqual(sobol_large._steps[0].model, Models.SOBOL)
             self.assertEqual(len(sobol_large._steps), 1)
         with self.subTest("Sobol (because of too many categories) with saasbo"):
-            ss = get_large_factorial_search_space()
             with self.assertLogs(
                 choose_generation_strategy.__module__, logging.WARNING
             ) as logger:
@@ -140,6 +138,14 @@ class TestDispatchUtils(TestCase):
                 )
             self.assertEqual(sobol_large._steps[0].model, Models.SOBOL)
             self.assertEqual(len(sobol_large._steps), 1)
+        with self.subTest("GPEI despite many unordered 2-value parameters"):
+            gs = choose_generation_strategy(
+                search_space=get_large_factorial_search_space(
+                    num_levels=2, num_parameters=10
+                ),
+            )
+            self.assertEqual(gs._steps[0].model, Models.SOBOL)
+            self.assertEqual(gs._steps[1].model, Models.GPEI)
         with self.subTest("GPEI-Batched"):
             sobol_gpei_batched = choose_generation_strategy(
                 search_space=get_branin_search_space(),
@@ -462,7 +468,7 @@ class TestDispatchUtils(TestCase):
             self.assertEqual(sobol_gpei._steps[0].model, Models.SOBOL)
             self.assertEqual(sobol_gpei._steps[1].model, Models.BO_MIXED)
         with self.subTest("with budget that is exhaustive, Sobol is used"):
-            sobol = choose_generation_strategy(search_space=ss, num_trials=24)
+            sobol = choose_generation_strategy(search_space=ss, num_trials=36)
             self.assertEqual(sobol._steps[0].model, Models.SOBOL)
             self.assertEqual(len(sobol._steps), 1)
         with self.subTest("with budget that is exhaustive and use_saasbo, it warns"):
@@ -471,7 +477,7 @@ class TestDispatchUtils(TestCase):
             ) as logger:
                 sobol = choose_generation_strategy(
                     search_space=ss,
-                    num_trials=24,
+                    num_trials=36,
                     use_saasbo=True,
                 )
                 self.assertTrue(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -747,15 +747,17 @@ def get_factorial_search_space() -> SearchSpace:
     )
 
 
-def get_large_factorial_search_space() -> SearchSpace:
+def get_large_factorial_search_space(
+    num_levels: int = 10, num_parameters: int = 6
+) -> SearchSpace:
     return SearchSpace(
         parameters=[
             ChoiceParameter(
                 name=f"factor{j}",
                 parameter_type=ParameterType.STRING,
-                values=[f"level1{i}" for i in range(10)],
+                values=[f"level1{i}" for i in range(num_levels)],
             )
-            for j in range(6)
+            for j in range(num_parameters)
         ]
     )
 
@@ -831,7 +833,7 @@ def get_discrete_search_space() -> SearchSpace:
         [
             RangeParameter("x", ParameterType.INT, 0, 3),
             RangeParameter("y", ParameterType.INT, 5, 7),
-            ChoiceParameter("z", ParameterType.STRING, ["red", "panda"]),
+            ChoiceParameter("z", ParameterType.STRING, ["red", "panda", "bear"]),
         ]
     )
 


### PR DESCRIPTION
Summary: Without this change, having lots of 2-level unordered parameters would lead to using Sobol. With 2-level parameters, being ordered vs unordered does not really make any difference in modeling, so we can treat them the same when choosing the GS.

Reviewed By: dme65

Differential Revision: D42912425

