### PR TITLE
Kill `restore_model_from_generator_run` as it's no longer needed! (#1300)

### DIFF
--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -221,35 +221,6 @@ class TestGenerationStrategy(TestCase):
         gs3 = gs1.clone_reset()
         self.assertEqual(gs1, gs3)
 
-    def test_restore_from_generator_run(self) -> None:
-        gs = GenerationStrategy(
-            steps=[GenerationStep(model=Models.SOBOL, num_trials=5)]
-        )
-        # No generator runs on GS, so can't restore from one.
-        with self.assertRaises(ValueError):
-            gs._restore_model_from_generator_run()
-        exp = get_branin_experiment(with_batch=True)
-        gs.gen(experiment=exp)
-        model = gs.model
-        # Create a copy of the generation strategy and check that when
-        # we restore from last generator run, the model will be set
-        # correctly and that `_seen_trial_indices_by_status` is filled.
-        new_gs = GenerationStrategy(
-            steps=[GenerationStep(model=Models.SOBOL, num_trials=5)]
-        )
-        new_gs._experiment = exp
-        new_gs._generator_runs = gs._generator_runs
-        self.assertIsNone(new_gs._seen_trial_indices_by_status)
-        new_gs._restore_model_from_generator_run()
-        self.assertEqual(gs._seen_trial_indices_by_status, exp.trial_indices_by_status)
-        # Model should be reset, but it should be the same model with same data.
-        self.assertIsNot(model, new_gs.model)
-        self.assertEqual(model.__class__, new_gs.model.__class__)  # Model bridge.
-        # pyre-fixme[16]: Optional type has no attribute `model`.
-        self.assertEqual(model.model.__class__, new_gs.model.model.__class__)  # Model.
-        # pyre-fixme[16]: Optional type has no attribute `_training_data`.
-        self.assertEqual(model._training_data, new_gs.model._training_data)
-
     def test_min_observed(self) -> None:
         # We should fail to transition the next model if there is not
         # enough data observed.

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -31,11 +31,7 @@ from ax.core.parameter_constraint import (
 from ax.core.search_space import SearchSpace
 from ax.exceptions.storage import JSONDecodeError
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
-from ax.modelbridge.registry import (
-    _decode_callables_from_references,
-    ModelRegistryBase,
-    Models,
-)
+from ax.modelbridge.registry import _decode_callables_from_references
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.storage.json_store.decoders import (
     batch_trial_from_json,
@@ -700,18 +696,6 @@ def generation_strategy_from_json(
         decoder_registry=decoder_registry,
         class_decoder_registry=class_decoder_registry,
     )
-    if generation_strategy_json.pop("had_initialized_model"):  # pragma: no cover
-        # If model in the current step was not directly from the `Models` enum,
-        # pass its type to `restore_model_from_generator_run`, which will then
-        # attempt to use this type to recreate the model.
-        if type(gs._curr.model) != Models:
-            models_enum = type(gs._curr.model)
-            assert issubclass(models_enum, ModelRegistryBase)
-            # pyre-ignore[6]: `models_enum` typing hackiness
-            gs._restore_model_from_generator_run(models_enum=models_enum)
-            return gs
-
-        gs._restore_model_from_generator_run()
     return gs
 
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -14,7 +14,6 @@ from ax.core.metric import Metric
 from ax.core.runner import Runner
 from ax.exceptions.storage import JSONDecodeError, JSONEncodeError
 from ax.metrics.jenatton import JenattonMetric
-from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.registry import Models
 from ax.storage.json_store.decoder import (
     generation_strategy_from_json,
@@ -373,11 +372,13 @@ class JSONStoreTest(TestCase):
             decoder_registry=CORE_DECODER_REGISTRY,
             class_decoder_registry=CORE_CLASS_DECODER_REGISTRY,
         )
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(generation_strategy, new_generation_strategy)
         self.assertIsInstance(new_generation_strategy._steps[0].model, Models)
-        # Since this GS has now generated one generator run, model should have
-        # been initialized and restored when decoding from JSON.
-        self.assertIsInstance(new_generation_strategy.model, ModelBridge)
 
         # Check that we can encode and decode the generation strategy after
         # it has generated some trials and been updated with some data.
@@ -395,9 +396,13 @@ class JSONStoreTest(TestCase):
             decoder_registry=CORE_DECODER_REGISTRY,
             class_decoder_registry=CORE_CLASS_DECODER_REGISTRY,
         )
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(generation_strategy, new_generation_strategy)
         self.assertIsInstance(new_generation_strategy._steps[0].model, Models)
-        self.assertIsInstance(new_generation_strategy.model, ModelBridge)
 
     def testEncodeDecodeNumpy(self) -> None:
         arr = np.array([[1, 2, 3], [4, 5, 6]])

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -41,7 +41,6 @@ from ax.core.search_space import HierarchicalSearchSpace, RobustSearchSpace, Sea
 from ax.core.trial import Trial
 from ax.exceptions.storage import SQADecodeError
 from ax.modelbridge.generation_strategy import GenerationStrategy
-from ax.modelbridge.registry import ModelRegistryBase, Models
 from ax.storage.json_store.decoder import object_from_json
 from ax.storage.sqa_store.db import session_scope
 from ax.storage.sqa_store.sqa_classes import (
@@ -770,6 +769,7 @@ class Decoder:
                 for gr in gs_sqa.generator_runs
             ]
         gs._experiment = experiment
+
         if len(gs._generator_runs) > 0:
             # Generation strategy had an initialized model.
             if experiment is None:
@@ -777,17 +777,8 @@ class Decoder:
                     "Cannot decode a generation strategy with a non-zero number of "
                     "generator runs without an experiment."
                 )
