### PR TITLE
Raise error if SQA version >= 2.0

### DIFF
--- a/ax/exceptions/core.py
+++ b/ax/exceptions/core.py
@@ -145,6 +145,12 @@ class SearchSpaceExhausted(OptimizationComplete):
         )
 
 
+class IncompatibleDependencyVersion(AxError):
+    """Raise when an imcompatible dependency version is installed."""
+
+    pass
+
+
 class AxWarning(Warning):
     """Base Ax warning.
 


### PR DESCRIPTION
Summary:
As raised in https://github.com/facebook/Ax/issues/1432 , Ax OSS users can get into the following bad state:

- User installs Ax without SQA storage extra
- User installs SQA >= 2.0 (perhaps as a dependency of another library)
- Ax breaks because Ax is not compatible with SQA >= 2.0

Differential Revision: D43479147

