### PR TITLE
Clean up usage of optimizer_options

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -685,7 +685,7 @@ class ModelBridge(ABC):
                 features that should be fixed at specified values during
                 generation.
             model_gen_options: A config dictionary that is passed along to the
-                model.
+                model. See `TorchOptConfig` for details.
 
         Returns:
             A GeneratorRun object that contains the generated points and other metadata.

--- a/ax/modelbridge/factory.py
+++ b/ax/modelbridge/factory.py
@@ -91,7 +91,7 @@ def get_MOO_NEHVI(
                 "optimizer_kwargs": {
                     # having a batch limit is very important for avoiding
                     # memory issues in the initialization
-                    "batch_limit": DEFAULT_EHVI_BATCH_LIMIT,
+                    "options": {"batch_limit": DEFAULT_EHVI_BATCH_LIMIT},
                     "sequential": True,
                 },
             },
@@ -173,7 +173,7 @@ def get_MTGP_NEHVI(
                 "optimizer_kwargs": {
                     # having a batch limit is very important for avoiding
                     # memory issues in the initialization
-                    "batch_limit": DEFAULT_EHVI_BATCH_LIMIT,
+                    "options": {"batch_limit": DEFAULT_EHVI_BATCH_LIMIT},
                     "sequential": True,
                 },
             },
@@ -526,7 +526,7 @@ def get_MOO_EHVI(
                 "optimizer_kwargs": {
                     # having a batch limit is very important for avoiding
                     # memory issues in the initialization
-                    "batch_limit": DEFAULT_EHVI_BATCH_LIMIT
+                    "options": {"batch_limit": DEFAULT_EHVI_BATCH_LIMIT},
                 },
             },
             optimization_config=optimization_config,

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -53,8 +53,10 @@ class KnowledgeGradientTest(TestCase):
         self.optimizer_options = {
             "num_restarts": 12,
             "raw_samples": 12,
-            "maxiter": 5,
-            "batch_limit": 1,
+            "options": {
+                "maxiter": 5,
+                "batch_limit": 1,
+            },
         }
         self.optimize_acqf = "ax.models.torch.botorch_kg.optimize_acqf"
         self.X_dummy = torch.ones(1, 3, **self.tkwargs)
@@ -110,8 +112,10 @@ class KnowledgeGradientTest(TestCase):
         optimizer_options2 = {
             "num_restarts": 1,
             "raw_samples": 1,
-            "maxiter": 5,
-            "batch_limit": 1,
+            "options": {
+                "maxiter": 5,
+                "batch_limit": 1,
+            },
             "partial_restarts": 2,
         }
         torch_opt_config.model_gen_options["optimizer_kwargs"] = optimizer_options2

