### PR TITLE
Warn if inoperable keyword arguments are passed to optimizers

### DIFF
--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -482,11 +482,15 @@ class Acquisition(Base):
                 )
                 n = num_choices
 
-            return optimize_acqf_discrete(
-                acq_function=self.acqf,
+            discrete_opt_options = optimizer_argparse(
+                self.acqf,
+                bounds=bounds,
                 q=n,
-                choices=all_choices,
-                **optimizer_options_with_defaults,
+                optimizer_options=optimizer_options,
+                optimizer_is_discrete=True,
+            )
+            return optimize_acqf_discrete(
+                acq_function=self.acqf, q=n, choices=all_choices, **discrete_opt_options
             )
 
         # 2b. Handle mixed search spaces that have discrete and continuous features.

--- a/ax/models/torch/botorch_modular/optimizer_argparse.py
+++ b/ax/models/torch/botorch_modular/optimizer_argparse.py
@@ -52,8 +52,15 @@ def _argparse_base(
     init_batch_limit: int = 32,
     batch_limit: int = 5,
     optimizer_options: Optional[Dict[str, Any]] = None,
+    optimizer_is_discrete: bool = False,
     **ignore: Any,
 ) -> Dict[str, Any]:
+    """
+    `optimizer_is_discrete`: True if the optimizer is `optimizer_acqf_discrete`,
+        which supports a limited set of arguments.
+    """
+    if optimizer_is_discrete:
+        return optimizer_options or {}
     return {
         "num_restarts": num_restarts,
         "raw_samples": raw_samples,

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -299,7 +299,6 @@ class AcquisitionTest(TestCase):
                 search_space_digest=ssd1,
                 fixed_features={3: 2.0},
                 rounding_func=self.rounding_func,
-                optimizer_options=self.optimizer_options,
             )
         # check that SearchSpaceExhausted is raised correctly
         acquisition = self.get_acquisition_function()
@@ -313,7 +312,6 @@ class AcquisitionTest(TestCase):
                 n=1,
                 search_space_digest=ssd1,
                 rounding_func=self.rounding_func,
-                optimizer_options=self.optimizer_options,
             )
         acquisition = self.get_acquisition_function()
         with self.assertWarnsRegex(
@@ -324,7 +322,6 @@ class AcquisitionTest(TestCase):
                 n=8,
                 search_space_digest=ssd1,
                 rounding_func=self.rounding_func,
-                optimizer_options=self.optimizer_options,
             )
 
         # check this works without any fixed_feature specified
@@ -335,7 +332,6 @@ class AcquisitionTest(TestCase):
             n=2,
             search_space_digest=ssd1,
             rounding_func=self.rounding_func,
-            optimizer_options=self.optimizer_options,
         )
         expected = torch.tensor([[2, 2, 4], [2, 3, 3]]).to(self.X)
         self.assertTrue(X_selected.shape == (2, 3))
@@ -360,7 +356,6 @@ class AcquisitionTest(TestCase):
             search_space_digest=ssd2,
             fixed_features=self.fixed_features,
             rounding_func=self.rounding_func,
-            optimizer_options=self.optimizer_options,
         )
         expected = torch.tensor([[4, 2, 4], [3, 2, 4], [4, 2, 3]]).to(self.X)
         self.assertTrue(X_selected.shape == (3, 3))
@@ -373,7 +368,6 @@ class AcquisitionTest(TestCase):
             n=1,
             search_space_digest=ssd2,
             rounding_func=self.rounding_func,
-            optimizer_options=self.optimizer_options,
             inequality_constraints=[
                 (torch.tensor([0, 1], dtype=torch.int64), -torch.ones(2), 0)
             ],
@@ -385,7 +379,6 @@ class AcquisitionTest(TestCase):
             n=1,
             search_space_digest=ssd2,
             rounding_func=self.rounding_func,
-            optimizer_options=self.optimizer_options,
             inequality_constraints=[
                 (torch.tensor([0], dtype=torch.int64), -torch.ones(1), 0),
                 (torch.tensor([1], dtype=torch.int64), -torch.ones(1), 0),


### PR DESCRIPTION
Summary: The previous diff discusses issues with kwargs in BoTorch optimizers and resolves some of them. This diff warns if keyword arguments that do nothing are passed to an optimizer, and stops Ax (botorch-modular) from doing that.

Differential Revision: D43277102

