### PR TITLE
Support Relativize transform when status_quo is out of design or None

### DIFF
--- a/ax/modelbridge/tests/test_relativize_transform.py
+++ b/ax/modelbridge/tests/test_relativize_transform.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from unittest.mock import Mock
 
 import numpy as np
+from ax.core import BatchTrial
 from ax.core.observation import (
     Observation,
     ObservationData,
@@ -17,18 +18,23 @@ from ax.core.observation import (
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.types import ComparisonOp
 from ax.metrics.branin import BraninMetric
+from ax.modelbridge import ModelBridge
 from ax.modelbridge.registry import Models
 from ax.modelbridge.transforms.relativize import Relativize
+from ax.models.base import Model
 from ax.utils.common.testutils import TestCase
-from ax.utils.common.typeutils import not_none
+from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.stats.statstools import relativize_data
 from ax.utils.testing.core_stubs import (
+    get_branin_data_batch,
+    get_branin_experiment,
     get_branin_multi_objective_optimization_config,
     get_branin_optimization_config,
     get_branin_with_multi_task,
     get_search_space,
 )
 from hypothesis import assume, given, settings, strategies as st
+from numpy import int64
 
 
 class RelativizeDataTest(TestCase):
@@ -42,6 +48,7 @@ class RelativizeDataTest(TestCase):
     def test_relativize_transform_requires_a_modelbridge_to_have_status_quo_data(
         self,
     ) -> None:
+        # modelbridge has no status quo
         sobol = Models.SOBOL(search_space=get_search_space())
         self.assertIsNone(sobol.status_quo)
         with self.assertRaisesRegex(ValueError, "status quo data"):
@@ -63,16 +70,91 @@ class RelativizeDataTest(TestCase):
                 ],
             )
 
+        # modelbridge has status quo
+        exp = get_branin_experiment(
+            with_batch=True,
+            with_status_quo=True,
+        )
+        # making status_quo out of design
+        not_none(exp._status_quo)._parameters["x1"] = 10000.0
+        for t in exp.trials.values():
+            t.mark_running(no_runner_required=True)
+            exp.attach_data(get_branin_data_batch(batch=checked_cast(BatchTrial, t)))
+            t.mark_completed()
+        data = exp.fetch_data()
+        modelbridge = ModelBridge(
+            search_space=exp.search_space,
+            model=Model(),
+            transforms=[Relativize],
+            experiment=exp,
+            data=data,
+        )
+        mean_in_data = data.df.query(f"arm_name == '{not_none(exp.status_quo).name}'")[
+            "mean"
+        ].item()
+        # modelbridge.status_quo_data_by_trial is accurate
+        self.assertEqual(
+            mean_in_data, not_none(modelbridge.status_quo_data_by_trial)[0].means[0]
+        )
+
+        # create a new experiment
+        new_exp = get_branin_experiment(
+            with_batch=True,
+            with_status_quo=True,
+        )
+        for t in new_exp.trials.values():
+            t.mark_running(no_runner_required=True)
+            new_exp.attach_data(
+                get_branin_data_batch(batch=checked_cast(BatchTrial, t))
+            )
+            t.mark_completed()
+        new_data = new_exp.fetch_data()
+        new_observations = observations_from_data(experiment=new_exp, data=new_data)
+        # calls modelbridge._set_training_data inside
+        modelbridge._set_training_data(
+            observations=new_observations, search_space=new_exp.search_space
+        )
+        # The new data is different from the original data
+        self.assertNotEqual(data, new_data)
+        self.assertFalse(data.df.equals(new_data.df))
+        mean_in_data = new_data.df.query(
+            f"arm_name == '{not_none(new_exp.status_quo).name}'"
+        )["mean"].item()
+        # modelbridge.status_quo_data_by_trial remains accurate
+        self.assertEqual(
+            mean_in_data, not_none(modelbridge.status_quo_data_by_trial)[0].means[0]
+        )
+
+        # Can still find status_quo_data_by_trial when status_quo name is None
+        mb_sq = not_none(modelbridge._status_quo)
+        mb_sq.arm_name = None
+        self.assertIsNotNone(modelbridge.status_quo_data_by_trial)
+
+        # test transform edge cases
+        observations = observations_from_data(
+            experiment=exp,
+            data=data,
+        )
+        tf = Relativize(
+            search_space=None,
+            observations=observations,
+            modelbridge=modelbridge,
+        )
+        # making observation coming from trial_index not in modelbridge
+        observations[0].features.trial_index = int64(999)
+        self.assertRaises(ValueError, tf.transform_observations, observations)
+
     def test_relativize_transform_observations(self) -> None:
