### PR TITLE
Add target task values to SearchSpaceDigest

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -439,7 +439,8 @@ class ChoiceParameter(Parameter):
             is longer than 2, else True.
         is_task: Treat the parameter as a task parameter for modeling.
         is_fidelity: Whether this parameter is a fidelity parameter.
-        target_value: Target value of this parameter if it's fidelity.
+        target_value: Target value of this parameter if it's a fidelity or
+            task parameter.
         sort_values: Whether to sort ``values`` before encoding.
             Defaults to False if ``parameter_type`` is STRING, else
             True.
@@ -459,9 +460,10 @@ class ChoiceParameter(Parameter):
         sort_values: Optional[bool] = None,
         dependents: Optional[Dict[TParamValue, List[str]]] = None,
     ) -> None:
-        if is_fidelity and (target_value is None):
+        if (is_fidelity or is_task) and (target_value is None):
+            ptype = "fidelity" if is_fidelity else "task"
             raise UserInputError(
-                "`target_value` should not be None for the fidelity parameter: "
+                f"`target_value` should not be None for the {ptype} parameter: "
                 "{}".format(name)
             )
 
@@ -612,10 +614,13 @@ class ChoiceParameter(Parameter):
             ret_val += f", is_task={self._is_task}"
 
         if self._is_fidelity:
+            ret_val += f", is_fidelity={self.is_fidelity}"
+
+        if self.target_value is not None:
             tval_rep = self.target_value
             if self.parameter_type == ParameterType.STRING:
                 tval_rep = f"'{tval_rep}'"
-            ret_val += f", is_fidelity={self.is_fidelity}, target_value={tval_rep}"
+            ret_val += f", target_value={tval_rep}"
 
         if self._dependents:
             ret_val += f", dependents={self._dependents}"

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -988,9 +988,8 @@ class SearchSpaceDigest:
             task parameters.
         fidelity_features: A list of parameter indices to be considered as
             fidelity parameters.
