### PR TITLE
Make X, Y, Yvar into properties in datasets

### DIFF
--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -100,10 +100,10 @@ class TorchModelBridgeTest(TestCase):
                 covariance=np.diag(yvar1 + yvar2),  # here yvar is already a list
             )
             for y1, y2, yvar1, yvar2 in zip(
-                datasets["y1"].Y().tolist(),
-                datasets["y2"].Y().tolist(),
-                not_none(datasets["y1"].Yvar)().tolist(),
-                not_none(datasets["y2"].Yvar)().tolist(),
+                datasets["y1"].Y.tolist(),
+                datasets["y2"].Y.tolist(),
+                not_none(datasets["y1"].Yvar).tolist(),
+                not_none(datasets["y2"].Yvar).tolist(),
             )
         ]
         observations = recombine_observations(observation_features, observation_data)
@@ -651,7 +651,7 @@ class TorchModelBridgeTest(TestCase):
             dtype=torch.double,
         )
         for dataset in datasets:
-            self.assertTrue(torch.equal(dataset.X(), X_expected))
+            self.assertTrue(torch.equal(dataset.X, X_expected))
 
         self.assertEqual(
             mock_model_fit.call_args[1].get("candidate_metadata"),
@@ -677,7 +677,7 @@ class TorchModelBridgeTest(TestCase):
         datasets = mock_model_update.call_args[1].get("datasets")
         X_expected = torch.cat((X_expected, torch.tensor([[1, 2]])), dim=-2)
         for dataset in datasets:
-            self.assertTrue(torch.equal(dataset.X(), X_expected))
+            self.assertTrue(torch.equal(dataset.X, X_expected))
 
         self.assertEqual(
             mock_model_update.call_args[1].get("candidate_metadata"),
@@ -710,7 +710,7 @@ class TorchModelBridgeTest(TestCase):
         datasets = mock_model_update.call_args[1].get("datasets")
         X_expected = torch.cat((X_expected, torch.tensor([[2, 4]])), dim=-2)
         for dataset in datasets:
-            self.assertTrue(torch.equal(dataset.X(), X_expected))
+            self.assertTrue(torch.equal(dataset.X, X_expected))
 
         self.assertEqual(
             mock_model_update.call_args[1].get("candidate_metadata"),

--- a/ax/models/tests/test_botorch_mes.py
+++ b/ax/models/tests/test_botorch_mes.py
@@ -300,7 +300,7 @@ class MaxValueEntropySearchTest(TestCase):
             target_fidelities={2: 1.0},
         )
         self.assertIsInstance(acq_function, qMultiFidelityMaxValueEntropy)
-        Xs = [self.training_data[0].X()]
+        Xs = [self.training_data[0].X]
         self.assertEqual(acq_function.expand(Xs), Xs)
 
         # test error that target fidelity and fidelity weight indices must match

--- a/ax/models/torch/botorch_modular/sebo.py
+++ b/ax/models/torch/botorch_modular/sebo.py
@@ -111,8 +111,7 @@ class SEBOAcquisition(Acquisition):
         self._objective_thresholds[-1] = self.sparsity_threshold
 
         Y_pareto = torch.cat(
-            # pyre-ignore[16]
-            [d.Y.values for d in self.surrogates["sebo"].training_data],
+            [d.Y for d in self.surrogates["sebo"].training_data],
             dim=-1,
         )
         ind_pareto = is_non_dominated(Y_pareto * self._full_objective_weights)

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -11,7 +11,6 @@ import inspect
 import warnings
 from copy import deepcopy
 from logging import Logger
-
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Type
 
 import torch
@@ -178,7 +177,7 @@ class Surrogate(Base):
             ):
                 Xi = dataset.X.values
             else:
-                Xi = dataset.X()
+                Xi = dataset.X
             for _ in range(dataset.Y.shape[-1]):
                 Xs.append(Xi)
         return Xs
@@ -312,7 +311,7 @@ class Surrogate(Base):
                 "variance observations and converting to `SupervisedDataset`.",
                 AxWarning,
             )
-            dataset = SupervisedDataset(X=dataset.X(), Y=dataset.Y())
+            dataset = SupervisedDataset(X=dataset.X, Y=dataset.Y)
 
         self._training_data = [dataset]
 

--- a/ax/models/torch/rembo.py
+++ b/ax/models/torch/rembo.py
@@ -13,7 +13,6 @@ from ax.core.types import TCandidateMetadata
 from ax.models.torch.botorch import BotorchModel
 from ax.models.torch_base import TorchGenResults, TorchModel, TorchOptConfig
 from ax.utils.common.docutils import copy_doc
-from botorch.utils.containers import DenseContainer
 from botorch.utils.datasets import SupervisedDataset
 from torch import Tensor
 
@@ -248,11 +247,11 @@ class REMBO(BotorchModel):
     def _convert_and_normalize_datasets(
         self, datasets: List[SupervisedDataset]
     ) -> List[SupervisedDataset]:
