### PR TITLE
Don't allow unused **kwargs in input_constructors except for a defined set of exceptions

### DIFF
--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -34,8 +34,6 @@ def get_sobol_botorch_modular_fixed_noise_gp_qnei(
             },
             Keys.ACQF_KWARGS: {
                 "prune_baseline": True,
-                "qmc": True,
-                "mc_samples": 512,
             },
         }
     }

--- a/ax/core/generator_run.py
+++ b/ax/core/generator_run.py
@@ -146,7 +146,10 @@ class GeneratorRun(SortableBase):
         if weights is None:
             weights = [1.0 for i in range(len(arms))]
         if len(arms) != len(weights):
-            raise ValueError("Weights and arms must have the same length.")
+            raise ValueError(
+                "Weights and arms must have the same length. Arms have length "
+                f"{len(arms)}, weights have length {len(weights)}."
+            )
         if bridge_kwargs is not None or model_kwargs is not None:
             if model_key is None:
                 raise ValueError(

--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -193,7 +193,7 @@ class Acquisition(Base):
         ]
 
         # Subset model only to the outcomes we need for the optimization.
-        if self.options.get(Keys.SUBSET_MODEL, True):
+        if self.options.pop(Keys.SUBSET_MODEL, True):
             subset_model_results = subset_model(
                 model=primary_surrogate.model,
                 objective_weights=torch_opt_config.objective_weights,

--- a/ax/models/torch/botorch_modular/sebo.py
+++ b/ax/models/torch/botorch_modular/sebo.py
@@ -61,8 +61,8 @@ class SEBOAcquisition(Acquisition):
 
         tkwargs = {"dtype": surrogate.dtype, "device": surrogate.device}
         options = options or {}
-        self.penalty_name: str = options.get("penalty", "L0_norm")
-        self.target_point: Tensor = options.get("target_point", None)
+        self.penalty_name: str = options.pop("penalty", "L0_norm")
+        self.target_point: Tensor = options.pop("target_point", None)
         if self.target_point is None:
             raise ValueError("please provide target point.")
         self.target_point.to(**tkwargs)  # pyre-ignore
@@ -93,6 +93,8 @@ class SEBOAcquisition(Acquisition):
         )
 
         # instantiate botorch_acqf_class
+        if not issubclass(botorch_acqf_class, qExpectedHypervolumeImprovement):
+            raise ValueError("botorch_acqf_class must be qEHVI to use SEBO")
         super().__init__(
             surrogates={"sebo": surrogate_f},
             search_space_digest=search_space_digest,

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -30,15 +30,26 @@ def get_benchmark_problem() -> BenchmarkProblem:
     )
 
 
-def get_single_objective_benchmark_problem() -> SingleObjectiveBenchmarkProblem:
+def get_single_objective_benchmark_problem(
+    infer_noise: bool = True,
+    num_trials: int = 4,
+) -> SingleObjectiveBenchmarkProblem:
     return SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
-        test_problem_class=Branin, test_problem_kwargs={}, num_trials=4
+        test_problem_class=Branin,
+        test_problem_kwargs={},
+        num_trials=num_trials,
+        infer_noise=infer_noise,
     )
 
 
-def get_multi_objective_benchmark_problem() -> MultiObjectiveBenchmarkProblem:
+def get_multi_objective_benchmark_problem(
+    infer_noise: bool = True, num_trials: int = 4
+) -> MultiObjectiveBenchmarkProblem:
     return MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
-        test_problem_class=BraninCurrin, test_problem_kwargs={}, num_trials=4
+        test_problem_class=BraninCurrin,
+        test_problem_kwargs={},
+        num_trials=num_trials,
+        infer_noise=infer_noise,
     )
 
 
@@ -67,6 +78,8 @@ def get_sobol_gpei_benchmark_method() -> BenchmarkMethod:
                     num_trials=-1,
                     model_kwargs={
                         "surrogate": Surrogate(SingleTaskGP),
+                        # TODO: tests should better reflect defaults and not
+                        # re-implement this logic.
                         "botorch_acqf_class": qNoisyExpectedImprovement,
                     },
                     model_gen_kwargs={
@@ -77,8 +90,6 @@ def get_sobol_gpei_benchmark_method() -> BenchmarkMethod:
                             },
                             Keys.ACQF_KWARGS: {
                                 "prune_baseline": True,
-                                "qmc": True,
-                                "mc_samples": 512,
                             },
                         }
                     },


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/1872

[x] Remove unused arguments from input constructors and related functions. The idea is especially not to let unused keyword arguments disappear into `**kwargs` and be silently ignored
[x] add arguments to some input constructors so they don't need any `**kwargs`
[x] Add a decorator that ensures that each input constructor can accept a certain set of keyword arguments, even if those are not used are the constructor, while still erroring on
[ ] Prevent arguments from having different defaults in the input constructors as in acquisition functions

Reviewed By: SebastianAment

Differential Revision: D46519588

