### PR TITLE
Don't test using SingleTaskGP with unsupported options in MBM

### DIFF
--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2133,7 +2133,6 @@ def get_surrogate() -> Surrogate:
     return Surrogate(
         botorch_model_class=get_model_type(),
         mll_class=get_mll_type(),
-        model_options={"some_option": "some_value"},
     )
 
 


### PR DESCRIPTION
Summary:
* Don't pass the option `some_option` to the SingleTaskGP input constructor.

This will trigger errors in https://github.com/pytorch/botorch/pull/2186

Differential Revision: D53825351


