### PR TITLE
removing RunIndefinitely criterion

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -704,18 +704,6 @@ class GenerationStep(GenerationNode, SortableBase):
                 )
             )
 
-        # For AEPsych usecases, leverage the `RunIndefinitely` criterion to set
-        # gen_unlimited_trials, if this criterion is not found, default to False.
-        if len(self.completion_criteria) > 0:
-            run_indefinitely_atrr = (
-                # Pyre-ignore [16]: Not all transition criterion have run_indefinetly
-                # attribute, and we don't want them to.
-                criterion.run_indefinitely
-                for criterion in self.completion_criteria
-                if criterion.criterion_class == "RunIndefinitely"
-            )
-            gen_unlimited_trials = next(run_indefinitely_atrr, False)
-
         transition_criteria += self.completion_criteria
         super().__init__(
             node_name=f"GenerationStep_{str(self.index)}",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/aepsych/pull/331

Removing RunIndefinitely as its usecase is covered by setting num_trials = -1.

Reviewed By: mgarrard

Differential Revision: D53132233

