### PR TITLE
Allow customizing timeout hours in get_sequential_optimization_scheduler_options

### DIFF
--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -25,14 +25,20 @@ class BenchmarkMethod(Base):
     scheduler_options: SchedulerOptions
 
 
-def get_sequential_optimization_scheduler_options() -> SchedulerOptions:
-    """The typical SchedulerOptions used in benchmarking."""
+def get_sequential_optimization_scheduler_options(
+    timeout_hours: int = 4,
+) -> SchedulerOptions:
+    """The typical SchedulerOptions used in benchmarking.
+
+    Args:
+        timeout_hours: The maximum amount of time (in hours) to run each
+            benchmark replication. Defaults to 4 hours.
+    """
     return SchedulerOptions(
         # Enforce sequential trials by default
         max_pending_trials=1,
         # Do not throttle, as is often necessary when polling real endpoints
         init_seconds_between_polls=0,
         min_seconds_before_poll=0,
-        # Time the experiment out after 4 hours
-        timeout_hours=4,
+        timeout_hours=timeout_hours,
     )

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -3,10 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ax.benchmark.benchmark_method import BenchmarkMethod
+from ax.benchmark.benchmark_method import (
+    BenchmarkMethod,
+    get_sequential_optimization_scheduler_options,
+)
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
-from ax.service.scheduler import SchedulerOptions
 from ax.utils.common.testutils import TestCase
 
 
@@ -21,10 +23,20 @@ class TestBenchmarkMethod(TestCase):
             ],
             name="SOBOL",
         )
-        options = SchedulerOptions(total_trials=10)
+        options = get_sequential_optimization_scheduler_options()
         method = BenchmarkMethod(
             name="Sobol10", generation_strategy=gs, scheduler_options=options
         )
 
         self.assertEqual(method.generation_strategy, gs)
         self.assertEqual(method.scheduler_options, options)
+        self.assertEqual(options.max_pending_trials, 1)
+        self.assertEqual(options.init_seconds_between_polls, 0)
+        self.assertEqual(options.min_seconds_before_poll, 0)
+        self.assertEqual(options.timeout_hours, 4)
+
+        options = get_sequential_optimization_scheduler_options(timeout_hours=10)
+        method = BenchmarkMethod(
+            name="Sobol10", generation_strategy=gs, scheduler_options=options
+        )
+        self.assertEqual(method.scheduler_options.timeout_hours, 10)


### PR DESCRIPTION
Summary: This is useful for custom benchmark runs where we know things will take longer than 4 hours to run.

Reviewed By: esantorella

Differential Revision: D47133668

