### PR TITLE
Pass in data_type to data_and_evaluations_from_raw_data

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -833,6 +833,7 @@ class BaseTrial(ABC, SortableBase):
             metric_names=list(set(self.experiment.metrics)),
             trial_index=self.index,
             sample_sizes=sample_sizes or {},
+            data_type=self.experiment.default_data_type,
             start_time=metadata.get("start_time"),
             end_time=metadata.get("end_time"),
         )

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -11,17 +11,16 @@ import re
 import warnings
 from collections import defaultdict, OrderedDict
 from datetime import datetime
-from enum import Enum
 from functools import partial, reduce
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Type
 
 import ax.core.observation as observation
-
 import pandas as pd
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, DEFAULT_STATUSES_TO_WARM_START, TrialStatus
 from ax.core.batch_trial import BatchTrial, LifecycleStage
 from ax.core.data import Data
+from ax.core.formatting_utils import DATA_TYPE_LOOKUP, DataType
 from ax.core.generator_run import GeneratorRun
 from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
@@ -42,19 +41,6 @@ from ax.utils.common.timeutils import current_timestamp_in_millis
 from ax.utils.common.typeutils import checked_cast, not_none
 
 logger: logging.Logger = get_logger(__name__)
-
-
-class DataType(Enum):
-    DATA = 1
-    MAP_DATA = 3
-
-
-# pyre-fixme[24]: Generic type `type` expects 1 type parameter, use `typing.Type` to
-#  avoid runtime subscripting errors.
-DATA_TYPE_LOOKUP: Dict[DataType, Type] = {
-    DataType.DATA: Data,
-    DataType.MAP_DATA: MapData,
-}
 
 DEFAULT_OBJECTIVE_NAME = "objective"
 

--- a/ax/core/formatting_utils.py
+++ b/ax/core/formatting_utils.py
@@ -4,16 +4,34 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import cast, Dict, List, Optional, Tuple, Union
+from enum import Enum
+from typing import cast, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 from ax.core.data import Data
 from ax.core.map_data import MapData
-from ax.core.types import TEvaluationOutcome, TMapTrialEvaluation, TTrialEvaluation
+from ax.core.types import (
+    TEvaluationOutcome,
+    TMapTrialEvaluation,
+    TTrialEvaluation,
+    validate_evaluation_outcome,
+)
+from ax.exceptions.core import UserInputError
 from ax.utils.common.typeutils import numpy_type_to_python_type
 
 
 # -------------------- Data formatting utils. ---------------------
