### PR TITLE
Allow for mixed relative/absolute objective thresholds in Pareto front computation

### DIFF
--- a/ax/modelbridge/tests/test_search_space_to_float_transform.py
+++ b/ax/modelbridge/tests/test_search_space_to_float_transform.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from copy import deepcopy
+
+from ax.core.observation import ObservationFeatures
+from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
+from ax.core.search_space import SearchSpace
+from ax.modelbridge.transforms.search_space_to_float import SearchSpaceToFloat
+from ax.utils.common.testutils import TestCase
+
+
+class SearchSpaceToFloatTest(TestCase):
+    def setUp(self) -> None:
+        self.search_space = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    "a", lower=1, upper=3, parameter_type=ParameterType.FLOAT
+                ),
+                ChoiceParameter(
+                    "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
+                ),
+            ]
+        )
+        self.observation_features = [
+            ObservationFeatures(parameters={"a": 2, "b": "a"}),
+            ObservationFeatures(parameters={"a": 3, "b": "b"}),
+            ObservationFeatures(parameters={"a": 3, "b": "c"}),
+        ]
+        self.transformed_features = [
+            ObservationFeatures(parameters={"HASH_PARAM": 805305186152.0}),
+            ObservationFeatures(parameters={"HASH_PARAM": 800097055771.0}),
+            ObservationFeatures(parameters={"HASH_PARAM": 1551602558.0}),
+        ]
+        self.t = SearchSpaceToFloat()
+
+    def testTransformSearchSpace(self) -> None:
+        ss2 = self.search_space.clone()
+        ss2 = self.t.transform_search_space(ss2)
+        self.assertEqual(len(ss2.parameters), 1)
+        expected_parameter = RangeParameter(
+            name="HASH_PARAM",
+            parameter_type=ParameterType.FLOAT,
+            lower=0.0,
+            upper=1e12,
+        )
+        self.assertEqual(ss2.parameters.get("HASH_PARAM"), expected_parameter)
+
+    def testTransformObservationFeatures(self) -> None:
+        obs_ft2 = deepcopy(self.observation_features)
+        obs_ft2 = self.t.transform_observation_features(obs_ft2)
+        self.assertEqual(obs_ft2, self.transformed_features)

--- a/ax/modelbridge/transforms/search_space_to_float.py
+++ b/ax/modelbridge/transforms/search_space_to_float.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List
+
+from ax.core.arm import Arm
+from ax.core.observation import ObservationFeatures
+from ax.core.parameter import ParameterType, RangeParameter
+from ax.core.search_space import SearchSpace
+from ax.modelbridge.transforms.base import Transform
+
+
+class SearchSpaceToFloat(Transform):
+    """Replaces the search space with a single range parameter, whose values
+    are derived from the signature of the arms.
+
+    NOTE: This will have collisions and so should not be used whenever unique
+    observation features need to be preserved. Its purpose is to enable
+    forward transforms for any search space regardless of parameterization.
+
+    Transform is done in-place.
+    """
+
+    def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
+        parameter = RangeParameter(
+            name="HASH_PARAM",
+            parameter_type=ParameterType.FLOAT,
+            lower=0.0,
+            upper=1e12,
+        )
+        return SearchSpace(parameters=[parameter])
+
+    def transform_observation_features(
+        self, observation_features: List[ObservationFeatures]
+    ) -> List[ObservationFeatures]:
+        for obsf in observation_features:
+            sig = Arm(parameters=obsf.parameters).signature
+            val = float(int(sig, 16) % 1000000000000)
+            obsf.parameters = {"HASH_PARAM": val}
+        return observation_features

--- a/ax/plot/pareto_frontier.py
+++ b/ax/plot/pareto_frontier.py
@@ -523,10 +523,21 @@ def interact_pareto_frontier(
     frontier_list: List[ParetoFrontierResults],
     CI_level: float = DEFAULT_CI_LEVEL,
     show_parameterization_on_hover: bool = True,
+    label_dict: Optional[Dict[str, str]] = None,
 ) -> AxPlotConfig:
