### PR TITLE
Deduplicate ChoiceParameter values

### DIFF
--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -12,7 +12,7 @@ from ax.core.parameter import (
     ParameterType,
     RangeParameter,
 )
-from ax.exceptions.core import UserInputError
+from ax.exceptions.core import AxWarning, UserInputError
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import not_none
 
@@ -493,6 +493,15 @@ class ChoiceParameterTest(TestCase):
                 "flags": "ordered, sorted",
             },
         )
+
+    def test_duplicate_values(self) -> None:
+        with self.assertWarnsRegex(AxWarning, "Duplicate values found"):
+            p = ChoiceParameter(
+                name="x",
+                parameter_type=ParameterType.STRING,
+                values=["foo", "bar", "foo"],
+            )
+        self.assertEqual(p.values, ["foo", "bar"])
 
 
 class FixedParameterTest(TestCase):

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -22,7 +22,7 @@ import numpy as np
 
 TNumeric = Union[float, int]
 TParamCounter = DefaultDict[int, int]
-TParamValue = Optional[Union[str, bool, float, int]]
+TParamValue = Union[None, str, bool, float, int]
 TParameterization = Dict[str, TParamValue]
 TParamValueList = List[TParamValue]  # a parameterization without the keys
 TContextStratum = Optional[Dict[str, Union[str, float, int]]]


### PR DESCRIPTION
Summary: Duplicate values in ChoiceParameters lead to errors in the transform layer. Deduplicating with a warning to avoid downstream errors.

Differential Revision: D53588482


