### PR TITLE
Removing `true_objective_metric_name` from early stopping strategies

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -314,13 +314,6 @@ class Experiment(Base):
         """The experiment's optimization config."""
         return self._optimization_config
 
-    @property
-    def is_moo_problem(self) -> bool:
-        """Whether the experiment's optimization config contains multiple objectives."""
-        if self.optimization_config is None:
-            return False
-        return not_none(self.optimization_config).is_moo_problem
-
     @optimization_config.setter
     def optimization_config(self, optimization_config: OptimizationConfig) -> None:
         if (
@@ -343,6 +336,13 @@ class Experiment(Base):
             for metric in optimization_config.metrics.values()
         ):
             self._default_data_type = DataType.MAP_DATA
+
+    @property
+    def is_moo_problem(self) -> bool:
+        """Whether the experiment's optimization config contains multiple objectives."""
+        if self.optimization_config is None:
+            return False
+        return not_none(self.optimization_config).is_moo_problem
 
     @property
     def data_by_trial(self) -> Dict[int, OrderedDict[int, Data]]:

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -7,7 +7,6 @@
 # pyre-strict
 
 import logging
-import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from logging import Logger
@@ -73,7 +72,6 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         max_progression: Optional[float] = None,
         min_curves: Optional[int] = None,
         trial_indices_to_ignore: Optional[List[int]] = None,
-        true_objective_metric_name: Optional[str] = None,
         normalize_progressions: bool = False,
     ) -> None:
         """A BaseEarlyStoppingStrategy class.
@@ -94,9 +92,6 @@ class BaseEarlyStoppingStrategy(ABC, Base):
                 `min_curves` trials are completed but their curve data was not
                 successfully retrieved, further trials may not be early-stopped.
             trial_indices_to_ignore: Trial indices that should not be early stopped.
-            true_objective_metric_name: The actual objective to be optimized; used in
-                situations where early stopping uses a proxy objective (such as training
-                loss instead of eval loss) for stopping decisions.
             normalize_progressions: Normalizes the progression column of the MapData df
                 by dividing by the max. If the values were originally in [0, `prog_max`]
                 (as we would expect), the transformed values will be in [0, 1]. Useful
@@ -113,13 +108,6 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         self.max_progression = max_progression
         self.min_curves = min_curves
         self.trial_indices_to_ignore = trial_indices_to_ignore
-        if true_objective_metric_name is not None:
-            warnings.warn(
-                ("`true_objective_metric_name` is deprecated and will be ignored."),
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         self.normalize_progressions = normalize_progressions
 
     @abstractmethod
@@ -429,7 +417,6 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         max_progression: Optional[float] = None,
         min_curves: Optional[int] = None,
         trial_indices_to_ignore: Optional[List[int]] = None,
-        true_objective_metric_name: Optional[str] = None,
         normalize_progressions: bool = False,
         min_progression_modeling: Optional[float] = None,
     ) -> None:
@@ -451,9 +438,6 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 `min_curves` trials are completed but their curve data was not
                 successfully retrieved, further trials may not be early-stopped.
             trial_indices_to_ignore: Trial indices that should not be early stopped.
-            true_objective_metric_name: The actual objective to be optimized; used in
-                situations where early stopping uses a proxy objective (such as training
-                loss instead of eval loss) for stopping decisions.
             normalize_progressions: Normalizes the progression column of the MapData df
                 by dividing by the max. If the values were originally in [0, `prog_max`]
                 (as we would expect), the transformed values will be in [0, 1]. Useful
@@ -472,7 +456,6 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             max_progression=max_progression,
             min_curves=min_curves,
             trial_indices_to_ignore=trial_indices_to_ignore,
-            true_objective_metric_name=true_objective_metric_name,
             normalize_progressions=normalize_progressions,
         )
         self.min_progression_modeling = min_progression_modeling

--- a/ax/early_stopping/strategies/logical.py
+++ b/ax/early_stopping/strategies/logical.py
@@ -19,11 +19,9 @@ class LogicalEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         left: BaseEarlyStoppingStrategy,
         right: BaseEarlyStoppingStrategy,
         seconds_between_polls: int = 300,
-        true_objective_metric_name: Optional[str] = None,
     ) -> None:
         super().__init__(
             seconds_between_polls=seconds_between_polls,
-            true_objective_metric_name=true_objective_metric_name,
         )
 
         self.left = left

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -34,7 +34,6 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         max_progression: Optional[float] = None,
         min_curves: Optional[int] = 5,
         trial_indices_to_ignore: Optional[List[int]] = None,
-        true_objective_metric_name: Optional[str] = None,
         normalize_progressions: bool = False,
     ) -> None:
         """Construct a PercentileEarlyStoppingStrategy instance.
