### PR TITLE
Allow passing jit_compile as part of mll_options

### DIFF
--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -273,11 +273,16 @@ def fit_botorch_model(
     mll_options: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Fit a BoTorch model."""
+    mll_options = mll_options or {}
     models = model.models if isinstance(model, ModelList) else [model]
     for m in models:
         # TODO: Support deterministic models when we support `ModelList`
         if is_fully_bayesian(m):
-            fit_fully_bayesian_model_nuts(m, disable_progbar=True)
+            fit_fully_bayesian_model_nuts(
+                m,
+                disable_progbar=True,
+                jit_compile=mll_options.get("jit_compile", False),
+            )
         elif isinstance(m, (GPyTorchModel, PairwiseGP)):
             mll_options = mll_options or {}
             mll = mll_class(likelihood=m.likelihood, model=m, **mll_options)

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -104,8 +104,14 @@ class SurrogateTest(TestCase):
     def _get_surrogate(
         self, botorch_model_class: Type[Model]
     ) -> Tuple[Surrogate, Dict[str, Any]]:
+        if botorch_model_class is SaasFullyBayesianSingleTaskGP:
+            mll_options = {"jit_compile": True}
+        else:
+            mll_options = None
         surrogate = Surrogate(
-            botorch_model_class=botorch_model_class, mll_class=self.mll_class
+            botorch_model_class=botorch_model_class,
+            mll_class=self.mll_class,
+            mll_options=mll_options,
         )
         surrogate_kwargs = botorch_model_class.construct_inputs(self.training_data[0])
         return surrogate, surrogate_kwargs
@@ -440,6 +446,8 @@ class SurrogateTest(TestCase):
             mock_state_dict.assert_not_called()
             mock_fit.assert_called_once()
             mock_state_dict.reset_mock()
+            if botorch_model_class is SaasFullyBayesianSingleTaskGP:
+                self.assertTrue(mock_fit.call_kwargs["jit_compile"])
             mock_MLL.reset_mock()
             mock_fit.reset_mock()
             # Check that the optional original_metric_names arg propagates


### PR DESCRIPTION
Summary:
Currently, we cannot specify `jit_compile` in MBM when fitting fully-Bayesian models. Since this is an argument exposed in `choose_generation_strategy`, we need to support it :)

This uses `mll_options` to pass in the arg, which avoids adding a new field to `SurrogateSpec`. Another option is to add a `model_fit_kwargs` field to `SurrogateSpec` and pass this down to `fit_botorch_model` and use it for both fully-Bayesian and other models from there. Happy to implement that if that's preferred.

Reviewed By: dme65

Differential Revision: D47349459

