### PR TITLE
Clean up legacy objective_name & minimize args from InstantiationBase

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -54,8 +54,6 @@ from ax.utils.common.typeutils import checked_cast, not_none
 
 logger: logging.Logger = get_logger(__name__)
 
-DEFAULT_OBJECTIVE_NAME = "objective"
-
 ROUND_FLOATS_IN_LOGS_TO_DECIMAL_PLACES: int = 6
 
 # pyre-fixme[5]: Global expression must be annotated.
@@ -1709,6 +1707,7 @@ def add_arm_and_prevent_naming_collision(
         except ValueError as e:
             warnings.warn(
                 f"Attaching arm {old_trial.arm} to trial {new_trial} while preserving "
-                f"its name failed with error: {e}. Retrying with `clear_name=True`."
+                f"its name failed with error: {e}. Retrying with `clear_name=True`.",
+                stacklevel=2,
             )
             new_trial.add_arm(not_none(old_trial.arm).clone(clear_name=True))

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -1433,8 +1433,10 @@ class TestAxClient(TestCase):
                     raw_data=[({"t": t}, {"branin": (branin(x, y) + t, 0.0)})],
                 )
             # pyre-fixme[16]: `Data` has no attribute `map_df`.
-            current_data = ax_client.experiment.fetch_data().map_df
-            self.assertEqual(len(current_data), 0 if t < 2 else 3)
+            fetch_data = ax_client.experiment.fetch_data().map_df
+            self.assertEqual(len(fetch_data), 0 if t < 2 else 3)
+            lookup_data = ax_client.experiment.lookup_data().map_df
+            self.assertEqual(len(lookup_data), t + 1)
 
         no_intermediate_data_ax_client = AxClient()
         no_intermediate_data_ax_client.create_experiment(

--- a/ax/service/tests/test_instantiation_utils.py
+++ b/ax/service/tests/test_instantiation_utils.py
@@ -10,7 +10,6 @@ from ax.core.metric import Metric
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.parameter import FixedParameter, ParameterType, RangeParameter
 from ax.core.search_space import HierarchicalSearchSpace
-from ax.exceptions.core import UnsupportedError
 from ax.service.utils.instantiation import InstantiationBase
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast
@@ -128,18 +127,6 @@ class TestInstantiationtUtils(TestCase):
                 # pyre-fixme[6]: For 2nd param expected `Dict[str, Parameter]` but
                 #  got `Dict[str, None]`.
                 {"x1": None, "x2": None, "x3": None},
-            )
-
-    def test_objective_validation(self) -> None:
-        with self.assertRaisesRegex(UnsupportedError, "Ambiguous objective definition"):
-            InstantiationBase.make_experiment(
-                # pyre-fixme[6]: For 1st param expected `List[Dict[str, Union[None,
-                #  Dict[str, List[str]], List[Union[None, bool, float, int, str]],
-                #  bool, float, int, str]]]` but got `Dict[str, Union[List[int],
-                #  str]]`.
-                parameters={"name": "x", "type": "range", "bounds": [0, 1]},
-                objective_name="branin",
-                objectives={"branin": "minimize", "currin": "maximize"},
             )
 
     def test_add_tracking_metrics(self) -> None:


### PR DESCRIPTION
Summary:
These are not used since D52846021 removed them from AxClient and related APIs. Removed the arguments and the methods that were only used with these args.

I also checked if using Metric vs MapMetric classes makes any difference (the legacy method used these based on `support_intermediate_data`). Since we don't really do any metric fetching in AxClient, I did not observe any difference. So, I kept it as Metric in both cases. `support_intermediate_data` is used to set the defaulty data type, which is used to cast data before attaching it on the AxClient, which seems to be all we need here.

Differential Revision: D52849419


