### PR TITLE
Use lookup_data rather than fetch_data on modelbridge and when getting fitted modelbridge from scheduler

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -1184,7 +1184,7 @@ def _predict_on_training_data(
         A tuple containing three dictionaries for 1) observed metric values, and the
         model's associated 2) predictive means and 3) predictive standard deviations.
     """
-    data = experiment.fetch_data()
+    data = experiment.lookup_data()
     observations = observations_from_data(
         experiment=experiment, data=data
     )  # List[Observation]

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1933,7 +1933,7 @@ def get_fitted_model_bridge(scheduler: Scheduler) -> ModelBridge:
     gs = scheduler.standard_generation_strategy
     model_bridge = gs.model  # Optional[ModelBridge]
     if model_bridge is None:  # Need to re-fit the model.
-        data = scheduler.experiment.fetch_data()
+        data = scheduler.experiment.lookup_data()
         gs._fit_current_model(data=data)
         model_bridge = cast(ModelBridge, gs.model)
     return model_bridge


### PR DESCRIPTION
Summary: I think we want to avoid unnecessary fetches since they can be quite expensive.

Reviewed By: SebastianAment

Differential Revision: D52265170


