### PR TITLE
Replace objective_thresholds with botorch_acqf_class in get_botorch_objective_and_transform

### DIFF
--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -131,7 +131,15 @@ class KnowledgeGradientTest(TestCase):
         dummy_acq = PosteriorMean(model=model.model, posterior_transform=posterior_tf)
         with mock.patch(
             "ax.models.torch.utils.PosteriorMean", return_value=dummy_acq
-        ) as mock_posterior_mean:
+        ) as mock_posterior_mean, mock.patch(
+            "ax.models.torch.utils.get_botorch_objective_and_transform",
+            return_value=(
+                None,
+                ScalarizedPosteriorTransform(
+                    weights=torch.tensor([1.0], dtype=torch.double)
+                ),
+            ),
+        ):
             gen_results = model.gen(
                 n=n,
                 search_space_digest=self.search_space_digest,

--- a/ax/models/torch/botorch_kg.py
+++ b/ax/models/torch/botorch_kg.py
@@ -122,6 +122,7 @@ class KnowledgeGradient(BotorchModel):
             outcome_constraints = torch_opt_config.outcome_constraints
 
         objective, posterior_transform = get_botorch_objective_and_transform(
+            botorch_acqf_class=qKnowledgeGradient,
             model=model,
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,

--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -572,10 +572,10 @@ class Acquisition(Base):
         risk_measure: Optional[RiskMeasureMCObjective] = None,
     ) -> Tuple[Optional[MCAcquisitionObjective], Optional[PosteriorTransform]]:
         return get_botorch_objective_and_transform(
+            botorch_acqf_class=botorch_acqf_class,
             model=model,
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
-            objective_thresholds=objective_thresholds,
             X_observed=X_observed,
             risk_measure=risk_measure,
         )

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -120,7 +120,7 @@ class AcquisitionTest(TestCase):
         )
         self.linear_constraints = None
         self.fixed_features = {1: 2.0}
-        self.options = {"best_f": 0.0}
+        self.options = {"best_f": 0.0, "cache_root": False, "prune_baseline": False}
         self.inequality_constraints = [
             (torch.tensor([0, 1], **tkwargs), torch.tensor([-1.0, 1.0], **tkwargs), 1)
         ]
@@ -553,7 +553,7 @@ class AcquisitionTest(TestCase):
             acquisition = Acquisition(
                 surrogates={"surrogate": self.surrogate},
                 search_space_digest=self.search_space_digest,
-                botorch_acqf_class=self.botorch_acqf_class,
+                botorch_acqf_class=qNoisyExpectedHypervolumeImprovement,
                 torch_opt_config=dataclasses.replace(
                     torch_opt_config,
                     objective_thresholds=None,
@@ -571,7 +571,7 @@ class AcquisitionTest(TestCase):
             acquisition = Acquisition(
                 surrogates={"surrogate": self.surrogate},
                 search_space_digest=self.search_space_digest,
-                botorch_acqf_class=self.botorch_acqf_class,
+                botorch_acqf_class=qNoisyExpectedHypervolumeImprovement,
                 torch_opt_config=dataclasses.replace(
                     torch_opt_config,
                     objective_thresholds=torch.tensor(


### PR DESCRIPTION
Summary: This was using the existance of `objective_thresholds` as a proxy for using a multi objective acquisition function. This is not ideal since it could lead to multi-output objectives being used with single-objective acquisition functions. With this change, we directly use the acquisition class to determine the type of the objective needed.

Differential Revision: D43880923

