### PR TITLE
Adding copyright comment to "test_transform_encode"

### DIFF
--- a/ax/storage/json_store/tests/test_transform_encode.py
+++ b/ax/storage/json_store/tests/test_transform_encode.py
@@ -1,4 +1,8 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 


### PR DESCRIPTION
Summary:
```
Every project specific source file must contain a doc block with an appropriate copyright header. Unrelated files must be listed as exceptions in the Copyright Headers Exceptions page in the repo dashboard.
A copyright header clearly indicates that the code is owned by Meta. Every open source file must start with a comment containing "Meta Platforms, Inc. and affiliates"
https://github.com/facebook/Ax/blob/main/ax/storage/json_store/tests/test_transform_encode.py:
The first 16 lines of 'ax/storage/json_store/tests/test_transform_encode.py' do not contain the patterns:
	Copyright
```

Adding the copyright doc block to the offending file.

Differential Revision: D57163822


