### PR TITLE
Merge inferred & fixed noise LCE-M models.

### DIFF
--- a/ax/models/tests/test_cbo_lcem.py
+++ b/ax/models/tests/test_cbo_lcem.py
@@ -9,7 +9,7 @@ import torch
 from ax.models.torch.cbo_lcem import LCEMBO
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import fast_botorch_optimize
-from botorch.models.contextual_multioutput import FixedNoiseLCEMGP, LCEMGP
+from botorch.models.contextual_multioutput import LCEMGP
 from botorch.models.model_list_gp_regression import ModelListGP
 
 
@@ -52,7 +52,7 @@ class LCEMBOTest(TestCase):
             metric_names=[],
         )
         self.assertIsInstance(gp, ModelListGP)
-        self.assertIsInstance(gp.models[0], FixedNoiseLCEMGP)
+        self.assertIsInstance(gp.models[0], LCEMGP)
 
         # Verify errors are raised in get_and_fit_model
         train_yvar = np.nan * torch.ones(train_y.shape)

--- a/ax/models/torch/cbo_lcem.py
+++ b/ax/models/torch/cbo_lcem.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional
 import torch
 from ax.models.torch.botorch import BotorchModel
 from botorch.fit import fit_gpytorch_mll
-from botorch.models.contextual_multioutput import FixedNoiseLCEMGP, LCEMGP
+from botorch.models.contextual_multioutput import LCEMGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from gpytorch.mlls.sum_marginal_log_likelihood import SumMarginalLogLikelihood
 from torch import Tensor
@@ -78,7 +78,7 @@ class LCEMBO(BotorchModel):
                     embs_dim_list=self.embs_dim_list,
                 )
             else:
-                gp_m = FixedNoiseLCEMGP(
+                gp_m = LCEMGP(
                     train_X=X,
                     train_Y=Ys[i],
                     train_Yvar=Yvar,


### PR DESCRIPTION
Summary: Deprecate FixedNoiseLCEMGP and merge to LCEMGP by adding an optional train_Yvar input.

Reviewed By: saitcakmak

Differential Revision: D48269239