-            # If model in the current step was not directly from the `Models` enum,
-            # pass its type to `restore_model_from_generator_run`, which will then
-            # attempt to use this type to recreate the model.
-            if type(gs._curr.model) != Models:
-                models_enum = type(gs._curr.model)
-                assert issubclass(models_enum, ModelRegistryBase)
-                # pyre-ignore[6]: `models_enum` typing hackiness
-                gs._restore_model_from_generator_run(models_enum=models_enum)
-            else:
-                gs._restore_model_from_generator_run()
         gs.db_id = gs_sqa.id
+
         return gs
 
     def runner_from_sqa(

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -5,10 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 from datetime import datetime
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 from ax.core.arm import Arm
-from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import LifecycleStage
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
@@ -20,7 +20,6 @@ from ax.core.types import ComparisonOp
 from ax.exceptions.core import ObjectNotFoundError
 from ax.exceptions.storage import SQADecodeError, SQAEncodeError
 from ax.metrics.branin import BraninMetric
-from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
 from ax.modelbridge.registry import Models
 from ax.runners.synthetic import SyntheticRunner
@@ -72,6 +71,7 @@ from ax.storage.utils import DomainType, MetricIntent, ParameterConstraintType
 from ax.utils.common.constants import Keys
 from ax.utils.common.serialization import serialize_init_args
 from ax.utils.common.testutils import TestCase
+from ax.utils.common.typeutils import not_none
 from ax.utils.testing.core_stubs import (
     get_arm,
     get_branin_data,
@@ -129,14 +129,11 @@ class SQAStoreTest(TestCase):
         init_engine_and_session_factory(url="sqlite://", force_init=True)
 
     def testConnectionToDBWithCreator(self) -> None:
-        # pyre-fixme[3]: Return type must be annotated.
-        def MockDBAPI():
+        def MockDBAPI() -> MagicMock:
             connection = Mock()
 
             # pyre-fixme[53]: Captured variable `connection` is not annotated.
-            # pyre-fixme[3]: Return type must be annotated.
-            # pyre-fixme[2]: Parameter must be annotated.
-            def connect(*args, **kwargs):
+            def connect(*args: Any, **kwargs: Any) -> Mock:
                 return connection
 
             return MagicMock(connect=Mock(side_effect=connect))
@@ -1182,12 +1179,17 @@ class SQAStoreTest(TestCase):
         new_generation_strategy = load_generation_strategy_by_experiment_name(
             experiment_name=experiment.name
         )
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(generation_strategy, new_generation_strategy)
         self.assertIsInstance(new_generation_strategy._steps[0].model, Models)
-        self.assertIsInstance(new_generation_strategy.model, ModelBridge)
         self.assertEqual(len(new_generation_strategy._generator_runs), 2)
-        # pyre-fixme[16]: Optional type has no attribute `_name`.
-        self.assertEqual(new_generation_strategy._experiment._name, experiment._name)
+        self.assertEqual(
+            not_none(new_generation_strategy._experiment)._name, experiment._name
+        )
 
     def testEncodeDecodeGenerationStrategyReducedState(self) -> None:
         """Try restoring the generation strategy using the experiment its attached to,
@@ -1218,15 +1220,26 @@ class SQAStoreTest(TestCase):
         generation_strategy._generator_runs[0]._model_state_after_gen = None
         generation_strategy._generator_runs[0]._search_space = None
         generation_strategy._generator_runs[0]._optimization_config = None
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         # Now the generation strategies should be equal.
+        # Reloaded generation strategy will not have attributes associated with fitting
+        # the model until after it's used to fit the model or generate candidates, so
+        # we unset those attributes here and compare equality of the rest.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(new_generation_strategy, generation_strategy)
         # Model should be successfully restored in generation strategy even with
         # the reduced state.
         self.assertIsInstance(new_generation_strategy._steps[0].model, Models)
-        self.assertIsInstance(new_generation_strategy.model, ModelBridge)
         self.assertEqual(len(new_generation_strategy._generator_runs), 2)
-        # pyre-fixme[16]: Optional type has no attribute `_name`.
-        self.assertEqual(new_generation_strategy._experiment._name, experiment._name)
+        self.assertEqual(
+            not_none(new_generation_strategy._experiment)._name, experiment._name
+        )
+        experiment.new_trial(new_generation_strategy.gen(experiment=experiment))
 
     def testEncodeDecodeGenerationStrategyReducedStateLoadExperiment(self) -> None:
         """Try restoring the generation strategy using the experiment its
@@ -1274,14 +1287,20 @@ class SQAStoreTest(TestCase):
         # Now experiment on generation strategy should be equal to the original
         # experiment with reduced state.
         self.assertEqual(new_generation_strategy.experiment, experiment)
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(new_generation_strategy, generation_strategy)
         # Model should be successfully restored in generation strategy even with
         # the reduced state.
         self.assertIsInstance(new_generation_strategy._steps[0].model, Models)
-        self.assertIsInstance(new_generation_strategy.model, ModelBridge)
         self.assertEqual(len(new_generation_strategy._generator_runs), 2)
-        # pyre-fixme[16]: Optional type has no attribute `_name`.
-        self.assertEqual(new_generation_strategy._experiment._name, experiment._name)
+        self.assertEqual(
+            not_none(new_generation_strategy._experiment)._name, experiment._name
+        )
+        experiment.new_trial(new_generation_strategy.gen(experiment=experiment))
 
     def testUpdateGenerationStrategy(self) -> None:
         generation_strategy = get_generation_strategy(with_callable_model_kwarg=False)
@@ -1296,6 +1315,11 @@ class SQAStoreTest(TestCase):
         loaded_generation_strategy = load_generation_strategy_by_experiment_name(
             experiment_name=experiment.name
         )
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(generation_strategy, loaded_generation_strategy)
 
         # add another generator run, save, reload
@@ -1307,14 +1331,11 @@ class SQAStoreTest(TestCase):
         loaded_generation_strategy = load_generation_strategy_by_experiment_name(
             experiment_name=experiment.name
         )
-        # During restoration of generation strategy's model from its last generator
-        # run, we set `_seen_trial_indices_by_status` to that of the experiment,
-        # from which we are grabbing the data to restore the model with. When the
-        # experiment was updated more recently than the last `gen` from generation
-        # strategy, the generation strategy prior to save might not have 'seen'
-        # some recently added trials, so we update the mappings to match and check
-        # that the generation strategies are equal otherwise.
-        generation_strategy._seen_trial_indices_by_status[TrialStatus.CANDIDATE].add(1)
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(generation_strategy, loaded_generation_strategy)
 
         # make sure that we can update the experiment too
@@ -1323,15 +1344,20 @@ class SQAStoreTest(TestCase):
         loaded_generation_strategy = load_generation_strategy_by_experiment_name(
             experiment_name=experiment.name
         )
+        # Reloaded generation strategy will not have attributes associated with fitting
+        # the model until after it's used to fit the model or generate candidates, so
+        # we unset those attributes here and compare equality of the rest.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(generation_strategy, loaded_generation_strategy)
+        self.assertIsNotNone(loaded_generation_strategy._experiment)
         self.assertEqual(
-            # pyre-fixme[16]: Optional type has no attribute `description`.
-            generation_strategy._experiment.description,
+            not_none(generation_strategy._experiment).description,
             experiment.description,
         )
         self.assertEqual(
-            generation_strategy._experiment.description,
-            loaded_generation_strategy._experiment.description,
+            not_none(generation_strategy._experiment).description,
+            not_none(loaded_generation_strategy._experiment).description,
         )
 
     def testGeneratorRunGenMetadata(self) -> None:
@@ -1369,7 +1395,11 @@ class SQAStoreTest(TestCase):
         loaded_generation_strategy = load_generation_strategy_by_experiment_name(
             experiment_name=experiment.name
         )
-        generation_strategy._save_seen_trial_indices()
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(generation_strategy, loaded_generation_strategy)
 
         # add even more generator runs, save using batch_size, reload
@@ -1392,7 +1422,11 @@ class SQAStoreTest(TestCase):
         loaded_generation_strategy = load_generation_strategy_by_experiment_name(
             experiment_name=experiment.name
         )
-        generation_strategy._save_seen_trial_indices()
+        # These fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._seen_trial_indices_by_status = None
+        generation_strategy._model = None
         self.assertEqual(generation_strategy, loaded_generation_strategy)
 
     def testUpdateRunner(self) -> None:
@@ -1503,13 +1537,12 @@ class SQAStoreTest(TestCase):
         ),
         side_effect=_get_experiment_sqa_immutable_opt_config_and_search_space,
     )
