### PR TITLE
Fix naming of reusable tutorials workflow

### DIFF
--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -20,8 +20,8 @@ on:
 
 jobs:
 
-  build-tutorials-with-pinned-botorch:
-    name: Tutorials with pinned BoTorch
+  build-tutorials:
+    name: Tutorials
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This was calling itself "Tutorials with pinned BoTorch" despite supporting both pinned & latest BoTorch. Updating the name to clear up the confusion.

Confusing naming before this: https://github.com/facebook/Ax/actions/runs/6117752845
No longer calling itself pinned while running latest: https://github.com/facebook/Ax/actions/runs/6117768518