### PR TITLE
Stop ignoring unused keyword arguments

### DIFF
--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -10,7 +10,7 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from logging import Logger
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple, Type
 
 import numpy as np
 import pandas as pd
@@ -115,7 +115,6 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         self,
         trial_indices: Set[int],
         experiment: Experiment,
-        **kwargs: Dict[str, Any],
     ) -> Dict[int, Optional[str]]:
         """Decide whether to complete trials before evaluation is fully concluded.
 

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 from logging import Logger
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import numpy as np
 import pandas as pd
@@ -92,7 +92,6 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         self,
         trial_indices: Set[int],
         experiment: Experiment,
-        **kwargs: Dict[str, Any],
     ) -> Dict[int, Optional[str]]:
         """Stop a trial if its performance is in the bottom `percentile_threshold`
         of the trials at the same step.

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 from logging import Logger
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import pandas as pd
 from ax.core.experiment import Experiment
@@ -84,7 +84,6 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         self,
         trial_indices: Set[int],
         experiment: Experiment,
-        **kwargs: Dict[str, Any],
     ) -> Dict[int, Optional[str]]:
         """Stop a trial if its performance doesn't reach a pre-specified threshold
         by `min_progression`.

--- a/ax/global_stopping/strategies/base.py
+++ b/ax/global_stopping/strategies/base.py
@@ -41,9 +41,7 @@ class BaseGlobalStoppingStrategy(ABC, Base):
         self.inactive_when_pending_trials = inactive_when_pending_trials
 
     @abstractmethod
-    def _should_stop_optimization(
-        self, experiment: Experiment, **kwargs: Any
-    ) -> Tuple[bool, str]:
+    def _should_stop_optimization(self, experiment: Experiment) -> Tuple[bool, str]:
         """
         Decide whether to stop optimization.
 

--- a/ax/global_stopping/strategies/improvement.py
+++ b/ax/global_stopping/strategies/improvement.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 from logging import Logger
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from ax.core.base_trial import BaseTrial, TrialStatus
@@ -87,7 +87,6 @@ class ImprovementGlobalStoppingStrategy(BaseGlobalStoppingStrategy):
         experiment: Experiment,
         trial_to_check: Optional[int] = None,
         objective_thresholds: Optional[List[ObjectiveThreshold]] = None,
-        **kwargs: Dict[str, Any],
     ) -> Tuple[bool, str]:
         """
         Check if the objective has improved significantly in the past
@@ -110,7 +109,6 @@ class ImprovementGlobalStoppingStrategy(BaseGlobalStoppingStrategy):
                 If no thresholds are provided, they are automatically inferred. They are
                 only inferred once for each instance of the strategy (i.e. inferred
                 thresholds don't update with additional data).
-            kwargs: Unused.
 
         Returns:
             A Tuple with a boolean determining whether the optimization should stop,

--- a/ax/models/torch/randomforest.py
+++ b/ax/models/torch/randomforest.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -73,7 +73,6 @@ class RandomForest(TorchModel):
         self,
         datasets: List[SupervisedDataset],
         X_test: Tensor,
-        **kwargs: Any,
     ) -> Tuple[Tensor, Tensor]:
         Xs, Ys, Yvars = _datasets_to_legacy_inputs(datasets=datasets)
         cv_models: List[RandomForestRegressor] = []


### PR DESCRIPTION
Summary: In the process of auditing cases where Ax silently ignores incorrect keyword arguments, I fixed the easier cases.

Differential Revision: D57250405


