### PR TITLE
In MBM model tests, match search space to model

### DIFF
--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -119,7 +119,6 @@ class AcquisitionTest(TestCase):
         self.search_space_digest = SearchSpaceDigest(
             feature_names=self.feature_names,
             bounds=[(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)],
-            fidelity_features=self.fidelity_features,
             target_values={2: 1.0},
         )
         self.surrogate.fit(

--- a/ax/models/torch/tests/test_multi_fidelity.py
+++ b/ax/models/torch/tests/test_multi_fidelity.py
@@ -17,7 +17,7 @@ from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import fast_botorch_optimize
 from botorch.acquisition.knowledge_gradient import qMultiFidelityKnowledgeGradient
-from botorch.models.gp_regression import SingleTaskGP
+from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.utils.datasets import SupervisedDataset
 
 
@@ -31,7 +31,7 @@ MFKG_PATH = (
 class MultiFidelityAcquisitionTest(TestCase):
     @fast_botorch_optimize
     def setUp(self) -> None:
-        self.botorch_model_class = SingleTaskGP
+        self.botorch_model_class = SingleTaskMultiFidelityGP
         self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
         self.X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])
         self.Y = torch.tensor([[3.0], [4.0]])


### PR DESCRIPTION
Summary: We have been testing multi-fidelity search spaces with single-fidelity models. Once https://github.com/pytorch/botorch/pull/2186 lands, this will raise an exception because fidelity parameters will be passed to Botorch model input constructors that don't accept them.

Differential Revision: D53444637


