### PR TITLE
Rename Models.BOTORCH to Models.LEGACY_BOTORCH

### DIFF
--- a/ax/modelbridge/factory.py
+++ b/ax/modelbridge/factory.py
@@ -253,7 +253,7 @@ def get_botorch(
         raise ValueError("`BotorchModel` requires non-empty data.")
     return checked_cast(
         TorchModelBridge,
-        Models.BOTORCH(
+        Models.LEGACY_BOTORCH(
             experiment=experiment,
             data=data,
             search_space=search_space or experiment.search_space,
@@ -284,7 +284,7 @@ def get_GPEI(
         raise ValueError("GP+EI BotorchModel requires non-empty data.")
     return checked_cast(
         TorchModelBridge,
-        Models.BOTORCH(
+        Models.LEGACY_BOTORCH(
             experiment=experiment,
             data=data,
             search_space=search_space or experiment.search_space,

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -16,9 +16,9 @@ from generator run, use `get_model_from_generator_run` utility from this module.
 
 from __future__ import annotations
 
+import warnings
 from enum import Enum
 from inspect import isfunction, signature
-
 from logging import Logger
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Type
 
@@ -164,12 +164,6 @@ model setup, which defines which model, model bridge, transforms, and
 standard arguments a given model requires.
 """
 MODEL_KEY_TO_MODEL_SETUP: Dict[str, ModelSetup] = {
-    "BO": ModelSetup(
-        bridge_class=TorchModelBridge,
-        model_class=BotorchModel,
-        transforms=Cont_X_trans + Y_trans,
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
-    ),
     "BoTorch": ModelSetup(
         bridge_class=TorchModelBridge,
         model_class=ModularBoTorchModel,
@@ -486,12 +480,11 @@ class Models(ModelRegistryBase):
     FULLYBAYESIAN_MTGP = "FullyBayesian_MTGP"
     FULLYBAYESIANMOO_MTGP = "FullyBayesianMOO_MTGP"
     THOMPSON = "Thompson"
-    BOTORCH = "BO"
+    LEGACY_BOTORCH = "GPEI"
     BOTORCH_MODULAR = "BoTorch"
     EMPIRICAL_BAYES_THOMPSON = "EB"
     UNIFORM = "Uniform"
     MOO = "MOO"
-    MOO_MODULAR = "MOO_Modular"
     ST_MTGP_LEGACY = "ST_MTGP_LEGACY"
     ST_MTGP = "ST_MTGP"
     ALEBO = "ALEBO"
@@ -499,6 +492,18 @@ class Models(ModelRegistryBase):
     ST_MTGP_NEHVI = "ST_MTGP_NEHVI"
     ALEBO_INITIALIZER = "ALEBO_Initializer"
     CONTEXT_SACBO = "Contextual_SACBO"
+
+    @classmethod
+    @property
+    def BOTORCH(cls) -> Models:
+        warnings.warn(
+            "`BOTORCH` Model class has been deprecated and renamed to "
+            "`LEGACY_BOTORCH`, and it will be removed in a future release. "
+            "Please use `BOTORCH_MODULAR` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.LEGACY_BOTORCH
 
 
 def get_model_from_generator_run(

--- a/ax/plot/tests/test_contours.py
+++ b/ax/plot/tests/test_contours.py
@@ -23,7 +23,7 @@ class ContoursTest(TestCase):
     def test_Contours(self) -> None:
         exp = get_branin_experiment(with_str_choice_param=True, with_batch=True)
         exp.trials[0].run()
-        model = Models.BOTORCH(
+        model = Models.BOTORCH_MODULAR(
             # Model bridge kwargs
             experiment=exp,
             data=exp.fetch_data(),

--- a/ax/plot/tests/test_diagnostic.py
+++ b/ax/plot/tests/test_diagnostic.py
@@ -22,7 +22,7 @@ class DiagnosticTest(TestCase):
     def setUp(self) -> None:
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()
-        self.model = Models.BOTORCH(
+        self.model = Models.BOTORCH_MODULAR(
             # Model bridge kwargs
             experiment=exp,
             data=exp.fetch_data(),

--- a/ax/plot/tests/test_feature_importances.py
+++ b/ax/plot/tests/test_feature_importances.py
@@ -29,7 +29,7 @@ DUMMY_CAPTION = "test_caption"
 def get_modelbridge() -> ModelBridge:
     exp = get_branin_experiment(with_batch=True)
     exp.trials[0].run()
-    return Models.BOTORCH(
+    return Models.LEGACY_BOTORCH(
         # Model bridge kwargs
         experiment=exp,
         data=exp.fetch_data(),

--- a/ax/plot/tests/test_fitted_scatter.py
+++ b/ax/plot/tests/test_fitted_scatter.py
@@ -26,7 +26,7 @@ class FittedScatterTest(TestCase):
         df = deepcopy(data.df)
         df["metric_name"] = "branin_dup"
 
-        model = Models.BOTORCH(
+        model = Models.BOTORCH_MODULAR(
             # Model bridge kwargs
             experiment=exp,
             data=Data.from_multiple_data([data, Data(df)]),

--- a/ax/plot/tests/test_slices.py
+++ b/ax/plot/tests/test_slices.py
@@ -23,7 +23,7 @@ class SlicesTest(TestCase):
     def test_Slices(self) -> None:
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()
-        model = Models.BOTORCH(
+        model = Models.BOTORCH_MODULAR(
             # Model bridge kwargs
             experiment=exp,
             data=exp.fetch_data(),

--- a/ax/plot/tests/test_traces.py
+++ b/ax/plot/tests/test_traces.py
@@ -22,7 +22,7 @@ class TracesTest(TestCase):
     def setUp(self) -> None:
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()
-        self.model = Models.BOTORCH(
+        self.model = Models.BOTORCH_MODULAR(
             # Model bridge kwargs
             experiment=exp,
             data=exp.fetch_data(),

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -61,8 +61,8 @@ class TestBestPointUtils(TestCase):
             trial.mark_completed()
             exp.attach_data(exp.fetch_data())
 
-        gpei = Models.BOTORCH(experiment=exp, data=exp.lookup_data())
-        generator_run = gpei.gen(n=1)
+        model = Models.BOTORCH_MODULAR(experiment=exp, data=exp.lookup_data())
+        generator_run = model.gen(n=1)
         trial = exp.new_trial(generator_run=generator_run)
         trial.run()
         trial.mark_completed()

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -330,7 +330,7 @@ class ReportUtilsTest(TestCase):
         )
         exp = get_branin_experiment(with_batch=True, minimize=True)
         exp.trials[0].run()
-        model = Models.BOTORCH(experiment=exp, data=exp.fetch_data())
+        model = Models.BOTORCH_MODULAR(experiment=exp, data=exp.fetch_data())
         for gsa, true_objective_metric_name in itertools.product(
             [False, True], ["branin", None]
         ):
@@ -451,7 +451,7 @@ class ReportUtilsTest(TestCase):
         exp.trials[1].run()
         plots = get_standard_plots(
             experiment=exp,
-            model=Models.BOTORCH(experiment=exp, data=exp.fetch_data()),
+            model=Models.BOTORCH_MODULAR(experiment=exp, data=exp.fetch_data()),
             true_objective_metric_name="branin",
         )
 
@@ -467,7 +467,7 @@ class ReportUtilsTest(TestCase):
         ):
             plots = get_standard_plots(
                 experiment=exp,
-                model=Models.BOTORCH(experiment=exp, data=exp.fetch_data()),
+                model=Models.BOTORCH_MODULAR(experiment=exp, data=exp.fetch_data()),
                 true_objective_metric_name="not_present",
             )
 

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -33,7 +33,7 @@ from torch import Tensor
 def get_modelbridge(modular: bool = False) -> ModelBridge:
     exp = get_branin_experiment(with_batch=True)
     exp.trials[0].run()
-    return (Models.BOTORCH_MODULAR if modular else Models.BOTORCH)(
+    return (Models.BOTORCH_MODULAR if modular else Models.LEGACY_BOTORCH)(
         # Model bridge kwargs
         experiment=exp,
         data=exp.fetch_data(),


### PR DESCRIPTION
Summary:
The name for this registry entry was a bit confusing. Changing it to make it obvious that this is a legacy model.

Also replaces some vanilla use cases with the MBM version to simplify future migration.

Differential Revision: D51214091


