### PR TITLE
Refactor estimate_early_stopping_savings and move onto the scheduler (and add to AxClient)

### DIFF
--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -147,7 +147,7 @@ class MapData(Data):
 
     @property
     # pyre-fixme[24]: Generic type `MapKeyInfo` expects 1 type parameter.
-    def map_key_infos(self) -> Iterable[MapKeyInfo]:
+    def map_key_infos(self) -> List[MapKeyInfo]:
         return self._map_key_infos
 
     @property

--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -77,7 +77,6 @@ class MapDataTest(TestCase):
     def test_map_key_info(self) -> None:
         self.assertEqual(self.map_key_infos, self.mmd.map_key_infos)
 
-        # pyre-fixme[16]: `Iterable` has no attribute `__getitem__`.
         self.assertEqual(self.mmd.map_key_infos[0].key, "epoch")
         self.assertEqual(self.mmd.map_key_infos[0].default_value, 0)
         self.assertEqual(self.mmd.map_key_infos[0].value_type, int)
@@ -176,7 +175,6 @@ class MapDataTest(TestCase):
                 downcast_combined.map_df[downcast_combined.map_df["arm_name"] == "0_4"][
                     "epoch"
                 ]
-                # pyre-fixme[16]: `Iterable` has no attribute `__getitem__`.
                 == self.mmd.map_key_infos[0].default_value
             ).all()
         )
@@ -217,8 +215,6 @@ class MapDataTest(TestCase):
 
         self.assertEqual(
             fresh.df.columns.size,
-            # pyre-fixme[6]: For 1st param expected `Sized` but got
-            #  `Iterable[MapKeyInfo[typing.Any]]`.
             fresh.map_df.columns.size - len(self.mmd.map_key_infos),
         )
 

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -2776,6 +2776,20 @@ class TestAxClient(TestCase):
         trial = ax_client.get_trial(idx)
         self.assertTrue(trial.status.is_early_stopped)
 
+    def test_estimate_early_stopping_savings(self) -> None:
+        ax_client = AxClient()
+        ax_client.create_experiment(
+            parameters=[
+                {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
+                {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
+            ],
+            support_intermediate_data=True,
+        )
+        _, idx = ax_client.get_next_trial()
+        ax_client.stop_trial_early(idx)
+
+        self.assertEqual(ax_client.estimate_early_stopping_savings(), 0)
+
     def test_max_parallelism_exception_when_early_stopping(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -926,6 +926,8 @@ class TestAxScheduler(TestCase):
         self.assertEqual(len(fetched_data.map_df), expected_num_rows)
         self.assertEqual(len(looked_up_data.map_df), expected_num_rows)
 
+        self.assertAlmostEqual(scheduler.estimate_early_stopping_savings(), 2 / 3)
+
     def test_run_trials_in_batches(self) -> None:
         # TODO[drfreund]: Use `Runner` instead when `poll_available_capacity`
         # is moved to `Runner`


### PR DESCRIPTION
Summary: This method was general enough that it should be in OSS Ax -- upstreaming it now. No functionality change in this diff

Differential Revision: D49432234


