### PR TITLE
Rename ChoiceEncode => ChoiceToNumericChoice

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -201,7 +201,7 @@ def extract_search_space_digest(
     assumptions regarding the parameters being transformed.
 
     For ChoiceParameters:
-    * The choices are assumed to be numerical. ChoiceEncode
+    * The choices are assumed to be numerical. ChoiceToNumericChoice
     and OrderedChoiceToIntegerRange
     transforms handle this.
     * If is_task, its index is added to task_features.

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -36,7 +36,7 @@ from ax.modelbridge.torch import TorchModelBridge
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.centered_unit_x import CenteredUnitX
 from ax.modelbridge.transforms.choice_encode import (
-    ChoiceEncode,
+    ChoiceToNumericChoice,
     OrderedChoiceToIntegerRange,
 )
 from ax.modelbridge.transforms.convert_metric_names import ConvertMetricNames
@@ -98,7 +98,7 @@ Discrete_X_trans: List[Type[Transform]] = [IntRangeToChoice]
 
 Mixed_transforms: List[Type[Transform]] = [
     RemoveFixed,
-    ChoiceEncode,
+    ChoiceToNumericChoice,
     IntToFloat,
     Log,
     Logit,

--- a/ax/modelbridge/transforms/choice_encode.py
+++ b/ax/modelbridge/transforms/choice_encode.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from ax import modelbridge as modelbridge_module  # noqa F401
 
 
-class ChoiceEncode(Transform):
+class ChoiceToNumericChoice(Transform):
     """Convert general ChoiceParameters to integer or float ChoiceParameters.
 
     If the parameter type is numeric (int, float) and the parameter is ordered,
@@ -56,7 +56,7 @@ class ChoiceEncode(Transform):
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
-        assert search_space is not None, "ChoiceEncode requires search space"
+        assert search_space is not None, "ChoiceToNumericChoice requires search space"
         # Identify parameters that should be transformed
         self.encoded_parameters: Dict[str, Dict[TParamValue, TParamValue]] = {}
         self.encoded_parameters_inverse: Dict[str, ClosestLookupDict] = {}
@@ -123,7 +123,14 @@ class ChoiceEncode(Transform):
         return observation_features
 
 
-class OrderedChoiceToIntegerRange(ChoiceEncode):
+class ChoiceEncode(DeprecatedTransformMixin, ChoiceToNumericChoice):
+    """Deprecated alias for ChoiceToNumericChoice."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class OrderedChoiceToIntegerRange(ChoiceToNumericChoice):
     """Convert ordered ChoiceParameters to integer RangeParameters.
 
     Parameters will be transformed to an integer RangeParameters, mapped from the
@@ -133,7 +140,7 @@ class OrderedChoiceToIntegerRange(ChoiceEncode):
     In the inverse transform, parameters will be mapped back onto the original domain.
 
     In order to encode all ChoiceParameters (not just ordered ChoiceParameters),
-    use ChoiceEncode instead.
+    use ChoiceToNumericChoice instead.
 
     Transform is done in-place.
     """

--- a/ax/modelbridge/transforms/tests/test_choice_encode_transform.py
+++ b/ax/modelbridge/transforms/tests/test_choice_encode_transform.py
@@ -15,7 +15,7 @@ from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.modelbridge.transforms.choice_encode import (
-    ChoiceEncode,
+    ChoiceToNumericChoice,
     OrderedChoiceEncode,
     OrderedChoiceToIntegerRange,
 )
@@ -25,7 +25,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 
 class ChoiceEncodeTransformTest(TestCase):
-    t_class = ChoiceEncode
+    t_class = ChoiceToNumericChoice
 
     def setUp(self) -> None:
         super().setUp()
@@ -126,7 +126,7 @@ class ChoiceEncodeTransformTest(TestCase):
                     tranformed_param.sort_values,
                     original_param.sort_values,
                 )
-                if self.t_class == ChoiceEncode:
+                if self.t_class == ChoiceToNumericChoice:
                     self.assertEqual(
                         tranformed_param.values,
                         [i for i, _ in enumerate(original_param.values)],

--- a/ax/storage/json_store/tests/test_transform_encode.py
+++ b/ax/storage/json_store/tests/test_transform_encode.py
@@ -1,0 +1,58 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+
+import unittest
+
+from ax.modelbridge.transforms.choice_encode import (
+    ChoiceEncode,
+    ChoiceToNumericChoice,
+    OrderedChoiceEncode,
+    OrderedChoiceToIntegerRange,
+)
+
+from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
+
+from ax.storage.json_store.decoders import transform_type_from_json
+from ax.storage.json_store.encoders import transform_type_to_dict
+
+
+class TestTransformEncode(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_encode_and_decode_transform(self) -> None:
+        registry_index = 2
+
+        transform_dict = transform_type_to_dict(IntRangeToChoice)
+        self.assertEqual(transform_dict["__type"], "Type[Transform]")
+        self.assertEqual(transform_dict["index_in_registry"], registry_index)
+        self.assertIn("IntRangeToChoice", transform_dict["transform_type"])
+
+        decoded_transform_type = transform_type_from_json(transform_dict)
+        self.assertEqual(decoded_transform_type, IntRangeToChoice)
+
+    def test_encode_and_decode_deprecated_choice_transform(self) -> None:
+        deprecated_type = ChoiceEncode
+        current_type = ChoiceToNumericChoice
+        registry_index = 19
+
+        transform_dict = transform_type_to_dict(deprecated_type)
+        self.assertEqual(transform_dict["__type"], "Type[Transform]")
+        self.assertEqual(transform_dict["index_in_registry"], registry_index)
+        self.assertIn("ChoiceEncode", transform_dict["transform_type"])
+
+        decoded_transform_type = transform_type_from_json(transform_dict)
+        self.assertEqual(decoded_transform_type, current_type)
+
+    def test_encode_and_decode_deprecated_ordered_choice_transform(self) -> None:
+        deprecated_type = OrderedChoiceEncode
+        current_type = OrderedChoiceToIntegerRange
+        registry_index = 7
+
+        transform_dict = transform_type_to_dict(deprecated_type)
+        self.assertEqual(transform_dict["__type"], "Type[Transform]")
+        self.assertEqual(transform_dict["index_in_registry"], registry_index)
+        self.assertIn("OrderedChoiceEncode", transform_dict["transform_type"])
+
+        decoded_transform_type = transform_type_from_json(transform_dict)
+        self.assertEqual(decoded_transform_type, current_type)

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -12,6 +12,7 @@ from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.cap_parameter import CapParameter
 from ax.modelbridge.transforms.choice_encode import (
     ChoiceEncode,
+    ChoiceToNumericChoice,
     OrderedChoiceEncode,
     OrderedChoiceToIntegerRange,
 )
@@ -80,7 +81,8 @@ TRANSFORM_REGISTRY: Dict[Type[Transform], int] = {
     Winsorize: 16,
     CapParameter: 17,
     PowerTransformY: 18,
-    ChoiceEncode: 19,
+    ChoiceEncode: 19,  # TO BE DEPRECATED
+    ChoiceToNumericChoice: 19,
     Logit: 20,
     MapUnitX: 21,
     MetricsAsTask: 22,
@@ -97,7 +99,8 @@ can still store properly, but when loading back the new class will
 be used.
 """
 DEPRECATED_TRANSFORMS: List[Type[Transform]] = [
-    OrderedChoiceEncode  # replaced by OrderedChoiceToIntegerRange
+    OrderedChoiceEncode,  # replaced by OrderedChoiceToIntegerRange
+    ChoiceEncode,  # replaced by ChoiceToNumericChoice
 ]
 
 REVERSE_TRANSFORM_REGISTRY: Dict[int, Type[Transform]] = {


### PR DESCRIPTION
Summary: Renaming the ChoiceEncode parameter to ChoiceToNumericChoice to better reflect its behavior.

Differential Revision: D56311291


