### PR TITLE
change "Total Sobol indices" -> "Variance-based sensitivity analysis"

### DIFF
--- a/ax/plot/feature_importances.py
+++ b/ax/plot/feature_importances.py
@@ -76,7 +76,7 @@ def plot_feature_importance_by_metric_plotly(model: ModelBridge) -> go.Figure:
     df = df.reindex(columns=(["index"] + [a for a in df.columns if a != "index"]))
 
     plot_fi = plot_feature_importance_plotly(
-        df, "Absolute Feature Importances by Metric"
+        df, "Absolute Parameter Importances by Metric"
     )
     num_subplots = len(df.columns)
     num_features = len(df)
@@ -198,7 +198,9 @@ def plot_feature_importance_by_feature_plotly(
     ]
     features = traces[0].y
     title = (
-        "Relative Feature Importances" if relative else "Absolute Feature Importances"
+        "Relative Parameter Importances"
+        if relative
+        else "Absolute Parameter Importances"
     )
     if importance_measure:
         title = title + " based on " + importance_measure
@@ -264,9 +266,9 @@ def plot_relative_feature_importance_plotly(model: ModelBridge) -> go.Figure:
         margin=go.layout.Margin(l=250),  # noqa E741
         barmode="group",
         yaxis={"title": ""},
-        xaxis={"title": "Relative Feature importance"},
+        xaxis={"title": "Relative Parameter importance"},
         showlegend=False,
-        title="Relative Feature Importance per Metric",
+        title="Relative Parameter Importance per Metric",
     )
     return go.Figure(data=data, layout=layout)
 

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -306,9 +306,9 @@ def get_standard_plots(
             experiment; used for visualizing when curves are stopped.
         - limit_points_per_plot: Limit the number of points used per metric in
             each curve plot. Passed to `_get_curve_plot_dropdown`.
-        - global_sensitivity_analysis: If True, plot total Sobol indices for the model
-            parameters. If False, plot sensitivities based on GP kernel lengthscales.
-            Defaults to True.
+        - global_sensitivity_analysis: If True, plot total Variance-based sensitivity
+            analysis for the model parameters. If False, plot sensitivities based on
+            GP kernel lengthscales. Defaults to True.
     Returns:
         - a plot of objective value vs. trial index, to show experiment progression
         - a plot of objective value vs. range parameter values, only included if the
@@ -391,7 +391,7 @@ def get_standard_plots(
             if global_sensitivity_analysis and isinstance(model, TorchModelBridge):
                 try:
                     sens = ax_parameter_sens(model, order="total")
-                    importance_measure = "Total Sobol Indices"
+                    importance_measure = '<a href="https://en.wikipedia.org/wiki/Variance-based_sensitivity_analysis">Variance-based sensitivity analysis</a>'
                 except NotImplementedError as e:
                     logger.info(f"Failed to compute global feature sensitivities: {e}")
             feature_importance_plot = plot_feature_importance_by_feature_plotly(


### PR DESCRIPTION
Summary: Users were getting confused with the term "Sobol indices" since Sobol did so many cool things (particularly Sobol sequences, which are used to generate exploratory trials at the beginning of a sweep and are referred to by name, thus the confusion). Switching to referring to this technique using the name of the corresponding [wikipedia article title](https://en.wikipedia.org/wiki/Variance-based_sensitivity_analysis) (sorry Ilya!).

Reviewed By: Balandat

Differential Revision: D46801454

