### PR TITLE
Model generalization metrics for logging

### DIFF
--- a/ax/modelbridge/tests/test_model_fit_metrics.py
+++ b/ax/modelbridge/tests/test_model_fit_metrics.py
@@ -10,6 +10,7 @@ from ax.core.experiment import Experiment
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
 from ax.metrics.branin import BraninMetric
+from ax.modelbridge.cross_validation import compute_model_fit_metrics_from_modelbridge
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
 from ax.runners.synthetic import SyntheticRunner
@@ -59,8 +60,10 @@ class TestModelBridgeFitMetrics(TestCase):
         scheduler.run_n_trials(max_trials=NUM_SOBOL + 1)
         model_bridge = get_fitted_model_bridge(scheduler)
 
-        # testing ModelBridge.compute_model_fit_metrics with default metrics
-        fit_metrics = model_bridge.compute_model_fit_metrics(self.branin_experiment)
+        # testing compute_model_fit_metrics_from_modelbridge with default metrics
+        fit_metrics = compute_model_fit_metrics_from_modelbridge(
+            model_bridge=model_bridge, experiment=self.branin_experiment
+        )
         r2 = fit_metrics.get("coefficient_of_determination")
         self.assertIsInstance(r2, dict)
         r2 = cast(Dict[str, float], r2)
@@ -76,8 +79,10 @@ class TestModelBridgeFitMetrics(TestCase):
         self.assertIsInstance(std_branin, float)
 
         # testing with empty metrics
-        empty_metrics = model_bridge.compute_model_fit_metrics(
-            self.branin_experiment, fit_metrics_dict={}
+        empty_metrics = compute_model_fit_metrics_from_modelbridge(
+            model_bridge=model_bridge,
+            experiment=self.branin_experiment,
+            fit_metrics_dict={},
         )
         self.assertIsInstance(empty_metrics, dict)
         self.assertTrue(len(empty_metrics) == 0)

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -26,6 +26,7 @@ from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
 from ax.exceptions.core import OptimizationComplete, UnsupportedError, UserInputError
 from ax.metrics.branin import BraninMetric
 from ax.metrics.branin_map import BraninTimestampMapMetric
+from ax.modelbridge.cross_validation import compute_model_fit_metrics_from_modelbridge
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
@@ -1655,9 +1656,9 @@ class AxSchedulerTestCase(TestCase):
         # testing get_fitted_model_bridge
         model_bridge = get_fitted_model_bridge(scheduler)
 
-        # testing compatibility with model_bridge.compute_model_fit_metrics
-        fit_metrics = model_bridge.compute_model_fit_metrics(
-            experiment=scheduler.experiment
+        # testing compatibility with compute_model_fit_metrics_from_modelbridge
+        fit_metrics = compute_model_fit_metrics_from_modelbridge(
+            model_bridge=model_bridge, experiment=scheduler.experiment
         )
         r2 = fit_metrics.get("coefficient_of_determination")
         self.assertIsInstance(r2, dict)
@@ -1674,8 +1675,10 @@ class AxSchedulerTestCase(TestCase):
         self.assertIsInstance(std_branin, float)
 
         # testing with empty metrics dict
-        empty_metrics = model_bridge.compute_model_fit_metrics(
-            experiment=scheduler.experiment, fit_metrics_dict={}
+        empty_metrics = compute_model_fit_metrics_from_modelbridge(
+            model_bridge=model_bridge,
+            experiment=scheduler.experiment,
+            fit_metrics_dict={},
         )
         self.assertIsInstance(empty_metrics, dict)
         self.assertTrue(len(empty_metrics) == 0)

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -41,7 +41,10 @@ from ax.core.trial import BaseTrial
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.modelbridge import ModelBridge
-from ax.modelbridge.cross_validation import cross_validate
+from ax.modelbridge.cross_validation import (
+    compute_model_fit_metrics_from_modelbridge,
+    cross_validate,
+)
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.random import RandomModelBridge
 from ax.modelbridge.torch import TorchModelBridge
@@ -1462,7 +1465,11 @@ def warn_if_unpredictable_metrics(
             "Not checking metric predictability."
         )
         return None
-    model_fit_dict = model_bridge.compute_model_fit_metrics(experiment=experiment)
+    model_fit_dict = compute_model_fit_metrics_from_modelbridge(
+        model_bridge=model_bridge,
+        experiment=experiment,
+        generalization=True,  # use generalization metrics for user warning
+    )
     fit_quality_dict = model_fit_dict[model_fit_metric_name]
 
     # Extract salient metrics from experiment.


### PR DESCRIPTION
Summary: [#1682](https://github.com/facebook/Ax/pull/1682) introduced model fit metrics, which are evaluated on the training data to check the model fitting. This commit introduces the option to evaluate on leave-one-out cross-validation data, thereby evaluating the generalization performance of the model.

Reviewed By: bernardbeckerman

Differential Revision: D52873121


