### PR TITLE
`ax_parameter_sens` with a multi-outcome `Surrogate`

### DIFF
--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -81,6 +81,8 @@ def align_partial_results(
     for tidx in df.index.levels[0]:  # this could be slow if there are many trials
         for metric in df.index.levels[1]:
             # grab trial+metric sub-df and reindex to common index
+            # NOTE (FIXME?): The following line can lead to a
+            # "PerformanceWarning: indexing past lexsort depth may impact performance."
             df_ridx = df.loc[(tidx, metric)].reindex(index_union)
             # interpolate / fill missing results
             # TODO: Allow passing of additional kwargs to `interpolate`

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -395,7 +395,7 @@ def get_standard_plots(
                         '<a href="https://en.wikipedia.org/wiki/Variance-based_'
                         'sensitivity_analysis">Variance-based sensitivity analysis</a>'
                     )
-                except NotImplementedError as e:
+                except Exception as e:
                     logger.info(f"Failed to compute global feature sensitivities: {e}")
             feature_importance_plot = plot_feature_importance_by_feature_plotly(
                 model=model,
@@ -413,7 +413,7 @@ def get_standard_plots(
             )
             output_plot_list.append(feature_importance_plot)
             output_plot_list.append(interact_fitted_plotly(model=model, rel=False))
-        except (NotImplementedError, AttributeError) as e:
+        except Exception as e:
             logger.exception(f"Feature importance plot failed with error: {e}")
 
     # Get plots for MapMetrics

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -16,6 +16,7 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.sensitivity.derivative_gp import posterior_derivative
 from ax.utils.sensitivity.derivative_measures import GpDGSMGpMean, GpDGSMGpSampling
 from ax.utils.sensitivity.sobol_measures import (
+    _get_input_dimensionality,
     _get_model_per_metric,
     ax_parameter_sens,
     compute_sobol_indices_from_model_list,
@@ -213,7 +214,7 @@ class SensitivityAnanlysisTest(TestCase):
             if not modular:
                 with self.assertRaisesRegex(
                     NotImplementedError,
-                    "but only IndependentModelList is supported",
+                    "but only ModelList is supported",
                 ):
                     # only applies if the number of outputs of model is greater than 1
                     with patch.object(
@@ -224,9 +225,12 @@ class SensitivityAnanlysisTest(TestCase):
                         mock.return_value = 2
                         ax_parameter_sens(model_bridge, model_bridge.outcomes)
 
-                # since only IndependentModelList is supported for BotorchModel:
+                # since only ModelList is supported for BotorchModel:
                 gpytorch_model = ModelListGP(cast(GPyTorchModel, torch_model.model))
                 torch_model.model = gpytorch_model
+
+                input_dim = _get_input_dimensionality(gpytorch_model)
+                self.assertEqual(input_dim, 2)
 
             for order in ["first", "total"]:
                 with self.subTest(order=order):


### PR DESCRIPTION
Summary: This commit introduces support for `Surrogate` objects with multiple outcomes by applying `subset_outcome` to the corresponding BoTorch `Model`.

Differential Revision: D47339090

