### PR TITLE
Fix get_countour_plot() not plotting all trials

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1032,6 +1032,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
                 )
                 return plot_contour(
                     model=not_none(self.generation_strategy.model),
+                    generator_runs_dict=self.experiment.trials,
                     param_x=param_x,
                     param_y=param_y,
                     metric_name=metric_name,


### PR DESCRIPTION
This fixes a bug where get_countour_plot() plots all but the last trial. The corresponding issue is here: https://github.com/facebook/Ax/issues/2221.