### PR TITLE
Revert D50906981: Multisect successfully blamed "D50906981: Make `Runner.poll_exceptions()` abstract" for test or build failures

### DIFF
--- a/ax/benchmark/problems/hpo/pytorch_cnn.py
+++ b/ax/benchmark/problems/hpo/pytorch_cnn.py
@@ -233,8 +233,3 @@ class PyTorchCNNRunner(Runner):
         self, trials: Iterable[BaseTrial]
     ) -> Dict[TrialStatus, Set[int]]:
         return {TrialStatus.COMPLETED: {t.index for t in trials}}
-
-    def poll_exception(self, trial: BaseTrial) -> str:
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement a `poll_exception` method."
-        )

--- a/ax/benchmark/problems/surrogate.py
+++ b/ax/benchmark/problems/surrogate.py
@@ -25,7 +25,6 @@ from ax.modelbridge.transforms.log import Log
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 
 from ax.utils.common.base import Base
-from ax.utils.common.docutils import copy_doc
 from ax.utils.common.equality import equality_typechecker
 from ax.utils.common.result import Err, Ok
 from ax.utils.common.serialization import TClassDecoderRegistry, TDecoderRegistry
@@ -299,12 +298,6 @@ class SurrogateRunner(Runner):
         self, trials: Iterable[BaseTrial]
     ) -> Dict[TrialStatus, Set[int]]:
         return {TrialStatus.COMPLETED: {t.index for t in trials}}
-
-    @copy_doc(Runner.poll_exception)
-    def poll_exception(self, trial: BaseTrial) -> str:
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement a `poll_exception` method."
-        )
 
     @classmethod
     # pyre-fixme[2]: Parameter annotation cannot be `Any`.

--- a/ax/core/runner.py
+++ b/ax/core/runner.py
@@ -111,7 +111,6 @@ class Runner(Base, SerializationMixin, ABC):
             "method."
         )
 
-    @abstractmethod
     def poll_exception(self, trial: core.base_trial.BaseTrial) -> str:
         """Returns the exception from a trial.
 
@@ -121,7 +120,10 @@ class Runner(Base, SerializationMixin, ABC):
         Returns:
             Exception string.
         """
-        pass
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement a `poll_exception` "
+            "method."
+        )
 
     def stop(
         self, trial: core.base_trial.BaseTrial, reason: Optional[str] = None

--- a/ax/core/tests/test_runner.py
+++ b/ax/core/tests/test_runner.py
@@ -17,11 +17,6 @@ class DummyRunner(Runner):
     def run(self, trial: BaseTrial):
         return {"metadatum": f"value_for_trial_{trial.index}"}
 
-    def poll_exception(self, trial: BaseTrial) -> str:
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement a `poll_exception` method."
-        )
-
 
 class RunnerTest(TestCase):
     def setUp(self) -> None:

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -196,12 +196,6 @@ class TrialTest(TestCase):
             def stop(self, trial, reason):
                 return {"reason": reason} if reason else {}
 
-            def poll_exception(self, trial: BaseTrial) -> str:
-                raise NotImplementedError(
-                    f"""{self.__class__.__name__} does not implement a `poll_exception`
-                    method."""
-                )
-
         # test valid stopping
         for reason, new_status in itertools.product(
             (None, "because"),

--- a/ax/runners/botorch_test_problem.py
+++ b/ax/runners/botorch_test_problem.py
@@ -10,7 +10,6 @@ import torch
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.runner import Runner
 from ax.utils.common.base import Base
-from ax.utils.common.docutils import copy_doc
 from ax.utils.common.equality import equality_typechecker
 from ax.utils.common.serialization import TClassDecoderRegistry, TDecoderRegistry
 from ax.utils.common.typeutils import checked_cast
@@ -118,12 +117,6 @@ class BotorchTestProblemRunner(Runner):
         self, trials: Iterable[BaseTrial]
     ) -> Dict[TrialStatus, Set[int]]:
         return {TrialStatus.COMPLETED: {t.index for t in trials}}
-
-    @copy_doc(Runner.poll_exception)
-    def poll_exception(self, trial: BaseTrial) -> str:
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement a `poll_exception` method."
-        )
 
     @classmethod
     # pyre-fixme [2]: Parameter `obj` must have a type other than `Any``

--- a/ax/runners/simulated_backend.py
+++ b/ax/runners/simulated_backend.py
@@ -11,7 +11,6 @@ from typing import Any, Callable, Dict, Iterable, Optional, Set
 import numpy as np
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.runner import Runner
-from ax.utils.common.docutils import copy_doc
 from ax.utils.testing.backend_simulator import BackendSimulator
 
 
