### PR TITLE
Prepare botorch_defaults for scalarized MOO with ModelListGP

### DIFF
--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
+
 from functools import partial
 
 from logging import Logger
@@ -340,10 +342,14 @@ class Trial(BaseTrial):
             A new instance of the trial.
         """
         experiment = self._experiment if experiment is None else experiment
-        new_trial = experiment.new_trial()
+        new_trial = experiment.new_trial(
+            ttl_seconds=self.ttl_seconds, trial_type=self.trial_type
+        )
         if self.generator_run is not None:
             new_trial.add_generator_run(self.generator_run.clone())
-        new_trial.trial_type = self._trial_type
+        new_trial._run_metadata = deepcopy(self._run_metadata)
+        new_trial._stop_metadata = deepcopy(self._stop_metadata)
+        new_trial._num_arms_created = self._num_arms_created
         new_trial.runner = self._runner.clone() if self._runner else None
 
         return new_trial

--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -285,6 +285,16 @@ class TestDispatchUtils(TestCase):
             self.assertEqual(gs_6_init_trials._steps[0].model, Models.SOBOL)
             self.assertEqual(gs_6_init_trials._steps[0].num_trials, 6)
             self.assertEqual(gs_6_init_trials._steps[1].model, Models.BOTORCH_MODULAR)
+        with self.subTest("suggested_model_override"):
+            sobol_gpei = choose_generation_strategy(
+                search_space=get_branin_search_space()
+            )
+            self.assertEqual(sobol_gpei._steps[1].model, Models.BOTORCH_MODULAR)
+            sobol_saasbo = choose_generation_strategy(
+                search_space=get_branin_search_space(),
+                suggested_model_override=Models.SAASBO,
+            )
+            self.assertEqual(sobol_saasbo._steps[1].model, Models.SAASBO)
 
     def test_make_botorch_step_extra(self) -> None:
         # Test parts of _make_botorch_step that are not directly exposed in


### PR DESCRIPTION
Summary:
For scalarized models with ModelListGP, we must:
1. remove any objective thresholds from the acqf getter kwargs, since single-objective acquisition functions are not expecting them.
2. reduce the dimensionality of the model predictions appropriately so that chebyshev scalarization can handle them.

Reviewed By: saitcakmak

Differential Revision: D52347017