-        X_D = _get_single_X([dataset.X() for dataset in datasets])
+        X_D = _get_single_X([dataset.X for dataset in datasets])
         X_d_01 = self.to_01(self.project_down(X_D))
         # Fit model in low-d space (adjusted to [0, 1]^d)
         for dataset in datasets:
-            dataset.X = DenseContainer(values=X_d_01, event_shape=X_d_01.shape[-1:])
+            dataset._X = X_d_01
         return datasets
 
 

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -194,7 +194,7 @@ class AcquisitionTest(TestCase):
         mock_get_X.assert_called_once()
         _, ckwargs = mock_get_X.call_args
         for X, dataset in zip(ckwargs["Xs"], self.training_data):
-            self.assertTrue(torch.equal(X, dataset.X()))
+            self.assertTrue(torch.equal(X, dataset.X))
         for attr in (
             "pending_observations",
             "objective_weights",

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -233,18 +233,18 @@ class BoTorchModelTest(TestCase):
             UnsupportedError, "Cannot convert mixed data with and without variance"
         ):
             self.model.fit(
-                datasets=[ds1, SupervisedDataset(X=ds2.X(), Y=ds2.Y())],
+                datasets=[ds1, SupervisedDataset(X=ds2.X, Y=ds2.Y)],
                 metric_names=self.metric_names * 2,
                 search_space_digest=self.mf_search_space_digest,
             )
 
         # Ensure non-block design data is converted with warnings
         ds = self.block_design_training_data[0]
-        X1 = ds.X()
+        X1 = ds.X
         X2 = torch.cat((X1[:1], torch.rand_like(X1[1:])))
         with warnings.catch_warnings(record=True) as ws:
             self.model.fit(
-                datasets=[ds, SupervisedDataset(X=X2, Y=ds.Y())],
+                datasets=[ds, SupervisedDataset(X=X2, Y=ds.Y)],
                 metric_names=self.metric_names * 2,
                 search_space_digest=self.mf_search_space_digest,
             )
@@ -575,11 +575,11 @@ class BoTorchModelTest(TestCase):
         self.assertEqual(m.num_outputs, 1)
         training_data = ckwargs["training_data"]
         self.assertIsInstance(training_data, SupervisedDataset)
-        self.assertTrue(torch.equal(training_data.X(), self.Xs[0]))
+        self.assertTrue(torch.equal(training_data.X, self.Xs[0]))
         self.assertTrue(
             torch.equal(
-                training_data.Y(),
-                torch.cat([ds.Y() for ds in self.block_design_training_data], dim=-1),
+                training_data.Y,
+                torch.cat([ds.Y for ds in self.block_design_training_data], dim=-1),
             )
         )
         self.assertIsNotNone(ckwargs["constraints"])
@@ -592,7 +592,7 @@ class BoTorchModelTest(TestCase):
             GenericMCObjective,
         )
         expected_X_baseline = _filter_X_observed(
-            Xs=[dataset.X() for dataset in self.block_design_training_data],
+            Xs=[dataset.X for dataset in self.block_design_training_data],
             objective_weights=self.objective_weights,
             outcome_constraints=self.outcome_constraints,
             bounds=self.search_space_digest.bounds,
@@ -910,17 +910,17 @@ class BoTorchModelTest(TestCase):
         self.assertEqual(m.num_outputs, 2)
         training_data = ckwargs["training_data"]
         self.assertIsNotNone(training_data.Yvar)
-        self.assertTrue(torch.equal(training_data.X(), self.Xs[0]))
+        self.assertTrue(torch.equal(training_data.X, self.Xs[0]))
         self.assertTrue(
             torch.equal(
-                training_data.Y(),
-                torch.cat([ds.Y() for ds in self.moo_training_data], dim=-1),
+                training_data.Y,
+                torch.cat([ds.Y for ds in self.moo_training_data], dim=-1),
             )
         )
         self.assertTrue(
             torch.equal(
-                training_data.Yvar(),
-                torch.cat([ds.Yvar() for ds in self.moo_training_data], dim=-1),
+                training_data.Yvar,
+                torch.cat([ds.Yvar for ds in self.moo_training_data], dim=-1),
             )
         )
         self.assertTrue(
@@ -948,7 +948,7 @@ class BoTorchModelTest(TestCase):
             )
         )
         expected_X_baseline = _filter_X_observed(
-            Xs=[dataset.X() for dataset in self.moo_training_data],
+            Xs=[dataset.X for dataset in self.moo_training_data],
             objective_weights=self.moo_objective_weights,
             outcome_constraints=self.moo_outcome_constraints,
             bounds=self.search_space_digest.bounds,
@@ -994,7 +994,7 @@ class BoTorchModelTest(TestCase):
                 ),
             )
             expected_X_baseline = _filter_X_observed(
-                Xs=[dataset.X() for dataset in self.moo_training_data],
+                Xs=[dataset.X for dataset in self.moo_training_data],
                 objective_weights=objective_weights,
                 outcome_constraints=outcome_constraints,
                 bounds=self.search_space_digest.bounds,

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -522,7 +522,7 @@ class SurrogateTest(TestCase):
                 mock_best_in_sample.assert_called_once()
                 _, ckwargs = mock_best_in_sample.call_args
                 for X, dataset in zip(ckwargs["Xs"], self.training_data):
-                    self.assertTrue(torch.equal(X, dataset.X()))
+                    self.assertTrue(torch.equal(X, dataset.X))
                 self.assertIs(ckwargs["model"], surrogate)
                 self.assertIs(ckwargs["bounds"], self.search_space_digest.bounds)
                 self.assertIs(ckwargs["options"], self.options)

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -369,8 +369,8 @@ class ConvertToBlockDesignTest(TestCase):
         )
         self.assertEqual(len(new_datasets), 1)
         self.assertIsInstance(new_datasets[0], SupervisedDataset)
