### PR TITLE
Make sure TestCase.setUp is executed in tests

### DIFF
--- a/ax/analysis/helpers/tests/test_cross_validation_helpers.py
+++ b/ax/analysis/helpers/tests/test_cross_validation_helpers.py
@@ -9,27 +9,22 @@
 import tempfile
 
 import plotly.graph_objects as go
-
 import plotly.io as pio
-
 from ax.analysis.cross_validation_plot import CrossValidationPlot
-
 from ax.analysis.helpers.constants import Z
-
 from ax.analysis.helpers.cross_validation_helpers import get_min_max_with_errors
-
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
 from ax.utils.testing.mock import fast_botorch_optimize
 from pandas import read_json
-
 from pandas.testing import assert_frame_equal
 
 
 class TestCrossValidationHelpers(TestCase):
     @fast_botorch_optimize
     def setUp(self) -> None:
+        super().setUp()
         self.exp = get_branin_experiment(with_batch=True)
         self.exp.trials[0].run()
         self.model = Models.BOTORCH_MODULAR(

--- a/ax/analysis/helpers/tests/test_cv_consistency_checks.py
+++ b/ax/analysis/helpers/tests/test_cv_consistency_checks.py
@@ -9,25 +9,18 @@
 import copy
 
 import plotly.graph_objects as go
-
 from ax.analysis.cross_validation_plot import CrossValidationPlot
-
 from ax.analysis.helpers.cross_validation_helpers import (
     error_scatter_data_from_cv_results,
 )
-
 from ax.analysis.helpers.scatter_helpers import error_scatter_trace_from_df
-
 from ax.modelbridge.cross_validation import cross_validate
 from ax.modelbridge.registry import Models
-
 from ax.plot.base import PlotMetric
-
 from ax.plot.diagnostic import (
     _get_cv_plot_data as PLOT_get_cv_plot_data,
     interact_cross_validation_plotly as PLOT_interact_cross_validation_plotly,
 )
-
 from ax.plot.scatter import (
     _error_scatter_data as PLOT_error_scatter_data,
     _error_scatter_trace as PLOT_error_scatter_trace,
@@ -40,6 +33,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 class TestCVConsistencyCheck(TestCase):
     @fast_botorch_optimize
     def setUp(self) -> None:
+        super().setUp()
         self.exp = get_branin_experiment(with_batch=True)
         self.exp.trials[0].run()
         self.model = Models.BOTORCH_MODULAR(

--- a/ax/analysis/tests/test_cross_validation_plot.py
+++ b/ax/analysis/tests/test_cross_validation_plot.py
@@ -7,10 +7,8 @@
 
 import plotly.graph_objects as go
 from ax.analysis.cross_validation_plot import CrossValidationPlot
-
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
-
 from ax.utils.testing.core_stubs import get_branin_experiment
 from ax.utils.testing.mock import fast_botorch_optimize
 
@@ -18,6 +16,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 class TestCrossValidationPlot(TestCase):
     @fast_botorch_optimize
     def setUp(self) -> None:
+        super().setUp()
         self.exp = get_branin_experiment(with_batch=True)
         self.exp.trials[0].run()
         self.model = Models.BOTORCH_MODULAR(

--- a/ax/analysis/tests/test_predicted_outcomes_dot_plot.py
+++ b/ax/analysis/tests/test_predicted_outcomes_dot_plot.py
@@ -9,17 +9,15 @@
 import unittest
 
 import plotly.graph_objects as go
-
 from ax.analysis.predicted_outcomes_dot_plot import PredictedOutcomesDotPlot
-
 from ax.exceptions.core import UnsupportedPlotError
-
 from ax.modelbridge.registry import Models
 from ax.utils.testing.core_stubs import get_branin_experiment
 
 
 class TestPredictedOutcomesDotPlot(unittest.TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.exp = get_branin_experiment(with_batch=True, with_status_quo=True)
         self.exp.trials[0].run()
         self.model = Models.BOTORCH_MODULAR(
@@ -27,8 +25,6 @@ class TestPredictedOutcomesDotPlot(unittest.TestCase):
             experiment=self.exp,
             data=self.exp.fetch_data(),
         )
-
-        super().setUp()
 
     def test_predicted_outcomes_dot_plot_no_status_quo(self) -> None:
         exp = get_branin_experiment(with_batch=True, with_status_quo=False)

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -8,7 +8,6 @@
 from typing import Dict, Type
 
 import numpy as np
-
 from ax.benchmark.benchmark import benchmark_replication
 from ax.benchmark.benchmark_method import get_benchmark_scheduler_options
 from ax.benchmark.methods.modular_botorch import get_sobol_botorch_modular_acquisition

--- a/ax/core/tests/test_arm.py
+++ b/ax/core/tests/test_arm.py
@@ -11,9 +11,6 @@ from ax.utils.common.testutils import TestCase
 
 
 class ArmTest(TestCase):
-    def setUp(self) -> None:
-        pass
-
     def test_Init(self) -> None:
         arm = Arm(parameters={"y": 0.25, "x": 0.75, "z": 75})
         self.assertEqual(str(arm), "Arm(parameters={'y': 0.25, 'x': 0.75, 'z': 75})")

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -21,6 +21,7 @@ from ax.utils.common.timeutils import current_timestamp_in_millis
 
 class DataTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.df_hash = "3dd7ab8c67942d43c78ea4af05bbb1c4"
         self.df = pd.DataFrame(
             [

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -88,6 +88,7 @@ class SyntheticRunnerWithMetadataKeys(SyntheticRunner):
 
 class ExperimentTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.experiment = get_experiment()
 
     def _setupBraninExperiment(self, n: int) -> Experiment:
@@ -1221,6 +1222,7 @@ class ExperimentTest(TestCase):
 
 class ExperimentWithMapDataTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.experiment = get_experiment_with_map_data_type()
 
     def _setupBraninExperiment(self, n: int, incremental: bool = False) -> Experiment:

--- a/ax/core/tests/test_generation_strategy_interface.py
+++ b/ax/core/tests/test_generation_strategy_interface.py
@@ -33,8 +33,8 @@ class MyGSI(GenerationStrategyInterface):
 
 
 class TestGenerationStrategyInterface(TestCase):
-
     def setUp(self) -> None:
+        super().setUp()
         self.exp = get_experiment()
         self.gsi = MyGSI(name="my_GSI")
         self.special_gsi = SpecialGenerationStrategy()

--- a/ax/core/tests/test_generator_run.py
+++ b/ax/core/tests/test_generator_run.py
@@ -25,6 +25,7 @@ GENERATOR_RUN_STR_PLUS_1 = "GeneratorRun(3 arms, total weight 4.0)"
 
 class GeneratorRunTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.model_predictions = get_model_predictions()
         self.optimization_config = get_optimization_config()
         self.search_space = get_search_space()

--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -14,6 +14,7 @@ from ax.utils.common.testutils import TestCase
 
 class MapDataTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.df = pd.DataFrame(
             [
                 {

--- a/ax/core/tests/test_map_metric.py
+++ b/ax/core/tests/test_map_metric.py
@@ -15,9 +15,6 @@ METRIC_STRING = "MapMetric('m1')"
 
 
 class MapMetricTest(TestCase):
-    def setUp(self) -> None:
-        pass
-
     def test_Init(self) -> None:
         metric = MapMetric(name="m1", lower_is_better=False)
         self.assertEqual(str(metric), METRIC_STRING)

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -14,6 +14,7 @@ from ax.utils.testing.core_stubs import get_branin_arms, get_multi_type_experime
 
 class MultiTypeExperimentTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.experiment = get_multi_type_experiment()
 
     def test_MTExperimentFlow(self) -> None:

--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -15,6 +15,7 @@ from ax.utils.common.testutils import TestCase
 
 class ObjectiveTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.metrics = {
             "m1": Metric(name="m1"),
             "m2": Metric(name="m2", lower_is_better=True),

--- a/ax/core/tests/test_optimization_config.py
+++ b/ax/core/tests/test_optimization_config.py
@@ -43,6 +43,7 @@ MOOC_STR = (
 
 class OptimizationConfigTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.metrics = {
             "m1": Metric(name="m1"),
             "m2": Metric(name="m2"),
@@ -267,6 +268,7 @@ class OptimizationConfigTest(TestCase):
 
 class MultiObjectiveOptimizationConfigTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.metrics = {
             "m1": Metric(name="m1", lower_is_better=True),
             "m2": Metric(name="m2", lower_is_better=False),

--- a/ax/core/tests/test_outcome_constraint.py
+++ b/ax/core/tests/test_outcome_constraint.py
@@ -26,6 +26,7 @@ OUTCOME_CONSTRAINT_PATH = "ax.core.outcome_constraint"
 
 class OutcomeConstraintTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.minimize_metric = Metric(name="bar", lower_is_better=True)
         self.maximize_metric = Metric(name="baz", lower_is_better=False)
         self.bound = 0
@@ -105,6 +106,7 @@ class OutcomeConstraintTest(TestCase):
 
 class ObjectiveThresholdTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.minimize_metric = Metric(name="bar", lower_is_better=True)
         self.maximize_metric = Metric(name="baz", lower_is_better=False)
         self.ambiguous_metric = Metric(name="buz")
@@ -177,6 +179,7 @@ class ObjectiveThresholdTest(TestCase):
 
 class ScalarizedOutcomeConstraintTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.metrics = [
             Metric(name="m1", lower_is_better=True),
             Metric(name="m2", lower_is_better=True),

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -23,6 +23,7 @@ from ax.utils.common.typeutils import not_none
 
 class RangeParameterTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.param1 = RangeParameter(
             name="x",
             parameter_type=ParameterType.FLOAT,
@@ -211,6 +212,7 @@ class RangeParameterTest(TestCase):
 
 class ChoiceParameterTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.param1 = ChoiceParameter(
             name="x", parameter_type=ParameterType.STRING, values=["foo", "bar", "baz"]
         )
@@ -510,6 +512,7 @@ class ChoiceParameterTest(TestCase):
 
 class FixedParameterTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.param1 = FixedParameter(
             name="x", parameter_type=ParameterType.BOOL, value=True
         )
@@ -633,6 +636,7 @@ class FixedParameterTest(TestCase):
 
 class ParameterEqualityTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.fixed_parameter = FixedParameter(
             name="x", parameter_type=ParameterType.BOOL, value=True
         )

--- a/ax/core/tests/test_parameter_constraint.py
+++ b/ax/core/tests/test_parameter_constraint.py
@@ -23,6 +23,7 @@ from ax.utils.common.testutils import TestCase
 
 class ParameterConstraintTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.constraint = ParameterConstraint(
             constraint_dict={"x": 2.0, "y": -3.0}, bound=6.0
         )
@@ -98,6 +99,7 @@ class ParameterConstraintTest(TestCase):
 
 class OrderConstraintTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.x = RangeParameter("x", ParameterType.INT, lower=0, upper=1)
         self.y = RangeParameter("y", ParameterType.INT, lower=0, upper=1)
         self.constraint = OrderConstraint(
@@ -153,6 +155,7 @@ class OrderConstraintTest(TestCase):
 
 class SumConstraintTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.x = RangeParameter("x", ParameterType.INT, lower=-5, upper=5)
         self.y = RangeParameter("y", ParameterType.INT, lower=-5, upper=5)
         self.constraint1 = SumConstraint(

--- a/ax/core/tests/test_runner.py
+++ b/ax/core/tests/test_runner.py
@@ -22,6 +22,7 @@ class DummyRunner(Runner):
 
 class RunnerTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.dummy_runner = DummyRunner()
         self.trials = [get_trial(), get_batch_trial()]
 

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -55,6 +55,7 @@ RANGE_PARAMS = 3
 
 class SearchSpaceTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.a = RangeParameter(
             name="a", parameter_type=ParameterType.FLOAT, lower=0.5, upper=5.5
         )
@@ -493,6 +494,7 @@ class SearchSpaceTest(TestCase):
 
 class SearchSpaceDigestTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.kwargs = {
             "feature_names": ["a", "b", "c"],
             "bounds": [(0.0, 1.0), (0, 2), (0, 4)],
@@ -527,6 +529,7 @@ class SearchSpaceDigestTest(TestCase):
 
 class RobustSearchSpaceDigestTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.kwargs = {
             "sample_param_perturbations": lambda: 1,
             "sample_environmental": lambda: 2,
@@ -550,6 +553,7 @@ class RobustSearchSpaceDigestTest(TestCase):
 
 class HierarchicalSearchSpaceTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.model_parameter = get_model_parameter()
         self.lr_parameter = get_lr_parameter()
         self.l2_reg_weight_parameter = get_l2_reg_weight_parameter()
@@ -1000,6 +1004,7 @@ class HierarchicalSearchSpaceTest(TestCase):
 
 class TestRobustSearchSpace(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.a = RangeParameter(
             name="a", parameter_type=ParameterType.FLOAT, lower=0.5, upper=5.5
         )

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -45,6 +45,7 @@ TEST_DATA = Data(
 
 class TrialTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.mock_supports_trial_type = mock.patch(
             f"{get_experiment.__module__}.Experiment.supports_trial_type",
             return_value=True,

--- a/ax/core/tests/test_types.py
+++ b/ax/core/tests/test_types.py
@@ -21,6 +21,7 @@ from ax.utils.common.testutils import TestCase
 
 class TypesTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.num_arms = 2
         mu = {"m1": [0.0, 0.5], "m2": [0.1, 0.6]}
         cov = {

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
-
 from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
@@ -46,6 +45,7 @@ from pyre_extensions import none_throws
 
 class UtilsTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.experiment = get_experiment()
         self.arm = Arm({"x": 5, "y": "foo", "z": True, "w": 5})
         self.trial = self.experiment.new_trial(GeneratorRun([self.arm]))

--- a/ax/metrics/tests/test_dict_lookup.py
+++ b/ax/metrics/tests/test_dict_lookup.py
@@ -18,6 +18,7 @@ from ax.utils.testing.core_stubs import get_trial
 
 class TestDictLookupMetric(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.lookup_dict = {
             (1.0, 2.0): 3.0,
             (2.0, 3.0): 4.0,

--- a/ax/modelbridge/tests/test_cross_validation.py
+++ b/ax/modelbridge/tests/test_cross_validation.py
@@ -39,6 +39,7 @@ from ax.utils.testing.modeling_stubs import get_observation1trans, get_observati
 
 class CrossValidationTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.training_data = [
             Observation(
                 features=ObservationFeatures(parameters={"x": 2.0}, trial_index=0),

--- a/ax/modelbridge/tests/test_discrete_modelbridge.py
+++ b/ax/modelbridge/tests/test_discrete_modelbridge.py
@@ -30,6 +30,7 @@ from ax.utils.common.testutils import TestCase
 
 class DiscreteModelBridgeTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.parameters = [
             ChoiceParameter("x", ParameterType.FLOAT, values=[0, 1]),
             ChoiceParameter("y", ParameterType.STRING, values=["foo", "bar"]),

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -32,6 +32,7 @@ logger: Logger = get_logger(__name__)
 
 class TestGenerationNode(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.sobol_model_spec = ModelSpec(
             model_enum=Models.SOBOL,
             model_kwargs={"init_position": 3},
@@ -195,6 +196,7 @@ class TestGenerationNode(TestCase):
 
 class TestGenerationStep(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.model_kwargs = {"init_position": 5}
         self.sobol_generation_step = GenerationStep(
             model=Models.SOBOL,
@@ -264,6 +266,7 @@ class TestGenerationStep(TestCase):
 class TestGenerationNodeWithBestModelSelector(TestCase):
     @fast_botorch_optimize
     def setUp(self) -> None:
+        super().setUp()
         self.branin_experiment = get_branin_experiment()
         sobol = Models.SOBOL(search_space=self.branin_experiment.search_space)
         sobol_run = sobol.gen(n=20)

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -64,6 +64,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 
 class TestGenerationStrategy(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.gr = GeneratorRun(arms=[Arm(parameters={"x1": 1, "x2": 2})])
 
         # Mock out slow GPEI.

--- a/ax/modelbridge/tests/test_hierarchical_search_space.py
+++ b/ax/modelbridge/tests/test_hierarchical_search_space.py
@@ -39,6 +39,7 @@ class TestHierarchicalSearchSpace(TestCase):
     """
 
     def setUp(self) -> None:
+        super().setUp()
         int_range = RangeParameter(
             name="int_range",
             parameter_type=ParameterType.INT,

--- a/ax/modelbridge/tests/test_model_fit_metrics.py
+++ b/ax/modelbridge/tests/test_model_fit_metrics.py
@@ -11,7 +11,6 @@ from itertools import product
 from typing import cast, Dict
 
 import numpy as np
-
 from ax.core.experiment import Experiment
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
@@ -35,6 +34,7 @@ NUM_SOBOL = 5
 
 class TestModelBridgeFitMetrics(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         # setting up experiment and generation strategy
         self.runner = SyntheticRunner()
         self.branin_experiment = Experiment(

--- a/ax/modelbridge/tests/test_model_spec.py
+++ b/ax/modelbridge/tests/test_model_spec.py
@@ -23,6 +23,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 
 class BaseModelSpecTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.experiment = get_branin_experiment()
         sobol = Models.SOBOL(search_space=self.experiment.search_space)
         sobol_run = sobol.gen(n=20)

--- a/ax/modelbridge/tests/test_pairwise_modelbridge.py
+++ b/ax/modelbridge/tests/test_pairwise_modelbridge.py
@@ -14,7 +14,6 @@ from ax.core import Arm, GeneratorRun
 from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.parameter import RangeParameter
 from ax.core.types import TEvaluationOutcome, TParameterization
-
 from ax.modelbridge.pairwise import (
     _binary_pref_to_comp_pair,
     _consolidate_comparisons,
@@ -35,6 +34,8 @@ from botorch.utils.datasets import RankingDataset
 
 class PairwiseModelBridgeTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
+
         def evaluate(
             parameters: Dict[str, TParameterization]
         ) -> Dict[str, TEvaluationOutcome]:

--- a/ax/modelbridge/tests/test_random_modelbridge.py
+++ b/ax/modelbridge/tests/test_random_modelbridge.py
@@ -7,12 +7,17 @@
 # pyre-strict
 
 from collections import OrderedDict
+from typing import List
 from unittest import mock
 
 import numpy as np
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
-from ax.core.parameter_constraint import OrderConstraint, SumConstraint
+from ax.core.parameter_constraint import (
+    OrderConstraint,
+    ParameterConstraint,
+    SumConstraint,
+)
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import SearchSpaceExhausted
 from ax.modelbridge.random import RandomModelBridge
@@ -25,20 +30,16 @@ from ax.utils.testing.core_stubs import get_small_discrete_search_space
 
 class RandomModelBridgeTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         x = RangeParameter("x", ParameterType.FLOAT, lower=0, upper=1)
         y = RangeParameter("y", ParameterType.FLOAT, lower=1, upper=2)
         z = RangeParameter("z", ParameterType.FLOAT, lower=0, upper=5)
         self.parameters = [x, y, z]
-        parameter_constraints = [
+        parameter_constraints: List[ParameterConstraint] = [
             OrderConstraint(x, y),
             SumConstraint([x, z], False, 3.5),
         ]
-
-        # pyre-fixme[6]: For 2nd param expected
-        #  `Optional[List[ParameterConstraint]]` but got `List[Union[OrderConstraint,
-        #  SumConstraint]]`.
         self.search_space = SearchSpace(self.parameters, parameter_constraints)
-
         self.model_gen_options = {"option": "yes"}
 
     @mock.patch("ax.modelbridge.random.RandomModelBridge.__init__", return_value=None)

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -47,6 +47,7 @@ TEST_PARAMETERIZATON_LIST = ["5", "foo", "True", "5"]
 
 class TestModelbridgeUtils(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.experiment = get_experiment()
         self.arm = Arm({"x": 5, "y": "foo", "z": True, "w": 5})
         self.trial = self.experiment.new_trial(GeneratorRun([self.arm]))

--- a/ax/modelbridge/transforms/tests/test_cap_parameter_transform.py
+++ b/ax/modelbridge/transforms/tests/test_cap_parameter_transform.py
@@ -16,6 +16,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class CapParameterTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/transforms/tests/test_cast_transform.py
+++ b/ax/modelbridge/transforms/tests/test_cast_transform.py
@@ -26,6 +26,7 @@ from ax.utils.testing.core_stubs import get_hierarchical_search_space
 
 class CastTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/transforms/tests/test_choice_encode_transform.py
+++ b/ax/modelbridge/transforms/tests/test_choice_encode_transform.py
@@ -28,6 +28,7 @@ class ChoiceEncodeTransformTest(TestCase):
     t_class = ChoiceEncode
 
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/transforms/tests/test_convert_metric_names_transform.py
+++ b/ax/modelbridge/transforms/tests/test_convert_metric_names_transform.py
@@ -20,6 +20,7 @@ from ax.utils.testing.core_stubs import get_multi_type_experiment
 
 class ConvertMetricNamesTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.experiment = get_multi_type_experiment(add_trials=True)
         self.data = self.experiment.fetch_data()
         self.observations = observations_from_data(self.experiment, self.data)

--- a/ax/modelbridge/transforms/tests/test_deprecated_transform_mixin.py
+++ b/ax/modelbridge/transforms/tests/test_deprecated_transform_mixin.py
@@ -32,6 +32,7 @@ class DeprecatedTransformTest(TestCase):
             super().__init__(*args)
 
     def setUp(self) -> None:
+        super().setUp()
         self.deprecated_t = self.DeprecatedTransform(MagicMock(), MagicMock())
         self.t = Transform(MagicMock(), MagicMock())
 

--- a/ax/modelbridge/transforms/tests/test_derelativize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_derelativize_transform.py
@@ -29,6 +29,7 @@ from ax.utils.common.testutils import TestCase
 
 class DerelativizeTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         m = mock.patch.object(ModelBridge, "__abstractmethods__", frozenset())
         self.addCleanup(m.stop)
         m.start()

--- a/ax/modelbridge/transforms/tests/test_int_range_to_choice_transform.py
+++ b/ax/modelbridge/transforms/tests/test_int_range_to_choice_transform.py
@@ -19,6 +19,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class IntRangeToChoiceTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter("a", lower=1, upper=5, parameter_type=ParameterType.INT),

--- a/ax/modelbridge/transforms/tests/test_int_to_float_transform.py
+++ b/ax/modelbridge/transforms/tests/test_int_to_float_transform.py
@@ -7,10 +7,11 @@
 # pyre-strict
 
 from copy import deepcopy
+from typing import List
 from unittest import mock
 
 from ax.core.observation import ObservationFeatures
-from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
+from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.parameter_constraint import OrderConstraint, SumConstraint
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.exceptions.core import UnsupportedError
@@ -22,7 +23,8 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class IntToFloatTransformTest(TestCase):
     def setUp(self) -> None:
-        parameters = [
+        super().setUp()
+        parameters: List[Parameter] = [
             RangeParameter("x", lower=1, upper=3, parameter_type=ParameterType.FLOAT),
             RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),
             RangeParameter("d", lower=1, upper=3, parameter_type=ParameterType.INT),
@@ -31,8 +33,6 @@ class IntToFloatTransformTest(TestCase):
             ),
         ]
         self.search_space = SearchSpace(
-            # pyre-fixme[6]: For 1st param expected `List[Parameter]` but got
-            #  `List[Union[ChoiceParameter, RangeParameter]]`.
             parameters=parameters,
             parameter_constraints=[
                 OrderConstraint(

--- a/ax/modelbridge/transforms/tests/test_inverse_gaussian_cdf_y_transform.py
+++ b/ax/modelbridge/transforms/tests/test_inverse_gaussian_cdf_y_transform.py
@@ -16,6 +16,7 @@ from ax.utils.common.testutils import TestCase
 
 class InverseGaussianCdfYTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.obsd_mid = ObservationData(
             metric_names=["m1", "m2"],
             means=np.array([0.5, 0.9]),

--- a/ax/modelbridge/transforms/tests/test_log_transform.py
+++ b/ax/modelbridge/transforms/tests/test_log_transform.py
@@ -20,6 +20,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class LogTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/transforms/tests/test_log_y_transform.py
+++ b/ax/modelbridge/transforms/tests/test_log_y_transform.py
@@ -30,6 +30,7 @@ from ax.utils.common.testutils import TestCase
 
 class LogYTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2", "m3"],
             means=np.array([0.5, 1.0, 1.0]),

--- a/ax/modelbridge/transforms/tests/test_logit_transform.py
+++ b/ax/modelbridge/transforms/tests/test_logit_transform.py
@@ -20,6 +20,7 @@ from scipy.special import expit, logit
 
 class LogitTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/transforms/tests/test_map_unit_x_transform.py
+++ b/ax/modelbridge/transforms/tests/test_map_unit_x_transform.py
@@ -18,6 +18,7 @@ from ax.utils.common.testutils import TestCase
 
 class MapUnitXTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.target_lb = MapUnitX.target_lb
         self.target_range = MapUnitX.target_range
         self.target_ub = self.target_lb + self.target_range

--- a/ax/modelbridge/transforms/tests/test_metrics_as_task_transform.py
+++ b/ax/modelbridge/transforms/tests/test_metrics_as_task_transform.py
@@ -9,7 +9,6 @@
 from copy import deepcopy
 
 import numpy as np
-
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.parameter import ChoiceParameter
 from ax.modelbridge.transforms.metrics_as_task import MetricsAsTask
@@ -19,6 +18,7 @@ from ax.utils.testing.core_stubs import get_search_space_for_range_values
 
 class MetricsAsTaskTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.metric_task_map = {
             "metric1": ["metric2", "metric3"],
             "metric2": ["metric3"],

--- a/ax/modelbridge/transforms/tests/test_one_hot_transform.py
+++ b/ax/modelbridge/transforms/tests/test_one_hot_transform.py
@@ -19,6 +19,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class OneHotTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/transforms/tests/test_percentile_y_transform.py
+++ b/ax/modelbridge/transforms/tests/test_percentile_y_transform.py
@@ -17,6 +17,7 @@ from ax.utils.common.testutils import TestCase
 
 class PercentileYTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2"],
             means=np.array([0.0, 0.0]),

--- a/ax/modelbridge/transforms/tests/test_power_y_transform.py
+++ b/ax/modelbridge/transforms/tests/test_power_y_transform.py
@@ -41,6 +41,7 @@ def get_constraint(
 
 class PowerTransformYTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2"],
             means=np.array([0.5, 0.9]),

--- a/ax/modelbridge/transforms/tests/test_remove_fixed_transform.py
+++ b/ax/modelbridge/transforms/tests/test_remove_fixed_transform.py
@@ -23,6 +23,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class RemoveFixedTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/transforms/tests/test_rounding_transform.py
+++ b/ax/modelbridge/transforms/tests/test_rounding_transform.py
@@ -15,9 +15,6 @@ from ax.utils.common.testutils import TestCase
 
 
 class RoundingTest(TestCase):
-    def setUp(self) -> None:
-        pass
-
     def test_OneHotRound(self) -> None:
         self.assertTrue(
             np.allclose(

--- a/ax/modelbridge/transforms/tests/test_search_space_to_float_transform.py
+++ b/ax/modelbridge/transforms/tests/test_search_space_to_float_transform.py
@@ -17,6 +17,7 @@ from ax.utils.common.testutils import TestCase
 
 class SearchSpaceToFloatTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/transforms/tests/test_standardize_y_transform.py
+++ b/ax/modelbridge/transforms/tests/test_standardize_y_transform.py
@@ -24,6 +24,7 @@ from ax.utils.common.testutils import TestCase
 
 class StandardizeYTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2", "m2"],
             means=np.array([1.0, 2.0, 1.0]),

--- a/ax/modelbridge/transforms/tests/test_stratified_standardize_y_transform.py
+++ b/ax/modelbridge/transforms/tests/test_stratified_standardize_y_transform.py
@@ -25,6 +25,7 @@ from ax.utils.common.testutils import TestCase
 
 class StratifiedStandardizeYTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2", "m2"],
             means=np.array([1.0, 2.0, 8.0]),

--- a/ax/modelbridge/transforms/tests/test_task_encode_transform.py
+++ b/ax/modelbridge/transforms/tests/test_task_encode_transform.py
@@ -18,6 +18,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class TaskEncodeTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
+++ b/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
@@ -20,6 +20,7 @@ from ax.utils.testing.core_stubs import get_robust_search_space
 
 class TrialAsTaskTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(

--- a/ax/modelbridge/transforms/tests/test_unit_x_transform.py
+++ b/ax/modelbridge/transforms/tests/test_unit_x_transform.py
@@ -27,6 +27,7 @@ class UnitXTransformTest(TestCase):
     expected_c_bounds = [0.0, 1.0]
 
     def setUp(self) -> None:
+        super().setUp()
         self.target_lb = self.transform_class.target_lb
         self.target_range = self.transform_class.target_range
         self.target_ub = self.target_lb + self.target_range

--- a/ax/modelbridge/transforms/tests/test_winsorize_legacy_transform.py
+++ b/ax/modelbridge/transforms/tests/test_winsorize_legacy_transform.py
@@ -18,6 +18,7 @@ from ax.utils.common.testutils import TestCase
 
 class WinsorizeTransformTestLegacy(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2", "m2"],
             means=np.array([0.0, 0.0, 1.0]),

--- a/ax/modelbridge/transforms/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_winsorize_transform.py
@@ -59,6 +59,7 @@ OBSERVATION_DATA = [
 
 class WinsorizeTransformTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.obsd1 = ObservationData(
             metric_names=["m1", "m2", "m2"],
             means=np.array([0.0, 0.0, 1.0]),

--- a/ax/models/tests/test_botorch_kg.py
+++ b/ax/models/tests/test_botorch_kg.py
@@ -36,6 +36,7 @@ def dummy_func(X: torch.Tensor) -> torch.Tensor:
 
 class KnowledgeGradientTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.tkwargs: Dict[str, Any] = {
             "device": torch.device("cpu"),
             "dtype": torch.double,

--- a/ax/models/tests/test_botorch_mes.py
+++ b/ax/models/tests/test_botorch_mes.py
@@ -28,6 +28,7 @@ from botorch.utils.datasets import SupervisedDataset
 
 class MaxValueEntropySearchTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.tkwargs: Dict[str, Any] = {
             "device": torch.device("cpu"),
             "dtype": torch.double,

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -51,6 +51,7 @@ def dummy_predict(model, X) -> Tuple[Tensor, Tensor]:
 
 class FrontierEvaluatorTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.X = torch.tensor(
             [[1.0, 0.0], [1.0, 1.0], [1.0, 3.0], [2.0, 2.0], [3.0, 1.0]]
         )

--- a/ax/models/tests/test_discrete.py
+++ b/ax/models/tests/test_discrete.py
@@ -12,9 +12,6 @@ from ax.utils.common.testutils import TestCase
 
 
 class DiscreteModelTest(TestCase):
-    def setUp(self) -> None:
-        pass
-
     def test_discrete_model_get_state(self) -> None:
         discrete_model = DiscreteModel()
         self.assertEqual(discrete_model._get_state(), {})

--- a/ax/models/tests/test_model_utils.py
+++ b/ax/models/tests/test_model_utils.py
@@ -21,9 +21,6 @@ from ax.utils.common.testutils import TestCase
 
 
 class ModelUtilsTest(TestCase):
-    def setUp(self) -> None:
-        pass
-
     def test_BestObservedPoint(self) -> None:
         model = MagicMock()
 

--- a/ax/models/tests/test_random.py
+++ b/ax/models/tests/test_random.py
@@ -15,6 +15,7 @@ from ax.utils.common.typeutils import not_none
 
 class RandomModelTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.random_model = RandomModel()
 
     def test_seed(self) -> None:

--- a/ax/models/tests/test_sobol.py
+++ b/ax/models/tests/test_sobol.py
@@ -18,6 +18,7 @@ from botorch.utils.sampling import sample_polytope
 
 class SobolGeneratorTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.tunable_param_bounds = (0.0, 1.0)
         self.fixed_param_bounds = (1.0, 100.0)
 

--- a/ax/models/tests/test_thompson.py
+++ b/ax/models/tests/test_thompson.py
@@ -15,6 +15,7 @@ from ax.utils.common.testutils import TestCase
 
 class ThompsonSamplerTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.Xs = [[[1, 1], [2, 2], [3, 3], [4, 4]]]  # 4 arms, each of dimensionality 2
         self.Ys = [[1, 2, 3, 4]]
         self.Yvars = [[1, 1, 1, 1]]

--- a/ax/models/tests/test_torch.py
+++ b/ax/models/tests/test_torch.py
@@ -15,6 +15,7 @@ from botorch.utils.datasets import SupervisedDataset
 
 class TorchModelTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.dataset = SupervisedDataset(
             X=torch.zeros(1, 1),
             Y=torch.zeros(1, 1),

--- a/ax/models/tests/test_torch_model_utils.py
+++ b/ax/models/tests/test_torch_model_utils.py
@@ -85,6 +85,7 @@ class TorchUtilsTest(TestCase):
 
 class SubsetModelTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.x = torch.zeros(1, 1)
         self.y = torch.rand(1, 2)
         self.obj_t = torch.rand(2)
@@ -198,6 +199,7 @@ class SubsetModelTest(TestCase):
 
 class SubsetModelTestMultiTask(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.x1 = torch.tensor([[1.0, 2.0, 1.0], [2.0, 3.0, 0.0]])
         self.y1 = torch.tensor([[0.0], [1.0]])
         self.x2 = torch.tensor([[0.0, 3.0, 1.0], [1.0, 4.0, 0.0]])

--- a/ax/models/tests/test_torch_utils.py
+++ b/ax/models/tests/test_torch_utils.py
@@ -39,6 +39,7 @@ from botorch.models.model import Model
 
 class TorchUtilsTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.device = torch.device("cpu")
         self.dtype = torch.double
         self.mock_botorch_model = MagicMock(Model)

--- a/ax/models/tests/test_uniform.py
+++ b/ax/models/tests/test_uniform.py
@@ -15,6 +15,7 @@ from ax.utils.common.testutils import TestCase
 
 class UniformGeneratorTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.tunable_param_bounds = (0, 1)
         self.fixed_param_bounds = (1, 100)
 

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -88,6 +88,7 @@ class DummyOneShotAcquisitionFunction(DummyAcquisitionFunction, qKnowledgeGradie
 class AcquisitionTest(TestCase):
     @fast_botorch_optimize
     def setUp(self) -> None:
+        super().setUp()
         qNEI_input_constructor = get_acqf_input_constructor(qNoisyExpectedImprovement)
         self.mock_input_constructor = mock.MagicMock(
             qNEI_input_constructor, side_effect=qNEI_input_constructor

--- a/ax/models/torch/tests/test_input_transform_argparse.py
+++ b/ax/models/torch/tests/test_input_transform_argparse.py
@@ -34,6 +34,7 @@ class DummyInputTransform(InputTransform):  # pyre-ignore [13]
 
 class InputTransformArgparseTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         X = torch.randn((10, 4))
         Y = torch.randn((10, 2))
         self.dataset = SupervisedDataset(

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -69,6 +69,7 @@ ACQ_OPTIONS: Dict[str, SobolQMCNormalSampler] = {
 
 class BoTorchModelTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.botorch_model_class = SingleTaskGP
         self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
         self.acquisition_class = Acquisition

--- a/ax/models/torch/tests/test_multi_fidelity.py
+++ b/ax/models/torch/tests/test_multi_fidelity.py
@@ -33,6 +33,7 @@ MFKG_PATH = (
 class MultiFidelityAcquisitionTest(TestCase):
     @fast_botorch_optimize
     def setUp(self) -> None:
+        super().setUp()
         self.botorch_model_class = SingleTaskMultiFidelityGP
         self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
         self.X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]])

--- a/ax/models/torch/tests/test_outcome_transform_argparse.py
+++ b/ax/models/torch/tests/test_outcome_transform_argparse.py
@@ -20,6 +20,7 @@ class DummyOutcomeTransform(OutcomeTransform):
 
 class OutcomeTransformArgparseTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         X = torch.randn((10, 4))
         Y = torch.randn((10, 1))
         self.dataset = SupervisedDataset(

--- a/ax/models/torch/tests/test_sebo.py
+++ b/ax/models/torch/tests/test_sebo.py
@@ -47,6 +47,7 @@ SURROGATE_PATH: str = Surrogate.__module__
 class TestSebo(TestCase):
     @fast_botorch_optimize
     def setUp(self) -> None:
+        super().setUp()
         tkwargs: Dict[str, Any] = {"dtype": torch.double}
         self.botorch_model_class = SingleTaskGP
         self.surrogates = Surrogate(botorch_model_class=self.botorch_model_class)

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -131,6 +131,7 @@ class ExtractModelKwargsTest(TestCase):
 
 class SurrogateTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.device = torch.device("cpu")
         self.dtype = torch.float
         self.tkwargs = {"device": self.device, "dtype": self.dtype}
@@ -732,6 +733,7 @@ class SurrogateTest(TestCase):
 
 class SurrogateWithModelListTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.outcomes = ["outcome_1", "outcome_2"]
         self.mll_class = ExactMarginalLogLikelihood
         self.dtype = torch.double

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -45,6 +45,7 @@ from botorch.utils.datasets import SupervisedDataset
 
 class BoTorchModelUtilsTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.dtype = torch.float
         (
             self.Xs,

--- a/ax/plot/tests/long_running/test_pareto_utils.py
+++ b/ax/plot/tests/long_running/test_pareto_utils.py
@@ -10,7 +10,6 @@ from ax.exceptions.core import UnsupportedError
 from ax.metrics.branin import BraninMetric
 from ax.modelbridge.registry import Models
 from ax.plot.pareto_utils import compute_posterior_pareto_frontier
-
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
 
@@ -22,6 +21,7 @@ from ax.utils.testing.core_stubs import get_branin_experiment
 # run in streesRun mode).
 class ComputePosteriorParetoFrontierTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         experiment = get_branin_experiment()
         experiment.add_tracking_metric(
             BraninMetric(name="m2", param_names=["x1", "x2"])

--- a/ax/plot/tests/test_diagnostic.py
+++ b/ax/plot/tests/test_diagnostic.py
@@ -22,6 +22,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 class DiagnosticTest(TestCase):
     @fast_botorch_optimize
     def setUp(self) -> None:
+        super().setUp()
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()
         self.model = Models.BOTORCH_MODULAR(

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -46,6 +46,7 @@ from ax.utils.testing.core_stubs import (
 
 class ParetoUtilsTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         experiment = get_branin_experiment()
         experiment.add_tracking_metric(
             BraninMetric(name="m2", param_names=["x1", "x2"])

--- a/ax/plot/tests/test_traces.py
+++ b/ax/plot/tests/test_traces.py
@@ -24,6 +24,7 @@ from ax.utils.testing.mock import fast_botorch_optimize
 class TracesTest(TestCase):
     @fast_botorch_optimize
     def setUp(self) -> None:
+        super().setUp()
         self.exp = get_branin_experiment(with_batch=True)
         self.exp.trials[0].run()
         self.model = Models.BOTORCH_MODULAR(

--- a/ax/runners/tests/test_torchx.py
+++ b/ax/runners/tests/test_torchx.py
@@ -32,6 +32,7 @@ from torchx.components import utils
 
 class TorchXRunnerTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.test_dir = tempfile.mkdtemp("torchx_runtime_hpo_ax_test")
 
         self.old_cwd = os.getcwd()

--- a/ax/service/tests/test_early_stopping.py
+++ b/ax/service/tests/test_early_stopping.py
@@ -20,6 +20,7 @@ class TestEarlyStoppingUtils(TestCase):
     main `AxClient` testing suite (`TestServiceAPI`)."""
 
     def setUp(self) -> None:
+        super().setUp()
         self.branin_experiment = get_branin_experiment()
 
     def test_should_stop_trials_early(self) -> None:

--- a/ax/service/tests/test_interactive_loop.py
+++ b/ax/service/tests/test_interactive_loop.py
@@ -25,9 +25,6 @@ from ax.utils.testing.mock import fast_botorch_optimize
 
 
 class TestInteractiveLoop(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-
     @fast_botorch_optimize
     def test_interactive_loop(self) -> None:
         def _elicit(

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -229,6 +229,7 @@ TEST_CASES = [
 
 class JSONStoreTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.experiment = get_experiment_with_batch_and_single_trial()
 
     def test_JSONEncodeFailure(self) -> None:

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -120,6 +120,7 @@ GET_GS_SQA_IMM_FUNC = _get_generation_strategy_sqa_immutable_opt_config_and_sear
 
 class SQAStoreTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         init_test_engine_and_session_factory(force_init=True)
         self.config = SQAConfig()
         self.encoder = Encoder(config=self.config)

--- a/ax/storage/sqa_store/tests/test_utils.py
+++ b/ax/storage/sqa_store/tests/test_utils.py
@@ -29,6 +29,7 @@ class DummyClassWithBaseline(Base):
 
 class SQAStoreUtilsTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         init_test_engine_and_session_factory(force_init=True)
 
     def test_CopyDBIDsBatchTrialExp(self) -> None:

--- a/ax/utils/common/tests/test_logger.py
+++ b/ax/utils/common/tests/test_logger.py
@@ -19,6 +19,7 @@ BASE_LOGGER_NAME = f"ax.{__name__}"
 
 class LoggerTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.warning_string = "Test warning"
 
     def test_Logger(self) -> None:

--- a/ax/utils/common/tests/test_result.py
+++ b/ax/utils/common/tests/test_result.py
@@ -11,6 +11,8 @@ from ax.utils.common.testutils import TestCase
 
 class ResultTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
+
         def safeDivide(a: float, b: float) -> Result[float, str]:
             if b == 0:
                 return Err("yikes")

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -324,6 +324,7 @@ class TestCase(fake_filesystem_unittest.TestCase):
 
         Also silences a number of common warnings originating from Ax & BoTorch.
         """
+        super().setUp()
         logger = get_logger(__name__, level=logging.WARNING)
         # Parent handlers are shared, so setting the level this
         # way applies it to all Ax loggers.

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -57,6 +57,7 @@ def get_modelbridge(modular: bool = False, saasbo: bool = False) -> ModelBridge:
 
 class SensitivityAnalysisTest(TestCase):
     def setUp(self) -> None:
+        super().setUp()
         self.model = get_modelbridge().model.model
         self.saas_model = (
             get_modelbridge(saasbo=True).model.surrogates["SAASBO_Surrogate"].model


### PR DESCRIPTION
Summary: The logger & warning filters in `TestCase.setUp` are only effective if it gets executed. Many test definitions were overwriting `setUp` without a `super().setUp()` call, ignoring these filters.

Reviewed By: esantorella

Differential Revision: D56375193
