### PR TITLE
fetch data in scheduler before generating

### DIFF
--- a/ax/runners/single_running_trial_mixin.py
+++ b/ax/runners/single_running_trial_mixin.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import defaultdict
+from typing import Dict, Iterable, Set
+
+from ax.core.base_trial import BaseTrial, TrialStatus
+
+
+class SingleRunningTrialMixin:
+    """Mixin for Runners with a single running trial.
+
+    This mixin implements a simple poll_trial_status method that
+    allows for a single running trial (the latest running trial).
+    The returned status of trials that currently are marked as
+    running is completed.
+    """
+
+    def poll_trial_status(
+        self, trials: Iterable[BaseTrial]
+    ) -> Dict[TrialStatus, Set[int]]:
+        """Checks the status of any non-terminal trials and returns their
+        indices as a mapping from TrialStatus to a list of indices. Required
+        for runners used with Ax ``Scheduler``.
+
+        NOTE: Does not need to handle waiting between polling calls while trials
+        are running; this function should just perform a single poll.
+
+        Args:
+            trials: Trials to poll.
+
+        Returns:
+            A dictionary mapping TrialStatus to a list of trial indices that have
+            the respective status at the time of the polling. This does not need to
+            include trials that at the time of polling already have a terminal
+            (ABANDONED, FAILED, COMPLETED) status (but it may).
+        """
+        if len(list(trials)) == 0:
+            return {}
+        trial_statuses = defaultdict(set)
+        running_trial_indices = list(trials)[0].experiment.running_trial_indices
+        max_running_trial_index = (
+            -1 if len(running_trial_indices) == 0 else max(running_trial_indices)
+        )
+        for trial in trials:
+            if trial.status in (
+                TrialStatus.ABANDONED,
+                TrialStatus.FAILED,
+                TrialStatus.COMPLETED,
+            ):
+                continue
+            elif (trial.status == TrialStatus.RUNNING) and (
+                trial.index < max_running_trial_index
+            ):
+                trial_statuses[TrialStatus.COMPLETED].add(trial.index)
+            else:
+                trial_statuses[trial.status].add(trial.index)
+        return dict(trial_statuses)

--- a/ax/runners/tests/test_single_running_trial_mixin.py
+++ b/ax/runners/tests/test_single_running_trial_mixin.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from ax.core.base_trial import TrialStatus
+from ax.runners.single_running_trial_mixin import SingleRunningTrialMixin
+from ax.runners.synthetic import SyntheticRunner
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_branin_experiment
+
+
+class SyntheticRunnerWithSingleRunningTrial(SingleRunningTrialMixin, SyntheticRunner):
+    ...
+
+
+class SingleRunningTrialMixinTest(TestCase):
+    def test_single_running_trial_mixin(self) -> None:
+        runner = SyntheticRunnerWithSingleRunningTrial()
+        exp = get_branin_experiment(with_trial=True, with_batch=True)
+        exp.runner = runner
+        trials = exp.trials.values()
+        for trial in trials:
+            trial.assign_runner()
+            trial.run()
+        trial_statuses = runner.poll_trial_status(trials=trials)
+        self.assertEqual(trial_statuses[TrialStatus.COMPLETED], {0})
+        self.assertEqual(trial_statuses[TrialStatus.RUNNING], {1})
+
+    def test_no_trials(self) -> None:
+        runner = SyntheticRunnerWithSingleRunningTrial()
+        trial_statuses = runner.poll_trial_status(trials=[])
+        self.assertEqual(trial_statuses, {})
+
+    def test_abandoned_trial(self) -> None:
+        runner = SyntheticRunnerWithSingleRunningTrial()
+        exp = get_branin_experiment(with_trial=True)
+        exp.runner = runner
+        trial = exp.trials[0]
+        trial.assign_runner()
+        trial.mark_abandoned()
+        trial_statuses = runner.poll_trial_status(trials=[trial])
+        self.assertEqual(trial_statuses, {})

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -651,13 +651,14 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             include trials that at the time of polling already have a terminal
             (ABANDONED, FAILED, COMPLETED) status (but it may).
         """
-        return self.runner.poll_trial_status(
-            trials=(
-                self.experiment.trials.values()
-                if poll_all_trial_statuses
-                else self.pending_trials
-            )
+        trials = (
+            self.experiment.trials.values()
+            if poll_all_trial_statuses
+            else self.pending_trials
         )
+        if len(trials) == 0:
+            return {}
+        return self.runner.poll_trial_status(trials=trials)
 
     @retry_on_exception(retries=3, no_retry_on_exception_types=NO_RETRY_EXCEPTIONS)
     def stop_trial_runs(
@@ -809,6 +810,15 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
                 "Optimization timed out (timeout hours: " f"{self._timeout_hours})!"
             )
         return timed_out
+
+    @property
+    def should_wait_for_running_trials(self) -> bool:
+        """Whether this scheduler should wait for running trials to complete.
+
+        If False, the scheduler will not wait for running trials to complete and
+        will simply exit.
+        """
+        return self.options.wait_for_running_trials
 
     def error_if_failure_rate_exceeded(self, force_check: bool = False) -> None:
         """Checks if the failure rate (set in scheduler options) has been exceeded.
