### PR TITLE
Moving analysis code out of report_utils.py

### DIFF
--- a/ax/analysis/utils/analysis_suffix_utils.py
+++ b/ax/analysis/utils/analysis_suffix_utils.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import defaultdict
+
+from logging import Logger
+from typing import Dict, List
+
+from ax.utils.common.logger import get_logger
+
+
+logger: Logger = get_logger(__name__)
+
+
+def _get_suffix(input_str: str, delim: str = ".", n_chunks: int = 1) -> str:
+    return delim.join(input_str.split(delim)[-n_chunks:])
+
+
+def _get_shortest_unique_suffix_dict(
+    input_str_list: List[str], delim: str = "."
+) -> Dict[str, str]:
+    """Maps a list of strings to their shortest unique suffixes
+
+    Maps all original strings to the smallest number of chunks, as specified by
+    delim, that are not a suffix of any other original string. If the original
+    string was a suffix of another string, map it to its unaltered self.
+
+    Args:
+        input_str_list: a list of strings to create the suffix mapping for
+        delim: the delimiter used to split up the strings into meaningful chunks
+
+    Returns:
+        dict: A dict with the original strings as keys and their abbreviations as
+            values
+    """
+
+    # all input strings must be unique
+    assert len(input_str_list) == len(set(input_str_list))
+    if delim == "":
+        raise ValueError("delim must be a non-empty string.")
+    suffix_dict = defaultdict(list)
+    # initialize suffix_dict with last chunk
+    for istr in input_str_list:
+        suffix_dict[_get_suffix(istr, delim=delim, n_chunks=1)].append(istr)
+    max_chunks = max(len(istr.split(delim)) for istr in input_str_list)
+    if max_chunks == 1:
+        return {istr: istr for istr in input_str_list}
+    # the upper range of this loop is `max_chunks + 2` because:
+    #     - `i` needs to take the value of `max_chunks`, hence one +1
+    #     - the contents of the loop are run one more time to check if `all_unique`,
+    #           hence the other +1
+    for i in range(2, max_chunks + 2):
+        new_dict = defaultdict(list)
+        all_unique = True
+        for suffix, suffix_str_list in suffix_dict.items():
+            if len(suffix_str_list) > 1:
+                all_unique = False
+                for istr in suffix_str_list:
+                    new_dict[_get_suffix(istr, delim=delim, n_chunks=i)].append(istr)
+            else:
+                new_dict[suffix] = suffix_str_list
+        if all_unique:
+            if len(set(input_str_list)) != len(suffix_dict.keys()):
+                break
+            return {
+                suffix_str_list[0]: suffix
+                for suffix, suffix_str_list in suffix_dict.items()
+            }
+        suffix_dict = new_dict
+    # If this function has not yet exited, some input strings still share a suffix.
+    # This is not expected, but in this case, the function will return the identity
+    # mapping, i.e., a dict with the original strings as both keys and values.
+    logger.warning(
+        "Something went wrong. Returning dictionary with original strings as keys and "
+        "values."
+    )
+    return {istr: istr for istr in input_str_list}

