### PR TITLE
default options for covar module

### DIFF
--- a/ax/models/torch/botorch_modular/input_constructors/covar_modules.py
+++ b/ax/models/torch/botorch_modular/input_constructors/covar_modules.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Type, Union
+
+import torch
+from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
+from ax.models.torch.botorch_modular.optimizer_argparse import (
+    _optimizerArgparse_encoder,
+)
+from botorch.models.gp_regression import FixedNoiseGP
+
+from botorch.models.model import Model
+from botorch.models.multitask import FixedNoiseMultiTaskGP
+from botorch.utils.datasets import SupervisedDataset
+from botorch.utils.dispatcher import Dispatcher
+from botorch.utils.types import _DefaultType, DEFAULT
+from gpytorch.kernels.kernel import Kernel
+from gpytorch.priors.torch_priors import Prior
+
+
+covar_module_argparse = Dispatcher(
+    name="covar_module_argparse", encoder=_optimizerArgparse_encoder
+)
+
+
+@covar_module_argparse.register(Kernel)
+def _covar_module_argparse_base(
+    covar_module_class: Type[Kernel],
+    botorch_model_class: Optional[Type[Model]] = None,
+    dataset: Optional[SupervisedDataset] = None,
+    covar_module_options: Optional[Dict[str, Any]] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """
+    Extract the covar module kwargs form the given arguments.
+
+    NOTE: Since `covar_module_options` is how the user would typically pass in these
+    options, it takes precedence over other arguments. E.g., if both `ard_num_dims`
+    and `covar_module_options["ard_num_dims"]` are provided, this will use
+    `ard_num_dims` from `covar_module_options`.
+
+    Args:
+        covar_module_class: Covariance module class.
+        botorch_model_class: ``Model`` class to be used as the underlying
+            BoTorch model.
+        dataset: Dataset containing feature matrix and the response.
+        covar_module_options: An optional dictionary of covariance module options.
+            This may include overrides for the above options. For example, when
+            covar_module_class is MaternKernel this dictionary might include
+            {
+                "nu": 2.5, # the smoothness parameter
+                "ard_num_dims": 3, # the num. of lengthscales per input dimension
+                "batch_shape": torch.Size([2]), # the num. of lengthscales per batch,
+                    # e.g., metric
+                "lengthscale_prior": GammaPrior(6.0, 3.0), # prior for the lengthscale
+                    # parameter
+            }
+            See `gpytorch/kernels/matern_kernel.py` for more options.
+
+    Returns:
+        A dictionary with covar module kwargs.
+    """
+    covar_module_options = covar_module_options or {}
+    return {**kwargs, **covar_module_options}
+
+
+@covar_module_argparse.register(ScaleMaternKernel)
+def _covar_module_argparse_scale_matern(
+    covar_module_class: Type[ScaleMaternKernel],
+    botorch_model_class: Type[Model],
+    dataset: SupervisedDataset,
+    ard_num_dims: Union[int, _DefaultType] = DEFAULT,
+    batch_shape: Union[torch.Size, _DefaultType] = DEFAULT,
+    lengthscale_prior: Optional[Prior] = None,
+    outputscale_prior: Optional[Prior] = None,
+    covar_module_options: Optional[Dict[str, Any]] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Extract the base covar module kwargs form the given arguments.
+
+    NOTE: This setup does not allow for setting multi-dimensional priors,
+        with different priors over lengthscales.
+
+    Args:
+        covar_module_class: Covariance module class.
+        botorch_model_class: Model class to be used as the underlying
+            BoTorch model.
+        dataset: Dataset containing feature matrix and the response.
+        ard_num_dims: Number of lengthscales per feature.
+        batch_shape: The number of lengthscales per batch.
+        lengthscale_prior: Lenthscale prior.
+        outputscale_prior: Outputscale prior.
+        covar_module_options: Covariance module kwargs.
+
+    Returns:
+        A dictionary with covar module kwargs.
+    """
+
+    if issubclass(botorch_model_class, FixedNoiseMultiTaskGP):
+        if ard_num_dims is DEFAULT:
+            ard_num_dims = dataset.X.shape[-1] - 1
+
+        if batch_shape is DEFAULT:
+            batch_shape = torch.Size([])
+
+    if issubclass(botorch_model_class, FixedNoiseGP):
+        if ard_num_dims is DEFAULT:
+            ard_num_dims = dataset.X.shape[-1]
+
+        if batch_shape is DEFAULT:
+            batch_shape = dataset.Y.shape[-1:]
+
+    return _covar_module_argparse_base(
+        covar_module_class=covar_module_class,
+        dataset=dataset,
+        botorch_model_class=botorch_model_class,
+        ard_num_dims=ard_num_dims,
+        lengthscale_prior=lengthscale_prior,
+        outputscale_prior=outputscale_prior,
+        batch_shape=batch_shape,
+        covar_module_options=covar_module_options,
+        **kwargs,
+    )

--- a/ax/models/torch/botorch_modular/kernels.py
+++ b/ax/models/torch/botorch_modular/kernels.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+from gpytorch.constraints import Interval
+from gpytorch.kernels.matern_kernel import MaternKernel
+from gpytorch.kernels.scale_kernel import ScaleKernel
+from gpytorch.priors.torch_priors import Prior
+
+
+class ScaleMaternKernel(ScaleKernel):
+    def __init__(
+        self,
+        ard_num_dims: Optional[int] = None,
+        batch_shape: Optional[torch.Size] = None,
+        lengthscale_prior: Optional[Prior] = None,
+        outputscale_prior: Optional[Prior] = None,
+        lengthscale_constraint: Optional[Interval] = None,
+        outputscale_constraint: Optional[Interval] = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            ard_num_dims: The number of lengthscales.
+            batch_shape: The batch shape.
+            lengthscale_prior: The prior over the lengthscale parameter.
+            outputscale_prior: The prior over the scaling parameter.
+            lengthscale_constraint: Optionally provide a lengthscale constraint.
+            outputscale_constraint: Optionally provide a output scale constraint.
+
+        Returns: None
+        """
+        base_kernel = MaternKernel(
+            nu=2.5,
+            ard_num_dims=ard_num_dims,
+            lengthscale_constraint=lengthscale_constraint,
+            lengthscale_prior=lengthscale_prior,
+            batch_shape=batch_shape,
+        )
+        super().__init__(
+            base_kernel=base_kernel,
+            outputscale_prior=outputscale_prior,
+            outputscale_constraint=outputscale_constraint,
+            **kwargs,
+        )

--- a/ax/models/torch/tests/test_covar_modules_argparse.py
+++ b/ax/models/torch/tests/test_covar_modules_argparse.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import torch
+from ax.models.torch.botorch_modular.input_constructors.covar_modules import (
+    covar_module_argparse,
+)
+from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
+from ax.utils.common.testutils import TestCase
+from botorch.models.gp_regression import FixedNoiseGP
+from botorch.models.multitask import FixedNoiseMultiTaskGP
+from botorch.utils.datasets import SupervisedDataset
+from gpytorch.kernels.kernel import Kernel
+from gpytorch.priors import GammaPrior
+
+
+class DummyKernel(Kernel):
+    pass
+
+
+class CovarModuleArgparseTest(TestCase):
+    def test_notImplemented(self) -> None:
+        with self.assertRaises(NotImplementedError) as e:
+            covar_module_argparse[
+                type(None)
+            ]  # passing `None` produces a different error
+            self.assertTrue("Could not find signature for" in str(e))
+
+    def test_register(self) -> None:
+        @covar_module_argparse.register(DummyKernel)
+        def _argparse(kernel: DummyKernel) -> None:
+            pass
+
+        self.assertEqual(covar_module_argparse[DummyKernel], _argparse)
+
+    def test_fallback(self) -> None:
+
+        with patch.dict(covar_module_argparse.funcs, {}):
+
+            @covar_module_argparse.register(Kernel)
+            def _argparse(covar_module_class: Kernel) -> None:
+                pass
+
+            self.assertEqual(covar_module_argparse[Kernel], _argparse)
+
+    def test_argparse_kernel(self) -> None:
+
+        X = torch.randn((10, 10))
+        Y = torch.randn((10, 2))
+        dataset = SupervisedDataset(X=X, Y=Y)
+
+        covar_module_kwargs = covar_module_argparse(
+            Kernel,
+            botorch_model_class=FixedNoiseGP,
+            dataset=dataset,
+        )
+
+        self.assertEqual(covar_module_kwargs, {})
+
+        covar_module_kwargs = covar_module_argparse(
+            Kernel,
+            botorch_model_class=FixedNoiseGP,
+            dataset=dataset,
+            ard_num_dims=19,
+            batch_shape=torch.Size([10]),
+        )
+
+        self.assertEqual(
+            covar_module_kwargs, {"ard_num_dims": 19, "batch_shape": torch.Size([10])}
+        )
+
+    def test_argparse_scalematern_kernel(self) -> None:
+
+        X = torch.randn((10, 10))
+        Y = torch.randn((10, 2))
+        dataset = SupervisedDataset(X=X, Y=Y)
+
+        covar_module_kwargs_defaults = [
+            {
+                "ard_num_dims": 10,
+                "lengthscale_prior_concentration": 6.0,
+                "lengthscale_prior_rate": 3.0,
+                "outputscale_prior_concentration": 2.0,
+                "outputscale_prior_rate": 0.15,
+                "batch_shape": torch.Size([2]),
+            },
+            {
+                "ard_num_dims": 9,
+                "lengthscale_prior_concentration": 6.0,
+                "lengthscale_prior_rate": 3.0,
+                "outputscale_prior_concentration": 2.0,
+                "outputscale_prior_rate": 0.15,
+                "batch_shape": torch.Size([]),
+            },
+        ]
+
+        for i, botorch_model_class in enumerate([FixedNoiseGP, FixedNoiseMultiTaskGP]):
+
+            covar_module_kwargs = covar_module_argparse(
+                ScaleMaternKernel,
+                botorch_model_class=botorch_model_class,
+                dataset=dataset,
+                lengthscale_prior=GammaPrior(6.0, 3.0),
+                outputscale_prior=GammaPrior(2, 0.15),
+            )
+
+            covar_module_kwargs[
+                "lengthscale_prior_concentration"
+            ] = covar_module_kwargs["lengthscale_prior"].concentration.item()
+            covar_module_kwargs["lengthscale_prior_rate"] = covar_module_kwargs[
+                "lengthscale_prior"
+            ].rate.item()
+
+            covar_module_kwargs[
+                "outputscale_prior_concentration"
+            ] = covar_module_kwargs["outputscale_prior"].concentration.item()
+            covar_module_kwargs["outputscale_prior_rate"] = covar_module_kwargs[
+                "outputscale_prior"
+            ].rate.item()
+
+            covar_module_kwargs.pop("lengthscale_prior")
+            covar_module_kwargs.pop("outputscale_prior")
+
+            for key in covar_module_kwargs.keys():
+                self.assertAlmostEqual(
+                    covar_module_kwargs[key],
+                    covar_module_kwargs_defaults[i][key],
+                    places=4,
+                )

--- a/ax/models/torch/tests/test_kernels.py
+++ b/ax/models/torch/tests/test_kernels.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import torch
+from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
+from ax.utils.common.testutils import TestCase
+from gpytorch.kernels import MaternKernel
+from gpytorch.priors import GammaPrior
+
+
+class KernelsTest(TestCase):
+    def test_scalematern_kernel(self) -> None:
+        covar = ScaleMaternKernel(
+            ard_num_dims=10,
+            lengthscale_prior=GammaPrior(6.0, 3.0),
+            outputscale_prior=GammaPrior(2.0, 0.15),
+            batch_shape=torch.Size([2]),
+        )
+        self.assertTrue(isinstance(covar.base_kernel, MaternKernel))
+        self.assertTrue(isinstance(covar.base_kernel, MaternKernel))
+        self.assertEqual(covar.base_kernel.ard_num_dims, 10)
+        self.assertEqual(
+            covar.base_kernel.lengthscale_prior.rate, 3.0  # pyre-ignore[16]
+        )
+        self.assertEqual(
+            covar.base_kernel.lengthscale_prior.concentration, 6.0  # pyre-ignore[16]
+        )
+        self.assertEqual(covar.outputscale_prior.rate, 0.15)  # pyre-ignore[16]
+        self.assertEqual(covar.outputscale_prior.concentration, 2.0)  # pyre-ignore[16]
+        self.assertEqual(covar.base_kernel.batch_shape[0], 2)


### PR DESCRIPTION
Summary: Allow input options, specifically covar module, to depend on the dataset dimensions when default is specified for the number of lengthscales (ard_num_dims) and the number of independent models.

Reviewed By: Balandat

Differential Revision: D45167311

