### PR TITLE
Fix test_duplicate_values

### DIFF
--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -501,7 +501,7 @@ class ChoiceParameterTest(TestCase):
                 parameter_type=ParameterType.STRING,
                 values=["foo", "bar", "foo"],
             )
-        self.assertEqual(p.values, ["foo", "bar"])
+        self.assertEqual({*p.values}, {"foo", "bar"})
 
 
 class FixedParameterTest(TestCase):


### PR DESCRIPTION
Summary: Fixing test failure on main. Nondeterministic ordering causes this to be flaky as is, prefer set equality

Differential Revision: D53611974


