### PR TITLE
Call object_from_json from decoder when issubclass(_class, SerializationMixin)

### DIFF
--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -268,6 +268,11 @@ def object_from_json(
             )
         elif isclass(_class) and issubclass(_class, SerializationMixin):
             return _class(
+                # Note: we do not recursively call object_from_json here again as
+                # that would invalidate design principles behind deserialize_init_args.
+                # Any Ax class that needs serialization and who's init args include
+                # another Ax class that needs serialization should implement its own
+                # _to_json and _from_json methods and register them appropriately.
                 **_class.deserialize_init_args(
                     args=object_json,
                     decoder_registry=decoder_registry,


### PR DESCRIPTION
Summary: As titled. This solves a relatively common problem (which may crop up again in some recently planning changes) in which the init args of some serializable Ax object is itself a serializable Ax object

Differential Revision: D56356035
