### PR TITLE
Log the model used to generate trials

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -539,7 +539,8 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
             raise e
         logger.info(
             f"Generated new trial {trial.index} with parameters "
-            f"{round_floats_for_logging(item=not_none(trial.arm).parameters)}."
+            f"{round_floats_for_logging(item=not_none(trial.arm).parameters)} "
+            f"using model {not_none(trial.generator_run)._model_key}."
         )
         trial.mark_running(no_runner_required=True)
         self._save_or_update_trial_in_db_if_possible(

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -682,7 +682,14 @@ class TestAxClient(TestCase):
         with self.assertRaisesRegex(ValueError, ".* no trials"):
             ax_client.get_optimization_trace(objective_optimum=branin.fmin)
         for i in range(6):
-            parameterization, trial_index = ax_client.get_next_trial()
+            with mock.patch("ax.service.ax_client.logger.info") as mock_log:
+                parameterization, trial_index = ax_client.get_next_trial()
+            log_message = mock_log.call_args.args[0]
+            if i < 5:
+                expected_model = "Sobol"
+            else:
+                expected_model = "BoTorch"
+            self.assertIn(f"using model {expected_model}", log_message)
             x, y = parameterization.get("x"), parameterization.get("y")
             ax_client.complete_trial(
                 trial_index,


### PR DESCRIPTION
Summary: Updates the candidate generation in `AxClient.get_next_trial` to include the model used to generate it.

Differential Revision: D53071245


