### PR TITLE
Replace get_generator_run_limit function on GenerationStep with new method on GenerationNode

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -308,7 +308,7 @@ class GenerationStrategy(Base):
             return 0, True
 
         # if the generation strategy is not complete, optimization is not complete
-        return self._curr.get_generator_run_limit(), False
+        return self._curr.generator_run_limit(), False
 
     def clone_reset(self) -> GenerationStrategy:
         """Copy this generation strategy without it's state."""


### PR DESCRIPTION
Summary:
This diff does the following:
Replaces the `get_generator_run_limit()` method on GenerationStep with `generator_run_limit` on GenerationNode. The new method relies on transition criterion to determine the number of generator runs, and only checks criterion that are trial based. I actually think this may not need to be expanded because the trial based criterion seem the most related to new generator run creation, but it could be expanded easily in the future if a usecase requires doing so.

upcoming:
(0) Finish removing GenerationStep methods in
(1) delete functions from GenStep that aren't needed anymore
(2) update the storage to include nodes independently (and not just as part of step)
(3) final pass on all the doc strings
(4) add transition criterion to the repr string + some of the other fields that havent made it yet on GeneratinoNode
(5) Do a final pass of the generationStrategy/GenerationNode files to see what else can be migrated/condensed
(6) rename transiton criterion to action criterion

Reviewed By: lena-kashtelyan

Differential Revision: D51169425


