### PR TITLE
Bump CI to 3.11

### DIFF
--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.11"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Torchx 0.6.0 has been released. This should be unblocked.