### PR TITLE
adding "improvement_over_baseline" field to telemetry

### DIFF
--- a/ax/telemetry/optimization.py
+++ b/ax/telemetry/optimization.py
@@ -305,6 +305,8 @@ class OptimizationCompletedRecord:
     model_fit_generalization: float
     model_std_generalization: float
 
+    improvement_over_baseline: float
+
     num_metric_fetch_e_encountered: int
     num_trials_bad_due_to_err: int
 
@@ -348,6 +350,9 @@ class OptimizationCompletedRecord:
             total_gen_time=experiment_completed_record.total_gen_time,
             best_point_quality=scheduler_completed_record.best_point_quality,
             **_extract_model_fit_dict(scheduler_completed_record),
+            improvement_over_baseline=(
+                scheduler_completed_record.improvement_over_baseline
+            ),
             num_metric_fetch_e_encountered=(
                 scheduler_completed_record.num_metric_fetch_e_encountered
             ),
@@ -397,6 +402,7 @@ class OptimizationCompletedRecord:
             estimated_early_stopping_savings=estimated_early_stopping_savings,
             estimated_global_stopping_savings=estimated_global_stopping_savings,
             # The following are not applicable for AxClient
+            improvement_over_baseline=float("-inf"),
             num_metric_fetch_e_encountered=-1,
             num_trials_bad_due_to_err=-1,
         )

--- a/ax/telemetry/scheduler.py
+++ b/ax/telemetry/scheduler.py
@@ -105,6 +105,8 @@ class SchedulerCompletedRecord:
     model_fit_generalization: float
     model_std_generalization: float
 
+    improvement_over_baseline: float
+
     num_metric_fetch_e_encountered: int
     num_trials_bad_due_to_err: int
 
@@ -141,6 +143,7 @@ class SchedulerCompletedRecord:
             model_std_quality=model_std_quality,
             model_fit_generalization=float("-inf"),  # TODO by cross_validate_by_trial
             model_std_generalization=float("-inf"),
+            improvement_over_baseline=float("-inf"),  # TODO extract improvement result
             num_metric_fetch_e_encountered=scheduler._num_metric_fetch_e_encountered,
             num_trials_bad_due_to_err=scheduler._num_trials_bad_due_to_err,
         )

--- a/ax/telemetry/tests/test_optimization.py
+++ b/ax/telemetry/tests/test_optimization.py
@@ -156,6 +156,7 @@ class TestOptimization(TestCase):
             "estimated_early_stopping_savings": 19,
             "estimated_global_stopping_savings": 98,
             # Extra fields
+            "improvement_over_baseline": float("-inf"),
             "num_metric_fetch_e_encountered": -1,
             "num_trials_bad_due_to_err": -1,
         }

--- a/ax/telemetry/tests/test_scheduler.py
+++ b/ax/telemetry/tests/test_scheduler.py
@@ -95,6 +95,7 @@ class TestScheduler(TestCase):
             model_std_quality=float("-inf"),
             model_fit_generalization=float("-inf"),
             model_std_generalization=float("-inf"),
+            improvement_over_baseline=float("-inf"),
             num_metric_fetch_e_encountered=0,
             num_trials_bad_due_to_err=0,
         )
@@ -110,6 +111,7 @@ class TestScheduler(TestCase):
             "model_std_quality": float("-inf"),
             "model_fit_generalization": float("-inf"),
             "model_std_generalization": float("-inf"),
+            "improvement_over_baseline": float("-inf"),
             "num_metric_fetch_e_encountered": 0,
             "num_trials_bad_due_to_err": 0,
         }
@@ -181,6 +183,7 @@ class TestScheduler(TestCase):
             model_std_quality=model_std_quality,
             model_fit_generalization=float("-inf"),
             model_std_generalization=float("-inf"),
+            improvement_over_baseline=float("-inf"),
             num_metric_fetch_e_encountered=0,
             num_trials_bad_due_to_err=0,
         )
@@ -196,6 +199,7 @@ class TestScheduler(TestCase):
             "model_std_quality": model_std_quality,
             "model_fit_generalization": float("-inf"),
             "model_std_generalization": float("-inf"),
+            "improvement_over_baseline": float("-inf"),
             "num_metric_fetch_e_encountered": 0,
             "num_trials_bad_due_to_err": 0,
         }


### PR DESCRIPTION
Summary:
In order to expose improvement from baseline to ax tables, adding the "improvement_over_baseline" column to the scheduler and optimization telemetry

Next steps:
- Update hive table to include "improvement_over_baseline" column
- Populate to hive
- Add calculation for improvement value

Differential Revision: D51507985


