### PR TITLE
Default `NaN` value for model fit metrics

### DIFF
--- a/ax/telemetry/ax_client.py
+++ b/ax/telemetry/ax_client.py
@@ -109,11 +109,11 @@ class AxClientCompletedRecord:
             experiment_completed_record=ExperimentCompletedRecord.from_experiment(
                 experiment=ax_client.experiment
             ),
-            best_point_quality=float("-inf"),  # TODO[T147907632]
-            model_fit_quality=float("-inf"),  # TODO[T147907632]
-            model_std_quality=float("-inf"),
-            model_fit_generalization=float("-inf"),  # TODO via cross_validate_by_trial
-            model_std_generalization=float("-inf"),
+            best_point_quality=float("nan"),  # TODO[T147907632]
+            model_fit_quality=float("nan"),  # TODO[T147907632]
+            model_std_quality=float("nan"),
+            model_fit_generalization=float("nan"),
+            model_std_generalization=float("nan"),
         )
 
     def flatten(self) -> Dict[str, Any]:

--- a/ax/telemetry/optimization.py
+++ b/ax/telemetry/optimization.py
@@ -533,7 +533,7 @@ class OptimizationCompletedRecord:
             estimated_early_stopping_savings=estimated_early_stopping_savings,
             estimated_global_stopping_savings=estimated_global_stopping_savings,
             # The following are not applicable for AxClient
-            improvement_over_baseline=float("-inf"),
+            improvement_over_baseline=float("nan"),
             num_metric_fetch_e_encountered=-1,
             num_trials_bad_due_to_err=-1,
         )

--- a/ax/telemetry/scheduler.py
+++ b/ax/telemetry/scheduler.py
@@ -137,10 +137,10 @@ class SchedulerCompletedRecord:
 
         except Exception as e:
             warn("Encountered exception in computing model fit quality: " + str(e))
-            model_fit_quality = float("-inf")
-            model_std_quality = float("-inf")
-            model_fit_generalization = float("-inf")
-            model_std_generalization = float("-inf")
+            model_fit_quality = float("nan")
+            model_std_quality = float("nan")
+            model_fit_generalization = float("nan")
+            model_std_generalization = float("nan")
 
         try:
             improvement_over_baseline = scheduler.get_improvement_over_baseline()
@@ -149,13 +149,13 @@ class SchedulerCompletedRecord:
                 "Encountered exception in computing improvement over baseline: "
                 + str(e)
             )
-            improvement_over_baseline = float("-inf")
+            improvement_over_baseline = float("nan")
 
         return cls(
             experiment_completed_record=ExperimentCompletedRecord.from_experiment(
                 experiment=scheduler.experiment
             ),
-            best_point_quality=float("-inf"),  # TODO[T147907632]
+            best_point_quality=float("nan"),  # TODO[T147907632]
             model_fit_quality=model_fit_quality,
             model_std_quality=model_std_quality,
             model_fit_generalization=model_fit_generalization,

--- a/ax/telemetry/tests/test_ax_client.py
+++ b/ax/telemetry/tests/test_ax_client.py
@@ -6,6 +6,8 @@
 
 from typing import Dict, List, Sequence, Union
 
+import numpy as np
+
 from ax.core.types import TParamValue
 from ax.service.ax_client import AxClient, ObjectiveProperties
 from ax.telemetry.ax_client import AxClientCompletedRecord, AxClientCreatedRecord
@@ -118,10 +120,31 @@ class TestAxClient(TestCase):
             experiment_completed_record=ExperimentCompletedRecord.from_experiment(
                 experiment=ax_client.experiment
             ),
-            best_point_quality=float("-inf"),
-            model_fit_quality=float("-inf"),
-            model_std_quality=float("-inf"),
-            model_fit_generalization=float("-inf"),
-            model_std_generalization=float("-inf"),
+            best_point_quality=float("nan"),
+            model_fit_quality=float("nan"),
+            model_std_quality=float("nan"),
+            model_fit_generalization=float("nan"),
+            model_std_generalization=float("nan"),
         )
-        self.assertEqual(record, expected)
+        self._compare_axclient_completed_records(record, expected)
+
+    def _compare_axclient_completed_records(
+        self, record: AxClientCompletedRecord, expected: AxClientCompletedRecord
+    ) -> None:
+        self.assertEqual(
+            record.experiment_completed_record, expected.experiment_completed_record
+        )
+        numeric_fields = [
+            "best_point_quality",
+            "model_fit_quality",
+            "model_std_quality",
+            "model_fit_generalization",
+            "model_std_generalization",
+        ]
+        for field in numeric_fields:
+            rec_field = getattr(record, field)
+            exp_field = getattr(expected, field)
+            if np.isnan(rec_field):
+                self.assertTrue(np.isnan(exp_field))
+            else:
+                self.assertAlmostEqual(rec_field, exp_field)

--- a/ax/telemetry/tests/test_optimization.py
+++ b/ax/telemetry/tests/test_optimization.py
@@ -239,7 +239,9 @@ class TestOptimization(TestCase):
             "estimated_global_stopping_savings": 98,
         }
 
-        self.assertEqual(asdict(record), expected_dict)
+        self.assertDictsAlmostEqual(
+            asdict(record), expected_dict, consider_nans_equal=True
+        )
 
     def test_optimization_completed_record_from_ax_client(self) -> None:
         ax_client = AxClient()
@@ -267,9 +269,11 @@ class TestOptimization(TestCase):
             "estimated_early_stopping_savings": 19,
             "estimated_global_stopping_savings": 98,
             # Extra fields
-            "improvement_over_baseline": float("-inf"),
+            "improvement_over_baseline": float("nan"),
             "num_metric_fetch_e_encountered": -1,
             "num_trials_bad_due_to_err": -1,
         }
 
-        self.assertEqual(asdict(record), expected_dict)
+        self.assertDictsAlmostEqual(
+            asdict(record), expected_dict, consider_nans_equal=True
+        )


### PR DESCRIPTION
Summary: This diff sets the default value for model fit metrics to NaN in Ax telemetry. This change is made in the `scheduler.py` and `optimization.py` files. The `telemetry/tests/test_scheduler.py` and `telemetry/tests/test_optimization.py` files are also updated to reflect this change. The `utils/testing/utils.py` file is also updated to include a new function `assert_dicts_are_almost_equal` which compares two dictionaries and checks if they are almost equal. This function is used in the `telemetry/tests/test_scheduler.py` and `telemetry/tests/test_optimization.py` files to compare the expected and actual dictionaries.

Differential Revision: D53047028


