### PR TITLE
Fix pareto front tensor converter

### DIFF
--- a/ax/modelbridge/tests/test_search_space_to_float_transform.py
+++ b/ax/modelbridge/tests/test_search_space_to_float_transform.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from copy import deepcopy
+
+from ax.core.observation import ObservationFeatures
+from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
+from ax.core.search_space import SearchSpace
+from ax.modelbridge.transforms.search_space_to_float import SearchSpaceToFloat
+from ax.utils.common.testutils import TestCase
+
+
+class SearchSpaceToFloatTest(TestCase):
+    def setUp(self) -> None:
+        self.search_space = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    "a", lower=1, upper=3, parameter_type=ParameterType.FLOAT
+                ),
+                ChoiceParameter(
+                    "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
+                ),
+            ]
+        )
+        self.observation_features = [
+            ObservationFeatures(parameters={"a": 2, "b": "a"}),
+            ObservationFeatures(parameters={"a": 3, "b": "b"}),
+            ObservationFeatures(parameters={"a": 3, "b": "c"}),
+        ]
+        self.transformed_features = [
+            ObservationFeatures(parameters={"HASH_PARAM": 805305186152.0}),
+            ObservationFeatures(parameters={"HASH_PARAM": 800097055771.0}),
+            ObservationFeatures(parameters={"HASH_PARAM": 1551602558.0}),
+        ]
+        self.t = SearchSpaceToFloat()
+
+    def testTransformSearchSpace(self) -> None:
+        ss2 = self.search_space.clone()
+        ss2 = self.t.transform_search_space(ss2)
+        self.assertEqual(len(ss2.parameters), 1)
+        expected_parameter = RangeParameter(
+            name="HASH_PARAM",
+            parameter_type=ParameterType.FLOAT,
+            lower=0.0,
+            upper=1e12,
+        )
+        self.assertEqual(ss2.parameters.get("HASH_PARAM"), expected_parameter)
+
+    def testTransformObservationFeatures(self) -> None:
+        obs_ft2 = deepcopy(self.observation_features)
+        obs_ft2 = self.t.transform_observation_features(obs_ft2)
+        self.assertEqual(obs_ft2, self.transformed_features)

--- a/ax/modelbridge/transforms/search_space_to_float.py
+++ b/ax/modelbridge/transforms/search_space_to_float.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List
+
+from ax.core.arm import Arm
+from ax.core.observation import ObservationFeatures
+from ax.core.parameter import ParameterType, RangeParameter
+from ax.core.search_space import SearchSpace
+from ax.modelbridge.transforms.base import Transform
+
+
+class SearchSpaceToFloat(Transform):
+    """Replaces the search space with a single range parameter, whose values
+    are derived from the signature of the arms.
+
+    NOTE: This will have collisions and so should not be used whenever unique
+    observation features need to be preserved. Its purpose is to enable
+    forward transforms for any search space regardless of parameterization.
+
+    Transform is done in-place.
+    """
+
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+        parameter = RangeParameter(
+            name="HASH_PARAM",
+            parameter_type=ParameterType.FLOAT,
+            lower=0.0,
+            upper=1e12,
+        )
+        return SearchSpace(parameters=[parameter])
+
+    def transform_observation_features(
+        self, observation_features: List[ObservationFeatures]
+    ) -> List[ObservationFeatures]:
+        for obsf in observation_features:
+            sig = Arm(parameters=obsf.parameters).signature
+            val = float(int(sig, 16) % 1_000_000_000_000)
+            obsf.parameters = {"HASH_PARAM": val}
+        return observation_features

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -34,12 +34,7 @@ from ax.modelbridge.modelbridge_utils import (
 )
 from ax.modelbridge.registry import Models
 from ax.modelbridge.torch import TorchModelBridge
