### PR TITLE
Lower the numerical tolerance when checking if a value is within the bounds for a float range parameter.

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -25,7 +25,8 @@ from pyre_extensions import assert_is_instance
 # and allows for serializing at rather low numerical precision.
 # TODO: Do a more comprehensive audit of how floating point precision issues
 # may creep up and implement a more principled fix
-EPS = 1.5e-7
+EPS = 1e-4
+MIN_WIDTH = 1.5e-5
 MAX_VALUES_CHOICE_PARAM = 1000
 FIXED_CHOICE_PARAM_ERROR = (
     "ChoiceParameters require multiple feasible values. "
@@ -306,7 +307,7 @@ class RangeParameter(Parameter):
                 f"Got: ({lower}, {upper})."
             )
         width: float = upper - lower
-        if width < 100 * EPS:
+        if width < MIN_WIDTH:
             raise UserInputError(
                 f"Parameter range ({width}) is very small and likely "
                 "to cause numerical errors. Consider reparameterizing your "

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -13,6 +13,7 @@ from ax.core.parameter import (
     ChoiceParameter,
     EPS,
     FixedParameter,
+    MIN_WIDTH,
     ParameterType,
     RangeParameter,
 )
@@ -108,7 +109,7 @@ class RangeParameterTest(TestCase):
             UserInputError,
             "likely to cause numerical errors. Consider reparameterizing",
         ):
-            RangeParameter("x", ParameterType.FLOAT, EPS, 2 * EPS)
+            RangeParameter("x", ParameterType.FLOAT, EPS, EPS + MIN_WIDTH / 2)
 
     def test_BadSetter(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Summary:
This avoids filtering out arms that are slightly outside the search space.

Reviewed By: saitcakmak

Differential Revision: D56936530


