### PR TITLE
Ax side changes for Dataset updates

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -604,10 +604,8 @@ class GenerationStrategy(Base):
         to_gen, to_complete = self._num_trials_to_gen_and_complete_in_curr_step()
         if to_gen == to_complete == -1:  # Unlimited trials, check completion_criteria
             if len(self._curr.completion_criteria) > 0 and all(
-                [
-                    criterion.is_met(experiment=self.experiment)
-                    for criterion in self._curr.completion_criteria
-                ]
+                criterion.is_met(experiment=self.experiment)
+                for criterion in self._curr.completion_criteria
             ):
                 if len(self._steps) == self._curr.index + 1:
                     raise GenerationStrategyCompleted(

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -29,6 +29,7 @@ from ax.modelbridge.torch import TorchModelBridge
 from ax.modelbridge.transforms.base import Transform
 from ax.models.torch_base import TorchGenResults, TorchModel
 from ax.utils.common.testutils import TestCase
+from ax.utils.common.typeutils import not_none
 from ax.utils.testing.core_stubs import (
     get_branin_data,
     get_branin_experiment,
@@ -37,7 +38,7 @@ from ax.utils.testing.core_stubs import (
     get_search_space_for_range_value,
 )
 from ax.utils.testing.modeling_stubs import get_observation1, transform_1, transform_2
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 
 
 class TorchModelBridgeTest(TestCase):
@@ -77,12 +78,12 @@ class TorchModelBridgeTest(TestCase):
         )
         X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **tkwargs)
         datasets = {
-            "y1": FixedNoiseDataset(
+            "y1": SupervisedDataset(
                 X=X,
                 Y=torch.tensor([[3.0], [1.0]], **tkwargs),
                 Yvar=torch.tensor([[4.0], [2.0]], **tkwargs),
             ),
-            "y2": FixedNoiseDataset(
+            "y2": SupervisedDataset(
                 X=X,
                 Y=torch.tensor([[2.0], [0.0]], **tkwargs),
                 Yvar=torch.tensor([[2.0], [1.0]], **tkwargs),
@@ -101,8 +102,8 @@ class TorchModelBridgeTest(TestCase):
             for y1, y2, yvar1, yvar2 in zip(
                 datasets["y1"].Y().tolist(),
                 datasets["y2"].Y().tolist(),
-                datasets["y1"].Yvar().tolist(),
-                datasets["y2"].Yvar().tolist(),
+                not_none(datasets["y1"].Yvar)().tolist(),
+                not_none(datasets["y2"].Yvar)().tolist(),
             )
         ]
         observations = recombine_observations(observation_features, observation_data)

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -63,7 +63,7 @@ from ax.models.torch_base import TorchModel, TorchOptConfig
 from ax.models.types import TConfig
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
-from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
+from botorch.utils.datasets import SupervisedDataset
 from torch import Tensor
 
 logger: Logger = get_logger(__name__)
@@ -329,7 +329,7 @@ class TorchModelBridge(ModelBridge):
             if Yvar.isnan().all():
                 dataset = SupervisedDataset(X=X, Y=Y)
             else:
-                dataset = FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar.clamp_min(1e-6))
+                dataset = SupervisedDataset(X=X, Y=Y, Yvar=Yvar.clamp_min(1e-6))
             datasets.append(dataset)
             candidate_metadata.append(candidate_metadata_dict[outcome])
 

--- a/ax/models/tests/test_alebo.py
+++ b/ax/models/tests/test_alebo.py
@@ -27,7 +27,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 from botorch.acquisition.analytic import ExpectedImprovement
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.models.model_list_gp_regression import ModelListGP
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 from torch.nn.parameter import Parameter
 
 
@@ -288,7 +288,7 @@ class ALEBOTest(TestCase):
         )
         train_Y = torch.tensor([[1.0], [2.0], [3.0]], dtype=torch.double)
         train_Yvar = 0.1 * torch.ones(3, 1, dtype=torch.double)
-        dataset = FixedNoiseDataset(X=train_X, Y=train_Y, Yvar=train_Yvar)
+        dataset = SupervisedDataset(X=train_X, Y=train_Y, Yvar=train_Yvar)
 
         # Test fit
         m.fit(
@@ -368,7 +368,7 @@ class ALEBOTest(TestCase):
             ],
             dtype=torch.double,
         )
