### PR TITLE
Update GitHub Actions Workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,43 +9,19 @@ on:
 
 jobs:
   tests-and-coverage:
-
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10"]
-      fail-fast: false
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      env:
-        ALLOW_BOTORCH_LATEST: true
-        ALLOW_LATEST_GPYTORCH_LINOP: true
-      run: |
-        # use latest Botorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ".[unittest]"
-    - name: Tests and coverage
-      run: |
-        pytest -ra --cov=ax
-    - name: Upload coverage
-      run: |
-        bash <(curl -s https://codecov.io/bash)
+    name: Tests with latest BoTorch
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      pinned_botorch: false
 
   lint:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.9"
     - name: Install dependencies
@@ -70,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.9"
     - name: Install dependencies

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -13,71 +13,35 @@ on:
 
 jobs:
 
-  tests-and-coverage:
+  tests-and-coverage-minimal:
+    name: Tests with latest BoTorch & minimal dependencies
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      pinned_botorch: false
+      minimal_dependencies: true
 
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        botorch: ['pinned', 'latest']
-        requirements: ['minimal', 'full']
-      fail-fast: false
+  tests-and-coverage-full:
+    name: Tests with latest BoTorch & full dependencies
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      pinned_botorch: false
+      minimal_dependencies: false
 
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.9"
-    - name: Install dependencies (full requirements, stable Botorch)
-      run: |
-        # will install the version of Botorch that is pinned in setup.py
-        pip install -e ".[unittest]"
-      if: matrix.botorch == 'pinned' && matrix.requirements == 'full'
-    - name: Install dependencies (minimal requirements, stable Botorch)
-      run: |
-        pip install -e ".[unittest_minimal]"
-      if: matrix.botorch == 'pinned' && matrix.requirements == 'minimal'
-    - name: Install dependencies (full requirements, Botorch main)
-      env:
-        ALLOW_BOTORCH_LATEST: true
-        ALLOW_LATEST_GPYTORCH_LINOP: true
-      run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ".[unittest]"
-      if: matrix.botorch == 'latest' && matrix.requirements == 'full'
-    - name: Install dependencies (minimal requirements, Botorch main)
-      env:
-        ALLOW_BOTORCH_LATEST: true
-        ALLOW_LATEST_GPYTORCH_LINOP: true
-      run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ".[unittest_minimal]"
-      if: matrix.botorch == 'latest' && matrix.requirements == 'minimal'
-    - name: Import Ax
-      run: |
-        python scripts/import_ax.py
-    - name: Tests
-      # run even if previous step (import Ax) failed
-      if: matrix.requirements == 'full'
-      run: |
-        pytest -ra
-
-  build-tutorials-with-pinned-botorch:
-    name: Build tutorials with pinned BoTorch
+  build-tutorials:
+    name: Build tutorials with latest BoTorch
     uses: ./.github/workflows/reusable_tutorials.yml
     with:
       smoke_test: false
+      pinned_botorch: false
 
   publish-latest-website:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.9"
     - name: Install dependencies
@@ -100,11 +64,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.9"
     - name: Install dependencies

--- a/.github/workflows/cron_pinned.yml
+++ b/.github/workflows/cron_pinned.yml
@@ -1,0 +1,31 @@
+name: Nightly Cron with Pinned BoTorch
+
+on:
+  schedule:
+    # midnight EST
+    - cron:  '0 5 * * *'
+  # allow this to be scheduled manually in addition to cron
+  workflow_dispatch:
+
+jobs:
+
+  tests-and-coverage-minimal:
+    name: Tests with pinned BoTorch & minimal dependencies
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      pinned_botorch: true
+      minimal_dependencies: true
+
+  tests-and-coverage-full:
+    name: Tests with pinned BoTorch & full dependencies
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      pinned_botorch: true
+      minimal_dependencies: false
+
+  build-tutorials:
+    name: Build tutorials with pinned BoTorch
+    uses: ./.github/workflows/reusable_tutorials.yml
+    with:
+      smoke_test: false
+      pinned_botorch: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,50 +8,27 @@ on:
     types: [created]
 
 jobs:
-  tests-and-coverage:
+  tests-and-coverage-latest:
+    name: Tests with latest BoTorch
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      pinned_botorch: false
 
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        botorch: ['latest', 'pinned']
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.9"
-    - name: Install dependencies (latest Botorch)
-      env:
-        ALLOW_BOTORCH_LATEST: true
-        ALLOW_LATEST_GPYTORCH_LINOP: true
-      run: |
-        # use latest Botorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ".[unittest]"
-      if: matrix.botorch == 'latest'
-    - name: Install dependencies (pinned Botorch)
-      run: |
-        # will install the version of Botorch that is pinned in setup.py
-        pip install -e ".[unittest]"
-      if: matrix.botorch == 'pinned'
-    - name: Import Ax
-      run: |
-        python scripts/import_ax.py
-    - name: Tests
-      run: |
-        pytest -ra
+  tests-and-coverage-pinned:
+    name: Tests with pinned BoTorch
+    uses: ./.github/workflows/reusable_test.yml
+    with:
+      pinned_botorch: true
 
   publish-stable-website:
 
-    needs: tests-and-coverage # only run if test step succeeds
+    needs: tests-and-coverage-pinned # only run if test step succeeds
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.9"
     - name: Install dependencies
@@ -66,13 +43,13 @@ jobs:
 
   deploy:
 
-    needs: tests-and-coverage # only run if test step succeeds
+    needs: tests-and-coverage-pinned # only run if test step succeeds
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.9"
     - name: Install dependencies

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -38,7 +38,7 @@ jobs:
     - if: ${{ inputs.pinned_botorch }}
       name: Install dependencies with pinned BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
       run: |
-        pip install -e ${{ (inputs.minimal_dependencies) && ".[unittest_minimal]") || ".[unittest]" }}
+        pip install -e ${{ (inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
 
     - if: ${{ !inputs.pinned_botorch }}
       name: Install dependencies with latest BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
@@ -48,7 +48,7 @@ jobs:
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ${{ (inputs.minimal_dependencies) && ".[unittest_minimal]") || ".[unittest]" }}
+        pip install -e ${{ (inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
 
     - name: Import Ax
       run: |

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -38,7 +38,7 @@ jobs:
     - if: ${{ inputs.pinned_botorch }}
       name: Install dependencies with pinned BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
       run: |
-        pip install -e ${{ (inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
+        pip install -e ${{ ((inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
 
     - if: ${{ !inputs.pinned_botorch }}
       name: Install dependencies with latest BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
@@ -48,7 +48,7 @@ jobs:
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ${{ (inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
+        pip install -e ${{ ((inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
 
     - name: Import Ax
       run: |

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -38,6 +38,9 @@ jobs:
     - if: ${{ inputs.pinned_botorch }}
       name: Install dependencies with pinned BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
       run: |
+        # The brackets returns '.[unittest_minimal]' if using minimal dependencies and '.[unittest]'
+        # otherwise. This saves us from needing 4 install dependencies blocks by supporting two
+        # different installation options in one line.
         pip install -e ${{ ((inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
 
     - if: ${{ !inputs.pinned_botorch }}

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -1,0 +1,61 @@
+name: Reusable Test Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      pinned_botorch:
+        required: true
+        type: boolean
+      minimal_dependencies:
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      pinned_botorch:
+        required: true
+        type: boolean
+      minimal_dependencies:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  tests-and-coverage:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - if: ${{ inputs.pinned_botorch }}
+      name: Install dependencies with pinned BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
+      run: |
+        pip install -e ${{ $inputs.minimal_dependencies && ".[unittest_minimal]") || ".[unittest]" }}
+
+    - if: ${{ !inputs.pinned_botorch }}
+      name: Install dependencies with latest BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
+      env:
+        ALLOW_BOTORCH_LATEST: true
+        ALLOW_LATEST_GPYTORCH_LINOP: true
+      run: |
+        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install git+https://github.com/pytorch/botorch.git
+        pip install -e ${{ $inputs.minimal_dependencies && ".[unittest_minimal]") || ".[unittest]" }}
+
+    - name: Import Ax
+      run: |
+        python scripts/import_ax.py
+    - name: Tests and coverage
+      run: |
+        pytest -ra --cov=ax
+    - name: Upload coverage
+      run: |
+        bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -53,9 +53,13 @@ jobs:
     - name: Import Ax
       run: |
         python scripts/import_ax.py
-    - name: Tests and coverage
+    - if: ${{ !inputs.minimal_dependencies }}
+      # Only run with full dependencies. Minimal does not include pytest.
+      name: Tests and coverage
       run: |
         pytest -ra --cov=ax
-    - name: Upload coverage
+    - if: ${{ !inputs.minimal_dependencies }}
+      # Using same condition as above since we need the coverage report for upload.
+      name: Upload coverage
       run: |
         bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -38,7 +38,7 @@ jobs:
     - if: ${{ inputs.pinned_botorch }}
       name: Install dependencies with pinned BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
       run: |
-        pip install -e ${{ $inputs.minimal_dependencies && ".[unittest_minimal]") || ".[unittest]" }}
+        pip install -e ${{ inputs.minimal_dependencies && ".[unittest_minimal]") || ".[unittest]" }}
 
     - if: ${{ !inputs.pinned_botorch }}
       name: Install dependencies with latest BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
@@ -48,7 +48,7 @@ jobs:
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ${{ $inputs.minimal_dependencies && ".[unittest_minimal]") || ".[unittest]" }}
+        pip install -e ${{ inputs.minimal_dependencies && ".[unittest_minimal]") || ".[unittest]" }}
 
     - name: Import Ax
       run: |

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -38,7 +38,7 @@ jobs:
     - if: ${{ inputs.pinned_botorch }}
       name: Install dependencies with pinned BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
       run: |
-        pip install -e ${{ inputs.minimal_dependencies && ".[unittest_minimal]") || ".[unittest]" }}
+        pip install -e ${{ (inputs.minimal_dependencies) && ".[unittest_minimal]") || ".[unittest]" }}
 
     - if: ${{ !inputs.pinned_botorch }}
       name: Install dependencies with latest BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
@@ -48,7 +48,7 @@ jobs:
       run: |
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ${{ inputs.minimal_dependencies && ".[unittest_minimal]") || ".[unittest]" }}
+        pip install -e ${{ (inputs.minimal_dependencies) && ".[unittest_minimal]") || ".[unittest]" }}
 
     - name: Import Ax
       run: |

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -6,9 +6,15 @@ on:
       smoke_test:
         required: true
         type: boolean
+      pinned_botorch:
+        required: true
+        type: boolean
   workflow_call:
     inputs:
       smoke_test:
+        required: true
+        type: boolean
+      pinned_botorch:
         required: true
         type: boolean
 
@@ -18,15 +24,27 @@ jobs:
     name: Tutorials with pinned BoTorch
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.9"
-    - name: Install dependencies
+
+    - if: ${{ inputs.pinned_botorch }}
+      name: Install dependencies with pinned BoTorch
       run: |
-        # will install the version of Botorch that is pinned in setup.py
         pip install -e ".[tutorial]"
+
+    - if: ${{ !inputs.pinned_botorch }}
+      name: Install dependencies with latest BoTorch
+      env:
+        ALLOW_BOTORCH_LATEST: true
+        ALLOW_LATEST_GPYTORCH_LINOP: true
+      run: |
+        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install git+https://github.com/pytorch/botorch.git
+        pip install -e ".[tutorial]"
+
     - if: ${{ inputs.smoke_test }}
       name: Build tutorials with smoke test
       run: |

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -14,8 +14,9 @@ on:
 
 jobs:
 
-  build-tutorials-with-pinned-botorch:
-    name: Tutorials with pinned BoTorch
+  build-tutorials-with-latest-botorch:
+    name: Tutorials with latest BoTorch
     uses: ./.github/workflows/reusable_tutorials.yml
     with:
       smoke_test: true
+      pinned_botorch: false


### PR DESCRIPTION
- Update `checkout` and `python-setup` to v3 & v4, respectively.
- Create a new `reusable_test` workflow and use this everywhere unit tests are ran. This supports pinned and latest BoTorch, as well as minimal and full dependencies.
- Update the `reusable_tutorials` workflow to support both latest and pinned BoTorch.
- Create a `cron_pinned` workflow and update `cron` to run only latest BoTorch version. This should make nightly cron into a much higher signal workflow and prevent it from failing due to latest Ax diverging from pinned BoTorch.