### PR TITLE
Store predictions as floats in SurrogatRunner

### DIFF
--- a/ax/benchmark/problems/surrogate.py
+++ b/ax/benchmark/problems/surrogate.py
@@ -290,7 +290,7 @@ class SurrogateRunner(Runner):
             for arm in trial.arms
         }
         return {
-            metric_name: {arm_name: pred[i] for arm_name, pred in preds.items()}
+            metric_name: {arm_name: float(pred[i]) for arm_name, pred in preds.items()}
             for i, metric_name in enumerate(self.metric_names)
         }
 

--- a/ax/benchmark/tests/test_surrogate_runner.py
+++ b/ax/benchmark/tests/test_surrogate_runner.py
@@ -55,7 +55,8 @@ class TestSurrogateRunner(TestCase):
         trial = Trial(experiment=MagicMock())
         trial.add_arm(Arm({"x": 2.5, "y": 10.0, "z": 1.0}, name="0_0"))
         run_output = runner.run(trial)
-        self.assertEqual(run_output["dummy metric"]["0_0"].item(), 0.0)
+        self.assertEqual(run_output["dummy metric"]["0_0"], 0.0)
+        self.assertIsInstance(run_output["dummy metric"]["0_0"], float)
         surrogate.predict.assert_called_once()
         X = surrogate.predict.call_args[1]["X"]
         self.assertTrue(torch.allclose(X, torch.tensor([[2.5, 1.0, 0.0]])))


### PR DESCRIPTION
Summary:
The predictions are recorded at `trial.run_metadata`. When saving the experiment to db with `save_experiment`, the metadata gets encoded using `json.dumps`, which doesn't support tensors. Storing them as floats makes it possible to save the benchmark experiments to db (after hacking around metrics etc).

Also verified that the BoTorchTestProblemRunner doesn't have this issue since it casts the values before returning.

Reviewed By: Balandat

Differential Revision: D51632031


