### PR TITLE
Don't add mintrials criterion if 0

### DIFF
--- a/ax/exceptions/generation_strategy.py
+++ b/ax/exceptions/generation_strategy.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import typing  # noqa F401, this is to enable type-checking
+from typing import Optional
 
 from ax.exceptions.core import AxError, OptimizationComplete
 
@@ -16,10 +17,24 @@ class MaxParallelismReachedException(AxError):
     are completed with data, to generate new trials.
     """
 
-    def __init__(self, step_index: int, model_name: str, num_running: int) -> None:
+    def __init__(
+        self,
+        model_name: str,
+        num_running: int,
+        step_index: Optional[int] = None,
+        node_name: Optional[str] = None,
+    ) -> None:
+        if node_name is not None:
+            msg_start = (
+                f"Maximum parallelism for generation node #{node_name} ({model_name})"
+            )
+        else:
+            msg_start = (
+                f"Maximum parallelism for generation step #{step_index} ({model_name})"
+            )
         super().__init__(
-            f"Maximum parallelism for generation step #{step_index} ({model_name})"
-            f" has been reached: {num_running} trials are currently 'running'. Some "
+            msg_start
+            + f" has been reached: {num_running} trials are currently 'running'. Some "
             "trials need to be completed before more trials can be generated. See "
             "https://ax.dev/docs/bayesopt.html to understand why limited parallelism "
             "improves performance of Bayesian optimization."

--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -615,14 +615,18 @@ class GenerationStep(GenerationNode, SortableBase):
                     block_transition_if_unmet=True,
                 )
             )
-            transition_criteria.append(
-                MinTrials(
-                    only_in_statuses=[TrialStatus.COMPLETED, TrialStatus.EARLY_STOPPED],
-                    threshold=self.min_trials_observed,
-                    block_gen_if_met=False,
-                    block_transition_if_unmet=True,
+            if self.min_trials_observed > 0:
+                transition_criteria.append(
+                    MinTrials(
+                        only_in_statuses=[
+                            TrialStatus.COMPLETED,
+                            TrialStatus.EARLY_STOPPED,
+                        ],
+                        threshold=self.min_trials_observed,
+                        block_gen_if_met=False,
+                        block_transition_if_unmet=True,
+                    )
                 )
-            )
         else:
             gen_unlimited_trials = True
         if self.max_parallelism is not None:

--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -81,6 +81,8 @@ class GenerationNode:
             condition that must be met before completing a GenerationNode. All `is_met`
             must evaluateTrue for the GenerationStrategy to move on to the next
             GenerationNode.
+        gen_unlimited_trials: If True the number of trials that can be generated from
+            this GenerationNode is unlimited.
 
     Note for developers: by "model" here we really mean an Ax ModelBridge object, which
     contains an Ax Model under the hood. We call it "model" here to simplify and focus
@@ -92,6 +94,7 @@ class GenerationNode:
     # TODO: Move `should_deduplicate` to `ModelSpec` if possible, and make optional
     should_deduplicate: bool
     _node_name: str
+    _gen_unlimited_trials: bool = True
 
     # Optional specifications
     _model_spec_to_gen_from: Optional[ModelSpec] = None
@@ -110,6 +113,7 @@ class GenerationNode:
         best_model_selector: Optional[BestModelSelector] = None,
         should_deduplicate: bool = False,
         transition_criteria: Optional[Sequence[TransitionCriterion]] = None,
+        gen_unlimited_trials: bool = True,
     ) -> None:
         self._node_name = node_name
         # While `GenerationNode` only handles a single `ModelSpec` in the `gen`
@@ -121,6 +125,7 @@ class GenerationNode:
         self.best_model_selector = best_model_selector
         self.should_deduplicate = should_deduplicate
         self._transition_criteria = transition_criteria
+        self._gen_unlimited_trials = gen_unlimited_trials
 
     @property
     def node_name(self) -> str:
@@ -211,6 +216,11 @@ class GenerationNode:
     def experiment(self) -> Experiment:
         """Returns the experiment associated with this GenerationStrategy"""
         return self.generation_strategy.experiment
+
+    @property
+    def gen_unlimited_trials(self) -> bool:
+        """If True, this GenerationNode can generate unlimited trials."""
+        return self._gen_unlimited_trials
 
     def fit(
         self,

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -105,9 +105,13 @@ class GenerationStrategy(Base):
             # Set transition_to field for all but the last step, which remains null.
             if idx != len(self._steps):
                 for transition_criteria in step.transition_criteria:
-                    transition_criteria._transition_to = (
-                        f"GenerationStep_{str(idx + 1)}"
-                    )
+                    if (
+                        transition_criteria.criterion_class == "MinTrials"
+                        or transition_criteria.criterion_class == "MaxTrials"
+                    ):
+                        transition_criteria._transition_to = (
+                            f"GenerationStep_{str(idx + 1)}"
+                        )
             step._generation_strategy = self
             if not isinstance(step.model, ModelRegistryBase):
                 self._uses_registered_models = False

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -119,6 +119,7 @@ class TestGenerationNode(TestCase):
         self.assertEqual(node.cv_results, node.model_specs[0].cv_results)
         self.assertEqual(node.diagnostics, node.model_specs[0].diagnostics)
         self.assertEqual(node.node_name, "test")
+        self.assertEqual(node.gen_unlimited_trials, True)
 
     def test_node_string_representation(self) -> None:
         node = GenerationNode(

--- a/ax/modelbridge/tests/test_transition_criterion.py
+++ b/ax/modelbridge/tests/test_transition_criterion.py
@@ -373,6 +373,7 @@ class TestTransitionCriterion(TestCase):
         """Tests that the repr string is correctly formatted for all
         TransitionCriterion child classes.
         """
+        self.maxDiff = None
         max_trials_criterion = MaxTrials(
             threshold=5,
             block_gen_if_met=True,
@@ -383,12 +384,12 @@ class TestTransitionCriterion(TestCase):
         )
         self.assertEqual(
             str(max_trials_criterion),
-            "MaxTrials(threshold=5, "
-            + "only_in_statuses=[<TrialStatus.COMPLETED: 3>], "
-            + "not_in_statuses=[<TrialStatus.FAILED: 2>], "
-            + "transition_to='GenerationStep_1', "
-            + "block_transition_if_unmet=False, "
-            + "block_gen_if_met=True)",
+            "MaxTrials({'threshold': 5, "
+            + "'only_in_statuses': [<TrialStatus.COMPLETED: 3>], "
+            + "'not_in_statuses': [<TrialStatus.FAILED: 2>], "
+            + "'transition_to': 'GenerationStep_1', "
+            + "'block_transition_if_unmet': False, "
+            + "'block_gen_if_met': True})",
         )
         minimum_trials_in_status_criterion = MinTrials(
             only_in_statuses=[TrialStatus.COMPLETED, TrialStatus.EARLY_STOPPED],
@@ -400,29 +401,30 @@ class TestTransitionCriterion(TestCase):
         )
         self.assertEqual(
             str(minimum_trials_in_status_criterion),
-            "MinTrials(threshold=0, only_in_statuses="
+            "MinTrials({'threshold': 0, 'only_in_statuses': "
             + "[<TrialStatus.COMPLETED: 3>, <TrialStatus.EARLY_STOPPED: 7>], "
-            + "not_in_statuses=[<TrialStatus.FAILED: 2>], "
-            + "transition_to='GenerationStep_2', "
-            + "block_transition_if_unmet=False, "
-            + "block_gen_if_met=True)",
+            + "'not_in_statuses': [<TrialStatus.FAILED: 2>], "
+            + "'transition_to': 'GenerationStep_2', "
+            + "'block_transition_if_unmet': False, "
+            + "'block_gen_if_met': True})",
         )
         minimum_preference_occurances_criterion = MinimumPreferenceOccurances(
             metric_name="m1", threshold=3
         )
         self.assertEqual(
             str(minimum_preference_occurances_criterion),
-            "MinimumPreferenceOccurances(metric_name='m1', threshold=3,"
-            + " transition_to=None, block_gen_if_met=False)",
+            "MinimumPreferenceOccurances({'metric_name': 'm1', 'threshold': 3, "
+            + "'transition_to': None, 'block_gen_if_met': False})",
         )
         deprecated_min_trials_criterion = MinimumTrialsInStatus(
             status=TrialStatus.COMPLETED, threshold=3
         )
         self.assertEqual(
             str(deprecated_min_trials_criterion),
-            "MinimumTrialsInStatus(threshold=3, "
-            + "status=TrialStatus.COMPLETED, "
-            + "transition_to='None')",
+            "MinimumTrialsInStatus({"
+            + "'status': <TrialStatus.COMPLETED: 3>, "
+            + "'threshold': 3, "
+            + "'transition_to': None})",
         )
         max_parallelism = MaxGenerationParallelism(
             only_in_statuses=[TrialStatus.EARLY_STOPPED],
@@ -434,10 +436,10 @@ class TestTransitionCriterion(TestCase):
         )
         self.assertEqual(
             str(max_parallelism),
-            "MaxGenerationParallelism(threshold=3, only_in_statuses="
+            "MaxGenerationParallelism({'threshold': 3, 'only_in_statuses': "
             + "[<TrialStatus.EARLY_STOPPED: 7>], "
-            + "not_in_statuses=[<TrialStatus.FAILED: 2>], "
-            + "transition_to='GenerationStep_2', "
-            + "block_transition_if_unmet=False, "
-            + "block_gen_if_met=True)",
+            + "'not_in_statuses': [<TrialStatus.FAILED: 2>], "
+            + "'transition_to': 'GenerationStep_2', "
+            + "'block_transition_if_unmet': False, "
+            + "'block_gen_if_met': True})",
         )

--- a/ax/modelbridge/tests/test_transition_criterion.py
+++ b/ax/modelbridge/tests/test_transition_criterion.py
@@ -116,11 +116,6 @@ class TestTransitionCriterion(TestCase):
                 only_in_statuses=None,
                 not_in_statuses=[TrialStatus.FAILED, TrialStatus.ABANDONED],
             ),
-            MinTrials(
-                only_in_statuses=[TrialStatus.COMPLETED, TrialStatus.EARLY_STOPPED],
-                threshold=0,
-                transition_to="GenerationStep_1",
-            ),
         ]
         step_1_expected_transition_criteria = [
             MaxTrials(

--- a/ax/modelbridge/transition_criterion.py
+++ b/ax/modelbridge/transition_criterion.py
@@ -14,7 +14,7 @@ from ax.exceptions.generation_strategy import MaxParallelismReachedException
 from ax.modelbridge.generation_strategy import DataRequiredError
 from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
-from ax.utils.common.serialization import SerializationMixin
+from ax.utils.common.serialization import SerializationMixin, serialize_init_args
 
 logger: Logger = get_logger(__name__)
 
@@ -80,7 +80,10 @@ class TransitionCriterion(Base, SerializationMixin):
     @property
     def criterion_class(self) -> str:
         """Name of the class of this TransitionCriterion."""
-        return type(self).__name__
+        return self.__class__.__name__
+
+    def __repr__(self) -> str:
+        return f"{self.criterion_class}({serialize_init_args(obj=self)})"
 
 
 class TrialBasedCriterion(TransitionCriterion):
@@ -228,17 +231,6 @@ class MaxGenerationParallelism(TrialBasedCriterion):
                 ),
             )
 
-    def __repr__(self) -> str:
-        """Returns a string representation of MaxGenerationParallelism"""
-        return (
-            f"{self.__class__.__name__}(threshold={self.threshold}, "
-            f"only_in_statuses={self.only_in_statuses}, "
-            f"not_in_statuses={self.not_in_statuses}, "
-            f"transition_to='{self.transition_to}', "
-            f"block_transition_if_unmet={self.block_transition_if_unmet}, "
-            f"block_gen_if_met={self.block_gen_if_met})"
-        )
-
 
 class MaxTrials(TrialBasedCriterion):
     """
