### PR TITLE
Update test_ST_MTGP_LEGACY

### DIFF
--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -421,11 +421,17 @@ class ModelRegistryTest(TestCase):
             status_quo_features=status_quo_features,
         )
         self.assertIsInstance(mtgp, TorchModelBridge)
+        # Test that it can generate.
+        mtgp_run = mtgp.gen(
+            n=1,
+            fixed_features=ObservationFeatures(parameters={}, trial_index=1),
+        )
+        self.assertEqual(len(mtgp_run.arms), 1)
 
         exp, status_quo_features = get_branin_experiment_with_status_quo_trials(
             num_sobol_trials=1
         )
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "TrialAsTask transform expects"):
             Models.ST_MTGP_LEGACY(
                 experiment=exp,
                 data=exp.fetch_data(),


### PR DESCRIPTION
Summary: I was looking through the tests for some inspiration for another test and got confused with the `ValueError` being raised. Updated it with `assertRaisesRegex` and also added a check for candidate generation.

Differential Revision: D53482825


