### PR TITLE
Add generation_node_name arg to GeneratorRun

### DIFF
--- a/ax/core/tests/test_generator_run.py
+++ b/ax/core/tests/test_generator_run.py
@@ -6,6 +6,7 @@
 
 from ax.core.arm import Arm
 from ax.core.generator_run import GeneratorRun
+from ax.exceptions.core import UnsupportedError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_arms,
@@ -107,7 +108,7 @@ class GeneratorRunTest(TestCase):
     def test_Index(self) -> None:
         self.assertIsNone(self.unweighted_run.index)
         self.unweighted_run.index = 1
-        with self.assertRaises(ValueError):
+        with self.assertRaises(UnsupportedError):
             self.unweighted_run.index = 2
 
     def test_ModelPredictions(self) -> None:

--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -307,8 +307,12 @@ class GenerationNode:
                         "generation step in an attempt to deduplicate. Candidates "
                         f"produced in the last generator run: {generator_run.arms}."
                     )
-
-        return not_none(generator_run)
+        assert generator_run is not None, (
+            "The GeneratorRun is None which is an unexpected state of this"
+            " GenerationStrategy. This occured on GenerationNode: {self.node_name}."
+        )
+        generator_run._generation_node_name = self.node_name
+        return generator_run
 
     # ------------------------- Model selection logic helpers. -------------------------
 

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -415,6 +415,7 @@ def generator_run_to_dict(generator_run: GeneratorRun) -> Dict[str, Any]:
         "model_state_after_gen": gr._model_state_after_gen,
         "generation_step_index": gr._generation_step_index,
         "candidate_metadata_by_arm_signature": cand_metadata,
+        "generation_node_name": gr._generation_node_name,
     }
 
 

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -717,6 +717,7 @@ class Decoder:
                 decoder_registry=self.config.json_decoder_registry,
                 class_decoder_registry=self.config.json_class_decoder_registry,
             ),
+            generation_node_name=generator_run_sqa.generation_node_name,
         )
         generator_run._time_created = generator_run_sqa.time_created
         generator_run._generator_run_type = self.get_enum_name(

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -821,6 +821,7 @@ class Encoder:
                 encoder_registry=self.config.json_encoder_registry,
                 class_encoder_registry=self.config.json_class_encoder_registry,
             ),
+            generation_node_name=generator_run._generation_node_name,
         )
         return gr_sqa
 

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -287,6 +287,8 @@ class SQAGeneratorRun(Base):
     candidate_metadata_by_arm_signature: Optional[Dict[str, Any]] = Column(
         JSONEncodedTextDict
     )
+    # pyre-fixme[8]: Attribute has type `Optional[str]`; used as `Column[str]`.
+    generation_node_name: Optional[str] = Column(String(NAME_OR_TYPE_FIELD_LENGTH))
 
     # relationships
     # Use selectin loading for collections to prevent idle timeout errors


### PR DESCRIPTION
Summary:
As we transition to using GenerationNodes by default in GenerationStrategy, we want to add in a geneartion_node_name argument to GeneratorRun. This arg is analogous to the generation_step_index, but more flexibile.

For backwards compatibility purposes, we aren't replacing generation_step_index at this time. I anticipate, over time we will be able to do so.

While I was here, I also updated the functions with docstrings to abide by our standards :)

Things in the pipeline:
(1) Update other code impacted by this generator run change
(2) Add the transition_to field to transition criterion class
(3) Update the transition criterion class to check on a per node basis, instead of per experiment
(4) add is_complete to generationNode and then use that in generation Strategy for moving forward
(5) [Mby] skip max trial criterion addition if numtrials == -1
(6) add transition criterion to the repr string + some of the other fields that havent made it yet

Differential Revision: D50276770


