### PR TITLE
Extend arm shortname to 8 characters

### DIFF
--- a/ax/core/arm.py
+++ b/ax/core/arm.py
@@ -55,14 +55,14 @@ class Arm(SortableBase):
 
     @property
     def name_or_short_signature(self) -> str:
-        """Returns arm name if exists; else last 4 characters of the hash.
+        """Returns arm name if exists; else last 8 characters of the hash.
 
         Used for presentation of candidates (e.g. plotting and tables),
         where the candidates do not yet have names (since names are
         automatically set upon addition to a trial).
 
         """
-        return self._name or self.signature[-4:]
+        return self._name or self.signature[-8:]
 
     @name.setter
     def name(self, name: str) -> None:

--- a/ax/core/tests/test_arm.py
+++ b/ax/core/tests/test_arm.py
@@ -36,7 +36,7 @@ class ArmTest(TestCase):
         self.assertEqual(arm.name_or_short_signature, "0_0")
 
         arm = Arm(parameters={"y": 0.25, "x": 0.75, "z": 75})
-        self.assertEqual(arm.name_or_short_signature, arm.signature[-4:])
+        self.assertEqual(arm.name_or_short_signature, arm.signature[-8:])
 
     def testEq(self) -> None:
         arm1 = Arm(parameters={"y": 0.25, "x": 0.75, "z": 75})


### PR DESCRIPTION
Summary:
Sterling found a bug where if there are too many (on the order of 16^4) unnamed arms on an experiment, when you call gr.param_df there can be collisions which result in dropped arms in the pandas df.

Frankly I do not know what this shortname is used for (and it looks like we dont use gr.param_df internally) but this is an easy thing to do to fix a corner case. Wdyt?

https://github.com/facebook/Ax/issues/1437

Reviewed By: bernardbeckerman

Differential Revision: D43479351

