### PR TITLE
update interpolation -> method per warning

### DIFF
--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -347,6 +347,7 @@ def _get_tukey_cutoffs(Y: np.ndarray, lower: bool) -> float:
 
     See https://mathworld.wolfram.com/Box-and-WhiskerPlot.html for more details.
     """
+    # TODO: replace interpolation->method once it becomes standard.
     q1 = np.percentile(Y, q=25, interpolation="lower")
     q3 = np.percentile(Y, q=75, interpolation="higher")
     iqr = q3 - q1
@@ -383,6 +384,7 @@ def _get_auto_winsorization_cutoffs_outcome_constraint(
     with a GEQ constraint.
     """
     Y = np.array(metric_values)
+    # TODO: replace interpolation->method once it becomes standard.
     q1 = np.percentile(Y, q=25, interpolation="lower")
     q3 = np.percentile(Y, q=75, interpolation="higher")
     lower_cutoff, upper_cutoff = DEFAULT_CUTOFFS

--- a/ax/plot/diagnostic.py
+++ b/ax/plot/diagnostic.py
@@ -129,6 +129,7 @@ def _obs_vs_pred_dropdown_plot(
         min_, max_ = _get_min_max_with_errors(y_raw, y_hat, se_raw, se_hat)
         if autoset_axis_limits:
             y_raw_np = np.array(y_raw)
+            # TODO: replace interpolation->method once it becomes standard.
             q1 = np.nanpercentile(y_raw_np, q=25, interpolation="lower").min()
             q3 = np.nanpercentile(y_raw_np, q=75, interpolation="higher").max()
             y_lower = q1 - 1.5 * (q3 - q1)

--- a/ax/plot/trace.py
+++ b/ax/plot/trace.py
@@ -512,6 +512,7 @@ def _autoset_axis_limits(
     If `force_include_value` is provided, the worst points will be truncated at this
     value if it is worse than the truncation point described above.
     """
+    # TODO: replace interpolation->method once it becomes standard.
     q1 = np.percentile(y, q=25, interpolation="lower").min()
     q2_min = np.percentile(y, q=50, interpolation="linear").min()
     q2_max = np.percentile(y, q=50, interpolation="linear").max()


### PR DESCRIPTION
Summary: removing this gets rid of some spurious warnings

Differential Revision: D51950507


