### PR TITLE
Add an option to disable model fitting on tracking metrics

### DIFF
--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -305,6 +305,7 @@ class TestGenerationStrategy(TestCase):
                         "transforms": Cont_X_trans,
                         "fit_out_of_design": False,
                         "fit_abandoned": False,
+                        "fit_tracking_metrics": True,
                         "fit_on_init": True,
                     },
                 )

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -174,6 +174,7 @@ class ModelRegistryTest(TestCase):
                 "transforms": Cont_X_trans + Y_trans,
                 "fit_out_of_design": False,
                 "fit_abandoned": False,
+                "fit_tracking_metrics": True,
                 "fit_on_init": True,
                 "default_model_gen_options": None,
             },
@@ -268,6 +269,7 @@ class ModelRegistryTest(TestCase):
                     "status_quo_features": None,
                     "fit_out_of_design": False,
                     "fit_abandoned": False,
+                    "fit_tracking_metrics": True,
                     "fit_on_init": True,
                 },
             ),
@@ -290,6 +292,7 @@ class ModelRegistryTest(TestCase):
                     "status_quo_features",
                     "fit_out_of_design",
                     "fit_abandoned",
+                    "fit_tracking_metrics",
                     "fit_on_init",
                 ]
             ),

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -107,6 +107,7 @@ class TorchModelBridge(ModelBridge):
         optimization_config: Optional[OptimizationConfig] = None,
         fit_out_of_design: bool = False,
         fit_abandoned: bool = False,
+        fit_tracking_metrics: bool = True,
         fit_on_init: bool = True,
         default_model_gen_options: Optional[TConfig] = None,
     ) -> None:
@@ -134,6 +135,7 @@ class TorchModelBridge(ModelBridge):
             optimization_config=optimization_config,
             fit_out_of_design=fit_out_of_design,
             fit_abandoned=fit_abandoned,
+            fit_tracking_metrics=fit_tracking_metrics,
             fit_on_init=fit_on_init,
         )
 
@@ -519,7 +521,10 @@ class TorchModelBridge(ModelBridge):
             parameters = self.parameters
         all_metric_names: Set[str] = set()
         observation_features, observation_data = separate_observations(observations)
-        if update_outcomes_and_parameters:
+        # Only update outcomes if fitting a model on tracking metrics. Otherwise,
+        # we will only fit models to the outcomes that are extracted from optimization
+        # config in ModelBridge.__init__.
+        if update_outcomes_and_parameters and self._fit_tracking_metrics:
             for od in observation_data:
                 all_metric_names.update(od.metric_names)
             self.outcomes = sorted(all_metric_names)  # Deterministic order

--- a/ax/plot/tests/test_feature_importances.py
+++ b/ax/plot/tests/test_feature_importances.py
@@ -49,7 +49,6 @@ def get_sensitivity_values(ax_model: ModelBridge) -> Dict:
         ls = ls.mean(dim=0)
     # pyre-fixme[16]: `float` has no attribute `detach`.
     importances_tensor = torch.stack([(1 / ls).detach().cpu()])
-    # pyre-fixme[16]: `ModelBridge` has no attribute `outcomes`.
     importances_dict = dict(zip(ax_model.outcomes, importances_tensor))
     res = {}
     for metric_name in ax_model.outcomes:

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -316,7 +316,7 @@ class SQAStoreTest(TestCase):
         self.assertEqual(len(mkw), 6)
         bkw = gr._bridge_kwargs
         self.assertIsNotNone(bkw)
-        self.assertEqual(len(bkw), 8)
+        self.assertEqual(len(bkw), 9)
         ms = gr._model_state_after_gen
         self.assertIsNotNone(ms)
         self.assertEqual(len(ms), 2)

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -569,6 +569,7 @@ def get_experiment_with_observations(
     minimize: bool = False,
     scalarized: bool = False,
     constrained: bool = False,
+    with_tracking_metrics: bool = False,
 ) -> Experiment:
     multi_objective = (len(observations[0]) - constrained) > 1
     if multi_objective:
@@ -626,6 +627,11 @@ def get_experiment_with_observations(
     exp = Experiment(
         search_space=get_search_space_for_range_values(min=0.0, max=1.0),
         optimization_config=optimization_config,
+        tracking_metrics=[
+            Metric(name=f"m{len(observations[0])}", lower_is_better=False)
+        ]
+        if with_tracking_metrics
+        else None,
         runner=SyntheticRunner(),
         is_test=True,
     )


### PR DESCRIPTION
Summary: Skipping model fitting for these metrics can reduce runtime when these models are not needed.

Differential Revision: D47617329

