### PR TITLE
Adding df and fig properties to BaseAnalysis and BasePlotlyVisualization to support loading analyses back from database.

### DIFF
--- a/ax/analysis/base_analysis.py
+++ b/ax/analysis/base_analysis.py
@@ -5,31 +5,49 @@
 
 # pyre-strict
 
-from abc import ABC, abstractmethod
+from typing import Optional
 
 import pandas as pd
 from ax.core.experiment import Experiment
 
 
-class BaseAnalysis(ABC):
+class BaseAnalysis:
     """
     Abstract Analysis class for ax.
     This is an interface that defines the methods to be implemented by all analyses.
     Computes an output dataframe for each analysis
     """
 
-    def __init__(self, experiment: Experiment) -> None:
+    def __init__(
+        self,
+        experiment: Experiment,
+        df_input: Optional[pd.DataFrame] = None,
+        # TODO: add support for passing in experiment name, and markdown message
+    ) -> None:
         """
         Initialize the analysis with the experiment object.
+        For scenarios where an analysis output is already available,
+        we can pass the dataframe as an input.
         """
         self._experiment = experiment
+        self._df: Optional[pd.DataFrame] = df_input
 
     @property
     def experiment(self) -> Experiment:
         return self._experiment
 
-    @abstractmethod
-    def get_df(self) -> pd.DataFrame:
+    @property
+    def df(self) -> pd.DataFrame:
         """
         Return the output of the analysis of this class.
         """
+        if self._df is None:
+            self._df = self.get_df()
+        return self._df
+
+    def get_df(self) -> pd.DataFrame:
+        """
+        Return the output of the analysis of this class.
+        Subclasses should overwrite this.
+        """
+        raise NotImplementedError("get_df must be implemented by subclass")

--- a/ax/analysis/base_plotly_visualization.py
+++ b/ax/analysis/base_plotly_visualization.py
@@ -5,11 +5,14 @@
 
 # pyre-strict
 
-from abc import abstractmethod
+from typing import Optional
+
+import pandas as pd
 
 import plotly.graph_objects as go
 
 from ax.analysis.base_analysis import BaseAnalysis
+from ax.core.experiment import Experiment
 
 
 class BasePlotlyVisualization(BaseAnalysis):
@@ -19,8 +22,32 @@ class BasePlotlyVisualization(BaseAnalysis):
     Computes an output dataframe for each analysis
     """
 
-    @abstractmethod
+    def __init__(
+        self,
+        experiment: Experiment,
+        df_input: Optional[pd.DataFrame] = None,
+        fig_input: Optional[go.Figure] = None,
+    ) -> None:
+        """
+        Initialize the analysis with the experiment object.
+        For scenarios where an analysis output is already available,
+        we can pass the dataframe as an input.
+        """
+        self._fig = fig_input
+        super().__init__(experiment=experiment, df_input=df_input)
+
+    @property
+    def fig(self) -> go.Figure:
+        """
+        Return the output of the analysis of this class.
+        """
+        if self._fig is None:
+            self._fig = self.get_fig()
+        return self._fig
+
     def get_fig(self) -> go.Figure:
         """
         Return the plotly figure of the analysis of this class.
