### PR TITLE
Update the model in ModelSpec.fit if all non-data args are the same

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -94,6 +94,7 @@ class ModelBridge(ABC):
         optimization_config: Optional[OptimizationConfig] = None,
         fit_out_of_design: bool = False,
         fit_abandoned: bool = False,
+        fit_on_init: bool = True,
     ) -> None:
         """
         Applies transforms and fits model.
@@ -122,12 +123,19 @@ class ModelBridge(ABC):
             fit_abandoned: Whether data for abandoned arms or trials should be
                 included in model training data. If ``False``, only
                 non-abandoned points are returned.
+            fit_on_init: Whether to fit the model on initialization. This can
+                be used to skip model fitting when a fitted model is not needed.
+                To fit the model afterwards, use `_process_and_transform_data`
+                to get the transformed inputs and call `_fit_if_implemented` with
+                the transformed inputs.
         """
-        t_fit_start = time.time()
+        t_fit_start = time.monotonic()
         transforms = transforms or []
         # pyre-ignore: Cast is a Tranform
         transforms: List[Type[Transform]] = [Cast] + transforms
 
+        self.fit_time: float = 0.0
+        self.fit_time_since_gen: float = 0.0
         self._metric_names: Set[str] = set()
         self._training_data: List[Observation] = []
         self._optimization_config: Optional[OptimizationConfig] = optimization_config
@@ -138,56 +146,89 @@ class ModelBridge(ABC):
         self._model_key: Optional[str] = None
         self._model_kwargs: Optional[Dict[str, Any]] = None
         self._bridge_kwargs: Optional[Dict[str, Any]] = None
-
-        # pyre-fixme[4]: Attribute must be annotated.
-        self._model_space = search_space.clone()
+        self._model_space: SearchSpace = search_space.clone()
         self._raw_transforms = transforms
         self._transform_configs: Optional[Dict[str, TConfig]] = transform_configs
         self._fit_out_of_design = fit_out_of_design
         self._fit_abandoned = fit_abandoned
-        imm = experiment and experiment.immutable_search_space_and_opt_config
-        # pyre-fixme[4]: Attribute must be annotated.
-        self._experiment_has_immutable_search_space_and_opt_config = imm
+        self._experiment_has_immutable_search_space_and_opt_config: bool = (
+            experiment is not None and experiment.immutable_search_space_and_opt_config
+        )
         if experiment is not None:
             if self._optimization_config is None:
                 self._optimization_config = experiment.optimization_config
             self._arms_by_signature = experiment.arms_by_signature
 
