### PR TITLE
Update sqa storage to include generation nodes

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -740,8 +740,24 @@ class Decoder:
             decoder_registry=self.config.json_decoder_registry,
             class_decoder_registry=self.config.json_class_decoder_registry,
         )
-        gs = GenerationStrategy(name=gs_sqa.name, steps=steps)
-        gs._curr = gs._steps[gs_sqa.curr_index]
+        nodes = object_from_json(
+            gs_sqa.nodes,
+            decoder_registry=self.config.json_decoder_registry,
+            class_decoder_registry=self.config.json_class_decoder_registry,
+        )
+
+        # GenerationStrategies can ony be initialized with either steps or nodes.
+        # Determine which to use to initialize this GenerationStrategy.
+        if len(steps) > 0:
+            gs = GenerationStrategy(name=gs_sqa.name, steps=steps)
+            gs._curr = gs._steps[gs_sqa.curr_index]
+        else:
+            gs = GenerationStrategy(name=gs_sqa.name, nodes=nodes)
+            curr_node_name = gs_sqa.curr_node_name
+            for node in gs._nodes:
+                if node.node_name == curr_node_name:
+                    gs._curr = node
+                    break
         immutable_ss_and_oc = (
             experiment.immutable_search_space_and_opt_config
             if experiment is not None

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -840,6 +840,7 @@ class Encoder:
             cast(Type[Base], GenerationStrategy)
         ]
         generator_runs_sqa = []
+        node_based_strategy = generation_strategy.is_node_based
         for idx, gr in enumerate(generation_strategy._generator_runs):
             # Never reduce the state of the last generator run because that
             # generator run is needed to recreate the model when reloading the
@@ -857,10 +858,22 @@ class Encoder:
                 generation_strategy._steps,
                 encoder_registry=self.config.json_encoder_registry,
                 class_encoder_registry=self.config.json_class_encoder_registry,
-            ),
-            curr_index=generation_strategy.current_step_index,
+            )
+            if not node_based_strategy
+            else [],
+            curr_index=generation_strategy.current_step_index
+            if not node_based_strategy
+            else -1,
             generator_runs=generator_runs_sqa,
             experiment_id=experiment_id,
+            nodes=object_to_json(
+                generation_strategy._nodes,
+                encoder_registry=self.config.json_encoder_registry,
+                class_encoder_registry=self.config.json_class_encoder_registry,
+            )
+            if node_based_strategy
+            else [],
+            curr_node_name=generation_strategy.current_node_name,
         )
         return gs_sqa
 


### PR DESCRIPTION
Summary:
This diff does the following:
update the sqa storage to include generationnodes

In coming diffs:
(2) delete now unused GenStep functions
(3) final pass on all the doc strings and variables -- lots to clean up here
(4) add transition criterion to the repr string + some of the other fields that havent made it yet on GeneratinoNode
(5) Do a final pass of the generationStrategy/GenerationNode files to see what else can be migrated/condensed
(6) rename transiton criterion to action criterion
(7) remove conditionals for legacy usecase
( clean up any lingering todos

Reviewed By: lena-kashtelyan

Differential Revision: D51970237


