### PR TITLE
Restoring storage backward compatibility after D47930866

### DIFF
--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -45,7 +45,7 @@ from pyfakefs import fake_filesystem_unittest
 
 
 T_AX_BASE_OR_ATTR_DICT = Union[Base, Dict[str, Any]]
-COMPARISON_STR_MAX_LEVEL = 3
+COMPARISON_STR_MAX_LEVEL = 8
 T = TypeVar("T")
 
 logger: Logger = get_logger(__name__)


### PR DESCRIPTION
Summary: When loading an experiment created before D47930866, an error occurs because the `input_transform` kwarg is no longer accepted by SurrogateSpec (N4262204). In this diff, we allow backwards compatibility by reconstructing the new keywords `input_transform_class` and `input_transform_options`.

Differential Revision: D49160210


