### PR TITLE
Adding schema for "AnalysisBatch" and "Analysis"

### DIFF
--- a/ax/analysis/analysis_batch.py
+++ b/ax/analysis/analysis_batch.py
@@ -1,0 +1,93 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional, Tuple, Union
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from ax.analysis.base_analysis import BaseAnalysis
+from ax.analysis.base_plotly_visualization import BasePlotlyVisualization
+
+from ax.core.experiment import Experiment
+
+from ax.utils.common.timeutils import current_timestamp_in_millis
+
+
+class AnalysisBatch:
+    """
+    A class corresponding to a set of analysis ran on the same
+    set of data from an experiment.
+    """
+
+    analyses: List[Union[BaseAnalysis, BasePlotlyVisualization]] = []
+    experiment: Experiment
+    time_started: int
+
+    analysis_output: Optional[
+        List[
+            Tuple[
+                Union[BaseAnalysis, BasePlotlyVisualization],
+                pd.DataFrame,
+                Optional[go.Figure],
+            ]
+        ]
+    ] = None
+
+    time_started: Optional[int] = None
+    time_completed: Optional[int] = None
+    db_id: Optional[int] = None
+
+    def __init__(self, experiment: Experiment) -> None:
+        """
+        Args:
+            experiment: Experiment which the analyses are generated from
+        """
+        self.experiment = experiment
+
+    def add_analysis(self, analysis: BaseAnalysis) -> None:
+        if self.analysis_output is not None:
+            raise ValueError(
+                "Analysis batch has already been run. Cannot add more analyses."
+            )
+
+        self.analyses.append(analysis)
+
+    def run_analysis_batch(
+        self,
+    ) -> List[
+        Tuple[
+            Union[BaseAnalysis, BasePlotlyVisualization],
+            pd.DataFrame,
+            Optional[go.Figure],
+        ]
+    ]:
+        """
+        Runs all analyses in the batch and returns a list of tuples
+        of the form (analysis, df, fig)
+        """
+        if self.analysis_output is not None:
+            return self.analysis_output
+
+        self.time_started = current_timestamp_in_millis()
+
+        output = []
+        for analysis in self.analyses:
+            output.append(
+                (
+                    analysis,
+                    analysis.get_df(),
+                    (
+                        None
+                        if not isinstance(analysis, BasePlotlyVisualization)
+                        else analysis.get_fig()
+                    ),
+                )
+            )
+        self.analysis_output = output
+
+        self.time_completed = current_timestamp_in_millis()
+
+        return output