-        dataset2 = FixedNoiseDataset(X=train_X2, Y=train_Y, Yvar=train_Yvar)
+        dataset2 = SupervisedDataset(X=train_X2, Y=train_Y, Yvar=train_Yvar)
         m.update(datasets=[dataset, dataset2])
         self.assertTrue(torch.allclose(m.Xs[0], (B @ train_X.t()).t()))
         self.assertTrue(torch.allclose(m.Xs[1], (B @ train_X2.t()).t()))

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
+from typing import Any, Dict
 from unittest import mock
 
 import torch
@@ -24,7 +25,7 @@ from botorch.acquisition.objective import (
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.transforms.input import Warp
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 
 
 def dummy_func(X: torch.Tensor) -> torch.Tensor:
@@ -33,14 +34,11 @@ def dummy_func(X: torch.Tensor) -> torch.Tensor:
 
 class KnowledgeGradientTest(TestCase):
     def setUp(self) -> None:
-        self.tkwargs = {"device": torch.device("cpu"), "dtype": torch.double}
-        self.dataset = FixedNoiseDataset(
-            # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-            #  `Union[device, dtype]`.
-            # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]` but
-            #  got `Union[device, dtype]`.
-            # pyre-fixme[6]: For 2nd param expected `bool` but got `Union[device,
-            #  dtype]`.
+        self.tkwargs: Dict[str, Any] = {
+            "device": torch.device("cpu"),
+            "dtype": torch.double,
+        }
+        self.dataset = SupervisedDataset(
             X=torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **self.tkwargs),
             Y=torch.tensor([[3.0], [4.0]], **self.tkwargs),
             Yvar=torch.tensor([[0.0], [2.0]], **self.tkwargs),

--- a/ax/models/tests/test_botorch_mes.py
+++ b/ax/models/tests/test_botorch_mes.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
+from typing import Any, Dict
 from unittest import mock
 
 import torch
@@ -20,20 +21,17 @@ from botorch.acquisition.max_value_entropy_search import (
 from botorch.exceptions.errors import UnsupportedError
 from botorch.models.transforms.input import Warp
 from botorch.sampling.normal import SobolQMCNormalSampler
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 
 
 class MaxValueEntropySearchTest(TestCase):
     def setUp(self) -> None:
-        self.tkwargs = {"device": torch.device("cpu"), "dtype": torch.double}
+        self.tkwargs: Dict[str, Any] = {
+            "device": torch.device("cpu"),
+            "dtype": torch.double,
+        }
         self.training_data = [
-            FixedNoiseDataset(
-                # pyre-fixme[6]: For 2nd param expected `Optional[dtype]` but got
-                #  `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `Union[None, str, device]`
-                #  but got `Union[device, dtype]`.
-                # pyre-fixme[6]: For 2nd param expected `bool` but got
-                #  `Union[device, dtype]`.
+            SupervisedDataset(
                 X=torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **self.tkwargs),
                 Y=torch.tensor([[3.0], [4.0]], **self.tkwargs),
                 Yvar=torch.tensor([[0.0], [2.0]], **self.tkwargs),
@@ -54,8 +52,6 @@ class MaxValueEntropySearchTest(TestCase):
     def test_MaxValueEntropySearch(self) -> None:
         model = MaxValueEntropySearch()
         model.fit(
-            # pyre-fixme[6]: For 1st param expected `List[SupervisedDataset]` but
-            #  got `List[FixedNoiseDataset]`.
             datasets=self.training_data,
             metric_names=self.metric_names,
             search_space_digest=self.search_space_digest,
@@ -139,8 +135,6 @@ class MaxValueEntropySearchTest(TestCase):
         self.assertFalse(model.use_input_warping)
         model = MaxValueEntropySearch(use_input_warping=True)
         model.fit(
-            # pyre-fixme[6]: For 1st param expected `List[SupervisedDataset]` but
-            #  got `List[FixedNoiseDataset]`.
             datasets=self.training_data,
             metric_names=self.metric_names,
             search_space_digest=self.search_space_digest,
@@ -153,8 +147,6 @@ class MaxValueEntropySearchTest(TestCase):
         self.assertFalse(model.use_loocv_pseudo_likelihood)
         model = MaxValueEntropySearch(use_loocv_pseudo_likelihood=True)
         model.fit(
-            # pyre-fixme[6]: For 1st param expected `List[SupervisedDataset]` but
-            #  got `List[FixedNoiseDataset]`.
             datasets=self.training_data,
             metric_names=self.metric_names,
             search_space_digest=self.search_space_digest,
@@ -169,8 +161,6 @@ class MaxValueEntropySearchTest(TestCase):
         )
         model = MaxValueEntropySearch()
         model.fit(
-            # pyre-fixme[6]: For 1st param expected `List[SupervisedDataset]` but
-            #  got `List[FixedNoiseDataset]`.
             datasets=self.training_data,
             metric_names=self.metric_names,
             search_space_digest=search_space_digest,
@@ -213,7 +203,6 @@ class MaxValueEntropySearchTest(TestCase):
             )
 
         # check generation
-
         n = 1
         gen_results = model.gen(
             n=n,
@@ -237,8 +226,6 @@ class MaxValueEntropySearchTest(TestCase):
         self.assertFalse(model.use_input_warping)
         model = MaxValueEntropySearch(use_input_warping=True)
         model.fit(
-            # pyre-fixme[6]: For 1st param expected `List[SupervisedDataset]` but
-            #  got `List[FixedNoiseDataset]`.
             datasets=self.training_data,
             metric_names=self.metric_names,
             search_space_digest=SearchSpaceDigest(
@@ -255,8 +242,6 @@ class MaxValueEntropySearchTest(TestCase):
         self.assertFalse(model.use_loocv_pseudo_likelihood)
         model = MaxValueEntropySearch(use_loocv_pseudo_likelihood=True)
         model.fit(
-            # pyre-fixme[6]: For 1st param expected `List[SupervisedDataset]` but
-            #  got `List[FixedNoiseDataset]`.
             datasets=self.training_data,
             metric_names=self.metric_names,
             search_space_digest=search_space_digest,
@@ -268,8 +253,6 @@ class MaxValueEntropySearchTest(TestCase):
 
         model = MaxValueEntropySearch()
         model.fit(
-            # pyre-fixme[6]: For 1st param expected `List[SupervisedDataset]` but
-            #  got `List[FixedNoiseDataset]`.
             datasets=self.training_data,
             metric_names=self.metric_names,
             search_space_digest=SearchSpaceDigest(
@@ -301,8 +284,6 @@ class MaxValueEntropySearchTest(TestCase):
         # multi-fidelity tests
         model = MaxValueEntropySearch()
         model.fit(
-            # pyre-fixme[6]: For 1st param expected `List[SupervisedDataset]` but
-            #  got `List[FixedNoiseDataset]`.
             datasets=self.training_data,
             metric_names=self.metric_names,
             search_space_digest=SearchSpaceDigest(

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -32,7 +32,7 @@ from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition.utils import get_infeasible_cost
 from botorch.models import FixedNoiseGP, ModelListGP, SingleTaskGP
 from botorch.models.transforms.input import Warp
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.objective import get_objective_weights_transform
 from gpytorch.likelihoods import _GaussianLikelihoodBase
 from gpytorch.mlls import ExactMarginalLogLikelihood, LeaveOneOutPseudoLikelihood
@@ -64,8 +64,8 @@ class BotorchModelTest(TestCase):
         )
         model = BotorchModel(multitask_gp_ranks={"y": 2, "w": 1})
         datasets = [
-            FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-            FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+            SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+            SupervisedDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
         ]
         with self.assertRaisesRegex(RuntimeError, "Please fit the model first"):
             model.model
@@ -119,8 +119,8 @@ class BotorchModelTest(TestCase):
         }
         model = BotorchModel(**kwargs)  # pyre-ignore [6]
         datasets = [
-            FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-            FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+            SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+            SupervisedDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
         ]
 
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
@@ -191,8 +191,8 @@ class BotorchModelTest(TestCase):
                 # make training data different for each output
                 Xs2_diff = [Xs2[0] + 0.1]
                 datasets = [
-                    FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-                    FixedNoiseDataset(X=Xs2_diff[0], Y=Ys2[0], Yvar=Yvars2[0]),
+                    SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+                    SupervisedDataset(X=Xs2_diff[0], Y=Ys2[0], Yvar=Yvars2[0]),
                 ]
                 with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
                     model.fit(
@@ -243,8 +243,8 @@ class BotorchModelTest(TestCase):
 
             # Test batched multi-output FixedNoiseGP
             datasets_block = [
-                FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-                FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+                SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+                SupervisedDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
             ]
             with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
                 model.fit(
@@ -453,8 +453,8 @@ class BotorchModelTest(TestCase):
 
             # Test cross-validation
             combined_datasets = [
-                FixedNoiseDataset(Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-                FixedNoiseDataset(Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+                SupervisedDataset(Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+                SupervisedDataset(Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
             ]
             mean, variance = model.cross_validate(
                 datasets=combined_datasets,
@@ -477,7 +477,7 @@ class BotorchModelTest(TestCase):
             # Test update
             model.refit_on_update = False
             model.update(
-                datasets=[FixedNoiseDataset(Xs2[0], Y=Ys2[0], Yvar=Yvars2[0])] * 2,
+                datasets=[SupervisedDataset(Xs2[0], Y=Ys2[0], Yvar=Yvars2[0])] * 2,
                 metric_names=["y1", "y2"],
             )
 
@@ -494,7 +494,7 @@ class BotorchModelTest(TestCase):
             model.refit_on_update = True
             with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
                 model.update(
-                    datasets=[FixedNoiseDataset(Xs2[0], Y=Ys2[0], Yvar=Yvars2[0])] * 2,
+                    datasets=[SupervisedDataset(Xs2[0], Y=Ys2[0], Yvar=Yvars2[0])] * 2,
                     metric_names=["y1", "y2"],
                 )
 
@@ -621,7 +621,7 @@ class BotorchModelTest(TestCase):
             )
             with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
                 model.fit(
-                    datasets=[FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0])],
+                    datasets=[SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0])],
                     metric_names=mns[:1],
                     search_space_digest=SearchSpaceDigest(
                         feature_names=fns,
@@ -670,8 +670,8 @@ class BotorchModelTest(TestCase):
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=[
-                    FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-                    FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+                    SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+                    SupervisedDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
                 ],
                 metric_names=mns,
                 search_space_digest=search_space_digest,

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -22,7 +22,7 @@ from ax.models.torch.botorch_moo_defaults import (
 )
 from ax.models.torch.utils import _get_X_pending_and_observed
 from ax.utils.common.testutils import TestCase
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.multi_objective.hypervolume import infer_reference_point
 from botorch.utils.sampling import manual_seed
 from botorch.utils.testing import MockModel, MockPosterior
@@ -74,7 +74,7 @@ class FrontierEvaluatorTest(TestCase):
         self.model = MultiObjectiveBotorchModel(model_predictor=dummy_predict)
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             self.model.fit(
-                datasets=[FixedNoiseDataset(X=self.X, Y=self.Y, Yvar=self.Yvar)],
+                datasets=[SupervisedDataset(X=self.X, Y=self.Y, Yvar=self.Yvar)],
                 metric_names=["a", "b", "c"],
                 search_space_digest=SearchSpaceDigest(
                     feature_names=["x1", "x2"],

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -30,7 +30,7 @@ from botorch.models import ModelListGP
 from botorch.models.transforms.input import Warp
 from botorch.optim.optimize import optimize_acqf_list
 from botorch.sampling.normal import IIDNormalSampler
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.multi_objective.hypervolume import infer_reference_point
 from botorch.utils.multi_objective.scalarization import get_chebyshev_scalarization
 from botorch.utils.testing import MockModel, MockPosterior
@@ -128,8 +128,8 @@ class BotorchMOOModelTest(TestCase):
             dtype=dtype, cuda=cuda, constant_noise=True
         )
         training_data = [
-            FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-            FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+            SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+            SupervisedDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
         ]
 
         n = 3
@@ -246,8 +246,8 @@ class BotorchMOOModelTest(TestCase):
             dtype=dtype, cuda=cuda, constant_noise=True
         )
         training_data = [
-            FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-            FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+            SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+            SupervisedDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
         ]
 
         n = 3
@@ -318,8 +318,8 @@ class BotorchMOOModelTest(TestCase):
             dtype=dtype, cuda=cuda, constant_noise=True
         )
         training_data = [
-            FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-            FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+            SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+            SupervisedDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
         ]
 
         n = 3
@@ -442,8 +442,8 @@ class BotorchMOOModelTest(TestCase):
             Yvars1 = [torch.cat([Yvars1[0], Yvars1[0] + 0.2], dim=0)]
             Yvars2 = [torch.cat([Yvars2[0], Yvars2[0] + 0.1], dim=0)]
             training_data_multiple = [
-                FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-                FixedNoiseDataset(X=Xs1[0], Y=Ys2[0], Yvar=Yvars2[0]),
+                SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+                SupervisedDataset(X=Xs1[0], Y=Ys2[0], Yvar=Yvars2[0]),
             ]
             model.fit(
                 datasets=training_data_multiple,
@@ -606,8 +606,8 @@ class BotorchMOOModelTest(TestCase):
             dtype=dtype, cuda=cuda, constant_noise=True
         )
         training_data = [
-            FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-            FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+            SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+            SupervisedDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
         ]
 
         n = 2
@@ -668,8 +668,8 @@ class BotorchMOOModelTest(TestCase):
             dtype=dtype, cuda=cuda, constant_noise=True
         )
         training_data = [
-            FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-            FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+            SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+            SupervisedDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
         ]
 
         n = 2
@@ -735,9 +735,9 @@ class BotorchMOOModelTest(TestCase):
             dtype=dtype, cuda=cuda, constant_noise=True
         )
         training_data = [
-            FixedNoiseDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
-            FixedNoiseDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
-            FixedNoiseDataset(X=Xs3[0], Y=Ys3[0], Yvar=Yvars3[0]),
+            SupervisedDataset(X=Xs1[0], Y=Ys1[0], Yvar=Yvars1[0]),
+            SupervisedDataset(X=Xs2[0], Y=Ys2[0], Yvar=Yvars2[0]),
+            SupervisedDataset(X=Xs3[0], Y=Ys3[0], Yvar=Yvars3[0]),
         ]
 
         n = 3

--- a/ax/models/tests/test_cbo_lcea.py
+++ b/ax/models/tests/test_cbo_lcea.py
@@ -14,7 +14,7 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import fast_botorch_optimize
 from botorch.models.contextual import LCEAGP
 from botorch.models.model_list_gp_regression import ModelListGP
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 
 
 class LCEABOTest(TestCase):
@@ -25,7 +25,7 @@ class LCEABOTest(TestCase):
         )
         train_Y = torch.tensor([[1.0], [2.0], [3.0]])
         train_Yvar = 0.1 * torch.ones(3, 1)
-        training_data = [FixedNoiseDataset(X=train_X, Y=train_Y, Yvar=train_Yvar)]
+        training_data = [SupervisedDataset(X=train_X, Y=train_Y, Yvar=train_Yvar)]
 
         # Test setting attributes
         decomposition = {"1": ["0", "1"], "2": ["2", "3"]}

--- a/ax/models/tests/test_cbo_sac.py
+++ b/ax/models/tests/test_cbo_sac.py
@@ -14,7 +14,7 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import fast_botorch_optimize
 from botorch.models.contextual import LCEAGP
 from botorch.models.model_list_gp_regression import ModelListGP
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 
 
 class SACBOTest(TestCase):
@@ -25,7 +25,7 @@ class SACBOTest(TestCase):
         )
         train_Y = torch.tensor([[1.0], [2.0], [3.0]])
         train_Yvar = 0.1 * torch.ones(3, 1)
-        dataset = FixedNoiseDataset(X=train_X, Y=train_Y, Yvar=train_Yvar)
+        dataset = SupervisedDataset(X=train_X, Y=train_Y, Yvar=train_Yvar)
 
         # test setting attributes
         decomposition = {"1": ["0", "1"], "2": ["2", "3"]}

--- a/ax/models/tests/test_fully_bayesian.py
+++ b/ax/models/tests/test_fully_bayesian.py
@@ -38,7 +38,7 @@ from botorch.models.transforms.input import Warp
 from botorch.optim.optimize import optimize_acqf
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.utils import get_objective_weights_transform
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 from gpytorch.constraints import GreaterThan, Positive
 from gpytorch.kernels import MaternKernel, RBFKernel, ScaleKernel
 from gpytorch.likelihoods import _GaussianLikelihoodBase
@@ -162,7 +162,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             ) as _mock_fit_model:
                 model.fit(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs, Ys, Yvars)
                     ],
                     search_space_digest=SearchSpaceDigest(
@@ -361,7 +361,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             ) as _mock_fit_model, self.assertRaises(NotImplementedError):
                 model.fit(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs_mt, Ys_mt, Yvars_mt)
                     ],
                     metric_names=mns_mt,
@@ -377,7 +377,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             ) as _mock_fit_model, self.assertRaises(NotImplementedError):
                 model.fit(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2)
                     ],
                     metric_names=mns,
@@ -406,7 +406,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             ) as _mock_fit_model:
                 model.fit(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs1 + Xs2, Ys1 + Ys2, Yvars)
                     ],
                     metric_names=mns,
@@ -589,7 +589,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             # Test cross-validation
             mean, variance = model.cross_validate(
                 datasets=[
-                    FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                    SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                     for X, Y, Yvar in zip(Xs1 + Xs2, Ys, Yvars)
                 ],
                 X_test=torch.tensor(
@@ -607,7 +607,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             ) as _mock_fit_model:
                 mean, variance = model.cross_validate(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs1 + Xs2, Ys, Yvars)
                     ],
                     X_test=torch.tensor(
@@ -623,7 +623,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             model.refit_on_update = False
             model.update(
                 datasets=[
-                    FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                    SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                     for X, Y, Yvar in zip(Xs2 + Xs2, Ys2 + Ys2, Yvars2 + Yvars2)
                 ]
             )
@@ -644,7 +644,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             ) as _mock_fit_model:
                 model.update(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs2 + Xs2, Ys2 + Ys2, Yvars2 + Yvars2)
                     ]
                 )
@@ -654,7 +654,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             with self.assertRaises(RuntimeError):
                 unfit_model.cross_validate(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2)
                     ],
                     X_test=Xs1[0],
@@ -662,7 +662,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
             with self.assertRaises(RuntimeError):
                 unfit_model.update(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2)
                     ]
                 )
