### PR TITLE
Allow more flexible definition of which trial statuses to fit.

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from copy import deepcopy
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 from ax.core.arm import Arm
 from ax.core.data import Data
@@ -76,7 +76,8 @@ class TrialStatus(int, Enum):
 
     NOTE: Data for abandoned trials (or abandoned arms in batch trials) is
     not passed to the model as part of training data, unless ``fit_abandoned``
-    option is specified to model bridge.
+    option is specified to model bridge. Additionally, data from MapMetrics is
+    typically excluded unless the corresponding trial is completed.
     """
 
     CANDIDATE = 0
@@ -164,6 +165,8 @@ DEFAULT_STATUSES_TO_WARM_START: List[TrialStatus] = [
     TrialStatus.ABANDONED,
     TrialStatus.EARLY_STOPPED,
 ]
+
+NON_ABANDONED_STATUSES: Set[TrialStatus] = set(TrialStatus) - {TrialStatus.ABANDONED}
 
 
 # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -274,6 +274,7 @@ class ObservationsTest(TestCase):
         }
         type(experiment).arms_by_name = PropertyMock(return_value=arms)
         type(experiment).trials = PropertyMock(return_value=trials)
+        type(experiment).metrics = PropertyMock(return_value={"a": "a", "b": "b"})
 
         df = pd.DataFrame(truth)[
             ["arm_name", "trial_index", "mean", "sem", "metric_name"]
@@ -362,6 +363,7 @@ class ObservationsTest(TestCase):
         }
         type(experiment).arms_by_name = PropertyMock(return_value=arms)
         type(experiment).trials = PropertyMock(return_value=trials)
+        type(experiment).metrics = PropertyMock(return_value={"a": "a", "b": "b"})
 
         df = pd.DataFrame(list(truth.values()))[
             ["arm_name", "trial_index", "mean", "sem", "metric_name", "fidelities"]
@@ -443,6 +445,7 @@ class ObservationsTest(TestCase):
         }
         type(experiment).arms_by_name = PropertyMock(return_value=arms)
         type(experiment).trials = PropertyMock(return_value=trials)
+        type(experiment).metrics = PropertyMock(return_value={"a": "a", "b": "b"})
 
         df = pd.DataFrame(list(truth.values()))[
             ["arm_name", "trial_index", "mean", "sem", "metric_name", "z", "timestamp"]
@@ -559,6 +562,7 @@ class ObservationsTest(TestCase):
         trials.get(2).mark_arm_abandoned(arm_name="2_1")
         type(experiment).arms_by_name = PropertyMock(return_value=arms)
         type(experiment).trials = PropertyMock(return_value=trials)
+        type(experiment).metrics = PropertyMock(return_value={"a": "a", "b": "b"})
 
         df = pd.DataFrame(list(truth.values()))[
             ["arm_name", "trial_index", "mean", "sem", "metric_name"]
@@ -635,6 +639,7 @@ class ObservationsTest(TestCase):
         }
         type(experiment).arms_by_name = PropertyMock(return_value=arms)
         type(experiment).trials = PropertyMock(return_value=trials)
+        type(experiment).metrics = PropertyMock(return_value={"a": "a", "b": "b"})
 
         df = pd.DataFrame(truth)[
             ["arm_name", "trial_index", "mean", "sem", "metric_name", "start_time"]
@@ -719,7 +724,7 @@ class ObservationsTest(TestCase):
         }
         type(experiment).arms_by_name = PropertyMock(return_value=arms_by_name)
         type(experiment).trials = PropertyMock(return_value=trials)
-
+        type(experiment).metrics = PropertyMock(return_value={"a": "a", "b": "b"})
         df = pd.DataFrame(truth)[
             [
                 "arm_name",
@@ -856,6 +861,7 @@ class ObservationsTest(TestCase):
         }
         type(experiment).arms_by_name = PropertyMock(return_value=arms)
         type(experiment).trials = PropertyMock(return_value=trials)
+        type(experiment).metrics = PropertyMock(return_value={"a": "a", "b": "b"})
 
         df = pd.DataFrame(truth)[
             ["arm_name", "trial_index", "mean", "sem", "metric_name"]

--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -18,6 +18,7 @@ from logging import Logger
 from typing import Any, Dict, List, MutableMapping, Optional, Set, Tuple, Type
 
 from ax.core.arm import Arm
+from ax.core.base_trial import NON_ABANDONED_STATUSES, TrialStatus
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import extract_arm_predictions, GeneratorRun
@@ -269,7 +270,10 @@ class ModelBridge(ABC):  # noqa: B024 -- ModelBridge doesn't have any abstract m
         if experiment is None or data is None:
             return []
         return observations_from_data(
-            experiment=experiment, data=data, include_abandoned=self._fit_abandoned
+            experiment=experiment,
+            data=data,
+            statuses_to_include=self.statuses_to_fit,
+            statuses_to_include_map_metric=self.statuses_to_fit_map_metric,
         )
 
     def _transform_data(
@@ -494,6 +498,18 @@ class ModelBridge(ABC):  # noqa: B024 -- ModelBridge doesn't have any abstract m
         is in-design for the model.
         """
         return self._training_in_design
