### PR TITLE
Only Plot Nominal Variable separately in Sensitivity Analysis plot

### DIFF
--- a/ax/plot/feature_importances.py
+++ b/ax/plot/feature_importances.py
@@ -149,7 +149,7 @@ def plot_feature_importance_by_feature_plotly(
         categorical_features = [
             name
             for name, par in model.model_space.parameters.items()
-            if isinstance(par, ChoiceParameter)
+            if isinstance(par, ChoiceParameter) and not par.is_ordered
         ]
 
     for i, metric_name in enumerate(sorted(sensitivity_values.keys())):


### PR DESCRIPTION
Summary: In Sensitivity Analysis plot, we want to plot (unordered) categorical separately and shows that it "affects" metrics while still showing "increases"/"decreases" metrics for ordinal variables.

Differential Revision: D56325368


