### PR TITLE
Handle the case of more unordered choices than ordered parameters in choose_gs

### DIFF
--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -32,6 +32,7 @@ from ax.utils.testing.core_stubs import (
     get_factorial_search_space,
     get_large_factorial_search_space,
     get_large_ordinal_search_space,
+    get_search_space_with_choice_parameters,
 )
 
 
@@ -138,6 +139,25 @@ class TestDispatchUtils(TestCase):
                 )
             self.assertEqual(sobol_large._steps[0].model, Models.SOBOL)
             self.assertEqual(len(sobol_large._steps), 1)
+        with self.subTest("SOBOL due to too many unordered choices"):
+            # Search space with more unordered choices than ordered parameters.
+            sobol = choose_generation_strategy(
+                search_space=get_search_space_with_choice_parameters(
+                    num_ordered_parameters=5,
+                    num_unordered_choices=100,
+                )
+            )
+            self.assertEqual(sobol._steps[0].model, Models.SOBOL)
+            self.assertEqual(len(sobol._steps), 1)
+        with self.subTest("GPEI with more unordered choices than ordered parameters"):
+            # Search space with more unordered choices than ordered parameters.
+            sobol_gpei = choose_generation_strategy(
+                search_space=get_search_space_with_choice_parameters(
+                    num_ordered_parameters=5,
+                    num_unordered_choices=10,
+                )
+            )
+            self.assertEqual(sobol_gpei._steps[1].model, Models.GPEI)
         with self.subTest("GPEI despite many unordered 2-value parameters"):
             gs = choose_generation_strategy(
                 search_space=get_large_factorial_search_space(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -877,6 +877,31 @@ def get_small_discrete_search_space() -> SearchSpace:
     )
 
 
+def get_search_space_with_choice_parameters(
+    num_ordered_parameters: int = 2,
+    num_unordered_choices: int = 5,
+) -> SearchSpace:
+    parameters = []
+    for i in range(num_ordered_parameters):
+        parameters.append(
+            ChoiceParameter(
+                name=f"ordered_{i}",
+                parameter_type=ParameterType.INT,
+                values=list(range(10)),  # pyre-ignore
+                is_ordered=True,
+            )
+        )
+    parameters.append(
+        ChoiceParameter(
+            name="unordered",
+            parameter_type=ParameterType.INT,
+            values=list(range(num_unordered_choices)),  # pyre-ignore
+            is_ordered=False,
+        )
+    )
+    return SearchSpace(parameters=parameters)
+
+
 def get_hierarchical_search_space(
     with_fixed_parameter: bool = False,
 ) -> HierarchicalSearchSpace:


### PR DESCRIPTION
Summary:
Previously, this would just dispatch to SOBOL, which is not ideal if the choice parameters have many options. We should be either using standard BO or BO MIXED.

This implementation favors standard BO options, though I don't have a good reason why this shouldn't be using BO MIXED.

Reviewed By: dme65

Differential Revision: D43724682

