### PR TITLE
Do not crash when `attach_data` fails in `_lookup_or_fetch_trials_results`

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -657,11 +657,17 @@ class Experiment(Base):
             }
 
         if contains_new_data:
-            self.attach_fetch_results(
-                results=results,
-                combine_with_last_data=combine_with_last_data,
-                overwrite_existing_data=overwrite_existing_data,
-            )
+            try:
+                self.attach_fetch_results(
+                    results=results,
+                    combine_with_last_data=combine_with_last_data,
+                    overwrite_existing_data=overwrite_existing_data,
+                )
+            except ValueError as e:
+                logger.error(
+                    f"Encountered ValueError {e} while attaching results. Proceeding "
+                    "and returning Results fetched without attaching."
+                )
 
         return results
 


### PR DESCRIPTION
Summary: In my opinion we should not outright fail if data attaching fails for any reason.

Differential Revision: D43748599

