### PR TITLE
Unify interface and data handling of model training and generalization metrics

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -717,7 +717,6 @@ class GenerationStrategy(GenerationStrategyInterface):
         # model state from last generator run and pass it to the model
         # being instantiated in this function.
         model_state_on_lgr = self._get_model_state_from_last_generator_run()
-
         if not data.df.empty:
             trial_indices_in_data = sorted(data.df["trial_index"].unique())
             logger.debug(f"Fitting model with data for trials: {trial_indices_in_data}")

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -2112,19 +2112,22 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         )
 
 
-def get_fitted_model_bridge(scheduler: Scheduler) -> ModelBridge:
+def get_fitted_model_bridge(
+    scheduler: Scheduler, force_refit: bool = False
+) -> ModelBridge:
     """Returns a fitted ModelBridge object. If the model is fit already, directly
     returns the already fitted model. Otherwise, fits and returns a new one.
 
     Args:
         scheduler: The scheduler object from which to get the fitted model.
+        force_refit: If True, will force a data lookup and a refit of the model.
 
     Returns:
         A ModelBridge object fitted to the observations of the scheduler's experiment.
     """
     gs = scheduler.standard_generation_strategy
     model_bridge = gs.model  # Optional[ModelBridge]
-    if model_bridge is None:  # Need to re-fit the model.
-        gs._fit_current_model(data=None)  # Will lookup_data if it none is provided.
+    if model_bridge is None or force_refit:  # Need to re-fit the model.
+        gs._fit_current_model(data=None)  # Will lookup_data if none is provided.
         model_bridge = cast(ModelBridge, gs.model)
     return model_bridge


### PR DESCRIPTION
Summary:
This commit unifies the interface of and the loading of the model's training data in `_predict_on_cross_validation_data` and `_predict_on_training_data`.  Previously, `_predict_on_training_data` would reload the data from the experiment, which could lead to differences in the number of observations to `_predict_on_cross_validation_data` if the model was not fit on all existing data.

In addition, this commit introduces a `force_refit` option for `get_fitted_model_bridge` which forces a reloading of the data and a refitting of the model to the reloaded data, even if a fitted, potentially out-dated model is on the scheduler.

Differential Revision: D56105161


