### PR TITLE
Allowing for treating control mean as constant in relativize and unrelativize

### DIFF
--- a/ax/modelbridge/transforms/relativize.py
+++ b/ax/modelbridge/transforms/relativize.py
@@ -241,6 +241,7 @@ class Relativize(Transform):
                     mean_c=mean_c,
                     sem_c=sem_c,
                     as_percent=True,
+                    control_as_constant=True,
                 )
             result.means[i] = means_rel
             result.covariance[i][i] = sems_rel**2

--- a/ax/utils/stats/tests/test_statstools.py
+++ b/ax/utils/stats/tests/test_statstools.py
@@ -148,47 +148,36 @@ class RelativizeDataTest(TestCase):
 
 class UnrelativizeTest(TestCase):
     def test_unrelativize(self) -> None:
-        def _check_unrelativized(
-            means_t: np.ndarray,
-            sems_t: np.ndarray,
-            mean_c: float,
-            sem_c: float,
-        ) -> None:
-            for bias_correction, cov_means, as_percent in product(
-                (True, False, None), (0.5, 0.0), (True, False, None)
-            ):
-                rel_mean_t, rel_sems_t = relativize(
-                    means_t,
-                    sems_t,
-                    mean_c,
-                    sem_c,
-                    cov_means=cov_means,
-                    bias_correction=bias_correction,
-                    as_percent=as_percent,
-                )
-                unrel_mean_t, unrel_sems_t = unrelativize(
-                    rel_mean_t,
-                    rel_sems_t,
-                    mean_c,
-                    sem_c,
-                    cov_means=cov_means,
-                    bias_correction=bias_correction,
-                    as_percent=as_percent,
-                )
-                self.assertTrue(np.allclose(means_t, unrel_mean_t))
-                self.assertTrue(np.allclose(sems_t, unrel_sems_t))
+        means_t = np.array([-100.0, 101.0, 200.0, 300.0, 400.0])
+        sems_t = np.array([2.0, 3.0, 2.0, 4.0, 0.0])
+        mean_c = 200.0
+        sem_c = 2.0
 
-        _check_unrelativized(
-            means_t=np.array([-100.0, 101.0, 200.0, 300.0, 400.0]),
-            sems_t=np.array([2.0, 3.0, 2.0, 4.0, 0.0]),
-            mean_c=200.0,
-            sem_c=2.0,
-        )
-
-        # This should trigger the max iteration warning in unrelativize
-        _check_unrelativized(
-            means_t=np.array([1.0]),
-            sems_t=np.array([1.0]),
-            mean_c=1.0,
-            sem_c=1.0,
-        )
+        for bias_correction, cov_means, as_percent, control_as_constant in product(
+            (True, False, None),
+            (0.5, 0.0),
+            (True, False, None),
+            (True, False, None),
+        ):
+            rel_mean_t, rel_sems_t = relativize(
+                means_t,
+                sems_t,
+                mean_c,
+                sem_c,
+                cov_means=cov_means,
+                bias_correction=bias_correction,
+                as_percent=as_percent,
+                control_as_constant=control_as_constant,
+            )
+            unrel_mean_t, unrel_sems_t = unrelativize(
+                rel_mean_t,
+                rel_sems_t,
+                mean_c,
+                sem_c,
+                cov_means=cov_means,
+                bias_correction=bias_correction,
+                as_percent=as_percent,
+                control_as_constant=control_as_constant,
+            )
+            self.assertTrue(np.allclose(means_t, unrel_mean_t))
+            self.assertTrue(np.allclose(sems_t, unrel_sems_t))


### PR DESCRIPTION
Summary:
The `unrelativize` transform doesn't always work correctly when the inputs (particulary `means_t` and `sems_t`) are not having the proper value inside the delta method's codomain, we may observe negative `s_t2` value, the unrelativized variance.

Specifically, in `unrelativize` if we wish to perform the reverse operation of delta method, when `sems_t > sem_c * mean_c * (means_t + 1)` is not satisfied, we will see the unrelativized treatment variance to be negative, causing errors.

This diff bypasses the problem by additing an optional argument `control_as_constant` to `relativize` and `unrelativize`, which are used in the `Relativize` Ax transform for modeling. In visualization, `relativize` with `control_as_constant=False` is still being called and should still work the same.

Differential Revision: D51078296


