### PR TITLE
Fix test_compare_to_baseline_equal

### DIFF
--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -1124,26 +1124,14 @@ class ReportUtilsTest(TestCase):
             "ax.service.utils.report_utils.exp_to_df",
             return_value=arms_df,
         ):
-            with self.assertLogs("ax", level=INFO) as log:
-                result = compare_to_baseline(
-                    experiment=experiment,
-                    optimization_config=optimization_config,
-                    comparison_arm_names=comparison_arm_names,
-                    baseline_arm_name=custom_baseline_arm_name,
-                )
-                self.assertEqual(result, None)
-                self.assertTrue(
-                    any(
-                        (
-                            "compare_to_baseline:"
-                            f" comparison arm equal"
-                            f" did not beat baseline arm {custom_baseline_arm_name}."
-                        )
-                        in log_str
-                        for log_str in log.output
-                    ),
-                    log.output,
-                )
+            result = compare_to_baseline(
+                experiment=experiment,
+                optimization_config=optimization_config,
+                comparison_arm_names=comparison_arm_names,
+                baseline_arm_name=custom_baseline_arm_name,
+            )
+
+            self.assertIsNone(result)
 
     def test_compare_to_baseline_select_baseline_arm(self) -> None:
         OBJECTIVE_METRIC = "objective"


### PR DESCRIPTION
Summary:
Remove log checking from test_compare_to_baseline_equal

Context: D54885250 moved some logs from INFO to DEBUG, breaking this test which checked for logs at the INFO level. However, we cant just change the level in  the assertLogs context manager to DEBUG because *DEBUG logs are silent by default in Ax* -- the default log level is INFO.

IMO we should just remove this test, and maybe remove the logs too. Right now its impossible for them to be seen by the user, and will only be visible to developers if they manually change the level of the logger in report_utils in source. If we were concerned enough about logspew to move these out of INFO, maybe we should just get rid of them altogether. Thoughts?

Reviewed By: bernardbeckerman

Differential Revision: D55248686


