### PR TITLE
Fix integration test

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -386,7 +386,7 @@ class GenerationStrategy(GenerationStrategyInterface):
 
             # Set transition_to field for all but the last step, which remains
             # null.
-            if idx != len(self._steps):
+            if idx != len(self._steps) - 1:
                 for transition_criteria in step.transition_criteria:
                     if (
                         transition_criteria.criterion_class


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/aepsych/pull/338

Previously the integration test was failing due to not allowing unlimited trials on the last step. This is because the final step was copied from the exisiting botorch step (which contains transition criterion). If transition criterion exist on the step/node, we default to using those for determining the state of the node. 

This fixes the test by manually unsetting the transition criterion arg for the aepsych strategy.py.

We also re-enable the test

Reviewed By: crasanders

Differential Revision: D54960088


