### PR TITLE
Bug fix: Different benchmark problems should have different names

### DIFF
--- a/ax/benchmark/problems/hd_embedding.py
+++ b/ax/benchmark/problems/hd_embedding.py
@@ -13,6 +13,14 @@ from ax.core.search_space import SearchSpace
 def embed_higher_dimension(
     problem: BenchmarkProblem, total_dimensionality: int
 ) -> BenchmarkProblem:
+    """
+    Return a new `BenchmarkProblem` with enough `RangeParameter`s added to the
+    search space to make its total dimensionality equal to `total_dimensionality`
+    and add `total_dimensionality` to its name.
+
+    The search space of the original `problem` is within the search space of the
+    new problem, and the constraints are copied from the original problem.
+    """
     num_dummy_dimensions = total_dimensionality - len(problem.search_space.parameters)
 
     search_space = SearchSpace(
@@ -31,8 +39,17 @@ def embed_higher_dimension(
         parameter_constraints=problem.search_space.parameter_constraints,
     )
 
+    # if problem name already has dimensionality in it, strip it
+    def _is_dim_suffix(s: str) -> bool:
+        return s[-1] == "d" and all(char in "0123456789" for char in s[:-1])
+
+    orig_name_without_dimensionality = "_".join(
+        [substr for substr in problem.name.split("_") if not _is_dim_suffix(substr)]
+    )
+    new_name = f"{orig_name_without_dimensionality}_{total_dimensionality}d"
+
     problem_kwargs = asdict(problem)
-    problem_kwargs["name"] = f"{problem_kwargs['name']}_{total_dimensionality}d"
+    problem_kwargs["name"] = new_name
     problem_kwargs["search_space"] = search_space
 
     return problem.__class__(**problem_kwargs)

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -60,8 +60,10 @@ def get_jenatton_benchmark_problem(
         )
     )
 
+    name = "Jenatton" + ("" if infer_noise else "_fixed_noise")
+
     return SingleObjectiveBenchmarkProblem(
-        name="Jenatton",
+        name=name,
         search_space=search_space,
         optimization_config=optimization_config,
         runner=SyntheticRunner(),

--- a/ax/benchmark/tests/test_problems.py
+++ b/ax/benchmark/tests/test_problems.py
@@ -16,3 +16,22 @@ class TestProblems(TestCase):
                 continue  # Skip these as they cause the test to take a long time
 
             get_problem(problem_name=name)
+
+    def test_name(self) -> None:
+        expected_names = [
+            ("branin", "Branin"),
+            ("hartmann3", "Hartmann_3d"),
+            ("hartmann6", "Hartmann_6d"),
+            ("hartmann30", "Hartmann_30d"),
+            ("branin_currin_fixed_noise", "BraninCurrin_fixed_noise"),
+            ("branin_currin30_fixed_noise", "BraninCurrin_fixed_noise_30d"),
+            ("levy4", "Levy_4d"),
+        ]
+        for registry_key, problem_name in expected_names:
+            problem = get_problem(problem_name=registry_key)
+            self.assertEqual(problem.name, problem_name)
+
+    def test_no_duplicates(self) -> None:
+        keys = [elt for elt in BENCHMARK_PROBLEM_REGISTRY.keys() if "MNIST" not in elt]
+        names = {get_problem(problem_name=key).name for key in keys}
+        self.assertEqual(len(keys), len(names))


### PR DESCRIPTION
Summary:
Addresses T156379332

Several `Problem`s in the registry currently have the same `name` attribute, which means that they get logged to `ae_benchmark` and `ae_benchmark_raw` with the same `problem` key and can't be distinguished.

[x] Add `_fixed_noise` to the names of the fixed noise problems.
[x] Add dimensionality to 3d and 6d Hartmann problems, the same way dimensionality is noted for other variable-dimensional problems, so these can be differentiated

Differential Revision: D46881455

