### PR TITLE
Factoring out compare_to_baseline_impl

### DIFF
--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -1172,8 +1172,8 @@ def _construct_comparison_message(
         )
         return None
 
-    if (objective_minimize and (baseline_value < comparison_value)) or (
-        not objective_minimize and (baseline_value > comparison_value)
+    if (objective_minimize and (baseline_value <= comparison_value)) or (
+        not objective_minimize and (baseline_value >= comparison_value)
     ):
         logger.info(
             f"compare_to_baseline: comparison arm {comparison_arm_name}"


### PR DESCRIPTION
Summary: There are scenarios where calling `maybe_extract_baseline_comparison_values` is more useful than obtaining the formatted comparison string. To support these scenarios, adding `compare_to_baseline_impl` which takes in the output of `maybe_extract_baseline_comparison_values`, and updates `compare_to_baseline` as a wrapper of `compare_to_baseline_impl`

Differential Revision: D51682579


