### PR TITLE
Cloning over _time_created when cloning Experiment

### DIFF
--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -197,7 +197,8 @@ def object_attribute_dicts_find_unequal_fields(
                     and hasattr(other_val, "model")
                     and isinstance(one_val.model, type(other_val.model))
                 )
-
+        elif field == "_time_created":
+            equal = True
         elif isinstance(one_val, list):
             equal = isinstance(other_val, list) and same_elements(one_val, other_val)
         elif isinstance(one_val, dict):


### PR DESCRIPTION
Summary:
Quick RFC for everyone:

This equality check is failing sometimes in Python 3.9 on open source ( T184131441 ):
```
def test_clone_with(self) -> None:
        experiment = get_experiment()
        cloned_experiment = experiment.clone_with()
        self.assertEqual(cloned_experiment.name, "cloned_experiment_" + experiment.name)
        cloned_experiment._name = experiment.name
        self.assertEqual(cloned_experiment, experiment)
```
The error is 
```
Experiment(test) (type <class 'ax.core.experiment.Experiment'>) != Experiment(test) (type <class 'ax.core.experiment.Experiment'>).

Fields with different values:

1) _time_created: 
2024-04-01 05:05:13.000613 (type <class 'datetime.datetime'>) 
!= 2024-04-01 05:05:12.998793 (type <class 'datetime.datetime'>).
```

This is a race condition, where if "get_experiment" and "clone_with" execute quickly the _time_created field will be equal, but if there is delay they'll be unequal. 

Proposed fixes:
1. In experiment equality check, ignore "_time_created" field entirely. 
2. In experiment equality check, check if the "_time_created" fields are "nearly equal"
3. Set the clone's _time_created field manually to experiment._time_created

I've taken the first approach for this diff, but want to get team feedback on what the preferred approach would be.

Differential Revision: D55596348


