### PR TITLE
Update GenStrategy._make_default_name to avoid fitting models

### DIFF
--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -300,7 +300,7 @@ class TestGenerationStrategy(TestCase):
         )
         self.assertEqual(
             str(gs3),
-            "GenerationStrategy(name='Sobol', nodes=[GenerationNode("
+            "GenerationStrategy(name='test', nodes=[GenerationNode("
             "model_specs=[ModelSpec(model_enum=Sobol, "
             "model_kwargs={}, model_gen_kwargs={}, model_cv_kwargs={},"
             " )], node_name=test, "


### PR DESCRIPTION
Summary: The current setup uses `node.model_spec_to_gen_from.model_key` to get the default name for a given node, which will attempt to fit models for GenNodes with multiple `model_spec`s. This diff avoids the `model_spec_to_gen_from` call for node-based GS and uses it only for step-based GS, where this is not an issue.

Differential Revision: D56732974
