### PR TITLE
Do not re-attach the same data in get_test_map_data_experiment

### DIFF
--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -390,7 +390,6 @@ def get_test_map_data_experiment(
         experiment.fetch_data()
     for i in range(num_complete):
         experiment.trials[i].mark_as(status=TrialStatus.COMPLETED)
-    experiment.attach_data(data=experiment.fetch_data())
     return experiment
 
 


### PR DESCRIPTION
Summary: Data is attached on `fetch_data`, so this last bit would re-attach the same data twice.

Differential Revision: D54880773


