### PR TITLE
Rename TaskEncode transform to TaskChoiceToIntTaskChoice

### DIFF
--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -52,7 +52,7 @@ from ax.modelbridge.transforms.remove_fixed import RemoveFixed
 from ax.modelbridge.transforms.search_space_to_choice import SearchSpaceToChoice
 from ax.modelbridge.transforms.standardize_y import StandardizeY
 from ax.modelbridge.transforms.stratified_standardize_y import StratifiedStandardizeY
-from ax.modelbridge.transforms.task_encode import TaskEncode
+from ax.modelbridge.transforms.task_encode import TaskChoiceToIntTaskChoice
 from ax.modelbridge.transforms.trial_as_task import TrialAsTask
 from ax.modelbridge.transforms.unit_x import UnitX
 from ax.models.base import Model
@@ -119,7 +119,7 @@ MT_MTGP_trans: List[Type[Transform]] = Cont_X_trans + [
     ConvertMetricNames,
     TrialAsTask,
     StratifiedStandardizeY,
-    TaskEncode,
+    TaskChoiceToIntTaskChoice,
 ]
 
 # Single-type MTGP transforms
@@ -127,14 +127,14 @@ ST_MTGP_trans: List[Type[Transform]] = Cont_X_trans + [
     Derelativize,
     TrialAsTask,
     StratifiedStandardizeY,
-    TaskEncode,
+    TaskChoiceToIntTaskChoice,
 ]
 
 # Single-type MTGP transforms
 Specified_Task_ST_MTGP_trans: List[Type[Transform]] = Cont_X_trans + [
     Derelativize,
     StratifiedStandardizeY,
-    TaskEncode,
+    TaskChoiceToIntTaskChoice,
 ]
 
 ALEBO_X_trans: List[Type[Transform]] = [RemoveFixed, IntToFloat, CenteredUnitX]

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -379,7 +379,8 @@ class TorchModelBridge(ModelBridge):
             if any(int(t) != t for t in task_choices):
                 raise ValueError(
                     "The values of the task feature must be integers. "
-                    "This is often accomplished using a TaskEncode transform. "
+                    "This is often accomplished using a "
+                    "TaskChoiceToIntTaskChoice transform. "
                     "Check that the model is using the correct set of transforms. "
                     f"Got {task_choices=}."
                 )

--- a/ax/modelbridge/transforms/choice_encode.py
+++ b/ax/modelbridge/transforms/choice_encode.py
@@ -40,7 +40,8 @@ class ChoiceToNumericChoice(Transform):
 
     In the inverse transform, parameters will be mapped back onto the original domain.
 
-    This transform does not transform task parameters (use TaskEncode for this).
+    This transform does not transform task parameters
+    (use TaskChoiceToIntTaskChoice for this).
 
     Note that this behavior is different from that of OrderedChoiceToIntegerRange, which
     transforms (ordered) ChoiceParameters to integer RangeParameters (rather than

--- a/ax/modelbridge/transforms/task_encode.py
+++ b/ax/modelbridge/transforms/task_encode.py
@@ -6,13 +6,17 @@
 
 # pyre-strict
 
-from typing import Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
 from ax.modelbridge.transforms.choice_encode import OrderedChoiceToIntegerRange
+
+from ax.modelbridge.transforms.deprecated_transform_mixin import (
+    DeprecatedTransformMixin,
+)
 from ax.modelbridge.transforms.utils import construct_new_search_space
 from ax.models.types import TConfig
 
@@ -21,7 +25,7 @@ if TYPE_CHECKING:
     from ax import modelbridge as modelbridge_module  # noqa F401
 
 
-class TaskEncode(OrderedChoiceToIntegerRange):
+class TaskChoiceToIntTaskChoice(OrderedChoiceToIntegerRange):
     """Convert task ChoiceParameters to integer-valued ChoiceParameters.
 
     Parameters will be transformed to an integer ChoiceParameter with
@@ -40,7 +44,9 @@ class TaskEncode(OrderedChoiceToIntegerRange):
         modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
         config: Optional[TConfig] = None,
     ) -> None:
-        assert search_space is not None, "TaskEncode requires search space"
+        assert (
+            search_space is not None
+        ), "TaskChoiceToIntTaskChoice requires search space"
         # Identify parameters that should be transformed
         self.encoded_parameters: Dict[str, Dict[TParamValue, int]] = {}
         self.target_values: Dict[str, int] = {}
@@ -96,3 +102,10 @@ class TaskEncode(OrderedChoiceToIntegerRange):
                 for pc in search_space.parameter_constraints
             ],
         )
+
+
+class TaskEncode(DeprecatedTransformMixin, TaskChoiceToIntTaskChoice):
+    """Deprecated alias for TaskChoiceToIntTaskChoice."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)

--- a/ax/modelbridge/transforms/tests/test_task_encode_transform.py
+++ b/ax/modelbridge/transforms/tests/test_task_encode_transform.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import RobustSearchSpace, SearchSpace
-from ax.modelbridge.transforms.task_encode import TaskEncode
+from ax.modelbridge.transforms.task_encode import TaskChoiceToIntTaskChoice, TaskEncode
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_robust_search_space
 
@@ -39,7 +39,7 @@ class TaskEncodeTransformTest(TestCase):
                 ),
             ]
         )
