### PR TITLE
MBM Surrogate: Clean up model fitting behavior and **kwargs usage

### DIFF
--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -47,7 +47,7 @@ from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
 from botorch.models.gp_regression import FixedNoiseGP
 from botorch.models.model_list_gp_regression import ModelListGP
-from botorch.models.multitask import FixedNoiseMultiTaskGP
+from botorch.models.multitask import MultiTaskGP
 from botorch.utils.types import DEFAULT
 from gpytorch.kernels.matern_kernel import MaternKernel
 from gpytorch.kernels.scale_kernel import ScaleKernel
@@ -475,7 +475,7 @@ class ModelRegistryTest(TestCase):
                 if use_saas
                 else [
                     Surrogate(
-                        botorch_model_class=FixedNoiseMultiTaskGP,
+                        botorch_model_class=MultiTaskGP,
                         mll_class=ExactMarginalLogLikelihood,
                         covar_module_class=ScaleMaternKernel,
                         covar_module_options={
@@ -514,9 +514,7 @@ class ModelRegistryTest(TestCase):
                 for i in range(len(models)):
                     self.assertIsInstance(
                         models[i],
-                        SaasFullyBayesianMultiTaskGP
-                        if use_saas
-                        else FixedNoiseMultiTaskGP,
+                        SaasFullyBayesianMultiTaskGP if use_saas else MultiTaskGP,
                     )
                     if use_saas is False:
                         self.assertIsInstance(models[i].covar_module, ScaleKernel)

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -31,7 +31,7 @@ from botorch.models.gp_regression_fidelity import (
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel, GPyTorchModel
 from botorch.models.model import Model, ModelList
-from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
+from botorch.models.multitask import MultiTaskGP
 from botorch.models.pairwise_gp import PairwiseGP
 from botorch.models.transforms.input import ChainedInputTransform
 from botorch.utils.datasets import SupervisedDataset
@@ -108,11 +108,9 @@ def choose_model_class(
             "errors. Variances should all be specified, or none should be."
         )
 
-    # Multi-task cases (when `task_features` specified).
-    if search_space_digest.task_features and all_inferred:
-        model_class = MultiTaskGP  # Unknown observation noise.
-    elif search_space_digest.task_features:
-        model_class = FixedNoiseMultiTaskGP  # Known observation noise.
+    # Multi-task case (when `task_features` is specified).
+    if search_space_digest.task_features:
+        model_class = MultiTaskGP
 
     # Single-task multi-fidelity cases.
     elif search_space_digest.fidelity_features and all_inferred:

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -117,12 +117,12 @@ class AcquisitionTest(TestCase):
         self.search_space_digest = SearchSpaceDigest(
             feature_names=self.feature_names,
             bounds=[(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)],
+            fidelity_features=self.fidelity_features,
             target_values={2: 1.0},
         )
         self.surrogate.construct(
             datasets=self.training_data,
             metric_names=self.metric_names,
-            fidelity_features=self.fidelity_features,
             search_space_digest=SearchSpaceDigest(
                 feature_names=self.search_space_digest.feature_names[:1],
                 bounds=self.search_space_digest.bounds,

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -819,7 +819,7 @@ class BoTorchModelTest(TestCase):
         # `mock_acquisition.return_value.evaluate`.
         mock_acquisition.return_value.evaluate.assert_called()
 
-    @mock.patch(f"{MODEL_PATH}.Surrogate.__init__", return_value=None)
+    @mock.patch(f"{MODEL_PATH}.Surrogate", wraps=Surrogate)
     @mock.patch(f"{SURROGATE_PATH}.Surrogate.fit", return_value=None)
     def test_surrogate_model_options_propagation(
         self, _: Mock, mock_init: Mock
@@ -853,7 +853,7 @@ class BoTorchModelTest(TestCase):
             allow_batched_models=True,
         )
 
-    @mock.patch(f"{MODEL_PATH}.Surrogate.__init__", return_value=None)
+    @mock.patch(f"{MODEL_PATH}.Surrogate", wraps=Surrogate)
     @mock.patch(f"{SURROGATE_PATH}.Surrogate.fit", return_value=None)
     def test_surrogate_options_propagation(self, _: Mock, mock_init: Mock) -> None:
         model = BoTorchModel(

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -38,7 +38,7 @@ from botorch.models.gp_regression_fidelity import (
 )
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
 from botorch.models.model import ModelList
-from botorch.models.multitask import FixedNoiseMultiTaskGP, MultiTaskGP
+from botorch.models.multitask import MultiTaskGP
 from botorch.models.transforms.input import (
     ChainedInputTransform,
     InputPerturbation,
@@ -140,26 +140,17 @@ class BoTorchModelUtilsTest(TestCase):
                     feature_names=[], bounds=[], task_features=[1, 2]
                 ),
             )
-        # With fidelity features and unknown variances, use SingleTaskMultiFidelityGP.
-        self.assertEqual(
-            MultiTaskGP,
-            choose_model_class(
-                datasets=self.supervised_datasets,
-                search_space_digest=SearchSpaceDigest(
-                    feature_names=[], bounds=[], task_features=[1]
+        # With task features use MultiTaskGP.
+        for datasets in (self.supervised_datasets, self.fixed_noise_datasets):
+            self.assertEqual(
+                MultiTaskGP,
+                choose_model_class(
+                    datasets=datasets,
+                    search_space_digest=SearchSpaceDigest(
+                        feature_names=[], bounds=[], task_features=[1]
+                    ),
                 ),
-            ),
-        )
-        # With fidelity features and known variances, use FixedNoiseMultiFidelityGP.
-        self.assertEqual(
-            FixedNoiseMultiTaskGP,
-            choose_model_class(
-                datasets=self.fixed_noise_datasets,
-                search_space_digest=SearchSpaceDigest(
-                    feature_names=[], bounds=[], task_features=[1]
-                ),
-            ),
-        )
+            )
 
     def test_choose_model_class_discrete_features(self) -> None:
         # With discrete features, use MixedSingleTaskyGP.


### PR DESCRIPTION
Summary:
Kwargs: These were originally added to support passing around additional kwargs in subclasses that no-longer exist. They later silently took on the role of carrying the kwargs that gets passed down to model input constructors. The argument name has been updated with added docstring explaining what these do. These are now used to update `Surrogate.model_options` and passed to the input constructors from there.

Model fitting clean up: We had a bunch of duplicate logic for constructing the models, left over from the merger of `Surrogate` & `ListSurrogate`, which led to several bugs in the past and made the code much harder to maintain and review. This diff deduplicates and simplifies the model fitting logic.

Differential Revision: D49707895


