### PR TITLE
fix num outcomes check in subset model

### DIFF
--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -280,6 +280,7 @@ class BotorchMOODefaultsTest(TestCase):
         wraps=lambda y: y,
     )
     def test_infer_objective_thresholds(self, _, cuda: bool = False) -> None:
+        # TODO: refactor this test into smaller test cases
         for dtype in (torch.float, torch.double):
             tkwargs: Dict[str, Any] = {
                 "device": torch.device("cuda") if cuda else torch.device("cpu"),
@@ -310,14 +311,6 @@ class BotorchMOODefaultsTest(TestCase):
                         wraps=infer_reference_point,
                     )
                 )
-                # after subsetting, the model will only have two outputs
-                _mock_num_outputs = es.enter_context(
-                    mock.patch(
-                        "botorch.utils.testing.MockModel.num_outputs",
-                        new_callable=mock.PropertyMock,
-                    )
-                )
-                _mock_num_outputs.return_value = 3
                 # after subsetting, the model will only have two outputs
                 model = MockModel(
                     MockPosterior(
@@ -402,6 +395,13 @@ class BotorchMOODefaultsTest(TestCase):
                         )
                     )
                 )
+                es.enter_context(
+                    mock.patch.object(
+                        model,
+                        "subset_output",
+                        return_value=model,
+                    )
+                )
 
                 # test passing X_observed
                 obj_thresholds = infer_objective_thresholds(
@@ -439,6 +439,13 @@ class BotorchMOODefaultsTest(TestCase):
                         ],
                         **tkwargs,
                     )