@@ -62,9 +61,6 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 `min_curves` trials are completed but their curve data was not
                 successfully retrieved, further trials may not be early-stopped.
             trial_indices_to_ignore: Trial indices that should not be early stopped.
-            true_objective_metric_name: The actual objective to be optimized; used in
-                situations where early stopping uses a proxy objective (such as training
-                loss instead of eval loss) for stopping decisions.
             normalize_progressions: Normalizes the progression column of the MapData df
                 by dividing by the max. If the values were originally in [0, `prog_max`]
                 (as we would expect), the transformed values will be in [0, 1]. Useful
@@ -80,7 +76,6 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             min_progression=min_progression,
             max_progression=max_progression,
             min_curves=min_curves,
-            true_objective_metric_name=true_objective_metric_name,
             normalize_progressions=normalize_progressions,
         )
 

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -31,7 +31,6 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         max_progression: Optional[float] = None,
         min_curves: Optional[int] = 5,
         trial_indices_to_ignore: Optional[List[int]] = None,
-        true_objective_metric_name: Optional[str] = None,
         normalize_progressions: bool = False,
     ) -> None:
         """Construct a ThresholdEarlyStoppingStrategy instance.
@@ -55,9 +54,6 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 `min_curves` trials are completed but their curve data was not
                 successfully retrieved, further trials may not be early-stopped.
             trial_indices_to_ignore: Trial indices that should not be early stopped.
-            true_objective_metric_name: The actual objective to be optimized; used in
-                situations where early stopping uses a proxy objective (such as training
-                loss instead of eval loss) for stopping decisions.
             normalize_progressions: Normalizes the progression column of the MapData df
                 by dividing by the max. If the values were originally in [0, `prog_max`]
                 (as we would expect), the transformed values will be in [0, 1]. Useful
@@ -69,7 +65,6 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         super().__init__(
             metric_names=metric_names,
             seconds_between_polls=seconds_between_polls,
-            true_objective_metric_name=true_objective_metric_name,
             min_progression=min_progression,
             max_progression=max_progression,
             min_curves=min_curves,

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -285,14 +285,6 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         )
         self.assertEqual(should_stop, {})
 
-        # True objective metric name
-        self.assertFalse(hasattr(early_stopping_strategy, "true_objective_metric_name"))
-        with self.assertWarnsRegex(DeprecationWarning, "ignored"):
-            early_stopping_strategy = PercentileEarlyStoppingStrategy(
-                true_objective_metric_name="true_obj_metric"
-            )
-        self.assertFalse(hasattr(early_stopping_strategy, "true_objective_metric_name"))
-
     def test_percentile_early_stopping_strategy(self) -> None:
         self._test_percentile_early_stopping_strategy(non_objective_metric=False)
 

--- a/ax/service/utils/early_stopping.py
+++ b/ax/service/utils/early_stopping.py
@@ -47,6 +47,7 @@ def get_early_stopping_metrics(
         return []
     if early_stopping_strategy.metric_names is not None:
         return list(early_stopping_strategy.metric_names)
+    # TODO: generalize this to multi-objective ess
     default_objective, _ = early_stopping_strategy._default_objective_and_direction(
         experiment=experiment
     )


### PR DESCRIPTION
Summary:
This commit removes `true_objective_metric_name` from early stopping strategies. 

`true_objective_metric_name` is used when the early stopping strategy works on a different metric than any of the objectives of the experiment. In this case however, I’d expect the “true objective” to show up in the experiments optimization config, so we wouldn’t need to keep track on it on the ESS. 

The only case I can think of where `true_objective_metric_name` would be required is when the “true objective” is not an actual objective on the experiment. Notably, early stopping strategies were historically registered as objectives of an experiment, and the "actual" optimization objectives were registered as tracking metrics. It seems we can remove `true_objective_metric_name` given recent usage.

Differential Revision: D54019501


