### PR TITLE
fix twisted import structure in botorch.acquisition.utils

### DIFF
--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -43,15 +43,15 @@ CHEBYSHEV_SCALARIZATION_PATH = (
     "ax.models.torch.botorch_defaults.get_chebyshev_scalarization"
 )
 NEHVI_ACQF_PATH = (
-    "botorch.acquisition.utils.moo_monte_carlo.qNoisyExpectedHypervolumeImprovement"
+    "botorch.acquisition.factory.moo_monte_carlo.qNoisyExpectedHypervolumeImprovement"
 )
 EHVI_ACQF_PATH = (
-    "botorch.acquisition.utils.moo_monte_carlo.qExpectedHypervolumeImprovement"
+    "botorch.acquisition.factory.moo_monte_carlo.qExpectedHypervolumeImprovement"
 )
 NEHVI_PARTITIONING_PATH = (
     "botorch.acquisition.multi_objective.monte_carlo.FastNondominatedPartitioning"
 )
-EHVI_PARTITIONING_PATH = "botorch.acquisition.utils.FastNondominatedPartitioning"
+EHVI_PARTITIONING_PATH = "botorch.acquisition.factory.FastNondominatedPartitioning"
 
 
 def dummy_func(X: torch.Tensor) -> torch.Tensor:
@@ -500,7 +500,7 @@ class BotorchMOOModelTest(TestCase):
             )
             es.enter_context(
                 mock.patch(
-                    "botorch.acquisition.utils.get_sampler",
+                    "botorch.acquisition.factory.get_sampler",
                     return_value=IIDNormalSampler(sample_shape=torch.Size([2])),
                 )
             )

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -14,11 +14,12 @@ from ax.models.model_utils import best_observed_point, get_observed
 from ax.models.torch.utils import _to_inequality_constraints
 from ax.models.torch_base import TorchModel
 from ax.models.types import TConfig
+from botorch.acquisition import get_acquisition_function
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
 from botorch.acquisition.objective import ConstrainedMCObjective, GenericMCObjective
 from botorch.acquisition.penalized import PenalizedMCObjective
-from botorch.acquisition.utils import get_acquisition_function, get_infeasible_cost
+from botorch.acquisition.utils import get_infeasible_cost
 from botorch.exceptions.errors import UnsupportedError
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP

--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -33,10 +33,10 @@ from ax.models.torch.utils import (
 )
 from ax.models.torch_base import TorchModel
 from ax.utils.common.typeutils import not_none
+from botorch.acquisition import get_acquisition_function
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.multi_objective.objective import WeightedMCMultiOutputObjective
 from botorch.acquisition.multi_objective.utils import get_default_partitioning_alpha
-from botorch.acquisition.utils import get_acquisition_function
 from botorch.models.model import Model
 from botorch.optim.optimize import optimize_acqf_list
 from botorch.posteriors.gpytorch import GPyTorchPosterior


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/botorch_fb/pull/14

See title. This fixes a twisted import structure where botorch.acquisition.monte_carlo imports from utils and utils imports botorch.acquisition.monte_carlo

Differential Revision: D48329866

