### PR TITLE
Update use cases of deprecated fixed noise models

### DIFF
--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -45,7 +45,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
-from botorch.models.gp_regression import FixedNoiseGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import MultiTaskGP
 from botorch.utils.types import DEFAULT
@@ -75,9 +75,9 @@ class ModelRegistryTest(TestCase):
         self.assertEqual(gpei.model.acquisition_class, Acquisition)
         self.assertEqual(gpei.model.acquisition_options, {"best_f": 0.0})
         self.assertIsInstance(gpei.model.surrogates[Keys.AUTOSET_SURROGATE], Surrogate)
-        # FixedNoiseGP should be picked since experiment data has fixed noise.
+        # SingleTaskGP should be picked.
         self.assertIsInstance(
-            gpei.model.surrogates[Keys.AUTOSET_SURROGATE].model, FixedNoiseGP
+            gpei.model.surrogates[Keys.AUTOSET_SURROGATE].model, SingleTaskGP
         )
 
         gr = gpei.gen(n=1)

--- a/ax/modelbridge/tests/test_robust.py
+++ b/ax/modelbridge/tests/test_robust.py
@@ -26,7 +26,7 @@ from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
     qNoisyExpectedHypervolumeImprovement,
 )
-from botorch.models.gp_regression import FixedNoiseGP
+from botorch.models.gp_regression import SingleTaskGP
 
 
 class TestRobust(TestCase):
