### PR TITLE
Handle missing objective thresholds in GSS

### DIFF
--- a/ax/global_stopping/tests/tests_strategies.py
+++ b/ax/global_stopping/tests/tests_strategies.py
@@ -253,7 +253,6 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
         return exp
 
     def test_multi_objective(self) -> None:
-
         metric_values = [
             (0.15, 0.6, 0.1),
             (0.25, 0.5, 0.2),
@@ -281,7 +280,7 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
         # Now we select a very far custom reference point against which the pareto front
         # has not increased in hypervolume at trial 4. Hence, it should stop the
         # optimization at this trial.
-        gss2 = ImprovementGlobalStoppingStrategy(
+        gss = ImprovementGlobalStoppingStrategy(
             min_trials=3, window_size=3, improvement_bar=0.1
         )
         objectives = exp.optimization_config.objective.objectives  # pyre-ignore
@@ -299,7 +298,7 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
                 relative=False,
             ),
         ]
-        stop, message = gss2.should_stop_optimization(
+        stop, message = gss.should_stop_optimization(
             experiment=exp,
             trial_to_check=4,
             objective_thresholds=custom_objective_thresholds,
@@ -311,8 +310,18 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
             "0.1.",
         )
 
-    def test_single_objective(self) -> None:
+        # Test with no objective thresholds specified.
+        checked_cast(
+            MultiObjectiveOptimizationConfig, exp._optimization_config
+        )._objective_thresholds = []
+        stop, message = gss.should_stop_optimization(
+            experiment=exp,
+            trial_to_check=4,
+            objective_thresholds=None,
+        )
+        self.assertTrue(stop)
 
+    def test_single_objective(self) -> None:
         metric_values = [
             (0.1, 0.6, 0.1),  # feasible, best_objective_so_far = 0.1
             (0.2, 0.3, 0.2),  # feasible, best_objective_so_far = 0.2

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -13,13 +13,11 @@ import numpy as np
 import torch
 from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
-from ax.core.objective import MultiObjective, Objective
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
-    ObjectiveThreshold,
     OptimizationConfig,
 )
-from ax.core.types import ComparisonOp, TModelPredictArm, TParameterization
+from ax.core.types import TModelPredictArm, TParameterization
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.modelbridge_utils import (
     extract_objective_thresholds,
@@ -38,7 +36,10 @@ from ax.models.torch.botorch_moo_defaults import (
 )
 from ax.plot.pareto_utils import get_tensor_converter_model
 from ax.service.utils import best_point as best_point_utils
-from ax.service.utils.best_point import extract_Y_from_data
+from ax.service.utils.best_point import (
+    extract_Y_from_data,
+    fill_missing_thresholds_from_nadir,
+)
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast, not_none
 from botorch.utils.multi_objective.box_decompositions import DominatedPartitioning
@@ -409,37 +410,10 @@ class BestPointMixin(metaclass=ABCMeta):
             torch.as_tensor, dtype=torch.double, device=torch.device("cpu")
         )
         if optimization_config.is_moo_problem:
-            multiobjective_optimization_config = checked_cast(
-                MultiObjectiveOptimizationConfig, optimization_config
-            )
-
-            provided_thresholds = (
-                multiobjective_optimization_config.objective_thresholds
-            )
-
-            # For Objectives without thresholds provided, infer the threshold from
-            # the nadir point.
-            provided_threshold_names = [
-                threshold.metric.name for threshold in provided_thresholds
-            ]
-            objectives_without_threshold = [
-                objective
-                for objective in checked_cast(
-                    MultiObjective, optimization_config.objective
-                ).objectives
-                if objective.metric.name not in provided_threshold_names
-            ]
-            inferred_thresholds = [
-                _objective_threshold_from_nadir(
-                    experiment=experiment,
-                    objective=objective,
-                    optimization_config=multiobjective_optimization_config,
-                )
-                for objective in objectives_without_threshold
-            ]
-
             objective_thresholds = extract_objective_thresholds(
-                objective_thresholds=[*provided_thresholds, *inferred_thresholds],
+                objective_thresholds=fill_missing_thresholds_from_nadir(
+                    experiment=experiment, optimization_config=optimization_config
+                ),
                 objective=optimization_config.objective,
                 outcomes=metric_names,
             )
@@ -564,30 +538,3 @@ class BestPointMixin(metaclass=ABCMeta):
         obj_vals = (df["mean"].cummin() if minimize else df["mean"].cummax()).to_numpy()
         best_observed = obj_vals[best_observed_idcs]
         return best_observed.tolist(), bins.squeeze(axis=0).tolist()
-
-
-def _objective_threshold_from_nadir(
-    experiment: Experiment,
-    objective: Objective,
-    optimization_config: Optional[MultiObjectiveOptimizationConfig] = None,
-) -> ObjectiveThreshold:
-    """
-    Find the worst value observed for each objective and create an ObjectiveThreshold
-    with this as the bound.
-    """
-
-    logger.info(f"Inferring ObjectiveThreshold for {objective} using nadir point.")
-
-    optimization_config = optimization_config or checked_cast(
-        MultiObjectiveOptimizationConfig, experiment.optimization_config
-    )
-
-    data_df = experiment.fetch_data().df
-
-    mean = data_df[data_df["metric_name"] == objective.metric.name]["mean"]
-    bound = max(mean) if objective.minimize else min(mean)
-    op = ComparisonOp.LEQ if objective.minimize else ComparisonOp.GEQ
-
-    return ObjectiveThreshold(
-        metric=objective.metric, bound=bound, op=op, relative=False
-    )


### PR DESCRIPTION
Summary: This makes it so that if no objective thresholds are provided (directly or on the experiment), it'll fill them in based on the nadir point. Previously, this would just error out later down the stack.

Differential Revision: D43684793

