### PR TITLE
do not group by time cols when creating observations

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -431,13 +431,12 @@ class ModelBridge(ABC):
 
             if len(sq_obs) == 0:
                 logger.warning(f"Status quo {status_quo_name} not present in data")
+            elif len(sq_obs) > 1:
+                logger.warning(
+                    f"Status quo {status_quo_name} found in data with multiple "
+                    "features. Use status_quo_features to specify which to use."
+                )
             else:
-                if len(sq_obs) > 1:
-                    logger.warning(
-                        f"Status quo {status_quo_name} found in data with multiple "
-                        "features. Use status_quo_features to specify which to use."
-                        " Defaulting to the first observation."
-                    )
                 self._status_quo = sq_obs[0]
 
         elif status_quo_features is not None:

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -578,14 +578,17 @@ class BaseModelBridgeTest(TestCase):
 
         # create data where metrics vary in start and end times
         data = get_non_monolithic_branin_moo_data()
-        bridge = ModelBridge(
-            experiment=exp,
-            data=data,
-            model=Model(),
-            search_space=exp.search_space,
-        )
+        with warnings.catch_warnings(record=True) as ws:
+            bridge = ModelBridge(
+                experiment=exp,
+                data=data,
+                model=Model(),
+                search_space=exp.search_space,
+            )
         # just testing it doesn't error
         bridge.gen(5)
+        self.assertTrue(any("start_time" in str(w.message) for w in ws))
+        self.assertTrue(any("end_time" in str(w.message) for w in ws))
         # pyre-fixme[16]: Optional type has no attribute `arm_name`.
         self.assertEqual(bridge.status_quo.arm_name, "status_quo")
 


### PR DESCRIPTION
Summary:
See title. Add the time columns only if all metrics for a given trial-arm pair have the same start/end time. This means that if one wants time to be included, then they should ensure the metric gives the same start/end time for each all metrics for a single trial-arm pair.

This was causing an issue where status quo data for a single trial could be split across multiple observations because the metrics had different start and end times. This largely reverts D54017025.

Reviewed By: Balandat

Differential Revision: D55099571


