### PR TITLE
outcome transform to outcome classes + options

### DIFF
--- a/ax/models/torch/botorch_modular/input_constructors/outcome_transform.py
+++ b/ax/models/torch/botorch_modular/input_constructors/outcome_transform.py
@@ -1,0 +1,70 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Type
+
+from ax.utils.common.typeutils import _argparse_type_encoder
+from botorch.models.transforms.outcome import OutcomeTransform, Standardize
+from botorch.utils.datasets import SupervisedDataset
+from botorch.utils.dispatcher import Dispatcher
+
+outcome_transform_argparse = Dispatcher(
+    name="outcome_transform_argparse", encoder=_argparse_type_encoder
+)
+
+
+@outcome_transform_argparse.register(OutcomeTransform)
+def _outcome_transform_argparse_base(
+    outcome_transform_class: Type[OutcomeTransform],
+    dataset: Optional[SupervisedDataset] = None,
+    outcome_transform_options: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Extract the outcome transform kwargs from the given arguments.
+
+    Args:
+        outcome_transform_class: Outcome transform class.
+        dataset: Dataset containing feature matrix and the response.
+        outcome_transform_options: An optional dictionary of outcome transform options.
+            This may include overrides for the above options. For example, when
+            `outcome_transform_class` is Standardize this dictionary might include
+            {
+                "m": 1, # the output dimension
+            }
+            See `botorch/models/transforms/outcome.py` for more options.
+
+    Returns:
+        A dictionary with outcome transform kwargs.
+    """
+    return outcome_transform_options or {}
+
+
+@outcome_transform_argparse.register(Standardize)
+def _outcome_transform_argparse_standardize(
+    outcome_transform_class: Type[Standardize],
+    dataset: SupervisedDataset,
+    outcome_transform_options: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Extract the outcome transform kwargs form the given arguments.
+
+    Args:
+        outcome_transform_class: Outcome transform class, which is Standardize in this
+            case.
+        dataset: Dataset containing feature matrix and the response.
+        outcome_transform_options: Outcome transform kwargs.
+            See botorch.models.transforms.outcome.Standardize for all available options
+
+    Returns:
+        A dictionary with outcome transform kwargs.
+    """
+
+    outcome_transform_options = outcome_transform_options or {}
+    m = dataset.Y.shape[-1]
+    outcome_transform_options.setdefault("m", m)
+
+    return outcome_transform_options

--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -91,7 +91,9 @@ class SurrogateSpec:
 
     input_transform_classes: Optional[List[Type[InputTransform]]] = None
     input_transform_options: Optional[Dict[str, Dict[str, Any]]] = None
-    outcome_transform: Optional[OutcomeTransform] = None
+
+    outcome_transform_classes: Optional[List[Type[OutcomeTransform]]] = None
+    outcome_transform_options: Optional[Dict[str, Dict[str, Any]]] = None
 
     allow_batched_models: bool = True
 
@@ -304,7 +306,8 @@ class BoTorchModel(TorchModel, Base):
                 likelihood_options=spec.likelihood_kwargs,
                 input_transform_classes=spec.input_transform_classes,
                 input_transform_options=spec.input_transform_options,
-                outcome_transform=spec.outcome_transform,
+                outcome_transform_classes=spec.outcome_transform_classes,
+                outcome_transform_options=spec.outcome_transform_options,
                 allow_batched_models=spec.allow_batched_models,
             )
             for label, spec in self.surrogate_specs.items()

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -848,7 +848,8 @@ class BoTorchModelTest(TestCase):
             likelihood_options=None,
             input_transform_classes=None,
             input_transform_options=None,
-            outcome_transform=None,
+            outcome_transform_classes=None,
+            outcome_transform_options=None,
             allow_batched_models=True,
         )
 
@@ -875,7 +876,8 @@ class BoTorchModelTest(TestCase):
             likelihood_options=None,
             input_transform_classes=None,
             input_transform_options=None,
-            outcome_transform=None,
+            outcome_transform_classes=None,
+            outcome_transform_options=None,
             allow_batched_models=False,
         )
 

