### PR TITLE
Add transition criteria to GenerationNode

### DIFF
--- a/ax/modelbridge/completion_criterion.py
+++ b/ax/modelbridge/completion_criterion.py
@@ -3,47 +3,51 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from abc import abstractmethod
+from logging import Logger
 
-from ax.core.base_trial import TrialStatus
+from ax.modelbridge.transition_criterion import (
+    MinimumPreferenceOccurances,
+    MinimumTrialsInStatus,
+    TransitionCriterion,
+)
+from ax.utils.common.logger import get_logger
 
-from ax.core.experiment import Experiment
-from ax.utils.common.base import Base
-from ax.utils.common.serialization import SerializationMixin
+logger: Logger = get_logger(__name__)
 
 
-class CompletionCriterion(Base, SerializationMixin):
+class CompletionCriterion(TransitionCriterion):
     """
-    Simple class to descibe a condition which must be met for a GenerationStraytegy
-    to move to its next GenerationStep.
+    Deprecated class that has been replaced by `TransitionCriterion`, and will be
+    fully reaped in a future release.
     """
 
-    def __init__(self) -> None:
-        pass
-
-    @abstractmethod
-    def is_met(self, experiment: Experiment) -> bool:
-        pass
+    logger.warning(
+        "CompletionCriterion is deprecated, please use TransitionCriterion instead."
+    )
+    pass
 
 
-class MinimumTrialsInStatus(CompletionCriterion):
-    def __init__(self, status: TrialStatus, threshold: int) -> None:
-        self.status = status
-        self.threshold = threshold
+class MinimumPreferenceOccurances(MinimumPreferenceOccurances):
+    """
+    Deprecated child class that has been replaced by `MinimumPreferenceOccurances`
+    in `TransitionCriterion`, and will be fully reaped in a future release.
+    """
 
-    def is_met(self, experiment: Experiment) -> bool:
-        return len(experiment.trial_indices_by_status[self.status]) >= self.threshold
+    logger.warning(
+        "CompletionCriterion, which MinimumPreferenceOccurance inherits from, is"
+        " deprecated. Please use TransitionCriterion instead."
+    )
+    pass
 
 
-class MinimumPreferenceOccurances(CompletionCriterion):
-    def __init__(self, metric_name: str, threshold: int) -> None:
-        self.metric_name = metric_name
-        self.threshold = threshold
+class MinimumTrialsInStatus(MinimumTrialsInStatus):
+    """
+    Deprecated child class that has been replaced by `MinimumTrialsInStatus`
+    in `TransitionCriterion`, and will be fully reaped in a future release.
+    """
 
-    def is_met(self, experiment: Experiment) -> bool:
-        data = experiment.fetch_data(metrics=[experiment.metrics[self.metric_name]])
-
-        count_no = (data.df["mean"] == 0).sum()
-        count_yes = (data.df["mean"] != 0).sum()
-
-        return count_no >= self.threshold and count_yes >= self.threshold
+    logger.warning(
+        "CompletionCriterion, which MinimumTrialsInStatus inherits from, is"
+        " deprecated. Please use TransitionCriterion instead."
+    )
+    pass

--- a/ax/modelbridge/tests/test_completion_criterion.py
+++ b/ax/modelbridge/tests/test_completion_criterion.py
@@ -19,6 +19,12 @@ from ax.utils.testing.core_stubs import get_experiment
 
 
 class TestCompletionCritereon(TestCase):
+    """
+    `CompletionCriterion` is deprecrated and replaced by `TransitionCriterion`.
+    However, some legacy code still depends on the skelton implementation of
+    `CompletionCriterion`, so we will keep this test case until full reaping.
+    """
+
     def test_single_criterion(self) -> None:
         criterion = MinimumPreferenceOccurances(metric_name="m1", threshold=3)
 