--- a/ax/analysis/utils/analysis_utils.py
+++ b/ax/analysis/utils/analysis_utils.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from logging import Logger
+from typing import Any, Callable, Dict, List, Optional, Union
+
+import pandas as pd
+
+from ax.core.experiment import Experiment
+from ax.core.generator_run import GeneratorRunType
+
+from ax.core.map_data import MapData
+from ax.core.metric import Metric
+from ax.core.multi_type_experiment import MultiTypeExperiment
+from ax.core.trial import BaseTrial
+from ax.exceptions.core import DataRequiredError
+
+from ax.service.utils.best_point import _derel_opt_config_wrapper, _is_row_feasible
+from ax.utils.common.logger import get_logger
+from ax.utils.common.typeutils import not_none
+from pandas.core.frame import DataFrame
+
+logger: Logger = get_logger(__name__)
+
+FEASIBLE_COL_NAME = "is_feasible"
+
+
+def _get_generation_method_str(trial: BaseTrial) -> str:
+    trial_generation_property = trial._properties.get("generation_model_key")
+    if trial_generation_property is not None:
+        return trial_generation_property
+
+    generation_methods = {
+        not_none(generator_run._model_key)
+        for generator_run in trial.generator_runs
+        if generator_run._model_key is not None
+    }
+
+    # add "Manual" if any generator_runs are manual
+    if any(
+        generator_run.generator_run_type == GeneratorRunType.MANUAL.name
+        for generator_run in trial.generator_runs
+    ):
+        generation_methods.add("Manual")
+    return ", ".join(generation_methods) if generation_methods else "Unknown"
+
+
+def _merge_trials_dict_with_df(
+    df: pd.DataFrame,
+    # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
+    trials_dict: Dict[int, Any],
+    column_name: str,
+    always_include_field_column: bool = False,
+) -> None:
+    """Add a column ``column_name`` to a DataFrame ``df`` containing a column
+    ``trial_index``. Each value of the new column is given by the element of
+    ``trials_dict`` indexed by ``trial_index``.
+
+    Args:
+        df: Pandas DataFrame with column ``trial_index``, to be appended with a new
+            column.
+        trials_dict: Dict mapping each ``trial_index`` to a value. The new column of
+            df will be populated with the value corresponding with the
+            ``trial_index`` of each row.
+        column_name: Name of the column to be appended to ``df``.
+        always_include_field_column: Even if all trials have missing values,
+            include the column.
+    """
+
+    if "trial_index" not in df.columns:
+        raise ValueError("df must have trial_index column")
+
+    # field present for some trial
+    if always_include_field_column or any(trials_dict.values()):
+        if not all(
+            v is not None for v in trials_dict.values()
+        ):  # not present for all trials
+            logger.warning(
+                f"Column {column_name} missing for some trials. "
+                "Filling with None when missing."
+            )
+        df[column_name] = [trials_dict[trial_index] for trial_index in df.trial_index]
+    else:
+        logger.warning(
+            f"Column {column_name} missing for all trials. " "Not appending column."
+        )
+
+
+def _merge_results_if_no_duplicates(
+    arms_df: pd.DataFrame,
+    results: pd.DataFrame,
+    key_components: List[str],
+    metrics: List[Metric],
+) -> DataFrame:
+    """Formats ``data.df`` and merges it with ``arms_df`` if all of the following are
+    True:
+        - ``data.df`` is not empty
+        - ``data.df`` contains columns corresponding to ``key_components``
+        - after any formatting, ``data.df`` contains no duplicates of the column
+            ``results_key_col``
+    """
+    if len(results.index) == 0:
+        logger.info(
+            f"No results present for the specified metrics `{metrics}`. "
+            "Returning arm parameters and metadata only."
+        )
+        return arms_df
+    if not all(col in results.columns for col in key_components):
+        logger.warning(
+            f"At least one of key columns `{key_components}` not present in results df "
+            f"`{results}`. Returning arm parameters and metadata only."
+        )
+        return arms_df
+    # prepare results for merge by concattenating the trial index with the arm name
+    # sparated by a comma
+    key_vals = pd.Series(
+        results[key_components].values.astype("str").tolist()
+    ).str.join(",")
+
+    results_key_col = "-".join(key_components)
+
+    # Reindex so new column isn't set to NaN.
+    key_vals.index = results.index
+    results[results_key_col] = key_vals
+    # Don't return results if duplicates remain
+    if any(results.duplicated(subset=[results_key_col, "metric_name"])):
+        logger.warning(
+            "Experimental results dataframe contains multiple rows with the same "
+            f"keys {results_key_col}. Returning dataframe without results."
+        )
+        return arms_df
+    metric_vals = results.pivot(
+        index=results_key_col, columns="metric_name", values="mean"
+    ).reset_index()
+
+    # dedupe results by key_components
+    metadata_cols = key_components + [results_key_col]
+    if FEASIBLE_COL_NAME in results.columns:
+        metadata_cols.append(FEASIBLE_COL_NAME)
+    metadata = results[metadata_cols].drop_duplicates()
+    metrics_df = pd.merge(metric_vals, metadata, on=results_key_col)
+    # drop synthetic key column
+    metrics_df = metrics_df.drop(results_key_col, axis=1)
+    # merge and return
+    return pd.merge(metrics_df, arms_df, on=key_components, how="outer")
+
+
+def exp_to_df(
+    exp: Experiment,
+    metrics: Optional[List[Metric]] = None,
+    run_metadata_fields: Optional[List[str]] = None,
+    trial_properties_fields: Optional[List[str]] = None,
+    trial_attribute_fields: Optional[List[str]] = None,
+    additional_fields_callables: Optional[
+        Dict[str, Callable[[Experiment], Dict[int, Union[str, float]]]]
+    ] = None,
+    always_include_field_columns: bool = False,
+    **kwargs: Any,
+) -> pd.DataFrame:
+    """Transforms an experiment to a DataFrame with rows keyed by trial_index
+    and arm_name, metrics pivoted into one row. If the pivot results in more than
+    one row per arm (or one row per ``arm * map_keys`` combination if ``map_keys`` are
+    present), results are omitted and warning is produced. Only supports
+    ``Experiment``.
+
+    Transforms an ``Experiment`` into a ``pd.DataFrame``.
+
+    Args:
+        exp: An ``Experiment`` that may have pending trials.
+        metrics: Override list of metrics to return. Return all metrics if ``None``.
+        run_metadata_fields: Fields to extract from ``trial.run_metadata`` for trial
+            in ``experiment.trials``. If there are multiple arms per trial, these
+            fields will be replicated across the arms of a trial.
+        trial_properties_fields: Fields to extract from ``trial._properties`` for trial
+            in ``experiment.trials``. If there are multiple arms per trial, these
+            fields will be replicated across the arms of a trial. Output columns names
+            will be prepended with ``"trial_properties_"``.
+        trial_attribute_fields: Fields to extract from trial attributes for each trial
+            in ``experiment.trials``. If there are multiple arms per trial, these
+            fields will be replicated across the arms of a trial.
+        additional_fields_callables: A dictionary of field names to callables, with
+            each being a function from `experiment` to a `trials_dict` of the form
+            {trial_index: value}. An example of a custom callable like this is the
+            function `compute_maximum_map_values`.
+        always_include_field_columns: If `True`, even if all trials have missing
+            values, include field columns anyway. Such columns are by default
+            omitted (False).
+    Returns:
+        DataFrame: A dataframe of inputs, metadata and metrics by trial and arm (and
+        ``map_keys``, if present). If no trials are available, returns an empty
+        dataframe. If no metric ouputs are available, returns a dataframe of inputs and
+        metadata. Columns include:
+            * trial_index
+            * arm_name
+            * trial_status
+            * generation_method
+            * any elements of exp.runner.run_metadata_report_keys that are present in
+              the trial.run_metadata of each trial
+            * one column per metric (named after the metric.name)
+            * one column per parameter (named after the parameter.name)
+    """
+
+    if len(kwargs) > 0:
+        logger.warning(
+            "`kwargs` in exp_to_df is deprecated. Please remove extra arguments."
+        )
+
+    # Accept Experiment and SimpleExperiment
+    if isinstance(exp, MultiTypeExperiment):
+        raise ValueError("Cannot transform MultiTypeExperiments to DataFrames.")
+
+    key_components = ["trial_index", "arm_name"]
+
+    # Get each trial-arm with parameters
+    arms_df = pd.DataFrame(
+        [
+            {
+                "arm_name": arm.name,
+                "trial_index": trial_index,
+                **arm.parameters,
+            }
+            for trial_index, trial in exp.trials.items()
+            for arm in trial.arms
+        ]
+    )
+    # Fetch results.
+    data = exp.lookup_data()
+    results = data.df
+
+    # Filter metrics.
+    if metrics is not None:
+        metric_names = [m.name for m in metrics]
+        results = results[results["metric_name"].isin(metric_names)]
+
+    # Add `FEASIBLE_COL_NAME` column according to constraints if any.
+    if (
+        exp.optimization_config is not None
+        and len(not_none(exp.optimization_config).all_constraints) > 0
+    ):
+        optimization_config = not_none(exp.optimization_config)
+        try:
+            if any(oc.relative for oc in optimization_config.all_constraints):
+                optimization_config = _derel_opt_config_wrapper(
+                    optimization_config=optimization_config,
+                    experiment=exp,
+                )
+            results[FEASIBLE_COL_NAME] = _is_row_feasible(
+                df=results,
+                optimization_config=optimization_config,
+            )
+        except (KeyError, ValueError, DataRequiredError) as e:
+            logger.warning(f"Feasibility calculation failed with error: {e}")
+
+    # If arms_df is empty, return empty results (legacy behavior)
+    if len(arms_df.index) == 0:
+        if len(results.index) != 0:
+            raise ValueError(
+                "exp.lookup_data().df returned more rows than there are experimental "
+                "arms. This is an inconsistent experimental state. Please report to "
+                "Ax support."
+            )
+        return results
+
+    # Create key column from key_components
+    arms_df["trial_index"] = arms_df["trial_index"].astype(int)
+
+    # Add trial status
+    trials = exp.trials.items()
+    trial_to_status = {index: trial.status.name for index, trial in trials}
+    _merge_trials_dict_with_df(
+        df=arms_df, trials_dict=trial_to_status, column_name="trial_status"
+    )
+
+    # Add trial reason for failed or abandoned trials
+    trial_to_reason = {
+        index: (
+            f"{trial.failed_reason[:15]}..."
+            if trial.status.is_failed and trial.failed_reason is not None
+            else f"{trial.abandoned_reason[:15]}..."
+            if trial.status.is_abandoned and trial.abandoned_reason is not None
+            else None
+        )
+        for index, trial in trials
+    }
+
+    _merge_trials_dict_with_df(
+        df=arms_df,
+        trials_dict=trial_to_reason,
+        column_name="reason",
+    )
+
+    # Add generation_method, accounting for the generic case that generator_runs is of
+    # arbitrary length. Repeated methods within a trial are condensed via `set` and an
+    # empty set will yield "Unknown" as the method.
+    trial_to_generation_method = {
+        trial_index: _get_generation_method_str(trial) for trial_index, trial in trials
+    }
+
+    _merge_trials_dict_with_df(
+        df=arms_df,
+        trials_dict=trial_to_generation_method,
+        column_name="generation_method",
+    )
+
+    # Add any trial properties fields to arms_df
+    if trial_properties_fields is not None:
+        # add trial._properties fields
+        for field in trial_properties_fields:
+            trial_to_properties_field = {
+                trial_index: (
+                    trial._properties[field] if field in trial._properties else None
+                )
+                for trial_index, trial in trials
+            }
+            _merge_trials_dict_with_df(
+                df=arms_df,
+                trials_dict=trial_to_properties_field,
+                column_name="trial_properties_" + field,
+                always_include_field_column=always_include_field_columns,
+            )
+
+    # Add any run_metadata fields to arms_df
+    if run_metadata_fields is not None:
+        # add run_metadata fields
+        for field in run_metadata_fields:
+            trial_to_metadata_field = {
+                trial_index: (
+                    trial.run_metadata[field] if field in trial.run_metadata else None
+                )
+                for trial_index, trial in trials
+            }
+            _merge_trials_dict_with_df(
+                df=arms_df,
+                trials_dict=trial_to_metadata_field,
+                column_name=field,
+                always_include_field_column=always_include_field_columns,
+            )
+
+    # Add any trial attributes fields to arms_df
+    if trial_attribute_fields is not None:
+        # add trial attribute fields
+        for field in trial_attribute_fields:
+            trial_to_attribute_field = {
+                trial_index: (getattr(trial, field) if hasattr(trial, field) else None)
+                for trial_index, trial in trials
+            }
+            _merge_trials_dict_with_df(
+                df=arms_df,
+                trials_dict=trial_to_attribute_field,
+                column_name=field,
+                always_include_field_column=always_include_field_columns,
+            )
+
+    # Add additional fields to arms_df
+    if additional_fields_callables is not None:
+        for field, func in additional_fields_callables.items():
+            trial_to_additional_field = func(exp)
+            _merge_trials_dict_with_df(
+                df=arms_df,
+                trials_dict=trial_to_additional_field,
+                column_name=field,
+                always_include_field_column=always_include_field_columns,
+            )
+
+    exp_df = _merge_results_if_no_duplicates(
+        arms_df=arms_df,
+        results=results,
+        key_components=key_components,
+        metrics=metrics or list(exp.metrics.values()),
+    )
+
+    exp_df = not_none(not_none(exp_df).sort_values(["trial_index"]))
+    initial_column_order = (
+        ["trial_index", "arm_name", "trial_status", "reason", "generation_method"]
+        + (run_metadata_fields or [])
+        + (trial_properties_fields or [])
+        + ([FEASIBLE_COL_NAME] if FEASIBLE_COL_NAME in exp_df.columns else [])
+    )
+    for column_name in reversed(initial_column_order):
+        if column_name in exp_df.columns:
+            # pyre-ignore[6]: In call `DataFrame.insert`, for 3rd positional argument,
+            # expected `Union[int, Series, Variable[ArrayLike <: [ExtensionArray,
+            # ndarray]]]` but got `Union[DataFrame, Series]`]
+            exp_df.insert(0, column_name, exp_df.pop(column_name))
+    return exp_df.reset_index(drop=True)
+
+
+def compute_maximum_map_values(
+    experiment: Experiment, map_key: Optional[str] = None
+) -> Dict[int, float]:
+    """A function that returns a map from trial_index to the maximum map value
+    reached. If map_key is not specified, it uses the first map_key."""
+    data = experiment.lookup_data()
+    if not isinstance(data, MapData):
+        raise ValueError("`compute_maximum_map_values` requires `MapData`.")
+    if map_key is None:
+        map_key = data.map_keys[0]
+    map_df = data.map_df
+    maximum_map_value_df = (
+        map_df[["trial_index"] + data.map_keys]
+        .groupby("trial_index")
+        .max()
+        .reset_index()
+    )
+    trials_dict = {}
+    for trial_index in experiment.trials:
+        value = None
+        if trial_index in maximum_map_value_df["trial_index"].values:
+            value = maximum_map_value_df[
+                maximum_map_value_df["trial_index"] == trial_index
+            ][map_key].iloc[0]
+        trials_dict[trial_index] = value
+    return trials_dict

