### PR TITLE
Add RangeParameter bounds tolerance

### DIFF
--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -7,6 +7,7 @@
 from ax.core.parameter import (
     _get_parameter_type,
     ChoiceParameter,
+    EPS,
     FixedParameter,
     ParameterType,
     RangeParameter,
@@ -73,6 +74,10 @@ class RangeParameterTest(TestCase):
         self.assertFalse(self.param1.validate("foo"))
         self.assertTrue(self.param1.validate(1))
         self.assertTrue(self.param1.validate(1.3))
+        self.assertFalse(self.param1.validate(3.5))
+        # Check with tolerances
+        self.assertTrue(self.param1.validate(1 - 0.5 * EPS))
+        self.assertTrue(self.param1.validate(3 + 0.5 * EPS))
 
     def testRepr(self) -> None:
         self.assertEqual(str(self.param1), self.param1_repr)
@@ -93,6 +98,12 @@ class RangeParameterTest(TestCase):
 
         with self.assertRaises(UserInputError):
             RangeParameter("x", ParameterType.INT, 0.5, 1, is_fidelity=True)
+
+        with self.assertRaisesRegex(
+            UserInputError,
+            "likely to cause numerical errors. Consider reparameterizing",
+        ):
+            RangeParameter("x", ParameterType.FLOAT, EPS, 2 * EPS)
 
     def testBadSetter(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Summary:
Due to numerical precision issues, RangeParameter validation can fail. This can be the case even for parameter configs that are generated by Ax itself (this can happen e.g. if the experiment state is serialized and reloaded).

This change adds a numerical tolerance to avoid these issues. This also adds an error in case the parameter range is extremely small and likely to cause numerical issues.

This is a quick fix; we should do a more comprehensive audit of how floating point precision issues may creep up in Ax and implement a more principled fix.

Reviewed By: bernardbeckerman

Differential Revision: D44245817

