### PR TITLE
Catch error when trying to mark trial as running after deployment

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -642,9 +642,10 @@ class BaseTrial(ABC, SortableBase):
         """Mark trial has started running.
 
         Args:
-            no_runner_required: Whether to skip the check for presence of a ``Runner``
-            on experiment.
+            no_runner_required: Whether to skip the check for presence of a
+                ``Runner`` on the experiment.
             unsafe: Ignore sanity checks on state transitions.
+
         Returns:
             The trial instance.
         """

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1474,7 +1474,13 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         def _process_trial(trial):
             if trial.index in metadata:
                 trial.update_run_metadata(metadata=metadata[trial.index])
-                trial.mark_running(no_runner_required=True)
+                try:
+                    trial.mark_running(no_runner_required=True)
+                except ValueError as e:
+                    self.logger.warn(
+                        "Unable to mark trial as RUNNING due to the following error:\n"
+                        + str(e)
+                    )
             else:
                 self.logger.debug(
                     f"Trial {trial.index} did not deploy, status: {trial.status}."


### PR DESCRIPTION
Summary:
In some situations a trial may be in a status that is incompatible with being
marked as RUNNING (e.g. CANDIDATE) status when processed in the Scheduler here:
https://github.com/facebook/Ax/blob/main/ax/service/scheduler.py#L1477

This may happen e.g. if the deployment in the Runner fails and the trial is
marked as FAILED.

This diff wraps the marking to RUNNNING in a try/except and logs a warning.

An alternative design would be to mark the trials that fail to deploy (e.g.
b/c of infra issues) not as FAILED but as CANDIDATES and pass richer
information to the Scheduler to be able to decide to retry deploying the trial
at a later time. This would require additional work though, and it's also not
clear whether it's the right thing to do (the trial may be stale at the next
deployment attempt).

Reviewed By: bernardbeckerman

Differential Revision: D46959540

