### PR TITLE
Replace np.int64 type hints with int

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -53,13 +53,13 @@ class BaseData(Base, SerializationMixin):
         "mean": np.float64,
         "sem": np.float64,
         # Metadata columns available for all subclasses.
-        "trial_index": np.int64,
+        "trial_index": int,
         "start_time": pd.Timestamp,
         "end_time": pd.Timestamp,
-        "n": np.int64,
+        "n": int,
         # Metadata columns available for only some subclasses.
         "frac_nonnull": np.float64,
-        "random_split": np.int64,
+        "random_split": int,
         "fidelities": str,  # Dictionary stored as json
     }
 
@@ -130,7 +130,7 @@ class BaseData(Base, SerializationMixin):
             ).items()
             if col in df.columns.values
             and not (
-                cls.column_data_types(extra_column_types)[col] is np.int64
+                cls.column_data_types(extra_column_types)[col] is int
                 and df.loc[:, col].isnull().any()
             )
             and not (coltype is Any)

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -62,10 +62,10 @@ class ObservationFeatures(Base):
     def __init__(
         self,
         parameters: TParameterization,
-        trial_index: Optional[np.int64] = None,
+        trial_index: Optional[int] = None,
         start_time: Optional[pd.Timestamp] = None,
         end_time: Optional[pd.Timestamp] = None,
-        random_split: Optional[np.int64] = None,
+        random_split: Optional[int] = None,
         metadata: TCandidateMetadata = None,
     ) -> None:
         self.parameters = parameters
