### PR TITLE
Remove gen_unlimited trials

### DIFF
--- a/ax/modelbridge/external_generation_node.py
+++ b/ax/modelbridge/external_generation_node.py
@@ -54,7 +54,6 @@ class ExternalGenerationNode(GenerationNode, ABC):
         node_name: str,
         should_deduplicate: bool = True,
         transition_criteria: Optional[Sequence[TransitionCriterion]] = None,
-        gen_unlimited_trials: bool = True,
     ) -> None:
         """Initialize an external generation node.
 
@@ -73,9 +72,6 @@ class ExternalGenerationNode(GenerationNode, ABC):
             transition_criteria: Criteria for determining whether to move to the next
                 node in the generation strategy. This is an advanced option that is
                 only relevant if the generation strategy consists of multiple nodes.
-            gen_unlimited_trials: Whether to generate unlimited trials from this node.
-                This should only be False if the generation strategy will transition to
-                another node after generating a limited number of trials from this node.
         """
         t_init_start = time.monotonic()
         super().__init__(
@@ -84,7 +80,6 @@ class ExternalGenerationNode(GenerationNode, ABC):
             best_model_selector=None,
             should_deduplicate=should_deduplicate,
             transition_criteria=transition_criteria,
-            gen_unlimited_trials=gen_unlimited_trials,
         )
         self.fit_time_since_gen: float = time.monotonic() - t_init_start
 

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -24,12 +24,7 @@ from ax.core.utils import (
     extend_pending_observations,
     get_pending_observation_features_based_on_trial_status,
 )
-from ax.exceptions.core import (
-    AxError,
-    DataRequiredError,
-    UnsupportedError,
-    UserInputError,
-)
+from ax.exceptions.core import DataRequiredError, UnsupportedError, UserInputError
 from ax.exceptions.generation_strategy import (
     GenerationStrategyCompleted,
     GenerationStrategyMisconfiguredException,
@@ -750,12 +745,6 @@ class GenerationStrategy(GenerationStrategyInterface):
             raise_data_required_error=raise_data_required_error
         )
         if move_to_next_node:
-            if self._curr.gen_unlimited_trials:
-                raise AxError(
-                    "The generation strategy is attempting to transition to next node "
-                    "despite the current node being configured to generate unlimited "
-                    "trials. This should not happen."
-                )
             if self.optimization_complete:
                 raise GenerationStrategyCompleted(
                     f"Generation strategy {self} generated all the trials as "

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-import logging
 from logging import Logger
 from unittest.mock import patch, PropertyMock
 
@@ -143,7 +142,6 @@ class TestGenerationNode(TestCase):
             node.model_spec_to_gen_from.diagnostics, node.model_specs[0].diagnostics
         )
         self.assertEqual(node.node_name, "test")
-        self.assertEqual(node.gen_unlimited_trials, True)
         self.assertEqual(node._unique_id, "test")
 
     def test_node_string_representation(self) -> None:
@@ -156,7 +154,6 @@ class TestGenerationNode(TestCase):
                     model_gen_kwargs={},
                 ),
             ],
-            gen_unlimited_trials=False,
             transition_criteria=[
                 MaxTrials(threshold=5, only_in_statuses=[TrialStatus.RUNNING])
             ],
@@ -167,7 +164,7 @@ class TestGenerationNode(TestCase):
             (
                 "GenerationNode(model_specs=[ModelSpec(model_enum=GPEI,"
                 " model_kwargs={}, model_gen_kwargs={}, model_cv_kwargs={},"
-                " )], node_name=test, gen_unlimited_trials=False, "
+                " )], node_name=test, "
                 "transition_criteria=[MaxTrials({'threshold': 5, "
                 "'only_in_statuses': [<enum 'TrialStatus'>.RUNNING], "
                 "'not_in_statuses': None, 'transition_to': None, "
@@ -194,37 +191,6 @@ class TestGenerationNode(TestCase):
             node.model_spec_to_gen_from.fixed_features,
             ObservationFeatures(parameters={"x": 0}),
         )
-
-    def test_generator_run_limit_unlimited_without_flag(self) -> None:
-        """This tests checks that when the `gen_unlimited_trials` flag is false
-        but there are no generation blocking criteria, then the generator run limit
-        is set to -1 and a warning is logged.
-        """
-        node = GenerationNode(
-            node_name="test",
-            model_specs=[
-                ModelSpec(
-                    model_enum=Models.GPEI,
-                    model_kwargs={},
-                    model_gen_kwargs={
-                        "n": -1,
-                        "fixed_features": ObservationFeatures(parameters={"x": 0}),
-                    },
-                ),
-            ],
-            gen_unlimited_trials=False,
-        )
-        warning_msg = (
-            "Even though this node is not flagged for generation of unlimited "
-            "trials, there are no generation blocking criterion, therefore, "
-            "unlimited trials will be generated."
-        )
-        with self.assertLogs(GenerationNode.__module__, logging.WARNING) as logger:
-            self.assertEqual(node.generator_run_limit(), -1)
-            self.assertTrue(
-                any(warning_msg in output for output in logger.output),
-                logger.output,
-            )
 
 
 class TestGenerationStep(TestCase):

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -162,13 +162,11 @@ class TestGenerationStrategy(TestCase):
             node_name="sobol_node",
             transition_criteria=self.sobol_criterion,
             model_specs=[self.sobol_model_spec],
