### PR TITLE
make constraints absolute in benchmarks

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -164,6 +164,7 @@ class BenchmarkProblem(Base):
                     ),
                     op=ComparisonOp.GEQ,
                     bound=0.0,
+                    relative=False,
                 )
                 for i in range(test_problem.num_constraints)
             ]


### PR DESCRIPTION
Summary: `OutcomeConstraint` defaults to `relative=True`. We don't want relative constraints for synthetic benchmarks

Differential Revision: D49691491

