### PR TITLE
Require Python >3.9 & update workflows to use 3.9 & 3.10

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.11"]
       fail-fast: false
 
     steps:
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       # Pin ufmt deps so they match intermal pyfmt.
       run: |
@@ -74,7 +74,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       env:
         ALLOW_BOTORCH_LATEST: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9", "3.10"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies (full requirements, stable Botorch)
       run: |
         # will install the version of Botorch that is pinned in setup.py
@@ -79,7 +79,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       env:
         ALLOW_BOTORCH_LATEST: true
@@ -106,7 +106,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       env:
         ALLOW_BOTORCH_LATEST: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies (latest Botorch)
       env:
         ALLOW_BOTORCH_LATEST: true
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         # use stable Botorch
@@ -74,7 +74,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         # use stable Botorch

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         # will install the version of Botorch that is pinned in setup.py

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ artificial evaluation function):
 ## Installation
 
 ### Requirements
-You need Python 3.8 or later to run Ax.
+You need Python 3.9 or later to run Ax.
 
 The required Python dependencies are:
 
@@ -84,7 +84,7 @@ conda install pytorch torchvision -c pytorch  # OSX only (details below)
 pip install ax-platform
 ```
 
-Installation will use Python wheels from PyPI, available for [OSX, Linux, and Windows](https://pypi.org/project/ax-platform/#files).
+Installation will use  wheels from PyPI, available for [OSX, Linux, and Windows](https://pypi.org/project/ax-platform/#files).
 
 *Note*: Make sure the `pip` being used to install `ax-platform` is actually the one from the newly created Conda environment.
 If you're using a Unix-based OS, you can use `which pip` to check.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ conda install pytorch torchvision -c pytorch  # OSX only (details below)
 pip install ax-platform
 ```
 
-Installation will use  wheels from PyPI, available for [OSX, Linux, and Windows](https://pypi.org/project/ax-platform/#files).
+Installation will use Python wheels from PyPI, available for [OSX, Linux, and Windows](https://pypi.org/project/ax-platform/#files).
 
 *Note*: Make sure the `pip` being used to install `ax-platform` is actually the one from the newly created Conda environment.
 If you're using a Unix-based OS, you can use `which pip` to check.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ title: Installation
 ---
 
 ## Requirements
-You need Python 3.8 or later to run Ax.
+You need Python 3.9 or later to run Ax.
 
 The required Python dependencies are:
 
@@ -22,13 +22,13 @@ We recommend installing Ax via pip (even if using Conda environment):
 
 ```
 conda install pytorch torchvision -c pytorch  # OSX only (details below)
-pip3 install ax-platform
+pip install ax-platform
 ```
 
 Installation will use Python wheels from PyPI, available for [OSX, Linux, and Windows](https://pypi.org/project/ax-platform/#files).
 
-*Note*: Make sure the `pip3` being used to install `ax-platform` is actually the one from the newly created Conda environment.
-If you're using a Unix-based OS, you can use `which pip3` to check.
+*Note*: Make sure the `pip` being used to install `ax-platform` is actually the one from the newly created Conda environment.
+If you're using a Unix-based OS, you can use `which pip` to check.
 
 *Recommendation for MacOS users*: PyTorch is a required dependency of BoTorch, and can be automatically installed via pip.
 However, **we recommend you [install PyTorch manually](https://pytorch.org/get-started/locally/#anaconda-1) before installing Ax, using the Anaconda package manager**.
@@ -41,12 +41,12 @@ If you need CUDA on MacOS, you will need to build PyTorch from source. Please co
 
 To use Ax with a notebook environment, you will need Jupyter. Install it first:
 ```
-pip3 install jupyter
+pip install jupyter
 ```
 
 If you want to store the experiments in MySQL, you will need SQLAlchemy:
 ```
-pip3 install SQLAlchemy
+pip install SQLAlchemy
 ```
 
 ## Latest Version
@@ -63,8 +63,8 @@ See also the recommendation for installing PyTorch for MacOS users above.
 
 At times, the bleeding edge for Ax can depend on bleeding edge versions of BoTorch (or GPyTorch). We therefore recommend installing those from Git as well:
 ```
-pip3 install git+https://github.com/cornellius-gp/gpytorch.git
-pip3 install git+https://github.com/pytorch/botorch.git
+pip install git+https://github.com/cornellius-gp/gpytorch.git
+pip install git+https://github.com/pytorch/botorch.git
 ```
 
 ### Optional Dependencies
@@ -87,12 +87,12 @@ When contributing to Ax, we recommend cloning the [repository](https://github.co
 
 ```
 # bleeding edge versions of GPyTorch + BoTorch are recommended
-pip3 install git+https://github.com/cornellius-gp/gpytorch.git
-pip3 install git+https://github.com/pytorch/botorch.git
+pip install git+https://github.com/cornellius-gp/gpytorch.git
+pip install git+https://github.com/pytorch/botorch.git
 
 git clone https://github.com/facebook/ax.git --depth 1
 cd ax
-pip3 install -e .[notebook,mysql,dev]
+pip install -e .[notebook,mysql,dev]
 ```
 
 See recommendation for installing PyTorch for MacOS users above.

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ def setup_package() -> None:
         ],
         long_description=long_description,
         long_description_content_type="text/markdown",
-        python_requires=">=3.8",
+        python_requires=">=3.9",
         install_requires=REQUIRES,
         packages=find_packages(),
         package_data={


### PR DESCRIPTION
Follow up to https://github.com/pytorch/botorch/pull/1924 to avoid CI failures.

NOTE: We cannot support 3.11 currently due to a failure in torchx tests. See https://github.com/pytorch/torchx/issues/744