### PR TITLE
remove restriction on unique start_time, end_time in Data

### DIFF
--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -338,29 +338,11 @@ def _observations_from_dataframe(
 
 
 def get_feature_cols(data: Data) -> List[str]:
-    feature_cols = OBS_COLS.intersection(data.df.columns)
-
-    for column in TIME_COLS:
-        if column in feature_cols and len(data.df[column].unique()) > 1:
-            warnings.warn(
-                f"`{column} is not consistent and being discarded from observation data"
-            )
-            feature_cols.discard(column)
-
-    return list(feature_cols)
+    return list(OBS_COLS.intersection(data.df.columns))
 
 
 def get_feature_cols_from_map_data(map_data: MapData) -> List[str]:
-    feature_cols = (OBS_COLS.intersection(map_data.df.columns)).union(map_data.map_keys)
-
-    for column in TIME_COLS:
-        if column in feature_cols and len(map_data.df[column].unique()) > 1:
-            warnings.warn(
-                f"`{column} is not consistent and being discarded from observation data"
-            )
-            feature_cols.discard(column)
-
-    return list(feature_cols)
+    return list(OBS_COLS.intersection(map_data.df.columns).union(map_data.map_keys))
 
 
 def observations_from_data(

--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -429,12 +429,13 @@ class ModelBridge(ABC):
 
             if len(sq_obs) == 0:
                 logger.warning(f"Status quo {status_quo_name} not present in data")
-            elif len(sq_obs) > 1:
-                logger.warning(
-                    f"Status quo {status_quo_name} found in data with multiple "
-                    "features. Use status_quo_features to specify which to use."
-                )
             else:
+                if len(sq_obs) > 1:
+                    logger.warning(
+                        f"Status quo {status_quo_name} found in data with multiple "
+                        "features. Use status_quo_features to specify which to use."
+                        " Defaulting to the first observation."
+                    )
                 self._status_quo = sq_obs[0]
 
         elif status_quo_features is not None:

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -576,17 +576,14 @@ class BaseModelBridgeTest(TestCase):
 
         # create data where metrics vary in start and end times
         data = get_non_monolithic_branin_moo_data()
-        with warnings.catch_warnings(record=True) as ws:
-            bridge = ModelBridge(
-                experiment=exp,
-                data=data,
-                model=Model(),
-                search_space=exp.search_space,
-            )
+        bridge = ModelBridge(
+            experiment=exp,
+            data=data,
+            model=Model(),
+            search_space=exp.search_space,
+        )
         # just testing it doesn't error
         bridge.gen(5)
-        self.assertTrue(any("start_time" in str(w.message) for w in ws))
-        self.assertTrue(any("end_time" in str(w.message) for w in ws))
         # pyre-fixme[16]: Optional type has no attribute `arm_name`.
         self.assertEqual(bridge.status_quo.arm_name, "status_quo")
 


### PR DESCRIPTION
Summary:
This removes the restriction on that `start_time` and `end_time` be the same across all rows in `Data` for those columns to be retained.

We need to retain these in order to leverage them in the model.

Removing this broke a couple of tests that verify that the `Modelbridge` has a `status_quo`---the `status_quo` was no longer set because there were multiple status_quo observations. Therefore, I added a default that when status_quo features are not specified and there are multiple status_quo observations, we should use the first observation (arbitrary) as the status quo on the `Modelbridge`. This enables using `Modelbridge.status_quo_by_trial` which in used in various `Transform`s. We still raise the warning, that really status_quo_features shoudl be used.

Reviewed By: mgarrard

Differential Revision: D54017025


