### PR TITLE
Fix smoke test for SEBO tutorial

### DIFF
--- a/tutorials/sebo.ipynb
+++ b/tutorials/sebo.ipynb
@@ -255,7 +255,7 @@
     "if SMOKE_TEST:\n",
     "    N_BATCHES = 1\n",
     "    BATCH_SIZE = 1\n",
-    "    SURROGATE_CLASS = SingleTaskGP\n",
+    "    SURROGATE_CLASS = None  # Auto-pick SingleTaskGP / FixedNoiseGP\n",
     "else:\n",
     "    N_BATCHES = 4\n",
     "    BATCH_SIZE = 5\n",


### PR DESCRIPTION
For the AxClient parts, this was returning noise levels but using `SingleTaskGP`, which doesn't accept `train_Yvar`. Leaving the model type as `None` should dispatch the correct model type.

Test Plan: https://github.com/facebook/Ax/actions/runs/6117752845