### PR TITLE
Allow combining of data with similar results

### DIFF
--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -448,20 +448,25 @@ class ExperimentTest(TestCase):
         # Test retrieving full exp data
         self.assertEqual(len(exp.lookup_data_for_ts(t2).df), 4 * n)
 
-        with self.assertRaisesRegex(ValueError, ".* for metric"):
-            exp.attach_data(batch_data, combine_with_last_data=True)
-
         self.assertEqual(len(full_dict[0]), 5)  # 5 data objs for batch 0
         new_data = Data(
             df=pd.DataFrame.from_records(
                 [
                     {
                         "arm_name": "0_0",
+                        # but now it is
+                        "metric_name": "not_yet_on_experiment",
+                        "mean": 3,
+                        "sem": 0,
+                        "trial_index": 0,
+                    },
+                    {
+                        "arm_name": "0_0",
                         "metric_name": "z",
                         "mean": 3,
                         "sem": 0,
                         "trial_index": 0,
-                    }
+                    },
                 ]
             )
         )

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -1551,12 +1551,6 @@ class TestAxClient(TestCase):
         # Cannot complete a trial twice, should use `update_trial_data`.
         with self.assertRaisesRegex(UnsupportedError, ".* already been completed"):
             ax_client.complete_trial(trial_index=idx, raw_data={"branin": (0, 0.0)})
-        # Cannot update trial data with observation for a metric it already has.
-        with self.assertRaisesRegex(ValueError, ".* contained an observation"):
-            ax_client.update_trial_data(trial_index=idx, raw_data={"branin": (0, 0.0)})
-        # Same as above, except objective name should be getting inferred.
-        with self.assertRaisesRegex(ValueError, ".* contained an observation"):
-            ax_client.update_trial_data(trial_index=idx, raw_data=1.0)
         ax_client.update_trial_data(trial_index=idx, raw_data={"m1": (1, 0.0)})
         metrics_in_data = ax_client.experiment.fetch_data().df["metric_name"].values
         self.assertNotIn("m1", metrics_in_data)


### PR DESCRIPTION
Summary: Right now, if we fetch results for a trial using `combine_with_last_data` and it has some metrics in common with the current data, it errors.  That ... sucks.

Differential Revision: D45668166

