### PR TITLE
Adding "analysis_batch" class to ax.analysis

### DIFF
--- a/ax/analysis/analysis_report.py
+++ b/ax/analysis/analysis_report.py
@@ -1,0 +1,107 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import List, Optional, Tuple
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from ax.analysis.base_analysis import BaseAnalysis
+from ax.analysis.base_plotly_visualization import BasePlotlyVisualization
+
+from ax.core.experiment import Experiment
+
+from ax.utils.common.timeutils import current_timestamp_in_millis
+
+
+class AnalysisReport:
+    """
+    A class corresponding to a set of analysis ran on the same
+    set of data from an experiment.
+    """
+
+    analyses: List[BaseAnalysis] = []
+    experiment: Experiment
+
+    report_completed: bool = False
+    time_started: Optional[int] = None
+    time_completed: Optional[int] = None
+
+    def __init__(
+        self,
+        experiment: Experiment,
+        analyses: List[BaseAnalysis],
+        report_completed: bool = False,
+        time_started: Optional[int] = None,
+        time_completed: Optional[int] = None,
+    ) -> None:
+        """
+        This class is a collection of AnalysisReport.
+        This class takes two states, indicated by "report_completed"
+        If report_completed is True, then the report has been run and
+            the time_started and time_completed are set.
+            "run_analysis_report" will not update the time_started
+            and time_completed fields, but will stil run the individual
+            analyses and return the outputs.
+        If report_completed is False, then the report has
+            not been run and the time_started and time_completed are None.
+            "run_analysis_report" will set the time_started and time_completed.
+
+        When loading an analysis report from the database, the report has already ran,
+            so will be loaded back with "report_completed" = True and
+            time_started and time_completed set.
+
+        Args:
+            experiment: Experiment which the analyses are generated from
+            report_completed: Whether the report was loaded from the database
+            time_started: time the completed report was started
+
+        """
+        self.experiment = experiment
+        self.analyses = analyses
+        if report_completed:
+            self.time_started = time_started
+            self.time_completed = time_completed
+            self.report_completed = True
+
+    def run_analysis_report(
+        self,
+    ) -> List[
+        Tuple[
+            BaseAnalysis,
+            pd.DataFrame,
+            Optional[go.Figure],
+        ]
+    ]:
+        """
+        Runs all analyses in the report and produces the result.
+
+        Returns:
+            analysis_report_result: list of tuples (analysis, df, Optional[fig])
+        """
+        if not self.report_completed:
+            self.time_started = current_timestamp_in_millis()
+
+        analysis_report_result = []
+        for analysis in self.analyses:
+            analysis_report_result.append(
+                (
+                    analysis,
+                    analysis.get_df(),
+                    (
+                        None
+                        if not isinstance(analysis, BasePlotlyVisualization)
+                        else analysis.get_fig()
+                    ),
+                )
+            )
+
+        if not self.report_completed:
+            self.time_completed = current_timestamp_in_millis()
+            self.report_completed = True
+
+        return analysis_report_result