+        Subclasses should overwrite this.
         """
+        raise NotImplementedError("get_fig must be implemented by subclass")

--- a/ax/analysis/tests/test_base_classes.py
+++ b/ax/analysis/tests/test_base_classes.py
@@ -1,0 +1,142 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import pandas as pd
+
+import plotly.express as px
+
+import plotly.graph_objects as go
+
+from ax.analysis.base_analysis import BaseAnalysis
+from ax.analysis.base_plotly_visualization import BasePlotlyVisualization
+
+from ax.modelbridge.registry import Models
+
+from ax.utils.common.testutils import TestCase
+
+from ax.utils.testing.core_stubs import get_branin_experiment
+from ax.utils.testing.mock import fast_botorch_optimize
+
+
+class TestBaseClasses(TestCase):
+    class TestAnalysis(BaseAnalysis):
+        get_df_call_count: int = 0
+
+        def get_df(self) -> pd.DataFrame:
+            self.get_df_call_count = self.get_df_call_count + 1
+            return pd.DataFrame()
+
+    class TestPlotlyVisualization(BasePlotlyVisualization):
+        get_df_call_count: int = 0
+        get_fig_call_count: int = 0
+
+        def get_df(self) -> pd.DataFrame:
+            self.get_df_call_count = self.get_df_call_count + 1
+            return pd.DataFrame()
+
+        def get_fig(self) -> go.Figure:
+            self.get_fig_call_count = self.get_fig_call_count + 1
+            return go.Figure()
+
+    @fast_botorch_optimize
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.exp = get_branin_experiment(with_batch=True)
+        self.exp.trials[0].run()
+        self.model = Models.BOTORCH_MODULAR(
+            # Model bridge kwargs
+            experiment=self.exp,
+            data=self.exp.fetch_data(),
+        )
+
+        self.test_analysis = self.TestAnalysis(experiment=self.exp)
+        self.test_plotly_visualization = self.TestPlotlyVisualization(
+            experiment=self.exp
+        )
+
+    def test_base_analysis_df_property(self) -> None:
+        test_analysis = self.TestAnalysis(experiment=self.exp)
+
+        self.assertEqual(test_analysis.get_df_call_count, 0)
+
+        # accessing the df property calls get_df
+        _ = test_analysis.df
+        self.assertEqual(test_analysis.get_df_call_count, 1)
+
+        # once saved, get_df is not called again.
+        _ = test_analysis.df
+        self.assertEqual(test_analysis.get_df_call_count, 1)
+
+    def test_base_analysis_pass_df_in(self) -> None:
+        existing_df = pd.DataFrame([1])
+        test_analysis = self.TestAnalysis(experiment=self.exp, df_input=existing_df)
+
+        self.assertEqual(test_analysis.get_df_call_count, 0)
+        saved_df = test_analysis.df
+        self.assertTrue(existing_df.equals(saved_df))
+
+        # when df is passed in directly, get_df is never called.
+        self.assertEqual(test_analysis.get_df_call_count, 0)
+
+    def test_base_plotly_visualization_fig_property(self) -> None:
+        test_analysis = self.TestPlotlyVisualization(experiment=self.exp)
+
+        self.assertEqual(test_analysis.get_fig_call_count, 0)
+
+        # accessing the fig property calls get_fig
+        _ = test_analysis.fig
+        self.assertEqual(test_analysis.get_fig_call_count, 1)
+
+        # once saved, get_fig is not called again.
+        _ = test_analysis.fig
+        self.assertEqual(test_analysis.get_fig_call_count, 1)
+
+    def test_base_plotly_visualization_pass_fig_in(self) -> None:
+        fig = px.scatter(x=[0, 1, 2, 3, 4], y=[0, 1, 4, 9, 16])
+        test_analysis = self.TestPlotlyVisualization(
+            experiment=self.exp,
+            fig_input=fig,
+        )
+
+        self.assertEqual(test_analysis.get_fig_call_count, 0)
+        saved_fig = test_analysis.fig
+        self.assertEqual(fig, saved_fig)
+
+        # when fig is passed in directly, get_fig is never called.
+        self.assertEqual(test_analysis.get_fig_call_count, 0)
+
+    def test_base_plotly_visualization_pass_df_and_fig(self) -> None:
+        df = pd.DataFrame([1])
+        fig = px.scatter(x=[0, 1, 2, 3, 4], y=[0, 1, 4, 9, 16])
+
+        test_analysis = self.TestPlotlyVisualization(
+            experiment=self.exp,
+            df_input=df,
+            fig_input=fig,
+        )
+
+        self.assertEqual(test_analysis.get_df_call_count, 0)
+        saved_df = test_analysis.df
+        self.assertTrue(df.equals(saved_df))
+        # when df is passed in directly, get_df is never called.
+        self.assertEqual(test_analysis.get_df_call_count, 0)
+
+        self.assertEqual(test_analysis.get_fig_call_count, 0)
+        saved_fig = test_analysis.fig
+        self.assertEqual(fig, saved_fig)
+        # when fig is passed in directly, get_fig is never called.
+        self.assertEqual(test_analysis.get_fig_call_count, 0)
+
+    def test_instantiate_base_classes(self) -> None:
+        test_analysis = BaseAnalysis(experiment=self.exp)
+        with self.assertRaises(NotImplementedError):
+            _ = test_analysis.df
+
+        test_fig = BasePlotlyVisualization(experiment=self.exp)
+        with self.assertRaises(NotImplementedError):
+            _ = test_fig.fig

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -34,7 +34,13 @@ from ax.storage.sqa_store.json import (
 )
 from ax.storage.sqa_store.sqa_enum import IntEnum, StringEnum
 from ax.storage.sqa_store.timestamp import IntTimestamp
-from ax.storage.utils import DataType, DomainType, MetricIntent, ParameterConstraintType
+from ax.storage.utils import (
+    AnalysisType,
+    DataType,
+    DomainType,
+    MetricIntent,
+    ParameterConstraintType,
+)
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -514,3 +520,54 @@ class SQAExperiment(Base):
         uselist=False,
         lazy=True,
     )
+
+
+class SQAAnalysis(Base):
+    __tablename__: str = "experiment_analysis"
+
+    # pyre-fixme[8]: Attribute has type `int`; used as `Column[int]`.
+    id: int = Column(Integer, primary_key=True)
+
+    # pyre-fixme[8]: Attribute has type `str`; used as `Column[str]`.
+    analysis_class_name: str = Column(String(NAME_OR_TYPE_FIELD_LENGTH), nullable=False)
+    # pyre-fixme[8]: Attribute has type `datetime`; used as `Column[typing.Any]`.
+    time_analysis_start: datetime = Column(IntTimestamp, nullable=False)
+    # pyre-fixme[8]: Attribute has type `datetime`; used as `Column[typing.Any]`.
+    time_analysis_completed: datetime = Column(IntTimestamp, nullable=False)
+
+    # pyre-fixme[8]: Attribute has type `AnalysisType`; used as
+    #  `Column[typing.Any]`.
+    experiment_analysis_type: AnalysisType = Column(
+        StringEnum(AnalysisType), nullable=False
+    )
+
+    # pyre-fixme[8]: Attribute has type `str`; used as `Column[str]`.
+    dataframe_json: str = Column(Text(LONGTEXT_BYTES), nullable=False)
+
+    # pyre-fixme[8]: Attribute has type `Optional[str]`; used as
+    #  `Column[Optional[str]]`.
+    fig_json: Optional[str] = Column(Text(LONGTEXT_BYTES), nullable=True)
+    # pyre-fixme[8]: Attribute has type `Optional[str]`; used as
+    #  `Column[Optional[str]]`.
+    plotly_version: Optional[str] = Column(String, nullable=True)
+
+    # pyre-fixme[8]: Attribute has type `int`; used as `Column[Optional[int]]`.
+    experiment_id: int = Column(Integer)
+    # pyre-fixme[8]: Attribute has type `int`; used as `Column[Optional[int]]`.
+    analysis_report_id: int = Column(Integer, ForeignKey("analysis_report_v2.id"))
+
+
+class SQAAnalysisReport(Base):
+    __tablename__: str = "analysis_report_v2"
+
+    # pyre-fixme[8]: Attribute has type `int`; used as `Column[int]`.
+    id: int = Column(Integer, primary_key=True)
+    # pyre-fixme[8]: Attribute has type `datetime`; used as `Column[typing.Any]`.
+    time_report_start: datetime = Column(IntTimestamp, nullable=False)
+
+    analyses: Optional[List[SQAAnalysis]] = relationship(
+        "SQAAnalysis", cascade="all, delete-orphan", lazy="selectin"
+    )
+
+    # pyre-fixme[8]: Attribute has type `int`; used as `Column[Optional[int]]`.
+    experiment_id: int = Column(Integer, ForeignKey("experiment_v2.id"))

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -62,7 +62,10 @@ from ax.storage.sqa_store.save import (
     update_runner_on_experiment,
 )
 from ax.storage.sqa_store.sqa_classes import (
+    AnalysisType,
     SQAAbandonedArm,
+    SQAAnalysis,
+    SQAAnalysisReport,
     SQAArm,
     SQAExperiment,
     SQAGeneratorRun,
@@ -1873,3 +1876,24 @@ class SQAStoreTest(TestCase):
         engine.dialect.default_schema_name = "ax"
         with self.assertRaises(ValueError):
             create_all_tables(engine)
+
+    def test_CreateAnalysisRecords(self) -> None:
+
+        sqa_analysis = SQAAnalysis(
+            analysis_class_name="CrossValidationPlot",
+            experiment_analysis_type=AnalysisType.PLOTLY_VISUALIZATION,
+            time_analysis_start=datetime.now(),
+            time_analysis_completed=datetime.now(),
+            dataframe_json="none",
+        )
+        with session_scope() as session:
+            _ = session.merge(sqa_analysis)
+            session.flush()
+
+    def test_CreateAnalysisReport(self) -> None:
+        sqa_analysis_report = SQAAnalysisReport(
+            time_report_start=datetime.now(),
+        )
+        with session_scope() as session:
+            _ = session.merge(sqa_analysis_report)
+            session.flush()

--- a/ax/storage/utils.py
+++ b/ax/storage/utils.py
@@ -60,3 +60,10 @@ def stable_hash(s: str) -> int:
         int: Hash, converted to an integer.
     """
     return int(md5(s.encode("utf-8")).hexdigest(), 16)
+
+
+class AnalysisType(enum.Enum):
+    """Class for enumerating different experiment analysis types."""
+
+    ANALYSIS: str = "analysis"
+    PLOTLY_VISUALIZATION: str = "plotly_visualization"


### PR DESCRIPTION
Summary:
Because Analyses need to execute analysis on experiment data to produce outputs, it does not make sense to load stored analysis back into their original class.
Instead, we should have Analysis classes just store and serve the dataframe and plots.

This change creates the BaseAnalysis and BasePlotlyVisualization classes to add "df" and "fig" properties respectively. Using these will first check for a saved df or fig and serve that, otherwise it will call "get_df" and "get_fig" respectively.

Differential Revision: D58031648
