### PR TITLE
Fix failures due to change in pandas API for groupby

### DIFF
--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -270,9 +270,11 @@ def _observations_from_dataframe(
     Returns:
         List of Observation objects.
     """
+    if len(cols) == 0:
+        return []
     observations = []
     abandoned_arms_dict = {}
-    for g, d in df.groupby(by=cols):
+    for g, d in df.groupby(by=cols if len(cols) > 1 else cols[0]):
         obs_kwargs = {}
         if arm_name_only:
             features = {"arm_name": g}
@@ -492,7 +494,11 @@ def observations_from_map_data(
         incomplete_df = None
     else:
         # The groupby and filter is expensive, so do it only if we have to.
-        grouped = map_data.map_df.groupby(by=complete_feature_cols)
+        grouped = map_data.map_df.groupby(
+            by=complete_feature_cols
+            if len(complete_feature_cols) > 1
+            else complete_feature_cols[0]
+        )
         complete_df = grouped.filter(lambda r: ~r[feature_cols].isnull().any().any())
         incomplete_df = grouped.filter(lambda r: r[feature_cols].isnull().any().any())
 

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -129,7 +129,7 @@ def _extract_sq_data(
         sq_df = data.df[
             data.df["arm_name"] == experiment.status_quo.name  # pyre-ignore
         ]
-        for metric, metric_df in sq_df.groupby(["metric_name"]):
+        for metric, metric_df in sq_df.groupby("metric_name"):
             sq_means[metric] = metric_df["mean"].values[0]
             sq_sems[metric] = metric_df["sem"].values[0]
     return sq_means, sq_sems


### PR DESCRIPTION
Addresses the following DeprecationWarning (which has now resulted in test failures after pandas 2.0 has been used in CI):

> In a future version of pandas, a length 1 tuple will be returned when iterating over a groupby with a grouper equal to a list of length 1. Don't supply a list with a single grouper to avoid this warning.
