### PR TITLE
Fix error in `make_tutorials.py`

### DIFF
--- a/scripts/make_tutorials.py
+++ b/scripts/make_tutorials.py
@@ -115,9 +115,7 @@ def run_script(
     tutorial: Path, timeout_minutes: int, env: Optional[Dict[str, str]] = None
 ) -> None:
     if env is not None:
-        env = {**os.environ, **env}
-    for k, v in env.items():
-        os.environ[k] = v
+        os.environ.update(env)
     papermill.execute_notebook(
         tutorial,
         tutorial,


### PR DESCRIPTION
If `env` is `None` then this raises a `'NoneType' object has no attribute 'items'` error. This change fixes this issue and simplifies the setup.