-        target_fidelities: A dictionary mapping parameter indices (of fidelity
-            parameters) to their respective target fidelity value. Only used
-            when generating candidates.
+        target_values: A dictionary mapping parameter indices of fidelity or
+            task parameters to their respective target value.
         robust_digest: An optional `RobustSearchSpaceDigest` that carries the
             additional attributes if using a `RobustSearchSpace`.
     """
@@ -1002,7 +1001,7 @@ class SearchSpaceDigest:
     discrete_choices: Dict[int, List[Union[int, float]]] = field(default_factory=dict)
     task_features: List[int] = field(default_factory=list)
     fidelity_features: List[int] = field(default_factory=list)
-    target_fidelities: Dict[int, Union[int, float]] = field(default_factory=dict)
+    target_values: Dict[int, Union[int, float]] = field(default_factory=dict)
     robust_digest: Optional[RobustSearchSpaceDigest] = None
 
 

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -189,6 +189,7 @@ class ChoiceParameterTest(TestCase):
             values=["foo", "bar", "baz"],
             is_ordered=True,
             is_task=True,
+            target_value="baz",
         )
         self.param3 = ChoiceParameter(
             name="x",
@@ -220,6 +221,13 @@ class ChoiceParameterTest(TestCase):
                 values=["foo", "foo2"],
                 is_fidelity=True,
             )
+        with self.assertRaises(UserInputError):
+            ChoiceParameter(
+                name="x",
+                parameter_type=ParameterType.STRING,
+                values=["foo", "foo2"],
+                is_task=True,
+            )
 
     def test_Eq(self) -> None:
         param4 = ChoiceParameter(
@@ -242,6 +250,7 @@ class ChoiceParameterTest(TestCase):
         self.assertFalse(self.param1.is_task)
         self.assertTrue(self.param2.is_ordered)
         self.assertTrue(self.param2.is_task)
+        self.assertEqual(self.param2.target_value, "baz")
         # check is_ordered defaults
         bool_param = ChoiceParameter(
             name="x", parameter_type=ParameterType.BOOL, values=[True, False]
@@ -251,11 +260,9 @@ class ChoiceParameterTest(TestCase):
             name="x", parameter_type=ParameterType.INT, values=[2, 1, 3]
         )
         self.assertTrue(int_param.is_ordered)
-        # pyre-fixme[6]: For 1st param expected
-        #  `Iterable[Variable[SupportsRichComparisonT (bound to
-        #  Union[SupportsDunderGT[typing.Any], SupportsDunderLT[typing.Any]])]]` but
-        #  got `List[Union[None, bool, float, int, str]]`.
-        self.assertListEqual(int_param.values, sorted(int_param.values))
+        self.assertListEqual(
+            int_param.values, sorted(int_param.values)  # pyre-fixme[6]
+        )
         float_param = ChoiceParameter(
             name="x", parameter_type=ParameterType.FLOAT, values=[1.5, 2.5, 3.5]
         )

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -399,7 +399,7 @@ class SearchSpaceDigestTest(TestCase):
             "discrete_choices": {1: [0, 1, 2], 2: [0, 0.25, 4.0]},
             "task_features": [3],
             "fidelity_features": [0],
-            "target_fidelities": {0: 1.0},
+            "target_values": {0: 1.0},
             "robust_digest": None,
         }
 

--- a/ax/modelbridge/tests/test_metrics_as_task_transform.py
+++ b/ax/modelbridge/tests/test_metrics_as_task_transform.py
@@ -130,3 +130,4 @@ class MetricsAsTaskTransformTest(TestCase):
             new_param.values, ["TARGET", "metric1", "metric2"]  # pyre-ignore
         )
         self.assertTrue(new_param.is_task)  # pyre-ignore
+        self.assertEqual(new_param.target_value, "TARGET")

--- a/ax/modelbridge/tests/test_stratified_standardize_y.py
+++ b/ax/modelbridge/tests/test_stratified_standardize_y.py
@@ -105,12 +105,14 @@ class StratifiedStandardizeYTransformTest(TestCase):
                     parameter_type=ParameterType.STRING,
                     values=["a", "b"],
                     is_task=True,
+                    target_value="a",
                 ),
                 ChoiceParameter(
                     name="z2",
                     parameter_type=ParameterType.STRING,
                     values=["a", "b"],
                     is_task=True,
+                    target_value="b",
                 ),
             ]
         )
@@ -131,6 +133,7 @@ class StratifiedStandardizeYTransformTest(TestCase):
                     parameter_type=ParameterType.STRING,
                     values=["a", "b"],
                     is_task=True,
+                    target_value="a",
                 ),
             ]
         )

--- a/ax/modelbridge/tests/test_task_encode_transform.py
+++ b/ax/modelbridge/tests/test_task_encode_transform.py
@@ -32,6 +32,7 @@ class TaskEncodeTransformTest(TestCase):
                     parameter_type=ParameterType.STRING,
                     values=["online", "offline"],
                     is_task=True,
+                    target_value="online",
                 ),
             ]
         )
@@ -74,6 +75,7 @@ class TaskEncodeTransformTest(TestCase):
 
         # pyre-fixme[16]: `Parameter` has no attribute `values`.
         self.assertEqual(ss2.parameters["c"].values, [0, 1])
+        self.assertEqual(ss2.parameters["c"].target_value, 0)
 
         # Test error if there are fidelities
         ss3 = SearchSpace(
@@ -98,6 +100,7 @@ class TaskEncodeTransformTest(TestCase):
         rss = get_robust_search_space()
         # pyre-fixme[16]: `Parameter` has no attribute `_is_task`.
         rss.parameters["c"]._is_task = True
+        rss.parameters["c"]._target_value = "red"
         # Transform a non-distributional parameter.
         t = TaskEncode(
             search_space=rss,

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -254,7 +254,7 @@ class TorchModelBridgeTest(TestCase):
         self.assertEqual(gen_opt_config.model_gen_options, {"option": "yes"})
         self.assertIs(gen_opt_config.rounding_func, torch.round)
         self.assertFalse(gen_opt_config.is_moo)
-        self.assertEqual(gen_args["search_space_digest"].target_fidelities, {})
+        self.assertEqual(gen_args["search_space_digest"].target_values, {})
         self.assertEqual(len(gen_run.arms), 1)
         self.assertEqual(gen_run.arms[0].parameters, {"x1": 1.0, "x2": 2.0, "x3": 3.0})
         self.assertEqual(gen_run.weights, [1.0])

--- a/ax/modelbridge/transforms/metrics_as_task.py
+++ b/ax/modelbridge/transforms/metrics_as_task.py
@@ -129,6 +129,7 @@ class MetricsAsTask(Transform):
             is_ordered=False,
             is_task=True,
             sort_values=True,
+            target_value="TARGET",
         )
         search_space.add_parameter(task_param)
         return search_space

--- a/ax/modelbridge/transforms/task_encode.py
+++ b/ax/modelbridge/transforms/task_encode.py
@@ -41,6 +41,7 @@ class TaskEncode(OrderedChoiceEncode):
         assert search_space is not None, "TaskEncode requires search space"
         # Identify parameters that should be transformed
         self.encoded_parameters: Dict[str, Dict[TParamValue, int]] = {}
+        self.target_values: Dict[str, int] = {}
         for p in search_space.parameters.values():
             if isinstance(p, ChoiceParameter) and p.is_task:
                 if p.is_fidelity:
@@ -52,6 +53,9 @@ class TaskEncode(OrderedChoiceEncode):
                     original_value: transformed_value
                     for transformed_value, original_value in enumerate(p.values)
                 }
+                self.target_values[p.name] = self.encoded_parameters[p.name][
+                    p.target_value
+                ]
         self.encoded_parameters_inverse: Dict[str, Dict[int, TParamValue]] = {
             p_name: {
                 transformed_value: original_value
@@ -76,6 +80,7 @@ class TaskEncode(OrderedChoiceEncode):
                     is_ordered=p.is_ordered,
                     is_task=True,
                     sort_values=True,
+                    target_value=self.target_values[p_name],
                 )
             else:
                 transformed_parameters[p.name] = p

--- a/ax/modelbridge/transforms/unit_x.py
+++ b/ax/modelbridge/transforms/unit_x.py
@@ -71,10 +71,10 @@ class UnitX(Transform):
                     lower=self.target_lb,
                     upper=self.target_lb + self.target_range,
                 )
-            if p.target_value is not None:
-                p._target_value = self._normalize_value(
-                    p.target_value, self.bounds[p_name]  # pyre-ignore[6]
-                )
+                if p.target_value is not None:
+                    p._target_value = self._normalize_value(
+                        p.target_value, self.bounds[p_name]  # pyre-ignore[6]
+                    )
         new_constraints: List[ParameterConstraint] = []
         for c in search_space.parameter_constraints:
             constraint_dict: Dict[str, float] = {}

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -203,7 +203,7 @@ class KnowledgeGradientTest(TestCase):
             feature_names=self.feature_names,
             bounds=self.bounds,
             fidelity_features=[2],
-            target_fidelities={2: 5.0},
+            target_values={2: 5.0},
         )
         model = KnowledgeGradient()
         model.fit(
@@ -234,7 +234,7 @@ class KnowledgeGradientTest(TestCase):
             model.best_point(
                 search_space_digest=dataclasses.replace(
                     search_space_digest,
-                    target_fidelities={},
+                    target_values={},
                 ),
                 torch_opt_config=torch_opt_config,
             )

--- a/ax/models/tests/test_botorch_mes.py
+++ b/ax/models/tests/test_botorch_mes.py
@@ -129,7 +129,9 @@ class MaxValueEntropySearchTest(TestCase):
         with self.assertRaises(RuntimeError):
             model.best_point(
                 search_space_digest=dataclasses.replace(
-                    self.search_space_digest, target_fidelities={2: 1.0}
+                    self.search_space_digest,
+                    fidelity_features=[2],
+                    target_values={2: 1.0},
                 ),
                 torch_opt_config=torch_opt_config,
             )
@@ -175,7 +177,8 @@ class MaxValueEntropySearchTest(TestCase):
         xbest = model.best_point(
             search_space_digest=dataclasses.replace(
                 search_space_digest,
-                target_fidelities={2: 5.0},
+                fidelity_features=[2],
+                target_values={2: 5.0},
             ),
             torch_opt_config=torch_opt_config,
         )
@@ -196,7 +199,7 @@ class MaxValueEntropySearchTest(TestCase):
             model.best_point(
                 search_space_digest=dataclasses.replace(
                     search_space_digest,
-                    target_fidelities={2: 1.0},
+                    target_values={2: 1.0},
                 ),
                 torch_opt_config=dataclasses.replace(
                     torch_opt_config,
@@ -210,7 +213,7 @@ class MaxValueEntropySearchTest(TestCase):
             n=n,
             search_space_digest=dataclasses.replace(
                 search_space_digest,
-                target_fidelities={2: 1.0},
+                target_values={2: 1.0},
             ),
             torch_opt_config=dataclasses.replace(
                 torch_opt_config,

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -468,7 +468,8 @@ class BotorchModelTest(TestCase):
                     n=n,
                     search_space_digest=dataclasses.replace(
                         search_space_digest,
-                        target_fidelities={0: 3.0},
+                        fidelity_features=[0],
+                        target_values={0: 3.0},
                     ),
                     torch_opt_config=torch_opt_config,
                 )
@@ -500,7 +501,8 @@ class BotorchModelTest(TestCase):
                 xbest = model.best_point(
                     search_space_digest=dataclasses.replace(
                         search_space_digest,
-                        target_fidelities={0: 3.0},
+                        fidelity_features=[0],
+                        target_values={0: 3.0},
                     ),
                     torch_opt_config=torch_opt_config,
                 )

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -330,9 +330,9 @@ class BotorchModel(TorchModel):
         acf_options = options.get(Keys.ACQF_KWARGS, {})
         optimizer_options = options.get(Keys.OPTIMIZER_KWARGS, {})
 
-        if search_space_digest.target_fidelities:
+        if search_space_digest.fidelity_features:
             raise NotImplementedError(
-                "target_fidelities not implemented for base BotorchModel"
+                "Base BotorchModel does not support fidelity_features."
             )
         X_pending, X_observed = _get_X_pending_and_observed(
             Xs=self.Xs,
@@ -437,6 +437,11 @@ class BotorchModel(TorchModel):
             raise NotImplementedError(
                 "Best observed point is incompatible with MOO problems."
             )
+        target_fidelities = {
+            k: v
+            for k, v in search_space_digest.target_values.items()
+            if k in search_space_digest.fidelity_features
+        }
         return self.best_point_recommender(  # pyre-ignore [28]
             model=self,
             bounds=search_space_digest.bounds,
@@ -445,7 +450,7 @@ class BotorchModel(TorchModel):
             linear_constraints=torch_opt_config.linear_constraints,
             fixed_features=torch_opt_config.fixed_features,
             model_gen_options=torch_opt_config.model_gen_options,
-            target_fidelities=search_space_digest.target_fidelities,
+            target_fidelities=target_fidelities,
         )
 
     @copy_doc(TorchModel.cross_validate)

--- a/ax/models/torch/botorch_kg.py
+++ b/ax/models/torch/botorch_kg.py
@@ -164,6 +164,11 @@ class KnowledgeGradient(BotorchModel):
         )
         bounds_ = bounds_.transpose(0, 1)
 
+        target_fidelities = {
+            k: v
+            for k, v in search_space_digest.target_values.items()
+            if k in search_space_digest.fidelity_features
+        }
         # get acquisition function
         acq_function = _instantiate_KG(
             model=model,
@@ -176,7 +181,7 @@ class KnowledgeGradient(BotorchModel):
             seed_inner=seed_inner,
             seed_outer=acf_options.get("seed_outer", None),
             X_pending=X_pending,
-            target_fidelities=search_space_digest.target_fidelities,
+            target_fidelities=target_fidelities,
             fidelity_weights=options.get("fidelity_weights"),
             current_value=current_value,
             cost_intercept=self.cost_intercept,
@@ -238,6 +243,11 @@ class KnowledgeGradient(BotorchModel):
         acquisition function' (typically `PosteriorMean` or `qSimpleRegret`), not of
         the Knowledge Gradient acquisition function.
         """
