### PR TITLE
Batch benchmark replications

### DIFF
--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -10,20 +10,40 @@ from ax.service.utils.scheduler_options import SchedulerOptions
 from ax.utils.common.base import Base
 
 
+# Used as a default for the `replications_per_machine` argument in
+# `BenchmarkMethod` and its subclasses. For more information, see the docstring
+# for `BenchmarkMethod`.
+DEFAULT_REPLICATIONS_PER_MACHINE = 10
+
+
 @dataclass(frozen=True)
 class BenchmarkMethod(Base):
-    """Benchmark method, represented in terms of Ax generation strategy (which tells us
-    which models to use when) and scheduler options (which tell us extra execution
-    information like maximum parallelism, early stopping configuration, etc.). Note:
-    if BenchmarkMethod.scheduler_optionss.total_trials is lower than
-    BenchmarkProblem.num_trials only the number of trials specified in the former will
-    be run.
+    """
+    Benchmark method, represented in terms of Ax generation strategy (which
+    tells us which models to use when) and scheduler options (which tell us
+    extra execution information like maximum parallelism, early stopping
+    configuration, etc.).
+
+    Note: If BenchmarkMethod.scheduler_options.total_trials is lower than
+    BenchmarkProblem.num_trials, only the number of trials specified in the
+    former will be run.
+
+    Args:
+        name: Name of the method.
+        generation_strategy: A `GenerationStrategy`, used to specify the
+            optimization method.
+        scheduler_options: A `SchedulerOptions` object, specifying how the
+            benchmarks will be run (e.g. sequentially or not).
+        replications_per_machine: How many replications to run (sequentially) on
+            a single machine. A benchmark replication can be run with
+            `ax.benchmark.benchmark.benchmark_replication`. Slower methods will
+            need a smaller value.
     """
 
     name: str
     generation_strategy: GenerationStrategy
     scheduler_options: SchedulerOptions
-    distribute_replications: bool = False
+    replications_per_machine: int = DEFAULT_REPLICATIONS_PER_MACHINE
 
 
 def get_sequential_optimization_scheduler_options(

--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional, Type, Union
 
 from ax.benchmark.benchmark_method import (
     BenchmarkMethod,
+    DEFAULT_REPLICATIONS_PER_MACHINE,
     get_sequential_optimization_scheduler_options,
 )
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
@@ -38,7 +39,7 @@ def get_sobol_botorch_modular_acquisition(
     model_cls: Type[Model],
     acquisition_cls: Type[AcquisitionFunction],
     scheduler_options: Optional[SchedulerOptions] = None,
-    distribute_replications: bool = False,
+    replications_per_machine: int = DEFAULT_REPLICATIONS_PER_MACHINE,
     name: Optional[str] = None,
 ) -> BenchmarkMethod:
     model_kwargs: Dict[
@@ -72,5 +73,5 @@ def get_sobol_botorch_modular_acquisition(
         generation_strategy=generation_strategy,
         scheduler_options=scheduler_options
         or get_sequential_optimization_scheduler_options(),
-        distribute_replications=distribute_replications,
+        replications_per_machine=replications_per_machine,
     )


### PR DESCRIPTION
Summary: Currently, benchmark methods have an attribute `distribute_replications` that indicates whether replications should be run fully in parallel or serially. This diff allows for batching the replications by replacing the Benchmarkmethod attribute `distribute_replications` with `repications_per_batch`.

Differential Revision: D49893686


