### PR TITLE
Fix bug in ModelBridge.fit_time_since_gen and GeneratorRun.fit_time

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -213,8 +213,9 @@ class ModelBridge(ABC):
                 search_space=search_space,
                 observations=observations,
             )
-            self.fit_time += time.monotonic() - t_fit_start + time_so_far
-            self.fit_time_since_gen += self.fit_time
+            increment = time.monotonic() - t_fit_start + time_so_far
+            self.fit_time += increment
+            self.fit_time_since_gen += increment
         except NotImplementedError:
             pass
 

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -312,6 +312,29 @@ class BaseModelBridgeTest(TestCase):
             modelbridge.status_quo.features.parameters, {"x1": 0.0, "x2": 0.0}
         )
 
+    @mock.patch("ax.modelbridge.base.ModelBridge._fit", autospec=True)
+    @mock.patch("ax.modelbridge.base.ModelBridge._gen", autospec=True)
+    def test_timing(self, mock_fit: Mock, mock_gen: Mock) -> None:
+        search_space = get_search_space_for_value()
+        modelbridge = ModelBridge(
+            search_space=search_space, model=Model(), fit_on_init=False
+        )
+        self.assertEqual(modelbridge.fit_time, 0.0)
+        modelbridge._fit_if_implemented(
+            search_space=search_space, observations=[], time_so_far=3.0
+        )
+        modelbridge._fit_if_implemented(
+            search_space=search_space, observations=[], time_so_far=2.0
+        )
+        modelbridge._fit_if_implemented(
+            search_space=search_space, observations=[], time_so_far=1.0
+        )
+        self.assertAlmostEqual(modelbridge.fit_time, 6.0, places=1)
+        self.assertAlmostEqual(modelbridge.fit_time_since_gen, 6.0, places=3)
+        modelbridge.gen(1)
+        self.assertAlmostEqual(modelbridge.fit_time, 6.0, places=1)
+        self.assertAlmostEqual(modelbridge.fit_time_since_gen, 0.0, places=3)
+
     @mock.patch(
         "ax.modelbridge.base.observations_from_data",
         autospec=True,


### PR DESCRIPTION
Summary:
ModelBridge._fit_if_implemented should increment `self.fit_time` and `self.fit_time_since_gen` by the same amount. Instead, starting on 3/16, it has been incrementing `self.fit_time_since_gen` by `self.fit_time`.

This is wrong (see explanation in test plan) and led to the benchmarks generating unreasonably large runtime estimates, as we can see in the benchmarks dashboard here: https://fburl.com/datainsights/4ry8j0bd

https://pxl.cl/2zwcp
https://pxl.cl/2zwcv

In N3325037 I ran some benchmarks through both FBLearner and plain Bento to check that the new runtime estimates are in fact wrong and the old ones were much closer.

Differential Revision: D44474500

