### PR TITLE
Cleanup in Derelativize and test

### DIFF
--- a/ax/modelbridge/tests/test_derelativize_transform.py
+++ b/ax/modelbridge/tests/test_derelativize_transform.py
@@ -145,9 +145,9 @@ class DerelativizeTransformTest(TestCase):
                 ),
             ],
         )
-        oc = t.transform_optimization_config(oc, g, None)
+        oc2 = t.transform_optimization_config(oc, g, None)
         self.assertTrue(
-            oc.outcome_constraints
+            oc2.outcome_constraints
             == [
                 OutcomeConstraint(
                     Metric("a"), ComparisonOp.LEQ, bound=2, relative=False
@@ -196,9 +196,9 @@ class DerelativizeTransformTest(TestCase):
                 ),
             ],
         )
-        oc = t.transform_optimization_config(oc, g, None)
+        oc2 = t.transform_optimization_config(oc, g, None)
         self.assertTrue(
-            oc.outcome_constraints
+            oc2.outcome_constraints
             == [
                 OutcomeConstraint(
                     Metric("a"), ComparisonOp.LEQ, bound=2, relative=False
@@ -238,8 +238,7 @@ class DerelativizeTransformTest(TestCase):
             ],
         )
         with self.assertRaises(RuntimeError):
-            #  `None`.
-            oc = t.transform_optimization_config(oc, g, None)
+            t.transform_optimization_config(oc, g, None)
 
         # Bypasses error if use_raw_sq
         t2 = Derelativize(
@@ -247,17 +246,18 @@ class DerelativizeTransformTest(TestCase):
             observations=[],
             config={"use_raw_status_quo": True},
         )
-        oc2 = t2.transform_optimization_config(deepcopy(oc), g, None)
+        t2.transform_optimization_config(deepcopy(oc), g, None)
 
-        # But not if sq arm is not available
+        # But not if sq arm is not available.
         with patch(
             f"{Derelativize.__module__}.unwrap_observation_data", return_value=({}, {})
         ), self.assertRaisesRegex(
-            DataRequiredError, "Status-quo metric value not yet available"
+            DataRequiredError, "Status-quo metric value not yet available for metric "
         ):
-            oc2 = t2.transform_optimization_config(deepcopy(oc), g, None)
+            t2.transform_optimization_config(deepcopy(oc), g, None)
 
         # Raises error with relative constraint, no status quo
+        # Raises error with relative constraint, no status quo.
         g = ModelBridge(
             search_space=search_space,
             model=None,
@@ -266,13 +266,11 @@ class DerelativizeTransformTest(TestCase):
             data=Data(),
         )
         with self.assertRaises(ValueError):
-            #  `None`.
-            oc = t.transform_optimization_config(oc, g, None)
+            t.transform_optimization_config(deepcopy(oc), g, None)
 
-        # Raises error with relative constraint, no modelbridge
+        # Raises error with relative constraint, no modelbridge.
         with self.assertRaises(ValueError):
-            #  `None`.
-            oc = t.transform_optimization_config(oc, None, None)
+            t.transform_optimization_config(deepcopy(oc), None, None)
 
     def testErrors(self) -> None:
         t = Derelativize(
@@ -290,8 +288,6 @@ class DerelativizeTransformTest(TestCase):
         )
         g = ModelBridge(search_space, None, [])
         with self.assertRaises(ValueError):
-            #  `None`.
             t.transform_optimization_config(oc, None, None)
         with self.assertRaises(ValueError):
-            #  `None`.
             t.transform_optimization_config(oc, g, None)

--- a/ax/modelbridge/transforms/derelativize.py
+++ b/ax/modelbridge/transforms/derelativize.py
@@ -14,6 +14,7 @@ from ax.exceptions.core import DataRequiredError
 from ax.modelbridge.base import unwrap_observation_data
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.ivw import ivw_metric_merge
+from ax.utils.common.typeutils import not_none
 
 
 if TYPE_CHECKING:
@@ -66,8 +67,7 @@ class Derelativize(Transform):
             ):
                 # Out-of-design: use the raw observation
                 sq_data = ivw_metric_merge(
-                    # pyre-fixme[16]: `Optional` has no attribute `data`.
-                    obsd=modelbridge.status_quo.data,
+                    obsd=not_none(modelbridge.status_quo).data,
                     conflicting_noiseless="raise",
                 )
                 f, _ = unwrap_observation_data([sq_data])


### PR DESCRIPTION
Summary: cleans up a pyre ignore; updates tests so that notation is consistent; there are no unnecessary variables; deepcopy is used consistently; and unnecessary comments are removed.

Differential Revision: D43876680

