### PR TITLE
fix the z-val for computing CI of PF plots

### DIFF
--- a/ax/plot/pareto_frontier.py
+++ b/ax/plot/pareto_frontier.py
@@ -274,7 +274,7 @@ def _get_single_pareto_trace(
         arm_names = [f"Arm {name}" for name in frontier.arm_names]
 
     if CI_level is not None:
-        Z = 0.5 * norm.ppf(1 - (1 - CI_level) / 2)
+        Z = norm.ppf(1 - (1 - CI_level) / 2)
     else:
         Z = None
 


### PR DESCRIPTION
Summary: Current [Z-value](https://www.internalfb.com/code/fbsource/[6411afbfc4a8]/fbcode/ax/plot/pareto_frontier.py?lines=277) mulitplies 0.5 to the quantile of a given confidence level. The z-value is later used in [`_format_CI`](https://www.internalfb.com/code/fbsource/[83dad0b4f5ea]/fbcode/ax/plot/helper.py?lines=93). By doing so, this cuts the CI by half.

Reviewed By: VilockLi

Differential Revision: D45277841

