### PR TITLE
Fix DeprecationWarning exception in Raytune tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ pip install git+https://github.com/pytorch/botorch.git
 export ALLOW_BOTORCH_LATEST=true
 git clone https://github.com/facebook/ax.git --depth 1
 cd ax
-pip install -e .[unittest]
+pip install -e .[tutorial]
 ```
 
 See recommendation for installing PyTorch for MacOS users above.

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -61,7 +61,10 @@ function require(deps, fxn) {
 
 
 def gen_tutorials(
-    repo_dir: str, exec_tutorials: bool, kernel_name: Optional[str] = None
+    repo_dir: str,
+    exec_tutorials: bool,
+    kernel_name: Optional[str] = None,
+    name: Optional[str] = None,
 ) -> None:
     """Generate HTML tutorials for Docusaurus Ax site from Jupyter notebooks.
 
@@ -76,6 +79,11 @@ def gen_tutorials(
     tutorial_configs = [
         config for category in tutorial_config.values() for config in category
     ]
+    # Running only the tutorial described by "name"
+    if name is not None:
+        tutorial_configs = [d for d in tutorial_configs if d["id"] == name]
+        if len(tutorial_configs) == 0:
+            raise RuntimeError(f"No tutorial found with name {name}.")
 
     # prepare paths for converted tutorials & files
     os.makedirs(os.path.join(repo_dir, "website", "_tutorials"), exist_ok=True)
@@ -227,5 +235,12 @@ if __name__ == "__main__":
         type=str,
         help="Name of IPython / Jupyter kernel to use for executing notebooks.",
     )
+    parser.add_argument(
+        "-n",
+        "--name",
+        help="Run a specific tutorial by name. The name should not include the "
+        ".ipynb extension. If the tutorial is on the ignore list, you still need "
+        "to specify --include-ignored.",
+    )
     args = parser.parse_args()
-    gen_tutorials(args.repo_dir, args.exec_tutorials, args.kernel_name)
+    gen_tutorials(args.repo_dir, args.exec_tutorials, args.kernel_name, name=args.name)

--- a/tutorials/raytune_pytorch_cnn.ipynb
+++ b/tutorials/raytune_pytorch_cnn.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "originalKey": "6dba2bea-d97e-4545-9803-4242850e1807"
@@ -27,7 +28,7 @@
     "\n",
     "from ray import tune\n",
     "from ray.tune import report\n",
-    "from ray.tune.suggest.ax import AxSearch\n",
+    "from ray.tune.search.ax import AxSearch\n",
     "\n",
     "logger = logging.getLogger(tune.__name__)\n",
     "logger.setLevel(\n",
@@ -55,6 +56,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "originalKey": "a26e18f8-caa7-411d-809a-61a9229cd6c6"
@@ -78,6 +80,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "originalKey": "1766919c-fb6f-4271-a8e1-6f972eee78f3"
@@ -142,6 +145,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "originalKey": "5fec848a-3538-489c-bcdd-a74051f48140"
@@ -180,6 +184,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "originalKey": "dda3574c-5967-43ea-8d23-7a151dc59ec9"
@@ -203,7 +208,7 @@
     "algo = AxSearch(ax_client=ax)\n",
     "# Wrap AxSearcher in a concurrently limiter, to ensure that Bayesian optimization receives the\n",
     "# data for completed trials before creating more trials\n",
-    "algo = tune.suggest.ConcurrencyLimiter(algo, max_concurrent=3)\n",
+    "algo = tune.search.ConcurrencyLimiter(algo, max_concurrent=3)\n",
     "tune.run(\n",
     "    train_evaluate,\n",
     "    num_samples=30,\n",
@@ -214,6 +219,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "originalKey": "cb00f812-e9e5-4208-a680-adf6619d74c4"
@@ -247,6 +253,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "originalKey": "12a87817-4409-4f07-a912-8d60eff71d68"


### PR DESCRIPTION
The `raytune_pytorch_cnn_tutorial` has been failing due to a `DeprecationWarning` that is raised as an exception. This PR
* Updates import paths so that there is no DeprecationWarning
* Updates the readme to recommend that developers install the "tutorials" dependencies, matching the text advice to install "all" dependencies
* Adds the option to run just one tutorial by name to the `make_tutorials.py` script, matching the BoTorch tutorials script.

# Test plan:

CI should pass now.