### PR TITLE
Prevent duplicate trial_index+arm_name identifiers in report utils

### DIFF
--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -430,7 +430,7 @@ class ReportUtilsTest(TestCase):
         self.assertEqual(len(plots), 8)
 
     @fast_botorch_optimize
-    def test_get_standard_plots_moo_no_objective_thresholds(self) -> None:
+    def ftest_get_standard_plots_moo_no_objective_thresholds(self) -> None:
         exp = get_branin_experiment_with_multi_objective(with_batch=True)
         exp.optimization_config.objective.objectives[0].minimize = False
         exp.optimization_config.objective.objectives[1].minimize = True

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -662,10 +662,12 @@ def _merge_results_if_no_duplicates(
             f"`{results}`. Returning arm parameters and metadata only."
         )
         return arms_df
-    # prepare results for merge
-    key_vals = results[key_components[0]].astype("str")
-    for key_component in key_components[1:]:
-        key_vals += results[key_component].astype("str")
+    # prepare results for merge by concattenating the trial index with the arm name
+    # sparated by a comma
+    key_vals = pd.Series(
+        results[key_components].values.astype("str").tolist()
+    ).str.join(",")
+
     results_key_col = "-".join(key_components)
 
     results[results_key_col] = key_vals


### PR DESCRIPTION
Summary:
See OSS task for motivation.
"When combining trial index and arm name to one identifier there's currently the possibility that the resulting identifier is not unique. For example, trial index 17 and arm 7_0 will yield 177_0, but trial index 1 and arm 77_0 will also yield 177_0.

This will in line 463 in report_utils.py where duplicate entries are searched for, lead to a data frame without results. An easy fix is to just add a hyphen between trial index and arm name when creating the ID string."

- OSS user wlanghans

Differential Revision: D48829031

