### PR TITLE
Code deduplication in TorchModelBridge and improved kwarg parsing in Surrogate._construct_model_list

### DIFF
--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -372,10 +372,11 @@ class Surrogate(Base):
             task_feature,
             submodel_input_transforms,
         ) = self._extract_construct_model_list_kwargs(
-            fidelity_features=kwargs.get(Keys.FIDELITY_FEATURES, []),
-            task_features=kwargs.get(Keys.TASK_FEATURES, []),
-            robust_digest=kwargs.get("robust_digest", None),
+            fidelity_features=kwargs.pop(Keys.FIDELITY_FEATURES, []),
+            task_features=kwargs.pop(Keys.TASK_FEATURES, []),
+            robust_digest=kwargs.pop("robust_digest", None),
         )
+        input_constructor_kwargs = {**self.model_options, **(kwargs or {})}
 
         submodels = []
         for m, dataset in zip(metric_names, datasets):
@@ -391,8 +392,7 @@ class Surrogate(Base):
                 training_data=dataset,
                 fidelity_features=fidelity_features,
                 task_feature=task_feature,
-                categorical_features=kwargs.get("categorical_features", None),
-                **self.model_options,
+                **input_constructor_kwargs,
             )
             # Add input / outcome transforms.
             # TODO: The use of `inspect` here is not ideal. We should find a better

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -859,6 +859,7 @@ class SurrogateWithModelListTest(TestCase):
             datasets=self.fixed_noise_training_data,
             metric_names=self.outcomes,
             task_features=self.task_features,
+            output_tasks=[2],
         )
         # Should construct inputs for MTGP twice.
         self.assertEqual(len(mock_MTGP_construct_inputs.call_args_list), 2)
@@ -870,15 +871,11 @@ class SurrogateWithModelListTest(TestCase):
                 {
                     "fidelity_features": [],
                     "task_feature": self.task_features[0],
-                    "categorical_features": None,
-                    # TODO: Figure out how to handle Multitask GPs and construct-inputs.
-                    # I believe this functionality with modlular botorch model is
-                    # currently broken as MultiTaskGP.construct_inputs expects a dict
-                    # mapping string keys (outcomes) to input datasets
                     "training_data": FixedNoiseDataset(
                         X=self.Xs[idx], Y=self.Ys[idx], Yvar=self.Yvars[idx]
                     ),
                     "rank": 1,
+                    "output_tasks": [2],
                 },
             )
 


### PR DESCRIPTION
Summary: This introduces `_get_fit_args`, a helper to deduplicate some shared code between `_fit` and `_cross_validate` in `TorchModelBridge`. It also updates `Surrogate._construct_model_list` to pass in some previously ignored kwargs to the input constructors.

Differential Revision: D46745348

