### PR TITLE
specify metric value precision using digits arg

### DIFF
--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -581,7 +581,12 @@ class ReportUtilsTest(TestCase):
             )
 
             output_text = _format_comparison_string(
-                comparison_arm_names[0], OBJECTIVE_METRIC, 1150.0, 0.2, 2.5
+                comparison_arm_name=comparison_arm_names[0],
+                objective_name=OBJECTIVE_METRIC,
+                percent_change=1150.0,
+                baseline_value=0.2,
+                comparison_value=2.5,
+                digits=2,
             )
 
             self.assertNotEqual(result, None)
@@ -639,7 +644,12 @@ class ReportUtilsTest(TestCase):
             )
 
             output_text = _format_comparison_string(
-                comparison_arm_names[0], OBJECTIVE_METRIC, 1150.0, 0.2, 2.5
+                comparison_arm_name=comparison_arm_names[0],
+                objective_name=OBJECTIVE_METRIC,
+                percent_change=1150.0,
+                baseline_value=0.2,
+                comparison_value=2.5,
+                digits=2,
             )
 
             self.assertNotEqual(result, None)
@@ -688,7 +698,12 @@ class ReportUtilsTest(TestCase):
             )
 
             output_text = _format_comparison_string(
-                comparison_arm_names[0], OBJECTIVE_METRIC, 50.0, 0.2, 0.1
+                comparison_arm_name=comparison_arm_names[0],
+                objective_name=OBJECTIVE_METRIC,
+                percent_change=50.0,
+                baseline_value=0.2,
+                comparison_value=0.1,
+                digits=2,
             )
 
             self.assertNotEqual(result, None)
@@ -991,11 +1006,30 @@ class ReportUtilsTest(TestCase):
                 "Each of the following arms optimizes a different "
                 "objective metric.<br>"
             )
-            output_text_0 = _format_comparison_string("opt_0", "m0", 150.0, 1.0, 2.5)
-            output_text_1 = _format_comparison_string(
-                "opt_1_min", "m1", 110.0, 1.0, -0.1
+            output_text_0 = _format_comparison_string(
+                comparison_arm_name="opt_0",
+                objective_name="m0",
+                percent_change=150.0,
+                baseline_value=1.0,
+                comparison_value=2.5,
+                digits=2,
             )
-            output_text_3 = _format_comparison_string("opt_3", "m3", 1.0, 1.0, 1.01)
+            output_text_1 = _format_comparison_string(
+                comparison_arm_name="opt_1_min",
+                objective_name="m1",
+                percent_change=110.0,
+                baseline_value=1.0,
+                comparison_value=-0.1,
+                digits=2,
+            )
+            output_text_3 = _format_comparison_string(
+                comparison_arm_name="opt_3",
+                objective_name="m3",
+                percent_change=1.0,
+                baseline_value=1.0,
+                comparison_value=1.01,
+                digits=2,
+            )
 
             result = not_none(
                 compare_to_baseline(

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -1144,6 +1144,7 @@ def _format_comparison_string(
     percent_change: float,
     baseline_value: float,
     comparison_value: float,
+    digits: int,
 ) -> str:
     baseline_arm_name = BASELINE_ARM_NAME
     return (
@@ -1151,8 +1152,8 @@ def _format_comparison_string(
         + "improves your objective metric "
         + f"{objective_name} by {percent_change:.2f}%. "
         + f" {baseline_arm_name=} was improved "
-        + f"from {baseline_value=:.2f}"
-        + f" to {comparison_value=:.2f}"
+        + f"from {baseline_value=:.{digits}f}"
+        + f" to {comparison_value=:.{digits}f}"
     )
 
 
@@ -1184,11 +1185,12 @@ def _construct_comparison_message(
     percent_change = ((abs(comparison_value - baseline_value)) / baseline_value) * 100
 
     return _format_comparison_string(
-        comparison_arm_name,
-        objective_name,
-        percent_change,
-        baseline_value,
-        comparison_value,
+        comparison_arm_name=comparison_arm_name,
+        objective_name=objective_name,
+        percent_change=percent_change,
+        baseline_value=baseline_value,
+        comparison_value=comparison_value,
+        digits=digits,
     )
 
 


### PR DESCRIPTION
Summary: Followup to D51534667 (see discussion [here](https://www.internalfb.com/diff/D51534667?dst_version_fbid=695417615900989&transaction_fbid=313641054783091)). Also contains some formatting fixes in tests (calls args of _format_comparison_string by name).

Reviewed By: Balandat

Differential Revision: D51588896


