### PR TITLE
Remove _check_previous_required_observation method

### DIFF
--- a/ax/service/tests/test_interactive_loop.py
+++ b/ax/service/tests/test_interactive_loop.py
@@ -12,6 +12,8 @@ from typing import Optional, Tuple
 
 import numpy as np
 from ax.core.types import TEvaluationOutcome
+from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.registry import Models
 from ax.service.ax_client import AxClient, TParameterization
 from ax.service.interactive_loop import interactive_optimize_with_client
 from ax.utils.common.testutils import TestCase
@@ -99,7 +101,11 @@ class TestInteractiveLoop(TestCase):
                 },
             )
 
-        ax_client = AxClient()
+        # GS with low max parallelismm to induce MaxParallelismException:
+        generation_strategy = GenerationStrategy(
+            steps=[GenerationStep(model=Models.SOBOL, max_parallelism=1, num_trials=-1)]
+        )
+        ax_client = AxClient(generation_strategy=generation_strategy)
         ax_client.create_experiment(
             name="hartmann_test_experiment",
             # pyre-fixme[6]
@@ -115,9 +121,6 @@ class TestInteractiveLoop(TestCase):
             tracking_metric_names=["l2norm"],
             minimize=True,
         )
-
-        # Lower max parallelism to induce MaxParallelismException
-        ax_client.generation_strategy._steps[0].max_parallelism = 1
 
         with self.assertLogs(logger="ax", level=WARN) as logger:
             interactive_optimize_with_client(


### PR DESCRIPTION
Summary: This method is redundant and checks for a state that we should never reach. In the process of updating to GenerationNode based GS, maintaining this method would entail keeping track of previous nodes. The tech debt of doing so outweighs the potential reward of keeping the function. Also I think since use_update has been deprecated this function is also less relevant.

Differential Revision: D51420534


