### PR TITLE
Update MaxTrials to accept list of statuses to check and avoid

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -521,7 +521,7 @@ class GenerationStep(GenerationNode, SortableBase):
         )
         transition_criteria.append(
             MinimumTrialsInStatus(
-                status=TrialStatus.COMPLETED,
+                statuses=[TrialStatus.COMPLETED, TrialStatus.EARLY_STOPPED],
                 threshold=self.min_trials_observed,
             )
         )

--- a/ax/modelbridge/tests/test_completion_criterion.py
+++ b/ax/modelbridge/tests/test_completion_criterion.py
@@ -76,7 +76,7 @@ class TestCompletionCritereon(TestCase):
     def test_many_criteria(self) -> None:
         criteria = [
             MinimumPreferenceOccurances(metric_name="m1", threshold=3),
-            MinimumTrialsInStatus(status=TrialStatus.COMPLETED, threshold=5),
+            MinimumTrialsInStatus(statuses=[TrialStatus.COMPLETED], threshold=5),
         ]
 
         experiment = get_experiment()

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -362,13 +362,18 @@ def transition_criteria_from_json(
         elif criterion_type == "MaxTrials":
             criterion_list.append(
                 MaxTrials(
-                    only_in_status=object_from_json(
-                        criterion_json.pop("only_in_status")
+                    only_in_statuses=object_from_json(
+                        criterion_json.pop("only_in_statuses")
                     )
-                    if "only_in_status" in criterion_json.keys()
+                    if "only_in_statuses" in criterion_json.keys()
                     else None,
                     threshold=criterion_json.pop("threshold"),
                     enforce=criterion_json.pop("enforce"),
+                    not_in_statuses=object_from_json(
+                        criterion_json.pop("not_in_statuses")
+                    )
+                    if "not_in_statuses" in criterion_json.keys()
+                    else None,
                 )
             )
         else:

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -355,7 +355,7 @@ def transition_criteria_from_json(
         if criterion_type == "MinimumTrialsInStatus":
             criterion_list.append(
                 MinimumTrialsInStatus(
-                    status=object_from_json(criterion_json.pop("status")),
+                    statuses=object_from_json(criterion_json.pop("statuses")),
                     threshold=criterion_json.pop("threshold"),
                 )
             )


### PR DESCRIPTION
Summary:
This updates the MaxTrials criterion class to accept a list of trials to check and a list of trials not to check which enables `only_in` and `not_in` functionality for MaxTrials allowing it to be a more flexible class.

Things in the pipeline:
(0) fix json decoding of `transition_to` argument
(1) Use the transition criterion to determine if a node is complete
(2) add is_complete to generationNode and then use that in generation Strategy for moving forward
(3) When transition_criterion list is empty, unlimited trials can be generated + skip max trial criterion addition if numtrials == -1
(4) add transition criterion to the repr string + some of the other fields that havent made it yet on GeneratinoNode
(5) Do a final pass of the generationStrategy/GenerationNode files to see what else can be migrated/condensed

Differential Revision: D50622912


