### PR TITLE
Use scheduler and early stopping strategy

### DIFF
--- a/ax/service/utils/scheduler_options.py
+++ b/ax/service/utils/scheduler_options.py
@@ -3,10 +3,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from logging import INFO
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
 from ax.global_stopping.strategies.base import BaseGlobalStoppingStrategy
@@ -102,6 +102,9 @@ class SchedulerOptions:
             it's encountered while saving to DB or loading from it.
         wait_for_running_trials: Whether the scheduler should wait for running trials
             or exit.
+        fetch_kwargs: Kwargs to be used when fetching data.
+        validate_metrics: Whether to raise an error if there is a problem with the
+            metrics attached to the experiment.
     """
 
     max_pending_trials: int = 10
@@ -123,3 +126,5 @@ class SchedulerOptions:
     global_stopping_strategy: Optional[BaseGlobalStoppingStrategy] = None
     suppress_storage_errors_after_retries: bool = False
     wait_for_running_trials: bool = True
+    fetch_kwargs: Dict[str, Any] = field(default_factory=dict)
+    validate_metrics: bool = True

--- a/ax/storage/sqa_store/save.py
+++ b/ax/storage/sqa_store/save.py
@@ -15,6 +15,7 @@ from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.runner import Runner
+from ax.core.trial import Trial
 from ax.exceptions.core import UserInputError
 from ax.exceptions.storage import SQADecodeError
 from ax.modelbridge.generation_strategy import GenerationStrategy
@@ -438,6 +439,25 @@ def update_properties_on_experiment(
         session.query(exp_sqa_class).filter_by(id=exp_id).update(
             {
                 "properties": experiment_with_updated_properties._properties,
+            }
+        )
+
+
+def update_properties_on_trial(
+    trial_with_updated_properties: BaseTrial,
+    config: Optional[SQAConfig] = None,
+) -> None:
+    config = config or SQAConfig()
+    trial_sqa_class = config.class_to_sqa_class[Trial]
+
+    trial_id = trial_with_updated_properties.db_id
+    if trial_id is None:
+        raise ValueError("Trial must be saved before being updated.")
+
+    with session_scope() as session:
+        session.query(trial_sqa_class).filter_by(id=trial_id).update(
+            {
+                "properties": trial_with_updated_properties._properties,
             }
         )
 

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -56,6 +56,7 @@ from ax.storage.sqa_store.save import (
     save_or_update_trials,
     update_generation_strategy,
     update_properties_on_experiment,
+    update_properties_on_trial,
     update_runner_on_experiment,
 )
 from ax.storage.sqa_store.sqa_classes import (
@@ -1755,6 +1756,29 @@ class SQAStoreTest(TestCase):
 
         loaded_experiment = load_experiment(experiment.name)
         self.assertTrue(loaded_experiment.immutable_search_space_and_opt_config)
+
+    def test_update_properties_on_trial(self) -> None:
+        experiment = get_experiment_with_batch_trial()
+        self.assertNotIn("foo", experiment.trials[0]._properties)
+        save_experiment(experiment)
+
+        # Add a property to the trial
+        experiment.trials[0]._properties["foo"] = "bar"
+        update_properties_on_trial(
+            trial_with_updated_properties=experiment.trials[0],
+        )
+        loaded_experiment = load_experiment(experiment.name)
+        self.assertEqual(loaded_experiment.trials[0]._properties["foo"], "bar")
+
+    def test_update_properties_on_trial_not_saved(self) -> None:
+        experiment = get_experiment_with_batch_trial()
+        experiment.trials[0]._properties["foo"] = "bar"
+        with self.assertRaisesRegex(
+            ValueError, "Trial must be saved before being updated."
+        ):
+            update_properties_on_trial(
+                trial_with_updated_properties=experiment.trials[0],
+            )
 
     def test_RepeatedArmStorage(self) -> None:
         experiment = get_experiment_with_batch_trial()

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1989,6 +1989,7 @@ class DummyEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         self, early_stop_trials: Optional[Dict[int, Optional[str]]] = None
     ) -> None:
         self.early_stop_trials: Dict[int, Optional[str]] = early_stop_trials or {}
+        self.seconds_between_polls = 1
 
     def should_stop_trials_early(
         self,


### PR DESCRIPTION
Summary:
Scheduler now needs to be able to:
- save trials with new data even if their status didn't update
- catch extra fetching errors.  it already handled most of them
- take fetch kwargs

We have a new method to update trial properties similar to experiment.

Differential Revision: D52349938


