### PR TITLE
Refactor Surrogate.fit to cache & reuse sub-models.

### DIFF
--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -120,7 +120,7 @@ class TestBenchmark(TestCase):
                 datasets = [get_dataset()]
                 surrogate.fit(
                     datasets,
-                    metric_names=[],
+                    metric_names=datasets[0].outcome_names,
                     search_space_digest=extract_search_space_digest(
                         problem.search_space,
                         param_names=[*problem.search_space.parameters.keys()],

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -443,7 +443,7 @@ class TorchModelBridge(ModelBridge):
         )
         # Use the model to do the cross validation
         f_test, cov_test = not_none(self.model).cross_validate(
-            datasets=[not_none(dataset) for dataset in datasets],
+            datasets=datasets,
             metric_names=self.outcomes,
             X_test=torch.as_tensor(X_test, dtype=self.dtype, device=self.device),
             search_space_digest=search_space_digest,
@@ -636,8 +636,7 @@ class TorchModelBridge(ModelBridge):
         # Fit
         self.model = model
         self.model.fit(
-            # datasets are guaranteed to have all outcomes here by construction
-            datasets=[not_none(dataset) for dataset in datasets],
+            datasets=datasets,
             metric_names=self.outcomes,
             search_space_digest=search_space_digest,
             candidate_metadata=candidate_metadata,

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -28,6 +28,7 @@ from ax.models.torch.utils import (
 from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.mock import fast_botorch_optimize
 from ax.utils.testing.utils import generic_equals
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.input_constructors import (
@@ -83,6 +84,7 @@ class DummyOneShotAcquisitionFunction(DummyAcquisitionFunction, qKnowledgeGradie
 
 
 class AcquisitionTest(TestCase):
+    @fast_botorch_optimize
     def setUp(self) -> None:
         qNEI_input_constructor = get_acqf_input_constructor(qNoisyExpectedImprovement)
         self.mock_input_constructor = mock.MagicMock(
@@ -120,7 +122,7 @@ class AcquisitionTest(TestCase):
             fidelity_features=self.fidelity_features,
             target_values={2: 1.0},
         )
-        self.surrogate.construct(
+        self.surrogate.fit(
             datasets=self.training_data,
             metric_names=self.metric_names,
             search_space_digest=SearchSpaceDigest(
@@ -604,6 +606,7 @@ class AcquisitionTest(TestCase):
         acquisition.evaluate(X=self.X)
         mock_evaluate.assert_called_with(X=self.X)
 
+    @fast_botorch_optimize
     @mock.patch(  # pyre-ignore
         "ax.models.torch.botorch_moo_defaults._check_posterior_type",
         wraps=lambda y: y,
@@ -626,7 +629,7 @@ class AcquisitionTest(TestCase):
         moo_objective_thresholds = torch.tensor(
             [0.5, 1.5, float("nan")], **self.tkwargs
         )
-        self.surrogate.construct(
+        self.surrogate.fit(
             datasets=moo_training_data,
             metric_names=["m1", "m2", "m3"],
             search_space_digest=self.search_space_digest,

--- a/ax/models/torch/tests/test_multi_fidelity.py
+++ b/ax/models/torch/tests/test_multi_fidelity.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 from ax.core.search_space import SearchSpaceDigest
@@ -15,6 +15,7 @@ from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.mock import fast_botorch_optimize
 from botorch.acquisition.knowledge_gradient import qMultiFidelityKnowledgeGradient
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.utils.datasets import SupervisedDataset
@@ -28,6 +29,7 @@ MFKG_PATH = (
 
 
 class MultiFidelityAcquisitionTest(TestCase):
+    @fast_botorch_optimize
     def setUp(self) -> None:
         self.botorch_model_class = SingleTaskGP
         self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
@@ -51,7 +53,7 @@ class MultiFidelityAcquisitionTest(TestCase):
             target_values={2: 1.0},
             fidelity_features=self.fidelity_features,
         )
-        self.surrogate.construct(
+        self.surrogate.fit(
             datasets=self.training_data,
             metric_names=self.metric_names,
             search_space_digest=self.search_space_digest,
@@ -86,20 +88,14 @@ class MultiFidelityAcquisitionTest(TestCase):
     @patch(f"{MULTI_FIDELITY_PATH}.InverseCostWeightedUtility", return_value=None)
     @patch(f"{MULTI_FIDELITY_PATH}.project_to_target_fidelity", return_value=None)
     @patch(f"{MULTI_FIDELITY_PATH}.expand_trace_observations", return_value=None)
-    # pyre-fixme[3]: Return type must be annotated.
     def test_compute_model_dependencies(
         self,
-        # pyre-fixme[2]: Parameter must be annotated.
-        mock_expand,
-        # pyre-fixme[2]: Parameter must be annotated.
-        mock_project,
-        # pyre-fixme[2]: Parameter must be annotated.
-        mock_inverse_utility,
-        # pyre-fixme[2]: Parameter must be annotated.
-        mock_affine_model,
-        # pyre-fixme[2]: Parameter must be annotated.
-        mock_Acquisition_compute,
-    ):
+        mock_expand: Mock,
+        mock_project: Mock,
+        mock_inverse_utility: Mock,
+        mock_affine_model: Mock,
+        mock_Acquisition_compute: Mock,
+    ) -> None:
         # TODO: Patch only `MFKG_PATH.__init__` once `construct_inputs`
         # implemented for qMFKG.
         with patch(

--- a/ax/models/torch/tests/test_sebo.py
+++ b/ax/models/torch/tests/test_sebo.py
@@ -21,6 +21,7 @@ from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import not_none
+from ax.utils.testing.mock import fast_botorch_optimize
 from botorch.acquisition import PosteriorMean
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
@@ -42,6 +43,7 @@ SURROGATE_PATH: str = Surrogate.__module__
 
 
 class TestSebo(TestCase):
+    @fast_botorch_optimize
     def setUp(self) -> None:
         tkwargs: Dict[str, Any] = {"dtype": torch.double}
         self.botorch_model_class = SingleTaskGP
@@ -60,7 +62,7 @@ class TestSebo(TestCase):
             bounds=[(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)],
             target_values={2: 1.0},
         )
-        self.surrogates.construct(
+        self.surrogates.fit(
             datasets=self.training_data,
             metric_names=["m1"],
             search_space_digest=self.search_space_digest,

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -5,24 +5,28 @@
 # LICENSE file in the root directory of this source tree.
 
 import warnings
+from typing import OrderedDict
 
 import numpy as np
 import torch
 from ax.core.search_space import SearchSpaceDigest
-from ax.exceptions.core import AxWarning, UnsupportedError
+from ax.exceptions.core import AxError, AxWarning, UnsupportedError
 from ax.models.torch.botorch_modular.utils import (
     _get_shared_rows,
     _tensor_difference,
+    check_metric_dataset_match,
     choose_botorch_acqf_class,
     choose_model_class,
     construct_acquisition_and_optimizer_options,
     convert_to_block_design,
+    get_subset_datasets,
+    subset_state_dict,
     use_model_list,
 )
 from ax.models.torch.utils import _to_inequality_constraints
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
-from ax.utils.common.typeutils import not_none
+from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition import qLogNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.logei import (
@@ -32,6 +36,7 @@ from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
+from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import MultiTaskGP
 from botorch.utils.datasets import SupervisedDataset
 
@@ -347,8 +352,6 @@ class BoTorchModelUtilsTest(TestCase):
 
         self.assertEqual(C.size(dim=0), 2)
 
-
-class ConvertToBlockDesignTest(TestCase):
     def test_get_shared_rows(self) -> None:
         X1 = torch.rand(4, 2)
 
@@ -396,15 +399,12 @@ class ConvertToBlockDesignTest(TestCase):
             )
             for i in range(2)
         ]
-        new_datasets, new_metric_names = convert_to_block_design(
-            datasets=datasets,
-            metric_names=metric_names,
-        )
+        new_datasets = convert_to_block_design(datasets=datasets)
         self.assertEqual(len(new_datasets), 1)
         self.assertIsInstance(new_datasets[0], SupervisedDataset)
         self.assertTrue(torch.equal(new_datasets[0].X, X))
         self.assertTrue(torch.equal(new_datasets[0].Y, torch.cat(Ys, dim=-1)))
-        self.assertEqual(new_metric_names, ["y1_y2"])
+        self.assertEqual(new_datasets[0].outcome_names, metric_names)
 
         # simple case: block design, fixed
         Yvars = [torch.rand(4, 1), torch.rand(4, 1)]
@@ -418,10 +418,7 @@ class ConvertToBlockDesignTest(TestCase):
             )
             for i in range(2)
         ]
-        new_datasets, new_metric_names = convert_to_block_design(
-            datasets=datasets,
-            metric_names=metric_names,
-        )
+        new_datasets = convert_to_block_design(datasets=datasets)
         self.assertEqual(len(new_datasets), 1)
         self.assertIsNotNone(new_datasets[0].Yvar)
         self.assertTrue(torch.equal(new_datasets[0].X, X))
@@ -429,24 +426,24 @@ class ConvertToBlockDesignTest(TestCase):
         self.assertTrue(
             torch.equal(not_none(new_datasets[0].Yvar), torch.cat(Yvars, dim=-1))
         )
-        self.assertEqual(new_metric_names, ["y1_y2"])
+        self.assertEqual(new_datasets[0].outcome_names, metric_names)
 
         # test error is raised if not block design and force=False
         X2 = torch.cat((X[:3], torch.rand(1, 2)))
         datasets = [
-            SupervisedDataset(X=X, Y=Y, feature_names=["x1", "x2"], outcome_names=["y"])
-            for X, Y in zip((X, X2), Ys)
+            SupervisedDataset(
+                X=X, Y=Y, feature_names=["x1", "x2"], outcome_names=[name]
+            )
+            for X, Y, name in zip((X, X2), Ys, metric_names)
         ]
         with self.assertRaisesRegex(
             UnsupportedError, "Cannot convert data to non-block design data."
         ):
-            convert_to_block_design(datasets=datasets, metric_names=metric_names)
+            convert_to_block_design(datasets=datasets)
 
         # test warning is issued if not block design and force=True (supervised)
         with warnings.catch_warnings(record=True) as ws:
-            new_datasets, new_metric_names = convert_to_block_design(
-                datasets=datasets, metric_names=metric_names, force=True
-            )
+            new_datasets = convert_to_block_design(datasets=datasets, force=True)
         # pyre-fixme[6]: For 1st param expected `Iterable[object]` but got `bool`.
         self.assertTrue(any(issubclass(w.category, AxWarning)) for w in ws)
         self.assertTrue(
@@ -462,19 +459,17 @@ class ConvertToBlockDesignTest(TestCase):
         self.assertTrue(
             torch.equal(new_datasets[0].Y, torch.cat([Y[:3] for Y in Ys], dim=-1))
         )
-        self.assertEqual(new_metric_names, ["y1_y2"])
+        self.assertEqual(new_datasets[0].outcome_names, metric_names)
 
         # test warning is issued if not block design and force=True (fixed)
         datasets = [
             SupervisedDataset(
-                X=X, Y=Y, Yvar=Yvar, feature_names=["x1", "x2"], outcome_names=["y"]
+                X=X, Y=Y, Yvar=Yvar, feature_names=["x1", "x2"], outcome_names=[name]
             )
-            for X, Y, Yvar in zip((X, X2), Ys, Yvars)
+            for X, Y, Yvar, name in zip((X, X2), Ys, Yvars, metric_names)
         ]
         with warnings.catch_warnings(record=True) as ws:
-            new_datasets, new_metric_names = convert_to_block_design(
-                datasets=datasets, metric_names=metric_names, force=True
-            )
+            new_datasets = convert_to_block_design(datasets=datasets, force=True)
         self.assertTrue(any(issubclass(w.category, AxWarning) for w in ws))
         self.assertTrue(
             any(
@@ -495,7 +490,7 @@ class ConvertToBlockDesignTest(TestCase):
                 torch.cat([Yvar[:3] for Yvar in Yvars], dim=-1),
             )
         )
-        self.assertEqual(new_metric_names, ["y1_y2"])
+        self.assertEqual(new_datasets[0].outcome_names, metric_names)
 
     def test_to_inequality_constraints(self) -> None:
         A = torch.tensor([[0, 1, -2, 3], [0, 1, 0, 0]])
@@ -512,3 +507,118 @@ class ConvertToBlockDesignTest(TestCase):
         self.assertTrue(torch.allclose(ineq_constraints[1][0], torch.tensor([1])))
         self.assertTrue(torch.allclose(ineq_constraints[1][1], torch.tensor([-1])))
         self.assertEqual(ineq_constraints[1][2], -2.0)
+
+    def test_check_metric_dataset_match(self) -> None:
+        ds = self.fixed_noise_datasets[0]
+        # Simple test with one metric & dataset.
+        for exact_match in (True, False):
+            self.assertIsNone(
+                check_metric_dataset_match(
+                    metric_names=ds.outcome_names,
+                    datasets=[ds],
+                    exact_match=exact_match,
+                )
+            )
+        # Error with duplicate metric names.
+        with self.assertRaisesRegex(AxError, "duplicate metric names"):
+            check_metric_dataset_match(
+                metric_names=["y", "y"], datasets=[ds], exact_match=False
+            )
+        ds2 = self.supervised_datasets[0]
+        # Error with duplicate outcomes in datasets.
+        with self.assertRaisesRegex(AxError, "duplicate outcomes"):
+            check_metric_dataset_match(
+                metric_names=["y", "y2"], datasets=[ds, ds2], exact_match=False
+            )
+        ds2.outcome_names = ["y2"]
+        # Simple test with two metrics & datasets.
+        for exact_match in (True, False):
+            self.assertIsNone(
+                check_metric_dataset_match(
+                    metric_names=["y", "y2"],
+                    datasets=[ds, ds2],
+                    exact_match=exact_match,
+                )
+            )
+        # Exact match required but too many datasets provided.
+        with self.assertRaisesRegex(AxError, "must correspond to an outcome"):
+            check_metric_dataset_match(
+                metric_names=["y"],
+                datasets=[ds, ds2],
+                exact_match=True,
+            )
+        # The same check passes if we don't require exact match.
+        self.assertIsNone(
+            check_metric_dataset_match(
+                metric_names=["y"],
+                datasets=[ds, ds2],
+                exact_match=False,
+            )
+        )
+        # Error if metric doesn't exist in the datasets.
+        for exact_match in (True, False):
+            with self.assertRaisesRegex(AxError, "but the datasets model"):
+                check_metric_dataset_match(
+                    metric_names=["z"],
+                    datasets=[ds, ds2],
+                    exact_match=exact_match,
+                )
+
+    def test_get_subset_datasets(self) -> None:
+        ds = self.fixed_noise_datasets[0]
+        ds2 = self.supervised_datasets[0]
+        ds2.outcome_names = ["y2"]
+        ds3 = SupervisedDataset(
+            X=torch.zeros(1, 2),
+            Y=torch.ones(1, 2),
+            feature_names=["x1", "x2"],
+            outcome_names=["y3", "y4"],
+        )
+        # Test with single dataset.
+        self.assertEqual(
+            [ds], get_subset_datasets(datasets=[ds], subset_metric_names=["y"])
+        )
+        # Edge case of empty metric list.
+        self.assertEqual([], get_subset_datasets(datasets=[ds], subset_metric_names=[]))
+        # Multiple datasets, single metric.
+        self.assertEqual(
+            [ds],
+            get_subset_datasets(datasets=[ds, ds2, ds3], subset_metric_names=["y"]),
+        )
+        self.assertEqual(
+            [ds2],
+            get_subset_datasets(datasets=[ds, ds2, ds3], subset_metric_names=["y2"]),
+        )
+        # Multi-output dataset, 1 metric -- not allowed.
+        with self.assertRaisesRegex(UnsupportedError, "multi-outcome dataset"):
+            get_subset_datasets(datasets=[ds, ds2, ds3], subset_metric_names=["y3"])
+        # Multiple datasets, multiple metrics -- datasets in the same order as metrics.
+        self.assertEqual(
+            [ds2, ds],
+            get_subset_datasets(
+                datasets=[ds, ds2, ds3], subset_metric_names=["y2", "y"]
+            ),
+        )
+        self.assertEqual(
+            [ds3, ds],
+            get_subset_datasets(
+                datasets=[ds, ds2, ds3], subset_metric_names=["y3", "y", "y4"]
+            ),
+        )
+
+    def test_subset_state_dict(self) -> None:
+        m0 = SingleTaskGP(train_X=torch.rand(5, 2), train_Y=torch.rand(5, 1))
+        m1 = SingleTaskGP(train_X=torch.rand(5, 2), train_Y=torch.rand(5, 1))
+        model_list = ModelListGP(m0, m1)
+        # pyre-ignore [6]: T168826187
+        model_list_state_dict = checked_cast(OrderedDict, model_list.state_dict())
+        # Subset the model dict from model list and check that it is correct.
+        m0_state_dict = model_list.models[0].state_dict()
+        subsetted_m0_state_dict = subset_state_dict(
+            state_dict=model_list_state_dict, submodel_index=0
+        )
+        self.assertEqual(m0_state_dict.keys(), subsetted_m0_state_dict.keys())
+        for k in m0_state_dict:
+            self.assertTrue(torch.equal(m0_state_dict[k], subsetted_m0_state_dict[k]))
+        # Check that it can be loaded on the model.
+        m0.load_state_dict(subsetted_m0_state_dict)


### PR DESCRIPTION
Summary:
Rewrites `Surrogate.fit` logic to fit sub-models independently and save & re-use them if the corresponding datasets are identical.

* The assumption of `metric_names` and `datasets` corresponding 1:1 is removed and replaced with the assumption that the outcomes in `datasets` correspond to `metric_names`. A dataset may model multiple metrics (e.g., `ContextualDataset`).
* Two new helpers `check_metric_dataset_match` and `get_subset_datasets` are introduced to ensure correct data gets passed around.
* With the model fitting moving lower in the stack the old `Surrogate.fit` ends up being only two lines of code, with the bulk of the work happening in the old `Surrogate.construct`. So, the two get merged to form the new `Surrogate.fit`.
* `Surrogate.fit` picks the model class based on the dataset and SSD, checks whether to use a model-list, concatenates datasets if needed, splits state-dict into state-dicts of sub-models if needed, calls `_construct_model` to fit each dataset one by one, and sets the fitted model / model-list and the outcomes on the `Surrogate`.
* `Surrogate._construct_model` fits a sub-model to the given dataset. It accepts `state_dict` and `refit` kwargs to control how the fitting is done. If a cached model fitted to an identical dataset exists, the cached model is returned. If a new model is fitted, it is cached before returning.
* Follow-up: We will utilize a soon to be upstreamed feature in `ModelListGP` to make sure `Surrogate` still produces outputs in the same order as `metric_names`. This is mainly for datasets that represent multiple metrics.
* Follow-up: A follow up diff (D50845412) will update `Surrogate._construct_model` to utilize a dispatcher to support further customization of model construction based on model class / dataset type.

Differential Revision: D50329311


