### PR TITLE
Check `lower_is_better` for `ScalarizedObjective`

### DIFF
--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -209,6 +209,18 @@ class ScalarizedObjective(Objective):
             if len(weights) != len(metrics):
                 raise ValueError("Length of weights must equal length of metrics")
 
+        # Check if the optimization direction is consistent with
+        # `lower_is_better` (if specified).
+        for m, w in zip(metrics, weights):
+            is_minimized = minimize if w > 0 else not minimize
+            if m.lower_is_better is not None and is_minimized != m.lower_is_better:
+                raise ValueError(
+                    f"Metric with name {m.name} specifies `lower_is_better` = "
+                    f"{m.lower_is_better}, which doesn't match the specified "
+                    "optimization direction. You most likely want to flip the sign of "
+                    "the corresponding metric weight."
+                )
+
         self._metrics = metrics
         self.weights = weights
         self.minimize = minimize

--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -39,13 +39,23 @@ class ObjectiveTest(TestCase):
             ]
         )
         self.scalarized_objective = ScalarizedObjective(
-            metrics=[self.metrics["m1"], self.metrics["m2"]]
+            metrics=[self.metrics["m1"], self.metrics["m2"]], minimize=True
         )
 
     def test_Init(self) -> None:
         with self.assertRaises(ValueError):
             ScalarizedObjective(
                 metrics=[self.metrics["m1"], self.metrics["m2"]], weights=[1.0]
+            )
+        with self.assertRaisesRegex(
+            ValueError,
+            "Metric with name m2 specifies `lower_is_better` = "
+            "True, which doesn't match the specified optimization direction.",
+        ):
+            # Should fail since m2 specifies lower_is_better=True
+            ScalarizedObjective(
+                metrics=[self.metrics["m1"], self.metrics["m2"]],
+                minimize=False,
             )
         warnings.resetwarnings()
         warnings.simplefilter("always", append=True)
@@ -120,7 +130,7 @@ class ObjectiveTest(TestCase):
             str(self.scalarized_objective),
             (
                 "ScalarizedObjective(metric_names=['m1', 'm2'], weights=[1.0, 1.0], "
-                "minimize=False)"
+                "minimize=True)"
             ),
         )
         self.assertEqual(

--- a/ax/core/tests/test_optimization_config.py
+++ b/ax/core/tests/test_optimization_config.py
@@ -283,7 +283,9 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
             objectives=[self.objectives["o2"]]
         )
         self.scalarized_objective = ScalarizedObjective(
-            metrics=list(self.metrics.values()), weights=[1.0, 1.0, 1.0]
+            metrics=list(self.metrics.values()),
+            weights=[-1.0, 1.0, 1.0],
+            minimize=False,
         )
         self.outcome_constraint = OutcomeConstraint(
             metric=self.metrics["m3"], op=ComparisonOp.GEQ, bound=-0.25

--- a/ax/modelbridge/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/tests/test_winsorize_transform.py
@@ -417,7 +417,9 @@ class WinsorizeTransformTest(TestCase):
         m3 = Metric(name="m3")
         # Scalarized objective shouldn't be winsorized but should print a warning
         optimization_config = OptimizationConfig(
-            objective=ScalarizedObjective(metrics=[m1, m2])
+            objective=ScalarizedObjective(
+                metrics=[m1, m2], weights=[1, -1], minimize=False
+            )
         )
         warnings.simplefilter("always", append=True)
         with warnings.catch_warnings(record=True) as ws:

--- a/ax/plot/tests/long_running/test_pareto_utils.py
+++ b/ax/plot/tests/long_running/test_pareto_utils.py
@@ -29,6 +29,7 @@ class ComputePosteriorParetoFrontierTest(TestCase):
         experiment.new_batch_trial(generator_run=a).run()
         self.experiment = experiment
         self.metrics = list(experiment.metrics.values())
+        self.metrics[1].lower_is_better = None
 
     def test_ComputePosteriorParetoFrontierByTrial(self) -> None:
         # Experiments with batch trials must specify trial_index or data

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -198,7 +198,7 @@ class TestBestPointUtils(TestCase):
     def test_best_raw_objective_point_scalarized(self) -> None:
         exp = get_branin_experiment()
         exp.optimization_config = OptimizationConfig(
-            ScalarizedObjective(metrics=[get_branin_metric()], minimize=False)
+            ScalarizedObjective(metrics=[get_branin_metric()], minimize=True)
         )
         with self.assertRaisesRegex(ValueError, "Cannot identify best "):
             get_best_raw_objective_point(exp)
@@ -213,9 +213,9 @@ class TestBestPointUtils(TestCase):
         exp = get_branin_experiment()
         exp.optimization_config = OptimizationConfig(
             ScalarizedObjective(
-                metrics=[get_branin_metric(), get_branin_metric()],
+                metrics=[get_branin_metric(), get_branin_metric(lower_is_better=False)],
                 weights=[0.1, -0.9],
-                minimize=False,
+                minimize=True,
             )
         )
         with self.assertRaisesRegex(ValueError, "Cannot identify best "):

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1335,10 +1335,15 @@ def get_metric() -> Metric:
     return Metric(name="m1", properties={"prop": "val"})
 
 
-def get_branin_metric(name: str = "branin") -> BraninMetric:
+def get_branin_metric(
+    name: str = "branin", lower_is_better: bool = True
+) -> BraninMetric:
     param_names = ["x1", "x2"]
     return BraninMetric(
-        name=name, param_names=param_names, noise_sd=0.01, lower_is_better=True
+        name=name,
+        param_names=param_names,
+        noise_sd=0.01,
+        lower_is_better=lower_is_better,
     )
 
 


### PR DESCRIPTION
Summary: Make sure `lower_is_better` is actually consistent with the optimization direction so we don't accidentally try to move a metric in an unintended direction.

Reviewed By: Balandat

Differential Revision: D51116235


