### PR TITLE
Populating BaseTrial failed_reason

### DIFF
--- a/ax/core/runner.py
+++ b/ax/core/runner.py
@@ -111,6 +111,20 @@ class Runner(Base, SerializationMixin, ABC):
             "method."
         )
 
+    def poll_exception(self, trial: core.base_trial.BaseTrial) -> str:
+        """Returns the exception from a trial.
+
+        Args:
+            trial: Trial to get exception for.
+
+        Returns:
+            Exception string.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement a `poll_exception` "
+            "method."
+        )
+
     def stop(
         self, trial: core.base_trial.BaseTrial, reason: Optional[str] = None
     ) -> Dict[str, Any]:

--- a/ax/core/tests/test_runner.py
+++ b/ax/core/tests/test_runner.py
@@ -47,6 +47,10 @@ class RunnerTest(TestCase):
         with self.assertRaises(NotImplementedError):
             self.dummy_runner.poll_trial_status(trials=self.trials)
 
+    def test_base_runner_poll_exception(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            self.dummy_runner.poll_exception(trial=self.trials[0])
+
     def test_poll_available_capacity(self) -> None:
         self.assertEqual(self.dummy_runner.poll_available_capacity(), -1)
 


### PR DESCRIPTION
Summary: Implementing logic in the runner and scheduler to populate a trial's failed_reason

Reviewed By: mpolson64

Differential Revision: D50374362


