### PR TITLE
Making BotorchModel.model a property

### DIFF
--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -318,7 +318,7 @@ class ModelRegistryTest(TestCase):
             )
             # Botorch model equality is tough to compare and training data
             # is unnecessary to compare, because data passed to model was the same
-            if key in ["model", "warm_start_refitting", "Xs", "Ys"]:
+            if key in ["_model", "warm_start_refitting", "Xs", "Ys"]:
                 continue
             self.assertEqual(original, restored)
 

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -131,7 +131,6 @@ class KnowledgeGradientTest(TestCase):
             mock_warmstart_initialization.assert_called_once()
 
         posterior_tf = ScalarizedPosteriorTransform(weights=self.objective_weights)
-        # pyre-fixme[6]: For 1st param expected `Model` but got `Optional[Model]`.
         dummy_acq = PosteriorMean(model=model.model, posterior_transform=posterior_tf)
         with mock.patch(
             "ax.models.torch.utils.PosteriorMean", return_value=dummy_acq
@@ -186,7 +185,6 @@ class KnowledgeGradientTest(TestCase):
         )
         self.assertTrue(model.use_input_warping)
         self.assertTrue(hasattr(model.model, "input_transform"))
-        # pyre-fixme[16]: Optional type has no attribute `input_transform`.
         self.assertIsInstance(model.model.input_transform, Warp)
 
         # test loocv pseudo likelihood
@@ -283,7 +281,6 @@ class KnowledgeGradientTest(TestCase):
         )
         self.assertTrue(model.use_input_warping)
         self.assertTrue(hasattr(model.model, "input_transform"))
-        # pyre-fixme[16]: Optional type has no attribute `input_transform`.
         self.assertIsInstance(model.model.input_transform, Warp)
 
         # test loocv pseudo likelihood
