### PR TITLE
Minor clean up of MBM & helpers

### DIFF
--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -189,14 +189,11 @@ class BoTorchModel(TorchModel, Base):
                 f"{Keys.AUTOSET_SURROGATE}, these are reserved."
             )
 
-        self._surrogates = {}
-        self.surrogate_specs = {}
-        if surrogate_specs is not None:
-            self.surrogate_specs: Dict[str, SurrogateSpec] = {
-                label: spec for label, spec in surrogate_specs.items()
-            }
-        elif surrogate is not None:
+        self.surrogate_specs = dict((surrogate_specs or {}).items())
+        if surrogate is not None:
             self._surrogates = {Keys.ONLY_SURROGATE: surrogate}
+        else:
+            self._surrogates = {}
 
         self.acquisition_class = acquisition_class or Acquisition
         self.acquisition_options = acquisition_options or {}

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -94,8 +94,6 @@ class SurrogateTest(TestCase):
             bounds=self.bounds,
             target_fidelities={1: 1.0},
         )
-        self.metric_names = ["x_y"]
-        self.original_metric_names = ["x", "y"]
         self.fixed_features = {1: 2.0}
         self.refit = True
         self.objective_weights = torch.tensor(
@@ -475,19 +473,6 @@ class SurrogateTest(TestCase):
                 self.assertTrue(mock_fit.call_kwargs["jit_compile"])
             mock_MLL.reset_mock()
             mock_fit.reset_mock()
-            # Check that the optional original_metric_names arg propagates
-            # through surrogate._outcomes.
-            surrogate.fit(
-                datasets=self.training_data,
-                metric_names=self.metric_names,
-                search_space_digest=self.search_space_digest,
-                refit=self.refit,
-                original_metric_names=self.original_metric_names,
-            )
-            self.assertEqual(surrogate.outcomes, self.original_metric_names)
-            mock_state_dict.reset_mock()
-            mock_MLL.reset_mock()
-            mock_fit.reset_mock()
             # Should `load_state_dict` when `state_dict` is not `None`
             # and `refit` is `False`.
             state_dict = {"state_attribute": torch.zeros(1)}
@@ -795,7 +780,7 @@ class SurrogateTest(TestCase):
         surrogate = Surrogate(allow_batched_models=False)
         surrogate.fit(
             datasets=training_data,
-            metric_names=self.original_metric_names,
+            metric_names=self.metric_names,
             search_space_digest=search_space_digest,
         )
         self.assertIsInstance(surrogate.model, ModelListGP)


### PR DESCRIPTION
Summary: Some no-op changes to Surrogate & helpers to clear out pyre & flake8 warnings.

Removes `original_metric_names` kwarg, which was introduced as a "hack", only for its only usage to disappear after a few months.

Reviewed By: esantorella

Differential Revision: D49657636


