### PR TITLE
allow int values in TrialAsTask

### DIFF
--- a/ax/modelbridge/tests/test_trial_as_task_transform.py
+++ b/ax/modelbridge/tests/test_trial_as_task_transform.py
@@ -140,6 +140,8 @@ class TrialAsTaskTransformTest(TestCase):
         self.assertEqual(set(p.values), {"0", "1", "2"})
         # pyre-fixme[16]: `Parameter` has no attribute `is_task`.
         self.assertTrue(p.is_task)
+        # pyre-fixme[16]: `Parameter` has no attribute `is_ordered`.
+        self.assertFalse(p.is_ordered)
         ss2 = deepcopy(self.search_space)
         ss2 = self.t2.transform_search_space(ss2)
         self.assertEqual(set(ss2.parameters.keys()), {"x", "bp1", "bp2"})
@@ -148,10 +150,24 @@ class TrialAsTaskTransformTest(TestCase):
         self.assertEqual(p.parameter_type, ParameterType.STRING)
         self.assertEqual(set(p.values), {"v1", "v2", "v3"})
         self.assertTrue(p.is_task)
+        self.assertFalse(p.is_ordered)
         p = ss2.parameters["bp2"]
         self.assertTrue(isinstance(p, ChoiceParameter))
         self.assertEqual(p.parameter_type, ParameterType.STRING)
         self.assertEqual(set(p.values), {"u1", "u2"})
+        self.assertTrue(p.is_task)
+        self.assertFalse(p.is_ordered)
+        t = TrialAsTask(
+            search_space=self.search_space,
+            observations=self.training_obs,
+            config={"trial_level_map": {"trial_index": {0: 10, 1: 11, 2: 12}}},
+        )
+        ss2 = deepcopy(self.search_space)
+        ss2 = t.transform_search_space(ss2)
+        p = ss2.parameters["trial_index"]
+        self.assertEqual(p.parameter_type, ParameterType.INT)
+        self.assertEqual(set(p.values), {10, 11, 12})
+        self.assertTrue(p.is_ordered)
         self.assertTrue(p.is_task)
 
     def test_w_robust_search_space(self) -> None:

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -113,6 +113,8 @@ class TorchModelBridge(ModelBridge):
     ) -> None:
         self.dtype: torch.dtype = torch.double if torch_dtype is None else torch_dtype
         self.device = torch_device
+        # pyre-ignore [4]: Attribute `_default_model_gen_options` of class
+        # `TorchModelBridge` must have a type that does not contain `Any`.
         self._default_model_gen_options = default_model_gen_options or {}
 
         # Handle init for multi-objective optimization.

--- a/ax/modelbridge/transforms/convert_metric_names.py
+++ b/ax/modelbridge/transforms/convert_metric_names.py
@@ -127,7 +127,7 @@ def tconfig_from_mt_experiment(experiment: MultiTypeExperiment) -> TConfig:
     """
 
     trial_index_to_type = {t.index: t.trial_type for t in experiment.trials.values()}
-    return {  # pyre-ignore[7]
+    return {
         "metric_name_map": experiment._metric_to_canonical_name,
         "trial_index_to_type": trial_index_to_type,
         "metric_name_to_trial_type": experiment.metric_to_trial_type,

--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -447,6 +447,8 @@ def _get_cutoffs_from_legacy_transform_config(
         if isinstance(winsorization_lower, dict):
             if metric_name in winsorization_lower:
                 winsorization_config.lower_quantile_margin = winsorization_lower[
+                    # pyre-fixme [6]: In call `dict.__getitem__`, for 1st positional
+                    # argument, expected `int` but got `str`.
                     metric_name
                 ]
         elif isinstance(winsorization_lower, (int, float)):
@@ -456,6 +458,8 @@ def _get_cutoffs_from_legacy_transform_config(
         if isinstance(winsorization_upper, dict):
             if metric_name in winsorization_upper:
                 winsorization_config.upper_quantile_margin = winsorization_upper[
+                    # pyre-fixme [6]: In call `dict.__getitem__`, for 1st positional
+                    # argument, expected `int` but got `str`.
                     metric_name
                 ]
         elif isinstance(winsorization_upper, (int, float)):
@@ -465,6 +469,8 @@ def _get_cutoffs_from_legacy_transform_config(
         output_percentile_bounds = (None, None)
         if isinstance(percentile_bounds, dict):
             if metric_name in percentile_bounds:
+                # pyre-fixme [6]: In call `dict.__getitem__`, for 1st positional
+                # argument, expected `int` but got `str`.
                 output_percentile_bounds = percentile_bounds[metric_name]
         elif isinstance(percentile_bounds, tuple):
             output_percentile_bounds = percentile_bounds

--- a/ax/models/types.py
+++ b/ax/models/types.py
@@ -10,6 +10,7 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.models.winsorization_config import WinsorizationConfig
 from botorch.acquisition import AcquisitionFunction
 
+# pyre-ignore [33]: `TConfig` cannot alias to a type containing `Any`.
 TConfig = Dict[
     str,
     Union[
@@ -17,6 +18,7 @@ TConfig = Dict[
         float,
         str,
         AcquisitionFunction,
+        Dict[int, Any],
         Dict[str, Any],
         OptimizationConfig,
         WinsorizationConfig,


### PR DESCRIPTION
Summary: This is useful for using integer task features in the temporal kernel (retaining ordering).

Reviewed By: bletham

Differential Revision: D49117529


