### PR TITLE
Silence input normalization warnings in cross validation

### DIFF
--- a/ax/modelbridge/tests/test_cross_validation.py
+++ b/ax/modelbridge/tests/test_cross_validation.py
@@ -17,7 +17,6 @@ from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
 )
-
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.parameter import FixedParameter, ParameterType
 from ax.core.search_space import SearchSpace
@@ -205,9 +204,7 @@ class CrossValidationTest(TestCase):
 
         # Test selector
 
-        # pyre-fixme[3]: Return type must be annotated.
-        # pyre-fixme[2]: Parameter must be annotated.
-        def test_selector(obs):
+        def test_selector(obs: Observation) -> bool:
             return obs.features.parameters["x"] != 4.0
 
         result = cross_validate(model=ma, folds=-1, test_selector=test_selector)
@@ -269,10 +266,9 @@ class CrossValidationTest(TestCase):
         with self.assertRaisesRegex(ValueError, "no training data"):
             cross_validate(model=sobol)
 
-    # pyre-fixme[3]: Return type must be annotated.
     def test_cross_validate_raises_not_implemented_error_for_non_cv_model_with_data(
         self,
-    ):
+    ) -> None:
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run().complete()
         sobol = Models.SOBOL(

--- a/ax/modelbridge/tests/test_model_fit_metrics.py
+++ b/ax/modelbridge/tests/test_model_fit_metrics.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import warnings
 from typing import cast, Dict
 
 from ax.core.experiment import Experiment
@@ -90,3 +91,15 @@ class TestModelBridgeFitMetrics(TestCase):
         )
         self.assertIsInstance(empty_metrics, dict)
         self.assertTrue(len(empty_metrics) == 0)
+
+        # testing log filtering
+        with warnings.catch_warnings(record=True) as ws:
+            fit_metrics = compute_model_fit_metrics_from_modelbridge(
+                model_bridge=model_bridge,
+                experiment=self.branin_experiment,
+                untransform=False,
+                generalization=True,
+            )
+        self.assertFalse(
+            any("Input data is not standardized" in str(w.message) for w in ws)
+        )


### PR DESCRIPTION
Summary: If we compute CV directly using `TorchModelBridge._cross_validate`, we skip the part of `ModelBridge.cross_validate` that silences these warnings. Replicated the same logic for CV computations in the untransformed space.

Differential Revision: D55648398


