### PR TITLE
Use logging.warning instead of logging.warn

### DIFF
--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -1051,7 +1051,7 @@ def get_figure_and_callback(
         try:
             new_fig = plot_fn(scheduler)
         except RuntimeError as e:
-            logging.warn(
+            logging.warning(
                 f"Plotting function called via callback failed with error {e}."
                 "Skipping plot update."
             )


### PR DESCRIPTION
Summary:
see https://docs.python.org/3/library/logging.html#logging.warning

quote:

> There is an obsolete function warn which is functionally identical to warning. As warn is deprecated, please do not use it - use warning instead

Differential Revision: D47722665

