### PR TITLE
Enable `qLogNEI` by default for modular `BoTorchModels`

### DIFF
--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -305,6 +305,7 @@ def _get_acquisition_func(
         objective = constrained_mc_objective(
             objective=objective, constraints=con_tfs or [], infeasible_cost=inf_cost
         )
+    # TODO: Either pass `con_tfs` to `get_acquisition_function` or move to MBM.
     return get_acquisition_function(
         acquisition_function_name=acquisition_function_name,
         model=model,

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -17,7 +17,7 @@ from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast
 from botorch.acquisition.acquisition import AcquisitionFunction
-from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
+from botorch.acquisition.logei import qLogNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
     qNoisyExpectedHypervolumeImprovement,
 )
@@ -160,7 +160,7 @@ def choose_botorch_acqf_class(
     ):
         acqf_class = qNoisyExpectedHypervolumeImprovement
     else:
-        acqf_class = qNoisyExpectedImprovement
+        acqf_class = qLogNoisyExpectedImprovement
 
     logger.debug(f"Chose BoTorch acquisition function class: {acqf_class}.")
     return acqf_class

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -25,7 +25,7 @@ from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast
 from ax.utils.testing.torch_stubs import get_torch_test_data
-from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
+from botorch.acquisition import qLogNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
     qNoisyExpectedHypervolumeImprovement,
 )
@@ -194,7 +194,7 @@ class BoTorchModelUtilsTest(TestCase):
         )
 
     def test_choose_botorch_acqf_class(self) -> None:
-        self.assertEqual(qNoisyExpectedImprovement, choose_botorch_acqf_class())
+        self.assertEqual(qLogNoisyExpectedImprovement, choose_botorch_acqf_class())
         self.assertEqual(
             qNoisyExpectedHypervolumeImprovement,
             choose_botorch_acqf_class(objective_thresholds=self.objective_thresholds),
@@ -204,7 +204,7 @@ class BoTorchModelUtilsTest(TestCase):
             choose_botorch_acqf_class(objective_weights=torch.tensor([0.5, 0.5])),
         )
         self.assertEqual(
-            qNoisyExpectedImprovement,
+            qLogNoisyExpectedImprovement,
             choose_botorch_acqf_class(objective_weights=torch.tensor([1.0, 0.0])),
         )
 

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -14,10 +14,20 @@ from ax.models.torch.botorch_modular.sebo import SEBOAcquisition
 
 # BoTorch `AcquisitionFunction` imports
 from botorch.acquisition.acquisition import AcquisitionFunction
-from botorch.acquisition.analytic import ExpectedImprovement
+
+from botorch.acquisition.analytic import (
+    ExpectedImprovement,
+    LogExpectedImprovement,
+    LogNoisyExpectedImprovement,
+    NoisyExpectedImprovement,
+)
 from botorch.acquisition.knowledge_gradient import (
     qKnowledgeGradient,
     qMultiFidelityKnowledgeGradient,
+)
+from botorch.acquisition.logei import (
+    qLogExpectedImprovement,
+    qLogNoisyExpectedImprovement,
 )
 from botorch.acquisition.max_value_entropy_search import (
     qMaxValueEntropy,
@@ -96,6 +106,9 @@ Mapping of Botorch `AcquisitionFunction` classes to class name strings.
 """
 ACQUISITION_FUNCTION_REGISTRY: Dict[Type[AcquisitionFunction], str] = {
     ExpectedImprovement: "ExpectedImprovement",
+    LogExpectedImprovement: "LogExpectedImprovement",
+    NoisyExpectedImprovement: "NoisyExpectedImprovement",
+    LogNoisyExpectedImprovement: "LogNoisyExpectedImprovement",
     qExpectedHypervolumeImprovement: "qExpectedHypervolumeImprovement",
     qNoisyExpectedHypervolumeImprovement: "qNoisyExpectedHypervolumeImprovement",
     qExpectedImprovement: "qExpectedImprovement",
@@ -104,6 +117,8 @@ ACQUISITION_FUNCTION_REGISTRY: Dict[Type[AcquisitionFunction], str] = {
     qMultiFidelityKnowledgeGradient: "qMultiFidelityKnowledgeGradient",
     qMultiFidelityMaxValueEntropy: "qMultiFidelityMaxValueEntropy",
     qNoisyExpectedImprovement: "qNoisyExpectedImprovement",
+    qLogExpectedImprovement: "qLogExpectedImprovement",
+    qLogNoisyExpectedImprovement: "qLogNoisyExpectedImprovement",
 }
 
 


### PR DESCRIPTION
Summary: This commit enables qLogNEI by default for all modular BoTorchModels. Same effect as D47377543, but open source.

Reviewed By: saitcakmak

Differential Revision: D47440933

