### PR TITLE
Use codecov github action for uploading coverage 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,7 @@ jobs:
     uses: ./.github/workflows/reusable_test.yml
     with:
       pinned_botorch: false
+    secrets: inherit
 
   lint:
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -26,6 +26,7 @@ jobs:
     with:
       pinned_botorch: false
       minimal_dependencies: false
+    secrets: inherit
 
   build-tutorials:
     name: Build tutorials with latest BoTorch

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       pinned_botorch: false
       minimal_dependencies: true
+    secrets: inherit
 
   tests-and-coverage-full:
     name: Tests with latest BoTorch & full dependencies

--- a/.github/workflows/cron_pinned.yml
+++ b/.github/workflows/cron_pinned.yml
@@ -12,6 +12,7 @@ jobs:
     with:
       pinned_botorch: true
       minimal_dependencies: true
+    secrets: inherit
 
   tests-and-coverage-full:
     name: Tests with pinned BoTorch & full dependencies
@@ -19,6 +20,7 @@ jobs:
     with:
       pinned_botorch: true
       minimal_dependencies: false
+    secrets: inherit
 
   build-tutorials:
     name: Build tutorials with pinned BoTorch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,14 @@ jobs:
     uses: ./.github/workflows/reusable_test.yml
     with:
       pinned_botorch: false
+    secrets: inherit
 
   tests-and-coverage-pinned:
     name: Tests with pinned BoTorch
     uses: ./.github/workflows/reusable_test.yml
     with:
       pinned_botorch: true
+    secrets: inherit
 
   publish-stable-website:
 

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -61,8 +61,8 @@ jobs:
       name: Tests and coverage
       run: |
         pytest -ra --cov=ax
-    - if: ${{ !inputs.minimal_dependencies }}
-      # Using same condition as above since we need the coverage report for upload.
+    - if: ${{ !inputs.minimal_dependencies && matrix.python-version == 3.10 }}
+      # Only upload codecov once per workflow.
       name: Upload coverage
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -64,5 +64,7 @@ jobs:
     - if: ${{ !inputs.minimal_dependencies }}
       # Using same condition as above since we need the coverage report for upload.
       name: Upload coverage
-      run: |
-        bash <(curl -s https://codecov.io/bash)
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Replicates https://github.com/pytorch/botorch/pull/2312

Codecov bash uploader is marked for deprecation: https://docs.codecov.com/docs/about-the-codecov-bash-uploader
Switching the CI to use the codecov github action with the newly added upload token: https://github.com/marketplace/actions/codecov

Test Plan:
Check for successful upload in CI signals