### PR TITLE
Update typing of TEvaluationFunction

### DIFF
--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -60,7 +60,10 @@ TEvaluationOutcome = Union[
     TFidelityTrialEvaluation,
     TMapTrialEvaluation,
 ]
-TEvaluationFunction = Callable[[TParameterization, Optional[float]], TEvaluationOutcome]
+TEvaluationFunction = Union[
+    Callable[[TParameterization], TEvaluationOutcome],
+    Callable[[TParameterization, Optional[float]], TEvaluationOutcome],
+]
 
 TBucket = List[Dict[str, List[str]]]
 

--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -62,7 +62,7 @@ class OptimizationLoop:
         self.total_trials = total_trials
         self.arms_per_trial = arms_per_trial
         self.random_seed = random_seed
-        self.evaluation_function = evaluation_function
+        self.evaluation_function: TEvaluationFunction = evaluation_function
         assert len(experiment.trials) == 0, (
             "Optimization Loop should not be initialized with an experiment "
             "that has trials already."
@@ -142,9 +142,10 @@ class OptimizationLoop:
         signature = inspect.signature(self.evaluation_function)
         num_evaluation_function_params = len(signature.parameters.items())
         if num_evaluation_function_params == 1:
-            # pyre-fixme[20]: Anonymous call expects argument `$1`.
+            # pyre-ignore [20]: Can't run instance checks on subscripted generics.
             evaluation = self.evaluation_function(parameterization)
         elif num_evaluation_function_params == 2:
+            # pyre-ignore [19]: Can't run instance checks on subscripted generics.
             evaluation = self.evaluation_function(parameterization, weight)
         else:
             raise UserInputError(

--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -248,7 +248,6 @@ class TestManagedLoop(TestCase):
                 {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
             ],
             # Booth function.
-            # pyre-fixme[6]: For 2nd param expected `(Dict[str, Union[None, bool, flo...
             evaluation_function=lambda p: (p["x1"] + 2 * p["x2"] - 7) ** 2
             + (2 * p["x1"] + p["x2"] - 5) ** 2,
             minimize=True,
@@ -278,7 +277,6 @@ class TestManagedLoop(TestCase):
                 {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
             ],
             # Booth function.
-            # pyre-fixme[6]: For 2nd param expected `(Dict[str, Union[None, bool, flo...
             evaluation_function=lambda p: (p["x1"] + 2 * p["x2"] - 7) ** 2
             + (2 * p["x1"] + p["x2"] - 5) ** 2,
             minimize=True,
@@ -304,7 +302,6 @@ class TestManagedLoop(TestCase):
                 {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
             ],
             # Booth function.
-            # pyre-fixme[6]: For 2nd param expected `(Dict[str, Union[None, bool, flo...
             evaluation_function=lambda p: (
                 (p["x1"] + 2 * p["x2"] - 7) ** 2 + (2 * p["x1"] + p["x2"] - 5) ** 2,
                 None,
@@ -330,7 +327,6 @@ class TestManagedLoop(TestCase):
                 {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
             ],
             # Booth function.
-            # pyre-fixme[6]: For 2nd param expected `(Dict[str, Union[None, bool, flo...
             evaluation_function=lambda p: (p["x1"] + 2 * p["x2"] - 7) ** 2
             + (2 * p["x1"] + p["x2"] - 5) ** 2,
             minimize=True,
@@ -348,7 +344,6 @@ class TestManagedLoop(TestCase):
                 {"name": "x2", "type": "choice", "values": [1, 2]},
             ],
             # Booth function.
-            # pyre-fixme[6]: For 2nd param expected `(Dict[str, Union[None, bool, flo...
             evaluation_function=lambda p: (
                 (p["x1"] + 2 * p["x2"] - 7) ** 2 + (2 * p["x1"] + p["x2"] - 5) ** 2,
                 None,
@@ -404,7 +399,6 @@ class TestManagedLoop(TestCase):
                 {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
             ],
             # Booth function.
-            # pyre-fixme[6]: For 2nd param expected `(Dict[str, Union[None, bool, flo...
             evaluation_function=lambda p: (
                 (p["x1"] + 2 * p["x2"] - 7) ** 2 + (2 * p["x1"] + p["x2"] - 5) ** 2,
                 None,
@@ -471,7 +465,6 @@ class TestManagedLoop(TestCase):
                 ],
                 experiment_name="test",
                 objective_name="foo",
-                # pyre-fixme[6]: For 4th param expected `(Dict[str, Union[None, bool,...
                 evaluation_function=lambda p: 0.0,
                 minimize=True,
                 total_trials=5,
@@ -488,8 +481,7 @@ class TestManagedLoop(TestCase):
                 ],
                 experiment_name="test",
                 objective_name="foo",
-                # pyre-fixme[6]: For 4th param expected `(Dict[str, Union[None, bool,...
-                evaluation_function=lambda: 1.0,
+                evaluation_function=lambda: 1.0,  # pyre-ignore
                 minimize=True,
                 total_trials=5,
             )


### PR DESCRIPTION
Summary:
I came across this erroneous type while working on something unrelated. This diff trades of a bunch of pyre-fixmes for a couple new ones, and updates the type hint with what I believe is the correct one.

An alternative type that doesn't require any pyre-fixme/ignores is `Callable[[TParameterization, ...], TEvaluationOutcome]` but I don't think it is the correct one. `...` denotes that there can be any number of `TParameterization` arguments, which `Optional[float]` is not.

Differential Revision: D50352771


