### PR TITLE
Add nodes and node_name column to SQAGenerationStrategy Table

### DIFF
--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -367,6 +367,11 @@ class SQAGenerationStrategy(Base):
     curr_index: int = Column(Integer, nullable=False)
     # pyre-fixme[8]: Attribute has type `Optional[int]`; used as `Column[int]`.
     experiment_id: Optional[int] = Column(Integer, ForeignKey("experiment_v2.id"))
+    # pyre-fixme[8]: Attribute has type `List[Dict[str, typing.Any]]`; used as
+    #  `Column[typing.Any]`.
+    nodes: List[Dict[str, Any]] = Column(JSONEncodedList, nullable=True)
+    # pyre-fixme[8]: Attribute has type `str`; used as `Column[str]`.
+    curr_node_name: str = Column(String(NAME_OR_TYPE_FIELD_LENGTH), nullable=True)
 
     generator_runs: List[SQAGeneratorRun] = relationship(
         "SQAGeneratorRun",


### PR DESCRIPTION
Summary:
This diff does the following:
adds the node_name and nodes column to the SQAGenerationStrategy table, will be paired with a www diff and then tested in diff 28 where we add the remainder of the fbcode

upcoming:
(1) update the sqa storage to include generation nodes
(2) delete now unused GenStep functions
(3) final pass on all the doc strings and variables -- lots to clean up here
(4) add transition criterion to the repr string + some of the other fields that havent made it yet on GeneratinoNode
(5) Do a final pass of the generationStrategy/GenerationNode files to see what else can be migrated/condensed
(6) rename transiton criterion to action criterion
(7) remove conditionals for legacy usecase
( clean up any lingering todos

Reviewed By: lena-kashtelyan

Differential Revision: D52052356


