### PR TITLE
Add extra checks on MetricFetchResult to prevent empty data construction

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -834,12 +834,12 @@ class Experiment(Base):
                     "Ignoring for now -- will retry query on next call to fetch."
                 )
 
+        if len(oks) < 1:
+            return None
+
         data = self.default_data_constructor.from_multiple_data(
             data=[ok.ok for ok in oks]
         )
-
-        if data.df.empty:
-            return None
 
         return self.attach_data(
             data=data,

--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -268,7 +268,10 @@ class Metric(SortableBase, SerializationMixin):
                     trials=[trial],
                     **kwargs,
                 )[trial.index]
-                contains_new_data = True
+
+                contains_new_data = any(
+                    result.is_ok() for result in fetched_trial_data.values()
+                )
             except NotImplementedError:
                 # Metric does not implement fetching logic and only uses lookup.
                 fetched_trial_data = {}


### PR DESCRIPTION
Reviewed By: danielrjiang

Differential Revision: D44179921