+        target_fidelities = {
+            k: v
+            for k, v in search_space_digest.target_values.items()
+            if k in search_space_digest.fidelity_features
+        }
         best_point_acqf, non_fixed_idcs = get_out_of_sample_best_point_acqf(
             model=model,
             Xs=self.Xs,
@@ -247,7 +257,7 @@ class KnowledgeGradient(BotorchModel):
             seed_inner=seed_inner,
             fixed_features=torch_opt_config.fixed_features,
             fidelity_features=self.fidelity_features,
-            target_fidelities=search_space_digest.target_fidelities,
+            target_fidelities=target_fidelities,
             qmc=qmc,
         )
 

--- a/ax/models/torch/botorch_mes.py
+++ b/ax/models/torch/botorch_mes.py
@@ -130,6 +130,11 @@ class MaxValueEntropySearch(BotorchModel):
         candidate_set = torch.rand(candidate_size, bounds_.size(1))
         candidate_set = bounds_[0] + (bounds_[1] - bounds_[0]) * candidate_set
 
+        target_fidelities = {
+            k: v
+            for k, v in search_space_digest.target_values.items()
+            if k in search_space_digest.fidelity_features
+        }
         acq_function = _instantiate_MES(
             model=model,
             candidate_set=candidate_set,
@@ -139,7 +144,7 @@ class MaxValueEntropySearch(BotorchModel):
             num_y_samples=num_y_samples,
             X_pending=X_pending,
             maximize=True if objective_weights[0] == 1 else False,
-            target_fidelities=search_space_digest.target_fidelities,
+            target_fidelities=target_fidelities,
             fidelity_weights=options.get("fidelity_weights"),
             cost_intercept=self.cost_intercept,
         )

