### PR TITLE
Fix flaky timing test

### DIFF
--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -330,10 +330,10 @@ class BaseModelBridgeTest(TestCase):
             search_space=search_space, observations=[], time_so_far=1.0
         )
         self.assertAlmostEqual(modelbridge.fit_time, 6.0, places=1)
-        self.assertAlmostEqual(modelbridge.fit_time_since_gen, 6.0, places=3)
+        self.assertAlmostEqual(modelbridge.fit_time_since_gen, 6.0, places=1)
         modelbridge.gen(1)
         self.assertAlmostEqual(modelbridge.fit_time, 6.0, places=1)
-        self.assertAlmostEqual(modelbridge.fit_time_since_gen, 0.0, places=3)
+        self.assertAlmostEqual(modelbridge.fit_time_since_gen, 0.0, places=1)
 
     @mock.patch(
         "ax.modelbridge.base.observations_from_data",


### PR DESCRIPTION
# Overview:

`ax.modelbridge.tests.test_base_modelbridge.BaseModelBridgeTest.test_timing` has been flaky because it makes assertions on how long something should take. The asserted equalities will hold exactly if everything runs instantaneously, but it has been taking longer (say 0.0088 seconds). I loosened the tolerance from 1e-3 to 1e-1. A loose tolerance is okay since this test is basically just checking addition of some much larger numbers (3 + 2 + 1 should be around 6).

# Test plan:

Ran it 100 times and it didn't fail.