### PR TITLE
Fix dataset subsetting bug in BoTorchModel.update

### DIFF
--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -401,7 +401,7 @@ class BoTorchModel(TorchModel, Base):
             # preconstructed Surrogate
             datasets_by_metric_name = dict(zip(metric_names, datasets))
             subset_metric_names = (
-                self.surrogate_specs[label].outcomes
+                self.surrogates[label].outcomes
                 if label not in (Keys.ONLY_SURROGATE, Keys.AUTOSET_SURROGATE)
                 else metric_names
             )


### PR DESCRIPTION
Summary: If the surrugate spec does not list the outcomes, this would pass down an empty list of datasets to Surrogate.update. Surrogate will list the outcomes it is modeling even if it wasn't listed in the surrogate spec, eliminating the issue.

Differential Revision: D49107013


