### PR TITLE
`distribute_replications` option for `BenchmarkMethod`

### DIFF
--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -23,6 +23,7 @@ class BenchmarkMethod(Base):
     name: str
     generation_strategy: GenerationStrategy
     scheduler_options: SchedulerOptions
+    distribute_replications: bool = False
 
 
 def get_sequential_optimization_scheduler_options(

--- a/ax/benchmark/methods/choose_generation_strategy.py
+++ b/ax/benchmark/methods/choose_generation_strategy.py
@@ -17,6 +17,7 @@ from ax.service.scheduler import SchedulerOptions
 def get_choose_generation_strategy_method(
     problem: BenchmarkProblemBase,
     scheduler_options: Optional[SchedulerOptions] = None,
+    distribute_replications: bool = False,
 ) -> BenchmarkMethod:
     generation_strategy = choose_generation_strategy(
         search_space=problem.search_space,
@@ -29,4 +30,5 @@ def get_choose_generation_strategy_method(
         generation_strategy=generation_strategy,
         scheduler_options=scheduler_options
         or get_sequential_optimization_scheduler_options(),
+        distribute_replications=distribute_replications,
     )

--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -111,17 +111,20 @@ def get_sobol_botorch_modular_fixed_noise_gp_qnehvi(
 
 def get_sobol_botorch_modular_saas_fully_bayesian_single_task_gp_qnei(
     scheduler_options: Optional[SchedulerOptions] = None,
+    distribute_replications: bool = True,
 ) -> BenchmarkMethod:  # noqa
     return get_sobol_botorch_modular_saas_fully_bayesian_single_task_gp(
         qNoisyExpectedImprovement,
         scheduler_options=scheduler_options
         or get_sequential_optimization_scheduler_options(),
+        distribute_replications=distribute_replications,
     )
 
 
 def get_sobol_botorch_modular_saas_fully_bayesian_single_task_gp(
     botorch_acqf_class: Type[AcquisitionFunction],
     scheduler_options: Optional[SchedulerOptions] = None,
+    distribute_replications: bool = True,
 ) -> BenchmarkMethod:  # noqa
     generation_strategy = GenerationStrategy(
         name="SOBOL+BOTORCH_MODULAR::SaasFullyBayesianSingleTaskGP_"
@@ -147,11 +150,13 @@ def get_sobol_botorch_modular_saas_fully_bayesian_single_task_gp(
         generation_strategy=generation_strategy,
         scheduler_options=scheduler_options
         or get_sequential_optimization_scheduler_options(),
+        distribute_replications=distribute_replications,
     )
 
 
 def get_sobol_botorch_modular_saas_fully_bayesian_single_task_gp_qnehvi(
     scheduler_options: Optional[SchedulerOptions] = None,
+    distribute_replications: bool = True,
 ) -> BenchmarkMethod:  # noqa
     generation_strategy = GenerationStrategy(
         name="SOBOL+BOTORCH_MODULAR::SaasFullyBayesianSingleTaskGP_qNoisyExpectedHypervolumeImprovement",  # noqa
@@ -179,11 +184,13 @@ def get_sobol_botorch_modular_saas_fully_bayesian_single_task_gp_qnehvi(
         generation_strategy=generation_strategy,
         scheduler_options=scheduler_options
         or get_sequential_optimization_scheduler_options(),
+        distribute_replications=distribute_replications,
     )
 
 
 def get_sobol_botorch_modular_default(
     scheduler_options: Optional[SchedulerOptions] = None,
+    distribute_replications: bool = False,
 ) -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name="SOBOL+BOTORCH_MODULAR::default",
@@ -202,6 +209,7 @@ def get_sobol_botorch_modular_default(
         generation_strategy=generation_strategy,
         scheduler_options=scheduler_options
         or get_sequential_optimization_scheduler_options(),
+        distribute_replications=distribute_replications,
     )
 
 
@@ -209,6 +217,7 @@ def get_sobol_botorch_modular_acquisition(
     acquisition_cls: Type[AcquisitionFunction],
     acquisition_options: Optional[Dict[str, Any]] = None,
     scheduler_options: Optional[SchedulerOptions] = None,
+    distribute_replications: bool = False,
 ) -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name=f"SOBOL+BOTORCH_MODULAR::{acquisition_cls.__name__}",
@@ -235,4 +244,5 @@ def get_sobol_botorch_modular_acquisition(
         generation_strategy=generation_strategy,
         scheduler_options=scheduler_options
         or get_sequential_optimization_scheduler_options(),
+        distribute_replications=distribute_replications,
     )

--- a/ax/benchmark/methods/saasbo.py
+++ b/ax/benchmark/methods/saasbo.py
@@ -16,6 +16,7 @@ from ax.service.scheduler import SchedulerOptions
 
 def get_saasbo_default(
     scheduler_options: Optional[SchedulerOptions] = None,
+    distribute_replications: bool = True,
 ) -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name="SOBOL+FULLYBAYESIAN::default",
@@ -34,11 +35,13 @@ def get_saasbo_default(
         generation_strategy=generation_strategy,
         scheduler_options=scheduler_options
         or get_sequential_optimization_scheduler_options(),
+        distribute_replications=distribute_replications,
     )
 
 
 def get_saasbo_moo_default(
     scheduler_options: Optional[SchedulerOptions] = None,
+    distribute_replications: bool = True,
 ) -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name="SOBOL+FULLYBAYESIANMOO::default",
@@ -57,4 +60,5 @@ def get_saasbo_moo_default(
         generation_strategy=generation_strategy,
         scheduler_options=scheduler_options
         or get_sequential_optimization_scheduler_options(),
+        distribute_replications=distribute_replications,
     )


### PR DESCRIPTION
Summary:
This diff seeks to reduce the number of operators that are launched for each benchmark run by optionally not parallelizing certain methods that have cheap replications, where the parallelization overhead would be comparatively large.

Reviewed By: esantorella

Differential Revision: D49163709


