### PR TITLE
Pass seed to HitAndRunPolytopeSampler

### DIFF
--- a/ax/models/random/base.py
+++ b/ax/models/random/base.py
@@ -135,7 +135,8 @@ class RandomModel(Model):
             if self.fallback_to_sample_polytope:
                 logger.info(
                     "Rejection sampling exceeded specified maximum draws."
-                    "Falling back on polytope sampler"
+                    "Falling back on HitAndRunPolytopeSampler instead of "
+                    f"{self.__class__.__name__}."
                 )
                 # If rejection sampling fails, try polytope sampler.
                 polytope_sampler = HitAndRunPolytopeSampler(

--- a/ax/models/random/base.py
+++ b/ax/models/random/base.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import random
 from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -58,7 +59,7 @@ class RandomModel(Model):
     ) -> None:
         super().__init__()
         self.deduplicate = deduplicate
-        self.seed = seed
+        self.seed: int = seed if seed is not None else random.randint(0, 100_000)
         # Used for deduplication.
         self.generated_points = generated_points
         self.fallback_to_sample_polytope = fallback_to_sample_polytope
@@ -113,8 +114,7 @@ class RandomModel(Model):
                 #  for 1st param but got
                 #  `Union[botorch.acquisition.acquisition.AcquisitionFunction, float,
                 #  int, str]`.
-                # pyre-fixme[35]: Target cannot be annotated.
-                max_draws: int = int(max_draws)
+                max_draws = int(max_draws)
         try:
             # Always rejection sample, but this only rejects if there are
             # constraints or actual duplicates and deduplicate is specified.
@@ -149,7 +149,14 @@ class RandomModel(Model):
                     interior_point=self._get_last_point(),
                     bounds=self._convert_bounds(bounds),
                 )
-                points = polytope_sampler.draw(n).numpy()
+                num_generated = (
+                    len(self.generated_points)
+                    if self.generated_points is not None
+                    else 0
+                )
+                points = polytope_sampler.draw(
+                    n=n, seed=self.seed + num_generated
+                ).numpy()
             else:
                 raise e
 

--- a/ax/models/random/uniform.py
+++ b/ax/models/random/uniform.py
@@ -24,7 +24,7 @@ class UniformGenerator(RandomModel):
 
     def __init__(self, deduplicate: bool = True, seed: Optional[int] = None) -> None:
         super().__init__(deduplicate=deduplicate, seed=seed)
-        self._rs = np.random.RandomState(seed=seed)
+        self._rs = np.random.RandomState(seed=self.seed)
 
     def _gen_samples(self, n: int, tunable_d: int) -> np.ndarray:
         """Generate samples from the scipy uniform distribution.

--- a/ax/models/tests/test_random.py
+++ b/ax/models/tests/test_random.py
@@ -8,11 +8,19 @@ import numpy as np
 import torch
 from ax.models.random.base import RandomModel
 from ax.utils.common.testutils import TestCase
+from ax.utils.common.typeutils import not_none
 
 
 class RandomModelTest(TestCase):
     def setUp(self) -> None:
         self.random_model = RandomModel()
+
+    def test_seed(self) -> None:
+        # With manual seed.
+        random_model = RandomModel(seed=5)
+        self.assertEqual(random_model.seed, 5)
+        # With no seed.
+        self.assertIsInstance(self.random_model.seed, int)
 
     def testRandomModelGenSamples(self) -> None:
         with self.assertRaises(NotImplementedError):
@@ -27,9 +35,9 @@ class RandomModelTest(TestCase):
     def testConvertEqualityConstraints(self) -> None:
         fixed_features = {3: 0.7, 1: 0.5}
         d = 4
-        # pyre-fixme[23]: Unable to unpack `Optional[Tuple[Tensor, Tensor]]` into 2
-        #  values.
-        C, c = self.random_model._convert_equality_constraints(d, fixed_features)
+        C, c = not_none(
+            self.random_model._convert_equality_constraints(d, fixed_features)
+        )
         c_expected = torch.tensor([[0.5], [0.7]], dtype=torch.double)
         C_expected = torch.tensor([[0, 1, 0, 0], [0, 0, 0, 1]], dtype=torch.double)
         c_comparison = c == c_expected
@@ -41,9 +49,9 @@ class RandomModelTest(TestCase):
     def testConvertInequalityConstraints(self) -> None:
         A = np.array([[1, 2], [3, 4]])
         b = np.array([[5], [6]])
-        # pyre-fixme[23]: Unable to unpack `Optional[Tuple[Tensor, Tensor]]` into 2
-        #  values.
-        A_result, b_result = self.random_model._convert_inequality_constraints((A, b))
+        A_result, b_result = not_none(
+            self.random_model._convert_inequality_constraints((A, b))
+        )
         A_expected = torch.tensor([[1, 2], [3, 4]], dtype=torch.double)
         b_expected = torch.tensor([[5], [6]], dtype=torch.double)
         A_comparison = A_result == A_expected
@@ -53,9 +61,7 @@ class RandomModelTest(TestCase):
         self.assertEqual(self.random_model._convert_inequality_constraints(None), None)
 
     def testConvertBounds(self) -> None:
-        bounds = [(1, 2), (3, 4), (5, 6)]
-        # pyre-fixme[6]: For 1st param expected `List[Tuple[float, float]]` but got
-        #  `List[Tuple[int, int]]`.
+        bounds = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
         bounds_result = self.random_model._convert_bounds(bounds)
         bounds_expected = torch.tensor([[1, 3, 5], [2, 4, 6]], dtype=torch.double)
         bounds_comparison = bounds_result == bounds_expected


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/Ax/issues/1439.

If we don't pass any seed to the polytope sampler, the samples produced by Sobol end up being non-deterministic.

Differential Revision: D43506373

