### PR TITLE
"Created" record creation logic

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from enum import Enum
+from math import inf
 from typing import Dict, List, Optional, Tuple, Type, Union
 from warnings import warn
 
@@ -75,6 +76,10 @@ class Parameter(SortableBase, metaclass=ABCMeta):
 
     @abstractmethod
     def validate(self, value: TParamValue) -> bool:
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def cardinality(self) -> float:
         pass  # pragma: no cover
 
     @property
@@ -196,6 +201,12 @@ class RangeParameter(Parameter):
             log_scale=log_scale,
             logit_scale=logit_scale,
         )
+
+    def cardinality(self) -> float:
+        if self.parameter_type == ParameterType.FLOAT:
+            return inf
+
+        return self.upper - self.lower + 1
 
     def _validate_range_param(
         self,
@@ -487,6 +498,9 @@ class ChoiceParameter(Parameter):
         )
         return default_bool
 
+    def cardinality(self) -> float:
+        return len(self.values)
+
     @property
     def sort_values(self) -> bool:
         return self._sort_values
@@ -630,6 +644,9 @@ class FixedParameter(Parameter):
                     f"{self.name}: {self.value}; got: {dependents}."
                 )
         self._dependents = dependents
+
+    def cardinality(self) -> float:
+        return 1.0
 
     @property
     def value(self) -> TParamValue:

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -687,6 +687,27 @@ class HierarchicalSearchSpace(SearchSpace):
 
         return self.parameters[root_parameters.pop()]
 
