### PR TITLE
Moves up the get_data_for_fit method and use_update property from Step to Node 2/n

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -63,6 +63,7 @@ class GenerationNode:
 
     model_specs: List[ModelSpec]
     should_deduplicate: bool
+    _node_name: str
     _model_spec_to_gen_from: Optional[ModelSpec] = None
     # [TODO] Handle experiment passing more eloquently by enforcing experiment
     # attribute is set in generation strategies class
@@ -72,10 +73,12 @@ class GenerationNode:
 
     def __init__(
         self,
+        node_name: str,
         model_specs: List[ModelSpec],
         best_model_selector: Optional[BestModelSelector] = None,
         should_deduplicate: bool = False,
     ) -> None:
+        self._node_name = node_name
         # While `GenerationNode` only handles a single `ModelSpec` in the `gen`
         # and `_pick_fitted_model_to_gen_from` methods, we validate the
         # length of `model_specs` in `_pick_fitted_model_to_gen_from` in order
@@ -84,6 +87,10 @@ class GenerationNode:
         self.model_specs = model_specs
         self.best_model_selector = best_model_selector
         self.should_deduplicate = should_deduplicate
+
+    @property
+    def node_name(self) -> str:
+        return self._node_name
 
     @property
     def model_spec_to_gen_from(self) -> ModelSpec:
@@ -463,6 +470,7 @@ class GenerationStep(GenerationNode, SortableBase):
                 # Factory functions may not always have a model key defined.
                 self.model_name = f"Unknown {model_spec.__class__.__name__}"
         super().__init__(
+            node_name=f"GenerationStep_{str(self.index)}",
             model_specs=[model_spec],
             should_deduplicate=self.should_deduplicate,
         )

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -98,6 +98,9 @@ class GenerationStrategy(Base):
                     "Maximum parallelism should be None (if no limit) or a positive"
                     f" number. Got: {step.max_parallelism} for step {step.model_name}."
                 )
+            # TODO[mgarrard]: Validate node name uniqueness when adding node support,
+            # uniqueness is gaurenteed for steps currently due to list structure.
+            step._node_name = f"GenerationStep_{str(idx)}"
             step.index = idx
             step._generation_strategy = self
             if not isinstance(step.model, ModelRegistryBase):

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -120,6 +120,27 @@ class TestGenerationNode(TestCase):
         self.assertEqual(node.diagnostics, node.model_specs[0].diagnostics)
         self.assertEqual(node.node_name, "test")
 
+    def test_node_string_representation(self) -> None:
+        node = GenerationNode(
+            node_name="test",
+            model_specs=[
+                ModelSpec(
+                    model_enum=Models.GPEI,
+                    model_kwargs={},
+                    model_gen_kwargs={},
+                ),
+            ],
+        )
+        string_rep = str(node)
+        self.assertEqual(
+            string_rep,
+            (
+                "GenerationNode(model_specs=[ModelSpec(model_enum=GPEI,"
+                " model_kwargs={}, model_gen_kwargs={}, model_cv_kwargs={},"
+                " )], node_name=test)"
+            ),
+        )
+
     def test_single_fixed_features(self) -> None:
         node = GenerationNode(
             node_name="test",
@@ -274,6 +295,9 @@ class TestGenerationNodeWithBestModelSelector(TestCase):
         # spec as the one to generate from.
         # TODO[adamobeng]: Test correct behavior here when implemented.
         self.assertEqual(gr._model_key, "GPEI")
+
+        # test model_to_gen_from_name property
+        self.assertEqual(self.model_selection_node.model_to_gen_from_name, "GPEI")
 
     def test_fixed_features_is_from_model_to_gen_from(self) -> None:
         self.model_selection_node.model_specs[0].fixed_features = ObservationFeatures(

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -29,7 +29,9 @@ class TestGenerationNode(TestCase):
             model_kwargs={"init_position": 3},
             model_gen_kwargs={"some_gen_kwarg": "some_value"},
         )
-        self.sobol_generation_node = GenerationNode(model_specs=[self.sobol_model_spec])
+        self.sobol_generation_node = GenerationNode(
+            node_name="test", model_specs=[self.sobol_model_spec]
+        )
         self.branin_experiment = get_branin_experiment(with_completed_trial=True)
 
     def test_init(self) -> None:
@@ -72,7 +74,8 @@ class TestGenerationNode(TestCase):
 
     def test_gen_validates_one_model_spec(self) -> None:
         generation_node = GenerationNode(
-            model_specs=[self.sobol_model_spec, self.sobol_model_spec]
+            node_name="test",
+            model_specs=[self.sobol_model_spec, self.sobol_model_spec],
         )
         # Base generation node can only handle one model spec at the moment
         # (this might change in the future), so it should raise a `NotImplemented
@@ -86,6 +89,7 @@ class TestGenerationNode(TestCase):
     @fast_botorch_optimize
     def test_properties(self) -> None:
         node = GenerationNode(
+            node_name="test",
             model_specs=[
                 ModelSpec(
                     model_enum=Models.GPEI,
@@ -114,9 +118,11 @@ class TestGenerationNode(TestCase):
         self.assertEqual(node.fixed_features, node.model_specs[0].fixed_features)
         self.assertEqual(node.cv_results, node.model_specs[0].cv_results)
         self.assertEqual(node.diagnostics, node.model_specs[0].diagnostics)
+        self.assertEqual(node.node_name, "test")
 
     def test_single_fixed_features(self) -> None:
         node = GenerationNode(
+            node_name="test",
             model_specs=[
                 ModelSpec(
                     model_enum=Models.GPEI,
@@ -132,6 +138,7 @@ class TestGenerationNode(TestCase):
 
     def test_multiple_same_fixed_features(self) -> None:
         node = GenerationNode(
+            node_name="test",
             model_specs=[
                 ModelSpec(
                     model_enum=Models.GPEI,
@@ -242,6 +249,7 @@ class TestGenerationNodeWithBestModelSelector(TestCase):
         self.fitted_model_specs = [ms_gpei, ms_gpkg]
 
         self.model_selection_node = GenerationNode(
+            node_name="test",
             model_specs=self.fitted_model_specs,
             best_model_selector=SingleDiagnosticBestModelSelector(
                 diagnostic="Fisher exact test p",

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -120,6 +120,20 @@ class TestGenerationStrategy(TestCase):
         self.discrete_model_bridge_patcher.stop()
         self.registry_setup_dict_patcher.stop()
 
+    def test_unique_step_names(self) -> None:
+        """This tests the name of the steps on generation strategy. The name is
+        inherited from the GenerationNode class, and for GenerationSteps the
+        name should follow the format "GenerationNode"+Stepidx.
+        """
+        gs = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        self.assertEqual(gs._steps[0].node_name, "GenerationStep_0")
+        self.assertEqual(gs._steps[1].node_name, "GenerationStep_1")
+
     def test_name(self) -> None:
         self.sobol_GS.name = "SomeGSName"
         self.assertEqual(self.sobol_GS.name, "SomeGSName")


### PR DESCRIPTION
Summary:
This is the diff is in the set of diffs that will work to migrate much of the logic from GenerationStep to GenerationNode. This diff finishes moving both model selection methods from step to node.

In this diff we move up the use_update field and the get_data_for_fit function In follow up diffs we'll:
(1) move up completion criteria to generation Node
(2) move the dedup logic into model spec
(3) pull the remaining model related methods from genstrat directly to gennode
(4) move up the trial related methods

Differential Revision: D49305797

