### PR TITLE
exp_to_df missing metrics when there are multiple curve metrics

### DIFF
--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -246,21 +246,21 @@ class ReportUtilsTest(TestCase):
         mock_results = dummy_struct(
             df=pd.DataFrame(
                 {
-                    "arm_name": ["0_0"],
-                    "metric_name": [OBJECTIVE_NAME],
-                    "mean": [DUMMY_OBJECTIVE_MEAN],
-                    "sem": [0],
-                    "trial_index": [0],
-                    "n": [123],
-                    "frac_nonnull": [1],
+                    "arm_name": ["0_0", "1_0"],
+                    "metric_name": [OBJECTIVE_NAME] * 2,
+                    "mean": [DUMMY_OBJECTIVE_MEAN] * 2,
+                    "sem": [0] * 2,
+                    "trial_index": [0, 1],
+                    "n": [123] * 2,
+                    "frac_nonnull": [1] * 2,
                 }
             )
         )
+        mock_results.df.index = range(len(exp.trials) * 2, len(exp.trials) * 2 + 2)
         with patch.object(Experiment, "lookup_data", lambda self: mock_results):
             df = exp_to_df(exp=exp)
-
-        # all but one row should have a metric value of NaN
-        self.assertEqual(pd.isna(df[OBJECTIVE_NAME]).sum(), len(df.index) - 1)
+        # all but two rows should have a metric value of NaN
+        self.assertEqual(pd.isna(df[OBJECTIVE_NAME]).sum(), len(df.index) - 2)
 
         # an experiment with more results than arms raises an error
         with patch.object(

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -670,6 +670,8 @@ def _merge_results_if_no_duplicates(
 
     results_key_col = "-".join(key_components)
 
+    # Reindex so new column isn't set to NaN.
+    key_vals.index = results.index
     results[results_key_col] = key_vals
     # Don't return results if duplicates remain
     if any(results.duplicated(subset=[results_key_col, "metric_name"])):


### PR DESCRIPTION
Summary: D48829031 introduced a bug whereby `exp_to_df` is not including metric values for experiments with multiple ESS metrics

Reviewed By: mpolson64

Differential Revision: D48975780


