### PR TITLE
Set `use_update=False` by default in `choose_generation_strategy`

### DIFF
--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -7,7 +7,6 @@
 import logging
 import warnings
 from typing import Any, Dict
-from unittest import mock
 
 import torch
 from ax.core.objective import MultiObjective
@@ -684,38 +683,14 @@ class TestDispatchUtils(TestCase):
 
     def test_use_update(self) -> None:
         search_space = get_branin_search_space()
-        # No experiment, no SAAS, default to False.
+        # Defaults to False.
         gs = choose_generation_strategy(search_space=search_space)
         self.assertFalse(gs._steps[1].use_update)
         # Pass in True.
         gs = choose_generation_strategy(search_space=search_space, use_update=True)
         self.assertTrue(gs._steps[1].use_update)
-        # With experiment without any metrics available while running.
+        # Metrics available while running.
         experiment = get_branin_experiment()
-        with mock.patch.object(
-            experiment.metrics["branin"],
-            "is_available_while_running",
-            return_value=False,
-        ):
-            # No SAAS, default to False.
-            gs = choose_generation_strategy(
-                search_space=search_space, experiment=experiment
-            )
-            self.assertFalse(gs._steps[1].use_update)
-            # SAAS, default to True.
-            gs = choose_generation_strategy(
-                search_space=search_space, experiment=experiment, use_saasbo=True
-            )
-            self.assertTrue(gs._steps[1].use_update)
-            # SAAS and pass in False.
-            gs = choose_generation_strategy(
-                search_space=search_space,
-                experiment=experiment,
-                use_saasbo=True,
-                use_update=False,
-            )
-            self.assertFalse(gs._steps[1].use_update)
-        # SAAS with metrics available while running.
         gs = choose_generation_strategy(
             search_space=search_space, experiment=experiment, use_saasbo=True
         )


### PR DESCRIPTION
Summary: This was previously added (with default of True when using SAAS) to get around some redundant model fitting. We now handle any possible redundant model fitting at `TorchModelBridge._fit`, so this is not necessary.

Differential Revision: D49026498


