### PR TITLE
Swap libfb none_throws with pyre_extensions

### DIFF
--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -33,7 +33,7 @@ from ax.utils.testing.core_stubs import (
     get_experiment_with_multi_objective,
     get_test_map_data_experiment,
 )
-from libfb.py.pyre import none_throws
+from pyre_extensions import none_throws
 
 
 class TestBaseEarlyStoppingStrategy(TestCase):


### PR DESCRIPTION
Summary: Accidentally imported the wrong none_throws in D45092300! No material change.

Differential Revision: D45274357

