### PR TITLE
deprecate transform_outcomes_and_configs per warning

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -869,7 +869,6 @@ def pareto_frontier(
         optimization_config=optimization_config,
         arm_names=arm_names,
         use_model_predictions=use_model_predictions,
-        transform_outcomes_and_configs=False,
     )
 
     # If no objective thresholds are present we cannot compute hypervolume -- return
@@ -1021,7 +1020,6 @@ def hypervolume(
         objective_thresholds=objective_thresholds,
         optimization_config=optimization_config,
         use_model_predictions=use_model_predictions,
-        transform_outcomes_and_configs=False,
     )
     if obj_t is None:
         raise ValueError(

--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -347,8 +347,8 @@ def _get_tukey_cutoffs(Y: np.ndarray, lower: bool) -> float:
 
     See https://mathworld.wolfram.com/Box-and-WhiskerPlot.html for more details.
     """
-    q1 = np.percentile(Y, q=25, interpolation="lower")
-    q3 = np.percentile(Y, q=75, interpolation="higher")
+    q1 = np.percentile(Y, q=25, method="lower")
+    q3 = np.percentile(Y, q=75, method="higher")
     iqr = q3 - q1
     return q1 - 1.5 * iqr if lower else q3 + 1.5 * iqr
 
@@ -383,8 +383,8 @@ def _get_auto_winsorization_cutoffs_outcome_constraint(
     with a GEQ constraint.
     """
     Y = np.array(metric_values)
-    q1 = np.percentile(Y, q=25, interpolation="lower")
-    q3 = np.percentile(Y, q=75, interpolation="higher")
+    q1 = np.percentile(Y, q=25, method="lower")
+    q3 = np.percentile(Y, q=75, method="higher")
     lower_cutoff, upper_cutoff = DEFAULT_CUTOFFS
     for oc in outcome_constraints:
         bnd = oc.bound
@@ -424,14 +424,14 @@ def _quantiles_to_cutoffs(
     elif lower == 0.0:  # Use the default cutoff if there is no winsorization
         cutoff_l = DEFAULT_CUTOFFS[0]
     else:
-        cutoff_l = np.percentile(Y, lower * 100, interpolation="lower")
+        cutoff_l = np.percentile(Y, lower * 100, method="lower")
 
     if upper == AUTO_WINS_QUANTILE:
         cutoff_u = _get_tukey_cutoffs(Y=Y, lower=False)
     elif upper == 0.0:  # Use the default cutoff if there is no winsorization
         cutoff_u = DEFAULT_CUTOFFS[1]
     else:
-        cutoff_u = np.percentile(Y, (1 - upper) * 100, interpolation="higher")
+        cutoff_u = np.percentile(Y, (1 - upper) * 100, method="higher")
 
     cutoff_l = min(cutoff_l, bnd_l) if bnd_l is not None else cutoff_l
     cutoff_u = max(cutoff_u, bnd_u) if bnd_u is not None else cutoff_u

--- a/ax/plot/diagnostic.py
+++ b/ax/plot/diagnostic.py
@@ -129,8 +129,8 @@ def _obs_vs_pred_dropdown_plot(
         min_, max_ = _get_min_max_with_errors(y_raw, y_hat, se_raw, se_hat)
         if autoset_axis_limits:
             y_raw_np = np.array(y_raw)
-            q1 = np.nanpercentile(y_raw_np, q=25, interpolation="lower").min()
-            q3 = np.nanpercentile(y_raw_np, q=75, interpolation="higher").max()
+            q1 = np.nanpercentile(y_raw_np, q=25, method="lower").min()
+            q3 = np.nanpercentile(y_raw_np, q=75, method="higher").max()
             y_lower = q1 - 1.5 * (q3 - q1)
             y_upper = q3 + 1.5 * (q3 - q1)
             y_raw_np = y_raw_np.clip(y_lower, y_upper).tolist()

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -639,7 +639,6 @@ def infer_reference_point_from_experiment(
         observation_data=obs_data,
         objective_thresholds=dummy_rp,
         use_model_predictions=False,
-        transform_outcomes_and_configs=False,
     )
 
     if len(frontier_observations) == 0:
@@ -665,7 +664,6 @@ def infer_reference_point_from_experiment(
             observation_data=obs_data,
             objective_thresholds=dummy_rp,
             use_model_predictions=False,
-            transform_outcomes_and_configs=False,
         )
         opt_config._outcome_constraints = outcome_constraints  # restoring constraints
 

--- a/ax/plot/trace.py
+++ b/ax/plot/trace.py
@@ -511,10 +511,10 @@ def _autoset_axis_limits(
     If `force_include_value` is provided, the worst points will be truncated at this
     value if it is worse than the truncation point described above.
     """
-    q1 = np.percentile(y, q=25, interpolation="lower").min()
-    q2_min = np.percentile(y, q=50, interpolation="linear").min()
-    q2_max = np.percentile(y, q=50, interpolation="linear").max()
-    q3 = np.percentile(y, q=75, interpolation="higher").max()
+    q1 = np.percentile(y, q=25, method="lower").min()
+    q2_min = np.percentile(y, q=50, method="linear").min()
+    q2_max = np.percentile(y, q=50, method="linear").max()
+    q3 = np.percentile(y, q=75, method="higher").max()
     if optimization_direction == "minimize":
         y_lower = y.min()
         y_upper = q2_max + 1.5 * (q2_max - q1)


### PR DESCRIPTION
Summary: removing this gets rid of some spurious warnings

Differential Revision: D51950478


