### PR TITLE
refactor and update map data subsample logic

### DIFF
--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -435,7 +435,7 @@ def observations_from_map_data(
     map_data: MapData,
     include_abandoned: bool = False,
     map_keys_as_parameters: bool = False,
-    limit_total_rows: Optional[int] = None,
+    limit_rows_per_metric: Optional[int] = None,
     limit_rows_per_group: Optional[int] = None,
 ) -> List[Observation]:
     """Convert MapData to observations.
@@ -453,8 +453,8 @@ def observations_from_map_data(
             be included in the observations, returned from this function.
         map_keys_as_parameters: Whether map_keys should be returned as part of
             the parameters of the Observation objects.
-        limit_total_rows: If specified, uses MapData.subsample() with
-            `limit_total_rows` equal to the specified value on the first
+        limit_rows_per_metric: If specified, uses MapData.subsample() with
+            `limit_rows_per_metric` equal to the specified value on the first
             map_key (map_data.map_keys[0]) to subsample the MapData. This is
             useful in, e.g., cases where learning curves are frequently
             updated, leading to an intractable number of Observation objects
@@ -466,10 +466,10 @@ def observations_from_map_data(
     Returns:
         List of Observation objects.
     """
-    if limit_total_rows is not None or limit_rows_per_group is not None:
+    if limit_rows_per_metric is not None or limit_rows_per_group is not None:
         map_data = map_data.subsample(
             map_key=map_data.map_keys[0],
-            limit_total_rows=limit_total_rows,
+            limit_rows_per_metric=limit_rows_per_metric,
             limit_rows_per_group=limit_rows_per_group,
             include_first_last=True,
         )

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -475,7 +475,7 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 via `_check_validity_and_get_data`.
             max_training_size: Subsample the learning curve to keep the total
                 number of data points less than this threshold. Passed to
-                MapData's `subsample` method as `limit_total_rows`.
+                MapData's `subsample` method as `limit_rows_per_metric`.
 
         Returns:
             An `EarlyStoppingTrainingData` that contains training data arrays X, Y,
@@ -484,7 +484,7 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         if max_training_size is not None:
             map_data = map_data.subsample(
                 map_key=map_data.map_keys[0],
-                limit_total_rows=max_training_size,
+                limit_rows_per_metric=max_training_size,
             )
         if outcomes is None:
             # default to the default objective

--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -64,7 +64,7 @@ class MapTorchModelBridge(TorchModelBridge):
         optimization_config: Optional[OptimizationConfig] = None,
         fit_out_of_design: bool = False,
         default_model_gen_options: Optional[TConfig] = None,
-        map_data_limit_total_rows: Optional[int] = None,
+        map_data_limit_rows_per_metric: Optional[int] = None,
         map_data_limit_rows_per_group: Optional[int] = None,
     ) -> None:
         """
@@ -94,8 +94,8 @@ class MapTorchModelBridge(TorchModelBridge):
             fit_out_of_design: If specified, all training data is returned.
                 Otherwise, only in design points are returned.
             default_model_gen_options: Options passed down to `model.gen(...)`.
-            map_data_limit_total_rows: Subsample the map data so that the total
-                number of rows is limited by this value.
+            map_data_limit_rows_per_metric: Subsample the map data so that the
+                total number of rows per metric is limited by this value.
             map_data_limit_rows_per_group: Subsample the map data so that the
                 number of rows in the `map_key` column for each (arm, metric)
                 is limited by this value.
@@ -107,7 +107,7 @@ class MapTorchModelBridge(TorchModelBridge):
             )
         # pyre-fixme[4]: Attribute must be annotated.
         self._map_key_features = data.map_keys
-        self._map_data_limit_total_rows = map_data_limit_total_rows
+        self._map_data_limit_rows_per_metric = map_data_limit_rows_per_metric
         self._map_data_limit_rows_per_group = map_data_limit_rows_per_group
 
         super().__init__(
@@ -243,7 +243,7 @@ class MapTorchModelBridge(TorchModelBridge):
             map_data=data,  # pyre-ignore[6]: Checked in __init__.
             map_keys_as_parameters=True,
             include_abandoned=self._fit_abandoned,
-            limit_total_rows=self._map_data_limit_total_rows,
+            limit_rows_per_metric=self._map_data_limit_rows_per_metric,
             limit_rows_per_group=self._map_data_limit_rows_per_group,
         )
 


### PR DESCRIPTION
Summary: The original logic for `limit_total_rows` was poor. This diff renames the argument explicitly to `limit_rows_per_metric` and implements the logic for each metric.

Differential Revision: D43865019

