### PR TITLE
Passing dictionary of metrics data to `is_eligible`

### DIFF
--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -272,7 +272,8 @@ class MultiObjectiveOptimizationConfig(OptimizationConfig):
         """Inits OptimizationConfig.
 
         Args:
-            objective: Metric+direction to use for the optimization.
+            objective: Metric+direction to use for the optimization. Should be either a
+                MultiObjective or a ScalarizedObjective.
             outcome_constraints: Constraints on metrics.
             objective_thesholds: Thresholds objectives must exceed. Used for
                 multi-objective optimization and for calculating frontiers

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -144,7 +144,7 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
 
         aligned_means = metric_to_aligned_means[metric_name]
         decisions = {
-            trial_index: self.should_stop_trial_early(
+            trial_index: self._should_stop_trial_early(
                 trial_index=trial_index,
                 experiment=experiment,
                 df=aligned_means,
@@ -160,7 +160,7 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             if should_stop
         }
 
-    def should_stop_trial_early(
+    def _should_stop_trial_early(
         self,
         trial_index: int,
         experiment: Experiment,

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -123,7 +123,7 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
 
         df_objective = df[df["metric_name"] == metric_name]
         decisions = {
-            trial_index: self.should_stop_trial_early(
+            trial_index: self._should_stop_trial_early(
                 trial_index=trial_index,
                 experiment=experiment,
                 df=df_objective,
@@ -138,7 +138,7 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             if should_stop
         }
 
-    def should_stop_trial_early(
+    def _should_stop_trial_early(
         self,
         trial_index: int,
         experiment: Experiment,


### PR DESCRIPTION
Summary:
This commit makes `is_eligible` for early stopping strategies loop over the data for each metric separately, in preparation for multi-objective early stopping strategies that require that data for all metrics pass the eligibility check.

Also, the commit makes `should_stop_trial_early` private as `_should_stop_trial_early`, highlighting that `should_stop_trials_early` is the public entry point for early stopping strategies.

Differential Revision: D53827530


