### PR TITLE
Replace consolidated_duplicates with botorch equivalent

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -16,7 +16,6 @@ from logging import Logger
 from typing import (
     Callable,
     Dict,
-    Iterator,
     List,
     MutableMapping,
     Optional,
@@ -1340,32 +1339,6 @@ def observation_features_to_array(
 ) -> np.ndarray:
     """Convert a list of Observation features to arrays."""
     return np.array([[of.parameters[p] for p in parameters] for of in obsf])
-
-
-def detect_duplicates(
-    X: Tensor,
-    rtol: float = 1e-5,
-    atol: float = 1e-8,
-) -> Iterator[Tuple[int, int]]:
-    """Returns an iterator over index pairs `(duplicate index, original index)` for all
-    duplicate entries of `X`.
-    """
-    tols = atol
-    if rtol:
-        rval = X.abs().max(dim=-1, keepdim=True).values
-        tols = tols + rtol * rval.max(rval.transpose(-1, -2))
-
-    n = X.shape[-2]
-    dist = torch.full((n, n), float("inf"), device=X.device, dtype=X.dtype)
-    dist[torch.triu_indices(n, n, offset=1).unbind()] = torch.nn.functional.pdist(
-        X, p=float("inf")
-    )
-    return (
-        (i, int(j))
-        # pyre-fixme[19]: Expected 1 positional argument.
-        for diff, j, i in zip(*(dist - tols).min(dim=-2), range(n))
-        if diff < 0
-    )
 
 
 def feasible_hypervolume(  # pragma: no cover

--- a/ax/modelbridge/tests/test_pairwise_modelbridge.py
+++ b/ax/modelbridge/tests/test_pairwise_modelbridge.py
@@ -116,3 +116,8 @@ class PairwiseModelBridgeTest(TestCase):
         consolidated_X, consolidated_Y = _consolidate_comparisons(X=X, Y=comp_pair_Y)
         self.assertTrue(torch.equal(consolidated_X, expected_X))
         self.assertTrue(torch.equal(consolidated_Y, expected_Y))
+
+        with self.assertRaises(ValueError):
+            _consolidate_comparisons(
+                X=X.expand(2, *X.shape), Y=comp_pair_Y.expand(2, *comp_pair_Y.shape)
+            )


### PR DESCRIPTION
Summary: Replace consolidated_duplicates with botorch equivalent.

Reviewed By: Balandat

Differential Revision: D44282216