+    @property
+    def height(self) -> int:
+        """
+        Height of the underlying tree structure of this hierarchical search space.
+        """
+
+        def _height_from_parameter(parameter: Parameter) -> int:
+            if len(parameter.dependents) == 0:
+                return 1
+
+            return (
+                max(
+                    _height_from_parameter(parameter=self[param_name])
+                    for deps in parameter.dependents.values()
+                    for param_name in deps
+                )
+                + 1
+            )
+
+        return _height_from_parameter(parameter=self.root)
+
     def _validate_hierarchical_structure(self) -> None:
         """Validate the structure of this hierarchical search space, ensuring that all
         subtrees are independent (not sharing any parameters) and that all parameters

--- a/ax/telemetry/optimization.py
+++ b/ax/telemetry/optimization.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from typing import Any, Dict, Optional
+
+from ax.telemetry.scheduler import SchedulerCreatedRecord
+
+
+@dataclass(frozen=True)
+class OptimizationCreatedRecord:
+    """
+    Record of the "Optimization" creation event. This includes the
+    SchedulerCreatedRecord as well as miscellaneous metadata about the optimization not
+    available from the Scheduler. In order to facilitate easy serialization only
+    include simple types: numbers, strings, bools, and None.
+    """
+
+    scheduler_created_record: SchedulerCreatedRecord
+
+    product_surface: str
+    launch_surface: str
+
+    deployed_job_id: int
+    trial_evaluation_identifier: Optional[str]
+
+    # Miscellaneous product info
+    is_manual_generation_strategy: bool
+    warm_started_from: Optional[str]
+    num_custom_trials: int
+
+    def flatten(self) -> Dict[str, Any]:
+        """
+        Flatten into an appropriate format for logging to a tabular database.
+        """
+
+        self_dict = asdict(self)
+        self_dict.pop("scheduler_created_record")
+        scheduler_created_record_dict = self.scheduler_created_record.flatten()
+
+        return {
+            **self_dict,
+            **scheduler_created_record_dict,
+        }

--- a/ax/telemetry/tests/test_experiment.py
+++ b/ax/telemetry/tests/test_experiment.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.telemetry.experiment import ExperimentCreatedRecord
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_experiment_with_custom_runner_and_metric
+
+
+class TestExperiment(TestCase):
+    def test_experiment_created_record_from_experiment(self) -> None:
+        experiment = get_experiment_with_custom_runner_and_metric()
+
+        record = ExperimentCreatedRecord.from_experiment(experiment=experiment)
+        expected = ExperimentCreatedRecord(
+            experiment_name="test",
+            experiment_type=None,
+            num_continuous_range_parameters=1,
+            num_int_range_parameters_small=0,
+            num_int_range_parameters_medium=0,
+            num_int_range_parameters_large=1,
+            num_log_scale_range_parameters=0,
+            num_unordered_choice_parameters_small=1,
+            num_unordered_choice_parameters_medium=0,
+            num_unordered_choice_parameters_large=0,
+            num_fixed_parameters=1,
+            dimensionality=3,
+            heirerarchical_tree_height=1,
+            num_parameter_constraints=3,
+            num_objectives=1,
+            num_tracking_metrics=1,
+            num_outcome_constraints=1,
+            num_map_metrics=0,
+            metric_cls_to_quantity={"Metric": 2, "CustomTestMetric": 1},
+            runner_cls="CustomTestRunner",
+        )
+        self.assertEqual(record, expected)

--- a/ax/telemetry/tests/test_generation_strategy.py
+++ b/ax/telemetry/tests/test_generation_strategy.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.telemetry.generation_strategy import GenerationStrategyCreatedRecord
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.modeling_stubs import get_generation_strategy
+
+
+class TestGenerationStrategy(TestCase):
+    def test_generation_strategy_created_record_from_generation_strategy(self) -> None:
+        gs = get_generation_strategy()
+        record = GenerationStrategyCreatedRecord.from_generation_strategy(
+            generation_strategy=gs
+        )
+        expected = GenerationStrategyCreatedRecord(
+            generation_strategy_name="Sobol+BO_MIXED",
+            num_requested_initialization_trials=6,
+            num_requested_bayesopt_trials=-1,
+            num_requested_other_trials=0,
+            max_parallelism=3,
+        )
+        self.assertEqual(record, expected)

--- a/ax/telemetry/tests/test_optimization.py
+++ b/ax/telemetry/tests/test_optimization.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.service.scheduler import Scheduler, SchedulerOptions
+from ax.telemetry.optimization import OptimizationCreatedRecord
+from ax.telemetry.scheduler import SchedulerCreatedRecord
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_branin_experiment
+from ax.utils.testing.modeling_stubs import get_generation_strategy
+
+
+class TestOptimization(TestCase):
+    def test_flatten(self) -> None:
+        scheduler = Scheduler(
+            experiment=get_branin_experiment(),
+            generation_strategy=get_generation_strategy(),
+            options=SchedulerOptions(
+                total_trials=0,
+                tolerated_trial_failure_rate=0.2,
+                init_seconds_between_polls=10,
+            ),
+        )
+
+        record = OptimizationCreatedRecord(
+            scheduler_created_record=SchedulerCreatedRecord.from_scheduler(
+                scheduler=scheduler
+            ),
+            product_surface="Axolotl",
+            launch_surface="web",
+            deployed_job_id=1118,
+            trial_evaluation_identifier="train",
+            is_manual_generation_strategy=True,
+            warm_started_from=None,
+            num_custom_trials=0,
+        )
+
+        flat = record.flatten()
+        expected_dict = {
+            **SchedulerCreatedRecord.from_scheduler(scheduler=scheduler).flatten(),
+            "product_surface": "Axolotl",
+            "launch_surface": "web",
+            "deployed_job_id": 1118,
+            "trial_evaluation_identifier": "train",
+            "is_manual_generation_strategy": True,
+            "warm_started_from": None,
+            "num_custom_trials": 0,
+        }
+
+        self.assertEqual(flat, expected_dict)

--- a/ax/telemetry/tests/test_scheduler.py
+++ b/ax/telemetry/tests/test_scheduler.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.service.scheduler import Scheduler, SchedulerOptions
+from ax.telemetry.experiment import ExperimentCreatedRecord
+from ax.telemetry.generation_strategy import GenerationStrategyCreatedRecord
+from ax.telemetry.scheduler import SchedulerCreatedRecord
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_branin_experiment
+from ax.utils.testing.modeling_stubs import get_generation_strategy
+
+
+class TestScheduler(TestCase):
+    def test_scheduler_created_record_from_scheduler(self) -> None:
+        scheduler = Scheduler(
+            experiment=get_branin_experiment(),
+            generation_strategy=get_generation_strategy(),
+            options=SchedulerOptions(
+                total_trials=0,
+                tolerated_trial_failure_rate=0.2,
+                init_seconds_between_polls=10,
+            ),
+        )
+
+        record = SchedulerCreatedRecord.from_scheduler(scheduler=scheduler)
+
+        expected = SchedulerCreatedRecord(
+            experiment_created_record=ExperimentCreatedRecord.from_experiment(
+                experiment=scheduler.experiment
+            ),
+            generation_strategy_created_record=(
+                GenerationStrategyCreatedRecord.from_generation_strategy(
+                    generation_strategy=scheduler.generation_strategy
+                )
+            ),
+            scheduler_total_trials=0,
+            scheduler_max_pending_trials=10,
+            arms_per_trial=1,
+            early_stopping_strategy_cls="NoneType",
+            global_stopping_strategy_cls="NoneType",
+            transformed_dimensionality=-1,
+        )
+        self.assertEqual(record, expected)
+
+        flat = record.flatten()
+        expected_dict = {
+            **ExperimentCreatedRecord.from_experiment(
+                experiment=scheduler.experiment
+            ).__dict__,
+            **GenerationStrategyCreatedRecord.from_generation_strategy(
+                generation_strategy=scheduler.generation_strategy
+            ).__dict__,
+            "scheduler_total_trials": 0,
+            "scheduler_max_pending_trials": 10,
+            "arms_per_trial": 1,
+            "early_stopping_strategy_cls": "NoneType",
+            "global_stopping_strategy_cls": "NoneType",
+            "transformed_dimensionality": -1,
+        }
+
+        self.assertEqual(flat, expected_dict)


### PR DESCRIPTION
Summary:
Wrote methods for generating FOOCreatedRecords. Geralized logic exists at a low level to prevent code duplication.

A similar diff will be handle Completed records

Small misc. other changes present in this diff:
1. Removed dataclass inheritance after speaking with Lena -- this was confusing compared to composition structure. This also necessitated creating a few `flatten` methods to prepare the data for storage in tabular form
2. Moved some fields that would be logged differently depending on their surface out of low level Records. This is what allows us to have standardized functions like `ExperimentCreatedRecord.from_experiment`
3. Added some utility methods to core Ax for computing HSS tree height, parameter cardinality, etc to prevent code duplication
4. Added logging for experiment type per quick request from Lena
5. `scheduler_` prepended to a few fields to make it more obvious what they are referring to in flat format

Differential Revision: D43511698