+
+    @property
+    def statuses_to_fit(self) -> Set[TrialStatus]:
+        """Statuses to fit the model on."""
+        if self._fit_abandoned:
+            return set(TrialStatus)
+        return NON_ABANDONED_STATUSES
+
+    @property
+    def statuses_to_fit_map_metric(self) -> Set[TrialStatus]:
+        """Statuses to fit the model on."""
+        return {TrialStatus.COMPLETED}
 
     @training_in_design.setter
     def training_in_design(self, training_in_design: List[bool]) -> None:

--- a/ax/modelbridge/tests/test_alebo_strategy.py
+++ b/ax/modelbridge/tests/test_alebo_strategy.py
@@ -32,7 +32,7 @@ class ALEBOStrategyTest(TestCase):
             pd.DataFrame(
                 {
                     "arm_name": ["0_0", "0_1", "0_2"],
-                    "metric_name": "y",
+                    "metric_name": "branin",
                     "mean": [-1.0, 0.0, 1.0],
                     "sem": 0.1,
                 }

--- a/ax/modelbridge/tests/test_pairwise_modelbridge.py
+++ b/ax/modelbridge/tests/test_pairwise_modelbridge.py
@@ -52,8 +52,8 @@ class PairwiseModelBridgeTest(TestCase):
             arm2_sum = float(sum(arm2_outcome_values))
             is_arm1_preferred = int(arm1_sum - arm2_sum > 0)
             return {
-                arm1: {Keys.PAIRWISE_PREFERENCE_QUERY: is_arm1_preferred},
-                arm2: {Keys.PAIRWISE_PREFERENCE_QUERY: 1 - is_arm1_preferred},
+                arm1: {Keys.PAIRWISE_PREFERENCE_QUERY.value: is_arm1_preferred},
+                arm2: {Keys.PAIRWISE_PREFERENCE_QUERY.value: 1 - is_arm1_preferred},
             }
 
         experiment = InstantiationBase.make_experiment(
@@ -70,7 +70,7 @@ class PairwiseModelBridgeTest(TestCase):
                     "bounds": [0.0, 0.7],
                 },
             ],
-            objectives={Keys.PAIRWISE_PREFERENCE_QUERY: "minimize"},
+            objectives={Keys.PAIRWISE_PREFERENCE_QUERY.value: "minimize"},
             is_test=True,
         )
 
@@ -145,12 +145,12 @@ class PairwiseModelBridgeTest(TestCase):
 
         observation_data = [
             ObservationData(
-                metric_names=[Keys.PAIRWISE_PREFERENCE_QUERY],
+                metric_names=[Keys.PAIRWISE_PREFERENCE_QUERY.value],
                 means=np.array([0]),
                 covariance=np.array([[np.nan]]),
             ),
             ObservationData(
-                metric_names=[Keys.PAIRWISE_PREFERENCE_QUERY],
+                metric_names=[Keys.PAIRWISE_PREFERENCE_QUERY.value],
                 means=np.array([1]),
                 covariance=np.array([[np.nan]]),
             ),
@@ -168,7 +168,7 @@ class PairwiseModelBridgeTest(TestCase):
             ),
         ]
         parameters = ["X1", "X2"]
