### PR TITLE
Implement ChainRunner

### DIFF
--- a/ax/runners/synthetic.py
+++ b/ax/runners/synthetic.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Iterable, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Set
 
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.runner import Runner
@@ -36,3 +36,6 @@ class SyntheticRunner(Runner):
         self, trials: Iterable[BaseTrial]
     ) -> Dict[TrialStatus, Set[int]]:
         return {TrialStatus.COMPLETED: {t.index for t in trials}}
+
+    def run_metadata_report_keys(self) -> List[str]:
+        return ["name"]


### PR DESCRIPTION
Summary:
Implements ChainRunner, which takes List[ChainRunnerStage] and runs the stages in sequence for each trial.

High-level logic is as follows:
* `ChainRunner.run` kicks off the first ChainRunnerStage in the list and records that stage's name in the trial's run_metadata.
* `ChainRunner.poll_trial_status` polls the current stage's runner's status. If this is `TrialStatus.COMPLETED` and there are more stages left in the chain, ChainRunner kicks off the next stage in the chain, updating the run_metadata in the process.

In the future this should be implemented such that this state management happens in the calling context (e.g., Scheduler, AxClient).

Differential Revision: D47484883


