### PR TITLE
Light cleanup of `GenerationStrategyInterface`

### DIFF
--- a/ax/core/generation_strategy_interface.py
+++ b/ax/core/generation_strategy_interface.py
@@ -5,46 +5,59 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+
 from typing import List, Optional
 
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
+from ax.exceptions.core import UnsupportedError
 from ax.utils.common.base import Base
 from ax.utils.common.typeutils import not_none
 
 
 class GenerationStrategyInterface(ABC, Base):
-    _name: Optional[str]
-    # All generator runs created through this generation strategy, in chronological
-    # order.
-    _generator_runs: List[GeneratorRun]
+    """Interface for all generation strategies: standard Ax
+    ``GenerationStrategy``, as well as non-standard (e.g. remote, external)
+    generation strategies.
+
+    NOTE: Currently in Beta; please do not use without discussion with the Ax
+    developers.
+    """
+
+    _name: str
     # Experiment, for which this generation strategy has generated trials, if
     # it exists.
     _experiment: Optional[Experiment] = None
+
+    def __init__(self, name: str) -> None:
+        self._name = name
 
     @abstractmethod
     def gen_for_multiple_trials_with_multiple_models(
         self,
         experiment: Experiment,
-        num_generator_runs: int,
         data: Optional[Data] = None,
+        # TODO[drfreund, danielcohennyc, mgarrard]: Update the format of the arguments
+        # below as we find the right one.
+        num_generator_runs: int = 1,
         n: int = 1,
     ) -> List[List[GeneratorRun]]:
-        """Produce GeneratorRuns for multiple trials at once with the possibility of
-        ensembling, or using multiple models per trial, getting multiple
-        GeneratorRuns per trial.
+        """Produce ``GeneratorRun``-s for multiple trials at once with the possibility
+        of joining ``GeneratorRun``-s from multiple models into one ``BatchTrial``.
 
         Args:
-            experiment: Experiment, for which the generation strategy is producing
-                a new generator run in the course of `gen`, and to which that
+            experiment: ``Experiment``, for which the generation strategy is producing
+                a new generator run in the course of ``gen``, and to which that
                 generator run will be added as trial(s). Information stored on the
                 experiment (e.g., trial statuses) is used to determine which model
                 will be used to produce the generator run returned from this method.
-            data: Optional data to be passed to the underlying model's `gen`, which
+            data: Optional data to be passed to the underlying model's ``gen``, which
                 is called within this method and actually produces the resulting
-                generator run. By default, data is all data on the `experiment`.
+                generator run. By default, data is all data on the ``experiment``.
             n: Integer representing how many trials should be in the generator run
                 produced by this method. NOTE: Some underlying models may ignore
                 the ``n`` and produce a model-determined number of arms. In that
@@ -55,27 +68,24 @@ class GenerationStrategyInterface(ABC, Base):
                 resuggesting points that are currently being evaluated.
 
         Returns:
-            A list of lists of lists generator runs. Each outer list represents
-            a trial being suggested and  each inner list represents a generator
-            run for that trial.
+            A list of lists of ``GeneratorRun``-s. Each outer list item represents
+            a ``(Batch)Trial`` being suggested, with a list of ``GeneratorRun``-s for
+            that trial.
         """
+        # When implementing your subclass' override for this method, don't forget
+        # to consider using "pending points", corresponding to arms in trials that
+        # are currently running / being evaluated/
+        pass
+
+    @abstractmethod
+    def clone_reset(self) -> GenerationStrategyInterface:
+        """Returns a clone of this generation strategy with all state reset."""
         pass
 
     @property
     def name(self) -> str:
-        """Name of this generation strategy. Defaults to a combination of model
-        names provided in generation steps.
-        """
-        if self._name is not None:
-            return not_none(self._name)
-
-        self._name = f"GenerationStrategy {self.db_id}"
-        return not_none(self._name)
-
-    @name.setter
-    def name(self, name: str) -> None:
-        """Set generation strategy name."""
-        self._name = name
+        """Name of this generation strategy."""
+        return self._name
 
     @property
     def experiment(self) -> Experiment:
@@ -91,20 +101,11 @@ class GenerationStrategyInterface(ABC, Base):
         experiment passed in is the same as the one saved and log an information
         statement if its not. Set the new experiment on this generation strategy.
         """
-        if self._experiment is None or experiment._name == self.experiment._name:
-            self._experiment = experiment
-        else:
-            raise ValueError(
+        if self._experiment is not None and experiment._name != self.experiment._name:
+            raise UnsupportedError(
                 "This generation strategy has been used for experiment "
                 f"{self.experiment._name} so far; cannot reset experiment"
-                f" to {experiment._name}. If this is a new optimization, "
+                f" to {experiment._name}. If this is a new experiment, "
                 "a new generation strategy should be created instead."
             )
-
-    @property
-    def last_generator_run(self) -> Optional[GeneratorRun]:
-        """Latest generator run produced by this generation strategy.
-        Returns None if no generator runs have been produced yet.
-        """
-        # Used to restore current model when decoding a serialized GS.
-        return self._generator_runs[-1] if self._generator_runs else None
+        self._experiment = experiment

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -149,7 +149,17 @@ class TestGenerationStrategy(TestCase):
         self.assertEqual(gs._steps[1].node_name, "GenerationStep_1")
 
     def test_name(self) -> None:
-        self.sobol_GS.name = "SomeGSName"
+        self.assertEqual(self.sobol_GS._name, "Sobol")
+        self.assertEqual(
+            GenerationStrategy(
+                steps=[
+                    GenerationStep(model=Models.SOBOL, num_trials=5),
+                    GenerationStep(model=Models.GPEI, num_trials=-1),
+                ],
+            ).name,
+            "Sobol+GPEI",
+        )
+        self.sobol_GS._name = "SomeGSName"
         self.assertEqual(self.sobol_GS.name, "SomeGSName")
 
     def test_validation(self) -> None:

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -7,6 +7,8 @@
 # pyre-strict
 
 
+from __future__ import annotations
+
 from collections import OrderedDict
 from datetime import datetime, timedelta
 
@@ -2311,3 +2313,8 @@ class SpecialGenerationStrategy(GenerationStrategyInterface):
         n: int = 1,
     ) -> List[List[GeneratorRun]]:
         return []
+
+    def clone_reset(self) -> SpecialGenerationStrategy:
+        clone = SpecialGenerationStrategy()
+        clone._name = self._name
+        return clone


### PR DESCRIPTION
Summary:
Key changes: 
1. bring back to GS aspects of GSI that are not needed there and are polluting the interface,
2. make `_name` a required attribute of both GSI and GS. 

Re: 2), having it be set during the first call to `name` property was causing weird bugs in equality checks, there two GSs looked like they were equal but they weren't at the time of the initial equality check (one had the `_name` set because its `name` prop was called, and another did not yet). They would become equal during the call to `__repr__` that occurred in reporting their inequality as an error (!), because `__repr__` would call `GS.name`, which would result in `GS._name` getting set. Weird stuff!

Reviewed By: danielcohenlive, mgarrard

Differential Revision: D51441575