--- a/ax/analysis/utils/tests/test_analysis_suffix_utils.py
+++ b/ax/analysis/utils/tests/test_analysis_suffix_utils.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ax.analysis.utils.analysis_suffix_utils import _get_shortest_unique_suffix_dict
+
+from ax.utils.common.testutils import TestCase
+
+
+class AnalysisSuffixUtilsTest(TestCase):
+    def test_get_shortest_unique_suffix_dict(self) -> None:
+        expected_output = {
+            "abc.123": "abc.123",
+            "asdf.abc.123": "asdf.abc.123",
+            "def.123": "def.123",
+            "abc.456": "456",
+            "": "",
+            "no_delimiter": "no_delimiter",
+        }
+        actual_output = _get_shortest_unique_suffix_dict(
+            ["abc.123", "abc.456", "def.123", "asdf.abc.123", "", "no_delimiter"]
+        )
+        self.assertDictEqual(expected_output, actual_output)

--- a/ax/analysis/utils/tests/test_analysis_utils.py
+++ b/ax/analysis/utils/tests/test_analysis_utils.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from collections import namedtuple
+from logging import WARN
+from typing import Dict, List
+
+from unittest.mock import patch
+
+import pandas as pd
+
+from ax.analysis.utils.analysis_utils import (
+    compute_maximum_map_values,
+    exp_to_df,
+    Experiment,
+    FEASIBLE_COL_NAME,
+)
+from ax.core.arm import Arm
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import (
+    get_branin_experiment,
+    get_experiment_with_observations,
+    get_multi_type_experiment,
+    get_test_map_data_experiment,
+)
+
+OBJECTIVE_NAME = "branin"
+PARAMETER_COLUMNS = ["x1", "x2"]
+FLOAT_COLUMNS: List[str] = [OBJECTIVE_NAME] + PARAMETER_COLUMNS
+EXPECTED_COLUMNS: List[str] = [
+    "trial_index",
+    "arm_name",
+    "trial_status",
+    "generation_method",
+] + FLOAT_COLUMNS
+DUMMY_OBJECTIVE_MEAN = 1.2345
+DUMMY_SOURCE = "test_source"
+
+
+DUMMY_MSG = "test_message"
+
+ANALYSIS_UTIL_PATH = "ax.analysis.utils.analysis_utils"
+
+
+class AnalysisUtilsTest(TestCase):
+    @patch(
+        f"{ANALYSIS_UTIL_PATH}._merge_results_if_no_duplicates",
+        autospec=True,
+        return_value=pd.DataFrame(
+            [
+                # Trial indexes are out-of-order.
+                {"arm_name": "a", "trial_index": 1},
+                {"arm_name": "b", "trial_index": 2},
+                {"arm_name": "c", "trial_index": 0},
+            ]
+        ),
+    )
+    def test_exp_to_df_row_ordering(self, _) -> None:
+        """
+        This test verifies that the returned data frame indexes are
+        in the same order as trial index. It mocks _merge_results_if_no_duplicates
+        to verify just the ordering of items in the final data frame.
+        """
+        exp = get_branin_experiment(with_trial=True)
+        df = exp_to_df(exp)
+        # Check that all 3 rows are in order
+        self.assertEqual(len(df), 3)
+        for idx, row in df.iterrows():
+            self.assertEqual(row["trial_index"], idx)
+
+    @patch(
+        f"{ANALYSIS_UTIL_PATH}._merge_results_if_no_duplicates",
+        autospec=True,
+        return_value=pd.DataFrame(
+            [
+                # Trial indexes are out-of-order.
+                {
+                    "col1": 1,
+                    "arm_name": "a",
+                    "trial_status": "FAILED",
+                    "generation_method": "Manual",
+                    "trial_index": 1,
+                },
+                {
+                    "col1": 2,
+                    "arm_name": "b",
+                    "trial_status": "COMPLETED",
+                    "generation_method": "BO",
+                    "trial_index": 2,
+                },
+                {
+                    "col1": 3,
+                    "arm_name": "c",
+                    "trial_status": "COMPLETED",
+                    "generation_method": "Manual",
+                    "trial_index": 0,
+                },
+            ]
+        ),
+    )
+    def test_exp_to_df_col_ordering(self, _) -> None:
+        """
+        This test verifies that the returned data frame indexes are
+        in the same order as trial index. It mocks _merge_results_if_no_duplicates
+        to verify just the ordering of items in the final data frame.
+        """
+        exp = get_branin_experiment(with_trial=True)
+        df = exp_to_df(exp)
+        self.assertListEqual(
+            list(df.columns),
+            ["trial_index", "arm_name", "trial_status", "generation_method", "col1"],
+        )
+
+    def test_exp_to_df_max_map_value(self) -> None:
+        exp = get_test_map_data_experiment(num_trials=3, num_fetches=5, num_complete=0)
+
+        def compute_maximum_map_values_timestamp(
+            experiment: Experiment,
+        ) -> Dict[int, float]:
+            return compute_maximum_map_values(
+                experiment=experiment, map_key="timestamp"
+            )
+
+        df = exp_to_df(
+            exp=exp,
+            additional_fields_callables={  # pyre-ignore
+                "timestamp": compute_maximum_map_values_timestamp
+            },
+        )
+        self.assertEqual(df["timestamp"].tolist(), [5.0, 5.0, 5.0])
+
+    def test_exp_to_df_trial_timing(self) -> None:
+        # 1. test all have started, none have completed
+        exp = get_test_map_data_experiment(num_trials=3, num_fetches=5, num_complete=0)
+        df = exp_to_df(
+            exp=exp,
+            trial_attribute_fields=["time_run_started", "time_completed"],
+            always_include_field_columns=True,
+        )
+        self.assertTrue("time_run_started" in list(df.columns))
+        self.assertTrue("time_completed" in list(df.columns))
+        # since all trials started, all should have values
+        self.assertFalse(any(df["time_run_started"].isnull()))
+        # since no trials are complete, all should be None
+        self.assertTrue(all(df["time_completed"].isnull()))
+
+        # 2. test some trials not started yet
+        exp.trials[0]._time_run_started = None
+        df = exp_to_df(
+            exp=exp, trial_attribute_fields=["time_run_started", "time_completed"]
+        )
+        # the first trial should have NaN for rel_time_run_started
+        self.assertTrue(df["time_run_started"].isnull().iloc[0])
+
+        # 3. test all trials not started yet
+        for t in exp.trials.values():
+            t._time_run_started = None
+        df = exp_to_df(
+            exp=exp,
+            trial_attribute_fields=["time_run_started", "time_completed"],
+            always_include_field_columns=True,
+        )
+        self.assertTrue(all(df["time_run_started"].isnull()))
+
+        # 4. test some trials are completed
+        exp = get_test_map_data_experiment(num_trials=3, num_fetches=5, num_complete=2)
+        df = exp_to_df(
+            exp=exp, trial_attribute_fields=["time_run_started", "time_completed"]
+        )
+        # the last trial should have NaN for rel_time_completed
+        self.assertTrue(df["time_completed"].isnull().iloc[2])
+
+    def test_exp_to_df_with_failure(self) -> None:
+        fail_reason = "test reason"
+
+        # Set up experiment with a failed trial
+        exp = get_branin_experiment(with_trial=True)
+        exp.trials[0].run()
+        exp.trials[0].mark_failed(reason=fail_reason)
+
+        df = exp_to_df(exp)
+        self.assertEqual(
+            set(EXPECTED_COLUMNS + ["reason"]) - set(df.columns), {OBJECTIVE_NAME}
+        )
+        self.assertEqual(f"{fail_reason}...", df["reason"].iloc[0])
+
+    def test_exp_to_df(self) -> None:
+        # MultiTypeExperiment should fail
+        exp = get_multi_type_experiment()
+        with self.assertRaisesRegex(ValueError, "MultiTypeExperiment"):
+            exp_to_df(exp=exp)
+
+        # exp with no trials should return empty results
+        exp = get_branin_experiment()
+        df = exp_to_df(exp=exp)
+        self.assertEqual(len(df), 0)
+
+        # set up experiment
+        exp = get_branin_experiment(with_batch=True)
+
+        # check that pre-run experiment returns all columns except objective
+        df = exp_to_df(exp)
+        self.assertEqual(set(EXPECTED_COLUMNS) - set(df.columns), {OBJECTIVE_NAME})
+        self.assertEqual(len(df.index), len(exp.arms_by_name))
+
+        exp.trials[0].run()
+        exp.fetch_data()
+
+        # assert result is df with expected columns and length
+        df = exp_to_df(exp=exp)
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertListEqual(sorted(df.columns), sorted(EXPECTED_COLUMNS))
+        self.assertEqual(len(df.index), len(exp.arms_by_name))
+
+        # test with run_metadata_fields and trial_properties_fields not empty
+        # add source to properties
+        for _, trial in exp.trials.items():
+            trial._properties["source"] = DUMMY_SOURCE
+        df = exp_to_df(
+            exp, run_metadata_fields=["name"], trial_properties_fields=["source"]
+        )
+        self.assertIn("name", df.columns)
+        self.assertIn("trial_properties_source", df.columns)
+
+        # test column values or types
+        self.assertTrue(all(x == 0 for x in df.trial_index))
+        self.assertTrue(all(x == "RUNNING" for x in df.trial_status))
+        self.assertTrue(all(x == "Sobol" for x in df.generation_method))
+        self.assertTrue(all(x == DUMMY_SOURCE for x in df.trial_properties_source))
+        self.assertTrue(all(x == "branin_test_experiment_0" for x in df.name))
+        for float_column in FLOAT_COLUMNS:
+            self.assertTrue(all(isinstance(x, float) for x in df[float_column]))
+
+        # works correctly for failed trials (will need to mock)
+        dummy_struct = namedtuple("dummy_struct", "df")
+        mock_results = dummy_struct(
+            df=pd.DataFrame(
+                {
+                    "arm_name": ["0_0", "1_0"],
+                    "metric_name": [OBJECTIVE_NAME] * 2,
+                    "mean": [DUMMY_OBJECTIVE_MEAN] * 2,
+                    "sem": [0] * 2,
+                    "trial_index": [0, 1],
+                    "n": [123] * 2,
+                    "frac_nonnull": [1] * 2,
+                }
+            )
+        )
+        mock_results.df.index = range(len(exp.trials) * 2, len(exp.trials) * 2 + 2)
+        with patch.object(Experiment, "lookup_data", lambda self: mock_results):
+            df = exp_to_df(exp=exp)
+        # all but two rows should have a metric value of NaN
+        self.assertEqual(pd.isna(df[OBJECTIVE_NAME]).sum(), len(df.index) - 2)
+
+        # an experiment with more results than arms raises an error
+        with patch.object(
+            Experiment, "lookup_data", lambda self: mock_results
+        ), self.assertRaisesRegex(ValueError, "inconsistent experimental state"):
+            exp_to_df(exp=get_branin_experiment())
+
+        # custom added trial has a generation_method of Manual
+        custom_arm = Arm(name="custom", parameters={"x1": 0, "x2": 0})
+        exp.new_trial().add_arm(custom_arm)
+        df = exp_to_df(exp)
+        self.assertEqual(
+            df[df.arm_name == "custom"].iloc[0].generation_method, "Manual"
+        )
+        # failing feasibility calculation doesn't warns and suppresses error
+        observations = [[1.0, 2.0, 3.0], [4.0, 5.0, -6.0], [7.0, 8.0, 9.0]]
+        exp = get_experiment_with_observations(
+            observations=observations,
+            constrained=True,
+        )
+        with patch(
+            f"{exp_to_df.__module__}._is_row_feasible", side_effect=KeyError(DUMMY_MSG)
+        ), self.assertLogs(logger="ax", level=WARN) as log:
+            exp_to_df(exp)
+            self.assertIn(
+                f"Feasibility calculation failed with error: '{DUMMY_MSG}'",
+                log.output[0],
+            )
+
+        # infeasible arm has `is_feasible = False`.
+        df = exp_to_df(exp)
+        self.assertListEqual(list(df[FEASIBLE_COL_NAME]), [True, False, True])
+
+        # all rows infeasible.
+        observations = [[1.0, 2.0, -3.0], [4.0, 5.0, -6.0], [7.0, 8.0, -9.0]]
+        exp = get_experiment_with_observations(
+            observations=observations,
+            constrained=True,
+        )
+        df = exp_to_df(exp)
+        self.assertListEqual(list(df[FEASIBLE_COL_NAME]), [False, False, False])

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -6,9 +6,7 @@
 
 import copy
 import itertools
