### PR TITLE
Temporal Kernel

### DIFF
--- a/ax/models/torch/botorch_modular/kernels.py
+++ b/ax/models/torch/botorch_modular/kernels.py
@@ -6,10 +6,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 import torch
+from ax.exceptions.core import AxError
 from gpytorch.constraints import Interval
+from gpytorch.kernels import PeriodicKernel
 from gpytorch.kernels.matern_kernel import MaternKernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
 from gpytorch.priors.torch_priors import Prior
@@ -46,6 +48,97 @@ class ScaleMaternKernel(ScaleKernel):
         )
         super().__init__(
             base_kernel=base_kernel,
+            outputscale_prior=outputscale_prior,
+            outputscale_constraint=outputscale_constraint,
+            **kwargs,
+        )
+
+
+class TemporalKernel(ScaleKernel):
+    """A product kernel of a periodic kernel and a Matern kernel.
+
+    The periodic kernel computes the similarity between temporal
+    features such as the time of day.
+
+    The Matern kernel computes the similarity between the tunable
+    parameters.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        temporal_features: List[int],
+        matern_ard_num_dims: Optional[int] = None,
+        batch_shape: Optional[torch.Size] = None,
+        lengthscale_prior: Optional[Prior] = None,
+        temporal_lengthscale_prior: Optional[Prior] = None,
+        period_length_prior: Optional[Prior] = None,
+        fixed_period_length: Optional[float] = None,
+        outputscale_prior: Optional[Prior] = None,
+        lengthscale_constraint: Optional[Interval] = None,
+        outputscale_constraint: Optional[Interval] = None,
+        temporal_lengthscale_constraint: Optional[Interval] = None,
+        period_length_constraint: Optional[Interval] = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            dim: The input dimension.
+            temporal_features: The features to pass to the periodic kernel.
+            matern_ard_num_dims: The number of lengthscales. This must be
+                equal to the total number of parameters (excluding
+                temporal parameters)
+            batch_shape: The batch shape.
+            lengthscale_prior: The prior over the lengthscale parameters.
+            temporal_lengthscale_prior: The prior over the lengthscale parameters
+                for the periodic kernel.
+            period_length_prior: The prior over the period length.
+            fixed_period_length: A fixed period length for the periodic kernel.
+                If provided, the period length will not be tuned with the other
+                hyperparameters.
+            outputscale_prior: The prior over the scaling parameter.
+            lengthscale_constraint: Optionally provide a lengthscale constraint.
+            outputscale_constraint: Optionally provide a output scale constraint.
+            temporal_lengthscale_constraint: Optionally provide a
+            lengthscale constraint for the periodic kernel.period_length_constraint:
+                Optionally provide a constraint for the period length.
+
+        """
+        if len(temporal_features) == 0:
+            raise AxError(
+                "The temporal kernel should only be used if there "
+                "are temporal features."
+            )
+        if fixed_period_length is not None and (
+            period_length_prior is not None or period_length_constraint is not None
+        ):
+            raise ValueError(
+                "If `fixed_period_length` is provided, then `period_length_prior` "
+                "and `period_length_constraint` are not used."
+            )
+        non_temporal_dims = sorted(set(range(dim)) - set(temporal_features))
+        matern_kernel = MaternKernel(
+            nu=2.5,
+            ard_num_dims=matern_ard_num_dims,
+            lengthscale_prior=lengthscale_prior,
+            active_dims=non_temporal_dims,
+            batch_shape=batch_shape,
+            lengthscale_constraint=lengthscale_constraint,
+        )
+        periodic_kernel = PeriodicKernel(
+            ard_num_dims=len(temporal_features),
+            active_dims=temporal_features,
+            lengthscale_prior=temporal_lengthscale_prior,
+            period_length_prior=period_length_prior,
+            lengthscale_constraint=temporal_lengthscale_constraint,
+            period_length_constraint=period_length_constraint,
+            batch_shape=batch_shape,
+        )
+        if fixed_period_length is not None:
+            periodic_kernel.raw_period_length.requires_grad_(False)
+            periodic_kernel.period_length = fixed_period_length
+        super().__init__(
+            base_kernel=matern_kernel * periodic_kernel,
             outputscale_prior=outputscale_prior,
             outputscale_constraint=outputscale_constraint,
             **kwargs,

--- a/ax/models/torch/tests/test_kernels.py
+++ b/ax/models/torch/tests/test_kernels.py
@@ -6,10 +6,14 @@
 
 from __future__ import annotations
 
+from itertools import product
+
 import torch
-from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
+from ax.exceptions.core import AxError
+from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel, TemporalKernel
 from ax.utils.common.testutils import TestCase
-from gpytorch.kernels import MaternKernel
+from gpytorch.constraints import Positive
+from gpytorch.kernels import MaternKernel, PeriodicKernel
 from gpytorch.priors import GammaPrior
 
 
@@ -29,3 +33,113 @@ class KernelsTest(TestCase):
         self.assertEqual(covar.outputscale_prior.rate, 0.15)
         self.assertEqual(covar.outputscale_prior.concentration, 2.0)
         self.assertEqual(covar.base_kernel.batch_shape[0], 2)
+
+    def test_temporal_kernel(self) -> None:
+        ls_prior = GammaPrior(6.0, 3.0)
+        os_prior = GammaPrior(2.0, 0.15)
+        tls_prior = GammaPrior(3.0, 6.0)
+        pl_prior = GammaPrior(2.0, 6.0)
+        temporal_features = [8, 9]
+        ls_constraint = Positive()
+        os_constraint = Positive()
+        tls_constraint = Positive()
+        pl_constraint = Positive()
+        for fixed_period_length, batch_shape, matern_ard_num_dims in product(
+            (6.0, None), (torch.Size([]), torch.Size([2])), (10, None)
+        ):
+            covar = TemporalKernel(
+                dim=12,
+                matern_ard_num_dims=matern_ard_num_dims,
+                temporal_features=temporal_features,
+                batch_shape=batch_shape,
+                lengthscale_prior=ls_prior,
+                outputscale_prior=os_prior,
+                temporal_lengthscale_prior=tls_prior,
+                period_length_prior=pl_prior if fixed_period_length is None else None,
+                fixed_period_length=fixed_period_length,
+                lengthscale_constraint=ls_constraint,
+                outputscale_constraint=os_constraint,
+                period_length_constraint=pl_constraint
+                if fixed_period_length is None
+                else None,
+                temporal_lengthscale_constraint=tls_constraint,
+            )
+            self.assertTrue(isinstance(covar.base_kernel.kernels[0], MaternKernel))
+            self.assertTrue(isinstance(covar.base_kernel.kernels[1], PeriodicKernel))
+            matern, periodic = covar.base_kernel.kernels
+
+            self.assertEqual(matern.ard_num_dims, matern_ard_num_dims)
+            self.assertEqual(
+                matern.active_dims.tolist(),
+                list(set(range(12)) - set(temporal_features)),
+            )
+            self.assertIs(matern.lengthscale_prior, ls_prior)
+            self.assertEqual(periodic.ard_num_dims, 2)
+            self.assertEqual(periodic.active_dims.tolist(), temporal_features)
+            self.assertIs(periodic.lengthscale_prior, tls_prior)
+            if fixed_period_length is None:
+                self.assertIs(periodic.period_length_prior, pl_prior)
+                self.assertIs(periodic.raw_period_length_constraint, pl_constraint)
+            self.assertIs(matern.raw_lengthscale_constraint, ls_constraint)
+            self.assertIs(periodic.raw_lengthscale_constraint, tls_constraint)
+            self.assertIs(covar.raw_outputscale_constraint, os_constraint)
+            self.assertIs(covar.outputscale_prior, os_prior)
+            self.assertEqual(matern.batch_shape, batch_shape)
+            self.assertEqual(periodic.batch_shape, batch_shape)
+            if fixed_period_length is not None:
+                self.assertTrue(
+                    torch.all(periodic.period_length == fixed_period_length)
+                )
+        # test no temporal features
+        msg = "The temporal kernel should only be used if there are temporal features."
+        with self.assertRaisesRegex(AxError, msg):
+            TemporalKernel(
+                dim=10,
+                matern_ard_num_dims=10,
+                temporal_features=[],
+                batch_shape=torch.Size([]),
+                lengthscale_prior=ls_prior,
+                outputscale_prior=os_prior,
+                temporal_lengthscale_prior=tls_prior,
+                period_length_prior=pl_prior,
+                lengthscale_constraint=ls_constraint,
+                outputscale_constraint=os_constraint,
+                period_length_constraint=pl_constraint,
+                temporal_lengthscale_constraint=tls_constraint,
+            )
+        # test exception raise when fixed_period_length is not None
+        # and period_length_prior or period_length_constraint are provided
+        msg = (
+            "If `fixed_period_length` is provided, then `period_length_prior` "
+            "and `period_length_constraint` are not used."
+        )
+        with self.assertRaisesRegex(ValueError, msg):
+            TemporalKernel(
+                dim=10,
+                matern_ard_num_dims=8,
+                temporal_features=[8, 9],
+                batch_shape=torch.Size([]),
+                lengthscale_prior=ls_prior,
+                outputscale_prior=os_prior,
+                fixed_period_length=5.0,
+                temporal_lengthscale_prior=tls_prior,
+                period_length_prior=pl_prior,
+                lengthscale_constraint=ls_constraint,
+                outputscale_constraint=os_constraint,
+                temporal_lengthscale_constraint=tls_constraint,
+            )
+        with self.assertRaisesRegex(ValueError, msg):
+            TemporalKernel(
+                dim=10,
+                matern_ard_num_dims=8,
+                temporal_features=[8, 9],
+                batch_shape=torch.Size([]),
+                lengthscale_prior=ls_prior,
+                outputscale_prior=os_prior,
+                fixed_period_length=5.0,
+                temporal_lengthscale_prior=tls_prior,
+                period_length_constraint=pl_constraint,
+                lengthscale_constraint=ls_constraint,
+                outputscale_constraint=os_constraint,
+                temporal_lengthscale_constraint=tls_constraint,
+            )


### PR DESCRIPTION
Summary:
see title. This is useful for modeling time of day.

This is a kernel implementation of the kernel. A bit more work would be needed to automated generating the input arguments, without manually specifying them via `covar_module_options`. This is convenient for now, as it unblocks its use, while leaving open options for how to treat temporal features more generally in Ax.

Reviewed By: Balandat

Differential Revision: D47633553


