### PR TITLE
delete empty file

### DIFF
--- a/ax/plot/benchmark.py
+++ b/ax/plot/benchmark.py
@@ -1,4 +1,0 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary: The previous diff had a scary warning that tests don't run on diffs that delete files, so I should empty the file and then delete it in a subsequent diff.

Differential Revision: D46921251

