### PR TITLE
Remove inferring reference point in Scheduler for GSS

### DIFF
--- a/ax/global_stopping/tests/test_strategies.py
+++ b/ax/global_stopping/tests/test_strategies.py
@@ -269,7 +269,7 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
         ]
         exp = self._create_multi_objective_experiment(metric_values=metric_values)
         gss = ImprovementGlobalStoppingStrategy(
-            min_trials=3, window_size=3, improvement_bar=0.1
+            min_trials=3, window_size=3, improvement_bar=0.3
         )
         stop, message = gss.should_stop_optimization(experiment=exp, trial_to_check=4)
         self.assertFalse(stop)
@@ -280,9 +280,9 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
 
         self.assertEqual(
             message,
-            "The improvement in hypervolume in the past 3 trials (=0.000) is "
-            "less than improvement_bar (=0.1) times the hypervolume at the "
-            "start of the window (=0.055).",
+            "The improvement in hypervolume in the past 3 trials (=0.289) is "
+            "less than improvement_bar (=0.3) times the hypervolume at the "
+            "start of the window (=0.104).",
         )
 
         # Now we select a very far custom reference point against which the pareto front

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -793,67 +793,6 @@ class AxSchedulerTestCase(TestCase):
             all(t.completed_successfully for t in scheduler.experiment.trials.values())
         )
 
-    def test_inferring_reference_point(self) -> None:
-        init_test_engine_and_session_factory(force_init=True)
-        experiment = get_branin_experiment_with_multi_objective()
-        experiment.runner = self.runner
-        gs = self._get_generation_strategy_strategy_for_test(
-            experiment=experiment,
-            generation_strategy=self.sobol_GS_no_parallelism,
-        )
-
-        scheduler = Scheduler(
-            experiment=experiment,
-            generation_strategy=gs,
-            options=SchedulerOptions(
-                # Stops the optimization after 5 trials.
-                global_stopping_strategy=DummyGlobalStoppingStrategy(
-                    min_trials=2, trial_to_stop=5
-                ),
-            ),
-            db_settings=self.db_settings,
-        )
-
-        with patch(
-            "ax.service.scheduler.infer_reference_point_from_experiment"
-        ) as mock_infer_rp:
-            scheduler.run_n_trials(max_trials=10)
-            mock_infer_rp.assert_called_once()
-
-    def test_inferring_reference_point_no_data(self) -> None:
-        init_test_engine_and_session_factory(force_init=True)
-        experiment = get_branin_experiment_with_multi_objective()
-        experiment.runner = self.runner
-        gs = self._get_generation_strategy_strategy_for_test(
-            experiment=experiment,
-            generation_strategy=self.sobol_GS_no_parallelism,
-        )
-
-        scheduler = Scheduler(
-            experiment=experiment,
-            generation_strategy=gs,
-            options=SchedulerOptions(
-                # Stops the optimization after 5 trials.
-                global_stopping_strategy=DummyGlobalStoppingStrategy(
-                    min_trials=0,
-                    trial_to_stop=5,
-                ),
-            ),
-            db_settings=self.db_settings,
-        )
-        empty_data = Data(
-            df=pd.DataFrame(
-                columns=["metric_name", "arm_name", "trial_index", "mean", "sem"]
-            )
-        )
-        with patch(
-            "ax.service.scheduler.infer_reference_point_from_experiment"
-        ) as mock_infer_rp, patch.object(
-            scheduler.experiment, "fetch_data", return_value=empty_data
-        ):
-            scheduler.run_n_trials(max_trials=1)
-            mock_infer_rp.assert_not_called()
-
     def test_global_stopping(self) -> None:
         gs = self._get_generation_strategy_strategy_for_test(
             experiment=self.branin_experiment,


### PR DESCRIPTION
Summary: We should be inferring the reference point in the GSS when needed. This moves the call to infer the reference point to inside of the GSS.

Reviewed By: Balandat

Differential Revision: D56227773


