### PR TITLE
fix skip_runners_and_metrics for metrics on generator runs with mutable multi-objective optimization config

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -635,7 +635,6 @@ class Decoder:
         for arm_sqa in generator_run_sqa.arms:
             arms.append(self.arm_from_sqa(arm_sqa=arm_sqa))
             weights.append(arm_sqa.weight)
-
         if not reduced_state and not immutable_search_space_and_opt_config:
             (
                 opt_config,

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -181,11 +181,16 @@ def get_experiment_with_custom_runner_and_metric(
 
     # Create a trial, set its runner and complete it.
     sobol_generator = get_sobol(search_space=experiment.search_space)
-    sobol_run = sobol_generator.gen(n=1)
+    sobol_run = sobol_generator.gen(
+        n=1,
+        optimization_config=experiment.optimization_config if not immutable else None,
+    )
     trial = experiment.new_trial(generator_run=sobol_run)
     trial.runner = experiment.runner
     trial.mark_running()
     experiment.attach_data(get_data(metric_name="custom_test_metric"))
+    experiment.attach_data(get_data(metric_name="m1"))
+    experiment.attach_data(get_data(metric_name="m3"))
     trial.mark_completed()
 
     if immutable:


### PR DESCRIPTION
Summary: This fixes load_experiment with `skip_runners_and_metricsmetrics` by setting properties SQAMetrics on  generator runs that have multi-objective intent, for experiments with mutable optimization configs

Reviewed By: Balandat

Differential Revision: D55663714


