### PR TITLE
Avoid pesky RuntimeWarning in plotting code due to invalid values

### DIFF
--- a/ax/plot/tests/test_traces.py
+++ b/ax/plot/tests/test_traces.py
@@ -33,14 +33,14 @@ class TracesTest(TestCase):
     def test_Traces(self) -> None:
         # Assert that each type of plot can be constructed successfully
         plot = optimization_trace_single_method_plotly(
-            np.array([[1., 2., 3.], [4., 5., 6.]]),
+            np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
             list(self.model.metric_names)[0],
             optimization_direction="minimize",
             autoset_axis_limits=False,
         )
         self.assertIsInstance(plot, go.Figure)
         plot = optimization_trace_single_method(
-            np.array([[1., 2., 3.], [4., 5., 6.]]),
+            np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
             list(self.model.metric_names)[0],
             optimization_direction="minimize",
             autoset_axis_limits=False,
@@ -50,7 +50,7 @@ class TracesTest(TestCase):
     def test_TracesAutoAxes(self) -> None:
         for optimization_direction in ["minimize", "maximize", "passthrough"]:
             plot = optimization_trace_single_method_plotly(
-                np.array([[1., 2., 3.], [4., 5., 6.]]),
+                np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
                 list(self.model.metric_names)[0],
                 optimization_direction=optimization_direction,
                 autoset_axis_limits=True,

--- a/ax/plot/tests/test_traces.py
+++ b/ax/plot/tests/test_traces.py
@@ -33,14 +33,14 @@ class TracesTest(TestCase):
     def test_Traces(self) -> None:
         # Assert that each type of plot can be constructed successfully
         plot = optimization_trace_single_method_plotly(
-            np.array([[1, 2, 3], [4, 5, 6]]),
+            np.array([[1., 2., 3.], [4., 5., 6.]]),
             list(self.model.metric_names)[0],
             optimization_direction="minimize",
             autoset_axis_limits=False,
         )
         self.assertIsInstance(plot, go.Figure)
         plot = optimization_trace_single_method(
-            np.array([[1, 2, 3], [4, 5, 6]]),
+            np.array([[1., 2., 3.], [4., 5., 6.]]),
             list(self.model.metric_names)[0],
             optimization_direction="minimize",
             autoset_axis_limits=False,
@@ -50,7 +50,7 @@ class TracesTest(TestCase):
     def test_TracesAutoAxes(self) -> None:
         for optimization_direction in ["minimize", "maximize", "passthrough"]:
             plot = optimization_trace_single_method_plotly(
-                np.array([[1, 2, 3], [4, 5, 6]]),
+                np.array([[1., 2., 3.], [4., 5., 6.]]),
                 list(self.model.metric_names)[0],
                 optimization_direction=optimization_direction,
                 autoset_axis_limits=True,

--- a/ax/plot/trace.py
+++ b/ax/plot/trace.py
@@ -256,6 +256,7 @@ def sem_range_scatter(
         Tuple[go.Scatter]: plotly graph objects for lower and upper bounds
     """
     mean = np.mean(y, axis=0)
+    y[np.isinf(y)] = np.nan  # avoids RuntimeWarning in np.std due to invalid values
     sem = np.std(y, axis=0) / np.sqrt(y.shape[0])
     return (
         go.Scatter(

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -2883,7 +2883,7 @@ class TestAxClient(TestCase):
             self.assertEqual(ff.parameters, {})
             self.assertEqual(ff.trial_index, 0)
 
-    def test_get_optimization_trace_discard_unfeasible_trials(self) -> None:
+    def test_get_optimization_trace_discard_infeasible_trials(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
             name="test_experiment",


### PR DESCRIPTION
In AxClient.get_optimization_trace(), best_objectives is computed as trial.objective_mean if the trial meets constraints, or “infinitely bad” otherwise (i.e., +/-inf for minimize=True/False, respectively - [pointer](https://github.com/facebook/Ax/blob/5dbc654600f79073ee28b50e8865050dcec00659/ax/service/ax_client.py#L941)). Trials are skipped if they don’t have status “completed”.

To get sem traces/scatters, np.std is used [here](https://github.com/facebook/Ax/blob/5dbc654600f79073ee28b50e8865050dcec00659/ax/plot/trace.py#L259), which creates an array of (value - mean) in numpy itself. If value and/or mean are +/-inf, “RunTimeWarning: invalid value encountered in subtract” is raised (specifically, inf values have to be of type np.float64 to raise this error, which they are once they’re results from wrapped in np.array).

This replaces the `inf` values in `y` by `NaN` which produces the same results but doesn't raise the RuntimeWarning