### PR TITLE
Support partial objective thresholds

### DIFF
--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -476,21 +476,13 @@ def check_objective_thresholds_match_objectives(
             )
         obj_thresh_metrics.add(metric_name)
 
-        if metric_name in objectives_by_name:
-            minimize = objectives_by_name[metric_name].minimize
-            bounded_above = threshold.op == ComparisonOp.LEQ
-            is_aligned = minimize == bounded_above
-            if not is_aligned:
-                raise UserInputError(
-                    f"Objective threshold on {metric_name} bounds from "
-                    f"{'above' if bounded_above else 'below'} "
-                    f"but {metric_name} is being "
-                    f"{'minimized' if minimize else 'maximized'}."
-                )
-
-    obj_metrics = set(objectives_by_name.keys())
-    if objective_thresholds and obj_thresh_metrics.symmetric_difference(obj_metrics):
-        raise UserInputError(
-            f"Objective thresholds: {obj_thresh_metrics} do not match objectives: "
-            f"{obj_metrics}."
-        )
+        minimize = objectives_by_name[metric_name].minimize
+        bounded_above = threshold.op == ComparisonOp.LEQ
+        is_aligned = minimize == bounded_above
+        if not is_aligned:
+            raise UserInputError(
+                f"Objective threshold on {metric_name} bounds from "
+                f"{'above' if bounded_above else 'below'} "
+                f"but {metric_name} is being "
+                f"{'minimized' if minimize else 'maximized'}."
+            )

--- a/ax/modelbridge/tests/test_torch_modelbridge_moo.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge_moo.py
@@ -38,7 +38,7 @@ from ax.models.torch.botorch_moo_defaults import (
 )
 from ax.service.utils.report_utils import exp_to_df
 from ax.utils.common.testutils import TestCase
-from ax.utils.common.typeutils import not_none
+from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.testing.core_stubs import (
     get_branin_data_multi_objective,
     get_branin_experiment_with_multi_objective,
@@ -475,93 +475,105 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             ParameterConstraint(constraint_dict={"x1": 1.0}, bound=10.0)
         ]
         search_space.add_parameter_constraints(param_constraints)
-        # pyre-fixme[16]: Optional type has no attribute `clone`.
-        oc = exp.optimization_config.clone()
+        oc = not_none(exp.optimization_config).clone()
         oc.objective._objectives[0].minimize = True
