### PR TITLE
Remove metric_names input to torch model fit

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -1393,7 +1393,6 @@ def process_contextual_datasets(
                         datasets[outcomes.index(metric_i)] for metric_i in metric_list
                     ],
                     parameter_decomposition=parameter_decomposition,
-                    context_buckets=context_buckets,
                     metric_decomposition=metric_decomposition,
                 )
             )
@@ -1409,7 +1408,6 @@ def process_contextual_datasets(
                 ContextualDataset(
                     datasets=[datasets[outcomes.index(metric_i)]],
                     parameter_decomposition=parameter_decomposition,
-                    context_buckets=context_buckets,
                 )
             )
     return contextual_datasets

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -143,7 +143,6 @@ class TorchModelBridgeTest(TestCase):
             )
         model_fit_args = model.fit.mock_calls[0][2]
         self.assertEqual(model_fit_args["datasets"], list(datasets.values()))
-        self.assertEqual(model_fit_args["metric_names"], ["y1", "y2"])
         self.assertEqual(model_fit_args["search_space_digest"], ssd)
         self.assertIsNone(model_fit_args["candidate_metadata"])
         self.assertEqual(ma._last_observations, observations)
@@ -702,7 +701,6 @@ class TorchModelBridgeTest(TestCase):
             else:
                 expected_outcomes = ["m1", "m2"]
             self.assertEqual(modelbridge.outcomes, expected_outcomes)