@@ -287,17 +279,6 @@ class MaxTrials(TrialBasedCriterion):
                 " are available."
             )
 
-    def __repr__(self) -> str:
-        """Returns a string representation of MaxTrials."""
-        return (
-            f"{self.__class__.__name__}(threshold={self.threshold}, "
-            f"only_in_statuses={self.only_in_statuses}, "
-            f"not_in_statuses={self.not_in_statuses}, "
-            f"transition_to='{self.transition_to}', "
-            f"block_transition_if_unmet={self.block_transition_if_unmet}, "
-            f"block_gen_if_met={self.block_gen_if_met})"
-        )
-
 
 class MinTrials(TrialBasedCriterion):
     """
@@ -338,17 +319,6 @@ class MinTrials(TrialBasedCriterion):
                 f"This criterion, {self.criterion_class} has been met but cannot "
                 "continue generation from its associated GenerationNode."
             )
-
-    def __repr__(self) -> str:
-        """Returns a string representation of MinTrials."""
-        return (
-            f"{self.__class__.__name__}(threshold={self.threshold}, "
-            f"only_in_statuses={self.only_in_statuses}, "
-            f"not_in_statuses={self.not_in_statuses}, "
-            f"transition_to='{self.transition_to}', "
-            f"block_transition_if_unmet={self.block_transition_if_unmet}, "
-            f"block_gen_if_met={self.block_gen_if_met})"
-        )
 
 
 class MinimumPreferenceOccurances(TransitionCriterion):
@@ -392,14 +362,6 @@ class MinimumPreferenceOccurances(TransitionCriterion):
     ) -> None:
         pass
 
-    def __repr__(self) -> str:
-        """Returns a string representation of MinimumPreferenceOccurances."""
-        return (
-            f"{self.__class__.__name__}(metric_name='{self.metric_name}', "
-            f"threshold={self.threshold}, transition_to={self.transition_to}, "
-            f"block_gen_if_met={self.block_gen_if_met})"
-        )
-
 
 # TODO: Deprecate once legacy usecase is updated
 class MinimumTrialsInStatus(TransitionCriterion):
@@ -427,11 +389,3 @@ class MinimumTrialsInStatus(TransitionCriterion):
         trials_from_node: Optional[Set[int]] = None,
     ) -> None:
         pass
-
-    def __repr__(self) -> str:
-        """Returns a string representation of MinimumTrialsInStatus."""
-        return (
-            f"{self.__class__.__name__}(threshold={self.threshold}, "
-            f"status={self.status}, "
-            f"transition_to='{self.transition_to}')"
-        )

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -369,7 +369,7 @@ def transition_criteria_from_json(
                     transition_to=criterion_json.pop("transition_to")
                     if "transition_to" in criterion_json.keys()
                     else None,
-                ),
+                )
             )
     return criterion_list
 

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -737,6 +737,11 @@ def generation_step_from_json(
         if "transition_criteria" in generation_step_json.keys()
         else None
     )
+    generation_step._gen_unlimited_trials = (
+        generation_step_json.pop("gen_unlimited_trials")
+        if "gen_unlimited_trials" in generation_step_json.keys()
+        else True
+    )
     return generation_step
 
 

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -477,6 +477,7 @@ def generation_step_to_dict(generation_step: GenerationStep) -> Dict[str, Any]:
         "index": generation_step.index,
         "should_deduplicate": generation_step.should_deduplicate,
         "transition_criteria": generation_step.transition_criteria,
+        "gen_unlimited_trials": generation_step.gen_unlimited_trials,
     }
 
 

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -79,6 +79,7 @@ from ax.modelbridge.factory import Models
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transition_criterion import (
+    MaxGenerationParallelism,
     MaxTrials,
     MinimumPreferenceOccurances,
     MinimumTrialsInStatus,
@@ -190,6 +191,7 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     MapData: map_data_to_dict,
     MapKeyInfo: map_key_info_to_dict,
     MapMetric: metric_to_dict,
+    MaxGenerationParallelism: transition_criterion_to_dict,
     MaxTrials: transition_criterion_to_dict,
     Metric: metric_to_dict,
     MinTrials: transition_criterion_to_dict,


### PR DESCRIPTION
Summary: The default value of min trials that is set on the GenStep constructor is 0, it is a bit redundant to add the mintrials criterion if the value is 0 -- so we don't add it. (This will probably make the the should_node_transition method simplier for most cases)

Reviewed By: saitcakmak

Differential Revision: D51116028