--- a/ax/modelbridge/tests/test_transition_criterion.py
+++ b/ax/modelbridge/tests/test_transition_criterion.py
@@ -1,0 +1,141 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import patch
+
+import pandas as pd
+from ax.core.base_trial import TrialStatus
+from ax.core.data import Data
+from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.registry import Models
+from ax.modelbridge.transition_criterion import (
+    MaxTrials,
+    MinimumPreferenceOccurances,
+    MinimumTrialsInStatus,
+)
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_experiment
+
+
+class TestTransitionCriterion(TestCase):
+    def test_minimum_preference_criterion(self) -> None:
+        """Tests the minimum preference criterion subcalss of TransitionCriterion."""
+        criterion = MinimumPreferenceOccurances(metric_name="m1", threshold=3)
+        experiment = get_experiment()
+        generation_strategy = GenerationStrategy(
+            name="SOBOL+GPEI::default",
+            steps=[
+                GenerationStep(
+                    model=Models.SOBOL,
+                    num_trials=-1,
+                    completion_criteria=[criterion],
+                ),
+                GenerationStep(
+                    model=Models.GPEI,
+                    num_trials=-1,
+                    max_parallelism=1,
+                ),
+            ],
+        )
+        generation_strategy.experiment = experiment
+
+        # Has not seen enough of each preference
+        self.assertFalse(
+            generation_strategy._maybe_move_to_next_step(
+                raise_data_required_error=False
+            )
+        )
+
+        data = Data(
+            df=pd.DataFrame(
+                {
+                    "trial_index": range(6),
+                    "arm_name": [f"{i}_0" for i in range(6)],
+                    "metric_name": ["m1" for _ in range(6)],
+                    "mean": [0, 0, 0, 1, 1, 1],
+                    "sem": [0 for _ in range(6)],
+                }
+            )
+        )
+        with patch.object(experiment, "fetch_data", return_value=data):
+            # We have seen three "yes" and three "no"
+            self.assertTrue(
+                generation_strategy._maybe_move_to_next_step(
+                    raise_data_required_error=False
+                )
+            )
+            self.assertEqual(generation_strategy._curr.model, Models.GPEI)
+
+    def test_default_step_criterion_setup(self) -> None:
+        """This test ensures that the default completion criterion for GenerationSteps
+        is set as expected.
+
+        The default completion criterion is to create two TransitionCriterion, one
+        of type `MaximumTrialsInStatus` and one of type `MinimumTrialsInStatus`.
+        These are constructed via the inputs of `num_trials`, `enforce_num_trials`,
+        and `minimum_trials_observed` on the GenerationStep.
+        """
+        experiment = get_experiment()
+        gs = GenerationStrategy(
+            name="SOBOL+GPEI::default",
+            steps=[
+                GenerationStep(
+                    model=Models.SOBOL,
+                    num_trials=3,
+                    enforce_num_trials=False,
+                ),
+                GenerationStep(
+                    model=Models.GPEI,
+                    num_trials=4,
+                    max_parallelism=1,
+                    min_trials_observed=2,
+                ),
+                GenerationStep(
+                    model=Models.GPEI,
+                    num_trials=-1,
+                    max_parallelism=1,
+                ),
+            ],
+        )
+        gs.experiment = experiment
+
+        step_0_expected_transition_criteria = [
+            MaxTrials(threshold=3, enforce=False),
+            MinimumTrialsInStatus(status=TrialStatus.COMPLETED, threshold=0),
+        ]
+        step_1_expected_transition_criteria = [
+            MaxTrials(threshold=4, enforce=True),
+            MinimumTrialsInStatus(status=TrialStatus.COMPLETED, threshold=2),
+        ]
+        step_2_expected_transition_criteria = [
+            MaxTrials(threshold=-1, enforce=True),
+            MinimumTrialsInStatus(status=TrialStatus.COMPLETED, threshold=0),
+        ]
+        self.assertEqual(
+            gs._steps[0].transition_criteria, step_0_expected_transition_criteria
+        )
+        self.assertEqual(
+            gs._steps[1].transition_criteria, step_1_expected_transition_criteria
+        )
+        self.assertEqual(
+            gs._steps[2].transition_criteria, step_2_expected_transition_criteria
+        )
+
+        # Check default results for `is_met` call
+        self.assertTrue(gs._steps[0].transition_criteria[0].is_met(experiment))
+        self.assertTrue(gs._steps[0].transition_criteria[1].is_met(experiment))
+        self.assertFalse(gs._steps[1].transition_criteria[0].is_met(experiment))
+        self.assertFalse(gs._steps[1].transition_criteria[1].is_met(experiment))
+
+    def test_max_trials_status_arg(self) -> None:
+        """Tests the `only_in_status` argument checks the threshold based on the
+        number of trials in specified status instead of all trials (which is the
+        default behavior).
+        """
+        experiment = get_experiment()
+        criterion = MaxTrials(
+            threshold=5, only_in_status=TrialStatus.RUNNING, enforce=True
+        )
+        self.assertFalse(criterion.is_met(experiment))

