### PR TITLE
Make target_value required for task parameters

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -439,7 +439,8 @@ class ChoiceParameter(Parameter):
             is longer than 2, else True.
         is_task: Treat the parameter as a task parameter for modeling.
         is_fidelity: Whether this parameter is a fidelity parameter.
-        target_value: Target value of this parameter if it's fidelity.
+        target_value: Target value of this parameter if it's a fidelity or
+            task parameter.
         sort_values: Whether to sort ``values`` before encoding.
             Defaults to False if ``parameter_type`` is STRING, else
             True.
@@ -459,9 +460,10 @@ class ChoiceParameter(Parameter):
         sort_values: Optional[bool] = None,
         dependents: Optional[Dict[TParamValue, List[str]]] = None,
     ) -> None:
-        if is_fidelity and (target_value is None):
+        if (is_fidelity or is_task) and (target_value is None):
+            ptype = "fidelity" if is_fidelity else "task"
             raise UserInputError(
-                "`target_value` should not be None for the fidelity parameter: "
+                f"`target_value` should not be None for the {ptype} parameter: "
                 "{}".format(name)
             )
 
@@ -612,10 +614,13 @@ class ChoiceParameter(Parameter):
             ret_val += f", is_task={self._is_task}"
 
         if self._is_fidelity:
+            ret_val += f", is_fidelity={self.is_fidelity}"
+
+        if self.target_value is not None:
             tval_rep = self.target_value
             if self.parameter_type == ParameterType.STRING:
                 tval_rep = f"'{tval_rep}'"
-            ret_val += f", is_fidelity={self.is_fidelity}, target_value={tval_rep}"
+            ret_val += f", target_value={tval_rep}"
 
         if self._dependents:
             ret_val += f", dependents={self._dependents}"

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -189,6 +189,7 @@ class ChoiceParameterTest(TestCase):
             values=["foo", "bar", "baz"],
             is_ordered=True,
             is_task=True,
+            target_value="baz",
         )
         self.param3 = ChoiceParameter(
             name="x",
@@ -220,6 +221,13 @@ class ChoiceParameterTest(TestCase):
                 values=["foo", "foo2"],
                 is_fidelity=True,
             )
+        with self.assertRaises(UserInputError):
+            ChoiceParameter(
+                name="x",
+                parameter_type=ParameterType.STRING,
+                values=["foo", "foo2"],
+                is_task=True,
+            )
 
     def test_Eq(self) -> None:
         param4 = ChoiceParameter(
@@ -242,6 +250,7 @@ class ChoiceParameterTest(TestCase):
         self.assertFalse(self.param1.is_task)
         self.assertTrue(self.param2.is_ordered)
         self.assertTrue(self.param2.is_task)
+        self.assertEqual(self.param2.target_value, "baz")
         # check is_ordered defaults
         bool_param = ChoiceParameter(
             name="x", parameter_type=ParameterType.BOOL, values=[True, False]
@@ -251,11 +260,9 @@ class ChoiceParameterTest(TestCase):
             name="x", parameter_type=ParameterType.INT, values=[2, 1, 3]
         )
         self.assertTrue(int_param.is_ordered)
-        # pyre-fixme[6]: For 1st param expected
-        #  `Iterable[Variable[SupportsRichComparisonT (bound to
-        #  Union[SupportsDunderGT[typing.Any], SupportsDunderLT[typing.Any]])]]` but
-        #  got `List[Union[None, bool, float, int, str]]`.
-        self.assertListEqual(int_param.values, sorted(int_param.values))
+        self.assertListEqual(
+            int_param.values, sorted(int_param.values)  # pyre-fixme[6]
+        )
         float_param = ChoiceParameter(
             name="x", parameter_type=ParameterType.FLOAT, values=[1.5, 2.5, 3.5]
         )

--- a/ax/modelbridge/tests/test_metrics_as_task_transform.py
+++ b/ax/modelbridge/tests/test_metrics_as_task_transform.py
@@ -130,3 +130,4 @@ class MetricsAsTaskTransformTest(TestCase):
             new_param.values, ["TARGET", "metric1", "metric2"]  # pyre-ignore
         )
         self.assertTrue(new_param.is_task)  # pyre-ignore
+        self.assertEqual(new_param.target_value, "TARGET")

--- a/ax/modelbridge/tests/test_stratified_standardize_y.py
+++ b/ax/modelbridge/tests/test_stratified_standardize_y.py
@@ -105,12 +105,14 @@ class StratifiedStandardizeYTransformTest(TestCase):
                     parameter_type=ParameterType.STRING,
                     values=["a", "b"],
                     is_task=True,
+                    target_value="a",
                 ),
                 ChoiceParameter(
                     name="z2",
                     parameter_type=ParameterType.STRING,
                     values=["a", "b"],
                     is_task=True,
+                    target_value="b",
                 ),
             ]
         )
@@ -131,6 +133,7 @@ class StratifiedStandardizeYTransformTest(TestCase):
                     parameter_type=ParameterType.STRING,
                     values=["a", "b"],
                     is_task=True,
+                    target_value="a",
                 ),
             ]
         )

--- a/ax/modelbridge/tests/test_task_encode_transform.py
+++ b/ax/modelbridge/tests/test_task_encode_transform.py
@@ -32,6 +32,7 @@ class TaskEncodeTransformTest(TestCase):
                     parameter_type=ParameterType.STRING,
                     values=["online", "offline"],
                     is_task=True,
