### PR TITLE
Adding DeprecatedTransformMixin class

### DIFF
--- a/ax/modelbridge/transforms/base.py
+++ b/ax/modelbridge/transforms/base.py
@@ -20,8 +20,10 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.exceptions.core import UnsupportedError
+from ax.modelbridge.transforms.deprecated_transform_mixin import (
+    DeprecatedTransformMixin,
+)
 from ax.models.types import TConfig
-
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
@@ -76,6 +78,33 @@ class Transform:
             config = {}
         self.config = config
         self.modelbridge = modelbridge
+
+    def __eq__(self, other: Transform) -> bool:
+        """Check if two transforms are equal by their attributes.
+        Add a special case where if one of the transforms are deprecated,
+        we compare the attribute dicts of the two transforms instead of the
+
+        Args:
+            other: The other transform to compare to.
+
+        Returns: True if the transforms are equal, False otherwise.
+        """
+        if isinstance(self, type(DeprecatedTransformMixin)) and not isinstance(
+            self, type(other)
+        ):
+            return False
+        if isinstance(other, type(DeprecatedTransformMixin)) and not isinstance(
+            other, type(self)
+        ):
+            return False
+        if (
+            isinstance(self, DeprecatedTransformMixin)
+            and isinstance(other, DeprecatedTransformMixin)
+            and (not isinstance(self, type(other)) or not isinstance(other, type(self)))
+        ):
+            return False
+
+        return self.__dict__ == other.__dict__
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         """Transform search space.

--- a/ax/modelbridge/transforms/deprecated_transform_mixin.py
+++ b/ax/modelbridge/transforms/deprecated_transform_mixin.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from logging import Logger
+from typing import Any
+
+from ax.utils.common.logger import get_logger
+
+logger: Logger = get_logger(__name__)
+
+
+class DeprecatedTransformMixin:
+    """
+    Mixin class for deprecated transforms.
+
+    This class is used to log warnings when a deprecated transform is used,
+    and will construct the new transform that should be used instead.
+
+    The deprecated transform should inherit as follows:
+
+    class DeprecatedTransform(DeprecatedTransformMixin, NewTransform):
+        ...
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """
+        Log a warning that the transform is deprecated, and construct the
+        new transform.
+        """
+        warning_msg = self.warn_deprecated_message(
+            self.__class__.__name__, type(self).__bases__[1].__name__
+        )
+        logger.warning(warning_msg)
+
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def warn_deprecated_message(
+        deprecated_transform_name: str, new_transform_name: str
+    ) -> str:
+        """
+        Constructs the warning message.
+        """
+        return (
+            f"`{deprecated_transform_name}` transform has been deprecated "
+            "and will be removed in a future release. "
+            f"Using `{new_transform_name}` instead."
+        )

--- a/ax/modelbridge/transforms/tests/test_deprecated_transform_mixin.py
+++ b/ax/modelbridge/transforms/tests/test_deprecated_transform_mixin.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.deprecated_transform_mixin import (
+    DeprecatedTransformMixin,
+)
+from ax.utils.common.testutils import TestCase
+
+
+class DeprecatedTransformTest(TestCase):
+    class DeprecatedTransform(DeprecatedTransformMixin, Transform):
+        def __init__(self, *args: Any) -> None:
+            super().__init__(*args)
+
+    def setUp(self) -> None:
+        self.deprecated_t = self.DeprecatedTransform(MagicMock(), MagicMock())
+        self.t = Transform(MagicMock(), MagicMock())
+
+    def test_isinstance(self) -> None:
+        self.assertTrue(isinstance(self.deprecated_t, type(self.t)))
+        self.assertTrue(isinstance(self.deprecated_t, Transform))
+        self.assertTrue(isinstance(self.deprecated_t, self.DeprecatedTransform))
+        self.assertTrue(isinstance(self.deprecated_t, DeprecatedTransformMixin))
+
+    def test_deprecated_transform_equality(self) -> None:
+        class DeprecatedTransform(DeprecatedTransformMixin, Transform):
+            def __init__(self, *args):
+                super().__init__(*args)
+
+        t = Transform(MagicMock(), MagicMock())
+        t2 = Transform(MagicMock(), MagicMock())
+        self.assertEqual(t, t2)
+
+        dt = DeprecatedTransform(MagicMock(), MagicMock())
+        self.assertEqual(t, dt)
+        self.assertEqual(dt, t)
+
+        class OtherDeprecatedTransform(DeprecatedTransformMixin, Transform):
+            def __init__(self, *args):
+                super().__init__(*args)
+
+        other_dt = OtherDeprecatedTransform(MagicMock(), MagicMock())
+        self.assertNotEqual(dt, other_dt)
+
+    def test_logging(self) -> None:
+        with self.assertLogs(
+            "ax.modelbridge.transforms.deprecated_transform_mixin",
+            level=logging.WARNING,
+        ) as logger:
+            _ = self.DeprecatedTransform(MagicMock(), MagicMock())
+            message = DeprecatedTransformMixin.warn_deprecated_message(
+                self.DeprecatedTransform.__name__,
+                Transform.__name__,
+            )
+            self.assertTrue(any(message in s for s in logger.output))


### PR DESCRIPTION
Summary:
This task starts the backlog task T182722751 "Rename Ax transforms in terms of what they transform from and to, when it isn't clear"

It has a list of transforms to have their names updated to clearer values
```
OrderedChoiceEncode -> OrderedChoiceToIntegerRange
ChoiceEncode -> ChoiceToNumericChoice
TaskEncode -> TaskChoiceToIntTaskChoice
Cast -> Map
```

This change
- Adds a "DeprecatedTransformMixin", which classes can inherit from in order to print a logging message with the deprecated transform and the new transform to update to. 
- Overrides the __eq__ built-in of Transform to support equality between a DeprecatedTransform(DeprecatedTransformMixin, Transform) and an equivalent Transform object. This is needed for cases where a DeprecatedTransform is saved to a sqa store, and loaded back as the equivalent renamed Transform

Subsequent changes will add the new transform classes, and update the transform registry to point to the new classes instead of the old. 

## Warning

The warning is as follows:
```
[WARNING 04-04 09:58:45] ax.modelbridge.transforms.deprecated_transform_mixin: 
`DeprecatedTransform` transform has been deprecated 
and will be removed in a future release. Using `Transform` instead.
```

Differential Revision: D55643016


