### PR TITLE
Recommend contributors install unittest dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ pip install git+https://github.com/pytorch/botorch.git
 export ALLOW_BOTORCH_LATEST=true
 git clone https://github.com/facebook/ax.git --depth 1
 cd ax
-pip install -e .[notebook,mysql,dev]
+pip install -e .[unittest]
 ```
 
 See recommendation for installing PyTorch for MacOS users above.


### PR DESCRIPTION
# Overview:

Contributors should be running unit tests, so they should have unit test dependencies installed. Since the "unittest" dependencies encompass the other optional dependencies, we only need to recommend the "unittest" dependencies.

# Test plan:

Installed it on my laptop and ran tests.