--- a/ax/models/tests/test_fully_bayesian.py
+++ b/ax/models/tests/test_fully_bayesian.py
@@ -466,7 +466,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             X_dummy = torch.tensor([[[1.0, 2.0, 3.0]]], **tkwargs)
             acqfv_dummy = torch.tensor([[[1.0, 2.0, 3.0]]], **tkwargs)
             model_gen_options = {
-                Keys.OPTIMIZER_KWARGS: {"maxiter": 1},
+                Keys.OPTIMIZER_KWARGS: {"options": {"maxiter": 1}},
                 Keys.ACQF_KWARGS: {"mc_samples": 3},
             }
             search_space_digest = SearchSpaceDigest(

--- a/ax/models/torch/botorch_kg.py
+++ b/ax/models/torch/botorch_kg.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 from ax.core.search_space import SearchSpaceDigest
@@ -377,6 +377,13 @@ def _optimize_and_get_candidates(
 
     botorch_rounding_func = get_rounding_func(rounding_func)
 
+    opt_options: Dict[str, Union[bool, float, int, str]] = {
+        "batch_limit": 8,
+        "maxiter": 200,
+        "method": "L-BFGS-B",
+        "nonnegative": False,
+    }
+    opt_options.update(optimizer_options.get("options", {}))
     candidates, _ = optimize_acqf(
         acq_function=acq_function,
         bounds=bounds_,
@@ -386,12 +393,7 @@ def _optimize_and_get_candidates(
         post_processing_func=botorch_rounding_func,
         num_restarts=num_restarts,
         raw_samples=raw_samples,
-        options={
-            "batch_limit": optimizer_options.get("batch_limit", 8),
-            "maxiter": optimizer_options.get("maxiter", 200),
-            "method": "L-BFGS-B",
-            "nonnegative": optimizer_options.get("nonnegative", False),
-        },
+        options=opt_options,
         batch_initial_conditions=batch_initial_conditions,
     )
     new_x = candidates.detach().cpu()

--- a/ax/models/torch/botorch_mes.py
+++ b/ax/models/torch/botorch_mes.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from ax.core.search_space import SearchSpaceDigest
@@ -146,6 +146,13 @@ class MaxValueEntropySearch(BotorchModel):
 
         # optimize and get new points
         botorch_rounding_func = get_rounding_func(torch_opt_config.rounding_func)
+        opt_options: Dict[str, Union[bool, float, int, str]] = {
+            "batch_limit": 8,
+            "maxiter": 200,
+            "method": "L-BFGS-B",
+            "nonnegative": False,
+        }
+        opt_options.update(optimizer_options.get("options", {}))
         candidates, _ = optimize_acqf(
             acq_function=acq_function,
             bounds=bounds_,
@@ -155,12 +162,7 @@ class MaxValueEntropySearch(BotorchModel):
             post_processing_func=botorch_rounding_func,
             num_restarts=num_restarts,
             raw_samples=raw_samples,
-            options={
-                "batch_limit": optimizer_options.get("batch_limit", 8),
-                "maxiter": optimizer_options.get("maxiter", 200),
-                "method": "L-BFGS-B",
-                "nonnegative": optimizer_options.get("nonnegative", False),
-            },
+            options=opt_options,
             sequential=True,
         )
         return TorchGenResults(

--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -284,19 +284,19 @@ def scipy_optimizer_list(
     num_restarts: int = kwargs.pop(Keys.NUM_RESTARTS, 20)
     raw_samples: int = kwargs.pop(Keys.RAW_SAMPLES, 50 * num_restarts)
 
-    # use SLSQP by default for small problems since it yields faster wall times
-    if "method" not in kwargs:
-        kwargs["method"] = "SLSQP"
-    if "init_batch_limit" not in kwargs:
-        kwargs["init_batch_limit"] = 32
-    if "batch_limit" not in kwargs:
-        kwargs["batch_limit"] = 5
+    # Use SLSQP by default for small problems since it yields faster wall times.
+    options: Dict[str, Union[bool, float, int, str]] = {
+        "batch_limit": 5,
+        "init_batch_limit": 32,
+        "method": "SLSQP",
+    }
+    options.update(kwargs.get("options", {}))
     X, expected_acquisition_value = optimize_acqf_list(
         acq_function_list=acq_function_list,
         bounds=bounds,
         num_restarts=num_restarts,
         raw_samples=raw_samples,
-        options=kwargs,
+        options=options,
         inequality_constraints=inequality_constraints,
         fixed_features=fixed_features,
         post_processing_func=rounding_func,

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -47,7 +47,26 @@ class TorchOptConfig:
         pending_observations:  A list of m (k_i x d) feature tensors X
             for m outcomes and k_i pending observations for outcome i.
         model_gen_options: A config dictionary that can contain
-            model-specific options.
+            model-specific options. This commonly includes `optimizer_kwargs`,
+            which often specifies the optimizer options to be passed to the
+            optimizer while optimizing the acquisition function. These are
+            generally expected to mimic the signature of `optimize_acqf`,
+            though not all models may support all possible arguments and some
+            models may support additional arguments that are not passed to the
+            optimizer. While constructing a generation strategy, these options
+            can be passed in as follows:
+            >>> model_gen_kwargs = {
+            >>>     "model_gen_options": {
+            >>>         "optimizer_kwargs": {
+            >>>             "num_restarts": 20,
+            >>>             "sequential": False,
+            >>>             "options": {
+            >>>                 "batch_limit: 5,
+            >>>                 "maxiter": 200,
+            >>>             },
+            >>>         },
+            >>>     },
+            >>> }
         rounding_func: A function that rounds an optimization result
             appropriately (i.e., according to `round-trip` transformations).
         opt_config_metrics: A dictionary of metrics that are included in

--- a/ax/utils/testing/torch_stubs.py
+++ b/ax/utils/testing/torch_stubs.py
@@ -11,10 +11,6 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 
 
-def get_optimizer_kwargs() -> Dict[str, int]:
-    return {"num_restarts": 2, "raw_samples": 2, "maxiter": 2, "batch_limit": 1}
-
-
 def get_torch_test_data(
     dtype: torch.dtype = torch.float,
     cuda: bool = False,


### PR DESCRIPTION
Summary:
Prior to this change, the `options` argument of `optimize_acqf` was being parsed inconsistently across various models. Some would look for the `options` among top level arguments in `optimizer_options`, others would look for explicit `options` dict in `optimizer_options`.

The second approach (explicit `options` dict) is consistent with the signature of `optimize_acqf`, and is being used in MBM. This updates the rest of the code base to make it all consistent with each other.

Differential Revision: D43637014

