### PR TITLE
Compute score trace for benchmark problems that have an 'optimal_value' regardles of what they subclass

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -5,7 +5,7 @@
 
 
 import abc
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable, Type
 
 from ax.core.metric import Metric
 
@@ -46,7 +46,8 @@ def _get_name(
     return f"{base_name}{fixed_noise}{dim_str}"
 
 
-class BenchmarkProblemBase(abc.ABC):
+@runtime_checkable
+class BenchmarkProblemBase(Protocol):
     """
     Specifies the interface any benchmark problem must adhere to.
 
@@ -66,7 +67,12 @@ class BenchmarkProblemBase(abc.ABC):
         pass  # pragma: no cover
 
 
-class BenchmarkProblem(Base, BenchmarkProblemBase):
+@runtime_checkable
+class BenchmarkProblemWithKnownOptimum(Protocol):
+    optimal_value: float
+
+
+class BenchmarkProblem(Base):
     """Benchmark problem, represented in terms of Ax search space, optimization
     config, and runner.
     """
@@ -257,6 +263,10 @@ class MultiObjectiveBenchmarkProblem(BenchmarkProblem):
             infer_noise=infer_noise,
             tracking_metrics=tracking_metrics,
         )
+
+    @property
+    def optimal_value(self) -> float:
+        return self.maximum_hypervolume
 
     @classmethod
     def from_botorch_multi_objective(

--- a/ax/benchmark/problems/hd_embedding.py
+++ b/ax/benchmark/problems/hd_embedding.py
@@ -4,15 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+from typing import TypeVar
 
 from ax.benchmark.benchmark_problem import BenchmarkProblem
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 
+TProblem = TypeVar("TProblem", bound=BenchmarkProblem)
 
-def embed_higher_dimension(
-    problem: BenchmarkProblem, total_dimensionality: int
-) -> BenchmarkProblem:
+
+def embed_higher_dimension(problem: TProblem, total_dimensionality: int) -> TProblem:
     """
     Return a new `BenchmarkProblem` with enough `RangeParameter`s added to the
     search space to make its total dimensionality equal to `total_dimensionality`

--- a/ax/benchmark/problems/surrogate.py
+++ b/ax/benchmark/problems/surrogate.py
@@ -178,6 +178,10 @@ class MOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
         self.reference_point = reference_point
         self.maximum_hypervolume = maximum_hypervolume
 
+    @property
+    def optimal_value(self) -> float:
+        return self.maximum_hypervolume
+
 
 class SurrogateMetric(Metric):
     def __init__(

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -12,12 +12,21 @@ from ax.benchmark.benchmark_problem import (
     SingleObjectiveBenchmarkProblem,
 )
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
+from ax.benchmark.problems.surrogate import (
+    MOOSurrogateBenchmarkProblem,
+    SOOSurrogateBenchmarkProblem,
+)
 from ax.core.experiment import Experiment
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.service.scheduler import SchedulerOptions
 from ax.utils.common.constants import Keys
+from ax.utils.testing.core_stubs import (
+    get_branin_multi_objective_optimization_config,
+    get_branin_optimization_config,
+    get_branin_search_space,
+)
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.test_functions.multi_objective import BraninCurrin
@@ -63,6 +72,37 @@ def get_sobol_benchmark_method() -> BenchmarkMethod:
         scheduler_options=SchedulerOptions(
             total_trials=4, init_seconds_between_polls=0
         ),
+    )
+
+
+def get_soo_surrogate() -> SOOSurrogateBenchmarkProblem:
+    surrogate = Surrogate(
+        botorch_model_class=SingleTaskGP,
+    )
+    return SOOSurrogateBenchmarkProblem(
+        name="test",
+        search_space=get_branin_search_space(),
+        optimization_config=get_branin_optimization_config(),
+        num_trials=6,
+        infer_noise=False,
+        metric_names=[],
+        get_surrogate_and_datasets=lambda: (surrogate, []),
+        optimal_value=0.0,
+    )
+
+
+def get_moo_surrogate() -> MOOSurrogateBenchmarkProblem:
+    surrogate = Surrogate(botorch_model_class=SingleTaskGP)
+    return MOOSurrogateBenchmarkProblem(
+        name="test",
+        search_space=get_branin_search_space(),
+        optimization_config=get_branin_multi_objective_optimization_config(),
+        num_trials=10,
+        infer_noise=False,
+        metric_names=[],
+        get_surrogate_and_datasets=lambda: (surrogate, []),
+        maximum_hypervolume=1.0,
+        reference_point=[],
     )
 
 


### PR DESCRIPTION
Summary:
Since D47685646 (https://github.com/facebook/Ax/pull/1738), which refactored the inheritance pattern of benchmark problems, scores have not been computed for surrogate benchmark problems because they don't have the right superclasses.

In this PR:
1. Check that instances conform to a `Protocol` rather than using `isinstance` to check their types. More Pythonic anyway :)
2. Fix some unrelated type annotations which were incorrect but not detected because tests weren't thorough enough.
3. Add a method `optimal_value` that equals the maximum hypervolume for multi-objective problems.
4. Moved construction of surrogate problems from surrogate tests to benchmark test stubs so they can be used more widely.

Differential Revision: D48629595

