### PR TITLE
Minor fix in Acquisition.optimize

### DIFF
--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -425,8 +425,9 @@ class Acquisition(Base):
                     raise ValueError(f"Invalid fixed_feature index: {i}")
 
         # 1. Handle the fully continuous search space.
-        if not discrete_features or optimizer_options_with_defaults.pop(
-            "force_use_optimize_acqf", False
+        if (
+            optimizer_options_with_defaults.pop("force_use_optimize_acqf", False)
+            or not discrete_features
         ):
             return optimize_acqf(
                 acq_function=self.acqf,

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -287,6 +287,8 @@ class AcquisitionTest(TestCase):
         post_processing_func = Mock(side_effect=lambda x: x**2)
         optimizer_options = self.optimizer_options.copy()
         optimizer_options["post_processing_func"] = post_processing_func
+        # Check that `force_use_optimize_acqf` does not lead to errors.
+        optimizer_options["force_use_optimize_acqf"] = True
         mock_optimize_acqf.reset_mock()
         acquisition.optimize(
             n=3,


### PR DESCRIPTION
Summary: Swaps the order of `force_use_optimize_acqf` and `discrete_features` checks to make sure `force_use_optimize_acqf` is never passed down to `optimize_acqf` (which triggers errors).

Differential Revision: D47276368

