### PR TITLE
Fix Acquisition.get_botorch_objective_and_transform

### DIFF
--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -36,6 +36,12 @@ from ax.utils.common.typeutils import not_none
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.input_constructors import get_acqf_input_constructor
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
+from botorch.acquisition.multi_objective.analytic import (
+    MultiObjectiveAnalyticAcquisitionFunction,
+)
+from botorch.acquisition.multi_objective.monte_carlo import (
+    MultiObjectiveMCAcquisitionFunction,
+)
 from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
 from botorch.acquisition.risk_measures import RiskMeasureMCObjective
 from botorch.models.model import Model, ModelDict
@@ -575,7 +581,15 @@ class Acquisition(Base):
             model=model,
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
-            objective_thresholds=objective_thresholds,
+            objective_thresholds=objective_thresholds
+            if issubclass(
+                botorch_acqf_class,
+                (
+                    MultiObjectiveMCAcquisitionFunction,
+                    MultiObjectiveAnalyticAcquisitionFunction,
+                ),
+            )
+            else None,
             X_observed=X_observed,
             risk_measure=risk_measure,
         )


### PR DESCRIPTION
Summary: This does not pass down the acqf class to the `get_botorch_objective_and_transform` helper, and always passes down `objective_thresholds` if they're available. As a result, `get_botorch_objective_and_transform` determines the type of the objective to construct (MOO or otherwise) based on the availability of `objective_thresholds`. This leads to weird downstream errors if objective thresholds are present when a single objective acquisition function is being used. This change should fix that.

Differential Revision: D43803349

