### PR TITLE
Rename fn arg from `parameters` to `parameterization` in Service API tutorial

### DIFF
--- a/tutorials/gpei_hartmann_service.ipynb
+++ b/tutorials/gpei_hartmann_service.ipynb
@@ -124,8 +124,8 @@
     "import numpy as np\n",
     "\n",
     "\n",
-    "def evaluate(parameters):\n",
-    "    x = np.array([parameters.get(f\"x{i+1}\") for i in range(6)])\n",
+    "def evaluate(parameterization):\n",
+    "    x = np.array([parameterization.get(f\"x{i+1}\") for i in range(6)])\n",
     "    # In our case, standard error is 0, since we are computing a synthetic function.\n",
     "    return {\"hartmann6\": (hartmann6(x), 0.0), \"l2norm\": (np.sqrt((x**2).sum()), 0.0)}"
    ]
@@ -158,9 +158,9 @@
    "outputs": [],
    "source": [
     "for i in range(25):\n",
-    "    parameters, trial_index = ax_client.get_next_trial()\n",
+    "    parameterization, trial_index = ax_client.get_next_trial()\n",
     "    # Local evaluation here can be replaced with deployment to external system.\n",
-    "    ax_client.complete_trial(trial_index=trial_index, raw_data=evaluate(parameters))"
+    "    ax_client.complete_trial(trial_index=trial_index, raw_data=evaluate(parameterization))"
    ]
   },
   {


### PR DESCRIPTION
Rename the argument in the Service API tutorial `evaluate` function from `parameters` to `parameterization` to avoid confusion with the `parameters` configuration dictionary kwarg. This is also in line with the way the evaluate function is defined in the [corresponding section in the loop API tutorial](https://ax.dev/tutorials/gpei_hartmann_loop.html#1.-Define-evaluation-function).

i.e.,

```python
def evaluate(parameters):
    x = np.array([parameters.get(f"x{i+1}") for i in range(6)])
    # In our case, standard error is 0, since we are computing a synthetic function.
    return {"hartmann6": (hartmann6(x), 0.0), "l2norm": (np.sqrt((x**2).sum()), 0.0)}

...

for i in range(25):
    parameters, trial_index = ax_client.get_next_trial()
    # Local evaluation here can be replaced with deployment to external system.
    ax_client.complete_trial(trial_index=trial_index, raw_data=evaluate(parameters))
```

becomes
```python
def evaluate(parameterization):
    x = np.array([parameters.get(f"x{i+1}") for i in range(6)])
    # In our case, standard error is 0, since we are computing a synthetic function.
    return {"hartmann6": (hartmann6(x), 0.0), "l2norm": (np.sqrt((x**2).sum()), 0.0)}

...

for i in range(25):
    parameterization, trial_index = ax_client.get_next_trial()
    # Local evaluation here can be replaced with deployment to external system.
    ax_client.complete_trial(trial_index=trial_index, raw_data=evaluate(parameterization))
```