### PR TITLE
plot top n features in contours

### DIFF
--- a/ax/plot/contour.py
+++ b/ax/plot/contour.py
@@ -8,7 +8,7 @@
 
 import re
 from copy import deepcopy
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import plotly.graph_objs as go
@@ -343,6 +343,7 @@ def interact_contour_plotly(
     lower_is_better: bool = False,
     fixed_features: Optional[ObservationFeatures] = None,
     trial_index: Optional[int] = None,
+    parameters_to_use: Optional[List[str]] = None,
 ) -> go.Figure:
     """Create interactive plot with predictions for a 2-d slice of the parameter
     space.
@@ -362,6 +363,8 @@ def interact_contour_plotly(
         fixed_features: An ObservationFeatures object containing the values of
             features (including non-parameter features like context) to be set
             in the slice.
+        parameters_to_use: List of parameters to use in the plot, in the order they
+            should appear. If None or empty list, use all parameters.
 
     Returns:
         go.Figure: interactive plot of objective vs. parameters
@@ -378,6 +381,15 @@ def interact_contour_plotly(
         slice_values["TRIAL_PARAM"] = str(trial_index)
 
     range_parameters = get_range_parameters(model, min_num_values=5)
+    if parameters_to_use is not None:
+        if len(parameters_to_use) <= 1:
+            raise ValueError(
+                "Contour plots require two or more parameters. "
+                f"Got {parameters_to_use=}."
+            )
+        # Subset range parameters and put them in the same order as parameters_to_use.
+        range_param_name_dict = {p.name: p for p in range_parameters}
+        range_parameters = [range_param_name_dict[pname] for pname in parameters_to_use]
     plot_data, _, _ = get_plot_data(
         model, generator_runs_dict or {}, {metric_name}, fixed_features=fixed_features
     )
@@ -886,6 +898,7 @@ def interact_contour(
     lower_is_better: bool = False,
     fixed_features: Optional[ObservationFeatures] = None,
     trial_index: Optional[int] = None,
+    parameters_to_use: Optional[List[str]] = None,
 ) -> AxPlotConfig:
     """Create interactive plot with predictions for a 2-d slice of the parameter
     space.
@@ -905,6 +918,8 @@ def interact_contour(
         fixed_features: An ObservationFeatures object containing the values of
             features (including non-parameter features like context) to be set
             in the slice.
+        parameters_to_use: List of parameters to use in the plot, in the order they
+            should appear. If None or empty list, use all parameters.
 
     Returns:
         AxPlotConfig: interactive plot of objective vs. parameters
@@ -920,6 +935,7 @@ def interact_contour(
             lower_is_better=lower_is_better,
             fixed_features=fixed_features,
             trial_index=trial_index,
+            parameters_to_use=parameters_to_use,
         ),
         plot_type=AxPlotTypes.GENERIC,
     )

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -769,7 +769,7 @@ def get_experiment_with_observations(
     return exp
 
 
-def get_high_dimensional_branin_experiment() -> Experiment:
+def get_high_dimensional_branin_experiment(with_batch: bool = False) -> Experiment:
     search_space = SearchSpace(
         # pyre-fixme[6]: In call `SearchSpace.__init__`, for 1st parameter `parameters`
         # expected `List[Parameter]` but got `List[RangeParameter]`.
@@ -803,12 +803,17 @@ def get_high_dimensional_branin_experiment() -> Experiment:
         )
     )
 
-    return Experiment(
+    exp = Experiment(
         name="high_dimensional_branin_experiment",
         search_space=search_space,
         optimization_config=optimization_config,
         runner=SyntheticRunner(),
     )
+    if with_batch:
+        sobol_generator = get_sobol(search_space=exp.search_space)
+        sobol_run = sobol_generator.gen(n=15)
+        exp.new_batch_trial().add_generator_run(sobol_run)
+    return exp
 
 
 ##############################


### PR DESCRIPTION
Summary:
This diff updates report_utils to plot only the top features, ranked by feature importance, rather than skipping plotting altogether when the number of features grows too large.

* Adds `parameters_to_use` arg to `interact_contour` and `interact_contour_plotly`, which subsets which range parameters are plotted in contour plots and sets their order.
* Adds `importance` arg to  `_get_objective_v_param_plots` ([pointer](https://www.internalfb.com/diff/D50501707?permalink=371874009149429)) to subset the top n parameters by importance on a per-metric basis, then provide those as `parameters_to_use` when calling `interact_contour_ploty`.

Differential Revision: D50501707