--- a/ax/modelbridge/transition_criterion.py
+++ b/ax/modelbridge/transition_criterion.py
@@ -1,0 +1,97 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import abstractmethod
+from typing import Optional
+
+from ax.core.base_trial import TrialStatus
+
+from ax.core.experiment import Experiment
+from ax.utils.common.base import Base
+from ax.utils.common.serialization import SerializationMixin
+
+
+class TransitionCriterion(Base, SerializationMixin):
+    """
+    Simple class to descibe a condition which must be met for a GenerationStrategy
+    to move to its next GenerationNode.
+    """
+
+    # TODO: @mgarrard add `transition_to` attribute to define the next node
+    def __init__(self) -> None:
+        pass
+
+    @abstractmethod
+    def is_met(self, experiment: Experiment) -> bool:
+        pass
+
+
+class MinimumTrialsInStatus(TransitionCriterion):
+    """
+    Simple class to decide if the number of trials of a given status in the
+    GenerationStrategy experiment has reached a certain threshold.
+    """
+
+    def __init__(self, status: TrialStatus, threshold: int) -> None:
+        self.status = status
+        self.threshold = threshold
+
+    def is_met(self, experiment: Experiment) -> bool:
+        return len(experiment.trial_indices_by_status[self.status]) >= self.threshold
+
+
+class MaxTrials(TransitionCriterion):
+    """
+    Simple class to enforce a maximum threshold for the number of trials generated
+    by a specific GenerationNode.
+
+    Args:
+        threshold: the designated maximum number of trials
+        enforce: whether or not to enforce the max trial constraint
+        only_in_status: optional argument for specifying only checking trials with
+            this status. If not specified, all trial statuses are counted.
+    """
+
+    def __init__(
+        self,
+        threshold: int,
+        enforce: bool,
+        only_in_status: Optional[TrialStatus] = None,
+    ) -> None:
+        self.threshold = threshold
+        self.enforce = enforce
+        # Optional argument for specifying only checking trials with this status
+        self.only_in_status = only_in_status
+
+    def is_met(self, experiment: Experiment) -> bool:
+        if self.enforce:
+            if self.only_in_status is not None:
+                return (
+                    len(experiment.trial_indices_by_status[self.only_in_status])
+                    >= self.threshold
+                )
+            return experiment.num_trials >= self.threshold
+        return True
+
+
+class MinimumPreferenceOccurances(TransitionCriterion):
+    """
+    In a preference Experiment (i.e. Metric values may either be zero for No and
+    nonzero for Yes) do not transition until a minimum number of both Yes and No
+    responses have been received.
+    """
+
+    def __init__(self, metric_name: str, threshold: int) -> None:
+        self.metric_name = metric_name
+        self.threshold = threshold
+
+    def is_met(self, experiment: Experiment) -> bool:
+        # TODO: @mgarrard replace fetch_data with lookup_data
+        data = experiment.fetch_data(metrics=[experiment.metrics[self.metric_name]])
+
+        count_no = (data.df["mean"] == 0).sum()
+        count_yes = (data.df["mean"] != 0).sum()
+
+        return count_no >= self.threshold and count_yes >= self.threshold

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -49,10 +49,10 @@ from ax.early_stopping.strategies import (
 from ax.exceptions.core import AxStorageWarning
 from ax.exceptions.storage import JSONEncodeError
 from ax.global_stopping.strategies.improvement import ImprovementGlobalStoppingStrategy
-from ax.modelbridge.completion_criterion import CompletionCriterion
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import _encode_callables_as_references
 from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transition_criterion import TransitionCriterion
 from ax.models.torch.botorch_modular.model import BoTorchModel
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.models.winsorization_config import WinsorizationConfig
@@ -475,6 +475,7 @@ def generation_step_to_dict(generation_step: GenerationStep) -> Dict[str, Any]:
         ),
         "index": generation_step.index,
         "should_deduplicate": generation_step.should_deduplicate,
+        "transition_criteria": generation_step.transition_criteria,
     }
 
 
@@ -499,8 +500,8 @@ def generation_strategy_to_dict(
     }
 
 
-def completion_criterion_to_dict(criterion: CompletionCriterion) -> Dict[str, Any]:
-    """Convert Ax CompletionCriterion to a dictionary."""
+def transition_criterion_to_dict(criterion: TransitionCriterion) -> Dict[str, Any]:
+    """Convert Ax TransitionCriterion to a dictionary."""
     properties = criterion.serialize_init_args(obj=criterion)
     properties["__type"] = criterion.__class__.__name__
     return properties

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -75,13 +75,14 @@ from ax.metrics.jenatton import JenattonMetric
 from ax.metrics.l2norm import L2NormMetric
 from ax.metrics.noisy_function import NoisyFunctionMetric
 from ax.metrics.sklearn import SklearnDataset, SklearnMetric, SklearnModelType
