### PR TITLE
Replace check_type in validate_kwargs_typing with pyre_extension logic

### DIFF
--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -34,7 +34,7 @@ from ax.utils.common.base import SortableBase
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.equality import datetime_equals, equality_typechecker
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
-from ax.utils.common.typeutils import checked_cast, checked_cast_complex, not_none
+from ax.utils.common.typeutils import checked_cast, not_none
 
 
 logger: Logger = get_logger(__name__)
@@ -43,10 +43,6 @@ logger: Logger = get_logger(__name__)
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
     from ax import core  # noqa F401  # pragma: no cover
-
-BATCH_TRIAL_RAW_DATA_FORMAT_ERROR_MESSAGE = (
-    "Raw data must be a dict for batched trials."
-)
 
 
 class LifecycleStage(int, Enum):
@@ -569,21 +565,14 @@ class BatchTrial(BaseTrial):
         """
 
         # Format the data to save.
-        raw_data_by_arm = checked_cast_complex(
-            Dict[str, TEvaluationOutcome],
-            raw_data,
-            message=BATCH_TRIAL_RAW_DATA_FORMAT_ERROR_MESSAGE,
-        )
-        not_trial_arm_names = set(raw_data_by_arm.keys()) - set(
-            self.arms_by_name.keys()
-        )
+        not_trial_arm_names = set(raw_data.keys()) - set(self.arms_by_name.keys())
         if not_trial_arm_names:
             raise UserInputError(  # pragma: no cover
                 f"Arms {not_trial_arm_names} are not part of trial #{self.index}."
             )
 
         evaluations, data = self._make_evaluations_and_data(
-            raw_data=raw_data_by_arm, metadata=metadata, sample_sizes=sample_sizes
+            raw_data=raw_data, metadata=metadata, sample_sizes=sample_sizes
         )
         self._validate_batch_trial_data(data=data)
 

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -19,13 +19,10 @@ from ax.core.generator_run import GeneratorRun, GeneratorRunType
 from ax.core.types import TCandidateMetadata, TEvaluationOutcome
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
-from ax.utils.common.typeutils import checked_cast_complex, not_none
+from ax.utils.common.typeutils import not_none
 
 logger: Logger = get_logger(__name__)
 
-TRIAL_RAW_DATA_FORMAT_ERROR_MESSAGE = (
-    "Raw data must be data for a single arm for non batched trials."
-)
 
 ROUND_FLOATS_IN_LOGS_TO_DECIMAL_PLACES: int = 6
 
@@ -294,13 +291,7 @@ class Trial(BaseTrial):
         sample_sizes = {not_none(self.arm).name: sample_size} if sample_size else {}
 
         arm_name = not_none(self.arm).name
-        raw_data_by_arm = {
-            arm_name: checked_cast_complex(
-                TEvaluationOutcome,
-                raw_data,
-                message=TRIAL_RAW_DATA_FORMAT_ERROR_MESSAGE,
-            )
-        }
+        raw_data_by_arm = {arm_name: raw_data}
         not_trial_arm_names = set(raw_data_by_arm.keys()) - set(
             self.arms_by_name.keys()
         )

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -28,7 +28,6 @@ from ax.core.parameter import (
 )
 from ax.core.parameter_constraint import OrderConstraint
 from ax.core.search_space import HierarchicalSearchSpace
-from ax.core.trial import TRIAL_RAW_DATA_FORMAT_ERROR_MESSAGE
 from ax.core.types import ComparisonOp, TModelPredictArm, TParameterization, TParamValue
 from ax.exceptions.core import (
     DataRequiredError,
@@ -1411,10 +1410,6 @@ class TestAxClient(TestCase):
             x, y = parameterization.get("x"), parameterization.get("y")
             # pyre-fixme[6]: For 2nd param expected `Union[List[Tuple[Dict[str, Union...
             ax_client.complete_trial(trial_index, raw_data=(branin(x, y), 0.0))
-        with self.assertRaisesRegex(ValueError, TRIAL_RAW_DATA_FORMAT_ERROR_MESSAGE):
-            # pyre-fixme[61]: `trial_index` is undefined, or not always defined.
-            # pyre-fixme[6]: For 2nd param expected `Union[List[Tuple[Dict[str, Union...
-            ax_client.update_trial_data(trial_index, raw_data="invalid_data")
 
     @fast_botorch_optimize
     def test_raw_data_format_with_map_results(self) -> None:

--- a/ax/utils/common/tests/test_typeutils.py
+++ b/ax/utils/common/tests/test_typeutils.py
@@ -4,13 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict
 
 import numpy as np
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import (
     checked_cast,
-    checked_cast_complex,
     checked_cast_dict,
     checked_cast_list,
     checked_cast_optional,
@@ -36,12 +34,6 @@ class TestTypeUtils(TestCase):
             checked_cast(
                 float, 2, exception=NotImplementedError("foo() doesn't support ints")
             )
-
-    def test_checked_cast_complex(self) -> None:
-        t = Dict[int, str]
-        self.assertEqual(checked_cast_complex(t, {1: "one"}), {1: "one"})
-        with self.assertRaises(ValueError):
-            checked_cast_complex(t, {"one": 1})
 
     def test_checked_cast_list(self) -> None:
         self.assertEqual(checked_cast_list(float, [1.0, 2.0]), [1.0, 2.0])

--- a/ax/utils/common/typeutils.py
+++ b/ax/utils/common/typeutils.py
@@ -4,10 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, cast, Dict, List, Optional, Tuple, Type, TypeVar
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 
 import numpy as np
-from typeguard import check_type
 
 
 T = TypeVar("T")
@@ -59,34 +58,6 @@ def checked_cast(typ: Type[T], val: V, exception: Optional[Exception] = None) ->
             f"Value was not of type {typ}:\n{val}"
         )
     return val
-
-
-def checked_cast_complex(typ: Type[T], val: V, message: Optional[str] = None) -> T:
-    """
-    Cast a value to a type (with a runtime safety check).  Used for subscripted generics
-    which isinstance cannot run against.
-
-    Returns the value unchanged and checks its type at runtime. This signals to the
-    typechecker that the value has the designated type.
-
-    Like `typing.cast`_ ``check_cast`` performs no runtime conversion on its argument,
-    but, unlike ``typing.cast``, ``checked_cast`` will throw an error if the value is
-    not of the expected type.
-
-    Args:
-        typ: the type to cast to
-        val: the value that we are casting
-        message: message to print on error
-    Returns:
-        the ``val`` argument casted to typ
-
-    .. _typing.cast: https://docs.python.org/3/library/typing.html#typing.cast
-    """
-    try:
-        check_type("val", val, typ)
-        return cast(T, val)
-    except TypeError:
-        raise ValueError(message or f"Value was not of type {typ}: {val}")
 
 
 def checked_cast_optional(typ: Type[T], val: Optional[V]) -> Optional[T]:


### PR DESCRIPTION
Summary: Replace check_type with a version of pyre_extension's safe_json function that will recrusively check the type through collections with the small caveat that in we allow any type to be a leaf (non-collection) value rather than just [int, float, str, bool, NoneType]. This will allow us to drop our typeguard dependency.

Differential Revision: D44147968

