### PR TITLE
Fix Modular BotAx tutorial

### DIFF
--- a/tutorials/modular_botax.ipynb
+++ b/tutorials/modular_botax.ipynb
@@ -93,7 +93,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 05-05 14:54:04] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+      "[INFO 06-07 16:00:42] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
      ]
     }
    ],
@@ -114,7 +114,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 05-05 14:54:04] ax.modelbridge.transforms.standardize_y: Outcome branin is constant, within tolerance.\n"
+      "[INFO 06-07 16:00:42] ax.modelbridge.transforms.standardize_y: Outcome branin is constant, within tolerance.\n"
      ]
     }
    ],
@@ -147,14 +147,6 @@
     "originalKey": "59582fc6-8089-4320-864e-d98ee271d4f7"
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/balandat/Code/gpytorch/gpytorch/distributions/multivariate_normal.py:259: NumericalWarning: Negative variance values detected. This is likely due to numerical instabilities. Rounding negative variances up to 1e-10.\n",
-      "  warnings.warn(\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
@@ -319,7 +311,7 @@
     "\n",
     "**Why is the `surrogate` argument expected to be an instance, but `botorch_acqf_class` –– a class?** Because a BoTorch `AcquisitionFunction` object (and therefore its Ax wrapper, `Acquisition`) is ephemeral: it is constructed, immediately used, and destroyed during `BoTorchModel.gen`, so there is no reason to keep around an `Acquisition` instance. A `Surrogate`, on another hand, is kept in memory as long as its parent `BoTorchModel` is.\n",
     "\n",
-    "**How to know when to use specify acquisition_class (and thereby a non-default Acquisition type) instead of just passing in botorch_acqf_class?** In short, custom `Acquisition` subclasses are needed when a given `AcquisitionFunction` in BoTorch needs some non-standard subcomponents or inputs (e.g. a custom BoTorch `AcquisitionObjective`). <TODO>\n",
+    "**How to know when to use specify acquisition_class (and thereby a non-default Acquisition type) instead of just passing in botorch_acqf_class?** In short, custom `Acquisition` subclasses are needed when a given `AcquisitionFunction` in BoTorch needs some non-standard subcomponents or inputs (e.g. a custom BoTorch `MCAcquisitionObjective`). <TODO>\n",
     "\n",
     "**Please post any other questions you have to our dedicated issue on Github: https://github.com/facebook/Ax/issues/363.** This functionality is in beta-release and your feedback will be of great help to us!"
    ]