@@ -980,7 +990,8 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             if self.should_abort_optimization():
                 yield self._abort_optimization(num_preexisting_trials=n_existing)
                 return
-
+            if not self.should_wait_for_running_trials:
+                return
             yield self.wait_for_completed_trials_and_report_results(
                 idle_callback, force_refit=True
             )
@@ -1032,6 +1043,15 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             >>> print(trials_info["n_completed"])
             3
         """
+        if not self.should_wait_for_running_trials:
+            if max_trials > self.options.max_pending_trials:
+                self.logger.warning(
+                    f"Since `SchedulerOptions.wait_for_running_trials=False` "
+                    f"and `max_trials` ({max_trials}) is greater than "
+                    f"`max_pending_trials` ({self.options.max_pending_trials}), "
+                    "all `max_trials` trials are unlikely to generated."
+                )
+        self.poll_and_process_results()
         for _ in self.run_trials_and_yield_results(
             max_trials=max_trials,
             ignore_global_stopping_strategy=ignore_global_stopping_strategy,
@@ -1085,13 +1105,11 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
                 "Please either specify `num_trials` in `SchedulerOptions` input "
                 "to the `Scheduler` or use `run_n_trials` instead of `run_all_trials`."
             )
-        for _ in self.run_trials_and_yield_results(
+        return self.run_n_trials(
             max_trials=not_none(self.options.total_trials),
             timeout_hours=timeout_hours,
             idle_callback=idle_callback,
-        ):
-            pass
-        return self.summarize_final_result()
+        )
 
     def run(self, max_new_trials: int) -> bool:
         """Schedules trial evaluation(s) if stopping criterion is not triggered,

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -10,7 +10,7 @@ from math import ceil
 from random import randint
 from tempfile import NamedTemporaryFile
 from typing import Any, Callable, cast, Dict, Iterable, Optional, Set, Type
