### PR TITLE
Update context order handling in ContextualDataset

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -1393,7 +1393,6 @@ def process_contextual_datasets(
                         datasets[outcomes.index(metric_i)] for metric_i in metric_list
                     ],
                     parameter_decomposition=parameter_decomposition,
-                    context_buckets=context_buckets,
                     metric_decomposition=metric_decomposition,
                 )
             )
@@ -1409,7 +1408,6 @@ def process_contextual_datasets(
                 ContextualDataset(
                     datasets=[datasets[outcomes.index(metric_i)]],
                     parameter_decomposition=parameter_decomposition,
-                    context_buckets=context_buckets,
                 )
             )
     return contextual_datasets


### PR DESCRIPTION
Summary:
Currently ContextualDataset will re-order outputs to match the specified order of context_buckets.

This has produced a somewhat confusing state, where at different places (ContextualDataset, the model, the surrogates) we have been passing around outcome lists or context lists that are expected to determine ordering in some way, but without a clear place where re-ordering is happening or where that order is being defined.

D51906856 was a step towards clarifying this, by setting the policy that the modelbridge will be responsible for defining the desired ordering; it will then order the datasets accordingly; and everything downstream is expected to return the outputs in the same order as the datasets. That is, it is expected to return the outputs in the same order as the inputs, which seems the cleanest and most logical policy.

This diff updates ContextualDataset in line with that philosophy so that hte output order is always the order that the outcomes are provided in the datasets. If the user wants a particular output order, that can be handled by ordering the input datasets accordingly rather than by specifying context buckets. With this change, the context_buckets input is no longer necessary since the bucket names can be read from the parameter decomposition, and the outcome order is taken from datasets.

Reviewed By: saitcakmak

Differential Revision: D52452236


