### PR TITLE
Support gen nodes and gensteps

### DIFF
--- a/ax/exceptions/generation_strategy.py
+++ b/ax/exceptions/generation_strategy.py
@@ -55,3 +55,14 @@ class GenerationStrategyRepeatedPoints(GenerationStrategyCompleted):
     """
 
     pass
+
+
+class GenerationStrategyMisconfiguredException(AxError):
+    """Special exception indicating that the generation strategy is misconfigured."""
+
+    def __init__(self, error_info: Optional[str]) -> None:
+        super().__init__(
+            "This GenerationStrategy was unable to be initialized properly. Please "
+            + "check the documentation, and adjust the configuration accordingly. "
+            + f"{error_info}"
+        )

--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -100,6 +100,7 @@ class GenerationNode:
 
     # Optional specifications
     _model_spec_to_gen_from: Optional[ModelSpec] = None
+    # TODO: @mgarrard should this be a dict criterion_class name -> criterion mapping?
     _transition_criteria: Optional[Sequence[TransitionCriterion]]
 
     # [TODO] Handle experiment passing more eloquently by enforcing experiment

--- a/ax/modelbridge/model_spec.py
+++ b/ax/modelbridge/model_spec.py
@@ -27,7 +27,7 @@ from ax.modelbridge.cross_validation import (
     CVResult,
 )
 from ax.modelbridge.registry import ModelRegistryBase
-from ax.utils.common.base import Base
+from ax.utils.common.base import SortableBase
 from ax.utils.common.kwargs import (
     consolidate_kwargs,
     filter_kwargs,
@@ -48,7 +48,7 @@ class ModelSpecJSONEncoder(json.JSONEncoder):
 
 
 @dataclass
-class ModelSpec(Base):
+class ModelSpec(SortableBase):
     model_enum: ModelRegistryBase
     # Kwargs to pass into the `Model` + `ModelBridge` constructors in
     # `ModelRegistryBase.__call__`.
@@ -287,6 +287,12 @@ class ModelSpec(Base):
 
     def __eq__(self, other: ModelSpec) -> bool:
         return repr(self) == repr(other)
+
+    @property
+    def _unique_id(self) -> str:
+        """Returns the unique ID of this model spec"""
+        # TODO @mgarrard verify that this is unique enough
+        return str(hash(self))
 
 
 @dataclass

--- a/ax/modelbridge/tests/test_completion_criterion.py
+++ b/ax/modelbridge/tests/test_completion_criterion.py
@@ -71,7 +71,7 @@ class TestCompletionCritereon(TestCase):
                 )
             )
 
-            self.assertEqual(generation_strategy._curr.model, Models.GPEI)
+            self.assertEqual(generation_strategy._curr.model_enum, Models.GPEI)
 
     def test_many_criteria(self) -> None:
         criteria = [
@@ -145,4 +145,4 @@ class TestCompletionCritereon(TestCase):
                 )
             )
 
-            self.assertEqual(generation_strategy._curr.model, Models.GPEI)
+            self.assertEqual(generation_strategy._curr.model_enum, Models.GPEI)

--- a/ax/modelbridge/tests/test_transition_criterion.py
+++ b/ax/modelbridge/tests/test_transition_criterion.py
@@ -74,7 +74,7 @@ class TestTransitionCriterion(TestCase):
                     raise_data_required_error=False
                 )
             )
-            self.assertEqual(generation_strategy._curr.model, Models.GPEI)
+            self.assertEqual(generation_strategy._curr.model_enum, Models.GPEI)
 
     def test_default_step_criterion_setup(self) -> None:
         """This test ensures that the default completion criterion for GenerationSteps

--- a/ax/modelbridge/transition_criterion.py
+++ b/ax/modelbridge/transition_criterion.py
@@ -12,14 +12,14 @@ from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
 from ax.exceptions.generation_strategy import MaxParallelismReachedException
 from ax.modelbridge.generation_strategy import DataRequiredError
-from ax.utils.common.base import Base
+from ax.utils.common.base import SortableBase
 from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import SerializationMixin, serialize_init_args
 
 logger: Logger = get_logger(__name__)
 
 
