### PR TITLE
Fix "cannot collect test class 'TestMetric' because it has a __init__ constructor (from: ax/core/tests/test_experiment.py)"

### DIFF
--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -75,6 +75,8 @@ DUMMY_ARM_NAME = "test_arm_name"
 class TestMetric(Metric):
     """Shell metric class for testing."""
 
+    __test__ = False
+
     pass
 
 

--- a/ax/core/tests/test_metric.py
+++ b/ax/core/tests/test_metric.py
@@ -18,6 +18,8 @@ from ax.utils.testing.core_stubs import (
 
 
 class TestMetric(Metric):
+    __test__ = False
+
     pass
 
 


### PR DESCRIPTION
Summary:
Noticed the "cannot collect test class 'TestMetric' because it has a __init__ constructor (from: ax/core/tests/test_experiment.py)" warning in test logs. This is because classes prefixed with "Test" are automatically collected as tests.

Adding the __test__ field = False fixes this

Differential Revision: D55594866


