### PR TITLE
Enable evaluating Branin test experiments with None status quo

### DIFF
--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2010,19 +2010,24 @@ def get_branin_data(
 
 
 def get_branin_data_batch(batch: BatchTrial) -> Data:
+    means = []
+    for arm in batch.arms:
+        if arm.parameters["x1"] is None or arm.parameters["x2"] is None:
+            means.append(5.0)
+        else:
+            means.append(
+                branin(
+                    float(not_none(arm.parameters["x1"])),
+                    float(not_none(arm.parameters["x2"])),
+                )
+            )
     return Data(
         pd.DataFrame(
             {
                 "trial_index": batch.index,
                 "arm_name": [arm.name for arm in batch.arms],
                 "metric_name": "branin",
-                "mean": [
-                    branin(
-                        float(not_none(arm.parameters["x1"])),
-                        float(not_none(arm.parameters["x2"])),
-                    )
-                    for arm in batch.arms
-                ],
+                "mean": means,
                 "sem": 0.1,
             }
         )


### PR DESCRIPTION
Summary:
The Branin test experiment is really helpful for writing unit tests.
None status quo is an important case to consider for some areas. This adds a
None status quo handling for the branin test experiment so it can be used for
those areas.

Differential Revision: D57999540