-        self.t = TaskEncode(
+        self.t = TaskChoiceToIntTaskChoice(
             search_space=self.search_space,
             observations=[],
         )
@@ -94,7 +94,7 @@ class TaskEncodeTransformTest(TestCase):
             ]
         )
         with self.assertRaises(ValueError):
-            TaskEncode(
+            TaskChoiceToIntTaskChoice(
                 search_space=ss3,
                 observations=[],
             )
@@ -105,10 +105,49 @@ class TaskEncodeTransformTest(TestCase):
         rss.parameters["c"]._is_task = True
         rss.parameters["c"]._target_value = "red"
         # Transform a non-distributional parameter.
+        t = TaskChoiceToIntTaskChoice(
+            search_space=rss,
+            observations=[],
+        )
+        rss_new = t.transform_search_space(rss)
+        # Make sure that the return value is still a RobustSearchSpace.
+        self.assertIsInstance(rss_new, RobustSearchSpace)
+        self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
+        # pyre-fixme[16]: `SearchSpace` has no attribute `parameter_distributions`.
+        self.assertEqual(rss.parameter_distributions, rss_new.parameter_distributions)
+        # pyre-fixme[16]: Optional type has no attribute `parameter_type`.
+        self.assertEqual(rss_new.parameters.get("c").parameter_type, ParameterType.INT)
+        # Test with environmental variables.
+        all_params = list(rss.parameters.values())
+        rss = RobustSearchSpace(
+            parameters=all_params[2:],
+            parameter_distributions=rss.parameter_distributions,
+            num_samples=rss.num_samples,
+            environmental_variables=all_params[:2],
+        )
+        t = TaskChoiceToIntTaskChoice(
+            search_space=rss,
+            observations=[],
+        )
+        rss_new = t.transform_search_space(rss)
+        self.assertIsInstance(rss_new, RobustSearchSpace)
+        self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
+        self.assertEqual(rss.parameter_distributions, rss_new.parameter_distributions)
+        # pyre-fixme[16]: `SearchSpace` has no attribute `_environmental_variables`.
+        self.assertEqual(rss._environmental_variables, rss_new._environmental_variables)
+        self.assertEqual(rss_new.parameters.get("c").parameter_type, ParameterType.INT)
+
+    def test_deprecated_w_parameter_distributions(self) -> None:
+        rss = get_robust_search_space()
+        # pyre-fixme[16]: `Parameter` has no attribute `_is_task`.
+        rss.parameters["c"]._is_task = True
+        rss.parameters["c"]._target_value = "red"
+        # Transform a non-distributional parameter.
         t = TaskEncode(
             search_space=rss,
             observations=[],
         )
+        self.assertIsInstance(t, TaskChoiceToIntTaskChoice)
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -129,6 +168,8 @@ class TaskEncodeTransformTest(TestCase):
             search_space=rss,
             observations=[],
         )
+        self.assertIsInstance(t, TaskChoiceToIntTaskChoice)
+
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
         self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))

--- a/ax/modelbridge/transforms/trial_as_task.py
+++ b/ax/modelbridge/transforms/trial_as_task.py
@@ -142,7 +142,7 @@ class TrialAsTask(Transform):
                 parameter_type=ParameterType.INT if is_int else ParameterType.STRING,
                 values=level_values,  # pyre-fixme [6]
                 # if all values are integers, retain the original order
-                # they are encoded in TaskEncode
+                # they are encoded in TaskChoiceToIntTaskChoice
                 is_ordered=is_int,
                 is_task=True,
                 sort_values=True,

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -39,7 +39,7 @@ from ax.modelbridge.transforms.remove_fixed import RemoveFixed
 from ax.modelbridge.transforms.search_space_to_choice import SearchSpaceToChoice
 from ax.modelbridge.transforms.standardize_y import StandardizeY
 from ax.modelbridge.transforms.stratified_standardize_y import StratifiedStandardizeY
-from ax.modelbridge.transforms.task_encode import TaskEncode
+from ax.modelbridge.transforms.task_encode import TaskChoiceToIntTaskChoice, TaskEncode
 from ax.modelbridge.transforms.time_as_feature import TimeAsFeature
 from ax.modelbridge.transforms.trial_as_task import TrialAsTask
 from ax.modelbridge.transforms.unit_x import UnitX
@@ -76,7 +76,8 @@ TRANSFORM_REGISTRY: Dict[Type[Transform], int] = {
     SearchSpaceToChoice: 10,
     StandardizeY: 11,
     StratifiedStandardizeY: 12,
-    TaskEncode: 13,
+    TaskEncode: 13,  # TO BE DEPRECATED
+    TaskChoiceToIntTaskChoice: 13,
     TrialAsTask: 14,
     UnitX: 15,
     Winsorize: 16,
@@ -103,6 +104,7 @@ be used.
 DEPRECATED_TRANSFORMS: List[Type[Transform]] = [
     OrderedChoiceEncode,  # replaced by OrderedChoiceToIntegerRange
     ChoiceEncode,  # replaced by ChoiceToNumericChoice
+    TaskEncode,  # replaced by TaskChoiceToIntTaskChoice
 ]
 
 REVERSE_TRANSFORM_REGISTRY: Dict[int, Type[Transform]] = {


### PR DESCRIPTION
Summary: Renaming the Task parameter to TaskChoiceToIntTaskChoice to better reflect its behavior.

Differential Revision: D57162739


