### PR TITLE
Fix modular_botax and Setup_and_Usage_of_BoTorch_Models_in_Ax tutorials

### DIFF
--- a/tutorials/modular_botax.ipynb
+++ b/tutorials/modular_botax.ipynb
@@ -258,10 +258,6 @@
     "        # BoTorch `Model` constructor\n",
     "        model_options={}\n",
     "    ),\n",
-    "    # Optional options to pass to auto-picked `Surrogate` if not\n",
-    "    # specifying the `surrogate` argument\n",
-    "    surrogate_options={},\n",
-    "    \n",
     "    # Optional BoTorch `AcquisitionFunction` to use instead of default\n",
     "    botorch_acqf_class=qExpectedImprovement,\n",
     "    # Optional dict of keyword arguments, passed to the input \n",
@@ -511,7 +507,7 @@
     "originalKey": "1d15082f-1df7-4cdb-958b-300483eb7808"
    },
    "source": [
-    "## 4. Using `Models.BOTORCH_MODULAR` and `Models.MOO_MODULAR`\n",
+    "## 4. Using `Models.BOTORCH_MODULAR` \n",
     "\n",
     "To simplify the instantiation of an Ax ModelBridge and its undelying Model, Ax provides a [`Models` registry enum](https://github.com/facebook/Ax/blob/main/ax/modelbridge/registry.py#L355). When calling entries of that enum (e.g. `Models.BOTORCH_MODULAR(experiment, data)`), the inputs are automatically distributed between a `Model` and a `ModelBridge` for a given setup. A call to a `Model` enum member yields a model bridge with an underlying model, ready for use to generate candidates.\n",
     "\n",
@@ -606,7 +602,7 @@
     "originalKey": "8b6a9ddc-d2d2-4cd5-a6a8-820113f78262"
    },
    "source": [
-    "And here we use `Models.MOO_MODULAR` (analogue of `Models.BOTORCH_MODULAR`, except set up with multi-objective model bridge) to set up a model for multi-objective optimization:"
+    "We can use the same `Models.BOTORCH_MODULAR` to set up a model for multi-objective optimization:"
    ]
   },
   {
@@ -640,7 +636,7 @@
     }
    ],
    "source": [
-    "model_bridge_with_EHVI = Models.MOO_MODULAR(\n",
+    "model_bridge_with_EHVI = Models.BOTORCH_MODULAR(\n",
     "    experiment=get_branin_experiment_with_multi_objective(has_objective_thresholds=True, with_batch=True),\n",
     "    data=get_branin_data_multi_objective(),\n",
     ")\n",


### PR DESCRIPTION
Summary: These tutorials were already broken when we started running tutorials tests regularly and need to be fixed before we release ax 0.3.0

Differential Revision: D43645540