@@ -51,12 +50,6 @@ class SimulatedBackendRunner(Runner):
             status = self.simulator.lookup_trial_index_status(t_index)
             trial_status[status].add(t_index)
         return dict(trial_status)
-
-    @copy_doc(Runner.poll_exception)
-    def poll_exception(self, trial: BaseTrial) -> str:
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement a `poll_exception` method."
-        )
 
     def run(self, trial: BaseTrial) -> Dict[str, Any]:
         """Start a trial on the BackendSimulator.

--- a/ax/runners/synthetic.py
+++ b/ax/runners/synthetic.py
@@ -39,8 +39,3 @@ class SyntheticRunner(Runner):
 
     def run_metadata_report_keys(self) -> List[str]:
         return ["name"]
-
-    def poll_exception(self, trial: BaseTrial) -> str:
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement a `poll_exception` method."
-        )

--- a/ax/runners/torchx.py
+++ b/ax/runners/torchx.py
@@ -12,7 +12,6 @@ from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Set
 from ax.core import Trial
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.runner import Runner
-from ax.utils.common.docutils import copy_doc
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 
@@ -177,13 +176,6 @@ try:
                 indices.add(trial.index)
 
             return trial_statuses
-
-        @copy_doc(Runner.poll_exception)
-        def poll_exception(self, trial: BaseTrial) -> str:
-            raise NotImplementedError(
-                f"""{self.__class__.__name__} does not implement a `poll_exception`
-                method."""
-            )
 
         def stop(
             self, trial: BaseTrial, reason: Optional[str] = None

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1222,7 +1222,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
                         reason = self.runner.poll_exception(trial)
                         trial.mark_as(status=status, unsafe=True, reason=reason)
                     except NotImplementedError:
-                        # Some runners do not implement poll_exception, so
+                        # Some runners do not implement poll_failure_reason, so
                         # we fall back to marking the without a reason.
                         trial.mark_as(status=status, unsafe=True)
                 else:

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -496,12 +496,6 @@ class JSONStoreTest(TestCase):
             def staging_required():
                 return False
 
-            def poll_exception(self, trial):
-                raise NotImplementedError(
-                    f"""{self.__class__.__name__} does not implement a `poll_exception`
-                    method."""
-                )
-
         class MyMetric(Metric):
             pass
 
@@ -544,12 +538,6 @@ class JSONStoreTest(TestCase):
 
             def staging_required():
                 return False
-
-            def poll_exception(self, trial):
-                raise NotImplementedError(
-                    f"""{self.__class__.__name__} does not implement a `poll_exception`
-                    method."""
-                )
 
         bundle = RegistryBundle(
             metric_clss={MyMetric: 1998}, runner_clss={MyRunner: None}

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -11,7 +11,6 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 from ax.core.arm import Arm
-from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import LifecycleStage
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
@@ -1161,12 +1160,6 @@ class SQAStoreTest(TestCase):
             def staging_required():
                 return False
 
-            def poll_exception(self, trial: BaseTrial) -> str:
-                raise NotImplementedError(
-                    f"""{self.__class__.__name__} does not implement a `poll_exception`
-                    method."""
-                )
-
         class MyMetric(Metric):
             pass
 
@@ -1202,12 +1195,6 @@ class SQAStoreTest(TestCase):
 
             def staging_required():
                 return False
-
-            def poll_exception(self, trial: BaseTrial) -> str:
-                raise NotImplementedError(
-                    f"""{self.__class__.__name__} does not implement a `poll_exception`
-                    method."""
-                )
 
         class MyMetric(Metric):
             pass

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2179,11 +2179,6 @@ class CustomTestRunner(Runner):
     def run(self, trial: BaseTrial) -> Dict[str, Any]:
         return {"foo": "bar"}
 
-    def poll_exception(self, trial: BaseTrial) -> str:
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement a `poll_exception` method."
-        )
-
 
 class CustomTestMetric(Metric):
     def __init__(self, name: str, test_attribute: str) -> None:

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -50,11 +50,6 @@ class MyRunner(Runner):
     def run():
         pass
 
-    def poll_exception(self, trial: BaseTrial) -> str:
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement a `poll_exception` method."
-        )
-
 class MyMetric(Metric):
     pass
 
@@ -154,11 +149,6 @@ from ax.storage.sqa_store.sqa_config import SQAConfig
 class MyRunner(Runner):
     def run():
         pass
-
-    def poll_exception(self, trial: BaseTrial) -> str:
-        raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement a `poll_exception` method."
-        )
 
 class MyMetric(Metric):
     pass


### PR DESCRIPTION
Summary: Revert Make `Runner.poll_exceptions()` abstract

Reviewed By: esantorella

Differential Revision: D51113963


