### PR TITLE
ImprovementGlobalStoppingStrategy cleanup

### DIFF
--- a/ax/global_stopping/strategies/improvement.py
+++ b/ax/global_stopping/strategies/improvement.py
@@ -61,11 +61,14 @@ class ImprovementGlobalStoppingStrategy(BaseGlobalStoppingStrategy):
                 The first trial that could be used for analysis is
                 `min_trials - window_size`; the first trial for which stopping
                 might be recommended is `min_trials`.
-            improvement_bar: Threshold (in [0,1]) for considering relative improvement
-                over the best point.
+            improvement_bar: Threshold for considering improvement over the best
+                point, relative to the interquartile range of values seen so
+                far. Must be >= 0.
             inactive_when_pending_trials: If set, the optimization will not stopped as
                 long as it has running trials.
         """
+        if improvement_bar < 0:
+            raise ValueError("improvement_bar must be >= 0.")
         super().__init__(
             min_trials=min_trials,
             inactive_when_pending_trials=inactive_when_pending_trials,
@@ -99,6 +102,7 @@ class ImprovementGlobalStoppingStrategy(BaseGlobalStoppingStrategy):
                 when computing hv of the pareto front against. This is used only in the
                 MOO setting. If not specified, the objective thresholds on the
                 experiment's optimization config will be used for the purpose.
+            kwargs: Unused.
 
         Returns:
             A Tuple with a boolean determining whether the optimization should stop,

--- a/ax/global_stopping/tests/tests_strategies.py
+++ b/ax/global_stopping/tests/tests_strategies.py
@@ -360,6 +360,12 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
             f"There are only 0 completed trials, but {gss} has a minumum of 2.",
         )
 
+    def test_improvement_bar_nonnegative(self) -> None:
+        with self.assertRaisesRegex(ValueError, "improvement_bar must be >= 0."):
+            ImprovementGlobalStoppingStrategy(
+                min_trials=2, window_size=3, improvement_bar=-0.1
+            )
+
     def test_constraint_satisfaction(self) -> None:
         metric_values = [
             (0.1, 0.6, 0.1),  # feasible


### PR DESCRIPTION
Summary:
- Correct a docstring: The `improvement_bar` in `ImprovementGlobalStoppingStrategy` can be greater than one, since an improvement of more than 1x the IQR is feasible.
- Add an exception when `improvement_bar` is negative.

Differential Revision: D54119242


