### PR TITLE
Fix GenerationNode transition logic

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -24,7 +24,6 @@ from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UserInputError
-
 from ax.exceptions.generation_strategy import GenerationStrategyRepeatedPoints
 from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.cross_validation import BestModelSelector, CVDiagnostics, CVResult
@@ -472,7 +471,11 @@ class GenerationNode(SerializationMixin, SortableBase):
                 raise NotImplementedError(
                     "Cannot currently select between multiple transition nodes."
                 )
-            return True, transition_nodes[0]
+            elif len(transition_nodes) == 1:
+                return True, transition_nodes[0]
+            else:
+                # Will transition to the next node in the list.
+                return True, None
         return False, None
 
     def generator_run_limit(self, supress_generation_errors: bool = True) -> int:
@@ -481,8 +484,8 @@ class GenerationNode(SerializationMixin, SortableBase):
         `transition_criteria` that are TrialBasedCriterion.
 
         Returns:
-              - the number of generator runs that can currently be produced, with -1
-                meaning unlimited generator runs,
+            The number of generator runs that can currently be produced, with -1
+            meaning unlimited generator runs.
         """
         # TODO: @mgarrard Should we consider returning `None` if there is no limit?
         # TODO:@mgarrard Should we instead have `raise_generation_error`? The name

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -11,7 +11,6 @@ from logging import Logger
 from unittest.mock import patch, PropertyMock
 
 from ax.core.base_trial import TrialStatus
-
 from ax.core.observation import ObservationFeatures
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.cross_validation import (

--- a/ax/modelbridge/transition_criterion.py
+++ b/ax/modelbridge/transition_criterion.py
@@ -10,7 +10,6 @@ from logging import Logger
 from typing import List, Optional, Set
 
 from ax.core.base_trial import TrialStatus
-
 from ax.core.experiment import Experiment
 from ax.exceptions.generation_strategy import MaxParallelismReachedException
 from ax.modelbridge.generation_strategy import DataRequiredError


### PR DESCRIPTION
Summary:
Fixes some bugs related to GenerationNode transition logic.

- If None of the transition blocking criteria specifies the next node to transition to, this would raise an IndexError.
- GS would not transition to the next node unless the transition criteria explicitly specified what node to transition to. We accept a list of nodes, so we can transition to the next one on the list.

Other things to follow up on:
- `gen_unlimited_trials` defaults to True regardless of the transition criteria. Is it even needed if we control the transitions using the criteria?
- There are a bunch of missing args / returns in the docstrings of TransitionCriterion. It'd be great to revisit that and improve the documentation.

Reviewed By: lena-kashtelyan

Differential Revision: D54522363


