### PR TITLE
Remove unused suppress_all_errors kwarg

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1758,11 +1758,9 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
     def _save_generation_strategy_to_db_if_possible(
         self,
         generation_strategy: Optional[GenerationStrategyInterface] = None,
-        suppress_all_errors: bool = False,
     ) -> bool:
         return super()._save_generation_strategy_to_db_if_possible(
             generation_strategy=generation_strategy or self.generation_strategy,
-            suppress_all_errors=suppress_all_errors,
         )
 
     def _gen_new_generator_run(

--- a/ax/service/utils/with_db_settings_base.py
+++ b/ax/service/utils/with_db_settings_base.py
@@ -392,7 +392,6 @@ class WithDBSettingsBase:
     def _save_generation_strategy_to_db_if_possible(
         self,
         generation_strategy: Optional[GenerationStrategyInterface] = None,
-        suppress_all_errors: bool = False,
     ) -> bool:
         """Saves given generation strategy if DB settings are set on this
         `WithDBSettingsBase` instance and the generation strategy is an
@@ -482,7 +481,7 @@ def _save_experiment_to_db_if_possible(
     experiment: Experiment,
     encoder: Encoder,
     decoder: Decoder,
-    suppress_all_errors: bool,
+    suppress_all_errors: bool,  # Used by the decorator.
 ) -> None:
     start_time = time.time()
     _save_experiment(
@@ -506,7 +505,7 @@ def _save_or_update_trials_in_db_if_possible(
     trials: List[BaseTrial],
     encoder: Encoder,
     decoder: Decoder,
-    suppress_all_errors: bool,
+    suppress_all_errors: bool,  # Used by the decorator.
     reduce_state_generator_runs: bool = False,
 ) -> None:
     start_time = time.time()
@@ -534,7 +533,7 @@ def _save_generation_strategy_to_db_if_possible(
     generation_strategy: GenerationStrategy,
     encoder: Encoder,
     decoder: Decoder,
-    suppress_all_errors: bool,
+    suppress_all_errors: bool,  # Used by the decorator.
 ) -> None:
     start_time = time.time()
     _save_generation_strategy(
@@ -558,7 +557,7 @@ def _update_generation_strategy_in_db_if_possible(
     new_generator_runs: List[GeneratorRun],
     encoder: Encoder,
     decoder: Decoder,
-    suppress_all_errors: bool,
+    suppress_all_errors: bool,  # Used by the decorator.
     reduce_state_generator_runs: bool = False,
 ) -> None:
     start_time = time.time()
@@ -585,7 +584,7 @@ def _update_generation_strategy_in_db_if_possible(
 def _update_experiment_properties_in_db(
     experiment_with_updated_properties: Experiment,
     sqa_config: SQAConfig,
-    suppress_all_errors: bool,
+    suppress_all_errors: bool,  # Used by the decorator.
 ) -> None:
     update_properties_on_experiment(
         experiment_with_updated_properties=experiment_with_updated_properties,


### PR DESCRIPTION
Summary: Audited usage of `suppress_all_errors` and removed the ignored kwarg (which was using the attribute set at the class level). Also added a comment on use cases where it appears to be unused, while actually getting consumed by the decorator.

Reviewed By: dme65, Balandat

Differential Revision: D58042565


