### PR TITLE
unify how map_key_info is specified in MapMetrics / AbstractCurveMetrics

### DIFF
--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Type
 
-from ax.core.map_data import MapData
+from ax.core.map_data import MapData, MapKeyInfo
 from ax.core.metric import Metric, MetricFetchE
 from ax.utils.common.result import Result
 
@@ -30,3 +30,4 @@ class MapMetric(Metric):
     """
 
     data_constructor: Type[MapData] = MapData
+    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="steps", default_value=0.0)

--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -30,8 +30,6 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
         self,
         name: str,
         param_names: Iterable[str],
-        # pyre-fixme[24]: Generic type `MapKeyInfo` expects 1 type parameter.
-        map_key_infos: Optional[Iterable[MapKeyInfo]] = None,
         noise_sd: float = 0.0,
         lower_is_better: Optional[bool] = None,
         rate: Optional[float] = None,
@@ -58,9 +56,6 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
         super().__init__(
             name=name,
             param_names=param_names,
-            map_key_infos=map_key_infos
-            if map_key_infos is not None
-            else [MapKeyInfo(key="timestamp", default_value=0.0)],
             noise_sd=noise_sd,
             lower_is_better=lower_is_better,
             cache_evaluations=cache_evaluations,
@@ -71,7 +66,6 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
         return (
             self.name == o.name
             and self.param_names == o.param_names
-            and self.map_key_infos == o.map_key_infos
             and self.noise_sd == o.noise_sd
             and self.lower_is_better == o.lower_is_better
         )
@@ -103,14 +97,13 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
                         "sem": self.noise_sd if noisy else 0.0,
                         "trial_index": trial.index,
                         "mean": [item["mean"] for item in res],
-                        **{
-                            mki.key: [item[mki.key] for item in res]
-                            for mki in self.map_key_infos
-                        },
+                        self.map_key_info.key: [
+                            item[self.map_key_info.key] for item in res
+                        ],
                     }
                 )
 
-                datas.append(MapData(df=df, map_key_infos=self.map_key_infos))
+                datas.append(MapData(df=df, map_key_infos=[self.map_key_info]))
 
             return Ok(value=MapData.from_multiple_map_data(datas))
 
@@ -133,6 +126,9 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
 
 
 class BraninFidelityMapMetric(NoisyFunctionMapMetric):
+
+    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="fidelity", default_value=0.0)
+
     def __init__(
         self,
         name: str,
@@ -143,7 +139,6 @@ class BraninFidelityMapMetric(NoisyFunctionMapMetric):
         super().__init__(
             name=name,
             param_names=param_names,
-            map_key_infos=[MapKeyInfo(key="fidelity", default_value=0.0)],
             noise_sd=noise_sd,
             lower_is_better=lower_is_better,
         )

--- a/ax/metrics/curve.py
+++ b/ax/metrics/curve.py
@@ -35,8 +35,7 @@ logger: Logger = get_logger(__name__)
 class AbstractCurveMetric(MapMetric, ABC):
     """Metric representing (partial) learning curves of ML model training jobs."""
 
-    # pyre-fixme[4]: Attribute must be annotated.
-    MAP_KEY = MapKeyInfo(key="training_rows", default_value=0.0)
+    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="training_rows", default_value=0.0)
 
     def __init__(
         self,
@@ -166,7 +165,7 @@ class AbstractCurveMetric(MapMetric, ABC):
                                     & (df["trial_index"] == trial.index)
                                 ]
                             ),
-                            map_key_infos=[cls.MAP_KEY],
+                            map_key_infos=[cls.map_key_info],
                         )
                     )
                     for metric in metrics
@@ -219,7 +218,7 @@ class AbstractCurveMetric(MapMetric, ABC):
                         curve_series=curve_series,
                         curve_name=m.curve_name,
                         metric_name=m.name,
-                        map_key=cls.MAP_KEY.key,
+                        map_key=cls.map_key_info.key,
                         trial=experiment.trials[trial_idx],
                         cumulative_best=m.cumulative_best,  # pyre-ignore[16]
                         lower_is_better=m.lower_is_better,  # pyre-ignore[6]
@@ -270,9 +269,9 @@ class AbstractCurveMetric(MapMetric, ABC):
             A dictionary mapping the backend id to the partial result
             curves, each of which is represented as a mapping from
             the metric name to a pandas Series indexed by the progression
-            (which will be mapped to the `MAP_KEY` of the metric class).
-            E.g. if `curve_name=loss` and `MAP_KEY=training_rows`, then a
-            Series should look like:
+            (which will be mapped to the `map_key_info.key` of the metric class).
+            E.g. if `curve_name=loss` and `map_key_info.key = training_rows`,
+            then a Series should look like:
 
                  training_rows (index) | loss
                 -----------------------|------
@@ -360,7 +359,7 @@ class AbstractScalarizedCurveMetric(AbstractCurveMetric):
                         curve_df = _get_single_curve(
                             curve_series=curve_series,
                             curve_name=curve_name,
-                            map_key=cls.MAP_KEY.key,
+                            map_key=cls.map_key_info.key,
                             trial=experiment.trials[trial_idx],
                             cumulative_best=m.cumulative_best,  # pyre-ignore[16]
                             lower_is_better=m.lower_is_better,  # pyre-ignore[6]
@@ -394,7 +393,7 @@ class AbstractScalarizedCurveMetric(AbstractCurveMetric):
             trial_curves = dfi["metric_name"].unique().tolist()
             dfs_mean, dfs_sem = align_partial_results(
                 dfi,
-                progr_key=cls.MAP_KEY.key,
+                progr_key=cls.map_key_info.key,
                 metrics=trial_curves,
                 do_forward_fill=True,
             )

--- a/ax/metrics/noisy_function_map.py
+++ b/ax/metrics/noisy_function_map.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from logging import Logger
 
-from typing import Any, Dict, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 import numpy as np
 import pandas as pd
@@ -18,8 +18,6 @@ from ax.core.map_metric import MapMetric, MapMetricFetchResult
 from ax.core.metric import MetricFetchE
 from ax.utils.common.logger import get_logger
 from ax.utils.common.result import Err, Ok
-from ax.utils.common.serialization import serialize_init_args
-from ax.utils.common.typeutils import checked_cast
 
 logger: Logger = get_logger(__name__)
 
@@ -29,12 +27,12 @@ class NoisyFunctionMapMetric(MapMetric):
     with mean 0 and mean_sd scale added to the result.
     """
 
