### PR TITLE
Enable use of transition_criterion to determine movement to next node

### DIFF
--- a/ax/exceptions/generation_strategy.py
+++ b/ax/exceptions/generation_strategy.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import typing  # noqa F401, this is to enable type-checking
+from typing import Optional
 
 from ax.exceptions.core import AxError, OptimizationComplete
 
@@ -16,10 +17,24 @@ class MaxParallelismReachedException(AxError):
     are completed with data, to generate new trials.
     """
 
-    def __init__(self, step_index: int, model_name: str, num_running: int) -> None:
+    def __init__(
+        self,
+        model_name: str,
+        num_running: int,
+        step_index: Optional[int] = None,
+        node_name: Optional[str] = None,
+    ) -> None:
+        if node_name is not None:
+            msg_start = (
+                f"Maximum parallelism for generation node #{node_name} ({model_name})"
+            )
+        else:
+            msg_start = (
+                f"Maximum parallelism for generation step #{step_index} ({model_name})"
+            )
         super().__init__(
-            f"Maximum parallelism for generation step #{step_index} ({model_name})"
-            f" has been reached: {num_running} trials are currently 'running'. Some "
+            msg_start
+            + f" has been reached: {num_running} trials are currently 'running'. Some "
             "trials need to be completed before more trials can be generated. See "
             "https://ax.dev/docs/bayesopt.html to understand why limited parallelism "
             "improves performance of Bayesian optimization."

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -105,9 +105,13 @@ class GenerationStrategy(Base):
             # Set transition_to field for all but the last step, which remains null.
             if idx != len(self._steps):
                 for transition_criteria in step.transition_criteria:
-                    transition_criteria._transition_to = (
-                        f"GenerationStep_{str(idx + 1)}"
-                    )
+                    if (
+                        transition_criteria.criterion_class == "MinTrials"
+                        or transition_criteria.criterion_class == "MaxTrials"
+                    ):
+                        transition_criteria._transition_to = (
+                            f"GenerationStep_{str(idx + 1)}"
+                        )
             step._generation_strategy = self
             if not isinstance(step.model, ModelRegistryBase):
                 self._uses_registered_models = False

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -369,7 +369,7 @@ def transition_criteria_from_json(
                     transition_to=criterion_json.pop("transition_to")
                     if "transition_to" in criterion_json.keys()
                     else None,
-                ),
+                )
             )
     return criterion_list
 

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -79,6 +79,7 @@ from ax.modelbridge.factory import Models
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transition_criterion import (
+    MaxGenerationParallelism,
     MaxTrials,
     MinimumPreferenceOccurances,
     MinimumTrialsInStatus,
@@ -190,6 +191,7 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     MapData: map_data_to_dict,
     MapKeyInfo: map_key_info_to_dict,
     MapMetric: metric_to_dict,
+    MaxGenerationParallelism: transition_criterion_to_dict,
     MaxTrials: transition_criterion_to_dict,
     Metric: metric_to_dict,
     MinTrials: transition_criterion_to_dict,


### PR DESCRIPTION
Summary:
This diff does the following:
(1) creates should_transition_to_next_node which  will replace is_step_completed in next node

(2) uses the new gen_unlimited_trials field on genNode when creating default GenStep transition criterion

(3)  creates the trialbasedaction class and then mintrials, maxtrials, and maxparallelism all inhert from

(4) updates the repr string for all transition criteria class



upcoming:
(0) actually uses should_transition_to_next at GenerationStrategy level & use transition_to argument to determine the next node
(1) delete functions from GenStep that aren't needed anymore
(2) update the storage to include nodes independently (and not just as part of step)
(3) final pass on all the doc strings
(4) add transition criterion to the repr string + some of the other fields that havent made it yet on GeneratinoNode
(5) Do a final pass of the generationStrategy/GenerationNode files to see what else can be migrated/condensed
(6) re-enable storage of transition criteria and rename to action criterion

Reviewed By: lena-kashtelyan

Differential Revision: D50677231


