### PR TITLE
Add __repr__ methods to benchmark problems

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -167,6 +167,20 @@ class BenchmarkProblem(Base):
             infer_noise=infer_noise,
         )
 
+    def __repr__(self) -> str:
+        """
+        Return a string representation that includes only the attributes that
+        print nicely and contain information likely to be useful.
+        """
+        return (
+            f"{self.__class__.__name__}("
+            f"name={self.name}, "
+            f"optimization_config={self.optimization_config}, "
+            f"num_trials={self.num_trials}, "
+            f"infer_noise={self.infer_noise}, "
+            f"tracking_metrics={self.tracking_metrics})"
+        )
+
 
 class SingleObjectiveBenchmarkProblem(BenchmarkProblem):
     """The most basic BenchmarkProblem, with a single objective and a known optimal

--- a/ax/benchmark/problems/surrogate.py
+++ b/ax/benchmark/problems/surrogate.py
@@ -95,6 +95,20 @@ class SurrogateBenchmarkProblemBase(Base, BenchmarkProblemBase):
             self.set_runner()
         return not_none(self._runner)
 
+    def __repr__(self) -> str:
+        """
+        Return a string representation that includes only the attributes that
+        print nicely and contain information likely to be useful.
+        """
+        return (
+            f"{self.__class__.__name__}("
+            f"name={self.name}, "
+            f"optimization_config={self.optimization_config}, "
+            f"num_trials={self.num_trials}, "
+            f"infer_noise={self.infer_noise}, "
+            f"tracking_metrics={self.tracking_metrics})"
+        )
+
 
 class SOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
     """

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -48,6 +48,17 @@ class TestBenchmarkProblem(TestCase):
 
         # Test optimum
         self.assertEqual(ackley_problem.optimal_value, test_problem._optimal_value)
+        # test repr method
+        expected_repr = (
+            "SingleObjectiveBenchmarkProblem(name=Ackley, "
+            "optimization_config=OptimizationConfig(objective=Objective(metric_name="
+            '"Ackley", '
+            "minimize=True), outcome_constraints=[]), "
+            "num_trials=1, "
+            "infer_noise=True, "
+            "tracking_metrics=[])"
+        )
+        self.assertEqual(repr(ackley_problem), expected_repr)
 
     def test_moo_from_botorch(self) -> None:
         test_problem = BraninCurrin()

--- a/ax/benchmark/tests/test_surrogate_problems.py
+++ b/ax/benchmark/tests/test_surrogate_problems.py
@@ -16,6 +16,17 @@ class TestSurrogateProblems(TestCase):
 
         # test instantiation from init
         sbp = get_soo_surrogate()
+        # test __repr__ method
+
+        expected_repr = (
+            "SOOSurrogateBenchmarkProblem(name=test, "
+            "optimization_config=OptimizationConfig(objective=Objective(metric_name="
+            '"branin", '
+            "minimize=False), "
+            "outcome_constraints=[]), num_trials=6, infer_noise=False, "
+            "tracking_metrics=[])"
+        )
+        self.assertEqual(repr(sbp), expected_repr)
 
         self.assertIsNone(sbp._runner)
         # sets runner


### PR DESCRIPTION
Summary: These classes lost their __repr__ methods when they stopped being dataclasses. Let's make them print nicely again.

Reviewed By: Balandat

Differential Revision: D49399537


