### PR TITLE
Json storage for input transforms

### DIFF
--- a/ax/exceptions/core.py
+++ b/ax/exceptions/core.py
@@ -166,3 +166,9 @@ class AxWarning(Warning):
 
     def __str__(self) -> str:
         return " ".join([self.message, getattr(self, "hint", "")]).rstrip()
+
+
+class AxStorageWarning(AxWarning):
+    """Ax warning used for storage related concerns."""
+
+    pass

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -42,6 +42,12 @@ from botorch.models.gp_regression_mixed import MixedSingleTaskGP
 from botorch.models.model import Model
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
+from botorch.models.transforms.input import (
+    ChainedInputTransform,
+    InputTransform,
+    Normalize,
+    Round,
+)
 
 # Miscellaneous BoTorch imports
 from gpytorch.constraints import Interval
@@ -117,6 +123,16 @@ GPYTORCH_COMPONENT_REGISTRY: Dict[Type[torch.nn.Module], str] = {
 }
 
 """
+Mapping of BoTorch `InputTransform` classes to class name strings.
+"""
+INPUT_TRANSFORM_REGISTRY: Dict[Type[InputTransform], str] = {
+    ChainedInputTransform: "ChainedInputTransform",
+    Normalize: "Normalize",
+    Round: "Round",
+}
+
+
+"""
 Overarching mapping from encoded classes to registry map.
 """
 # pyre-fixme[5]: Global annotation cannot contain `Any`.
@@ -128,6 +144,7 @@ CLASS_TO_REGISTRY: Dict[Any, Dict[Type[Any], str]] = {
     Model: MODEL_REGISTRY,
     Interval: GPYTORCH_COMPONENT_REGISTRY,
     GammaPrior: GPYTORCH_COMPONENT_REGISTRY,
+    InputTransform: INPUT_TRANSFORM_REGISTRY,
 }
 
 
@@ -153,13 +170,21 @@ REVERSE_MLL_REGISTRY: Dict[str, Type[MarginalLogLikelihood]] = {
     v: k for k, v in MLL_REGISTRY.items()
 }
 
+
 REVERSE_LIKELIHOOD_REGISTRY: Dict[str, Type[Likelihood]] = {
     v: k for k, v in LIKELIHOOD_REGISTRY.items()
 }
 
+
 REVERSE_GPYTORCH_COMPONENT_REGISTRY: Dict[str, Type[torch.nn.Module]] = {
     v: k for k, v in GPYTORCH_COMPONENT_REGISTRY.items()
 }
