### PR TITLE
Allow "sort_values" to be specified in make_experiment

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -149,6 +149,9 @@ class GenerationStrategy(GenerationStrategyInterface):
                 "so optimization is not resumable if interrupted."
             )
         self._seen_trial_indices_by_status = None
+        # Set name to an explicit value ahead of time to avoid
+        # adding properties during equality checks
+        self._name = self.name
 
     @property
     def is_node_based(self) -> bool:

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -1294,6 +1294,54 @@ class TestGenerationStrategy(TestCase):
         ):
             gs_test.current_step_index
 
+    def test_generation_strategy_eq_print(self) -> None:
+        """
+        Calling a GenerationStrategy's ``__repr__`` method should not alter
+        its ``__dict__`` attribute.
+        In the past, ``__repr__``  was causing ``name`` to change
+        under the hood, resulting in
+        ``RuntimeError: dictionary changed size during iteration.``
+        This test ensures this issue doesn't reappear.
+        """
+        gs1 = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        gs2 = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        self.assertEqual(gs1, gs2)
+
+    def test_generation_strategy_eq_no_print(self) -> None:
+        """
+        Calling a GenerationStrategy's ``__repr__`` method should not alter
+        its ``__dict__`` attribute.
+        In the past, ``__repr__``  was causing ``name`` to change
+        under the hood, resulting in
+        ``RuntimeError: dictionary changed size during iteration.``
+        This test ensures this issue doesn't reappear.
+        """
+        gs1 = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        gs2 = GenerationStrategy(
+            steps=[
+                GenerationStep(model=Models.SOBOL, num_trials=5),
+                GenerationStep(model=Models.GPEI, num_trials=-1),
+            ]
+        )
+        print(gs1)
+        print(gs2)
+        self.assertEqual(gs1, gs2)
+
     # ------------- Testing helpers (put tests above this line) -------------
 
     def _run_GS_for_N_rounds(

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -70,6 +70,7 @@ EXPECTED_KEYS_IN_PARAM_REPR = {
     "log_scale",
     "target_value",
     "is_fidelity",
+    "sort_values",
     "is_ordered",
     "is_task",
     "digits",
@@ -241,6 +242,9 @@ class InstantiationBase:
             is_fidelity=checked_cast(bool, representation.get("is_fidelity", False)),
             is_task=checked_cast(bool, representation.get("is_task", False)),
             target_value=representation.get("target_value", None),  # pyre-ignore[6]
+            sort_values=checked_cast_optional(
+                bool, representation.get("sort_values", None)
+            ),
             dependents=checked_cast_optional(
                 dict, representation.get("dependents", None)
             ),


### PR DESCRIPTION
Summary:
When making ChoiceParameters, we see 
```
UserWarning: sort_values is not specified for ChoiceParameter "xxx". Defaulting to True for parameters of ParameterType FLOAT. To override this behavior (or avoid this warning), specify sort_values during ChoiceParameter construction.
```

However, when making Choice parameters using the ```parameter_from_json``` interface, there was currently no way to pass in the "sort_values" flag. This change adds that functionality

Differential Revision: D54315481


