### PR TITLE
Store bounds in double precision in test functions

### DIFF
--- a/ax/benchmark/tests/test_mixed_integer_problems.py
+++ b/ax/benchmark/tests/test_mixed_integer_problems.py
@@ -63,7 +63,8 @@ class TestMixedIntegerProblems(TestCase):
         trial = Trial(experiment=MagicMock())
         trial.add_arm(Arm(parameters={f"x{i+1}": 0.0 for i in range(6)}, name="--"))
         runner.run(trial)
-        self.assertTrue(torch.allclose(mock_call.call_args[0][0], torch.zeros(6)))
+        actual = mock_call.call_args[0][0]
+        self.assertTrue(torch.allclose(actual, torch.zeros(6, dtype=actual.dtype)))
         # Evaluate at 3, 3, 19, 19, 1, 1 - corresponds to 1.
         arm = not_none(trial.arm)
         arm._parameters = {
@@ -75,13 +76,15 @@ class TestMixedIntegerProblems(TestCase):
             "x6": 1.0,
         }
         runner.run(trial)
-        self.assertTrue(torch.allclose(mock_call.call_args[0][0], torch.ones(6)))
+        actual = mock_call.call_args[0][0]
+        self.assertTrue(torch.allclose(actual, torch.ones(6, dtype=actual.dtype)))
         # Ackley - evaluate at 0 - corresponds to 0.
         runner = checked_cast(BotorchTestProblemRunner, get_discrete_ackley().runner)
         runner.test_problem.forward = mock_call
         arm._parameters = {f"x{i+1}": 0.0 for i in range(13)}
         runner.run(trial)
-        self.assertTrue(torch.allclose(mock_call.call_args[0][0], torch.zeros(13)))
+        actual = mock_call.call_args[0][0]
+        self.assertTrue(torch.allclose(actual, torch.zeros(13, dtype=actual.dtype)))
         # Evaluate at 2 x 5, 4 x 5, 1.0 x 3 - corresponds to 1.
         arm._parameters = {
             **{f"x{i+1}": 2 for i in range(0, 5)},
@@ -89,7 +92,8 @@ class TestMixedIntegerProblems(TestCase):
             **{f"x{i+1}": 1.0 for i in range(10, 13)},
         }
         runner.run(trial)
-        self.assertTrue(torch.allclose(mock_call.call_args[0][0], torch.ones(13)))
+        actual = mock_call.call_args[0][0]
+        self.assertTrue(torch.allclose(actual, torch.ones(13, dtype=actual.dtype)))
         # Rosenbrock - evaluate at 0 - corresponds to -5.0.
         runner = checked_cast(
             BotorchTestProblemRunner, get_discrete_rosenbrock().runner
@@ -97,8 +101,9 @@ class TestMixedIntegerProblems(TestCase):
         runner.test_problem.forward = mock_call
         arm._parameters = {f"x{i+1}": 0.0 for i in range(10)}
         runner.run(trial)
+        actual = mock_call.call_args[0][0]
         self.assertTrue(
-            torch.allclose(mock_call.call_args[0][0], torch.full((10,), -5.0))
+            torch.allclose(actual, torch.full((10,), -5.0, dtype=actual.dtype))
         )
         # Evaluate at 3 x 6, 1.0 x 4 - corresponds to 10.0.
         arm._parameters = {
@@ -106,6 +111,7 @@ class TestMixedIntegerProblems(TestCase):
             **{f"x{i+1}": 1.0 for i in range(6, 10)},
         }
         runner.run(trial)
+        actual = mock_call.call_args[0][0]
         self.assertTrue(
-            torch.allclose(mock_call.call_args[0][0], torch.full((10,), 10.0))
+            torch.allclose(actual, torch.full((10,), 10.0, dtype=actual.dtype))
         )


### PR DESCRIPTION
Summary:
## Motivation

* BoTorch recommends double precision in optimization, and will warn on single-precision inputs.
* `torch.tensor(a_float)` will use single precision by default. This is how bounds are currently instantiated in test problems.
* Native floats are already double precision, so this is actually downcasting them.

X-link: https://github.com/pytorch/botorch/pull/1996

Reviewed By: saitcakmak

Differential Revision: D48757569

Pulled By: esantorella

