### PR TITLE
Fix breaking "fix lint" github signal

### DIFF
--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import dataclasses
-import warnings
 from contextlib import ExitStack
 from copy import deepcopy
 from typing import Dict, OrderedDict, Type


### PR DESCRIPTION
Summary:
"fix lint" signal is failing on github https://github.com/facebook/Ax/actions/runs/8090412501/job/22107860418#step:6:13
```
Run flake8
  flake8
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.9.18/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.9.18/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.9.18/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.9.18/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.9.18/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.9.18/x64/lib
./ax/models/torch/tests/test_model.py:8:1: F401 'warnings' imported but unused
Error: Process completed with exit code 1.
```

Fixing to unbreak

Reviewed By: mpolson64

Differential Revision: D54370344