+                )
+            )
+            es.enter_context(
+                mock.patch.object(
+                    subset_model,
+                    "subset_output",
+                    return_value=subset_model,
                 )
             )
             obj_thresholds = infer_objective_thresholds(

--- a/ax/models/tests/test_torch_model_utils.py
+++ b/ax/models/tests/test_torch_model_utils.py
@@ -15,7 +15,10 @@ from ax.models.torch.utils import (
     tensor_callable_to_array_callable,
 )
 from ax.utils.common.testutils import TestCase
-from botorch.models import HeteroskedasticSingleTaskGP, ModelListGP, SingleTaskGP
+from ax.utils.common.typeutils import not_none
+from botorch.models import HeteroskedasticSingleTaskGP, SingleTaskGP
+from botorch.models.model_list_gp_regression import ModelListGP
+from botorch.models.multitask import MultiTaskGP
 from torch import Tensor
 
 
@@ -45,108 +48,6 @@ class TorchUtilsTest(TestCase):
         with self.assertRaises(ValueError):
             nlzd_indices = normalize_indices([-4], 3)
 
-    def test_SubsetModel(self) -> None:
-        x = torch.zeros(1, 1)
-        y = torch.rand(1, 2)
-        obj_t = torch.rand(2)
-        model = SingleTaskGP(x, y)
-        self.assertEqual(model.num_outputs, 2)
-        # basic test, can subset
-        obj_weights = torch.tensor([1.0, 0.0])
-        subset_model_results = subset_model(model, obj_weights)
-        model_sub = subset_model_results.model
-        obj_weights_sub = subset_model_results.objective_weights
-        ocs_sub = subset_model_results.outcome_constraints
-        obj_t_sub = subset_model_results.objective_thresholds
-        self.assertIsNone(ocs_sub)
-        self.assertIsNone(obj_t_sub)
-        self.assertEqual(model_sub.num_outputs, 1)
-        self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
-        # basic test, cannot subset
-        obj_weights = torch.tensor([1.0, 2.0])
-        subset_model_results = subset_model(model, obj_weights)
-        model_sub = subset_model_results.model
-        obj_weights_sub = subset_model_results.objective_weights
-        ocs_sub = subset_model_results.outcome_constraints
-        obj_t_sub = subset_model_results.objective_thresholds
-        self.assertIsNone(ocs_sub)
-        self.assertIsNone(obj_t_sub)
-        self.assertIs(model_sub, model)  # check identity
-        self.assertIs(obj_weights_sub, obj_weights)  # check identity
-        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
-        # test w/ outcome constraints, can subset
-        obj_weights = torch.tensor([1.0, 0.0])
-        ocs = (torch.tensor([[1.0, 0.0]]), torch.tensor([1.0]))
-        subset_model_results = subset_model(model, obj_weights, ocs)
-        model_sub = subset_model_results.model
-        obj_weights_sub = subset_model_results.objective_weights
-        ocs_sub = subset_model_results.outcome_constraints
-        obj_t_sub = subset_model_results.objective_thresholds
-        self.assertEqual(model_sub.num_outputs, 1)
-        self.assertIsNone(obj_t_sub)
-        self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
-        # pyre-fixme[16]: Optional type has no attribute `__getitem__`.
-        self.assertTrue(torch.equal(ocs_sub[0], torch.tensor([[1.0]])))
-        self.assertTrue(torch.equal(ocs_sub[1], torch.tensor([1.0])))
-        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0])))
-        # test w/ outcome constraints, cannot subset
-        obj_weights = torch.tensor([1.0, 0.0])
-        ocs = (torch.tensor([[0.0, 1.0]]), torch.tensor([1.0]))
-        subset_model_results = subset_model(model, obj_weights, ocs)
-        model_sub = subset_model_results.model
-        obj_weights_sub = subset_model_results.objective_weights
-        ocs_sub = subset_model_results.outcome_constraints
-        obj_t_sub = subset_model_results.objective_thresholds
-        self.assertIs(model_sub, model)  # check identity
-        self.assertIsNone(obj_t_sub)
-        self.assertIs(obj_weights_sub, obj_weights)  # check identity
-        self.assertIs(ocs_sub, ocs)  # check identity
-        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
-        # test w/ objective thresholds, cannot subset
-        obj_weights = torch.tensor([1.0, 0.0])
-        ocs = (torch.tensor([[0.0, 1.0]]), torch.tensor([1.0]))
-        subset_model_results = subset_model(model, obj_weights, ocs, obj_t)
-        model_sub = subset_model_results.model
-        obj_weights_sub = subset_model_results.objective_weights
-        ocs_sub = subset_model_results.outcome_constraints
-        obj_t_sub = subset_model_results.objective_thresholds
-        self.assertIs(model_sub, model)  # check identity
-        self.assertIs(obj_t, obj_t_sub)
-        self.assertIs(obj_weights_sub, obj_weights)  # check identity
-        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
-        self.assertIs(ocs_sub, ocs)  # check identity
-        # test w/ objective thresholds, can subset
-        obj_weights = torch.tensor([1.0, 0.0])
-        ocs = (torch.tensor([[1.0, 0.0]]), torch.tensor([1.0]))
-        subset_model_results = subset_model(model, obj_weights, ocs, obj_t)
-        model_sub = subset_model_results.model
-        obj_weights_sub = subset_model_results.objective_weights
-        ocs_sub = subset_model_results.outcome_constraints
-        obj_t_sub = subset_model_results.objective_thresholds
-        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0])))
-        self.assertEqual(model_sub.num_outputs, 1)
-        self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
-        # pyre-fixme[6]: For 1st param expected `Tensor` but got `Optional[Tensor]`.
-        self.assertTrue(torch.equal(obj_t_sub, obj_t[:1]))
-        self.assertTrue(torch.equal(ocs_sub[0], torch.tensor([[1.0]])))
-        self.assertTrue(torch.equal(ocs_sub[1], torch.tensor([1.0])))
-        # test unsupported
-        yvar = torch.ones(1, 2)
-        model = HeteroskedasticSingleTaskGP(x, y, yvar)
-        subset_model_results = subset_model(model, obj_weights)
-        model_sub = subset_model_results.model
-        obj_weights_sub = subset_model_results.objective_weights
-        ocs_sub = subset_model_results.outcome_constraints
-        obj_t_sub = subset_model_results.objective_thresholds
-        self.assertIsNone(ocs_sub)
-        self.assertIs(model_sub, model)  # check identity
-        self.assertIs(obj_weights_sub, obj_weights)  # check identity
-        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
-        # test error on size inconsistency
-        obj_weights = torch.ones(3)
-        with self.assertRaises(RuntimeError):
-            subset_model(model, obj_weights)
-
     def test_GenerateSobolPoints(self) -> None:
         bounds = [(0.0, 1.0) for _ in range(3)]
         linear_constraints = (
@@ -169,10 +70,152 @@ class TorchUtilsTest(TestCase):
 
     def test_TensorCallableToArrayCallable(self) -> None:
         def tensor_func(x: Tensor) -> Tensor:
-            return np.exp(x)
+            return torch.pow(x, 2)
 
         new_func = tensor_callable_to_array_callable(
             tensor_func=tensor_func, device=torch.device("cpu")
         )
-        self.assertTrue(callable(new_func))
-        self.assertIsInstance(new_func(np.array([1.0, 2.0])), np.ndarray)
+        x = np.array([5.0, 2.0])
+        self.assertTrue(np.array_equal(new_func(x), np.array([25.0, 4.0])))
+
+
+class SubsetModelTest(TestCase):
+    def setUp(self) -> None:
+        self.x = torch.zeros(1, 1)
+        self.y = torch.rand(1, 2)
+        self.obj_t = torch.rand(2)
+        self.model = SingleTaskGP(self.x, self.y)
+        self.obj_weights = torch.tensor([1.0, 0.0])
+
+    def test_can_subset(self) -> None:
+        # basic test, can subset
+        subset_model_results = subset_model(self.model, self.obj_weights)
+        model_sub = subset_model_results.model
+        obj_weights_sub = subset_model_results.objective_weights
+        ocs_sub = subset_model_results.outcome_constraints
+        obj_t_sub = subset_model_results.objective_thresholds
+        self.assertIsNone(ocs_sub)
+        self.assertIsNone(obj_t_sub)
+        self.assertEqual(model_sub.num_outputs, 1)
+        self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
+
+    def test_cannot_subset(self) -> None:
+        obj_weights = torch.tensor([1.0, 2.0])
+        subset_model_results = subset_model(self.model, obj_weights)
+        model_sub = subset_model_results.model
+        obj_weights_sub = subset_model_results.objective_weights
+        ocs_sub = subset_model_results.outcome_constraints
+        obj_t_sub = subset_model_results.objective_thresholds
+        self.assertIsNone(ocs_sub)
+        self.assertIsNone(obj_t_sub)
+        self.assertIs(model_sub, self.model)  # check identity
+        self.assertIs(obj_weights_sub, obj_weights)  # check identity
+        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
+
+    def test_with_outcome_constraints_can_subset(self) -> None:
+        ocs = (torch.tensor([[1.0, 0.0]]), torch.tensor([1.0]))
+        subset_model_results = subset_model(self.model, self.obj_weights, ocs)
+        model_sub = subset_model_results.model
+        obj_weights_sub = subset_model_results.objective_weights
+        ocs_sub = subset_model_results.outcome_constraints
+        obj_t_sub = subset_model_results.objective_thresholds
+        self.assertEqual(model_sub.num_outputs, 1)
+        self.assertIsNone(obj_t_sub)
+        self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
+        # pyre-fixme[16]: Optional type has no attribute `__getitem__`.
+        self.assertTrue(torch.equal(ocs_sub[0], torch.tensor([[1.0]])))
+        self.assertTrue(torch.equal(ocs_sub[1], torch.tensor([1.0])))
+        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0])))
+
+    def test_with_outcome_constraints_cannot_subset(self) -> None:
+        ocs = (torch.tensor([[0.0, 1.0]]), torch.tensor([1.0]))
+        subset_model_results = subset_model(self.model, self.obj_weights, ocs)
+        model_sub = subset_model_results.model
+        obj_weights_sub = subset_model_results.objective_weights
+        ocs_sub = subset_model_results.outcome_constraints
+        obj_t_sub = subset_model_results.objective_thresholds
+        self.assertIs(model_sub, self.model)  # check identity
+        self.assertIsNone(obj_t_sub)
+        self.assertIs(obj_weights_sub, self.obj_weights)  # check identity
+        self.assertIs(ocs_sub, ocs)  # check identity
+        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
+
+    def test_with_obj_thresholds_cannot_subset(self) -> None:
+        # test w/ objective thresholds, cannot subset
+        ocs = (torch.tensor([[0.0, 1.0]]), torch.tensor([1.0]))
+        subset_model_results = subset_model(
+            self.model, self.obj_weights, ocs, self.obj_t
+        )
+        model_sub = subset_model_results.model
+        obj_weights_sub = subset_model_results.objective_weights
+        ocs_sub = subset_model_results.outcome_constraints
+        obj_t_sub = subset_model_results.objective_thresholds
+        self.assertIs(model_sub, self.model)  # check identity
+        self.assertIs(self.obj_t, obj_t_sub)
+        self.assertIs(obj_weights_sub, self.obj_weights)  # check identity
+        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
+        self.assertIs(ocs_sub, ocs)  # check identity
+
+    def test_with_obj_thresholds_can_subset(self) -> None:
+        # test w/ objective thresholds, can subset
+        ocs = (torch.tensor([[1.0, 0.0]]), torch.tensor([1.0]))
+        subset_model_results = subset_model(
+            self.model, self.obj_weights, ocs, self.obj_t
+        )
+        model_sub = subset_model_results.model
+        obj_weights_sub = subset_model_results.objective_weights
+        ocs_sub = not_none(subset_model_results.outcome_constraints)
+        obj_t_sub = subset_model_results.objective_thresholds
+        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0])))
+        self.assertEqual(model_sub.num_outputs, 1)
+        self.assertTrue(torch.equal(obj_weights_sub, torch.tensor([1.0])))
+        # pyre-fixme[6]: For 1st param expected `Tensor` but got `Optional[Tensor]`.
+        self.assertTrue(torch.equal(obj_t_sub, self.obj_t[:1]))
+        self.assertTrue(torch.equal(ocs_sub[0], torch.tensor([[1.0]])))
+        self.assertTrue(torch.equal(ocs_sub[1], torch.tensor([1.0])))
+
+    def test_unsupported(self) -> None:
+        yvar = torch.ones(1, 2)
+        model = HeteroskedasticSingleTaskGP(self.x, self.y, yvar)
+        subset_model_results = subset_model(model, self.obj_weights)
+        model_sub = subset_model_results.model
+        obj_weights_sub = subset_model_results.objective_weights
+        ocs_sub = subset_model_results.outcome_constraints
+        self.assertIsNone(ocs_sub)
+        self.assertIs(model_sub, model)  # check identity
+        self.assertIs(obj_weights_sub, self.obj_weights)  # check identity
+        self.assertTrue(torch.equal(subset_model_results.indices, torch.tensor([0, 1])))
+        # test error on size inconsistency
+        obj_weights = torch.ones(4)
+        obj_weights[0] = 0
+        with self.assertRaises(RuntimeError):
+            subset_model(model, obj_weights)
+
+    def test_multitask_modellist(self) -> None:
+        x1 = torch.tensor([[1.0, 2.0, 1.0], [2.0, 3.0, 0.0]])
+        y1 = torch.tensor([[0.0, 1.0]])
+        x2 = torch.tensor([[0.0, 3.0, 1.0], [1.0, 4.0, 0.0]])
+        y2 = torch.tensor([[2.0, 3.0]])
+        m1 = MultiTaskGP(x1, y1, task_feature=2)
+        m2 = MultiTaskGP(x2, y2, task_feature=2)
+        model = ModelListGP(m1, m2)
+        # test model is not subset when model.num_outputs >
+        # len(obj_weights), but all outcomes are relevant.
+        # This test is explicitly tests that model is not
+        # subset when subset_model is called because all
+        # outcomes are relevant.
+        obj_weights = torch.ones(2)
+        subset_model_results = subset_model(model, obj_weights)
+        self.assertIs(subset_model_results.model, model)
+        # test subset
+        subset_model_results = subset_model(model, self.obj_weights)
+        self.assertIsInstance(subset_model_results.model, ModelListGP)
+        self.assertEqual(len(subset_model_results.model.models), 1)
+        self.assertIsInstance(subset_model_results.model.models[0], MultiTaskGP)
+        # check that the model is m1
+        self.assertTrue(
+            torch.equal(subset_model_results.model.models[0].train_inputs[0], x1)
+        )
+        self.assertTrue(
+            torch.equal(subset_model_results.model.models[0].train_targets, y1)
+        )