-class TransitionCriterion(Base, SerializationMixin):
+class TransitionCriterion(SortableBase, SerializationMixin):
     # TODO: @mgarrard rename to ActionCriterion
     """
     Simple class to descibe a condition which must be met for this GenerationNode to
@@ -66,7 +66,7 @@ class TransitionCriterion(Base, SerializationMixin):
         """If the criterion of this TransitionCriterion is met, returns True."""
         pass
 
-    @abstractmethod
+    # TODO: @mgarrard add back abstractmethod once legacy usecases are updated
     def block_continued_generation_error(
         self,
         node_name: Optional[str],
@@ -84,6 +84,12 @@ class TransitionCriterion(Base, SerializationMixin):
 
     def __repr__(self) -> str:
         return f"{self.criterion_class}({serialize_init_args(obj=self)})"
+
+    @property
+    def _unique_id(self) -> str:
+        """Unique id for this TransitionCriterion."""
+        # TODO @mgarrard validate that this is unique enough
+        return str(self)
 
 
 class TrialBasedCriterion(TransitionCriterion):

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -1983,6 +1983,7 @@ class TestAxClient(TestCase):
         # set during next model fitting call), so we unset them on the original GS as
         # well.
         gs._unset_non_persistent_state_fields()
+        ax_client.generation_strategy._unset_non_persistent_state_fields()
         self.assertEqual(gs, ax_client.generation_strategy)
         with self.assertRaises(ValueError):
             # Overwriting existing experiment.
@@ -2342,7 +2343,10 @@ class TestAxClient(TestCase):
         ax_client.generation_strategy._fit_current_model(
             data=ax_client.experiment.lookup_data()
         )
-        self.assertEqual(ax_client.generation_strategy._curr.model_name, "BoTorch")
+        self.assertEqual(
+            ax_client.generation_strategy._curr.model_spec_to_gen_from.model_key,
+            "BoTorch",
+        )
 
         # Check calling get_best_parameters fails (user must call
         # get_pareto_optimal_parameters).
@@ -2409,7 +2413,10 @@ class TestAxClient(TestCase):
         ax_client, _ = get_branin_currin_optimization_with_N_sobol_trials(
             num_trials=20, minimize=minimize, outcome_constraints=outcome_constraints
         )
-        self.assertEqual(ax_client.generation_strategy._curr.model_name, "Sobol")
+        self.assertEqual(
+            ax_client.generation_strategy._curr.model_spec_to_gen_from.model_key,
+            "Sobol",
+        )
 
         cfg = not_none(ax_client.experiment.optimization_config)
         assert isinstance(cfg, MultiObjectiveOptimizationConfig)

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -266,7 +266,7 @@ class BestPointMixin(metaclass=ABCMeta):
         # TODO[drfreund]: Find a way to include data for last trial in the
         # calculation of best parameters.
         if use_model_predictions:
-            current_model = generation_strategy._curr.model
+            current_model = generation_strategy._curr.model_enum
             # Cover for the case where source of `self._curr.model` was not a `Models`
             # enum but a factory function, in which case we cannot do
             # `get_model_from_generator_run` (since we don't have model type and inputs
@@ -381,7 +381,7 @@ class BestPointMixin(metaclass=ABCMeta):
         )
 
         if use_model_predictions:
-            current_model = generation_strategy._curr.model
+            current_model = generation_strategy._curr.model_enum
             # Cover for the case where source of `self._curr.model` was not a `Models`
             # enum but a factory function, in which case we cannot do
             # `get_model_from_generator_run` (since we don't have model type and inputs

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -494,7 +494,7 @@ def generation_strategy_to_dict(
         "db_id": generation_strategy._db_id,
         "name": generation_strategy.name,
         "steps": generation_strategy._steps,
-        "curr_index": generation_strategy._curr.index,
+        "curr_index": generation_strategy.current_step_index,
         "generator_runs": generation_strategy._generator_runs,
         "had_initialized_model": generation_strategy.model is not None,
         "experiment": generation_strategy._experiment,

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -858,7 +858,7 @@ class Encoder:
                 encoder_registry=self.config.json_encoder_registry,
                 class_encoder_registry=self.config.json_class_encoder_registry,
             ),
-            curr_index=generation_strategy._curr.index,
+            curr_index=generation_strategy.current_step_index,
             generator_runs=generator_runs_sqa,
             experiment_id=experiment_id,
         )

--- a/ax/storage/sqa_store/save.py
+++ b/ax/storage/sqa_store/save.py
@@ -328,7 +328,7 @@ def _update_generation_strategy(
     with session_scope() as session:
         session.query(gs_sqa_class).filter_by(id=gs_id).update(
             {
-                "curr_index": generation_strategy._curr.index,
+                "curr_index": generation_strategy.current_step_index,
                 "experiment_id": experiment_id,
             }
         )

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -1270,6 +1270,10 @@ class SQAStoreTest(TestCase):
             # pyre-fixme[6]: For 1st param expected `int` but got `Optional[int]`.
             gs_id=generation_strategy._db_id
         )
+        # Some fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._unset_non_persistent_state_fields()
         self.assertEqual(generation_strategy, new_generation_strategy)
         self.assertIsNone(generation_strategy._experiment)
 

--- a/ax/storage/sqa_store/utils.py
+++ b/ax/storage/sqa_store/utils.py
@@ -35,6 +35,7 @@ COPY_DB_IDS_ATTRS_TO_SKIP = {
     "_seen_trial_indices_by_status",
     "_steps",
     "analysis_scheduler",
+    "_nodes",
 }
 SKIP_ATTRS_ERROR_SUFFIX = "Consider adding to COPY_DB_IDS_ATTRS_TO_SKIP if appropriate."
 


### PR DESCRIPTION
Summary:
Support both steps and nodes at the generation strategy level

This diff does the following:
Supports GenerationNodes at the level of GenerationStrategy. This is the big hurrah diff!

upcoming:
(1) update the storage to include nodes independently (and not just as part of step)
(2) delete now unused GenStep functions
(3) final pass on all the doc strings
(4) add transition criterion to the repr string + some of the other fields that havent made it yet on GeneratinoNode
(5) Do a final pass of the generationStrategy/GenerationNode files to see what else can be migrated/condensed
(6) rename transiton criterion to action criterion
(7) remove conditionals for legacy usecase

Differential Revision: D51120002


