### PR TITLE
Migrate max_parallelism logic from generation stategy to generation step 2/n

### DIFF
--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -21,14 +21,11 @@ from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.exceptions.generation_strategy import (
     GenerationStrategyCompleted,
     GenerationStrategyRepeatedPoints,
+    MaxParallelismReachedException,
 )
 from ax.modelbridge.discrete import DiscreteModelBridge
 from ax.modelbridge.factory import get_sobol
-from ax.modelbridge.generation_strategy import (
-    GenerationStep,
-    GenerationStrategy,
-    MaxParallelismReachedException,
-)
+from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.model_spec import ModelSpec
 from ax.modelbridge.modelbridge_utils import (
     get_pending_observation_features_based_on_trial_status as get_pending,


### PR DESCRIPTION
Summary:
This is a step in the direction of migrating much of the logic from generation strategy to generation step, and then to generation node

This diff moves the `max_parallelism` func and the helper to generation node.

More diffs to follow

Reviewed By: lena-kashtelyan

Differential Revision: D47995975

