### PR TITLE
Using arm_name to identify status quo in Relativize transform

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -254,6 +254,10 @@ class Experiment(Base):
                 sq_idx += 1
 
             self._name_and_store_arm_if_not_exists(arm=status_quo, proposed_name=name)
+            logger.warn(
+                "Experiment's status_quo is updated. "
+                "Generally the status_quo should not be changed after being set."
+            )
 
         # If old status_quo not present in any trials,
         # remove from _arms_by_signature

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -554,10 +554,17 @@ def separate_observations(
 def recombine_observations(
     observation_features: List[ObservationFeatures],
     observation_data: List[ObservationData],
+    arm_names: Optional[List[str]] = None,
 ) -> List[Observation]:
     if len(observation_features) != len(observation_data):
         raise ValueError("Got features and data of different lengths")
+    if arm_names is not None and len(observation_features) != len(arm_names):
+        raise ValueError("Got features and arm_names of different lengths")
     return [
-        Observation(features=observation_features[i], data=obsd)
+        Observation(
+            features=observation_features[i],
+            data=obsd,
+            arm_name=None if arm_names is None else arm_names[i],
+        )
         for i, obsd in enumerate(observation_data)
     ]

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -665,12 +665,13 @@ class ObservationsTest(TestCase):
             self.assertEqual(obs.arm_name, cname_truth[i])
 
     def testSeparateObservations(self) -> None:
+        obs_arm_name = "0_0"
         obs = Observation(
             features=ObservationFeatures(parameters={"x": 20}),
             data=ObservationData(
                 means=np.array([1]), covariance=np.array([[2]]), metric_names=["a"]
             ),
-            arm_name="0_0",
+            arm_name=obs_arm_name,
         )
         obs_feats, obs_data = separate_observations(observations=[obs])
         self.assertEqual(obs.features, ObservationFeatures(parameters={"x": 20}))
@@ -682,9 +683,14 @@ class ObservationsTest(TestCase):
         )
         with self.assertRaises(ValueError):
             recombine_observations(observation_features=obs_feats, observation_data=[])
-        new_obs = recombine_observations(obs_feats, obs_data)[0]
+        with self.assertRaises(ValueError):
+            recombine_observations(
+                observation_features=obs_feats, observation_data=obs_data, arm_names=[]
+            )
+        new_obs = recombine_observations(obs_feats, obs_data, [obs_arm_name])[0]
         self.assertEqual(new_obs.features, obs.features)
         self.assertEqual(new_obs.data, obs.data)
+        self.assertEqual(new_obs.arm_name, obs_arm_name)
         obs_feats, obs_data = separate_observations(observations=[obs], copy=True)
         self.assertEqual(obs.features, ObservationFeatures(parameters={"x": 20}))
         self.assertEqual(

--- a/ax/modelbridge/tests/test_relativize_transform.py
+++ b/ax/modelbridge/tests/test_relativize_transform.py
@@ -58,11 +58,13 @@ class RelativizeDataTest(TestCase):
                             covariance=np.array([[0.1]]),
                         ),
                         features=ObservationFeatures(parameters={"x": 1}),
+                        arm_name="0_0",
                     )
                 ],
             )
 
     def test_relativize_transform_observations(self) -> None:
+        arm_names = ["status_quo", "0_0"]
         obs_data = [
             ObservationData(
                 metric_names=["foobar", "foobaz"],
@@ -81,11 +83,10 @@ class RelativizeDataTest(TestCase):
             # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures(parameters={"x": 2}, trial_index=0),
         ]
-        observations = recombine_observations(obs_features, obs_data)
+        observations = recombine_observations(obs_features, obs_data, arm_names)
         modelbridge = Mock(
             status_quo=Mock(
-                data=obs_data[0],
-                features=obs_features[0],
+                data=obs_data[0], features=obs_features[0], arm_name=arm_names[0]
             )
         )
         tf = Relativize(
@@ -139,6 +140,7 @@ class RelativizeDataTest(TestCase):
         assume(abs(sq_mean) >= 1e-10)
         assume(abs(sq_mean) != sq_sem)
 
+        arm_names = ["status_quo", "0_0"]
         obs_data = [
             ObservationData(
                 metric_names=["foo"],
@@ -159,11 +161,10 @@ class RelativizeDataTest(TestCase):
         ]
         modelbridge = Mock(
             status_quo=Mock(
-                data=obs_data[0],
-                features=obs_features[0],
+                data=obs_data[0], features=obs_features[0], arm_name=arm_names[0]
             )
         )
-        observations = recombine_observations(obs_features, obs_data)
+        observations = recombine_observations(obs_features, obs_data, arm_names)
         transform = Relativize(
             search_space=None,
             observations=observations,
@@ -204,6 +205,7 @@ class RelativizeDataTest(TestCase):
                 features=ObservationFeatures(
                     parameters=not_none(experiment.status_quo).parameters
                 ),
+                arm_name="status_quo",
             )
         )
 


### PR DESCRIPTION
Summary: Using arm_name to identify status quo in Relativize transform. Previously we rely on the arm signature, which mismatch as the status quo(s) in `observations` are transformed while `modelbridge.status_quo` is untransformed.

Differential Revision: D48057736