@@ -78,10 +78,10 @@ class ObservationFeatures(Base):
     @staticmethod
     def from_arm(
         arm: Arm,
-        trial_index: Optional[np.int64] = None,
+        trial_index: Optional[int] = None,
         start_time: Optional[pd.Timestamp] = None,
         end_time: Optional[pd.Timestamp] = None,
-        random_split: Optional[np.int64] = None,
+        random_split: Optional[int] = None,
         metadata: TCandidateMetadata = None,
     ) -> ObservationFeatures:
         """Convert a Arm to an ObservationFeatures, including additional

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -83,7 +83,6 @@ class ObservationsTest(TestCase):
     def test_Clone(self) -> None:
         # Test simple cloning.
         arm = Arm({"x": 0, "y": "a"})
-        # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
         obsf = ObservationFeatures.from_arm(arm, trial_index=3)
         self.assertIsNot(obsf, obsf.clone())
         self.assertEqual(obsf, obsf.clone())
@@ -96,7 +95,6 @@ class ObservationsTest(TestCase):
 
     def test_ObservationFeaturesFromArm(self) -> None:
         arm = Arm({"x": 0, "y": "a"})
-        # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
         obsf = ObservationFeatures.from_arm(arm, trial_index=3)
         self.assertEqual(obsf.parameters, arm.parameters)
         self.assertEqual(obsf.trial_index, 3)
@@ -119,11 +117,9 @@ class ObservationsTest(TestCase):
             # pyre-fixme[6]: For 1st param expected `Dict[str, Union[None, bool,
             #  float, int, str]]` but got `Dict[str, str]`.
             parameters=new_parameters,
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             trial_index=4,
             start_time=pd.Timestamp("2005-02-25"),
             end_time=pd.Timestamp("2005-02-26"),
-            # pyre-fixme[6]: For 5th param expected `Optional[int64]` but got `int`.
             random_split=7,
         )
         obsf.update_features(new_obsf)

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -49,7 +49,7 @@ class UtilsTest(TestCase):
         self.batch_trial = self.experiment_2.new_batch_trial(GeneratorRun([self.arm]))
         self.batch_trial.set_status_quo_with_weight(self.experiment_2.status_quo, 1)
         self.obs_feat = ObservationFeatures.from_arm(
-            arm=self.trial.arm, trial_index=np.int64(self.trial.index)
+            arm=self.trial.arm, trial_index=self.trial.index
         )
         self.hss_arm = Arm({"model": "XGBoost", "num_boost_rounds": 12})
         self.hss_exp = get_hierarchical_search_space_experiment()
@@ -75,12 +75,12 @@ class UtilsTest(TestCase):
         ).copy()
         self.hss_obs_feat = ObservationFeatures.from_arm(
             arm=self.hss_arm,
-            trial_index=np.int64(self.hss_trial.index),
+            trial_index=self.hss_trial.index,
             metadata=self.hss_cand_metadata,
         )
         self.hss_obs_feat_all_params = ObservationFeatures.from_arm(
             arm=Arm(self.hss_full_parameterization),
-            trial_index=np.int64(self.hss_trial.index),
+            trial_index=self.hss_trial.index,
             metadata={Keys.FULL_PARAMETERIZATION: self.hss_full_parameterization},
         )
         self.df = pd.DataFrame(

--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -252,7 +252,7 @@ def get_pending_observation_features(
                     pending_features[metric_name].append(
                         ObservationFeatures.from_arm(
                             arm=arm,
-                            trial_index=np.int64(trial_index),
+                            trial_index=trial_index,
                             metadata=trial._get_candidate_metadata(arm_name=arm.name),
                         )
                     )
@@ -265,7 +265,7 @@ def get_pending_observation_features(
                     not_none(pending_features.get(metric_name)).append(
                         ObservationFeatures.from_arm(
                             arm=arm,
-                            trial_index=np.int64(trial_index),
+                            trial_index=trial_index,
                             metadata=trial._get_candidate_metadata(arm_name=arm.name),
                         )
                     )
@@ -321,7 +321,7 @@ def get_pending_observation_features_based_on_trial_status(
                     pending_features[metric_name].append(
                         ObservationFeatures.from_arm(
                             arm=arm,
-                            trial_index=np.int64(trial.index),
+                            trial_index=trial.index,
                             metadata=trial._get_candidate_metadata(arm_name=arm.name),
                         )
                     )

--- a/ax/modelbridge/factory.py
+++ b/ax/modelbridge/factory.py
@@ -156,8 +156,6 @@ def get_MTGP_NEHVI(
     else:
         status_quo_features = ObservationFeatures(
             parameters=status_quo.parameters,
-            # pyre-fixme[6]: Expected `Optional[numpy.int64]` for 2nd param but got
-            #  `int`.
             trial_index=trial_index,
         )
 
@@ -376,8 +374,6 @@ def get_MTGP_LEGACY(
     else:
         status_quo_features = ObservationFeatures(
             parameters=status_quo.parameters,
-            # pyre-fixme[6]: Expected `Optional[numpy.int64]` for 2nd param but got
-            #  `int`.
             trial_index=trial_index,
         )
 
@@ -654,8 +650,6 @@ def get_MTGP_PAREGO(
     else:
         status_quo_features = ObservationFeatures(
             parameters=status_quo.parameters,
-            # pyre-fixme[6]: Expected `Optional[numpy.int64]` for 2nd param but got
-            #  `int`.
             trial_index=trial_index,
         )
     return checked_cast(

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -488,7 +488,7 @@ class BaseModelBridgeTest(TestCase):
         mock_gen.return_value = GenResults(
             observation_features=[
                 ObservationFeatures(
-                    parameters={"x1": float(i), "x2": float(i)}, trial_index=np.int64(1)
+                    parameters={"x1": float(i), "x2": float(i)}, trial_index=1
                 )
                 for i in range(5)
             ],
@@ -539,7 +539,6 @@ class BaseModelBridgeTest(TestCase):
         status_quo_features = ObservationFeatures(
             # pyre-fixme[16]: `BaseTrial` has no attribute `status_quo`.
             parameters=exp.trials[trial_index].status_quo.parameters,
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             trial_index=trial_index,
         )
         modelbridge = ModelBridge(

--- a/ax/modelbridge/tests/test_cross_validation.py
+++ b/ax/modelbridge/tests/test_cross_validation.py
@@ -36,7 +36,6 @@ class CrossValidationTest(TestCase):
     def setUp(self) -> None:
         self.training_data = [
             Observation(
-                # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
                 features=ObservationFeatures(parameters={"x": 2.0}, trial_index=0),
                 data=ObservationData(
                     means=np.array([2.0, 4.0]),
@@ -46,7 +45,6 @@ class CrossValidationTest(TestCase):
                 arm_name="1_1",
             ),
             Observation(
-                # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
                 features=ObservationFeatures(parameters={"x": 2.0}, trial_index=1),
                 data=ObservationData(
                     means=np.array([3.0, 5.0, 6.0]),
@@ -67,7 +65,6 @@ class CrossValidationTest(TestCase):
                 arm_name="1_2",
             ),
             Observation(
-                # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
                 features=ObservationFeatures(parameters={"x": 4.0}, trial_index=2),
                 data=ObservationData(
                     means=np.array([9.0, 10.0]),

--- a/ax/modelbridge/tests/test_factory.py
+++ b/ax/modelbridge/tests/test_factory.py
@@ -401,7 +401,6 @@ class ModelBridgeFactoryTestMultiObjective(TestCase):
         self.assertEqual(task_covar_factor.shape, torch.Size([2, 2]))
         mt_ehvi_run = mt_ehvi.gen(
             n=1,
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             fixed_features=ObservationFeatures(parameters={}, trial_index=1),
         )
         self.assertEqual(len(mt_ehvi_run.arms), 1)
@@ -542,7 +541,6 @@ class ModelBridgeFactoryTestMultiObjective(TestCase):
         self.assertEqual(task_covar_factor.shape, torch.Size([2, 2]))
         mt_ehvi_run = mt_ehvi.gen(
             n=1,
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             fixed_features=ObservationFeatures(parameters={}, trial_index=1),
         )
         self.assertEqual(len(mt_ehvi_run.arms), 1)

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -103,8 +103,6 @@ class TestGenerationNode(TestCase):
                         "n": 1,
                         "fixed_features": ObservationFeatures(
                             parameters={},
-                            # pyre-fixme[6]: For 2nd param expected
-                            #  `Optional[int64]` but got `int`.
                             trial_index=0,
                         ),
                     },

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -8,8 +8,6 @@ from typing import cast, List
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-import numpy as np
-
 from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
@@ -765,7 +763,7 @@ class TestGenerationStrategy(TestCase):
             # GRs now (remaining in Sobol step) even though we requested 3.
             original_pending = not_none(get_pending(experiment=exp))
             first_3_trials_obs_feats = [
-                ObservationFeatures.from_arm(arm=a, trial_index=np.int64(idx))
+                ObservationFeatures.from_arm(arm=a, trial_index=idx)
                 for idx, trial in exp.trials.items()
                 for a in trial.arms
             ]
@@ -851,7 +849,7 @@ class TestGenerationStrategy(TestCase):
         # GRs now (remaining in Sobol step) even though we requested 3.
         original_pending = not_none(get_pending(experiment=exp))
         first_3_trials_obs_feats = [
-            ObservationFeatures.from_arm(arm=a, trial_index=np.int64(idx))
+            ObservationFeatures.from_arm(arm=a, trial_index=idx)
             for idx, trial in exp.trials.items()
             for a in trial.arms
         ]

--- a/ax/modelbridge/tests/test_pairwise_modelbridge.py
+++ b/ax/modelbridge/tests/test_pairwise_modelbridge.py
@@ -56,17 +56,13 @@ class PairwiseModelBridgeTest(TestCase):
             ),
         ]
         observation_features = [
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures(parameters={"y1": 0.1, "y2": 0.2}, trial_index=0),
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures(parameters={"y1": 0.3, "y2": 0.4}, trial_index=0),
         ]
         observation_features_with_metadata = [
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures(parameters={"y1": 0.1, "y2": 0.2}, trial_index=0),
             ObservationFeatures(
                 parameters={"y1": 0.3, "y2": 0.4},
-                # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
                 trial_index=0,
                 metadata={"metadata_key": "metadata_val"},
             ),

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -450,7 +450,6 @@ class ModelRegistryTest(TestCase):
         # test it can generate
         mtgp_run = mtgp.gen(
             n=1,
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             fixed_features=ObservationFeatures(parameters={}, trial_index=1),
         )
         self.assertEqual(len(mtgp_run.arms), 1)
@@ -531,9 +530,7 @@ class ModelRegistryTest(TestCase):
 
                 gr = mtgp.gen(
                     n=1,
-                    fixed_features=ObservationFeatures(
-                        {}, trial_index=1  # pyre-ignore[6]
-                    ),
+                    fixed_features=ObservationFeatures({}, trial_index=1),
                 )
                 self.assertEqual(len(gr.arms), 1)
 

--- a/ax/modelbridge/tests/test_torch_moo_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_moo_modelbridge.py
@@ -605,7 +605,6 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             experiment=exp,
             data=data,
         )
-        # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
         fixed_features = ObservationFeatures(parameters={}, trial_index=1)
         expected_base_gen_args = modelbridge._get_transformed_gen_args(
             search_space=search_space.clone(),

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -52,7 +52,7 @@ class TestModelbridgeUtils(TestCase):
         self.batch_trial = self.experiment_2.new_batch_trial(GeneratorRun([self.arm]))
         self.batch_trial.set_status_quo_with_weight(self.experiment_2.status_quo, 1)
         self.obs_feat = ObservationFeatures.from_arm(
-            arm=self.trial.arm, trial_index=np.int64(self.trial.index)
+            arm=self.trial.arm, trial_index=self.trial.index
         )
         self.hss_exp = get_hierarchical_search_space_experiment()
         self.hss_sobol = Models.SOBOL(search_space=self.hss_exp.search_space)
@@ -73,12 +73,12 @@ class TestModelbridgeUtils(TestCase):
         )
         self.hss_obs_feat = ObservationFeatures.from_arm(
             arm=self.hss_arm,
-            trial_index=np.int64(self.hss_trial.index),
+            trial_index=self.hss_trial.index,
             metadata=self.hss_cand_metadata,
         )
         self.hss_obs_feat_all_params = ObservationFeatures.from_arm(
             arm=Arm(self.hss_full_parameterization),
-            trial_index=np.int64(self.hss_trial.index),
+            trial_index=self.hss_trial.index,
             metadata={Keys.FULL_PARAMETERIZATION: self.hss_full_parameterization},
         )
 

--- a/ax/modelbridge/transforms/tests/test_cast_transform.py
+++ b/ax/modelbridge/transforms/tests/test_cast_transform.py
@@ -52,7 +52,6 @@ class CastTransformTest(TestCase):
                 "l2_reg_weight": 0.0001,
                 "num_boost_rounds": 12,
             },
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             trial_index=9,
             metadata=None,
         )
@@ -63,7 +62,6 @@ class CastTransformTest(TestCase):
                 "l2_reg_weight": 0.0001,
                 "num_boost_rounds": 12,
             },
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             trial_index=10,
             metadata=None,
         )

--- a/ax/modelbridge/transforms/tests/test_relativize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_relativize_transform.py
@@ -36,7 +36,6 @@ from ax.utils.testing.core_stubs import (
     get_search_space,
 )
 from hypothesis import assume, given, settings, strategies as st
-from numpy import int64
 
 
 class RelativizeDataTest(TestCase):
@@ -143,7 +142,7 @@ class RelativizeDataTest(TestCase):
             modelbridge=modelbridge,
         )
         # making observation coming from trial_index not in modelbridge
-        observations[0].features.trial_index = int64(999)
+        observations[0].features.trial_index = 999
         self.assertRaises(ValueError, tf.transform_observations, observations)
 
         # When observation has missing trial_index and
@@ -214,9 +213,7 @@ class RelativizeDataTest(TestCase):
             ),
         ]
         obs_features = [
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures(parameters={"x": 1}, trial_index=0),
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures(parameters={"x": 2}, trial_index=0),
         ]
         observations = recombine_observations(obs_features, obs_data, arm_names)
@@ -275,9 +272,7 @@ class RelativizeDataTest(TestCase):
             ),
         ]
         obs_features = [
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures(parameters={"x": 1}, trial_index=0),
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures(parameters={"x": 2}, trial_index=0),
         ]
         modelbridge = Mock(

--- a/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
+++ b/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
@@ -26,13 +26,9 @@ class TrialAsTaskTransformTest(TestCase):
             ]
         )
         self.training_feats = [
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures({"x": 1}, trial_index=0),
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures({"x": 2}, trial_index=0),
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures({"x": 3}, trial_index=1),
-            # pyre-fixme[6]: For 2nd param expected `Optional[int64]` but got `int`.
             ObservationFeatures({"x": 4}, trial_index=2),
         ]
         self.training_obs = [

--- a/ax/modelbridge/transforms/trial_as_task.py
+++ b/ax/modelbridge/transforms/trial_as_task.py
@@ -7,7 +7,6 @@
 from logging import Logger
 from typing import Dict, List, Optional, TYPE_CHECKING, Union
 
-import numpy as np
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import RobustSearchSpace, SearchSpace
@@ -158,5 +157,5 @@ class TrialAsTask(Transform):
                 pval = obsf.parameters.pop(p_name)
             if self.inverse_map is not None:
                 # pyre-fixme[61]: `pval` may not be initialized here.
-                obsf.trial_index = np.int64(self.inverse_map[pval])
+                obsf.trial_index = self.inverse_map[pval]
         return observation_features

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -441,7 +441,6 @@ def compute_posterior_pareto_frontier(
                 [
                     ObservationFeatures(
                         parameters=status_quo.parameters,
-                        # pyre-fixme [6]: Expected `Optional[np.int64]` for trial_index
                         trial_index=trial_index,
                     )
                 ]

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass
 from logging import Logger
 from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
-import numpy as np
-
 from ax.core.arm import Arm
 from ax.core.experiment import DataType, DEFAULT_OBJECTIVE_NAME, Experiment
 from ax.core.map_metric import MapMetric
@@ -966,5 +964,5 @@ class InstantiationBase:
             parameters=fixed_features.parameters,
             trial_index=None
             if fixed_features.trial_index is None
-            else np.int64(fixed_features.trial_index),
+            else fixed_features.trial_index,
         )

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -255,7 +255,7 @@ def get_branin_experiment_with_status_quo_trials(
         t.run().mark_completed()
     status_quo_features = ObservationFeatures(
         parameters=exp.trials[0].status_quo.parameters,  # pyre-fixme [16]
-        trial_index=0,  # pyre-ignore [6] See T163830566
+        trial_index=0,
     )
     return exp, status_quo_features
 

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -39,9 +39,7 @@ logger: Logger = get_logger(__name__)
 
 
 def get_observation_features() -> ObservationFeatures:
-    return ObservationFeatures(
-        parameters={"x": 2.0, "y": 10.0}, trial_index=np.int64(0)
-    )
+    return ObservationFeatures(parameters={"x": 2.0, "y": 10.0}, trial_index=0)
 
 
 def get_observation(
@@ -49,9 +47,7 @@ def get_observation(
     second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
-        features=ObservationFeatures(
-            parameters={"x": 2.0, "y": 10.0}, trial_index=np.int64(0)
-        ),
+        features=ObservationFeatures(parameters={"x": 2.0, "y": 10.0}, trial_index=0),
         data=ObservationData(
             means=np.array([2.0, 4.0]),
             covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
@@ -66,9 +62,7 @@ def get_observation1(
     second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
-        features=ObservationFeatures(
-            parameters={"x": 2.0, "y": 10.0}, trial_index=np.int64(0)
-        ),
+        features=ObservationFeatures(parameters={"x": 2.0, "y": 10.0}, trial_index=0),
         data=ObservationData(
             means=np.array([2.0, 4.0]),
             covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
@@ -85,7 +79,7 @@ def get_observation_status_quo0(
     return Observation(
         features=ObservationFeatures(
             parameters={"w": 0.85, "x": 1, "y": "baz", "z": False},
-            trial_index=np.int64(0),
+            trial_index=0,
         ),
         data=ObservationData(
             means=np.array([2.0, 4.0]),
@@ -103,7 +97,7 @@ def get_observation_status_quo1(
     return Observation(
         features=ObservationFeatures(
             parameters={"w": 0.85, "x": 1, "y": "baz", "z": False},
-            trial_index=np.int64(1),
+            trial_index=1,
         ),
         data=ObservationData(
             means=np.array([2.0, 4.0]),
@@ -119,9 +113,7 @@ def get_observation1trans(
     second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
-        features=ObservationFeatures(
-            parameters={"x": 9.0, "y": 121.0}, trial_index=np.int64(0)
-        ),
+        features=ObservationFeatures(parameters={"x": 9.0, "y": 121.0}, trial_index=0),
         data=ObservationData(
             means=np.array([9.0, 25.0]),
             covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
@@ -136,9 +128,7 @@ def get_observation2(
     second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
-        features=ObservationFeatures(
-            parameters={"x": 3.0, "y": 2.0}, trial_index=np.int64(1)
-        ),
+        features=ObservationFeatures(parameters={"x": 3.0, "y": 2.0}, trial_index=1),
         data=ObservationData(
             means=np.array([2.0, 1.0]),
             covariance=np.array([[2.0, 3.0], [4.0, 5.0]]),
@@ -153,9 +143,7 @@ def get_observation2trans(
     second_metric_name: str = "b",
 ) -> Observation:
     return Observation(
-        features=ObservationFeatures(
-            parameters={"x": 16.0, "y": 9.0}, trial_index=np.int64(1)
-        ),
+        features=ObservationFeatures(parameters={"x": 16.0, "y": 9.0}, trial_index=1),
         data=ObservationData(
             means=np.array([9.0, 4.0]),
             covariance=np.array([[2.0, 3.0], [4.0, 5.0]]),


### PR DESCRIPTION
Summary: Replace np.int64 type hints with int and clean up use cases

Differential Revision: D51630885


