### PR TITLE
Add pointers for T147907632

### DIFF
--- a/ax/telemetry/experiment.py
+++ b/ax/telemetry/experiment.py
@@ -255,8 +255,8 @@ class ExperimentCompletedRecord:
     num_abandoned_trials: int
     num_early_stopped_trials: int
 
-    total_fit_time: float
-    total_gen_time: float
+    total_fit_time: int
+    total_gen_time: int
 
     @classmethod
     def from_experiment(cls, experiment: Experiment) -> ExperimentCompletedRecord:
@@ -290,6 +290,6 @@ class ExperimentCompletedRecord:
             num_failed_trials=trial_count_by_status[TrialStatus.FAILED],
             num_abandoned_trials=trial_count_by_status[TrialStatus.ABANDONED],
             num_early_stopped_trials=trial_count_by_status[TrialStatus.EARLY_STOPPED],
-            total_fit_time=fit_time,
-            total_gen_time=gen_time,
+            total_fit_time=int(fit_time),
+            total_gen_time=int(gen_time),
         )

--- a/ax/telemetry/scheduler.py
+++ b/ax/telemetry/scheduler.py
@@ -53,10 +53,14 @@ class SchedulerCreatedRecord:
             # If batch_size is None then we are using single-Arm trials
             arms_per_trial=scheduler.options.batch_size or 1,
             early_stopping_strategy_cls=(
-                scheduler.options.early_stopping_strategy.__class__.__name__
+                None
+                if scheduler.options.early_stopping_strategy is None
+                else scheduler.options.early_stopping_strategy.__class__.__name__
             ),
             global_stopping_strategy_cls=(
-                scheduler.options.global_stopping_strategy.__class__.__name__
+                None
+                if scheduler.options.global_stopping_strategy is None
+                else scheduler.options.global_stopping_strategy.__class__.__name__
             ),
             transformed_dimensionality=-1,  # TODO[mpolson64]
         )

--- a/ax/telemetry/scheduler.py
+++ b/ax/telemetry/scheduler.py
@@ -62,7 +62,7 @@ class SchedulerCreatedRecord:
                 if scheduler.options.global_stopping_strategy is None
                 else scheduler.options.global_stopping_strategy.__class__.__name__
             ),
-            transformed_dimensionality=-1,  # TODO[mpolson64]
+            transformed_dimensionality=-1,  # TODO[T147907632]
         )
 
     def flatten(self) -> Dict[str, Any]:
@@ -104,9 +104,8 @@ class SchedulerCompletedRecord:
             experiment_completed_record=ExperimentCompletedRecord.from_experiment(
                 experiment=scheduler.experiment
             ),
-            # TODO[mpolson64] Create metrics for point quality and model quality
-            best_point_quality=-1,
-            model_fit_quality=-1,
+            best_point_quality=-1,  # TODO[T147907632]
+            model_fit_quality=-1,  # TODO[T147907632]
             num_metric_fetch_e_encountered=scheduler._num_metric_fetch_e_encountered,
             num_trials_bad_due_to_err=scheduler._num_trials_bad_due_to_err,
         )

--- a/ax/telemetry/tests/test_experiment.py
+++ b/ax/telemetry/tests/test_experiment.py
@@ -54,7 +54,7 @@ class TestExperiment(TestCase):
             num_failed_trials=0,
             num_abandoned_trials=0,
             num_early_stopped_trials=0,
-            total_fit_time=fit_time,
-            total_gen_time=gen_time,
+            total_fit_time=int(fit_time),
+            total_gen_time=int(gen_time),
         )
         self.assertEqual(record, expected)

--- a/ax/telemetry/tests/test_scheduler.py
+++ b/ax/telemetry/tests/test_scheduler.py
@@ -39,8 +39,8 @@ class TestScheduler(TestCase):
             scheduler_total_trials=0,
             scheduler_max_pending_trials=10,
             arms_per_trial=1,
-            early_stopping_strategy_cls="NoneType",
-            global_stopping_strategy_cls="NoneType",
+            early_stopping_strategy_cls=None,
+            global_stopping_strategy_cls=None,
             transformed_dimensionality=-1,
         )
         self.assertEqual(record, expected)
@@ -56,8 +56,8 @@ class TestScheduler(TestCase):
             "scheduler_total_trials": 0,
             "scheduler_max_pending_trials": 10,
             "arms_per_trial": 1,
-            "early_stopping_strategy_cls": "NoneType",
-            "global_stopping_strategy_cls": "NoneType",
+            "early_stopping_strategy_cls": None,
+            "global_stopping_strategy_cls": None,
             "transformed_dimensionality": -1,
         }
         self.assertEqual(flat, expected_dict)


### PR DESCRIPTION
Summary: There are some metrics for telemetry that are not being calculated yet, so I've added `# TODO[T147907632]` in various places around the codebase. I will be soliciting help to define these metrics via posts and on the task

Reviewed By: bernardbeckerman

Differential Revision: D44031101

