### PR TITLE
Test that we're not referencing same parameter dict in ObservationFeatures.from_arm

### DIFF
--- a/ax/core/arm.py
+++ b/ax/core/arm.py
@@ -39,7 +39,7 @@ class Arm(SortableBase):
     def parameters(self) -> TParameterization:
         """Get mapping from parameter names to values."""
         # Make a copy before returning so it cannot be accidentally mutated
-        return dict(self._parameters)
+        return self._parameters.copy()
 
     @property
     def has_name(self) -> bool:

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -92,6 +92,9 @@ class ObservationFeatures(Base):
         data as specified.
         """
         return ObservationFeatures(
+            # NOTE: Arm.parameters makes a copy of the original dict, so any
+            # modifications to the parameters dict will not be reflected in
+            # the original Arm parameters.
             parameters=arm.parameters,
             trial_index=trial_index,
             start_time=start_time,

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -102,6 +102,7 @@ class ObservationsTest(TestCase):
     def test_ObservationFeaturesFromArm(self) -> None:
         arm = Arm({"x": 0, "y": "a"})
         obsf = ObservationFeatures.from_arm(arm, trial_index=3)
+        self.assertIsNot(arm.parameters, obsf.parameters)
         self.assertEqual(obsf.parameters, arm.parameters)
         self.assertEqual(obsf.trial_index, 3)
 


### PR DESCRIPTION
Summary:
`ObservationFeatures.from_arm` is used to make the `ObservationFeatures` for the `pending_observations` dict.

Pending observations is a dict of the form `metric_name -> List[ObservationFeatures]`.  In `ModelBridge._get_transformed_gen_args`, we transform each pending `ObservationFeature` for each metric one by one. If the dict references the same object twice, we try to transform it twice, which leads to errors due to most transforms operating in-place.

~~This diff updates `ObservationFeatures.from_arm` to avoid referencing the same `parameters` dict in multiple `ObservationFeatures` objects.~~ This diff adds a test checking that `ObservationFeatures.from_arm` does not result in objects referencing the same parameters dict.
- `ObservationFeature.from_arm` is used to append the newly generated arms as pending observations in `GS._gen_multiple -> extend_pending_observations`.
- Both`get_pending_observation_features_based_on_trial_status` and `get_pending_observation_features` also use `ObservationFeature.from_arm`.

Here's a dummy example that mimics what the transform layer does to `pending_observations` (if they were to reference the same object):
{F1657963796}

Differential Revision: D57933199