+
+
+class DataType(Enum):
+    DATA = 1
+    MAP_DATA = 3
+
+
+DATA_TYPE_LOOKUP: Dict[DataType, Type[Data]] = {
+    DataType.DATA: Data,
+    DataType.MAP_DATA: MapData,
+}
 
 
 def raw_data_to_evaluation(
@@ -29,24 +47,39 @@ def raw_data_to_evaluation(
     """
     if isinstance(raw_data, dict):
         if any(isinstance(x, dict) for x in raw_data.values()):
-            raise ValueError("Raw data is expected to be just for one arm.")
+            raise UserInputError("Raw data is expected to be just for one arm.")
         for metric_name, dat in raw_data.items():
             if not isinstance(dat, tuple):
                 if not isinstance(dat, (float, int)):
-                    raise ValueError(
+                    raise UserInputError(
                         "Raw data for an arm is expected to either be a tuple of "
                         "numerical mean and SEM or just a numerical mean."
                         f"Got: {dat} for metric '{metric_name}'."
                     )
                 raw_data[metric_name] = (float(dat), None)
         return raw_data
-    elif len(metric_names) > 1:
-        raise ValueError(
-            "Raw data must be a dictionary of metric names to mean "
-            "for multi-objective optimizations."
+    try:
+        validate_evaluation_outcome(outcome=raw_data)
+    except Exception as e:
+        raise UserInputError(
+            "Raw data does not conform to the expected structure. For simple "
+            "evaluations of one or more metrics, `raw_data` is expected to be "
+            "a dictionary of the form `{metric_name -> mean}` or `{metric_name "
+            "-> (mean, SEM)}`. For fidelity or mapping (e.g., early stopping) "
+            "evaluation, the expected format is `[(fidelities, {metric_name -> "
+            "(mean, SEM)})]` or `[({mapping_key, mapping_value}, {metric_name -> "
+            "(mean, SEM)})]`."
+            f"Received {raw_data=}. Original validation error: {e}."
         )
-    elif isinstance(raw_data, list):
+    if isinstance(raw_data, list):
+        validate_evaluation_outcome(raw_data)
         return raw_data
+    elif len(metric_names) > 1:
+        raise UserInputError(
+            "Raw data must be a dictionary of metric names to mean "
+            "for experiments with multiple metrics attached. "
+            f"Got {raw_data=} for {metric_names=}."
+        )
     elif isinstance(raw_data, tuple):
         return {metric_names[0]: raw_data}
     elif isinstance(raw_data, (float, int)):
@@ -54,7 +87,7 @@ def raw_data_to_evaluation(
     elif isinstance(raw_data, (np.float32, np.float64, np.int32, np.int64)):
         return {metric_names[0]: (numpy_type_to_python_type(raw_data), None)}
     else:
-        raise ValueError(
+        raise UserInputError(
             "Raw data has an invalid type. The data must either be in the form "
             "of a dictionary of metric names to mean, sem tuples, "
             "or a single mean, sem tuple, or a single mean."
@@ -66,6 +99,7 @@ def data_and_evaluations_from_raw_data(
     metric_names: List[str],
     trial_index: int,
     sample_sizes: Dict[str, int],
+    data_type: DataType,
     start_time: Optional[Union[int, str]] = None,
     end_time: Optional[Union[int, str]] = None,
 ) -> Tuple[Dict[str, TEvaluationOutcome], Data]:
@@ -98,6 +132,15 @@ def data_and_evaluations_from_raw_data(
         for arm_name in raw_data
     }
     if all(isinstance(evaluations[x], dict) for x in evaluations.keys()):
+        if data_type is DataType.MAP_DATA:
+            raise UserInputError(
+                "The format of the `raw_data` is not compatible with `MapData`. "
+                "Possible cause: Did you set default data type to `MapData`, e.g., "
+                "for early stopping, but forgot to provide the `raw_data` "
+                "in the form of `[(fidelities, {metric_name -> (mean, SEM)})]` or "
+                "`[({mapping_key, mapping_value}, {metric_name -> (mean, SEM)})]`? "
+                f"Received: {raw_data=}"
+            )
         # All evaluations are no-fidelity evaluations.
         data = Data.from_evaluations(
             evaluations=cast(Dict[str, TTrialEvaluation], evaluations),
@@ -107,6 +150,13 @@ def data_and_evaluations_from_raw_data(
             end_time=end_time,
         )
     elif all(isinstance(evaluations[x], list) for x in evaluations.keys()):
+        if data_type is DataType.DATA:
+            raise UserInputError(
+                "The format of the `raw_data` is not compatible with `Data`. "
+                "Possible cause: Did you provide data for multi-fidelity evaluations, "
+                "e.g., for early stopping, but forgot to set the default data type "
+                f"to `MapData`? Received: {raw_data=}"
+            )
         # All evaluations are map evaluations.
         data = MapData.from_map_evaluations(
             evaluations=cast(Dict[str, TMapTrialEvaluation], evaluations),

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -16,20 +16,12 @@ from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, immutable_once_run
 from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun, GeneratorRunType
-from ax.core.types import (
-    TCandidateMetadata,
-    TEvaluationOutcome,
-    validate_evaluation_outcome,
-)
+from ax.core.types import TCandidateMetadata, TEvaluationOutcome
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
 from ax.utils.common.typeutils import not_none
 
 logger: Logger = get_logger(__name__)
-
-TRIAL_RAW_DATA_FORMAT_ERROR_MESSAGE = (
-    "Raw data must be data for a single arm for non batched trials."
-)
 
 ROUND_FLOATS_IN_LOGS_TO_DECIMAL_PLACES: int = 6
 
@@ -314,11 +306,6 @@ class Trial(BaseTrial):
         """
         arm_name = not_none(self.arm).name
         sample_sizes = {arm_name: sample_size} if sample_size else {}
-
-        try:
-            validate_evaluation_outcome(outcome=raw_data)
-        except Exception:
-            raise ValueError(TRIAL_RAW_DATA_FORMAT_ERROR_MESSAGE)
         raw_data_by_arm = {arm_name: raw_data}
 
         evaluations, data = self._make_evaluations_and_data(

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -204,7 +204,7 @@ def validate_evaluation_outcome(outcome: TEvaluationOutcome) -> None:
             except Exception:
                 raise TypeError(
                     "Expected either TFidelityTrialEvaluation or TMapTrialEvaluation, "
-                    f"found {type(outcome)}"
+                    f"found {outcome}"
                 )
 
     else:

--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -209,6 +209,7 @@ class OptimizationLoop:
             },
             trial_index=self.current_trial,
             sample_sizes={},
+            data_type=self.experiment.default_data_type,
             metric_names=not_none(
                 self.experiment.optimization_config
             ).objective.metric_names,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -29,7 +29,6 @@ from ax.core.parameter import (
 )
 from ax.core.parameter_constraint import OrderConstraint
 from ax.core.search_space import HierarchicalSearchSpace
-from ax.core.trial import TRIAL_RAW_DATA_FORMAT_ERROR_MESSAGE
 from ax.core.types import (
     ComparisonOp,
     TEvaluationOutcome,
@@ -42,6 +41,7 @@ from ax.exceptions.core import (
     OptimizationComplete,
     UnsupportedError,
     UnsupportedPlotError,
+    UserInputError,
 )
 from ax.exceptions.generation_strategy import MaxParallelismReachedException
 from ax.metrics.branin import branin
@@ -1424,7 +1424,9 @@ class TestAxClient(TestCase):
             x, y = parameterization.get("x"), parameterization.get("y")
             # pyre-fixme[6]: For 2nd param expected `Union[List[Tuple[Dict[str, Union...
             ax_client.complete_trial(trial_index, raw_data=(branin(x, y), 0.0))
-        with self.assertRaisesRegex(ValueError, TRIAL_RAW_DATA_FORMAT_ERROR_MESSAGE):
+        with self.assertRaisesRegex(
+            UserInputError, "Raw data does not conform to the expected structure."
+        ):
             # pyre-fixme[61]: `trial_index` is undefined, or not always defined.
             # pyre-fixme[6]: For 2nd param expected `Union[List[Tuple[Dict[str, Union...
             ax_client.update_trial_data(trial_index, raw_data="invalid_data")

--- a/ax/storage/utils.py
+++ b/ax/storage/utils.py
@@ -7,7 +7,7 @@
 import enum
 from hashlib import md5
 
-from ax.core.experiment import DataType  # noqa F401
+from ax.core.formatting_utils import DataType  # noqa F401
 
 
 class DomainType(enum.Enum):


### PR DESCRIPTION
Summary:
`data_and_evaluations_from_raw_data` infers the DataType from the format of the `raw_data`. As a result, it was possible to attach the wrong data with the wrong type to the experiment, which leads to errors down the line (e.g., in SQA storage or while updating the trial data).

This passes in the data_type from trial to `data_and_evaluations_from_raw_data`; checks that the format of the `raw_data` is compatible with the data dtype; and raises an informative error otherwise.

Differential Revision: D49174012