-from unittest.mock import Mock, patch, PropertyMock
+from unittest.mock import call, Mock, patch, PropertyMock
 
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, TrialStatus
@@ -29,6 +29,7 @@ from ax.metrics.branin_map import BraninTimestampMapMetric
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
+from ax.runners.single_running_trial_mixin import SingleRunningTrialMixin
 from ax.runners.synthetic import SyntheticRunner
 from ax.service.scheduler import (
     ExperimentStatusProperties,
@@ -37,9 +38,8 @@ from ax.service.scheduler import (
     OptimizationResult,
     Scheduler,
     SchedulerInternalError,
-    SchedulerOptions,
 )
-from ax.service.utils.scheduler_options import TrialType
+from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.service.utils.with_db_settings_base import WithDBSettingsBase
 from ax.storage.json_store.encoders import runner_to_dict
 from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
@@ -84,6 +84,10 @@ class SyntheticRunnerWithStatusPolling(SyntheticRunner):
             running = [t.index for t in trials]
             return {TrialStatus.COMPLETED: {running[randint(0, len(running) - 1)]}}
         return {}
+
+
+class SyntheticRunnerWithSingleRunningTrial(SingleRunningTrialMixin, SyntheticRunner):
+    ...
 
 
 class TestScheduler(Scheduler):
@@ -600,6 +604,74 @@ class AxSchedulerTestCase(TestCase):
 
         self.assertFalse(test_obj[0] == 0)
         self.assertTrue(test_obj[1] == "apple")
+
+    def test_run_n_trials_single_step_existing_experiment(self) -> None:
+        # Test using the Scheduler to run a single experiment update step.
+        # This is the typical behavior in Axolotl.
+        branin_experiment = get_branin_experiment(
+            with_batch=True,
+            with_status_quo=True,
+            with_completed_trial=True,
+        )
+        runner = SyntheticRunnerWithSingleRunningTrial()
+        branin_experiment.runner = runner
+        trial0 = branin_experiment.trials[0]
+        trial0.assign_runner()
+        branin_experiment.trials[1].assign_runner()
+        trial0.mark_running()
+        gs = self._get_generation_strategy_strategy_for_test(
+            experiment=branin_experiment,
+            generation_strategy=self.two_sobol_steps_GS,
+        )
+        # With runners & metrics, `Scheduler.run_all_trials` should run.
+        scheduler = Scheduler(
+            experiment=branin_experiment,  # Has runner and metrics.
+            generation_strategy=gs,
+            options=SchedulerOptions(
+                # pyre-fixme[6]: For 1st param expected `Optional[int]` but got `float`.
+                init_seconds_between_polls=0.1,  # Short between polls so test is fast.
+                wait_for_running_trials=False,
+            ),
+            db_settings=self.db_settings_if_always_needed,
+        )
+        with patch.object(
+            Scheduler,
+            "poll_and_process_results",
+            wraps=scheduler.poll_and_process_results,
+        ) as mock_poll_and_process_results, patch.object(
+            Scheduler,
+            "run_trials_and_yield_results",
+            wraps=scheduler.run_trials_and_yield_results,
+        ) as mock_run_trials_and_yield_results:
+            manager = Mock()
+            manager.attach_mock(
+                mock_poll_and_process_results, "poll_and_process_results"
+            )
+            manager.attach_mock(
+                mock_run_trials_and_yield_results, "run_trials_and_yield_results"
+            )
+            scheduler.run_n_trials(max_trials=1)
+            # test order of calls
+            expected_calls = [
+                call.poll_and_process_results(),
+                call.run_trials_and_yield_results(
+                    max_trials=1,
+                    ignore_global_stopping_strategy=False,
+                    timeout_hours=None,
+                    idle_callback=None,
+                ),
+                call.poll_and_process_results(),
+            ]
+            self.assertEqual(manager.mock_calls, expected_calls)
+            self.assertEqual(len(scheduler.experiment.trials), 3)
+            # check status
+            self.assertEqual(
+                scheduler.experiment.trials[0].status, TrialStatus.COMPLETED
+            )
+            self.assertEqual(
+                scheduler.experiment.trials[1].status, TrialStatus.COMPLETED
+            )
+            self.assertEqual(scheduler.experiment.trials[2].status, TrialStatus.RUNNING)
 
     def test_run_preattached_trials_only(self) -> None:
         gs = self._get_generation_strategy_strategy_for_test(
@@ -1823,4 +1895,35 @@ class AxSchedulerTestCase(TestCase):
         with self.assertRaises(UserInputError):
             scheduler.get_improvement_over_baseline(
                 baseline_arm_name="baseline_arm_not_in_data",
+            )
+
+    def test_warning_run_n_trials(self) -> None:
+        """
+        Test that a warning is raised when `run_n_trials` is
+        called with `max_trials` > `max_pending_trials` and
+        `wait_for_running_trials=False`.
+        """
+        gs = self._get_generation_strategy_strategy_for_test(
+            experiment=self.branin_experiment,
+            generation_strategy=self.two_sobol_steps_GS,
+        )
+        scheduler = Scheduler(
+            experiment=self.branin_experiment,  # Has runner and metrics.
+            options=SchedulerOptions(
+                wait_for_running_trials=False,
+                max_pending_trials=1,
+            ),
+            generation_strategy=gs,
+        )
+        msg = (
+            r"Since `SchedulerOptions.wait_for_running_trials=False` "
+            r"and `max_trials` \(2\) is greater than "
+            r"`max_pending_trials` \(1\), "
+            r"all `max_trials` trials are unlikely to generated\."
+        )
+        with self.assertLogs(scheduler.logger.logger, level="INFO") as cm:
+            scheduler.run_n_trials(max_trials=2)
+            self.assertRegex(
+                cm.output[0],
+                r"WARNING:ax.service.scheduler.Scheduler.*:" + msg,
             )

--- a/ax/service/utils/scheduler_options.py
+++ b/ax/service/utils/scheduler_options.py
@@ -100,6 +100,8 @@ class SchedulerOptions:
             multiple times. Only use if SQL storage is not important for the given
             use case, since this will only log, but not raise, an exception if
             it's encountered while saving to DB or loading from it.
+        wait_for_running_trials: Whether the scheduler should wait for running trials
+            or exit.
     """
 
     max_pending_trials: int = 10
@@ -120,3 +122,4 @@ class SchedulerOptions:
     early_stopping_strategy: Optional[BaseEarlyStoppingStrategy] = None
     global_stopping_strategy: Optional[BaseGlobalStoppingStrategy] = None
     suppress_storage_errors_after_retries: bool = False
+    wait_for_running_trials: bool = True

--- a/sphinx/source/runners.rst
+++ b/sphinx/source/runners.rst
@@ -15,6 +15,13 @@ BoTorch Test Problem
     :undoc-members:
     :show-inheritance:
 
+SingleRunningTrialMixin
+~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.runners.single_running_trial_mixin
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Synthetic Runner
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Summary: see title. This is important for using the scheduler scenarios where it is (repeatedly) instantiated and used for a single update step.

Differential Revision: D52963588