-        outcomes = [checked_cast(str, Keys.PAIRWISE_PREFERENCE_QUERY)]
+        outcomes = [checked_cast(str, Keys.PAIRWISE_PREFERENCE_QUERY.value)]
 
         datasets, _, candidate_metadata = pmb._convert_observations(
             observation_data=observation_data,

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -380,7 +380,7 @@ class ModelRegistryTest(TestCase):
             pd.DataFrame(
                 {
                     "arm_name": ["0_0", "0_1", "0_2"],
-                    "metric_name": "y",
+                    "metric_name": "branin",
                     "mean": [-1.0, 0.0, 1.0],
                     "sem": 0.1,
                 }

--- a/ax/plot/tests/test_fitted_scatter.py
+++ b/ax/plot/tests/test_fitted_scatter.py
@@ -14,7 +14,7 @@ from ax.modelbridge.registry import Models
 from ax.plot.base import AxPlotConfig
 from ax.plot.scatter import interact_fitted, interact_fitted_plotly
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_branin_experiment
+from ax.utils.testing.core_stubs import get_branin_experiment, get_branin_metric
 from ax.utils.testing.mock import fast_botorch_optimize
 
 
@@ -27,6 +27,7 @@ class FittedScatterTest(TestCase):
         data = exp.fetch_data()
         df = deepcopy(data.df)
         df["metric_name"] = "branin_dup"
+        exp.add_tracking_metric(get_branin_metric(name="branin_dup"))
 
         model = Models.BOTORCH_MODULAR(
             # Model bridge kwargs
@@ -47,11 +48,12 @@ class FittedScatterTest(TestCase):
         self.assertIsInstance(plot, AxPlotConfig)
 
         # Make sure all parameters and metrics are displayed in tooltips
-        tooltips = list(exp.parameters.keys()) + list(exp.metrics.keys())
-        for d in plot.data["data"]:
+        metric_names = ["branin", "branin_dup", "branin:agg"]
+        tooltips = [list(exp.parameters.keys()) + [m_name] for m_name in metric_names]
+        for idata, d in enumerate(plot.data["data"]):
             # Only check scatter plots hoverovers
             if d["type"] != "scatter":
                 continue
             for text in d["text"]:
-                for tt in tooltips:
+                for tt in tooltips[idata]:
                     self.assertTrue(tt in text)

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -81,6 +81,7 @@ from pyre_extensions import none_throws
 from sqlalchemy.orm.exc import StaleDataError
 
 DUMMY_EXCEPTION = "test_exception"
+TEST_MEAN = 1.0
 
 
 class SyntheticRunnerWithStatusPolling(SyntheticRunner):
@@ -2147,28 +2148,26 @@ class AxSchedulerTestCase(TestCase):
                 df=pd.DataFrame(
                     {
                         "arm_name": ["0_0"],
-                        "metric_name": ["foo"],
-                        "mean": [1.0],
+                        "metric_name": ["branin"],
+                        "mean": [TEST_MEAN],
                         "sem": [0.1],
                         "trial_index": [0],
                     }
                 )
             )
         )
-        attached_metrics = (
-            self.branin_experiment.lookup_data().df["metric_name"].unique()
-        )
+
+        attached_means = self.branin_experiment.lookup_data().df["mean"].unique()
         # the attach has overwritten the data, so we can infer that
         # fetching happened in the next `run_n_trials()`
-        self.assertNotIn("branin", attached_metrics)
+        self.assertIn(TEST_MEAN, attached_means)
+        self.assertEqual(len(attached_means), 1)
 
         scheduler.run_n_trials(max_trials=1)
-        attached_metrics = (
-            self.branin_experiment.lookup_data().df["metric_name"].unique()
-        )
-        # it did fetch again, but kept "foo" because of the combine kwarg
-        self.assertIn("foo", attached_metrics)
-        self.assertIn("branin", attached_metrics)
+        attached_means = self.branin_experiment.lookup_data().df["mean"].unique()
+        # it did fetch again, but kept both rows because of the combine kwarg
+        self.assertIn(TEST_MEAN, attached_means)
+        self.assertEqual(len(attached_means), 2)
 
     @fast_botorch_optimize
     def test_it_works_with_multitask_models(

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -1500,7 +1500,6 @@ class TestAxClient(TestCase):
         ax_client = get_branin_optimization()
         params, idx = ax_client.get_next_trial()
         ax_client.complete_trial(trial_index=idx, raw_data={"branin": (0, 0.0)})
-        ax_client.update_trial_data(trial_index=idx, raw_data={"m1": (1, 0.0)})
         metrics_in_data = ax_client.experiment.fetch_data().df["metric_name"].values
         self.assertNotIn("m1", metrics_in_data)
         self.assertIn("branin", metrics_in_data)


### PR DESCRIPTION
Summary:
Changes `observations_from_data` and `observations_from_map_data` signatures, replacing arg `fit_abandoned: bool` -> `statuses_to_fit` and `statuses_to_fit_map_metric` which are both `Optional[List[TrialStatus]]`. In `observations_from_data`, these default to `None` in which case `{TrialStatus.COMPLETED}` is used for any MapMetrics, else `NON_ABANDONED_STATUSES`, i.e., all trial statuses except abandoned. In `observations_from_map_data`, `NON_ABANDONED_STATUSES` are the default for all metrics.

NOTE: As of this diff, any rows of `Data.df` containing `metric_names` that don't exist on `experiment` will be filtered out ([pointer](https://www.internalfb.com/diff/D56634321?permalink=330145676765780)).

Reviewed By: saitcakmak

Differential Revision: D56634321


