### PR TITLE
Don't let MBM pass `raw_samples` to `optimize_acqf_discrete`

### DIFF
--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -530,6 +530,11 @@ class Acquisition(Base):
                 )
                 n = num_choices
 
+            # `raw_samples` is not supported by `optimize_acqf_discrete`.
+            # TODO[santorella]: Rather than manually removing it, we should
+            # ensure that it is never passed.
+            if optimizer_options is not None:
+                optimizer_options.pop("raw_samples")
             discrete_opt_options = optimizer_argparse(
                 self.acqf,
                 bounds=bounds,


### PR DESCRIPTION
Summary: https://github.com/pytorch/botorch/pull/2390 broke workflows that were passing this argument, which used to be silently ignored. This is a hotfix that will stop those usages from failing.

Differential Revision: D59161641
