### PR TITLE
Update log message in WithDBSettingsBase._load_experiment_and_generation_strategy

### DIFF
--- a/ax/service/utils/with_db_settings_base.py
+++ b/ax/service/utils/with_db_settings_base.py
@@ -257,10 +257,10 @@ class WithDBSettingsBase:
         )
         if not isinstance(experiment, Experiment):
             raise ValueError("Service API only supports `Experiment`.")
+        num_trials = len(experiment.trials)
         logger.info(
-            f"Loaded experiment {experiment_name} in "
-            f"{_round_floats_for_logging(time.time() - start_time)} seconds, "
-            f"loading trials in mini-batches of {LOADING_MINI_BATCH_SIZE}."
+            f"Loaded experiment {experiment_name} & {num_trials} trials in "
+            f"{_round_floats_for_logging(time.time() - start_time)} seconds."
         )
 
         try:


### PR DESCRIPTION
Summary: The previous message would make me think that the trials were being loaded after the log as opposed to being loaded as part of the experiment. Updated the message to clear the confusion.

Reviewed By: Balandat

Differential Revision: D55044629


