### PR TITLE
Reduce default `max_num_slice_plots` and `max_num_contour_plots` to limit latency of `_get_objective_v_param_plots`

### DIFF
--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -145,8 +145,8 @@ def _get_objective_trace_plot(
 def _get_objective_v_param_plots(
     experiment: Experiment,
     model: ModelBridge,
-    max_num_slice_plots: int = 100,
-    max_num_contour_plots: int = 100,
+    max_num_slice_plots: int = 50,
+    max_num_contour_plots: int = 20,
 ) -> List[go.Figure]:
     search_space = experiment.search_space
 


### PR DESCRIPTION
Summary: Latency at old defaults was close to 10 minutes in local tests. This reduces latency to a few seconds.

Differential Revision: D44338881

