### PR TITLE
Support ContextualDatasets in legacy botorch model

### DIFF
--- a/ax/models/torch/utils.py
+++ b/ax/models/torch/utils.py
@@ -682,10 +682,11 @@ def _datasets_to_legacy_inputs(
     for dataset in datasets:
         if not isinstance(dataset, SupervisedDataset):
             raise UnsupportedError("Legacy setup only supports `SupervisedDataset`s")
-        Xs.append(dataset.X)
-        Ys.append(dataset.Y)
-        if dataset.Yvar is not None:
-            Yvars.append(dataset.Yvar)
-        else:
-            Yvars.append(torch.full_like(Ys[-1], float("nan")))
+        for i, _ in enumerate(dataset.outcome_names):
+            Xs.append(dataset.X)
+            Ys.append(dataset.Y[:, i].unsqueeze(-1))
+            if dataset.Yvar is not None:
+                Yvars.append(dataset.Yvar[:, i].unsqueeze(-1))
+            else:
+                Yvars.append(torch.full_like(Ys[-1], float("nan")))
     return Xs, Ys, Yvars


### PR DESCRIPTION
Summary: Legacy botorch model converts Datasets to tensors in a way that doesn't support ContextualDatasets. This fixes that, for the purpose of testing; this will only be of short-term use while contextual models are migrated off of legacy botorch model anyway.

Reviewed By: saitcakmak

Differential Revision: D52303582


