### PR TITLE
split common target into native/non-native parts

### DIFF
--- a/ax/core/arm.py
+++ b/ax/core/arm.py
@@ -13,7 +13,7 @@ from typing import Optional
 from ax.core.types import TParameterization
 from ax.utils.common.base import SortableBase
 from ax.utils.common.equality import equality_typechecker
-from ax.utils.common.typeutils import numpy_type_to_python_type
+from ax.utils.common.typeutils_nonnative import numpy_type_to_python_type
 
 
 class Arm(SortableBase):

--- a/ax/core/formatting_utils.py
+++ b/ax/core/formatting_utils.py
@@ -19,7 +19,7 @@ from ax.core.types import (
     validate_evaluation_outcome,
 )
 from ax.exceptions.core import UserInputError
-from ax.utils.common.typeutils import numpy_type_to_python_type
+from ax.utils.common.typeutils_nonnative import numpy_type_to_python_type
 
 
 # -------------------- Data formatting utils. ---------------------

--- a/ax/storage/json_store/encoder.py
+++ b/ax/storage/json_store/encoder.py
@@ -23,7 +23,7 @@ from ax.storage.json_store.registry import (
     CORE_ENCODER_REGISTRY,
 )
 from ax.utils.common.serialization import _is_named_tuple
-from ax.utils.common.typeutils import numpy_type_to_python_type
+from ax.utils.common.typeutils_nonnative import numpy_type_to_python_type
 from ax.utils.common.typeutils_torch import torch_type_to_str
 
 

--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from ax.utils.common.typeutils import numpy_type_to_python_type
+from ax.utils.common.typeutils_nonnative import numpy_type_to_python_type
 
 
 # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.

--- a/ax/utils/common/kwargs.py
+++ b/ax/utils/common/kwargs.py
@@ -12,7 +12,7 @@ from logging import Logger
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from ax.utils.common.logger import get_logger
-from ax.utils.common.typeutils import version_safe_check_type
+from ax.utils.common.typeutils_nonnative import version_safe_check_type
 
 logger: Logger = get_logger(__name__)
 

--- a/ax/utils/common/tests/test_typeutils.py
+++ b/ax/utils/common/tests/test_typeutils.py
@@ -15,8 +15,8 @@ from ax.utils.common.typeutils import (
     checked_cast_list,
     checked_cast_optional,
     not_none,
-    numpy_type_to_python_type,
 )
+from ax.utils.common.typeutils_nonnative import numpy_type_to_python_type
 
 
 class TestTypeUtils(TestCase):

--- a/ax/utils/common/typeutils.py
+++ b/ax/utils/common/typeutils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
@@ -6,11 +5,8 @@
 
 # pyre-strict
 
-from inspect import signature
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 
-import numpy as np
-from typeguard import check_type
 
 T = TypeVar("T")
 V = TypeVar("V")
@@ -111,33 +107,6 @@ def checked_cast_to_tuple(typ: Tuple[Type[V], ...], val: V) -> T:
         raise ValueError(f"Value was not of type {type!r}:\n{val!r}")
     # pyre-fixme[7]: Expected `T` but got `V`.
     return val
-
-
-def version_safe_check_type(argname: str, value: T, expected_type: Type[T]) -> None:
-    """Excecute the check_type function if it has the expected signature, otherwise
-    warn.  This is done to support newer versions of typeguard with minimal loss
-    of functionality for users that have dependency conflicts"""
-    # Get the signature of the check_type function
-    sig = signature(check_type)
-    # Get the parameters of the check_type function
-    params = sig.parameters
-    # Check if the check_type function has the expected signature
-    params = set(params.keys())
-    if all(arg in params for arg in ["argname", "value", "expected_type"]):
-        check_type(argname, value, expected_type)
-
-
-# pyre-fixme[3]: Return annotation cannot be `Any`.
-# pyre-fixme[2]: Parameter annotation cannot be `Any`.
-def numpy_type_to_python_type(value: Any) -> Any:
-    """If `value` is a Numpy int or float, coerce to a Python int or float.
-    This is necessary because some of our transforms return Numpy values.
-    """
-    if isinstance(value, np.integer):
-        value = int(value)  # pragma: nocover (covered by generator tests)
-    if isinstance(value, np.floating):
-        value = float(value)  # pragma: nocover  (covered by generator tests)
-    return value
 
 
 # pyre-fixme[2]: Parameter annotation cannot be `Any`.

--- a/ax/utils/common/typeutils_nonnative.py
+++ b/ax/utils/common/typeutils_nonnative.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from inspect import signature
+from typing import Any, Type, TypeVar
+
+import numpy as np
+from typeguard import check_type
+
+T = TypeVar("T")
+V = TypeVar("V")
+K = TypeVar("K")
+X = TypeVar("X")
+Y = TypeVar("Y")
+
+
+def version_safe_check_type(argname: str, value: T, expected_type: Type[T]) -> None:
+    """Excecute the check_type function if it has the expected signature, otherwise
+    warn.  This is done to support newer versions of typeguard with minimal loss
+    of functionality for users that have dependency conflicts"""
+    # Get the signature of the check_type function
+    sig = signature(check_type)
+    # Get the parameters of the check_type function
+    params = sig.parameters
+    # Check if the check_type function has the expected signature
+    params = set(params.keys())
+    if all(arg in params for arg in ["argname", "value", "expected_type"]):
+        check_type(argname, value, expected_type)
+
+
+# pyre-fixme[3]: Return annotation cannot be `Any`.
+# pyre-fixme[2]: Parameter annotation cannot be `Any`.
+def numpy_type_to_python_type(value: Any) -> Any:
+    """If `value` is a Numpy int or float, coerce to a Python int or float.
+    This is necessary because some of our transforms return Numpy values.
+    """
+    if isinstance(value, np.integer):
+        value = int(value)  # pragma: nocover (covered by generator tests)
+    if isinstance(value, np.floating):
+        value = float(value)  # pragma: nocover  (covered by generator tests)
+    return value

--- a/sphinx/source/utils.rst
+++ b/sphinx/source/utils.rst
@@ -123,6 +123,14 @@ Typeutils
     :undoc-members:
     :show-inheritance:
 
+Typeutils Non-Native
+~~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.common.typeutils_nonnative
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Typeutils Torch
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary: This removes pandas, numpy, and several other packages as a deps from several targets

Reviewed By: Balandat

Differential Revision: D54861556


