### PR TITLE
Set logging level to WARNING for unit tests

### DIFF
--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -12,6 +12,7 @@
 import contextlib
 import io
 import linecache
+import logging
 import signal
 import sys
 import types
@@ -298,6 +299,18 @@ class TestCase(fake_filesystem_unittest.TestCase):
 
         super().__init__(methodName=methodName)
         signal.signal(signal.SIGALRM, signal_handler)
+
+    def setUp(self) -> None:
+        """
+        Only show log messages of WARNING or higher while testing.
+
+        Ax prints a lot of INFO logs that are not relevant for unit tests.
+        """
+        logger = get_logger(__name__, level=logging.WARNING)
+        # Parent handlers are shared, so setting the level this
+        # way applies it to all Ax loggers.
+        if logger.parent is not None and hasattr(logger.parent, "handlers"):
+            logger.parent.handlers[0].setLevel(logging.WARNING)
 
     def run(
         self, result: Optional[unittest.result.TestResult] = ...


### PR DESCRIPTION
The default Ax logging level is INFO, and Ax prints a lot of INFO logs. This is annoying for unit tests, where we only want to know when something is wrong, and drowns out useful warnings. This sets the logging level one level higher, to WARNING and above.

# Test plan

Ran unit tests and made sure that INFO logs were not printed, but WARNING logs were.