### PR TITLE
Remove unnecessary to decode gen_unlimited trials

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -639,7 +639,9 @@ class GenerationStep(GenerationNode, SortableBase):
                     transition_to=None,
                 )
             )
-        transition_criteria += self.completion_criteria
+        if len(self.completion_criteria) > 0:
+            transition_criteria += self.completion_criteria
+            gen_unlimited_trials = False
         super().__init__(
             node_name=f"GenerationStep_{str(self.index)}",
             model_specs=[model_spec],

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -737,11 +737,6 @@ def generation_step_from_json(
         if "transition_criteria" in generation_step_json.keys()
         else None
     )
-    generation_step._gen_unlimited_trials = (
-        generation_step_json.pop("gen_unlimited_trials")
-        if "gen_unlimited_trials" in generation_step_json.keys()
-        else True
-    )
     return generation_step
 
 

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -477,7 +477,6 @@ def generation_step_to_dict(generation_step: GenerationStep) -> Dict[str, Any]:
         "index": generation_step.index,
         "should_deduplicate": generation_step.should_deduplicate,
         "transition_criteria": generation_step.transition_criteria,
-        "gen_unlimited_trials": generation_step.gen_unlimited_trials,
     }
 
 


### PR DESCRIPTION
Summary: this is not needed because this argument is created during the init of a generation step based on the default criterion. This removes it from our encodeing

Reviewed By: mpolson64

Differential Revision: D51204630


