### PR TITLE
Add an error if "use_batch_trials" is passed to AxClient

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1707,6 +1707,14 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
         if any.
         """
         choose_generation_strategy_kwargs = choose_generation_strategy_kwargs or {}
+        if (
+            "use_batch_trials" in choose_generation_strategy_kwargs
+            and type(self) is AxClient
+        ):
+            raise UnsupportedError(
+                "AxClient API does not support batch trials yet."
+                " We plan to add this support in coming versions."
+            )
         random_seed = choose_generation_strategy_kwargs.pop(
             "random_seed", self._random_seed
         )

--- a/ax/telemetry/tests/test_ax_client.py
+++ b/ax/telemetry/tests/test_ax_client.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Sequence, Union
 import numpy as np
 
 from ax.core.types import TParamValue
+from ax.exceptions.core import UnsupportedError
 from ax.service.ax_client import AxClient, ObjectiveProperties
 from ax.telemetry.ax_client import AxClientCompletedRecord, AxClientCreatedRecord
 from ax.telemetry.experiment import ExperimentCompletedRecord, ExperimentCreatedRecord
@@ -129,6 +130,25 @@ class TestAxClient(TestCase):
             model_std_generalization=float("nan"),
         )
         self._compare_axclient_completed_records(record, expected)
+
+    def test_batch_trial_warning(self) -> None:
+        ax_client = AxClient()
+        error_msg = (
+            "AxClient API does not support batch trials yet."
+            " We plan to add this support in coming versions."
+        )
+        with self.assertRaisesRegex(UnsupportedError, error_msg):
+            ax_client.create_experiment(
+                name="test_experiment",
+                parameters=[
+                    {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
+                ],
+                objectives={"branin": ObjectiveProperties(minimize=True)},
+                is_test=True,
+                choose_generation_strategy_kwargs={
+                    "use_batch_trials": True,
+                },
+            )
 
     def _compare_axclient_completed_records(
         self, record: AxClientCompletedRecord, expected: AxClientCompletedRecord


### PR DESCRIPTION
Summary:
This is a follow up to https://github.com/facebook/Ax/issues/2301?fbclid=IwAR01__ZzEs0zl3isRWT7QOvqOH_Ev7OvF8d66h1eBuPBdPNTdizrJv0e6aM

The user was trying to use batch trials, but we don't currently expose this via AxClient we want to add an error to let users know this isn't really having any affect.

Reviewed By: saitcakmak

Differential Revision: D56048665


