### PR TITLE
update run_metadata in BaseTrial.run instead of overwriting

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -408,7 +408,7 @@ class BaseTrial(ABC, SortableBase):
         if self._runner is None:
             raise ValueError("No runner set on trial or experiment.")
 
-        self._run_metadata = not_none(self._runner).run(self)
+        self.update_run_metadata(not_none(self._runner).run(self))
 
         if not_none(self._runner).staging_required:
             self.mark_staged()

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -164,6 +164,21 @@ class TrialTest(TestCase):
         self.assertTrue(self.trial.did_not_complete)
         self.assertEqual(self.trial.failed_reason, fail_reason)
 
+    def test_trial_run_does_not_overwrite_existing_metadata(self) -> None:
+        self.trial.runner = SyntheticRunner(dummy_metadata="y")
+        self.trial.update_run_metadata({"orig_metadata": "x"})
+        self.trial.run()
+        self.assertDictEqual(
+            self.trial.run_metadata,
+            {
+                "name": "test_0",
+                "orig_metadata": "x",
+                "dummy_metadata": "y",
+                # this is set in setUp
+                "foo": "bar",
+            },
+        )
+
     def test_mark_as(self) -> None:
         for terminal_status in (
             TrialStatus.ABANDONED,


### PR DESCRIPTION
Summary: see title. This enables storing metadata from multiple runners.

Reviewed By: Balandat

Differential Revision: D55767138


