### PR TITLE
Introduces AxGenerationException to facilitate exception handling

### DIFF
--- a/ax/exceptions/generation_strategy.py
+++ b/ax/exceptions/generation_strategy.py
@@ -12,7 +12,13 @@ from typing import Optional
 from ax.exceptions.core import AxError, OptimizationComplete
 
 
-class MaxParallelismReachedException(AxError):
+class AxGenerationException(AxError):
+    """Raised when there is an issue with the generation strategy."""
+
+    pass
+
+
+class MaxParallelismReachedException(AxGenerationException):
     """Special exception indicating that maximum number of trials running in
     parallel set on a given step (as `GenerationStep.max_parallelism`) has been
     reached. Upon getting this exception, users should wait until more trials
@@ -59,7 +65,7 @@ class GenerationStrategyRepeatedPoints(GenerationStrategyCompleted):
     pass
 
 
-class GenerationStrategyMisconfiguredException(AxError):
+class GenerationStrategyMisconfiguredException(AxGenerationException):
     """Special exception indicating that the generation strategy is misconfigured."""
 
     def __init__(self, error_info: Optional[str]) -> None:

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -53,7 +53,10 @@ from ax.exceptions.core import (
     UnsupportedError,
     UserInputError,
 )
-from ax.exceptions.generation_strategy import MaxParallelismReachedException
+from ax.exceptions.generation_strategy import (
+    AxGenerationException,
+    MaxParallelismReachedException,
+)
 from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.plot.pareto_utils import infer_reference_point_from_experiment
@@ -1713,11 +1716,11 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
                 )
             self.logger.debug(f"Message from generation strategy: {err}")
             return []
-        except Exception as err:
+        except AxGenerationException as err:
             if self._log_next_no_trials_reason:
                 self.logger.info(
                     "Generated all trials that can be generated currently. "
-                    "`generation_strategy` encountered an unknown error "
+                    "`generation_strategy` encountered an error "
                     f"{err}."
                 )
             self.logger.debug(f"Message from generation strategy: {err}")


### PR DESCRIPTION
Summary: Adds AxGenerationException so that we can catch exceptions from within the GenerationStrategy without needing to `except Exception`, which was obscuring error messages and making it harder to debug.

Reviewed By: saitcakmak

Differential Revision: D54604928


