### PR TITLE
Relax dependents check in Parameter.is_hierarchical

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -110,9 +110,8 @@ class Parameter(SortableBase, metaclass=ABCMeta):
 
     @property
     def is_hierarchical(self) -> bool:
-        return (
-            isinstance(self, (ChoiceParameter, FixedParameter))
-            and self._dependents is not None
+        return isinstance(self, (ChoiceParameter, FixedParameter)) and bool(
+            self._dependents
         )
 
     @property

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -321,6 +321,12 @@ class ChoiceParameterTest(TestCase):
                 #  bool, float, int, str], List[str]]]` but got `Dict[str, str]`.
                 dependents={"not_a_value": "other_param"},
             )
+        # Check that empty dependents doesn't flag as hierarchical.
+        self.param4._dependents = {}
+        self.assertFalse(self.param4.is_hierarchical)
+        # Check that valid dependents are detected.
+        self.param4._dependents = {1: ["other_param"]}
+        self.assertTrue(self.param4.is_hierarchical)
 
     def test_MaxValuesValidation(self) -> None:
         ChoiceParameter(


### PR DESCRIPTION
Summary: This would previously count `dependents={}` as a hierarchical parameter. With this change, both `None` and `{}` will count as not hierarchical.

Reviewed By: bernardbeckerman

Differential Revision: D50098268


