### PR TITLE
Do not transform search space in-place in Modelbridge._get_transformed_gen_args

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -690,6 +690,7 @@ class ModelBridge(ABC):  # noqa: B024 -- ModelBridge doesn't have any abstract m
         # TODO(T34225037): replace deepcopy with native clone() in Ax
         pending_observations = deepcopy(pending_observations)
         fixed_features = deepcopy(fixed_features)
+        search_space = search_space.clone()
 
         # Transform
         for t in self.transforms.values():


### PR DESCRIPTION
Summary: The current setup leads to issues when calling `evaluate_acquisition_function()` in between generation steps, see discussion on https://github.com/facebook/Ax/issues/2083

Differential Revision: D56400492


