### PR TITLE
Add workflow_run_id to Python lib

### DIFF
--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1021,6 +1021,7 @@ def get_trial() -> Trial:
     trial.add_arm(arm)
     trial.runner = SyntheticRunner()
     trial._generation_step_index = 0
+    trial.update_run_metadata({"workflow_run_id": [12345]})
     return trial
 
 


### PR DESCRIPTION
Summary:
Adding a workflow_run_id to the DB schema for indexing.

I don't think we need to import this back from the database, we just need to ensure it is denormalized into the DB schema on export.

Reviewed By: lena-kashtelyan

Differential Revision: D42415925

