### PR TITLE
save status quo name and feature when multiple status quo present

### DIFF
--- a/sphinx/source/utils.rst
+++ b/sphinx/source/utils.rst
@@ -280,6 +280,14 @@ Modeling Stubs
     :undoc-members:
     :show-inheritance:
 
+Preference Stubs
+~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.testing.preference_stubs
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Mocking
 ~~~~~~~


### PR DESCRIPTION
Summary: When multiple status_quo is present in the data, we should still be able to save status quo name and features, which should be the same for all these status quos.

Differential Revision: D57309789


