### PR TITLE
Reap deprecated argument `transform_outcomes_and_configs` in `get_pareto_frontier_and_configs`

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -60,7 +60,7 @@ from ax.core.utils import (  # noqa F402: Temporary import for backward compatib
     get_pending_observation_features,  # noqa F401
     get_pending_observation_features_based_on_trial_status,  # noqa F401
 )
-from ax.exceptions.core import DataRequiredError, UnsupportedError, UserInputError
+from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.utils import (
     derelativize_optimization_config_with_raw_status_quo,
@@ -690,7 +690,6 @@ def get_pareto_frontier_and_configs(
     optimization_config: Optional[MultiObjectiveOptimizationConfig] = None,
     arm_names: Optional[List[Optional[str]]] = None,
     use_model_predictions: bool = True,
-    transform_outcomes_and_configs: Optional[bool] = None,
 ) -> Tuple[List[Observation], Tensor, Tensor, Optional[Tensor]]:
     """Helper that applies transforms and calls ``frontier_evaluator``.
 
@@ -712,11 +711,6 @@ def get_pareto_frontier_and_configs(
             ``observation_features`` to compute Pareto front. If ``False``,
             will use ``observation_data`` directly to compute Pareto front, ignoring
             ``observation_features``.
-        transform_outcomes_and_configs: Deprecated and must be ``False`` if provided.
-            Previously, if ``True``, would transform the optimization
-            config, observation features and observation data, before calling
-            ``frontier_evaluator``, then will untransform all of the above before
-            returning the observations.
 
     Returns: Four-item tuple of:
           - frontier_observations: Observations of points on the pareto frontier,
@@ -726,30 +720,6 @@ def get_pareto_frontier_and_configs(
           - obj_t: m tensor of objective thresholds corresponding to Y, or None if no
             objective thresholds used.
     """
-    if transform_outcomes_and_configs is None:
-        warnings.warn(
-            "FYI: The default behavior of `get_pareto_frontier_and_configs` when "
-            "`transform_outcomes_and_configs` is not specified has changed. Previously,"
-            " the default was `transform_outcomes_and_configs=True`; now this argument "
-            "is deprecated and behavior is as if "
-            "`transform_outcomes_and_configs=False`. You did not specify "
-            "`transform_outcomes_and_configs`, so this warning requires no action.",
-            stacklevel=2,
-        )
-    elif transform_outcomes_and_configs:
-        raise UnsupportedError(
-            "`transform_outcomes_and_configs=True` is no longer supported, and the "
-            "`transform_outcomes_and_configs` argument is deprecated. Please do not "
-            "specify this argument."
-        )
-    else:
-        warnings.warn(
-            "You passed `transform_outcomes_and_configs=False`. Specifying "
-            "`transform_outcomes_and_configs` at all is deprecated because `False` is "
-            "now the only allowed behavior. In the future, this will become an error.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
     # Input validation
     if use_model_predictions:
         if observation_data is not None:

--- a/ax/modelbridge/tests/test_torch_moo_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_moo_modelbridge.py
@@ -21,7 +21,6 @@ from ax.core.outcome_constraint import (
     OutcomeConstraint,
 )
 from ax.core.parameter_constraint import ParameterConstraint
-from ax.exceptions.core import UnsupportedError
 from ax.modelbridge.factory import get_sobol
 from ax.modelbridge.modelbridge_utils import (
     get_pareto_frontier_and_configs,
@@ -288,41 +287,6 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             ObservationFeatures(parameters={"x1": 0.0, "x2": 1.0}),
             ObservationFeatures(parameters={"x1": 1.0, "x2": 0.0}),
         ]
-
-        with self.assertWarns(
-            Warning,
-            msg="FYI: The default behavior of `get_pareto_frontier_and_configs` when "
-            "`transform_outcomes_and_configs` is not specified has changed. Previously,"
-            " the default was `transform_outcomes_and_configs=True`; now this argument "
-            "is deprecated and behavior is as if "
-            "`transform_outcomes_and_configs=False`. You did not specify "
-            "`transform_outcomes_and_configs`, so this warning requires no action.",
-        ):
-            res = get_pareto_frontier_and_configs(
-                modelbridge=modelbridge,
-                observation_features=observation_features,
-            )
-            self.assertEqual(len(res), 4)
-
-        with self.assertRaises(UnsupportedError):
-            get_pareto_frontier_and_configs(
-                modelbridge=modelbridge,
-                observation_features=observation_features,
-                transform_outcomes_and_configs=True,
-            )
-
-        with self.assertWarns(
-            DeprecationWarning,
-            msg="You passed `transform_outcomes_and_configs=False`. Specifying "
-            "`transform_outcomes_and_configs` at all is deprecated because `False` is "
-            "now the only allowed behavior. In the future, this will become an error.",
-        ):
-            res = get_pareto_frontier_and_configs(
-                modelbridge=modelbridge,
-                observation_features=observation_features,
-                transform_outcomes_and_configs=False,
-            )
-            self.assertEqual(len(res), 4)
 
         with self.assertWarns(
             Warning,


### PR DESCRIPTION
Summary: This was deprecated in v0.2.9 in  https://github.com/facebook/Ax/pull/1200. On the usual deprecation schedule, it should only be removed on 4.0.0, while we're only at 0.3.7. However, I think this is fine to remove now since the change is almost a year and a half old. `get_pareto_frontier_and_configs` is spitting out an annoying warning about the default behavior changing even when this parameter is not passed; that could in theory be removed on its own, with the argument reaped later, but I don't think it justifies a second PR.

Reviewed By: lena-kashtelyan

Differential Revision: D54902341


