### PR TITLE
Safe/stable hashing of Ax classes for registry

### DIFF
--- a/ax/storage/metric_registry.py
+++ b/ax/storage/metric_registry.py
@@ -18,6 +18,7 @@ from ax.metrics.noisy_function import NoisyFunctionMetric
 from ax.metrics.sklearn import SklearnMetric
 from ax.storage.json_store.encoders import metric_to_dict
 from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
+from ax.storage.utils import stable_hash
 from ax.utils.common.logger import get_logger
 
 logger: Logger = get_logger(__name__)
@@ -68,7 +69,7 @@ def register_metric(
     """
     metric_registry = metric_registry or {Metric: 0}
 
-    registered_val = val or abs(hash(metric_cls.__name__)) % (10**5)
+    registered_val = val or abs(stable_hash(metric_cls.__name__)) % (10**5)
 
     new_metric_registry = {metric_cls: registered_val, **metric_registry}
     new_encoder_registry = {metric_cls: metric_to_dict, **encoder_registry}
@@ -104,7 +105,9 @@ def register_metrics(
 
     new_metric_registry = {
         **{
-            metric_cls: val if val else abs(hash(metric_cls.__name__)) % (10**5)
+            metric_cls: val
+            if val
+            else abs(stable_hash(metric_cls.__name__)) % (10**5)
             for metric_cls, val in metric_clss.items()
         },
         **metric_registry,

--- a/ax/storage/runner_registry.py
+++ b/ax/storage/runner_registry.py
@@ -11,6 +11,7 @@ from ax.core.runner import Runner
 from ax.runners.synthetic import SyntheticRunner
 from ax.storage.json_store.encoders import runner_to_dict
 from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
+from ax.storage.utils import stable_hash
 from ax.utils.common.logger import get_logger
 
 logger: Logger = get_logger(__name__)
@@ -51,7 +52,7 @@ def register_runner(
     """Add a custom runner class to the SQA and JSON registries.
     For the SQA registry, if no int is specified, use a hash of the class name.
     """
-    registered_val = val or abs(hash(runner_cls.__name__)) % (10**5)
+    registered_val = val or abs(stable_hash(runner_cls.__name__)) % (10**5)
 
     new_runner_registry = {runner_cls: registered_val, **runner_registry}
     new_encoder_registry = {runner_cls: runner_to_dict, **encoder_registry}
@@ -85,7 +86,9 @@ def register_runners(
     """
     new_runner_registry = {
         **{
-            runner_cls: val if val else abs(hash(runner_cls.__name__)) % (10**5)
+            runner_cls: val
+            if val
+            else abs(stable_hash(runner_cls.__name__)) % (10**5)
             for runner_cls, val in runner_clss.items()
         },
         **runner_registry,

--- a/ax/storage/utils.py
+++ b/ax/storage/utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import enum
+from hashlib import md5
 
 from ax.core.experiment import DataType  # noqa F401
 
@@ -44,3 +45,16 @@ class ParameterConstraintType(enum.Enum):
     ORDER: int = 1
     SUM: int = 2
     DISTRIBUTION: int = 3
+
+
+def stable_hash(s: str) -> int:
+    """Return an integer hash of a string that is consistent across re-invocations
+    of the interpreter (unlike the built-in hash, which is salted by default).
+
+    Args:
+        s (str): String to hash.
+    Returns:
+
+        int: Hash, converted to an integer.
+    """
+    return int(md5(s.encode("utf-8")).hexdigest(), 16)


### PR DESCRIPTION
In the metric and runner registries, Ax used `hash` to generate ids of new runners or metrics. Per https://docs.python.org/3/reference/datamodel.html#object.__hash__: 
> By default, the [\_\_hash\_\_()](https://docs.python.org/3/reference/datamodel.html#object.__hash__) values of str and bytes objects are “salted” with an unpredictable random value. Although they remain constant within an individual Python process, they are not predictable between repeated invocations of Python.

This means that hash values are not consistent across re-invocations of the interpreter, and loading an experiment with custom metrics or runners will fail because the registries won't match. This fixes by using a stable hashing function from `hashlib`. 