### PR TITLE
Use delta in assertAlmostEqual

### DIFF
--- a/ax/models/tests/test_eb_thompson.py
+++ b/ax/models/tests/test_eb_thompson.py
@@ -93,7 +93,7 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
             for weight, expected_weight in zip(
                 weights, [4 * i for i in [0.66, 0.25, 0.07, 0.02]]
             ):
-                self.assertAlmostEqual(weight, expected_weight, 1)
+                self.assertAlmostEqual(weight, expected_weight, delta=0.1)
 
     def testEmpiricalBayesThompsonSamplerWarning(self) -> None:
         generator = EmpiricalBayesThompsonSampler(min_weight=0.0)


### PR DESCRIPTION
Summary: Expected weight is always within .1

Reviewed By: mpolson64

Differential Revision: D47551158

