### PR TITLE
Replace calls to trial related step specific methods in GenerationStrategy

### DIFF
--- a/ax/service/tests/test_interactive_loop.py
+++ b/ax/service/tests/test_interactive_loop.py
@@ -12,6 +12,8 @@ from typing import Optional, Tuple
 
 import numpy as np
 from ax.core.types import TEvaluationOutcome
+from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.registry import Models
 from ax.service.ax_client import AxClient, TParameterization
 from ax.service.interactive_loop import interactive_optimize_with_client
 from ax.utils.common.testutils import TestCase
@@ -99,7 +101,11 @@ class TestInteractiveLoop(TestCase):
                 },
             )
 
-        ax_client = AxClient()
+        # GS with low max parallelismm to induce MaxParallelismException:
+        generation_strategy = GenerationStrategy(
+            steps=[GenerationStep(model=Models.SOBOL, max_parallelism=1, num_trials=-1)]
+        )
+        ax_client = AxClient(generation_strategy=generation_strategy)
         ax_client.create_experiment(
             name="hartmann_test_experiment",
             # pyre-fixme[6]
@@ -115,9 +121,6 @@ class TestInteractiveLoop(TestCase):
             tracking_metric_names=["l2norm"],
             minimize=True,
         )
-
-        # Lower max parallelism to induce MaxParallelismException
-        ax_client.generation_strategy._steps[0].max_parallelism = 1
 
         with self.assertLogs(logger="ax", level=WARN) as logger:
             interactive_optimize_with_client(


### PR DESCRIPTION
Summary: This diff removes the last uses of num_remaining_trials_until_max_parallelism(), num_trials, num_can_complete, and enforce_num_trials from the GenerationStrategy file. This can be done becasue we can compute all the necessary info on GenerationNode now. And, since we want GenerationStrategy to accept GenerationNodes and GenerationSteps we cannot have any leftover calls from the GenerationStep level.

Differential Revision: D51172395