-            self.assertEqual(call_kwargs["metric_names"], expected_outcomes)
             self.assertEqual(len(call_kwargs["datasets"]), len(expected_outcomes))
 
     def test_convert_observations(self) -> None:

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -448,7 +448,6 @@ class TorchModelBridge(ModelBridge):
         # Use the model to do the cross validation
         f_test, cov_test = not_none(self.model).cross_validate(
             datasets=datasets,
-            metric_names=self.outcomes,
             X_test=torch.as_tensor(X_test, dtype=self.dtype, device=self.device),
             search_space_digest=search_space_digest,
             **kwargs,
@@ -647,7 +646,6 @@ class TorchModelBridge(ModelBridge):
         self.model = model
         self.model.fit(
             datasets=datasets,
-            metric_names=self.outcomes,
             search_space_digest=search_space_digest,
             candidate_metadata=candidate_metadata,
             **kwargs,

--- a/ax/models/tests/test_alebo.py
+++ b/ax/models/tests/test_alebo.py
@@ -309,7 +309,6 @@ class ALEBOTest(TestCase):
         # Test fit
         m.fit(
             datasets=[dataset, dataset],
-            metric_names=["y1", "y2"],
             search_space_digest=SearchSpaceDigest(
                 feature_names=[],
                 # pyre-fixme[6]: For 2nd param expected `List[Tuple[Union[float,

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -74,7 +74,6 @@ class KnowledgeGradientTest(TestCase):
         model = KnowledgeGradient()
         model.fit(
             datasets=[self.dataset],
-            metric_names=self.metric_names,
             search_space_digest=self.search_space_digest,
         )
 
@@ -181,7 +180,6 @@ class KnowledgeGradientTest(TestCase):
         model.fit(
             datasets=[self.dataset],
             search_space_digest=self.search_space_digest,
-            metric_names=self.metric_names,
         )
         self.assertTrue(model.use_input_warping)
         self.assertTrue(hasattr(model.model, "input_transform"))
@@ -193,7 +191,6 @@ class KnowledgeGradientTest(TestCase):
         model.fit(
             datasets=[self.dataset],
             search_space_digest=self.search_space_digest,
-            metric_names=self.metric_names,
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
@@ -208,7 +205,6 @@ class KnowledgeGradientTest(TestCase):
         model = KnowledgeGradient()
         model.fit(
             datasets=[self.dataset],
-            metric_names=["L2NormMetric"],
             search_space_digest=search_space_digest,
         )
 
@@ -276,7 +272,6 @@ class KnowledgeGradientTest(TestCase):
         model = KnowledgeGradient(use_input_warping=True)
         model.fit(
             datasets=[self.dataset],
-            metric_names=["L2NormMetric"],
             search_space_digest=search_space_digest,
         )
         self.assertTrue(model.use_input_warping)
@@ -288,7 +283,6 @@ class KnowledgeGradientTest(TestCase):
         model = KnowledgeGradient(use_loocv_pseudo_likelihood=True)
         model.fit(
             datasets=[self.dataset],
-            metric_names=["L2NormMetric"],
             search_space_digest=search_space_digest,
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
@@ -298,7 +292,6 @@ class KnowledgeGradientTest(TestCase):
         model = KnowledgeGradient()
         model.fit(
             datasets=[self.dataset],
-            metric_names=["L2NormMetric"],
             search_space_digest=SearchSpaceDigest(
                 feature_names=self.feature_names,
                 bounds=self.bounds,
@@ -377,7 +370,6 @@ class KnowledgeGradientTest(TestCase):
         model = KnowledgeGradient()
         model.fit(
             datasets=[self.dataset],
-            metric_names=["L2NormMetric"],
             search_space_digest=SearchSpaceDigest(
                 feature_names=self.feature_names,
                 bounds=self.bounds,

--- a/ax/models/tests/test_botorch_mes.py
+++ b/ax/models/tests/test_botorch_mes.py
@@ -55,7 +55,6 @@ class MaxValueEntropySearchTest(TestCase):
         model = MaxValueEntropySearch()
         model.fit(
             datasets=self.training_data,
-            metric_names=self.metric_names,
             search_space_digest=self.search_space_digest,
         )
 
@@ -140,7 +139,6 @@ class MaxValueEntropySearchTest(TestCase):
         model = MaxValueEntropySearch(use_input_warping=True)
         model.fit(
             datasets=self.training_data,
-            metric_names=self.metric_names,
             search_space_digest=self.search_space_digest,
         )
         self.assertTrue(model.use_input_warping)
@@ -152,7 +150,6 @@ class MaxValueEntropySearchTest(TestCase):
         model = MaxValueEntropySearch(use_loocv_pseudo_likelihood=True)
         model.fit(
             datasets=self.training_data,
-            metric_names=self.metric_names,
             search_space_digest=self.search_space_digest,
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
@@ -166,7 +163,6 @@ class MaxValueEntropySearchTest(TestCase):
         model = MaxValueEntropySearch()
         model.fit(
             datasets=self.training_data,
-            metric_names=self.metric_names,
             search_space_digest=search_space_digest,
         )
 
@@ -232,7 +228,6 @@ class MaxValueEntropySearchTest(TestCase):
         model = MaxValueEntropySearch(use_input_warping=True)
         model.fit(
             datasets=self.training_data,
-            metric_names=self.metric_names,
             search_space_digest=SearchSpaceDigest(
                 feature_names=self.feature_names,
                 bounds=self.bounds,
@@ -248,7 +243,6 @@ class MaxValueEntropySearchTest(TestCase):
         model = MaxValueEntropySearch(use_loocv_pseudo_likelihood=True)
         model.fit(
             datasets=self.training_data,
-            metric_names=self.metric_names,
             search_space_digest=search_space_digest,
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
@@ -259,7 +253,6 @@ class MaxValueEntropySearchTest(TestCase):
         model = MaxValueEntropySearch()
         model.fit(
             datasets=self.training_data,
-            metric_names=self.metric_names,
             search_space_digest=SearchSpaceDigest(
                 feature_names=self.feature_names,
                 bounds=self.bounds,
@@ -290,7 +283,6 @@ class MaxValueEntropySearchTest(TestCase):
         model = MaxValueEntropySearch()
         model.fit(
             datasets=self.training_data,
-            metric_names=self.metric_names,
             search_space_digest=SearchSpaceDigest(
                 feature_names=self.feature_names,
                 bounds=self.bounds,

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -70,14 +70,14 @@ class BotorchModelTest(TestCase):
                 Y=Ys1[0],
                 Yvar=Yvars1[0],
                 feature_names=feature_names,
-                outcome_names=metric_names,
+                outcome_names=["y"],
             ),
             SupervisedDataset(
                 X=Xs2[0],
                 Y=Ys2[0],
                 Yvar=Yvars2[0],
                 feature_names=feature_names,
-                outcome_names=metric_names,
+                outcome_names=["w"],
             ),
         ]
         with self.assertRaisesRegex(RuntimeError, "Please fit the model first"):
@@ -97,7 +97,6 @@ class BotorchModelTest(TestCase):
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=datasets,
-                metric_names=["y", "w"],
                 search_space_digest=search_space_digest,
             )
             self.assertTrue(isinstance(model.search_space_digest, SearchSpaceDigest))
@@ -151,7 +150,6 @@ class BotorchModelTest(TestCase):
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=datasets,
-                metric_names=["y", "w"],
                 search_space_digest=SearchSpaceDigest(
                     feature_names=feature_names,
                     bounds=bounds,
@@ -240,7 +238,6 @@ class BotorchModelTest(TestCase):
                 with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
                     model.fit(
                         datasets=datasets,
-                        metric_names=metric_names,
                         search_space_digest=SearchSpaceDigest(
                             feature_names=feature_names,
                             bounds=bounds,
@@ -304,7 +301,6 @@ class BotorchModelTest(TestCase):
             with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
                 model.fit(
                     datasets=datasets_block,
-                    metric_names=["y1", "y2"],
                     search_space_digest=SearchSpaceDigest(
                         feature_names=feature_names,
                         bounds=bounds,
@@ -528,7 +524,6 @@ class BotorchModelTest(TestCase):
             ]
             mean, variance = model.cross_validate(
                 datasets=combined_datasets,
-                metric_names=["y1", "y2"],
                 X_test=torch.tensor([[1.2, 3.2, 4.2], [2.4, 5.2, 3.2]], **tkwargs),
             )
             self.assertTrue(mean.shape == torch.Size([2, 2]))
@@ -538,7 +533,6 @@ class BotorchModelTest(TestCase):
             model.refit_on_cv = True
             mean, variance = model.cross_validate(
                 datasets=combined_datasets,
-                metric_names=["y1", "y2"],
                 X_test=torch.tensor([[1.2, 3.2, 4.2], [2.4, 5.2, 3.2]], **tkwargs),
             )
             self.assertTrue(mean.shape == torch.Size([2, 2]))
@@ -555,7 +549,6 @@ class BotorchModelTest(TestCase):
             ):
                 unfit_model.cross_validate(
                     datasets=combined_datasets,
-                    metric_names=["y1", "y2"],
                     X_test=Xs1[0],
                 )
             with self.assertRaisesRegex(
@@ -624,7 +617,6 @@ class BotorchModelTest(TestCase):
             model.fit(
                 # pyre-fixme[61]: `datasets` is undefined, or not always defined.
                 datasets=datasets,
-                metric_names=metric_names,
                 search_space_digest=SearchSpaceDigest(
                     feature_names=feature_names,
                     bounds=bounds,
@@ -680,7 +672,6 @@ class BotorchModelTest(TestCase):
                             outcome_names=metric_names,
                         )
                     ],
-                    metric_names=metric_names[:1],
                     search_space_digest=SearchSpaceDigest(
                         feature_names=feature_names,
                         bounds=bounds,
@@ -749,7 +740,6 @@ class BotorchModelTest(TestCase):
                         outcome_names=metric_names,
                     ),
                 ],
-                metric_names=metric_names,
                 search_space_digest=search_space_digest,
             )
             _mock_fit_model.assert_called_once()
@@ -777,7 +767,6 @@ class BotorchModelTest(TestCase):
         ):
             model.fit(
                 datasets=[],
-                metric_names=metric_names,
                 search_space_digest=search_space_digest,
             )
 

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -80,7 +80,6 @@ class FrontierEvaluatorTest(TestCase):
                         outcome_names=["a", "b", "c"],
                     )
                 ],
-                metric_names=["a", "b", "c"],
                 search_space_digest=SearchSpaceDigest(
                     feature_names=["x1", "x2"],
                     bounds=bounds,

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -181,7 +181,6 @@ class BotorchMOOModelTest(TestCase):
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=training_data,
-                metric_names=["y1", "y2"],
                 search_space_digest=search_space_digest,
             )
             _mock_fit_model.assert_called_once()
@@ -238,7 +237,6 @@ class BotorchMOOModelTest(TestCase):
         )
         model.fit(
             datasets=training_data,
-            metric_names=["y1", "y2"],
             search_space_digest=search_space_digest,
         )
         self.assertTrue(model.use_input_warping)
@@ -257,7 +255,6 @@ class BotorchMOOModelTest(TestCase):
         )
         model.fit(
             datasets=training_data,
-            metric_names=["y1", "y2"],
             search_space_digest=search_space_digest,
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
@@ -314,7 +311,6 @@ class BotorchMOOModelTest(TestCase):
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=training_data,
-                metric_names=["y1", "y2"],
                 search_space_digest=search_space_digest,
             )
             _mock_fit_model.assert_called_once()
@@ -425,7 +421,6 @@ class BotorchMOOModelTest(TestCase):
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=training_data,
-                metric_names=["y1", "y2"],
                 search_space_digest=search_space_digest,
             )
             _mock_fit_model.assert_called_once()
@@ -484,7 +479,6 @@ class BotorchMOOModelTest(TestCase):
 
             model.fit(
                 datasets=training_data_m3,
-                metric_names=["y1", "y2", "y3"],
                 search_space_digest=search_space_digest,
             )
             torch_opt_config = TorchOptConfig(
@@ -531,7 +525,6 @@ class BotorchMOOModelTest(TestCase):
             ]
             model.fit(
                 datasets=training_data_multiple,
-                metric_names=["y1", "y2", "dummy_metric"],
                 search_space_digest=search_space_digest,
             )
             es.enter_context(
@@ -727,7 +720,6 @@ class BotorchMOOModelTest(TestCase):
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=training_data,
-                metric_names=metric_names,
                 search_space_digest=search_space_digest,
             )
             _mock_fit_model.assert_called_once()
@@ -806,7 +798,6 @@ class BotorchMOOModelTest(TestCase):
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=training_data,
-                metric_names=metric_names,
                 search_space_digest=search_space_digest,
             )
             _mock_fit_model.assert_called_once()
@@ -911,7 +902,6 @@ class BotorchMOOModelTest(TestCase):
         with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
             model.fit(
                 datasets=training_data,
-                metric_names=metric_names,
                 search_space_digest=search_space_digest,
             )
             _mock_fit_model.assert_called_once()

--- a/ax/models/tests/test_cbo_lcea.py
+++ b/ax/models/tests/test_cbo_lcea.py
@@ -49,7 +49,6 @@ class LCEABOTest(TestCase):
         # Test fit
         m1.fit(
             datasets=training_data,
-            metric_names=metric_names,
             search_space_digest=SearchSpaceDigest(
                 feature_names=feature_names,
                 bounds=[(0.0, 1.0) for _ in range(4)],
@@ -87,7 +86,6 @@ class LCEABOTest(TestCase):
         m2 = LCEABO(decomposition={"1": ["x0", "x2"], "2": ["x1", "x3"]})
         m2.fit(
             datasets=training_data,
-            metric_names=metric_names,
             search_space_digest=SearchSpaceDigest(
                 feature_names=feature_names,
                 bounds=[(0.0, 1.0) for _ in range(4)],
@@ -102,7 +100,6 @@ class LCEABOTest(TestCase):
         with self.assertRaises(ValueError):
             m2.fit(
                 datasets=training_data,
-                metric_names=metric_names,
                 search_space_digest=SearchSpaceDigest(
                     feature_names=[],
                     bounds=[(0.0, 1.0) for _ in range(4)],
@@ -113,7 +110,6 @@ class LCEABOTest(TestCase):
         with self.assertRaises(AssertionError):
             m2.fit(
                 datasets=training_data,
-                metric_names=metric_names,
                 search_space_digest=SearchSpaceDigest(
                     feature_names=["x0", "x6", "x10", "z"],
                     bounds=[(0.0, 1.0) for _ in range(4)],

--- a/ax/models/tests/test_cbo_sac.py
+++ b/ax/models/tests/test_cbo_sac.py
@@ -43,7 +43,6 @@ class SACBOTest(TestCase):
         # test fit
         m1.fit(
             datasets=[dataset],
-            metric_names=metric_names,
             search_space_digest=SearchSpaceDigest(
                 feature_names=feature_names,
                 bounds=[(0.0, 1.0) for _ in range(4)],
@@ -81,7 +80,6 @@ class SACBOTest(TestCase):
         m2 = SACBO(decomposition={"1": ["x1", "x3"], "2": ["x2", "x4"]})
         m2.fit(
             datasets=[dataset],
-            metric_names=metric_names,
             search_space_digest=SearchSpaceDigest(
                 feature_names=["x1", "x2", "x3", "x4"],
                 bounds=[(0.0, 1.0) for _ in range(4)],
@@ -96,7 +94,6 @@ class SACBOTest(TestCase):
         with self.assertRaises(ValueError):
             m2.fit(
                 datasets=[dataset],
-                metric_names=metric_names,
                 search_space_digest=SearchSpaceDigest(
                     feature_names=[],
                     bounds=[(0.0, 1.0) for _ in range(4)],
@@ -107,7 +104,6 @@ class SACBOTest(TestCase):
         with self.assertRaises(AssertionError):
             m2.fit(
                 datasets=[dataset],
-                metric_names=metric_names,
                 search_space_digest=SearchSpaceDigest(
                     feature_names=["x0", "x1", "x2", "x3"],
                     bounds=[(0.0, 1.0) for _ in range(4)],

--- a/ax/models/tests/test_fully_bayesian.py
+++ b/ax/models/tests/test_fully_bayesian.py
@@ -176,7 +176,6 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                         bounds=bounds,
                         task_features=tfs,
                     ),
-                    metric_names=["y1", "y2"],
                 )
 
                 # Check that there are no unexpected constraints on the hyperparameters
@@ -376,7 +375,6 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                         )
                         for X, Y, Yvar, mn in zip(Xs_mt, Ys_mt, Yvars_mt, mns_mt)
                     ],
-                    metric_names=mns_mt,
                     search_space_digest=SearchSpaceDigest(
                         feature_names=fns_mt,
                         bounds=bounds_mt,
@@ -396,7 +394,6 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                             Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2, mns * 2
                         )
                     ],
-                    metric_names=mns,
                     search_space_digest=SearchSpaceDigest(
                         feature_names=fns,
                         bounds=bounds,
@@ -427,7 +424,6 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                         )
                         for X, Y, Yvar, mn in zip(Xs1 + Xs2, Ys1 + Ys2, Yvars, mns * 2)
                     ],
-                    metric_names=mns,
                     search_space_digest=SearchSpaceDigest(
                         feature_names=fns,
                         bounds=bounds,
@@ -762,7 +758,6 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                         Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2, mns * 2
                     )
                 ],
-                metric_names=mns,
                 search_space_digest=search_space_digest,
             )
             # pyre-fixme[16]: `BaseFullyBayesianBotorchModelTest` has no
@@ -826,7 +821,6 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                             Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2, mns * 2
                         )
                     ],
-                    metric_names=mns,
                     search_space_digest=SearchSpaceDigest(
                         feature_names=fns,
                         bounds=bounds,
@@ -872,7 +866,6 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                             Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2, mns * 2
                         )
                     ],
-                    metric_names=mns,
                     search_space_digest=SearchSpaceDigest(
                         feature_names=fns,
                         bounds=bounds,
@@ -906,7 +899,6 @@ class BaseFullyBayesianBotorchModelTest(ABC):
                             Xs1 + Xs2, Ys1 + Ys2, Yvars1 + Yvars2, mns * 2
                         )
                     ],
-                    metric_names=mns,
                     search_space_digest=SearchSpaceDigest(
                         feature_names=fns,
                         bounds=bounds,
@@ -1014,7 +1006,6 @@ class SingleObjectiveFullyBayesianBotorchModelTest(
                         )
                         for X, Y, Yvar, mn in zip(Xs1, Ys1, Yvars1, mns)
                     ],
-                    metric_names=[mns[0]],
                     search_space_digest=SearchSpaceDigest(
                         feature_names=fns,
                         bounds=bounds,

--- a/ax/models/tests/test_posterior_mean.py
+++ b/ax/models/tests/test_posterior_mean.py
@@ -52,7 +52,6 @@ class PosteriorMeanTest(TestCase):
         )
         model.fit(
             datasets=[dataset],
-            metric_names=["y"],
             search_space_digest=self.search_space_digest,
         )
 
@@ -84,7 +83,6 @@ class PosteriorMeanTest(TestCase):
         model = MultiObjectiveBotorchModel(acqf_constructor=get_PosteriorMean)
         model.fit(
             datasets=[dataset, dataset],
-            metric_names=["m1", "m2"],
             search_space_digest=self.search_space_digest,
         )
         new_X_dummy = torch.rand(1, 1, 3, **self.tkwargs)

--- a/ax/models/tests/test_randomforest.py
+++ b/ax/models/tests/test_randomforest.py
@@ -27,7 +27,6 @@ class RandomForestTest(TestCase):
         m = RandomForest(num_trees=5)
         m.fit(
             datasets=datasets,
-            metric_names=["y1", "y2"],
             search_space_digest=SearchSpaceDigest(
                 feature_names=["x1", "x2"],
                 # pyre-fixme[6]: For 2nd param expected `List[Tuple[Union[float,

--- a/ax/models/tests/test_rembo.py
+++ b/ax/models/tests/test_rembo.py
@@ -47,7 +47,6 @@ class REMBOTest(TestCase):
         with self.assertRaises(AssertionError):
             m.fit(
                 datasets=datasets,
-                metric_names=my_metric_names,
                 search_space_digest=SearchSpaceDigest(
                     feature_names=[], bounds=[(0.0, 1.0)] * 4
                 ),
@@ -55,7 +54,6 @@ class REMBOTest(TestCase):
         search_space_digest = SearchSpaceDigest(feature_names=[], bounds=bounds)
         m.fit(
             datasets=datasets,
-            metric_names=my_metric_names,
             search_space_digest=search_space_digest,
         )
 

--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -30,7 +30,6 @@ class TorchModelTest(TestCase):
         torch_model = TorchModel()
         torch_model.fit(
             datasets=[self.dataset],
-            metric_names=["y"],
             search_space_digest=SearchSpaceDigest(
                 feature_names=["x1"],
                 bounds=[(0, 1)],
@@ -64,7 +63,6 @@ class TorchModelTest(TestCase):
         with self.assertRaises(NotImplementedError):
             torch_model.cross_validate(
                 datasets=[self.dataset],
-                metric_names=["y"],
                 X_test=torch.ones(1),
                 search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
             )

--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -838,7 +838,6 @@ class ALEBO(BotorchModel):
     def fit(
         self,
         datasets: List[SupervisedDataset],
-        metric_names: List[str],
         search_space_digest: SearchSpaceDigest,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -293,14 +293,13 @@ class BotorchModel(TorchModel):
     def fit(
         self,
         datasets: List[SupervisedDataset],
-        metric_names: List[str],
         search_space_digest: SearchSpaceDigest,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
         if len(datasets) == 0:
             raise DataRequiredError("BotorchModel.fit requires non-empty data sets.")
         self.Xs, self.Ys, self.Yvars = _datasets_to_legacy_inputs(datasets=datasets)
-        self.metric_names = metric_names
+        self.metric_names = sum((ds.outcome_names for ds in datasets), [])
         # Store search space info for later use (e.g. during generation)
         self._search_space_digest = search_space_digest
         self.dtype = self.Xs[0].dtype

--- a/ax/models/torch/cbo_lcea.py
+++ b/ax/models/torch/cbo_lcea.py
@@ -117,7 +117,6 @@ class LCEABO(BotorchModel):
     def fit(
         self,
         datasets: List[SupervisedDataset],
-        metric_names: List[str],
         search_space_digest: SearchSpaceDigest,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
@@ -126,7 +125,6 @@ class LCEABO(BotorchModel):
         self.feature_names = search_space_digest.feature_names
         super().fit(
             datasets=datasets,
-            metric_names=metric_names,
             search_space_digest=search_space_digest,
         )
 

--- a/ax/models/torch/cbo_sac.py
+++ b/ax/models/torch/cbo_sac.py
@@ -50,7 +50,6 @@ class SACBO(BotorchModel):
     def fit(
         self,
         datasets: List[SupervisedDataset],
-        metric_names: List[str],
         search_space_digest: SearchSpaceDigest,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
@@ -59,7 +58,6 @@ class SACBO(BotorchModel):
         self.feature_names = search_space_digest.feature_names
         super().fit(
             datasets=datasets,
-            metric_names=metric_names,
             search_space_digest=search_space_digest,
         )
 

--- a/ax/models/torch/randomforest.py
+++ b/ax/models/torch/randomforest.py
@@ -47,7 +47,6 @@ class RandomForest(TorchModel):
     def fit(
         self,
         datasets: List[SupervisedDataset],
-        metric_names: List[str],
         search_space_digest: SearchSpaceDigest,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:

--- a/ax/models/torch/rembo.py
+++ b/ax/models/torch/rembo.py
@@ -65,7 +65,6 @@ class REMBO(BotorchModel):
     def fit(
         self,
         datasets: List[SupervisedDataset],
-        metric_names: List[str],
         search_space_digest: SearchSpaceDigest,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
@@ -79,7 +78,6 @@ class REMBO(BotorchModel):
         low_d_datasets = self._convert_and_normalize_datasets(datasets=datasets)
         super().fit(
             datasets=low_d_datasets,
-            metric_names=metric_names,
             search_space_digest=SearchSpaceDigest(
                 feature_names=[f"x{i}" for i in range(self.A.shape[1])],
                 bounds=[(0.0, 1.0)] * len(self.bounds_d),

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -350,16 +350,7 @@ class BoTorchModelTest(TestCase):
             state_dict=None,
             refit=True,
         )
-        # ensure that error is raised when len(metric_names) != len(datasets)
-        with self.assertRaisesRegex(
-            AxError,
-            "Each metric name must correspond to an outcome in the datasets.",
-        ):
-            self.model.fit(
-                datasets=self.block_design_training_data,
-                metric_names=self.metric_names + ["zzz", "zzzzzz"],
-                search_space_digest=self.mf_search_space_digest,
-            )
+
         # since Surrogate.fit is mocked, it didn't actually assign the outcomes
         with patch.object(
             self.model.surrogate,
@@ -380,7 +371,6 @@ class BoTorchModelTest(TestCase):
     def test_cross_validate(self, mock_fit: Mock) -> None:
         self.model.fit(
             datasets=self.block_design_training_data,
-            metric_names=self.metric_names,
             search_space_digest=self.mf_search_space_digest,
             candidate_metadata=self.candidate_metadata,
         )
@@ -403,7 +393,6 @@ class BoTorchModelTest(TestCase):
             ) as mock_clone_reset:
                 self.model.cross_validate(
                     datasets=self.block_design_training_data,
-                    metric_names=self.metric_names,
                     X_test=self.X_test,
                     search_space_digest=self.mf_search_space_digest,
                 )

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -119,7 +119,6 @@ class TorchModel(BaseModel):
     def fit(
         self,
         datasets: List[SupervisedDataset],
-        metric_names: List[str],
         search_space_digest: SearchSpaceDigest,
         candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
     ) -> None:
@@ -128,8 +127,6 @@ class TorchModel(BaseModel):
         Args:
             datasets: A list of ``SupervisedDataset`` containers, each
                 corresponding to the data of one metric (outcome).
-            metric_names: A list of metric names, with the i-th metric
-                corresponding to the i-th dataset.
             search_space_digest: A ``SearchSpaceDigest`` object containing
                 metadata on the features in the datasets.
             candidate_metadata: Model-produced metadata for candidates, in
@@ -198,7 +195,6 @@ class TorchModel(BaseModel):
     def cross_validate(
         self,
         datasets: List[SupervisedDataset],
-        metric_names: List[str],
         X_test: Tensor,
         search_space_digest: SearchSpaceDigest,
     ) -> Tuple[Tensor, Tensor]:
@@ -210,8 +206,6 @@ class TorchModel(BaseModel):
         Args:
             datasets: A list of ``SupervisedDataset`` containers, each
                 corresponding to the data of one metric (outcome).
-            metric_names: A list of metric names, with the i-th metric
-                corresponding to the i-th dataset.
             X_test: (j x d) tensor of the j points at which to make predictions.
             search_space_digest: A SearchSpaceDigest object containing
                 metadata on the features in X.


### PR DESCRIPTION
Summary:
This input is no longer necessary due to the metric names already
being specified in datasets.

Reviewed By: qingfeng10

Differential Revision: D53814087


