### PR TITLE
Deprecate `true_objective_metric_name` for early stopping strategies

### DIFF
--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from logging import Logger
@@ -110,7 +111,13 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         self.max_progression = max_progression
         self.min_curves = min_curves
         self.trial_indices_to_ignore = trial_indices_to_ignore
-        self.true_objective_metric_name = true_objective_metric_name
+        if true_objective_metric_name is not None:
+            warnings.warn(
+                ("`true_objective_metric_name` is deprecated and will be ignored."),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.normalize_progressions = normalize_progressions
 
     @abstractmethod

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -284,13 +284,12 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         self.assertEqual(should_stop, {})
 
         # True objective metric name
-        self.assertIsNone(
-            early_stopping_strategy.true_objective_metric_name
-        )  # default none
-        early_stopping_strategy.true_objective_metric_name = "true_obj_metric"
-        self.assertEqual(
-            early_stopping_strategy.true_objective_metric_name, "true_obj_metric"
-        )
+        self.assertFalse(hasattr(early_stopping_strategy, "true_objective_metric_name"))
+        with self.assertWarnsRegex(DeprecationWarning, "ignored"):
+            early_stopping_strategy = PercentileEarlyStoppingStrategy(
+                true_objective_metric_name="true_obj_metric"
+            )
+        self.assertFalse(hasattr(early_stopping_strategy, "true_objective_metric_name"))
 
     def test_percentile_early_stopping_strategy(self) -> None:
         self._test_percentile_early_stopping_strategy(non_objective_metric=False)

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -665,7 +665,6 @@ def percentile_early_stopping_strategy_to_dict(
         "min_progression": strategy.min_progression,
         "min_curves": strategy.min_curves,
         "trial_indices_to_ignore": strategy.trial_indices_to_ignore,
-        "true_objective_metric_name": strategy.true_objective_metric_name,
         "seconds_between_polls": strategy.seconds_between_polls,
         "normalize_progressions": strategy.normalize_progressions,
     }
@@ -681,7 +680,6 @@ def threshold_early_stopping_strategy_to_dict(
         "metric_threshold": strategy.metric_threshold,
         "min_progression": strategy.min_progression,
         "trial_indices_to_ignore": strategy.trial_indices_to_ignore,
-        "true_objective_metric_name": strategy.true_objective_metric_name,
         "normalize_progressions": strategy.normalize_progressions,
     }
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -99,7 +99,6 @@ from ax.utils.testing.core_stubs import (
     get_pathlib_path,
     get_percentile_early_stopping_strategy,
     get_percentile_early_stopping_strategy_with_non_objective_metric_name,
-    get_percentile_early_stopping_strategy_with_true_objective_metric_name,
     get_range_parameter,
     get_risk_measure,
     get_robust_search_space,
@@ -192,10 +191,6 @@ TEST_CASES = [
     ("OutcomeConstraint", get_outcome_constraint),
     ("Path", get_pathlib_path),
     ("PercentileEarlyStoppingStrategy", get_percentile_early_stopping_strategy),
-    (
-        "PercentileEarlyStoppingStrategy",
-        get_percentile_early_stopping_strategy_with_true_objective_metric_name,
-    ),
     (
         "PercentileEarlyStoppingStrategy",
         get_percentile_early_stopping_strategy_with_non_objective_metric_name,

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1974,12 +1974,6 @@ def get_percentile_early_stopping_strategy() -> PercentileEarlyStoppingStrategy:
     )
 
 
-def get_percentile_early_stopping_strategy_with_true_objective_metric_name() -> PercentileEarlyStoppingStrategy:  # noqa
-    strategy = get_percentile_early_stopping_strategy()
-    strategy.true_objective_metric_name = "true_objective"
-    return strategy
-
-
 def get_percentile_early_stopping_strategy_with_non_objective_metric_name() -> PercentileEarlyStoppingStrategy:  # noqa
     return PercentileEarlyStoppingStrategy(
         metric_names=["foo"],
@@ -1993,7 +1987,6 @@ def get_percentile_early_stopping_strategy_with_non_objective_metric_name() -> P
 
 def get_threshold_early_stopping_strategy() -> ThresholdEarlyStoppingStrategy:
     return ThresholdEarlyStoppingStrategy(
-        true_objective_metric_name="true_objective",
         metric_threshold=0.1,
         min_progression=0.2,
         trial_indices_to_ignore=[0, 1, 2],


### PR DESCRIPTION
Summary: Adding deprecation warning and ignoring  any non-`None` `true_objective_metric_name`. Old experiments containing `true_objective_metric_name` can still be loaded after this change.

Differential Revision: D54090801