-    """Plot a pareto frontier from a list of objects"""
+    """Plot a pareto frontier from a list of objects
+
+    Args:
+        frontier_list: List of ParetoFrontierResults objects to be plotted.
+        CI_level: CI level for error bars.
+        show_parameterization_on_hover: Show parameterization on hover.
+        label_dict: Map from metric name to shortened alias to use on plot.
+    """
     if not frontier_list:
         raise ValueError("Must receive a non-empty list of pareto frontiers to plot.")
+    label_dict_use = {k: k for k in frontier_list[0].means}
+    if label_dict is not None:
+        label_dict_use.update(label_dict)
 
     traces = []
     shapes = []
@@ -555,8 +566,8 @@ def interact_pareto_frontier(
             visible[j] = True
         rel_y = frontier.primary_metric not in frontier.absolute_metrics
         rel_x = frontier.secondary_metric not in frontier.absolute_metrics
-        primary_metric = frontier.primary_metric
-        secondary_metric = frontier.secondary_metric
+        primary_metric = label_dict_use[frontier.primary_metric]
+        secondary_metric = label_dict_use[frontier.secondary_metric]
         dropdown.append(
             {
                 "method": "update",
@@ -570,7 +581,7 @@ def interact_pareto_frontier(
                         "shapes": shapes[i],
                     },
                 ],
-                "label": f"{primary_metric} vs {secondary_metric}",
+                "label": f"{primary_metric}<br>vs {secondary_metric}",
             }
         )
 