-from ax.modelbridge.transforms.choice_encode import OrderedChoiceEncode
-from ax.modelbridge.transforms.derelativize import Derelativize
-from ax.modelbridge.transforms.int_to_float import IntToFloat
-from ax.modelbridge.transforms.one_hot import OneHot
-from ax.modelbridge.transforms.remove_fixed import RemoveFixed
-from ax.modelbridge.transforms.search_space_to_choice import SearchSpaceToChoice
+from ax.modelbridge.transforms.search_space_to_float import SearchSpaceToFloat
 from ax.models.torch.posterior_mean import get_PosteriorMean
 from ax.models.torch_base import TorchModel
 from ax.utils.common.logger import get_logger
@@ -125,7 +120,6 @@ def get_observed_pareto_frontiers(
     data: Optional[Data] = None,
     rel: bool = True,
     arm_names: Optional[List[str]] = None,
-    is_pex: Optional[bool] = False,
 ) -> List[ParetoFrontierResults]:
     """
     Find all Pareto points from an experiment.
@@ -166,10 +160,7 @@ def get_observed_pareto_frontiers(
             # Make sure status quo is always included, for derelativization
             arm_names.append(experiment.status_quo.name)
         data = Data(data.df[data.df["arm_name"].isin(arm_names)])
-    if is_pex:
-        mb = pex_get_tensor_converter_model(experiment=experiment, data=data)
-    else:
-        mb = get_tensor_converter_model(experiment=experiment, data=data)
+    mb = get_tensor_converter_model(experiment=experiment, data=data)
     pareto_observations = observed_pareto_frontier(modelbridge=mb)
     # Convert to ParetoFrontierResults
     objective_metric_names = {
@@ -268,35 +259,6 @@ def to_nonrobust_search_space(search_space: SearchSpace) -> SearchSpace:
         return search_space
 
 
-# TODO: delete this function after merging with get_tensor_converter_model
-def pex_get_tensor_converter_model(
-    experiment: Experiment, data: Data
-) -> TorchModelBridge:
-    """
-    Copy of get_tensor_converter_model which retains the old transforms for pex usage
-
-    Args:
-        experiment: Experiment.
-        data: Data for fitting the model.
-
-    Returns: A torch modelbridge with transforms set.
-    """
-    # Transforms is the minimal set that will work for converting any search
-    # space to tensors.
-    return TorchModelBridge(
-        experiment=experiment,
-        search_space=to_nonrobust_search_space(experiment.search_space),
-        data=data,
-        model=TorchModel(),
-        transforms=[Derelativize, SearchSpaceToChoice, OrderedChoiceEncode, IntToFloat],
-        transform_configs={
-            "Derelativize": {"use_raw_status_quo": True},
-            "SearchSpaceToChoice": {"use_ordered": True},
-        },
-        fit_out_of_design=True,
-    )
-
-
 def get_tensor_converter_model(experiment: Experiment, data: Data) -> TorchModelBridge:
     """
     Constructs a minimal model for converting things to tensors.
@@ -320,7 +282,7 @@ def get_tensor_converter_model(experiment: Experiment, data: Data) -> TorchModel
         search_space=to_nonrobust_search_space(experiment.search_space),
         data=data,
         model=TorchModel(),
-        transforms=[RemoveFixed, OrderedChoiceEncode, OneHot, IntToFloat],
+        transforms=[SearchSpaceToFloat],
         fit_out_of_design=True,
     )
 

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -315,7 +315,15 @@ Transforms
     :undoc-members:
     :show-inheritance:
 
-`ax.modelbridge.transforms.standardize\_y`
+`ax.modelbridge.transforms.search\_space\_to\_float`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.search_space_to_float
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ `ax.modelbridge.transforms.standardize\_y`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.modelbridge.transforms.standardize_y


### PR DESCRIPTION
Summary: The pareto front tensor converter model had a bug where it didn't work on experiments with only one arm, because it couldn't convert that to a ChoiceParameter. D42478964 fixed that by changing the transforms, but the new set of transforms broke the PEX use case, and also has broken support for some replay experiments. This fixes both and removes the patch for fixing PEX earlier.

Differential Revision: D44174796

