### PR TITLE
Model CV in transformed space

### DIFF
--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -236,12 +236,28 @@ class BaseModelBridgeTest(TestCase):
         )
         cv_training_data = [get_observation2()]
         cv_test_points = [get_observation1().features]
+
+        # Test transforms applied on cv_training_data, cv_test_points
+        (
+            transformed_cv_training_data,
+            transformed_cv_test_points,
+            transformed_ss,
+        ) = modelbridge._transform_inputs_for_cv(
+            cv_training_data=cv_training_data, cv_test_points=cv_test_points
+        )
+        self.assertEqual(transformed_cv_training_data, [get_observation2trans()])
+        self.assertEqual(transformed_cv_test_points, [get_observation1trans().features])
+        self.assertEqual(
+            transformed_ss, SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)])
+        )
+
         with warnings.catch_warnings(record=True) as ws:
             cv_predictions = modelbridge.cross_validate(
                 cv_training_data=cv_training_data, cv_test_points=cv_test_points
             )
         self.assertTrue(called)
         self.assertFalse(any(w.category is InputDataWarning for w in ws))
+
         # pyre-fixme[16]: Callable `_cross_validate` has no attribute
         #  `assert_called_with`.
         modelbridge._cross_validate.assert_called_with(

--- a/ax/modelbridge/tests/test_model_fit_metrics.py
+++ b/ax/modelbridge/tests/test_model_fit_metrics.py
@@ -62,7 +62,9 @@ class TestModelBridgeFitMetrics(TestCase):
 
         # testing compute_model_fit_metrics_from_modelbridge with default metrics
         fit_metrics = compute_model_fit_metrics_from_modelbridge(
-            model_bridge=model_bridge, experiment=self.branin_experiment
+            model_bridge=model_bridge,
+            experiment=self.branin_experiment,
+            untransform=False,
         )
         r2 = fit_metrics.get("coefficient_of_determination")
         self.assertIsInstance(r2, dict)

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -1852,7 +1852,9 @@ class AxSchedulerTestCase(TestCase):
 
         # testing compatibility with compute_model_fit_metrics_from_modelbridge
         fit_metrics = compute_model_fit_metrics_from_modelbridge(
-            model_bridge=model_bridge, experiment=scheduler.experiment
+            model_bridge=model_bridge,
+            experiment=scheduler.experiment,
+            untransform=False,
         )
         r2 = fit_metrics.get("coefficient_of_determination")
         self.assertIsInstance(r2, dict)
@@ -1873,6 +1875,7 @@ class AxSchedulerTestCase(TestCase):
             model_bridge=model_bridge,
             experiment=scheduler.experiment,
             fit_metrics_dict={},
+            untransform=False,
         )
         self.assertIsInstance(empty_metrics, dict)
         self.assertTrue(len(empty_metrics) == 0)

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -1472,6 +1472,7 @@ def warn_if_unpredictable_metrics(
         model_bridge=model_bridge,
         experiment=experiment,
         generalization=True,  # use generalization metrics for user warning
+        untransform=False,
     )
     fit_quality_dict = model_fit_dict[model_fit_metric_name]
 

--- a/ax/telemetry/scheduler.py
+++ b/ax/telemetry/scheduler.py
@@ -119,6 +119,7 @@ class SchedulerCompletedRecord:
                 model_bridge=model_bridge,
                 experiment=scheduler.experiment,
                 generalization=False,
+                untransform=False,
             )
             model_fit_quality = _model_fit_metric(model_fit_dict)
             # similar for uncertainty quantification, but distance from 1 matters
@@ -130,6 +131,7 @@ class SchedulerCompletedRecord:
                 model_bridge=model_bridge,
                 experiment=scheduler.experiment,
                 generalization=True,
+                untransform=False,
             )
             model_fit_generalization = _model_fit_metric(model_gen_dict)
             gen_std = list(model_gen_dict["std_of_the_standardized_error"].values())

--- a/ax/telemetry/tests/test_scheduler.py
+++ b/ax/telemetry/tests/test_scheduler.py
@@ -188,6 +188,7 @@ class TestScheduler(TestCase):
             model_bridge=model_bridge,
             experiment=scheduler.experiment,
             generalization=False,
+            untransform=False,
         )
         # checking fit metrics
         r2 = fit_metrics.get("coefficient_of_determination")
@@ -211,6 +212,7 @@ class TestScheduler(TestCase):
             model_bridge=model_bridge,
             experiment=scheduler.experiment,
             generalization=True,
+            untransform=False,
         )
         r2_gen = gen_metrics.get("coefficient_of_determination")
         r2_gen = cast(Dict[str, float], r2_gen)


### PR DESCRIPTION
Summary:
We want to calculate model fit quality metrics in the transformed space, which involves making CV predictions and training data predictions in transformed space. More broadly, we also want to give users the option to cross validate on transformed data

1. In `cross_validation.py`, we add a tag `untransform=True` so users of `cross_validation.cross_validate` module can choose to make CV predictions on transformed or untransformed space
1a. More specifically, modelbridge base.py method `cross_validate` is broken down into `_tranform_inputs_for_cv`, `_cross_validate`, and untransform results.
1b. `untransform=True` (default) `cross_validation.cross_validate` will directly call `modelbridge.cross_validate`, else, it'd call the two hidden methods to return predictions on transformed space.

2. When calcualting model fit quality metrics on Cross Validation data, `_predict_on_cross_validation_data` will call `cross_validate` with `untransform=False`

3. When calculating model fit quality metrics on training data, `_predict_on_training_data` will leverage the hidden methods in model bridge base.py `_tranform_inputs_for_cv` & `_cross_validate` to transform training data and make predictions. `_predict_on_training_data` is a special case where training and test data are the same, so we just need to make sure we use `_cross_validate` in a way that we're using train data features to predict train true observations. We no longer use `modelbridge.predit`, which returns predictions in untransformed sapce, to avoid transforming and untransforming for multiple times.

Differential Revision: D54040302


