### PR TITLE
Add Global Stopping Strategy Tutorial

### DIFF
--- a/tutorials/gss.ipynb
+++ b/tutorials/gss.ipynb
@@ -1,0 +1,578 @@
+{
+  "metadata": {
+    "dataExplorerConfig": {},
+    "kernelspec": {
+      "cinder_runtime": true,
+      "display_name": "ae",
+      "ipyflow_runtime": false,
+      "language": "python",
+      "name": "bento_kernel_ae",
+      "metadata": {
+        "kernel_name": "bento_kernel_ae",
+        "nightly_builds": false,
+        "fbpkg_supported": true,
+        "cinder_runtime": true,
+        "ipyflow_runtime": false,
+        "is_prebuilt": true
+      }
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3"
+    },
+    "last_server_session_id": "b038dfa7-ddfd-4396-88ea-0fec88aa292a",
+    "last_kernel_id": "19da859e-aef3-4acd-9821-8324bf01749c",
+    "last_base_url": "https://bento.edge.x2p.facebook.net/",
+    "last_msg_id": "ef6f5808-af75f2e299a3f40164d8edf8_190",
+    "captumWidgetMessage": {},
+    "outputWidgetContext": {}
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2,
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "customInput": null,
+        "originalKey": "06e172a0-2da3-4c90-93c2-be01bf4f6d45",
+        "showInput": false
+      },
+      "source": [
+        "This tutorial illustrates use of a Global Stopping Strategy (GSS) in combination with the Service API. For background on the Service API, see the Service API Tutorial: https://ax.dev/tutorials/gpei_hartmann_service.html GSS is also supported in the Scheduler API, where it can be provided as part of `SchedulerOptions`. For more on `Scheduler`, see the Scheduler tutorial: https://ax.dev/tutorials/scheduler.html\n",
+        "\n",
+        "Global Stopping stops an optimization loop when some data-based criteria are met which suggest that future trials will not be very helpful. For example, we might stop when there has been very little improvement in the last five trials. This is as opposed to trial-level early stopping, which monitors the results of expensive evaluations and terminates those that are unlikely to produce promising results, freeing resources to explore more promising configurations. For more on trial-level early stopping, see the tutorial: https://ax.dev/tutorials/early_stopping/early_stopping.html"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customOutput": null,
+        "executionStartTime": 1683829335587,
+        "executionStopTime": 1683829339370,
+        "originalKey": "00a04d2c-d990-41c1-9eef-bbb05fba000d",
+        "requestMsgId": "1c560539-1c7d-4c7a-ae55-e87c3b601859"
+      },
+      "source": [
+        "import numpy as np\n",
+        "\n",
+        "from ax.service.ax_client import AxClient, ObjectiveProperties\n",
+        "from ax.utils.measurement.synthetic_functions import Branin, branin\n",
+        "from ax.utils.notebook.plotting import render, init_notebook_plotting\n",
+        "\n",
+        "init_notebook_plotting()"
+      ],
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "customInput": null,
+        "originalKey": "8688d729-b402-4a4c-b796-94fdcf5e022c",
+        "showInput": false
+      },
+      "source": [
+        "# 1. What happens without global stopping? Optimization can run for too long.\n",
+        "This example uses the Branin test problem. We run 25 trials, which turns out to be far more than needed, because we get close to the optimum quite quickly."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829339516,
+        "executionStopTime": 1683829339531,
+        "originalKey": "320a952b-9e78-43e1-a55b-76a355e90f83",
+        "requestMsgId": "14e3a517-c7d0-4300-92d9-57ceb5afca34",
+        "showInput": true
+      },
+      "source": [
+        "def evaluate(parameters):\n",
+        "    x = np.array([parameters.get(f\"x{i+1}\") for i in range(2)])\n",
+        "    return {\"branin\": (branin(x), 0.0)}"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829339659,
+        "executionStopTime": 1683829339668,
+        "originalKey": "5740fbc2-97d6-465b-b01c-61e6c34c0220",
+        "requestMsgId": "ff819cc9-ff17-4763-a857-83662b01e955",
+        "showInput": true
+      },
+      "source": [
+        "params = [\n",
+        "    {\n",
+        "        \"name\": f\"x{i + 1}\",\n",
+        "        \"type\": \"range\",\n",
+        "        \"bounds\": [*Branin._domain[i]],\n",
+        "        \"value_type\": \"float\",\n",
+        "        \"log_scale\": False,\n",
+        "    }\n",
+        "\n",
+        "    for i in range(2)\n",
+        "]"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829339782,
+        "executionStopTime": 1683829339834,
+        "originalKey": "65667172-14df-437b-bdd0-5a59580e4054",
+        "requestMsgId": "e0bc2847-17a5-43d7-bf49-ed97c90f1d50",
+        "showInput": true
+      },
+      "source": [
+        "ax_client = AxClient(random_seed=0, verbose_logging=False)\n",
+        "\n",
+        "ax_client.create_experiment(\n",
+        "    name=\"branin_test_experiment\",\n",
+        "    parameters=params,\n",
+        "    objectives={\"branin\": ObjectiveProperties(minimize=True)},\n",
+        "    is_test=True,\n",
+        ")"
+      ],
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829339928,
+        "executionStopTime": 1683829356006,
+        "originalKey": "1f208de3-5189-4847-a779-940795977845",
+        "requestMsgId": "95f327f2-327f-4284-93ae-3053c9b6ec45",
+        "showInput": true
+      },
+      "source": [
+        "%%time\n",
+        "for i in range(25):\n",
+        "    parameters, trial_index = ax_client.get_next_trial()\n",
+        "    # Local evaluation here can be replaced with deployment to external system.\n",
+        "    ax_client.complete_trial(\n",
+        "        trial_index=trial_index, raw_data=evaluate(parameters)\n",
+        "    )"
+      ],
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829356136,
+        "executionStopTime": 1683829356616,
+        "originalKey": "a369aafa-8ee4-4c02-bea6-673271da81ab",
+        "requestMsgId": "b601e1e9-fd2d-4faf-a369-04e5c4a9f8cb",
+        "showInput": true
+      },
+      "source": [
+        "render(ax_client.get_optimization_trace())"
+      ],
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "customInput": null,
+        "originalKey": "ca391462-4695-44f1-bc53-070a947c5648",
+        "showInput": false
+      },
+      "source": [
+        "# 2. Optimization with global stopping, with the Service API"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "customInput": null,
+        "originalKey": "5a2690ef-0990-4cbd-9bc9-529b1455a4c3",
+        "showInput": false
+      },
+      "source": [
+        "Rather than running a fixed number of trials, we can use a GlobalStoppingStrategy (GSS), which checks whether some stopping criteria have been met when `get_next_trial` is called. Here, we use an `ImprovementGlobalStoppingStrategy`, which checks whether the the last `window_size` trials have improved by more than some threshold amount.\n",
+        "\n",
+        "For single-objective optimization, which we are doing here, `ImprovementGlobalStoppingStrategy` checks if an improvement is \"significant\" by comparing it to the inter-quartile range (IQR) of the objective values attained so far. \n",
+        "\n",
+        "`ImprovementGlobalStoppingStrategy` also supports multi-objective optimization (MOO), in which case it checks whether the percentage improvement in hypervolume over the last `window_size` trials exceeds `improvement_bar`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829356716,
+        "executionStopTime": 1683829356725,
+        "originalKey": "a6634232-448a-4b84-98cd-399c755537df",
+        "requestMsgId": "7e428336-eeeb-4e5b-91c4-fcf5a671773d",
+        "showInput": true
+      },
+      "source": [
+        "from ax.global_stopping.strategies.improvement import ImprovementGlobalStoppingStrategy\n",
+        "from ax.exceptions.core import OptimizationShouldStop"
+      ],
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829356822,
+        "executionStopTime": 1683829356829,
+        "originalKey": "c313de63-03ee-4a65-aa5c-5e7b6f436480",
+        "requestMsgId": "953b064b-8db6-430f-909d-872469bc1e16",
+        "showInput": true
+      },
+      "source": [
+        "# Start considering stopping only after the 5 initialization trials + 5 GPEI trials.\n",
+        "# Stop if the improvement in the best point in the past 5 trials is less than\n",
+        "# 1% of the IQR thus far.\n",
+        "stopping_strategy = ImprovementGlobalStoppingStrategy(\n",
+        "    min_trials=5 + 5, window_size=5, improvement_bar=0.01\n",
+        ")"
+      ],
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829356961,
+        "executionStopTime": 1683829356997,
+        "originalKey": "a2c6c699-f0d2-4001-9bee-3964594e435c",
+        "requestMsgId": "2ba6f82b-1443-4274-83d1-03c56f0190d0",
+        "showInput": true
+      },
+      "source": [
+        "ax_client_gss = AxClient(\n",
+        "    global_stopping_strategy=stopping_strategy, random_seed=0, verbose_logging=False\n",
+        ")\n",
+        "\n",
+        "ax_client_gss.create_experiment(\n",
+        "    name=\"branin_test_experiment\",\n",
+        "    parameters=params,\n",
+        "    objectives={\"branin\": ObjectiveProperties(minimize=True)},\n",
+        "    is_test=True,\n",
+        ")"
+      ],
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "customInput": null,
+        "originalKey": "7ff170a1-e885-429f-9695-8b64b5b8e209",
+        "showInput": false
+      },
+      "source": [
+        "If there has not been much improvement, `ImprovementGlobalStoppingStrategy` will raise an exception. If the exception is raised, we catch it and terminate optimization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829357114,
+        "executionStopTime": 1683829363866,
+        "originalKey": "3db097cb-1e6e-4320-806a-981dcef6bade",
+        "requestMsgId": "fd039109-2a23-4287-8935-b74274405e56",
+        "showInput": true
+      },
+      "source": [
+        "for i in range(25):\n",
+        "    try:\n",
+        "        parameters, trial_index = ax_client_gss.get_next_trial()\n",
+        "    except OptimizationShouldStop as exc:\n",
+        "        print(exc.message)\n",
+        "        break\n",
+        "    ax_client_gss.complete_trial(trial_index=trial_index, raw_data=evaluate(parameters))"
+      ],
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829363988,
+        "executionStopTime": 1683829364103,
+        "originalKey": "ffb53ed2-8775-492d-a357-348957637454",
+        "requestMsgId": "f0f765dd-85db-4519-90d0-064a1bf64b6d",
+        "showInput": true
+      },
+      "source": [
+        "render(ax_client_gss.get_optimization_trace())"
+      ],
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "customInput": null,
+        "originalKey": "b01707f3-0bbf-4003-9222-29ba5e3c77b2",
+        "showInput": false
+      },
+      "source": [
+        "# 3. Write your own custom Global Stopping Strategy"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "customInput": null,
+        "originalKey": "23b8372b-0067-4934-b599-210b994e06f1",
+        "showInput": false
+      },
+      "source": [
+        "You can write a custom Global Stopping Strategy by subclassing `BaseGlobalStoppingStrategy` and use it where  `ImprovementGlobalStoppingStrategy` was used above."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829364214,
+        "executionStopTime": 1683829364222,
+        "originalKey": "2e5512a9-82ed-43a0-8616-6cee7f648b0f",
+        "requestMsgId": "d5c268a1-fefe-49d5-8ff4-a2cb40fe278b",
+        "showInput": true
+      },
+      "source": [
+        "from ax.global_stopping.strategies.base import BaseGlobalStoppingStrategy\n",
+        "from typing import Tuple\n",
+        "from ax.core.experiment import Experiment\n",
+        "from ax.core.base_trial import TrialStatus\n",
+        "from ax.global_stopping.strategies.improvement import constraint_satisfaction"
+      ],
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "customInput": null,
+        "originalKey": "584df5ac-c0f6-4c48-8cec-f9765a04e635",
+        "showInput": false
+      },
+      "source": [
+        "Here, we define `SimpleThresholdGlobalStoppingStrategy`, which stops when we observe a point better than a provided threshold. This can be useful when there is a known optimum. For example, the Branin function has an optimum of zero. When the optimum is not known, this can still be useful from a satisficing perspective: For example, maybe we need a model to take up less than a certain amount of RAM so it doesn't crash our usual hardware, but there is no benefit to further improvements."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829490325,
+        "executionStopTime": 1683829490340,
+        "originalKey": "bbd24d6e-a873-49d6-abe3-4d832acb8a60",
+        "requestMsgId": "74b77cb7-54eb-4321-afae-942b62b90f5d",
+        "showInput": true
+      },
+      "source": [
+        "class SimpleThresholdGlobalStoppingStrategy(BaseGlobalStoppingStrategy):\n",
+        "    \"\"\"\n",
+        "    A GSS that stops when we observe a point better than `threshold`.\n",
+        "    \"\"\"\n",
+        "    def __init__(\n",
+        "        self,\n",
+        "        min_trials: int,\n",
+        "        inactive_when_pending_trials: bool = True,\n",
+        "        threshold: float = 0.1\n",
+        "    ):\n",
+        "        self.threshold = threshold\n",
+        "        super().__init__(\n",
+        "            min_trials=min_trials,\n",
+        "            inactive_when_pending_trials=inactive_when_pending_trials\n",
+        "        )\n",
+        "    \n",
+        "    def _should_stop_optimization(\n",
+        "        self, experiment: Experiment\n",
+        "    ) -> Tuple[bool, str]:\n",
+        "        \"\"\"\n",
+        "        Check if the best seen is better than `self.threshold`.\n",
+        "        \"\"\"\n",
+        "        feasible_objectives = [\n",
+        "            trial.objective_mean\n",
+        "            for trial in experiment.trials_by_status[TrialStatus.COMPLETED]\n",
+        "            if constraint_satisfaction(trial)\n",
+        "        ]\n",
+        "\n",
+        "        # Computing the interquartile for scaling the difference\n",
+        "        if len(feasible_objectives) <= 1:\n",
+        "            message = \"There are not enough feasible arms tried yet.\"\n",
+        "            return False, message\n",
+        "        \n",
+        "        minimize = experiment.optimization_config.objective.minimize\n",
+        "        if minimize:\n",
+        "            best = np.min(feasible_objectives)\n",
+        "            stop = best < self.threshold\n",
+        "        else:\n",
+        "            best = np.max(feasible_objectives)\n",
+        "            stop = best > self.threshold\n",
+        "\n",
+        "        comparison = \"less\" if minimize else \"greater\"\n",
+        "        if stop:\n",
+        "            message = (\n",
+        "                f\"The best objective seen is {best:.3f}, which is {comparison} \"\n",
+        "                f\"than the threshold of {self.threshold:.3f}.\"\n",
+        "            )\n",
+        "        else:\n",
+        "            message = \"\"\n",
+        "\n",
+        "        return stop, message"
+      ],
+      "execution_count": 20,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829491609,
+        "executionStopTime": 1683829491626,
+        "originalKey": "f3dc5682-0539-4c85-a66a-0d3128f0cc1c",
+        "requestMsgId": "9ee9e413-be32-49fc-a7bc-8e1898d1dbf5",
+        "showInput": true
+      },
+      "source": [
+        "stopping_strategy = SimpleThresholdGlobalStoppingStrategy(min_trials=5, threshold=1.)"
+      ],
+      "execution_count": 21,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829491833,
+        "executionStopTime": 1683829491894,
+        "originalKey": "3d6c1ab2-c3ee-49c8-9969-45f2455bbd60",
+        "requestMsgId": "08232010-46f8-4b28-b581-454ddacdc57b",
+        "showInput": true
+      },
+      "source": [
+        "ax_client_custom_gss = AxClient(\n",
+        "    global_stopping_strategy=stopping_strategy,\n",
+        "    random_seed=0,\n",
+        "    verbose_logging=False,\n",
+        ")\n",
+        "\n",
+        "ax_client_custom_gss.create_experiment(\n",
+        "    name=\"branin_test_experiment\",\n",
+        "    parameters=params,\n",
+        "    objectives={\"branin\": ObjectiveProperties(minimize=True)},\n",
+        "    is_test=True,\n",
+        ")"
+      ],
+      "execution_count": 22,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "customOutput": null,
+        "executionStartTime": 1683829492064,
+        "executionStopTime": 1683829495338,
+        "originalKey": "a306cb15-364f-4e91-b569-9067843a7578",
+        "requestMsgId": "81121dac-3a2a-4dde-b866-44e448e73ad5",
+        "showInput": true
+      },
+      "source": [
+        "for i in range(25):\n",
+        "    try:\n",
+        "        parameters, trial_index = ax_client_custom_gss.get_next_trial()\n",
+        "    except OptimizationShouldStop as exc:\n",
+        "        print(exc.message)\n",
+        "        break\n",
+        "    ax_client_custom_gss.complete_trial(\n",
+        "        trial_index=trial_index, raw_data=evaluate(parameters)\n",
+        "    )"
+      ],
+      "execution_count": 23,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "collapsed": false,
+        "customInput": null,
+        "executionStartTime": 1683829495351,
+        "executionStopTime": 1683829495740,
+        "originalKey": "3cb59624-d9bb-4b7a-9f57-7cb968dce889",
+        "requestMsgId": "4dd4ed93-07ab-4dd1-92a9-f003f405ccbc",
+        "showInput": true,
+        "customOutput": null
+      },
+      "source": [
+        "render(ax_client_custom_gss.get_optimization_trace())"
+      ],
+      "execution_count": 24,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "originalKey": "5f4eaa42-a8cb-42b2-b8b4-b2fa53398270",
+        "showInput": true,
+        "customInput": null
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/website/tutorials.json
+++ b/website/tutorials.json
@@ -60,6 +60,10 @@
       "dir": "early_stopping",
       "id": "early_stopping",
       "title": "Trial-Level Early Stopping"
+    },
+    {
+      "id": "gss",
+      "title": "Global Stopping (Experiment-Level Early Stopping)"
     }
   ],
   "Field Experiments": [


### PR DESCRIPTION
Summary: This only uses the Service API. GSS is also supported by Scheduler, but I didn't include this since a minimal example with `Scheduler` is pretty involved. I think it would make sense to add a little bit about GSS into the existing scheduler tutorial, to avoid a lot of unnecessary duplication.

Differential Revision: D45671161

