### PR TITLE
Fixing Generation Strategy Equality Test

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -149,6 +149,9 @@ class GenerationStrategy(GenerationStrategyInterface):
                 "so optimization is not resumable if interrupted."
             )
         self._seen_trial_indices_by_status = None
+        # Set name to an explicit value ahead of time to avoid
+        # adding properties during equality checks
+        self._name = self.name
 
     @property
     def is_node_based(self) -> bool:

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+from copy import deepcopy
 from typing import cast, List
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -45,7 +46,10 @@ from ax.modelbridge.transition_criterion import (
     MinTrials,
 )
 from ax.models.random.sobol import SobolGenerator
-from ax.utils.common.equality import same_elements
+from ax.utils.common.equality import (
+    object_attribute_dicts_find_unequal_fields,
+    same_elements,
+)
 from ax.utils.common.mock import mock_patch_method_original
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import not_none
@@ -1293,6 +1297,102 @@ class TestGenerationStrategy(TestCase):
             UnsupportedError, "is not supported for GenerationNode based"
         ):
             gs_test.current_step_index
+
+    def test_generation_strategy_eq_print(self) -> None:
+        """
+        Checking equality of generation
+        strategies would cause RuntimeError: dictionary changed size during iteration.
+        The dictionary being the __dict__ representation of the strategy itself,
+        meaning that a field was added during the equality check.
+        (The added field was generation strategy.name)
+        Printing the generation strategy would set this field.
+        """
+        gs1 = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        gs2 = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        self.assertEqual(gs1, gs2)
+
+    def test_generation_strategy_eq_no_print(self) -> None:
+        """
+        Checking equality of generation
+        strategies would cause RuntimeError: dictionary changed size during iteration.
+        The dictionary being the __dict__ representation of the strategy itself,
+        meaning that a field was added during the equality check.
+        (The added field was generation strategy.name)
+        Printing the generation strategy would set this field.
+
+        Adding tests to ensure this issue doesn't reappear
+        """
+        gs1 = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        gs2 = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        print(gs1)
+        print(gs2)
+        self.assertEqual(gs1, gs2)
+
+    def test_generation_strategy_eq_not_mutible(self) -> None:
+        """
+        Checking equality of generation
+        strategies would cause RuntimeError: dictionary changed size during iteration.
+        The dictionary being the __dict__ representation of the strategy itself,
+        meaning that a field was added during the equality check.
+        (The added field was generation strategy.name)
+        Printing the generation strategy would set this field.
+
+        Adding tests to ensure this issue doesn't reappear
+        """
+        gs1 = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        gs1_dict = deepcopy(gs1.__dict__)
+        print(gs1)
+        gs2_dict = gs1.__dict__
+        type_dict, value_dict = object_attribute_dicts_find_unequal_fields(
+            gs2_dict, gs1_dict
+        )
+
+    def test_generation_strategy_eq_repr(self) -> None:
+        """
+        Checking equality of generation
+        strategies would cause RuntimeError: dictionary changed size during iteration.
+        The dictionary being the __dict__ representation of the strategy itself,
+        meaning that a field was added during the equality check.
+        (The added field was generation strategy.name)
+        Printing the generation strategy would set this field.
+
+        Adding tests to ensure this issue doesn't reappear
+        """
+        gs1 = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        keys = gs1.__dict__.keys()
+        print(gs1.__repr__())
+        new_keys = gs1.__dict__.keys()
+        self.assertEqual(keys, new_keys)
 
     # ------------- Testing helpers (put tests above this line) -------------
 

--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -150,6 +150,7 @@ def object_attribute_dicts_find_unequal_fields(
         one_val = numpy_type_to_python_type(one_val)
         other_val = numpy_type_to_python_type(other_val)
         skip_type_check = skip_db_id_check and field == "_db_id"
+
         if not skip_type_check and (type(one_val) is not type(other_val)):
             unequal_type[field] = (one_val, other_val)
             if fast_return:
@@ -168,6 +169,7 @@ def object_attribute_dicts_find_unequal_fields(
             # Prevent infinite loop when checking equality of Trials (on Experiment,
             # with back-pointer), GenSteps (on GenerationStrategy), AnalysisRun-s
             # (on AnalysisScheduler).
+
             if one_val is None or other_val is None:
                 equal = one_val is None and other_val is None
             else:


### PR DESCRIPTION
Summary:
Equality checks would add a new property "GenerationStrategy.name" dynamically
This would update the "GenerationStrategy.__dict__" field, which caused a
RunTimeError: dictionary changed size during iteration error.

Differential Revision: D54307333


