### PR TITLE
Use default dtype in Experiment.clone_with

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1587,7 +1587,9 @@ class Experiment(Base):
             else:
                 raise NotImplementedError(f"Cloning of {type(trial)} is not supported.")
 
-        cloned_experiment.attach_data(Data.from_multiple_data(datas))
+        cloned_experiment.attach_data(
+            self.default_data_constructor.from_multiple_data(datas)
+        )
 
         return cloned_experiment
 

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -48,6 +48,7 @@ from ax.utils.testing.core_stubs import (
     get_search_space,
     get_sobol,
     get_status_quo,
+    get_test_map_data_experiment,
 )
 
 DUMMY_RUN_METADATA_KEY = "test_run_metadata_key"
@@ -1053,6 +1054,17 @@ class ExperimentTest(TestCase):
         self.assertEqual(
             checked_cast(Arm, experiment.status_quo).parameters, {"x1": 0.0, "x2": 0.0}
         )
+
+        # Clone with MapData.
+        experiment = get_test_map_data_experiment(
+            num_trials=5, num_fetches=3, num_complete=4
+        )
+        cloned_experiment = experiment.clone_with(
+            search_space=larger_search_space,
+            status_quo=new_status_quo,
+        )
+        new_data = cloned_experiment.lookup_data()
+        self.assertIsInstance(new_data, MapData)
 
 
 class ExperimentWithMapDataTest(TestCase):


### PR DESCRIPTION
Summary: Replaces `Data.from_multiple_data` with `self.default_data_constructor.from_multiple_data`, which will use `MapData.from_multiple_data` where applicable.

Reviewed By: Balandat

Differential Revision: D51333709


