### PR TITLE
Update docs to avoid deprecation warning

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,17 +2,57 @@
 id: api
 title: APIs
 ---
-The modular design of Ax enables three different usage modes, with different balances of structure to flexibility and reproducibility. Navigate to the ["Tutorials" page](/tutorials) for the in-depth walk-throughs of each API and usage mode. From most lightweight to fullest functionality, they are:
-  - **Loop API** ([tutorial](/tutorials/gpei_hartmann_loop.html)) is intended for synchronous optimization loops, where [trials](glossary.md#trial) can be evaluated right away. With this API, optimization can be executed in a single call and [experiment](glossary.md#experiment) introspection is available once optimization is complete. **Use this API only for the simplest use cases where running a single trial is fast and only one trial should be running at a time.**
-  - **Service API** ([tutorial](/tutorials/gpei_hartmann_service.html)) can be used as a lightweight service for parameter-tuning applications where trials might be evaluated in parallel and data is available asynchronously (e.g. hyperparameter or simulation optimization). It requires little to no knowledge of Ax data structures and easily integrates with various schedulers. In this mode, Ax suggests one-[arm](glossary.md#arm) trials to be evaluated by the client application, and expects them to be completed with [metric](glossary.md#metric) data when available. **This is our most popular API and a good place to start as a new user. Use it to leverage nearly full hyperparameter optimization functionality of Ax without the need to learn its architecture and how things work under the hood.**
-    - In both the Loop and the Service API, it is possible to configure the optimization algorithm via an Ax `GenerationStrategy` ([tutorial](/tutorials/generation_strategy.html)), so use of Developer API is not required to control the optimization algorithm in Ax.
-  - **Developer API** ([tutorial](/tutorials/gpei_hartmann_developer.html)) is for ad-hoc use by data scientists, machine learning engineers, and researchers.  The developer API allows for a great deal of customization and introspection, and is recommended for those who plan to use Ax to optimize A/B tests. Using the developer API requires some knowledge of [Ax architecture](core.md). **Use this API if you are looking to perform field experiments with `BatchTrial`-s, customize or contribute to Ax, or leverage advanced functionality that is not exposed in other APIs.**
-    - While not an API, the **`Scheduler`** ([tutorial](/tutorials/scheduler.html)) is an important and distinct use-case of the Ax Developer API. With the `Scheduler`, it's possible to run a configurable, managed closed-loop optimization where trials are deployed and polled in an async fashion and no human intervention/oversight is required until the experiment is complete. **Use the `Scheduler` when you are looking to configure and start a full experiment that will need to interact with an external system to evaluate trials.**
 
-Here is a comparison of the three APIs in the simple case of evaluating the unconstrained synthetic Branin function:
+The modular design of Ax enables three different usage modes, with different
+balances of structure to flexibility and reproducibility. Navigate to the
+["Tutorials" page](/tutorials) for the in-depth walk-throughs of each API and
+usage mode. From most lightweight to fullest functionality, they are:
+
+- **Loop API** ([tutorial](/tutorials/gpei_hartmann_loop.html)) is intended for
+  synchronous optimization loops, where [trials](glossary.md#trial) can be
+  evaluated right away. With this API, optimization can be executed in a single
+  call and [experiment](glossary.md#experiment) introspection is available once
+  optimization is complete. **Use this API only for the simplest use cases where
+  running a single trial is fast and only one trial should be running at a
+  time.**
+- **Service API** ([tutorial](/tutorials/gpei_hartmann_service.html)) can be
+  used as a lightweight service for parameter-tuning applications where trials
+  might be evaluated in parallel and data is available asynchronously (e.g.
+  hyperparameter or simulation optimization). It requires little to no knowledge
+  of Ax data structures and easily integrates with various schedulers. In this
+  mode, Ax suggests one-[arm](glossary.md#arm) trials to be evaluated by the
+  client application, and expects them to be completed with
+  [metric](glossary.md#metric) data when available. **This is our most popular
+  API and a good place to start as a new user. Use it to leverage nearly full
+  hyperparameter optimization functionality of Ax without the need to learn its
+  architecture and how things work under the hood.**
+  - In both the Loop and the Service API, it is possible to configure the
+    optimization algorithm via an Ax `GenerationStrategy`
+    ([tutorial](/tutorials/generation_strategy.html)), so use of Developer API
+    is not required to control the optimization algorithm in Ax.
+- **Developer API** ([tutorial](/tutorials/gpei_hartmann_developer.html)) is for
+  ad-hoc use by data scientists, machine learning engineers, and researchers.
+  The developer API allows for a great deal of customization and introspection,
+  and is recommended for those who plan to use Ax to optimize A/B tests. Using
+  the developer API requires some knowledge of [Ax architecture](core.md). **Use
+  this API if you are looking to perform field experiments with `BatchTrial`-s,
+  customize or contribute to Ax, or leverage advanced functionality that is not
+  exposed in other APIs.**
+  - While not an API, the **`Scheduler`**
+    ([tutorial](/tutorials/scheduler.html)) is an important and distinct
+    use-case of the Ax Developer API. With the `Scheduler`, it's possible to run
+    a configurable, managed closed-loop optimization where trials are deployed
+    and polled in an async fashion and no human intervention/oversight is
+    required until the experiment is complete. **Use the `Scheduler` when you
+    are looking to configure and start a full experiment that will need to
+    interact with an external system to evaluate trials.**
+
+Here is a comparison of the three APIs in the simple case of evaluating the
+unconstrained synthetic Branin function:
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--Loop-->
+
 ```py
 from ax import optimize
 from ax.utils.measurement.synthetic_functions import branin
@@ -36,8 +76,9 @@ best_parameters, values, experiment, model = optimize(
 ```
 
 <!--Service-->
+
 ```py
-from ax.service.ax_client import AxClient
+from ax.service.ax_client import AxClient, ObjectiveProperties
 from ax.utils.measurement.synthetic_functions import branin
 
 ax_client = AxClient()
@@ -56,8 +97,7 @@ ax_client.create_experiment(
             "bounds": [0.0, 10.0],
         },
     ],
-    objective_name="branin",
-    minimize=True,
+    objectives={"branin": ObjectiveProperties(minimize=True)},
 )
 
 for _ in range(15):
@@ -68,6 +108,7 @@ best_parameters, metrics = ax_client.get_best_parameters()
 ```
 
 <!--Developer-->
+
 ```py
 from ax import *
 
@@ -119,6 +160,7 @@ best_parameters = best_arm.parameters
 ```
 
 <!--Scheduler-->
+
 ```py
 from ax import *
 from ax.modelbridge.generation_strategy import GenerationStrategy


### PR DESCRIPTION
Summary:
Service API demo on https://ax.dev/docs/api.html uses deprecated parameters, updating to use modern spec.

First noted by Sterling here: https://github.com/facebook/Ax/issues/2072

Differential Revision: D52085093


