### PR TITLE
Switch legacy LCE-A to qLogNEI from legacy `ei_or_nei`

### DIFF
--- a/ax/models/torch/cbo_lcea.py
+++ b/ax/models/torch/cbo_lcea.py
@@ -11,8 +11,8 @@ from typing import Any, cast, Dict, List, Optional, Tuple, Union
 
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
-from ax.models.torch.alebo import ei_or_nei
 from ax.models.torch.botorch import BotorchModel
+from ax.models.torch.botorch_defaults import get_qLogNEI
 from ax.models.torch.cbo_sac import generate_model_space_decomposition
 from ax.models.torch_base import TorchModel, TorchOptConfig
 from ax.utils.common.docutils import copy_doc
@@ -111,8 +111,7 @@ class LCEABO(BotorchModel):
         # pyre-fixme[4]: Attribute must be annotated.
         self.train_embedding = self.gp_model_args.get("train_embedding", True)
         super().__init__(
-            model_constructor=self.get_and_fit_model,
-            acqf_constructor=ei_or_nei,  # pyre-ignore
+            model_constructor=self.get_and_fit_model, acqf_constructor=get_qLogNEI
         )
 
     @copy_doc(TorchModel.fit)


### PR DESCRIPTION
Summary:
Context for this stack: we've been meaning to deprecate ALEBO and REMBO for a long time. Tests on them break periodically and slow down development of `GenerationStrategy`, which these classes hack around, so there's substantial maintenance burden to keeping them.

Context for this diff: LCE-A was depending on ALEBO for, it seems, no reason other than convenience of where the acquisition function constructor lived. This diff aims to address.

**[RfC] But also this made me wonder: maybe better to replace use of `ei_or_nei` in LCE-A with something newer?**

Reviewed By: saitcakmak

Differential Revision: D56037477