-from collections import namedtuple
 from logging import INFO, WARN
-from typing import Dict, List
 from unittest import mock
 from unittest.mock import patch
 
@@ -33,14 +31,10 @@ from ax.service.utils.report_utils import (
     _get_metric_name_pairs,
     _get_objective_trace_plot,
     _get_objective_v_param_plots,
-    _get_shortest_unique_suffix_dict,
     _objective_vs_true_objective_scatter,
     BASELINE_ARM_NAME,
     compare_to_baseline,
-    compute_maximum_map_values,
-    exp_to_df,
     Experiment,
-    FEASIBLE_COL_NAME,
     get_standard_plots,
     plot_feature_importance_by_feature_plotly,
     select_baseline_arm,
@@ -54,297 +48,14 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment_with_multi_objective,
     get_branin_experiment_with_timestamp_map_metric,
     get_branin_search_space,
-    get_experiment_with_observations,
     get_high_dimensional_branin_experiment,
-    get_multi_type_experiment,
-    get_test_map_data_experiment,
 )
 from ax.utils.testing.mock import fast_botorch_optimize
 from ax.utils.testing.modeling_stubs import get_generation_strategy
 from plotly import graph_objects as go
 
-OBJECTIVE_NAME = "branin"
-PARAMETER_COLUMNS = ["x1", "x2"]
-FLOAT_COLUMNS: List[str] = [OBJECTIVE_NAME] + PARAMETER_COLUMNS
-EXPECTED_COLUMNS: List[str] = [
-    "trial_index",
-    "arm_name",
-    "trial_status",
-    "generation_method",
-] + FLOAT_COLUMNS
-DUMMY_OBJECTIVE_MEAN = 1.2345
-DUMMY_SOURCE = "test_source"
-DUMMY_MAP_KEY = "test_map_key"
-TRUE_OBJECTIVE_NAME = "other_metric"
-TRUE_OBJECTIVE_MEAN = 2.3456
-DUMMY_MSG = "test_message"
-
 
 class ReportUtilsTest(TestCase):
