### PR TITLE
Do not overwrite generation step index when adding custom arms to BatchTrial

### DIFF
--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -308,9 +308,10 @@ class BatchTrial(BaseTrial):
         if self.status_quo is not None and self.optimize_for_power:
             self.set_status_quo_and_optimize_power(status_quo=not_none(self.status_quo))
 
-        self._set_generation_step_index(
-            generation_step_index=generator_run._generation_step_index
-        )
+        if generator_run._generation_step_index is not None:
+            self._set_generation_step_index(
+                generation_step_index=generator_run._generation_step_index
+            )
         self._refresh_arms_by_name()
         return self
 

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -96,10 +96,13 @@ class BatchTrialTest(TestCase):
         self.assertEqual(len(self.batch.generator_run_structs), 2)
         self.assertEqual(sum(self.batch.weights), sum(self.weights) + 3)
 
-    def testAddGeneratorRun(self) -> None:
+    def test_add_generator_run(self) -> None:
         self.assertEqual(len(self.batch.arms), len(self.arms))
         self.assertEqual(len(self.batch.generator_run_structs), 1)
         self.assertEqual(sum(self.batch.weights), sum(self.weights))
+
+        # Overwrite the GS index to not-None.
+        self.batch._generation_step_index = 0
 
         # one of these arms already exists on the BatchTrial,
         # so we should just update its weight
@@ -114,6 +117,8 @@ class BatchTrialTest(TestCase):
         self.assertEqual(len(self.batch.arms), len(self.arms) + 1)
         self.assertEqual(len(self.batch.generator_run_structs), 2)
         self.assertEqual(sum(self.batch.weights), sum(self.weights) + 2)
+        # Check the GS index was not overwritten to None.
+        self.assertEqual(self.batch._generation_step_index, 0)
 
     def testInitWithGeneratorRun(self) -> None:
         generator_run = GeneratorRun(arms=self.arms, weights=self.weights)


### PR DESCRIPTION
Summary:
When adding a generator run to a BatchTrial, we update the generation step index to match the generation step index of the generator run. This ensures that we do not mix arms generated from different generation steps in a trial.

However, we support mixing custom arms with arms generated by the generation strategy. When it comes to adding these arms, a "manual" generator run is generated and attached to the trial. In the current setup, this overwrites the generation step index to None, which breaks the `should_move_to_next_step` logic of generation strategy.

This change makes it so that the manual arms do not overwrite the generation step index. This allows the trial to be associated with the generation step that originally created it, which makes sure that we don't get stuck in the Sobol step indefinitely.

Reviewed By: qingfeng10

Differential Revision: D45298272

