### PR TITLE
Simplify dataset signatures in TorchModelBridge

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -1462,7 +1462,7 @@ def transform_search_space(
     return search_space
 
 
-def process_contextual_datesets(
+def process_contextual_datasets(
     datasets: List[SupervisedDataset],
     outcomes: List[str],
     parameter_decomposition: Dict[str, List[str]],

--- a/ax/modelbridge/pairwise.py
+++ b/ax/modelbridge/pairwise.py
@@ -28,9 +28,7 @@ class PairwiseModelBridge(TorchModelBridge):
         outcomes: List[str],
         parameters: List[str],
         search_space_digest: Optional[SearchSpaceDigest],
-    ) -> Tuple[
-        List[Optional[SupervisedDataset]], Optional[List[List[TCandidateMetadata]]]
-    ]:
+    ) -> Tuple[List[SupervisedDataset], Optional[List[List[TCandidateMetadata]]]]:
         """Converts observations to a dictionary of `Dataset` containers and (optional)
         candidate metadata.
         """
@@ -50,7 +48,7 @@ class PairwiseModelBridge(TorchModelBridge):
             observation_data, observation_features, parameters
         )
 
-        datasets: List[Optional[SupervisedDataset]] = []
+        datasets: List[SupervisedDataset] = []
         candidate_metadata = []
         for outcome in outcomes:
             X = torch.stack(Xs[outcome], dim=0)

--- a/ax/modelbridge/tests/test_modelbridge_utils.py
+++ b/ax/modelbridge/tests/test_modelbridge_utils.py
@@ -23,7 +23,7 @@ from ax.modelbridge.modelbridge_utils import (
     extract_risk_measure,
     extract_robust_digest,
     feasible_hypervolume,
-    process_contextual_datesets,
+    process_contextual_datasets,
     RISK_MEASURE_NAME_TO_CLASS,
     transform_search_space,
 )
@@ -271,7 +271,7 @@ class TestModelBridgeUtils(TestCase):
 
         self.assertEqual(transformed_search_space, expected)
 
-    def test_process_contextual_datesets(self) -> None:
+    def test_process_contextual_datasets(self) -> None:
         num_samples = 5
         num_contexts = 3
         feature_names = [f"x_c{i}" for i in range(num_contexts)]
@@ -301,7 +301,7 @@ class TestModelBridgeUtils(TestCase):
             ),
         ]
         # process dataset list with overall outcome only
-        contextual_datasets = process_contextual_datesets(
+        contextual_datasets = process_contextual_datasets(
             datasets=dataset_list,
             outcomes=["m1_overall", "m2_overall"],
             parameter_decomposition=parameter_decomposition,
@@ -322,7 +322,7 @@ class TestModelBridgeUtils(TestCase):
                 )
             )
         # # process dataset list with context-level outcomes
-        contextual_datasets = process_contextual_datesets(
+        contextual_datasets = process_contextual_datasets(
             datasets=dataset_list[2:],
             outcomes=context_outcome_list,
             parameter_decomposition=parameter_decomposition,
@@ -333,7 +333,7 @@ class TestModelBridgeUtils(TestCase):
         self.assertListEqual(contextual_datasets[0].outcome_names, context_outcome_list)
 
         # process dataset list with overall outcome and context-level outcomes
-        contextual_datasets = process_contextual_datesets(
+        contextual_datasets = process_contextual_datasets(
             datasets=dataset_list,
             outcomes=["m1_overall", "m2_overall"] + context_outcome_list,
             parameter_decomposition=parameter_decomposition,

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -227,7 +227,7 @@ class TorchModel(BaseModel):
 
     def update(
         self,
-        datasets: List[Optional[SupervisedDataset]],
+        datasets: List[SupervisedDataset],
         metric_names: List[str],
         search_space_digest: SearchSpaceDigest,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,


### PR DESCRIPTION
Summary: Before removal of `update`, some of the datasets could be `None`, which lead to the signature `List[Optional[SupervisedDataset]]` being used in `TorchModelBridge`. All remaining use cases pass down datasets with a `not_none` filter, so we can clean up the signature and the checks it required.

Differential Revision: D50825713


