### PR TITLE
Enable the "new" scientific python stack for ax targets

### DIFF
--- a/ax/plot/diagnostic.py
+++ b/ax/plot/diagnostic.py
@@ -599,7 +599,7 @@ def tile_cross_validation(
             y_raw.append(arm.y[metric])
             se_raw.append(arm.se[metric])
         min_, max_ = _get_min_max_with_errors(y_raw, y_hat, se_raw, se_hat)
-        fig.append_trace(
+        fig.append_trace(  # pyre-ignore[16]
             _diagonal_trace(min_, max_), int(np.floor(i / 2)) + 1, i % 2 + 1
         )
         fig.append_trace(

--- a/ax/plot/feature_importances.py
+++ b/ax/plot/feature_importances.py
@@ -37,7 +37,7 @@ def plot_feature_importance_plotly(df: pd.DataFrame, title: str) -> go.Figure:
     )
 
     for idx, item in enumerate(data):
-        fig.append_trace(item, idx + 1, 1)
+        fig.append_trace(item, idx + 1, 1)  # pyre-ignore[16]
     fig.layout.showlegend = False
     fig.layout.margin = go.layout.Margin(
         l=8 * min(max(len(idx) for idx in df.index), 75)  # noqa E741

--- a/ax/plot/marginal_effects.py
+++ b/ax/plot/marginal_effects.py
@@ -59,7 +59,7 @@ def plot_marginal_effects(model: ModelBridge, metric: str) -> AxPlotConfig:
         shared_yaxes=True,
     )
     for idx, item in enumerate(data):
-        fig.append_trace(item, 1, idx + 1)
+        fig.append_trace(item, 1, idx + 1)  # pyre-ignore[16]
     fig.layout.showlegend = False
     # fig.layout.margin = go.layout.Margin(l=2, r=2)
     fig.layout.title = "Marginal Effects by Factor"

--- a/ax/plot/scatter.py
+++ b/ax/plot/scatter.py
@@ -860,7 +860,7 @@ def lattice_multiple_metrics(
                     visible=True,
                     show_arm_details_on_hover=show_arm_details_on_hover,
                 )
-                fig.append_trace(obs_insample_trace, j, i)
+                fig.append_trace(obs_insample_trace, j, i)  # pyre-ignore[16]
                 fig.append_trace(predicted_insample_trace, j, i)
 
                 # iterate over models here
@@ -1390,7 +1390,9 @@ def tile_fitted(
             "zerolinecolor": "red",
         }
         for d in data:
-            fig.append_trace(d, int(np.floor(i / ncols)) + 1, i % ncols + 1)
+            fig.append_trace(  # pyre-ignore[16]
+                d, int(np.floor(i / ncols)) + 1, i % ncols + 1
+            )
 
     order_options = [
         {"args": [name_order_args], "label": "Name", "method": "relayout"},

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -459,7 +459,7 @@ class ReportUtilsTest(TestCase):
         self.assertTrue(all(isinstance(plot, go.Figure) for plot in plots))
         self.assertIn(
             "Objective branin_map vs. True Objective Metric branin",
-            [p.layout.title.text for p in plots],
+            [p.layout.title.text for p in plots],  # pyre-ignore[16]
         )
 
         with self.assertRaisesRegex(

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -83,7 +83,6 @@ CROSS_VALIDATION_CAPTION = (
 FEASIBLE_COL_NAME = "is_feasible"
 
 
-# pyre-ignore[11]: Annotation `go.Figure` is not defined as a type.
 def _get_cross_validation_plots(model: ModelBridge) -> List[go.Figure]:
     cv = cross_validate(model=model)
     return [
@@ -1092,7 +1091,11 @@ def get_figure_and_callback(
                 "Skipping plot update."
             )
             return
-        fig.update(data=new_fig._data, layout=new_fig._layout, overwrite=True)
+        fig.update(
+            data=new_fig._data,  # pyre-ignore[16]
+            layout=new_fig._layout,  # pyre-ignore[16]
+            overwrite=True,
+        )
 
     return fig, _update_fig_in_place
 
@@ -1100,7 +1103,7 @@ def get_figure_and_callback(
 def _warn_and_create_warning_plot(warning_msg: str) -> go.Figure:
     logger.warning(warning_msg)
     return (
-        go.Figure()
+        go.Figure()  # pyre-ignore[16]
         .add_annotation(text=warning_msg, showarrow=False, font={"size": 20})
         .update_xaxes(showgrid=False, showticklabels=False, zeroline=False)
         .update_yaxes(showgrid=False, showticklabels=False, zeroline=False)

--- a/ax/utils/testing/mock.py
+++ b/ax/utils/testing/mock.py
@@ -15,7 +15,7 @@ from botorch.optim.initializers import (
     gen_batch_initial_conditions,
     gen_one_shot_kg_initial_conditions,
 )
-from scipy.optimize.optimize import OptimizeResult
+from scipy.optimize import OptimizeResult
 from torch import Tensor
 
 
@@ -31,7 +31,9 @@ def fast_botorch_optimize_context_manager(
             USE RESPONSIBLY.
     """
 
-    def one_iteration_minimize(*args: Any, **kwargs: Any) -> OptimizeResult:
+    def one_iteration_minimize(
+        *args: Any, **kwargs: Any
+    ) -> OptimizeResult:  # pyre-ignore[11]
         if kwargs["options"] is None:
             kwargs["options"] = {}
 


### PR DESCRIPTION
Summary:
It's about time. See
https://fb.workplace.com/groups/pythonfoundation/permalink/3524397191207068

This change is also needed to be able to run some newer 3rd party libs that depend on the updated stack (e.g. D49354458).

Reviewed By: esantorella

Differential Revision: D49372390


