### PR TITLE
Copy covar_module_options and likelihood_options

### DIFF
--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -405,13 +405,13 @@ class Surrogate(Base):
                     [
                         "covar_module",
                         self.covar_module_class,
-                        self.covar_module_options,
+                        deepcopy(self.covar_module_options),
                         None,
                     ],
                     [
                         "likelihood",
                         self.likelihood_class,
-                        self.likelihood_options,
+                        deepcopy(self.likelihood_options),
                         None,
                     ],
                     [


### PR DESCRIPTION
Summary: We need to copy `covar_module_options` and `likelihood_options` since these may contain objects (such as a `MaternKernel`) that we don't want to share between different metrics.

Reviewed By: Balandat

Differential Revision: D44689895

