### PR TITLE
fixing the derivative gp posterior for matern kernel (#1431)

### DIFF
--- a/ax/utils/sensitivity/derivative_measures.py
+++ b/ax/utils/sensitivity/derivative_measures.py
@@ -43,11 +43,8 @@ class GpDGSMGpMean(object):
             model: A BoTorch model.
             bounds: Parameter bounds over which to evaluate model sensitivity.
             derivative_gp: If true, the derivative of the GP is used to compute
-                the gradient instead of backward. If `kernel_type` is matern_l1,
-                only the mean function of derivative GP can be used, and the
-                variance is not defined.
-            kernel_type: Takes "rbf" or "matern_l1" or "matern_l2", set only
-                if `derivative_gp` is true.
+                the gradient instead of backward.
+            kernel_type: Takes "rbf" or "matern", set only if `derivative_gp` is true.
             Y_scale: Scale the derivatives by this amount, to undo scaling
                 done on the training data.
             num_mc_samples: The number of MonteCarlo grid samples
@@ -222,10 +219,8 @@ class GpDGSMGpSampling(GpDGSMGpMean):
             num_gp_samples: If method is "GP samples", the number of GP samples has
                 to be set.
             derivative_gp: If true, the derivative of the GP is used to compute the
-                gradient instead of backward. If `kernel_type` is matern_l1,
-                `derivative_gp` should be False because the variance is not defined.
-            kernel_type: Takes "rbf" or "matern_l1" or "matern_l2", set only if
-                `derivative_gp` is true.
+                gradient instead of backward.
+            kernel_type: Takes "rbf" or "matern", set only if `derivative_gp` is true.
             Y_scale: Scale the derivatives by this amount, to undo scaling done on
                 the training data.
             num_mc_samples: The number of Monte Carlo grid samples.

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -303,7 +303,7 @@ class SensitivityAnanlysisTest(TestCase):
 
     def test_DerivativeGp(self) -> None:
         test_x = torch.rand(2, 2)
-        posterior = posterior_derivative(self.model, test_x, kernel_type="matern_l1")
+        posterior = posterior_derivative(self.model, test_x, kernel_type="matern")
         self.assertIsInstance(posterior, MultivariateNormal)
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Summary:
The previous implementation had a distinction between Matern with l1 distance and l2 distance. This distinction is not accurate and is unnecessary.


Test Plan: Existing unit tests

Reviewed By: saitcakmak

Differential Revision: D43467145

Pulled By: saitcakmak


