### PR TITLE
Don't try to save lists of python primitives

### DIFF
--- a/ax/storage/sqa_store/tests/test_utils.py
+++ b/ax/storage/sqa_store/tests/test_utils.py
@@ -41,6 +41,11 @@ class SQAStoreUtilsTest(TestCase):
         # pyre-fixme[8]: Attribute has type `int`; used as `None`.
         exp2.trials[0].generator_runs[0].arms[0].db_id = None
 
+        # this proves it does not error trying to sort lists in run_metadata
+        run_metadata = {"arms": [arm.parameters for arm in exp2.trials[0].arms]}
+        exp1.trials[0].update_run_metadata(run_metadata)
+        exp2.trials[0].update_run_metadata(run_metadata)
+
         # copy db_ids from exp1 to exp2
         copy_db_ids(exp1, exp2)
         self.assertEqual(exp1, exp2)

--- a/ax/storage/sqa_store/utils.py
+++ b/ax/storage/sqa_store/utils.py
@@ -142,9 +142,13 @@ def copy_db_ids(source: Any, target: Any, path: Optional[List[str]] = None) -> N
             source = sorted(source)
             target = sorted(target)
         except TypeError as e:
-            raise SQADecodeError(
-                error_message_prefix + f"TypeError encountered during sorting: {e}"
-            )
+            if any(isinstance(o, Base) for o in source + target):
+                raise SQADecodeError(
+                    error_message_prefix + f"TypeError encountered during sorting: {e}"
+                )
+            else:
+                # source and target are not lists of things that need to be saved
+                return
 
         for index, x in enumerate(source):
             copy_db_ids(x, target[index], path + [str(index)])


### PR DESCRIPTION
Summary:
There was generating a long log warning in N3122283.  In looks like `copy_db_ids()` just traverses down the hierarchy of an object trying to put db ids on everything.

This should be a no op other than raising an error which was _always_ caught and logged.  I think this error was originally meant for catching lists of `Base` where `SortableBase` was needed.

Differential Revision: D43475289

