### PR TITLE
Expose version string on the top-level ax module

### DIFF
--- a/ax/__init__.py
+++ b/ax/__init__.py
@@ -34,6 +34,13 @@ from ax.modelbridge import Models
 from ax.service import OptimizationLoop, optimize
 from ax.storage import json_load, json_save
 
+try:
+    # Marking this as a manual import to avoid autodeps complaints
+    # due to imports from non-existent file.
+    from ax.version import version as __version__  # @manual
+except Exception:  # pragma: no cover
+    __version__ = "Unknown"
+
 
 __all__ = [
     "Arm",

--- a/ax/__version__.py
+++ b/ax/__version__.py
@@ -1,6 +1,0 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
-__version__: str = "0.3.1"


### PR DESCRIPTION
Deletes some remnant `__version__` file - this is now set via setuptools_scm.

Imports the version string from the module written by setutools_scm on the top level ax module so it's available via `ax.__version__`. This is the same setup as in BoTorch: https://github.com/pytorch/botorch/blob/main/botorch/__init__.py#L32-L37