### PR TITLE
Filter InputDataWarning in model cross-validation

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -933,7 +933,7 @@ class ModelBridge(ABC):  # noqa: B024 -- ModelBridge doesn't have any abstract m
             # users with this warning, we filter it out.
             warnings.filterwarnings(
                 "ignore",
-                message="Input data is not standardized.",
+                message="Data is not standardized",
                 category=InputDataWarning,
             )
             cv_predictions = self._cross_validate(

--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -188,7 +188,7 @@ def cross_validate(
                 # To avoid confusing users with this warning, we filter it out.
                 warnings.filterwarnings(
                     "ignore",
-                    message="Input data is not standardized.",
+                    message="Data is not standardized",
                     category=InputDataWarning,
                 )
                 cv_test_predictions = model._cross_validate(

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -225,8 +225,7 @@ class BaseModelBridgeTest(TestCase):
             nonlocal called
             called = True
             warnings.warn(
-                "Input data is not standardized. Please consider scaling the "
-                "input to zero mean and unit variance.",
+                "Data is not standardized",
                 InputDataWarning,
                 stacklevel=2,
             )

--- a/ax/modelbridge/tests/test_model_fit_metrics.py
+++ b/ax/modelbridge/tests/test_model_fit_metrics.py
@@ -140,7 +140,7 @@ class TestModelBridgeFitMetrics(TestCase):
                         generalization=generalization,
                     )
                 self.assertFalse(
-                    any("Input data is not standardized" in str(w.message) for w in ws)
+                    any("Data is not standardized" in str(w.message) for w in ws)
                 )
 
 


### PR DESCRIPTION
Summary: D57931412 did some nice cleanup of our standardization warnings, but ended up creating a bunch of warnings in our cross validation routines that relied on filtering these by the message. This diff updates the cross validation to catch these warnings and also adds a unit test that doesn't hardcode the warning message.

Differential Revision: D58849105
