### PR TITLE
Replace calls to deprecated `mvn` argument of `GPyTorchPosterior` with `distribution`

### DIFF
--- a/ax/models/torch/alebo.py
+++ b/ax/models/torch/alebo.py
@@ -398,7 +398,7 @@ class ALEBOGP(SingleTaskGP):
         assert output_indices is None
         assert not observation_noise
         mvn = self(X)
-        posterior = GPyTorchPosterior(mvn=mvn)
+        posterior = GPyTorchPosterior(distribution=mvn)
         if posterior_transform is not None:
             return posterior_transform(posterior)
         return posterior


### PR DESCRIPTION
Summary: This will not change behavior.

Reviewed By: saitcakmak

Differential Revision: D55094724


