### PR TITLE
Fix missing categorical_features in BO_MIXED inputs

### DIFF
--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -351,10 +351,12 @@ class Surrogate(Base):
 
             **kwargs: Keyword arguments, accepts:
                 - ``fidelity_features``: Indices of columns in X that represent
-                    fidelity
-                - ``task_features``: Indices of columns in X that represent tasks
+                    fidelity features.
+                - ``task_features``: Indices of columns in X that represent tasks.
+                - ``categorical_features``: Indices of columns in X that represent
+                    categorical features.
                 - ``robust_digest``: An optional `RobustSearchSpaceDigest` that carries
-                    additional attributes if using a `RobustSearchSpace`
+                    additional attributes if using a `RobustSearchSpace`.
         """
         if self.botorch_model_class is None and search_space_digest is None:
             raise UserInputError(
@@ -389,6 +391,7 @@ class Surrogate(Base):
                 training_data=dataset,
                 fidelity_features=fidelity_features,
                 task_feature=task_feature,
+                categorical_features=kwargs.get("categorical_features", None),
                 **self.model_options,
             )
             # Add input / outcome transforms.


### PR DESCRIPTION
Summary: BO_MIXED requires `categorical_features` to be passed to the model constructor. This is available on `search_space_digest` and gets passed down as part of `kwargs`, so we can extract it from there.

Differential Revision: D44158617

