### PR TITLE
Adding ValueError catch for Fisher Exact Test

### DIFF
--- a/ax/utils/stats/model_fit_stats.py
+++ b/ax/utils/stats/model_fit_stats.py
@@ -170,6 +170,28 @@ def _rank_correlation(
 def _fisher_exact_test_p(
     y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
 ) -> float:
+    """Perform a Fisher exact test on the contingency table constructed from
+    agreement/disagreement between the predicted and observed data.
+
+    Null hypothesis: Agreement between the predicted and observed data arises consistent
+    with random chance
+
+    P-value < 0.05 indicates that the null hypothesis may be rejected at the 5% level of
+    significance i.e. the model's predictive performance would be unlikely to arise
+    through random chance.
+
+    Args:
+        y_obs: NumPy array of observed data of shape (n_obs,)
+        y_pred: NumPy array of predicted data of shape (n_obs,)
+        se_pred: NumPy array of standard errors of shape (n_obs,), not used by the
+            calculation but required for interface compatbility.
+    Returns:
+        The p-value of the Fisher exact test on the contingency table.
+    """
+
+    if y_obs.ndim != 1 or y_pred.ndim != 1:
+        raise ValueError("y_obs and y_pred must be 1-dimensional.")
+
     n_half = len(y_obs) // 2
     top_obs = y_obs.argsort(axis=0)[-n_half:]
     top_est = y_pred.argsort(axis=0)[-n_half:]

--- a/ax/utils/stats/tests/test_model_fit_stats.py
+++ b/ax/utils/stats/tests/test_model_fit_stats.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import numpy as np
+from ax.utils.common.testutils import TestCase
+from ax.utils.stats.model_fit_stats import _fisher_exact_test_p
+from scipy.stats import fisher_exact
+
+
+class FisherExactTestTest(TestCase):
+    def test_contingency_table_construction(self) -> None:
+        # Create a dummy set of observations and predictions
+        y_obs = np.array([1, 3, 2, 5, 7, 3])
+        y_pred = np.array([2, 4, 1, 6, 8, 2.5])
+
+        # Compute ground truth contingency table
+        true_table = np.array([[2, 1], [1, 2]])
+
+        scipy_result = fisher_exact(true_table, alternative="greater")[1]
+        ax_result = _fisher_exact_test_p(y_obs, y_pred, se_pred=None)
+
+        self.assertEqual(scipy_result, ax_result)


### PR DESCRIPTION
Summary:
Amendment to make input shape assumption clear.

Context: The set operation fails with a shaped NumPy array.

Reviewed By: esantorella

Differential Revision: D48709648

