### PR TITLE
Handle `RunIndefinetly` criterion to set gen_unlimited

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -703,9 +703,19 @@ class GenerationStep(GenerationNode, SortableBase):
                     transition_to=None,
                 )
             )
-        # handle legacy completion_criteria, @mgarrard to revist after update
+
+        # For AEPsych usecases, leverage the `RunIndefinitely` criterion to set
+        # gen_unlimited_trials, if this criterion is not found, default to False.
         if len(self.completion_criteria) > 0:
-            gen_unlimited_trials = False
+            run_indefinitely_atrr = (
+                # Pyre-ignore [16]: Not all transition criterion have run_indefinetly
+                # attribute, and we don't want them to.
+                criterion.run_indefinitely
+                for criterion in self.completion_criteria
+                if criterion.criterion_class == "RunIndefinitely"
+            )
+            gen_unlimited_trials = next(run_indefinitely_atrr, False)
+
         transition_criteria += self.completion_criteria
         super().__init__(
             node_name=f"GenerationStep_{str(self.index)}",


### PR DESCRIPTION
Summary:
In this diff we handle the `RunIndeifinetly` criterion, which is replaced by the `gen_unlimited_trials` property. Ideally, AEPsych GSs can set `gen_unlimited_trials` for the necessary nodes directly instead of using the `RunIndefinity` criterion, but this is a fix from our side for now

In following diffs we will:
- revisit storage

Differential Revision: D52898721

