### PR TITLE
Ax Bugfix: scheduler to pass optimization_config to best_point_mixin

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -441,6 +441,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         return self._get_best_trial(
             experiment=self.experiment,
             generation_strategy=self.generation_strategy,
+            optimization_config=optimization_config,
             trial_indices=trial_indices,
             use_model_predictions=use_model_predictions,
         )
@@ -455,6 +456,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         return self._get_pareto_optimal_parameters(
             experiment=self.experiment,
             generation_strategy=self.generation_strategy,
+            optimization_config=optimization_config,
             trial_indices=trial_indices,
             use_model_predictions=use_model_predictions,
         )

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -580,7 +580,9 @@ def get_pareto_optimal_parameters(
     # { trial_index --> (parameterization, (means, covariances) }
     pareto_util = predicted_pareto if use_model_predictions else observed_pareto
     pareto_optimal_observations = pareto_util(
-        modelbridge=modelbridge, objective_thresholds=objective_thresholds_override
+        modelbridge=modelbridge,
+        optimization_config=moo_optimization_config,
+        objective_thresholds=objective_thresholds_override,
     )
     return {
         int(not_none(obs.features.trial_index)): (

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -254,7 +254,10 @@ class BestPointMixin(metaclass=ABCMeta):
         trial_indices: Optional[Iterable[int]] = None,
         use_model_predictions: bool = True,
     ) -> Optional[Tuple[int, TParameterization, Optional[TModelPredictArm]]]:
-        if not_none(experiment.optimization_config).is_moo_problem:
+        optimization_config = optimization_config or not_none(
+            experiment.optimization_config
+        )
+        if optimization_config.is_moo_problem:
             raise NotImplementedError(  # pragma: no cover
                 "Please use `get_pareto_optimal_parameters` for multi-objective "
                 "problems."
@@ -298,7 +301,10 @@ class BestPointMixin(metaclass=ABCMeta):
         trial_indices: Optional[Iterable[int]] = None,
         use_model_predictions: bool = True,
     ) -> Dict[int, Tuple[TParameterization, TModelPredictArm]]:
-        if not not_none(experiment.optimization_config).is_moo_problem:
+        optimization_config = optimization_config or not_none(
+            experiment.optimization_config
+        )
+        if not optimization_config.is_moo_problem:
             raise NotImplementedError(  # pragma: no cover
                 "Please use `get_best_parameters` for single-objective problems."
             )


### PR DESCRIPTION
Summary:
Fixes two minor issues
1. Pass optimization_config to best_post_mixin from scheduler
2. Use optimization_config parameter in preference to the optimization_config on the experiment if one is provided

Differential Revision: D43885183

