### PR TITLE
[WIP] Require exact equality for Pandas DataFrames to be considered equal

### DIFF
--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -364,7 +364,7 @@ class JSONStoreTest(TestCase):
                 class_encoder_registry=CORE_CLASS_ENCODER_REGISTRY,
             )
 
-        # Key error on desearialization.
+        # Key error on deserialization.
         x_json = object_to_json(
             x,
             encoder_registry=CORE_ENCODER_REGISTRY,

--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -75,6 +75,8 @@ def datetime_equals(dt1: Optional[datetime], dt2: Optional[datetime]) -> bool:
     return dt1.replace(microsecond=0) == dt2.replace(microsecond=0)
 
 
+# TODO: can use pd.testing.assert_equal to generalize this for Series,
+# DataFrame, ExtensionArray
 def dataframe_equals(df1: pd.DataFrame, df2: pd.DataFrame) -> bool:
     """Compare equality of two pandas dataframes."""
     try:
@@ -82,7 +84,7 @@ def dataframe_equals(df1: pd.DataFrame, df2: pd.DataFrame) -> bool:
             equal = True
         else:
             pd.testing.assert_frame_equal(
-                df1.sort_index(axis=1), df2.sort_index(axis=1), check_exact=False
+                df1.sort_index(axis=1), df2.sort_index(axis=1), check_exact=True
             )
             equal = True
     except AssertionError:

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -234,7 +234,8 @@ def _build_comparison_str(
             bul = "*"
         else:
             raise RuntimeError(
-                "Reached level > `COMPARISON_STR_MAX_LEVEL`, which should've been "
+                "While building comparison error message, "
+                "reached level > `COMPARISON_STR_MAX_LEVEL`, which should've been "
                 "unreachable."
             )
         msg += f"\n{indent}{bul} {field}: {_unequal_str(first=first, second=second)}\n"

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1666,7 +1666,7 @@ def get_data(
         "trial_index": trial_index,
         "metric_name": metric_name,
         "arm_name": arm_names,
-        "mean": [1, 3, 2, 2.25, 1.75][:num_arms],
+        "mean": [-0.03730201721191406, 3, 2, 2.25, 1.75][:num_arms],
         "sem": [0, 0.5, 0.25, 0.40, 0.15][:num_arms],
         "n": [100, 100, 100, 100, 100][:num_arms],
     }


### PR DESCRIPTION
While debugging a numerical issue, I encountered a case where an experiment had float64 trial data where the data changed values after being saved and reloaded. It looks like the data was converted to float32 and then back to float64. However, equality checks still passed because Ax is only testing that values are approximately equal, to 1e-8.

I changed tests so that this failure is surfaced, but still need to fix it.

# Test plan

Changed a unit test so that this failure is triggered.