-            gen_unlimited_trials=False,
         )
         self.gpei_node = GenerationNode(
             node_name="GPEI_node",
             transition_criteria=self.gpei_criterion,
             model_specs=[self.gpei_model_spec],
-            gen_unlimited_trials=False,
         )
 
         self.sobol_GPEI_GS_nodes = GenerationStrategy(
@@ -304,7 +302,7 @@ class TestGenerationStrategy(TestCase):
             "GenerationStrategy(name='Sobol', nodes=[GenerationNode("
             "model_specs=[ModelSpec(model_enum=Sobol, "
             "model_kwargs={}, model_gen_kwargs={}, model_cv_kwargs={},"
-            " )], node_name=test, gen_unlimited_trials=True, "
+            " )], node_name=test, "
             "transition_criteria=[])])",
         )
 
@@ -637,7 +635,6 @@ class TestGenerationStrategy(TestCase):
                             transition_to="sobol_3_trial",
                         )
                     ],
-                    gen_unlimited_trials=False,
                 ),
                 GenerationNode(
                     node_name="sobol_3_trial",
@@ -651,7 +648,6 @@ class TestGenerationStrategy(TestCase):
                             transition_to=None,
                         )
                     ],
-                    gen_unlimited_trials=False,
                 ),
             ]
         )
@@ -1296,9 +1292,6 @@ class TestGenerationStrategy(TestCase):
                     block_transition_if_unmet=True,
                 ),
             ],
-            # If we remove this, the test will fail.
-            # This behavior needs to be improved.
-            gen_unlimited_trials=False,
         )
         gpei_model_spec = ModelSpec(
             model_enum=Models.GPEI,
@@ -1308,7 +1301,6 @@ class TestGenerationStrategy(TestCase):
         gpei_node = GenerationNode(
             node_name="GPEI_node",
             model_specs=[gpei_model_spec],
-            gen_unlimited_trials=True,
         )
         gs = GenerationStrategy(
             name="Sobol+GPEI_Nodes",

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -710,7 +710,6 @@ def generation_node_from_json(
         # isn't implemented
         best_model_selector=generation_node_json.pop("best_model_selector", None),
         should_deduplicate=generation_node_json.pop("should_deduplicate", False),
-        gen_unlimited_trials=generation_node_json.pop("gen_unlimited_trials", True),
         transition_criteria=(
             object_from_json(
                 generation_node_json.pop("transition_criteria"),

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -498,7 +498,6 @@ def generation_node_to_dict(generation_node: GenerationNode) -> Dict[str, Any]:
         "model_specs": generation_node.model_specs,
         "should_deduplicate": generation_node.should_deduplicate,
         "node_name": generation_node.node_name,
-        "gen_unlimited_trials": generation_node.gen_unlimited_trials,
         "model_spec_to_gen_from": generation_node._model_spec_to_gen_from,
         "transition_criteria": generation_node.transition_criteria,
     }

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -256,13 +256,11 @@ def sobol_gpei_generation_node_gs() -> GenerationStrategy:
         node_name="sobol_node",
         transition_criteria=sobol_criterion,
         model_specs=[sobol_model_spec],
-        gen_unlimited_trials=False,
     )
     gpei_node = GenerationNode(
         node_name="GPEI_node",
         transition_criteria=gpei_criterion,
         model_specs=[gpei_model_spec],
-        gen_unlimited_trials=False,
     )
 
     sobol_GPEI_GS_nodes = GenerationStrategy(

--- a/tutorials/external_generation_node.ipynb
+++ b/tutorials/external_generation_node.ipynb
@@ -228,7 +228,6 @@
         "                    block_transition_if_unmet=True,\n",
         "                )\n",
         "            ],\n",
-        "            gen_unlimited_trials=False,\n",
         "        ),\n",
         "        RandomForestGenerationNode(num_samples=128, regressor_options={}),\n",
         "    ],\n",


### PR DESCRIPTION
Summary: This diff removes the gen_unlimited_trials property from GenerationNode based on a recent discussion with the team about not needing this property anymore. It is pretty duplicative of the transition_criteria, and adds extra complexity in the code that isn't outweighing the verboseness of the property.

Reviewed By: lena-kashtelyan

Differential Revision: D55001716
