### PR TITLE
Address numpy deprecation warning

### DIFF
--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -349,9 +349,8 @@ def _get_tukey_cutoffs(Y: np.ndarray, lower: bool) -> float:
 
     See https://mathworld.wolfram.com/Box-and-WhiskerPlot.html for more details.
     """
-    # TODO: replace interpolation->method once it becomes standard.
-    q1 = np.percentile(Y, q=25, interpolation="lower")
-    q3 = np.percentile(Y, q=75, interpolation="higher")
+    q1 = np.percentile(Y, q=25, method="lower")
+    q3 = np.percentile(Y, q=75, method="higher")
     iqr = q3 - q1
     return q1 - 1.5 * iqr if lower else q3 + 1.5 * iqr
 

--- a/ax/plot/diagnostic.py
+++ b/ax/plot/diagnostic.py
@@ -131,9 +131,8 @@ def _obs_vs_pred_dropdown_plot(
         min_, max_ = _get_min_max_with_errors(y_raw, y_hat, se_raw, se_hat)
         if autoset_axis_limits:
             y_raw_np = np.array(y_raw)
-            # TODO: replace interpolation->method once it becomes standard.
-            q1 = np.nanpercentile(y_raw_np, q=25, interpolation="lower").min()
-            q3 = np.nanpercentile(y_raw_np, q=75, interpolation="higher").max()
+            q1 = np.nanpercentile(y_raw_np, q=25, method="lower").min()
+            q3 = np.nanpercentile(y_raw_np, q=75, method="higher").max()
             y_lower = q1 - 1.5 * (q3 - q1)
             y_upper = q3 + 1.5 * (q3 - q1)
             y_raw_np = y_raw_np.clip(y_lower, y_upper).tolist()

--- a/ax/plot/trace.py
+++ b/ax/plot/trace.py
@@ -461,11 +461,10 @@ def _autoset_axis_limits(
     If `force_include_value` is provided, the worst points will be truncated at this
     value if it is worse than the truncation point described above.
     """
-    # TODO: replace interpolation->method once it becomes standard.
-    q1 = np.percentile(y, q=25, interpolation="lower").min()
-    q2_min = np.percentile(y, q=50, interpolation="linear").min()
-    q2_max = np.percentile(y, q=50, interpolation="linear").max()
-    q3 = np.percentile(y, q=75, interpolation="higher").max()
+    q1 = np.percentile(y, q=25, method="lower").min()
+    q2_min = np.percentile(y, q=50, method="linear").min()
+    q2_max = np.percentile(y, q=50, method="linear").max()
+    q3 = np.percentile(y, q=75, method="higher").max()
     if optimization_direction == "minimize":
         y_lower = y.min()
         y_upper = q2_max + 1.5 * (q2_max - q1)


### PR DESCRIPTION
Summary:
Address this warning that was coming up in the tests:

```
ax/plot/trace.py:500: DeprecationWarning: the `interpolation=` argument to percentile was renamed to `method=`, which has additional options.
Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review the method they used. (Deprecated NumPy 1.22)
  q1 = np.percentile(y, q=25, interpolation="lower").min()
```

Differential Revision: D51443080


