### PR TITLE
Saving SearchSpaceDigest in BotorchModel's fit

### DIFF
--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -67,17 +67,25 @@ class BotorchModelTest(TestCase):
             FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
             FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
         ]
+        with self.assertRaises(RuntimeError):
+            model.search_space_digest
+
+        search_space_digest = SearchSpaceDigest(
+            feature_names=fns,
+            bounds=bounds,
+            task_features=[0],
+        )
+        with self.assertRaises(RuntimeError):
+            model.search_space_digest = search_space_digest
 
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=datasets,
                 metric_names=["y", "w"],
-                search_space_digest=SearchSpaceDigest(
-                    feature_names=fns,
-                    bounds=bounds,
-                    task_features=[0],
-                ),
+                search_space_digest=search_space_digest,
             )
+            self.assertTrue(isinstance(model.search_space_digest, SearchSpaceDigest))
+            self.assertEqual(model.search_space_digest, search_space_digest)
             _mock_fit_model.assert_called_once()
 
         # Check ranks


### PR DESCRIPTION
Summary: This commit stores the `SearchSpaceDigest` object during a `BotorchModel`'s `fit` call, which allows access to the search space parameters after `fit` has completed for e.g. sensitivity analysis. For a modular BoTorch model, the `SearchSpaceDigest` is already stored in the object upon a `fit` call, so this commit merely syncs the behavior of the two model types in this regard.

Reviewed By: bletham

Differential Revision: D44514681

