### PR TITLE
Refactor __repr__ to use new attributes

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod, abstractproperty
 from enum import Enum
 from math import inf
 from typing import Dict, List, Optional, Tuple, Type, Union
@@ -146,6 +146,15 @@ class Parameter(SortableBase, metaclass=ABCMeta):
             f"name='{self._name}', "
             f"parameter_type={self.parameter_type.name}, "
         )
+
+    @abstractproperty
+    def domain_repr(self) -> str:
+        """Returns a string representation of the domain."""
+        pass
+
+    @property
+    def available_flags(self) -> List[str]:
+        return ["is_fidelity"]
 
 
 class RangeParameter(Parameter):
@@ -424,6 +433,14 @@ class RangeParameter(Parameter):
 
         return ret_val + ")"
 
+    @property
+    def available_flags(self) -> List[str]:
+        return super().available_flags + ["log_scale", "logit_scale"]
+
+    @property
+    def domain_repr(self) -> str:
+        return f"range={[self.lower, self.upper]}"
+
 
 class ChoiceParameter(Parameter):
     """Parameter object that specifies a discrete set of values.
@@ -626,6 +643,19 @@ class ChoiceParameter(Parameter):
 
         return ret_val + ")"
 
+    @property
+    def available_flags(self) -> List[str]:
+        return super().available_flags + [
+            "is_ordered",
+            "is_hierarchical",
+            "is_task",
+            "sort_values",
+        ]
+
+    @property
+    def domain_repr(self) -> str:
+        return f"values={self.values}"
+
 
 class FixedParameter(Parameter):
     """Parameter object that specifies a single fixed value."""
@@ -727,3 +757,14 @@ class FixedParameter(Parameter):
                 f", fidelity={self.is_fidelity}, target_value={self.target_value}"
             )
         return ret_val + ")"
+
+    @property
+    def available_flags(self) -> List[str]:
+        return super().available_flags + ["is_hierarchical"]
+
+    @property
+    def domain_repr(self) -> str:
+        if self._parameter_type == ParameterType.STRING:
+            return f"value='{self._value}'"
+        else:
+            return f"value={self._value}"

--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -27,6 +27,13 @@ FIXED_CHOICE_PARAM_ERROR = (
     "ChoiceParameters require multiple feasible values. "
     "Please use FixedParameter instead when setting a single possible value."
 )
+REPR_FLAGS_IF_TRUE_ONLY = [
+    "is_fidelity",
+    "is_task",
+    "is_hierarchical",
+    "log_scale",
+    "logit_scale",
+]
 
 
 class ParameterType(Enum):
@@ -141,11 +148,29 @@ class Parameter(SortableBase, metaclass=ABCMeta):
         return str(self)
 
     def _base_repr(self) -> str:
-        return (
+        ret_val = (
             f"{self.__class__.__name__}("
             f"name='{self._name}', "
             f"parameter_type={self.parameter_type.name}, "
+            f"{self.domain_repr}"
         )
+
+        # Add binary flags.
+        for flag in self.available_flags:
+            val = getattr(self, flag, False)
+            if flag not in REPR_FLAGS_IF_TRUE_ONLY or (
+                flag in REPR_FLAGS_IF_TRUE_ONLY and val is True
+            ):
+                ret_val += f", {flag}={val}"
+
+        # Add target_value if one exists.
+        if self.target_value is not None:
+            tval_rep = self.target_value
+            if self.parameter_type == ParameterType.STRING:
+                tval_rep = f"'{tval_rep}'"
+            ret_val += f", target_value={tval_rep}"
+
+        return ret_val
 
     @abstractproperty
     def domain_repr(self) -> str:
@@ -415,21 +440,9 @@ class RangeParameter(Parameter):
 
     def __repr__(self) -> str:
         ret_val = self._base_repr()
-        ret_val += f"range=[{self._lower}, {self._upper}]"
 
-        if self._log_scale:
-            ret_val += f", log_scale={self._log_scale}"
-
-        if self._logit_scale:
-            ret_val += f", logit_scale={self._logit_scale}"
-
-        if self._digits:
+        if self._digits is not None:
             ret_val += f", digits={self._digits}"
-
-        if self.is_fidelity:
-            ret_val += (
-                f", fidelity={self.is_fidelity}, target_value={self.target_value}"
-            )
 
         return ret_val + ")"
 
@@ -622,21 +635,6 @@ class ChoiceParameter(Parameter):
 
     def __repr__(self) -> str:
         ret_val = self._base_repr()
-        ret_val += f"values={self._values}, "
-        ret_val += f"is_ordered={self._is_ordered}, "
-        ret_val += f"sort_values={self._sort_values}"
-
-        if self._is_task:
-            ret_val += f", is_task={self._is_task}"
-
-        if self._is_fidelity:
-            ret_val += f", is_fidelity={self.is_fidelity}"
-
-        if self.target_value is not None:
-            tval_rep = self.target_value
-            if self.parameter_type == ParameterType.STRING:
-                tval_rep = f"'{tval_rep}'"
-            ret_val += f", target_value={tval_rep}"
 
         if self._dependents:
             ret_val += f", dependents={self._dependents}"
@@ -746,16 +744,6 @@ class FixedParameter(Parameter):
 
     def __repr__(self) -> str:
         ret_val = self._base_repr()
-
-        if self._parameter_type == ParameterType.STRING:
-            ret_val += f"value='{self._value}'"
-        else:
-            ret_val += f"value={self._value}"
-
-        if self._is_fidelity:
-            ret_val += (
-                f", fidelity={self.is_fidelity}, target_value={self.target_value}"
-            )
         return ret_val + ")"
 
     @property

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -29,9 +29,8 @@ class RangeParameterTest(TestCase):
             target_value=2,
         )
         self.param1_repr = (
-            "RangeParameter(name='x', parameter_type=FLOAT, "
-            "range=[1.0, 3.0], log_scale=True, digits=5, fidelity=True, target_"
-            "value=2.0)"
+            "RangeParameter(name='x', parameter_type=FLOAT, range=[1.0, 3.0], "
+            "is_fidelity=True, log_scale=True, target_value=2.0, digits=5)"
         )
 
         self.param2 = RangeParameter(
@@ -200,6 +199,11 @@ class ChoiceParameterTest(TestCase):
             is_task=True,
             target_value="baz",
         )
+        self.param2_repr = (
+            "ChoiceParameter(name='x', parameter_type=STRING, "
+            "values=['foo', 'bar', 'baz'], is_ordered=False, is_task=True, "
+            "sort_values=False, target_value='baz')"
+        )
         self.param3 = ChoiceParameter(
             name="x",
             parameter_type=ParameterType.STRING,
@@ -209,8 +213,8 @@ class ChoiceParameterTest(TestCase):
         )
         self.param3_repr = (
             "ChoiceParameter(name='x', parameter_type=STRING, "
-            "values=['foo', 'bar'], is_ordered=False, sort_values=False, "
-            "is_fidelity=True, target_value='bar')"
+            "values=['foo', 'bar'], is_fidelity=True, is_ordered=False, "
+            "sort_values=False, target_value='bar')"
         )
         self.param4 = ChoiceParameter(
             name="x",
@@ -420,6 +424,9 @@ class FixedParameterTest(TestCase):
         self.param1_repr = "FixedParameter(name='x', parameter_type=BOOL, value=True)"
         self.param2 = FixedParameter(
             name="y", parameter_type=ParameterType.STRING, value="foo"
+        )
+        self.param2_repr = (
+            "FixedParameter(name='y', parameter_type=STRING, value='foo')"
         )
 
     def test_BadCreations(self) -> None:

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -173,6 +173,15 @@ class RangeParameterTest(TestCase):
         with self.assertRaises(NotImplementedError):
             self.param1.dependents
 
+    def test_available_flags(self) -> None:
+        range_flags = ["is_fidelity", "log_scale", "logit_scale"]
+        self.assertListEqual(self.param1.available_flags, range_flags)
+        self.assertListEqual(self.param2.available_flags, range_flags)
+
+    def test_domain_repr(self) -> None:
+        self.assertEqual(self.param1.domain_repr, "range=[1.0, 3.0]")
+        self.assertEqual(self.param2.domain_repr, "range=[10, 15]")
+
 
 class ChoiceParameterTest(TestCase):
     def setUp(self) -> None:
@@ -383,6 +392,25 @@ class ChoiceParameterTest(TestCase):
                 dependents={"c": "other_param"},
             )
 
+    def test_available_flags(self) -> None:
+        choice_flags = [
+            "is_fidelity",
+            "is_ordered",
+            "is_hierarchical",
+            "is_task",
+            "sort_values",
+        ]
+        self.assertListEqual(self.param1.available_flags, choice_flags)
+        self.assertListEqual(self.param2.available_flags, choice_flags)
+        self.assertListEqual(self.param3.available_flags, choice_flags)
+        self.assertListEqual(self.param4.available_flags, choice_flags)
+
+    def test_domain_repr(self) -> None:
+        self.assertEqual(self.param1.domain_repr, "values=['foo', 'bar', 'baz']")
+        self.assertEqual(self.param2.domain_repr, "values=['foo', 'bar', 'baz']")
+        self.assertEqual(self.param3.domain_repr, "values=['foo', 'bar']")
+        self.assertEqual(self.param4.domain_repr, "values=[1, 2]")
+
 
 class FixedParameterTest(TestCase):
     def setUp(self) -> None:
@@ -390,6 +418,9 @@ class FixedParameterTest(TestCase):
             name="x", parameter_type=ParameterType.BOOL, value=True
         )
         self.param1_repr = "FixedParameter(name='x', parameter_type=BOOL, value=True)"
+        self.param2 = FixedParameter(
+            name="y", parameter_type=ParameterType.STRING, value="foo"
+        )
 
     def test_BadCreations(self) -> None:
         with self.assertRaises(UserInputError):
@@ -470,6 +501,15 @@ class FixedParameterTest(TestCase):
                 #  bool, float, int, str], List[str]]]` but got `Dict[bool, str]`.
                 dependents={False: "other_param"},
             )
+
+    def test_available_flags(self) -> None:
+        fixed_flags = ["is_fidelity", "is_hierarchical"]
+        self.assertListEqual(self.param1.available_flags, fixed_flags)
+        self.assertListEqual(self.param2.available_flags, fixed_flags)
+
+    def test_domain_repr(self) -> None:
+        self.assertEqual(self.param1.domain_repr, "value=True")
+        self.assertEqual(self.param2.domain_repr, "value='foo'")
 
 
 class ParameterEqualityTest(TestCase):


### PR DESCRIPTION
Summary: Simplifies __repr__ using attributes `available_flags` and `domain_repr`.

Differential Revision: D52122906


