### PR TITLE
Add set handling to json serialization

### DIFF
--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -140,6 +140,8 @@ def object_from_json(
                 decoder_registry=decoder_registry,
                 class_decoder_registry=class_decoder_registry,
             )
+        elif _type == "set":
+            return set(object_json["value"])
         # Used for decoding classes (not objects).
         elif _type in class_decoder_registry:
             return class_decoder_registry[_type](object_json)

--- a/ax/storage/json_store/encoder.py
+++ b/ax/storage/json_store/encoder.py
@@ -172,6 +172,8 @@ def object_to_json(  # noqa C901
         return {"__type": _type.__name__, "name": obj.name}
     elif _type is np.ndarray or issubclass(_type, np.ndarray):
         return {"__type": _type.__name__, "value": obj.tolist()}
+    elif _type is set:
+        return {"__type": _type.__name__, "value": list(obj)}
     elif _type is torch.Tensor:
         return tensor_to_dict(obj=obj)
     elif _type.__module__ == "torch":

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -467,6 +467,21 @@ class JSONStoreTest(TestCase):
             )
         )
 
+    def testEncodeDecodeSet(self) -> None:
+        a = {"a", 1, False}
+        self.assertEqual(
+            a,
+            object_from_json(
+                object_to_json(
+                    a,
+                    encoder_registry=CORE_ENCODER_REGISTRY,
+                    class_encoder_registry=CORE_CLASS_ENCODER_REGISTRY,
+                ),
+                decoder_registry=CORE_DECODER_REGISTRY,
+                class_decoder_registry=CORE_CLASS_DECODER_REGISTRY,
+            ),
+        )
+
     def testRegistryAdditions(self) -> None:
         class MyRunner(Runner):
             def run():


### PR DESCRIPTION
Summary: Sets are not json serializable objects, so to handle classes with sets as attributes we need to add handling for it to the json store.

Reviewed By: bernardbeckerman

Differential Revision: D49468658


