### PR TITLE
Remove max_parallelism setting from benchmark methods

### DIFF
--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -65,7 +65,6 @@ def get_sobol_botorch_modular_acquisition(
             GenerationStep(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
-                max_parallelism=1,
                 model_kwargs=model_kwargs,
             ),
         ],


### PR DESCRIPTION
Summary: Setting this on the benchmark method prevents the parallelism from being modified using SchedulerOptions.

Reviewed By: dme65

Differential Revision: D52188720


