### PR TITLE
Update tutorial execution to eliminate SIGTERM

### DIFF
--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -30,20 +30,20 @@ jobs:
       with:
         python-version: "3.9"
 
-    - if: ${{ inputs.pinned_botorch }}
-      name: Install dependencies with pinned BoTorch
-      run: |
-        pip install -e ".[tutorial]"
+    # - if: ${{ inputs.pinned_botorch }}
+    #   name: Install dependencies with pinned BoTorch
+    #   run: |
+    #     pip install -e ".[tutorial]"
 
-    - if: ${{ !inputs.pinned_botorch }}
-      name: Install dependencies with latest BoTorch
-      env:
-        ALLOW_BOTORCH_LATEST: true
-        ALLOW_LATEST_GPYTORCH_LINOP: true
-      run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ".[tutorial]"
+    # - if: ${{ !inputs.pinned_botorch }}
+    #   name: Install dependencies with latest BoTorch
+    #   env:
+    #     ALLOW_BOTORCH_LATEST: true
+    #     ALLOW_LATEST_GPYTORCH_LINOP: true
+    #   run: |
+    #     pip install git+https://github.com/cornellius-gp/gpytorch.git
+    #     pip install git+https://github.com/pytorch/botorch.git
+    #     pip install -e ".[tutorial]"
 
     - if: ${{ inputs.smoke_test }}
       name: Build tutorials with smoke test

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -30,20 +30,20 @@ jobs:
       with:
         python-version: "3.9"
 
-    # - if: ${{ inputs.pinned_botorch }}
-    #   name: Install dependencies with pinned BoTorch
-    #   run: |
-    #     pip install -e ".[tutorial]"
+    - if: ${{ inputs.pinned_botorch }}
+      name: Install dependencies with pinned BoTorch
+      run: |
+        pip install -e ".[tutorial]"
 
-    # - if: ${{ !inputs.pinned_botorch }}
-    #   name: Install dependencies with latest BoTorch
-    #   env:
-    #     ALLOW_BOTORCH_LATEST: true
-    #     ALLOW_LATEST_GPYTORCH_LINOP: true
-    #   run: |
-    #     pip install git+https://github.com/cornellius-gp/gpytorch.git
-    #     pip install git+https://github.com/pytorch/botorch.git
-    #     pip install -e ".[tutorial]"
+    - if: ${{ !inputs.pinned_botorch }}
+      name: Install dependencies with latest BoTorch
+      env:
+        ALLOW_BOTORCH_LATEST: true
+        ALLOW_LATEST_GPYTORCH_LINOP: true
+      run: |
+        pip install git+https://github.com/cornellius-gp/gpytorch.git
+        pip install git+https://github.com/pytorch/botorch.git
+        pip install -e ".[tutorial]"
 
     - if: ${{ inputs.smoke_test }}
       name: Build tutorials with smoke test

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -158,17 +158,19 @@ def gen_tutorials(
         # track total exec time (non-None if exec_on_build=True)
         total_time = None
 
-        if exec_tutorials and exec_on_build and False:
+        if exec_tutorials and exec_on_build:
             print("Executing tutorial {}".format(tid))
             kwargs = {"kernel_name": kernel_name} if kernel_name is not None else {}
             # 2.5 hours, in seconds; 1 hour if smoke test mode
             timeout = int(60 * 60) if smoke_test else int(60 * 60 * 2.5)
+            print("initializing execute processor")
             ep = ExecutePreprocessor(timeout=timeout, **kwargs)
             start_time = time.time()
 
             # try / catch failures for now
             # will re-raise at the end
             try:
+                print("In executing tutorial")
                 # execute notebook, using `tutorial_dir` as working directory
                 ep.preprocess(nb, {"metadata": {"path": paths["tutorial_dir"]}})
                 total_time = time.time() - start_time
@@ -178,6 +180,7 @@ def gen_tutorials(
                     )
                 )
             except Exception as exc:
