### PR TITLE
Add transition_to argument to TransitionCriterion

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -205,7 +205,7 @@ class GenerationNode:
         """Returns the sequence of TransitionCriteria that will be used to determine
         if this GenerationNode is complete and should transition to the next node.
         """
-        return not_none(self._transition_criteria)
+        return [] if self._transition_criteria is None else self._transition_criteria
 
     @property
     def experiment(self) -> Experiment:
@@ -489,7 +489,8 @@ class GenerationStep(GenerationNode, SortableBase):
         # Create transition criteria for this step. MaximumTrialsInStatus can be used
         # to ensure that requirements related to num_trials and enforce_num_trials
         # are met. MinimumTrialsInStatus can be used enforce the min_trials_observed
-        # requirement.
+        # requirement. We set transition_to on GenerationStrategy instead of here as
+        # GenerationStrategy can see the full list of steps.
         transition_criteria = []
         transition_criteria.append(
             MaxTrials(
@@ -499,7 +500,8 @@ class GenerationStep(GenerationNode, SortableBase):
         )
         transition_criteria.append(
             MinimumTrialsInStatus(
-                status=TrialStatus.COMPLETED, threshold=self.min_trials_observed
+                status=TrialStatus.COMPLETED,
+                threshold=self.min_trials_observed,
             )
         )
         transition_criteria += self.completion_criteria

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -101,6 +101,13 @@ class GenerationStrategy(Base):
             # uniqueness is gaurenteed for steps currently due to list structure.
             step._node_name = f"GenerationStep_{str(idx)}"
             step.index = idx
+
+            # Set transition_to field for all but the last step, which remains null.
+            if idx != len(self._steps):
+                for transition_criteria in step.transition_criteria:
+                    transition_criteria._transition_to = (
+                        f"GenerationStep_{str(idx + 1)}"
+                    )
             step._generation_strategy = self
             if not isinstance(step.model, ModelRegistryBase):
                 self._uses_registered_models = False

--- a/ax/modelbridge/tests/test_transition_criterion.py
+++ b/ax/modelbridge/tests/test_transition_criterion.py
@@ -102,16 +102,28 @@ class TestTransitionCriterion(TestCase):
         gs.experiment = experiment
 
         step_0_expected_transition_criteria = [
-            MaxTrials(threshold=3, enforce=False),
-            MinimumTrialsInStatus(status=TrialStatus.COMPLETED, threshold=0),
+            MaxTrials(threshold=3, enforce=False, transition_to="GenerationStep_1"),
+            MinimumTrialsInStatus(
+                status=TrialStatus.COMPLETED,
+                threshold=0,
+                transition_to="GenerationStep_1",
+            ),
         ]
         step_1_expected_transition_criteria = [
-            MaxTrials(threshold=4, enforce=True),
-            MinimumTrialsInStatus(status=TrialStatus.COMPLETED, threshold=2),
+            MaxTrials(threshold=4, enforce=True, transition_to="GenerationStep_2"),
+            MinimumTrialsInStatus(
+                status=TrialStatus.COMPLETED,
+                threshold=2,
+                transition_to="GenerationStep_2",
+            ),
         ]
         step_2_expected_transition_criteria = [
-            MaxTrials(threshold=-1, enforce=True),
-            MinimumTrialsInStatus(status=TrialStatus.COMPLETED, threshold=0),
+            MaxTrials(threshold=-1, enforce=True, transition_to="GenerationStep_3"),
+            MinimumTrialsInStatus(
+                status=TrialStatus.COMPLETED,
+                threshold=0,
+                transition_to="GenerationStep_3",
+            ),
         ]
         self.assertEqual(
             gs._steps[0].transition_criteria, step_0_expected_transition_criteria


### PR DESCRIPTION
Summary:
It is important that the transition criteria can tell the GenerationStrategy which node to move to once the criteria is met. This diff adds the transition_to field to TransitionCriterion

Things in the pipeline:
(1) Update the transition criterion class to check on a per node basis, instead of per experiment
(2) Use the transition criterion to determine if a node is complete
(3) add is_complete to generationNode and then use that in generation Strategy for moving forward
(4) [Mby] skip max trial criterion addition if numtrials == -1
(5) add transition criterion to the repr string + some of the other fields that havent made it yet
(6) Do a final pass of the generationStrategy/GenerationNode files to see what else can be migrated/condensed

Reviewed By: lena-kashtelyan

Differential Revision: D50295684

