### PR TITLE
fixing the derivative gp posterior for matern kernel

### DIFF
--- a/ax/utils/sensitivity/derivative_gp.py
+++ b/ax/utils/sensitivity/derivative_gp.py
@@ -28,7 +28,7 @@ def get_KxX_dx(gp: Model, x: Tensor, kernel_type: str = "rbf") -> Tensor:
     Args:
         gp: Botorch model.
         x: (n x D) Test points.
-        kernel_type: Takes "rbf" or "matern_l1" or "matern_l2"
+        kernel_type: Takes "rbf" or "matern"
     Returns:
         Tensor (n x D) The derivative of the kernel K(x,X) w.r.t. x.
     """
@@ -42,25 +42,18 @@ def get_KxX_dx(gp: Model, x: Tensor, kernel_type: str = "rbf") -> Tensor:
         part1 = -torch.eye(D, device=x.device, dtype=x.dtype) / lengthscale**2
         part2 = x.view(n, 1, D) - X.view(1, N, D)
         return part1 @ (part2 * K_xX.view(n, N, 1)).transpose(1, 2)
-    # Else, we have a Matern kernel, either L1 or L2
+    # Else, we have a Matern kernel
     mean = x.reshape(-1, x.size(-1)).mean(0)[(None,) * (x.dim() - 1)]
     x1_ = (x - mean).div(lengthscale)
     x2_ = (X - mean).div(lengthscale)
-    matern_norml2 = kernel_type == "matern_l2"
-    distance = gp.covar_module.covar_dist(  # pyre-ignore
-        x1_, x2_, square_dist=matern_norml2
-    )
+    distance = gp.covar_module.covar_dist(x1_, x2_)
     exp_component = torch.exp(-math.sqrt(5.0) * distance)  # pyre-ignore
     constant_component = (-5.0 / 3.0) * distance - (5.0 * math.sqrt(5.0) / 3.0) * (
         distance**2
     )
     sigma_f = gp.covar_module.outputscale.detach()  # pyre-ignore
-    if matern_norml2:
-        part1 = torch.eye(D, device=lengthscale.device) / lengthscale**2
-        part2 = 2 * (x.view(n, 1, D) - X.view(1, N, D))
-    else:
-        part1 = torch.eye(D, device=lengthscale.device) / lengthscale
-        part2 = (x1_.view(n, 1, D) - x2_.view(1, N, D)) / distance.unsqueeze(2)
+    part1 = torch.eye(D, device=lengthscale.device) / lengthscale
+    part2 = (x1_.view(n, 1, D) - x2_.view(1, N, D)) / distance.unsqueeze(2)
     total_k = sigma_f * constant_component * exp_component
     total = part1 @ (part2 * total_k.view(n, N, 1)).transpose(1, 2)
     return total
@@ -70,20 +63,18 @@ def get_Kxx_dx2(gp: Model, kernel_type: str = "rbf") -> Tensor:
     r"""Computes the analytic second derivative of the kernel w.r.t. the training data
     Args:
         gp: Botorch model.
-        kernel_type: Takes "rbf" or "matern_l1" or "matern_l2"
+        kernel_type: Takes "rbf" or "matern"
     Returns:
         Tensor (n x D x D) The second derivative of the kernel w.r.t. the training data.
     """
     X = gp.train_inputs[0]  # pyre-ignore
     D = X.shape[1]
     lengthscale = gp.covar_module.base_kernel.lengthscale.detach()  # pyre-ignore
+    sigma_f = gp.covar_module.outputscale.detach()  # pyre-ignore
+    res = (torch.eye(D, device=lengthscale.device) / lengthscale**2) * sigma_f
     if kernel_type == "rbf":
-        sigma_f = gp.covar_module.outputscale.detach()  # pyre-ignore
-        return (torch.eye(D, device=lengthscale.device) / lengthscale**2) * sigma_f
-    if kernel_type == "matern_l2":
-        return torch.zeros(D, D, device=lengthscale.device)
-    warnings.warn("second derivative of Matern undefined when x1==x2")
-    return torch.eye(D, device=lengthscale.device) * 1e10
+        return res
+    return res * (5/3)
 
 
 def posterior_derivative(
@@ -97,17 +88,17 @@ def posterior_derivative(
     Args:
         gp: Botorch model
         x: (n x D) Test points.
-        kernel_type: Takes "rbf" or "matern_l1" or "matern_l2"
+        kernel_type: Takes "rbf" or "matern"
     Returns:
         A Botorch Posterior.
     """
     if gp.prediction_strategy is None:
         gp.posterior(x)  # Call this to update prediction strategy of GPyTorch.
-    if kernel_type not in ["rbf", "matern_l1", "matern_l2"]:
+    if kernel_type not in ["rbf", "matern"]:
         raise ValueError("only matern and rbf kernels are supported")
     K_xX_dx = get_KxX_dx(gp, x, kernel_type=kernel_type)
     Kxx_dx2 = get_Kxx_dx2(gp, kernel_type=kernel_type)
-    mean_d = K_xX_dx @ get_KXX_inv(gp) @ gp.train_targets
+    mean_d = K_xX_dx @ get_KXX_inv(gp) @ (gp.train_targets - gp.mean_module(gp.train_inputs[0]))
     variance_d = Kxx_dx2 - K_xX_dx @ get_KXX_inv(gp) @ K_xX_dx.transpose(1, 2)
     variance_d = variance_d.clamp_min(1e-9)
     try:

--- a/ax/utils/sensitivity/derivative_measures.py
+++ b/ax/utils/sensitivity/derivative_measures.py
@@ -43,11 +43,8 @@ class GpDGSMGpMean(object):
             model: A BoTorch model.
             bounds: Parameter bounds over which to evaluate model sensitivity.
             derivative_gp: If true, the derivative of the GP is used to compute
-                the gradient instead of backward. If `kernel_type` is matern_l1,
-                only the mean function of derivative GP can be used, and the
-                variance is not defined.
-            kernel_type: Takes "rbf" or "matern_l1" or "matern_l2", set only
-                if `derivative_gp` is true.
+                the gradient instead of backward.
+            kernel_type: Takes "rbf" or "matern", set only if `derivative_gp` is true.
             Y_scale: Scale the derivatives by this amount, to undo scaling
                 done on the training data.
             num_mc_samples: The number of MonteCarlo grid samples
@@ -222,10 +219,8 @@ class GpDGSMGpSampling(GpDGSMGpMean):
             num_gp_samples: If method is "GP samples", the number of GP samples has
                 to be set.
             derivative_gp: If true, the derivative of the GP is used to compute the
-                gradient instead of backward. If `kernel_type` is matern_l1,
-                `derivative_gp` should be False because the variance is not defined.
-            kernel_type: Takes "rbf" or "matern_l1" or "matern_l2", set only if
-                `derivative_gp` is true.
+                gradient instead of backward.
+            kernel_type: Takes "rbf" or "matern", set only if `derivative_gp` is true.
             Y_scale: Scale the derivatives by this amount, to undo scaling done on
                 the training data.
             num_mc_samples: The number of Monte Carlo grid samples.

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -199,7 +199,7 @@ class SensitivityAnanlysisTest(TestCase):
 
     def testDerivativeGp(self) -> None:
         test_x = torch.rand(2, 2)
-        posterior = posterior_derivative(self.model, test_x, kernel_type="matern_l1")
+        posterior = posterior_derivative(self.model, test_x, kernel_type="matern")
         self.assertIsInstance(posterior, MultivariateNormal)
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
The previous implementation had a distinction between Matern with l1 distance and l2 distance. This distinction is not accurate and is unnecessary. 