+        metric_names = ["foobar", "foobaz"]
         arm_names = ["status_quo", "0_0"]
         obs_data = [
             ObservationData(
-                metric_names=["foobar", "foobaz"],
+                metric_names=metric_names,
                 means=np.array([2, 5]),
                 covariance=np.array([[0.1, 0.0], [0.0, 0.2]]),
             ),
             ObservationData(
-                metric_names=["foobar", "foobaz"],
+                metric_names=metric_names,
                 means=np.array([1.0, 10.0]),
                 covariance=np.array([[0.3, 0.0], [0.0, 0.4]]),
             ),
@@ -87,7 +169,8 @@ class RelativizeDataTest(TestCase):
         modelbridge = Mock(
             status_quo=Mock(
                 data=obs_data[0], features=obs_features[0], arm_name=arm_names[0]
-            )
+            ),
+            status_quo_data_by_trial={0: obs_data[0]},
         )
         tf = Relativize(
             search_space=None,
@@ -95,7 +178,7 @@ class RelativizeDataTest(TestCase):
             modelbridge=modelbridge,
         )
         results = tf.transform_observations(observations)
-        self.assertEqual(results[0].data.metric_names, ["foobar", "foobaz"])
+        self.assertEqual(results[0].data.metric_names, metric_names)
         # status quo means must always be zero
         self.assertTrue(
             np.allclose(results[0].data.means, np.array([0.0, 0.0])),
@@ -106,7 +189,7 @@ class RelativizeDataTest(TestCase):
             np.allclose(results[0].data.covariance, np.array([[0.0, 0.0], [0.0, 0.0]])),
             results[0].data.covariance,
         )
-        self.assertEqual(results[1].data.metric_names, ["foobar", "foobaz"])
+        self.assertEqual(results[1].data.metric_names, metric_names)
         self.assertTrue(
             np.allclose(results[1].data.means, np.array([-51.25, 98.4])),
             results[1].data.means,
@@ -162,7 +245,8 @@ class RelativizeDataTest(TestCase):
         modelbridge = Mock(
             status_quo=Mock(
                 data=obs_data[0], features=obs_features[0], arm_name=arm_names[0]
-            )
+            ),
+            status_quo_data_by_trial={0: obs_data[0]},
         )
         observations = recombine_observations(obs_features, obs_data, arm_names)
         transform = Relativize(
@@ -192,21 +276,31 @@ class RelativizeDataTest(TestCase):
                 include_sq=True,
             ),
         )
-        status_quo_row = data.df.loc[
-            (data.df["arm_name"] == "status_quo") & (data.df["trial_index"] == 1)
-        ]
+
+        sq_obs_data = []
+        for i in data.df["trial_index"].unique():
+            status_quo_data = data.df.loc[
+                (data.df["arm_name"] == "status_quo") & (data.df["trial_index"] == i)
+            ]
+            sq_obs_data.append(
+                ObservationData(
+                    metric_names=status_quo_data["metric_name"].to_numpy(),
+                    means=status_quo_data["mean"].to_numpy(),
+                    covariance=status_quo_data["sem"].to_numpy()[np.newaxis, :] ** 2,
+                )
+            )
+
         modelbridge = Mock(
             status_quo=Observation(
-                data=ObservationData(
-                    metric_names=status_quo_row["metric_name"].values,
-                    means=status_quo_row["mean"].values,
-                    covariance=np.array([status_quo_row["sem"].values ** 2]),
-                ),
+                data=sq_obs_data[0],
                 features=ObservationFeatures(
                     parameters=not_none(experiment.status_quo).parameters
                 ),
                 arm_name="status_quo",
-            )
+            ),
+            status_quo_data_by_trial={
+                i: sq_obs_data[i] for i in range(len(sq_obs_data))
+            },
         )
 
         transform = Relativize(
@@ -214,6 +308,7 @@ class RelativizeDataTest(TestCase):
             observations=observations,
             modelbridge=modelbridge,
         )
+
         relative_obs_t = transform.transform_observations(observations)
         self.maxDiff = None
         # this assertion just checks that order is the same, which

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1790,6 +1790,7 @@ def get_branin_data_batch(batch: BatchTrial) -> Data:
     return Data(
         pd.DataFrame(
             {
+                "trial_index": batch.index,
                 "arm_name": [arm.name for arm in batch.arms],
                 "metric_name": "branin",
                 "mean": [


### PR DESCRIPTION
Summary: Relativize transform would fail when status_quo is out of design or None is it will be excluded from training data.

Differential Revision: D48250758