--- a/ax/models/torch/tests/test_outcome_transform_argparse.py
+++ b/ax/models/torch/tests/test_outcome_transform_argparse.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from ax.models.torch.botorch_modular.input_constructors.outcome_transform import (
+    outcome_transform_argparse,
+)
+from ax.utils.common.testutils import TestCase
+from botorch.models.transforms.outcome import OutcomeTransform, Standardize
+from botorch.utils.datasets import SupervisedDataset
+
+
+class DummyOutcomeTransform(OutcomeTransform):
+    pass
+
+
+class OutcomeTransformArgparseTest(TestCase):
+    def setUp(self) -> None:
+        X = torch.randn((10, 4))
+        Y = torch.randn((10, 1))
+        self.dataset = SupervisedDataset(
+            X=X,
+            Y=Y,
+            feature_names=["chicken", "eggs", "pigeons", "bunnies"],
+            outcome_names=["farm"],
+        )
+
+    def test_notImplemented(self) -> None:
+        with self.assertRaises(NotImplementedError) as e:
+            outcome_transform_argparse[type(None)]
+            self.assertTrue("Could not find signature for" in str(e))
+
+    def test_register(self) -> None:
+        @outcome_transform_argparse.register(DummyOutcomeTransform)
+        def _argparse(outcome_transform: DummyOutcomeTransform) -> None:
+            pass
+
+        self.assertEqual(_argparse, outcome_transform_argparse[DummyOutcomeTransform])
+
+    def test_argparse_outcome_transform(self) -> None:
+        outcome_transform_kwargs_a = outcome_transform_argparse(OutcomeTransform)
+        outcome_transform_kwargs_b = outcome_transform_argparse(
+            OutcomeTransform, outcome_transform_options={"x": 5}, dataset=self.dataset
+        )
+
+        self.assertEqual(outcome_transform_kwargs_a, {})
+        self.assertEqual(outcome_transform_kwargs_b, {"x": 5})
+
+    def test_argparse_standardize(self) -> None:
+        outcome_transform_kwargs_a = outcome_transform_argparse(
+            Standardize, dataset=self.dataset
+        )
+        outcome_transform_kwargs_b = outcome_transform_argparse(
+            Standardize, dataset=self.dataset, outcome_transform_options={"m": 10}
+        )
+        self.assertEqual(outcome_transform_kwargs_a, {"m": 1})
+        self.assertEqual(outcome_transform_kwargs_b, {"m": 10})

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -62,6 +62,11 @@ from botorch.models.transforms.input import (
     Round,
     Warp,
 )
+from botorch.models.transforms.outcome import (
+    ChainedOutcomeTransform,
+    OutcomeTransform,
+    Standardize,
+)
 
 # Miscellaneous BoTorch imports
 from gpytorch.constraints import Interval
@@ -153,6 +158,13 @@ INPUT_TRANSFORM_REGISTRY: Dict[Type[InputTransform], str] = {
     InputPerturbation: "InputPerturbation",
 }
 
+"""
+Mapping of BoTorch `OutcomeTransform` classes to class name strings.
+"""
+OUTCOME_TRANSFORM_REGISTRY: Dict[Type[OutcomeTransform], str] = {
+    ChainedOutcomeTransform: "ChainedOutcomeTransform",
+    Standardize: "Standardize",
+}
 
 """
 Overarching mapping from encoded classes to registry map.
@@ -167,6 +179,7 @@ CLASS_TO_REGISTRY: Dict[Any, Dict[Type[Any], str]] = {
     Interval: GPYTORCH_COMPONENT_REGISTRY,
     GammaPrior: GPYTORCH_COMPONENT_REGISTRY,
     InputTransform: INPUT_TRANSFORM_REGISTRY,
+    OutcomeTransform: OUTCOME_TRANSFORM_REGISTRY,
 }
 
 
@@ -207,6 +220,9 @@ REVERSE_INPUT_TRANSFORM_REGISTRY: Dict[str, Type[InputTransform]] = {
     v: k for k, v in INPUT_TRANSFORM_REGISTRY.items()
 }
 
+REVERSE_OUTCOME_TRANSFORM_REGISTRY: Dict[str, Type[OutcomeTransform]] = {
+    v: k for k, v in OUTCOME_TRANSFORM_REGISTRY.items()
+}
 
 """
 Overarching mapping from encoded classes to reverse registry map.