+                    target_value="online",
                 ),
             ]
         )
@@ -74,6 +75,7 @@ class TaskEncodeTransformTest(TestCase):
 
         # pyre-fixme[16]: `Parameter` has no attribute `values`.
         self.assertEqual(ss2.parameters["c"].values, [0, 1])
+        self.assertEqual(ss2.parameters["c"].target_value, 0)
 
         # Test error if there are fidelities
         ss3 = SearchSpace(
@@ -98,6 +100,7 @@ class TaskEncodeTransformTest(TestCase):
         rss = get_robust_search_space()
         # pyre-fixme[16]: `Parameter` has no attribute `_is_task`.
         rss.parameters["c"]._is_task = True
+        rss.parameters["c"]._target_value = "red"
         # Transform a non-distributional parameter.
         t = TaskEncode(
             search_space=rss,

--- a/ax/modelbridge/transforms/metrics_as_task.py
+++ b/ax/modelbridge/transforms/metrics_as_task.py
@@ -129,6 +129,7 @@ class MetricsAsTask(Transform):
             is_ordered=False,
             is_task=True,
             sort_values=True,
+            target_value="TARGET",
         )
         search_space.add_parameter(task_param)
         return search_space

--- a/ax/modelbridge/transforms/task_encode.py
+++ b/ax/modelbridge/transforms/task_encode.py
@@ -41,6 +41,7 @@ class TaskEncode(OrderedChoiceEncode):
         assert search_space is not None, "TaskEncode requires search space"
         # Identify parameters that should be transformed
         self.encoded_parameters: Dict[str, Dict[TParamValue, int]] = {}
+        self.target_values: Dict[str, int] = {}
         for p in search_space.parameters.values():
             if isinstance(p, ChoiceParameter) and p.is_task:
                 if p.is_fidelity:
@@ -52,6 +53,9 @@ class TaskEncode(OrderedChoiceEncode):
                     original_value: transformed_value
                     for transformed_value, original_value in enumerate(p.values)
                 }
+                self.target_values[p.name] = self.encoded_parameters[p.name][
+                    p.target_value
+                ]
         self.encoded_parameters_inverse: Dict[str, Dict[int, TParamValue]] = {
             p_name: {
                 transformed_value: original_value
@@ -76,6 +80,7 @@ class TaskEncode(OrderedChoiceEncode):
                     is_ordered=p.is_ordered,
                     is_task=True,
                     sort_values=True,
+                    target_value=self.target_values[p_name],
                 )
             else:
                 transformed_parameters[p.name] = p

--- a/ax/modelbridge/transforms/unit_x.py
+++ b/ax/modelbridge/transforms/unit_x.py
@@ -71,10 +71,10 @@ class UnitX(Transform):
                     lower=self.target_lb,
                     upper=self.target_lb + self.target_range,
                 )
-            if p.target_value is not None:
-                p._target_value = self._normalize_value(
-                    p.target_value, self.bounds[p_name]  # pyre-ignore[6]
-                )
+                if p.target_value is not None:
+                    p._target_value = self._normalize_value(
+                        p.target_value, self.bounds[p_name]  # pyre-ignore[6]
+                    )
         new_constraints: List[ParameterConstraint] = []
         for c in search_space.parameter_constraints:
             constraint_dict: Dict[str, float] = {}

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1244,11 +1244,9 @@ def get_task_choice_parameter() -> ChoiceParameter:
     return ChoiceParameter(
         name="y",
         parameter_type=ParameterType.INT,
-        # Expected `List[typing.Optional[typing.Union[bool, float, str]]]` for 4th
-        # parameter `values` to call
-        # `ax.core.parameter.ChoiceParameter.__init__` but got `List[str]`.
         values=[1, 2, 3],
         is_task=True,
+        target_value=1,
     )
 
 


### PR DESCRIPTION
Summary:
Task parameters have a "target_value" attribute, but we haven't been using it; it has previously only been used for fidelity parameters. But at the core level, there's nothing in its implementation that would restrict its use to fidelity parameters. But all of our applications of multi-task models have a target task, and the new MultiTaskDataset in botorch requires specifying a target task.

In order to migrate our multi-task models to use MultiTaskDataset (D49604249), we need to have a target task. This diff makes target_value a required attribute for task parameters, the same way it is currently required for fidelity parameters.

Propagating the target value to the search space digest will happen in a stacked diff.

Transforms that create task parameters (TrialAsTask and MetricsAsTask) are adjusted to appropriately specify the target value. For MetricsAsTask the correct target value is clear. For TrialAsTask it may not be (should it be trial 0 if that is an LRT? Should it be the last trial if it is a fully sequential experiment?). Moreover, the user may want to use the model to predict multiple tasks (e.g. to do cross validation on each task in the model). Fortunately, choosing the "right" target value is not essential at this point. Currently with TrialAsTask, we require specifying the target task as part of the prediction in every call to predict or gen. That will continue to work exactly as-is. So the way we currently use TrialAsTask, the behavior will not be affected by which trial is chosen as the target task. In the future, we will be able to replace specifying the target task as a fixed feature to `gen` with specifying the target task as a config option to the TrialAsTask transform. We can make that transition later.

Differential Revision: D49659731