-from ax.modelbridge.completion_criterion import (
-    MinimumPreferenceOccurances,
-    MinimumTrialsInStatus,
-)
 from ax.modelbridge.factory import Models
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transition_criterion import (
+    MaxTrials,
+    MinimumPreferenceOccurances,
+    MinimumTrialsInStatus,
+)
 from ax.models.torch.botorch_modular.acquisition import Acquisition
 from ax.models.torch.botorch_modular.model import BoTorchModel, SurrogateSpec
 from ax.models.torch.botorch_modular.surrogate import Surrogate
@@ -104,7 +105,6 @@ from ax.storage.json_store.encoders import (
     botorch_model_to_dict,
     botorch_modular_to_dict,
     choice_parameter_to_dict,
-    completion_criterion_to_dict,
     data_to_dict,
     experiment_to_dict,
     fixed_parameter_to_dict,
@@ -141,6 +141,7 @@ from ax.storage.json_store.encoders import (
     surrogate_to_dict,
     threshold_early_stopping_strategy_to_dict,
     transform_type_to_dict,
+    transition_criterion_to_dict,
     trial_to_dict,
     winsorization_config_to_dict,
 )
@@ -189,8 +190,9 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     MapKeyInfo: map_key_info_to_dict,
     MapMetric: metric_to_dict,
     Metric: metric_to_dict,
-    MinimumTrialsInStatus: completion_criterion_to_dict,
-    MinimumPreferenceOccurances: completion_criterion_to_dict,
+    MinimumTrialsInStatus: transition_criterion_to_dict,
+    MinimumPreferenceOccurances: transition_criterion_to_dict,
+    MaxTrials: transition_criterion_to_dict,
     MultiObjective: multi_objective_to_dict,
     MultiObjectiveBenchmarkProblem: multi_objective_benchmark_problem_to_dict,
     MultiObjectiveOptimizationConfig: multi_objective_optimization_config_to_dict,
@@ -300,6 +302,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "MapData": MapData,
     "MapMetric": MapMetric,
     "MapKeyInfo": MapKeyInfo,
+    "MaxTrials": MaxTrials,
     "Metric": Metric,
     "MinimumTrialsInStatus": MinimumTrialsInStatus,
     "MinimumPreferenceOccurances": MinimumPreferenceOccurances,

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -14,12 +14,12 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import FixedParameter, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.base import ModelBridge
-from ax.modelbridge.completion_criterion import MinimumPreferenceOccurances
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.int_to_float import IntToFloat
+from ax.modelbridge.transition_criterion import MinimumPreferenceOccurances
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.utils.common.logger import get_logger
 from ax.utils.testing.core_stubs import (

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -31,6 +31,12 @@ Completion Criterion
     :undoc-members:
     :show-inheritance:
 
+Transition Criterion
+.. automodule:: ax.modelbridge.transition_criterion
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Registry
 ~~~~~~~~~~~~~~~~~~~~
 .. automodule:: ax.modelbridge.registry


### PR DESCRIPTION
Summary:
In this diff we do a few things:
(1) Create a TransitionCriterion class:
- this class will subsume the CompletionCriterion class and will be a bit more flexible
- it has the same child classes + maximumtrialsinstatus subclass, we may add more subclasses or fields later as we further test

(2) Create an list of transitioncriterion from the generationstep class:
- minimum_trials_observed can be taken care of by the more flexible MinimumTrialsInStatus class
- num_trials and enforce_num_trials can be taken care of by the more flexible MaximumTrialsInStatus class

(3) adds a doc string to GenNode class - tangential but easy

(4) updates the type of completion_criteria of GenerationStep from CompletionCriterion to TransitionCriterion

(5) clean up compeletion_criterion class bc we don't need it anymore

In following diffs we will:
(1) add transition criterion to the repr string + some of the other fields that havent made it yet
(2) begin moving the functions related to completing the step up to node and leveraging the transition criterion for checks instead of indexes -- this is where we may need to add additional fields to transitioncriterion
(3) add doc strings to everywhere in teh GenNode class
(4) add additional unit tests to MaxTrials to bring coverage to 100%
(5) skip max trial criterion addition if numtrials == -1

Reviewed By: lena-kashtelyan

Differential Revision: D49509997


