### PR TITLE
Enable storage of GenNodes directly

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -42,6 +42,7 @@ from ax.modelbridge.transition_criterion import (
 )
 from ax.utils.common.base import Base, SortableBase
 from ax.utils.common.logger import get_logger
+from ax.utils.common.serialization import SerializationMixin
 from ax.utils.common.typeutils import not_none
 
 
@@ -62,7 +63,7 @@ MAX_GEN_DRAWS_EXCEEDED_MESSAGE = (
 )
 
 
-class GenerationNode:
+class GenerationNode(SerializationMixin, SortableBase):
     """Base class for GenerationNode, capable of fitting one or more model specs under
     the hood and generating candidates from them.
 
@@ -240,6 +241,11 @@ class GenerationNode:
         the next node.
         """
         return self.should_transition_to_next_node(raise_data_required_error=False)[0]
+
+    @property
+    def _unique_id(self) -> str:
+        """Returns a unique id for this GenerationNode"""
+        return self.node_name
 
     def fit(
         self,

--- a/ax/modelbridge/model_spec.py
+++ b/ax/modelbridge/model_spec.py
@@ -33,6 +33,7 @@ from ax.utils.common.kwargs import (
     filter_kwargs,
     get_function_argument_names,
 )
+from ax.utils.common.serialization import SerializationMixin
 from ax.utils.common.typeutils import not_none
 
 
@@ -48,7 +49,7 @@ class ModelSpecJSONEncoder(json.JSONEncoder):
 
 
 @dataclass
-class ModelSpec(SortableBase):
+class ModelSpec(SortableBase, SerializationMixin):
     model_enum: ModelRegistryBase
     # Kwargs to pass into the `Model` + `ModelBridge` constructors in
     # `ModelRegistryBase.__call__`.

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -123,6 +123,7 @@ class TestGenerationNode(TestCase):
         self.assertEqual(node.diagnostics, node.model_specs[0].diagnostics)
         self.assertEqual(node.node_name, "test")
         self.assertEqual(node.gen_unlimited_trials, True)
+        self.assertEqual(node._unique_id, "test")
 
     def test_node_string_representation(self) -> None:
         node = GenerationNode(

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -76,7 +76,10 @@ from ax.metrics.l2norm import L2NormMetric
 from ax.metrics.noisy_function import NoisyFunctionMetric
 from ax.metrics.sklearn import SklearnDataset, SklearnMetric, SklearnModelType
 from ax.modelbridge.factory import Models
-from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.generation_node import GenerationNode, GenerationStep
+from ax.modelbridge.generation_strategy import GenerationStrategy
+from ax.modelbridge.model_spec import ModelSpec
+from ax.modelbridge.registry import ModelRegistryBase
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transition_criterion import (
     MaxGenerationParallelism,
@@ -84,6 +87,7 @@ from ax.modelbridge.transition_criterion import (
     MinimumPreferenceOccurances,
     MinimumTrialsInStatus,
     MinTrials,
+    TransitionCriterion,
 )
 from ax.models.torch.botorch_modular.acquisition import Acquisition
 from ax.models.torch.botorch_modular.model import BoTorchModel, SurrogateSpec
@@ -110,6 +114,7 @@ from ax.storage.json_store.encoders import (
     data_to_dict,
     experiment_to_dict,
     fixed_parameter_to_dict,
+    generation_node_to_dict,
     generation_step_to_dict,
     generation_strategy_to_dict,
     generator_run_to_dict,
@@ -118,6 +123,7 @@ from ax.storage.json_store.encoders import (
     map_data_to_dict,
     map_key_info_to_dict,
     metric_to_dict,
+    model_spec_to_dict,
     multi_objective_benchmark_problem_to_dict,
     multi_objective_optimization_config_to_dict,
     multi_objective_to_dict,
@@ -181,6 +187,7 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     FixedParameter: fixed_parameter_to_dict,
     GammaPrior: botorch_component_to_dict,
     GenerationStep: generation_step_to_dict,
+    GenerationNode: generation_node_to_dict,
     GenerationStrategy: generation_strategy_to_dict,
     GeneratorRun: generator_run_to_dict,
     Hartmann6Metric: metric_to_dict,
@@ -197,6 +204,7 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     MinTrials: transition_criterion_to_dict,
     MinimumTrialsInStatus: transition_criterion_to_dict,
     MinimumPreferenceOccurances: transition_criterion_to_dict,
+    ModelSpec: model_spec_to_dict,
     MultiObjective: multi_objective_to_dict,
     MultiObjectiveBenchmarkProblem: multi_objective_benchmark_problem_to_dict,
     MultiObjectiveOptimizationConfig: multi_objective_optimization_config_to_dict,
@@ -228,6 +236,7 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     RiskMeasure: risk_measure_to_dict,
     RobustSearchSpace: robust_search_space_to_dict,
     Round: botorch_component_to_dict,
+    TransitionCriterion: transition_criterion_to_dict,
     ScalarizedObjective: scalarized_objective_to_dict,
     SearchSpace: search_space_to_dict,
     SingleObjectiveBenchmarkProblem: single_objective_benchmark_problem_to_dict,
@@ -292,6 +301,7 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "FactorialMetric": FactorialMetric,
     "FixedParameter": FixedParameter,
     "GammaPrior": GammaPrior,
+    "GenerationNode": GenerationNode,
     "GenerationStrategy": GenerationStrategy,
     "GenerationStep": GenerationStep,
     "GeneratorRun": GeneratorRun,
@@ -312,6 +322,8 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "MinimumTrialsInStatus": MinimumTrialsInStatus,
     "MinimumPreferenceOccurances": MinimumPreferenceOccurances,
     "Models": Models,
+    "ModelRegistryBase": ModelRegistryBase,
+    "ModelSpec": ModelSpec,
     "MultiObjective": MultiObjective,
     "MultiObjectiveBenchmarkProblem": MultiObjectiveBenchmarkProblem,
     "MultiObjectiveOptimizationConfig": MultiObjectiveOptimizationConfig,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -160,6 +160,15 @@ TEST_CASES = [
             get_generation_strategy, with_experiment=True, with_completion_criteria=3
         ),
     ),
+    (
+        "GenerationStrategy",
+        partial(
+            get_generation_strategy,
+            with_experiment=True,
+            with_generation_nodes=True,
+            with_callable_model_kwarg=False,
+        ),
+    ),
     ("GeneratorRun", get_generator_run),
     ("Hartmann6Metric", get_hartmann_metric),
     ("HierarchicalSearchSpace", get_hierarchical_search_space),
@@ -607,6 +616,27 @@ class JSONStoreTest(TestCase):
             "does not have a corresponding entry in CLASS_TO_REVERSE_REGISTRY",
         ):
             class_from_json({"index": 0, "class": "unknown_path"})
+
+    def test_unregistered_model_not_supported_in_nodes(self) -> None:
+        """Support for callables within model kwargs on ModelSpecs stored on
+        GenerationNodes is currently not supported. This is supported for
+        GenerationSteps due to legacy compatibility.
+        """
+        with self.assertRaisesRegex(
+            JSONEncodeError,
+            "is not registered with a corresponding encoder",
+        ):
+            gs = get_generation_strategy(
+                with_experiment=True,
+                with_generation_nodes=True,
+                with_callable_model_kwarg=True,
+                with_completion_criteria=0,
+            )
+            object_to_json(
+                gs,
+                encoder_registry=CORE_ENCODER_REGISTRY,
+                class_encoder_registry=CORE_CLASS_ENCODER_REGISTRY,
+            )
 
     def test_BadStateDict(self) -> None:
         interval = get_interval()


### PR DESCRIPTION
Summary:
This diff does the following:
update the json storage to include nodes independently (and not just as part of step)

upcoming:
(1) update the sqa storage to include generation nodes
(2) delete now unused GenStep functions
(3) final pass on all the doc strings and variables -- lots to clean up here
(4) add transition criterion to the repr string + some of the other fields that havent made it yet on GeneratinoNode
(5) Do a final pass of the generationStrategy/GenerationNode files to see what else can be migrated/condensed
(6) rename transiton criterion to action criterion
(7) remove conditionals for legacy usecase
( clean up any lingering todos

Differential Revision: D50819895


