### PR TITLE
Updating pyre version after old version expired

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1612,10 +1612,13 @@ class Experiment(Base):
         datas = []
         # clone only the specified trials
         original_trial_indices = self.trials.keys()
+        # pyre-fixme[9]: trial_indices has type `Optional[List[int]]`; used as
+        #  `Set[int]`.
         trial_indices = (
             set(original_trial_indices) if trial_indices is None else set(trial_indices)
         )
         if (
+            # pyre-fixme[16]: `Optional` has no attribute `difference`.
             len(trial_indices_diff := trial_indices.difference(original_trial_indices))
             > 0
         ):
@@ -1624,6 +1627,7 @@ class Experiment(Base):
                 "of the original experiment. ",
                 stacklevel=2,
             )
+        # pyre-fixme[16]: `Optional` has no attribute `intersection`.
         for trial_index in trial_indices.intersection(original_trial_indices):
             trial = self.trials[trial_index]
             if isinstance(trial, BatchTrial) or isinstance(trial, Trial):

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -125,6 +125,8 @@ class MultiTypeExperiment(Experiment):
         self._trial_type_to_runner[trial_type] = runner
         return self
 
+    # pyre-fixme[14]: `add_tracking_metric` overrides method defined in `Experiment`
+    #  inconsistently.
     def add_tracking_metric(
         self, metric: Metric, trial_type: str, canonical_name: Optional[str] = None
     ) -> "MultiTypeExperiment":
@@ -144,6 +146,8 @@ class MultiTypeExperiment(Experiment):
             self._metric_to_canonical_name[metric.name] = canonical_name
         return self
 
+    # pyre-fixme[14]: `update_tracking_metric` overrides method defined in
+    #  `Experiment` inconsistently.
     def update_tracking_metric(
         self, metric: Metric, trial_type: str, canonical_name: Optional[str] = None
     ) -> "MultiTypeExperiment":

--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -112,6 +112,8 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
                 MetricFetchE(message=f"Failed to fetch {self.name}", exception=e)
             )
 
+    # pyre-fixme[14]: `f` overrides method defined in `NoisyFunctionMapMetric`
+    #  inconsistently.
     def f(self, x: np.ndarray, timestamp: int) -> Mapping[str, Any]:
         x1, x2 = x
 

--- a/ax/metrics/tests/test_chemistry.py
+++ b/ax/metrics/tests/test_chemistry.py
@@ -77,6 +77,9 @@ class ChemistryMetricTest(TestCase):
                 params = dict(zip(param_names, param_values))
                 trial = get_trial()
                 trial._generator_run = GeneratorRun(
+                    # pyre-fixme[6]: For 2nd argument expected `Dict[str,
+                    #  Union[None, bool, float, int, str]]` but got `Dict[str,
+                    #  Union[float, int, str]]`.
                     arms=[Arm(name="0_0", parameters=params)]
                 )
                 df = metric.fetch_trial_data(trial).unwrap().df

--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -325,6 +325,10 @@ class MapTorchModelBridge(TorchModelBridge):
                         map_key_range = map_key_ranges[o][p]
                         if map_key_range is not None:
                             range_min, range_max = map_key_range
+                            # pyre-fixme[58]: `<` is not supported for operand types
+                            #  `Union[None, bool, float, int, str]` and `Any`.
+                            # pyre-fixme[58]: `>` is not supported for operand types
+                            #  `Union[None, bool, float, int, str]` and `Any`.
                             if map_key_value < range_min or map_key_value > range_max:
                                 p_idx = metric_names.index(o)
                                 metric_names.pop(p_idx)

--- a/ax/modelbridge/transforms/tests/test_map_unit_x_transform.py
+++ b/ax/modelbridge/transforms/tests/test_map_unit_x_transform.py
@@ -73,7 +73,12 @@ class MapUnitXTransformTest(TestCase):
             for step in ("step_1", "step_2"):
                 if step in expected_obsf.parameters:
                     self.assertAlmostEqual(
-                        obsf.parameters[step], expected_obsf.parameters[step]
+                        obsf.parameters[step],
+                        # pyre-fixme[6]: For 2nd argument expected
+                        #  `SupportsRSub[Variable[_T],
+                        #  SupportsAbs[SupportsRound[object]]]` but got `Union[None,
+                        #  bool, float, int, str]`.
+                        expected_obsf.parameters[step],
                     )
 
         obs_ft2 = self.t.untransform_observation_features(obs_ft2)
