### PR TITLE
Remove usage of MinimumTrialsInStatus in AEPsych

### DIFF
--- a/ax/modelbridge/completion_criterion.py
+++ b/ax/modelbridge/completion_criterion.py
@@ -7,7 +7,6 @@ from logging import Logger
 
 from ax.modelbridge.transition_criterion import (
     MinimumPreferenceOccurances,
-    MinimumTrialsInStatus,
     TransitionCriterion,
 )
 from ax.utils.common.logger import get_logger
@@ -35,19 +34,6 @@ class MinimumPreferenceOccurances(MinimumPreferenceOccurances):
 
     logger.warning(
         "CompletionCriterion, which MinimumPreferenceOccurance inherits from, is"
-        " deprecated. Please use TransitionCriterion instead."
-    )
-    pass
-
-
-class MinimumTrialsInStatus(MinimumTrialsInStatus):
-    """
-    Deprecated child class that has been replaced by `MinimumTrialsInStatus`
-    in `TransitionCriterion`, and will be fully reaped in a future release.
-    """
-
-    logger.warning(
-        "CompletionCriterion, which MinimumTrialsInStatus inherits from, is"
         " deprecated. Please use TransitionCriterion instead."
     )
     pass

--- a/ax/modelbridge/tests/test_completion_criterion.py
+++ b/ax/modelbridge/tests/test_completion_criterion.py
@@ -8,12 +8,10 @@ from unittest.mock import patch
 import pandas as pd
 from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
-from ax.modelbridge.completion_criterion import (
-    MinimumPreferenceOccurances,
-    MinimumTrialsInStatus,
-)
+from ax.modelbridge.completion_criterion import MinimumPreferenceOccurances
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
+from ax.modelbridge.transition_criterion import MinTrials
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_experiment
 
@@ -76,7 +74,7 @@ class TestCompletionCritereon(TestCase):
     def test_many_criteria(self) -> None:
         criteria = [
             MinimumPreferenceOccurances(metric_name="m1", threshold=3),
-            MinimumTrialsInStatus(status=TrialStatus.COMPLETED, threshold=5),
+            MinTrials(only_in_statuses=[TrialStatus.COMPLETED], threshold=5),
         ]
 
         experiment = get_experiment()


### PR DESCRIPTION
Summary:
We have replaced the more limited MinimumTrialsInStatus with the more flexible TransitionCriterion `MinTrials`. This diff is the first in a set of diffs intended to update the legacy usage of CompletionCriterion in AEPsych. 

In following diffs we will:
- Completely remove the completion criterion file
- update all four completion criterion defined in aepsych code here: https://www.internalfb.com/code/fbsource/[409e3dfb01ec5c613d34e58c491d63e8051d10d9]/fbcode/frl/ae/aepsych/tests/generators/test_completion_criteria.py?lines=12-15 
- revisit storage 
- remove all todos in gennode, genstrat, and transitioncriterion classes related to maintaining this deprecated code
- update AEPsych GSs as needed 
- determine if run indefinetly can be replaced by simply having gen_unlimited_trials = true

Additional info: https://docs.google.com/document/d/1JWaD20ux8dRVWom3VhTBkh4_1v170XNJ3Xf7EdWsMc8/edit?usp=sharing

Differential Revision: D52848140


