### PR TITLE
Use skip_runners_and_metrics when loading experiments for remote_gen

### DIFF
--- a/ax/service/utils/with_db_settings_base.py
+++ b/ax/service/utils/with_db_settings_base.py
@@ -215,6 +215,7 @@ class WithDBSettingsBase:
         self,
         experiment_name: str,
         reduced_state: bool = False,
+        skip_runners_and_metrics: bool = False,
     ) -> Tuple[Optional[Experiment], Optional[GenerationStrategy]]:
         """Loads experiment and its corresponding generation strategy from database
         if DB settings are set on this `WithDBSettingsBase` instance.
@@ -250,6 +251,7 @@ class WithDBSettingsBase:
             reduced_state=reduced_state,
             load_trials_in_batches_of_size=LOADING_MINI_BATCH_SIZE,
             ax_object_field_overrides=self.AX_OBJECT_FIELD_OVERRIDES,
+            skip_runners_and_metrics=skip_runners_and_metrics,
         )
         if not isinstance(experiment, Experiment):
             raise ValueError("Service API only supports `Experiment`.")

--- a/ax/storage/sqa_store/load.py
+++ b/ax/storage/sqa_store/load.py
@@ -334,6 +334,7 @@ def load_generation_strategy_by_experiment_name(
     config: Optional[SQAConfig] = None,
     experiment: Optional[Experiment] = None,
     reduced_state: bool = False,
+    skip_runners_and_metrics: bool = False,
 ) -> GenerationStrategy:
     """Finds a generation strategy attached to an experiment specified by a name
     and restores it from its corresponding SQA object.
@@ -345,6 +346,7 @@ def load_generation_strategy_by_experiment_name(
         decoder=decoder,
         experiment=experiment,
         reduced_state=reduced_state,
+        skip_runners_and_metrics=skip_runners_and_metrics,
     )
 
 
@@ -367,6 +369,7 @@ def _load_generation_strategy_by_experiment_name(
     decoder: Decoder,
     experiment: Optional[Experiment] = None,
     reduced_state: bool = False,
+    skip_runners_and_metrics: bool = False,
 ) -> GenerationStrategy:
     """Load a generation strategy attached to an experiment specified by a name,
     using given Decoder instance.
@@ -387,6 +390,7 @@ def _load_generation_strategy_by_experiment_name(
             experiment_name=experiment_name,
             decoder=decoder,
             reduced_state=reduced_state,
+            skip_runners_and_metrics=skip_runners_and_metrics,
         )
     return _load_generation_strategy_by_id(
         gs_id=gs_id, decoder=decoder, experiment=experiment, reduced_state=reduced_state


### PR DESCRIPTION
Reviewed By: lena-kashtelyan

Differential Revision: D51587979


