### PR TITLE
Fix transform args in _get_trace

### DIFF
--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -399,8 +399,9 @@ class BestPointMixin(metaclass=ABCMeta):
         )
         optimization_config = tf.transform_optimization_config(
             optimization_config=optimization_config.clone(),
-            # pyre-ignore -- experiment works here since we only need the status quo.
-            modelbridge=experiment,
+            modelbridge=get_tensor_converter_model(
+                experiment=experiment, data=experiment.lookup_data()
+            ),
             fixed_features=None,
         )
 


### PR DESCRIPTION
Summary: This was passing in an `experiment` for the `modelbridge` arg of `Derelativize.transform_optimization_config`, which does not work when there is a status quo arm. Passing in a minimal modelbridge should fix it.

Reviewed By: Balandat

Differential Revision: D44978152

