### PR TITLE
Refit or update the modelbridge in `ModelSpec.fit` if all non-data args are the same

### DIFF
--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -63,6 +63,7 @@ class MapTorchModelBridge(TorchModelBridge):
         status_quo_features: Optional[ObservationFeatures] = None,
         optimization_config: Optional[OptimizationConfig] = None,
         fit_out_of_design: bool = False,
+        fit_on_init: bool = True,
         default_model_gen_options: Optional[TConfig] = None,
         map_data_limit_rows_per_metric: Optional[int] = None,
         map_data_limit_rows_per_group: Optional[int] = None,
@@ -93,6 +94,11 @@ class MapTorchModelBridge(TorchModelBridge):
                 the model.
             fit_out_of_design: If specified, all training data is returned.
                 Otherwise, only in design points are returned.
+            fit_on_init: Whether to fit the model on initialization. This can
+                be used to skip model fitting when a fitted model is not needed.
+                To fit the model afterwards, use `_process_and_transform_data`
+                to get the transformed inputs and call `_fit_if_implemented` with
+                the transformed inputs.
             default_model_gen_options: Options passed down to `model.gen(...)`.
             map_data_limit_rows_per_metric: Subsample the map data so that the
                 total number of rows per metric is limited by this value.
@@ -123,6 +129,7 @@ class MapTorchModelBridge(TorchModelBridge):
             status_quo_features=status_quo_features,
             optimization_config=optimization_config,
             fit_out_of_design=fit_out_of_design,
+            fit_on_init=fit_on_init,
             default_model_gen_options=default_model_gen_options,
         )
 

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -59,7 +59,9 @@ class TestGenerationStrategy(TestCase):
             f"{TorchModelBridge.__module__}.TorchModelBridge", spec=True
         )
         self.mock_torch_model_bridge = self.torch_model_bridge_patcher.start()
-        self.mock_torch_model_bridge.return_value.gen.return_value = self.gr
+        mock_mb = self.mock_torch_model_bridge.return_value
+        mock_mb.gen.return_value = self.gr
+        mock_mb._process_and_transform_data.return_value = (None, None)
 
         # Mock out slow TS.
         self.discrete_model_bridge_patcher = patch(
@@ -302,6 +304,7 @@ class TestGenerationStrategy(TestCase):
                         "transforms": Cont_X_trans,
                         "fit_out_of_design": False,
                         "fit_abandoned": False,
+                        "fit_on_init": True,
                     },
                 )
                 ms = g._model_state_after_gen

--- a/ax/modelbridge/tests/test_model_spec.py
+++ b/ax/modelbridge/tests/test_model_spec.py
@@ -5,12 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import warnings
-from unittest.mock import Mock, patch
+from unittest import mock
+from unittest.mock import MagicMock, Mock, patch
 
 from ax.core.observation import ObservationFeatures
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.factory import get_sobol
 from ax.modelbridge.model_spec import FactoryFunctionModelSpec, ModelSpec
+from ax.modelbridge.modelbridge_utils import extract_search_space_digest
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
@@ -39,23 +41,49 @@ class ModelSpecTest(BaseModelSpecTest):
         with self.assertRaises(NotImplementedError):
             ms.update(experiment=self.experiment, new_data=self.data)
 
+    @fast_botorch_optimize
+    # We can use `extract_search_space_digest` as a surrogate for executing
+    # the full TorchModelBridge._fit.
+    @mock.patch(
+        "ax.modelbridge.torch.extract_search_space_digest",
+        wraps=extract_search_space_digest,
+    )
+    def test_fit(self, wrapped_extract_ssd: Mock) -> None:
+        ms = ModelSpec(model_enum=Models.GPEI)
+        # This should fit the model as usual.
+        ms.fit(experiment=self.experiment, data=self.data)
+        wrapped_extract_ssd.assert_called_once()
+        self.assertIsNotNone(ms._last_fit_arg_ids)
+        self.assertEqual(ms._last_fit_arg_ids["experiment"], id(self.experiment))
+        # This should skip the model fit.
+        with mock.patch("ax.modelbridge.torch.logger") as mock_logger:
+            ms.fit(experiment=self.experiment, data=self.data)
+        mock_logger.info.assert_called_with(
+            "The observations are identical to the last set of observations "
+            "used to fit the model. Skipping model fitting."
+        )
+        wrapped_extract_ssd.assert_called_once()
+
     def test_model_key(self) -> None:
         ms = ModelSpec(model_enum=Models.GPEI)
         self.assertEqual(ms.model_key, "GPEI")
 
     @patch(f"{ModelSpec.__module__}.compute_diagnostics")
     @patch(f"{ModelSpec.__module__}.cross_validate", return_value=["fake-cv-result"])
-    # pyre-fixme[3]: Return type must be annotated.
-    def test_cross_validate_with_GP_model(self, mock_cv: Mock, mock_diagnostics: Mock):
+    def test_cross_validate_with_GP_model(
+        self, mock_cv: Mock, mock_diagnostics: Mock
+    ) -> None:
         mock_enum = Mock()
