### PR TITLE
Allow customizing the name of a GenerationStep

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -346,6 +346,9 @@ class GenerationStep(GenerationNode, SortableBase):
     should_deduplicate: bool = False
     index: int = -1  # Index of this step, set internally.
 
+    # Optional model name. Defaults to `model_spec.model_key`.
+    model_name: str = field(default_factory=str)
+
     def __post_init__(self) -> None:
         if (
             self.enforce_num_trials
@@ -376,6 +379,12 @@ class GenerationStep(GenerationNode, SortableBase):
                 model_kwargs=self.model_kwargs,
                 model_gen_kwargs=self.model_gen_kwargs,
             )
+        if self.model_name == "":
+            try:
+                self.model_name = model_spec.model_key
+            except TypeError:
+                # Factory functions may not always have a model key defined.
+                self.model_name = f"Unknown {model_spec.__class__.__name__}"
         super().__init__(
             model_specs=[model_spec], should_deduplicate=self.should_deduplicate
         )
@@ -383,10 +392,6 @@ class GenerationStep(GenerationNode, SortableBase):
     @property
     def model_spec(self) -> ModelSpec:
         return self.model_specs[0]
-
-    @property
-    def model_name(self) -> str:
-        return self.model_spec.model_key
 
     @property
     def _unique_id(self) -> str:

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 from ax.core.observation import ObservationFeatures
 from ax.exceptions.core import UserInputError
@@ -175,6 +175,25 @@ class TestGenerationStep(TestCase):
             self.sobol_generation_step.model_specs,
             [self.model_spec],
         )
+        self.assertEqual(self.sobol_generation_step.model_name, "Sobol")
+
+        named_generation_step = GenerationStep(
+            model=Models.SOBOL,
+            num_trials=5,
+            model_kwargs=self.model_kwargs,
+            model_name="Custom Sobol",
+        )
+        self.assertEqual(named_generation_step.model_name, "Custom Sobol")
+
+        with patch.object(
+            ModelSpec, "model_key", new=PropertyMock(side_effect=TypeError)
+        ):
+            unknown_generation_step = GenerationStep(
+                model=Models.SOBOL,
+                num_trials=5,
+                model_kwargs=self.model_kwargs,
+            )
+        self.assertEqual(unknown_generation_step.model_name, "Unknown ModelSpec")
 
     def test_min_trials_observed(self) -> None:
         with self.assertRaisesRegex(UserInputError, "min_trials_observed > num_trials"):
@@ -200,7 +219,6 @@ class TestGenerationStep(TestCase):
 
     def test_properties(self) -> None:
         self.assertEqual(self.sobol_generation_step.model_spec, self.model_spec)
-        self.assertEqual(self.sobol_generation_step.model_name, "Sobol")
         self.assertEqual(self.sobol_generation_step._unique_id, "-1")
 
 


### PR DESCRIPTION
Summary: Currently, the generation steps carry the names of the `ModelSpec`s they are constructed from, without a way of customizing it. This makes it so that every GStep that is constructed from `BoTorch` (MBM) registry entry produces the name `BoTorch`. This is not ideal since MBM is highly customizable through `model_kwargs`. Having a way of re-naming customized models without having to define a new `ModelSpec` would simplify things.

Reviewed By: lena-kashtelyan

Differential Revision: D47747138

