### PR TITLE
Add is_valid_name

### DIFF
--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -107,6 +107,9 @@ class Metric(SortableBase, SerializationMixin):
             lower_is_better: Flag for metrics which should be minimized.
             properties: Dictionary of this metric's properties
         """
+        if name is None:
+            raise ValueError("Metric name cannot be `None`.")
+
         self._name = name
         self.lower_is_better = lower_is_better
         self.properties: Dict[str, Any] = properties or {}

--- a/ax/utils/common/tests/test_validation.py
+++ b/ax/utils/common/tests/test_validation.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.utils.common.testutils import TestCase
+from ax.utils.common.validation import is_valid_name
+
+
+class ValidationTest(TestCase):
+
+    def test_is_valid_name(self) -> None:
+        self.assertTrue(is_valid_name("foo"))
+        self.assertTrue(is_valid_name("_foo"))
+        self.assertTrue(is_valid_name("foo1"))
+        self.assertTrue(is_valid_name("foo_bar"))
+        self.assertTrue(is_valid_name("foo:bar"))
+
+        self.assertFalse(is_valid_name(""))
+        self.assertFalse(is_valid_name("1foo"))
+        self.assertFalse(is_valid_name("foo bar"))
+        self.assertFalse(is_valid_name("foo/bar"))

--- a/ax/utils/common/validation.py
+++ b/ax/utils/common/validation.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+
+
+def is_valid_name(name: str) -> bool:
+    """
+    Check if a name is valid (ex. for a Metric's or Parameter's name field).
+
+    Naming conventions are very similar to those of Python variables, however colons
+    are allowed as well:
+        - Names must be non-empty
+        - Names must start with a letter or underscore
+        - After the first character, names can contain letters, numbers, underscores
+            and colons
+    """
+    return re.fullmatch(r"[_a-zA-Z][_a-zA-Z0-9:]*", name) is not None


### PR DESCRIPTION
Summary: is_valid_name will be used for Metric and Paramter name validation. Constricting the values allowed will help with both parsing (as used in AxClient's constraints), plotting/report building, and more.

Differential Revision: D56305954