-    # pyre-fixme[3]: Return type must be annotated.
     def testImmutableSearchSpaceAndOptConfigLoading(
         self,
         _mock_get_exp_sqa_imm_oc_ss,
         _mock_get_gs_sqa_imm_oc_ss,
         _mock_gr_from_sqa,
-    ):
+    ) -> None:
         experiment = get_experiment_with_batch_trial()
         experiment._properties = {Keys.IMMUTABLE_SEARCH_SPACE_AND_OPT_CONF: True}
         save_experiment(experiment)

--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -166,13 +166,20 @@ def object_attribute_dicts_find_unequal_fields(
         elif field == "_model":  # pragma: no cover (tested in modelbridge)
             # TODO[T52643706]: replace with per-`ModelBridge` method like
             # `equivalent_models`, to compare models more meaningfully.
-            if not hasattr(one_val, "model"):
-                equal = not hasattr(other_val, "model")
+            if not hasattr(one_val, "model") or not hasattr(other_val, "model"):
+                equal = not hasattr(other_val, "model") and not hasattr(
+                    other_val, "model"
+                )
             else:
                 # If model bridges have a `model` attribute, the types of the
                 # values of those attributes should be equal if the model
                 # bridge is the same.
-                equal = isinstance(one_val.model, type(other_val.model))
+                equal = (
+                    hasattr(one_val, "model")
+                    and hasattr(other_val, "model")
+                    and isinstance(one_val.model, type(other_val.model))
+                )
+
         elif isinstance(one_val, list):
             equal = isinstance(other_val, list) and same_elements(one_val, other_val)
         elif isinstance(one_val, dict):


### PR DESCRIPTION
Summary:
NOTE: Copied from D32605396 (too stale to rebase)

Now that we refactored generation strategy to use generation nodes, we no longer need to refit the model on generation strategy re-loading. Instead, we can just fit it next time generation_strategy.gen is called, which is great because re-fitting the model really does not belong in the deserialization call anyway –– it's kind of a big side effect and makes the deserialization heavy and slow...

Pull Request resolved: https://github.com/facebook/Ax/pull/1300

Reviewed By: mpolson64

Differential Revision: D41687258

Pulled By: lena-kashtelyan