@@ -221,6 +237,7 @@ CLASS_TO_REVERSE_REGISTRY: Dict[Any, Dict[str, Type[Any]]] = {
     Interval: REVERSE_GPYTORCH_COMPONENT_REGISTRY,
     GammaPrior: REVERSE_GPYTORCH_COMPONENT_REGISTRY,
     InputTransform: REVERSE_INPUT_TRANSFORM_REGISTRY,
+    OutcomeTransform: REVERSE_OUTCOME_TRANSFORM_REGISTRY,
 }
 
 

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -92,6 +92,7 @@ from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.storage.json_store.decoders import (
     class_from_json,
     input_transform_type_from_json,
+    outcome_transform_type_from_json,
     pathlib_from_json,
     transform_type_from_json,
 )
@@ -368,4 +369,5 @@ CORE_CLASS_DECODER_REGISTRY: Dict[str, Callable[[Dict[str, Any]], Any]] = {
     "Type[Model]": class_from_json,
     "Type[Transform]": transform_type_from_json,
     "Type[InputTransform]": input_transform_type_from_json,
+    "Type[OutcomeTransform]": outcome_transform_type_from_json,
 }

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -119,6 +119,7 @@ from ax.utils.testing.modeling_stubs import (
     get_generation_strategy,
     get_input_transform_type,
     get_observation_features,
+    get_outcome_transfrom_type,
     get_transform_type,
 )
 from ax.utils.testing.utils import generic_equals
@@ -210,6 +211,7 @@ TEST_CASES = [
     ("Type[MarginalLogLikelihood]", get_mll_type),
     ("Type[Transform]", get_transform_type),
     ("Type[InputTransform]", get_input_transform_type),
+    ("Type[OutcomeTransform]", get_outcome_transfrom_type),
     ("ThresholdEarlyStoppingStrategy", get_threshold_early_stopping_strategy),
     ("Trial", get_trial),
     ("WinsorizationConfig", get_winsorization_config),

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -30,6 +30,7 @@ from ax.utils.testing.core_stubs import (
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.transforms.input import InputTransform, Normalize
+from botorch.models.transforms.outcome import OutcomeTransform, Standardize
 
 logger: Logger = get_logger(__name__)
 
@@ -199,6 +200,10 @@ def get_input_transform_type() -> Type[InputTransform]:
     return Normalize
 
 
+def get_outcome_transfrom_type() -> Type[OutcomeTransform]:
+    return Standardize
+
+
 def get_experiment_for_value() -> Experiment:
     return Experiment(get_search_space_for_value(), "test")
 
@@ -239,7 +244,23 @@ def get_legacy_list_surrogate_generation_step_as_dict() -> Dict[str, Any]:
                     ),
                 },
                 "mll_options": {},
-                "submodel_outcome_transforms": None,
+                "submodel_outcome_transforms": [
+                    {
+                        "__type": "Standardize",
+                        "index": {
+                            "__type": "Type[OutcomeTransform]",
+                            "index": "Standardize",
+                            "class": (
+                                "<class 'botorch.models.transforms.outcome."
+                                "OutcomeTransform'>"
+                            ),
+                        },
+                        "class": (
+                            "<class 'botorch.models.transforms.outcome.Standardize'>"
+                        ),
+                        "state_dict": {"m": 1, "outputs": None, "min_stdv": 1e-8},
+                    }
+                ],
                 "submodel_input_transforms": [
                     {
                         "__type": "Normalize",
@@ -301,6 +322,10 @@ def get_surrogate_generation_step() -> GenerationStep:
                         "min_range": 1e-08,
                         "learn_bounds": False,
                     }
+                },
+                outcome_transform_classes=[Standardize],
+                outcome_transform_options={
+                    "Standardize": {"m": 1, "outputs": None, "min_stdv": 1e-8}
                 },
             ),
             "botorch_acqf_class": qNoisyExpectedImprovement,

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -296,6 +296,14 @@ ax.models.torch.botorch_modular.input_constructors.input_transforms module
     :undoc-members:
     :show-inheritance:
 
+ax.models.torch.botorch_modular.input_constructors.outcome_transform module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.models.torch.botorch_modular.input_constructors.outcome_transform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ax.models.torch.cbo_lcea module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary:
- Make Surrogate and SurrogateSpec take outcome_transform_classes and outcome_transform_options as inputs instead of BoTorch outcome_transform
- Construct BoTorch outcome transforms using outcome_transform_classes and outcome_transform_options plus other input available to Surrogate during Surrogate.fit(). Currently only support Standardize.
- Updated the storage code to be able to encode/decode outcome_transform_classes and outcome_transform_options, and to be backward compatible.

Reviewed By: saitcakmak

Differential Revision: D49609383


