### PR TITLE
Remove MOO_Modular

### DIFF
--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -219,12 +219,6 @@ MODEL_KEY_TO_MODEL_SETUP: Dict[str, ModelSetup] = {
         transforms=Cont_X_trans + Y_trans,
         standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
-    "MOO_Modular": ModelSetup(
-        bridge_class=TorchModelBridge,
-        model_class=ModularBoTorchModel,
-        transforms=Cont_X_trans + Y_trans,
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
-    ),
     "ST_MTGP": ModelSetup(
         bridge_class=TorchModelBridge,
         model_class=BotorchModel,


### PR DESCRIPTION
Summary:
Craig reached out to me because he stumbled into this and was confused whether to use this or BOTORCH_MODULAR for MOO. As far as I can tell this is now just an alais for the same setup as BOTORCH_MODULAR (maybe we consolodated functionality at some point?) and it has no usage that Im aware of -- should we just clean it up to eliminate any confusion?

If this isnt actually dead code please let me know and I will abandon.

Reviewed By: saitcakmak

Differential Revision: D43583980

