### PR TITLE
Fix device issues with botorch_mes.

### DIFF
--- a/ax/models/torch/botorch_mes.py
+++ b/ax/models/torch/botorch_mes.py
@@ -127,7 +127,7 @@ class MaxValueEntropySearch(BotorchModel):
         )
         bounds_ = bounds_.transpose(0, 1)
 
-        candidate_set = torch.rand(candidate_size, bounds_.size(1))
+        candidate_set = torch.rand(candidate_size, bounds_.size(1), device=self.device)
         candidate_set = bounds_[0] + (bounds_[1] - bounds_[0]) * candidate_set
 
         target_fidelities = {


### PR DESCRIPTION
Previously specifying any `torch_device` other than `"cpu"` would cause `RuntimeError` in torch. This is due to a device mismatch in MES's implementation.