### PR TITLE
Fix generic_equals

### DIFF
--- a/ax/utils/testing/tests/test_backend_simulator.py
+++ b/ax/utils/testing/tests/test_backend_simulator.py
@@ -13,8 +13,7 @@ from ax.utils.testing.backend_simulator import BackendSimulator, BackendSimulato
 
 class BackendSimulatorTest(TestCase):
     @patch("ax.utils.testing.backend_simulator.time.time")
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_backend_simulator(self, time_mock: Mock):
+    def test_backend_simulator(self, time_mock: Mock) -> None:
         time_mock.return_value = 0.0
         dt = 0.001
         options = BackendSimulatorOptions(max_concurrency=2)

--- a/ax/utils/testing/tests/test_utils.py
+++ b/ax/utils/testing/tests/test_utils.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import numpy as np
+import torch
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.utils import generic_equals
+
+
+class TestUtils(TestCase):
+    def test_generic_equals(self) -> None:
+        # Basics.
+        self.assertTrue(generic_equals(5, 5))
+        self.assertFalse(generic_equals(5, 1))
+        self.assertTrue(generic_equals("abc", "abc"))
+        self.assertFalse(generic_equals("abc", "abcd"))
+        self.assertFalse(generic_equals("abc", 5))
+        # With tensors.
+        self.assertTrue(generic_equals(torch.ones(2), torch.ones(2)))
+        self.assertFalse(generic_equals(torch.ones(2), torch.zeros(2)))
+        self.assertFalse(generic_equals(torch.ones(2), [0, 0]))
+        # Dictionaries.
+        self.assertTrue(generic_equals({"a": torch.ones(2)}, {"a": torch.ones(2)}))
+        self.assertFalse(generic_equals({"a": torch.ones(2)}, {"a": torch.zeros(2)}))
+        self.assertFalse(
+            generic_equals({"a": torch.ones(2)}, {"a": torch.ones(2), "b": 5})
+        )
+        self.assertFalse(generic_equals({"a": torch.ones(2)}, [torch.ones(2)]))
+        self.assertTrue(
+            generic_equals({"a": torch.ones(2), "b": 2}, {"b": 2, "a": torch.ones(2)})
+        )
+        # Tuple / list.
+        self.assertTrue(generic_equals([3, 2], [3, 2]))
+        self.assertTrue(generic_equals([3, (2, 3)], [3, (2, 3)]))
+        self.assertFalse(generic_equals([3, (2, 3)], [3, (2, 4)]))
+        self.assertFalse(generic_equals([0, 1], range(2)))
+        # Other.
+        self.assertTrue(generic_equals(range(2), range(2)))
+        self.assertTrue(generic_equals(np.ones(2), np.ones(2)))
+        self.assertFalse(generic_equals(np.ones(2), np.zeros(2)))
+        self.assertTrue(generic_equals({1, 2}, {1, 2}))
+        self.assertFalse(generic_equals({1, 2}, {1, 2, 3}))

--- a/ax/utils/testing/utils.py
+++ b/ax/utils/testing/utils.py
@@ -3,8 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Iterable
+from typing import Any
 
+import numpy as np
 import torch
 from torch import Tensor
 
@@ -12,8 +13,18 @@ from torch import Tensor
 # pyre-fixme[2]: Parameter annotation cannot be `Any`.
 def generic_equals(first: Any, second: Any) -> bool:
     if isinstance(first, Tensor):
-        return torch.equal(first, second)
-    if isinstance(first, Iterable):
+        return isinstance(second, Tensor) and torch.equal(first, second)
+    if isinstance(first, np.ndarray):
+        return isinstance(second, np.ndarray) and np.array_equal(
+            first, second, equal_nan=True
+        )
+    if isinstance(first, dict):
+        return isinstance(second, dict) and generic_equals(
+            sorted(first.items()), sorted(second.items())
+        )
+    if isinstance(first, (tuple, list)):
+        if type(first) != type(second) or len(first) != len(second):
+            return False
         for f, s in zip(first, second):
             if not generic_equals(f, s):
                 return False


### PR DESCRIPTION
Summary: Prior to this, it would go into an infinite loop with strings, only compare the keys for dicts and ignore extra elements with any other iterable (due to the use of zip).

Differential Revision: D43593246

