### PR TITLE
Rename OrderedChoiceEncode => OrderedChoiceToIntegerRange

### DIFF
--- a/ax/modelbridge/transforms/choice_encode.py
+++ b/ax/modelbridge/transforms/choice_encode.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 from ax.core.observation import Observation, ObservationFeatures
@@ -14,6 +14,9 @@ from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangePa
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
 from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.deprecated_transform_mixin import (
+    DeprecatedTransformMixin,
+)
 from ax.modelbridge.transforms.utils import (
     ClosestLookupDict,
     construct_new_search_space,
@@ -120,7 +123,7 @@ class ChoiceEncode(Transform):
         return observation_features
 
 
-class OrderedChoiceEncode(ChoiceEncode):
+class OrderedChoiceToIntegerRange(ChoiceEncode):
     """Convert ordered ChoiceParameters to integer RangeParameters.
 
     Parameters will be transformed to an integer RangeParameters, mapped from the
@@ -185,6 +188,13 @@ class OrderedChoiceEncode(ChoiceEncode):
                 for pc in search_space.parameter_constraints
             ],
         )
+
+
+class OrderedChoiceEncode(DeprecatedTransformMixin, OrderedChoiceToIntegerRange):
+    """Deprecated alias for OrderedChoiceToIntegerRange."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
 
 
 def transform_choice_values(p: ChoiceParameter) -> Tuple[np.ndarray, ParameterType]:

--- a/ax/modelbridge/transforms/deprecated_transform_mixin.py
+++ b/ax/modelbridge/transforms/deprecated_transform_mixin.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from logging import Logger
+from typing import Any
+
+from ax.utils.common.logger import get_logger
+
+logger: Logger = get_logger(__name__)
+
+
+class DeprecatedTransformMixin:
+    """
+    Mixin class for deprecated transforms.
+
+    This class is used to log warnings when a deprecated transform is used,
+    and will construct the new transform that should be used instead.
+
+    The deprecated transform should inherit as follows:
+
+    class DeprecatedTransform(DeprecatedTransformMixin, NewTransform):
+        ...
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """
+        Log a warning that the transform is deprecated, and construct the
+        new transform.
+        """
+        warning_msg = self.warn_deprecated_message(
+            self.__class__.__name__, type(self).__bases__[1].__name__
+        )
+        logger.warning(warning_msg)
+
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def warn_deprecated_message(
+        deprecated_transform_name: str, new_transform_name: str
+    ) -> str:
+        """
+        Constructs the warning message.
+        """
+        return (
+            f"`{deprecated_transform_name}` transform has been deprecated "
+            "and will be removed in a future release. "
+            f"Using `{new_transform_name}` instead."
+        )

--- a/ax/modelbridge/transforms/tests/test_deprecated_transform_mixin.py
+++ b/ax/modelbridge/transforms/tests/test_deprecated_transform_mixin.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.deprecated_transform_mixin import (
+    DeprecatedTransformMixin,
+)
+from ax.utils.common.testutils import TestCase
+
+
+class DeprecatedTransformTest(TestCase):
+    class DeprecatedTransform(DeprecatedTransformMixin, Transform):
+        def __init__(self, *args: Any) -> None:
+            super().__init__(*args)
+
+    class DummyTransform(Transform):
+        def __init__(self, *args: Any) -> None:
+            super().__init__(*args)
+
+    class DeprecatedDummyTransform(DeprecatedTransformMixin, DummyTransform):
+        def __init__(self, *args: Any) -> None:
+            super().__init__(*args)
+
+    def setUp(self) -> None:
+        self.deprecated_t = self.DeprecatedTransform(MagicMock(), MagicMock())
+        self.t = Transform(MagicMock(), MagicMock())
+
+    def test_isinstance(self) -> None:
+        self.assertTrue(isinstance(self.deprecated_t, type(self.t)))
+        self.assertTrue(isinstance(self.deprecated_t, Transform))
+        self.assertTrue(isinstance(self.deprecated_t, self.DeprecatedTransform))
+        self.assertTrue(isinstance(self.deprecated_t, DeprecatedTransformMixin))
+
+    def test_deprecated_transform_equality(self) -> None:
+        class DeprecatedTransform(DeprecatedTransformMixin, Transform):
+            def __init__(self, *args):
+                super().__init__(*args)
+
+        t = Transform(MagicMock(), MagicMock())
+        t2 = Transform(MagicMock(), MagicMock())
+        self.assertEqual(t.__dict__, t2.__dict__)
+
+        dt = DeprecatedTransform(MagicMock(), MagicMock())
+        self.assertEqual(t.__dict__, dt.__dict__)
+
+    def test_logging(self) -> None:
+        with self.assertLogs(
+            "ax.modelbridge.transforms.deprecated_transform_mixin",
+            level=logging.WARNING,
+        ) as logger:
+            _ = self.DeprecatedTransform(MagicMock(), MagicMock())
+            message = DeprecatedTransformMixin.warn_deprecated_message(
+                self.DeprecatedTransform.__name__,
+                Transform.__name__,
+            )
+            self.assertTrue(any(message in s for s in logger.output))

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -6,11 +6,15 @@
 
 # pyre-strict
 
-from typing import Dict, Type
+from typing import Dict, List, Type
 
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.cap_parameter import CapParameter
-from ax.modelbridge.transforms.choice_encode import ChoiceEncode, OrderedChoiceEncode
+from ax.modelbridge.transforms.choice_encode import (
+    ChoiceEncode,
+    OrderedChoiceEncode,
+    OrderedChoiceToIntegerRange,
+)
 from ax.modelbridge.transforms.convert_metric_names import ConvertMetricNames
 from ax.modelbridge.transforms.derelativize import Derelativize
 from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
@@ -56,7 +60,8 @@ TRANSFORM_REGISTRY: Dict[Type[Transform], int] = {
     IVW: 4,
     Log: 5,
     OneHot: 6,
-    OrderedChoiceEncode: 7,
+    OrderedChoiceEncode: 7,  # TO BE DEPRECATED
+    OrderedChoiceToIntegerRange: 7,
     # This transform was upstreamed into the base modelbridge.
     # Old transforms serialized with this will have the OutOfDesign transform
     # replaced with a no-op, the base transform.
@@ -81,7 +86,15 @@ TRANSFORM_REGISTRY: Dict[Type[Transform], int] = {
     RelativizeWithConstantControl: 25,
 }
 
+"""
+List of new classes of transforms which will be deprecated.
+The reverse transform registry will refer to the old transforms at first,
+and will be later migrated to point to the new transforms.
+"""
+TRANSFORMS_TO_UPDATE: List[Type[Transform]] = [
+    OrderedChoiceToIntegerRange  # will replace OrderedChoiceEncode
+]
 
 REVERSE_TRANSFORM_REGISTRY: Dict[int, Type[Transform]] = {
-    v: k for k, v in TRANSFORM_REGISTRY.items()
+    v: k for k, v in TRANSFORM_REGISTRY.items() if k not in TRANSFORMS_TO_UPDATE
 }


### PR DESCRIPTION
Summary:
This change renames the OrderedChoiceEncode transform to one which reflects its behavior- see T182722751 for the overall task. 

- Adds a new "OrderedChoiceToIntegerRange" class with the logic from the original OrderedChoiceEncode
- Updates OrderedChoiceEncode to inherit from DeprecatedTransformMixin and OrderedChoiceToIntegerRange
- Updates the registry to support the new transform.

Initially, the new classes will be decoded into the deprecated classes to maintain backwards compatibility. Once the new classes are landed, call sites will be updated to use the new class instead of the old.

Differential Revision: D55754487


