### PR TITLE
Stop ignoring unused kwargs in MAP SAAS

### DIFF
--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -127,7 +127,7 @@ class BotorchModel(TorchModel):
             data using the `update` method.
         warm_start_refitting: If True, start model refitting from previous
             model parameters in order to speed up the fitting process.
-        prior: A optinal dictionary that contains the specification of GP model prior.
+        prior: An optional dictionary that contains the specification of GP model prior.
             Currently, the keys include:
             - covar_module_prior: prior on covariance matrix e.g.
                 {"lengthscale_prior": GammaPrior(3.0, 6.0)}.
@@ -301,6 +301,7 @@ class BotorchModel(TorchModel):
         self.fidelity_features = normalize_indices(
             search_space_digest.fidelity_features, d=self.Xs[0].size(-1)
         )
+        extra_kwargs = {} if self.prior is None else {"prior": self.prior}
         self._model = self.model_constructor(  # pyre-ignore [28]
             Xs=self.Xs,
             Ys=self.Ys,
@@ -310,7 +311,7 @@ class BotorchModel(TorchModel):
             metric_names=self.metric_names,
             use_input_warping=self.use_input_warping,
             use_loocv_pseudo_likelihood=self.use_loocv_pseudo_likelihood,
-            prior=self.prior,
+            **extra_kwargs,
             **self._kwargs,
         )
 


### PR DESCRIPTION
Summary: Change `fit` method of legacy `BotorchModel` so that `prior` is only passed to `model_constructor` if the prior is not `None`, because not all models accept a prior. This is somewhat ugly, with the benefit that model constructors are no longer forced to accept the `prior` kwarg if they don't use it.

Reviewed By: SebastianAment

Differential Revision: D49501978

