### PR TITLE
Fix bounds handling in mixed integer benchmark problems

### DIFF
--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -41,7 +41,7 @@ def _get_problem_from_common_inputs(
     test_problem_class: Type[SyntheticTestFunction],
     benchmark_name: str,
     num_trials: int,
-    modified_bounds: Optional[List[Tuple[float, float]]] = None,
+    test_problem_bounds: Optional[List[Tuple[float, float]]] = None,
 ) -> BenchmarkProblem:
     """This is a helper that deduplicates common bits of the below problems.
 
@@ -54,7 +54,8 @@ def _get_problem_from_common_inputs(
         test_problem_class: The BoTorch test problem class.
         benchmark_name: The name of the benchmark problem.
         num_trials: The number of trials.
-        modified_bounds: Optional bounds to evaluate the base test problem on.
+        test_problem_bounds: Optional bounds to evaluate the base test problem on.
+            These are passed in as `bounds` while initializing the test problem.
 
     Returns:
         A mixed-integer BenchmarkProblem constructed from the given inputs.
@@ -83,11 +84,12 @@ def _get_problem_from_common_inputs(
         )
     )
     test_problem_kwargs: Dict[str, Any] = {"dim": dim}
-    if modified_bounds is not None:
-        test_problem_kwargs["bounds"] = modified_bounds
+    if test_problem_bounds is not None:
+        test_problem_kwargs["bounds"] = test_problem_bounds
     runner = BotorchTestProblemRunner(
         test_problem_class=test_problem_class,
         test_problem_kwargs=test_problem_kwargs,
+        modified_bounds=bounds,
     )
     return BenchmarkProblem(
         name=benchmark_name,
@@ -151,7 +153,7 @@ def get_discrete_ackley(
         test_problem_class=Ackley,
         benchmark_name="Discrete Ackley",
         num_trials=num_trials,
-        modified_bounds=[(0.0, 1.0)] * dim,
+        test_problem_bounds=[(0.0, 1.0)] * dim,
     )
 
 

--- a/ax/benchmark/tests/test_mixed_integer_problems.py
+++ b/ax/benchmark/tests/test_mixed_integer_problems.py
@@ -3,15 +3,21 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from unittest.mock import MagicMock
+
+import torch
+
 from ax.benchmark.problems.synthetic.discretized.mixed_integer import (
     get_discrete_ackley,
     get_discrete_hartmann,
     get_discrete_rosenbrock,
 )
+from ax.core.arm import Arm
 from ax.core.parameter import ParameterType
+from ax.core.trial import Trial
 from ax.runners.botorch_test_problem import BotorchTestProblemRunner
 from ax.utils.common.testutils import TestCase
-from ax.utils.common.typeutils import checked_cast
+from ax.utils.common.typeutils import checked_cast, not_none
 
 
 class TestMixedIntegerProblems(TestCase):
@@ -48,3 +54,58 @@ class TestMixedIntegerProblems(TestCase):
                 ).test_problem._bounds,
                 expected_bounds,
             )
+
+        # Test that they match correctly to the original problems.
+        # Hartmann - evaluate at 0 - should correspond to 0.
+        runner = checked_cast(BotorchTestProblemRunner, get_discrete_hartmann().runner)
+        mock_call = MagicMock(return_value=torch.tensor(0.0))
+        runner.test_problem.forward = mock_call
+        trial = Trial(experiment=MagicMock())
+        trial.add_arm(Arm(parameters={f"x{i+1}": 0.0 for i in range(6)}, name="--"))
+        runner.run(trial)
+        self.assertTrue(torch.allclose(mock_call.call_args[0][0], torch.zeros(6)))
+        # Evaluate at 3, 3, 19, 19, 1, 1 - corresponds to 1.
+        arm = not_none(trial.arm)
+        arm._parameters = {
+            "x1": 3,
+            "x2": 3,
+            "x3": 19,
+            "x4": 19,
+            "x5": 1.0,
+            "x6": 1.0,
+        }
+        runner.run(trial)
+        self.assertTrue(torch.allclose(mock_call.call_args[0][0], torch.ones(6)))
+        # Ackley - evaluate at 0 - corresponds to 0.
+        runner = checked_cast(BotorchTestProblemRunner, get_discrete_ackley().runner)
+        runner.test_problem.forward = mock_call
+        arm._parameters = {f"x{i+1}": 0.0 for i in range(13)}
+        runner.run(trial)
+        self.assertTrue(torch.allclose(mock_call.call_args[0][0], torch.zeros(13)))
+        # Evaluate at 2 x 5, 4 x 5, 1.0 x 3 - corresponds to 1.
+        arm._parameters = {
+            **{f"x{i+1}": 2 for i in range(0, 5)},
+            **{f"x{i+1}": 4 for i in range(5, 10)},
+            **{f"x{i+1}": 1.0 for i in range(10, 13)},
+        }
+        runner.run(trial)
+        self.assertTrue(torch.allclose(mock_call.call_args[0][0], torch.ones(13)))
+        # Rosenbrock - evaluate at 0 - corresponds to -5.0.
+        runner = checked_cast(
+            BotorchTestProblemRunner, get_discrete_rosenbrock().runner
+        )
+        runner.test_problem.forward = mock_call
+        arm._parameters = {f"x{i+1}": 0.0 for i in range(10)}
+        runner.run(trial)
+        self.assertTrue(
+            torch.allclose(mock_call.call_args[0][0], torch.full((10,), -5.0))
+        )
+        # Evaluate at 3 x 6, 1.0 x 4 - corresponds to 10.0.
+        arm._parameters = {
+            **{f"x{i+1}": 3 for i in range(0, 6)},
+            **{f"x{i+1}": 1.0 for i in range(6, 10)},
+        }
+        runner.run(trial)
+        self.assertTrue(
+            torch.allclose(mock_call.call_args[0][0], torch.full((10,), 10.0))
+        )


### PR DESCRIPTION
Summary:
This brings back `modified_bounds` that I had in the original diff but removed thinking it was a no-op. Added docstring explains what these are and how they're expected to work.

Discovered after observing very different results in a recent benchmark run.

Reviewed By: dme65

Differential Revision: D44324752