@@ -578,8 +589,8 @@ def interact_pareto_frontier(
     initial_frontier = frontier_list[0]
     rel_x = initial_frontier.secondary_metric not in initial_frontier.absolute_metrics
     rel_y = initial_frontier.primary_metric not in initial_frontier.absolute_metrics
-    secondary_metric = initial_frontier.secondary_metric
-    primary_metric = initial_frontier.primary_metric
+    secondary_metric = label_dict_use[initial_frontier.secondary_metric]
+    primary_metric = label_dict_use[initial_frontier.primary_metric]
 
     layout = go.Layout(
         title="Pareto Frontier",

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -34,12 +34,7 @@ from ax.modelbridge.modelbridge_utils import (
 )
 from ax.modelbridge.registry import Models
 from ax.modelbridge.torch import TorchModelBridge
-from ax.modelbridge.transforms.choice_encode import OrderedChoiceEncode
-from ax.modelbridge.transforms.derelativize import Derelativize
-from ax.modelbridge.transforms.int_to_float import IntToFloat
-from ax.modelbridge.transforms.one_hot import OneHot
-from ax.modelbridge.transforms.remove_fixed import RemoveFixed
-from ax.modelbridge.transforms.search_space_to_choice import SearchSpaceToChoice
+from ax.modelbridge.transforms.search_space_to_float import SearchSpaceToFloat
 from ax.models.torch.posterior_mean import get_PosteriorMean
 from ax.models.torch_base import TorchModel
 from ax.utils.common.logger import get_logger
@@ -125,7 +120,6 @@ def get_observed_pareto_frontiers(
     data: Optional[Data] = None,
     rel: bool = True,
     arm_names: Optional[List[str]] = None,
-    is_pex: Optional[bool] = False,
 ) -> List[ParetoFrontierResults]:
     """
     Find all Pareto points from an experiment.
@@ -166,10 +160,7 @@ def get_observed_pareto_frontiers(
             # Make sure status quo is always included, for derelativization
             arm_names.append(experiment.status_quo.name)
         data = Data(data.df[data.df["arm_name"].isin(arm_names)])
-    if is_pex:
-        mb = pex_get_tensor_converter_model(experiment=experiment, data=data)
-    else:
-        mb = get_tensor_converter_model(experiment=experiment, data=data)
+    mb = get_tensor_converter_model(experiment=experiment, data=data)
     pareto_observations = observed_pareto_frontier(modelbridge=mb)
     # Convert to ParetoFrontierResults
     objective_metric_names = {
@@ -268,35 +259,6 @@ def to_nonrobust_search_space(search_space: SearchSpace) -> SearchSpace:
         return search_space
 
 
-# TODO: delete this function after merging with get_tensor_converter_model
-def pex_get_tensor_converter_model(
-    experiment: Experiment, data: Data
-) -> TorchModelBridge:
-    """
-    Copy of get_tensor_converter_model which retains the old transforms for pex usage
-
-    Args:
-        experiment: Experiment.
-        data: Data for fitting the model.
-
-    Returns: A torch modelbridge with transforms set.
-    """
-    # Transforms is the minimal set that will work for converting any search
-    # space to tensors.
-    return TorchModelBridge(
-        experiment=experiment,
-        search_space=to_nonrobust_search_space(experiment.search_space),
-        data=data,
-        model=TorchModel(),
-        transforms=[Derelativize, SearchSpaceToChoice, OrderedChoiceEncode, IntToFloat],
-        transform_configs={
-            "Derelativize": {"use_raw_status_quo": True},
-            "SearchSpaceToChoice": {"use_ordered": True},
-        },
-        fit_out_of_design=True,
-    )
-
-
 def get_tensor_converter_model(experiment: Experiment, data: Data) -> TorchModelBridge:
     """
     Constructs a minimal model for converting things to tensors.
@@ -320,7 +282,7 @@ def get_tensor_converter_model(experiment: Experiment, data: Data) -> TorchModel
         search_space=to_nonrobust_search_space(experiment.search_space),
         data=data,
         model=TorchModel(),
-        transforms=[RemoveFixed, OrderedChoiceEncode, OneHot, IntToFloat],
+        transforms=[SearchSpaceToFloat],
         fit_out_of_design=True,
     )
 

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -18,7 +18,10 @@ from ax.core.search_space import SearchSpace
 from ax.core.types import ComparisonOp
 from ax.metrics.branin import BraninMetric, NegativeBraninMetric
 from ax.modelbridge.registry import Models
-from ax.plot.pareto_frontier import interact_multiple_pareto_frontier
+from ax.plot.pareto_frontier import (
+    interact_multiple_pareto_frontier,
+    interact_pareto_frontier,
+)
 from ax.plot.pareto_utils import (
     _extract_observed_pareto_2d,
     get_observed_pareto_frontiers,
@@ -139,7 +142,7 @@ class ParetoUtilsTest(TestCase):
             #  `Optional[typing.List[typing.Optional[str]]]`.
             self.assertTrue("status_quo" in pfr.arm_names)
 
-    def testPlotMultipleParetoFrontiers(self) -> None:
+    def testPlotParetoFrontiers(self) -> None:
         experiment = get_branin_experiment_with_multi_objective(
             has_objective_thresholds=True,
         )
@@ -148,6 +151,14 @@ class ParetoUtilsTest(TestCase):
         experiment.new_batch_trial(generator_run=a).run()
         experiment.fetch_data()
         pfrs = get_observed_pareto_frontiers(experiment=experiment)
+        label_dict = {"branin_a": "a_new_metric"}
+        b = interact_pareto_frontier(pfrs, label_dict=label_dict)
+        self.assertEqual(
+            b.data["layout"]["updatemenus"][0]["buttons"][0]["label"],
+            "a_new_metric<br>vs branin_b",
+        )
+        self.assertEqual(b.data["layout"]["xaxis"]["title"]["text"], "branin_b")
+        self.assertEqual(b.data["layout"]["yaxis"]["title"]["text"], "a_new_metric")
         pfrs2 = copy.deepcopy(pfrs)
         pfr_lists = {"pfrs 1": pfrs, "pfrs 2": pfrs2}
         self.assertIsNotNone(interact_multiple_pareto_frontier(pfr_lists))

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -315,7 +315,15 @@ Transforms
     :undoc-members:
     :show-inheritance:
 
-`ax.modelbridge.transforms.standardize\_y`
+`ax.modelbridge.transforms.search\_space\_to\_float`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.search_space_to_float
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+ `ax.modelbridge.transforms.standardize\_y`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.modelbridge.transforms.standardize_y


### PR DESCRIPTION
Summary: Pareto front computation in the plotting utils currently assumes that all objective thresholds will be either relative or not. Sometimes we want to have a mix, which this diff enables.

Differential Revision: D44180215

