### PR TITLE
Downgrade error to beta-warning for gs selection in AxClient

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1732,9 +1732,9 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
             "use_batch_trials" in choose_generation_strategy_kwargs
             and type(self) is AxClient
         ):
-            raise UnsupportedError(
-                "AxClient API does not support batch trials yet."
-                " We plan to add this support in coming versions."
+            logger.warning(
+                "Selecting a GenerationStrategy when using BatchTrials is in beta. "
+                "Double check the recommended strategy matches your expectations."
             )
         random_seed = choose_generation_strategy_kwargs.pop(
             "random_seed", self._random_seed

--- a/ax/telemetry/tests/test_ax_client.py
+++ b/ax/telemetry/tests/test_ax_client.py
@@ -6,12 +6,12 @@
 
 # pyre-strict
 
+import logging
 from typing import Dict, List, Sequence, Union
 
 import numpy as np
 
 from ax.core.types import TParamValue
-from ax.exceptions.core import UnsupportedError
 from ax.service.ax_client import AxClient, ObjectiveProperties
 from ax.telemetry.ax_client import AxClientCompletedRecord, AxClientCreatedRecord
 from ax.telemetry.experiment import ExperimentCompletedRecord, ExperimentCreatedRecord
@@ -133,11 +133,8 @@ class TestAxClient(TestCase):
 
     def test_batch_trial_warning(self) -> None:
         ax_client = AxClient()
-        error_msg = (
-            "AxClient API does not support batch trials yet."
-            " We plan to add this support in coming versions."
-        )
-        with self.assertRaisesRegex(UnsupportedError, error_msg):
+        warning_msg = "GenerationStrategy when using BatchTrials is in beta."
+        with self.assertLogs(AxClient.__module__, logging.WARNING) as logger:
             ax_client.create_experiment(
                 name="test_experiment",
                 parameters=[
@@ -148,6 +145,10 @@ class TestAxClient(TestCase):
                 choose_generation_strategy_kwargs={
                     "use_batch_trials": True,
                 },
+            )
+            self.assertTrue(
+                any(warning_msg in output for output in logger.output),
+                logger.output,
             )
 
     def _compare_axclient_completed_records(


### PR DESCRIPTION
Summary:
Previously we added this error in D56048665 in response to a github issue, however now that we are adding support for GenerationStrategy selection for BatchTrials this can be a warning that this method is in development.

In the future we should be able to fully remove the method

Differential Revision: D59143308
