### PR TITLE
Change early stopping estimated savings calculation

### DIFF
--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -952,7 +952,7 @@ class TestAxScheduler(TestCase):
         self.assertEqual(len(fetched_data.map_df), expected_num_rows)
         self.assertEqual(len(looked_up_data.map_df), expected_num_rows)
 
-        self.assertAlmostEqual(scheduler.estimate_early_stopping_savings(), 2 / 3)
+        self.assertAlmostEqual(scheduler.estimate_early_stopping_savings(), 0.5)
 
     def test_run_trials_in_batches(self) -> None:
         # TODO[drfreund]: Use `Runner` instead when `poll_available_capacity`


### PR DESCRIPTION
Summary:
The old method of estimation was incredibly optimistic and compared the cost of every trial to the cost of the most expensive completed trial. This was giving us some silly results, ex. 1 of 9 trials stopped yielding 47% savings.

The new method assumes any early stopped trial would have took the mean resources of completed trials had it completed successfully, with some thresholding to set negative savings estimates to zero savings.

Differential Revision: D50841014


