### PR TITLE
Modelbridge outcome order matches order in datasets

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -710,7 +710,8 @@ def get_pareto_frontier_and_configs(
             " the default was `transform_outcomes_and_configs=True`; now this argument "
             "is deprecated and behavior is as if "
             "`transform_outcomes_and_configs=False`. You did not specify "
-            "`transform_outcomes_and_configs`, so this warning requires no action."
+            "`transform_outcomes_and_configs`, so this warning requires no action.",
+            stacklevel=2,
         )
     elif transform_outcomes_and_configs:
         raise UnsupportedError(
@@ -724,13 +725,15 @@ def get_pareto_frontier_and_configs(
             "`transform_outcomes_and_configs` at all is deprecated because `False` is "
             "now the only allowed behavior. In the future, this will become an error.",
             DeprecationWarning,
+            stacklevel=2,
         )
     # Input validation
     if use_model_predictions:
         if observation_data is not None:
             warnings.warn(
                 "You provided `observation_data` when `use_model_predictions` is True; "
-                "`observation_data` will not be used."
+                "`observation_data` will not be used.",
+                stacklevel=2,
             )
     else:
         if observation_data is None:
@@ -1363,12 +1366,8 @@ def process_contextual_datasets(
                 'context2': ['m1_c2', 'm2_c2', 'm3_c2'],
             }
 
-    Returns: A list of `ContextualDataset` objects.
-        - If datasets contain overall outcome only, each element in the list can
-        correspond and the list is sorted based on the outcomes.
-        - If datasets contains a mixed of context-level and overall outcomes, each
-        element may contain multiple outcomes; and the ordering of predicted output
-        will be handled by the downstream
+    Returns: A list of `ContextualDataset` objects. Order generally will not be that of
+        `outcomes`.
     """
     context_buckets = list(parameter_decomposition.keys())
     remaining_metrics = deepcopy(outcomes)

--- a/ax/modelbridge/pairwise.py
+++ b/ax/modelbridge/pairwise.py
@@ -28,7 +28,9 @@ class PairwiseModelBridge(TorchModelBridge):
         outcomes: List[str],
         parameters: List[str],
         search_space_digest: Optional[SearchSpaceDigest],
-    ) -> Tuple[List[SupervisedDataset], Optional[List[List[TCandidateMetadata]]]]:
+    ) -> Tuple[
+        List[SupervisedDataset], List[str], Optional[List[List[TCandidateMetadata]]]
+    ]:
         """Converts observations to a dictionary of `Dataset` containers and (optional)
         candidate metadata.
         """
@@ -74,9 +76,9 @@ class PairwiseModelBridge(TorchModelBridge):
             candidate_metadata.append(candidate_metadata_dict[outcome])
 
         if not any_candidate_metadata_is_not_none:
-            return datasets, None
+            return datasets, outcomes, None
 
-        return datasets, candidate_metadata
+        return datasets, outcomes, candidate_metadata
 
 
 def _binary_pref_to_comp_pair(Y: Tensor) -> Tensor:

--- a/ax/modelbridge/tests/test_pairwise_modelbridge.py
+++ b/ax/modelbridge/tests/test_pairwise_modelbridge.py
@@ -70,7 +70,7 @@ class PairwiseModelBridgeTest(TestCase):
         parameters = ["y1", "y2"]
         outcomes = ["pairwise_pref_query"]
 
-        datasets, candidate_metadata = pmb._convert_observations(
+        datasets, _, candidate_metadata = pmb._convert_observations(
             observation_data=observation_data,
             observation_features=observation_features,
             outcomes=outcomes,
@@ -81,7 +81,7 @@ class PairwiseModelBridgeTest(TestCase):
         self.assertTrue(isinstance(datasets[0], RankingDataset))
         self.assertTrue(candidate_metadata is None)
 
-        datasets, candidate_metadata = pmb._convert_observations(
+        datasets, _, candidate_metadata = pmb._convert_observations(
             observation_data=observation_data,
             observation_features=observation_features_with_metadata,
             outcomes=outcomes,


### PR DESCRIPTION
Summary:
Currently the torch modelbridge specifies an order for outcomes (`TorchModelBridge.outcomes`) and expects the Model to return a tensor in which outcomes follow that same order.

When each outcome has a separate model, this is done by simply ordering those models in the model list according to `outcomes`.

Things become more complicated when ContextualDatasets are involved, and now a single model might be responsible for several metrics. Currently for contextual multi-output models, this is handled via the MixedOutputModelListGP being able to re-order the outputs of the models in the list to match `outcomes`.

This really is backwards; it should be the responsibility of the ModelBridge to order things in a convenient way, and not the responsibility of the Model to adapt to whatever arbitrary order the modelbridge comes up with (alphabetically sorted, currently).

Now, I've made it the behavior of the modelbridge for `outcomes` to have the same order as the outcomes in the Datasets that are sent over to the Model at fit time. Returning things in the same order as the Dataset outcomes is a much more natural expectation on the Model.

Reviewed By: saitcakmak

Differential Revision: D51906856


