### PR TITLE
support scalarized metric in visualizations

### DIFF
--- a/ax/modelbridge/tests/test_prediction_utils.py
+++ b/ax/modelbridge/tests/test_prediction_utils.py
@@ -33,6 +33,34 @@ class TestPredictionUtils(TestCase):
         self.assertEqual(len(y_hat), 1)
         self.assertEqual(len(se_hat), 1)
 
+        y_hat, se_hat = predict_at_point(
+            model=not_none(ax_client.generation_strategy.model),
+            obsf=observation_features,
+            metric_names={"test_metric1", "test_metric2", "test_metric:agg"},
+            scalarized_metric_config=[
+                {
+                    "name": "test_metric:agg",
+                    "weight": {"test_metric1": 0.5, "test_metric2": 0.5},
+                },
+            ],
+        )
+        self.assertEqual(len(y_hat), 3)
+        self.assertEqual(len(se_hat), 3)
+
+        y_hat, se_hat = predict_at_point(
+            model=not_none(ax_client.generation_strategy.model),
+            obsf=observation_features,
+            metric_names={"test_metric1"},
+            scalarized_metric_config=[
+                {
+                    "name": "test_metric:agg",
+                    "weight": {"test_metric1": 0.5, "test_metric2": 0.5},
+                },
+            ],
+        )
+        self.assertEqual(len(y_hat), 1)
+        self.assertEqual(len(se_hat), 1)
+
     def test_predict_by_features(self) -> None:
         ax_client = _set_up_client_for_get_model_predictions_no_next_trial()
         _attach_completed_trials(ax_client)


### PR DESCRIPTION
Summary:
We want to allow visualization scalarized metrics, e.g. aggregated outcomes from a set of context breakdown outcomes, by passing the weight dict info to fitted outcome plots.

Examples of scalarization info are `[{"name": "session:agg", "weight": {"session:cohort1": 0.5, "session:cohort1": 0.5}}]`

Differential Revision: D48068265