@@ -46,7 +46,7 @@ class TestRobust(TestCase):
             modelbridge = Models.BOTORCH_MODULAR(
                 experiment=exp,
                 data=exp.fetch_data(),
-                surrogate=Surrogate(botorch_model_class=FixedNoiseGP),
+                surrogate=Surrogate(botorch_model_class=SingleTaskGP),
                 botorch_acqf_class=acqf_class or qNoisyExpectedImprovement,
             )
             trial = (

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -30,11 +30,12 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import fast_botorch_optimize
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition.utils import get_infeasible_cost
-from botorch.models import FixedNoiseGP, ModelListGP, SingleTaskGP
+from botorch.models import ModelListGP, SingleTaskGP
 from botorch.models.transforms.input import Warp
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.objective import get_objective_weights_transform
 from gpytorch.likelihoods import _GaussianLikelihoodBase
+from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
 from gpytorch.mlls import ExactMarginalLogLikelihood, LeaveOneOutPseudoLikelihood
 from gpytorch.priors import GammaPrior
 from gpytorch.priors.lkj_prior import LKJCovariancePrior
@@ -283,7 +284,7 @@ class BotorchModelTest(TestCase):
                     else:
                         self.assertFalse(hasattr(m, "input_transform"))
 
-            # Test batched multi-output FixedNoiseGP
+            # Test batched multi-output SingleTaskGP
             datasets_block = [
                 SupervisedDataset(
                     X=Xs1[0],
@@ -324,7 +325,8 @@ class BotorchModelTest(TestCase):
                 models = [model.model]
             Ys = [Ys1[0], Ys2[0]]
             for i, m in enumerate(models):
-                self.assertIsInstance(m, FixedNoiseGP)
+                self.assertIsInstance(m, SingleTaskGP)
+                self.assertIsInstance(m.likelihood, FixedNoiseGaussianLikelihood)
                 expected_train_inputs = Xs1[0]
 
                 if not use_input_warping:

--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -41,7 +41,7 @@ from ax.utils.common.typeutils import checked_cast
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.analytic import ExpectedImprovement
 from botorch.acquisition.objective import PosteriorTransform
-from botorch.models.gp_regression import FixedNoiseGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.optim.fit import fit_gpytorch_mll_scipy
@@ -310,7 +310,7 @@ class ALEBOKernel(Kernel):
         return postprocess_rbf(diff)
 
 
-class ALEBOGP(FixedNoiseGP):
+class ALEBOGP(SingleTaskGP):
     """The GP for ALEBO.
 
     Uses the Mahalanobis kernel defined in ALEBOKernel, along with a

--- a/ax/models/torch/botorch_modular/input_constructors/covar_modules.py
+++ b/ax/models/torch/botorch_modular/input_constructors/covar_modules.py
@@ -12,10 +12,8 @@ import torch
 from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
 from ax.utils.common.typeutils import _argparse_type_encoder
 from botorch.models import MultiTaskGP
-from botorch.models.gp_regression import FixedNoiseGP
-
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.model import Model
-from botorch.models.multitask import FixedNoiseMultiTaskGP
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.dispatcher import Dispatcher
 from botorch.utils.types import _DefaultType, DEFAULT
@@ -101,16 +99,14 @@ def _covar_module_argparse_scale_matern(
         A dictionary with covar module kwargs.
     """
 
-    if issubclass(botorch_model_class, FixedNoiseMultiTaskGP) or issubclass(
-        botorch_model_class, MultiTaskGP
-    ):
+    if issubclass(botorch_model_class, MultiTaskGP):
         if ard_num_dims is DEFAULT:
             ard_num_dims = dataset.X.shape[-1] - 1
 
         if batch_shape is DEFAULT:
             batch_shape = torch.Size([])
 
-    if issubclass(botorch_model_class, FixedNoiseGP):
+    if issubclass(botorch_model_class, SingleTaskGP):
         if ard_num_dims is DEFAULT:
             ard_num_dims = dataset.X.shape[-1]
 

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import inspect
-import warnings
 from copy import deepcopy
 from logging import Logger
 from typing import Any, Dict, List, Optional, Tuple, Type
@@ -15,7 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
-from ax.exceptions.core import AxWarning, UnsupportedError, UserInputError
+from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.models.model_utils import best_in_sample_point
 from ax.models.torch.botorch_modular.input_constructors.covar_modules import (
     covar_module_argparse,
@@ -321,24 +320,6 @@ class Surrogate(Base):
             "categorical_features": categorical_features,
         }
         botorch_model_class_args = inspect.getfullargspec(botorch_model_class).args
-
-        # Temporary workaround to allow models to consume data from
-        # `FixedNoiseDataset`s even if they don't accept variance observations.
-        if "train_Yvar" not in botorch_model_class_args and dataset.Yvar is not None:
-            warnings.warn(
-                f"Provided model class {botorch_model_class} does not accept "
-                "`train_Yvar` argument, but received dataset with `Yvar`. Ignoring "
-                "variance observations.",
-                AxWarning,
-            )
-            dataset = SupervisedDataset(
-                X=dataset.X,
-                Y=dataset.Y,
-                Yvar=None,
-                feature_names=dataset.feature_names,
-                outcome_names=dataset.outcome_names,
-            )
-
         formatted_model_inputs = botorch_model_class.construct_inputs(
             training_data=dataset, **input_constructor_kwargs
         )

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -23,11 +23,8 @@ from botorch.acquisition.multi_objective.monte_carlo import (
 )
 from botorch.fit import fit_fully_bayesian_model_nuts, fit_gpytorch_mll
 from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
-from botorch.models.gp_regression import FixedNoiseGP, SingleTaskGP
-from botorch.models.gp_regression_fidelity import (
-    FixedNoiseMultiFidelityGP,
-    SingleTaskMultiFidelityGP,
-)
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel, GPyTorchModel
 from botorch.models.model import Model, ModelList
@@ -113,28 +110,19 @@ def choose_model_class(
         model_class = MultiTaskGP
 
     # Single-task multi-fidelity cases.
-    elif search_space_digest.fidelity_features and all_inferred:
-        model_class = SingleTaskMultiFidelityGP  # Unknown observation noise.
     elif search_space_digest.fidelity_features:
-        model_class = FixedNoiseMultiFidelityGP  # Known observation noise.
+        model_class = SingleTaskMultiFidelityGP
 
     # Mixed optimization case. Note that presence of categorical
     # features in search space digest indicates that downstream in the
     # stack we chose not to perform continuous relaxation on those
     # features.
     elif search_space_digest.categorical_features:
-        if not all_inferred:
-            logger.warning(
-                "Using `MixedSingleTaskGP` despire the known `Yvar` values. This "
-                "is a temporary measure while fixed-noise mixed BO is in the works."
-            )
         model_class = MixedSingleTaskGP
 
     # Single-task single-fidelity cases.
-    elif all_inferred:  # Unknown observation noise.
-        model_class = SingleTaskGP
     else:
-        model_class = FixedNoiseGP  # Known observation noise.
+        model_class = SingleTaskGP
 
     logger.debug(f"Chose BoTorch model class: {model_class}.")
     return model_class

--- a/ax/models/torch/tests/test_covar_modules_argparse.py
+++ b/ax/models/torch/tests/test_covar_modules_argparse.py
@@ -14,8 +14,8 @@ from ax.models.torch.botorch_modular.input_constructors.covar_modules import (
 )
 from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
 from ax.utils.common.testutils import TestCase
-from botorch.models.gp_regression import FixedNoiseGP
-from botorch.models.multitask import FixedNoiseMultiTaskGP
+from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.multitask import MultiTaskGP
 from botorch.utils.datasets import SupervisedDataset
 from gpytorch.kernels.kernel import Kernel
 from gpytorch.priors import GammaPrior
@@ -64,7 +64,7 @@ class CovarModuleArgparseTest(TestCase):
     def test_argparse_kernel(self) -> None:
         covar_module_kwargs = covar_module_argparse(
             Kernel,
-            botorch_model_class=FixedNoiseGP,
+            botorch_model_class=SingleTaskGP,
             dataset=self.dataset,
         )
 
@@ -72,7 +72,7 @@ class CovarModuleArgparseTest(TestCase):
 
         covar_module_kwargs = covar_module_argparse(
             Kernel,
-            botorch_model_class=FixedNoiseGP,
+            botorch_model_class=SingleTaskGP,
             dataset=self.dataset,
             ard_num_dims=19,
             batch_shape=torch.Size([10]),
@@ -102,7 +102,7 @@ class CovarModuleArgparseTest(TestCase):
             },
         ]
 
-        for i, botorch_model_class in enumerate([FixedNoiseGP, FixedNoiseMultiTaskGP]):
+        for i, botorch_model_class in enumerate([SingleTaskGP, MultiTaskGP]):
 
             covar_module_kwargs = covar_module_argparse(
                 ScaleMaternKernel,
@@ -143,7 +143,7 @@ class CovarModuleArgparseTest(TestCase):
         )
         covar_module_kwargs = covar_module_argparse(
             ScaleMaternKernel,
-            botorch_model_class=FixedNoiseGP,
+            botorch_model_class=SingleTaskGP,
             dataset=dataset,
             lengthscale_prior=GammaPrior(6.0, 3.0),
             outputscale_prior=GammaPrior(2, 0.15),

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -24,12 +24,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from ax.utils.testing.utils import generic_equals
 from botorch.acquisition.monte_carlo import qSimpleRegret
-from botorch.models import (
-    FixedNoiseGP,
-    ModelListGP,
-    SaasFullyBayesianSingleTaskGP,
-    SingleTaskGP,
-)
+from botorch.models import ModelListGP, SaasFullyBayesianSingleTaskGP, SingleTaskGP
 from botorch.models.deterministic import GenericDeterministicModel
 from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
@@ -942,10 +937,10 @@ class SurrogateWithModelListTest(TestCase):
             Surrogate(botorch_model_class=SaasFullyBayesianSingleTaskGP),
             Surrogate(botorch_model_class=SaasFullyBayesianMultiTaskGP),
             Surrogate(  # Batch model
-                botorch_model_class=FixedNoiseGP, mll_class=ExactMarginalLogLikelihood
+                botorch_model_class=SingleTaskGP, mll_class=ExactMarginalLogLikelihood
             ),
             Surrogate(  # ModelListGP
-                botorch_model_class=FixedNoiseGP,
+                botorch_model_class=SingleTaskGP,
                 mll_class=ExactMarginalLogLikelihood,
                 allow_batched_models=False,
             ),
@@ -987,7 +982,7 @@ class SurrogateWithModelListTest(TestCase):
             elif i == 3:
                 self.assertEqual(mock_MLL.call_count, 1)
                 self.assertEqual(mock_fit_gpytorch.call_count, 1)
-                self.assertTrue(isinstance(surrogate.model, FixedNoiseGP))
+                self.assertTrue(isinstance(surrogate.model, SingleTaskGP))
                 mock_state_dict.reset_mock()
                 mock_MLL.reset_mock()
                 mock_fit_gpytorch.reset_mock()

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -95,9 +95,12 @@ ACQUISITION_REGISTRY: Dict[Type[Acquisition], str] = {
 Mapping of BoTorch `Model` classes to class name strings.
 """
 MODEL_REGISTRY: Dict[Type[Model], str] = {
-    FixedNoiseGP: "FixedNoiseGP",
-    FixedNoiseMultiFidelityGP: "FixedNoiseMultiFidelityGP",
-    FixedNoiseMultiTaskGP: "FixedNoiseMultiTaskGP",
+    # NOTE: Fixed noise models are deprecated. They point to their
+    # supported parent classes, so that we can reap them with minimal
+    # concern for backwards compatibility when the time comes.
+    FixedNoiseGP: "SingleTaskGP",
+    FixedNoiseMultiFidelityGP: "SingleTaskMultiFidelityGP",
+    FixedNoiseMultiTaskGP: "MultiTaskGP",
     MixedSingleTaskGP: "MixedSingleTaskGP",
     ModelListGP: "ModelListGP",
     MultiTaskGP: "MultiTaskGP",


### PR DESCRIPTION
Summary:
Updates use cases of fixed noise models that were deprecated in  https://github.com/pytorch/botorch/pull/2052 & elsewhere.

The only remaining usage is `botorch_modular_registry`. I updated these to point to the parent models, so that they'll be less likely to cause backwards compatibility issues when we delete the models for good.

Reviewed By: esantorella

Differential Revision: D50431137

