### PR TITLE
MultiTaskDataset propagation

### DIFF
--- a/ax/modelbridge/pairwise.py
+++ b/ax/modelbridge/pairwise.py
@@ -11,6 +11,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 import torch
 from ax.core.observation import ObservationData, ObservationFeatures
+from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
 from ax.modelbridge.torch import TorchModelBridge
 from botorch.models.utils.assorted import consolidate_duplicates
@@ -26,6 +27,7 @@ class PairwiseModelBridge(TorchModelBridge):
         observation_features: List[ObservationFeatures],
         outcomes: List[str],
         parameters: List[str],
+        search_space_digest: Optional[SearchSpaceDigest],
     ) -> Tuple[
         List[Optional[SupervisedDataset]], Optional[List[List[TCandidateMetadata]]]
     ]:

--- a/ax/modelbridge/tests/test_pairwise_modelbridge.py
+++ b/ax/modelbridge/tests/test_pairwise_modelbridge.py
@@ -79,6 +79,7 @@ class PairwiseModelBridgeTest(TestCase):
             observation_features=observation_features,
             outcomes=outcomes,
             parameters=parameters,
+            search_space_digest=None,
         )
         self.assertTrue(len(datasets) == 1)
         self.assertTrue(isinstance(datasets[0], RankingDataset))
@@ -89,6 +90,7 @@ class PairwiseModelBridgeTest(TestCase):
             observation_features=observation_features_with_metadata,
             outcomes=outcomes,
             parameters=parameters,
+            search_space_digest=None,
         )
         self.assertTrue(len(datasets) == 1)
         self.assertTrue(isinstance(datasets[0], RankingDataset))


### PR DESCRIPTION
Summary:
Updates `TorchModelBridge._convert_observations` to construct a `MultiTaskDataset` if a task feature exists.

`MultiTaskDataset` behaves just like any other for the current use cases.

Differential Revision: D49604249

