### PR TITLE
Add `__version__.py`

### DIFF
--- a/ax/__version__.py
+++ b/ax/__version__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+__version__: str = "0.3.0"

--- a/scripts/validate_sphinx.py
+++ b/scripts/validate_sphinx.py
@@ -64,7 +64,7 @@ def validate_complete_sphinx(path_to_ax: str) -> None:
         for importer, modname, ispkg in pkgutil.walk_packages(
             path=[AX_LIBRARY_PATH], onerror=lambda x: None
         )
-        if modname not in {"fb", "version"}
+        if modname not in {"fb", "__version__"}
     }
 
     # Load all rst files (these contain the documentation for Sphinx)


### PR DESCRIPTION
Summary:
Most python libs have their version written in code in a file like this. An OSS users specifially requested this here: https://github.com/facebook/Ax/issues/1438

I will land this just before releasing version 0.3.0

Differential Revision: D43623862

