### PR TITLE
Make `copy_run_metadata_keys` default to run_metadata_report_keys on old runner

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1171,7 +1171,8 @@ class Experiment(Base):
         Args:
             old_experiment: The experiment from which to transfer trials and data
             copy_run_metadata_keys: A list of keys denoting which items to copy over
-                from each trial's run_metadata.
+                from each trial's run_metadata. Defaults to
+                ``old_experiment.runner.run_metadata_report_keys``.
             trial_statuses_to_copy: All trials with a status in this list will be
                 copied. By default, copies all ``RUNNING``, ``COMPLETED``,
                 ``ABANDONED``, and ``EARLY_STOPPED`` trials.
@@ -1187,6 +1188,9 @@ class Experiment(Base):
                 f"Can only warm-start experiments that don't yet have trials. "
                 f"Experiment {self._name} has {len(self.trials)} trials."
             )
+
+        if copy_run_metadata_keys is None and old_experiment.runner is not None:
+            copy_run_metadata_keys = old_experiment.runner.run_metadata_report_keys
 
         old_parameter_names = set(old_experiment.search_space.parameters.keys())
         parameter_names = set(self.search_space.parameters.keys())

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Dict, Type
+from typing import Dict, List, Type
 from unittest.mock import patch
 
 import pandas as pd
@@ -49,6 +49,12 @@ DUMMY_RUN_METADATA_VALUE = "test_run_metadata_value"
 DUMMY_RUN_METADATA: Dict[str, str] = {DUMMY_RUN_METADATA_KEY: DUMMY_RUN_METADATA_VALUE}
 DUMMY_ABANDONED_REASON = "test abandoned reason"
 DUMMY_ARM_NAME = "test_arm_name"
+
+
+class SyntheticRunnerWithMetadataKeys(SyntheticRunner):
+    @property
+    def run_metadata_report_keys(self) -> List[str]:
+        return [DUMMY_RUN_METADATA_KEY]
 
 
 class ExperimentTest(TestCase):
@@ -835,6 +841,7 @@ class ExperimentTest(TestCase):
         i_abandoned_trial = 3
         i_running_trial = 5
         old_experiment = get_branin_experiment()
+        old_experiment.runner = SyntheticRunnerWithMetadataKeys()
         for i_old_trial in range(len_old_trials):
             sobol_run = get_sobol(search_space=old_experiment.search_space).gen(n=1)
             trial = old_experiment.new_trial(generator_run=sobol_run)
@@ -872,7 +879,6 @@ class ExperimentTest(TestCase):
         old_experiment.trials[0].arm._name = DUMMY_ARM_NAME
         new_experiment.warm_start_from_old_experiment(
             old_experiment=old_experiment,
-            copy_run_metadata_keys=[DUMMY_RUN_METADATA_KEY],
         )
         self.assertEqual(len(new_experiment.trials), len(old_experiment.trials) - 1)
         i_old_trial = 0


### PR DESCRIPTION
Summary:
In `Experiment.warm_start_from_old_experiment`, makes `copy_run_metadata_keys` default to the `run_metadata_report_keys` property (D46042501) of `old_experiment`'s Runner. Also removes redundant specification of the `copy_run_metadata_keys` arg from `warm_start_from_old_experiment` callsites.

We may want to remove the `copy_run_metadata_keys` arg entirely, since it's hard to imagine wanting it to be set to anything else. Leaving as is for the time being.

Differential Revision: D46662942