@@ -81,7 +86,12 @@ class MapUnitXTransformTest(TestCase):
             for step in ("step_1", "step_2"):
                 if step in expected_obsf.parameters:
                     self.assertAlmostEqual(
-                        obsf.parameters[step], expected_obsf.parameters[step]
+                        obsf.parameters[step],
+                        # pyre-fixme[6]: For 2nd argument expected
+                        #  `SupportsRSub[Variable[_T],
+                        #  SupportsAbs[SupportsRound[object]]]` but got `Union[None,
+                        #  bool, float, int, str]`.
+                        expected_obsf.parameters[step],
                     )
 
     def test_TransformSearchSpace(self) -> None:

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -427,6 +427,7 @@ class Surrogate(Base):
         ]
 
         input_transforms = [
+            # pyre-fixme[45]: Cannot instantiate abstract class `InputTransform`.
             single_input_class(**single_input_transform_kwargs)
             for single_input_class, single_input_transform_kwargs in zip(
                 input_classes, input_transform_kwargs
@@ -470,6 +471,7 @@ class Surrogate(Base):
         ]
 
         outcome_transforms = [
+            # pyre-fixme[45]: Cannot instantiate abstract class `OutcomeTransform`.
             input_class(**single_outcome_transform_kwargs)
             for input_class, single_outcome_transform_kwargs in zip(
                 input_classes, outcome_transform_kwargs

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -214,6 +214,7 @@ def convert_to_block_design(
         Y = torch.cat([ds.Y[i] for ds, i in zip(datasets, idcs_shared)], dim=-1)
         if is_fixed:
             Yvar = torch.cat(
+                # pyre-fixme[16]: `Optional` has no attribute `__getitem__`.
                 [ds.Yvar[i] for ds, i in zip(datasets, idcs_shared)],
                 dim=-1,
             )

--- a/ax/models/torch/tests/test_sebo.py
+++ b/ax/models/torch/tests/test_sebo.py
@@ -226,6 +226,7 @@ class TestSebo(TestCase):
             options={"penalty": "L0_norm", "target_point": self.target_point},
         )
         # overwrite acqf to validate homotopy
+        # pyre-fixme[61]: `p` is undefined, or not always defined.
         model = GenericDeterministicModel(f=lambda x: 5 - (x - p) ** 2)
         acqf = PosteriorMean(model=model)
         acquisition.acqf = acqf

--- a/ax/plot/slice.py
+++ b/ax/plot/slice.py
@@ -463,8 +463,10 @@ def interact_slice_plotly(
 
     # Populate mbuttons, which allows the user to select which metric to plot
     mbuttons = []
+    # pyre-fixme[61]: `metrics` is undefined, or not always defined.
     for i, metric in enumerate(metrics):
         trace_cnt = 3 + len(arm_data[metric]["out_of_sample"].keys())
+        # pyre-fixme[61]: `metrics` is undefined, or not always defined.
         visible = [False] * (len(metrics) * trace_cnt)
         for j in range(i * trace_cnt, (i + 1) * trace_cnt):
             visible[j] = True

--- a/ax/plot/trace.py
+++ b/ax/plot/trace.py
@@ -471,7 +471,9 @@ def optimization_trace_single_method_plotly(
             y_lower = np.percentile(y, 25, axis=0).min()
             y_upper = np.percentile(y, 75, axis=0).max()
         else:
+            # pyre-fixme[61]: `y_running_optimum` is undefined, or not always defined.
             y_lower = np.percentile(y_running_optimum, 25, axis=0).min()
+            # pyre-fixme[61]: `y_running_optimum` is undefined, or not always defined.
             y_upper = np.percentile(y_running_optimum, 75, axis=0).max()
         if optimum is not None and optimum < y_lower:
             y_lower = optimum

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -94,7 +94,6 @@ class _AssertRaisesContextOn(unittest.case._AssertRaisesContext):
         )
         self.lineno = None
         self.filename = None
-        # pyre-fixme[28]: Unexpected keyword argument `expected`.
         super().__init__(
             expected=expected, test_case=test_case, expected_regex=expected_regex
         )
@@ -283,6 +282,10 @@ def setup_import_mocks(
     # Replace the original import with the custom one
     # pyre-fixme[61]
     original_import = builtins.__import__
+    # pyre-fixme[9]: __import__ has type `(name: str, globals: Optional[Mapping[str,
+    #  object]] = ..., locals: Optional[Mapping[str, object]] = ..., fromlist:
+    #  Sequence[str] = ..., level: int = ...) -> ModuleType`; used as `(name: str,
+    #  *(Any), **(Any)) -> Any`.
     builtins.__import__ = custom_import
 
 
@@ -410,7 +413,6 @@ class TestCase(fake_filesystem_unittest.TestCase):
     ) -> ContextManager[None]:
         """Assert that an exception is raised on a specific line."""
         context = _AssertRaisesContextOn(exc, self, line, regex)
-        # pyre-ignore [16]: ... has no attribute `handle`.
         return context.handle("assertRaisesOn", [], {})
 
     def assertDictsAlmostEqual(

--- a/ax/utils/sensitivity/sobol_measures.py
+++ b/ax/utils/sensitivity/sobol_measures.py
@@ -662,6 +662,7 @@ class SobolSensitivityGPSampling(object):
                 second_order_idxs_list.append(second_order_idxs.unsqueeze(0))
             second_order_idxs_list = torch.cat(second_order_idxs_list, dim=0)
             second_order_idxs_mean_var = []
+            # pyre-fixme[61]: `second_order_idxs` is undefined, or not always defined.
             for i in range(len(second_order_idxs)):
                 second_order_idxs_mean_var.append(
                     torch.tensor(

--- a/ax/utils/stats/tests/test_statstools.py
+++ b/ax/utils/stats/tests/test_statstools.py
@@ -165,8 +165,14 @@ class UnrelativizeTest(TestCase):
                 mean_c,
                 sem_c,
                 cov_means=cov_means,
+                # pyre-fixme[6]: For 6th argument expected `bool` but got
+                #  `Optional[bool]`.
                 bias_correction=bias_correction,
+                # pyre-fixme[6]: For 7th argument expected `bool` but got
+                #  `Optional[bool]`.
                 as_percent=as_percent,
+                # pyre-fixme[6]: For 8th argument expected `bool` but got
+                #  `Optional[bool]`.
                 control_as_constant=control_as_constant,
             )
             unrel_mean_t, unrel_sems_t = unrelativize(
@@ -175,8 +181,14 @@ class UnrelativizeTest(TestCase):
                 mean_c,
                 sem_c,
                 cov_means=cov_means,
+                # pyre-fixme[6]: For 6th argument expected `bool` but got
+                #  `Optional[bool]`.
                 bias_correction=bias_correction,
+                # pyre-fixme[6]: For 7th argument expected `bool` but got
+                #  `Optional[bool]`.
                 as_percent=as_percent,
+                # pyre-fixme[6]: For 8th argument expected `bool` but got
+                #  `Optional[bool]`.
                 control_as_constant=control_as_constant,
             )
             self.assertTrue(np.allclose(means_t, unrel_mean_t))


### PR DESCRIPTION
Summary:
Pyre in Ax stopped working suddenly for multiple devs with the error message 
```
File "tools/pyre/facebook/client/environment.py", line 264, in download_from_manifold
    raise ManifoldDownloadException(response.reason)
tools.pyre.facebook.client.environment.ManifoldDownloadException: Not Found"
```

Looking into the message, it has been seen when Pyre packages have expired:
https://fb.workplace.com/groups/pyreqa/permalink/6561314563958320/

The fix is to update the pyre version in Ax to one still in retention. Updating the version caused many new Pyre errors, so also ran
```
pyre --output=json | pyre-upgrade
```
To add fixmes to them

Reviewed By: mpolson64

Differential Revision: D54215160


