### PR TITLE
[Easy] Minor updates to Service API tutorial

### DIFF
--- a/tutorials/gpei_hartmann_service.ipynb
+++ b/tutorials/gpei_hartmann_service.ipynb
@@ -51,8 +51,8 @@
    "metadata": {},
    "source": [
     "## 2. Set up experiment\n",
-    "An experiment consists of a **search space** (parameters and parameter constraints) and **optimization configuration** (objective name, minimization setting, and outcome constraints). Note that:\n",
-    "- Only `name`, `parameters`, and `objective_name` arguments are required.\n",
+    "An experiment consists of a **search space** (parameters and parameter constraints) and **optimization configuration** (objectives and outcome constraints). Note that:\n",
+    "- Only `parameters`, and `objectives` arguments are required.\n",
     "- Dictionaries in `parameters` have the following required keys: \"name\" - parameter name, \"type\" - parameter type (\"range\", \"choice\" or \"fixed\"), \"bounds\" for range parameters, \"values\" for choice parameters, and \"value\" for fixed parameters.\n",
     "- Dictionaries in `parameters` can optionally include \"value_type\" (\"int\", \"float\", \"bool\" or \"str\"), \"log_scale\" flag for range parameters, and \"is_ordered\" flag for choice parameters.\n",
     "- `parameter_constraints` should be a list of strings of form \"p1 >= p2\" or \"p1 + p2 <= some_bound\".\n",
@@ -112,7 +112,7 @@
    "metadata": {},
    "source": [
     "## 3. Define how to evaluate trials\n",
-    "When using Ax a service, evaluation of parameterizations suggested by Ax is done either locally or, more commonly, using an external scheduler. Below is a dummy evaluation function that outputs data for two metrics \"hartmann6\" and \"l2norm\". Note that all returned metrics correspond to either the `objective_name` set on experiment creation or the metric names mentioned in `outcome_constraints`."
+    "When using Ax a service, evaluation of parameterizations suggested by Ax is done either locally or, more commonly, using an external scheduler. Below is a dummy evaluation function that outputs data for two metrics \"hartmann6\" and \"l2norm\". Note that all returned metrics correspond to either the `objectives` set on experiment creation or the metric names mentioned in `outcome_constraints`."
    ]
   },
   {


### PR DESCRIPTION
Replaces `objective_name` with `objectives` to match the code and avoid confusion.