### PR TITLE
Update np.Inf -> np.inf per numpy 2.0 release

### DIFF
--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -141,7 +141,7 @@ def best_feasible_objective(
     objective = optimization_config.objective
     f = values[objective.metric.name]
     # Set infeasible points to have infinitely bad values
-    infeas_val = np.Inf if objective.minimize else -np.Inf
+    infeas_val = np.inf if objective.minimize else -np.inf
     for oc in optimization_config.outcome_constraints:
         if oc.relative:
             raise ValueError(

--- a/ax/models/discrete/thompson.py
+++ b/ax/models/discrete/thompson.py
@@ -213,9 +213,9 @@ class ThompsonSampler(DiscreteModel):
         objective_values = np.dot(
             samples_per_metric, objective_weights
         )  # (k x num_samples)
-        objective_values[any_violation] = -np.Inf
+        objective_values[any_violation] = -np.inf
         best_arm = objective_values.max(axis=0)  # (num_samples,)
-        all_arms_infeasible = best_arm == -np.Inf  # (num_samples,)
+        all_arms_infeasible = best_arm == -np.inf  # (num_samples,)
         fraction_all_infeasible = all_arms_infeasible.mean()
         filtered_objective = objective_values[:, ~all_arms_infeasible]  # (k x ?)
         return filtered_objective, fraction_all_infeasible

--- a/ax/models/model_utils.py
+++ b/ax/models/model_utils.py
@@ -453,7 +453,7 @@ def best_in_sample_point(
     # Identify best point
     if method == "feasible_threshold":
         utility = obj
-        utility[pfeas < threshold] = -np.Inf
+        utility[pfeas < threshold] = -np.inf
     elif method == "max_utility":
         if B is None:
             B = obj.min()
@@ -461,7 +461,7 @@ def best_in_sample_point(
     else:  # pragma: no cover
         raise UnsupportedError(f"Unknown best point method {method}.")
     i = np.argmax(utility)
-    if utility[i] == -np.Inf:
+    if utility[i] == -np.inf:
         return None
     else:
         return X_obs[i, :], utility[i]


### PR DESCRIPTION
Summary:
Numpy 2.0 was released yesterday ([post](https://numpy.org/news/#numpy-20-release-date-june-16)) and accordingly a couple of tests started breaking due to usage of a now-outdated API. This updates references to the now-deprecated `np.Inf` to `np.inf`, which is available in both old and new versions of numpy and so shouldn't create any issues.

Our early-stopping tutorial is still breaking due to a similar issue in TensorBoard (https://github.com/tensorflow/tensorboard/issues/6869), so not all tests are expected to pass as of now.

Differential Revision: D58672474
