### PR TITLE
Prevent unused NaNs from marking constraints as infeasible in pareto_frontier_evaluator

### DIFF
--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-from unittest import mock
 from unittest.mock import patch
 
 import numpy as np
@@ -219,15 +218,25 @@ class TestModelbridgeUtils(TestCase):
             means=np.array([1, 2]),
             covariance=np.array([[1, 2], [4, 5]]),
         )
-        with mock.patch("ax.modelbridge.modelbridge_utils.logger.warning") as mock_warn:
-            Y, Ycov = observation_data_to_array(
-                outcomes=outcomes, observation_data=[obsd, obsd2]
-            )
-        self.assertTrue(np.array_equal(Y, np.array([[2, 3, 1]])))
-        self.assertTrue(
-            np.array_equal(Ycov, np.array([[[5, 6, 4], [8, 9, 7], [2, 3, 1]]]))
+        Y, Ycov = observation_data_to_array(
+            outcomes=outcomes, observation_data=[obsd, obsd2]
         )
-        mock_warn.assert_called_once()
+        nan = float("nan")
+        self.assertTrue(
+            np.array_equal(Y, np.array([[2, 3, 1], [2, nan, 1]]), equal_nan=True)
+        )
+        self.assertTrue(
+            np.array_equal(
+                Ycov,
+                np.array(
+                    [
+                        [[5, 6, 4], [8, 9, 7], [2, 3, 1]],
+                        [[5, nan, 4], [nan, nan, nan], [2, nan, 1]],
+                    ]
+                ),
+                equal_nan=True,
+            )
+        )
 
     def test_feasible_hypervolume(self) -> None:
         ma = Metric(name="a", lower_is_better=False)

--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -628,8 +628,13 @@ def pareto_frontier_evaluator(
     # Get feasible points that do not violate outcome_constraints
     if outcome_constraints is not None:
         cons_tfs = get_outcome_constraint_transforms(outcome_constraints)
+        # Handle NaNs in Y, if those elements are not part of the constraints.
+        # By setting the unused elements to 0, we prevent them from marking
+        # the whole constraint value as NaN and evaluating to infeasible.
+        Y_cons = Y.clone()
+        Y_cons[..., (outcome_constraints[0] == 0).all(dim=0)] = 0
         # pyre-ignore [16]
-        feas = torch.stack([c(Y) <= 0 for c in cons_tfs], dim=-1).all(dim=-1)
+        feas = torch.stack([c(Y_cons) <= 0 for c in cons_tfs], dim=-1).all(dim=-1)
         Y = Y[feas]
         Yvar = Yvar[feas]
         Y_obj = Y_obj[feas]


### PR DESCRIPTION
Summary: `get_outcome_constraint_transforms` evaluates the constraints by taking the product of tensor `A` with `Y` and comparing the outcome to `rhs` (uses einsum for this). The product of `0` and `nan` evaluates to `nan`, leading to the constraint being marked infeasible, even if that `nan` is from some unused metric. By setting unused elements to `0`, this diff prevents such issues.

Differential Revision: D56953680


