### PR TITLE
Fix GenerationStrategy and GenerataionNode todos

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -331,10 +331,7 @@ class GenerationStrategy(GenerationStrategyInterface):
         """Checks whether all nodes are completed in the generation strategy and
         the current node is not an AEPsych node.
         """
-        # TODO: @mgarrard clean up with legacy usecase removal
-        return all(node.is_completed for node in self._nodes) and "AEPsych" not in str(
-            self._curr
-        )
+        return all(node.is_completed for node in self._nodes)
 
     @step_based_gs_only
     def _validate_and_set_step_sequence(self, steps: List[GenerationStep]) -> None:
@@ -379,8 +376,8 @@ class GenerationStrategy(GenerationStrategyInterface):
             if idx != len(self._steps):
                 for transition_criteria in step.transition_criteria:
                     if (
-                        transition_criteria.criterion_class == "MinTrials"
-                        or transition_criteria.criterion_class == "MaxTrials"
+                        transition_criteria.criterion_class
+                        != "MaxGenerationParallelism"
                     ):
                         transition_criteria._transition_to = (
                             f"GenerationStep_{str(idx + 1)}"

--- a/ax/modelbridge/tests/test_aepsych_criterion.py
+++ b/ax/modelbridge/tests/test_aepsych_criterion.py
@@ -49,6 +49,11 @@ class TestAEPsychCriterion(TestCase):
                 raise_data_required_error=False
             )
         )
+        # check the transition_to is being set
+        self.assertEqual(
+            generation_strategy._curr.transition_criteria[0].transition_to,
+            "GenerationStep_1",
+        )
 
         data = Data(
             df=pd.DataFrame(

--- a/ax/modelbridge/transition_criterion.py
+++ b/ax/modelbridge/transition_criterion.py
@@ -378,7 +378,10 @@ class MinimumTrialsInStatus(TransitionCriterion):
     """
 
     def __init__(
-        self, status: TrialStatus, threshold: int, transition_to: Optional[str] = None
+        self,
+        status: TrialStatus,
+        threshold: int,
+        transition_to: Optional[str] = None,
     ) -> None:
         self.status = status
         self.threshold = threshold

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -391,6 +391,10 @@ def transition_criteria_from_json(
                     transition_to=criterion_json.pop("transition_to")
                     if "transition_to" in criterion_json.keys()
                     else None,
+                    block_transition_if_unmet=criterion_json.pop(
+                        "block_transition_if_unmet", True
+                    ),
+                    block_gen_if_met=criterion_json.pop("block_gen_if_met", False),
                 )
             )
         elif criterion_type == "MaxGenerationParallelism":

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -342,13 +342,17 @@ class JSONStoreTest(TestCase):
             if isinstance(original_object, GenerationStrategy):
                 original_object._unset_non_persistent_state_fields()
                 # for the test, completion criterion are set post init
-                # and therefore do not become transition critirion, unset
+                # and therefore do not become transition criterion, unset
                 # for this specific test only
                 if "with_completion_criteria" in fake_func.keywords:
                     for step in original_object._steps:
                         step._transition_criteria = None
                     for step in converted_object._steps:
                         step._transition_criteria = None
+                    # also unset the `transition_to` field for the same reason
+                    for criterion in converted_object._steps[0].completion_criteria:
+                        if criterion.criterion_class == "MinimumPreferenceOccurances":
+                            criterion._transition_to = None
             try:
                 self.assertEqual(
                     original_object,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/aepsych/pull/330

In this diff we update the Ax GenerationStrategy code to remove all todos related to aepsych, and use the standard GS code flow for aepsych usecases. This required some minimal updates to the aepsych criterion and one of the storage tests.

In following diffs we will:
- revisit storage
- update AEPsych GSs as needed
- determine if run indefinetly can be replaced by simply having gen_unlimited_trials = true

Differential Revision: D52898268

