### PR TITLE
Finalize fix of not needing to store transition criterion on steps

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -330,8 +330,6 @@ class GenerationStrategy(Base):
         self._model = None
         for s in self._steps:
             s._model_spec_to_gen_from = None
-            # TODO: @mgarrard remove once re-enabled criterion storage
-            s._transition_criteria = []
 
     def __repr__(self) -> str:
         """String representation of this generation strategy."""

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -614,7 +614,6 @@ class TestAxClient(TestCase):
         )
         second_client = AxClient(db_settings=db_settings)
         second_client.load_experiment_from_database("unique_test_experiment")
-        generation_strategy._unset_non_persistent_state_fields()
         self.assertEqual(second_client.generation_strategy, generation_strategy)
 
     @patch(

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -777,7 +777,6 @@ class TestAxScheduler(TestCase):
         # Check that experiment and GS were saved.
         exp, gs = scheduler._load_experiment_and_generation_strategy(experiment.name)
         self.assertEqual(exp, experiment)
-        self.two_sobol_steps_GS._unset_non_persistent_state_fields()
         self.assertEqual(gs, self.two_sobol_steps_GS)
         scheduler.run_all_trials()
         # Check that experiment and GS were saved and test reloading with reduced state.

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -728,14 +728,7 @@ def generation_step_from_json(
         if gen_kwargs
         else None,
         index=generation_step_json.pop("index", -1),
-        should_deduplicate=generation_step_json.pop("should_deduplicate")
-        if "should_deduplicate" in generation_step_json
-        else False,
-    )
-    generation_step._transition_criteria = transition_criteria_from_json(
-        generation_step_json.pop("transition_criteria")
-        if "transition_criteria" in generation_step_json.keys()
-        else None
+        should_deduplicate=generation_step_json.pop("should_deduplicate", False),
     )
     return generation_step
 

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -1226,7 +1226,6 @@ class SQAStoreTest(TestCase):
             # pyre-fixme[6]: For 1st param expected `int` but got `Optional[int]`.
             gs_id=generation_strategy._db_id
         )
-        generation_strategy._unset_non_persistent_state_fields()
         self.assertEqual(generation_strategy, new_generation_strategy)
         self.assertIsNone(generation_strategy._experiment)
 


### PR DESCRIPTION
Summary:
This diff:
Finalizes the fix to the storage by removing the need to unset transiton criteria and doesn't store transition criterion anymore. It can do so because in the decoder we reconstruct the generation step, which automatically fills in the relevant node fields during its init method.

Differential Revision: D50752054


