### PR TITLE
[Easy] Address torch.tensor warnings in derivative sensitivity measures

### DIFF
--- a/ax/utils/sensitivity/derivative_measures.py
+++ b/ax/utils/sensitivity/derivative_measures.py
@@ -168,7 +168,7 @@ class GpDGSMGpMean(object):
             else
                 Tensor: (values) x dim
         """
-        return self.aggregation(torch.tensor)
+        return self.aggregation(torch.as_tensor)
 
     def gradient_absolute_measure(self) -> torch.Tensor:
         r"""Computes the gradient absolute measure:


### PR DESCRIPTION
Eliminates 5 instances of the following warning in tests:
```
UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
```