+
+
+REVERSE_INPUT_TRANSFORM_REGISTRY: Dict[str, Type[InputTransform]] = {
+    v: k for k, v in INPUT_TRANSFORM_REGISTRY.items()
+}
+
 
 """
 Overarching mapping from encoded classes to reverse registry map.
@@ -173,6 +198,7 @@ CLASS_TO_REVERSE_REGISTRY: Dict[Any, Dict[str, Type[Any]]] = {
     Model: REVERSE_MODEL_REGISTRY,
     Interval: REVERSE_GPYTORCH_COMPONENT_REGISTRY,
     GammaPrior: REVERSE_GPYTORCH_COMPONENT_REGISTRY,
+    InputTransform: REVERSE_INPUT_TRANSFORM_REGISTRY,
 }
 
 

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -36,6 +36,7 @@ from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.storage.json_store.decoders import (
     batch_trial_from_json,
     botorch_component_from_json,
+    tensor_from_json,
     trial_from_json,
 )
 from ax.storage.json_store.registry import (
@@ -125,24 +126,7 @@ def object_from_json(
         elif _type == "ndarray":
             return np.array(object_json["value"])
         elif _type == "Tensor":
-            device = (
-                object_from_json(
-                    object_json["device"],
-                    decoder_registry=decoder_registry,
-                    class_decoder_registry=class_decoder_registry,
-                )
-                if torch.cuda.is_available()
-                else torch.device("cpu")
-            )
-            return torch.tensor(
-                object_json["value"],
-                dtype=object_from_json(
-                    object_json["dtype"],
-                    decoder_registry=decoder_registry,
-                    class_decoder_registry=class_decoder_registry,
-                ),
-                device=device,
-            )
+            return tensor_from_json(json=object_json)
         elif _type.startswith("torch"):
             # Torch types will be encoded as "torch_<type_name>", so we drop prefix
             return torch_type_from_str(

--- a/ax/storage/json_store/encoder.py
+++ b/ax/storage/json_store/encoder.py
@@ -15,6 +15,7 @@ import numpy as np
 import pandas as pd
 import torch
 from ax.exceptions.storage import JSONEncodeError
+from ax.storage.json_store.encoders import tensor_to_dict
 from ax.storage.json_store.registry import (
     CORE_CLASS_ENCODER_REGISTRY,
     CORE_ENCODER_REGISTRY,
@@ -171,21 +172,7 @@ def object_to_json(  # noqa C901
     elif _type is np.ndarray or issubclass(_type, np.ndarray):
         return {"__type": _type.__name__, "value": obj.tolist()}
     elif _type is torch.Tensor:
-        return {
-            "__type": _type.__name__,
-            # TODO: check size and add warning for large tensors: T69137799
-            "value": obj.tolist(),
-            "dtype": object_to_json(
-                obj.dtype,
-                encoder_registry=encoder_registry,
-                class_encoder_registry=class_encoder_registry,
-            ),
-            "device": object_to_json(
-                obj.device,
-                encoder_registry=encoder_registry,
-                class_encoder_registry=class_encoder_registry,
-            ),
-        }
+        return tensor_to_dict(obj=obj)
     elif _type.__module__ == "torch":
         # Torch does not support saving to string, so save to buffer first
         return {"__type": f"torch_{_type.__name__}", "value": torch_type_to_str(obj)}

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -141,6 +141,7 @@ from ax.storage.json_store.encoders import (
 from ax.storage.utils import DomainType, ParameterConstraintType
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.models.model import Model
+from botorch.models.transforms.input import ChainedInputTransform, Normalize, Round
 from gpytorch.constraints import Interval
 from gpytorch.likelihoods.likelihood import Likelihood
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
@@ -161,6 +162,7 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     BotorchTestProblemRunner: runner_to_dict,
     BraninMetric: metric_to_dict,
     BraninTimestampMapMetric: metric_to_dict,
+    ChainedInputTransform: botorch_component_to_dict,
     ChoiceParameter: choice_parameter_to_dict,
     Data: data_to_dict,
     Experiment: experiment_to_dict,
@@ -184,6 +186,7 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     MultiObjective: multi_objective_to_dict,
     MultiObjectiveOptimizationConfig: multi_objective_optimization_config_to_dict,
     MultiTypeExperiment: multi_type_experiment_to_dict,
+    Normalize: botorch_component_to_dict,
     PercentileEarlyStoppingStrategy: percentile_early_stopping_strategy_to_dict,
     SklearnMetric: metric_to_dict,
     ChemistryMetric: metric_to_dict,
@@ -209,6 +212,7 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     RangeParameter: range_parameter_to_dict,
     RiskMeasure: risk_measure_to_dict,
     RobustSearchSpace: robust_search_space_to_dict,
+    Round: botorch_component_to_dict,
     ScalarizedObjective: scalarized_objective_to_dict,
     SearchSpace: search_space_to_dict,
     HierarchicalSearchSpace: search_space_to_dict,
@@ -259,6 +263,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "BotorchTestProblemRunner": BotorchTestProblemRunner,
     "BraninMetric": BraninMetric,
     "BraninTimestampMapMetric": BraninTimestampMapMetric,
+    "ChainedInputTransform": ChainedInputTransform,
     "ChemistryMetric": ChemistryMetric,
     "ChemistryProblemType": ChemistryProblemType,
     "ChoiceParameter": ChoiceParameter,
@@ -294,6 +299,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "MultiTypeExperiment": MultiTypeExperiment,
     "NegativeBraninMetric": NegativeBraninMetric,
     "NoisyFunctionMetric": NoisyFunctionMetric,
+    "Normalize": Normalize,
     "Objective": Objective,
     "ObjectiveThreshold": ObjectiveThreshold,
     "OptimizationConfig": OptimizationConfig,
@@ -317,6 +323,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "RangeParameter": RangeParameter,
     "RiskMeasure": RiskMeasure,
     "RobustSearchSpace": RobustSearchSpace,
+    "Round": Round,
     "ScalarizedObjective": ScalarizedObjective,
     "SchedulerOptions": SchedulerOptions,
     "SearchSpace": SearchSpace,

--- a/ax/utils/common/typeutils_torch.py
+++ b/ax/utils/common/typeutils_torch.py
@@ -4,27 +4,31 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Union
+import json
+from typing import Union
 
 import torch
 from ax.utils.common.typeutils import checked_cast
 
 
-# pyre-fixme[2]: Parameter annotation cannot be `Any`.
-def torch_type_to_str(value: Any) -> str:
+def torch_type_to_str(value: Union[torch.dtype, torch.device, torch.Size]) -> str:
     """Converts torch types, commonly used in Ax, to string representations."""
     if isinstance(value, torch.dtype):
         return str(value)
     if isinstance(value, torch.device):
         return checked_cast(str, value.type)
+    if isinstance(value, torch.Size):
+        return json.dumps(list(value))
     raise ValueError(f"Object {value} was of unexpected torch type.")
 
 
 def torch_type_from_str(
     identifier: str, type_name: str
-) -> Union[torch.dtype, torch.device]:
+) -> Union[torch.dtype, torch.device, torch.Size]:
     if type_name == "device":
         return torch.device(identifier)
     if type_name == "dtype":
         return getattr(torch, identifier[6:])
+    if type_name == "Size":
+        return torch.Size(json.loads(identifier))
     raise ValueError(f"Unexpected type: {type_name} for identifier: {identifier}.")

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -101,6 +101,7 @@ from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.model import Model
+from botorch.models.transforms.input import ChainedInputTransform, Normalize, Round
 from gpytorch.constraints import Interval
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
@@ -2008,6 +2009,18 @@ def get_gamma_prior() -> GammaPrior:
 
 def get_interval() -> Interval:
     return Interval(lower_bound=1e-6, upper_bound=0.1)
+
+
+def get_chained_input_transform() -> ChainedInputTransform:
+    bounds = torch.tensor([[0, 0], [3, 5]], dtype=torch.double)
+    return ChainedInputTransform(
+        round=Round(
+            integer_indices=[1],
+            transform_on_eval=True,
+            transform_on_train=False,
+        ),
+        normalize=Normalize(d=2, bounds=bounds),
+    )
 
 
 ##############################


### PR DESCRIPTION
Summary: Extends botorch component storage to support `ChainedInputTransform`, `Round` and `Normalize`.

Differential Revision: D43593464

