### PR TITLE
Update hard-coded weights in `compute_posterior_pareto_frontier `

### DIFF
--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -413,8 +413,16 @@ def compute_posterior_pareto_frontier(
         except Exception as e:
             logger.info(f"Could not fetch data from experiment or trial: {e}")
 
+    # The weights here are just dummy weights that we pass in to construct the
+    # modelbridge. We set the weight to -1 if `lower_is_better` is `True` and
+    # 1 otherwise. This code would benefit from a serious revamp.
     oc = _build_new_optimization_config(
-        weights=np.array([0.5, 0.5]),
+        weights=np.array(
+            [
+                -1 if primary_objective.lower_is_better else 1,
+                -1 if secondary_objective.lower_is_better else 1,
+            ]
+        ),
         primary_objective=primary_objective,
         secondary_objective=secondary_objective,
         outcome_constraints=outcome_constraints,

--- a/ax/plot/tests/long_running/test_pareto_utils.py
+++ b/ax/plot/tests/long_running/test_pareto_utils.py
@@ -29,7 +29,8 @@ class ComputePosteriorParetoFrontierTest(TestCase):
         experiment.new_batch_trial(generator_run=a).run()
         self.experiment = experiment
         self.metrics = list(experiment.metrics.values())
-        self.metrics[1].lower_is_better = None
+        self.metrics[0].lower_is_better = True
+        self.metrics[1].lower_is_better = False
 
     def test_ComputePosteriorParetoFrontierByTrial(self) -> None:
         # Experiments with batch trials must specify trial_index or data


### PR DESCRIPTION
Summary: This was using dummy weights of 0.5 to construct the modelbridge, which didn't play well with the changes in D51116235. This modifies this part of the code to set the sign of the weights based on `lower_is_better`, but this code ultimately needs a big revamp.

Differential Revision: D51143382


