### PR TITLE
Fix for constrained benchmark problems: Optimization config should not have None for constraint noise when infer_noise is False

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -170,12 +170,14 @@ class BenchmarkProblem(Base):
 
         if is_constrained:
             n_con = test_problem.num_constraints
-            if test_problem.constraint_noise_std is None:
+            if infer_noise:
                 constraint_noise_sds = [None] * n_con
+            elif test_problem.constraint_noise_std is None:
+                constraint_noise_sds = [0.0] * n_con
             elif isinstance(test_problem.constraint_noise_std, list):
                 constraint_noise_sds = test_problem.constraint_noise_std[:n_con]
             else:
-                constraint_noise_sds = [noise_sd] * n_con
+                constraint_noise_sds = [test_problem.constraint_noise_std] * n_con
 
             outcome_constraints = [
                 OutcomeConstraint(

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -18,6 +18,7 @@ from ax.benchmark.benchmark_method import (
 from ax.benchmark.benchmark_problem import SingleObjectiveBenchmarkProblem
 from ax.benchmark.benchmark_result import BenchmarkResult
 from ax.benchmark.methods.modular_botorch import get_sobol_botorch_modular_acquisition
+from ax.benchmark.problems.registry import get_problem
 from ax.modelbridge.modelbridge_utils import extract_search_space_digest
 from ax.service.utils.scheduler_options import SchedulerOptions
 from ax.storage.json_store.load import load_experiment
@@ -142,6 +143,15 @@ class TestBenchmark(TestCase):
     @fast_botorch_optimize
     def test_replication_mbm(self) -> None:
         for method, problem, expected_name in [
+            (
+                get_sobol_botorch_modular_acquisition(
+                    model_cls=SingleTaskGP,
+                    acquisition_cls=qLogNoisyExpectedImprovement,
+                    distribute_replications=True,
+                ),
+                get_problem("constrained_gramacy_fixed_noise", num_trials=6),
+                "MBM::SingleTaskGP_qLogNEI",
+            ),
             (
                 get_sobol_botorch_modular_acquisition(
                     model_cls=SingleTaskGP,

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from itertools import product
 from typing import List, Optional, Union
 
 from ax.benchmark.benchmark_problem import (

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -21,10 +21,6 @@ from botorch.test_functions.synthetic import (
 from hypothesis import given, strategies as st
 
 
-def _get_hypothesis_nonnegative_floats():
-    return st.floats(min_value=0.0, allow_nan=False, allow_infinity=False)
-
-
 class TestBenchmarkProblem(TestCase):
     def test_single_objective_from_botorch(self) -> None:
         for botorch_test_problem in [Ackley(), ConstrainedHartmann(dim=6)]:
@@ -106,12 +102,8 @@ class TestBenchmarkProblem(TestCase):
 
     @given(
         st.booleans(),
-        st.one_of(st.none(), _get_hypothesis_nonnegative_floats()),
-        st.one_of(
-            st.none(),
-            _get_hypothesis_nonnegative_floats(),
-            st.lists(_get_hypothesis_nonnegative_floats(), min_size=2, max_size=2),
-        ),
+        st.one_of(st.none(), st.just(0.1)),
+        st.one_of(st.none(), st.just(0.2), st.just([0.3, 0.4])),
     )
     def test_constrained_from_botorch(
         self,


### PR DESCRIPTION
* For both objectives and constraints, `None` indicates zero noise in a BoTorch test problem but indicates unknown noise in an Ax optimization config. In Ax benchmark problems, this was done correctly for objective metrics but not for constraints. This diff fixes that.
* Fixing what looks like a typo: When noise levels are known, `constraint_noise_sds` in the optimization config should  match the constraint noise in the corresponding BoTorch test problem, not the objective noise.

## Test plan:
* Added a unit test checking all cases for `BenchmarkProblem.from_botorch` in the presence of constraints.
* Added a unit test for benchmarking the constrained Gramacy test problem, which was previously not working.
* `python -m unittest -k benchmark`