@@ -762,7 +762,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
         ) as _mock_fit_model:
             model.fit(
                 datasets=[
-                    FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                    SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                     for X, Y, Yvar in zip(Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2)
                 ],
                 metric_names=mns,
@@ -822,7 +822,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                 )
                 model.fit(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2)
                     ],
                     metric_names=mns,
@@ -864,7 +864,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                 _mock_nuts = es.enter_context(mock.patch(NUTS_PATH))
                 model.fit(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2)
                     ],
                     metric_names=mns,
@@ -894,7 +894,7 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                 # testing purposes
                 model.fit(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2)
                     ],
                     metric_names=mns,
@@ -1000,7 +1000,7 @@ class SingleObjectiveFullyBayesianBotorchModelTest(
             ) as _mock_fit_model:
                 model.fit(
                     datasets=[
-                        FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                        SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                         for X, Y, Yvar in zip(Xs1, Ys1, Yvars1)
                     ],
                     metric_names=[mns[0]],

--- a/ax/models/tests/test_posterior_mean.py
+++ b/ax/models/tests/test_posterior_mean.py
@@ -12,7 +12,7 @@ from ax.models.torch.posterior_mean import get_PosteriorMean
 from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import fast_botorch_optimize
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 
 
 # TODO (jej): Streamline testing for a simple acquisition function.
@@ -44,7 +44,7 @@ class PosteriorMeanTest(TestCase):
 
         # pyre-fixme[6]: For 1st param expected `(Model, Tensor, Optional[Tuple[Tenso...
         model = BotorchModel(acqf_constructor=get_PosteriorMean)
-        dataset = FixedNoiseDataset(X=self.X, Y=self.Y, Yvar=self.Yvar)
+        dataset = SupervisedDataset(X=self.X, Y=self.Y, Yvar=self.Yvar)
         model.fit(
             datasets=[dataset],
             metric_names=["y"],

--- a/ax/models/tests/test_randomforest.py
+++ b/ax/models/tests/test_randomforest.py
@@ -8,13 +8,13 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.randomforest import RandomForest
 from ax.utils.common.testutils import TestCase
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 
 
 class RandomForestTest(TestCase):
     def testRFModel(self) -> None:
         datasets = [
-            FixedNoiseDataset(
+            SupervisedDataset(
                 X=torch.rand(10, 2), Y=torch.rand(10, 1), Yvar=torch.rand(10, 1)
             )
             for _ in range(2)

--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -8,12 +8,12 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch_base import TorchModel, TorchOptConfig
 from ax.utils.common.testutils import TestCase
-from botorch.utils.datasets import FixedNoiseDataset
+from botorch.utils.datasets import SupervisedDataset
 
 
 class TorchModelTest(TestCase):
     def setUp(self) -> None:
-        self.dataset = FixedNoiseDataset(
+        self.dataset = SupervisedDataset(
             X=torch.zeros(1), Y=torch.zeros(1), Yvar=torch.ones(1)
         )
         self.search_space_digest = SearchSpaceDigest(

--- a/ax/models/torch/rembo.py
+++ b/ax/models/torch/rembo.py
@@ -13,6 +13,7 @@ from ax.core.types import TCandidateMetadata
 from ax.models.torch.botorch import BotorchModel
 from ax.models.torch_base import TorchGenResults, TorchModel, TorchOptConfig
 from ax.utils.common.docutils import copy_doc
+from botorch.utils.containers import DenseContainer
 from botorch.utils.datasets import SupervisedDataset
 from torch import Tensor
 
@@ -250,7 +251,9 @@ class REMBO(BotorchModel):
         X_D = _get_single_X([dataset.X() for dataset in datasets])
         X_d_01 = self.to_01(self.project_down(X_D))
         # Fit model in low-d space (adjusted to [0, 1]^d)
-        return [dataclasses.replace(dataset, X=X_d_01) for dataset in datasets]
+        for dataset in datasets:
+            dataset.X = DenseContainer(values=X_d_01, event_shape=X_d_01.shape[-1:])
+        return datasets
 
 
 def _get_single_X(Xs: List[Tensor]) -> Tensor:

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -42,7 +42,7 @@ from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
 from botorch.models.gp_regression_fidelity import FixedNoiseMultiFidelityGP
 from botorch.models.model import ModelList
 from botorch.sampling.normal import SobolQMCNormalSampler
-from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
+from botorch.utils.datasets import SupervisedDataset
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 
 
@@ -86,7 +86,7 @@ class BoTorchModelTest(TestCase):
             SupervisedDataset(X=X, Y=Y) for X, Y in zip(Xs1, Ys1)
         ]
         self.non_block_design_training_data = [
-            FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+            SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
             for X, Y, Yvar in zip(Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2)
         ]
         self.search_space_digest = SearchSpaceDigest(
@@ -116,7 +116,7 @@ class BoTorchModelTest(TestCase):
         self.pending_observations = None
         self.rounding_func = "func"
         self.moo_training_data = [  # block design
-            FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+            SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
             for X, Y, Yvar in zip(Xs1 * 3, Ys1 + Ys2 + Ys1, Yvars1 * 3)
         ]
         self.moo_metric_names = ["y1", "y2", "y3"]
@@ -825,7 +825,7 @@ class BoTorchModelTest(TestCase):
         self.assertIsInstance(m, FixedNoiseGP)
         self.assertEqual(m.num_outputs, 2)
         training_data = ckwargs["training_data"]
-        self.assertIsInstance(training_data, FixedNoiseDataset)
+        self.assertIsNotNone(training_data.Yvar)
         self.assertTrue(torch.equal(training_data.X(), self.Xs[0]))
         self.assertTrue(
             torch.equal(

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -39,7 +39,7 @@ from botorch.models.pairwise_gp import PairwiseGP, PairwiseLaplaceMarginalLogLik
 from botorch.models.transforms.input import InputPerturbation, Normalize
 from botorch.models.transforms.outcome import Standardize
 from botorch.sampling.normal import SobolQMCNormalSampler
-from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
+from botorch.utils.datasets import SupervisedDataset
 from gpytorch.constraints import GreaterThan, Interval
 from gpytorch.kernels import Kernel, MaternKernel, RBFKernel, ScaleKernel  # noqa: F401
 from gpytorch.likelihoods import (  # noqa: F401
@@ -781,14 +781,14 @@ class SurrogateWithModelListTest(TestCase):
         self.botorch_submodel_class_per_outcome = {
             self.outcomes[0]: choose_model_class(
                 datasets=[
-                    FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                    SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                     for X, Y, Yvar in zip(Xs1, Ys1, Yvars1)
                 ],
                 search_space_digest=self.search_space_digest,
             ),
             self.outcomes[1]: choose_model_class(
                 datasets=[
-                    FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+                    SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
                     for X, Y, Yvar in zip(Xs2, Ys2, Yvars2)
                 ],
                 search_space_digest=self.search_space_digest,
@@ -801,7 +801,7 @@ class SurrogateWithModelListTest(TestCase):
         self.Ys = Ys1 + Ys2
         self.Yvars = Yvars1 + Yvars2
         self.fixed_noise_training_data = [
-            FixedNoiseDataset(X=X, Y=Y, Yvar=Yvar)
+            SupervisedDataset(X=X, Y=Y, Yvar=Yvar)
             for X, Y, Yvar in zip(self.Xs, self.Ys, self.Yvars)
         ]
         self.supervised_training_data = [
@@ -853,7 +853,7 @@ class SurrogateWithModelListTest(TestCase):
                 {
                     "fidelity_features": [],
                     "task_feature": self.task_features[0],
-                    "training_data": FixedNoiseDataset(
+                    "training_data": SupervisedDataset(
                         X=self.Xs[idx], Y=self.Ys[idx], Yvar=self.Yvars[idx]
                     ),
                     "rank": 1,
@@ -879,8 +879,8 @@ class SurrogateWithModelListTest(TestCase):
             metric_names=self.outcomes,
         )
         for ds in not_none(surrogate._training_data):
-            self.assertTrue(isinstance(ds, SupervisedDataset))
-            self.assertFalse(isinstance(ds, FixedNoiseDataset))
+            self.assertIsInstance(ds, SupervisedDataset)
+            self.assertIsNone(ds.Yvar)
         self.assertEqual(len(not_none(surrogate._training_data)), 2)
 
     @patch.object(

--- a/ax/models/torch/utils.py
+++ b/ax/models/torch/utils.py
@@ -57,7 +57,7 @@ from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.posteriors.posterior_list import PosteriorList
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.constraints import get_outcome_constraint_transforms
-from botorch.utils.datasets import FixedNoiseDataset, SupervisedDataset
+from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.objective import get_objective_weights_transform
 from botorch.utils.sampling import sample_hypersphere, sample_simplex
 from torch import Tensor
@@ -687,7 +687,7 @@ def _datasets_to_legacy_inputs(
             raise UnsupportedError("Legacy setup only supports `SupervisedDataset`s")
         Xs.append(dataset.X())
         Ys.append(dataset.Y())
-        if isinstance(dataset, FixedNoiseDataset):
+        if dataset.Yvar is not None:
             Yvars.append(dataset.Yvar())
         else:
             Yvars.append(torch.full_like(Ys[-1], float("nan")))


### PR DESCRIPTION
Summary: This follows the dataset changes in https://github.com/pytorch/botorch/pull/1945 to deprecate the use of FixedNoiseDataset in Ax.

Differential Revision: D48051393

