### PR TITLE
Added missing space in error message

### DIFF
--- a/ax/core/formatting_utils.py
+++ b/ax/core/formatting_utils.py
@@ -53,7 +53,7 @@ def raw_data_to_evaluation(
                 if not isinstance(dat, (float, int)):
                     raise UserInputError(
                         "Raw data for an arm is expected to either be a tuple of "
-                        "numerical mean and SEM or just a numerical mean."
+                        "numerical mean and SEM or just a numerical mean. "
                         f"Got: {dat} for metric '{metric_name}'."
                     )
                 raw_data[metric_name] = (float(dat), None)


### PR DESCRIPTION
In the error message "Raw data for an arm is expected to either be a tuple of numerical mean and SEM or just a numerical mean.Got: None for metric 'result'." there was a missing space between "mean." and "Got". I've just added that single space.