-    @patch(
-        "ax.service.utils.report_utils._merge_results_if_no_duplicates",
-        autospec=True,
-        return_value=pd.DataFrame(
-            [
-                # Trial indexes are out-of-order.
-                {"arm_name": "a", "trial_index": 1},
-                {"arm_name": "b", "trial_index": 2},
-                {"arm_name": "c", "trial_index": 0},
-            ]
-        ),
-    )
-    def test_exp_to_df_row_ordering(self, _) -> None:
-        """
-        This test verifies that the returned data frame indexes are
-        in the same order as trial index. It mocks _merge_results_if_no_duplicates
-        to verify just the ordering of items in the final data frame.
-        """
-        exp = get_branin_experiment(with_trial=True)
-        df = exp_to_df(exp)
-        # Check that all 3 rows are in order
-        self.assertEqual(len(df), 3)
-        for idx, row in df.iterrows():
-            self.assertEqual(row["trial_index"], idx)
-
-    @patch(
-        "ax.service.utils.report_utils._merge_results_if_no_duplicates",
-        autospec=True,
-        return_value=pd.DataFrame(
-            [
-                # Trial indexes are out-of-order.
-                {
-                    "col1": 1,
-                    "arm_name": "a",
-                    "trial_status": "FAILED",
-                    "generation_method": "Manual",
-                    "trial_index": 1,
-                },
-                {
-                    "col1": 2,
-                    "arm_name": "b",
-                    "trial_status": "COMPLETED",
-                    "generation_method": "BO",
-                    "trial_index": 2,
-                },
-                {
-                    "col1": 3,
-                    "arm_name": "c",
-                    "trial_status": "COMPLETED",
-                    "generation_method": "Manual",
-                    "trial_index": 0,
-                },
-            ]
-        ),
-    )
-    def test_exp_to_df_col_ordering(self, _) -> None:
-        """
-        This test verifies that the returned data frame indexes are
-        in the same order as trial index. It mocks _merge_results_if_no_duplicates
-        to verify just the ordering of items in the final data frame.
-        """
-        exp = get_branin_experiment(with_trial=True)
-        df = exp_to_df(exp)
-        self.assertListEqual(
-            list(df.columns),
-            ["trial_index", "arm_name", "trial_status", "generation_method", "col1"],
-        )
-
-    def test_exp_to_df_max_map_value(self) -> None:
-        exp = get_test_map_data_experiment(num_trials=3, num_fetches=5, num_complete=0)
-
-        def compute_maximum_map_values_timestamp(
-            experiment: Experiment,
-        ) -> Dict[int, float]:
-            return compute_maximum_map_values(
-                experiment=experiment, map_key="timestamp"
-            )
-
-        df = exp_to_df(
-            exp=exp,
-            additional_fields_callables={  # pyre-ignore
-                "timestamp": compute_maximum_map_values_timestamp
-            },
-        )
-        self.assertEqual(df["timestamp"].tolist(), [5.0, 5.0, 5.0])
-
-    def test_exp_to_df_trial_timing(self) -> None:
-        # 1. test all have started, none have completed
-        exp = get_test_map_data_experiment(num_trials=3, num_fetches=5, num_complete=0)
-        df = exp_to_df(
-            exp=exp,
-            trial_attribute_fields=["time_run_started", "time_completed"],
-            always_include_field_columns=True,
-        )
-        self.assertTrue("time_run_started" in list(df.columns))
-        self.assertTrue("time_completed" in list(df.columns))
-        # since all trials started, all should have values
-        self.assertFalse(any(df["time_run_started"].isnull()))
-        # since no trials are complete, all should be None
-        self.assertTrue(all(df["time_completed"].isnull()))
-
-        # 2. test some trials not started yet
-        exp.trials[0]._time_run_started = None
-        df = exp_to_df(
-            exp=exp, trial_attribute_fields=["time_run_started", "time_completed"]
-        )
-        # the first trial should have NaN for rel_time_run_started
-        self.assertTrue(df["time_run_started"].isnull().iloc[0])
-
-        # 3. test all trials not started yet
-        for t in exp.trials.values():
-            t._time_run_started = None
-        df = exp_to_df(
-            exp=exp,
-            trial_attribute_fields=["time_run_started", "time_completed"],
-            always_include_field_columns=True,
-        )
-        self.assertTrue(all(df["time_run_started"].isnull()))
-
-        # 4. test some trials are completed
-        exp = get_test_map_data_experiment(num_trials=3, num_fetches=5, num_complete=2)
-        df = exp_to_df(
-            exp=exp, trial_attribute_fields=["time_run_started", "time_completed"]
-        )
-        # the last trial should have NaN for rel_time_completed
-        self.assertTrue(df["time_completed"].isnull().iloc[2])
-
-    def test_exp_to_df_with_failure(self) -> None:
-        fail_reason = "test reason"
-
-        # Set up experiment with a failed trial
-        exp = get_branin_experiment(with_trial=True)
-        exp.trials[0].run()
-        exp.trials[0].mark_failed(reason=fail_reason)
-
-        df = exp_to_df(exp)
-        self.assertEqual(
-            set(EXPECTED_COLUMNS + ["reason"]) - set(df.columns), {OBJECTIVE_NAME}
-        )
-        self.assertEqual(f"{fail_reason}...", df["reason"].iloc[0])
-
-    def test_exp_to_df(self) -> None:
-        # MultiTypeExperiment should fail
-        exp = get_multi_type_experiment()
-        with self.assertRaisesRegex(ValueError, "MultiTypeExperiment"):
-            exp_to_df(exp=exp)
-
-        # exp with no trials should return empty results
-        exp = get_branin_experiment()
-        df = exp_to_df(exp=exp)
-        self.assertEqual(len(df), 0)
-
-        # set up experiment
-        exp = get_branin_experiment(with_batch=True)
-
-        # check that pre-run experiment returns all columns except objective
-        df = exp_to_df(exp)
-        self.assertEqual(set(EXPECTED_COLUMNS) - set(df.columns), {OBJECTIVE_NAME})
-        self.assertEqual(len(df.index), len(exp.arms_by_name))
-
-        exp.trials[0].run()
-        exp.fetch_data()
-
-        # assert result is df with expected columns and length
-        df = exp_to_df(exp=exp)
-        self.assertIsInstance(df, pd.DataFrame)
-        self.assertListEqual(sorted(df.columns), sorted(EXPECTED_COLUMNS))
-        self.assertEqual(len(df.index), len(exp.arms_by_name))
-
-        # test with run_metadata_fields and trial_properties_fields not empty
-        # add source to properties
-        for _, trial in exp.trials.items():
-            trial._properties["source"] = DUMMY_SOURCE
-        df = exp_to_df(
-            exp, run_metadata_fields=["name"], trial_properties_fields=["source"]
-        )
-        self.assertIn("name", df.columns)
-        self.assertIn("trial_properties_source", df.columns)
-
-        # test column values or types
-        self.assertTrue(all(x == 0 for x in df.trial_index))
-        self.assertTrue(all(x == "RUNNING" for x in df.trial_status))
-        self.assertTrue(all(x == "Sobol" for x in df.generation_method))
-        self.assertTrue(all(x == DUMMY_SOURCE for x in df.trial_properties_source))
-        self.assertTrue(all(x == "branin_test_experiment_0" for x in df.name))
-        for float_column in FLOAT_COLUMNS:
-            self.assertTrue(all(isinstance(x, float) for x in df[float_column]))
-
-        # works correctly for failed trials (will need to mock)
-        dummy_struct = namedtuple("dummy_struct", "df")
-        mock_results = dummy_struct(
-            df=pd.DataFrame(
-                {
-                    "arm_name": ["0_0", "1_0"],
-                    "metric_name": [OBJECTIVE_NAME] * 2,
-                    "mean": [DUMMY_OBJECTIVE_MEAN] * 2,
-                    "sem": [0] * 2,
-                    "trial_index": [0, 1],
-                    "n": [123] * 2,
-                    "frac_nonnull": [1] * 2,
-                }
-            )
-        )
-        mock_results.df.index = range(len(exp.trials) * 2, len(exp.trials) * 2 + 2)
-        with patch.object(Experiment, "lookup_data", lambda self: mock_results):
-            df = exp_to_df(exp=exp)
-        # all but two rows should have a metric value of NaN
-        self.assertEqual(pd.isna(df[OBJECTIVE_NAME]).sum(), len(df.index) - 2)
-
-        # an experiment with more results than arms raises an error
-        with patch.object(
-            Experiment, "lookup_data", lambda self: mock_results
-        ), self.assertRaisesRegex(ValueError, "inconsistent experimental state"):
-            exp_to_df(exp=get_branin_experiment())
-
-        # custom added trial has a generation_method of Manual
-        custom_arm = Arm(name="custom", parameters={"x1": 0, "x2": 0})
-        exp.new_trial().add_arm(custom_arm)
-        df = exp_to_df(exp)
-        self.assertEqual(
-            df[df.arm_name == "custom"].iloc[0].generation_method, "Manual"
-        )
-        # failing feasibility calculation doesn't warns and suppresses error
-        observations = [[1.0, 2.0, 3.0], [4.0, 5.0, -6.0], [7.0, 8.0, 9.0]]
-        exp = get_experiment_with_observations(
-            observations=observations,
-            constrained=True,
-        )
-        with patch(
-            f"{exp_to_df.__module__}._is_row_feasible", side_effect=KeyError(DUMMY_MSG)
-        ), self.assertLogs(logger="ax", level=WARN) as log:
-            exp_to_df(exp)
-            self.assertIn(
-                f"Feasibility calculation failed with error: '{DUMMY_MSG}'",
-                log.output[0],
-            )
-
-        # infeasible arm has `is_feasible = False`.
-        df = exp_to_df(exp)
-        self.assertListEqual(list(df[FEASIBLE_COL_NAME]), [True, False, True])
-
-        # all rows infeasible.
-        observations = [[1.0, 2.0, -3.0], [4.0, 5.0, -6.0], [7.0, 8.0, -9.0]]
-        exp = get_experiment_with_observations(
-            observations=observations,
-            constrained=True,
-        )
-        df = exp_to_df(exp)
-        self.assertListEqual(list(df[FEASIBLE_COL_NAME]), [False, False, False])
-
-    def test_get_shortest_unique_suffix_dict(self) -> None:
-        expected_output = {
-            "abc.123": "abc.123",
-            "asdf.abc.123": "asdf.abc.123",
-            "def.123": "def.123",
-            "abc.456": "456",
-            "": "",
-            "no_delimiter": "no_delimiter",
-        }
-        actual_output = _get_shortest_unique_suffix_dict(
-            ["abc.123", "abc.456", "def.123", "asdf.abc.123", "", "no_delimiter"]
-        )
-        self.assertDictEqual(expected_output, actual_output)
-
     @fast_botorch_optimize
     def test_get_standard_plots(self) -> None:
         exp = get_branin_experiment()

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -6,40 +6,30 @@
 
 import itertools
 import logging
