### PR TITLE
Avoid spurious UserWarning in get_pareto_frontier_and_configs

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -1015,6 +1015,7 @@ def pareto_frontier(
         optimization_config=optimization_config,
         arm_names=arm_names,
         use_model_predictions=use_model_predictions,
+        transform_outcomes_and_configs=False,
     )[0]
 
 
@@ -1137,6 +1138,7 @@ def hypervolume(
         objective_thresholds=objective_thresholds,
         optimization_config=optimization_config,
         use_model_predictions=use_model_predictions,
+        transform_outcomes_and_configs=False,
     )
     if obj_t is None:
         raise ValueError(  # pragma: no cover

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -629,6 +629,7 @@ def infer_reference_point_from_experiment(
         observation_data=obs_data,
         objective_thresholds=dummy_rp,
         use_model_predictions=False,
+        transform_outcomes_and_configs=False,
     )
 
     # Need to reshuffle columns of `f` and `obj_w` to be consistent


### PR DESCRIPTION
Prior to this change, using `AxClient` for multi-objective optimization would needlessly spam the logs with a `UserWarning` about deprecated use of `transform_outcomes_and_configs` in `get_pareto_frontier_and_configs`. The reason is that #1200 did not update all the call sites. 