### PR TITLE
Call "get_improvement_over_baseline" when making scheduler log

### DIFF
--- a/ax/telemetry/scheduler.py
+++ b/ax/telemetry/scheduler.py
@@ -134,6 +134,15 @@ class SchedulerCompletedRecord:
             model_fit_quality = float("-inf")
             model_std_quality = float("-inf")
 
+        try:
+            improvement_over_baseline = scheduler.get_improvement_over_baseline()
+        except Exception as e:
+            warn(
+                "Encountered exception in computing improvement over baseline: "
+                + str(e)
+            )
+            improvement_over_baseline = float("-inf")
+
         return cls(
             experiment_completed_record=ExperimentCompletedRecord.from_experiment(
                 experiment=scheduler.experiment
@@ -143,7 +152,7 @@ class SchedulerCompletedRecord:
             model_std_quality=model_std_quality,
             model_fit_generalization=float("-inf"),  # TODO by cross_validate_by_trial
             model_std_generalization=float("-inf"),
-            improvement_over_baseline=float("-inf"),  # TODO extract improvement result
+            improvement_over_baseline=improvement_over_baseline,
             num_metric_fetch_e_encountered=scheduler._num_metric_fetch_e_encountered,
             num_trials_bad_due_to_err=scheduler._num_trials_bad_due_to_err,
         )


### PR DESCRIPTION
Summary: Integrating  SchedulerCompletedRecord.from_scheduler with `scheduler.get_improvement_over_baseline`

Differential Revision: D51858443