-from collections import defaultdict
+
 from datetime import timedelta
 from logging import Logger
-from typing import (
-    Any,
-    Callable,
-    cast,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import Callable, cast, Iterable, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import gpytorch
 
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
+from ax.analysis.utils.analysis_suffix_utils import _get_shortest_unique_suffix_dict
+from ax.analysis.utils.analysis_utils import compute_maximum_map_values, exp_to_df
 from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
 from ax.core.experiment import Experiment
-from ax.core.generator_run import GeneratorRunType
+
 from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
-from ax.core.metric import Metric
-from ax.core.multi_type_experiment import MultiTypeExperiment
+
 from ax.core.objective import MultiObjective, ScalarizedObjective
 from ax.core.optimization_config import OptimizationConfig
-from ax.core.trial import BaseTrial
+
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
-from ax.exceptions.core import DataRequiredError, UserInputError
+from ax.exceptions.core import UserInputError
 from ax.modelbridge import ModelBridge
 from ax.modelbridge.cross_validation import (
     compute_model_fit_metrics_from_modelbridge,
@@ -65,16 +55,18 @@ from ax.plot.trace import (
     map_data_multiple_metrics_dropdown_plotly,
     plot_objective_value_vs_trial_index,
 )
-from ax.service.utils.best_point import _derel_opt_config_wrapper, _is_row_feasible
 from ax.service.utils.early_stopping import get_early_stopping_metrics
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.sensitivity.sobol_measures import ax_parameter_sens
-from pandas.core.frame import DataFrame
 
 if TYPE_CHECKING:
     from ax.service.scheduler import Scheduler
 
+# LEGACY: manually export _get_shortest_unique_suffix_dict and exp_to_df
+_get_shortest_unique_suffix_dict = _get_shortest_unique_suffix_dict
+exp_to_df = exp_to_df
+compute_maximum_map_values = compute_maximum_map_values
 
 logger: Logger = get_logger(__name__)
 FEATURE_IMPORTANCE_CAPTION = (
@@ -217,71 +209,6 @@ def _get_objective_v_param_plots(
         warning_plot = _warn_and_create_warning_plot(warning_msg=warning_msg)
         output_plots.append(warning_plot)
     return output_plots
-
-
-def _get_suffix(input_str: str, delim: str = ".", n_chunks: int = 1) -> str:
-    return delim.join(input_str.split(delim)[-n_chunks:])
-
-
-def _get_shortest_unique_suffix_dict(
-    input_str_list: List[str], delim: str = "."
-) -> Dict[str, str]:
-    """Maps a list of strings to their shortest unique suffixes
-
-    Maps all original strings to the smallest number of chunks, as specified by
-    delim, that are not a suffix of any other original string. If the original
-    string was a suffix of another string, map it to its unaltered self.
-
-    Args:
-        input_str_list: a list of strings to create the suffix mapping for
-        delim: the delimiter used to split up the strings into meaningful chunks
-
-    Returns:
-        dict: A dict with the original strings as keys and their abbreviations as
-            values
-    """
-
-    # all input strings must be unique
-    assert len(input_str_list) == len(set(input_str_list))
-    if delim == "":
-        raise ValueError("delim must be a non-empty string.")
-    suffix_dict = defaultdict(list)
-    # initialize suffix_dict with last chunk
-    for istr in input_str_list:
-        suffix_dict[_get_suffix(istr, delim=delim, n_chunks=1)].append(istr)
-    max_chunks = max(len(istr.split(delim)) for istr in input_str_list)
-    if max_chunks == 1:
-        return {istr: istr for istr in input_str_list}
-    # the upper range of this loop is `max_chunks + 2` because:
-    #     - `i` needs to take the value of `max_chunks`, hence one +1
-    #     - the contents of the loop are run one more time to check if `all_unique`,
-    #           hence the other +1
-    for i in range(2, max_chunks + 2):
-        new_dict = defaultdict(list)
-        all_unique = True
-        for suffix, suffix_str_list in suffix_dict.items():
-            if len(suffix_str_list) > 1:
-                all_unique = False
-                for istr in suffix_str_list:
-                    new_dict[_get_suffix(istr, delim=delim, n_chunks=i)].append(istr)
-            else:
-                new_dict[suffix] = suffix_str_list
-        if all_unique:
-            if len(set(input_str_list)) != len(suffix_dict.keys()):
-                break
-            return {
-                suffix_str_list[0]: suffix
-                for suffix, suffix_str_list in suffix_dict.items()
-            }
-        suffix_dict = new_dict
-    # If this function has not yet exited, some input strings still share a suffix.
-    # This is not expected, but in this case, the function will return the identity
-    # mapping, i.e., a dict with the original strings as both keys and values.
-    logger.warning(
-        "Something went wrong. Returning dictionary with original strings as keys and "
-        "values."
-    )
-    return {istr: istr for istr in input_str_list}
 
 
 def get_standard_plots(
@@ -594,394 +521,6 @@ def _get_curve_plot_dropdown(
         },
         lower_is_better_by_metric={m.name: m.lower_is_better for m in map_metrics},
     )
-
-
-def _merge_trials_dict_with_df(
-    df: pd.DataFrame,
-    # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
-    trials_dict: Dict[int, Any],
-    column_name: str,
-    always_include_field_column: bool = False,
-) -> None:
-    """Add a column ``column_name`` to a DataFrame ``df`` containing a column
-    ``trial_index``. Each value of the new column is given by the element of
-    ``trials_dict`` indexed by ``trial_index``.
-
-    Args:
-        df: Pandas DataFrame with column ``trial_index``, to be appended with a new
-            column.
-        trials_dict: Dict mapping each ``trial_index`` to a value. The new column of
-            df will be populated with the value corresponding with the
-            ``trial_index`` of each row.
-        column_name: Name of the column to be appended to ``df``.
-        always_include_field_column: Even if all trials have missing values,
-            include the column.
-    """
-
-    if "trial_index" not in df.columns:
-        raise ValueError("df must have trial_index column")
-
-    # field present for some trial
-    if always_include_field_column or any(trials_dict.values()):
-        if not all(
-            v is not None for v in trials_dict.values()
-        ):  # not present for all trials
-            logger.warning(
-                f"Column {column_name} missing for some trials. "
-                "Filling with None when missing."
-            )
-        df[column_name] = [trials_dict[trial_index] for trial_index in df.trial_index]
-    else:
-        logger.warning(
-            f"Column {column_name} missing for all trials. " "Not appending column."
-        )
-
-
-def _get_generation_method_str(trial: BaseTrial) -> str:
-    trial_generation_property = trial._properties.get("generation_model_key")
-    if trial_generation_property is not None:
-        return trial_generation_property
-
-    generation_methods = {
-        not_none(generator_run._model_key)
-        for generator_run in trial.generator_runs
-        if generator_run._model_key is not None
-    }
-
-    # add "Manual" if any generator_runs are manual
-    if any(
-        generator_run.generator_run_type == GeneratorRunType.MANUAL.name
-        for generator_run in trial.generator_runs
-    ):
-        generation_methods.add("Manual")
-    return ", ".join(generation_methods) if generation_methods else "Unknown"
-
-
-def _merge_results_if_no_duplicates(
-    arms_df: pd.DataFrame,
-    results: pd.DataFrame,
-    key_components: List[str],
-    metrics: List[Metric],
-) -> DataFrame:
-    """Formats ``data.df`` and merges it with ``arms_df`` if all of the following are
-    True:
-        - ``data.df`` is not empty
-        - ``data.df`` contains columns corresponding to ``key_components``
-        - after any formatting, ``data.df`` contains no duplicates of the column
-            ``results_key_col``
-    """
-    if len(results.index) == 0:
-        logger.info(
-            f"No results present for the specified metrics `{metrics}`. "
-            "Returning arm parameters and metadata only."
-        )
-        return arms_df
-    if not all(col in results.columns for col in key_components):
-        logger.warning(
-            f"At least one of key columns `{key_components}` not present in results df "
-            f"`{results}`. Returning arm parameters and metadata only."
-        )
-        return arms_df
-    # prepare results for merge by concattenating the trial index with the arm name
-    # sparated by a comma
-    key_vals = pd.Series(
-        results[key_components].values.astype("str").tolist()
-    ).str.join(",")
-
-    results_key_col = "-".join(key_components)
-
-    # Reindex so new column isn't set to NaN.
-    key_vals.index = results.index
-    results[results_key_col] = key_vals
-    # Don't return results if duplicates remain
-    if any(results.duplicated(subset=[results_key_col, "metric_name"])):
-        logger.warning(
-            "Experimental results dataframe contains multiple rows with the same "
-            f"keys {results_key_col}. Returning dataframe without results."
-        )
-        return arms_df
-    metric_vals = results.pivot(
-        index=results_key_col, columns="metric_name", values="mean"
-    ).reset_index()
-
-    # dedupe results by key_components
-    metadata_cols = key_components + [results_key_col]
-    if FEASIBLE_COL_NAME in results.columns:
-        metadata_cols.append(FEASIBLE_COL_NAME)
-    metadata = results[metadata_cols].drop_duplicates()
-    metrics_df = pd.merge(metric_vals, metadata, on=results_key_col)
-    # drop synthetic key column
-    metrics_df = metrics_df.drop(results_key_col, axis=1)
-    # merge and return
-    return pd.merge(metrics_df, arms_df, on=key_components, how="outer")
-
-
-def exp_to_df(
-    exp: Experiment,
-    metrics: Optional[List[Metric]] = None,
-    run_metadata_fields: Optional[List[str]] = None,
-    trial_properties_fields: Optional[List[str]] = None,
-    trial_attribute_fields: Optional[List[str]] = None,
-    additional_fields_callables: Optional[
-        Dict[str, Callable[[Experiment], Dict[int, Union[str, float]]]]
-    ] = None,
-    always_include_field_columns: bool = False,
-    **kwargs: Any,
-) -> pd.DataFrame:
-    """Transforms an experiment to a DataFrame with rows keyed by trial_index
-    and arm_name, metrics pivoted into one row. If the pivot results in more than
-    one row per arm (or one row per ``arm * map_keys`` combination if ``map_keys`` are
-    present), results are omitted and warning is produced. Only supports
-    ``Experiment``.
-
-    Transforms an ``Experiment`` into a ``pd.DataFrame``.
-
-    Args:
-        exp: An ``Experiment`` that may have pending trials.
-        metrics: Override list of metrics to return. Return all metrics if ``None``.
-        run_metadata_fields: Fields to extract from ``trial.run_metadata`` for trial
-            in ``experiment.trials``. If there are multiple arms per trial, these
-            fields will be replicated across the arms of a trial.
-        trial_properties_fields: Fields to extract from ``trial._properties`` for trial
-            in ``experiment.trials``. If there are multiple arms per trial, these
-            fields will be replicated across the arms of a trial. Output columns names
-            will be prepended with ``"trial_properties_"``.
-        trial_attribute_fields: Fields to extract from trial attributes for each trial
-            in ``experiment.trials``. If there are multiple arms per trial, these
-            fields will be replicated across the arms of a trial.
-        additional_fields_callables: A dictionary of field names to callables, with
-            each being a function from `experiment` to a `trials_dict` of the form
-            {trial_index: value}. An example of a custom callable like this is the
-            function `compute_maximum_map_values`.
-        always_include_field_columns: If `True`, even if all trials have missing
-            values, include field columns anyway. Such columns are by default
-            omitted (False).
-    Returns:
-        DataFrame: A dataframe of inputs, metadata and metrics by trial and arm (and
-        ``map_keys``, if present). If no trials are available, returns an empty
-        dataframe. If no metric ouputs are available, returns a dataframe of inputs and
-        metadata. Columns include:
-            * trial_index
-            * arm_name
-            * trial_status
-            * generation_method
-            * any elements of exp.runner.run_metadata_report_keys that are present in
-              the trial.run_metadata of each trial
-            * one column per metric (named after the metric.name)
-            * one column per parameter (named after the parameter.name)
-    """
-
-    if len(kwargs) > 0:
-        logger.warning(
-            "`kwargs` in exp_to_df is deprecated. Please remove extra arguments."
-        )
-
-    # Accept Experiment and SimpleExperiment
-    if isinstance(exp, MultiTypeExperiment):
-        raise ValueError("Cannot transform MultiTypeExperiments to DataFrames.")
-
-    key_components = ["trial_index", "arm_name"]
-
-    # Get each trial-arm with parameters
-    arms_df = pd.DataFrame(
-        [
-            {
-                "arm_name": arm.name,
-                "trial_index": trial_index,
-                **arm.parameters,
-            }
-            for trial_index, trial in exp.trials.items()
-            for arm in trial.arms
-        ]
-    )
-    # Fetch results.
-    data = exp.lookup_data()
-    results = data.df
-
-    # Filter metrics.
-    if metrics is not None:
-        metric_names = [m.name for m in metrics]
-        results = results[results["metric_name"].isin(metric_names)]
-
-    # Add `FEASIBLE_COL_NAME` column according to constraints if any.
-    if (
-        exp.optimization_config is not None
-        and len(not_none(exp.optimization_config).all_constraints) > 0
-    ):
-        optimization_config = not_none(exp.optimization_config)
-        try:
-            if any(oc.relative for oc in optimization_config.all_constraints):
-                optimization_config = _derel_opt_config_wrapper(
-                    optimization_config=optimization_config,
-                    experiment=exp,
-                )
-            results[FEASIBLE_COL_NAME] = _is_row_feasible(
-                df=results,
-                optimization_config=optimization_config,
-            )
-        except (KeyError, ValueError, DataRequiredError) as e:
-            logger.warning(f"Feasibility calculation failed with error: {e}")
-
-    # If arms_df is empty, return empty results (legacy behavior)
-    if len(arms_df.index) == 0:
-        if len(results.index) != 0:
-            raise ValueError(
-                "exp.lookup_data().df returned more rows than there are experimental "
-                "arms. This is an inconsistent experimental state. Please report to "
-                "Ax support."
-            )
-        return results
-
-    # Create key column from key_components
-    arms_df["trial_index"] = arms_df["trial_index"].astype(int)
-
-    # Add trial status
-    trials = exp.trials.items()
-    trial_to_status = {index: trial.status.name for index, trial in trials}
-    _merge_trials_dict_with_df(
-        df=arms_df, trials_dict=trial_to_status, column_name="trial_status"
-    )
-
-    # Add trial reason for failed or abandoned trials
-    trial_to_reason = {
-        index: (
-            f"{trial.failed_reason[:15]}..."
-            if trial.status.is_failed and trial.failed_reason is not None
-            else f"{trial.abandoned_reason[:15]}..."
-            if trial.status.is_abandoned and trial.abandoned_reason is not None
-            else None
-        )
-        for index, trial in trials
-    }
-
-    _merge_trials_dict_with_df(
-        df=arms_df,
-        trials_dict=trial_to_reason,
-        column_name="reason",
-    )
-
-    # Add generation_method, accounting for the generic case that generator_runs is of
-    # arbitrary length. Repeated methods within a trial are condensed via `set` and an
-    # empty set will yield "Unknown" as the method.
-    trial_to_generation_method = {
-        trial_index: _get_generation_method_str(trial) for trial_index, trial in trials
-    }
-
-    _merge_trials_dict_with_df(
-        df=arms_df,
-        trials_dict=trial_to_generation_method,
-        column_name="generation_method",
-    )
-
-    # Add any trial properties fields to arms_df
-    if trial_properties_fields is not None:
-        # add trial._properties fields
-        for field in trial_properties_fields:
-            trial_to_properties_field = {
-                trial_index: (
-                    trial._properties[field] if field in trial._properties else None
-                )
-                for trial_index, trial in trials
-            }
-            _merge_trials_dict_with_df(
-                df=arms_df,
-                trials_dict=trial_to_properties_field,
-                column_name="trial_properties_" + field,
-                always_include_field_column=always_include_field_columns,
-            )
-
-    # Add any run_metadata fields to arms_df
-    if run_metadata_fields is not None:
-        # add run_metadata fields
-        for field in run_metadata_fields:
-            trial_to_metadata_field = {
-                trial_index: (
-                    trial.run_metadata[field] if field in trial.run_metadata else None
-                )
-                for trial_index, trial in trials
-            }
-            _merge_trials_dict_with_df(
-                df=arms_df,
-                trials_dict=trial_to_metadata_field,
-                column_name=field,
-                always_include_field_column=always_include_field_columns,
-            )
-
-    # Add any trial attributes fields to arms_df
-    if trial_attribute_fields is not None:
-        # add trial attribute fields
-        for field in trial_attribute_fields:
-            trial_to_attribute_field = {
-                trial_index: (getattr(trial, field) if hasattr(trial, field) else None)
-                for trial_index, trial in trials
-            }
-            _merge_trials_dict_with_df(
-                df=arms_df,
-                trials_dict=trial_to_attribute_field,
-                column_name=field,
-                always_include_field_column=always_include_field_columns,
-            )
-
-    # Add additional fields to arms_df
-    if additional_fields_callables is not None:
-        for field, func in additional_fields_callables.items():
-            trial_to_additional_field = func(exp)
-            _merge_trials_dict_with_df(
-                df=arms_df,
-                trials_dict=trial_to_additional_field,
-                column_name=field,
-                always_include_field_column=always_include_field_columns,
-            )
-
-    exp_df = _merge_results_if_no_duplicates(
-        arms_df=arms_df,
-        results=results,
-        key_components=key_components,
-        metrics=metrics or list(exp.metrics.values()),
-    )
-
-    exp_df = not_none(not_none(exp_df).sort_values(["trial_index"]))
-    initial_column_order = (
-        ["trial_index", "arm_name", "trial_status", "reason", "generation_method"]
-        + (run_metadata_fields or [])
-        + (trial_properties_fields or [])
-        + ([FEASIBLE_COL_NAME] if FEASIBLE_COL_NAME in exp_df.columns else [])
-    )
-    for column_name in reversed(initial_column_order):
-        if column_name in exp_df.columns:
-            # pyre-ignore[6]: In call `DataFrame.insert`, for 3rd positional argument,
-            # expected `Union[int, Series, Variable[ArrayLike <: [ExtensionArray,
-            # ndarray]]]` but got `Union[DataFrame, Series]`]
-            exp_df.insert(0, column_name, exp_df.pop(column_name))
-    return exp_df.reset_index(drop=True)
-
-
-def compute_maximum_map_values(
-    experiment: Experiment, map_key: Optional[str] = None
-) -> Dict[int, float]:
-    """A function that returns a map from trial_index to the maximum map value
-    reached. If map_key is not specified, it uses the first map_key."""
-    data = experiment.lookup_data()
-    if not isinstance(data, MapData):
-        raise ValueError("`compute_maximum_map_values` requires `MapData`.")
-    if map_key is None:
-        map_key = data.map_keys[0]
-    map_df = data.map_df
-    maximum_map_value_df = (
-        map_df[["trial_index"] + data.map_keys]
-        .groupby("trial_index")
-        .max()
-        .reset_index()
-    )
-    trials_dict = {}
-    for trial_index in experiment.trials:
-        value = None
-        if trial_index in maximum_map_value_df["trial_index"].values:
-            value = maximum_map_value_df[
-                maximum_map_value_df["trial_index"] == trial_index
-            ][map_key].iloc[0]
-        trials_dict[trial_index] = value
-    return trials_dict
 
 
 def _pairwise_pareto_plotly_scatter(


### PR DESCRIPTION
Summary: Moving general analysis code out of report_utils.py, so that the new Ax Analysis module does not need to take it up as a dependency.

Differential Revision: D53285478