--- a/ax/analysis/tests/test_analysis_report.py
+++ b/ax/analysis/tests/test_analysis_report.py
@@ -1,0 +1,146 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from ax.analysis.analysis_report import AnalysisReport
+
+from ax.analysis.base_analysis import BaseAnalysis
+from ax.analysis.base_plotly_visualization import BasePlotlyVisualization
+
+from ax.modelbridge.registry import Models
+from ax.utils.common.testutils import TestCase
+
+from ax.utils.common.timeutils import current_timestamp_in_millis
+from ax.utils.testing.core_stubs import get_branin_experiment
+from ax.utils.testing.mock import fast_botorch_optimize
+
+
+class TestCrossValidationPlot(TestCase):
+
+    class TestAnalysis(BaseAnalysis):
+        def get_df(self) -> pd.DataFrame:
+            return pd.DataFrame()
+
+    class TestPlotlyVisualization(BasePlotlyVisualization):
+        def get_df(self) -> pd.DataFrame:
+            return pd.DataFrame()
+
+        def get_fig(self) -> go.Figure:
+            return go.Figure()
+
+    @fast_botorch_optimize
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.exp = get_branin_experiment(with_batch=True)
+        self.exp.trials[0].run()
+        self.model = Models.BOTORCH_MODULAR(
+            # Model bridge kwargs
+            experiment=self.exp,
+            data=self.exp.fetch_data(),
+        )
+
+        self.test_analysis = self.TestAnalysis(experiment=self.exp)
+        self.test_plotly_visualization = self.TestPlotlyVisualization(
+            experiment=self.exp
+        )
+
+    def test_init_analysis_report(self) -> None:
+        analysis_report = AnalysisReport(
+            experiment=self.exp,
+            analyses=[self.test_analysis, self.test_plotly_visualization],
+        )
+
+        self.assertEqual(len(analysis_report.analyses), 2)
+
+        self.assertIsInstance(analysis_report.analyses[0], BaseAnalysis)
+        self.assertIsInstance(analysis_report.analyses[1], BasePlotlyVisualization)
+
+        self.assertIsNone(analysis_report.time_started)
+        self.assertIsNone(analysis_report.time_completed)
+        self.assertFalse(analysis_report.report_completed)
+
+    def test_execute_analysis_report(self) -> None:
+        analysis_report = AnalysisReport(
+            experiment=self.exp,
+            analyses=[self.test_analysis, self.test_plotly_visualization],
+        )
+
+        self.assertEqual(len(analysis_report.analyses), 2)
+
+        results = analysis_report.run_analysis_report()
+        self.assertEqual(len(results), 2)
+
+        self.assertIsNotNone(analysis_report.time_started)
+        self.assertIsNotNone(analysis_report.time_completed)
+        self.assertTrue(analysis_report.report_completed)
+
+        # assert no plot is returned for BaseAnalysis
+        self.assertIsInstance(results[0][1], pd.DataFrame)
+        self.assertIsNone(results[0][2])
+
+        # assert plot is returned for BasePlotlyVisualization
+        self.assertIsInstance(results[1][1], pd.DataFrame)
+        self.assertIsInstance(results[1][2], go.Figure)
+
+    def test_analysis_report_repeated_execute(self) -> None:
+        analysis_report = AnalysisReport(
+            experiment=self.exp,
+            analyses=[self.test_analysis, self.test_plotly_visualization],
+        )
+
+        self.assertEqual(len(analysis_report.analyses), 2)
+
+        _ = analysis_report.run_analysis_report()
+
+        saved_start = analysis_report.time_started
+        self.assertIsNotNone(saved_start)
+
+        # ensure analyses are not re-ran
+        _ = analysis_report.run_analysis_report()
+        self.assertEqual(saved_start, analysis_report.time_started)
+
+    def test_no_analysis_report(self) -> None:
+        analysis_report = AnalysisReport(
+            experiment=self.exp,
+            analyses=[],
+        )
+
+        self.assertEqual(len(analysis_report.analyses), 0)
+
+        results = analysis_report.run_analysis_report()
+        self.assertEqual(len(results), 0)
+
+    def test_singleton_analysis_report(self) -> None:
+        analysis_report = AnalysisReport(
+            experiment=self.exp,
+            analyses=[self.test_plotly_visualization],
+        )
+
+        self.assertEqual(len(analysis_report.analyses), 1)
+
+        results = analysis_report.run_analysis_report()
+        self.assertEqual(len(results), 1)
+
+        # assert plot is returned for BasePlotlyVisualization
+        self.assertIsInstance(results[0][1], pd.DataFrame)
+        self.assertIsInstance(results[0][2], go.Figure)
+
+    def test_create_report_as_completed(self) -> None:
+        analysis_report = AnalysisReport(
+            experiment=self.exp,
+            analyses=[self.test_analysis, self.test_plotly_visualization],
+            report_completed=True,
+            time_started=current_timestamp_in_millis(),
+            time_completed=current_timestamp_in_millis(),
+        )
+
+        self.assertIsNotNone(analysis_report.time_started)
+        self.assertIsNotNone(analysis_report.time_completed)
+        self.assertTrue(analysis_report.report_completed)


### PR DESCRIPTION
Summary:
Adding an "AnalysisBatch" class to the ax.analysis module corresponding to the XDB tables generated in this diff: D57408428

New analyses are added to the batch using the "add_analysis" method- analyses are constructed outside of the batch object because they take in different arguments.

Next steps are adding support for encoding, decoding, and saving Analysis and Analyses batch to the database.

Differential Revision: D58027893


