### PR TITLE
Explicitly accessing RankingDataset X values for PairwiseGP

### DIFF
--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -53,6 +53,7 @@ from botorch.models.transforms.input import (
     InputTransform,
 )
 from botorch.models.transforms.outcome import ChainedOutcomeTransform, OutcomeTransform
+from botorch.utils.containers import SliceContainer
 from botorch.utils.datasets import RankingDataset, SupervisedDataset
 from gpytorch.kernels import Kernel
 from gpytorch.likelihoods.likelihood import Likelihood
@@ -207,7 +208,9 @@ class Surrogate(Base):
             if self.botorch_model_class == PairwiseGP and isinstance(
                 dataset, RankingDataset
             ):
-                Xi = dataset.X.values
+                # directly accessing the d-dim X tensor values
+                # instead of the augmented 2*d-dim dataset.X from RankingDataset
+                Xi = checked_cast(SliceContainer, dataset._X).values
             else:
                 Xi = dataset.X
             for _ in range(dataset.Y.shape[-1]):

--- a/ax/utils/common/constants.py
+++ b/ax/utils/common/constants.py
@@ -81,6 +81,7 @@ class Keys(str, Enum):
     TASK_FEATURES = "task_features"
     WARM_START_REFITTING = "warm_start_refitting"
     X_BASELINE = "X_baseline"
+    PAIRWISE_PREFERENCE_QUERY = "pairwise_pref_query"
 
 
 DEFAULT_WINSORIZATION_LIMITS_MINIMIZATION: Tuple[float, float] = (0.0, 0.2)


### PR DESCRIPTION
Summary:
Explicitly accessing RankingDataset X values for PairwiseGP for correct tensor shape.

Also removed mocks in test_pairwise_modelbridge

Differential Revision: D52545610