-        self.assertTrue(torch.equal(new_datasets[0].X(), X))
-        self.assertTrue(torch.equal(new_datasets[0].Y(), torch.cat(Ys, dim=-1)))
+        self.assertTrue(torch.equal(new_datasets[0].X, X))
+        self.assertTrue(torch.equal(new_datasets[0].Y, torch.cat(Ys, dim=-1)))
         self.assertEqual(new_metric_names, ["y1_y2"])
 
         # simple case: block design, fixed
@@ -384,10 +384,10 @@ class ConvertToBlockDesignTest(TestCase):
         )
         self.assertEqual(len(new_datasets), 1)
         self.assertIsNotNone(new_datasets[0].Yvar)
-        self.assertTrue(torch.equal(new_datasets[0].X(), X))
-        self.assertTrue(torch.equal(new_datasets[0].Y(), torch.cat(Ys, dim=-1)))
+        self.assertTrue(torch.equal(new_datasets[0].X, X))
+        self.assertTrue(torch.equal(new_datasets[0].Y, torch.cat(Ys, dim=-1)))
         self.assertTrue(
-            torch.equal(not_none(new_datasets[0].Yvar)(), torch.cat(Yvars, dim=-1))
+            torch.equal(not_none(new_datasets[0].Yvar), torch.cat(Yvars, dim=-1))
         )
         self.assertEqual(new_metric_names, ["y1_y2"])
 
@@ -415,9 +415,9 @@ class ConvertToBlockDesignTest(TestCase):
         )
         self.assertEqual(len(new_datasets), 1)
         self.assertIsNone(new_datasets[0].Yvar)
-        self.assertTrue(torch.equal(new_datasets[0].X(), X[:3]))
+        self.assertTrue(torch.equal(new_datasets[0].X, X[:3]))
         self.assertTrue(
-            torch.equal(new_datasets[0].Y(), torch.cat([Y[:3] for Y in Ys], dim=-1))
+            torch.equal(new_datasets[0].Y, torch.cat([Y[:3] for Y in Ys], dim=-1))
         )
         self.assertEqual(new_metric_names, ["y1_y2"])
 
@@ -440,13 +440,13 @@ class ConvertToBlockDesignTest(TestCase):
         )
         self.assertEqual(len(new_datasets), 1)
         self.assertIsNotNone(new_datasets[0].Yvar)
-        self.assertTrue(torch.equal(new_datasets[0].X(), X[:3]))
+        self.assertTrue(torch.equal(new_datasets[0].X, X[:3]))
         self.assertTrue(
-            torch.equal(new_datasets[0].Y(), torch.cat([Y[:3] for Y in Ys], dim=-1))
+            torch.equal(new_datasets[0].Y, torch.cat([Y[:3] for Y in Ys], dim=-1))
         )
         self.assertTrue(
             torch.equal(
-                not_none(new_datasets[0].Yvar)(),
+                not_none(new_datasets[0].Yvar),
                 torch.cat([Yvar[:3] for Yvar in Yvars], dim=-1),
             )
         )

--- a/ax/models/torch/utils.py
+++ b/ax/models/torch/utils.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from dataclasses import dataclass
-
 from logging import Logger
 from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Type
 
@@ -683,10 +682,10 @@ def _datasets_to_legacy_inputs(
     for dataset in datasets:
         if not isinstance(dataset, SupervisedDataset):
             raise UnsupportedError("Legacy setup only supports `SupervisedDataset`s")
-        Xs.append(dataset.X())
-        Ys.append(dataset.Y())
+        Xs.append(dataset.X)
+        Ys.append(dataset.Y)
         if dataset.Yvar is not None:
-            Yvars.append(dataset.Yvar())
+            Yvars.append(dataset.Yvar)
         else:
             Yvars.append(torch.full_like(Ys[-1], float("nan")))
     return Xs, Ys, Yvars


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/2004

Since the primary use case of the datasets is to house a couple tensors, this simplifies the process by making dataset.X/Y/Yvar into a tensor rather than a callable.

This also eliminates the need to make tensors into containers, eliminating a step in the process.

Differential Revision: D48926544

