### PR TITLE
Support empty input/outcome transform class lists

### DIFF
--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -584,7 +584,7 @@ class Surrogate(Base):
         dataset: SupervisedDataset,
         search_space_digest: SearchSpaceDigest,
         input_options: Dict[str, Dict[str, Any]],
-    ) -> InputTransform:
+    ) -> Optional[InputTransform]:
         """
         Makes a BoTorch input transform from the provided input classes and options.
         """
@@ -593,6 +593,8 @@ class Surrogate(Base):
             and all(issubclass(c, InputTransform) for c in input_classes)
         ):
             raise UserInputError("Expected a list of input transforms.")
+        if len(input_classes) == 0:
+            return None
 
         input_transform_kwargs = [
             input_transform_argparse(
@@ -628,7 +630,7 @@ class Surrogate(Base):
         input_classes: List[Type[OutcomeTransform]],
         input_options: Dict[str, Dict[str, Any]],
         dataset: SupervisedDataset,
-    ) -> OutcomeTransform:
+    ) -> Optional[OutcomeTransform]:
         """
         Makes a BoTorch outcome transform from the provided classes and options.
         """
@@ -637,6 +639,8 @@ class Surrogate(Base):
             and all(issubclass(c, OutcomeTransform) for c in input_classes)
         ):
             raise UserInputError("Expected a list of outcome transforms.")
+        if len(input_classes) == 0:
+            return None
 
         outcome_transform_kwargs = [
             outcome_transform_argparse(

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -1018,6 +1018,9 @@ class SurrogateWithModelListTest(TestCase):
             Surrogate(
                 botorch_model_class=default_class,
                 mll_class=ExactMarginalLogLikelihood,
+                # Check that empty lists also work fine.
+                outcome_transform_classes=[],
+                input_transform_classes=[],
             ),
             Surrogate(botorch_model_class=SaasFullyBayesianSingleTaskGP),
             Surrogate(botorch_model_class=SaasFullyBayesianMultiTaskGP),

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -209,7 +209,7 @@ def object_from_json(
                     input_transform_classes_json,
                     input_transform_options_json,
                 ) = get_input_transform_json_components(
-                    input_transforms_json=[object_json.pop("input_transform")],
+                    input_transforms_json=object_json.pop("input_transform"),
                     decoder_registry=decoder_registry,
                     class_decoder_registry=class_decoder_registry,
                 )
@@ -220,7 +220,7 @@ def object_from_json(
                     outcome_transform_classes_json,
                     outcome_transform_options_json,
                 ) = get_outcome_transform_json_components(
-                    outcome_transforms_json=[object_json.pop("outcome_transform")],
+                    outcome_transforms_json=object_json.pop("outcome_transform"),
                     decoder_registry=decoder_registry,
                     class_decoder_registry=class_decoder_registry,
                 )

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -361,6 +361,39 @@ def get_surrogate_as_dict() -> Dict[str, Any]:
     }
 
 
+def get_surrogate_spec_as_dict() -> Dict[str, Any]:
+    """
+    For use ensuring backwards compatibility when loading SurrogateSpec
+    with input_transform and outcome_transform kwargs.
+    """
+    return {
+        "__type": "SurrogateSpec",
+        "botorch_model_class": {
+            "__type": "Type[Model]",
+            "index": "SingleTaskGP",
+            "class": "<class 'botorch.models.model.Model'>",
+        },
+        "botorch_model_kwargs": {},
+        "mll_class": {
+            "__type": "Type[MarginalLogLikelihood]",
+            "index": "ExactMarginalLogLikelihood",
+            "class": (
+                "<class 'gpytorch.mlls.marginal_log_likelihood"
+                ".MarginalLogLikelihood'>"
+            ),
+        },
+        "mll_kwargs": {},
+        "covar_module_class": None,
+        "covar_module_kwargs": None,
+        "likelihood_class": None,
+        "likelihood_kwargs": None,
+        "input_transform": None,
+        "outcome_transform": None,
+        "allow_batched_models": False,
+        "outcomes": [],
+    }
+
+
 class transform_1(Transform):
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         new_ss = search_space.clone()


### PR DESCRIPTION
Summary:
Before this diff, calling `_make_botorch_input/outcome_transform` with empty list of classes would've raised an `IndexError`.

Also updates the backwards-compatibility decoders to convert `None` transform objects to `None` rather than an empty list of classes.

Reviewed By: susanxia1006

Differential Revision: D49833563

