### PR TITLE
Support skip_runners_and_metrics for multi-objective

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1036,6 +1036,12 @@ class Decoder:
                 because the parent metric has no children metrics."
             )
 
+        if parent_metric_sqa.properties and parent_metric_sqa.properties.get(
+            "skip_runners_and_metrics"
+        ):
+            for child_metric in metrics_sqa_children:
+                child_metric.metric_type = self.config.metric_registry[Metric]
+
         # Extracting metric and weight for each child
         objectives = [
             Objective(

--- a/ax/storage/sqa_store/load.py
+++ b/ax/storage/sqa_store/load.py
@@ -26,6 +26,8 @@ from ax.storage.sqa_store.sqa_classes import (
     SQATrial,
 )
 from ax.storage.sqa_store.sqa_config import SQAConfig
+
+from ax.storage.utils import MetricIntent
 from ax.utils.common.constants import Keys
 from ax.utils.common.typeutils import checked_cast, not_none
 from sqlalchemy.orm import defaultload, lazyload, noload
@@ -136,6 +138,13 @@ def _load_experiment(
         base_metric_type_int = decoder.config.metric_registry[Metric]
         for sqa_metric in experiment_sqa.metrics:
             sqa_metric.metric_type = base_metric_type_int
+            # Handle multi-objective metrics that are not directly attached to
+            # the experiment
+            if sqa_metric.intent == MetricIntent.MULTI_OBJECTIVE:
+                if sqa_metric.properties is None:
+                    sqa_metric.properties = {}
+                sqa_metric.properties["skip_runners_and_metrics"] = True
+
         assign_metric_on_gr = not reduced_state and not imm_OC_and_SS
         if assign_metric_on_gr:
             try:

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -245,36 +245,38 @@ class SQAStoreTest(TestCase):
         )
 
         for immutable in [True, False]:
-            experiment = get_experiment_with_custom_runner_and_metric(
-                constrain_search_space=False,
-                immutable=immutable,
-            )
+            for multi_objective in [True, False]:
+                experiment = get_experiment_with_custom_runner_and_metric(
+                    constrain_search_space=False,
+                    immutable=immutable,
+                    multi_objective=multi_objective,
+                )
 
-            # Save the experiment to db using the updated registries.
-            save_experiment(experiment, config=sqa_config)
+                # Save the experiment to db using the updated registries.
+                save_experiment(experiment, config=sqa_config)
 
-            # At this point try to load the experiment back without specifying
-            # updated registries. Confirm that this attempt fails.
-            with self.assertRaises(SQADecodeError):
-                loaded_experiment = load_experiment(experiment.name)
+                # At this point try to load the experiment back without specifying
+                # updated registries. Confirm that this attempt fails.
+                with self.assertRaises(SQADecodeError):
+                    loaded_experiment = load_experiment(experiment.name)
 
-            # Now load it with the skip_runners_and_metrics argument set.
-            # The experiment should load (i.e. no exceptions raised)
-            loaded_experiment = load_experiment(
-                experiment.name, skip_runners_and_metrics=True
-            )
+                # Now load it with the skip_runners_and_metrics argument set.
+                # The experiment should load (i.e. no exceptions raised)
+                loaded_experiment = load_experiment(
+                    experiment.name, skip_runners_and_metrics=True
+                )
 
-            # Validate that:
-            #   - the runner is not loaded
-            #   - the metric is loaded as a base Metric class, not CustomTestMetric
-            self.assertIs(loaded_experiment.runner, None)
-            self.assertTrue("custom_test_metric" in loaded_experiment.metrics)
-            self.assertEqual(
-                loaded_experiment.metrics["custom_test_metric"].__class__, Metric
-            )
-            self.assertEqual(len(loaded_experiment.trials), 1)
-            self.assertIs(loaded_experiment.trials[0].runner, None)
-            delete_experiment(exp_name=experiment.name)
+                # Validate that:
+                #   - the runner is not loaded
+                #   - the metric is loaded as a base Metric class, not CustomTestMetric
+                self.assertIs(loaded_experiment.runner, None)
+                self.assertTrue("custom_test_metric" in loaded_experiment.metrics)
+                self.assertEqual(
+                    loaded_experiment.metrics["custom_test_metric"].__class__, Metric
+                )
+                self.assertEqual(len(loaded_experiment.trials), 1)
+                self.assertIs(loaded_experiment.trials[0].runner, None)
+                delete_experiment(exp_name=experiment.name)
 
     @patch(
         f"{Decoder.__module__}.Decoder.generator_run_from_sqa",


### PR DESCRIPTION
Summary:
The `skip_runners_and_metrics` flag didn't work properly for multi-objective metrics, since it didn't override the metric type of the child metrics.

Add support for this case.

Reviewed By: lena-kashtelyan

Differential Revision: D53635847


