### PR TITLE
Handle None objective thresholds in get_pareto_frontier_and_configs

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -908,7 +908,8 @@ def get_pareto_frontier_and_configs(
         objective=optimization_config.objective,
         outcomes=modelbridge.outcomes,
     )
-    obj_t = array_to_tensor(obj_t)
+    if obj_t is not None:
+        obj_t = array_to_tensor(obj_t)
     # Transform to tensors.
     obj_w, oc_c, _, _, _ = validate_and_apply_final_transform(
         objective_weights=objective_weights,
@@ -942,7 +943,12 @@ def get_pareto_frontier_and_configs(
             )
         )
 
-    return frontier_observations, f, obj_w.cpu(), obj_t.cpu()
+    return (
+        frontier_observations,
+        f,
+        obj_w.cpu(),
+        obj_t.cpu() if obj_t is not None else None,
+    )
 
 
 def pareto_frontier(
@@ -1231,8 +1237,10 @@ def observed_hypervolume(
 
     Args:
         modelbridge: Modelbridge that holds previous training data.
-        objective_thresholds: point defining the origin of hyperrectangles that
-            can contribute to hypervolume.
+        objective_thresholds: Point defining the origin of hyperrectangles that
+            can contribute to hypervolume. Note that if this is None,
+            `objective_thresholds` must be present on the
+            `modelbridge.optimization_config`.
         observation_features: observation features to predict. Model's training
             data used by default if unspecified.
         optimization_config: Optimization config

--- a/ax/modelbridge/tests/test_torch_modelbridge_moo.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge_moo.py
@@ -195,12 +195,16 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
         )
         self.assertEqual(observed_frontier, observed_frontier2)
 
+        # Remove the thresholds for testing None handling.
+        checked_cast(
+            MultiObjectiveOptimizationConfig, modelbridge._optimization_config
+        )._objective_thresholds = []
         with patch(
             PARETO_FRONTIER_EVALUATOR_PATH, wraps=pareto_frontier_evaluator
         ) as wrapped_frontier_evaluator:
             (observed_frontier, f, obj_w, obj_t,) = get_pareto_frontier_and_configs(
                 modelbridge=modelbridge,
-                objective_thresholds=objective_thresholds,
+                objective_thresholds=None,
                 observation_features=observation_features,
                 observation_data=observation_data,
                 use_model_predictions=False,
@@ -215,6 +219,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             )
         )
         self.assertTrue(torch.equal(f[:, :2], true_Y[1:, :]))
+        self.assertIsNone(obj_t)
 
     def test_pareto_frontier(self) -> None:
         """


### PR DESCRIPTION
Summary: Without this change, it would throw an uninformative error if the objective threshold is not provided and is not available on the optimization config. This will push the error down to line 1115, where an informative error is raised.

Differential Revision: D43684776

