### PR TITLE
Model fit metrics for logging

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -12,8 +12,9 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 
 from logging import Logger
-from typing import Any, Dict, List, MutableMapping, Optional, Set, Tuple, Type
+from typing import Any, cast, Dict, List, MutableMapping, Optional, Set, Tuple, Type
 
+import numpy as np
 from ax.core.arm import Arm
 from ax.core.data import Data
 from ax.core.experiment import Experiment
@@ -36,6 +37,13 @@ from ax.modelbridge.transforms.cast import Cast
 from ax.models.types import TConfig
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast, not_none
+from ax.utils.stats.model_fit_stats import (
+    coefficient_of_determination,
+    compute_model_fit_metrics,
+    mean_of_the_standardized_error,
+    ModelFitMetricProtocol,
+    std_of_the_standardized_error,
+)
 from botorch.exceptions.warnings import InputDataWarning
 
 logger: Logger = get_logger(__name__)
@@ -918,6 +926,51 @@ class ModelBridge(ABC):
         """
         raise NotImplementedError  # pragma: no cover
 
+    def compute_model_fit_metrics(
+        self,
+        experiment: Experiment,
+        fit_metrics_dict: Optional[Dict[str, ModelFitMetricProtocol]] = None,
+    ) -> Dict[str, Dict[str, float]]:
+        """Computes the model fit metrics from the scheduler state.
+
+        Args:
+            experiment: The experiment with whose data to compute the model fit metrics.
+            fit_metrics_dict: An optional dictionary with model fit metric functions,
+            i.e. a ModelFitMetricProtocol, as values and their names as keys.
+
+        Returns:
+            A nested dictionary mapping from the *model fit* metric names and the
+            *experimental metric* names to the values of the model fit metrics.
+
+            Example for an imaginary AutoML experiment that seeks to minimize the test
+            error after training an expensive model, with respect to hyper-parameters:
+
+            ```
+            model_fit_dict = model_fit_metrics_from_scheduler(scheduler)
+            model_fit_dict["coefficient_of_determination"]["test error"] =
+                `coefficient of determination of the test error predictions`
+            ```
+        """
+        # TODO: cross_validate_by_trial-based generalization quality
+        # IDEA: store y_obs, y_pred, se_pred as well
+        y_obs, y_pred, se_pred = _predict_on_training_data(
+            model_bridge=self, experiment=experiment
+        )
+        if fit_metrics_dict is None:
+            fit_metrics_dict = {
+                "coefficient_of_determination": coefficient_of_determination,
+                "mean_of_the_standardized_error": mean_of_the_standardized_error,
+                "std_of_the_standardized_error": std_of_the_standardized_error,
+            }
+            fit_metrics_dict = cast(Dict[str, ModelFitMetricProtocol], fit_metrics_dict)
+
+        return compute_model_fit_metrics(
+            y_obs=y_obs,
+            y_pred=y_pred,
+            se_pred=se_pred,
+            fit_metrics_dict=fit_metrics_dict,
+        )
+
     def _set_kwargs_to_save(
         self,
         model_key: str,
@@ -1099,3 +1152,56 @@ def clamp_observation_features(
                 )
                 obsf.parameters[p.name] = p.upper
     return observation_features
+
+
+"""
+############################## Model Fit Metrics Utils ##############################
+"""
+
+
+def _predict_on_training_data(
+    model_bridge: ModelBridge,
+    experiment: Experiment,
+) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray], Dict[str, np.ndarray],]:
+    """Makes predictions on the training data of a given experiment using a ModelBridge
+    and returning the observed values, and the corresponding predictive means and
+    predictive standard deviations of the model.
+
+     NOTE: This is a helper function for `ModelBridge.compute_model_fit_metrics` and
+    could be attached to the class.
+
+    Args:
+        model_bridge: A ModelBridge object with which to make predictions.
+        experiment: The experiment with whose data to compute the model fit metrics.
+
+    Returns:
+        A tuple containing three dictionaries for 1) observed metric values, and the
+        model's associated 2) predictive means and 3) predictive standard deviations.
+    """
+    data = experiment.fetch_data()
+    observations = observations_from_data(
+        experiment=experiment, data=data
+    )  # List[Observation]
+    observation_features = [obs.features for obs in observations]
+    mean_predicted, cov_predicted = model_bridge.predict(
+        observation_features=observation_features
+    )  # Dict[str, List[float]]
+    mean_observed = [
+        obs.data.means_dict for obs in observations
+    ]  # List[Dict[str, float]]
+    metric_names = list(data.metric_names)
+    mean_observed = _list_of_dicts_to_dict_of_lists(
+        list_of_dicts=mean_observed, keys=metric_names
+    )
+    # converting dictionary values to arrays
+    mean_observed = {k: np.array(v) for k, v in mean_observed.items()}
+    mean_predicted = {k: np.array(v) for k, v in mean_predicted.items()}
+    std_predicted = {m: np.sqrt(np.array(cov_predicted[m][m])) for m in cov_predicted}
+    return mean_observed, mean_predicted, std_predicted
+
+
+def _list_of_dicts_to_dict_of_lists(
+    list_of_dicts: List[Dict[str, float]], keys: List[str]
+) -> Dict[str, List[float]]:
+    """Converts a list of dicts indexed by a string to a dict of lists."""
+    return {key: [d[key] for d in list_of_dicts] for key in keys}

--- a/ax/modelbridge/tests/test_model_fit_metrics.py
+++ b/ax/modelbridge/tests/test_model_fit_metrics.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import cast, Dict
+
+from ax.core.experiment import Experiment
+from ax.core.objective import Objective
+from ax.core.optimization_config import OptimizationConfig
+from ax.metrics.branin import BraninMetric
+from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.registry import Models
+from ax.runners.synthetic import SyntheticRunner
+from ax.service.scheduler import get_fitted_model_bridge, Scheduler, SchedulerOptions
+from ax.utils.common.constants import Keys
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_branin_search_space
+
+NUM_SOBOL = 5
+
+
+class TestModelBridgeFitMetrics(TestCase):
+    def setUp(self) -> None:
+        # setting up experiment and generation strategy
+        self.runner = SyntheticRunner()
+        self.branin_experiment = Experiment(
+            name="branin_test_experiment",
+            search_space=get_branin_search_space(),
+            runner=self.runner,
+            optimization_config=OptimizationConfig(
+                objective=Objective(
+                    metric=BraninMetric(name="branin", param_names=["x1", "x2"]),
+                    minimize=True,
+                ),
+            ),
+            is_test=True,
+        )
+        self.branin_experiment._properties[
+            Keys.IMMUTABLE_SEARCH_SPACE_AND_OPT_CONF
+        ] = True
+        self.generation_strategy = GenerationStrategy(
+            steps=[
+                GenerationStep(
+                    model=Models.SOBOL, num_trials=NUM_SOBOL, max_parallelism=NUM_SOBOL
+                ),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+
+    def test_model_fit_metrics(self) -> None:
+        scheduler = Scheduler(
+            experiment=self.branin_experiment,
+            generation_strategy=self.generation_strategy,
+            options=SchedulerOptions(),
+        )
+        # need to run some trials to initialize the ModelBridge
+        scheduler.run_n_trials(max_trials=NUM_SOBOL + 1)
+        model_bridge = get_fitted_model_bridge(scheduler)
+
+        # testing ModelBridge.compute_model_fit_metrics with default metrics
+        fit_metrics = model_bridge.compute_model_fit_metrics(self.branin_experiment)
+        r2 = fit_metrics.get("coefficient_of_determination")
+        self.assertIsInstance(r2, dict)
+        r2 = cast(Dict[str, float], r2)
+        self.assertTrue("branin" in r2)
+        r2_branin = r2["branin"]
+        self.assertIsInstance(r2_branin, float)
+
+        std = fit_metrics.get("std_of_the_standardized_error")
+        self.assertIsInstance(std, dict)
+        std = cast(Dict[str, float], std)
+        self.assertTrue("branin" in std)
+        std_branin = std["branin"]
+        self.assertIsInstance(std_branin, float)
+
+        # testing with empty metrics
+        empty_metrics = model_bridge.compute_model_fit_metrics(
+            self.branin_experiment, fit_metrics_dict={}
+        )
+        self.assertIsInstance(empty_metrics, dict)
+        self.assertTrue(len(empty_metrics) == 0)

--- a/ax/telemetry/ax_client.py
+++ b/ax/telemetry/ax_client.py
@@ -106,8 +106,8 @@ class AxClientCompletedRecord:
             experiment_completed_record=ExperimentCompletedRecord.from_experiment(
                 experiment=ax_client.experiment
             ),
-            best_point_quality=-1,  # TODO[T147907632]
-            model_fit_quality=-1,  # TODO[T147907632]
+            best_point_quality=float("-inf"),  # TODO[T147907632]
+            model_fit_quality=float("-inf"),  # TODO[T147907632]
         )
 
     def flatten(self) -> Dict[str, Any]:

--- a/ax/telemetry/optimization.py
+++ b/ax/telemetry/optimization.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from ax.service.ax_client import AxClient
 from ax.service.scheduler import Scheduler
@@ -340,7 +340,7 @@ class OptimizationCompletedRecord:
             total_fit_time=experiment_completed_record.total_fit_time,
             total_gen_time=experiment_completed_record.total_gen_time,
             best_point_quality=scheduler_completed_record.best_point_quality,
-            model_fit_quality=scheduler_completed_record.model_fit_quality,
+            **_extract_model_fit_dict(scheduler_completed_record),
             num_metric_fetch_e_encountered=(
                 scheduler_completed_record.num_metric_fetch_e_encountered
             ),
@@ -384,7 +384,7 @@ class OptimizationCompletedRecord:
             total_fit_time=experiment_completed_record.total_fit_time,
             total_gen_time=experiment_completed_record.total_gen_time,
             best_point_quality=ax_client_completed_record.best_point_quality,
-            model_fit_quality=ax_client_completed_record.model_fit_quality,
+            **_extract_model_fit_dict(ax_client_completed_record),
             unique_identifier=unique_identifier,
             deployed_job_id=deployed_job_id,
             estimated_early_stopping_savings=estimated_early_stopping_savings,
@@ -393,3 +393,12 @@ class OptimizationCompletedRecord:
             num_metric_fetch_e_encountered=-1,
             num_trials_bad_due_to_err=-1,
         )
+
+
+def _extract_model_fit_dict(
+    completed_record: Union[SchedulerCompletedRecord, AxClientCompletedRecord],
+) -> Dict[str, float]:
+    model_fit_names = [
+        "model_fit_quality",  # TODO: add calibration, generalization.
+    ]
+    return {n: getattr(completed_record, n) for n in model_fit_names}

--- a/ax/telemetry/tests/test_ax_client.py
+++ b/ax/telemetry/tests/test_ax_client.py
@@ -118,7 +118,7 @@ class TestAxClient(TestCase):
             experiment_completed_record=ExperimentCompletedRecord.from_experiment(
                 experiment=ax_client.experiment
             ),
-            best_point_quality=-1,
-            model_fit_quality=-1,
+            best_point_quality=float("-inf"),
+            model_fit_quality=float("-inf"),
         )
         self.assertEqual(record, expected)

--- a/ax/telemetry/tests/test_scheduler.py
+++ b/ax/telemetry/tests/test_scheduler.py
@@ -4,13 +4,25 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ax.service.scheduler import Scheduler, SchedulerOptions
+from typing import cast, Dict
+
+from ax.core.experiment import Experiment
+from ax.core.objective import Objective
+from ax.core.optimization_config import OptimizationConfig
+from ax.metrics.branin import BraninMetric
+from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.registry import Models
+from ax.runners.synthetic import SyntheticRunner
+from ax.service.scheduler import get_fitted_model_bridge, Scheduler, SchedulerOptions
 from ax.telemetry.experiment import ExperimentCompletedRecord, ExperimentCreatedRecord
 from ax.telemetry.generation_strategy import GenerationStrategyCreatedRecord
 from ax.telemetry.scheduler import SchedulerCompletedRecord, SchedulerCreatedRecord
+from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_branin_experiment
+from ax.utils.testing.core_stubs import get_branin_experiment, get_branin_search_space
 from ax.utils.testing.modeling_stubs import get_generation_strategy
+
+NUM_SOBOL = 5
 
 
 class TestScheduler(TestCase):
@@ -78,8 +90,8 @@ class TestScheduler(TestCase):
             experiment_completed_record=ExperimentCompletedRecord.from_experiment(
                 experiment=scheduler.experiment
             ),
-            best_point_quality=-1,
-            model_fit_quality=-1,
+            best_point_quality=float("-inf"),
+            model_fit_quality=float("-inf"),  # -inf because no model has been fit
             num_metric_fetch_e_encountered=0,
             num_trials_bad_due_to_err=0,
         )
@@ -90,8 +102,88 @@ class TestScheduler(TestCase):
             **ExperimentCompletedRecord.from_experiment(
                 experiment=scheduler.experiment
             ).__dict__,
-            "best_point_quality": -1,
-            "model_fit_quality": -1,
+            "best_point_quality": float("-inf"),
+            "model_fit_quality": float("-inf"),
+            "num_metric_fetch_e_encountered": 0,
+            "num_trials_bad_due_to_err": 0,
+        }
+        self.assertEqual(flat, expected_dict)
+
+    def test_scheduler_model_fit_metrics_logging(self) -> None:
+        # set up for model fit metrics
+        branin_experiment = Experiment(
+            name="branin_test_experiment",
+            search_space=get_branin_search_space(),
+            runner=SyntheticRunner(),
+            optimization_config=OptimizationConfig(
+                objective=Objective(
+                    metric=BraninMetric(name="branin", param_names=["x1", "x2"]),
+                    minimize=True,
+                ),
+            ),
+            is_test=True,
+        )
+        branin_experiment._properties[Keys.IMMUTABLE_SEARCH_SPACE_AND_OPT_CONF] = True
+        generation_strategy = GenerationStrategy(
+            steps=[
+                GenerationStep(
+                    model=Models.SOBOL, num_trials=NUM_SOBOL, max_parallelism=NUM_SOBOL
+                ),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+
+        # starting proper tests
+        scheduler = Scheduler(
+            experiment=branin_experiment,
+            generation_strategy=generation_strategy,
+            options=SchedulerOptions(),
+        )
+        # Trying to attain a record without any trials yields an error in ModelFitRecord
+        # and a warning in SchedulerCompletedRecord.
+
+        scheduler.run_n_trials(max_trials=NUM_SOBOL + 1)
+
+        # end-to-end test with Scheduler
+        record = SchedulerCompletedRecord.from_scheduler(scheduler=scheduler)
+        model_bridge = get_fitted_model_bridge(scheduler)
+        fit_metrics = model_bridge.compute_model_fit_metrics(
+            experiment=scheduler.experiment
+        )
+        r2 = fit_metrics.get("coefficient_of_determination")
+        self.assertIsInstance(r2, dict)
+        r2 = cast(Dict[str, float], r2)
+        self.assertTrue("branin" in r2)
+        r2_branin = r2["branin"]
+        self.assertIsInstance(r2_branin, float)
+
+        std = fit_metrics.get("std_of_the_standardized_error")
+        self.assertIsInstance(std, dict)
+        std = cast(Dict[str, float], std)
+        self.assertTrue("branin" in std)
+        std_branin = std["branin"]
+        self.assertIsInstance(std_branin, float)
+        # log_std_branin = math.log10(std_branin)
+        # model_std_quality = -log_std_branin  # align positivity with over-estimation
+
+        expected = SchedulerCompletedRecord(
+            experiment_completed_record=ExperimentCompletedRecord.from_experiment(
+                experiment=scheduler.experiment
+            ),
+            best_point_quality=float("-inf"),
+            model_fit_quality=r2_branin,
+            num_metric_fetch_e_encountered=0,
+            num_trials_bad_due_to_err=0,
+        )
+        self.assertEqual(record, expected)
+
+        flat = record.flatten()
+        expected_dict = {
+            **ExperimentCompletedRecord.from_experiment(
+                experiment=scheduler.experiment
+            ).__dict__,
+            "best_point_quality": float("-inf"),
+            "model_fit_quality": r2_branin,
             "num_metric_fetch_e_encountered": 0,
             "num_trials_bad_due_to_err": 0,
         }

--- a/ax/utils/stats/model_fit_stats.py
+++ b/ax/utils/stats/model_fit_stats.py
@@ -1,0 +1,183 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Mapping, Optional, Protocol
+
+import numpy as np
+from scipy.stats import fisher_exact, norm, pearsonr, spearmanr
+
+"""
+################################ Model Fit Metrics ###############################
+"""
+
+
+class ModelFitMetricProtocol(Protocol):
+    """Structural type for model fit metrics."""
+
+    @staticmethod
+    def __call__(y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray) -> float:
+        pass  # pragma: no cover  # pyre-ignore[7]
+
+
+def compute_model_fit_metrics(
+    y_obs: Mapping[str, np.ndarray],
+    y_pred: Mapping[str, np.ndarray],
+    se_pred: Mapping[str, np.ndarray],
+    fit_metrics_dict: Mapping[str, ModelFitMetricProtocol],
+) -> Dict[str, Dict[str, float]]:
+    """Computes the model fit metrics for each experimental metric in the input dicts.
+
+    Args:
+        y_obs: A dictionary mapping from experimental metric name to observed values.
+        y_pred: A dictionary mapping from experimental metric name to predicted values.
+        se_pred: A dictionary mapping from experimental metric name to predicted
+            standard errors.
+        fit_metrics_dict: A dictionary mapping from *model fit* metric name to a
+            ModelFitMetricProtocol function that evaluates a model fit metric.
+
+    Returns:
+        A nested dictionary mapping from *model fit* and *experimental* metric names
+        to their corresponding model fit metrics values.
+    """
+    metric_names = list(y_obs.keys())
+    return {
+        fit_metric_name: {
+            exp_metric_name: fit_metric(
+                y_obs=y_obs[exp_metric_name],
+                y_pred=y_pred[exp_metric_name],
+                se_pred=se_pred[exp_metric_name],
+            )
+            for exp_metric_name in metric_names
+        }
+        for fit_metric_name, fit_metric in fit_metrics_dict.items()
+    }
+
+
+def coefficient_of_determination(
+    y_obs: np.ndarray,
+    y_pred: np.ndarray,
+    se_pred: Optional[np.ndarray] = None,
+    eps: float = 1e-12,
+) -> float:
+    """Computes coefficient of determination, the proportion of variance in `y_obs`
+    accounted for by predictions `y_pred`.
+
+    Args:
+        y_obs: An array of observations for a single metric.
+        y_pred: An array of the predicted values corresponding to y_obs.
+        se_pred: Not used, kept for API compatibility.
+        eps: A small constant to add to the denominator for numerical stability.
+
+    Returns:
+        The scalar coefficient of determination, "R squared".
+    """
+    ss_res = ((y_obs - y_pred) ** 2).sum()
+    ss_tot = ((y_obs - y_obs.mean()) ** 2).sum()
+    return 1 - (ss_res / (ss_tot + eps))
+
+
+def mean_of_the_standardized_error(  # i.e. standardized bias
+    y_obs: np.ndarray,
+    y_pred: np.ndarray,
+    se_pred: np.ndarray,
+) -> float:
+    """Computes the mean of the error standardized by the predictive standard deviation
+    of the model `se_pred`. If the model makes good predictions and its uncertainty is
+    quantified well, should be close to 0 and be normally distributed.
+
+    NOTE: This assumes that `se_pred` is the predictive standard deviation of the
+    *observations* of the objective `y`, not the predictive standard deviation of the
+    objective `f` itself. In practice, this will matter for very noisy observations.
+
+    Args:
+        y_obs: An array of observations for a single metric.
+        y_pred: An array of the predicted values corresponding to y_obs.
+        se_pred: An array of the standard errors of the predicted values.
+
+    Returns:
+        The scalar mean of the standardized error.
+    """
+    return ((y_obs - y_pred) / se_pred).mean()
+
+
+def std_of_the_standardized_error(
+    y_obs: np.ndarray,
+    y_pred: np.ndarray,
+    se_pred: np.ndarray,
+) -> float:
+    """Standard deviation of the error standardized by the predictive standard deviation
+    of the model `se_pred`. If the uncertainty is quantified well, should be close to 1.
+
+    NOTE: This assumes that `se_pred` is the predictive standard deviation of the
+    *observations* of the objective `y`, not the predictive standard deviation of the
+    objective `f` itself. In practice, this will matter for very noisy observations.
+
+    Args:
+        y_obs: An array of observations for a single metric.
+        y_pred: An array of the predicted values corresponding to y_obs.
+        se_pred: An array of the standard errors of the predicted values.
+
+    Returns:
+        The scalar standard deviation of the standardized error.
+    """
+    return ((y_obs - y_pred) / se_pred).std()
+
+
+def _mean_prediction_ci(
+    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+) -> float:
+    # Pyre does not allow float * np.ndarray.
+    return float(np.mean(1.96 * 2 * se_pred / np.abs(y_obs)))
+
+
+def _log_likelihood(
+    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+) -> float:
+    return float(np.sum(norm.logpdf(y_obs, loc=y_pred, scale=se_pred)))
+
+
+def _mape(y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray) -> float:
+    """Mean absolute predictive error"""
+    return float(np.mean(np.abs((y_pred - y_obs) / y_obs)))
+
+
+def _total_raw_effect(
+    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+) -> float:
+    min_y_obs = np.min(y_obs)
+    return float((np.max(y_obs) - min_y_obs) / min_y_obs)
+
+
+def _correlation_coefficient(
+    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+) -> float:
+    with np.errstate(invalid="ignore"):
+        rho, _ = pearsonr(y_pred, y_obs)
+    return float(rho)
+
+
+def _rank_correlation(
+    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+) -> float:
+    with np.errstate(invalid="ignore"):
+        rho, _ = spearmanr(y_pred, y_obs)
+    return float(rho)
+
+
+def _fisher_exact_test_p(
+    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+) -> float:
+    n_half = len(y_obs) // 2
+    top_obs = y_obs.argsort(axis=0)[-n_half:]
+    top_est = y_pred.argsort(axis=0)[-n_half:]
+    # Construct contingency table
+    tp = len(set(top_est).intersection(top_obs))
+    fp = n_half - tp
+    fn = n_half - tp
+    tn = (len(y_obs) - n_half) - (n_half - tp)
+    table = np.array([[tp, fp], [fn, tn]])
+    # Compute the test statistic
+    _, p = fisher_exact(table, alternative="greater")
+    return float(p)

--- a/sphinx/source/utils.rst
+++ b/sphinx/source/utils.rst
@@ -213,6 +213,14 @@ Statstools
     :undoc-members:
     :show-inheritance:
 
+Model Fit Metrics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.stats.model_fit_stats
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Storage
 ---------------
 


### PR DESCRIPTION
Summary: This commit adds metrics in order to quantify and log model fit quality for each *experimental* metric. The commit adds metrics based on the posterior statistics of the model, which can be extended readily by adding to the `fit_metrics` dict, and can be generalized with other metric types in follow up work.

Differential Revision: D46816506

