### PR TITLE
Only do checks for `_optimize_acqf_sequential_q` when it will be used

### DIFF
--- a/ax/benchmark/tests/test_methods.py
+++ b/ax/benchmark/tests/test_methods.py
@@ -3,9 +3,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from dataclasses import replace
+
+import numpy as np
+
+from ax.benchmark.benchmark import benchmark_replication
 from ax.benchmark.methods.modular_botorch import get_sobol_botorch_modular_acquisition
+from ax.benchmark.problems.registry import get_problem
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.mock import fast_botorch_optimize
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
 
 
@@ -23,3 +30,15 @@ class TestMethods(TestCase):
         # pyre-fixme[16]: Optional type has no attribute `__getitem__`.
         self.assertEqual(model_kwargs["botorch_acqf_class"], qKnowledgeGradient)
         self.assertEqual(model_kwargs["acquisition_options"], {"num_fantasies": 16})
+
+    @fast_botorch_optimize
+    def test_benchmark_replication_runs(self) -> None:
+        problem = get_problem(problem_name="ackley4")
+        method = get_sobol_botorch_modular_acquisition(
+            acquisition_cls=qKnowledgeGradient
+        )
+        n_sobol_trials = method.generation_strategy._steps[0].num_trials
+        # Only run one non-Sobol trial
+        problem = replace(problem, num_trials=n_sobol_trials + 1)
+        result = benchmark_replication(problem=problem, method=method, seed=0)
+        self.assertTrue(np.isfinite(result.score_trace).all())


### PR DESCRIPTION
Summary:
`optimize_acqf` calls `_optimize_acqf_sequential_q` when `sequential=True` and `q > 1`. We had been doing input validation for `_optimize_acqf_sequential` even when it was not called, in the `q=1` case. This unnecessary check became a problem when `sequential=True` became a default for MBM in https://github.com/facebook/Ax/pull/1585 , breaking Ax benchmarks.

This PR moves checks for sequential optimization to `_optimize_acqf_sequential_q`, so they will only happen if `_optimize_acqf_sequential_q` is called.

Reviewed By: saitcakmak

Differential Revision: D45324522

