### PR TITLE
Update datetime equality checks to use an absolute tolerance

### DIFF
--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -68,13 +68,16 @@ def same_elements(list1: List[Any], list2: List[Any]) -> bool:
     return True
 
 
-def datetime_equals(dt1: Optional[datetime], dt2: Optional[datetime]) -> bool:
-    """Compare equality of two datetimes, ignoring microseconds."""
+def datetime_equals(
+    dt1: Optional[datetime], dt2: Optional[datetime], tol: float = 1e-2
+) -> bool:
+    """Compare equality of two datetimes, up to a tolerance (in seconds)."""
     if not dt1 and not dt2:
         return True
     if not (dt1 and dt2):
         return False
-    return dt1.replace(microsecond=0) == dt2.replace(microsecond=0)
+    abs_diff = abs(dt1 - dt2)
+    return abs_diff.total_seconds() < tol
 
 
 def dataframe_equals(df1: pd.DataFrame, df2: pd.DataFrame) -> bool:

--- a/ax/utils/common/tests/test_equality.py
+++ b/ax/utils/common/tests/test_equality.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
@@ -41,6 +41,8 @@ class EqualityTest(TestCase):
         self.assertTrue(datetime_equals(None, None))
         self.assertFalse(datetime_equals(None, now))
         self.assertTrue(datetime_equals(now, now))
+        self.assertFalse(datetime_equals(now, now + timedelta(seconds=2e-2)))
+        self.assertTrue(datetime_equals(now, now + timedelta(seconds=5e-2), tol=1))
 
     def test_DataframeEquals(self) -> None:
         pd1 = pd.DataFrame.from_records([{"x": 100, "y": 200}])


### PR DESCRIPTION
Summary: Previously, this would set microseconds to 0, effectively comparing that the events happened in the same second. If the seconds differed, even when the absolute difference was negligible, the checks would fail making some tests flaky. Updating the logic to rely on an absolute difference instead, with a default tolerance of 1e-2 seconds (which is sufficient to have existing, occassionally flaky tests pass).

Differential Revision: D56077050


