### PR TITLE
Raise FullyBayesianPosterior deprecation warning only when used

### DIFF
--- a/ax/models/torch/utils.py
+++ b/ax/models/torch/utils.py
@@ -612,7 +612,7 @@ def pick_best_out_of_sample_point_acqf_class(
 def predict_from_model(model: Model, X: Tensor) -> Tuple[Tensor, Tensor]:
     r"""Predicts outcomes given a model and input tensor.
 
-    For a `FullyBayesianPosterior` we currently use a Gaussian approximation where we
+    For a `GaussianMixturePosterior` we currently use a Gaussian approximation where we
     compute the mean and variance of the Gaussian mixture. This should ideally be
     changed to compute quantiles instead when Ax supports non-Gaussian distributions.
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/2116

Currently, this warns on import, which leads to excessive warnings since it is imported in the `__init__` file. Moving to `FullyBayesianPosterior.__init__` resolves the issue.

Differential Revision: D51445186


