### PR TITLE
Ban spaces in metric/parameter names in AxClient

### DIFF
--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -153,6 +153,12 @@ class InstantiationBase:
         for_opt_config: bool = False,
         metric_definitions: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> Metric:
+        if " " in name:
+            raise ValueError(
+                "Metric names cannot contain spaces when used with AxClient. Got "
+                f"{name!r}."
+            )
+
         return metric_class(
             name=name,
             lower_is_better=lower_is_better,
@@ -312,6 +318,12 @@ class InstantiationBase:
             assert isinstance(parameter_type, str) and parameter_type in PARAM_TYPES, (
                 "Value type in parameter JSON representation must be 'int', 'float', "
                 "'bool' or 'str'."
+            )
+
+        if " " in name:
+            raise ValueError(
+                "Parameter names cannot contain spaces when used with AxClient. Got "
+                f"{name!r}."
             )
 
         if parameter_class == "range":


### PR DESCRIPTION
Summary: Spaces in names break parsing needed for contraints in AxClient. We discussed many options fo rmoving forward here but this simple solution is the least disruptive

Differential Revision: D56576451