--- a/ax/analysis/tests/test_analysis_batch.py
+++ b/ax/analysis/tests/test_analysis_batch.py
@@ -1,0 +1,107 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from ax.analysis.analysis_batch import AnalysisBatch
+
+from ax.analysis.base_analysis import BaseAnalysis
+from ax.analysis.base_plotly_visualization import BasePlotlyVisualization
+
+from ax.modelbridge.registry import Models
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_branin_experiment
+from ax.utils.testing.mock import fast_botorch_optimize
+
+
+class TestCrossValidationPlot(TestCase):
+
+    class TestAnalysis(BaseAnalysis):
+        def get_df(self) -> pd.DataFrame:
+            return pd.DataFrame()
+
+    class TestPlotlyVisualization(BasePlotlyVisualization):
+        def get_df(self) -> pd.DataFrame:
+            return pd.DataFrame()
+
+        def get_fig(self) -> go.Figure:
+            return go.Figure()
+
+    @fast_botorch_optimize
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.exp = get_branin_experiment(with_batch=True)
+        self.exp.trials[0].run()
+        self.model = Models.BOTORCH_MODULAR(
+            # Model bridge kwargs
+            experiment=self.exp,
+            data=self.exp.fetch_data(),
+        )
+
+        self.test_analysis = self.TestAnalysis(experiment=self.exp)
+        self.test_plotly_visualization = self.TestPlotlyVisualization(
+            experiment=self.exp
+        )
+
+    def test_init_analysis_batch(self) -> None:
+        analysis_batch = AnalysisBatch(experiment=self.exp)
+
+        analysis_batch.add_analysis(self.test_analysis)
+        analysis_batch.add_analysis(self.test_plotly_visualization)
+        self.assertEqual(len(analysis_batch.analyses), 2)
+
+        # check that dataframe is created for all analyses
+        self.assertIsInstance(analysis_batch.analyses[0], BaseAnalysis)
+
+        # check that figure is accessed only for plotly visualizations
+        self.assertIsInstance(analysis_batch.analyses[1], BasePlotlyVisualization)
+
+        self.assertIsNone(analysis_batch.time_started)
+        self.assertIsNone(analysis_batch.time_completed)
+        self.assertIsNone(analysis_batch.analysis_output)
+
+    def test_execute_analysis_batch(self) -> None:
+        analysis_batch = AnalysisBatch(experiment=self.exp)
+
+        analysis_batch.add_analysis(self.test_analysis)
+        analysis_batch.add_analysis(self.test_plotly_visualization)
+        self.assertEqual(len(analysis_batch.analyses), 2)
+
+        results = analysis_batch.run_analysis_batch()
+        self.assertEqual(len(results), 2)
+
+        self.assertIsNotNone(analysis_batch.time_started)
+        self.assertIsNotNone(analysis_batch.time_completed)
+        self.assertIsNotNone(analysis_batch.analysis_output)
+
+        self.assertIsInstance(results[0][1], pd.DataFrame)
+        self.assertIsNone(results[0][2])
+
+        self.assertIsInstance(results[1][1], pd.DataFrame)
+        self.assertIsInstance(results[1][2], go.Figure)
+
+    def test_analysis_batch_execute_gives_saved_results(self) -> None:
+        analysis_batch = AnalysisBatch(experiment=self.exp)
+
+        analysis_batch.add_analysis(self.test_analysis)
+        analysis_batch.add_analysis(self.test_plotly_visualization)
+        self.assertEqual(len(analysis_batch.analyses), 2)
+
+        _ = analysis_batch.run_analysis_batch()
+
+        saved_start = analysis_batch.time_started
+        self.assertIsNotNone(saved_start)
+
+        # ensure analyses are not re-ran
+        _ = analysis_batch.run_analysis_batch()
+        self.assertEqual(saved_start, analysis_batch.time_started)
+
+        # trying to add new analysis after batch raises exception
+        with self.assertRaises(ValueError):
+            analysis_batch.add_analysis(self.test_analysis)

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -34,7 +34,13 @@ from ax.storage.sqa_store.json import (
 )
 from ax.storage.sqa_store.sqa_enum import IntEnum, StringEnum
 from ax.storage.sqa_store.timestamp import IntTimestamp
-from ax.storage.utils import DataType, DomainType, MetricIntent, ParameterConstraintType
+from ax.storage.utils import (
+    AnalysisType,
+    DataType,
+    DomainType,
+    MetricIntent,
+    ParameterConstraintType,
+)
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -514,3 +520,54 @@ class SQAExperiment(Base):
         uselist=False,
         lazy=True,
     )