+    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="timestamp", default_value=0.0)
+
     def __init__(
         self,
         name: str,
         param_names: Iterable[str],
-        # pyre-fixme[24]: Generic type `MapKeyInfo` expects 1 type parameter.
-        map_key_infos: Iterable[MapKeyInfo],
         noise_sd: float = 0.0,
         lower_is_better: Optional[bool] = None,
         cache_evaluations: bool = True,
@@ -59,7 +57,6 @@ class NoisyFunctionMapMetric(MapMetric):
                 observation noise.
         """
         self.param_names = param_names
-        self.map_key_infos = map_key_infos
         self.noise_sd = noise_sd
         # pyre-fixme[4]: Attribute must be annotated.
         self.cache = {}
@@ -78,7 +75,6 @@ class NoisyFunctionMapMetric(MapMetric):
         return self.__class__(
             name=self._name,
             param_names=self.param_names,
-            map_key_infos=self.map_key_infos,
             noise_sd=self.noise_sd,
             lower_is_better=self.lower_is_better,
             cache_evaluations=self.cache_evaluations,
@@ -100,14 +96,12 @@ class NoisyFunctionMapMetric(MapMetric):
                     "sem": self.noise_sd if noisy else 0.0,
                     "trial_index": trial.index,
                     "mean": [item["mean"] for item in res],
-                    **{
-                        mki.key: [item[mki.key] for item in res]
-                        for mki in self.map_key_infos
-                    },
+                    self.map_key_info.key: [
+                        item[self.map_key_info.key] for item in res
+                    ],
                 }
             )
-
-            return Ok(value=MapData(df=df, map_key_infos=self.map_key_infos))
+            return Ok(value=MapData(df=df, map_key_infos=[self.map_key_info]))
 
         except Exception as e:
             return Err(
@@ -117,20 +111,3 @@ class NoisyFunctionMapMetric(MapMetric):
     def f(self, x: np.ndarray) -> Mapping[str, Any]:
         """The deterministic function that produces the metric outcomes."""
         raise NotImplementedError
-
-    @classmethod
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
-    def serialize_init_args(cls, obj: Any) -> Dict[str, Any]:
-        nf_map_metric = checked_cast(NoisyFunctionMapMetric, obj)
-        init_args = serialize_init_args(
-            object=nf_map_metric, exclude_fields=["map_key_infos"]
-        )
-        init_args["map_key_infos"] = [
-            serialize_init_args(object=mki) for mki in nf_map_metric.map_key_infos
-        ]
-        return init_args
-
-    @classmethod
-    def deserialize_init_args(cls, args: Dict[str, Any]) -> Dict[str, Any]:
-        args["map_key_infos"] = [MapKeyInfo(**mki) for mki in args["map_key_infos"]]
-        return super().deserialize_init_args(args=args)

--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -29,8 +29,7 @@ try:
     class TensorboardCurveMetric(AbstractCurveMetric):
         """A `CurveMetric` for getting Tensorboard curves."""
 
-        # pyre-fixme[4]: Attribute must be annotated.
-        MAP_KEY = MapKeyInfo(key="steps", default_value=0.0)
+        map_key_info: MapKeyInfo[float] = MapKeyInfo(key="steps", default_value=0.0)
 
         @classmethod
         def get_curves_from_ids(

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -472,7 +472,7 @@ def _get_curve_plot_dropdown(
             always_include_field_columns=True,
         )
     for m in curve_metrics:
-        map_key = m.MAP_KEY.key
+        map_key = m.map_key_info.key
         subsampled_data = (
             data
             if limit_points_per_plot is None
@@ -530,7 +530,8 @@ def _get_curve_plot_dropdown(
         stopping_markers_by_metric=stopping_markers_by_metric,
         title=title,
         xlabels_by_metric={
-            m.name: "wall time" if by_walltime else m.MAP_KEY.key for m in curve_metrics
+            m.name: "wall time" if by_walltime else m.map_key_info.key
+            for m in curve_metrics
         },
         lower_is_better_by_metric={m.name: m.lower_is_better for m in curve_metrics},
     )

--- a/ax/utils/testing/metrics/branin_backend_map.py
+++ b/ax/utils/testing/metrics/branin_backend_map.py
@@ -4,10 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Iterable, List, Optional
+from typing import List, Optional
 
 import numpy as np
-from ax.core.map_data import MapKeyInfo
 from ax.metrics.branin_map import BraninTimestampMapMetric
 from ax.utils.testing.metrics.backend_simulator_map import (
     BackendSimulatorTimestampMapMetric,
@@ -24,8 +23,6 @@ class BraninBackendMapMetric(
         self,
         name: str,
         param_names: List[str],
-        # pyre-fixme[24]: Generic type `MapKeyInfo` expects 1 type parameter.
-        map_key_infos: Optional[Iterable[MapKeyInfo]] = None,
         noise_sd: float = 0.0,
         lower_is_better: Optional[bool] = True,
         cache_evaluations: bool = True,
@@ -48,9 +45,6 @@ class BraninBackendMapMetric(
             self,
             name=name,
             param_names=param_names,
-            map_key_infos=map_key_infos
-            if map_key_infos is not None
-            else [MapKeyInfo(key="timestamp", default_value=0.0)],
             noise_sd=noise_sd,
             lower_is_better=lower_is_better,
             cache_evaluations=cache_evaluations,


### PR DESCRIPTION
Summary:
Previously:
- In `MapMetric`, there we no default way to specify a `map_key_info`,
- But in `NoisyFunctionMapMetric`, we pass in a list of `map_key_infos` for each instance
- And in `AbstractCurveMetric`, we specify a class attribute `MAP_KEY`, which defaults to a map_key_info with key = `training_rows`.

Proposal:
- Unify these by putting a class attribute `map_key_info` on the base class `MapMetric`. This way we can always determine the map_key_info for all map metrics in a unified way.
- Note that previously `NoisyFunctionMapMetric` allowed passing in a list of `map_key_infos`. I don't see any obvious use cases of this at the moment. If there are, then we could allow for that as well. But if not, we might want to keep things simple and assume a single `map_key_info` per metric.

Reviewed By: Balandat

Differential Revision: D43999431

