### PR TITLE
Do not log improvement when baseline=comparison

### DIFF
--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -1172,8 +1172,8 @@ def _construct_comparison_message(
         )
         return None
 
-    if (objective_minimize and (baseline_value < comparison_value)) or (
-        not objective_minimize and (baseline_value > comparison_value)
+    if (objective_minimize and (baseline_value <= comparison_value)) or (
+        not objective_minimize and (baseline_value >= comparison_value)
     ):
         logger.info(
             f"compare_to_baseline: comparison arm {comparison_arm_name}"


### PR DESCRIPTION
Summary: When generating compare_to_baseline message, fail when baseline objective value is equal to comparison value.

Reviewed By: bernardbeckerman

Differential Revision: D51821928


