### PR TITLE
add strata_mapping to StratifiedStandardizeY

### DIFF
--- a/ax/modelbridge/transforms/tests/test_stratified_standardize_y_transform.py
+++ b/ax/modelbridge/transforms/tests/test_stratified_standardize_y_transform.py
@@ -59,6 +59,43 @@ class StratifiedStandardizeYTransformTest(TestCase):
             observations=[self.obs1, self.obs2],
             config={"parameter_name": "z"},
         )
+        self.search_space2 = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x", parameter_type=ParameterType.FLOAT, lower=0, upper=10
+                ),
+                ChoiceParameter(
+                    name="z",
+                    parameter_type=ParameterType.STRING,
+                    values=["a", "b", "c"],
+                ),
+            ]
+        )
+        self.strata_mapping = {"a": 0, "b": 1, "c": 1}
+        self.obsf3 = ObservationFeatures({"x": 5, "z": "c"})
+        self.obsd3 = ObservationData(
+            metric_names=["m1", "m2", "m2"],
+            means=np.array([2.0, 4.0, 16.0]),
+            covariance=np.array([[1.2, 0.2, 0.4], [0.2, 2.0, 0.8], [0.4, 0.8, 3.0]]),
+        )
+        self.obs3 = Observation(features=self.obsf3, data=self.obsd3)
+        self.t2 = StratifiedStandardizeY(
+            search_space=self.search_space2,
+            observations=[self.obs1, self.obs2, self.obs3],
+            config={"parameter_name": "z", "strata_mapping": self.strata_mapping},
+        )
+        self.m1 = Metric(name="m1")
+        self.m2 = Metric(name="m2")
+        self.m3 = Metric(name="m3")
+        self.objective = Objective(metric=self.m3, minimize=False)
+        self.cons = [
+            OutcomeConstraint(
+                metric=self.m1, op=ComparisonOp.GEQ, bound=2.0, relative=False
+            ),
+            OutcomeConstraint(
+                metric=self.m2, op=ComparisonOp.LEQ, bound=3.5, relative=False
+            ),
+        ]
 
     def test_Init(self) -> None:
         Ymean_expected = {
@@ -148,6 +185,9 @@ class StratifiedStandardizeYTransformTest(TestCase):
         for k, v in t2.Ystd.items():
             self.assertAlmostEqual(v, Ystd_expected[k])
 
+        # test strata_mapping
+        self.assertEqual(self.t2.strata_mapping, self.strata_mapping)
+
     def test_TransformObservations(self) -> None:
         std_m2_a = sqrt(2) * 3
         obsd1_ta = ObservationData(
@@ -191,51 +231,118 @@ class StratifiedStandardizeYTransformTest(TestCase):
             [Observation(data=obsd2, features=ObservationFeatures({"z": "b"}))]
         )[0].data
         self.assertTrue(osd_allclose(obsd2, self.obsd1))
+        # test strata_mapping
+        # "a" should be the same as above
+        obsd2 = deepcopy(self.obsd1)
+        obsd2 = self.t2.transform_observations(
+            [Observation(data=obsd2, features=ObservationFeatures({"z": "a"}))]
+        )[0].data
+        self.assertTrue(osd_allclose(obsd2, obsd1_ta))
+        # "b" and "c" should result in the same transformed values
+        obsd2 = deepcopy(self.obsd1)
+        obsd2 = self.t2.transform_observations(
+            [Observation(data=obsd2, features=ObservationFeatures({"z": "b"}))]
+        )[0].data
+        obsd3 = deepcopy(self.obsd1)
+        obsd3 = self.t2.transform_observations(
+            [Observation(data=obsd3, features=ObservationFeatures({"z": "c"}))]
+        )[0].data
+        self.assertTrue(osd_allclose(obsd2, obsd3))
+        obsd3 = self.t2.untransform_observations(
+            [Observation(data=obsd3, features=ObservationFeatures({"z": "c"}))]
+        )[0].data
+        self.assertTrue(osd_allclose(obsd3, self.obsd1))
+        obsd2 = self.t2.untransform_observations(
+            [Observation(data=obsd2, features=ObservationFeatures({"z": "b"}))]
+        )[0].data
+        self.assertTrue(osd_allclose(obsd2, self.obsd1))
 
     def test_TransformOptimizationConfig(self) -> None:
-        m1 = Metric(name="m1")
-        m2 = Metric(name="m2")
-        m3 = Metric(name="m3")
-        objective = Objective(metric=m3, minimize=False)
-        cons = [
-            OutcomeConstraint(
-                metric=m1, op=ComparisonOp.GEQ, bound=2.0, relative=False
-            ),
-            OutcomeConstraint(
-                metric=m2, op=ComparisonOp.LEQ, bound=3.5, relative=False
-            ),
-        ]
-        oc = OptimizationConfig(objective=objective, outcome_constraints=cons)
+        cons2 = deepcopy(self.cons)
+        oc = OptimizationConfig(objective=self.objective, outcome_constraints=cons2)
         fixed_features = ObservationFeatures({"z": "a"})
         oc = self.t.transform_optimization_config(oc, None, fixed_features)
         cons_t = [
             OutcomeConstraint(
-                metric=m1, op=ComparisonOp.GEQ, bound=1.0, relative=False
+                metric=self.m1, op=ComparisonOp.GEQ, bound=1.0, relative=False
             ),
             OutcomeConstraint(
-                metric=m2,
+                metric=self.m2,
                 op=ComparisonOp.LEQ,
                 bound=(3.5 - 5.0) / (sqrt(2) * 3),
                 relative=False,
             ),
         ]
         self.assertTrue(oc.outcome_constraints == cons_t)
-        self.assertTrue(oc.objective == objective)
+        self.assertTrue(oc.objective == self.objective)
 
         # No constraints
-        oc2 = OptimizationConfig(objective=objective)
+        oc2 = OptimizationConfig(objective=self.objective)
         oc3 = deepcopy(oc2)
+        fixed_features = ObservationFeatures({"z": "a"})
         oc3 = self.t.transform_optimization_config(oc3, None, fixed_features)
         self.assertTrue(oc2 == oc3)
 
         # Check fail with relative
         con = OutcomeConstraint(
-            metric=m1, op=ComparisonOp.GEQ, bound=2.0, relative=True
+            metric=self.m1, op=ComparisonOp.GEQ, bound=2.0, relative=True
         )
-        oc = OptimizationConfig(objective=objective, outcome_constraints=[con])
+        oc = OptimizationConfig(objective=self.objective, outcome_constraints=[con])
         with self.assertRaises(ValueError):
             oc = self.t.transform_optimization_config(oc, None, fixed_features)
         # Fail without strat param fixed
         fixed_features = ObservationFeatures({"x": 2.0})
         with self.assertRaises(ValueError):
             oc = self.t.transform_optimization_config(oc, None, fixed_features)
+
+    def test_TransformOptimizationConfigWithStrataMapping(self) -> None:
+        cons2 = deepcopy(self.cons)
+        oc = OptimizationConfig(objective=self.objective, outcome_constraints=cons2)
+        fixed_features = ObservationFeatures({"z": "a"})
+        cons_t = [
+            OutcomeConstraint(
+                metric=self.m1, op=ComparisonOp.GEQ, bound=1.0, relative=False
+            ),
+            OutcomeConstraint(
+                metric=self.m2,
+                op=ComparisonOp.LEQ,
+                bound=(3.5 - 5.0) / (sqrt(2) * 3),
+                relative=False,
+            ),
+        ]
+        cons2 = deepcopy(self.cons)
+        oc = OptimizationConfig(objective=self.objective, outcome_constraints=cons2)
+        oc = self.t2.transform_optimization_config(oc, None, fixed_features)
+        self.assertTrue(oc.outcome_constraints == cons_t)
+        self.assertTrue(oc.objective == self.objective)
+        fixed_features = ObservationFeatures({"z": "c"})
+        cons2 = deepcopy(self.cons)
+        oc = OptimizationConfig(objective=self.objective, outcome_constraints=cons2)
+        oc = self.t2.transform_optimization_config(oc, None, fixed_features)
+        cons_t2 = [
+            OutcomeConstraint(
+                metric=self.m1,
+                op=ComparisonOp.GEQ,
+                bound=(2.0 - self.t2.Ymean[("m1", 1)]) / self.t2.Ystd[("m1", 1)],
+                relative=False,
+            ),
+            OutcomeConstraint(
+                metric=self.m2,
+                op=ComparisonOp.LEQ,
+                bound=(3.5 - self.t2.Ymean[("m2", 1)]) / self.t2.Ystd[("m2", 1)],
+                relative=False,
+            ),
+        ]
+        self.assertEqual(oc.outcome_constraints, cons_t2)
+        self.assertTrue(oc.objective == self.objective)
+        cons_t = [
+            OutcomeConstraint(
+                metric=self.m1, op=ComparisonOp.GEQ, bound=1.0, relative=False
+            ),
+            OutcomeConstraint(
+                metric=self.m2,
+                op=ComparisonOp.LEQ,
+                bound=(3.5 - 5.0) / (sqrt(2) * 3),
+                relative=False,
+            ),
+        ]


### PR DESCRIPTION
Summary: This adds support for specifying a `strata_mapping`, which determines that strata which are standardized separately. Specifically, this allows multiple task values to be mapped to the same strata and standardized together.

Reviewed By: danielcohenlive

Differential Revision: D52735430


