### PR TITLE
Delete register_metric and remove default metric from register_metrics

### DIFF
--- a/ax/storage/metric_registry.py
+++ b/ax/storage/metric_registry.py
@@ -46,44 +46,8 @@ CORE_METRIC_REGISTRY: Dict[Type[Metric], int] = {
 
 
 # pyre-fixme[3]: Return annotation cannot contain `Any`.
-def register_metric(
-    metric_cls: Type[Metric],
-    metric_registry: Optional[Dict[Type[Metric], int]] = None,
-    # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
-    # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-    #  `typing.Type` to avoid runtime subscripting errors.
-    encoder_registry: Dict[
-        Type, Callable[[Any], Dict[str, Any]]
-    ] = CORE_ENCODER_REGISTRY,
-    # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-    #  `typing.Type` to avoid runtime subscripting errors.
-    decoder_registry: Dict[str, Type] = CORE_DECODER_REGISTRY,
-    val: Optional[int] = None,
-    # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use `typing.Type` to
-    #  avoid runtime subscripting errors.
-) -> Tuple[
-    Dict[Type[Metric], int],
-    Dict[Type, Callable[[Any], Dict[str, Any]]],
-    Dict[str, Type],
-]:
-    """Add a custom metric class to the SQA and JSON registries.
-    For the SQA registry, if no int is specified, use a hash of the class name.
-    """
-    metric_registry = metric_registry or {Metric: 0}
-
-    registered_val = val or abs(stable_hash(metric_cls.__name__)) % (10**5)
-
-    new_metric_registry = {metric_cls: registered_val, **metric_registry}
-    new_encoder_registry = {metric_cls: metric_to_dict, **encoder_registry}
-    new_decoder_registry = {metric_cls.__name__: metric_cls, **decoder_registry}
-
-    return new_metric_registry, new_encoder_registry, new_decoder_registry
-
-
-# pyre-fixme[3]: Return annotation cannot contain `Any`.
 def register_metrics(
     metric_clss: Dict[Type[Metric], Optional[int]],
-    metric_registry: Optional[Dict[Type[Metric], int]] = None,
     # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
     # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
     #  `typing.Type` to avoid runtime subscripting errors.
@@ -103,14 +67,10 @@ def register_metrics(
     """Add custom metric classes to the SQA and JSON registries.
     For the SQA registry, if no int is specified, use a hash of the class name.
     """
-    metric_registry = metric_registry or {Metric: 1}
 
     new_metric_registry = {
-        **{
-            metric_cls: val if val else abs(stable_hash(metric_cls.__name__)) % (10**5)
-            for metric_cls, val in metric_clss.items()
-        },
-        **metric_registry,
+        metric_cls: val if val else abs(stable_hash(metric_cls.__name__)) % (10**5)
+        for metric_cls, val in metric_clss.items()
     }
     new_encoder_registry = {
         **{metric_cls: metric_to_dict for metric_cls in metric_clss},

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -27,7 +27,7 @@ from ax.metrics.branin import BraninMetric
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
 from ax.modelbridge.registry import Models
 from ax.runners.synthetic import SyntheticRunner
-from ax.storage.metric_registry import CORE_METRIC_REGISTRY, register_metric
+from ax.storage.metric_registry import CORE_METRIC_REGISTRY, register_metrics
 from ax.storage.registry_bundle import RegistryBundle
 from ax.storage.runner_registry import CORE_RUNNER_REGISTRY, register_runner
 from ax.storage.sqa_store.db import (
@@ -235,7 +235,7 @@ class SQAStoreTest(TestCase):
             metric_registry,
             partial_encoder_registry,
             partial_decoder_registry,
-        ) = register_metric(metric_cls=CustomTestMetric)
+        ) = register_metrics(metric_clss={CustomTestMetric: None, Metric: 0})
 
         runner_registry, encoder_registry, decoder_registry = register_runner(
             runner_cls=CustomTestRunner,
@@ -1244,7 +1244,7 @@ class SQAStoreTest(TestCase):
             metric_registry,
             partial_encoder_registry,
             partial_decoder_registry,
-        ) = register_metric(metric_cls=MyMetric)
+        ) = register_metrics(metric_clss={MyMetric: None, Metric: 0})
         runner_registry, encoder_registry, decoder_registry = register_runner(
             runner_cls=MyRunner,
             encoder_registry=partial_encoder_registry,
@@ -1277,7 +1277,7 @@ class SQAStoreTest(TestCase):
             pass
 
         bundle = RegistryBundle(
-            metric_clss={MyMetric: 1998}, runner_clss={MyRunner: None}
+            metric_clss={MyMetric: 1998, Metric: 0}, runner_clss={MyRunner: None}
         )
 
         experiment = get_experiment_with_batch_trial()


### PR DESCRIPTION
Summary:
- `register_metric` duplicates the functionality of `register_metrics`, so it is removed.
- `metrics_registry` is an unused argument of `register_metrics`, so it is removed.
- `register_metrics` would overwrite the `metrics_registry` to forcefully add `Metric: 1` to each `RegistryBundle`. This value is inconsistent with `Metric: 0` in `CORE_METRIC_REGISTRY`, so it is removed. All future `RegistryBundles` that wish to support `Metric` should manually specify it.

Differential Revision: D59305865
