### PR TITLE
Fix deprecation warning from pandas.read_json

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -12,6 +12,7 @@ import json
 from abc import abstractmethod
 from functools import reduce
 from hashlib import md5
+from io import StringIO
 from typing import Any, Dict, Iterable, List, Optional, Set, Type, TypeVar, Union
 
 import numpy as np
@@ -202,7 +203,7 @@ class BaseData(Base, SerializationMixin):
         if "df" in args and not isinstance(args["df"], pd.DataFrame):
             # NOTE: Need dtype=False, otherwise infers arm_names like
             # "4_1" should be int 41.
-            args["df"] = pd.read_json(args["df"]["value"], dtype=False)
+            args["df"] = pd.read_json(StringIO(args["df"]["value"]), dtype=False)
         return extract_init_args(args=args, class_=cls)
 
     @property

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -449,8 +449,9 @@ class BatchTrialTest(TestCase):
         batch.mark_running(no_runner_required=True)
         new_batch_trial = batch.clone_to()
         self.assertEqual(new_batch_trial.index, 2)
-        # Set index to original trial's value for equality check.
+        # Set index & time_created to original trial's value for equality check.
         new_batch_trial._index = batch.index
+        new_batch_trial._time_created = batch._time_created
         self.assertEqual(new_batch_trial, batch)
 
     def test_Runner(self) -> None:

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -10,6 +10,7 @@ import datetime
 from collections import OrderedDict
 from enum import Enum
 from inspect import isclass
+from io import StringIO
 from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
@@ -132,7 +133,7 @@ def object_from_json(
         elif _type == "DataFrame":
             # Need dtype=False, otherwise infers arm_names like "4_1"
             # should be int 41
-            return pd.read_json(object_json["value"], dtype=False)
+            return pd.read_json(StringIO(object_json["value"]), dtype=False)
         elif _type == "ndarray":
             return np.array(object_json["value"])
         elif _type == "Tensor":

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -9,6 +9,7 @@
 import json
 from collections import defaultdict, OrderedDict
 from enum import Enum
+from io import StringIO
 from logging import Logger
 from typing import Any, cast, Dict, List, Optional, Tuple, Type, Union
 
@@ -982,7 +983,7 @@ class Decoder:
         # Override df from deserialize_init_args with `data_json`.
         # NOTE: Need dtype=False, otherwise infers arm_names like
         # "4_1" should be int 41.
-        kwargs["df"] = pd.read_json(data_sqa.data_json, dtype=False)
+        kwargs["df"] = pd.read_json(StringIO(data_sqa.data_json), dtype=False)
 
         dat = data_constructor(**kwargs)
 


### PR DESCRIPTION
Summary:
Addresses the following warning:
```
Passing literal json to 'read_json' is deprecated and will
be removed in a future version. To read from a literal string, wrap it in a 'StringIO' object.
```

Seen in dev API tutorial: https://ax.dev/tutorials/gpei_hartmann_developer.html

Differential Revision: D55978442


