### PR TITLE
More thorough PTS testing

### DIFF
--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -73,7 +73,8 @@ class ALEBOKernel(Kernel):
         )
         # pyre-fixme[4]: Attribute must be annotated.
         self.d, D = B.shape
-        assert self.d < D
+        if not self.d < D:
+            raise ValueError(f"Expected B.shape[0] < B.shape[1], but got {B.shape=}.")
         self.B = B
         # Initialize U
         Arnd = torch.randn(D, D, dtype=B.dtype, device=B.device)


### PR DESCRIPTION
Summary:
Background: Jelena somehow noticed that D46519588 could break PTS because an unused argument was being passed and ignored, which D46519588 would disallow. See https://fburl.com/diff/ttaw0v83

It turns out that there are _two or three_ reasons that unit tests would not have caught this issue:
* There was no sufficiently end-to-end test for usage of FBModels.BOPE and FBModels.BOPE_MTGP; we never "gen" based on them
* "gen" is mocked out in the analyzer tests, so we wouldn't have caught those errors anyway
* Exceptions are logged rather than raised, so without careful testing, the exception raised wouldn't have triggered a test breakage.

Changes: So we need 1) a test that combines FBModels.BOPE and FBModels.BOPE with actually generating candidates (perhaps with fast_botorch_optimize), and 2) better testing in PTSAnalyzer and perhaps other parts of PTS in general.

I attempted to add (1) and remove the mock of "gen", but I'm haaving a hard time due to my lack of familiarity with PTS. Help writing these tests would be very appreciated!

Reviewed By: lena-kashtelyan

Differential Revision: D48288094

