### PR TITLE
only infer objective thresholds for HV-based methods

### DIFF
--- a/ax/modelbridge/tests/test_factory.py
+++ b/ax/modelbridge/tests/test_factory.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from unittest import mock
+
 import pandas as pd
 import torch
 from ax.core.data import Data
@@ -338,7 +340,11 @@ class ModelBridgeFactoryTestMultiObjective(TestCase):
             },
             moo_parego._default_model_gen_options,
         )
-        moo_parego_run = moo_parego.gen(n=2)
+        with mock.patch(
+            "ax.models.torch.botorch_moo.infer_objective_thresholds"
+        ) as mock_infer_ot:
+            moo_parego_run = moo_parego.gen(n=2)
+            mock_infer_ot.assert_not_called()
         self.assertEqual(len(moo_parego_run.arms), 2)
 
     @fast_botorch_optimize

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -615,10 +615,11 @@ class TorchModelBridge(ModelBridge):
         )
 
         gen_metadata = gen_results.gen_metadata
-        if is_moo_problem:
+        if is_moo_problem and "objective_thresholds" in gen_metadata:
             # If objective_thresholds are supplied by the user, then the transformed
             # user-specified objective thresholds are in gen_metadata. Otherwise,
-            # inferred objective thresholds are in gen_metadata.
+            # if using a hypervolume based acquisition function, then
+            # the inferred objective thresholds are in gen_metadata.
             opt_config_metrics = (
                 torch_opt_config.opt_config_metrics
                 or not_none(self._optimization_config).metrics


### PR DESCRIPTION
Summary: see title. These don't need to be inferred for random scalarization-based methods

Reviewed By: Balandat

Differential Revision: D48654160

