### PR TITLE
Updating from "pivot" to "pivot_table" to fix errors generating Pareto Frontier charts

### DIFF
--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -14,6 +14,7 @@ from ax.core.generator_run import GeneratorRun
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.trial import Trial
 from ax.exceptions.core import DataRequiredError
+from ax.service.utils.best_point import extract_Y_from_data
 from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast, not_none
@@ -170,3 +171,18 @@ class TestBestPointMixin(TestCase):
             scalarized=True,
         )
         self.assertEqual(get_best(exp), 6)
+
+    def test_extract_Y_from_data(self) -> None:
+        # Single objective, minimize.
+        exp = get_experiment_with_observations(
+            observations=[[11], [10], [9], [15], [5]], minimize=True
+        )
+        self.assertNotEqual(len(exp.lookup_data().df), 0)
+
+        if not exp.optimization_config:
+            raise TypeError("No objective")
+
+        metric_names = exp.optimization_config.objective.metric_names
+
+        output, _ = extract_Y_from_data(experiment=exp, metric_names=metric_names)
+        self.assertNotEqual(len(output), 0)

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -835,9 +835,13 @@ def extract_Y_from_data(
             0, dtype=torch.long
         )
 
-    data_as_wide = df[keeps].pivot(
-        columns="metric_name", index=["trial_index", "arm_name"], values="mean"
+    data_as_wide = pd.pivot_table(
+        df[keeps],
+        index=["trial_index", "arm_name"],
+        columns="metric_name",
+        values="mean",
     )[metric_names]
+
     means = torch.tensor(data_as_wide.to_numpy()).to(torch.double)
     trial_indices = torch.tensor(
         data_as_wide.reset_index()["trial_index"].to_numpy(), dtype=torch.long


### PR DESCRIPTION
Summary:
In the logs of this fblearner run https://www.internalfb.com/mlhub/pipelines/runs/fblearner/532020554?tab=Operator%20Details

In the logs, the creation of the pareto frontier charts fails in “best_point.py”. The process errors out with the following exception: 
```
ValueError: Length of passed values is 1248, index implies 2.
```

When investigating, I found that this "index implies 2" error is
- Caused by Pandas pivot
- Only occurs in Panda versions prior to 1.1.12
- Happens sporadically on the same set of data

Through investigation I found that FbLearner runs with Pandas version 1.0.4, and Bento runs with Pandas version 2.0.3. This explains why the issue occurs only in FbLearner, and only occurs for some FBLearner runs. 

The fix is to use "pivot_table" instead which gives the desired output without introducing this error

Differential Revision: D54006659


