### PR TITLE
Update GenerationNode.model_to_gen_from_name

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -143,7 +143,10 @@ class GenerationNode(SerializationMixin, SortableBase):
         """Returns the name of the model that will be used for gen, if there is one.
         Otherwise, returns None.
         """
-        return self.model_spec_to_gen_from.model_key
+        if self._model_spec_to_gen_from is not None:
+            return self._model_spec_to_gen_from.model_key
+        else:
+            return None
 
     @property
     def generation_strategy(self) -> modelbridge.generation_strategy.GenerationStrategy:

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from functools import wraps
-
 from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
@@ -595,18 +594,25 @@ class GenerationStrategy(GenerationStrategyInterface):
 
     def _make_default_name(self) -> str:
         """Make a default name for this generation strategy; used when no name is passed
-        to the constructor. Makes the name from model keys on generation nodes, set on
-        this generation strategy, and should only be called once the nodes are set.
+        to the constructor. For node-based generation strategies, the name is
+        constructed by joining together the names of the nodes set on this
+        generation strategy. For step-based generation strategies, the model keys
+        of the underlying model specs are used.
+        Note: This should only be called once the nodes are set.
         """
         if not self._nodes:
             raise UnsupportedError(
                 "Cannot make a default name for a generation strategy with no nodes "
                 "set yet."
             )
-        factory_names = (node.model_spec_to_gen_from.model_key for node in self._nodes)
-        # Trim the "get_" beginning of the factory function if it's there.
-        factory_names = (n[4:] if n[:4] == "get_" else n for n in factory_names)
-        return "+".join(factory_names)
+        # TODO: Simplify this after updating GStep names to represent underlying models.
+        if self.is_node_based:
+            node_names = (node.node_name for node in self._nodes)
+        else:
+            node_names = (node.model_spec_to_gen_from.model_key for node in self._nodes)
+            # Trim the "get_" beginning of the factory function if it's there.
+            node_names = (n[4:] if n[:4] == "get_" else n for n in node_names)
+        return "+".join(node_names)
 
     def __repr__(self) -> str:
         """String representation of this generation strategy."""

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -113,6 +113,7 @@ class TestGenerationNode(TestCase):
                 ),
             ],
         )
+        self.assertIsNone(node.model_to_gen_from_name)
         dat = self.branin_experiment.lookup_data()
         node.fit(
             experiment=self.branin_experiment,
@@ -124,6 +125,7 @@ class TestGenerationNode(TestCase):
         self.assertEqual(
             node.model_spec_to_gen_from.model_kwargs, node.model_specs[0].model_kwargs
         )
+        self.assertEqual(node.model_to_gen_from_name, "GPEI")
         self.assertEqual(
             node.model_spec_to_gen_from.model_gen_kwargs,
             node.model_specs[0].model_gen_kwargs,

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -300,7 +300,7 @@ class TestGenerationStrategy(TestCase):
         )
         self.assertEqual(
             str(gs3),
-            "GenerationStrategy(name='Sobol', nodes=[GenerationNode("
+            "GenerationStrategy(name='test', nodes=[GenerationNode("
             "model_specs=[ModelSpec(model_enum=Sobol, "
             "model_kwargs={}, model_gen_kwargs={}, model_cv_kwargs={},"
             " )], node_name=test, "


### PR DESCRIPTION
Summary: Updates the behavior to match the docstring. Previously, this would call `model_spec_to_gen_from`, which could lead to fitting multiple models if the node had multiple model specs. The return type was always `str` rather than `Optional[str]` suggested by the type hints.

Differential Revision: D56735619
