### PR TITLE
Add LogY to TRANSFORM_REGISTRY

### DIFF
--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -15,6 +15,7 @@ from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
 from ax.modelbridge.transforms.int_to_float import IntToFloat
 from ax.modelbridge.transforms.ivw import IVW
 from ax.modelbridge.transforms.log import Log
+from ax.modelbridge.transforms.log_y import LogY
 from ax.modelbridge.transforms.logit import Logit
 from ax.modelbridge.transforms.map_unit_x import MapUnitX
 from ax.modelbridge.transforms.metrics_as_task import MetricsAsTask
@@ -69,6 +70,7 @@ TRANSFORM_REGISTRY: Dict[Type[Transform], int] = {
     Logit: 20,
     MapUnitX: 21,
     MetricsAsTask: 22,
+    LogY: 23,
 }
 
 


### PR DESCRIPTION
Summary:
This should prevent errors like
```
/mnt/xarfuse/uid-352651/d30e011b-seed-nspid4026531836_cgpid22290725-ns-4026531840/ax/storage/json_store/encoders.py in transform_type_to_dict(transform_type)
    390     return {
    391         "__type": "Type[Transform]",
--> 392         "index_in_registry": TRANSFORM_REGISTRY[transform_type],
    393         "transform_type": f"{transform_type}",
    394     }
KeyError: <class 'ax.modelbridge.transforms.log_y.LogY'>
```

Differential Revision: D43401848

