### PR TITLE
Fix prediction on training data in transformed space when calculating model fit quality metrics

### DIFF
--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -566,12 +566,12 @@ def _predict_on_training_data(
     observations = observations_from_data(
         experiment=experiment, data=data
     )  # List[Observation]
-    observation_features = [obs.features for obs in observations]
 
-    # Transform observation features
-    observation_features = deepcopy(observation_features)
+    # Transform observations -- this will transform both obs data and features
     for t in model_bridge.transforms.values():
-        observation_features = t.transform_observation_features(observation_features)
+        observations = t.transform_observations(observations)
+
+    observation_features = [obs.features for obs in observations]
 
     # Make predictions in transformed space
     observation_data_pred = model_bridge._predict(observation_features)


### PR DESCRIPTION
Summary:
D54040302 enabled model fit quality metric calculation in transformed space for both training data and CV data. However, in the calculation of model fit quality metric on training data, we didn't transform training data original observation into transformed space and ended up calculating model fit quality metrics on y_obs on original_scale and y_predicted in transformed space. 

This diff fixes this bug

Differential Revision: D54927552