@@ -313,7 +310,6 @@ class KnowledgeGradientTest(TestCase):
 
         # test acquisition setting
         acq_function = _instantiate_KG(
-            # pyre-fixme[6]: For 1st param expected `Model` but got `Optional[Model]`.
             model=model.model,
             posterior_transform=posterior_tf,
             n_fantasies=10,
@@ -326,7 +322,6 @@ class KnowledgeGradientTest(TestCase):
         self.assertEqual(acq_function.num_fantasies, 10)
 
         acq_function = _instantiate_KG(
-            # pyre-fixme[6]: For 1st param expected `Model` but got `Optional[Model]`.
             model=model.model,
             posterior_transform=posterior_tf,
             n_fantasies=10,
@@ -335,7 +330,6 @@ class KnowledgeGradientTest(TestCase):
         self.assertIsInstance(acq_function.sampler, IIDNormalSampler)
 
         acq_function = _instantiate_KG(
-            # pyre-fixme[6]: For 1st param expected `Model` but got `Optional[Model]`.
             model=model.model,
             posterior_transform=posterior_tf,
             qmc=False,
@@ -343,7 +337,6 @@ class KnowledgeGradientTest(TestCase):
         self.assertIsNone(acq_function.inner_sampler)
 
         acq_function = _instantiate_KG(
-            # pyre-fixme[6]: For 1st param expected `Model` but got `Optional[Model]`.
             model=model.model,
             posterior_transform=posterior_tf,
             qmc=True,
@@ -393,7 +386,6 @@ class KnowledgeGradientTest(TestCase):
         )
 
         acq_function = _instantiate_KG(
-            # pyre-fixme[6]: For 1st param expected `Model` but got `Optional[Model]`.
             model=model.model,
             posterior_transform=posterior_tf,
             target_fidelities={2: 1.0},
@@ -403,7 +395,6 @@ class KnowledgeGradientTest(TestCase):
         self.assertIsInstance(acq_function, qMultiFidelityKnowledgeGradient)
 
         acq_function = _instantiate_KG(
-            # pyre-fixme[6]: For 1st param expected `Model` but got `Optional[Model]`.
             model=model.model,
             objective=LinearMCObjective(weights=self.objective_weights),
         )
@@ -412,8 +403,6 @@ class KnowledgeGradientTest(TestCase):
         # test error that target fidelity and fidelity weight indices must match
         with self.assertRaises(RuntimeError):
             _instantiate_KG(
-                # pyre-fixme[6]: For 1st param expected `Model` but got
-                #  `Optional[Model]`.
                 model=model.model,
                 posterior_transform=posterior_tf,
                 target_fidelities={1: 1.0},

--- a/ax/models/tests/test_botorch_mes.py
+++ b/ax/models/tests/test_botorch_mes.py
@@ -147,7 +147,6 @@ class MaxValueEntropySearchTest(TestCase):
         )
         self.assertTrue(model.use_input_warping)
         self.assertTrue(hasattr(model.model, "input_transform"))
-        # pyre-fixme[16]: Optional type has no attribute `input_transform`.
         self.assertIsInstance(model.model.input_transform, Warp)
 
         # test loocv pseudo likelihood
@@ -250,7 +249,6 @@ class MaxValueEntropySearchTest(TestCase):
         )
         self.assertTrue(model.use_input_warping)
         self.assertTrue(hasattr(model.model, "input_transform"))
-        # pyre-fixme[16]: Optional type has no attribute `input_transform`.
         self.assertIsInstance(model.model.input_transform, Warp)
 
         # test loocv pseudo likelihood
@@ -283,7 +281,6 @@ class MaxValueEntropySearchTest(TestCase):
         # test acquisition setting
         X_dummy = torch.ones(1, 3, **self.tkwargs)
         candidate_set = torch.rand(10, 3, **self.tkwargs)
-        # pyre-fixme[6]: For 1st param expected `Model` but got `Optional[Model]`.
         acq_function = _instantiate_MES(model=model.model, candidate_set=candidate_set)
 
         self.assertIsInstance(acq_function, qMaxValueEntropy)
@@ -295,7 +292,6 @@ class MaxValueEntropySearchTest(TestCase):
         self.assertEqual(acq_function.maximize, True)
 
         acq_function = _instantiate_MES(
-            # pyre-fixme[6]: For 1st param expected `Model` but got `Optional[Model]`.
             model=model.model,
             candidate_set=candidate_set,
             X_pending=X_dummy,
@@ -318,7 +314,6 @@ class MaxValueEntropySearchTest(TestCase):
 
         candidate_set = torch.rand(10, 3, **self.tkwargs)
         acq_function = _instantiate_MES(
-            # pyre-fixme[6]: For 1st param expected `Model` but got `Optional[Model]`.
             model=model.model,
             candidate_set=candidate_set,
             target_fidelities={2: 1.0},
@@ -332,8 +327,6 @@ class MaxValueEntropySearchTest(TestCase):
         # test error that target fidelity and fidelity weight indices must match
         with self.assertRaises(RuntimeError):
             _instantiate_MES(
-                # pyre-fixme[6]: For 1st param expected `Model` but got
-                #  `Optional[Model]`.
                 model=model.model,
                 candidate_set=candidate_set,
                 target_fidelities={1: 1.0},

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -214,7 +214,7 @@ class BotorchMOODefaultsTest(TestCase):
             get_NEHVI(
                 # pyre-fixme[6]: For 1st param expected `Model` but got
                 #  `Optional[Model]`.
-                model=model.model,
+                model=model._model,
                 objective_weights=weights,
                 objective_thresholds=objective_thresholds,
             )

--- a/ax/models/tests/test_cbo_lcea.py
+++ b/ax/models/tests/test_cbo_lcea.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from typing import cast
+
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.cbo_lcea import LCEABO
@@ -81,8 +83,9 @@ class LCEABOTest(TestCase):
                 bounds=[(0.0, 1.0) for _ in range(4)],
             ),
         )
-        # pyre-fixme[16]: Optional type has no attribute `decomposition`.
-        self.assertDictEqual(m2.model.decomposition, {"1": [0, 2], "2": [1, 3]})
+        self.assertDictEqual(
+            cast(LCEAGP, m2.model).decomposition, {"1": [0, 2], "2": [1, 3]}
+        )
 
         # Test decomposition validation in get_and_fit_model
         # does not pass feature names when decomposition uses feature names

--- a/ax/models/tests/test_cbo_sac.py
+++ b/ax/models/tests/test_cbo_sac.py
@@ -5,11 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from typing import cast
+
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.cbo_sac import SACBO, SACGP
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import fast_botorch_optimize
+from botorch.models.contextual import LCEAGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.utils.datasets import FixedNoiseDataset
 
@@ -76,8 +79,9 @@ class SACBOTest(TestCase):
                 bounds=[(0.0, 1.0) for _ in range(4)],
             ),
         )
-        # pyre-fixme[16]: Optional type has no attribute `decomposition`.
-        self.assertDictEqual(m2.model.decomposition, {"1": [0, 2], "2": [1, 3]})
+        self.assertDictEqual(
+            cast(LCEAGP, m2.model).decomposition, {"1": [0, 2], "2": [1, 3]}
+        )
 
         # test decomposition validation in get_and_fit_model
         # the feature_names is not passed

--- a/ax/models/torch/botorch_mes.py
+++ b/ax/models/torch/botorch_mes.py
@@ -104,7 +104,7 @@ class MaxValueEntropySearch(BotorchModel):
         # subset model only to the outcomes we need for the optimization
         if options.get("subset_model", True):
             subset_model_results = subset_model(
-                model=model,  # pyre-ignore [6]
+                model=model,
                 objective_weights=torch_opt_config.objective_weights,
                 outcome_constraints=torch_opt_config.outcome_constraints,
             )
@@ -131,7 +131,7 @@ class MaxValueEntropySearch(BotorchModel):
         candidate_set = bounds_[0] + (bounds_[1] - bounds_[0]) * candidate_set
 
         acq_function = _instantiate_MES(
-            model=model,  # pyre-ignore [6]
+            model=model,
             candidate_set=candidate_set,
             num_fantasies=num_fantasies,
             num_trace_observations=options.get("num_trace_observations", 0),

--- a/ax/models/torch/cbo_lcea.py
+++ b/ax/models/torch/cbo_lcea.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from logging import Logger
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, cast, Dict, List, Optional, Tuple, Union
 
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
@@ -184,3 +184,7 @@ class LCEABO(BotorchModel):
             model = ModelListGP(*models)
         model.to(Xs[0])
         return model
+
+    @property
+    def model(self) -> Union[LCEAGP, ModelListGP]:
+        return cast(Union[LCEAGP, ModelListGP], super().model)

--- a/ax/models/torch/fully_bayesian.py
+++ b/ax/models/torch/fully_bayesian.py
@@ -475,17 +475,17 @@ def get_fully_bayesian_acqf_nehvi(
 
 
 class FullyBayesianBotorchModelMixin:
-    model: Optional[Model] = None
+    _model: Optional[Model] = None
 
     def feature_importances(self) -> np.ndarray:
-        if self.model is None:
+        if self._model is None:
             raise RuntimeError(
                 "Cannot calculate feature_importances without a fitted model"
             )
-        elif isinstance(self.model, ModelListGP):
-            models = self.model.models
+        elif isinstance(self._model, ModelListGP):
+            models = self._model.models
         else:
-            models = [self.model]
+            models = [self._model]
         lengthscales = []
         for m in models:
             ls = m.covar_module.base_kernel.lengthscale

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -262,10 +262,10 @@ class BoTorchModelTest(TestCase):
     def test_fit(self, mock_fit: Mock) -> None:
         # If surrogate is not yet set, initialize it with dispatcher functions.
         self.model._surrogates = {}
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "is not initialized. Must `fit`"):
             self.model.search_space_digest  # can't access before fit
 
-        with self.assertRaises(RuntimeError):  # can't manually assign
+        with self.assertRaisesRegex(RuntimeError, "manually is disallowed"):
             self.model.search_space_digest = self.mf_search_space_digest
 
         self.model.fit(

--- a/ax/utils/sensitivity/sobol_measures.py
+++ b/ax/utils/sensitivity/sobol_measures.py
@@ -5,7 +5,7 @@
 
 from copy import deepcopy
 
-from typing import Any, Callable, cast, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy as np
 
@@ -804,7 +804,7 @@ def _get_model_per_metric(
     """
     if isinstance(model, BotorchModel):
         # guaranteed not to be None after accessing search_space_digest
-        gp_model = cast(Model, model.model)
+        gp_model = model.model
         model_idx = [model.metric_names.index(m) for m in metrics]
         if not isinstance(gp_model, IndependentModelList):
             if gp_model.num_outputs == 1:  # can accept single output models


### PR DESCRIPTION
Summary: This commit makes `BotorchModel.model` a property, which makes Pyre a bit happier throughout.

Differential Revision: D44719618

