### PR TITLE
Fix link to Early Stopping tutorial

### DIFF
--- a/website/pages/tutorials/index.js
+++ b/website/pages/tutorials/index.js
@@ -128,7 +128,7 @@ class TutorialHome extends React.Component {
             </ul>
             <ul>
               <li>
-                <a href="early_stopping.html">
+                <a href="early_stopping/early_stopping.html">
                   Trial-Level Early Stopping
                 </a>
                 &nbsp; shows how to use trial-level early stopping on an ML


### PR DESCRIPTION
Summary:
The main text currently links here, which gives a 404 error: https://ax.dev/tutorials/early_stopping.html

The sidebar links here, which is correct: https://ax.dev/tutorials/early_stopping/early_stopping.html

Reviewed By: bernardbeckerman

Differential Revision: D45697017

