### PR TITLE
Use correct set of transforms in _make_botorch_step

### DIFF
--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -16,7 +16,7 @@ from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UnsupportedError
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
-from ax.modelbridge.registry import Cont_X_trans, Models, Y_trans
+from ax.modelbridge.registry import Models
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.winsorize import Winsorize
 from ax.models.types import TConfig
@@ -98,7 +98,9 @@ def _make_botorch_step(
     ] = derelativization_transform_config
 
     if not no_winsorization:
-        transforms = model_kwargs.get("transforms", Cont_X_trans + Y_trans)
+        _, default_bridge_kwargs = model.view_defaults()
+        default_transforms = default_bridge_kwargs["transforms"]
+        transforms = model_kwargs.get("transforms", default_transforms)
         model_kwargs["transforms"] = [cast(Type[Transform], Winsorize)] + transforms
         if winsorization_transform_config is not None:
             model_kwargs["transform_configs"][

--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -20,7 +20,7 @@ from ax.modelbridge.dispatch_utils import (
     DEFAULT_BAYESIAN_PARALLELISM,
 )
 from ax.modelbridge.factory import Cont_X_trans, Y_trans
-from ax.modelbridge.registry import Models
+from ax.modelbridge.registry import Mixed_transforms, Models
 from ax.modelbridge.transforms.log_y import LogY
 from ax.modelbridge.transforms.winsorize import Winsorize
 from ax.models.winsorization_config import WinsorizationConfig
@@ -183,7 +183,7 @@ class TestDispatchUtils(TestCase):
             self.assertEqual(bo_mixed._steps[1].model, Models.BO_MIXED)
             expected_model_kwargs = {
                 "torch_device": None,
-                "transforms": expected_transforms,
+                "transforms": [Winsorize] + Mixed_transforms + Y_trans,
                 "transform_configs": expected_transform_configs,
             }
             self.assertEqual(bo_mixed._steps[1].model_kwargs, expected_model_kwargs)
@@ -197,7 +197,7 @@ class TestDispatchUtils(TestCase):
             self.assertEqual(bo_mixed_2._steps[1].model, Models.BO_MIXED)
             expected_model_kwargs = {
                 "torch_device": None,
-                "transforms": expected_transforms,
+                "transforms": [Winsorize] + Mixed_transforms + Y_trans,
                 "transform_configs": expected_transform_configs,
             }
             self.assertEqual(bo_mixed._steps[1].model_kwargs, expected_model_kwargs)


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/Ax/issues/1516

This used to hard code `Cont_X_trans + Y_trans` as defaults. With this change, it will get the defaults from the model registry instead.

Differential Revision: D44140016