+                print("CAUGHT AN EXCEPTION")
                 has_errors = True
                 print("Couldn't execute tutorial {}!".format(tid))
                 print(exc)

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -117,12 +117,11 @@ def gen_tutorials(
     download.
     """
     print("In gen_tutorials")
-    return
     has_errors = False
 
     with open(os.path.join(repo_dir, "website", "tutorials.json"), "r") as infile:
         tutorial_config = json.loads(infile.read())
-
+    print("past json loads")
     # flatten config dict
     tutorial_configs = [
         config for category in tutorial_config.values() for config in category
@@ -132,13 +131,14 @@ def gen_tutorials(
         tutorial_configs = [d for d in tutorial_configs if d["id"] == name]
         if len(tutorial_configs) == 0:
             raise RuntimeError(f"No tutorial found with name {name}.")
-
+    print("making dirs")
     # prepare paths for converted tutorials & files
     os.makedirs(os.path.join(repo_dir, "website", "_tutorials"), exist_ok=True)
     os.makedirs(os.path.join(repo_dir, "website", "static", "files"), exist_ok=True)
     if smoke_test:
         os.environ["SMOKE_TEST"] = str(smoke_test)
 
+    return
     for config in tutorial_configs:
         tid = config["id"]
         t_dir = config.get("dir")

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -12,6 +12,7 @@ import tarfile
 import time
 from pathlib import Path
 from typing import Dict, Optional
+
 import nbformat
 from bs4 import BeautifulSoup
 from nbconvert import HTMLExporter, ScriptExporter

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -115,7 +115,7 @@ def run_script(
         capture_output=True,
         text=True,
         env=env,
-        # timeout=timeout_minutes * 60,  # TODO: utilize time out.
+        timeout=timeout_minutes * 60,
     )
     return run_out
 
@@ -171,8 +171,10 @@ def gen_tutorials(
             # try / catch failures for now
             # will re-raise at the end
             try:
-                # Execute notebook. TODO: use timeout in the future.
-                run_script(tutorial=tutorial_path, timeout_minutes=None)
+                # Execute notebook.
+                # TODO: [T163244135] Speed up tutorials and reduce timeout limits.
+                timeout_minutes = 15 if smoke_test else 150
+                run_script(tutorial=tutorial_path, timeout_minutes=timeout_minutes)
                 total_time = time.time() - start_time
                 print(
                     "Done executing tutorial {}. Took {:.2f} seconds.".format(

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -138,8 +138,8 @@ def gen_tutorials(
     if smoke_test:
         os.environ["SMOKE_TEST"] = str(smoke_test)
 
-    return
     for config in tutorial_configs:
+        print("entering loop")
         tid = config["id"]
         t_dir = config.get("dir")
         exec_on_build = config.get("exec_on_build", True)
@@ -147,16 +147,18 @@ def gen_tutorials(
         print("Generating {} tutorial".format(tid))
 
         paths = _get_paths(repo_dir=repo_dir, t_dir=t_dir, tid=tid)
+        print("got paths")
 
         # load notebook
         with open(paths["tutorial_path"], "r") as infile:
             nb_str = infile.read()
             nb = nbformat.reads(nb_str, nbformat.NO_CONVERT)
+        print("loaded notebook")
 
         # track total exec time (non-None if exec_on_build=True)
         total_time = None
 
-        if exec_tutorials and exec_on_build:
+        if exec_tutorials and exec_on_build and False:
             print("Executing tutorial {}".format(tid))
             kwargs = {"kernel_name": kernel_name} if kernel_name is not None else {}
             # 2.5 hours, in seconds; 1 hour if smoke test mode
@@ -184,12 +186,14 @@ def gen_tutorials(
         # convert notebook to HTML
         exporter = HTMLExporter(template_name="classic")
         html, _ = exporter.from_notebook_node(nb)
+        print("converted to html")
 
         # pull out html div for notebook
         soup = BeautifulSoup(html, "html.parser")
         nb_meat = soup.find("div", {"id": "notebook-container"})
         del nb_meat.attrs["id"]
         nb_meat.attrs["class"] = ["notebook"]
+        print("made into soup")
 
         # when output html, iframe it (useful for Ax reports)
         for html_div in nb_meat.findAll("div", {"class": "output_html"}):
@@ -201,12 +205,14 @@ def gen_tutorials(
                 # replace `#` in CSS
                 iframe.attrs["src"] = iframe.attrs["src"].replace("#", "%23")
                 html_div.contents = [iframe]
+        print("made it into iframe")
 
         html_out = MOCK_JS_REQUIRES + str(nb_meat)
 
         # generate HTML file
         with open(paths["html_path"], "w") as html_outfile:
             html_outfile.write(html_out)
+        print("wrote to html outfile")
 
         # generate JS file
         t_dir_js = t_dir if t_dir else ""
@@ -217,6 +223,7 @@ def gen_tutorials(
         )
         with open(paths["js_path"], "w") as js_outfile:
             js_outfile.write(script)
+        print("generated js file")
 
         # output tutorial in both ipynb & py form
         nbformat.write(nb, paths["ipynb_path"])
@@ -224,6 +231,7 @@ def gen_tutorials(
         script, _ = exporter.from_notebook_node(nb)
         with open(paths["py_path"], "w") as py_outfile:
             py_outfile.write(script)
+        print("wrote to py outfile")
 
         # create .tar archive (if necessary)
         if t_dir is not None:
@@ -232,6 +240,7 @@ def gen_tutorials(
                     paths["tutorial_dir"],
                     arcname=os.path.basename(paths["tutorial_dir"]),
                 )
+        print("added to tar")
 
     if has_errors:
         raise Exception("There are errors in tutorials, will not continue to publish")

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -172,7 +172,7 @@ def gen_tutorials(
             try:
                 print("In executing tutorial")
                 # execute notebook, using `tutorial_dir` as working directory
-                ep.preprocess(nb, {"metadata": {"path": paths["tutorial_dir"]}})
+                # ep.preprocess(nb, {"metadata": {"path": paths["tutorial_dir"]}})
                 total_time = time.time() - start_time
                 print(
                     "Done executing tutorial {}. Took {:.2f} seconds.".format(

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -165,9 +165,6 @@ def gen_tutorials(
         if exec_tutorials and exec_on_build:
             tutorial_path = Path(paths["tutorial_path"])
             print("Executing tutorial {}".format(tid))
-            kwargs = {"kernel_name": kernel_name} if kernel_name is not None else {}
-            # 2.5 hours, in seconds; 1 hour if smoke test mode
-            timeout = int(60 * 60) if smoke_test else int(60 * 60 * 2.5)  # NOTE: unused!
             start_time = time.time()
 
             # try / catch failures for now

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -11,10 +11,10 @@ import tarfile
 import time
 from typing import Dict, Optional
 
-import nbformat
-from bs4 import BeautifulSoup
-from nbconvert import HTMLExporter, ScriptExporter
-from nbconvert.preprocessors import ExecutePreprocessor
+# import nbformat
+# from bs4 import BeautifulSoup
+# from nbconvert import HTMLExporter, ScriptExporter
+# from nbconvert.preprocessors import ExecutePreprocessor
 
 
 TEMPLATE = """const CWD = process.cwd();

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -15,7 +15,6 @@ from typing import Dict, Optional
 import nbformat
 from bs4 import BeautifulSoup
 from nbconvert import HTMLExporter, ScriptExporter
-from nbconvert.preprocessors import ExecutePreprocessor
 
 
 TEMPLATE = """const CWD = process.cwd();

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -268,10 +268,10 @@ if __name__ == "__main__":
         "to specify --include-ignored.",
     )
     args = parser.parse_args()
-    gen_tutorials(
-        args.repo_dir,
-        args.exec_tutorials,
-        args.kernel_name,
-        smoke_test=args.smoke,
-        name=args.name,
-    )
+    # gen_tutorials(
+    #     args.repo_dir,
+    #     args.exec_tutorials,
+    #     args.kernel_name,
+    #     smoke_test=args.smoke,
+    #     name=args.name,
+    # )

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -11,10 +11,10 @@ import tarfile
 import time
 from typing import Dict, Optional
 
-# import nbformat
-# from bs4 import BeautifulSoup
-# from nbconvert import HTMLExporter, ScriptExporter
-# from nbconvert.preprocessors import ExecutePreprocessor
+import nbformat
+from bs4 import BeautifulSoup
+from nbconvert import HTMLExporter, ScriptExporter
+from nbconvert.preprocessors import ExecutePreprocessor
 
 
 TEMPLATE = """const CWD = process.cwd();
@@ -116,6 +116,8 @@ def gen_tutorials(
     Also create ipynb and py versions of tutorial in Docusaurus site for
     download.
     """
+    print("In gen_tutorials")
+    return
     has_errors = False
 
     with open(os.path.join(repo_dir, "website", "tutorials.json"), "r") as infile:
@@ -268,10 +270,10 @@ if __name__ == "__main__":
         "to specify --include-ignored.",
     )
     args = parser.parse_args()
-    # gen_tutorials(
-    #     args.repo_dir,
-    #     args.exec_tutorials,
-    #     args.kernel_name,
-    #     smoke_test=args.smoke,
-    #     name=args.name,
-    # )
+    gen_tutorials(
+        args.repo_dir,
+        args.exec_tutorials,
+        args.kernel_name,
+        smoke_test=args.smoke,
+        name=args.name,
+    )

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ TUTORIAL_REQUIRES = UNITTEST_REQUIRES + [
     "matplotlib",  # Required for building Multi-objective tutorial notebook.
     "pyro-ppl",  # Required for to call run_inference.
     "pytorch-lightning",  # For the early stopping tutorial.
+    "papermill",  # For executing the tutorials.
 ]
 
 


### PR DESCRIPTION
The current tutorial script hangs for a while and produces
```
*** SIGTERM received at time=1694205109 on cpu 0 ***
PC: @     0x7f5698ffcfde  (unknown)  epoll_wait
    @     0x7f5698f19520  (unknown)  (unknown)
[2023-09-08 20:31:49,723 E 2808 2808] logging.cc:361: *** SIGTERM received at time=1694205109 on cpu 0 ***
[2023-09-08 20:31:49,723 E 2808 2808] logging.cc:361: PC: @     0x7f5698ffcfde  (unknown)  epoll_wait
[2023-09-08 20:31:49,723 E 2808 2808] logging.cc:361:     @     0x7f5698f19520  (unknown)  (unknown)
```
before moving onto executing the tutorials. Identified `ExecutePreprocessor` as the source of this and replaced it with `papermill` (code borrowed from BoTorch) to eliminate the issue.

Example workflow before this diff: https://github.com/facebook/Ax/actions/runs/6125894824/job/16628813894
Workflow with this diff: https://github.com/facebook/Ax/actions/runs/6126463133/job/16630514050
The new one ran significantly faster!