### PR TITLE
Add pyre-extensions to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIRES = [
     # Needed for compatibility with ipywidgets >= 8.0.0
     "plotly>=5.12.0",
     "typeguard==2.13.3",
+    "pyre-extensions",
 ]
 
 # pytest-cov requires pytest >= 3.6


### PR DESCRIPTION
Ax uses `pyre-extensions` but does not list it under dependencies. `torchx` lists `pyre-extensions` as a dependency and Ax uses `torchx` dependency in all CI, so this doesn't cause any issues with Ax CI. BoTorch CI does not install `torchx`, so it runs into issues when importing from Ax: https://github.com/pytorch/botorch/actions/runs/6260496570/job/16998644302