### PR TITLE
Stop running cron_pinned on a schedule

### DIFF
--- a/.github/workflows/cron_pinned.yml
+++ b/.github/workflows/cron_pinned.yml
@@ -1,10 +1,7 @@
-name: Nightly Cron with Pinned BoTorch
+name: Replicate Nightly Cron with Pinned BoTorch
 
 on:
-  schedule:
-    # midnight EST
-    - cron:  '0 5 * * *'
-  # allow this to be scheduled manually in addition to cron
+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This fails more often than it succeeds, creating a lot of noise. Its main use case is to test against newly pinned BoTorch just before a new release, which we can support using manual runs. 