### PR TITLE
Speed up sebo tutorial

### DIFF
--- a/tutorials/sebo.ipynb
+++ b/tutorials/sebo.ipynb
@@ -1,1756 +1,1652 @@
 {
-  "cells": [
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {
-        "collapsed": true,
-        "customInput": null,
-        "originalKey": "d3a0136e-94fa-477c-a839-20e5b7f1cdd2",
-        "showInput": false
-      },
-      "source": [
-        "# Sparsity Exploration Bayesian Optimization (SEBO) Ax API \n",
-        "\n",
-        "This tutorial introduces the Sparsity Exploration Bayesian Optimization (SEBO) method and demonstrates how to utilize it using the Ax API. SEBO is designed to enhance Bayesian Optimization (BO) by taking the interpretability and simplicity of configurations into consideration. In essence, SEBO incorporates sparsity, modeled as the $L_0$ norm, as an additional objective in BO. By employing multi-objective optimization techniques such as Expected Hyper-Volume Improvement, SEBO enables the joint optimization of objectives while simultaneously incorporating feature-level sparsity. This allows users to efficiently explore different trade-offs between objectives and sparsity.\n",
-        "\n",
-        "\n",
-        "For a more detailed understanding of the SEBO algorithm, please refer to the following publication:\n",
-        "\n",
-        "[1] [S. Liu, Q. Feng, D. Eriksson, B. Letham and E. Bakshy. Sparse Bayesian Optimization. International Conference on Artificial Intelligence and Statistics, 2023.](https://proceedings.mlr.press/v206/liu23b/liu23b.pdf)\n",
-        "\n",
-        "By following this tutorial, you will learn how to leverage the SEBO method through the Ax API, empowering you to effectively balance objectives and sparsity in your optimization tasks. Let's get started!"
-      ]
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "customInput": null,
+    "jupyter": {
+     "outputs_hidden": true
     },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "collapsed": false,
-        "customOutput": null,
-        "executionStartTime": 1689117385062,
-        "executionStopTime": 1689117389874,
-        "originalKey": "cea96143-019a-41c1-a388-545f48992db9",
-        "requestMsgId": "c2c22a5d-aee0-4a1e-98d9-b360aa1851ff",
-        "showInput": true
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "I0711 161625.198 _utils_internal.py:199] NCCL_DEBUG env var is set to None\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "I0711 161625.200 _utils_internal.py:217] NCCL_DEBUG is forced to WARN from None\n"
-          ]
-        }
-      ],
-      "source": [
-        "import os\n",
-        "\n",
-        "from ax import Data, Experiment, ParameterType, RangeParameter, SearchSpace\n",
-        "from ax.modelbridge.registry import Models\n",
-        "from ax.runners.synthetic import SyntheticRunner\n",
-        "\n",
-        "import warnings\n",
-        "warnings.filterwarnings('ignore')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "customOutput": null,
-        "executionStartTime": 1689117389896,
-        "executionStopTime": 1689117389898,
-        "originalKey": "89cb2c13-8484-4bf9-82e0-3bed87ceb838",
-        "requestMsgId": "abc49ffd-df0a-4f2a-b460-73a89d73b361",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "customOutput": null,
-        "executionStartTime": 1689117389905,
-        "executionStopTime": 1689117389913,
-        "originalKey": "1f13d0a1-accf-4faf-b40e-fbc21aeb94d9",
-        "requestMsgId": "b360f1fd-9b8e-43c1-ab93-48df1580a9fb",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "import torch\n",
-        "\n",
-        "\n",
-        "torch.manual_seed(12345)  # To always get the same Sobol points\n",
-        "tkwargs = {\n",
-        "    \"dtype\": torch.double,\n",
-        "    \"device\": torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\"),\n",
-        "}"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {
-        "customInput": null,
-        "originalKey": "7f07af01-ad58-4cfb-beca-f624310d278d",
-        "showInput": false
-      },
-      "source": [
-        "# Demo of using Developer API"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {
-        "customInput": null,
-        "originalKey": "c8a27a2f-1120-4894-9302-48bfde402268",
-        "showInput": false
-      },
-      "source": [
-        "## Problem Setup \n",
-        "\n",
-        "In this simple experiment we use the Branin function embedded in a 10-dimensional space. Additional resources:\n",
-        "- To set up a custom metric for your problem, refer to the dedicated section of the Developer API tutorial: https://ax.dev/tutorials/gpei_hartmann_developer.html#8.-Defining-custom-metrics.\n",
-        "- To avoid needing to setup up custom metrics by Ax Service API: https://ax.dev/tutorials/gpei_hartmann_service.html."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "executionStartTime": 1689117390036,
-        "executionStopTime": 1689117390038,
-        "originalKey": "e91fc838-9f47-44f1-99ac-4477df208566",
-        "requestMsgId": "1591e6b0-fa9b-4b9f-be72-683dccbe923a",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "import math \n",
-        "import numpy as np\n",
-        "\n",
-        "\n",
-        "aug_dim = 8 \n",
-        "\n",
-        "# evaluation function \n",
-        "def branin_augment(x_vec, augment_dim):\n",
-        "    assert len(x_vec) == augment_dim\n",
-        "    x1, x2 = (\n",
-        "        15 * x_vec[0] - 5,\n",
-        "        15 * x_vec[1],\n",
-        "    )  # Only dimensions 0 and augment_dim-1 affect the value of the function\n",
-        "    t1 = x2 - 5.1 / (4 * math.pi**2) * x1**2 + 5 / math.pi * x1 - 6\n",
-        "    t2 = 10 * (1 - 1 / (8 * math.pi)) * np.cos(x1)\n",
-        "    return t1**2 + t2 + 10"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "customOutput": null,
-        "executionStartTime": 1689117390518,
-        "executionStopTime": 1689117390540,
-        "originalKey": "850830c6-509f-4087-bce8-da0be4fd48ef",
-        "requestMsgId": "56726053-205d-4d7e-b1b5-1a76324188ee",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "from ax.core.objective import Objective\n",
-        "from ax.core.optimization_config import OptimizationConfig\n",
-        "from ax.metrics.noisy_function import NoisyFunctionMetric\n",
-        "from ax.utils.common.typeutils import checked_cast\n",
-        "\n",
-        "\n",
-        "class AugBraninMetric(NoisyFunctionMetric):\n",
-        "    def f(self, x: np.ndarray) -> float:\n",
-        "        return checked_cast(float, branin_augment(x_vec=x, augment_dim=aug_dim))\n",
-        "\n",
-        "\n",
-        "# Create search space in Ax \n",
-        "search_space = SearchSpace(\n",
-        "    parameters=[\n",
-        "        RangeParameter(\n",
-        "            name=f\"x{i}\",\n",
-        "            parameter_type=ParameterType.FLOAT, \n",
-        "            lower=0.0, upper=1.0\n",
-        "        )\n",
-        "        for i in range(aug_dim)\n",
-        "    ]\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "executionStartTime": 1689117391899,
-        "executionStopTime": 1689117391915,
-        "originalKey": "d039b709-67c6-475a-96ce-290f869e0f88",
-        "requestMsgId": "3e23ed64-7d10-430b-b790-91a0c7cf72fe",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "# Create optimization goals \n",
-        "optimization_config = OptimizationConfig(\n",
-        "    objective=Objective(\n",
-        "        metric=AugBraninMetric(\n",
-        "            name=\"objective\",\n",
-        "            param_names=[f\"x{i}\" for i in range(aug_dim)],\n",
-        "            noise_sd=None,  # Set noise_sd=None if you want to learn the noise, otherwise it defaults to 1e-6\n",
-        "        ),\n",
-        "        minimize=True,\n",
-        "    )\n",
-        ")\n",
-        "\n",
-        "# Experiment\n",
-        "experiment = Experiment(\n",
-        "    name=\"sebo_experiment\",\n",
-        "    search_space=search_space,\n",
-        "    optimization_config=optimization_config,\n",
-        "    runner=SyntheticRunner(),\n",
-        ")\n",
-        "\n",
-        "# target sparse point to regularize towards to. Here we set target sparse value being zero for all the parameters. \n",
-        "target_point = torch.tensor([0 for _ in range(aug_dim)], **tkwargs)"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {
-        "customInput": null,
-        "originalKey": "e57edb00-eafc-4d07-bdb9-e8cf073b4caa",
-        "showInput": false
-      },
-      "source": [
-        "## Run optimization loop"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "customOutput": null,
-        "executionStartTime": 1689117393959,
-        "executionStopTime": 1689117393962,
-        "originalKey": "d0f279d5-da98-44da-9a4e-c30553e4d95a",
-        "requestMsgId": "20d42853-0502-4a5c-8749-7fc1dcbc9879",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "import torch \n",
-        "from ax.models.torch.botorch_modular.surrogate import Surrogate\n",
-        "from botorch.models import SingleTaskGP, FixedNoiseGP, SaasFullyBayesianSingleTaskGP\n",
-        "from ax.models.torch.botorch_modular.sebo import SEBOAcquisition\n",
-        "from botorch.acquisition.multi_objective import qNoisyExpectedHypervolumeImprovement"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "customOutput": null,
-        "executionStartTime": 1689117395051,
-        "executionStopTime": 1689117395069,
-        "originalKey": "c4848148-bff5-44a7-9ad5-41e78ccb413c",
-        "requestMsgId": "8aa87d22-bf89-471f-be9f-7c31f7b8bd62",
-        "showInput": true
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Doing 50 evaluations\n"
-          ]
-        }
-      ],
-      "source": [
-        "N_INIT = 10\n",
-        "BATCH_SIZE = 1\n",
-        "\n",
-        "if SMOKE_TEST:\n",
-        "    N_BATCHES = 1\n",
-        "    SURROGATE_CLASS = SingleTaskGP\n",
-        "else:\n",
-        "    N_BATCHES = 20\n",
-        "    SURROGATE_CLASS = SaasFullyBayesianSingleTaskGP\n",
-        "\n",
-        "print(f\"Doing {N_INIT + N_BATCHES * BATCH_SIZE} evaluations\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "customOutput": null,
-        "executionStartTime": 1689117396326,
-        "executionStopTime": 1689117396376,
-        "originalKey": "b260d85f-2797-44e3-840a-86587534b589",
-        "requestMsgId": "2cc516e3-b16e-40ca-805f-dcd792c92fa6",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "# Initial Sobol points\n",
-        "sobol = Models.SOBOL(search_space=experiment.search_space)\n",
-        "for _ in range(N_INIT):\n",
-        "    experiment.new_trial(sobol.gen(1)).run()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "customOutput": null,
-        "executionStartTime": 1689117396900,
-        "executionStopTime": 1689124188959,
-        "originalKey": "7c198035-add2-4717-be27-4fb67c4d1782",
-        "requestMsgId": "d844fa20-0adf-4ba3-ace5-7253ba678db2",
-        "showInput": true
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 0, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 1, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 2, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 3, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 4, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 5, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 6, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 7, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 8, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 9, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 10, Best so far: 2.494\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 11, Best so far: 1.990\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 12, Best so far: 1.990\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 13, Best so far: 1.990\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 14, Best so far: 1.990\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 15, Best so far: 1.990\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 16, Best so far: 0.662\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 17, Best so far: 0.662\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 18, Best so far: 0.453\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 19, Best so far: 0.453\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 20, Best so far: 0.453\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 21, Best so far: 0.424\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 22, Best so far: 0.424\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 23, Best so far: 0.424\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 24, Best so far: 0.424\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 25, Best so far: 0.424\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 26, Best so far: 0.424\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 27, Best so far: 0.424\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 28, Best so far: 0.424\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 29, Best so far: 0.424\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 30, Best so far: 0.416\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 31, Best so far: 0.416\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 32, Best so far: 0.408\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 33, Best so far: 0.408\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 34, Best so far: 0.408\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 35, Best so far: 0.408\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 36, Best so far: 0.408\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 37, Best so far: 0.408\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 38, Best so far: 0.408\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Iteration: 39, Best so far: 0.408\n"
-          ]
-        }
-      ],
-      "source": [
-        "data = experiment.fetch_data()\n",
-        "\n",
-        "for i in range(N_BATCHES):\n",
-        "\n",
-        "    model = Models.BOTORCH_MODULAR(\n",
-        "        experiment=experiment, \n",
-        "        data=data,\n",
-        "        surrogate=Surrogate(botorch_model_class=SURROGATE_CLASS),  # can use SAASGP (i.e. SaasFullyBayesianSingleTaskGP) for high-dim cases\n",
-        "        search_space=experiment.search_space,\n",
-        "        botorch_acqf_class=qNoisyExpectedHypervolumeImprovement,\n",
-        "        acquisition_class=SEBOAcquisition,\n",
-        "        acquisition_options={\n",
-        "            \"penalty\": \"L0_norm\", # it can be L0_norm or L1_norm. \n",
-        "            \"target_point\": target_point, \n",
-        "            \"sparsity_threshold\": aug_dim,\n",
-        "        },\n",
-        "        torch_device=tkwargs['device'],\n",
-        "    )\n",
-        "\n",
-        "    generator_run = model.gen(BATCH_SIZE)\n",
-        "    trial = experiment.new_batch_trial(generator_run=generator_run)\n",
-        "    trial.run()\n",
-        "\n",
-        "    new_data = trial.fetch_data(metrics=list(experiment.metrics.values()))\n",
-        "    data = Data.from_multiple_data([data, new_data])\n",
-        "    print(f\"Iteration: {i}, Best so far: {data.df['mean'].min():.3f}\")"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {
-        "customInput": null,
-        "originalKey": "7998635d-6750-4825-b93d-c7b61f74c3c5",
-        "showInput": false
-      },
-      "source": [
-        "## Plot sparisty vs objective \n",
-        "\n",
-        "Visualize the objective and sparsity trade-offs using SEBO. Each point represent designs along the Pareto frontier found by SEBO. The x-axis corresponds to the number of active parameters used, i.e.\n",
-        "non-sparse parameters, and the y-axis corresponds the best identified objective values. Based on this, decision-makers balance both simplicity/interpretability of generated policies and optimization performance when deciding which configuration to use."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "customOutput": null,
-        "executionStartTime": 1689124189044,
-        "executionStopTime": 1689124189182,
-        "originalKey": "416ccd12-51a1-4bfe-9e10-436cd88ec6be",
-        "requestMsgId": "5143ae57-1d0d-4f9d-bc9d-9d151f3e9af0",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "def nnz_exact(x, sparse_point):\n",
-        "    return len(x) - (np.array(x) == np.array(sparse_point)).sum()\n",
-        "\n",
-        "    \n",
-        "df = data.df\n",
-        "df['L0_norm'] = df['arm_name'].apply(lambda d: nnz_exact(list(experiment.arms_by_name[d].parameters.values()), [0 for _ in range(aug_dim)]) )"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "customOutput": null,
-        "executionStartTime": 1689124189219,
-        "executionStopTime": 1689124189321,
-        "originalKey": "97b96822-7d7f-4a5d-8458-01ff890d2fde",
-        "requestMsgId": "34abdf8d-6f0c-48a1-8700-8e2c3075a085",
-        "showInput": true
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "{1: 5.915850721937628,\n",
-              " 2: 0.41574213444366315,\n",
-              " 3: 0.41574213444366315,\n",
-              " 4: 0.40790508387544655,\n",
-              " 5: 0.40790508387544655,\n",
-              " 6: 0.40790508387544655,\n",
-              " 7: 0.40790508387544655,\n",
-              " 8: 0.40790508387544655}"
-            ]
-          },
-          "execution_count": 12,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "result_by_sparsity = {l: df[df.L0_norm <= l]['mean'].min() for l in range(1, aug_dim+1)}\n",
-        "result_by_sparsity"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 20,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "customOutput": null,
-        "executionStartTime": 1689134836494,
-        "executionStopTime": 1689134837813,
-        "originalKey": "7193e2b0-e192-439a-b0d0-08a2029f64ca",
-        "requestMsgId": "f095d820-55e0-4201-8e3a-77f17b2155f1",
-        "showInput": true
-      },
-      "outputs": [
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfEAAAGWCAYAAABow7qfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3deZwcdZnH8U8xgQQyEAhHOAMEAoQESCZcAkIkQowil/rIiqyguOt6IigYYBUFVETFRV0F8UYXH1DkMrA6SzgUkSMhgFxyH0FIIIYEyDGp/WOelqaZo3ume6qr+vt+vebV09XVVc+vM+mnfkf9fkmapoiIiEj+rJF1ACIiIjIwSuIiIiI5pSQuIiKSU0riIiIiOaUkLiIiklNK4iIiIjmlJC4iIpJTSuIi8k9JkuyYJMnjSZKclHUsItI/JXGRIZIkSWeSJHclSfJ0kiTLkyR5LkmSW5Ik+WCSJEnW8YUNgM2BbRp5kiRJNkuS5JEkSRbHZ7EqSZJXkiSZlyTJz5Mk2XmQxx+VJMl5SZI8nCTJsiRJ7kmS5BNJkug7Twol0YxtIkMjSZIUWAFcAbwMjAYOAkYAZ6Zp+vmsYyQSYJqm/2jwObYGHgOWANcDy4AEmAjsGp/T6WmanjvA418HHAzcCTwEHAhsDHw2TdOv179EItlQEhcZIpHEF6ZpunHZtp0j0awC1kvTdHW2UQ6NsiR+e5qme1S89m7gZ8BwYJ80TW+t8di7AncBNwBvSdM0TZJkC+AB4Mk0TSfUvUAiGVHTkkiG0jT9K3AvMBIYW9qeJMmUJEn+liTJ6UmSnJwkyRNJktxT9vrBSZL8IfqvX06S5MEkSS5LkuSAynNEM/7fkiSZkCTJb5MkeTZJkhei2Xr9in0PSJIkTZLkCxXbj0+SZGmSJDOTJDkrSZL7o5n69iRJ3lznz+Qy4Fvx/fSdARxix3i8PI1aSpqmT0eNfGzfbxXJFyVxkQxFH+0Y4BXg72UvrQdsB3w6fm6NZviS4cCGsf038d5DgTlRyy03LpLXndGk3Ak8B7wfOKfKULeIC41LgaOAe4CbgA7g10mSrFeHj6PcucBqYPckSbaq8b1PxeP40oYkSTYEJgG31zdMkWwNyzoAkVaVJMlo4NRIkKekafpKD7vNAw5N03RZ+cY0Ta8Crqo43o+BY3s53UvAvmma3h/7rgMsBGbUGPYZwDdKNdwkSX4K/Gsk8zk1HqtXaZq+mCTJw5GIJwJPRiL+ah9v+1yapovSNL0lSZIrgQ8nSXIXcF00zz8PfKJeMYo0AyVxkaG1UfSNlzsjTdOv9bL/jZUJfICWlBI43Uny5SRJ7gT2qfE4t6WvH0hzUyTxRjRTL4wkvkE8bweO72P/s4BF8fu7gEuAC4E0fvZP03R+A+IUyYySuMjQWg78PH5fF9gf+HySJOulaVr1vdnRDH8EMAXYJEZ271tjLCvjfYOxshTSII/Tk3Xi8e90X3g8XsN5DotWhr8A1wAfBWYnSXJEmqadDYhVJBNK4iJD66U0TT9cehLN2jcBJyZJcn2aplf3d4BI4L+P26aKbIt4fKiWNyVJMh74RYwhODpN01VJkvwgRqx7kiTbpGn6UmNCFhlaSuIiGYpm7YujT/lAoN8kDrwt9r0JeF+apk/Rf594riRJsjmwEfAq8DSvDU7rt08cOCYG/n0zTdNVdH/OC5IkceBjwH7A7CErjEgDKYmLZG9EPFbb9126z/mSUgIvoI/H44/K7p2vtk+81Ide+XmuiEd970lh6I9ZJENRu/xQPP1LlW8rzaa2S8X20sVAW53Cy0SSJEfHbXVLgS+VttfQJ35fPL47boUrdVu8I7ZrcJsUhpK4yNAalSTJZVFLXA84IGqOV1bZlE7c5/1q3EI1IW6d2i3uNwe4MEmSG9I0PbOB5ehVkiTbAI/GbXO9jbov2SFJksvj8xgGTI7JWhYCx6Rp+vd+3t8TB04HvpAkyTRgQYzCHwt8Py4GRApBk72IDJ07o7n3ndFvewDwSNy7/N60yjmQ0zR9NG6huhfYI5rXLwC2jnu19yhrOs5CaRa4VX3ssxy4Oy5G3g78S4woXwL8N7BbmqbXDuTkaZouBKYDv44LgncCLwIn6D5xKRrNnS4idZUkyX9EIj4wTdPrs45HpMiUxEWkbpIkWStaCFYCE6ttXRCRgVGfuIjU0zmxFvk+SuAijac+cRGpiyRJ1o0JWj6fpultWccj0grUnC4iIpJTuWtO7+zs1FWHiIi0nOnTp79hnoTcJXG6C1K3Y82ZM4dp06bV7XjNSuUsFpWzWFTOYmlEOTs7e163R33iIiIiOaUkLiIiklNK4iIiIjmlJC4iIpJTTTGwzcwmxyQRe0ZM33P3k7OOS0REpJllnsTNbBfgRmA1cDOwZiwKISIiIn3IPIkDJ0YcO7v7Y1kHIyIikheZJnEzWwN4b9TE9zezU4F5wAXu3pVlbCIiIs0u02lXzWxTYAGwFGgve+kCd/9IT+/p7OxM29ra6hbD0qVLaW9vr2LPfFM5i0XlLBaVs1gaUc6urq6mnLFt83jsAiYBS4AbgOPN7GR3X9LTm+oxE05XF8yeDb/5zaMceeS2zJwJdbw2aDqaKalYVM5iUTmLZShnbMs6iZfS5v+5+710186vAE4AtgPmNuKkXV0wYwbceissW7YNl14Ke+0F111X7EQuIiLFkvV94n+PxxVl21b1sK2uZs/uTuBLl0KaJixd2v189uxGnVFERKT+sq6JL4gm9N3NbFg0q+8LrAQebdRJ586FZctev23ZMpg3Dw45pFFnFRERqa9Ma+LuvhL4aTSd3wb8BXgT8EN3f7lR550yBUaOfP22kSNh8uRGnVFERKT+sm5OBzgFuAjYDNgS+C7w6UaecObM7j7w7sGDKcOHdz+fObORZxUREamvrJvTcfdXgA8P5Tnb2roHsc2eDWedtYgNNtiIq6/WoDYREcmXZqiJZ6Ktrbv/++ijn2TRIiVwERHJn5ZN4iXbb7+Ue+6BlSuzjkRERKQ2LZ/E1167i623hvvuyzoSERGR2rR8Egfo6IA77sg6ChERkdooiUcSv/POrKMQERGpjZK4kriIiOSUknhM/nLXXd1zqouIiOSFkjiw/vowZgw8+GDWkYiIiFRPSTyoSV1ERPJGSTxMnaokLiIi+aIkHlQTFxGRvFESD1OmdCfx1auzjkRERKQ6SuJh441h1Ch45JGsIxEREamOkngZNamLiEieKImXURIXEZE8URIvoyQuIiJ5oiReppTE0zTrSERERPqnJF5m881hzTXhySezjkRERKR/SuIV1KQuIiJ5oSReQWuLi4hIXiiJV1BNXERE8kJJvIKSuIiI5IWSeIWxY2HFCliwIOtIRERE+qYkXiFJVBsXEZF8UBLvgZK4iIjkgZJ4D7S2uIiI5IGSeA9UExcRkTxQEu/BuHGweDEsXJh1JCIiIr1TEu/BGmvAlCmqjYuISHNTEu+FmtRFRKTZKYn3QklcRESanZJ4L5TERUSk2SmJ92LHHeHZZ7sHuImIiDQjJfFetLXBbrvBvHlZRyIiItIzJfE+qEldRESamZJ4H5TERUSkmSmJ96GjA+64I+soREREeqYk3oedd4bHH4elS7OORERE5I2UxPuw5powcSLcdVfWkYiIiLyRkng/1C8uIiLNSkm8H0riIiLSrJTE+6G1xUVEpFkpifdj0iR46CF49dWsIxEREXk9JfF+jBgBO+wAd9+ddSQiIiKvNyzLk5vZDODais0vu/vIjELqUel+8T32yDoSERGR12SaxIGt4rETeD5+X5RhPD3S4DYREWlGSZqmmZ3czL4IfB7Yzd3nV/Oezs7OtK2trW4xLF26lPb29j73ueee9fj2t8dzwQX5nb6tmnIWgcpZLCpnsaicA9fV1cX06dOTyu1Z18Q3jMeaat/Tpk2rWwBz5szp93h77AEnnwz77DONtdaq26mHVDXlLAKVs1hUzmJROQeus7Ozx+1ZD2wr9X1/2cxON7MdMo6nRyNHwjbbwF//mnUkIiIir2mWJP6vwJnA/WZ2XMYx9Uj3i4uISLPJOokfEzGMBN4LdAHnm1n9Or3rRIPbRESk2WTaJ+7uy+PXlwE3s1nAZGAc8FCWsVXq6IBLL806ChERkddkXRP/JzPbANgZWAk8kXU8lSZPhvnzYdWqrCMRERHplvVkL98D9gOeBPYF1gLOKauhN41Ro2CzzeCBB7qXJxUREcla1jXxJXEhcQDwFHACcFrGMfVK/eIiItJMsu4TPwU4JcsYalFK4scck3UkIiIi2dfEc0U1cRERaSZK4jXo6IC5c2H16qwjERERURKvyYYbwujR8PDDWUciIiKiJF4zNamLiEizUBKvUWltcRERkawpiddINXEREWkWSuI1KiXxDJdhFxERASXx2m26KYwYAY8/nnUkIiLS6pTEB0BN6iIi0gyUxAdAa4uLiEgzUBIfANXERUSkGSiJD0DpNjMNbhMRkSwpiQ/Allt2T736zDNZRyIiIq1MSXwAkkRN6iIikj0l8QFSEhcRkawpiQ+QkriIiGRNSXyAlMRFRCRrw3p7wcyWASMGcMzU3Xs9blGMGwcvvQTPPQebbJJ1NCIi0or6SrazgdFlzycCGwM3AV097D869rm5AXE2ndLgtrlzYcaMrKMREZFW1GsSd/d3lz83s5uBV939gJ72N7ORwOPAtxsRaDMqNakriYuISBZq6ROfCNza24vuvixq4Z+rT2jNT2uLi4hIlmpJ4i9WNK/3ZAWw0yBjyg0NbhMRkSzVksTvAKaZ2eE9vWhmOwBvBZ6qX3jNbfx4eP55ePHFrCMREZFWVMso8pOBGcCvzexu4G5gITAS2AaYBrQBZzcw3qbS1ga77dY9uO3AA7OORkREWk3VNXF3fxTYL0at7wocDXwKOD5q4IuB09z9G40NubmoSV1ERLJS0/3c7j4fOMTMNgK2BcYCy4EngfvdfXnjQm1OU6fCdddlHYWIiLSiAU3K4u4Loyn9tvqHlC8dHfCVr2QdhYiItCJNuzpIEybAk092z94mIiIylGqqiZvZ1sAB0Yye9LJb6u5n1Se85jdsGEyaBPPmwZvfnHU0IiLSSqpO4nFr2S+B4X0kcIAUaJkkTtngNiVxEREZSrXUxM+OW8jOjPnTVzYwrlzp6ICbW2LGeBERaSa1JPGtgWvc/YwGxpNLHR1w/vlZRyEiIq2mloFtjzQwjlybNAkefhhefjnrSEREpJXUksR/DOxuZm0NjCeXhg+HnXaCu+/OOhIREWkltTSn/wNYHzjXzOb2taO7/3zwoeVLaXDbXntlHYmIiLSKWpL414F24IQYgd6TJF5r2SQuIiIyVGpJ4kcDGzcwllzr6IAf/jDrKEREpJVUncTdfXZjQ8m3XXeF++6D5cu7+8hFREQaTdOu1sk668C4cXDvvVlHIiIirUJJvI7ULy4iIkOplmlXL4wZ2/qTuvvxgwsrn5TERURkKNUysO2wKge2pUBLJvGpU+GSS7KOQkREWkUtSbyjn5r4boADA1oGxMymANcC57v72QM5RtYmT+6e8GXVqu7VzURERBqpltHpT/ezyxNm9gRwHHD7AGI5G9gEuH4A720K664LW24J99/fPRWriIhIIyVp2tu8LbUzs6uBHd19fI3v2wP4C9Dp7m/ta9/Ozs60ra1+M78uXbqU9vb2uh3vzDMnsOeeLzBjxt/rdsx6qHc5m5XKWSwqZ7GonAPX1dXF9OnT37AMeL0bfbcGNh3A+06Nx6rWIZ82bdoATtGzOXPm1PV4t90GTz01hmnTJtTtmPVQ73I2K5WzWFTOYlE5B66zs7PH7bWMTj+tj1vShgNvBXYGbqwlMDPbDjgU+COwyMxOiSVP76nlOM2iowOuvDLrKEREpBXUUhM/Adiwn30eBD5eYwyfiIuDM2Pw3FeBZ4FcJvEpU2DePFi9GtbQXfgiItJAtSTxQ6LG3ZMUeAp4zN2r7mQ3s3VjINxt7n6dmX2ghnia0ujRsNFG8NBDsOOOWUcjIiJFVsvo9FsbcP5pwHrAGDO7CRgT208zs2XuflkDztlwU6d2T/qiJC4iIo2UdYNv6fxjgf2A0qj28cBaGcY1KJq5TUREhkLNo9PNbKMYxDYO2Dya0R8Cfufur9RyLHe/ItYgLx37C8AZwLHu/staY2sWHR1w7rlZRyEiIkVXUxI3sxOBzwPrliff6BN/xsxOdPdL6x9mvkyZ0l0TT1NI3nBXn4iISH1U3ZxuZocDXwe6gG8D/wa8Kx6/DYwEfmFmew4injlRE583iGNkbswYGDkSHn0060hERKTIaqmJfwZ4Eehw98crXzSzbwFzgS8CMwcSjLvfANwwkPc2m1K/+LhxWUciIiJFVcvAtp2B63tK4HQn4MeA/4t7vVueBreJiEij1ZLEX4wm876sBawcZEyFoCQuIiKNVksSvwWYbmaH9PSimR0Qo9bvql94+VW6V7yO68uIiIi8Ti194p8FDgauMLO7YlrURcD6wE7AnsAKYFYD482NzTfvHpn+9NPdy5OKiIjUW9U1cXdfEBOyXAlMBt4PfAr4ALBXrCH+Nnef39iQ8yFJ1KQuIiKNVdN94u7+IHCEmW0cs6ptGYuVPObuTzQuzHwqJfFDD806EhERKaIBrSfu7s8Dz9c/nGLp6ICf/CTrKEREpKh6bU43s1+b2UfLnl9hZscNWWQFoOZ0ERFppL76xA8CDix7/k5g7yGIqTC22QZefhmefTbrSEREpIj6ak7/C3CwmZ0OlCZ42cHMjunvoO7+8/qFmF+lwW1z58LMAc1hJyIi0ru+kviJwLXAl2KBkxTYP356k8R+SuKhdL+4kriIiNRbr0nc3eeb2U7APsAY4Mcxr/mPhzbEfOvogEtbfl03ERFphD5Hp7v7kqiNl2Zku8HdfzZk0RVARwfM0vQ3IiLSAFXfYubuH2xsKMW0/fawaBG88AKMHp11NCIiUiS1zJ0uA7DGGjB5sm41ExGR+lMSHwK6X1xERBpBSXwIKImLiEgjKIkPASVxERFpBCXxIbDTTt1Lki5ZknUkIiJSJDUtgGJmmwMnxVKkWwKr3X1CvLYB8B/AX939tw2LOIeGDYNdd4V582D/vqbKERERqUHVSTwmfrkNGAksAkYA65Tt8grw2ZiuVUm8QqlJXUlcRETqpZbm9G/E/vu6+8bAJeUvuvurkcAn1T/M/FO/uIiI1FstSXx34Fp3vyWepz3s8zywfp1iK5SODrjjjqyjEBGRIqklia+IBU76si3wyCBjKqSJE+HRR2HZsqwjERGRoqglif8ZmGFme/T0opm9D3hT7CcV1loLJkyA+fOzjkRERIqiltHpnwbeAtxiZvOBjehO3lcD2wPjY8DbqY0LN99K/eJvelPWkYiISBFUXRN396eADuAnwE5xi1kCvB3YDrgM2Mvdn29syPlVWltcRESkHmq6T9zdnwCOB443s82ArYCFwBPuvqpxYRZDRwdccEHWUYiISFHUlMTLufsCYEF9wym2XXaBBx6A5cth+PCsoxERkbzTtKtDaO21u9cXv+eerCMREZEiqGXGttOqTPqpu581uLCKq3S/+NSpWUciIiJ5V0tz+gnAhv3sU5oARkm8F5q5TURE6qWWJH4I0FdP7q7AucC76xBXYXV0wMUXZx2FiIgUQdVJ3N1v7WeXG83sM8A+wDWDD62YJk/u7hNfuRLWXDPraEREJM/qPbDtPuCIOh+zUNrbYeut4b77so5ERETyrt5JfDQwts7HLBz1i4uISD3UMjr9/X0sgDIcOAjYA9BaXf0oJfFjj806EhERybNaBradD4zq5bVScl8Uc6xLHzo64PLLs45CRETyrpYk/m/AOr28lgJPAXe6+z/qFFthTZkCd90FXV3Q1pZ1NCIikle1jE6/rLGhtI7114dNNoEHH+xenlRERGQgNO1qRjS4TUREBmvAC6DUi5ldBOwXo9oXAQ7McvcVWcfWSKUkfvTRWUciIiJ5laRp2uMLZnYtMJDpSFJ3f2u1O5vZ74AxwAsxUcw6wFfdfVZP+3d2dqZtdexIXrp0Ke3t7XU7XrVuu20DfvnLsZx33l1Dcr6syjnUVM5iUTmLReUcuK6uLqZPn/6GO8T6qonvAmw2gHP1fFXQC3d/e+l3MzsM+G3UzHs1bdq0AYTVszlz5tT1eNWaOBHOPhv2338aawxBp0ZW5RxqKmexqJzFonIOXGdnZ4/be03i7r5FXSOoTeHvNd94Y1hvPXj0Udhuu6yjERGRPGqGPvGNgG8DawMHAH8CvpZ1XEOh1C+uJC4iIgNR14ZcM/uImb2vxreNBI4CDgPWB54HXq5nXM1KI9RFRGQw6t0be3DM7FY1d3/c3ZOYDe6kSOZX1zmuptTRAXcUvuNAREQapZa50ydX2Vc9byCBuPsS4JtmdhKwr5mNKvrsb6WaeJpC0tus9CIiIr2opU/8hBh5fmM83zFGr8+J5yOACcAhg4wpAbqAQt8nDrDZZjBsGDz5JIzV2m8iIlKjWpL4HsDt7n4g3TXzC4EPlT1PgMeB6cDF1R40+tDnAC8C/xoXBre7+ysDKVCeJAlMndpdG1cSFxGRWtXSJz4W+FtvL7p7CtxeyypmZrZeJPynYzDb94ElwIdriCvXNLhNREQGqpYkvqRiPfFFdCfiDcu2jQB2qOGYq4D3A18GfgScAmzn7gPqV88jJXERERmoWprTHwS2LXv+10jq3zWzn8QMb2+JJvWquPvLwC9rC7lYOjrgYx/LOgoREcmjWpL4RcB6Zc8vAT4HGPCeSOgpcHYD4iyssWNh+XJYsKB7oJuIiEi1allP/BcVz1ea2e7AsTEq/R/ANe7+54ZEWlBJ8lqT+jvekXU0IiKSJ4OadjVGkH+vfuG0JiVxEREZiFome/lN3CN+tbv3OkpdatfRAZdcknUUIiKSN7XUxKcDhwPfMLMHgSuBq9z95gbG1xKmToWTT846ChERyZtakvgYYEYk8ncAnwU+Y2ZPxwjz/3H3uxoYa2GNGweLF8PChbDRRllHIyIieVH1feLu/qq7X+HuxwGbxrKh/wWsBE4G7jSze81sVmNDLp411oApU2Du3KwjERGRPBnQwDZ3Xw3cFD8nmtnesQLZkcBZwFfqH2qxlQa3HXRQ1pGIiEheDHh0upltDBwazevTgeFxr/it9Q2xNXR0wFVXZR2FiIjkSU1J3MzGRdI+HHhTNMcnwPyY/OUSd3+sceEWV0cHnHFG1lGIiEie1HKL2Z3AbmUzs90JXN3duu73NTbM4ttxR3j22e4Bbuuvn3U0IiKSB7XUxDcBrorEfY27L2hgXC2nrQ123RXmzYNp07KORkRE8qCWJL6Nu69qYCwtr7S2uJK4iIhUo5ZbzJTAG0zLkoqISC1qWU9cGkxJXEREaqEk3kR23hkeewyWLcs6EhERyQMl8Say5powcSLcpclrRUSkClUncTMbY2Z9DoQzs5PM7D/qElmL6uiAO+7IOgoREcmDWmrizwDf6WefmcDHBhlTS1O/uIiIVKuWJJ7ET19WA1sNMqaWpiQuIiLV6q95fCawe9mmDjP7zx52TYDNgWmaO31wdtkFHnoIXn0VRozIOhoREWlm/U32shPwxfg9BabGT28eUnP64IwYATvsAHffDXvskXU0IiLSzPpL4j8H7oia9vUx5erXe9ivC3gWeDSWKZVBKDWpK4mLiEhf+kzi7r4QuJHupvUzgDvd/cYhi65FqV9cRESqUfXc6e7+pcaGIiUdHfDTn2YdhYiINLua1hPviZltAOwDLAJu1xzrg7fbbnDvvbBiBay1VtbRiIhIs6plspdrzexPFdv2BP4GXAn8EfizmW3ckEhbyMiRsM028Ne/Zh2JiIg0s1ruE98RWLv0JGZv+yGwQQx6+wPQAZzWmFBbi/rFRUSkP7Uk8TFxC1nJccBE4AZ3f6u7z4iR7Ic1IM6WU1pbXEREpDe1JPEngS3oroWvAZwQ945/pWyfB4FN6x9m61FNXERE+lNLEv81sJeZ/SbuF58A3Oju/1u2z1jghQbE2XImT4b586GrK+tIRESkWdWSxM8B/gQcDrwNWAx8vPSimY0G9gLmNibU1jJqFGy2GTzwQNaRiIhIs6o6ibv7P4C3AHsCRwA7uvu9ZbssA94FnN2YUFuPmtRFRKQvNd0n7u5dwO3xU/nacuCqukbX4kpri7///VlHIiIizWhAk73EwLYxQOruz9Y/LCGS+FlnZR2FiIg0q5qSuJkdBnwemBTvTUvHMLPNgJ8Cne5+TsMibiEdHTB3LqxeDWvUMnpBRERaQi0ztr0TuDxuM7sSeDhWN4Pu5vQFMSHMuxoWbYvZcEMYPRoefjjrSEREpBnVUr+bBSwAdnL39wBzethnLrBtHeNreRrcJiIivaklie8MzHH3xX3s8yqwZh3ikqAkLiIivakliT/T12xsZpYAuwG6s7mOlMRFRKQ3tQxsuxb4lJmdBPyg/AUz2xT4ArADcEa1BzSzL8Zc6+Ojqf777v71mkpQcKUknqaQJFW8QUREWkatfeK3A+cCL8YCKJjZMuBp4N9jAZSv9H+ofxoTTfA3A1sC55rZsbUXo7g23RSGD4fHH886EhERaTZJmqZV7xxN5kcDxwDbAFsBC4FHgF8BF8aEMNUebw13Xx2/Hx81/Evd3Xp7T2dnZ9rW1lZ1zP1ZunQp7e3tdTteI8yatQszZy5g//0XDvgYeShnPaicxaJyFovKOXBdXV1Mnz79De2xtc7YlgIXx8+glRJ4eDoeV/ey+z9NmzatHqcHYM6cOXU9XiMcdBCsWLEhgwkzD+WsB5WzWFTOYlE5B66zs7PH7c00hciH4/HKjONoOlpbXEREelJ1TdzMxgJ/jznSS9veDhwYi5/8xd2vGUgQZnZKLKoyG7hkIMcostIc6hrcJiIi5fpN4mZ2BnAiMBJ4xcy+4O7fMLOvA58um7UtNbMrgKPcfUU1J4852M8GPgf8DrCKJnYBttyye+rVBQtg882zjkZERJpFn0nczI6LudKXx2xsY4Cvmdk6wAmx7WJgBHB83C72IeB7VZ7/UuDIOP4y4CIzA/i8uz9UlxIWQJK8dquZkriIiJaFOLsAABkWSURBVJT01yf+YeAVYIq77w6MBc4Dvgg8C+zn7t9y968CewGLS7eeVakjHocD7wGOip8Bra5WZJr0RUREKvWXLLcDfu/u9xOj083s7Ghev9HdXy3t6O6LzOwGYP9qT+7umme9Sh0d8ItfZB2FiIg0k/5q4qOAF8o3uPuL8etLPey/BFi/fuFJSWlwm4iISEl/SXwhsE4NxxsJrBxkTNKDcePgpZfgueeyjkRERJpFf83pC4HDzOzvFdtT4BgzO7xi+yhgUZ1jlLLBbXPnwowZWUcjIiLNoL8kvigGnW3cw2sj4qfSM3WKTSqUBrcpiYuICP0lcXefPnShSH86OuDyy7OOQkREmkUzTbsq/dBtZiIiUk5JPEfGj+8e2Pbii1XsLCIihackniNtbbDbbjBvXtaRiIhIM1ASzxndLy4iIiVK4jmjfnERESlREs8ZrS0uIiIlSuI5M2ECPPlk9+xtIiLS2pTEc2bYMJg0Ce66K+tIREQka0riOaR+cRERQUk8n5TERUQEJfF8UhIXERGUxPNp0iT429/glVeyjkRERLKkJJ5Dw4fDjjvC/PlZRyIiIllSEs8p3S8uIiJK4jmlfnEREVESzyklcRERURLPqV13hfvugxUrso5ERESyoiSeU+usA+PGwb33Zh2JiIhkRUk8x9SkLiLS2pTEc0xri4uItDYl8RxTTVxEpLUpiefYlClw992walXWkYiISBaUxHNs3XVhyy3h/vuzjkRERLKgJJ5zalIXEWldSuI5pyQuItK6lMRzTklcRKR1KYnn3JQpMG8erF6ddSQiIjLUlMRzbvRo2HBDeOihrCMREZGhpiReAGpSFxFpTUriBaC1xUVEWpOSeAGoJi4i0pqUxAtgypTuJJ6mWUciIiJDSUm8AMaMgZEj4bHHso5ERESGkpJ4QahJXUSk9SiJF4SSuIhI61ESLwitLS4i0nqUxAuiVBPX4DYRkdahJF4QW2wBSQJPP511JCIiMlSUxAsiSdQvLiLSaoZleXIz+xjwDmAqsAnwE3c/LsuY8qyUxA89NOtIRERkKGRdEz8YOAhYkXEchaCauIhIa0nSDEdCmdloYAmwBfBYNTXxzs7OtK2trW4xLF26lPb29rodL0sLFozgk5+cwqWX3vKG14pUzr6onMWichaLyjlwXV1dTJ8+Pancnmlzuru/QHcyr+l906ZNq1sMc+bMqevxspSm8NGPwoQJ0xgz5vWvFamcfVE5i0XlLBaVc+A6Ozt73J51c7rUkQa3iYi0FiXxglESFxFpHUriBaO1xUVEWkfWt5j9IQa1rRmbjjCzvYHz3P3CLGPLq44OmDUr6yhERGQoZJrEge2Abcqej4qfNft4j/Rh++1h0SJ44QUYPTrraEREpJGyHp2+bZbnL6I11oDJk2HuXJg+PetoRESkkdQnXkAa3CYi0hqUxAtISVxEpDUoiReQkriISGtQEi+gnXaCp56CJUuyjkRERBpJSbyAhg2DXXeFefOyjkRERBpJSbyg1KQuIlJ8SuIFpSQuIlJ8SuIFpSQuIlJ8SuIFNXEiPPIIvPxy1pGIiEijKIkX1FprwYQJMH9+1pGIiEijKIkXmJrURUSKTUm8wDo64I47so5CREQaRUm8wLS2uIhIsSmJF9guu8ADD8Dy5VlHIiIijaAkXmBrr929vvg992QdiYiINIKSeMFpcJuISHEpiReckriISHEpiReckriISHEpiRfcbrt194mvWpVkHYqIiNSZknjBrbsubLUVPP74OlmHIiIidaYk3gKmToWHHlo36zBERKTOlMQLrqsLRoyAK6/cjKuv7n5eRF1dcPXV8LOfba1yFoDKWSwqZwOlaZqrnz/84Q9pPV1//fV1PV4zWbUqTadPT9O1105TWJ22t3c/X7Uq68jqq1TO9vY0TRKVM+9Uzqwjqy+Vsz7Hj9z3hpw4bAiuEyQjs2fDrbfCK68AJCxdCp2d0N4Owwr0L79qFbz6aunZa+UcNaq7FWKNNV77SZLXP6/2tcG8t17HfewxuPFGWLnytXLeeCMcdVT3pD5F8be/qZwqZ/70VM5bb+3+Hj7kkMadt0Bf5VJp7lxYtuz125IEPvMZOPnkrKKqv3POgS9/GdL0tW1JAp/8JJx4Iqxe/fqfNH3jtmpeG8x763Hc++4rfUG8ZuVKWLwY1ltvyD/2hlm8WOVUOfOnp3IuWwbz5imJywBNmQIjR8LSpa9tGzkS9tqre9R6Uey9d8/l3Gcf2GijLCOrr/Hj4Y9/fH0529vhU59q7JfEUNtlF/jzn1XOomjlco4cCZMnN/a8GthWYDNndifs9nZIkpT29u7nM2dmHVl9qZxZR1ZfKmfWkdWXytnY86omXmBtbXDddd19Mpdf/hhHHLEtM2d2by8SlTPryOpL5cw6svpSORt7XiXxgmtr626yam9/nGnTts06nIZROYtF5SwWlbNx1JwuIiKSU0riIiIiOaUkLiIiklNK4iIiIjmlJC4iIpJTSuIiIiI5pSQuIiKSU0riIiIiOaUkLiIiklNK4iIiIjmVpOXrN+ZAZ2dnvgIWERGpg+nTpyeV23KXxEVERKSbmtNFRERySklcREQkp5TERUREckpJXEREJKeUxEVERHJKSVxERCSnhmUdgIhIKzOzycA5wJ7xnfw9dz8567ikdma2PvAN4B3ACOAW4AR3f6BR51QSFxHJiJntAtwIrAZuBtYEHsk6LhmwbwPvB+4HXgbeBlwG7NKoE7ZsEjezj8XV0lRgE+An7n5c1nHVm5l9ETgMGA8sAL7v7l/POi6RvpjZDODais0vu/vIjEJqlBPje3hnd38s62Bk0N4OPAVMdPfVZnYLsLeZre/uixtxwpZN4sDBwEHAs1kH0mBjgFfjKv8A4FwzW+juP8k6sHoys4uA/YCxwCLAgVnuviLr2BrBzKZEkjvf3c/OOp4G2CoeO4Hn4/dFGcZTd2a2BvDeqInvb2anAvOAC9y9K+v46sXMNgee7uXlae5+wxCH1EjPAxsCpelR1wIeb1QCp8WT+HHAEmALoMhXwB9199V0/2c6HvhBXC0WKokDmwPLgD8C+0QNZwUwK+vAGuTsaEG6PutAGqSUxE909/kZx9IomwBrA/sCM8q27wp8JMO46m0xcEnFtunAxtHkXCTnA98F5pjZI8BOwHsaecKWTeLu/gLdiS3rUBqqlMBD6Wp4dS+755a7v730u5kdBvw2auaFY2Z7ADOBTnf/U9bxNMiG8Vio2neFzeOxC5gUlYobgOPN7GR3X5JxfHXh7i8D/1J6HjXzR4B73f22bKOrux8Ax0dFYj/gAeCeRp5Qt5i1lg/H45UZxzFU7sg6gAY5NR7PyjiORir1fX/ZzE43sx0yjqcR2uLx/9z9Xnd/Ergitm+XcWyNdCIwHDgv60AawIGty1pXxgC3mFnDKswtWxNvNWZ2CnAEMLuHpq3cM7ONYmTo2tH3/yfga1nHVW9mth1waHQbLIp/12vcvaFX+xkoJfF/jccvmdmH3P3HGcZUb3+Px/JxG6t62FYYZjYa+PfoO/5F1vHUk5ltGoOIf+juf45tvwY+FEm9IX3/SuIFF4NnzgY+B/wOsIom9qIYCRxV9vz5Ava3AXwiWtDOBDqAr8bgzKIl8WNi0NfawCHxhX++mf2sQIO+FkQT+u5RU+uKL/uVwKNZB9cgnwTagW+4+6tZB1NnG8WAti3LtpV+X6tRJ23ZJG5mf4hBbWvGpiPMbG/gPHe/MOPw6ulS4EhgeQz8uijGAXze3R/KOrh6cffHgcTM1os+qW8AVxepX9zM1o0Bmbe5+3Vm9oGsY2oUd18ev74MuJnNAiYD44BC/N26+0oz+2lcmN0WtfDd4zbQwl2Amll7lPUV4L+zjqcBHgCeBN5mZvfExfaEGIv050adtJX7xLeLkYOlvqdR8XzNft6XNx3xODxGSR4VP4W8gHP3Je7+TeAZYF8zG5V1THU0DVgPGGNmNwGnxfbTzOzdGcfWMGa2AbBz1FCfyDqeOjsFuAjYLGpt3wU+nXVQDfLvwOi4SHku62Dqzd1XRqtRZ9zquglwDTDD3V9q1HkL+UVeDXffNusYhkKrlLMHSTRPFqlvsXTRPTZ+SsY3srkuC2b2vWhFeTKamNcCzimroReCu79SNuC0sMxsOHBSzFlRuLEqJXE75FuH8pwtm8SlWMzsfcAc4MUYDLUZcHt8SRaCu19RNokEZvYF4AzgWHf/ZbbR1d2S+H46IOZxuBD4TtZByYAdG/8n/8vdiz7B1pBSEpfci37wi8sTXCSBwtdwisrdT4mmZsk5M2sDTo5a+DlZx1M0rdwnLsWxKhYd+DLwo/jy387d52UdWIPNiZp40cspORZ3E0wH3uzuC7KOp2iSNE2zjkFEREQGQDVxERGRnFISFxERySkNbJPCMbP3ABcAp7t7riaVMLPdYqKavYA/uPsRWcdEd1znxT2we7r7i1nHIyLdlMSlamb2FLAB8C/u/oZFVMwsBea4+1uyifCf1ok4kyr2bRoxMc3smNDlf4H/G8JzrwN8EFjs7hf3sMv2MRnJyLiNTzJiZvvGKnbfcveFWccj2VJzutRii0iQ55pZ0Wa2awb7xL2057r7ke4+lPdFbxwLyEzv5fXDgE3c/akhjEl6dnzM1jeyin2l4FQTl1otA3YA/gM4P+tgCmaTeHws4zjeIBbNadjUkSIyMLrFTKoWzeXXxjzW7cD25f2jPTWnR//0hcCn3P1nZdv3jgVK/svdzyzbfjzwrZjffUYsu7l2rMD2b1FbPSMWw1ga8zCfVRHnB4CfRG1lDPBOYMO4n/okd7+9h7LtH8edArwQTdmfdffFZftsGvdm3xBLnZ4exx/l7j3+R4pV5D4T89bvFHN//w74QvkiF2b245jVqtzV7v7OXo57cEygMT5q0U8B84Fvu/sbljw0s7dGvJOjBe4J4HPufnXZ51VpH3e/Jd5/PTDN3ZN4/i7gp7GQzjcrznVszK52nLtfWrb9I7Es406xStf/xFSqva6qZ2aTo2vh+8A/YgKfLYH7gC+5+1UV+78/aqo7RLfEE7G4yLfcfW7FvvfE69+J1eB2ALZ19wVmtlXMY75DrA/9HPBwzEPwq5gnu3ScL8a/xQGxwMd0YHWU72TgXTHl6KQ4zlfd/Qc9lHUr4JvAm2Ka2dvj7/W+sn0eBbapeOv/uvuMsn3agFnxNzcuFub4vrtfVHG+fwO+EP+v3gUcDvzS3T8er28efzNvixaip4Gb3b3y71QypOZ0qdUI4KxYyOA/q9h/HWD9Hvqnh0dirfwb3CKaCX8FHBjJ8gXgA8AdwO/jPdfGMc40s6Po2VlxEXA7cCewP/BHMxtfvpOZHRZJewJwXXyxHw9cb2blcQ8HdgTeDZwH3Atc0lsCD5fHLFUj46IliaT+p1h+suTG+Cn9fhHw2z6OW/r8bgV+E2tTHwrMMbOtK8p3bCTCXaOcfwY2LVuq9aH4vEu/XxQ/fbUI3BAXVz0NvDssXptTFsPXge/F9ivj3/DL8Tn2ZVRcpMyKBHlPnHsKcEVcnJRbL/5Gb4jzLI2JgO7s4dgT46Lwkpij/cqyNb6XxOv3Aw78FZgK/Bx4X8VxxsY5r4+/oRsiiX8mLhwvjhas2XHRd4GZ7VN+gPg3mxuDB2+P9eLfAtxuZuVLW/6qbBW3X8W/028q4vlVLFW7HLgq/q/+wMwqF1bZDNgc+Bmwd/yfKq2DvV78rXw4/g6ui+O19/PvJUNMzekyED+KL9SPmdl/u/vfGnCO0939PLq/UEbG+uCTgN3d/Y7YfmCsGPS2+CKu9F/AZ0rrT5vZfwJfioTwQV6rtZwTX96TSi0LZnZa2UXAFRXHfQY40N2f76sAcXFwKPBr4L3u3hXn+1XUfI6PGibu/mMzWx0XGj9y95/2deyogVbWQt9Qm4/lH78KLAQ6yvu0Sxco7v4nM3s61u/+o7v3O12tuy80sz8D+5jZGHf/exxzbeBg4NbS52Nm28Y60lcDh8fnsEYktY+Y2Vn9fZZR6//3sn/LYyL5zAL+UBbXf1cuc1lqRejluMtiJrFHKsr3j7IVDkvH6a3FouT97n557Dsuau5bAbuUlv01sw8CP4zP6E9l7/3PSLb7uHspke4L3By1+E9HXJ8zszHRAnNKLMFbHuN+8bf1PXf/KK8tPnIHcKqZnd/DeuwXAqdWXIzOiAvW8939U32UWTKmmrjULL4ETiqtLNWg0/yz5uTuy0rPSwk8lGquY9/w7m7zKr6wvhuP5bWgPePL6tKKW6dKiXtyD8e9vYqkQyy9CHBWKY54PDu2H1nFMQbrbVH7+3HloLR+WhCqcVV8h5Q3+R8UrS/lFxhHxRK/Pyz7HFbHPmtF90x/nqz4t/wlsBjYr6K1pFYPVibwQSj/m30kmp//UUrg4Q1/sxH/0cD8UgKPY/wRWNTL32BvjonHC8uOszxq2RtFV0Sla3v4W9giHtep4dySAdXEZUDc/fdmdg1wpJnt7+43VvG2wVhZucHdV5kZ1d5K5u4vmNlLFUm/tFTrvmZW3k+5Xjz29KVXrfFAGk2x5e6N7eMGeuCoyR4RzcqbxGewbw+7lmqT9/Xw2mBdDXwl+lJL/a2Hx2N5Ei99xh80s3eUbd8xHmv+jKM2/1S0zmxSagY3s7XiomHn6G4oP09NzOxNsazk5vFduUONh3jD32zZtvK/2c2iOX6jir9BYnstn0/psz7ZzJaVbd89HrcEHu/hfZV+H7Eeb2a7RrfHr+pw4Sd1piQug/GZaHb7ppntkXUwVVoKbGJmbVGz2yq27172RVduMF9aWwIvufvr1jR39xVmtjSSQ80igf8+xgz0p9Q//o+BnKsv7n6PmT0GvNXM1o0+9ncCj7r7PWW7lj7jHgfpDeIzLo2WX5vX7nW/rcqafZ/M7IwY9DUUSp/PFtHFUqmWz6d0rH/p5fWqjuXu95rZ9Bj0t2cM0vu4mX3I3R+oIR5pMCVxGTB3v9/Mvg98PEbCVva1NZVotty4omm2NFnGKe7+tTqf8llg67ILhlIca8UAoYGOJXhbJPCbgPeVmsl7GeFe6iIYPeBS9O1S4LMR07PRZHthxT6lz3gvd/9LHc+9YfzNlboJjo0Efhnw0bI++b76xN8gBnWdHnEfHM3cXVX0iQ9U6fOZ7e5vr9Oxxrj7c4M5kLvfZGYdMZDzc9HS8zsz26l8dL5kS33iMlhnRN/kCcArPbxeuvIfPsRx9WRSXLiWJ89Sf+j2DTjfY9FsWtkMu3Nsf6iX9/VnQjxeUsXkK6UR5jv1s1/pIqPW/uX/icfDY1R6+baSun/GZrZ+tDI85e6rYnPpc/lxlWMWejMeaAOud/e5PQwEq7cn4vOv9vPp69+qrp+1u3e5+69iGuD7owuov78lGUJK4jIo7r4oRny/qZfbT0pJ5qDShqgR7zIE4f1zVrmYYe6MePq9sn1uiS/Ro8zsdV9OZjam4jawWl0WjyeXBl/F6PTTYvtFvb+1T6Wm8crPcEQ8tpVtuyYurj5QcasS0QRe8lxccNXUxB/3Xj8IvDlG1s+vaEonPofVwKdjatnyGKrt722reH5qXBj+sGzbGz6X+NyH81o3RDVq+XwHLWq1vwHGm9nR5a+Z2dpmVtmK8mw89vRvVbpVcFaMSi8/VtV962Y2qvzvI7qESuVeVO1xpPHUnC718F3go71c/d8Z/+nfbWZ/iXu+J8SI6UYp1cy+a2ZHxpfy7hHf/8a929D95fSqmZ0Utcc7zezmuJ1t66h9vCVu8xmIC4GPRDPvZDO7L0YaTwCuKd2ONACdwKvAh81sQsS7W9lneqGZ3eDuZ7r7M2Z2VoyIv9vMboyk3hGJ43O81k9/ffRv3xz9zQ+4+wlVxPM/0X+8Zel45dz9bjP7NvAp4IG4NW1F1Oi2M7PRMYK6L6fHv+U9MVBtctzC9a2yfa6J5P5FM5sWn9HuZYMUf21mv69iUZxHYjDizjEhzPwYIFhqUTkpBr19wt1freLzqcasmCTmYjP7WEyGs3H0R389bncsuS4uBH8b/547Aoe4++Pu/jszuyJaRR40s9LERrtEpa3aGvoHgK+a2a3AghhAOT6a/J+pU5mlDlQTl0GLq/TPRvJ8peK1xXEr1Z3RnL1NfOm/p4Hx/CLuz74hzvnOuHg4FZhZOcLW3S+LyS4644vqyEhIvxnMVKNRw9o77lcfHjG9ApwSvw/0uI/GvcD3AnvERcEFceExJ7atKNv/y9HcPTcuTA6JBPdwxaGPj4ucSZGwqi37Jb38Xh7zCTFJyv1xi9/b4/ayn1R5G9MD0Yx8SLzvu8AUd/9njDG73HHRsrJ//K2dHt0X82JGtSX9nShufzsyBg+OjXjviKbk78QAtI3rmMBx94cjzh/FBDdHRuK9vfLuBne/KbqvXoo++xcqPsMj4r78p+Mi9K3x7315DS1Lj8REQhMjljVjch6rV5mlPjTtqog0LTM7IC5MznD3L2Ydj0izUU1cREQkp5TERUREckpJXEREJKfUJy4iIpJTqomLiIjklJK4iIhITimJi4iI5JSSuIiISE4piYuIiOSUkriIiEhO/T/pzs5llxWyfwAAAABJRU5ErkJggg==",
-            "text/plain": [
-              "<Figure size 576x432 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "needs_background": "light"
-          },
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "import matplotlib\n",
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "\n",
-        "%matplotlib inline\n",
-        "matplotlib.rcParams.update({\"font.size\": 16})\n",
-        "\n",
-        "fig, ax = plt.subplots(figsize=(8, 6))\n",
-        "ax.plot(list(result_by_sparsity.keys()), list(result_by_sparsity.values()), '.b-', label=\"sebo\", markersize=10)\n",
-        "ax.grid(True)\n",
-        "ax.set_title(f\"Branin, D={aug_dim}\", fontsize=20)\n",
-        "ax.set_xlabel(\"Number of active parameters\", fontsize=20)\n",
-        "ax.set_ylabel(\"Best value found\", fontsize=20)\n",
-        "# ax.legend(fontsize=18)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {
-        "customInput": null,
-        "originalKey": "1ba68dc9-d60b-4b39-8e58-ea9bdc06b44c",
-        "showInput": false
-      },
-      "source": [
-        "# Demo of Using GenerationStrategy and Service API \n",
-        "\n",
-        "Please check [Service API tutorial](https://ax.dev/tutorials/gpei_hartmann_service.html) for more detailed information. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "executionStartTime": 1689124191398,
-        "executionStopTime": 1689124192949,
-        "originalKey": "c9eac7a0-d8c2-49c9-a53a-4e05b6694ced",
-        "requestMsgId": "0dc37045-8f54-4091-913f-69b11b072e19",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "from ax.service.ax_client import AxClient, ObjectiveProperties\n",
-        "\n",
-        "from ax.modelbridge.generation_strategy import GenerationStrategy, GenerationStep"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "executionStartTime": 1689124192961,
-        "executionStopTime": 1689124192970,
-        "originalKey": "92678568-4757-4a9e-9424-837352f04bbc",
-        "requestMsgId": "e1e19d91-06a5-4f8c-a8be-ca7bd1856c58",
-        "showInput": true
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Doing 50 evaluations\n"
-          ]
-        }
-      ],
-      "source": [
-        "N_INIT = 10\n",
-        "BATCH_SIZE = 1\n",
-        "\n",
-        "if SMOKE_TEST:\n",
-        "    NUM_TRIALS = 1\n",
-        "    SURROGATE_CLASS = FixedNoiseGP\n",
-        "else:\n",
-        "    NUM_TRIALS = 40\n",
-        "    SURROGATE_CLASS = SaasFullyBayesianSingleTaskGP\n",
-        "\n",
-        "print(f\"Doing {N_INIT + NUM_TRIALS * BATCH_SIZE} evaluations\")"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {
-        "customInput": null,
-        "originalKey": "45e5586c-55eb-4908-aa73-bca4ee883b56",
-        "showInput": false
-      },
-      "source": [
-        "## Create `GenerationStrategy`"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "executionStartTime": 1689124192972,
-        "executionStopTime": 1689124192975,
-        "originalKey": "7c0bfe37-8f1f-4999-8833-42ffb2569c04",
-        "requestMsgId": "bbd9058a-709e-4262-abe1-720d37e8786f",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "gs = GenerationStrategy(\n",
-        "    name=\"SEBO_L0\",\n",
-        "    steps=[\n",
-        "        GenerationStep(  # Initialization step\n",
-        "            model=Models.SOBOL,     \n",
-        "            num_trials=N_INIT,\n",
-        "        ),\n",
-        "        GenerationStep(  # BayesOpt step\n",
-        "            model=Models.BOTORCH_MODULAR,\n",
-        "            # No limit on how many generator runs will be produced\n",
-        "            num_trials=-1,\n",
-        "            model_kwargs={  # Kwargs to pass to `BoTorchModel.__init__`\n",
-        "                \"surrogate\": Surrogate(botorch_model_class=SURROGATE_CLASS),\n",
-        "                \"acquisition_class\": SEBOAcquisition,\n",
-        "                \"botorch_acqf_class\": qNoisyExpectedHypervolumeImprovement,\n",
-        "                \"acquisition_options\": {\n",
-        "                    \"penalty\": \"L0_norm\", # it can be L0_norm or L1_norm.\n",
-        "                    \"target_point\": target_point, \n",
-        "                    \"sparsity_threshold\": aug_dim,\n",
-        "                },\n",
-        "            },\n",
-        "        )\n",
-        "    ]\n",
-        ")"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {
-        "customInput": null,
-        "originalKey": "e4911bc6-32cb-42a5-908f-57f3f04e58e5",
-        "showInput": false
-      },
-      "source": [
-        "## Initialize client and set up experiment"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "executionStartTime": 1689124192979,
-        "executionStopTime": 1689124192984,
-        "originalKey": "47938102-0613-4b37-acb2-9f1f5f3fe6b1",
-        "requestMsgId": "38b4b17c-6aae-43b8-aa58-2df045f522fe",
-        "showInput": true
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Starting optimization with verbose logging. To disable logging, set the `verbose_logging` argument to `False`. Note that float values in the logs are rounded to 6 decimal points.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.utils.instantiation: Created search space: SearchSpace(parameters=[RangeParameter(name='x0', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x1', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x2', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x3', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x4', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x5', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x6', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x7', parameter_type=FLOAT, range=[0.0, 1.0])], parameter_constraints=[]).\n"
-          ]
-        }
-      ],
-      "source": [
-        "ax_client = AxClient(generation_strategy=gs)\n",
-        "\n",
-        "experiment_parameters = [\n",
-        "    {\n",
-        "        \"name\": f\"x{i}\",\n",
-        "        \"type\": \"range\",\n",
-        "        \"bounds\": [0, 1],\n",
-        "        \"value_type\": \"float\",\n",
-        "        \"log_scale\": False,\n",
-        "    }\n",
-        "    for i in range(aug_dim)\n",
-        "]\n",
-        "\n",
-        "objective_metrics = {\n",
-        "    \"objective\": ObjectiveProperties(minimize=False, threshold=-10),\n",
-        "}\n",
-        "\n",
-        "ax_client.create_experiment(\n",
-        "    name=\"branin_augment_sebo_experiment\",\n",
-        "    parameters=experiment_parameters,\n",
-        "    objectives=objective_metrics,\n",
-        ")"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {
-        "customInput": null,
-        "originalKey": "6a7942e4-9727-43d9-8d8d-c327d38c2373",
-        "showInput": false
-      },
-      "source": [
-        "## Define evaluation function "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "executionStartTime": 1689124192990,
-        "executionStopTime": 1689124192992,
-        "originalKey": "4e2994ff-36ac-4d48-a789-3d0398e1e856",
-        "requestMsgId": "8f74a775-a8ce-462d-993c-5c9291c748b9",
-        "showInput": true
-      },
-      "outputs": [],
-      "source": [
-        "def evaluation(parameters):\n",
-        "    # put parameters into 1-D array\n",
-        "    x = [parameters.get(param[\"name\"]) for param in experiment_parameters]\n",
-        "    res = branin_augment(x_vec=x, augment_dim=aug_dim)\n",
-        "    eval_res = {\n",
-        "        # flip the sign to maximize\n",
-        "        \"objective\": (res * -1, 0.0),\n",
-        "    }\n",
-        "    return eval_res"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "metadata": {
-        "customInput": null,
-        "originalKey": "4597531b-7ac8-4dd0-94c4-836672e0f4c4",
-        "showInput": false
-      },
-      "source": [
-        "## Run optimization loop"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
-      "metadata": {
-        "collapsed": false,
-        "customInput": null,
-        "executionStartTime": 1689124193044,
-        "executionStopTime": 1689130398208,
-        "originalKey": "bc7accb2-48a2-4c88-a932-7c79ec81075a",
-        "requestMsgId": "f054e5b1-12eb-459b-a508-6944baf82dfb",
-        "showInput": true
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 0 with parameters {'x0': 0.340745, 'x1': 0.592392, 'x2': 0.307124, 'x3': 0.136736, 'x4': 0.453162, 'x5': 0.407409, 'x6': 0.898588, 'x7': 0.712434}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 0 with data: {'objective': (-28.913967, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 1 with parameters {'x0': 0.596941, 'x1': 0.798649, 'x2': 0.111305, 'x3': 0.329006, 'x4': 0.187743, 'x5': 0.589378, 'x6': 0.500772, 'x7': 0.008061}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 1 with data: {'objective': (-108.522848, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 2 with parameters {'x0': 0.310899, 'x1': 0.906665, 'x2': 0.859498, 'x3': 0.861769, 'x4': 0.565173, 'x5': 0.849893, 'x6': 0.743119, 'x7': 0.485293}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 2 with data: {'objective': (-68.762484, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 3 with parameters {'x0': 0.222246, 'x1': 0.682503, 'x2': 0.697094, 'x3': 0.262685, 'x4': 0.660106, 'x5': 0.783381, 'x6': 0.537969, 'x7': 0.607574}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 3 with data: {'objective': (-10.589478, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 4 with parameters {'x0': 0.391554, 'x1': 0.769673, 'x2': 0.363151, 'x3': 0.522279, 'x4': 0.8752, 'x5': 0.921642, 'x6': 0.892081, 'x7': 0.614701}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 4 with data: {'objective': (-62.905011, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 5 with parameters {'x0': 0.319981, 'x1': 0.578814, 'x2': 0.58387, 'x3': 0.310305, 'x4': 0.198673, 'x5': 0.78394, 'x6': 0.423361, 'x7': 0.853005}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 5 with data: {'objective': (-24.971551, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 6 with parameters {'x0': 0.889574, 'x1': 0.540804, 'x2': 0.668386, 'x3': 0.511087, 'x4': 0.587279, 'x5': 0.966997, 'x6': 0.699696, 'x7': 0.919272}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 6 with data: {'objective': (-46.419155, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 7 with parameters {'x0': 0.816103, 'x1': 0.454254, 'x2': 0.498263, 'x3': 0.609042, 'x4': 0.080031, 'x5': 0.321146, 'x6': 0.505942, 'x7': 0.386978}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 7 with data: {'objective': (-46.485345, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 8 with parameters {'x0': 0.687349, 'x1': 0.282216, 'x2': 0.751967, 'x3': 0.566662, 'x4': 0.79098, 'x5': 0.641958, 'x6': 0.724017, 'x7': 0.590121}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 8 with data: {'objective': (-24.65791, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 9 with parameters {'x0': 0.130133, 'x1': 0.712254, 'x2': 0.760572, 'x3': 0.411107, 'x4': 0.542096, 'x5': 0.526756, 'x6': 0.787764, 'x7': 0.674992}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 9 with data: {'objective': (-2.309687, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:11:36] ax.service.ax_client: Generated new trial 10 with parameters {'x0': 0.0, 'x1': 0.0, 'x2': 1.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.892852}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:11:36] ax.service.ax_client: Completed trial 10 with data: {'objective': (-308.129096, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:13:39] ax.service.ax_client: Generated new trial 11 with parameters {'x0': 0.0, 'x1': 0.640271, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.946358, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:13:39] ax.service.ax_client: Completed trial 11 with data: {'objective': (-70.230069, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:15:44] ax.service.ax_client: Generated new trial 12 with parameters {'x0': 0.0, 'x1': 0.519038, 'x2': 1.0, 'x3': 0.0, 'x4': 1.0, 'x5': 0.0, 'x6': 0.870499, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:15:44] ax.service.ax_client: Completed trial 12 with data: {'objective': (-101.117533, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:17:37] ax.service.ax_client: Generated new trial 13 with parameters {'x0': 0.0, 'x1': 0.0, 'x2': 0.0, 'x3': 1.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.727362, 'x7': 1.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:17:37] ax.service.ax_client: Completed trial 13 with data: {'objective': (-308.129096, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:19:31] ax.service.ax_client: Generated new trial 14 with parameters {'x0': 0.0, 'x1': 0.784581, 'x2': 1.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.700215, 'x6': 0.0, 'x7': 0.724654}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:19:31] ax.service.ax_client: Completed trial 14 with data: {'objective': (-42.085428, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:21:33] ax.service.ax_client: Generated new trial 15 with parameters {'x0': 0.0, 'x1': 0.710437, 'x2': 0.953762, 'x3': 0.0, 'x4': 0.0, 'x5': 0.662267, 'x6': 1.0, 'x7': 0.840749}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:21:33] ax.service.ax_client: Completed trial 15 with data: {'objective': (-55.375218, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:23:43] ax.service.ax_client: Generated new trial 16 with parameters {'x0': 0.0, 'x1': 0.712456, 'x2': 0.0, 'x3': 0.0, 'x4': 1.0, 'x5': 0.628146, 'x6': 0.0, 'x7': 0.846157}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:23:43] ax.service.ax_client: Completed trial 16 with data: {'objective': (-54.980534, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:26:09] ax.service.ax_client: Generated new trial 17 with parameters {'x0': 1.0, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:26:09] ax.service.ax_client: Completed trial 17 with data: {'objective': (-10.960889, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:28:06] ax.service.ax_client: Generated new trial 18 with parameters {'x0': 1.0, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 1.0, 'x6': 0.0, 'x7': 1.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:28:06] ax.service.ax_client: Completed trial 18 with data: {'objective': (-10.960889, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:29:44] ax.service.ax_client: Generated new trial 19 with parameters {'x0': 0.770094, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:29:44] ax.service.ax_client: Completed trial 19 with data: {'objective': (-20.508312, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:31:30] ax.service.ax_client: Generated new trial 20 with parameters {'x0': 0.137802, 'x1': 0.779453, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:31:30] ax.service.ax_client: Completed trial 20 with data: {'objective': (-0.613746, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:33:09] ax.service.ax_client: Generated new trial 21 with parameters {'x0': 0.536321, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:33:09] ax.service.ax_client: Completed trial 21 with data: {'objective': (-5.973257, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:34:47] ax.service.ax_client: Generated new trial 22 with parameters {'x0': 0.503722, 'x1': 0.219186, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:34:47] ax.service.ax_client: Completed trial 22 with data: {'objective': (-2.260464, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:36:41] ax.service.ax_client: Generated new trial 23 with parameters {'x0': 1.0, 'x1': 0.281918, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:36:41] ax.service.ax_client: Completed trial 23 with data: {'objective': (-3.445743, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:38:29] ax.service.ax_client: Generated new trial 24 with parameters {'x0': 0.549118, 'x1': 0.133697, 'x2': 0.0, 'x3': 1.0, 'x4': 0.0, 'x5': 1.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:38:29] ax.service.ax_client: Completed trial 24 with data: {'objective': (-0.479951, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:40:18] ax.service.ax_client: Generated new trial 25 with parameters {'x0': 0.080214, 'x1': 1.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:40:19] ax.service.ax_client: Completed trial 25 with data: {'objective': (-3.585129, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:42:08] ax.service.ax_client: Generated new trial 26 with parameters {'x0': 1.0, 'x1': 1.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:42:08] ax.service.ax_client: Completed trial 26 with data: {'objective': (-145.872191, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:44:13] ax.service.ax_client: Generated new trial 27 with parameters {'x0': 0.542029, 'x1': 0.136864, 'x2': 0.0, 'x3': 0.0, 'x4': 1.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:44:14] ax.service.ax_client: Completed trial 27 with data: {'objective': (-0.451738, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:46:25] ax.service.ax_client: Generated new trial 28 with parameters {'x0': 0.117749, 'x1': 0.847684, 'x2': 0.0, 'x3': 0.0, 'x4': 1.0, 'x5': 1.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:46:25] ax.service.ax_client: Completed trial 28 with data: {'objective': (-0.486016, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:48:39] ax.service.ax_client: Generated new trial 29 with parameters {'x0': 0.122207, 'x1': 0.831379, 'x2': 1.0, 'x3': 1.0, 'x4': 1.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:48:39] ax.service.ax_client: Completed trial 29 with data: {'objective': (-0.41913, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:51:07] ax.service.ax_client: Generated new trial 30 with parameters {'x0': 0.608958, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:51:07] ax.service.ax_client: Completed trial 30 with data: {'objective': (-7.404426, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:53:20] ax.service.ax_client: Generated new trial 31 with parameters {'x0': 0.532365, 'x1': 0.141486, 'x2': 0.0, 'x3': 1.0, 'x4': 0.0, 'x5': 0.0, 'x6': 1.0, 'x7': 1.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:53:20] ax.service.ax_client: Completed trial 31 with data: {'objective': (-0.591731, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:55:48] ax.service.ax_client: Generated new trial 32 with parameters {'x0': 0.950988, 'x1': 0.171879, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:55:48] ax.service.ax_client: Completed trial 32 with data: {'objective': (-0.575591, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:58:07] ax.service.ax_client: Generated new trial 33 with parameters {'x0': 0.973297, 'x1': 0.183923, 'x2': 1.0, 'x3': 0.0, 'x4': 1.0, 'x5': 1.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 18:58:07] ax.service.ax_client: Completed trial 33 with data: {'objective': (-0.561572, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:00:53] ax.service.ax_client: Generated new trial 34 with parameters {'x0': 0.972473, 'x1': 0.184526, 'x2': 0.0, 'x3': 1.0, 'x4': 0.0, 'x5': 0.0, 'x6': 1.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:00:53] ax.service.ax_client: Completed trial 34 with data: {'objective': (-0.547382, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:03:58] ax.service.ax_client: Generated new trial 35 with parameters {'x0': 0.543579, 'x1': 0.145004, 'x2': 1.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:03:58] ax.service.ax_client: Completed trial 35 with data: {'objective': (-0.406784, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:08:04] ax.service.ax_client: Generated new trial 36 with parameters {'x0': 0.56372, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:08:04] ax.service.ax_client: Completed trial 36 with data: {'objective': (-5.040681, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:10:39] ax.service.ax_client: Generated new trial 37 with parameters {'x0': 0.128424, 'x1': 0.814467, 'x2': 1.0, 'x3': 0.0, 'x4': 0.0, 'x5': 1.0, 'x6': 0.0, 'x7': 1.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:10:39] ax.service.ax_client: Completed trial 37 with data: {'objective': (-0.431012, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:13:21] ax.service.ax_client: Generated new trial 38 with parameters {'x0': 0.967249, 'x1': 0.189143, 'x2': 0.0, 'x3': 1.0, 'x4': 1.0, 'x5': 0.0, 'x6': 0.0, 'x7': 1.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:13:21] ax.service.ax_client: Completed trial 38 with data: {'objective': (-0.516046, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:17:03] ax.service.ax_client: Generated new trial 39 with parameters {'x0': 0.563272, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:17:03] ax.service.ax_client: Completed trial 39 with data: {'objective': (-5.040172, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:20:43] ax.service.ax_client: Generated new trial 40 with parameters {'x0': 0.111004, 'x1': 0.841851, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:20:43] ax.service.ax_client: Completed trial 40 with data: {'objective': (-0.590424, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:24:20] ax.service.ax_client: Generated new trial 41 with parameters {'x0': 0.563578, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:24:20] ax.service.ax_client: Completed trial 41 with data: {'objective': (-5.040465, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:27:24] ax.service.ax_client: Generated new trial 42 with parameters {'x0': 1.0, 'x1': 0.173494, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:27:24] ax.service.ax_client: Completed trial 42 with data: {'objective': (-2.103578, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:30:34] ax.service.ax_client: Generated new trial 43 with parameters {'x0': 0.563448, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:30:34] ax.service.ax_client: Completed trial 43 with data: {'objective': (-5.040312, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:34:21] ax.service.ax_client: Generated new trial 44 with parameters {'x0': 0.563267, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:34:21] ax.service.ax_client: Completed trial 44 with data: {'objective': (-5.04017, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:38:27] ax.service.ax_client: Generated new trial 45 with parameters {'x0': 0.563496, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:38:27] ax.service.ax_client: Completed trial 45 with data: {'objective': (-5.040364, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:41:52] ax.service.ax_client: Generated new trial 46 with parameters {'x0': 0.563076, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:41:52] ax.service.ax_client: Completed trial 46 with data: {'objective': (-5.040109, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:45:10] ax.service.ax_client: Generated new trial 47 with parameters {'x0': 0.563165, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:45:10] ax.service.ax_client: Completed trial 47 with data: {'objective': (-5.040126, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:48:48] ax.service.ax_client: Generated new trial 48 with parameters {'x0': 0.562984, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:48:48] ax.service.ax_client: Completed trial 48 with data: {'objective': (-5.040112, 0.0)}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:53:17] ax.service.ax_client: Generated new trial 49 with parameters {'x0': 0.563213, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "[INFO 07-11 19:53:17] ax.service.ax_client: Completed trial 49 with data: {'objective': (-5.040143, 0.0)}.\n"
-          ]
-        }
-      ],
-      "source": [
-        "for _ in range(NUM_TRIALS+N_INIT):    \n",
-        "    parameters, trial_index = ax_client.get_next_trial()\n",
-        "    res = evaluation(parameters)\n",
-        "    ax_client.complete_trial(trial_index=trial_index, raw_data=res)"
-      ]
-    }
-  ],
-  "metadata": {
-    "fileHeader": "",
-    "kernelspec": {
-      "display_name": "python3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3"
-    }
+    "originalKey": "d3a0136e-94fa-477c-a839-20e5b7f1cdd2",
+    "showInput": false
+   },
+   "source": [
+    "# Sparsity Exploration Bayesian Optimization (SEBO) Ax API \n",
+    "\n",
+    "This tutorial introduces the Sparsity Exploration Bayesian Optimization (SEBO) method and demonstrates how to utilize it using the Ax API. SEBO is designed to enhance Bayesian Optimization (BO) by taking the interpretability and simplicity of configurations into consideration. In essence, SEBO incorporates sparsity, modeled as the $L_0$ norm, as an additional objective in BO. By employing multi-objective optimization techniques such as Expected Hyper-Volume Improvement, SEBO enables the joint optimization of objectives while simultaneously incorporating feature-level sparsity. This allows users to efficiently explore different trade-offs between objectives and sparsity.\n",
+    "\n",
+    "\n",
+    "For a more detailed understanding of the SEBO algorithm, please refer to the following publication:\n",
+    "\n",
+    "[1] [S. Liu, Q. Feng, D. Eriksson, B. Letham and E. Bakshy. Sparse Bayesian Optimization. International Conference on Artificial Intelligence and Statistics, 2023.](https://proceedings.mlr.press/v206/liu23b/liu23b.pdf)\n",
+    "\n",
+    "By following this tutorial, you will learn how to leverage the SEBO method through the Ax API, empowering you to effectively balance objectives and sparsity in your optimization tasks. Let's get started!"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "customOutput": null,
+    "executionStartTime": 1689117385062,
+    "executionStopTime": 1689117389874,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "cea96143-019a-41c1-a388-545f48992db9",
+    "requestMsgId": "c2c22a5d-aee0-4a1e-98d9-b360aa1851ff",
+    "showInput": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import warnings\n",
+    "import math\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "from ax import Data, Experiment, ParameterType, RangeParameter, SearchSpace\n",
+    "from ax.core.objective import Objective\n",
+    "from ax.core.optimization_config import OptimizationConfig\n",
+    "from ax.metrics.noisy_function import NoisyFunctionMetric\n",
+    "from ax.modelbridge.generation_strategy import GenerationStrategy, GenerationStep\n",
+    "from ax.modelbridge.registry import Models\n",
+    "from ax.models.torch.botorch_modular.sebo import SEBOAcquisition\n",
+    "from ax.models.torch.botorch_modular.surrogate import Surrogate\n",
+    "from ax.runners.synthetic import SyntheticRunner\n",
+    "from ax.service.ax_client import AxClient, ObjectiveProperties\n",
+    "from ax.utils.common.typeutils import checked_cast\n",
+    "from botorch.acquisition.multi_objective import qNoisyExpectedHypervolumeImprovement\n",
+    "from botorch.models import SingleTaskGP, FixedNoiseGP, SaasFullyBayesianSingleTaskGP\n",
+    "%matplotlib inline\n",
+    "matplotlib.rcParams.update({\"font.size\": 16})\n",
+    "\n",
+    "warnings.filterwarnings('ignore')\n",
+    "SMOKE_TEST = os.environ.get(\"SMOKE_TEST\")\n",
+    "\n",
+    "torch.manual_seed(12345)  # To always get the same Sobol points\n",
+    "tkwargs = {\n",
+    "    \"dtype\": torch.double,\n",
+    "    \"device\": torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\"),\n",
+    "}"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "7f07af01-ad58-4cfb-beca-f624310d278d",
+    "showInput": false
+   },
+   "source": [
+    "# Demo of using Developer API"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "c8a27a2f-1120-4894-9302-48bfde402268",
+    "showInput": false
+   },
+   "source": [
+    "## Problem Setup \n",
+    "\n",
+    "In this simple experiment we use the Branin function embedded in a 10-dimensional space. Additional resources:\n",
+    "- To set up a custom metric for your problem, refer to the dedicated section of the Developer API tutorial: https://ax.dev/tutorials/gpei_hartmann_developer.html#8.-Defining-custom-metrics.\n",
+    "- To avoid needing to setup up custom metrics by Ax Service API: https://ax.dev/tutorials/gpei_hartmann_service.html."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "executionStartTime": 1689117390036,
+    "executionStopTime": 1689117390038,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "e91fc838-9f47-44f1-99ac-4477df208566",
+    "requestMsgId": "1591e6b0-fa9b-4b9f-be72-683dccbe923a",
+    "showInput": true
+   },
+   "outputs": [],
+   "source": [
+    "aug_dim = 8 \n",
+    "\n",
+    "# evaluation function \n",
+    "def branin_augment(x_vec, augment_dim):\n",
+    "    assert len(x_vec) == augment_dim\n",
+    "    x1, x2 = (\n",
+    "        15 * x_vec[0] - 5,\n",
+    "        15 * x_vec[1],\n",
+    "    )  # Only dimensions 0 and augment_dim-1 affect the value of the function\n",
+    "    t1 = x2 - 5.1 / (4 * math.pi**2) * x1**2 + 5 / math.pi * x1 - 6\n",
+    "    t2 = 10 * (1 - 1 / (8 * math.pi)) * np.cos(x1)\n",
+    "    return t1**2 + t2 + 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1689117390518,
+    "executionStopTime": 1689117390540,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "850830c6-509f-4087-bce8-da0be4fd48ef",
+    "requestMsgId": "56726053-205d-4d7e-b1b5-1a76324188ee",
+    "showInput": true
+   },
+   "outputs": [],
+   "source": [
+    "class AugBraninMetric(NoisyFunctionMetric):\n",
+    "    def f(self, x: np.ndarray) -> float:\n",
+    "        return checked_cast(float, branin_augment(x_vec=x, augment_dim=aug_dim))\n",
+    "\n",
+    "\n",
+    "# Create search space in Ax \n",
+    "search_space = SearchSpace(\n",
+    "    parameters=[\n",
+    "        RangeParameter(\n",
+    "            name=f\"x{i}\",\n",
+    "            parameter_type=ParameterType.FLOAT, \n",
+    "            lower=0.0, upper=1.0\n",
+    "        )\n",
+    "        for i in range(aug_dim)\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "executionStartTime": 1689117391899,
+    "executionStopTime": 1689117391915,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "d039b709-67c6-475a-96ce-290f869e0f88",
+    "requestMsgId": "3e23ed64-7d10-430b-b790-91a0c7cf72fe",
+    "showInput": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create optimization goals \n",
+    "optimization_config = OptimizationConfig(\n",
+    "    objective=Objective(\n",
+    "        metric=AugBraninMetric(\n",
+    "            name=\"objective\",\n",
+    "            param_names=[f\"x{i}\" for i in range(aug_dim)],\n",
+    "            noise_sd=None,  # Set noise_sd=None if you want to learn the noise, otherwise it defaults to 1e-6\n",
+    "        ),\n",
+    "        minimize=True,\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# Experiment\n",
+    "experiment = Experiment(\n",
+    "    name=\"sebo_experiment\",\n",
+    "    search_space=search_space,\n",
+    "    optimization_config=optimization_config,\n",
+    "    runner=SyntheticRunner(),\n",
+    ")\n",
+    "\n",
+    "# target sparse point to regularize towards to. Here we set target sparse value being zero for all the parameters. \n",
+    "target_point = torch.tensor([0 for _ in range(aug_dim)], **tkwargs)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "e57edb00-eafc-4d07-bdb9-e8cf073b4caa",
+    "showInput": false
+   },
+   "source": [
+    "## Run optimization loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1689117395051,
+    "executionStopTime": 1689117395069,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "c4848148-bff5-44a7-9ad5-41e78ccb413c",
+    "requestMsgId": "8aa87d22-bf89-471f-be9f-7c31f7b8bd62",
+    "showInput": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Doing 30 evaluations\n"
+     ]
+    }
+   ],
+   "source": [
+    "N_INIT = 10\n",
+    "\n",
+    "if SMOKE_TEST:\n",
+    "    N_BATCHES = 1\n",
+    "    BATCH_SIZE = 1\n",
+    "    SURROGATE_CLASS = SingleTaskGP\n",
+    "else:\n",
+    "    N_BATCHES = 4\n",
+    "    BATCH_SIZE = 5\n",
+    "    SURROGATE_CLASS = SaasFullyBayesianSingleTaskGP\n",
+    "\n",
+    "print(f\"Doing {N_INIT + N_BATCHES * BATCH_SIZE} evaluations\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1689117396326,
+    "executionStopTime": 1689117396376,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "b260d85f-2797-44e3-840a-86587534b589",
+    "requestMsgId": "2cc516e3-b16e-40ca-805f-dcd792c92fa6",
+    "showInput": true
+   },
+   "outputs": [],
+   "source": [
+    "# Initial Sobol points\n",
+    "sobol = Models.SOBOL(search_space=experiment.search_space)\n",
+    "for _ in range(N_INIT):\n",
+    "    experiment.new_trial(sobol.gen(1)).run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1689117396900,
+    "executionStopTime": 1689124188959,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "7c198035-add2-4717-be27-4fb67c4d1782",
+    "requestMsgId": "d844fa20-0adf-4ba3-ace5-7253ba678db2",
+    "showInput": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 0, Best so far: 2.494\n",
+      "Iteration: 1, Best so far: 2.494\n",
+      "Iteration: 2, Best so far: 1.964\n",
+      "Iteration: 3, Best so far: 0.412\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 4, Best so far: 2.494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 5, Best so far: 2.494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 6, Best so far: 2.494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 7, Best so far: 2.494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 8, Best so far: 2.494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 9, Best so far: 2.494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 10, Best so far: 2.494\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 11, Best so far: 1.990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 12, Best so far: 1.990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 13, Best so far: 1.990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 14, Best so far: 1.990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 15, Best so far: 1.990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 16, Best so far: 0.662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 17, Best so far: 0.662\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 18, Best so far: 0.453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 19, Best so far: 0.453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 20, Best so far: 0.453\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 21, Best so far: 0.424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 22, Best so far: 0.424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 23, Best so far: 0.424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 24, Best so far: 0.424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 25, Best so far: 0.424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 26, Best so far: 0.424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 27, Best so far: 0.424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 28, Best so far: 0.424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 29, Best so far: 0.424\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 30, Best so far: 0.416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 31, Best so far: 0.416\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 32, Best so far: 0.408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 33, Best so far: 0.408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 34, Best so far: 0.408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 35, Best so far: 0.408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 36, Best so far: 0.408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 37, Best so far: 0.408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 38, Best so far: 0.408\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration: 39, Best so far: 0.408\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = experiment.fetch_data()\n",
+    "\n",
+    "for i in range(N_BATCHES):\n",
+    "\n",
+    "    model = Models.BOTORCH_MODULAR(\n",
+    "        experiment=experiment, \n",
+    "        data=data,\n",
+    "        surrogate=Surrogate(botorch_model_class=SURROGATE_CLASS),  # can use SAASGP (i.e. SaasFullyBayesianSingleTaskGP) for high-dim cases\n",
+    "        search_space=experiment.search_space,\n",
+    "        botorch_acqf_class=qNoisyExpectedHypervolumeImprovement,\n",
+    "        acquisition_class=SEBOAcquisition,\n",
+    "        acquisition_options={\n",
+    "            \"penalty\": \"L0_norm\", # it can be L0_norm or L1_norm. \n",
+    "            \"target_point\": target_point, \n",
+    "            \"sparsity_threshold\": aug_dim,\n",
+    "        },\n",
+    "        torch_device=tkwargs['device'],\n",
+    "    )\n",
+    "\n",
+    "    generator_run = model.gen(BATCH_SIZE)\n",
+    "    trial = experiment.new_batch_trial(generator_run=generator_run)\n",
+    "    trial.run()\n",
+    "\n",
+    "    new_data = trial.fetch_data(metrics=list(experiment.metrics.values()))\n",
+    "    data = Data.from_multiple_data([data, new_data])\n",
+    "    print(f\"Iteration: {i}, Best so far: {data.df['mean'].min():.3f}\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "7998635d-6750-4825-b93d-c7b61f74c3c5",
+    "showInput": false
+   },
+   "source": [
+    "## Plot sparisty vs objective \n",
+    "\n",
+    "Visualize the objective and sparsity trade-offs using SEBO. Each point represent designs along the Pareto frontier found by SEBO. The x-axis corresponds to the number of active parameters used, i.e.\n",
+    "non-sparse parameters, and the y-axis corresponds the best identified objective values. Based on this, decision-makers balance both simplicity/interpretability of generated policies and optimization performance when deciding which configuration to use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1689124189044,
+    "executionStopTime": 1689124189182,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "416ccd12-51a1-4bfe-9e10-436cd88ec6be",
+    "requestMsgId": "5143ae57-1d0d-4f9d-bc9d-9d151f3e9af0",
+    "showInput": true
+   },
+   "outputs": [],
+   "source": [
+    "def nnz_exact(x, sparse_point):\n",
+    "    return len(x) - (np.array(x) == np.array(sparse_point)).sum()\n",
+    "\n",
+    "    \n",
+    "df = data.df\n",
+    "df['L0_norm'] = df['arm_name'].apply(lambda d: nnz_exact(list(experiment.arms_by_name[d].parameters.values()), [0 for _ in range(aug_dim)]) )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1689124189219,
+    "executionStopTime": 1689124189321,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "97b96822-7d7f-4a5d-8458-01ff890d2fde",
+    "requestMsgId": "34abdf8d-6f0c-48a1-8700-8e2c3075a085",
+    "showInput": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{1: 5.188541393850756,\n",
+       " 2: 0.41219620231106724,\n",
+       " 3: 0.41219620231106724,\n",
+       " 4: 0.41219620231106724,\n",
+       " 5: 0.41219620231106724,\n",
+       " 6: 0.41219620231106724,\n",
+       " 7: 0.41219620231106724,\n",
+       " 8: 0.41219620231106724}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result_by_sparsity = {l: df[df.L0_norm <= l]['mean'].min() for l in range(1, aug_dim+1)}\n",
+    "result_by_sparsity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "customOutput": null,
+    "executionStartTime": 1689134836494,
+    "executionStopTime": 1689134837813,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "7193e2b0-e192-439a-b0d0-08a2029f64ca",
+    "requestMsgId": "f095d820-55e0-4201-8e3a-77f17b2155f1",
+    "showInput": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArkAAAI/CAYAAABzt8FxAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAABzSUlEQVR4nO3dd3gU1f7H8c+kkJAQQgmdSJEOISQC6gUVC6ioKKKioBSx61WsP/WqwLVdGxZUsNBUUBQpIqiAUqUIhGoUUYiAlNBbIKSc3x97d28wPbPZ2V3er+fZJ5udcr57dgifTM7MsYwxRgAAAEAQCXG6AAAAAMDbCLkAAAAIOoRcAAAABB1CLgAAAIIOIRcAAABBh5ALAACAoEPIBQAAQNAh5AIAACDoEHIBAAAQdAi5AOCH0tLSZFmWLMvSuHHjnC4HAAIOIReA35k/f74n4BX0qFSpkpo1a6ZbbrlFP/zwg9PlQlLDhg0L/azq1aunxMRE9evXTyNGjNBff/3ldLkeubm5mjRpkq655hrFx8crMjJSUVFRatSokXr37q1vvvnG6RIBlJFljDFOFwEAec2fP18XXnhhidfv16+fxowZo9DQ0HKsyrfS0tLUqFEjSdLYsWM1YMAAZwsqRsOGDfXnn3+WaN3Q0FD16NFDw4cPV8OGDcu3sCIcOHBAV199tRYtWlTker169dKECRMUERHho8oAeEOY0wUAQFHuvvtu3XPPPZ7vjTHav3+/li5dqtdff13p6en66KOPFB8fr+eee87BSr2rYcOGCsRzEHXr1tV3333n+T4rK0sHDhzQn3/+qSVLluiLL77QoUOHNHXqVH3//ff65JNPdNVVVzlS64033ugJuI0aNdKjjz6qhIQEZWVladWqVXrppZe0d+9effnll4qLi9OoUaMcqRNA2XAmF4DfyXsmd8iQIRo6dGiB66Wmpuqss87SiRMnFBMTo71796pChQo+rBRu7jO5DRo0UFpaWqHrHT16VEOGDNHw4cMlSRUrVtTChQvVvn17H1XqsnLlSnXo0EGS1LhxY61Zs0YxMTGnrLN161YlJibq4MGDCgkJ0c6dO1WzZk2f1gmg7BiTCyBgtWrVSldccYUk6ciRI/r1118drgjFqVSpkl577TX95z//kSQdP35ct912m8/rWLJkief54MGD8wVcSTrjjDM0cOBASa6xu8uXL/dZfQDsI+QCCGjucauSlJmZmW/5uHHjPBdBpaWlKTMzU2+88YbOOeccxcXFybKsU84Unzx5UjNmzNB9992nDh06qGrVqgoPD1f16tV19tlna+jQodq7d2+RNbkvwnKPo924caNuv/12NWzYUBEREapVq5Z69uypZcuWFbqP4u6uMHToUM9ySTpx4oReeeUVJScnKyYmRjExMerYsaPefvttZWdnF1mvEx577DGdffbZkqS1a9dq1qxZPm3/5MmTnueNGzcudL0zzzyzwG0A+D/G5AIIaHkvdjrjjDOKXHfv3r3q2bOn1qxZU+g6d9xxh8aPH5/v9f379+unn37STz/9pLffflvTp09Xp06diq1v6tSpuvnmm5WRkeF5LT09XdOmTdOMGTM0YcIE9e7du9j9FGX37t267LLL8r2vFStWaMWKFZo9e7amTZumkBD/Oa9hWZYeeOAB9enTR5I0bdo0de/e3WftN2/e3PN88+bNha73xx9/FLgNAP/nPz/xAKCUfv31V3399deSpHPOOUe1atUqcv1BgwZp7dq16tevn2bOnKlVq1Zp6tSpnjOKkpSdna3GjRvr4Ycf1qRJk7R06VKtWLFCkydP1l133aUKFSpo37596tmzp9LT04tsb/369erTp49q1aqlt99+W8uWLdPSpUs1dOhQRUZGKicnR3fccYf27Nljqx+uvfZapaam6v7779ecOXO0atUqTZw4US1btpQkzZgxQx988IGtNsrDJZdc4nle3B0OvO3SSy/1/BXgzTff1LFjx/Kts337ds9Z9M6dO6tNmza+LBGAXQYA/My8efOMJCPJ3H333Wb9+vWex7p168zChQvNSy+9ZGrXrm0kmdjYWLN06dIC9zV27FjPviSZDz/8sMi2f//9d5Obm1vo8nXr1plKlSoZSeapp54qcJ0GDRp42jvrrLPMoUOH8q3zySefeNYZPnx4vuVbtmzxLB87dmy+5UOGDPEsDw8PN/Pmzcu3zr59+0ytWrWMJNO2bdvC37QXuN9zgwYNSrVd/fr1jSQTFhaWb1ne48DOY8uWLQW2vXTpUhMXF2ckmTPPPNOMGjXKLF682MybN8+8+uqrpmbNmkaSady4sfntt9/K0CsAnETIBeB3ShpuQkJCzF133WU2btxY6L7yhtyLLrrIK/UNHjzYSDJt2rQpcHnekLt27doC18nNzTV169Y1kkzPnj3zLS9NyH3ooYcKrfXxxx83koxlWebgwYMle4NlUNaQm5iY6Hkff/9loLxDrjHGbNu2zTzyyCMmPDw833aVKlUyzz77rNm3b18ZegSA0xiTCyBg5ebm6rPPPlNkZKT+85//FHuz/r59+5a6jQMHDmj//v06ceKE5761VapUkeS6hVlWVpbCw8ML3DYhIUFt27YtcJllWUpKStKOHTuKHBNaEkW9r7POOkuS6/7CW7ZsUbt27Wy15W2VKlXyPD9y5IgqV67s+b5Dhw5av3697Tbq1atX4OvGGH322Wf6/PPPlZWVlW/50aNHNWHCBNWtW1e33nqr7ToA+BYhF4BfK+g+ucePH9fvv/+ujz/+WK+//rreeOMNrVy5Ut99952ioqIK3VdhgfPv1q9fr9dff13ffPONdu3aVeh6ubm5OnDgQKH3Tm3RokWR7VSrVk2SK9zZUVQ77ja80U55yFtT3oArSdHR0eU2DjY3N1c33nijvvjiC0mu8dr33nuvWrZsqZycHK1Zs0Yvv/yyvvrqKw0aNEjr1q3TG2+8US61ACgfXHgGIOBUrFhRCQkJevnll/Xuu+9KkhYvXqwXXnihyO2qVq1a7L5Hjx6t5ORkjR07tsiA63b8+PFClxUVuCV57naQk5NTbDtFKaqdvHdUsNtOeXDfji0sLKzAe9WWl5EjR3oC7tChQ/Xhhx8qKSlJkZGRio6OVqdOnTR9+nTdcsstklwXp82YMcNn9QGwjzO5AALaoEGD9Pjjj2v//v0aM2ZMkVP7hoaGFrmvX3/9VXfddZeys7NVs2ZNPfroo7rooovUsGFDxcTEeIYljBkzRoMGDZKkgJx611+kp6drx44dkgq+PdexY8e0ZcsW2+00b94835CSDz/8UJIUExOjxx9/vNBtX3jhBX388ceSXJ+7U1MQAyg9Qi6AgBYSEqKmTZtq+fLl2rlzp/bt26fq1auXaV/jxo1Tdna2QkNDtWDBgkKHAezfv99OyfivOXPmeJ537tw53/IVK1Z4pne2Y8uWLWrYsOEpr/3yyy+SXLPmFTWWu379+qpVq5Z2797NjHpAgGG4AoCAl3dGLzuze/3888+SpMTExCLHua5cubLMbcDFGKO33nrL833Pnj192n5YmOscT0mOF/dFae5tAAQGQi6AgJaRkaHU1FRJrrG6cXFxZd6XO/AUNDGA286dO/XVV1+VuQ24vPTSS/rpp58kScnJybr00kvzrdOlSxcZ160ubT3+fhZX+t900Bs2bNDBgwcLrXPDhg2eM/d5p5AG4P8IuQAC2tChQz0Xf1166aXFjrstStOmTSVJmzZt0pIlS/Itz8jIUJ8+fYq82CzQpKWlybIsWZalLl26lHt7R48e1SOPPKInnnhCkuuiOff4WF9yj63NzMzUQw89VODY6hMnTuj+++/3fH/llVf6rD4A9vG3FwB+LT09XRs2bDjltRMnTmjTpk366KOP9O2330qSIiMj9e9//9tWW7fccotGjBih3NxcXXHFFXr00UfVuXNnRUZGatWqVXr99de1adMmderUST/++KOttoJVVlbWKZ9XVlaWDh48qLS0NC1ZskSTJ0/2nDmNjY3VhAkTlJSU5PM6H3roIY0ePVrp6ekaO3asNm3apLvuukstWrRQTk6OVq9erbfeesvzV4KWLVtqwIABPq8TQNkRcgH4tZEjR2rkyJFFrlOjRg198sknSkhIsNVWhw4dNGzYMA0ZMkQHDx7Uv/71r3zrPPzww2rTpk3QhNy8Z6XLesFeXjt27Cj2cwgLC1OPHj00fPhwNWjQwHabZREXF6fvvvtO1157rbZs2aLFixdr8eLFBa7brl07TZs2TRUqVPBxlQDsIOQCCDgVKlRQtWrV1Lp1a3Xv3l0DBw4s0T1wS+KZZ55R+/bt9eabb2rFihU6duyYatasqY4dO+quu+5S165dNW7cOK+05Q+WLl3qef7ggw96ff9RUVGKjY1VXFycEhMT1bFjR/Xq1Ut169b1elul1a5dO61fv17jx4/X9OnTtW7dOu3fv1+WZalmzZpKSkrS9ddfr969exc6qx0A/2UZbvIIAKetAQMGaPz48brwwgv1ww8/OF0OAHgNF54BwGlswYIFklxnsAEgmHAmFwBOU9u3b1d8fLzOO+88LVy40OlyAMCrCLkAAAAIOgxXAAAAQNAh5AIAACDoEHIBAAAQdLhPbh65ubnasWOHYmJiZFmW0+UAAADgb4wxOnLkiOrWrauQkMLP1xJy89ixY4fi4+OdLgMAAADF2LZtm+rXr1/ockJuHjExMZJcnVa5cuVyby8rK0uzZ89Wt27dmE2nDOg/++hDe+g/++hDe+g/++hDe5zov8OHDys+Pt6T2wpDyM3DPUShcuXKPgu5UVFRqly5Mv+wyoD+s48+tIf+s48+tIf+s48+tMfJ/ituaCkXngEAACDoEHIBAAAQdAi5AAAACDqEXAAAAAQdQi4AAACCDiEXAAAAQYeQCwAAgKBDyAUAAEDQIeQCAAAg6BByAQAAEHQIuQAAAAg6hFwAAAAEHUIuAAAAgg4hFwAAAEEnzOkCTlebNkkffBCiZcvO0o8/huj226WmTZ2uCgAAIDhwJtcBY8dKLVpIw4eHaPHiuho+PEQtWkjjxjldGQAAQHAg5PrYpk3SbbdJublSTo4lY0KUk2MpN1caNEj6/XenKwQAAAh8hFwfGzNGsqyCl1mWNHq0b+sBAAAIRoRcH0tLk4wpeJkxruUAAACwh5DrYw0bFn0mt2FDX1YDAAAQnAi5PnbrrUWfyR00yLf1AAAABCNCro81beoadxsSIlmWK+1allFIiOv1Jk0cLhAAACAIEHIdMGCAtHGjdOGFrpB75pmu7wcMcLQsAACAoEHIdUiTJtKTT+ZKkrKyOIMLAADgTYRcByUmus7k/vmnpf37HS4GAAAgiBByHRQbK9WqdUyStGaNs7UAAAAEE0Kuwxo3PiRJSklxuBAAAIAgErAhd8CAAbIsq8jHiRMnnC6zWI0bH5QkrV7tbB0AAADBJMzpAuzq1KmTmhRy1VZoaKiPqyk995lcQi4AAID3BHzIve222zQggO+95Q65GzdKGRlSVJTDBQEAAASBgB2uECyqVs1U7dpGubnSunVOVwMAABAcCLl+oF07163EGLIAAADgHQE/XGHevHlav369jhw5ourVq6tjx47q3r27IiIinC6txBITjb79lpALAADgLQEfcj/66KN8r9WpU0djxozRZZddVuS2mZmZyszM9Hx/+PBhSVJWVpaysrK8W2gB3G0kJGRLClVKSq6ysnLKvd1g4e4/X3xWwYo+tIf+s48+tIf+s48+tMeJ/itpW5YxxpRzLeXi9ddfV2hoqC6++GKdccYZOn78uNauXauhQ4dqyZIlCg8P1+zZs9WlS5dC9zF06FANGzYs3+sTJ05UlA+vANu5M0p3391V4eE5+vTTmQoLC8iPBAAAoNxlZGSoT58+OnTokCpXrlzoegEbcgtjjFHPnj01ffp0JSYmak0RU4kVdCY3Pj5ee/fuLbLTvCUrK0tz5szRxRd3Vb16FXX4sKVVq7KUkFDuTQcFd/917dpV4eHhTpcTkOhDe+g/++hDe+g/++hDe5zov8OHDysuLq7YkBvwwxX+zrIsDRs2TNOnT9fatWu1bds2xcfHF7huREREgWN3w8PDfXqgR0SEq107SwsXShs2hCs52WdNBwVff17BiD60h/6zjz60h/6zjz60x5f9V9J2gvLuCi1btvQ83759u4OVlFxSkusrF58BAADYF5Qhd9++fZ7nMTExDlZScu6Qm5LibB0AAADBIChD7meffSZJqly5spo3b+5wNSXjDrlr1ki5uY6WAgAAEPACMuSuWbNGX331lbKzs095PTc3V6NHj9aTTz4pSbr//vsDZnxNy5ZSRIR0+LC0ZYvT1QAAAAS2gLzwLC0tTT179lTVqlWVnJysWrVq6eDBg9qwYYO2bt0qSbrppps0ZMgQhystufBwKSFBWrnSNS73zDOdrggAACBwBeSZ3MTERA0ePFitW7fWr7/+qilTpuj777+XJF133XWaOXOmJk6cqLCwwMrwXHwGAADgHYGVAv+rUaNGev31150uw+sIuQAAAN4RkGdygxUhFwAAwDsIuX6kbVspJETatcv1AAAAQNkQcv1IVJTkvuMZZ3MBAADKjpDrZxiyAAAAYB8h188QcgEAAOwj5PoZQi4AAIB9hFw/4w65f/whHTrkbC0AAACBipDrZ6pVk844w/V8zRpHSwEAAAhYhFw/xJAFAAAAewi5fig52fWVkAsAAFA2hFw/xJlcAAAAewi5fsgdclNTpRMnnK0FAAAgEBFy/VC9elJcnJSTI23Y4HQ1AAAAgYeQ64csiyELAAAAdhBy/RQhFwAAoOwIuX6KkAsAAFB2hFw/5Q6569a5xuYCAACg5Ai5fqppUyk6WsrIkH77zelqAAAAAgsh10+FhEiJia7nDFkAAAAoHUKuH3MPWUhJcbYOAACAQEPI9WNcfAYAAFA2hFw/ljfkGuNsLQAAAIGEkOvHWreWwsOlAwekrVudrgYAACBwEHL9WESEK+hKDFkAAAAoDUKun2NcLgAAQOkRcv0cIRcAAKD0CLl+jpALAABQeoRcP5eYKFmWtH27tHev09UAAAAEBkKun4uJkZo0cT3nbC4AAEDJEHIDAEMWAAAASoeQGwAIuQAAAKVDyA0AhFwAAIDSIeQGAHfI/e036ehRZ2sBAAAIBITcAFCzplS3rmSMtHat09UAAAD4P0JugEhOdn1lyAIAAEDxCLkBgnG5AAAAJUfIDRCEXAAAgJIj5AYId8jdsEE6edLZWgAAAPwdITdANGggVa0qZWVJqalOVwMAAODfCLkBwrKkdu1czxmyAAAAUDRCbgBhXC4AAEDJEHIDCCEXAACgZAi5AcQdcteskXJzHS0FAADArxFyA0jz5lJkpGtq3z/+cLoaAAAA/0XIDSBhYVLbtq7nDFkAAAAoHCE3wLiHLKSkOFsHAACAPyPkBhguPgMAACgeITfAJCe7vq5eLRnjbC0AAAD+ipAbYBISpNBQac8eaccOp6sBAADwT4TcABMZKbVs6XrOkAUAAICCEXIDEONyAQAAikbIDUCEXAAAgKIRcgMQIRcAAKBohNwA1K6d62tamnTggJOVAAAA+CdCbgCqUkVq1Mj1fM0aJysBAADwT4TcAMWQBQAAgMIRcgMUIRcAAKBwhNwA5Q65KSnO1gEAAOCPCLkByh1yf/1VyshwthYAAAB/Q8gNUHXqSDVrSrm50vr1TlcDAADgXwi5AcqypORk13PG5QIAAJyKkBvAuPgMAACgYITcAEbIBQAAKBghN4C5Q+769VJ2trO1AAAA+BNCbgBr3FiKiZFOnHDdZQEAAAAuhNwAFhIitWvnes6QBQAAgP8h5AY4xuUCAADkR8gNcIRcAACA/Ai5Ac4dcteskYxxtBQAAAC/QcgNcK1aSRUqSAcPSmlpTlcDAADgHwi5AS48XGrTxvU8JcXZWgAAAPxFiUJuaGio1x9hYWFefzOPPfaYLMuSZVl67rnnvL5/f8W4XAAAgFOVKGmaABjsuWTJEr322muyLCsg6vUmQi4AAMCpShRyhwwZUuTymTNnauXKlZKk1q1bq2PHjqpVq5Ykaffu3VqxYoU2bNggy7LUvn17de/e3WbZp8rIyNCAAQNUp04ddejQQdOmTfPq/v1dcrLrKyEXAADAxXbI/fe//62VK1cqMTFR77//vjp06FDgeitWrNCdd96plStX6oorrtAzzzxTtooL8MQTT2jTpk2aOXOmPv/8c6/tN1C0bStZlrRzp7R7t/Tf3y8AAABOW7YuPPv+++81dOhQNWvWTIsXLy404EpShw4dtGjRIjVp0kTDhg3T3Llz7TTtMX/+fI0YMUL9+vXz+hniQBEdLTVv7nrO2VwAAACbIfett96SZVl6/PHHFR0dXez60dHRevzxx2WM0YgRI+w0LUk6evSobr31VtWqVUtvvPGG7f0FMsblAgAA/I+tWxy4x+G2bdu2xNskJiZKcg1fsOuRRx7Rli1bNHXqVFWtWrXU22dmZiozM9Pz/eHDhyVJWVlZysrKsl1fcdxteKOttm1D9OmnoVq1KldZWTm29xcIvNl/pyv60B76zz760B76zz760B4n+q+kbdkKufv375ckHTp0qMTbuIPkgQMH7DSt2bNn67333tONN96oa665pkz7ePHFFzVs2LAC9x0VFWWrvtKYM2eO7X2cPFlD0j+0ZEmGZs363n5RAcQb/Xe6ow/tof/sow/tof/sow/t8WX/ZWRklGg9WyG3bt26SktL05dffqkLL7ywRNtMnjxZklSnTp0yt3vo0CENGjRINWrUsDXs4YknntBDDz3k+f7w4cOKj49Xt27dVLly5TLvt6SysrI0Z84cde3aVeHh4bb2dfbZ0pAh0s6dldS5c3f5oHzHebP/Tlf0oT30n330oT30n330oT1O9J/7hGlxbIXcyy67TCNHjtR7772n888/XzfccEOR60+ePFnvvfeeLMuydZHY4MGDtX37dk2aNElxcXFl3k9ERIQiIiLyvR4eHu7TA90b7dWuLcXHS9u2Samp4TrvPC8VFwB8/XkFI/rQHvrPPvrQHvrPPvrQHl/2X0nbsXXh2ZNPPqnKlSsrNzdXN910k6655hpNmzZNf/31l7KyspSdna2//vpL06ZNU8+ePdW7d2/l5OQoJiZGTzzxRJnbnTp1qsLCwvTuu++qS5cupzy+/fZbSdLo0aPVpUsX3XjjjXbeYkDh4jMAAAAXW2dy69WrpxkzZuiqq67S4cOHNWPGDM2YMaPQ9Y0xiomJ0fTp01WvXj07TSs7O1sLFiwodHlaWprS0tLUoEEDW+0EkqQk6auvpJQUpysBAABwlq0zuZJ03nnnaf369erVq5dCQkJkjCnwERISomuvvVbr1q3TBRdcYKvNgwcPFtpO//79JUnPPvusjDFKS0uz+xYDBmdyAQAAXGydyXWLj4/XF198od27d2vevHlav369584LVatWVUJCgi688ELVrl3bG82hEO6Qm5oqZWZKBQw3BgAAOC14JeS61apVSzfeeONpNQ7Wn8THS9WqSfv3Sxs2SGed5XRFAAAAzrA9XAH+w7Kk5GTXc4YsAACA01nQhdxx48bJGKOnnnrK6VIcwbhcAAAALw5X2Ldvn5YuXarNmzfryJEjyskpfmrZZ555xlvN478IuQAAAF4Iuenp6XrwwQc1efJkZWdnl2pbQq73uUPu2rVSTo4UGupsPQAAAE6wFXIPHDigzp07648//pAxxls1wYamTaWoKCkjQ9q0SWrRwumKAAAAfM/WmNz//Oc/+v3332WMUbdu3fTtt99qz549ysnJUW5ubrEPeF9oqJSY6HrOkAUAAHC6shVyp0+fLsuydOWVV+rbb79Vt27dVL16dVmW5a36UAaMywUAAKc7WyF369atkqR7773XK8XAOwi5AADgdGcr5FaqVEmSaxII+I+8IZeh0gAA4HRkK+QmJCRIkv7880+vFAPvaNNGCguT9u2Ttm1zuhoAAADfsxVy77zzThlj9PHHH3urHnhBRITUqpXrOUMWAADA6chWyL3hhhvUt29fTZ06Vf/5z3+8VRO8gHG5AADgdGbrPrkLFy7UoEGDtGXLFv3rX//SlClT1KdPH7Vo0UJRUVHFbn/++efbaR5FSE6Wxo8n5AIAgNOTrZDbpUuXU24XtmrVKq1atapE21qWVeoZ0lBynMkFAACnM9vT+jLTmX9yTwixbZvrArTq1Z2tBwAAwJdshdx58+Z5qw54WeXKUpMm0u+/u87mXnKJ0xUBAAD4jq2Qe8EFF3irDpSDpCRCLgAAOD3ZursC/BvjcgEAwOmKkBvECLkAAOB0RcgNYu6Qu3GjdOyYs7UAAAD4kq0xuRdddFGZt7UsS99//72d5lGMWrWkOnWknTuldeukc891uiIAAADfsBVy58+fL8uyiryNWN776Er/u+XY319H+UhKcoXc1asJuQAA4PRhK+Sef/75xYbVY8eO6ffff9fBgwdlWZaaNWumOnXq2GkWpZCUJM2aJaWkOF0JAACA79g+k1tSs2bN0v3336/9+/dr9OjR6tSpk52mUUJcfAYAAE5HPrvwrHv37lq8eLHCwsLUs2dP/fXXX75q+rTmDrkbNkhZWc7WAgAA4Cs+vbtC7dq19eCDD2rv3r16+eWXfdn0aatRIyk2Vjp5UkpNdboaAAAA3/D5LcQ6d+4sSZo5c6avmz4tWRZDFgAAwOnH5yG3QoUKkqQdO3b4uunTFiEXAACcbnwechcvXixJioqK8nXTpy1CLgAAON34NOQuXbpU//73v2VZljp27OjLpk9r7pC7Zo2Um+toKQAAAD5h6xZi//73v4tdJzc3VwcOHNDKlSu1fPly5ebmyrIsPfjgg3aaRim0aCFFRkpHjkibN0tNmjhdEQAAQPmyFXKHDh1aqpnLjDEKCwvTyy+/rK5du9ppGqUQFiYlJEgrVriGLBByAQBAsLM9XMEYU+RDkmJiYtS2bVvdf//9WrNmjQYPHmy3WZQS43IBAMDpxNaZ3FwGeAYMQi4AADid+PzuCnCGO+SmpEj/PcEOAAAQtAi5p4mEBCkkREpPl3budLoaAACA8lUuITc7O1t79uzRnj17lJ2dXR5NoJSiolx3WZAYsgAAAIKf10LuL7/8on/+859q2bKlIiMjVbt2bdWuXVuRkZFq2bKl7r//fqWmpnqrOZQB43IBAMDpwish94knnlDbtm317rvvauPGjcrNzfXcXSE3N1cbN27UO++8o8TERD355JPeaBJlkJzs+krIBQAAwc7W3RUk6Z///Kfeffddz+3CWrZsqbPPPlu1a9eWJO3atUs//fSTUlNTlZOTo5deeknHjh3Tm2++abdplBJncgEAwOnCVsj98ccf9c4778iyLLVq1Urvv/++/vGPfxS47tKlS3XXXXdp/fr1evvtt9W7d+9C10X5aNfO9XXLFungQalKFQeLAQAAKEe2hiu89957kqRGjRrpxx9/LDK0nnvuuVq4cKEaN24sSRo1apSdplEGVatKDRu6nq9Z42QlAAAA5ctWyF20aJEsy9Ljjz+u2NjYYtePjY3V//3f/8kYo0WLFtlpGmXEkAUAAHA6sBVyd+3aJUlKcienEkj+79VPu3fvttM0yoiQCwAATge2Qm5kZKQk6dixYyXexr1uRESEnaZRRoRcAABwOrAVchs1aiRJmjFjRom3ca/rHpsL33KH3F9+kY4fd7YWAACA8mIr5Hbv3l3GGI0YMULff/99sevPmzdPI0aMkGVZ6t69u52mUUZ160o1akg5OdKGDU5XAwAAUD5shdzBgwercuXKysrK0uWXX6777rtPKSkpys3N9ayTm5urlJQU3Xfffbrssst08uRJVa5cWYMHD7ZbO8rAsv53NjclxdlaAAAAyout++TGxcXp888/V48ePXTy5EmNHDlSI0eOVIUKFVStWjVZlqV9+/bp5MmTkiRjjCpUqKAvvvhC1atX98obQOklJUmzZzMuFwAABC/b0/p269ZNy5YtU/v27T1T+WZmZmrnzp3asWOHMjMzPa+3b99ey5cv1yWXXOKN2lFGXHwGAACCne1pfSWpXbt2+umnn7RixQrNnTtXGzZs0P79+yVJ1apVU5s2bXTJJZeoQ4cO3mgONrlD7rp1Una2FOaVowAAAMB/lCjefPXVV5Kkiy++WNHR0YWu16FDB4JsAGjSRKpUSTp6VNq4UWrd2umKAAAAvKtEwxWuueYaXXvttfrzzz9Pef3WW2/VoEGDtHPnznIpDuUjJERq1871nCELAAAgGJV4TK4xJt9r48aN07hx43TgwAGvFoXyx7hcAAAQzEoUct2zkx09erRci4HvEHIBAEAwK1HIrVevniRp0aJF5VoMfCdvyC3gJD0AAEBAK9GFZxdffLE++OADPfnkk/rpp5/UrFkzhYeHe5a/++67qlmzZqkbf+aZZ0q9DbyjVSspPFw6eFD680+pYUOnKwIAAPCeEoXcp556SlOmTNG+ffs0efLkU5YZYzRy5MgyNU7IdU6FClKbNq4zuatXE3IBAEBwKdFwhfj4eKWkpOi2225Tw4YNFR4eLmOMLMuSJM9kD6V9wFmMywUAAMGqxNMAxMfH6/333z/ltZCQEFmWpfXr16tVq1ZeLw7lyx1yU1KcrQMAAMDbbE/ri8DFmVwAABCsbE3oOnbsWElS/fr1vVIMfCsxUbIsaccOKT1dKsO1gwAAAH7JVsjt37+/t+qAAypVkpo2lX77zXU299JLna4IAADAOxiucJpjyAIAAAhGhNzTXHKy6yshFwAABBNC7mmOM7kAACAYEXJPc+6Qu2mTdOSIs7UAAAB4CyH3NBcXJ7lvjrF2rbO1AAAAeAshFwxZAAAAQYeQC0IuAAAIOoRcEHIBAEDQIeTCE3J//lnKzHS2FgAAAG+wNeNZXrm5uZo3b56WLl2qXbt2KSMjQ88//7zq1KnjWefkyZPKzs5WaGioIiIivNU0bDrjDKlqVenAAVfQdd87FwAAIFB55Uzu119/rSZNmqhbt24aMmSIRo4cqfHjx+vAgQOnrPfhhx8qJiZGNWvW1LFjx2y1OWHCBPXr10+JiYmqWbOmwsPDFRsbq44dO+rFF1/U0aNHbe3/dGJZDFkAAADBxXbI/eCDD3T11VcrLS1NxhhVr15dxpgC173tttsUGxuro0ePaurUqbbaHTlypD755BNlZ2crOTlZ119/vdq3b68NGzboySefVFJSknbs2GGrjdMJIRcAAAQTWyF306ZNuvfeeyVJF110kVJTU5Wenl7o+hUqVFCvXr1kjNHs2bPtNK3XXntNe/fu1c8//6xvv/1WEydO1Pfff69t27apc+fO+v333/Xwww/bauN0QsgFAADBxFbIff3115Wdna3WrVtr1qxZatGiRbHbnHfeeZKk1TbT1Nlnn61q1arle7169ep64YUXJMl2kD6duMfhrl0r5eQ4WwsAAIBdtkLuDz/8IMuyNHjwYFWoUKFE2zRp0kSStG3bNjtNFykszHU9HRe3lVyzZlJUlHTsmPT7705XAwAAYI+tkLt9+3ZJUmJiYom3iY6OliRlZGTYabpQR44c0dChQyVJPXr0KJc2glFoqNS2res5QxYAAECgs3ULMcuyJJUusO7bt0+SFBsba6dpj9mzZ2vixInKzc3V7t27tXTpUh05ckSXXXaZXnrppSK3zczMVGaeG8MePnxYkpSVlaWsrCyv1FcUdxu+aKskEhNDtGxZqFauzFGvXrlOl1Msf+u/QEQf2kP/2Ucf2kP/2Ucf2uNE/5W0LVsht169etq0aZM2b97sGWtbnMWLF0uSGjdubKdpj9TUVI0fP/6U1/r06aPhw4cXG6RffPFFDRs2LN/rs2fPVlRUlFfqK4k5c+b4rK2ihIY2kNROc+fu03nnLXW6nBLzl/4LZPShPfSfffShPfSfffShPb7sv5KeXLVMYff7KoG77rpL77//vrp06aIffvjB83pISIgsy9L69evVqlUrz+uHDh1Sy5YttXv3bj322GN68cUXy9p0PllZWdq6daumT5+u5557TpZlaerUqTr//PML3aagM7nx8fHau3evKleu7LXaiqp5zpw56tq1q8LDw8u9veKsWmXp3HPDFBdn9Ndf2frviXq/5W/9F4joQ3voP/voQ3voP/voQ3uc6L/Dhw8rLi5Ohw4dKjKv2TqTe+edd+qDDz7QggULNG7cOA0YMKDQdfft26frrrtOu3btUnh4uO666y47TecTHh6uM888Uw899JA6deqkc889VzfffLM2btyoihUrFrhNREREgRenhYeH+/RA93V7hWnXzjU2d+9eS+np4apf3+mKSsZf+i+Q0Yf20H/20Yf20H/20Yf2+LL/StqOrQvPkpKS9MADD8gYo0GDBql37976/PPPPcuXLFmiiRMn6t5771WTJk20cOFCWZalp59+Wg0aNLDTdJHOPvtstWrVStu2bdPKlSvLrZ1gExkpuU+8c/EZAAAIZLbO5EquSRkyMzM1cuRITZ48WZMnT/ZckHbnnXd61nOPihg8eLCeeuopu80Wy30Xh6Imp0B+SUnS+vVSSop01VVOVwMAAFA2tqf1tSxL77zzjr777jt16dJFlmXJGHPKQ5LOPfdczZw5U8OHD7dddHH27t2rtWvXSpKaNWtW7u0FE2Y+AwAAwcD2mVy3rl27qmvXrjpy5IhWr16t9PR05eTkqHr16mrXrp3i4uK81ZRSU1O1evVq9erVS5GRkacs++2333TnnXcqMzNT55xzjhISErzW7umAkAsAAIKB10KuW0xMTJF3NPCG9PR03XzzzbrzzjuVlJSk+vXr6+TJk9q6datSUlKUm5urli1batKkSeVaRzBq1871detWad8+qXp1R8sBAAAoE6+HXF9o3bq1nn/+eS1atEi//vqrVq9eraysLFWrVk0XX3yxrr32Wg0cOJBpfcsgNlZq3FjavFlas0a6+GKnKwIAACi9gAy5NWrU0JNPPul0GUErOdkVclevJuQCAIDAZCvk3nrrrWXe1rIsjR492k7zKCdJSdLkyYzLBQAAgctWyB03bpzndmGlYYwh5PoxLj4DAACBzlbIPeOMM4oNuceOHdO+ffs8wTYuLk5RUVF2mkU5c4fcjRuljAyJjwsAAAQaWyE3LS2tROsdOHBAn376qZ555hlVqVJFX331lZo3b26naZSj2rVdj127pHXrpHPOcboiAACA0rE9GURJVK1aVffcc49+/PFHpaen6/LLL9eBAwd80TTKiCELAAAgkPkk5Lo1b95c999/v9LS0vTaa6/5smmUEiEXAAAEMp+GXEm65JJLJElTpkzxddMoBUIuAAAIZD4PuZUqVZIkbd261ddNoxTcIXfdOikry9laAAAASsvnIXf1f08NhoeH+7pplEKjRlLlytLJk9IvvzhdDQAAQOn4NORu2bJFQ4cOlWVZateunS+bRimFhEjuj4ghCwAAINDYuoXYRx99VOw6ubm5OnDggFauXKnp06crIyNDlmXprrvustM0fCApSVq40BVy+/d3uhoAAICSsxVyBwwYUKoZz4wxkqT7779fvXv3ttM0fICLzwAAQKCyFXKl/wXX4lSpUkXnn3++7rnnHnXr1s1us/CB5GTX1zVrpNxc1xAGAACAQGAr5G7ZsqXYdUJCQhQTE6MqVarYaQoOaNFCioiQDh+WtmyRzjzT6YoAAABKxlbIbdCggbfqgB8KD5cSEqSVK11DFgi5AAAgUPAHaBSJcbkAACAQEXJRJEIuAAAIRIRcFImQCwAAAlGJxuQ2btzY6w1blqU//vjD6/uFd7Vt67qrwq5drkft2k5XBAAAULwShdy0tDSvN1ya++vCOVFRUvPmrql9V6+WLr/c6YoAAACKV6KQ25/prk5rSUmukJuSQsgFAACBoUQhd+zYseVdB/xYUpI0cSLjcgEAQODgwjMUi4vPAABAoCHkoljukLt5s3TokLO1AAAAlAQhF8WqVk064wzX8zVrHC0FAACgRGxN61uQtLQ07d27V8ePH5cxpsh1zz//fG83j3KSnCxt3eoasnDBBU5XAwAAUDSvhNyNGzfqhRde0FdffaXDhw+XaBvLspSdne2N5uEDSUnStGmMywUAAIHBdsidNm2a+vbtqxMnThR75haBi4vPAABAILEVcrdt26abb75Zx48fV7169fToo48qKipKd9xxhyzL0ty5c7V//36tXLlSH3/8sXbs2KHOnTtr6NChCg0N9dZ7gA+4Q25qqnTihBQZ6Ww9AAAARbEVct966y1lZGQoJiZGy5cvV926dfXzzz97ll944YWSpF69eumZZ57RoEGDNGnSJI0ePVoTJkywVzl8ql49KS5O2rtX2rBBat/e6YoAAAAKZ+vuCnPnzpVlWbrnnntUt27dItetWLGiPvnkEyUlJemzzz7Tl19+aadp+JhlMWQBAAAEDlshNy0tTZL0j3/8w/OaZVme53+/sCwkJET333+/jDEaM2aMnabhAEIuAAAIFLZC7rFjxyRJ8fHxnteioqI8zw8VMHNA69atJUlr16610zQc4A65KSnO1gEAAFAcWyE3NjZWknTixAnPa9WrV/c8/+OPP/Jt4w6+e/futdM0HOAOuevWSTk5ztYCAABQFFsht3nz5pKkzZs3e16LiYlRgwYNJEmzZ8/Ot82cOXMkSVWqVLHTNBzQtKkUHS0dPy5t3Oh0NQAAAIWzFXLPPfdcSdKyZctOef3KK6+UMUavvPKK5s2b53n9888/15tvvinLstSpUyc7TcMBISFSYqLrOeNyAQCAP7MVcrt37y5jjKZMmaKcPH+/dt8v9+jRo7rkkktUo0YNxcTE6KabbtKJEycUEhKiRx991Hbx8D0uPgMAAIHAVsjt0qWLhgwZooEDB+qvv/7yvH7GGWfoiy++UGxsrIwx2rdvn44dOyZjjCIiIvTBBx/onHPOsV08fI+QCwAAAoGtySAsy9KQIUMKXHb55Zdr06ZNmjx5sn7++WdlZ2eradOmuuGGG1SvXj07zcJBycmur6tXS8a47p8LAADgb2yF3OJUr15dd955Z3k2AR9r3VoKD5cOHJC2bpX+e40hAACAX7E1XAGnnwoVXEFXYsgCAADwX7ZC7jnnnKO3335be/bs8VY9CACMywUAAP7OVsj96aef9MADD6hevXq6/PLL9cknn3hmQUPwIuQCAAB/ZyvkNm3aVMYYZWdna/bs2erfv79q1aqlPn36aObMmafcVgzBg5ALAAD8na2Qu3HjRq1YsUIPPvig6tSpI2OMMjIyNGnSJPXo0UN16tTRfffdpyVLlnirXviBxETXXRW2b5cYqQIAAPyR7QvPzjrrLL322mvatm2b5s6dq1tvvdVzf9y9e/dq5MiROu+889S4cWM9/fTT+uWXX7xRNxwUEyM1aeJ6ztlcAADgj7x2dwXLsnTRRRfpww8/1K5du/Tll1+qV69eioiIkDFGaWlpeuGFF9SmTRslJydr+PDh3moaDmDIAgAA8GflcguxChUqqGfPnvriiy+0e/dujR49WhdffLFCQkJkjNGaNWuY1jfAEXIBAIA/K/f75MbExGjgwIGaPXu2xo0bpypVqpR3k/ABQi4AAPBn5TrjmSSlpKRo4sSJ+uyzz7Rz587ybg4+4g65mzZJR49KlSo5Ww8AAEBe5RJyN2/erAkTJmjixIn67bffJEnGGElSdHS0rrnmGvXt27c8moaP1Kwp1a0r7dghrV0rderkdEUAAAD/47WQu2fPHn322WeaOHGifvrpJ0n/C7ZhYWHq1q2b+vbtq6uvvlpRUVHeahYOSk52hdzVqwm5AADAv9gKuceOHdOUKVM0YcIE/fDDD57JH9zh9txzz1Xfvn11ww03KC4uzn618CtJSdLXXzMuFwAA+B9bIbdmzZo6ceKEpP8F2xYtWqhv377q06ePGjVqZL9C+C0uPgMAAP7KVsg9fvy4JKlu3bq68cYb1bdvXyW5kw+Cnvuj3rBBOnlSqlDB2XoAAADcbIXcgQMHqm/fvrrwwgtlWZa3akKAaNBAqlpVOnBASk2V2rVzuiIAAAAXW/fJHT16tC666CIC7mnKsv4XbBmyAAAA/Em5TwaB4OYespCS4mwdAAAAeRFyYQsXnwEAAH9EyIUt7pC7dq2Um+tsLQAAAG6EXNjSvLkUGema2vf3352uBgAAwIWQC1vCwqS2bV3PGbIAAAD8BSEXtjEuFwAA+BtCLmxLTnZ9JeQCAAB/QciFbXnP5P53dmcAAABHEXJhW0KCFBoq7dkj7djhdDUAAAA2Q26jRo105pln6vdSXFa/detWNW7cWGeeeaadpuFHIiOlli1dzxmyAAAA/IGtkPvnn38qLS1NJ0+eLPE2WVlZSktLU1pamp2m4We4+AwAAPgThivAKwi5AADAn/g85B46dEiSFBUV5eumUY4IuQAAwJ/4POR+8sknkqQGDRr4ummUo3btXF/T0qT9+52sBAAAQAorzcoXXXRRga8PHDhQ0dHRRW6bmZmpzZs3Kz09XZZlqVu3bqVp+hRZWVlauHChvv32W82fP1+bNm3SsWPHVL16dXXs2FF33nmnrrjiijLvH6VXpYrUqJG0ZYu0Zo1UyKECAADgE6UKufPnz5dlWTJ5boZqjNGKFStK1Wjjxo31xBNPlGqbvBYsWKCuXbtKkmrXrq3OnTsrOjpaqampmjFjhmbMmKE77rhDo0aNkmVZZW4HpZOU5Aq5q1cTcgEAgLNKFXLPP//8U0LjggULZFmWzjrrrCLP5FqWpcjISNWpU0f/+Mc/dOONNxZ75rcoISEh6tWrlx544AGdd955pyybNGmS+vbtq/fff1+dOnVSv379ytwOSicpSZoyhXG5AADAeaU+k5tXSIhrSO+4cePUqlUrrxVVnIsuuqjQoRO9e/fWnDlzNHr0aH300UeEXB/i4jMAAOAvShVy/65fv36yLEtVq1b1Vj1ekfTftLVt2zaHKzm9uEPur79KGRkSN9AAAABOsRVyx40b56UyvGvTpk2SpDp16jhcyemlTh2pVi1p925p/Xrp7LOdrggAAJyubIXckvrjjz+0d+9eNWzYULVq1SrXtnbt2uUJ37169Spy3czMTGVmZnq+P3z4sCTX3RuysrLKrUY3dxu+aMtX2rUL1XffhWjlyhwlJ+eWa1vB2H++Rh/aQ//ZRx/aQ//ZRx/a40T/lbQty+S9VUIppaena/LkyZKkvn37KjY29pTlv//+u3r37q01a9a4GrMsXX311frwww/LZYhDdna2LrvsMn3//fdKSEjQypUrVaFChULXHzp0qIYNG5bv9YkTJzJZRRl9/HFLffllM3XrlqZ77lnrdDkAACDIZGRkqE+fPjp06JAqV65c6Hq2Qu6oUaN0zz33qGnTptq4ceMpyzIzM9WmTRtt3rz5lFuOWZalTp06aeHChWVttlC33XabRo8ererVq2vJkiVq1qxZkesXdCY3Pj5ee/fuLbLTvCUrK0tz5sxR165dFR4eXu7t+cLkyZb69AlT+/a5WrIkp1zbCsb+8zX60B76zz760B76zz760B4n+u/w4cOKi4srNuTaGq4we/ZsWZalnj175ls2btw4/fHHH7IsSz169NDFF1+suXPnasaMGfrxxx81adIk9e7d207zp3jggQc0evRoVa1aVXPmzCk24EpSRESEIiIi8r0eHh7u0wPd1+2Vpw4dXF83bAiRZYUozAcDYoKp/5xCH9pD/9lHH9pD/9lHH9rjy/4raTu2pvV1n70955xz8i2bOHGiJNftvqZNm6Z//vOfmj59ui655BIZY/TZZ5/ZafoUDz/8sN566y1VqVJFs2fP9txdAb7XuLEUEyOdOOG6ywIAAIATbIXcPXv2SJLq169/yuvHjx/XsmXLZFmW7rjjjlOW3XrrrZKklJQUO017PPbYYxo+fLhiY2M1e/ZstW/f3iv7RdmEhEjt2rmec79cAADgFFsh9+DBg66dhJy6m2XLlikrK0uWZemSSy45ZVmjRo0kuS5as+vxxx/XK6+8otjYWM2ZM0cd3H8rh6PcJ9K99HsMAABAqdkKuZUqVZLkum1XXu6Z0Vq1apXvLgrucRRhNgdrPvXUU3rppZdUpUoVAq6fYeYzAADgNFtJs0WLFlq+fLm+/fZbde/e3fP6l19+KcuydMEFF+Tbxh2I7dwv96uvvtLzzz8vSWrSpIneeeedAteLi4vTq6++WuZ2UDbukLtmjWSMZFmOlgMAAE5DtkLuFVdcoWXLlun9999Xy5Ytdd5552ncuHFKTU2VZVm69tpr823jHotbr169Mre7f/9+z/OVK1dq5cqVBa7XoEEDQq4DWrWSKlSQDh2StmxxXYwGAADgS7aGK9x3332qU6eOTp48qfvuu0+JiYl6/fXXJUnnnnuuLrzwwnzbzJgxQ5Zl2RpeMGDAABljin2kpaWVuQ2UXXi41KaN6zlDFgAAgBNshdzY2FjNnTtXycnJp4TL8847T59//nm+9deuXasVK1ZIkrp27Wqnafg5xuUCAAAn2b5Vf8uWLbVy5Upt2bJFu3btUp06ddSwYcNC1x87dqwk1/1zEbySk6XRowm5AADAGV6bj6pRo0ae24MVJjExUYmJid5qEn6MM7kAAMBJtoYrAIVp29Z1V4WdO6Xdu52uBgAAnG68diY3NzdX8+bN09KlS7Vr1y5lZGTo+eefV506dTzrnDx5UtnZ2QoNDVVERIS3moYfio6Wmjd3Te27erV02WVOVwQAAE4nXjmT+/XXX6tJkybq1q2bhgwZopEjR2r8+PE6cODAKet9+OGHiomJUc2aNXXs2DFvNA0/xpAFAADgFNsh94MPPtDVV1+ttLQ0GWNUvXp1GWMKXPe2225TbGysjh49qqlTp9ptGn6OkAsAAJxiK+Ru2rRJ9957ryTX3RJSU1OVnp5e6PoVKlRQr169ZIzR7Nmz7TSNAOAOuf+d/wMAAMBnbIXc119/XdnZ2WrdurVmzZqlFi1aFLvNeeedJ0lazem9oOcOuX/84Zr9DAAAwFdshdwffvhBlmVp8ODBqlChQom2adKkiSRp27ZtdppGAKheXYqPdz1fu9bZWgAAwOnFVsjdvn27JJXq3rfR0dGSpIyMDDtNI0AwLhcAADjBVsi1LEtS6QLrvn37JLmmBEbwI+QCAAAn2Aq59erVkyRt3ry5xNssXrxYktS4cWM7TSNAEHIBAIATbIXcLl26yBij8ePHl2j9Q4cOadSoUbIsSxdddJGdphEg3CE3NVXKzHS2FgAAcPqwFXLvvPNOWZalBQsWaNy4cUWuu2/fPl1zzTXatWuXwsLCdNddd9lpGgEiPt51AVp2trRhg9PVAACA04WtkJuUlKQHHnhAxhgNGjRIvXv31ueff+5ZvmTJEk2cOFH33nuvmjRpooULF8qyLD399NNq0KCB7eLh/yyLIQsAAMD3wuzu4LXXXlNmZqZGjhypyZMna/LkyZ4L0u68807Peu5Z0AYPHqynnnrKbrMIIElJ0ty5hFwAAOA7tqf1tSxL77zzjr777jt16dJFlmXJGHPKQ5LOPfdczZw5U8OHD7ddNAILZ3IBAICv2T6T69a1a1d17dpVR44c0erVq5Wenq6cnBxVr15d7dq1U1xcnLeaQoBxh9y1a6WcHCk01Nl6AABA8PNayHWLiYnR+eef7+3dIoA1bSpFRUkZGdKmTVIJZn8GAACwxfZwBaA4oaGSe1K8lBRnawEAAKeHcg+5Bw4c0J49ezxjc3F6YlwuAADwpTKF3OzsbG3YsEGrVq3Snj178i0/ceKEnnnmGdWvX19xcXGqXbu2YmJidN111+nnn3+2XTQCDyEXAAD4UqlCrjFGzzzzjOLi4pSYmKiOHTuqdu3a6ty5s1asWCFJOnnypC699FI9//zz2rlzp+cOCxkZGZo6dao6duyo77//vlzeDPxX3pDLSX0AAFDeSnXh2cCBA/Xxxx9L0inDD5YsWaLLLrtMy5cv17vvvqtFixZJkqpVq6amTZsqOztbqampOn78uI4fP66+fftq48aNio2N9eJbgT9r00YKC5P275e2bZPOOMPpigAAQDAr8ZncefPm6aOPPpIkRUREqFevXnrkkUd0/fXXq2LFijp48KBef/11jRs3TuHh4Xr//fe1Z88eLV26VCtWrNDevXv1yCOPSJL27NlT7DTACC4REVKrVq7nDFkAAADlrcQhd+zYsZKkmjVratWqVfriiy/08ssva9KkSVq1apVq1aql999/X4cOHdKDDz6o2267zTPzmSRVrFhRL7/8si699FIZYzRz5kzvvxv4NcblAgAAXylxyF2+fLksy9KDDz6oli1bnrKsRYsWevDBB5WTkyNJuuWWWwrdT//+/SWJC9BOQ8nJrq+EXAAAUN5KHHJ37NghyTU9b0Hyvt6kSZNC99O0aVNJ0v79+0vaNIIEZ3IBAICvlDjkHjt2TJLrYrKCVKlSxfM8IiKi0P1ERkZKct2FAacX94QQ27ZJ+/Y5WwsAAAhupb5Pbt5xtiV5HXCrXFlyn+TnbC4AAChPTOsLn2LIAgAA8AVCLnzKHXJTUpytAwAABLdSTQYhSe+++65q1qyZ7/X09HTP83//+9+Fbp93PZx+OJMLAAB8odQhd+TIkYUuc4/LHTZsWNkrQlBzh9zffpOOHpUqVXK2HgAAEJxKNVzBGOOVB05ftWpJdepIxkjr1jldDQAACFYlPpM7b9688qwDp5GkJGnnTteQhX/8w+lqAABAMCpxyL3gggvKsw6cRpKSpFmzGJcLAADKD3dXgM9x8RkAAChvhFz4XHKy6+uGDVJWlrO1AACA4ETIhc81bChVqSKdPCmlpjpdDQAACEaEXPicZUnt2rmeM2QBAACUB0IuHMG4XAAAUJ4IuXAEIRcAAJQnQi4c4Q65a9ZIubmOlgIAAIIQIReOaNFCioyUjhyR/vjD6WoAAECwIeTCEWFhUkKC6zlDFgAAgLcRcuEYxuUCAIDyQsiFYwi5AACgvBBy4Zi8IdcYZ2sBAADBhZALxyQkSCEhUnq6tHOn09UAAIBgQsiFY6KiXHdZkBiyAAAAvIuQC0clJ7u+EnIBAIA3EXLhKC4+AwAA5YGQC0cRcgEAQHkg5MJR7dq5vm7ZIh086GQlAAAgmBBy4aiqVaWGDV3P16xxshIAABBMCLlwHEMWAACAtxFy4Th3yE1JcbYOAAAQPAi5cBxncgEAgLcRcuE4d8j99Vfp+HFnawEAAMGBkAvH1a0r1agh5eRI69c7XQ0AAAgGhFw4zrIYsgAAALyLkAu/QMgFAADeRMiFXyDkAgAAbyLkwi8kJ7u+rlsnZWc7WwsAAAh8hFz4hTPPlGJipBMnpI0bna4GAAAEOkIu/EJIiJSY6HrOkAUAAGAXIRd+g3G5AADAWwi58BuEXAAA4C2EXPiNvCHXGGdrAQAAgS1gQ+7GjRs1YsQIDRgwQAkJCQoLC5NlWXruueecLg1l1KqVFB4uHTwopaU5XQ0AAAhkYU4XUFYjR47Um2++6XQZ8KIKFaQ2bVxnclevlho1croiAAAQqAL2TG6bNm30yCOPaMKECfrll190yy23OF0SvIBxuQAAwBsC9kzubbfddsr3ISEBm9eRByEXAAB4A8kQfoWQCwAAvIGQC7+SmChZlrRjh5Se7nQ1AAAgUAXscAVvyMzMVGZmpuf7w4cPS5KysrKUlZVV7u272/BFW4EiIkJq0iRMmzZZWrEiW926FX4vMfrPPvrQHvrPPvrQHvrPPvrQHif6r6RtndYh98UXX9SwYcPyvT579mxFRUX5rI45c+b4rK1AULv2Wdq0qb4mTfpN2dmbil2f/rOPPrSH/rOPPrSH/rOPPrTHl/2XkZFRovVO65D7xBNP6KGHHvJ8f/jwYcXHx6tbt26qXLlyubeflZWlOXPmqGvXrgoPDy/39gJFamqIFi2Sjh9voe7dmxa6Hv1nH31oD/1nH31oD/1nH31ojxP95/7Le3FO65AbERGhiIiIfK+Hh4f79ED3dXv+rn1719e1a0MUHl78sHH6zz760B76zz760B76zz760B5f9l9J2+HCM/gd9x0WNm2SjhxxthYAABCYCLnwO3FxUv36rudr1zpbCwAACEyEXPgl99nclBRn6wAAAIGJkAu/xKQQAADAjoC98CwlJUX33HOP5/s//vhDkvTee+/p66+/9rw+depU1alTx+f1wR5CLgAAsCNgQ+7hw4e1fPnyfK9v375d27dv93yfd7IHBA53yP35Zykz0zVJBAAAQEkF7HCFLl26yBhT7KNhw4ZOl4oyOOMMqWpVKTvbFXQBAABKI2BDLoKbZTFkAQAAlB0hF36LkAsAAMqKkAu/RcgFAABlRciF30pOdn1du1bKyXG2FgAAEFgIufBbzZpJUVHSsWPS7787XQ0AAAgkhFz4rdBQqW1b13OGLAAAgNIg5MKvMS4XAACUBSEXfs0dclNSnK0DAAAEFkIu/FreM7nGOFsLAAAIHIRc+LU2bVxjc/ftk/LM1gwAAFAkQi78WmSk1KqV6znjcgEAQEkRcuH3uPgMAACUFiEXfo+QCwAASouQC79HyAUAAKVFyIXfa9fO9XXrVtcFaAAAAMUh5MLvxcZKjRu7nq9Z42gpAAAgQBByERCSk11fGbIAAABKgpCLgMC4XAAAUBqEXAQEQi4AACgNQi4CgjvkbtwoHTvmbC0AAMD/EXIREGrXdj1yc6V165yuBgAA+DtCLgIGQxYAAEBJEXIRMAi5AACgpAi5CBiEXAAAUFKEXAQMd8hdv17KynK2FgAA4N8IuQgYjRpJlStLJ09Kv/zidDUAAMCfEXIRMEJCpHbtXM8ZsgAAAIpCyEVAYVwuAAAoCUIuAkpysusrIRcAABSFkIuA4j6Tu2aNa2IIAACAghByEVBatJAiIqTDh6UtW5yuBgAA+CtCLgJKeLiUkOB6vmaN5WwxAADAbxFyEXD+d/EZIRcAABSMkIuA4w65a9cScgEAQMEIuQg4/7v4jJALAAAKRshFwGnb1jUxxO7dlvbvj3C6HAAA4IcIuQg4UVFS8+au55s3xzpbDAAA8EuEXAQk95CFLVuqOFoHAADwT2FOFwCURf36rq/ffttA//pXiG6/XWra1NmaAs2mTdIHH4Ro2bKz9OOP9GFp0X/20Yf20H/20Yf2+H3/GXgcOnTISDKHDh3ySXsnT54006ZNMydPnvRJe8FizBhjQkKMkYyRck1oaK4JCTFm7FinKwsc7j4MDc01lpVDH5YS/WcffWgP/WcffWiPk/1X0rzGmVwElE2bpNtuyzulr6WcHNezW2+Vjh2T6tRxqrrAsGOHdP/9rl8RJEv0YenQf/bRh/bQf/bRh/YU1X+DBkmdO0tNmjhY4H9ZxrhKhHT48GHFxsbq0KFDqly5crm3l5WVpVmzZql79+4KDw8v9/aCwRNPSK+8Is8/JgAA4D9CQ6VHH5VefLH82ihpXuNMLgJKWpr7N8eCxcX9784LKNjGjdLevYUvpw+LRv/ZRx/aQ//ZRx/aU1T/GeP6v9ofEHIRUBo2lKxC5oAIDXUNZSjP3x6DQVFnw+nD4tF/9tGH9tB/9tGH9hTVf5bl+r/aH3ALMQSUW28t/EyuMa6xQCgafWgP/WcffWgP/WcffWhPoPQfIRcBpWlTafRo14xnoaFGISG5//3qet0fBrr7O/rQHvrPPvrQHvrPPvrQnkDpPy48y4MLzwLH779L77+fo2XLduqcc+rojjtC/eYfVaCgD+2h/+yjD+2h/+yjD+1xqv9KmtcIuXkQcgML/WcffWgP/WcffWgP/WcffWiPE/1X0rzGcAUAAAAEHUIuAAAAgg4hFwAAAEGHkAsAAICgQ8gFAABA0CHkAgAAIOgQcgEAABB0CLkAAAAIOoRcAAAABB1CLgAAAIIOIRcAAABBh5ALAACAoEPIBQAAQNAh5AIAACDohDldgD8xxkiSDh8+7JP2srKylJGRocOHDys8PNwnbQYT+s8++tAe+s8++tAe+s8++tAeJ/rPndPcua0whNw8jhw5IkmKj493uBIAAAAU5ciRI4qNjS10uWWKi8GnkdzcXO3YsUMxMTGyLKvc2zt8+LDi4+O1bds2Va5cudzbCzb0n330oT30n330oT30n330oT1O9J8xRkeOHFHdunUVElL4yFvO5OYREhKi+vXr+7zdypUr8w/LBvrPPvrQHvrPPvrQHvrPPvrQHl/3X1FncN248AwAAABBh5ALAACAoEPIdVBERISGDBmiiIgIp0sJSPSfffShPfSfffShPfSfffShPf7cf1x4BgAAgKDDmVwAAAAEHUIuAAAAgg4hFwAAAEGHkOtDGzdu1IgRIzRgwAAlJCQoLCxMlmXpueeec7q0gJCVlaXvv/9ejz76qDp06KAqVaooPDxctWvXVo8ePTRz5kynS/R7EyZMUL9+/ZSYmKiaNWsqPDxcsbGx6tixo1588UUdPXrU6RIDzmOPPSbLsvi3XEIDBgzw9FdhjxMnTjhdZkA4efKk3nrrLXXu3FnVqlVTZGSk6tevr8svv1yTJk1yujy/lZaWVuwx6H4sXLjQ6XL91tatW3XfffepefPmqlixoiIjI9WoUSP1799fa9eudbo8SUwG4VMjR47Um2++6XQZAWvBggXq2rWrJKl27drq3LmzoqOjlZqaqhkzZmjGjBm64447NGrUKJ/MWBeIRo4cqSVLlqhly5ZKTk5WtWrVtHv3bi1dulQrVqzQmDFjtGDBAtWtW9fpUgPCkiVL9Nprr8myrGLnUMepOnXqpCZNmhS4LDQ01MfVBJ7t27fr0ksvVWpqquLi4tSpUydFR0dr27ZtWrhwoaKjo9W7d2+ny/RLlSpVUv/+/QtdnpqaqhUrVigmJkZnnXWWDysLHMuXL1fXrl115MgR1atXT926dVNoaKjWrFmjjz76SBMnTtTEiRN1/fXXO1uogc988MEH5pFHHjETJkwwv/zyi7nllluMJPPss886XVpA+P77702vXr3MwoUL8y377LPPTGhoqJFkxo8f70B1gWHZsmVm3759+V7fu3ev6dy5s5FkbrzxRgcqCzzHjh0zTZs2NfXq1TPXXHMN/5ZLqH///kaSGTt2rNOlBKyMjAzTokULI8kMHTrUnDx58pTlx44dM6tXr3amuCBw+eWXG0nm9ttvd7oUv9W2bVsjydxxxx2nHH85OTnmqaeeMpJMlSpVzPHjxx2s0hhCroPcP+z5j9E7Bg0aZCSZiy++2OlSAtLChQuNJFOtWjWnSwkI999/v5FkZs6cyb/lUiDk2vf00097Aga8a/v27SYkJMRIMsuWLXO6HL+0d+9eI8lIMunp6fmWZ2dnm4oVKxpJJiUlxYEK/4cxuQgaSUlJkqRt27Y5XElgCgtzjV7yxxt6+5v58+drxIgR6tevn7p37+50OTiNZGVlaeTIkZKkRx991OFqgs+4ceOUm5ur1q1b6+yzz3a6HL9Umv8j4uLiyrGS4jEmF0Fj06ZNkqQ6deo4XEngOXLkiIYOHSpJ6tGjh7PF+LmjR4/q1ltvVa1atfTGG284XU7AmjdvntavX68jR46oevXq6tixo7p3784vWcVISUnR3r17VbduXTVp0kTr16/XlClTtGPHDlWtWlXnnXeeLr/8coWEcA6rLMaNGydJGjRokLOF+LFKlSrpvPPO06JFi/TUU0/p7bffVnh4uCQpNzdXQ4cO1fHjx3X55ZcrPj7e0VoJuQgKu3bt8vxw6tWrl7PFBIDZs2dr4sSJys3N9Vx4duTIEV122WV66aWXnC7Prz3yyCPasmWLpk6dqqpVqzpdTsD66KOP8r1Wp04djRkzRpdddpkDFQWGdevWSZLq16+vxx9/XC+//PIpFz2+9NJLSkpK0rRp03TGGWc4VWZAWrBggX7//XdVqFBBt9xyi9Pl+LUPPvhA3bt31/vvv6+ZM2eqffv2Cg0N1erVq/XXX3/plltu0dtvv+10mdxCDIEvOztbN998sw4dOqSEhATdeeedTpfk91JTUzV+/Hh9/PHHmj17to4cOaI+ffpo3Lhxio2Ndbo8vzV79my99957uvHGG3XNNdc4XU5ASkxM1JtvvqkNGzbo8OHD2r17t2bPnq1//OMf2rlzp3r06KH58+c7Xabf2rdvnyRp9erVeumll3TPPfdo48aNOnTokObMmaNmzZpp9erVuuKKK5SVleVwtYFlzJgxklx/zXL6z+z+rnnz5lq6dKm6deumv/76S9OnT9eUKVO0ZcsWNWnSRF26dFHlypWdLpO7KziJi1W8w33BWfXq1c3GjRudLiegnDx50vz+++/mtddeM1WrVjXVqlUzCxYscLosv3Tw4EFTv359U6NGDbNnz55TlvFv2b7c3Fxz9dVXG0kmMTHR6XL81gsvvOC56Oemm27Kt/zPP/80kZGRRpL56KOPHKgwMB06dMhERUUZSWbWrFlOl+P3Fi9ebGrWrGnq1q1rJk6caHbt2mX2799vZsyYYZo2bWokmVtvvdXpMrnwDIHtgQce0OjRo1W1alXPWQyUXHh4uM4880w99NBD+uabb3TgwAHdfPPNOn78uNOl+Z3Bgwdr+/btevvttznLUw4sy9KwYcMkSWvXruUC0kLExMR4nhf0V6szzjhDV1xxhSRp7ty5Pqsr0H322WfKyMhQ/fr1demllzpdjl87ePCgevbsqT179mjKlCm66aabVKtWLVWtWlVXXnmlvv32W0VFRWnMmDGaN2+eo7USchGwHn74Yb311luqUqWKZs+e7bm7Asrm7LPPVqtWrbRt2zatXLnS6XL8ztSpUxUWFqZ3331XXbp0OeXx7bffSpJGjx6tLl266MYbb3S42sDUsmVLz/Pt27c7WIn/aty4cYHPC1pn586dPqkpGLiHKgwYMICL9ooxc+ZM7dmzR40bNy7wDhR5X3f6Fy0uPENAeuyxxzR8+HDFxsZq9uzZat++vdMlBYXo6GhJUnp6usOV+Kfs7GwtWLCg0OVpaWlKS0tTgwYNfFhV8HCPN5VOPWOJ/0lOTvbMsLd3794Cr17fu3evJNdV8Cheamqqli9fLsuyNHDgQKfL8Xtbt26VpCLH3Lqv7di/f79PaioMv64g4Dz++ON65ZVXFBsbqzlz5qhDhw5OlxQU9u7d65lvnGEf+R08eFDGNYFOvod7itBnn31WxhilpaU5W2yA+uyzzyS5/vNs3ry5w9X4J/eU5lLBZ8mysrI8v4h17NjRp7UFqtGjR0uSLrzwwkLPjuN/6tWrJ0n69ddfdejQoXzLs7KylJKSIklq1KiRT2v7O0IuAspTTz2ll156SVWqVCHgllJqaqomTJigEydO5Fv222+/6frrr1dmZqbOOeccJSQkOFAhgt2aNWv01VdfKTs7+5TXc3NzNXr0aD355JOSpPvvv99z303kN2TIEEnSiy++qGXLlnlez87O1sMPP6zNmzcrJiaGs5IlkJWVpU8++UQS98Ytqcsvv1zR0dE6fvy4br/9dh09etSz7OTJk3rwwQe1detWhYeH67rrrnOwUoYr+FRKSoruuecez/d//PGHJOm9997T119/7Xl96tSpTGhQgK+++krPP/+8JKlJkyZ65513ClwvLi5Or776qi9LCwjp6em6+eabdeeddyopKUn169fXyZMntXXrVqWkpCg3N1ctW7bUpEmTnC4VQSotLU09e/ZU1apVlZycrFq1aungwYPasGGD50+gN910kyfEoWAXX3yxnn32WT399NM677zz1LFjR9WuXVspKSlKS0tTxYoV9emnn6pWrVpOl+r3vv76a6Wnp6tKlSq69tprnS4nINSoUUOjRo3SwIED9cUXX2j+/Pnq0KGDwsPDtXLlSv31118KCQnRW2+95fyZcedu7HD6mTdvnufWL0U9tmzZ4nSpfmns2LEl6r8GDRo4XapfSk9PN88//7y57LLLTMOGDU10dLSpUKGCqV27tunatasZOXKkOXHihNNlBiRuIVYymzdvNoMHDzadO3c29erVM5GRkSYiIsKcccYZ5rrrrjMzZ850usSA8t1335nLL7/cVKtWzYSHh5v4+HgzYMAA88svvzhdWsC48sorjSRzzz33OF1KwFmzZo0ZMGCAady4sYmIiDAVKlQwDRo0MH379jXLly93ujxjjDGWMXmmSgEAAACCAGNyAQAAEHQIuQAAAAg6hFwAAAAEHUIuAAAAgg4hFwAAAEGHkAsAAICgQ8gFAABA0CHkAgAAIOgQcgEAABB0CLlAALMsS5ZlaejQoU6X4rdycnL05ptvqmPHjqpcubKnz6655hqnSysX8+fP97zH+fPnO10OADiGkIuAlPc/csuy1Lt372K3GTBggGd9nD5uuukmDR48WCtWrNCRI0ecLgcA4COEXASFL774QuvXr3e6DPiZJUuW6IsvvpAkXXHFFZozZ47WrVun9evX66233nK4upJLS0vz/II2btw4p8sB8uGvSvBHYU4XAHiDMUZDhgzRlClTnC4FfmTu3LmSpNDQUE2cOFGVK1d2uKLy16VLFxljnC4DABzHmVwEvLi4OEnS1KlTtXr1aoergT/566+/JEm1atU6LQIuAOB/CLkIePfff78iIiIkSc8884zD1cCfZGZmSpLCw8MdrgQA4GuEXAS8+Ph43XHHHZKkr7/+Wj/99FOZ9tOwYUNZlqUBAwYUuZ77AraGDRvmW1bQ2MkpU6aoW7duqlmzpqKjo5WYmKgRI0YoKyvLs50xRhMnTlSXLl1Us2ZNRUVFKTk5WaNGjSrVn57nzp2rHj16qE6dOoqMjFTjxo113333ec5oFiclJUV33XWXmjdvrkqVKik6OlrNmzfX3Xffrd9++63Q7caNG+d532lpacrMzNQbb7yhc845R3FxcbbG6q1fv1533HGHmjZtqqioKMXExKh169Z68MEHlZaWVuA27lrGjx8vSfrzzz9PuVCxLBcfbtiwQc8995wuvfRS1a9fXxEREapUqZKaNm2q/v37a9myZSXe148//qjbbrtNzZs3V+XKlVWhQgXVr19fV155pd555x0dPHjwlPfSqFEjz/cDBw7M917y9m1hd1f4888/FRISIsuy9K9//avYGj/99FPPfmbNmlXgOr///rsefPBBJSQkKDY2VhUrVlTjxo01YMAArVy5ssT9UZCCjqlXX31VycnJio2NVeXKlXX22Wfr3XffVU5OTqH7yc3N1Q8//KBHHnlEnTp1UlxcnMLDw1WlShW1a9dOjzzyiLZu3VpkLV26dJFlWerSpYskadOmTbrvvvs8x6S7RredO3fq3Xff1XXXXaemTZsqOjpaERERqlevnq6++mpNmjRJubm5hbb398/QGKPRo0erc+fOql69uipXrqyOHTvq448/PmW7kydPatSoUTrnnHNUrVo1xcTEqFOnTvr888+L73BJu3bt0r/+9S+1b99e1apVU0REhOLj43XDDTd4hv78nfvnptuwYcPyHZ+F/Uwt6/Hz9/7Jzc3VmDFjdOGFF6pWrVoKCQnJ1+aqVas0aNAgNWvWTNHR0YqMjFR8fLzOOuss3Xvvvfrqq68Y5hOMDBCA5s2bZyQZSWbs2LFmx44dpmLFikaS6datW4Hb9O/f37NNQRo0aGAkmf79+xfZtns/DRo0yLdsy5Ytp9R19913e77/++Paa6812dnZ5sSJE+a6664rdL3bb7+90Frc6wwZMsQMHTq00H3ExsaahQsXFrqfnJwc8+CDDxrLsgrdR1hYmHnvvfcK3H7s2LGe9VasWGHatWuXb/shQ4YU2a8FeeGFF0xISEihNUVERJjx48cX2i9FPUoj7/FW1OPxxx8vcj8ZGRnmpptuKnY/efuqJO3mXT9vrfPmzTul/c6dOxtJplGjRsW+5yuuuMJIMjVq1DBZWVn5lr/yyismPDy80JosyzJPP/10se0UJu8xlZKSYs4666xC2zr//PPNkSNHCtzPkCFDiu2/qKgoM2XKlEJrueCCC4wkc8EFF5hp06aZ6OjofPvYsmWLMcaY7OzsIo9Z96Nr166F1pz3M5w9e7a56qqrCt3P/fffb4wxZv/+/eb8888vdL3nn3++yP7+5JNPCnxfeR+DBg3Kdyy4f24W9SjoZ6qd4ydv/3zzzTfmkksuKbLN4cOHl+gzKezzQOAi5CIg/T3kGmPMQw895Hlt0aJF+bbxdcg9++yzjSTTvXt3M2XKFLNq1Sozbdo0z+uSzAcffGD++c9/GkmmT58+5uuvvzarVq0yn332mWnRosUpP8gL4l7evn17I8k0b97cjB492qxYscLMnTvX3HnnnZ4f7pUrVzZbt24tcD/33HPPKYFhzJgxZv78+eann34yH3zwgWndurVn+fTp0/NtnzeQtG3b1liWZfr162dmzpxpVq1aZaZOnWpmzZpVZL/+3TvvvOPZZ40aNcyrr75qli5dahYvXmyGDh3q+Q/Zsiwzc+bMU7Zdv369Wb9+vbn66quNJFO3bl3Pa+5HacyZM8dER0ebG264wYwaNcrMnz/fpKSkmG+//da89tprp/xHP2bMmAL3kZOTY7p27epZr2nTpub11183ixYtMqtWrTJff/21efLJJ02TJk1OCa3r16833333nWe75557Lt972b17t2f9okLuyJEjPct+/PHHQt/v3r17PQHk3nvvzbf85ZdfPuXzHjlypJk7d65ZuXKlmTBhgjn33HM9y998881S9bVb3mOqQ4cORpLp3bu3mTVrllm5cqWZOHGi53VJ5pprrilwP//6179MnTp1zD333GM+/vhj8+OPP3r+LT722GOmUqVKRpKJjIw0qampBe7DHXIbNWpkKlWqZGrUqGH+85//mB9//NEsW7bMjBgxwuzZs8cYY0xWVpYJCQkxF110kXnllVfMt99+a1atWmXmz59vxowZc0rf9OvXr8D28n6G7p8Xffv29fx7+vTTT03z5s0968yZM8f06NHDhIWFmbvvvtvMnj3brFq1yowePdrUrVvXSDKhoaFmw4YNBbY3adIkzy+4jRs3NsOHD/fU/eWXX5ru3bt72nrwwQdP2Xbjxo1m/fr1nuV33313vuNz+/btp2xj9/jJ2z9t27Y1kkyPHj08P2dnzZplPvvsM2OMMWvXrvX8DGzUqJF57bXXzPfff29Wr15tFi5caD744APTp08fEx0dTcgNQoRcBKSCQu7u3bs9wefCCy/Mt42vQ64kM3jw4HzrHDt2zNNW9erVjWVZ5o033si33s6dO01MTIznB3hB8raVnJxc4A/pjz76yLPO9ddfn2/57NmzPcs//PDDAts5fvy4ueiiizzv++9nc/IGkqL2U1Lp6ekmKirKE1ALCucpKSmez7tevXrm5MmT+dYp6rMqjT179pgDBw4UujwzM9MTYBs0aGCys7PzrfPmm296+qdnz57mxIkTBe4rJycnXyj4+18IilJUyC0uvLrlDcNLliw5ZdnPP//s2ceQIUNMbm5uge/h5ptvNpJMpUqVzP79+4usuSB/P6ZeeOGFfOtkZWWZSy+91LPO33/ZMcbVdwUdG27btm0z9erVM5LMzTffXOA67pDrPh7//PPPQveXm5trNm3aVOR7e+aZZzy/oP3222/5lv/9LwfF/XyoUaOGsSzLTJ06Nd96eUOe+6xvXnv27DGxsbFGkrn11lsLPGtvjDFPPvmkkWRCQkLMr7/+mm+5u9bi/mLjjePn7/3z1FNPFdre008/bSSZ6Ohos2vXrkLXO3jwoMnJySmydgQeQi4CUkEh1xhj/u///s/z+g8//HDKNr4OufHx8YX+5+r+T06SOeeccwptq1+/fkaSqVq1aoHL8/6gX7lyZaH7ufzyy43kGnKwc+fOU5a5w2uvXr0K3d4YY1JTUz1tzZ49+5RleQPJRRddVOR+SuKll17y7M99RqYgzz33nGe9zz//PN9yb4XcklizZk2hn0VOTo6pX7++kWTq169f6jNG3gq5xhjPn74LG4ZgzP+GNTRu3DjfsltvvdVIrr8eFBRQ3A4cOGAiIiKMJPP+++8XWXNB/v7XgcLa2rZtmyc0XXHFFaVuxxhj3njjDSO5/tpRUDt5Q+5HH31Upjbyys7ONnFxcUaSefXVV/Mt//uZ3MK4fz5IrrPchXEPY0hKSsq37N///rfnF8XCfvEyxvULhfuXgSeffDLf8pKGXG8cP3n7p1mzZgX+Uul2++23F/reEfy48AxB5dFHH1VMTIwk6emnn3a0lmuvvbbQq/oTExM9z4uarc293oEDB065GOnvEhISdNZZZxW6/NZbb5UkZWdnn3Ix0uHDhz3fX3fddYVuL0ktW7b03K5t6dKlha7Xt2/fIvdTEu6LXKpUqaJrr7220PVuu+22fNv4QmZmprZu3arU1FRt2LBBGzZsOOWilbVr156y/po1a7R9+3ZJ0u23365KlSr5rNa/c38+e/bs0Zw5c/It37p1q3788UdJUp8+ffItnzFjhiSpV69eRV7AV6VKFSUkJEgq+ngpif79+xfaVv369dWtWzdJrguSiroITXId81u2bNHPP//s+eyioqJOWVaYChUq6Prrry9V7bm5udqxY4c2btzoae+XX35R/fr1JeU/Vv7uxhtvLHRZ3p8jJVlv8+bN+ZZ99dVXkqQrr7zSc5eagoSFhencc8+VZO/z9Pbx07t3b4WGhha6vE6dOpKk1NTUMl+UjMBFyEVQqV69ugYPHizJdQX7d99951gtzZo1K3RZlSpVSr1eUVPSdujQochaOnbs6Hmed2a41atXe67yvummm/JdFf33x969eyW5rsIuTNu2bYuspSQ2bNggSUpOTi7y9l+1atXy3OXCvU15OXbsmF588UUlJiYqOjpaDRo0UOvWrZWQkKCEhAQlJSV51nX3k1ve+zefd9555VpncXr06OH5RXDChAn5ln/66aeewP73X1j+/PNP7dmzR5L0xBNPFHu8uK+QL+p4KYmSHt/Hjh0rMMj9+eef+uc//6mGDRsqNjZWjRs3Vps2bTyfnfvuLFL+zy6vpk2bKjIysth6jTH65JNPdOGFF6pSpUqqV6+eWrRo4WkvISFBa9asKbY9ybs/R/7+MyQnJ8dTx3vvvVfs5zl58mRJZf88y+P4Ke7nzU033aTw8HBlZmaqU6dOuuqqqzRq1Kh8v5giOBFyEXQeeughzw/1IUOGOFaH++xQQUJCQkq9XlFnqGrWrFlkLbVq1fI8379/v+d5enp6kdsVJiMjo9BlVatWLdM+83LXWNz7kqTatWufsk15SEtLU0JCgp588kmtW7eu2LOFx48fP+X7vEHGfWbJKRUrVlTPnj0lSdOmTcv3WbqDb3Jyslq0aHHKsvI4XkqirMe3JH3zzTdq1aqV3n77bf3555/FtvX3zy6vkhzbJ06c0BVXXKFbbrlF8+fPL3J/xbUneffnyN9vW7Z//35lZ2cX2X5Byvp5OvHzpkWLFvr0009VtWpVZWdn6+uvv9bdd9+thIQE1axZU7fccosWLVpUprrg/5jWF0GnSpUqeuihh/TMM89o+fLl+vrrr3XllVc6XVa5Kst9X6VTg/N7772nf/zjHyXarqj/WIr602FplfV9edstt9yiLVu2yLIsDRw4UDfeeKNatmypGjVqqEKFCrIsS7m5uZ737u9niPr27auPPvpIx44d0/Tp03XTTTdJkn7++WfPmf6Chp3kPV6eeeaZEv/pPjo62la9ZT0O9u7dqz59+igjI0OVKlXSI488oksvvVRnnnmmYmNjVaFCBUnSDz/8oIsvvlhS0Z9dSY7t559/Xt98840k6YILLtC9996r5ORk1a5dWxUrVvQEzvPPP1+LFi1y9FjJ+3nedttteuCBB0q0nbvf7LTnreOnJJ9Jr169dMkll2jSpEn67rvvtGjRIu3Zs0d79+7VJ598ok8++UT9+/fXmDFjTvnFAYGPkIugNHjwYL355pvat2+fhgwZUqKQW9jZjr87duyYV2r0pt27d5d4ebVq1TzPq1ev7nkeFRWlNm3aeL+4MqhWrZp27txZ7PuS/venzLzvy5t+/fVXLV68WJL05JNP6rnnnitwvaLOJLvHMkuuiQL+fobU1y6++GLVqlVLu3fv1oQJEzwh130WNyQkpMAxnnmPl/DwcJ8dL7t37y7yz/GFHd+TJ0/2jGWfOnWqLrnkkgK399ZfAYwx+vDDDyW5hqX88MMPhYam8vzLQ0nl7StjTLl/nk4dP5IUGxurO+64wzM05ZdfftH06dM1YsQI7dixQ+PHj1dSUlKJgz4CA7+yICjFxMTo0UcfleSaxWvq1Kkl2kZyXeRVlKJm/nLKihUrSrw8738s7dq185wlc19s5A/cNaakpBT559T09HTPn6DL6z/Mn3/+2fO8qIsEi5qhKTk52fN84cKFpa7B22e0Q0NDPSF29uzZ2rdvn4wx+vTTTyVJF154oerWrZtvu8aNGys2NlaSb4+Xkh7fUVFRaty4sed192dXrVq1QgOuVPRnVxr79+/3/NJ1/fXXFxpwjx49qo0bN3qlTTsqVKig1q1bS/LN5+nU8VOQli1b6vHHH9eyZcs8Z4pLOjMcAgchF0Hrvvvu84zlGzJkSLF/FnRPnZqSklLouj///LPWrVvn3UK9YP369adc3PR3Y8aMkeQKN+6pSSWpRo0aOueccyRJEydO9FwU4jR3IDl48KCmTJlS6HqjR4/2fFZFhRg78obsos7ijxo1qtBliYmJio+PlyR9+OGHOnr0aKlqyHuxU2ZmZqm2LYx7OEJWVpY+//xzLVmyxDM1bWF3yAgNDVX37t0lucLxL7/84pVaivPxxx8X+m/yr7/+0uzZsyW5pt/N++dr92d34sSJQv9Ck5GRkW963LIq6bHy4YcflmksbHno0aOHJNdfLOxcqOs+Ros6Pp06fooSHx/v+StBcRcBIvAQchG0oqOj9X//93+SXCFw1qxZRa5/wQUXSJJ27NjhOaOV15EjRzRo0CDvF+old9xxR4H/sU6cONHz3q+55pp8Fz499dRTkly3T7ruuuuKvFVZZmam3nnnHZ04ccJ7hRdg4MCBngtpHn74Yf3111/51lm7dq1eeOEFSVK9evV0zTXXlEstTZs29TwfN25cgeuMHDlS06dPL3QfISEhnr8sbN++Xf369dPJkycLXNd9y6m8qlev7hkH+ccff5Sm/EJ16NDB894mTJigiRMnSnKFlV69ehW63RNPPKHQ0FDl5ubquuuu89warSA5OTmaMGFCkeuUxJo1a/TKK6/kez07O1u33367py/vvvvuU5a7319GRkaBZ+lycnJ022235evvsqpRo4bnotdPP/20wMC3YsUKx29vmNcDDzzguaXdwIEDT/nLRUFmzpxZ4C/67p8rxR2fvj5+pk2bVuTPtG3btunXX3+V9L8THQgiTtycF7CrsMkg/i4jI8PUqVPnlEkTCjvs09PTTeXKlY3kmuJz2LBhZtmyZWb58uXm3XffNU2aNDGRkZEmKSmpRJNBFFVXcTfsd8t7Q/wtW7bkW+5e5p7Wt0WLFmbs2LFm5cqV5vvvvzd33323Z7ajmJiYAvdhjDEPPPCAZ1+1a9c2Q4cONXPnzjWrV682ixcvNuPGjTODBg0yVatWNVL+Od6Lq7Ms8k7rW6tWLfP666+b5cuXmx9//NEMGzbMMx1rQdP6unljMojc3FzTpk0bTy033HCDmTFjhlm5cqWZNm2aue6664wk06lTpyJviP/3aX2bNWtm3njjDbN48WKTkpJiZs2aZZ555hnTtGnTArd377969epm4sSJJjU11WzatMls2rTJ7Nu3z7NeSY8tY4wZOnSopw/ds15dd911xfbJ66+/7mkjNjbWPProo+abb74xKSkpZsmSJWbixInmn//8p+ffXmmnUTbm1GPKfXzfdNNN5ptvvvFMfd2xY0fPOldddVW+fWzbts0zoUBkZKT5v//7PzN37lyzYsUKM27cOHPWWWfl++wK6jP3ZBAXXHBBsXXfe++9p9Q9ceJEzzTbDz30kImMjDRxcXGmWbNmhe7TWz8f3IYMGVLkz74vv/zSM61vZGSkueuuu8z06dPNqlWrzLJly8zkyZPNY489Zho3bmwkmRkzZuTbR9++fY0kExERYUaNGmXWr1/vOT7zTjttjP3jpzTH+AUXXGCioqLM9ddfb0aOHGnmz59vVq9ebX744Qfz8ssvm/j4eM++CpoxDoGNkIuAVNKQa4wxI0aMKFHINcaYzz//3ISGhuZbX5KpWLGi+eKLL0o845kvQ+6QIUNO+Y/s74/KlSub+fPnF9pObm6uGTZsmAkLCyt0H+5HdHS0ycjIKFWdZfX88897QnpBj4iICDN+/PhCt/fWjGerV6/2BPyCHgkJCWbHjh1FhlxjXFM6u0NxUY+Ctv/66689QaSo9UsTADZt2pRvXyX9j/7999/3TL1c1KNChQrFTnNbkLzHVEpKiueXy4IenTp1MocPHy5wP2PGjCnyGOrdu7eZO3eu10LuwYMHTbt27Qptr1q1ambBggVF7tPXIdcYY7766itTrVq1Yj/PkJCQfLNJGuP6N+L+heLvj4JmkbRz/JQ25JbkPT377LNF7geBieEKCHq33367Zzxkca6//notWbJEPXv29NweKj4+Xv3799eKFSuKnRXMSUOHDtW3336rK664QrVq1VKFChXUsGFD3XPPPfr55589wzEKYlmWnnnmGf3222967LHH1L59e1WrVk2hoaGKiYlRq1at1LdvX40fP147d+5UxYoVffKennzySa1evVq33367zjzzTFWsWFHR0dFq2bKlHnjgAf3666/q169fudfRrl07rVmzRnfddZcaNGig8PBwVatWTR07dtSrr76qn376qUT3v42KitIXX3yhH374QbfccosaNWqkihUreo6zq666Su+9954efvjhfNteccUV+v7773X11Verbt26RU6SUVJNmjQ5ZaKQqlWresZMFuf222/X5s2bNWzYMHXq1ElxcXEKCwtTdHS0mjVrpl69emnUqFH666+/1KRJE1t1Vq1aVUuWLNGLL76odu3aKSYmRpUqVVKHDh00YsQILViwwHPh6N8NHDhQixYt0jXXXKMaNWooPDxcderU0WWXXaZJkybps88+8+pt72JjY/Xjjz/q2WefVUJCgiIjI1WpUiW1bNlSjzzyiNauXavzzz/fa+15y1VXXaUtW7bo1Vdf1UUXXaRatWopPDxcFStWVKNGjXTllVdq+PDhSktL04UXXphv+3bt2mnp0qW66aabdMYZZxQ5e5rku+Pn008/1fvvv68+ffqoXbt2ql27tsLCwlSpUiW1bt1ad999t1avXu0ZtoXgYhnj5zd0BACcdsaNG6eBAwdKkrZs2eKZ2Q4ASoozuQAAAAg6hFwAAAAEHUIuAAAAgg4hFwAAAEGHkAsAAICgw90VAAAAEHQ4kwsAAICgQ8gFAABA0CHkAgAAIOgQcgEAABB0CLkAAAAIOoRcAAAABB1CLgAAAIIOIRcAAABB5/8BFcEZZAGOBqUAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 800x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(8, 6))\n",
+    "ax.plot(list(result_by_sparsity.keys()), list(result_by_sparsity.values()), '.b-', label=\"sebo\", markersize=10)\n",
+    "ax.grid(True)\n",
+    "ax.set_title(f\"Branin, D={aug_dim}\", fontsize=20)\n",
+    "ax.set_xlabel(\"Number of active parameters\", fontsize=20)\n",
+    "ax.set_ylabel(\"Best value found\", fontsize=20)\n",
+    "# ax.legend(fontsize=18)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "1ba68dc9-d60b-4b39-8e58-ea9bdc06b44c",
+    "showInput": false
+   },
+   "source": [
+    "# Demo of Using GenerationStrategy and Service API \n",
+    "\n",
+    "Please check [Service API tutorial](https://ax.dev/tutorials/gpei_hartmann_service.html) for more detailed information. "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "45e5586c-55eb-4908-aa73-bca4ee883b56",
+    "showInput": false
+   },
+   "source": [
+    "## Create `GenerationStrategy`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "executionStartTime": 1689124192972,
+    "executionStopTime": 1689124192975,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "7c0bfe37-8f1f-4999-8833-42ffb2569c04",
+    "requestMsgId": "bbd9058a-709e-4262-abe1-720d37e8786f",
+    "showInput": true
+   },
+   "outputs": [],
+   "source": [
+    "gs = GenerationStrategy(\n",
+    "    name=\"SEBO_L0\",\n",
+    "    steps=[\n",
+    "        GenerationStep(  # Initialization step\n",
+    "            model=Models.SOBOL,     \n",
+    "            num_trials=N_INIT,\n",
+    "        ),\n",
+    "        GenerationStep(  # BayesOpt step\n",
+    "            model=Models.BOTORCH_MODULAR,\n",
+    "            # No limit on how many generator runs will be produced\n",
+    "            num_trials=-1,\n",
+    "            model_kwargs={  # Kwargs to pass to `BoTorchModel.__init__`\n",
+    "                \"surrogate\": Surrogate(botorch_model_class=SURROGATE_CLASS),\n",
+    "                \"acquisition_class\": SEBOAcquisition,\n",
+    "                \"botorch_acqf_class\": qNoisyExpectedHypervolumeImprovement,\n",
+    "                \"acquisition_options\": {\n",
+    "                    \"penalty\": \"L0_norm\", # it can be L0_norm or L1_norm.\n",
+    "                    \"target_point\": target_point, \n",
+    "                    \"sparsity_threshold\": aug_dim,\n",
+    "                },\n",
+    "            },\n",
+    "        )\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "e4911bc6-32cb-42a5-908f-57f3f04e58e5",
+    "showInput": false
+   },
+   "source": [
+    "## Initialize client and set up experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "executionStartTime": 1689124192979,
+    "executionStopTime": 1689124192984,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "47938102-0613-4b37-acb2-9f1f5f3fe6b1",
+    "requestMsgId": "38b4b17c-6aae-43b8-aa58-2df045f522fe",
+    "showInput": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Starting optimization with verbose logging. To disable logging, set the `verbose_logging` argument to `False`. Note that float values in the logs are rounded to 6 decimal points.\n",
+      "[INFO 09-07 16:58:10] ax.service.utils.instantiation: Created search space: SearchSpace(parameters=[RangeParameter(name='x0', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x1', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x2', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x3', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x4', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x5', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x6', parameter_type=FLOAT, range=[0.0, 1.0]), RangeParameter(name='x7', parameter_type=FLOAT, range=[0.0, 1.0])], parameter_constraints=[]).\n"
+     ]
+    }
+   ],
+   "source": [
+    "ax_client = AxClient(generation_strategy=gs)\n",
+    "\n",
+    "experiment_parameters = [\n",
+    "    {\n",
+    "        \"name\": f\"x{i}\",\n",
+    "        \"type\": \"range\",\n",
+    "        \"bounds\": [0, 1],\n",
+    "        \"value_type\": \"float\",\n",
+    "        \"log_scale\": False,\n",
+    "    }\n",
+    "    for i in range(aug_dim)\n",
+    "]\n",
+    "\n",
+    "objective_metrics = {\n",
+    "    \"objective\": ObjectiveProperties(minimize=False, threshold=-10),\n",
+    "}\n",
+    "\n",
+    "ax_client.create_experiment(\n",
+    "    name=\"branin_augment_sebo_experiment\",\n",
+    "    parameters=experiment_parameters,\n",
+    "    objectives=objective_metrics,\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "6a7942e4-9727-43d9-8d8d-c327d38c2373",
+    "showInput": false
+   },
+   "source": [
+    "## Define evaluation function "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "executionStartTime": 1689124192990,
+    "executionStopTime": 1689124192992,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "4e2994ff-36ac-4d48-a789-3d0398e1e856",
+    "requestMsgId": "8f74a775-a8ce-462d-993c-5c9291c748b9",
+    "showInput": true
+   },
+   "outputs": [],
+   "source": [
+    "def evaluation(parameters):\n",
+    "    # put parameters into 1-D array\n",
+    "    x = [parameters.get(param[\"name\"]) for param in experiment_parameters]\n",
+    "    res = branin_augment(x_vec=x, augment_dim=aug_dim)\n",
+    "    eval_res = {\n",
+    "        # flip the sign to maximize\n",
+    "        \"objective\": (res * -1, 0.0),\n",
+    "    }\n",
+    "    return eval_res"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "customInput": null,
+    "originalKey": "4597531b-7ac8-4dd0-94c4-836672e0f4c4",
+    "showInput": false
+   },
+   "source": [
+    "## Run optimization loop\n",
+    "\n",
+    "Running only 1 BO trial for demonstration. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false,
+    "customInput": null,
+    "executionStartTime": 1689124193044,
+    "executionStopTime": 1689130398208,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "originalKey": "bc7accb2-48a2-4c88-a932-7c79ec81075a",
+    "requestMsgId": "f054e5b1-12eb-459b-a508-6944baf82dfb",
+    "showInput": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Generated new trial 0 with parameters {'x0': 0.855412, 'x1': 0.843304, 'x2': 0.539811, 'x3': 0.677753, 'x4': 0.984633, 'x5': 0.410373, 'x6': 0.815671, 'x7': 0.403255}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Completed trial 0 with data: {'objective': (-135.451198, 0.0)}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Generated new trial 1 with parameters {'x0': 0.189944, 'x1': 0.800578, 'x2': 0.071822, 'x3': 0.895905, 'x4': 0.077662, 'x5': 0.256718, 'x6': 0.829401, 'x7': 0.777747}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Completed trial 1 with data: {'objective': (-8.689241, 0.0)}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Generated new trial 2 with parameters {'x0': 0.998764, 'x1': 0.749793, 'x2': 0.951167, 'x3': 0.483164, 'x4': 0.216034, 'x5': 0.013638, 'x6': 0.14137, 'x7': 0.746281}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Completed trial 2 with data: {'objective': (-70.113099, 0.0)}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Generated new trial 3 with parameters {'x0': 0.594559, 'x1': 0.150197, 'x2': 0.539827, 'x3': 0.616142, 'x4': 0.846122, 'x5': 0.211888, 'x6': 0.299617, 'x7': 0.825836}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Completed trial 3 with data: {'objective': (-3.407976, 0.0)}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Generated new trial 4 with parameters {'x0': 0.165938, 'x1': 0.332497, 'x2': 0.836972, 'x3': 0.73132, 'x4': 0.580262, 'x5': 0.407918, 'x6': 0.761584, 'x7': 0.733809}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Completed trial 4 with data: {'objective': (-36.155637, 0.0)}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Generated new trial 5 with parameters {'x0': 0.171989, 'x1': 0.180371, 'x2': 0.112051, 'x3': 0.919738, 'x4': 0.712023, 'x5': 0.913378, 'x6': 0.729944, 'x7': 0.11163}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Completed trial 5 with data: {'objective': (-65.245844, 0.0)}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Generated new trial 6 with parameters {'x0': 0.868458, 'x1': 0.39993, 'x2': 0.372801, 'x3': 0.253683, 'x4': 0.156089, 'x5': 0.996918, 'x6': 0.035147, 'x7': 0.379257}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Completed trial 6 with data: {'objective': (-28.156639, 0.0)}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Generated new trial 7 with parameters {'x0': 0.506108, 'x1': 0.958914, 'x2': 0.918143, 'x3': 0.385513, 'x4': 0.511529, 'x5': 0.818457, 'x6': 0.291341, 'x7': 0.301845}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Completed trial 7 with data: {'objective': (-137.320621, 0.0)}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Generated new trial 8 with parameters {'x0': 0.658366, 'x1': 0.812094, 'x2': 0.267501, 'x3': 0.064048, 'x4': 0.440092, 'x5': 0.223525, 'x6': 0.660195, 'x7': 0.05373}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Completed trial 8 with data: {'objective': (-129.720931, 0.0)}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Generated new trial 9 with parameters {'x0': 0.521977, 'x1': 0.30404, 'x2': 0.867921, 'x3': 0.812355, 'x4': 0.102222, 'x5': 0.981173, 'x6': 0.358049, 'x7': 0.947661}.\n",
+      "[INFO 09-07 16:58:10] ax.service.ax_client: Completed trial 9 with data: {'objective': (-4.981193, 0.0)}.\n",
+      "[INFO 09-07 16:58:28] ax.service.ax_client: Generated new trial 10 with parameters {'x0': 0.0, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 1.0}.\n",
+      "[INFO 09-07 16:58:28] ax.service.ax_client: Completed trial 10 with data: {'objective': (-308.129096, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 2 with parameters {'x0': 0.310899, 'x1': 0.906665, 'x2': 0.859498, 'x3': 0.861769, 'x4': 0.565173, 'x5': 0.849893, 'x6': 0.743119, 'x7': 0.485293}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 2 with data: {'objective': (-68.762484, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 3 with parameters {'x0': 0.222246, 'x1': 0.682503, 'x2': 0.697094, 'x3': 0.262685, 'x4': 0.660106, 'x5': 0.783381, 'x6': 0.537969, 'x7': 0.607574}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 3 with data: {'objective': (-10.589478, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 4 with parameters {'x0': 0.391554, 'x1': 0.769673, 'x2': 0.363151, 'x3': 0.522279, 'x4': 0.8752, 'x5': 0.921642, 'x6': 0.892081, 'x7': 0.614701}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 4 with data: {'objective': (-62.905011, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 5 with parameters {'x0': 0.319981, 'x1': 0.578814, 'x2': 0.58387, 'x3': 0.310305, 'x4': 0.198673, 'x5': 0.78394, 'x6': 0.423361, 'x7': 0.853005}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 5 with data: {'objective': (-24.971551, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 6 with parameters {'x0': 0.889574, 'x1': 0.540804, 'x2': 0.668386, 'x3': 0.511087, 'x4': 0.587279, 'x5': 0.966997, 'x6': 0.699696, 'x7': 0.919272}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 6 with data: {'objective': (-46.419155, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 7 with parameters {'x0': 0.816103, 'x1': 0.454254, 'x2': 0.498263, 'x3': 0.609042, 'x4': 0.080031, 'x5': 0.321146, 'x6': 0.505942, 'x7': 0.386978}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 7 with data: {'objective': (-46.485345, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 8 with parameters {'x0': 0.687349, 'x1': 0.282216, 'x2': 0.751967, 'x3': 0.566662, 'x4': 0.79098, 'x5': 0.641958, 'x6': 0.724017, 'x7': 0.590121}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 8 with data: {'objective': (-24.65791, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Generated new trial 9 with parameters {'x0': 0.130133, 'x1': 0.712254, 'x2': 0.760572, 'x3': 0.411107, 'x4': 0.542096, 'x5': 0.526756, 'x6': 0.787764, 'x7': 0.674992}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:09:53] ax.service.ax_client: Completed trial 9 with data: {'objective': (-2.309687, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:11:36] ax.service.ax_client: Generated new trial 10 with parameters {'x0': 0.0, 'x1': 0.0, 'x2': 1.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.892852}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:11:36] ax.service.ax_client: Completed trial 10 with data: {'objective': (-308.129096, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:13:39] ax.service.ax_client: Generated new trial 11 with parameters {'x0': 0.0, 'x1': 0.640271, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.946358, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:13:39] ax.service.ax_client: Completed trial 11 with data: {'objective': (-70.230069, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:15:44] ax.service.ax_client: Generated new trial 12 with parameters {'x0': 0.0, 'x1': 0.519038, 'x2': 1.0, 'x3': 0.0, 'x4': 1.0, 'x5': 0.0, 'x6': 0.870499, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:15:44] ax.service.ax_client: Completed trial 12 with data: {'objective': (-101.117533, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:17:37] ax.service.ax_client: Generated new trial 13 with parameters {'x0': 0.0, 'x1': 0.0, 'x2': 0.0, 'x3': 1.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.727362, 'x7': 1.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:17:37] ax.service.ax_client: Completed trial 13 with data: {'objective': (-308.129096, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:19:31] ax.service.ax_client: Generated new trial 14 with parameters {'x0': 0.0, 'x1': 0.784581, 'x2': 1.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.700215, 'x6': 0.0, 'x7': 0.724654}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:19:31] ax.service.ax_client: Completed trial 14 with data: {'objective': (-42.085428, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:21:33] ax.service.ax_client: Generated new trial 15 with parameters {'x0': 0.0, 'x1': 0.710437, 'x2': 0.953762, 'x3': 0.0, 'x4': 0.0, 'x5': 0.662267, 'x6': 1.0, 'x7': 0.840749}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:21:33] ax.service.ax_client: Completed trial 15 with data: {'objective': (-55.375218, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:23:43] ax.service.ax_client: Generated new trial 16 with parameters {'x0': 0.0, 'x1': 0.712456, 'x2': 0.0, 'x3': 0.0, 'x4': 1.0, 'x5': 0.628146, 'x6': 0.0, 'x7': 0.846157}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:23:43] ax.service.ax_client: Completed trial 16 with data: {'objective': (-54.980534, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:26:09] ax.service.ax_client: Generated new trial 17 with parameters {'x0': 1.0, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:26:09] ax.service.ax_client: Completed trial 17 with data: {'objective': (-10.960889, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:28:06] ax.service.ax_client: Generated new trial 18 with parameters {'x0': 1.0, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 1.0, 'x6': 0.0, 'x7': 1.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:28:06] ax.service.ax_client: Completed trial 18 with data: {'objective': (-10.960889, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:29:44] ax.service.ax_client: Generated new trial 19 with parameters {'x0': 0.770094, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:29:44] ax.service.ax_client: Completed trial 19 with data: {'objective': (-20.508312, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:31:30] ax.service.ax_client: Generated new trial 20 with parameters {'x0': 0.137802, 'x1': 0.779453, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:31:30] ax.service.ax_client: Completed trial 20 with data: {'objective': (-0.613746, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:33:09] ax.service.ax_client: Generated new trial 21 with parameters {'x0': 0.536321, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:33:09] ax.service.ax_client: Completed trial 21 with data: {'objective': (-5.973257, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:34:47] ax.service.ax_client: Generated new trial 22 with parameters {'x0': 0.503722, 'x1': 0.219186, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:34:47] ax.service.ax_client: Completed trial 22 with data: {'objective': (-2.260464, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:36:41] ax.service.ax_client: Generated new trial 23 with parameters {'x0': 1.0, 'x1': 0.281918, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:36:41] ax.service.ax_client: Completed trial 23 with data: {'objective': (-3.445743, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:38:29] ax.service.ax_client: Generated new trial 24 with parameters {'x0': 0.549118, 'x1': 0.133697, 'x2': 0.0, 'x3': 1.0, 'x4': 0.0, 'x5': 1.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:38:29] ax.service.ax_client: Completed trial 24 with data: {'objective': (-0.479951, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:40:18] ax.service.ax_client: Generated new trial 25 with parameters {'x0': 0.080214, 'x1': 1.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:40:19] ax.service.ax_client: Completed trial 25 with data: {'objective': (-3.585129, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:42:08] ax.service.ax_client: Generated new trial 26 with parameters {'x0': 1.0, 'x1': 1.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:42:08] ax.service.ax_client: Completed trial 26 with data: {'objective': (-145.872191, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:44:13] ax.service.ax_client: Generated new trial 27 with parameters {'x0': 0.542029, 'x1': 0.136864, 'x2': 0.0, 'x3': 0.0, 'x4': 1.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:44:14] ax.service.ax_client: Completed trial 27 with data: {'objective': (-0.451738, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:46:25] ax.service.ax_client: Generated new trial 28 with parameters {'x0': 0.117749, 'x1': 0.847684, 'x2': 0.0, 'x3': 0.0, 'x4': 1.0, 'x5': 1.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:46:25] ax.service.ax_client: Completed trial 28 with data: {'objective': (-0.486016, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:48:39] ax.service.ax_client: Generated new trial 29 with parameters {'x0': 0.122207, 'x1': 0.831379, 'x2': 1.0, 'x3': 1.0, 'x4': 1.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:48:39] ax.service.ax_client: Completed trial 29 with data: {'objective': (-0.41913, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:51:07] ax.service.ax_client: Generated new trial 30 with parameters {'x0': 0.608958, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:51:07] ax.service.ax_client: Completed trial 30 with data: {'objective': (-7.404426, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:53:20] ax.service.ax_client: Generated new trial 31 with parameters {'x0': 0.532365, 'x1': 0.141486, 'x2': 0.0, 'x3': 1.0, 'x4': 0.0, 'x5': 0.0, 'x6': 1.0, 'x7': 1.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:53:20] ax.service.ax_client: Completed trial 31 with data: {'objective': (-0.591731, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:55:48] ax.service.ax_client: Generated new trial 32 with parameters {'x0': 0.950988, 'x1': 0.171879, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:55:48] ax.service.ax_client: Completed trial 32 with data: {'objective': (-0.575591, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:58:07] ax.service.ax_client: Generated new trial 33 with parameters {'x0': 0.973297, 'x1': 0.183923, 'x2': 1.0, 'x3': 0.0, 'x4': 1.0, 'x5': 1.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 18:58:07] ax.service.ax_client: Completed trial 33 with data: {'objective': (-0.561572, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:00:53] ax.service.ax_client: Generated new trial 34 with parameters {'x0': 0.972473, 'x1': 0.184526, 'x2': 0.0, 'x3': 1.0, 'x4': 0.0, 'x5': 0.0, 'x6': 1.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:00:53] ax.service.ax_client: Completed trial 34 with data: {'objective': (-0.547382, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:03:58] ax.service.ax_client: Generated new trial 35 with parameters {'x0': 0.543579, 'x1': 0.145004, 'x2': 1.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:03:58] ax.service.ax_client: Completed trial 35 with data: {'objective': (-0.406784, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:08:04] ax.service.ax_client: Generated new trial 36 with parameters {'x0': 0.56372, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:08:04] ax.service.ax_client: Completed trial 36 with data: {'objective': (-5.040681, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:10:39] ax.service.ax_client: Generated new trial 37 with parameters {'x0': 0.128424, 'x1': 0.814467, 'x2': 1.0, 'x3': 0.0, 'x4': 0.0, 'x5': 1.0, 'x6': 0.0, 'x7': 1.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:10:39] ax.service.ax_client: Completed trial 37 with data: {'objective': (-0.431012, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:13:21] ax.service.ax_client: Generated new trial 38 with parameters {'x0': 0.967249, 'x1': 0.189143, 'x2': 0.0, 'x3': 1.0, 'x4': 1.0, 'x5': 0.0, 'x6': 0.0, 'x7': 1.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:13:21] ax.service.ax_client: Completed trial 38 with data: {'objective': (-0.516046, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:17:03] ax.service.ax_client: Generated new trial 39 with parameters {'x0': 0.563272, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:17:03] ax.service.ax_client: Completed trial 39 with data: {'objective': (-5.040172, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:20:43] ax.service.ax_client: Generated new trial 40 with parameters {'x0': 0.111004, 'x1': 0.841851, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:20:43] ax.service.ax_client: Completed trial 40 with data: {'objective': (-0.590424, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:24:20] ax.service.ax_client: Generated new trial 41 with parameters {'x0': 0.563578, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:24:20] ax.service.ax_client: Completed trial 41 with data: {'objective': (-5.040465, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:27:24] ax.service.ax_client: Generated new trial 42 with parameters {'x0': 1.0, 'x1': 0.173494, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:27:24] ax.service.ax_client: Completed trial 42 with data: {'objective': (-2.103578, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:30:34] ax.service.ax_client: Generated new trial 43 with parameters {'x0': 0.563448, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:30:34] ax.service.ax_client: Completed trial 43 with data: {'objective': (-5.040312, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:34:21] ax.service.ax_client: Generated new trial 44 with parameters {'x0': 0.563267, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:34:21] ax.service.ax_client: Completed trial 44 with data: {'objective': (-5.04017, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:38:27] ax.service.ax_client: Generated new trial 45 with parameters {'x0': 0.563496, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:38:27] ax.service.ax_client: Completed trial 45 with data: {'objective': (-5.040364, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:41:52] ax.service.ax_client: Generated new trial 46 with parameters {'x0': 0.563076, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:41:52] ax.service.ax_client: Completed trial 46 with data: {'objective': (-5.040109, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:45:10] ax.service.ax_client: Generated new trial 47 with parameters {'x0': 0.563165, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:45:10] ax.service.ax_client: Completed trial 47 with data: {'objective': (-5.040126, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:48:48] ax.service.ax_client: Generated new trial 48 with parameters {'x0': 0.562984, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:48:48] ax.service.ax_client: Completed trial 48 with data: {'objective': (-5.040112, 0.0)}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:53:17] ax.service.ax_client: Generated new trial 49 with parameters {'x0': 0.563213, 'x1': 0.0, 'x2': 0.0, 'x3': 0.0, 'x4': 0.0, 'x5': 0.0, 'x6': 0.0, 'x7': 0.0}.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO 07-11 19:53:17] ax.service.ax_client: Completed trial 49 with data: {'objective': (-5.040143, 0.0)}.\n"
+     ]
+    }
+   ],
+   "source": [
+    "for _ in range(N_INIT + 1):    \n",
+    "    parameters, trial_index = ax_client.get_next_trial()\n",
+    "    res = evaluation(parameters)\n",
+    "    ax_client.complete_trial(trial_index=trial_index, raw_data=res)"
+   ]
+  }
+ ],
+ "metadata": {
+  "fileHeader": "",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Updates the SEBO tutorial to run 4 batches of 5 trials, reducing the # of times the model needs to be fit significantly. Also reduces the # of trials in Service API example to speed things up further.