### PR TITLE
equality check fixes

### DIFF
--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -149,8 +149,8 @@ def object_attribute_dicts_find_unequal_fields(
         other_val = other_dict.get(field)
         one_val = numpy_type_to_python_type(one_val)
         other_val = numpy_type_to_python_type(other_val)
-
-        if type(one_val) != type(other_val):
+        skip_type_check = skip_db_id_check and field == "_db_id"
+        if not skip_type_check and (type(one_val) != type(other_val)):
             unequal_type[field] = (one_val, other_val)
             if fast_return:
                 return unequal_type, unequal_value

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -357,7 +357,7 @@ class TestCase(fake_filesystem_unittest.TestCase):
             second, Base, "Second argument is not a subclass of Ax `Base`."
         )
         if (
-            first._eq_skip_db_id_check(other=second)
+            not first._eq_skip_db_id_check(other=second)
             if skip_db_id_check
             else first != second
         ):


### PR DESCRIPTION
Summary:
1. Rectifies backward equality check in `assertAxBaseEqual`
2. In `object_attribute_dicts_find_unequal_fields`, skips type equality check for _db_id field if `skip_db_id_check` is True.

Reviewed By: danielcohenlive

Differential Revision: D44727443

