### PR TITLE
Add wMAPE diagnostic

### DIFF
--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -27,6 +27,7 @@ from ax.utils.stats.model_fit_stats import (
     _mean_prediction_ci,
     _rank_correlation,
     _total_raw_effect,
+    _wmape,
     compute_model_fit_metrics,
 )
 
@@ -36,6 +37,7 @@ CVDiagnostics = Dict[str, Dict[str, float]]
 
 MEAN_PREDICTION_CI = "Mean prediction CI"
 MAPE = "MAPE"
+wMAPE = "wMAPE"
 TOTAL_RAW_EFFECT = "Total raw effect"
 CORRELATION_COEFFICIENT = "Correlation coefficient"
 RANK_CORRELATION = "Rank correlation"
@@ -202,6 +204,7 @@ def compute_diagnostics(result: List[CVResult]) -> CVDiagnostics:
       predictions, relative to the observed mean.
     - 'MAPE': mean absolute percentage error of the estimated mean relative
       to the observed mean.
+    - 'wMAPE': Weighted mean absolute percentage error.
     - 'Total raw effect': the multiple change from the smallest observed
       mean to the largest observed mean, i.e. `(max - min) / min`.
     - 'Correlation coefficient': the Pearson correlation of the estimated
@@ -242,6 +245,7 @@ def compute_diagnostics(result: List[CVResult]) -> CVDiagnostics:
     diagnostic_fns = {
         MEAN_PREDICTION_CI: _mean_prediction_ci,
         MAPE: _mape,
+        wMAPE: _wmape,
         TOTAL_RAW_EFFECT: _total_raw_effect,
         CORRELATION_COEFFICIENT: _correlation_coefficient,
         RANK_CORRELATION: _rank_correlation,

--- a/ax/modelbridge/tests/test_cross_validation.py
+++ b/ax/modelbridge/tests/test_cross_validation.py
@@ -241,6 +241,14 @@ class CrossValidationTest(TestCase):
             self.assertEqual(set(v.keys()), {"a", "b"})
         # Check for correct computation, relative to manually computed result
         self.assertAlmostEqual(diag["MAPE"]["a"], 0.4984126984126984)
+        self.assertAlmostEqual(diag["MAPE"]["b"], 0.8312499999999999)
+        self.assertAlmostEqual(
+            diag["wMAPE"]["a"],
+            sum([0.0, 1.0, 4.0, 5.0, 7.0]) / sum([2, 3, 6, 7, 9]),
+        )
+        self.assertAlmostEqual(
+            diag["wMAPE"]["b"], sum([3.0, 4.0, 7.0, 9.0]) / sum([4, 5, 8, 10])
+        )
         self.assertAlmostEqual(diag["Total raw effect"]["a"], 3.5)
         self.assertAlmostEqual(diag["Total raw effect"]["b"], 1.5)
         self.assertAlmostEqual(diag["Log likelihood"]["a"], -50.09469266602336)

--- a/ax/utils/stats/model_fit_stats.py
+++ b/ax/utils/stats/model_fit_stats.py
@@ -141,7 +141,14 @@ def _log_likelihood(
 
 def _mape(y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray) -> float:
     """Mean absolute predictive error"""
-    return float(np.mean(np.abs((y_pred - y_obs) / y_obs)))
+    eps = np.finfo(y_obs.dtype).eps
+    return float(np.mean(np.abs(y_pred - y_obs) / np.abs(y_obs).clip(min=eps)))
+
+
+def _wmape(y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray) -> float:
+    """Weighted mean absolute predictive error"""
+    eps = np.finfo(y_obs.dtype).eps
+    return float(np.sum(np.abs(y_pred - y_obs)) / np.sum(np.abs(y_obs)).clip(min=eps))
 
 
 def _total_raw_effect(


### PR DESCRIPTION
Summary: MAPE will be nan/inf if any observed value is exactly 0. wMAPE doesn't have that issue and is a useful alternative in such settings.

Reviewed By: lena-kashtelyan

Differential Revision: D48569393