--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -273,7 +273,11 @@ class Acquisition(Base):
             if len(self.surrogates) > 1
             else {"model": model}
         )
-
+        target_fidelities = {
+            k: v
+            for k, v in search_space_digest.target_values.items()
+            if k in search_space_digest.fidelity_features
+        }
         input_constructor_kwargs = {
             "X_baseline": unique_Xs_observed,
             "X_pending": unique_Xs_pending,
@@ -281,7 +285,7 @@ class Acquisition(Base):
             "constraints": get_outcome_constraint_transforms(
                 outcome_constraints=outcome_constraints
             ),
-            "target_fidelities": search_space_digest.target_fidelities,
+            "target_fidelities": target_fidelities,
             "bounds": search_space_digest.bounds,
             **acqf_model_kwarg,
             **model_deps,

--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -443,11 +443,11 @@ class BoTorchModel(TorchModel, Base):
             acqf_options=self.acquisition_options,
             model_gen_options=torch_opt_config.model_gen_options,
         )
-        # update bounds / target fidelities
+        # update bounds / target values
         search_space_digest = dataclasses.replace(
             self.search_space_digest,
             bounds=search_space_digest.bounds,
-            target_fidelities=search_space_digest.target_fidelities or {},
+            target_values=search_space_digest.target_values or {},
         )
 
         acqf = self._instantiate_acquisition(

--- a/ax/models/torch/botorch_modular/multi_fidelity.py
+++ b/ax/models/torch/botorch_modular/multi_fidelity.py
@@ -36,7 +36,11 @@ class MultiFidelityAcquisition(Acquisition):
             raise UnsupportedError(
                 f"{self.__class__.__name__} does not support risk measures."
             )
-        target_fidelities = search_space_digest.target_fidelities
+        target_fidelities = {
+            k: v
+            for k, v in search_space_digest.target_values.items()
+            if k in search_space_digest.fidelity_features
+        }
         if not target_fidelities:
             raise ValueError(
                 "Target fidelities are required for {self.__class__.__name__}."

--- a/ax/models/torch/botorch_moo.py
+++ b/ax/models/torch/botorch_moo.py
@@ -246,9 +246,9 @@ class MultiObjectiveBotorchModel(BotorchModel):
         acf_options = options.get("acquisition_function_kwargs", {})
         optimizer_options = options.get("optimizer_kwargs", {})
 
-        if search_space_digest.target_fidelities:  # untested
+        if search_space_digest.fidelity_features:  # untested
             raise NotImplementedError(
-                "target_fidelities not implemented for base BotorchModel"
+                "fidelity_features not implemented for base BotorchModel"
             )
         if (
             torch_opt_config.objective_thresholds is not None

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -117,7 +117,7 @@ class AcquisitionTest(TestCase):
         self.search_space_digest = SearchSpaceDigest(
             feature_names=self.feature_names,
             bounds=[(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)],
-            target_fidelities={2: 1.0},
+            target_values={2: 1.0},
         )
         self.surrogate.construct(
             datasets=self.training_data,
@@ -126,7 +126,7 @@ class AcquisitionTest(TestCase):
             search_space_digest=SearchSpaceDigest(
                 feature_names=self.search_space_digest.feature_names[:1],
                 bounds=self.search_space_digest.bounds,
-                target_fidelities=self.search_space_digest.target_fidelities,
+                target_values=self.search_space_digest.target_values,
             ),
         )
 

--- a/ax/models/torch/tests/test_input_transform_argparse.py
+++ b/ax/models/torch/tests/test_input_transform_argparse.py
@@ -48,7 +48,7 @@ class InputTransformArgparseTest(TestCase):
             discrete_choices={1: [0, 1, 2], 2: [0, 0.25, 4.0]},
             task_features=[3],
             fidelity_features=[0],
-            target_fidelities={0: 1.0},
+            target_values={0: 1.0},
             robust_digest=None,
         )
 

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -123,7 +123,7 @@ class BoTorchModelTest(TestCase):
             bounds=[(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)],
             task_features=[],
             fidelity_features=[2],
-            target_fidelities={1: 1.0},
+            target_values={1: 1.0},
         )
         self.metric_names = ["y"]
         self.metric_names_for_list_surrogate = ["y1", "y2"]

--- a/ax/models/torch/tests/test_multi_fidelity.py
+++ b/ax/models/torch/tests/test_multi_fidelity.py
@@ -48,7 +48,7 @@ class MultiFidelityAcquisitionTest(TestCase):
         self.search_space_digest = SearchSpaceDigest(
             feature_names=self.feature_names,
             bounds=[(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)],
-            target_fidelities={2: 1.0},
+            target_values={2: 1.0},
             fidelity_features=self.fidelity_features,
         )
         self.surrogate.construct(
@@ -120,7 +120,9 @@ class MultiFidelityAcquisitionTest(TestCase):
             mf_acquisition.compute_model_dependencies(
                 surrogates={"regression": self.surrogate},
                 search_space_digest=dataclasses.replace(
-                    self.search_space_digest, target_fidelities={1: 5.0}
+                    self.search_space_digest,
+                    fidelity_features=[1],
+                    target_values={1: 5.0},
                 ),
                 torch_opt_config=self.torch_opt_config,
                 options=self.options,
@@ -129,7 +131,9 @@ class MultiFidelityAcquisitionTest(TestCase):
         mf_acquisition.compute_model_dependencies(
             surrogates={"regression": self.surrogate},
             search_space_digest=dataclasses.replace(
-                self.search_space_digest, target_fidelities={2: 5.0, 3: 5.0}
+                self.search_space_digest,
+                fidelity_features=[2, 3],
+                target_values={2: 5.0, 3: 5.0},
             ),
             torch_opt_config=self.torch_opt_config,
             options={Keys.COST_INTERCEPT: 1.0, Keys.NUM_TRACE_OBSERVATIONS: 0},
@@ -163,12 +167,12 @@ class MultiFidelityAcquisitionTest(TestCase):
         project(torch.tensor([1.0]))
         mock_project.assert_called_with(
             X=torch.tensor([1.0]),
-            target_fidelities=self.search_space_digest.target_fidelities,
+            target_fidelities=self.search_space_digest.target_values,
         )
         expand = dependencies.get(Keys.EXPAND)
         expand(torch.tensor([1.0]))
         mock_expand.assert_called_with(
             X=torch.tensor([1.0]),
-            fidelity_dims=sorted(self.search_space_digest.target_fidelities),
+            fidelity_dims=sorted(self.search_space_digest.target_values),
             num_trace_obs=self.options.get(Keys.NUM_TRACE_OBSERVATIONS),
         )

--- a/ax/models/torch/tests/test_sebo.py
+++ b/ax/models/torch/tests/test_sebo.py
@@ -58,7 +58,7 @@ class TestSebo(TestCase):
         self.search_space_digest = SearchSpaceDigest(
             feature_names=["a", "b", "c"],
             bounds=[(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)],
-            target_fidelities={2: 1.0},
+            target_values={2: 1.0},
         )
         self.surrogates.construct(
             datasets=self.training_data,

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -92,7 +92,7 @@ class SurrogateTest(TestCase):
         self.search_space_digest = SearchSpaceDigest(
             feature_names=["x1", "x2"],
             bounds=self.bounds,
-            target_fidelities={1: 1.0},
+            target_values={1: 1.0},
         )
         self.fixed_features = {1: 2.0}
         self.refit = True

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1244,11 +1244,9 @@ def get_task_choice_parameter() -> ChoiceParameter:
     return ChoiceParameter(
         name="y",
         parameter_type=ParameterType.INT,
-        # Expected `List[typing.Optional[typing.Union[bool, float, str]]]` for 4th
-        # parameter `values` to call
-        # `ax.core.parameter.ChoiceParameter.__init__` but got `List[str]`.
         values=[1, 2, 3],
         is_task=True,
+        target_value=1,
     )
 
 


### PR DESCRIPTION
Summary: Earlier in this stack we add "target_value" as a required attribute for task parameters, like it has been for fidelity parameters. The first place in the stack where "target_value" is considered to be exclusively for fidelity parameters is in SearchSpaceDigest, so this adjusts the logic there to also track target values for task parameters. And renames the attribute, to make it more clear that it is not restricted to fidelity parameters.

Differential Revision: D49701286

