### PR TITLE
ST_MTGP added to generation node builder

### DIFF
--- a/ax/models/torch/botorch_modular/input_constructors/covar_modules.py
+++ b/ax/models/torch/botorch_modular/input_constructors/covar_modules.py
@@ -13,6 +13,7 @@ from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
 from ax.models.torch.botorch_modular.optimizer_argparse import (
     _optimizerArgparse_encoder,
 )
+from botorch.models import MultiTaskGP
 from botorch.models.gp_regression import FixedNoiseGP
 
 from botorch.models.model import Model
@@ -102,7 +103,9 @@ def _covar_module_argparse_scale_matern(
         A dictionary with covar module kwargs.
     """
 
-    if issubclass(botorch_model_class, FixedNoiseMultiTaskGP):
+    if issubclass(botorch_model_class, FixedNoiseMultiTaskGP) or issubclass(
+        botorch_model_class, MultiTaskGP
+    ):
         if ard_num_dims is DEFAULT:
             ard_num_dims = dataset.X.shape[-1] - 1
 


### PR DESCRIPTION
Summary: Changed ST_MTGP_LEGACY into ST_MTGP in the generation node builder.

Reviewed By: danielcohenlive

Differential Revision: D47486276

