### PR TITLE
remove errant ftest (focused test for tsloop)

### DIFF
--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -430,7 +430,7 @@ class ReportUtilsTest(TestCase):
         self.assertEqual(len(plots), 8)
 
     @fast_botorch_optimize
-    def ftest_get_standard_plots_moo_no_objective_thresholds(self) -> None:
+    def test_get_standard_plots_moo_no_objective_thresholds(self) -> None:
         exp = get_branin_experiment_with_multi_objective(with_batch=True)
         exp.optimization_config.objective.objectives[0].minimize = False
         exp.optimization_config.objective.objectives[1].minimize = True


### PR DESCRIPTION
Summary:
These get left in from time to time. Not sure how D48829031 landed given that the linter usually stops this.

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: mpolson64

Differential Revision: D48883557

