### PR TITLE
Benchmarks: restore some deleted functionality

### DIFF
--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -75,6 +75,9 @@ class TestBenchmark(TestCase):
             "All experiments must have 4 trials",
         )
 
+        for col in ["mean", "P25", "P50", "P75"]:
+            self.assertTrue((agg.score_trace[col] <= 100).all())
+
     @fast_botorch_optimize
     def test_full_run(self) -> None:
         aggs = benchmark_full_run(
@@ -84,6 +87,10 @@ class TestBenchmark(TestCase):
         )
 
         self.assertEqual(len(aggs), 2)
+
+        for agg in aggs:
+            for col in ["mean", "P25", "P50", "P75"]:
+                self.assertTrue((agg.score_trace[col] <= 100).all())
 
     def test_timeout(self) -> None:
         problem = SingleObjectiveBenchmarkProblem.from_botorch_synthetic(


### PR DESCRIPTION
Summary: Put percentiles back into AggregatedBenchmarkResult since Sait is using them

Reviewed By: Balandat

Differential Revision: D46921900

