### PR TITLE
Remove unused experiment arg from compute_model_fit_metrics_from_modelbridge

### DIFF
--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -18,7 +18,6 @@ from numbers import Number
 from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
 
 import numpy as np
-from ax.core.experiment import Experiment
 from ax.core.observation import Observation, ObservationData, recombine_observations
 from ax.core.optimization_config import OptimizationConfig
 from ax.modelbridge.base import ModelBridge, unwrap_observation_data
@@ -495,7 +494,6 @@ class SingleDiagnosticBestModelSelector(BestModelSelector):
 
 def compute_model_fit_metrics_from_modelbridge(
     model_bridge: ModelBridge,
-    experiment: Experiment,
     fit_metrics_dict: Optional[Dict[str, ModelFitMetricProtocol]] = None,
     generalization: bool = False,
     untransform: bool = False,

--- a/ax/modelbridge/tests/test_model_fit_metrics.py
+++ b/ax/modelbridge/tests/test_model_fit_metrics.py
@@ -79,7 +79,6 @@ class TestModelBridgeFitMetrics(TestCase):
         # testing compute_model_fit_metrics_from_modelbridge with default metrics
         fit_metrics = compute_model_fit_metrics_from_modelbridge(
             model_bridge=model_bridge,
-            experiment=self.branin_experiment,
             untransform=False,
         )
         r2 = fit_metrics.get("coefficient_of_determination")
@@ -101,7 +100,6 @@ class TestModelBridgeFitMetrics(TestCase):
             with self.subTest(untransform=untransform):
                 fit_metrics = compute_model_fit_metrics_from_modelbridge(
                     model_bridge=model_bridge,
-                    experiment=scheduler.experiment,
                     generalization=generalization,
                     untransform=untransform,
                     fit_metrics_dict={"Entropy": entropy_of_observations},
@@ -128,7 +126,6 @@ class TestModelBridgeFitMetrics(TestCase):
                 # testing with empty metrics
                 empty_metrics = compute_model_fit_metrics_from_modelbridge(
                     model_bridge=model_bridge,
-                    experiment=self.branin_experiment,
                     fit_metrics_dict={},
                 )
                 self.assertIsInstance(empty_metrics, dict)
@@ -138,7 +135,6 @@ class TestModelBridgeFitMetrics(TestCase):
                 with warnings.catch_warnings(record=True) as ws:
                     fit_metrics = compute_model_fit_metrics_from_modelbridge(
                         model_bridge=model_bridge,
-                        experiment=self.branin_experiment,
                         untransform=untransform,
                         generalization=generalization,
                     )

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -1929,7 +1929,6 @@ class AxSchedulerTestCase(TestCase):
         # testing compatibility with compute_model_fit_metrics_from_modelbridge
         fit_metrics = compute_model_fit_metrics_from_modelbridge(
             model_bridge=model_bridge,
-            experiment=scheduler.experiment,
             untransform=False,
         )
         r2 = fit_metrics.get("coefficient_of_determination")
@@ -1949,7 +1948,6 @@ class AxSchedulerTestCase(TestCase):
         # testing with empty metrics dict
         empty_metrics = compute_model_fit_metrics_from_modelbridge(
             model_bridge=model_bridge,
-            experiment=scheduler.experiment,
             fit_metrics_dict={},
             untransform=False,
         )

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -1522,7 +1522,6 @@ def warn_if_unpredictable_metrics(
         return None
     model_fit_dict = compute_model_fit_metrics_from_modelbridge(
         model_bridge=model_bridge,
-        experiment=experiment,
         generalization=True,  # use generalization metrics for user warning
         untransform=False,
     )

--- a/ax/telemetry/scheduler.py
+++ b/ax/telemetry/scheduler.py
@@ -119,7 +119,6 @@ class SchedulerCompletedRecord:
             model_bridge = get_fitted_model_bridge(scheduler)
             model_fit_dict = compute_model_fit_metrics_from_modelbridge(
                 model_bridge=model_bridge,
-                experiment=scheduler.experiment,
                 generalization=False,
                 untransform=False,
             )
@@ -131,7 +130,6 @@ class SchedulerCompletedRecord:
             # generalization metrics
             model_gen_dict = compute_model_fit_metrics_from_modelbridge(
                 model_bridge=model_bridge,
-                experiment=scheduler.experiment,
                 generalization=True,
                 untransform=False,
             )

--- a/ax/telemetry/tests/test_scheduler.py
+++ b/ax/telemetry/tests/test_scheduler.py
@@ -188,7 +188,6 @@ class TestScheduler(TestCase):
 
         fit_metrics = compute_model_fit_metrics_from_modelbridge(
             model_bridge=model_bridge,
-            experiment=scheduler.experiment,
             generalization=False,
             untransform=False,
         )
@@ -212,7 +211,6 @@ class TestScheduler(TestCase):
         # check generalization metrics
         gen_metrics = compute_model_fit_metrics_from_modelbridge(
             model_bridge=model_bridge,
-            experiment=scheduler.experiment,
             generalization=True,
             untransform=False,
         )


### PR DESCRIPTION
Summary: This will make it easier to call on model spec.

Reviewed By: saitcakmak

Differential Revision: D58208209


