### PR TITLE
Migrate generation strategy logic to generation step 1/n

### DIFF
--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -493,7 +493,10 @@ class TestGenerationStrategy(TestCase):
     def test_trials_as_df(self) -> None:
         exp = get_branin_experiment()
         sobol_generation_strategy = GenerationStrategy(
-            steps=[GenerationStep(model=Models.SOBOL, num_trials=5)]
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=2),
+                GenerationStep(model=Models.SOBOL, num_trials=3),
+            ]
         )
         # No trials yet, so the DF will be None.
         self.assertIsNone(sobol_generation_strategy.trials_as_df)
@@ -510,6 +513,16 @@ class TestGenerationStrategy(TestCase):
         trial._status = TrialStatus.RUNNING
         self.assertEqual(
             sobol_generation_strategy.trials_as_df.head()["Trial Status"][0], "RUNNING"
+        )
+        # Check that rows are present for step 0 and 1 after moving to step 1
+        for _i in range(3):
+            # attach necessary trials to fill up the Generation Strategy
+            trial = exp.new_trial(sobol_generation_strategy.gen(experiment=exp))
+        self.assertEqual(
+            sobol_generation_strategy.trials_as_df.head()["Generation Step"][0], 0
+        )
+        self.assertEqual(
+            sobol_generation_strategy.trials_as_df.head()["Generation Step"][2], 1
         )
 
     def test_max_parallelism_reached(self) -> None:


### PR DESCRIPTION
Summary:
This diff is the first in a stack of diffs that will migrate much of the logic from generation strategy into generation step (and then subsquently generation node).

In this diff we move `num_trials_to_gen_and_complete_in_curr_step()` to generation step. As a part of this we also move a few helper functions:
- trial_indices_by_step
- num_can_complete_this_step
- num_completed_this_step

There is a bit of weirdness with how the experiment is being set right now that i've left a todo to clean up as we move through this restructuring

In follow up diffs plan to work my way up to the gen_multiple function call moving out pieces as we go

Differential Revision: D47956491

