### PR TITLE
Update MinimumTrialsInStatus to accept a list of statuses to check

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -521,7 +521,7 @@ class GenerationStep(GenerationNode, SortableBase):
         )
         transition_criteria.append(
             MinimumTrialsInStatus(
-                status=TrialStatus.COMPLETED,
+                statuses=[TrialStatus.COMPLETED, TrialStatus.EARLY_STOPPED],
                 threshold=self.min_trials_observed,
             )
         )

--- a/ax/modelbridge/tests/test_completion_criterion.py
+++ b/ax/modelbridge/tests/test_completion_criterion.py
@@ -76,7 +76,7 @@ class TestCompletionCritereon(TestCase):
     def test_many_criteria(self) -> None:
         criteria = [
             MinimumPreferenceOccurances(metric_name="m1", threshold=3),
-            MinimumTrialsInStatus(status=TrialStatus.COMPLETED, threshold=5),
+            MinimumTrialsInStatus(statuses=[TrialStatus.COMPLETED], threshold=5),
         ]
 
         experiment = get_experiment()

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -355,7 +355,7 @@ def transition_criteria_from_json(
         if criterion_type == "MinimumTrialsInStatus":
             criterion_list.append(
                 MinimumTrialsInStatus(
-                    status=object_from_json(criterion_json.pop("status")),
+                    statuses=object_from_json(criterion_json.pop("statuses")),
                     threshold=criterion_json.pop("threshold"),
                 )
             )


### PR DESCRIPTION
Summary:
This updates the MinimumTrialsInStatus criterion class to accept a list of trials to check and a list of trials not to check which enables `only_in` allowing it to be a more flexible class


Things in the pipeline:
(0) Update maxtrials to accept a list of statuses to check and a list of statuses to not check
(1) Use the transition criterion to determine if a node is complete
(2) add is_complete to generationNode and then use that in generation Strategy for moving forward
(3) When transition_criterion list is empty, unlimited trials can be generated + skip max trial criterion addition if numtrials == -1
(4) add transition criterion to the repr string + some of the other fields that havent made it yet on GeneratinoNode
(5) Do a final pass of the generationStrategy/GenerationNode files to see what else can be migrated/condensed

Differential Revision: D50608777


