### PR TITLE
Add a helper for setting RNG seed

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -44,8 +44,8 @@ from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.utils import get_model_times
 from ax.service.scheduler import Scheduler
 from ax.utils.common.logger import get_logger
+from ax.utils.common.random import with_rng_seed
 from ax.utils.common.typeutils import checked_cast, not_none
-from botorch.utils.sampling import manual_seed
 
 logger: Logger = get_logger(__name__)
 
@@ -126,8 +126,7 @@ def benchmark_replication(
     Args:
         problem: The BenchmarkProblem to test against (can be synthetic or real)
         method: The BenchmarkMethod to test
-        seed: The seed to use for this replication, set using `manual_seed`
-            from `botorch.utils.sampling`.
+        seed: The seed to use for this replication.
     """
 
     experiment = _create_benchmark_experiment(problem=problem, method_name=method.name)
@@ -138,7 +137,7 @@ def benchmark_replication(
         options=method.scheduler_options,
     )
 
-    with manual_seed(seed=seed):
+    with with_rng_seed(seed=seed):
         scheduler.run_n_trials(max_trials=problem.num_trials)
 
     if not problem.is_noiseless and problem.has_ground_truth:

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -43,6 +43,7 @@ from ax.runners.synthetic import SyntheticRunner
 from ax.service.ax_client import AxClient
 from ax.service.utils.instantiation import ObjectiveProperties
 from ax.utils.common.constants import EXPERIMENT_IS_TEST_WARNING, Keys
+from ax.utils.common.random import set_rng_seed
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast
 from ax.utils.testing.core_stubs import (
@@ -1419,8 +1420,7 @@ class ExperimentWithMapDataTest(TestCase):
         exp.new_batch_trial(generator_runs=[sobol.gen(n=7)]).run().complete()
 
         data = exp.fetch_data()
-        torch.manual_seed(seed)
-        np.random.seed(seed)
+        set_rng_seed(seed)
         gp = Models.BOTORCH_MODULAR(
             experiment=exp, search_space=exp.search_space, data=data
         )

--- a/ax/modelbridge/tests/test_torch_moo_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_moo_modelbridge.py
@@ -39,6 +39,7 @@ from ax.models.torch.botorch_moo_defaults import (
     pareto_frontier_evaluator,
 )
 from ax.service.utils.report_utils import exp_to_df
+from ax.utils.common.random import set_rng_seed
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.testing.core_stubs import (
@@ -572,7 +573,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
         trial.add_generator_run(sobol_run)
         trial.mark_running(no_runner_required=True).mark_completed()
         data = exp.fetch_data()
-        torch.manual_seed(0)  # make model fitting deterministic
+        set_rng_seed(0)  # make model fitting deterministic
         modelbridge = TorchModelBridge(
             search_space=exp.search_space,
             model=MultiObjectiveBotorchModel(),

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -23,11 +23,11 @@ from ax.models.torch.botorch_moo_defaults import (
     pareto_frontier_evaluator,
 )
 from ax.models.torch.utils import _get_X_pending_and_observed
+from ax.utils.common.random import with_rng_seed
 from ax.utils.common.testutils import TestCase
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.multi_objective.hypervolume import infer_reference_point
-from botorch.utils.sampling import manual_seed
 from botorch.utils.testing import MockModel, MockPosterior
 from torch._tensor import Tensor
 
@@ -245,7 +245,7 @@ class BotorchMOODefaultsTest(TestCase):
         )
         (weighted_obj, new_obj_thresholds) = obj_and_obj_t
         cons_tfs = get_outcome_constraint_transforms(constraints)
-        with manual_seed(0):
+        with with_rng_seed(0):
             seed = torch.randint(1, 10000, (1,)).item()
         with ExitStack() as es:
             mock_get_acqf = es.enter_context(mock.patch(GET_ACQF_PATH))
@@ -254,7 +254,7 @@ class BotorchMOODefaultsTest(TestCase):
             )
             es.enter_context(mock.patch(GET_CONSTRAINT_PATH, return_value=cons_tfs))
             es.enter_context(mock.patch(GET_OBJ_PATH, return_value=obj_and_obj_t))
-            es.enter_context(manual_seed(0))
+            es.enter_context(with_rng_seed(0))
             get_qLogEHVI(
                 model=mm,
                 objective_weights=weights,

--- a/ax/models/tests/test_fully_bayesian.py
+++ b/ax/models/tests/test_fully_bayesian.py
@@ -29,6 +29,7 @@ from ax.models.torch.fully_bayesian import (
 from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger
+from ax.utils.common.random import set_rng_seed, with_rng_seed
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition.utils import get_infeasible_cost
@@ -688,8 +689,7 @@ class BaseFullyBayesianBotorchModelTestCases:
             for use_input_warping, gp_kernel in product(
                 [False, True], ["rbf", "matern"]
             ):
-                with torch.random.fork_rng():
-                    torch.manual_seed(0)
+                with with_rng_seed(0):
                     X = torch.randn(3, 2)
                     Y = torch.randn(3, 1)
                     Yvar = torch.randn(3, 1)
@@ -714,7 +714,7 @@ class BaseFullyBayesianBotorchModelTestCases:
                         self.assertNotIn("c1", samples)
 
         def test_gp_kernels(self) -> None:
-            torch.manual_seed(0)
+            set_rng_seed(0)
             X = torch.randn(3, 2)
             Y = torch.randn(3, 1)
             Yvar = torch.randn(3, 1)

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -95,8 +95,8 @@ from ax.storage.json_store.registry import (
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.executils import retry_on_exception
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
+from ax.utils.common.random import with_rng_seed
 from ax.utils.common.typeutils import checked_cast, not_none
-from botorch.utils.sampling import manual_seed
 from pyre_extensions import assert_is_instance
 
 logger: Logger = get_logger(__name__)
@@ -1786,7 +1786,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
             if fixed_features
             else None
         )
-        with manual_seed(seed=self._random_seed):
+        with with_rng_seed(seed=self._random_seed):
             return not_none(self.generation_strategy).gen(
                 experiment=self.experiment,
                 n=n,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -71,6 +71,7 @@ from ax.storage.sqa_store.decoder import Decoder
 from ax.storage.sqa_store.encoder import Encoder
 from ax.storage.sqa_store.sqa_config import SQAConfig
 from ax.storage.sqa_store.structs import DBSettings
+from ax.utils.common.random import with_rng_seed
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.measurement.synthetic_functions import Branin
@@ -78,7 +79,6 @@ from ax.utils.testing.core_stubs import DummyEarlyStoppingStrategy
 from ax.utils.testing.mock import fast_botorch_optimize
 from ax.utils.testing.modeling_stubs import get_observation1, get_observation1trans
 from botorch.test_functions.multi_objective import BraninCurrin
-from botorch.utils.sampling import manual_seed
 
 if TYPE_CHECKING:
     from ax.core.types import TTrialEvaluation
@@ -2386,7 +2386,7 @@ class TestAxClient(TestCase):
         assert isinstance(cfg, MultiObjectiveOptimizationConfig)
         thresholds = np.array([t.bound for t in cfg.objective_thresholds])
 
-        with manual_seed(seed=RANDOM_SEED):
+        with with_rng_seed(seed=RANDOM_SEED):
             predicted_pareto = ax_client.get_pareto_optimal_parameters()
 
         # For the predicted frontier, we don't know the solution a priori, so let's
@@ -2494,7 +2494,7 @@ class TestAxClient(TestCase):
             data=ax_client.experiment.lookup_data()
         )
 
-        with manual_seed(seed=RANDOM_SEED):
+        with with_rng_seed(seed=RANDOM_SEED):
             predicted_pareto = ax_client.get_pareto_optimal_parameters()
 
         # Check that we specified objective threshold overrides (because we
@@ -2506,7 +2506,7 @@ class TestAxClient(TestCase):
         mock_observed_pareto.assert_not_called()
         self.assertGreater(len(predicted_pareto), 0)
 
-        with manual_seed(seed=RANDOM_SEED):
+        with with_rng_seed(seed=RANDOM_SEED):
             observed_pareto = ax_client.get_pareto_optimal_parameters(
                 use_model_predictions=False
             )

--- a/ax/utils/common/random.py
+++ b/ax/utils/common/random.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import random
+from contextlib import contextmanager
+from typing import Generator, Optional
+
+import numpy as np
+import torch
+
+
+def set_rng_seed(seed: int) -> None:
+    """Sets seeds for random number generators from numpy, pytorch,
+    and the native random module.
+
+    Args:
+        seed: The random number generator seed.
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+@contextmanager
+def with_rng_seed(seed: Optional[int]) -> Generator[None, None, None]:
+    """Context manager that sets the random number generator seeds
+    to a given value and restores the previous state on exit.
+
+    Args:
+        seed: The random number generator seed. If None, this
+            does not set the random seed, but still restores
+            the random seed upon exit.
+    """
+    old_state = {
+        "random": random.getstate(),
+        "numpy": np.random.get_state(),
+        "torch": torch.get_rng_state(),
+    }
+    try:
+        if seed is not None:
+            set_rng_seed(seed)
+        yield
+    finally:
+        random.setstate(old_state["random"])
+        np.random.set_state(old_state["numpy"])
+        torch.set_rng_state(old_state["torch"])

--- a/ax/utils/common/tests/test_random.py
+++ b/ax/utils/common/tests/test_random.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import random
+
+import numpy as np
+import torch
+from ax.utils.common.random import set_rng_seed, with_rng_seed
+from ax.utils.common.testutils import TestCase
+
+
+class TestRandom(TestCase):
+    def test_set_rng_seed(self) -> None:
+        # Set the seeds manually & using the helper, and compares the random numbers.
+        seed = 0
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        native_rand = random.random()
+        np_rand = np.random.rand(5)
+        torch_rand = torch.rand(5)
+
+        set_rng_seed(seed)
+        self.assertEqual(random.random(), native_rand)
+        self.assertTrue(np.allclose(np_rand, np.random.rand(5)))
+        self.assertTrue(torch.allclose(torch_rand, torch.rand(5)))
+
+    def test_with_rng_seed(self, with_none_seed: bool = False) -> None:
+        # Test that the context manager sets the seed and restores the state.
+        native_state = random.getstate()
+        np_state = np.random.get_state()
+        torch_state = torch.get_rng_state()
+        with with_rng_seed(None if with_none_seed else 0):
+            native_rand = random.random()
+            numpy_rand = np.random.rand(5)
+            torch_rand = torch.rand(5)
+        self.assertEqual(random.getstate(), native_state)
+        for first, second in zip(np_state, np.random.get_state()):
+            if isinstance(first, np.ndarray):
+                self.assertTrue(np.equal(first, second).all())
+            else:
+                self.assertEqual(first, second)
+        self.assertTrue(torch.equal(torch_state, torch.get_rng_state()))
+
+        set_rng_seed(0)
+        if with_none_seed:
+            # The seed is None, so the random numbers should be different.
+            self.assertNotEqual(random.random(), native_rand)
+            self.assertFalse(np.allclose(numpy_rand, np.random.rand(5)))
+            self.assertFalse(torch.allclose(torch_rand, torch.rand(5)))
+        else:
+            # The seed was set, so the random numbers should be the same.
+            self.assertEqual(random.random(), native_rand)
+            self.assertTrue(np.allclose(numpy_rand, np.random.rand(5)))
+            self.assertTrue(torch.allclose(torch_rand, torch.rand(5)))
+
+    def test_with_rng_seed_with_none_seed(self) -> None:
+        self.test_with_rng_seed(with_none_seed=True)

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -16,6 +16,7 @@ from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.registry import Models
 from ax.modelbridge.torch import TorchModelBridge
 from ax.models.torch.botorch import BotorchModel
+from ax.utils.common.random import set_rng_seed
 from ax.utils.common.testutils import TestCase
 from ax.utils.sensitivity.derivative_gp import posterior_derivative
 from ax.utils.sensitivity.derivative_measures import (
@@ -308,7 +309,7 @@ class SensitivityAnalysisTest(TestCase):
         for bridge in [model_bridge, cat_model_bridge]:
             discrete_features = bridge.model.search_space_digest.categorical_features
             with self.subTest(model_bridge=bridge):
-                torch.manual_seed(seed)
+                set_rng_seed(seed)
                 # Unsigned
                 ind_dict = ax_parameter_sens(
                     model_bridge=bridge,  # pyre-ignore
@@ -323,7 +324,7 @@ class SensitivityAnalysisTest(TestCase):
                     discrete_features=discrete_features,
                     **sobol_kwargs,
                 )
-                torch.manual_seed(seed)  # reset seed to keep discrete features the same
+                set_rng_seed(seed)  # reset seed to keep discrete features the same
                 cat_indices = bridge.model.search_space_digest.categorical_features
                 ind_dict_signed = ax_parameter_sens(
                     model_bridge=bridge,  # pyre-ignore

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -110,6 +110,7 @@ from ax.runners.synthetic import SyntheticRunner
 from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger
+from ax.utils.common.random import set_rng_seed
 from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.measurement.synthetic_functions import branin
 from botorch.acquisition.acquisition import AcquisitionFunction
@@ -999,7 +1000,7 @@ def get_large_ordinal_search_space(
 def get_hartmann_search_space(with_fidelity_parameter: bool = False) -> SearchSpace:
     parameters = [
         RangeParameter(
-            name=f"x{idx+1}", parameter_type=ParameterType.FLOAT, lower=0.0, upper=1.0
+            name=f"x{idx + 1}", parameter_type=ParameterType.FLOAT, lower=0.0, upper=1.0
         )
         for idx in range(6)
     ]
@@ -1807,7 +1808,6 @@ def get_weights() -> List[float]:
 
 
 def get_branin_arms(n: int, seed: int) -> List[Arm]:
-    # TODO replace with sobol
     np.random.seed(seed)
     x1_raw = np.random.rand(n)
     x2_raw = np.random.rand(n)
@@ -2319,7 +2319,7 @@ def get_dataset(
         seed: An optional seed used to generate the data.
     """
     if seed is not None:
-        torch.manual_seed(seed)
+        set_rng_seed(seed)
     feature_names = feature_names or [f"x{i}" for i in range(d)]
     outcome_names = outcome_names or [f"y{i}" for i in range(m)]
     tkwargs = tkwargs or {}


### PR DESCRIPTION
Summary:
Adds a helper & a context manager that can be used to set the RNG seed for numpy, pytorch & the native random module.

Updates previous usage of botorch `manual_seed` (and some `torch.manual_seed`) with the new helper.

Differential Revision: D56738900