--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -712,34 +712,19 @@ def infer_objective_thresholds(
         )
     num_outcomes = objective_weights.shape[0]
     if subset_idcs is None:
-        # check if only a subset of outcomes are modeled
-        nonzero = objective_weights != 0
-        if outcome_constraints is not None:
-            A, _ = outcome_constraints
-            nonzero = nonzero | torch.any(A != 0, dim=0)
-        expected_subset_idcs = nonzero.nonzero().view(-1)
-        if model.num_outputs > expected_subset_idcs.numel():
-            # subset the model so that we only compute the posterior
-            # over the relevant outcomes
-            subset_model_results = subset_model(
-                model=model,
-                objective_weights=objective_weights,
-                outcome_constraints=outcome_constraints,
-            )
-            model = subset_model_results.model
-            objective_weights = subset_model_results.objective_weights
-            outcome_constraints = subset_model_results.outcome_constraints
-            subset_idcs = subset_model_results.indices
-        else:
-            # model is already subsetted.
-            subset_idcs = expected_subset_idcs
-            # subset objective weights and outcome constraints
-            objective_weights = objective_weights[subset_idcs]
-            if outcome_constraints is not None:
-                outcome_constraints = (
-                    outcome_constraints[0][:, subset_idcs],
-                    outcome_constraints[1],
-                )
+        # Subset the model so that we only compute the posterior
+        # over the relevant outcomes.
+        # This is a no-op if the model is already only modeling
+        # the relevant outcomes.
+        subset_model_results = subset_model(
+            model=model,
+            objective_weights=objective_weights,
+            outcome_constraints=outcome_constraints,
+        )
+        model = subset_model_results.model
+        objective_weights = subset_model_results.objective_weights
+        outcome_constraints = subset_model_results.outcome_constraints
+        subset_idcs = subset_model_results.indices
     else:
         objective_weights = objective_weights[subset_idcs]
         if outcome_constraints is not None:

