### PR TITLE
Add `run_metadata_report_keys` property to `Runner` class

### DIFF
--- a/ax/core/runner.py
+++ b/ax/core/runner.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterable, Optional, Set, TYPE_CHECKING
+from typing import Any, Dict, Iterable, List, Optional, Set, TYPE_CHECKING
 
 from ax.utils.common.base import Base
 from ax.utils.common.serialization import SerializationMixin
@@ -25,6 +25,13 @@ class Runner(Base, SerializationMixin, ABC):
     def staging_required(self) -> bool:
         """Whether the trial goes to staged or running state once deployed."""
         return False
+
+    @property
+    def run_metadata_report_keys(self) -> List[str]:
+        """A list of keys of the metadata dict returned by `run()` that are
+        relevant outside the runner-internal impolementation. These can e.g.
+        be reported in `Scheduler.report_results()`."""
+        return []
 
     @abstractmethod
     def run(self, trial: core.base_trial.BaseTrial) -> Dict[str, Any]:

--- a/ax/core/tests/test_runner.py
+++ b/ax/core/tests/test_runner.py
@@ -49,3 +49,6 @@ class RunnerTest(TestCase):
 
     def test_poll_available_capacity(self) -> None:
         self.assertEqual(self.dummy_runner.poll_available_capacity(), -1)
+
+    def test_run_metadata_report_keys(self) -> None:
+        self.assertEqual(self.dummy_runner.run_metadata_report_keys, [])


### PR DESCRIPTION
Summary: Adds a `run_metadata_report_keys` property to the base `Runner` class. This can be used to specify which of the keys used in the `run_metadata` dict returned by a runner's `run()` method are relevant outside the internals of the runner. These can e.g. be utilized in `Scheduler.report_results()` or other places.

Reviewed By: bernardbeckerman

Differential Revision: D46042501