@@ -432,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "interested-search",
    "metadata": {
     "code_folding": [],
@@ -443,10 +435,10 @@
     {
      "data": {
       "text/plain": [
-       "<ax.models.torch.botorch_modular.model.BoTorchModel at 0x7fabd0852b50>"
+       "<ax.models.torch.botorch_modular.model.BoTorchModel at 0x7fd2d820b4c0>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -455,7 +447,6 @@
     "from ax.models.torch.botorch_modular.optimizer_argparse import optimizer_argparse\n",
     "from botorch.acquisition.acquisition import AcquisitionFunction\n",
     "from botorch.acquisition.input_constructors import MaybeDict, acqf_input_constructor\n",
-    "from botorch.acquisition.objective import AcquisitionObjective\n",
     "from botorch.utils.datasets import SupervisedDataset\n",
     "from torch import Tensor\n",
     "\n",
@@ -470,7 +461,6 @@
     "    model: Model,\n",
     "    training_data: MaybeDict[SupervisedDataset],\n",
     "    objective_thresholds: Tensor,\n",
-    "    objective: Optional[AcquisitionObjective] = None,\n",
     "    **kwargs: Any,\n",
     ") -> Dict[str, Any]:\n",
     "    pass\n",
@@ -526,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "attached-border",
    "metadata": {
     "originalKey": "385b2f30-fd86-4d88-8784-f238ea8a6abb"
@@ -536,9 +526,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 05-05 14:54:04] ax.modelbridge.transforms.standardize_y: Outcome branin is constant, within tolerance.\n",
-      "/Users/balandat/Code/gpytorch/gpytorch/distributions/multivariate_normal.py:259: NumericalWarning: Negative variance values detected. This is likely due to numerical instabilities. Rounding negative variances up to 1e-10.\n",
-      "  warnings.warn(\n"
+      "[INFO 06-07 16:00:43] ax.modelbridge.transforms.standardize_y: Outcome branin is constant, within tolerance.\n"
      ]
     },
     {
@@ -547,7 +535,7 @@
        "GeneratorRun(1 arms, total weight 1.0)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -562,7 +550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "powerful-gamma",
    "metadata": {
     "originalKey": "89930a31-e058-434b-b587-181931e247b6"
@@ -574,7 +562,7 @@
        "botorch.acquisition.monte_carlo.qNoisyExpectedImprovement"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -585,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "improved-replication",
    "metadata": {
     "originalKey": "f9a9cb14-20c3-4e1d-93a3-6a35c281ae01"
@@ -597,7 +585,7 @@
        "botorch.models.gp_regression.FixedNoiseGP"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -618,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "documentary-jurisdiction",
    "metadata": {
     "originalKey": "8001de33-d9d9-4888-a5d1-7a59ebeccfd5"
@@ -628,10 +616,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 05-05 14:54:04] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n",
-      "[INFO 05-05 14:54:04] ax.modelbridge.transforms.standardize_y: Outcome branin_a is constant, within tolerance.\n",
-      "[INFO 05-05 14:54:04] ax.modelbridge.transforms.standardize_y: Outcome branin_b is constant, within tolerance.\n",
-      "/Users/balandat/Code/gpytorch/gpytorch/distributions/multivariate_normal.py:259: NumericalWarning: Negative variance values detected. This is likely due to numerical instabilities. Rounding negative variances up to 1e-10.\n",
+      "[INFO 06-07 16:00:43] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n",
+      "[INFO 06-07 16:00:43] ax.modelbridge.transforms.standardize_y: Outcome branin_a is constant, within tolerance.\n",
+      "[INFO 06-07 16:00:43] ax.modelbridge.transforms.standardize_y: Outcome branin_b is constant, within tolerance.\n",
+      "/Users/santorella/repos/botorch/botorch/optim/initializers.py:403: BadInitialCandidatesWarning: Unable to find non-zero acquisition function values - initial conditions are being selected randomly.\n",
       "  warnings.warn(\n"
      ]
     },
@@ -641,7 +629,7 @@
        "GeneratorRun(1 arms, total weight 1.0)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -658,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "id": "changed-maintenance",
    "metadata": {
     "originalKey": "dcfdbecc-4a9a-49ac-ad55-0bc04b2ec566"
@@ -670,7 +658,7 @@
        "botorch.acquisition.multi_objective.monte_carlo.qNoisyExpectedHypervolumeImprovement"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -681,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "id": "operating-shelf",
    "metadata": {
     "originalKey": "16727a51-337d-4715-bf51-9cb6637a950f"
@@ -693,7 +681,7 @@
        "botorch.models.gp_regression.FixedNoiseGP"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -728,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "id": "received-registration",
    "metadata": {
     "originalKey": "f7eabbcf-607c-4bed-9a0e-6ac6e8b04350"
@@ -776,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "viral-cheese",
    "metadata": {
     "originalKey": "30cfcdd7-721d-4f89-b851-7a94140dfad6"
@@ -786,7 +774,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 05-05 14:54:04] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+      "[INFO 06-07 16:00:44] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
      ]
     },
     {
@@ -795,7 +783,7 @@
        "SearchSpace(parameters=[RangeParameter(name='x1', parameter_type=FLOAT, range=[-5.0, 10.0]), RangeParameter(name='x2', parameter_type=FLOAT, range=[0.0, 15.0])], parameter_constraints=[])"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -822,20 +810,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "id": "casual-spread",
    "metadata": {
     "originalKey": "58aafd65-a366-4b66-a1b1-31b207037a2e"
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/balandat/Code/gpytorch/gpytorch/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
-      "  warnings.warn(\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -844,84 +824,12 @@
       "Completed trial #1, suggested by Sobol.\n",
       "Completed trial #2, suggested by Sobol.\n",
       "Completed trial #3, suggested by Sobol.\n",
-      "Completed trial #4, suggested by Sobol.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/balandat/Code/gpytorch/gpytorch/distributions/multivariate_normal.py:259: NumericalWarning: Negative variance values detected. This is likely due to numerical instabilities. Rounding negative variances up to 1e-10.\n",
-      "  warnings.warn(\n",
-      "/Users/balandat/Code/gpytorch/gpytorch/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Completed trial #5, suggested by BoTorch.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/balandat/Code/gpytorch/gpytorch/distributions/multivariate_normal.py:259: NumericalWarning: Negative variance values detected. This is likely due to numerical instabilities. Rounding negative variances up to 1e-10.\n",
-      "  warnings.warn(\n",
-      "/Users/balandat/Code/gpytorch/gpytorch/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Completed trial #6, suggested by BoTorch.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/balandat/Code/gpytorch/gpytorch/distributions/multivariate_normal.py:259: NumericalWarning: Negative variance values detected. This is likely due to numerical instabilities. Rounding negative variances up to 1e-10.\n",
-      "  warnings.warn(\n",
-      "/Users/balandat/Code/gpytorch/gpytorch/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Completed trial #7, suggested by BoTorch.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/balandat/Code/gpytorch/gpytorch/distributions/multivariate_normal.py:259: NumericalWarning: Negative variance values detected. This is likely due to numerical instabilities. Rounding negative variances up to 1e-10.\n",
-      "  warnings.warn(\n",
-      "/Users/balandat/Code/gpytorch/gpytorch/utils/cholesky.py:40: NumericalWarning: A not p.d., added jitter of 1.0e-08 to the diagonal\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Completed trial #4, suggested by Sobol.\n",
+      "Completed trial #5, suggested by BoTorch.\n",
+      "Completed trial #6, suggested by BoTorch.\n",
+      "Completed trial #7, suggested by BoTorch.\n",
       "Completed trial #8, suggested by BoTorch.\n",
       "Completed trial #9, suggested by BoTorch.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/balandat/Code/gpytorch/gpytorch/distributions/multivariate_normal.py:259: NumericalWarning: Negative variance values detected. This is likely due to numerical instabilities. Rounding negative variances up to 1e-10.\n",
-      "  warnings.warn(\n"
      ]
     }
    ],
@@ -957,7 +865,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "id": "significant-particular",
    "metadata": {
     "originalKey": "ca12913d-e3fd-4617-a247-e3432665bac1"
@@ -984,147 +892,147 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>branin</th>\n",
        "      <th>trial_index</th>\n",
        "      <th>arm_name</th>\n",
-       "      <th>x1</th>\n",
-       "      <th>x2</th>\n",
        "      <th>trial_status</th>\n",
        "      <th>generation_method</th>\n",
+       "      <th>branin</th>\n",
+       "      <th>x1</th>\n",
+       "      <th>x2</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>2.516686</td>\n",
        "      <td>0</td>\n",
        "      <td>0_0</td>\n",
-       "      <td>-3.452563</td>\n",
-       "      <td>11.747097</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
+       "      <td>18.295380</td>\n",
+       "      <td>-4.560280</td>\n",
+       "      <td>12.821902</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>20.213358</td>\n",
        "      <td>1</td>\n",
        "      <td>1_0</td>\n",
-       "      <td>0.016540</td>\n",
-       "      <td>6.756372</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
+       "      <td>17.709690</td>\n",
+       "      <td>0.695902</td>\n",
+       "      <td>4.371646</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>2.814679</td>\n",
        "      <td>2</td>\n",
        "      <td>2_0</td>\n",
-       "      <td>8.801378</td>\n",
-       "      <td>2.780774</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
+       "      <td>55.483925</td>\n",
+       "      <td>8.846689</td>\n",
+       "      <td>9.346672</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>8.135274</td>\n",
        "      <td>3</td>\n",
        "      <td>3_0</td>\n",
-       "      <td>9.412488</td>\n",
-       "      <td>5.246138</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
+       "      <td>21.169355</td>\n",
+       "      <td>-0.904083</td>\n",
+       "      <td>9.831698</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>86.629987</td>\n",
        "      <td>4</td>\n",
        "      <td>4_0</td>\n",
-       "      <td>-2.326716</td>\n",
-       "      <td>1.280123</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>Sobol</td>\n",
+       "      <td>41.183817</td>\n",
+       "      <td>8.152092</td>\n",
+       "      <td>7.442010</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>92.951388</td>\n",
        "      <td>5</td>\n",
        "      <td>5_0</td>\n",
-       "      <td>1.478336</td>\n",
-       "      <td>12.988449</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>BoTorch</td>\n",
+       "      <td>129.479026</td>\n",
+       "      <td>-5.000000</td>\n",
+       "      <td>6.382025</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>68.276197</td>\n",
        "      <td>6</td>\n",
        "      <td>6_0</td>\n",
-       "      <td>-5.000000</td>\n",
-       "      <td>9.734009</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>BoTorch</td>\n",
+       "      <td>44.640343</td>\n",
+       "      <td>-1.675659</td>\n",
+       "      <td>15.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>7.770399</td>\n",
        "      <td>7</td>\n",
        "      <td>7_0</td>\n",
-       "      <td>-2.838986</td>\n",
-       "      <td>14.193263</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>BoTorch</td>\n",
+       "      <td>21.171942</td>\n",
+       "      <td>2.527968</td>\n",
+       "      <td>7.163640</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
-       "      <td>4.334985</td>\n",
        "      <td>8</td>\n",
        "      <td>8_0</td>\n",
-       "      <td>-2.251821</td>\n",
-       "      <td>10.855681</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>BoTorch</td>\n",
+       "      <td>1.585450</td>\n",
+       "      <td>3.511702</td>\n",
+       "      <td>2.737128</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>27.557474</td>\n",
        "      <td>9</td>\n",
        "      <td>9_0</td>\n",
-       "      <td>7.033479</td>\n",
-       "      <td>4.442162</td>\n",
        "      <td>COMPLETED</td>\n",
        "      <td>BoTorch</td>\n",
+       "      <td>11.785506</td>\n",
+       "      <td>2.374472</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "      branin  trial_index arm_name        x1         x2 trial_status  \\\n",
-       "0   2.516686            0      0_0 -3.452563  11.747097    COMPLETED   \n",
-       "1  20.213358            1      1_0  0.016540   6.756372    COMPLETED   \n",
-       "2   2.814679            2      2_0  8.801378   2.780774    COMPLETED   \n",
-       "3   8.135274            3      3_0  9.412488   5.246138    COMPLETED   \n",
-       "4  86.629987            4      4_0 -2.326716   1.280123    COMPLETED   \n",
-       "5  92.951388            5      5_0  1.478336  12.988449    COMPLETED   \n",
-       "6  68.276197            6      6_0 -5.000000   9.734009    COMPLETED   \n",
-       "7   7.770399            7      7_0 -2.838986  14.193263    COMPLETED   \n",
-       "8   4.334985            8      8_0 -2.251821  10.855681    COMPLETED   \n",
-       "9  27.557474            9      9_0  7.033479   4.442162    COMPLETED   \n",
+       "   trial_index arm_name trial_status generation_method      branin        x1   \n",
+       "0            0      0_0    COMPLETED             Sobol   18.295380 -4.560280  \\\n",
+       "1            1      1_0    COMPLETED             Sobol   17.709690  0.695902   \n",
+       "2            2      2_0    COMPLETED             Sobol   55.483925  8.846689   \n",
+       "3            3      3_0    COMPLETED             Sobol   21.169355 -0.904083   \n",
+       "4            4      4_0    COMPLETED             Sobol   41.183817  8.152092   \n",
+       "5            5      5_0    COMPLETED           BoTorch  129.479026 -5.000000   \n",
+       "6            6      6_0    COMPLETED           BoTorch   44.640343 -1.675659   \n",
+       "7            7      7_0    COMPLETED           BoTorch   21.171942  2.527968   \n",
+       "8            8      8_0    COMPLETED           BoTorch    1.585450  3.511702   \n",
+       "9            9      9_0    COMPLETED           BoTorch   11.785506  2.374472   \n",
        "\n",
-       "  generation_method  \n",
-       "0             Sobol  \n",
-       "1             Sobol  \n",
-       "2             Sobol  \n",
-       "3             Sobol  \n",
-       "4             Sobol  \n",
-       "5           BoTorch  \n",
-       "6           BoTorch  \n",
-       "7           BoTorch  \n",
-       "8           BoTorch  \n",
-       "9           BoTorch  "
+       "          x2  \n",
+       "0  12.821902  \n",
+       "1   4.371646  \n",
+       "2   9.346672  \n",
+       "3   9.831698  \n",
+       "4   7.442010  \n",
+       "5   6.382025  \n",
+       "6  15.000000  \n",
+       "7   7.163640  \n",
+       "8   2.737128  \n",
+       "9   0.000000  "
       ]
      },
-     "execution_count": 21,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1144,7 +1052,7 @@
     "\n",
     "We expect the base `Surrogate` and `Acquisition` classes to work with most BoTorch components, but there could be a case where you would need to subclass one of aforementioned abstractions to handle a given BoTorch component. If you run into a case like this, feel free to open an issue on our [Github issues page](https://github.com/facebook/Ax/issues) –– it would be very useful for us to know \n",
     "\n",
-    "One such example would be a need for a custom `AcquisitionObjective` or for a custom acquisition function optimization utility. To subclass `Acquisition` accordingly, one would override the `get_botorch_objective` method:"
+    "One such example would be a need for a custom `MCAcquisitionObjective` or posterior transform. To subclass `Acquisition` accordingly, one would override the `get_botorch_objective_and_transform` method:"
    ]
   },
   {
@@ -1156,8 +1064,11 @@
    },
    "outputs": [],
    "source": [
+    "from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform\n",
+    "from botorch.acquisition.risk_measures import RiskMeasureMCObjective\n",
+    "\n",
     "class CustomObjectiveAcquisition(Acquisition):\n",
-    "    def get_botorch_objective(\n",
+    "    def get_botorch_objective_and_transform(\n",
     "        self,\n",
     "        botorch_acqf_class: Type[AcquisitionFunction],\n",
     "        model: Model,\n",
@@ -1165,8 +1076,9 @@
     "        objective_thresholds: Optional[Tensor] = None,\n",
     "        outcome_constraints: Optional[Tuple[Tensor, Tensor]] = None,\n",
     "        X_observed: Optional[Tensor] = None,\n",
-    "    ) -> AcquisitionObjective:\n",
-    "        ...  # Produce the desired `AcquisitionObjective` instead of the default"
+    "        risk_measure: Optional[RiskMeasureMCObjective] = None,\n",
+    "    ) -> Tuple[Optional[MCAcquisitionObjective], Optional[PosteriorTransform]]:\n",
+    "        ...  # Produce the desired `MCAcquisitionObjective` and `PosteriorTransform` instead of the default"
    ]
   },
   {
@@ -1191,13 +1103,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO 05-05 14:54:07] ax.modelbridge.transforms.standardize_y: Outcome branin is constant, within tolerance.\n"
+      "[INFO 06-07 16:01:54] ax.modelbridge.transforms.standardize_y: Outcome branin is constant, within tolerance.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<ax.modelbridge.torch.TorchModelBridge at 0x7fabd08529d0>"
+       "<ax.modelbridge.torch.TorchModelBridge at 0x7fd2d821c3a0>"
       ]
      },
      "execution_count": 23,
@@ -1312,7 +1224,7 @@
  "metadata": {
   "dataExplorerConfig": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1326,7 +1238,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.8"
   },
   "last_base_url": "https://devbig824.prn1.facebook.com:8090/",
   "last_kernel_id": "249fdd46-baf9-4864-b6fa-cf420e16c166",


### PR DESCRIPTION
The MBM tutorial broke due to a recent BoTorch pull request that removed some long-deprecated functionality. This PR fixes this by cutting the tutorial over to the current BoTorch syntax.

Test plan: Ran the notebook