--- a/ax/models/torch/utils.py
+++ b/ax/models/torch/utils.py
@@ -291,7 +291,11 @@ def subset_model(
         nonzero = nonzero | torch.any(A != 0, dim=0)
     idcs_t = torch.arange(nonzero.size(0), device=objective_weights.device)[nonzero]
     idcs = idcs_t.tolist()
-    if len(idcs) == model.num_outputs:
+    # note that the number of metrics can be different than
+    # model.num_outputs which counts multiple tasks per
+    # outcome as separate outputs
+    num_outcomes = objective_weights.shape[0]
+    if len(idcs) == num_outcomes:
         # if we use all model outputs, just return the inputs
         return SubsetModelData(
             model=model,
@@ -299,13 +303,13 @@ def subset_model(
             outcome_constraints=outcome_constraints,
             objective_thresholds=objective_thresholds,
             indices=torch.arange(
-                model.num_outputs,
+                num_outcomes,
                 device=objective_weights.device,
             ),
         )
     elif len(idcs) > model.num_outputs:
         raise RuntimeError(
-            "Model size inconsistency. Tryting to subset a model with "
+            "Model size inconsistency. Trying to subset a model with "
             f"{model.num_outputs} outputs to {len(idcs)} outputs"
         )
     try:


### PR DESCRIPTION
Summary: This didn't cause incorrect behavior, but it would lead to unnecessary deepcopying when the model is a `ModelListGP` where some of constituent models are MTGPs because `ModelListGP.num_outputs` is defined as `sum(model.num_outputs for model in self.models)`.

Differential Revision: D53666930


