### PR TITLE
Remove psycopg2 from TUTORIAL_REQUIRES since it is unused

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -82,7 +82,7 @@ To save an experiment to SQL, first initialize a session by passing a URL pointi
 from ax.storage.sqa_store.db import init_engine_and_session_factory
 
 # url is of the form "dialect+driver://username:password@host:port/database"
-init_engine_and_session_factory(url="postgresql+psycopg2://sarah:c82i94d@localhost:5432/foobar")
+init_engine_and_session_factory(url="postgresql+psycopg2://[USERNAME]:[PASSWORD]@localhost:[PORT]/[DATABASE]")
 ```
 
 Then create all tables:

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ UNITTEST_REQUIRES = (
 )
 
 TUTORIAL_REQUIRES = UNITTEST_REQUIRES + [
-    "psycopg2",  # Used in example DBSettings in a tutorial (as part of postgres).
     "ray",  # Required for building RayTune tutorial notebook.
     "tabulate",  # Required for building RayTune tutorial notebook.
     "pyarrow",  # Required for building RayTune tutorial notebook.


### PR DESCRIPTION
We are not actually using psycopg2, so we can remove it. It can be tricky to install, and I'm having trouble installing it, so this will make things easier on users.

## Test plan:

Tutorials will run in the CI. I am also running them locally: `python scripts/make_tutorials.py -w .  -s -e`