-        mock_enum.return_value = "fake-modelbridge"
+        fake_mb = MagicMock()
+        fake_mb._process_and_transform_data = MagicMock(return_value=(None, None))
+        mock_enum.return_value = fake_mb
         ms = ModelSpec(model_enum=mock_enum, model_cv_kwargs={"test_key": "test-value"})
         ms.fit(
             experiment=self.experiment,
             data=self.experiment.trials[0].fetch_data(),
         )
         cv_results, cv_diagnostics = ms.cross_validate()
-        mock_cv.assert_called_with(model="fake-modelbridge", test_key="test-value")
+        mock_cv.assert_called_with(model=fake_mb, test_key="test-value")
         mock_diagnostics.assert_called_with(["fake-cv-result"])
 
         self.assertIsNotNone(cv_results)
@@ -84,15 +112,14 @@ class ModelSpecTest(BaseModelSpecTest):
 
             self.assertIsNotNone(cv_results)
             self.assertIsNotNone(cv_diagnostics)
-            mock_cv.assert_called_with(model="fake-modelbridge", test_key="test-value")
+            mock_cv.assert_called_with(model=fake_mb, test_key="test-value")
             mock_diagnostics.assert_called_with(["fake-cv-result"])
 
     @patch(f"{ModelSpec.__module__}.compute_diagnostics")
     @patch(f"{ModelSpec.__module__}.cross_validate", side_effect=NotImplementedError)
-    # pyre-fixme[3]: Return type must be annotated.
     def test_cross_validate_with_non_GP_model(
         self, mock_cv: Mock, mock_diagnostics: Mock
-    ):
+    ) -> None:
         mock_enum = Mock()
         mock_enum.return_value = "fake-modelbridge"
         ms = ModelSpec(model_enum=mock_enum, model_cv_kwargs={"test_key": "test-value"})

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -137,6 +137,7 @@ class ModelRegistryTest(TestCase):
                 "transforms": Cont_X_trans + Y_trans,
                 "fit_out_of_design": False,
                 "fit_abandoned": False,
+                "fit_on_init": True,
                 "default_model_gen_options": None,
             },
         )
@@ -230,6 +231,7 @@ class ModelRegistryTest(TestCase):
                     "status_quo_features": None,
                     "fit_out_of_design": False,
                     "fit_abandoned": False,
+                    "fit_on_init": True,
                 },
             ),
         )
@@ -251,6 +253,7 @@ class ModelRegistryTest(TestCase):
                     "status_quo_features",
                     "fit_out_of_design",
                     "fit_abandoned",
+                    "fit_on_init",
                 ]
             ),
         )

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -107,6 +107,7 @@ class TorchModelBridge(ModelBridge):
         optimization_config: Optional[OptimizationConfig] = None,
         fit_out_of_design: bool = False,
         fit_abandoned: bool = False,
+        fit_on_init: bool = True,
         default_model_gen_options: Optional[TConfig] = None,
     ) -> None:
         self.dtype: torch.dtype = torch.double if torch_dtype is None else torch_dtype
@@ -133,6 +134,7 @@ class TorchModelBridge(ModelBridge):
             optimization_config=optimization_config,
             fit_out_of_design=fit_out_of_design,
             fit_abandoned=fit_abandoned,
+            fit_on_init=fit_on_init,
         )
 
     def feature_importances(self, metric_name: str) -> Dict[str, float]:

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -273,7 +273,7 @@ class SQAStoreTest(TestCase):
         f"{Decoder.__module__}.Decoder.experiment_from_sqa",
         side_effect=Decoder(SQAConfig()).experiment_from_sqa,
     )
-    def testExperimentSaveAndLoadReducedState(
+    def test_ExperimentSaveAndLoadReducedState(
         self, _mock_exp_from_sqa, _mock_trial_from_sqa, _mock_gr_from_sqa
     ) -> None:
         # 1. No abandoned arms + no trials case, reduced state should be the
@@ -316,7 +316,7 @@ class SQAStoreTest(TestCase):
         self.assertEqual(len(mkw), 6)
         bkw = gr._bridge_kwargs
         self.assertIsNotNone(bkw)
-        self.assertEqual(len(bkw), 7)
+        self.assertEqual(len(bkw), 8)
         ms = gr._model_state_after_gen
         self.assertIsNotNone(ms)
         self.assertEqual(len(ms), 2)


### PR DESCRIPTION
Summary: This is a redo of https://github.com/facebook/Ax/pull/1507, which was reverted due to issues with order of operations when using a status quo: We need to be setting the train data before setting the status quo, and setting the status quo before transforming the data.

In `ModelSpec.fit`, calling `ModelBridge._fit` instead of constructing a fresh `ModelBridge` will make sure that we can avoid model fitting when it is not necessary (the necessary logic was introduced in https://github.com/facebook/Ax/pull/1344).

This also adds a `fit_on_init` kwarg to `ModelBridge.__init__`, which can be used to skip model fitting when a fitted model is not needed.

Differential Revision: D44096998

