### PR TITLE
Rework TransitionCriterion storage to remove circular dep

### DIFF
--- a/ax/modelbridge/transition_criterion.py
+++ b/ax/modelbridge/transition_criterion.py
@@ -7,7 +7,7 @@
 
 from abc import abstractmethod
 from logging import Logger
-from typing import Any, Dict, List, Optional, Set
+from typing import List, Optional, Set
 
 from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
@@ -16,13 +16,7 @@ from ax.exceptions.generation_strategy import MaxParallelismReachedException
 
 from ax.utils.common.base import SortableBase
 from ax.utils.common.logger import get_logger
-from ax.utils.common.serialization import (
-    SerializationMixin,
-    serialize_init_args,
-    TClassDecoderRegistry,
-    TDecoderRegistry,
-)
-from ax.utils.common.typeutils import not_none
+from ax.utils.common.serialization import SerializationMixin, serialize_init_args
 
 logger: Logger = get_logger(__name__)
 
@@ -145,32 +139,6 @@ class TrialBasedCriterion(TransitionCriterion):
             block_transition_if_unmet=block_transition_if_unmet,
             block_gen_if_met=block_gen_if_met,
         )
-
-    @classmethod
-    def deserialize_init_args(
-        cls,
-        args: Dict[str, Any],
-        decoder_registry: Optional[TDecoderRegistry] = None,
-        class_decoder_registry: Optional[TClassDecoderRegistry] = None,
-    ) -> Dict[str, Any]:
-        """Given a dictionary, extract the properties needed to initialize the object.
-        Used for storage.
-        """
-        # import here to avoid circular import
-        from ax.storage.json_store.decoder import object_from_json
-
-        decoder_registry = not_none(decoder_registry)
-        class_decoder_registry = class_decoder_registry or {}
-        init_args = super().deserialize_init_args(args=args)
-
-        return {
-            key: object_from_json(
-                object_json=value,
-                decoder_registry=decoder_registry,
-                class_decoder_registry=class_decoder_registry,
-            )
-            for key, value in init_args.items()
-        }
 
     def experiment_trials_by_status(
         self, experiment: Experiment, statuses: List[TrialStatus]

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -114,6 +114,7 @@ from ax.utils.testing.core_stubs import (
     get_synthetic_runner,
     get_threshold_early_stopping_strategy,
     get_trial,
+    get_trial_based_criterion,
     get_winsorization_config,
 )
 from ax.utils.testing.modeling_stubs import (
@@ -218,6 +219,7 @@ TEST_CASES = [
     ("Type[Transform]", get_transform_type),
     ("Type[InputTransform]", get_input_transform_type),
     ("Type[OutcomeTransform]", get_outcome_transfrom_type),
+    ("TransitionCriterionList", get_trial_based_criterion),
     ("ThresholdEarlyStoppingStrategy", get_threshold_early_stopping_strategy),
     ("Trial", get_trial),
     ("WinsorizationConfig", get_winsorization_config),

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -95,6 +95,11 @@ from ax.metrics.factorial import FactorialMetric
 from ax.metrics.hartmann6 import AugmentedHartmann6Metric, Hartmann6Metric
 from ax.modelbridge.factory import Cont_X_trans, get_factorial, get_sobol
 from ax.modelbridge.generation_strategy import GenerationStrategy
+from ax.modelbridge.transition_criterion import (
+    MaxGenerationParallelism,
+    MaxTrials,
+    TrialBasedCriterion,
+)
 from ax.models.torch.botorch_modular.acquisition import Acquisition
 from ax.models.torch.botorch_modular.model import BoTorchModel, SurrogateSpec
 from ax.models.torch.botorch_modular.sebo import SEBOAcquisition
@@ -151,6 +156,23 @@ def get_experiment_with_map_data_type() -> Experiment:
         is_test=True,
         default_data_type=DataType.MAP_DATA,
     )
+
+
+def get_trial_based_criterion() -> List[TrialBasedCriterion]:
+    return [
+        MaxTrials(
+            threshold=3,
+            only_in_statuses=[TrialStatus.RUNNING, TrialStatus.COMPLETED],
+            not_in_statuses=None,
+        ),
+        MaxGenerationParallelism(
+            threshold=5,
+            only_in_statuses=None,
+            not_in_statuses=[
+                TrialStatus.RUNNING,
+            ],
+        ),
+    ]
 
 
 def get_experiment_with_custom_runner_and_metric(


### PR DESCRIPTION
Summary:
In D52982664 I introduced a circular dep by moving some storage related logic directly onto transitioncriterion class. In the past week and half, this has been pretty annoying for folks on the team (sorry everyone!). This diff fixes that dep by:

1. Keeping all storage related logic in the storage files
2. Adding a specific check in object_from_json for ```TrialBasedCriterion``. These criterion contain lists of TrialStatuses, specifically in not_in_statuses and only_in_statuses args, which makes the standard deserialization fail to properly unpack these lists in a way that maintains the TrialStatuses type. Here we add a special method to do so.
3. All other transitioncriterion can continue using deserialize method

There is a larger question here about ideally if a class inherits from SerializationMixin and all it's fields also inherit from SerializationMixin that the deserialization should eloquently handle this. I tried to find a solution for that for a bit in this period, but i kept introducing circular deps and it seems to be a larger undertaking than i have scope for at the time.

Differential Revision: D55727618