-        expected_base_gen_args = modelbridge._get_transformed_gen_args(
-            search_space=search_space.clone(),
-            optimization_config=oc,
-            fixed_features=fixed_features,
-        )
-        with ExitStack() as es:
-            mock_model_infer_obj_t = es.enter_context(
-                patch(
-                    "ax.modelbridge.torch.infer_objective_thresholds",
-                    wraps=infer_objective_thresholds,
-                )
-            )
-            mock_get_transformed_gen_args = es.enter_context(
-                patch.object(
-                    modelbridge,
-                    "_get_transformed_gen_args",
-                    wraps=modelbridge._get_transformed_gen_args,
-                )
-            )
-            mock_get_transformed_model_gen_args = es.enter_context(
-                patch.object(
-                    modelbridge,
-                    "_get_transformed_model_gen_args",
-                    wraps=modelbridge._get_transformed_model_gen_args,
-                )
-            )
-            mock_untransform_objective_thresholds = es.enter_context(
-                patch.object(
-                    modelbridge,
-                    "_untransform_objective_thresholds",
-                    wraps=modelbridge._untransform_objective_thresholds,
-                )
-            )
-            obj_thresholds = modelbridge.infer_objective_thresholds(
-                search_space=search_space,
+
+        for use_partial_thresholds in (False, True):
+            if use_partial_thresholds:
+                checked_cast(
+                    MultiObjectiveOptimizationConfig, oc
+                )._objective_thresholds = [
+                    ObjectiveThreshold(
+                        metric=oc.objective.metrics[0],
+                        bound=2.0,
+                        relative=False,
+                        op=ComparisonOp.LEQ,
+                    )
+                ]
+            expected_base_gen_args = modelbridge._get_transformed_gen_args(
+                search_space=search_space.clone(),
                 optimization_config=oc,
                 fixed_features=fixed_features,
             )
-            expected_obj_weights = torch.tensor([-1.0, 1.0], dtype=torch.double)
-            ckwargs = mock_model_infer_obj_t.call_args[1]
-            self.assertTrue(
-                torch.equal(ckwargs["objective_weights"], expected_obj_weights)
-            )
-            # check that transforms have been applied (at least UnitX)
-            self.assertEqual(ckwargs["bounds"], [(0.0, 1.0), (0.0, 1.0)])
-            lc = ckwargs["linear_constraints"]
-            self.assertTrue(
-                torch.equal(lc[0], torch.tensor([[15.0, 0.0]], dtype=torch.double))
-            )
-            self.assertTrue(
-                torch.equal(lc[1], torch.tensor([[15.0]], dtype=torch.double))
-            )
-            self.assertEqual(ckwargs["fixed_features"], {0: 1.0 / 3.0})
-            mock_get_transformed_gen_args.assert_called_once()
-            mock_get_transformed_model_gen_args.assert_called_once_with(
-                search_space=expected_base_gen_args.search_space,
-                fixed_features=expected_base_gen_args.fixed_features,
-                pending_observations=expected_base_gen_args.pending_observations,
-                optimization_config=expected_base_gen_args.optimization_config,
-            )
-            mock_untransform_objective_thresholds.assert_called_once()
-            ckwargs = mock_untransform_objective_thresholds.call_args[1]
+            with ExitStack() as es:
+                mock_model_infer_obj_t = es.enter_context(
+                    patch(
+                        "ax.modelbridge.torch.infer_objective_thresholds",
+                        wraps=infer_objective_thresholds,
+                    )
+                )
+                mock_get_transformed_gen_args = es.enter_context(
+                    patch.object(
+                        modelbridge,
+                        "_get_transformed_gen_args",
+                        wraps=modelbridge._get_transformed_gen_args,
+                    )
+                )
+                mock_get_transformed_model_gen_args = es.enter_context(
+                    patch.object(
+                        modelbridge,
+                        "_get_transformed_model_gen_args",
+                        wraps=modelbridge._get_transformed_model_gen_args,
+                    )
+                )
+                mock_untransform_objective_thresholds = es.enter_context(
+                    patch.object(
+                        modelbridge,
+                        "_untransform_objective_thresholds",
+                        wraps=modelbridge._untransform_objective_thresholds,
+                    )
+                )
+                obj_thresholds = modelbridge.infer_objective_thresholds(
+                    search_space=search_space,
+                    optimization_config=oc,
+                    fixed_features=fixed_features,
+                )
+                expected_obj_weights = torch.tensor([-1.0, 1.0], dtype=torch.double)
+                ckwargs = mock_model_infer_obj_t.call_args[1]
+                self.assertTrue(
+                    torch.equal(ckwargs["objective_weights"], expected_obj_weights)
+                )
+                # check that transforms have been applied (at least UnitX)
+                self.assertEqual(ckwargs["bounds"], [(0.0, 1.0), (0.0, 1.0)])
+                lc = ckwargs["linear_constraints"]
+                self.assertTrue(
+                    torch.equal(lc[0], torch.tensor([[15.0, 0.0]], dtype=torch.double))
+                )
+                self.assertTrue(
+                    torch.equal(lc[1], torch.tensor([[15.0]], dtype=torch.double))
+                )
+                self.assertEqual(ckwargs["fixed_features"], {0: 1.0 / 3.0})
+                mock_get_transformed_gen_args.assert_called_once()
+                mock_get_transformed_model_gen_args.assert_called_once_with(
+                    search_space=expected_base_gen_args.search_space,
+                    fixed_features=expected_base_gen_args.fixed_features,
+                    pending_observations=expected_base_gen_args.pending_observations,
+                    optimization_config=expected_base_gen_args.optimization_config,
+                )
+                mock_untransform_objective_thresholds.assert_called_once()
+                ckwargs = mock_untransform_objective_thresholds.call_args[1]
 
+                self.assertTrue(
+                    torch.equal(ckwargs["objective_weights"], expected_obj_weights)
+                )
+            self.assertEqual(obj_thresholds[0].metric.name, "branin_a")
+            self.assertEqual(obj_thresholds[1].metric.name, "branin_b")
+            self.assertEqual(obj_thresholds[0].op, ComparisonOp.LEQ)
+            self.assertEqual(obj_thresholds[1].op, ComparisonOp.GEQ)
+            self.assertFalse(obj_thresholds[0].relative)
+            self.assertFalse(obj_thresholds[1].relative)
+            df = exp_to_df(exp)
+            Y = np.stack([df.branin_a.values, df.branin_b.values]).T
+            Y = torch.from_numpy(Y)
+            Y[:, 0] *= -1
+            pareto_Y = Y[is_non_dominated(Y)]
+            nadir = pareto_Y.min(dim=0).values
             self.assertTrue(
-                torch.equal(ckwargs["objective_weights"], expected_obj_weights)
+                np.all(
+                    np.array([-obj_thresholds[0].bound, obj_thresholds[1].bound])
+                    < nadir.numpy()
+                )
             )
-        self.assertEqual(obj_thresholds[0].metric.name, "branin_a")
-        self.assertEqual(obj_thresholds[1].metric.name, "branin_b")
-        self.assertEqual(obj_thresholds[0].op, ComparisonOp.LEQ)
-        self.assertEqual(obj_thresholds[1].op, ComparisonOp.GEQ)
-        self.assertFalse(obj_thresholds[0].relative)
-        self.assertFalse(obj_thresholds[1].relative)
-        df = exp_to_df(exp)
-        Y = np.stack([df.branin_a.values, df.branin_b.values]).T
-        Y = torch.from_numpy(Y)
-        Y[:, 0] *= -1
-        pareto_Y = Y[is_non_dominated(Y)]
-        nadir = pareto_Y.min(dim=0).values
-        self.assertTrue(
-            np.all(
-                np.array([-obj_thresholds[0].bound, obj_thresholds[1].bound])
-                < nadir.numpy()
-            )
-        )
 
         # test using MTGP
         sobol_generator = get_sobol(

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -558,17 +558,18 @@ class TestModelbridgeUtils(TestCase):
         # pyre-fixme[16]: Optional type has no attribute `shape`.
         self.assertEqual(obj_t.shape[0], 4)
 
-        # Fails if threshold not provided for all objective metrics
-        with self.assertRaises(ValueError):
-            extract_objective_thresholds(
-                objective_thresholds=objective_thresholds[:2],
-                objective=objective,
-                outcomes=outcomes,
-            )
+        # Returns NaN for objectives without a threshold.
+        obj_t = extract_objective_thresholds(
+            objective_thresholds=objective_thresholds[:2],
+            objective=objective,
+            outcomes=outcomes,
+        )
+        self.assertTrue(np.array_equal(obj_t[:2], expected_obj_t_not_nan[:2]))
+        self.assertTrue(np.isnan(obj_t[-2:]).all())
 
-        # Fails if number of thresholds doesn't equal number of objectives
+        # Fails if a threshold does not have a corresponding metric.
         objective2 = Objective(Metric("m1"))
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "corresponding metrics"):
             extract_objective_thresholds(
                 objective_thresholds=objective_thresholds,
                 objective=objective2,

--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -211,9 +211,11 @@ class Acquisition(Base):
         # thresholds are not specified, infer them using the model that
         # has already been subset to avoid re-subsetting it within
         # `inter_objective_thresholds`.
-        if (
-            objective_weights.nonzero().numel() > 1
-            and self._objective_thresholds is None
+        if objective_weights.nonzero().numel() > 1 and (
+            self._objective_thresholds is None
+            or self._objective_thresholds[torch_opt_config.objective_weights != 0]
+            .isnan()
+            .any()
         ):
             if torch_opt_config.risk_measure is not None:
                 # TODO[T131759263]: modify the heuristic to support risk measures.
@@ -226,6 +228,7 @@ class Acquisition(Base):
                 outcome_constraints=full_outcome_constraints,
                 X_observed=primary_Xs_observed,
                 subset_idcs=subset_idcs,
+                objective_thresholds=self._objective_thresholds,
             )
             objective_thresholds = (
                 not_none(self._objective_thresholds)[subset_idcs]

--- a/ax/models/torch/botorch_moo.py
+++ b/ax/models/torch/botorch_moo.py
@@ -292,13 +292,17 @@ class MultiObjectiveBotorchModel(BotorchModel):
             outcome_constraints = torch_opt_config.outcome_constraints
             objective_thresholds = torch_opt_config.objective_thresholds
             idcs = None
-        if objective_thresholds is None:
+        if (
+            objective_thresholds is None
+            or objective_thresholds[objective_weights != 0].isnan().any()
+        ):
             full_objective_thresholds = infer_objective_thresholds(
                 model=model,
                 X_observed=not_none(X_observed),
                 objective_weights=full_objective_weights,
                 outcome_constraints=full_outcome_constraints,
                 subset_idcs=idcs,
+                objective_thresholds=objective_thresholds,
             )
             # subset the objective thresholds
             objective_thresholds = (

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -211,7 +211,6 @@ class AcquisitionTest(TestCase):
             "fixed_features",
         ):
             self.assertTrue(generic_equals(ckwargs[attr], getattr(self, attr)))
-            # self.assertEqual(ckwargs[attr], getattr(self, attr))
         self.assertIs(ckwargs["bounds"], self.search_space_digest.bounds)
 
         # Call `subset_model` only when needed
@@ -572,6 +571,26 @@ class AcquisitionTest(TestCase):
                 torch.equal(
                     acquisition.objective_thresholds[:2],
                     torch.tensor([9.9, 3.3], **self.tkwargs),
+                )
+            )
+            self.assertTrue(np.isnan(acquisition.objective_thresholds[2].item()))
+            # With partial thresholds.
+            acquisition = Acquisition(
+                surrogates={"surrogate": self.surrogate},
+                search_space_digest=self.search_space_digest,
+                botorch_acqf_class=self.botorch_acqf_class,
+                torch_opt_config=dataclasses.replace(
+                    torch_opt_config,
+                    objective_thresholds=torch.tensor(
+                        [float("nan"), 5.5, float("nan")], **self.tkwargs
+                    ),
+                ),
+                options=self.options,
+            )
+            self.assertTrue(
+                torch.equal(
+                    acquisition.objective_thresholds[:2],
+                    torch.tensor([9.9, 5.5], **self.tkwargs),
                 )
             )
             self.assertTrue(np.isnan(acquisition.objective_thresholds[2].item()))


### PR DESCRIPTION
Summary: We currently require the objective thresholds to be specified for all or none of the objectives. With this change, the user can specify the objective thresholds for any subset of objectives and the rest will be inferred.

Differential Revision: D43210628

