### PR TITLE
Disallow modeling metrics not attached to the experiment

### DIFF
--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -24,6 +24,7 @@ from ax.core.data import Data
 from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
 from ax.core.types import TCandidateMetadata, TParameterization
+from ax.exceptions.core import UserInputError
 from ax.utils.common.base import Base
 from ax.utils.common.constants import Keys
 from ax.utils.common.typeutils import checked_cast, not_none
@@ -381,14 +382,14 @@ def _filter_data_on_status(
     dfs = []
     for g, d in df.groupby(by="metric_name"):
         metric_name = g
-        # Filter out any metrics that are not on the experiment.
         if metric_name not in experiment.metrics:
-            warnings.warn(
-                f"Metric {metric_name} not found on {experiment}. Not attaching to "
-                "observation.",
-                stacklevel=2,
+            # Observations can only be made for metrics attached to the experiment.
+            raise UserInputError(
+                f"Data contains metric {metric_name} that has not been added to the "
+                "experiment. You can either update the `optimization_config` or attach "
+                "it as a tracking metric using `Experiment.add_tracking_metrics` "
+                "or `AxClient.add_tracking_metrics`."
             )
-            continue
         metric = experiment.metrics[metric_name]
         statuses_to_include_metric = (
             statuses_to_include_map_metric


### PR DESCRIPTION
Summary:
In the past it has been possible to model metrics that were not
attached to the experiment, and this has been common practice in notebook
analysis of PTS experiments where additional metrics to consider will come up
during discussion of the results for a particular batch.

This behavior was changed in D56634321, which silently drops data for metrics
that are not attached to the experiment.

I spent a while trying to figure out why my
data were being dropped.

We should either (1) allow modeling metrics that are not attached to the
experiment, or (2) not allow it, by raising an error instead of silently
dropping the data.

This diff implements (2) and raises an error that there is an issue with the metrics in the data.

This also fixes a bug in the test that was not correctly testing whether the map
metric was being included or not.

Differential Revision: D57165887
