### PR TITLE
Activating `qLogNEI` by default for all `BotorchModels`

### DIFF
--- a/ax/modelbridge/factory.py
+++ b/ax/modelbridge/factory.py
@@ -34,7 +34,11 @@ from ax.models.torch.botorch import (
     TModelPredictor,
     TOptimizer,
 )
-from ax.models.torch.botorch_defaults import get_and_fit_model, get_NEI, scipy_optimizer
+from ax.models.torch.botorch_defaults import (
+    get_and_fit_model,
+    get_qLogNEI,
+    scipy_optimizer,
+)
 from ax.models.torch.botorch_moo_defaults import get_EHVI
 from ax.models.torch.utils import predict_from_model
 from ax.models.types import TConfig
@@ -238,7 +242,7 @@ def get_botorch(
     transform_configs: Optional[Dict[str, TConfig]] = None,
     model_constructor: TModelConstructor = get_and_fit_model,
     model_predictor: TModelPredictor = predict_from_model,
-    acqf_constructor: TAcqfConstructor = get_NEI,
+    acqf_constructor: TAcqfConstructor = get_qLogNEI,
     acqf_optimizer: TOptimizer = scipy_optimizer,  # pyre-ignore[9]
     refit_on_cv: bool = False,
     refit_on_update: bool = True,
@@ -556,7 +560,7 @@ def get_MOO_PAREGO(
             search_space=search_space or experiment.search_space,
             torch_dtype=dtype,
             torch_device=device,
-            acqf_constructor=get_NEI,
+            acqf_constructor=get_qLogNEI,
             default_model_gen_options={
                 "acquisition_function_kwargs": {
                     "chebyshev_scalarization": True,
@@ -592,7 +596,7 @@ def get_MOO_RS(
             search_space=search_space or experiment.search_space,
             torch_dtype=dtype,
             torch_device=device,
-            acqf_constructor=get_NEI,
+            acqf_constructor=get_qLogNEI,
             default_model_gen_options={
                 "acquisition_function_kwargs": {
                     "random_scalarization": True,
@@ -662,7 +666,7 @@ def get_MTGP_PAREGO(
             search_space=search_space or experiment.search_space,
             torch_dtype=dtype,
             torch_device=device,
-            acqf_constructor=get_NEI,
+            acqf_constructor=get_qLogNEI,
             status_quo_features=status_quo_features,
             transforms=transforms,
             transform_configs=transform_configs,

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -136,7 +136,7 @@ class ModelRegistryTest(TestCase):
             {
                 "acqf_constructor": {
                     "is_callable_as_path": True,
-                    "value": f"{botorch_defaults}.get_NEI",
+                    "value": f"{botorch_defaults}.get_qLogNEI",
                 },
                 "acqf_optimizer": {
                     "is_callable_as_path": True,

--- a/ax/models/tests/test_alebo.py
+++ b/ax/models/tests/test_alebo.py
@@ -24,8 +24,8 @@ from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast
 from ax.utils.testing.mock import fast_botorch_optimize
+from botorch.acquisition import qLogNoisyExpectedImprovement
 from botorch.acquisition.analytic import ExpectedImprovement
-from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.utils.datasets import SupervisedDataset
 from torch.nn.parameter import Parameter
@@ -231,7 +231,7 @@ class ALEBOTest(TestCase):
             q=1,
             noiseless=False,
         )
-        self.assertIsInstance(acq, qNoisyExpectedImprovement)
+        self.assertIsInstance(acq, qLogNoisyExpectedImprovement)
 
         with mock.patch(
             "ax.models.torch.alebo.optimize_acqf",
@@ -255,7 +255,7 @@ class ALEBOTest(TestCase):
 
         self.assertEqual(optim_mock.call_count, 2)
         self.assertIsInstance(
-            optim_mock.mock_calls[0][2]["acq_function"], qNoisyExpectedImprovement
+            optim_mock.mock_calls[0][2]["acq_function"], qLogNoisyExpectedImprovement
         )
         self.assertEqual(optim_mock.mock_calls[0][2]["num_restarts"], 5)
         self.assertEqual(optim_mock.mock_calls[0][2]["inequality_constraints"], 5.0)

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import AxError
-from ax.models.torch.botorch_defaults import get_NEI
+from ax.models.torch.botorch_defaults import get_qLogNEI
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.botorch_moo_defaults import (
     get_EHVI,
@@ -141,7 +141,7 @@ class BotorchMOOModelTest(TestCase):
             bounds=bounds,
             task_features=tfs,
         )
-        model = MultiObjectiveBotorchModel(acqf_constructor=get_NEI)
+        model = MultiObjectiveBotorchModel(acqf_constructor=get_qLogNEI)
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=training_data,
@@ -197,7 +197,7 @@ class BotorchMOOModelTest(TestCase):
         # test input warping
         self.assertFalse(model.use_input_warping)
         model = MultiObjectiveBotorchModel(
-            acqf_constructor=get_NEI,
+            acqf_constructor=get_qLogNEI,
             use_input_warping=True,
         )
         model.fit(
@@ -216,7 +216,7 @@ class BotorchMOOModelTest(TestCase):
         # test loocv pseudo likelihood
         self.assertFalse(model.use_loocv_pseudo_likelihood)
         model = MultiObjectiveBotorchModel(
-            acqf_constructor=get_NEI,
+            acqf_constructor=get_qLogNEI,
             use_loocv_pseudo_likelihood=True,
         )
         model.fit(
@@ -256,7 +256,7 @@ class BotorchMOOModelTest(TestCase):
             bounds=bounds,
             task_features=tfs,
         )
-        model = MultiObjectiveBotorchModel(acqf_constructor=get_NEI)
+        model = MultiObjectiveBotorchModel(acqf_constructor=get_qLogNEI)
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=training_data,
@@ -611,7 +611,7 @@ class BotorchMOOModelTest(TestCase):
         n = 2
         objective_weights = torch.tensor([1.0, 1.0], **tkwargs)
         obj_t = torch.tensor([1.0, 1.0], **tkwargs)
-        model = MultiObjectiveBotorchModel(acqf_constructor=get_NEI)
+        model = MultiObjectiveBotorchModel(acqf_constructor=get_qLogNEI)
 
         search_space_digest = SearchSpaceDigest(
             feature_names=fns,
@@ -672,7 +672,7 @@ class BotorchMOOModelTest(TestCase):
         n = 2
         objective_weights = torch.tensor([1.0, 1.0], **tkwargs)
         obj_t = torch.tensor([1.0, 1.0], **tkwargs)
-        model = MultiObjectiveBotorchModel(acqf_constructor=get_NEI)
+        model = MultiObjectiveBotorchModel(acqf_constructor=get_qLogNEI)
 
         search_space_digest = SearchSpaceDigest(
             feature_names=fns,

--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -19,7 +19,7 @@ from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
 from ax.models.random.alebo_initializer import ALEBOInitializer
 from ax.models.torch.botorch import BotorchModel
-from ax.models.torch.botorch_defaults import get_NEI
+from ax.models.torch.botorch_defaults import get_qLogNEI
 from ax.models.torch.utils import _datasets_to_legacy_inputs
 from ax.models.torch_base import TorchGenResults, TorchModel, TorchOptConfig
 from ax.utils.common.docutils import copy_doc
@@ -481,7 +481,7 @@ def ei_or_nei(
         return ExpectedImprovement(model=model, best_f=best_f, maximize=maximize)
     else:
         with gpytorch.settings.max_cholesky_size(2000):
-            acq = get_NEI(
+            acq = get_qLogNEI(
                 model=model,
                 objective_weights=objective_weights,
                 outcome_constraints=outcome_constraints,

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -18,7 +18,7 @@ from ax.core.types import TCandidateMetadata
 from ax.exceptions.core import DataRequiredError
 from ax.models.torch.botorch_defaults import (
     get_and_fit_model,
-    get_NEI,
+    get_qLogNEI,
     recommend_best_observed_point,
     scipy_optimizer,
     TAcqfConstructor,
@@ -98,9 +98,9 @@ class BotorchModel(TorchModel):
     r"""
     Customizable botorch model.
 
-    By default, this uses a noisy Expected Improvement acquisition function on
-    top of a model made up of separate GPs, one for each outcome. This behavior
-    can be modified by providing custom implementations of the following
+    By default, this uses a noisy Log Expected Improvement (qLogNEI) acquisition
+    function on top of a model made up of separate GPs, one for each outcome. This
+    behavior can be modified by providing custom implementations of the following
     components:
 
     - a `model_constructor` that instantiates and fits a model on data
@@ -185,7 +185,7 @@ class BotorchModel(TorchModel):
     the (linear) outcome constraints, `X_observed` are previously observed points,
     and `X_pending` are points whose evaluation is pending. `acq_function` is a
     BoTorch acquisition function crafted from these inputs. For additional
-    details on the arguments, see `get_NEI`.
+    details on the arguments, see `get_qLogNEI`.
 
     ::
 
@@ -244,7 +244,7 @@ class BotorchModel(TorchModel):
         self,
         model_constructor: TModelConstructor = get_and_fit_model,
         model_predictor: TModelPredictor = predict_from_model,
-        acqf_constructor: TAcqfConstructor = get_NEI,
+        acqf_constructor: TAcqfConstructor = get_qLogNEI,
         # pyre-fixme[9]: acqf_optimizer declared/used type mismatch
         acqf_optimizer: TOptimizer = scipy_optimizer,
         best_point_recommender: TBestPointRecommender = recommend_best_observed_point,

--- a/ax/models/torch/botorch_moo.py
+++ b/ax/models/torch/botorch_moo.py
@@ -138,7 +138,7 @@ class MultiObjectiveBotorchModel(BotorchModel):
     the (linear) outcome constraints, `X_observed` are previously observed points,
     and `X_pending` are points whose evaluation is pending. `acq_function` is a
     BoTorch acquisition function crafted from these inputs. For additional
-    details on the arguments, see `get_NEI`.
+    details on the arguments, see `get_NEHVI`.
 
     ::
 

--- a/ax/models/torch/fully_bayesian.py
+++ b/ax/models/torch/fully_bayesian.py
@@ -47,7 +47,7 @@ from ax.models.torch.botorch import (
     TOptimizer,
 )
 from ax.models.torch.botorch_defaults import (
-    get_NEI,
+    get_qLogNEI,
     MIN_OBSERVED_NOISE_LEVEL,
     recommend_best_observed_point,
     scipy_optimizer,
@@ -434,7 +434,7 @@ def get_fully_bayesian_acqf(
     that is shared by all other legacy Ax acquisition function constructors.
     """
     kwargs["marginalize_dim"] = -3
-    acqf_constructor: TAcqfConstructor = kwargs.pop("acqf_constructor", get_NEI)
+    acqf_constructor: TAcqfConstructor = kwargs.pop("acqf_constructor", get_qLogNEI)
     acqf = acqf_constructor(
         model=model,
         objective_weights=objective_weights,


### PR DESCRIPTION
Summary: This commit changes the default acquisition function for all `BotorchModels` from `qNEI` to `qLogNEI`.

Differential Revision: D48610442

