### PR TITLE
Fix sebo tutorial

### DIFF
--- a/ax/models/torch/botorch_modular/sebo.py
+++ b/ax/models/torch/botorch_modular/sebo.py
@@ -66,7 +66,7 @@ class SEBOAcquisition(Acquisition):
         if self.target_point is None:
             raise ValueError("please provide target point.")
         self.target_point.to(**tkwargs)  # pyre-ignore
-        self.sparsity_threshold: int = options.get(
+        self.sparsity_threshold: int = options.pop(
             "sparsity_threshold", surrogate.Xs[0].shape[-1]
         )
         # construct determinsitic model for penalty term

--- a/tutorials/sebo.ipynb
+++ b/tutorials/sebo.ipynb
@@ -305,7 +305,7 @@
         "    N_BATCHES = 1\n",
         "    SURROGATE_CLASS = SingleTaskGP\n",
         "else:\n",
-        "    N_BATCHES = 40\n",
+        "    N_BATCHES = 20\n",
         "    SURROGATE_CLASS = SaasFullyBayesianSingleTaskGP\n",
         "\n",
         "print(f\"Doing {N_INIT + N_BATCHES * BATCH_SIZE} evaluations\")"


### PR DESCRIPTION
Summary:
Sebo tutorial was failing (marked "flaky" because it has never succeeded since creation) because it was not included in the target graph. Also,  mixed use of options.get and options.pop was causing issues with input constructor validations. Both issues are resolved now.

Finally, I changed the number of batches from 40 to 20. Let me know if this is acceptable -- it puts our runtime at 8:46 in opt mode which is still close to timeout but should be consistently safe.

Reviewed By: esantorella

Differential Revision: D48737511