+
+
+class SQAAnalysis(Base):
+    __tablename__: str = "experiment_analysis"
+
+    # pyre-fixme[8]: Attribute has type `int`; used as `Column[int]`.
+    id: int = Column(Integer, primary_key=True)
+
+    # pyre-fixme[8]: Attribute has type `str`; used as `Column[str]`.
+    analysis_class_name: str = Column(String(NAME_OR_TYPE_FIELD_LENGTH), nullable=False)
+    # pyre-fixme[8]: Attribute has type `datetime`; used as `Column[typing.Any]`.
+    time_analysis_start: datetime = Column(IntTimestamp, nullable=False)
+    # pyre-fixme[8]: Attribute has type `datetime`; used as `Column[typing.Any]`.
+    time_analysis_completed: datetime = Column(IntTimestamp, nullable=False)
+
+    # pyre-fixme[8]: Attribute has type `AnalysisType`; used as
+    #  `Column[typing.Any]`.
+    experiment_analysis_type: AnalysisType = Column(
+        StringEnum(AnalysisType), nullable=False
+    )
+
+    # pyre-fixme[8]: Attribute has type `str`; used as `Column[str]`.
+    dataframe_json: str = Column(Text(LONGTEXT_BYTES), nullable=False)
+
+    # pyre-fixme[8]: Attribute has type `Optional[str]`; used as
+    #  `Column[Optional[str]]`.
+    fig_json: Optional[str] = Column(Text(LONGTEXT_BYTES), nullable=True)
+    # pyre-fixme[8]: Attribute has type `Optional[str]`; used as
+    #  `Column[Optional[str]]`.
+    plotly_version: Optional[str] = Column(String, nullable=True)
+
+    # pyre-fixme[8]: Attribute has type `int`; used as `Column[Optional[int]]`.
+    experiment_id: int = Column(Integer)
+    # pyre-fixme[8]: Attribute has type `int`; used as `Column[Optional[int]]`.
+    analysis_batch_id: int = Column(Integer, ForeignKey("analysis_batch.id"))
+
+
+class SQAAnalysisBatch(Base):
+    __tablename__: str = "analysis_batch"
+
+    # pyre-fixme[8]: Attribute has type `int`; used as `Column[int]`.
+    id: int = Column(Integer, primary_key=True)
+    # pyre-fixme[8]: Attribute has type `datetime`; used as `Column[typing.Any]`.
+    time_batch_start: datetime = Column(IntTimestamp, nullable=False)
+
+    analyses: Optional[List[SQAAnalysis]] = relationship(
+        "SQAAnalysis", cascade="all, delete-orphan", lazy="selectin"
+    )
+
+    # pyre-fixme[8]: Attribute has type `int`; used as `Column[Optional[int]]`.
+    experiment_id: int = Column(Integer, ForeignKey("experiment_v2.id"))

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -62,7 +62,10 @@ from ax.storage.sqa_store.save import (
     update_runner_on_experiment,
 )
 from ax.storage.sqa_store.sqa_classes import (
+    AnalysisType,
     SQAAbandonedArm,
+    SQAAnalysis,
+    SQAAnalysisBatch,
     SQAArm,
     SQAExperiment,
     SQAGeneratorRun,
@@ -1873,3 +1876,24 @@ class SQAStoreTest(TestCase):
         engine.dialect.default_schema_name = "ax"
         with self.assertRaises(ValueError):
             create_all_tables(engine)
+
+    def test_CreateAnalysisRecords(self) -> None:
+
+        sqa_analysis = SQAAnalysis(
+            analysis_class_name="CrossValidationPlot",
+            experiment_analysis_type=AnalysisType.PLOTLY_VISUALIZATION,
+            time_analysis_start=datetime.now(),
+            time_analysis_completed=datetime.now(),
+            dataframe_json="none",
+        )
+        with session_scope() as session:
+            _ = session.merge(sqa_analysis)
+            session.flush()
+
+    def test_CreateAnalysisBatch(self) -> None:
+        sqa_analysis_batch = SQAAnalysisBatch(
+            time_batch_start=datetime.now(),
+        )
+        with session_scope() as session:
+            _ = session.merge(sqa_analysis_batch)
+            session.flush()

--- a/ax/storage/utils.py
+++ b/ax/storage/utils.py
@@ -60,3 +60,10 @@ def stable_hash(s: str) -> int:
         int: Hash, converted to an integer.
     """
     return int(md5(s.encode("utf-8")).hexdigest(), 16)
+
+
+class AnalysisType(enum.Enum):
+    """Class for enumerating different experiment analysis types."""
+
+    ANALYSIS: str = "analysis"
+    PLOTLY_VISUALIZATION: str = "plotly_visualization"


### PR DESCRIPTION
Summary:
Adding SQA schema objects for Analysis and AnalysisBatch

Next step is to add support for encoding and decoding the analysis objects.

Differential Revision: D57632287


