### PR TITLE
Deprecate legacy fully Bayesian registry entries

### DIFF
--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -161,10 +161,8 @@ def _suggest_gp_model(
     parameter and the number of parameters needed to encode all unordered parameters
     is less than ``MAX_ONE_HOT_ENCODINGS_CONTINUOUS_OPTIMIZATION``, we use BO with
     continuous relaxation.
-    * If ``optimization_config`` has multiple objectives, we use ``MOO`` if
-    ``use_saasbo is False`` and ``FULLYBAYESIANMOO`` otherwise.
-    * Otherwise, we use ``GPEI`` if ``use_saasbo is False`` and ``FULLYBAYESIAN``
-    otherwise.
+    * For BO, we use Modular BoTorch Model with ``SingleTaskGP`` if ``use_saasbo is
+    False`` and with ``SaasFullyBayesianSingleTaskGP`` (aka SAASBO) otherwise.
     """
     # Count tunable parameter types.
     num_ordered_parameters = 0
@@ -490,7 +488,7 @@ def choose_generation_strategy(
         )
         steps = []
         # `verbose` and `disable_progbar` defaults and overrides
-        model_is_saasbo = is_saasbo(suggested_model)
+        model_is_saasbo = suggested_model is Models.SAASBO
         if verbose is None and model_is_saasbo:
             verbose = True
         elif verbose is not None and not model_is_saasbo:
@@ -589,7 +587,3 @@ def _get_winsorization_transform_config(
     if winsorization_config:
         return {"winsorization_config": winsorization_config}
     return {"derelativize_with_raw_status_quo": derelativize_with_raw_status_quo}
-
-
-def is_saasbo(model: ModelRegistryBase) -> bool:
-    return model.name in ["SAASBO", "FULLYBAYESIAN", "FULLYBAYESIANMOO"]

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -70,10 +70,6 @@ from ax.models.torch.botorch_modular.model import (
 )
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.cbo_sac import SACBO
-from ax.models.torch.fully_bayesian import (
-    FullyBayesianBotorchModel,
-    FullyBayesianMOOBotorchModel,
-)
 from ax.utils.common.kwargs import (
     consolidate_kwargs,
     get_function_argument_names,
@@ -252,18 +248,6 @@ MODEL_KEY_TO_MODEL_SETUP: Dict[str, ModelSetup] = {
         },
         standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
-    "FullyBayesian": ModelSetup(
-        bridge_class=TorchModelBridge,
-        model_class=FullyBayesianBotorchModel,
-        transforms=Cont_X_trans + Y_trans,
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
-    ),
-    "FullyBayesianMOO": ModelSetup(
-        bridge_class=TorchModelBridge,
-        model_class=FullyBayesianMOOBotorchModel,
-        transforms=Cont_X_trans + Y_trans,
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
-    ),
     "SAAS_MTGP": ModelSetup(
         bridge_class=TorchModelBridge,
         model_class=ModularBoTorchModel,
@@ -275,18 +259,6 @@ MODEL_KEY_TO_MODEL_SETUP: Dict[str, ModelSetup] = {
                 )
             },
         },
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
-    ),
-    "FullyBayesian_MTGP": ModelSetup(
-        bridge_class=TorchModelBridge,
-        model_class=FullyBayesianBotorchModel,
-        transforms=ST_MTGP_trans,
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
-    ),
-    "FullyBayesianMOO_MTGP": ModelSetup(
-        bridge_class=TorchModelBridge,
-        model_class=FullyBayesianMOOBotorchModel,
-        transforms=ST_MTGP_trans,
         standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
     "ST_MTGP_NEHVI": ModelSetup(
@@ -463,11 +435,7 @@ class Models(ModelRegistryBase):
     GPEI = "GPEI"
     FACTORIAL = "Factorial"
     SAASBO = "SAASBO"
-    FULLYBAYESIAN = "FullyBayesian"
-    FULLYBAYESIANMOO = "FullyBayesianMOO"
     SAAS_MTGP = "SAAS_MTGP"
-    FULLYBAYESIAN_MTGP = "FullyBayesian_MTGP"
-    FULLYBAYESIANMOO_MTGP = "FullyBayesianMOO_MTGP"
     THOMPSON = "Thompson"
     LEGACY_BOTORCH = "GPEI"
     BOTORCH_MODULAR = "BoTorch"
@@ -493,6 +461,44 @@ class Models(ModelRegistryBase):
             stacklevel=2,
         )
         return cls.LEGACY_BOTORCH
+
+    @classmethod
+    @property
+    def FULLYBAYESIAN(cls) -> Models:
+        return _deprecated_model_with_warning(
+            old_model_str="FULLYBAYESIAN", new_model=cls.SAASBO
+        )
+
+    @classmethod
+    @property
+    def FULLYBAYESIANMOO(cls) -> Models:
+        return _deprecated_model_with_warning(
+            old_model_str="FULLYBAYESIANMOO", new_model=cls.SAASBO
+        )
+
+    @classmethod
+    @property
+    def FULLYBAYESIAN_MTGP(cls) -> Models:
+        return _deprecated_model_with_warning(
+            old_model_str="FULLYBAYESIAN_MTGP", new_model=cls.SAAS_MTGP
+        )
+
+    @classmethod
+    @property
+    def FULLYBAYESIANMOO_MTGP(cls) -> Models:
+        return _deprecated_model_with_warning(
+            old_model_str="FULLYBAYESIANMOO_MTGP", new_model=cls.SAAS_MTGP
+        )
+
+
+def _deprecated_model_with_warning(old_model_str: str, new_model: Models) -> Models:
+    warnings.warn(
+        f"{old_model_str} is deprecated and replaced by {new_model}. "
+        f"Please use {new_model}. This will become an error in a future release.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return new_model
 
 
 def get_model_from_generator_run(

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -543,3 +543,25 @@ class ModelRegistryTest(TestCase):
 
     def test_SAAS_MTGP(self) -> None:
         self.test_ST_MTGP(use_saas=True)
+
+    def test_deprecated_models(self) -> None:
+        """Tests that deprecated models raise a warning and point to correct models.
+
+        Due to differences in internal and external Python, this test runs the
+        same check in a couple different ways.
+        """
+        for old_model_str, new_model in [
+            ("FULLYBAYESIAN", Models.SAASBO),
+            ("FULLYBAYESIANMOO", Models.SAASBO),
+            ("FULLYBAYESIAN_MTGP", Models.SAAS_MTGP),
+            ("FULLYBAYESIANMOO_MTGP", Models.SAAS_MTGP),
+        ]:
+            with self.assertWarnsRegex(
+                DeprecationWarning, "deprecated and replaced by"
+            ):
+                try:
+                    self.assertEqual(new_model, getattr(Models, old_model_str))
+                except AssertionError:
+                    self.assertEqual(
+                        new_model, getattr(Models, old_model_str).fget(Models)
+                    )


### PR DESCRIPTION
Summary: This diff makes the legacy fully Bayesian registry entries raise a deprecation warning and point to the MBM alternatives. A following diff will clean up the code for these.

Differential Revision: D56916013