-        # Convert Data to Observations
-        observations = self._prepare_observations(experiment=experiment, data=data)
-
-        observations_raw = self._set_training_data(
-            observations=observations, search_space=search_space
+        # Convert Data to Observations, transform observations & search space.
+        observations, search_space = self._process_and_transform_data(
+            experiment=experiment, data=data
         )
-        # Set model status quo
+
+        # Set model status quo.
         # NOTE: training data must be set before setting the status quo.
         self._set_status_quo(
             experiment=experiment,
             status_quo_name=status_quo_name,
             status_quo_features=status_quo_features,
         )
-        observations, search_space = self._transform_data(
-            observations=observations_raw,
-            search_space=search_space,
-            transforms=transforms,
-            transform_configs=transform_configs,
-        )
 
-        # Save model, apply terminal transform, and fit
+        # Save model, apply terminal transform, and fit.
         self.model = model
+        if fit_on_init:
+            self._fit_if_implemented(
+                search_space=search_space,
+                observations=observations,
+                time_so_far=time.monotonic() - t_fit_start,
+            )
+
+    def _fit_if_implemented(
+        self,
+        search_space: SearchSpace,
+        observations: List[Observation],
+        time_so_far: float,
+    ) -> None:
+        r"""Fits the model if `_fit` is implemented and stores fit time.
+
+        Args:
+            search_space: A transformed search space for fitting the model.
+            observations: The observations to fit the model with. These should
+                also be transformed.
+            time_so_far: Time spent in initializing the model up to
+                `_fit_if_implemented` call.
+        """
         try:
+            t_fit_start = time.monotonic()
             self._fit(
-                model=model,
+                model=self.model,
                 search_space=search_space,
                 observations=observations,
             )
-            # pyre-fixme[4]: Attribute must be annotated.
-            self.fit_time = time.time() - t_fit_start
-            # pyre-fixme[4]: Attribute must be annotated.
-            self.fit_time_since_gen = float(self.fit_time)
+            self.fit_time += time.monotonic() - t_fit_start + time_so_far
+            self.fit_time_since_gen += self.fit_time
         except NotImplementedError:
-            self.fit_time = 0.0
-            self.fit_time_since_gen = 0.0
+            pass
+
+    def _process_and_transform_data(
+        self,
+        experiment: Optional[Experiment] = None,
+        data: Optional[Data] = None,
+    ) -> Tuple[List[Observation], SearchSpace]:
+        r"""Processes the data into observations and returns transformed
+        observations and the search space. This packages the following methods:
+        * self._prepare_observations
+        * self._set_training_data
+        * self._transform_data
+        """
+        observations = self._prepare_observations(experiment=experiment, data=data)
+        observations_raw = self._set_training_data(
+            observations=observations, search_space=self._model_space
+        )
+        return self._transform_data(
+            observations=observations_raw,
+            search_space=self._model_space,
+            transforms=self._raw_transforms,
+            transform_configs=self._transform_configs,
+        )
 
     def _prepare_observations(
         self, experiment: Optional[Experiment], data: Optional[Data]
@@ -566,7 +607,7 @@ class ModelBridge(ABC):
                 `update`.
             experiment: Experiment, in which this data was obtained.
         """
-        t_update_start = time.time()
+        t_update_start = time.monotonic()
         observations = self._prepare_observations(experiment=experiment, data=new_data)
         obs_raw = self._extend_training_data(observations=observations)
         observations, search_space = self._transform_data(
@@ -579,8 +620,8 @@ class ModelBridge(ABC):
             search_space=search_space,
             observations=observations,
         )
-        self.fit_time += time.time() - t_update_start
-        self.fit_time_since_gen += time.time() - t_update_start
+        self.fit_time += time.monotonic() - t_update_start
+        self.fit_time_since_gen += time.monotonic() - t_update_start
 
     def _update(
         self,

--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -63,6 +63,7 @@ class MapTorchModelBridge(TorchModelBridge):
         status_quo_features: Optional[ObservationFeatures] = None,
         optimization_config: Optional[OptimizationConfig] = None,
         fit_out_of_design: bool = False,
+        fit_on_init: bool = True,
         default_model_gen_options: Optional[TConfig] = None,
         map_data_limit_rows_per_metric: Optional[int] = None,
         map_data_limit_rows_per_group: Optional[int] = None,
@@ -93,6 +94,11 @@ class MapTorchModelBridge(TorchModelBridge):
                 the model.
             fit_out_of_design: If specified, all training data is returned.
                 Otherwise, only in design points are returned.
+            fit_on_init: Whether to fit the model on initialization. This can
+                be used to skip model fitting when a fitted model is not needed.
+                To fit the model afterwards, use `_process_and_transform_data`
+                to get the transformed inputs and call `_fit_if_implemented` with
+                the transformed inputs.
             default_model_gen_options: Options passed down to `model.gen(...)`.
             map_data_limit_rows_per_metric: Subsample the map data so that the
                 total number of rows per metric is limited by this value.
@@ -123,6 +129,7 @@ class MapTorchModelBridge(TorchModelBridge):
             status_quo_features=status_quo_features,
             optimization_config=optimization_config,
             fit_out_of_design=fit_out_of_design,
+            fit_on_init=fit_on_init,
             default_model_gen_options=default_model_gen_options,
         )
 

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -258,6 +258,15 @@ class BaseModelBridgeTest(TestCase):
             modelbridge.transform_observation_features([get_observation2().features])
         mock_tr.assert_called_with(modelbridge, [get_observation2trans().features])
 
+        # Test that fit is not called when fit_on_init = False.
+        mock_fit.reset_mock()
+        modelbridge = ModelBridge(
+            search_space=ss,
+            model=Model(),
+            fit_on_init=False,
+        )
+        self.assertEqual(mock_fit.call_count, 0)
+
     @mock.patch(
         "ax.modelbridge.base.observations_from_data",
         autospec=True,

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -59,7 +59,9 @@ class TestGenerationStrategy(TestCase):
             f"{TorchModelBridge.__module__}.TorchModelBridge", spec=True
         )
         self.mock_torch_model_bridge = self.torch_model_bridge_patcher.start()
-        self.mock_torch_model_bridge.return_value.gen.return_value = self.gr
+        mock_mb = self.mock_torch_model_bridge.return_value
+        mock_mb.gen.return_value = self.gr
+        mock_mb._process_and_transform_data.return_value = (None, None)
 
         # Mock out slow TS.
         self.discrete_model_bridge_patcher = patch(
@@ -302,6 +304,7 @@ class TestGenerationStrategy(TestCase):
                         "transforms": Cont_X_trans,
                         "fit_out_of_design": False,
                         "fit_abandoned": False,
+                        "fit_on_init": True,
                     },
                 )
                 ms = g._model_state_after_gen

--- a/ax/modelbridge/tests/test_model_spec.py
+++ b/ax/modelbridge/tests/test_model_spec.py
@@ -5,12 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import warnings
-from unittest.mock import Mock, patch
+from unittest import mock
+from unittest.mock import MagicMock, Mock, patch
 
 from ax.core.observation import ObservationFeatures
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.factory import get_sobol
 from ax.modelbridge.model_spec import FactoryFunctionModelSpec, ModelSpec
+from ax.modelbridge.modelbridge_utils import extract_search_space_digest
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
@@ -39,23 +41,49 @@ class ModelSpecTest(BaseModelSpecTest):
         with self.assertRaises(NotImplementedError):
             ms.update(experiment=self.experiment, new_data=self.data)
 
+    @fast_botorch_optimize
+    # We can use `extract_search_space_digest` as a surrogate for executing
+    # the full TorchModelBridge._fit.
+    @mock.patch(
+        "ax.modelbridge.torch.extract_search_space_digest",
+        wraps=extract_search_space_digest,
+    )
+    def test_fit(self, wrapped_extract_ssd: Mock) -> None:
+        ms = ModelSpec(model_enum=Models.GPEI)
+        # This should fit the model as usual.
+        ms.fit(experiment=self.experiment, data=self.data)
+        wrapped_extract_ssd.assert_called_once()
+        self.assertIsNotNone(ms._last_fit_arg_ids)
+        self.assertEqual(ms._last_fit_arg_ids["experiment"], id(self.experiment))
+        # This should skip the model fit.
+        with mock.patch("ax.modelbridge.torch.logger") as mock_logger:
+            ms.fit(experiment=self.experiment, data=self.data)
+        mock_logger.info.assert_called_with(
+            "The observations are identical to the last set of observations "
+            "used to fit the model. Skipping model fitting."
+        )
+        wrapped_extract_ssd.assert_called_once()
+
     def test_model_key(self) -> None:
         ms = ModelSpec(model_enum=Models.GPEI)
         self.assertEqual(ms.model_key, "GPEI")
 
     @patch(f"{ModelSpec.__module__}.compute_diagnostics")
     @patch(f"{ModelSpec.__module__}.cross_validate", return_value=["fake-cv-result"])
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_cross_validate_with_GP_model(self, mock_cv: Mock, mock_diagnostics: Mock):
+    def test_cross_validate_with_GP_model(
+        self, mock_cv: Mock, mock_diagnostics: Mock
+    ) -> None:
         mock_enum = Mock()
-        mock_enum.return_value = "fake-modelbridge"
+        fake_mb = MagicMock()
+        fake_mb._process_and_transform_data = MagicMock(return_value=(None, None))
+        mock_enum.return_value = fake_mb
         ms = ModelSpec(model_enum=mock_enum, model_cv_kwargs={"test_key": "test-value"})
         ms.fit(
             experiment=self.experiment,
             data=self.experiment.trials[0].fetch_data(),
         )
         cv_results, cv_diagnostics = ms.cross_validate()
-        mock_cv.assert_called_with(model="fake-modelbridge", test_key="test-value")
+        mock_cv.assert_called_with(model=fake_mb, test_key="test-value")
         mock_diagnostics.assert_called_with(["fake-cv-result"])
 
         self.assertIsNotNone(cv_results)
@@ -84,15 +112,14 @@ class ModelSpecTest(BaseModelSpecTest):
 
             self.assertIsNotNone(cv_results)
             self.assertIsNotNone(cv_diagnostics)
-            mock_cv.assert_called_with(model="fake-modelbridge", test_key="test-value")
+            mock_cv.assert_called_with(model=fake_mb, test_key="test-value")
             mock_diagnostics.assert_called_with(["fake-cv-result"])
 
     @patch(f"{ModelSpec.__module__}.compute_diagnostics")
     @patch(f"{ModelSpec.__module__}.cross_validate", side_effect=NotImplementedError)
-    # pyre-fixme[3]: Return type must be annotated.
     def test_cross_validate_with_non_GP_model(
         self, mock_cv: Mock, mock_diagnostics: Mock
-    ):
+    ) -> None:
         mock_enum = Mock()
         mock_enum.return_value = "fake-modelbridge"
         ms = ModelSpec(model_enum=mock_enum, model_cv_kwargs={"test_key": "test-value"})

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -137,6 +137,7 @@ class ModelRegistryTest(TestCase):
                 "transforms": Cont_X_trans + Y_trans,
                 "fit_out_of_design": False,
                 "fit_abandoned": False,
+                "fit_on_init": True,
                 "default_model_gen_options": None,
             },
         )
@@ -230,6 +231,7 @@ class ModelRegistryTest(TestCase):
                     "status_quo_features": None,
                     "fit_out_of_design": False,
                     "fit_abandoned": False,
+                    "fit_on_init": True,
                 },
             ),
         )
@@ -251,6 +253,7 @@ class ModelRegistryTest(TestCase):
                     "status_quo_features",
                     "fit_out_of_design",
                     "fit_abandoned",
+                    "fit_on_init",
                 ]
             ),
         )

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -107,6 +107,7 @@ class TorchModelBridge(ModelBridge):
         optimization_config: Optional[OptimizationConfig] = None,
         fit_out_of_design: bool = False,
         fit_abandoned: bool = False,
+        fit_on_init: bool = True,
         default_model_gen_options: Optional[TConfig] = None,
     ) -> None:
         self.dtype: torch.dtype = torch.double if torch_dtype is None else torch_dtype
@@ -133,6 +134,7 @@ class TorchModelBridge(ModelBridge):
             optimization_config=optimization_config,
             fit_out_of_design=fit_out_of_design,
             fit_abandoned=fit_abandoned,
+            fit_on_init=fit_on_init,
         )
 
     def feature_importances(self, metric_name: str) -> Dict[str, float]:

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -273,7 +273,7 @@ class SQAStoreTest(TestCase):
         f"{Decoder.__module__}.Decoder.experiment_from_sqa",
         side_effect=Decoder(SQAConfig()).experiment_from_sqa,
     )
-    def testExperimentSaveAndLoadReducedState(
+    def test_ExperimentSaveAndLoadReducedState(
         self, _mock_exp_from_sqa, _mock_trial_from_sqa, _mock_gr_from_sqa
     ) -> None:
         # 1. No abandoned arms + no trials case, reduced state should be the
@@ -316,7 +316,7 @@ class SQAStoreTest(TestCase):
         self.assertEqual(len(mkw), 6)
         bkw = gr._bridge_kwargs
         self.assertIsNotNone(bkw)
-        self.assertEqual(len(bkw), 7)
+        self.assertEqual(len(bkw), 8)
         ms = gr._model_state_after_gen
         self.assertIsNotNone(ms)
         self.assertEqual(len(ms), 2)


### PR DESCRIPTION
Summary:
Follow up to https://github.com/facebook/Ax/pull/1344. Calling `ModelBridge._fit` instead of constructing a fresh `ModelBridge` will make sure that we can avoid model fitting when it is not necessary.

Also adds a `fit_on_init` kwarg to `ModelBridge.__init__`, which can be used to skip model fitting when a fitted model is not needed.

Differential Revision: D42270109

