### PR TITLE
Bring back notebook outputs in make_tutorials script

### DIFF
--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -7,16 +7,15 @@
 import argparse
 import json
 import os
-import subprocess
 import tarfile
 import time
 from pathlib import Path
 from typing import Dict, Optional
 
-import papermill
 import nbformat
-from nbclient.exceptions import CellTimeoutError
+import papermill
 from bs4 import BeautifulSoup
+from nbclient.exceptions import CellTimeoutError
 from nbconvert import HTMLExporter, ScriptExporter
 
 TUTORIALS_TO_SKIP = [
@@ -194,9 +193,7 @@ def gen_tutorials(
                 )
             except Exception as e:
                 has_errors = True
-                print(
-                    f"Encountered error running tutorial {tid}: \n {e}"
-                )
+                print(f"Encountered error running tutorial {tid}: \n {e}")
 
         # load notebook
         with open(paths["tutorial_path"], "r") as infile:

--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -15,7 +15,6 @@ from typing import Dict, Optional
 
 import nbformat
 from bs4 import BeautifulSoup
-from memory_profiler import memory_usage
 from nbconvert import HTMLExporter, ScriptExporter
 
 TUTORIALS_TO_SKIP = [

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ TUTORIAL_REQUIRES = UNITTEST_REQUIRES + [
     "pyro-ppl",  # Required for to call run_inference.
     "pytorch-lightning",  # For the early stopping tutorial.
     "papermill",  # For executing the tutorials.
-    "memory_profiler",  # For measuring memory usage of the tutorials.
 ]
 
 


### PR DESCRIPTION
The current script does not produce notebook outputs that get included in the website. This is an attempt to revert the recent changes that caused it.

Local website build: 
<img width="1124" alt="Screenshot 2023-12-08 at 12 49 51 PM" src="https://github.com/facebook/Ax/assets/9263852/604da793-711c-45b8-badd-e1836983e7cb">
