### PR TITLE
(Fixes OSS CI) Have Sphinx track `deprecated_transform_mixin`, but make it private

### DIFF
--- a/ax/modelbridge/transforms/deprecated_transform_mixin.py
+++ b/ax/modelbridge/transforms/deprecated_transform_mixin.py
@@ -25,6 +25,8 @@ class DeprecatedTransformMixin:
 
     class DeprecatedTransform(DeprecatedTransformMixin, NewTransform):
         ...
+
+    :meta private:
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -145,6 +145,13 @@ Dispatch Utilities
 
 Transforms
 ----------
+`ax.modelbridge.transforms.deprecated_transform_mixin`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.deprecated_transform_mixin
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 `ax.modelbridge.transforms.base`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Summary:
The OSS CI is failing: https://github.com/facebook/Ax/actions/runs/8581833037/job/23519269134?pr=2329

This should fix the Sphinx error. Adding `:meta private:` to the docstring will stop it from rendering, since OSS users shouldn't need to know about `DeprecatedTransformMixin` and can read the code on GH if they need to.

Differential Revision: D55837917


