### PR TITLE
Improve typing of *_kwargs fields in ModelSpec

### DIFF
--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -128,7 +128,7 @@ def get_sobol_botorch_modular_acquisition(
                 model=Models.BOTORCH_MODULAR,
                 num_trials=-1,
                 model_kwargs=model_kwargs,
-                model_gen_kwargs=model_gen_kwargs,
+                model_gen_kwargs=model_gen_kwargs or {},
             ),
         ],
     )

--- a/ax/modelbridge/best_model_selector.py
+++ b/ax/modelbridge/best_model_selector.py
@@ -16,12 +16,13 @@ from typing import Callable, List, Union
 import numpy as np
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.model_spec import ModelSpec
+from ax.utils.common.base import Base
 from ax.utils.common.typeutils import not_none
 
 ARRAYLIKE = Union[np.ndarray, List[float], List[np.ndarray]]
 
 
-class BestModelSelector(ABC):
+class BestModelSelector(ABC, Base):
     @abstractmethod
     def best_model(self, model_specs: List[ModelSpec]) -> int:
         """

--- a/ax/modelbridge/best_model_selector.py
+++ b/ax/modelbridge/best_model_selector.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from functools import partial
+from typing import Callable, List, Union
+
+import numpy as np
+from ax.exceptions.core import UserInputError
+from ax.modelbridge.model_spec import ModelSpec
+from ax.utils.common.typeutils import not_none
+
+ARRAYLIKE = Union[np.ndarray, List[float], List[np.ndarray]]
+
+
+class BestModelSelector(ABC):
+    @abstractmethod
+    def best_model(self, model_specs: List[ModelSpec]) -> int:
+        """
+        Return the index of the best ``ModelSpec``.
+        """
+
+
+class ReductionCriterion(Enum):
+    """An enum for callables that are used for aggregating diagnostics over metrics
+    and selecting the best diagnostic in ``SingleDiagnosticBestModelSelector``.
+
+    NOTE: This is used to ensure serializability of the callables.
+    """
+
+    # NOTE: Callables need to be wrapped in `partial` to be registered as members.
+    MEAN: Callable[[ARRAYLIKE], np.ndarray] = partial(np.mean)
+    MIN: Callable[[ARRAYLIKE], np.ndarray] = partial(np.min)
+    MAX: Callable[[ARRAYLIKE], np.ndarray] = partial(np.max)
+
+    def __call__(self, array_like: ARRAYLIKE) -> np.ndarray:
+        return self.value(array_like)
+
+
+class SingleDiagnosticBestModelSelector(BestModelSelector):
+    """Choose the best model using a single cross-validation diagnostic.
+
+    The input is a list of ``ModelSpec``, each corresponding to one model.
+    The specified diagnostic is extracted from each of the models,
+    its values (each of which corresponds to a separate metric) are
+    aggregated with the aggregation function, the best one is determined
+    with the criterion, and the index of the best diagnostic result is returned.
+
+    Example:
+     ::
+        s = SingleDiagnosticBestModelSelector(
+            diagnostic = 'Fisher exact test p',
+            metric_aggregation = ReductionCriterion.MEAN,
+            criterion = ReductionCriterion.MIN,
+        )
+        best_diagnostic_index = s.best_diagnostic(diagnostics)
+
+    Args:
+        diagnostic: The name of the diagnostic to use, which should be
+            a key in ``CVDiagnostic``.
+        metric_aggregation: ``ReductionCriterion`` applied to the values of the
+            diagnostic for a single model to produce a single number.
+        criterion: ``ReductionCriterion`` used to determine which of the
+            (aggregated) diagnostics is the best.
+
+    Returns:
+        int: index of the selected best diagnostic.
+    """
+
+    def __init__(
+        self,
+        diagnostic: str,
+        metric_aggregation: ReductionCriterion,
+        criterion: ReductionCriterion,
+    ) -> None:
+        self.diagnostic = diagnostic
+        if not isinstance(metric_aggregation, ReductionCriterion) or not isinstance(
+            criterion, ReductionCriterion
+        ):
+            raise UserInputError(
+                "Both `metric_aggregation` and `criterion` must be "
+                f"`ReductionCriterion`. Got {metric_aggregation=}, {criterion=}."
+            )
+        if criterion == ReductionCriterion.MEAN:
+            raise UserInputError(
+                f"{criterion=} is not supported. Please use MIN or MAX."
+            )
+        self.metric_aggregation = metric_aggregation
+        self.criterion = criterion
+
+    def best_model(self, model_specs: List[ModelSpec]) -> int:
+        for model_spec in model_specs:
+            model_spec.cross_validate()
+        aggregated_diagnostic_values = [
+            self.metric_aggregation(
+                list(not_none(model_spec.diagnostics)[self.diagnostic].values())
+            )
+            for model_spec in model_specs
+        ]
+        best_diagnostic = self.criterion(aggregated_diagnostic_values).item()
+        return aggregated_diagnostic_values.index(best_diagnostic)

--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -132,8 +132,7 @@ def _make_botorch_step(
         min_trials_observed=min_trials_observed or ceil(num_trials / 2),
         enforce_num_trials=enforce_num_trials,
         max_parallelism=max_parallelism,
-        # `model_kwargs` should default to `None` if empty
-        model_kwargs=model_kwargs if len(model_kwargs) > 0 else None,
+        model_kwargs=model_kwargs,
         should_deduplicate=should_deduplicate,
     )
 

--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -615,9 +615,9 @@ class GenerationStep(GenerationNode, SortableBase):
 
     # Optional model specifications:
     # Kwargs to pass into the Models constructor (or factory function).
-    model_kwargs: Optional[Dict[str, Any]] = None
+    model_kwargs: Dict[str, Any] = field(default_factory=dict)
     # Kwargs to pass into the Model's `.gen` function.
-    model_gen_kwargs: Optional[Dict[str, Any]] = None
+    model_gen_kwargs: Dict[str, Any] = field(default_factory=dict)
 
     # Optional specifications for use in generation strategy:
     completion_criteria: Sequence[TransitionCriterion] = field(default_factory=list)
@@ -651,6 +651,9 @@ class GenerationStep(GenerationNode, SortableBase):
                 f"{self.num_trials}`), making completion of this step impossible. "
                 "Please alter inputs so that `min_trials_observed <= num_trials`."
             )
+        # For backwards compatibility with None / Optional input.
+        self.model_kwargs = self.model_kwargs or {}
+        self.model_gen_kwargs = self.model_gen_kwargs or {}
         if not isinstance(self.model, ModelRegistryBase):
             if not callable(self.model):
                 raise UserInputError(

--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-
 from dataclasses import dataclass, field
 from logging import Logger
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
@@ -28,7 +27,7 @@ from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UserInputError
 from ax.exceptions.generation_strategy import GenerationStrategyRepeatedPoints
 from ax.modelbridge.base import ModelBridge
-from ax.modelbridge.cross_validation import BestModelSelector
+from ax.modelbridge.best_model_selector import BestModelSelector
 from ax.modelbridge.model_spec import FactoryFunctionModelSpec, ModelSpec
 from ax.modelbridge.registry import ModelRegistryBase
 from ax.modelbridge.transition_criterion import (
@@ -360,11 +359,8 @@ class GenerationNode(SerializationMixin, SortableBase):
                 raise NotImplementedError(CANNOT_SELECT_ONE_MODEL_MSG)
             return self.model_specs[0]
 
-        for model_spec in self.model_specs:
-            model_spec.cross_validate()
-
-        best_model_index = not_none(self.best_model_selector).best_diagnostic(
-            diagnostics=[not_none(m.diagnostics) for m in self.model_specs],
+        best_model_index = not_none(self.best_model_selector).best_model(
+            model_specs=self.model_specs,
         )
         return self.model_specs[best_model_index]
 

--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -65,8 +65,11 @@ class GenerationNode(SerializationMixin, SortableBase):
     the hood and generating candidates from them.
 
     Args:
+        node_name: A unique name for the GenerationNode. Used for storage purposes.
         model_specs: A list of ModelSpecs to be selected from for generation in this
-            GenerationNode
+            GenerationNode.
+        best_model_selector: A ``BestModelSelector`` used to select the ``ModelSpec``
+            to generate from in ``GenerationNode`` with multiple ``ModelSpec``s.
         should_deduplicate: Whether to deduplicate the parameters of proposed arms
             against those of previous arms via rejection sampling. If this is True,
             the GenerationStrategy will discard generator runs produced from the
@@ -76,7 +79,6 @@ class GenerationNode(SerializationMixin, SortableBase):
             attempts, a `GenerationStrategyRepeatedPoints` error will be raised, as we
             assume that the optimization converged when the model can no longer suggest
             unique arms.
-        node_name: A unique name for the GenerationNode. Used for storage purposes.
         transition_criteria: List of TransitionCriterion, each of which describes a
             condition that must be met before completing a GenerationNode. All `is_met`
             must evaluateTrue for the GenerationStrategy to move on to the next

--- a/ax/modelbridge/tests/test_best_model_selector.py
+++ b/ax/modelbridge/tests/test_best_model_selector.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest.mock import Mock
+
+from ax.exceptions.core import UserInputError
+from ax.modelbridge.best_model_selector import (
+    ReductionCriterion,
+    SingleDiagnosticBestModelSelector,
+)
+from ax.modelbridge.model_spec import ModelSpec
+from ax.modelbridge.registry import Models
+from ax.utils.common.testutils import TestCase
+
+
+class TestBestModelSelector(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        # Construct a series of model specs with dummy CV diagnostics.
+        self.model_specs = []
+        for diagnostics in [
+            {"Fisher exact test p": {"y_a": 0.0, "y_b": 0.4}},
+            {"Fisher exact test p": {"y_a": 0.1, "y_b": 0.1}},
+            {"Fisher exact test p": {"y_a": 0.5, "y_b": 0.6}},
+        ]:
+            ms = ModelSpec(model_enum=Models.BOTORCH_MODULAR)
+            ms._cv_results = Mock()
+            ms._diagnostics = diagnostics
+            self.model_specs.append(ms)
+
+    def test_user_input_error(self) -> None:
+        with self.assertRaisesRegex(UserInputError, "ReductionCriterion"):
+            SingleDiagnosticBestModelSelector(
+                "Fisher exact test p", metric_aggregation=min, criterion=max
+            )
+        with self.assertRaisesRegex(UserInputError, "use MIN or MAX"):
+            SingleDiagnosticBestModelSelector(
+                "Fisher exact test p",
+                metric_aggregation=ReductionCriterion.MEAN,
+                criterion=ReductionCriterion.MEAN,
+            )
+
+    def test_SingleDiagnosticBestModelSelector_min_mean(self) -> None:
+        s = SingleDiagnosticBestModelSelector(
+            diagnostic="Fisher exact test p",
+            criterion=ReductionCriterion.MIN,
+            metric_aggregation=ReductionCriterion.MEAN,
+        )
+        self.assertEqual(s.best_model(model_specs=self.model_specs), 1)
+
+    def test_SingleDiagnosticBestModelSelector_min_min(self) -> None:
+        s = SingleDiagnosticBestModelSelector(
+            diagnostic="Fisher exact test p",
+            criterion=ReductionCriterion.MIN,
+            metric_aggregation=ReductionCriterion.MIN,
+        )
+        self.assertEqual(s.best_model(model_specs=self.model_specs), 0)
+
+    def test_SingleDiagnosticBestModelSelector_max_mean(self) -> None:
+        s = SingleDiagnosticBestModelSelector(
+            diagnostic="Fisher exact test p",
+            criterion=ReductionCriterion.MAX,
+            metric_aggregation=ReductionCriterion.MEAN,
+        )
+        self.assertEqual(s.best_model(model_specs=self.model_specs), 2)

--- a/ax/modelbridge/tests/test_cross_validation.py
+++ b/ax/modelbridge/tests/test_cross_validation.py
@@ -30,7 +30,6 @@ from ax.modelbridge.cross_validation import (
     CVDiagnostics,
     CVResult,
     has_good_opt_config_model_fit,
-    SingleDiagnosticBestModelSelector,
 )
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
@@ -419,27 +418,3 @@ class CrossValidationTest(TestCase):
             assess_model_fit_result=assess_model_fit_result,
         )
         self.assertFalse(has_good_fit)
-
-    def test_SingleDiagnosticBestModelSelector_min_mean(self) -> None:
-        s = SingleDiagnosticBestModelSelector(
-            diagnostic="Fisher exact test p",
-            criterion=min,
-            metric_aggregation=np.mean,
-        )
-        self.assertEqual(s.best_diagnostic(self.diagnostics), 1)
-
-    def test_SingleDiagnosticBestModelSelector_min_min(self) -> None:
-        s = SingleDiagnosticBestModelSelector(
-            diagnostic="Fisher exact test p",
-            criterion=min,
-            metric_aggregation=min,
-        )
-        self.assertEqual(s.best_diagnostic(self.diagnostics), 0)
-
-    def test_SingleDiagnosticBestModelSelector_max_mean(self) -> None:
-        s = SingleDiagnosticBestModelSelector(
-            diagnostic="Fisher exact test p",
-            criterion=max,
-            metric_aggregation=np.mean,
-        )
-        self.assertEqual(s.best_diagnostic(self.diagnostics), 2)

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -210,7 +210,6 @@ class TestGenerationStep(TestCase):
             #  `Union[typing.Callable[..., ModelBridge], ModelRegistryBase]`.
             model_enum=self.sobol_generation_step.model,
             model_kwargs=self.model_kwargs,
-            model_gen_kwargs=None,
         )
 
     def test_init(self) -> None:
@@ -251,13 +250,7 @@ class TestGenerationStep(TestCase):
         generation_step = GenerationStep(model=get_sobol, num_trials=-1)
         self.assertEqual(
             generation_step.model_specs,
-            [
-                FactoryFunctionModelSpec(
-                    factory_function=get_sobol,
-                    model_kwargs=None,
-                    model_gen_kwargs=None,
-                )
-            ],
+            [FactoryFunctionModelSpec(factory_function=get_sobol)],
         )
 
     def test_properties(self) -> None:

--- a/ax/modelbridge/tests/test_model_spec.py
+++ b/ax/modelbridge/tests/test_model_spec.py
@@ -146,7 +146,6 @@ class ModelSpecTest(BaseModelSpecTest):
         new_features = ObservationFeatures(parameters={"a": 1.0})
         ms.fixed_features = new_features
         self.assertEqual(ms.fixed_features, new_features)
-        # pyre-fixme[16]: Optional type has no attribute `__getitem__`.
         self.assertEqual(ms.model_gen_kwargs["fixed_features"], new_features)
 
     def test_gen_attaches_empty_model_fit_metadata_if_fit_not_applicable(self) -> None:

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -2816,7 +2816,6 @@ class TestAxClient(TestCase):
             )
         ax_client = get_branin_optimization(torch_device=device)
         gpei_step_kwargs = ax_client.generation_strategy._steps[1].model_kwargs
-        # pyre-fixme[16]: `Optional` has no attribute `__getitem__`.
         self.assertEqual(gpei_step_kwargs["torch_device"], device)
 
     def test_repr_function(
@@ -3019,5 +3018,5 @@ def _attach_not_completed_trials(ax_client) -> None:
 # Test metric evaluation method
 # pyre-fixme[2]: Parameter must be annotated.
 def _evaluate_test_metrics(parameters) -> Dict[str, Tuple[float, float]]:
-    x = np.array([parameters.get(f"x{i+1}") for i in range(2)])
+    x = np.array([parameters.get(f"x{i + 1}") for i in range(2)])
     return {"test_metric1": (x[0] / x[1], 0.0), "test_metric2": (x[0] + x[1], 0.0)}

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -718,7 +718,7 @@ def generation_step_from_json(
                 ),
             )
             if kwargs
-            else None
+            else {}
         ),
         model_gen_kwargs=(
             _decode_callables_from_references(
@@ -729,7 +729,7 @@ def generation_step_from_json(
                 ),
             )
             if gen_kwargs
-            else None
+            else {}
         ),
         index=generation_step_json.pop("index", -1),
         should_deduplicate=generation_step_json.pop("should_deduplicate", False),
@@ -761,7 +761,7 @@ def model_spec_from_json(
                 ),
             )
             if kwargs
-            else None
+            else {}
         ),
         model_gen_kwargs=(
             _decode_callables_from_references(
@@ -772,7 +772,7 @@ def model_spec_from_json(
                 ),
             )
             if gen_kwargs
-            else None
+            else {}
         ),
     )
 

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -657,9 +657,11 @@ def generation_node_from_json(
             decoder_registry=decoder_registry,
             class_decoder_registry=class_decoder_registry,
         ),
-        # TODO @mgarrad this should probably be a object_from_json but bestmodelselector
-        # isn't implemented
-        best_model_selector=generation_node_json.pop("best_model_selector", None),
+        best_model_selector=object_from_json(
+            generation_node_json.pop("best_model_selector", None),
+            decoder_registry=decoder_registry,
+            class_decoder_registry=class_decoder_registry,
+        ),
         should_deduplicate=generation_node_json.pop("should_deduplicate", False),
         transition_criteria=(
             object_from_json(

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -51,6 +51,7 @@ from ax.early_stopping.strategies import (
 from ax.exceptions.core import AxStorageWarning
 from ax.exceptions.storage import JSONEncodeError
 from ax.global_stopping.strategies.improvement import ImprovementGlobalStoppingStrategy
+from ax.modelbridge.best_model_selector import BestModelSelector
 from ax.modelbridge.generation_node import GenerationNode
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.model_spec import FactoryFunctionModelSpec, ModelSpec
@@ -495,11 +496,12 @@ def generation_node_to_dict(generation_node: GenerationNode) -> Dict[str, Any]:
     """Convert Ax generation node to a dictionary."""
     return {
         "__type": generation_node.__class__.__name__,
-        "model_specs": generation_node.model_specs,
-        "should_deduplicate": generation_node.should_deduplicate,
         "node_name": generation_node.node_name,
-        "model_spec_to_gen_from": generation_node._model_spec_to_gen_from,
+        "model_specs": generation_node.model_specs,
+        "best_model_selector": generation_node.best_model_selector,
+        "should_deduplicate": generation_node.should_deduplicate,
         "transition_criteria": generation_node.transition_criteria,
+        "model_spec_to_gen_from": generation_node._model_spec_to_gen_from,
     }
 
 
@@ -548,6 +550,16 @@ def model_spec_to_dict(model_spec: ModelSpec) -> Dict[str, Any]:
         "model_enum": model_spec.model_enum,
         "model_kwargs": model_spec.model_kwargs,
         "model_gen_kwargs": model_spec.model_gen_kwargs,
+    }
+
+
+def best_model_selector_to_dict(
+    best_model_selector: BestModelSelector,
+) -> Dict[str, Any]:
+    """Convert ``BestModelSelector`` to a dictionary."""
+    return {
+        "__type": best_model_selector.__class__.__name__,
+        **serialize_init_args(obj=best_model_selector),
     }
 
 

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -10,7 +10,6 @@ import pathlib
 from typing import Any, Callable, Dict, Type
 
 import torch
-
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_problem import (
     BenchmarkProblem,
@@ -83,6 +82,10 @@ from ax.metrics.hartmann6 import AugmentedHartmann6Metric, Hartmann6Metric
 from ax.metrics.l2norm import L2NormMetric
 from ax.metrics.noisy_function import NoisyFunctionMetric
 from ax.metrics.sklearn import SklearnDataset, SklearnMetric, SklearnModelType
+from ax.modelbridge.best_model_selector import (
+    ReductionCriterion,
+    SingleDiagnosticBestModelSelector,
+)
 from ax.modelbridge.factory import Models
 from ax.modelbridge.generation_node import GenerationNode, GenerationStep
 from ax.modelbridge.generation_strategy import GenerationStrategy
@@ -114,6 +117,7 @@ from ax.storage.json_store.encoders import (
     arm_to_dict,
     batch_to_dict,
     benchmark_problem_to_dict,
+    best_model_selector_to_dict,
     botorch_component_to_dict,
     botorch_model_to_dict,
     botorch_modular_to_dict,
@@ -179,9 +183,9 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     AugmentedBraninMetric: metric_to_dict,
     AugmentedHartmann6Metric: metric_to_dict,
     BatchTrial: batch_to_dict,
+    BenchmarkMetric: metric_to_dict,
     BenchmarkProblem: benchmark_problem_to_dict,
     BoTorchModel: botorch_model_to_dict,
-    BenchmarkMetric: metric_to_dict,
     BotorchTestProblemRunner: runner_to_dict,
     BraninMetric: metric_to_dict,
     BraninTimestampMapMetric: metric_to_dict,
@@ -247,6 +251,7 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     TransitionCriterion: transition_criterion_to_dict,
     ScalarizedObjective: scalarized_objective_to_dict,
     SearchSpace: search_space_to_dict,
+    SingleDiagnosticBestModelSelector: best_model_selector_to_dict,
     SingleObjectiveBenchmarkProblem: single_objective_benchmark_problem_to_dict,
     HierarchicalSearchSpace: search_space_to_dict,
     SumConstraint: sum_parameter_constraint_to_dict,
@@ -286,8 +291,8 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "AugmentedBraninMetric": AugmentedBraninMetric,
     "AugmentedHartmann6Metric": AugmentedHartmann6Metric,
     "Arm": Arm,
-    "BatchTrial": BatchTrial,
     "AggregatedBenchmarkResult": AggregatedBenchmarkResult,
+    "BatchTrial": BatchTrial,
     "BenchmarkMethod": BenchmarkMethod,
     "BenchmarkMetric": BenchmarkMetric,
     "BenchmarkProblem": BenchmarkProblem,
@@ -365,12 +370,14 @@ CORE_DECODER_REGISTRY: Dict[str, Type] = {
     "PyTorchCNNMetric": PyTorchCNNMetric,
     "PyTorchCNNTorchvisionRunner": PyTorchCNNTorchvisionRunner,
     "RangeParameter": RangeParameter,
+    "ReductionCriterion": ReductionCriterion,
     "RiskMeasure": RiskMeasure,
     "RobustSearchSpace": RobustSearchSpace,
     "Round": Round,
     "ScalarizedObjective": ScalarizedObjective,
     "SchedulerOptions": SchedulerOptions,
     "SearchSpace": SearchSpace,
+    "SingleDiagnosticBestModelSelector": SingleDiagnosticBestModelSelector,
     "SingleObjectiveBenchmarkProblem": SingleObjectiveBenchmarkProblem,
     "SklearnDataset": SklearnDataset,
     "SklearnMetric": SklearnMetric,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -125,6 +125,7 @@ from ax.utils.testing.modeling_stubs import (
     get_observation_features,
     get_outcome_transfrom_type,
     get_transform_type,
+    sobol_gpei_generation_node_gs,
 )
 from ax.utils.testing.utils import generic_equals
 
@@ -172,6 +173,10 @@ TEST_CASES = [
             with_generation_nodes=True,
             with_callable_model_kwarg=False,
         ),
+    ),
+    (
+        "GenerationStrategy",
+        partial(sobol_gpei_generation_node_gs, with_model_selection=True),
     ),
     ("GeneratorRun", get_generator_run),
     ("Hartmann6Metric", get_hartmann_metric),

--- a/ax/telemetry/tests/test_generation_strategy.py
+++ b/ax/telemetry/tests/test_generation_strategy.py
@@ -40,7 +40,7 @@ class TestGenerationStrategy(TestCase):
                 generation_strategy=gs
             )
         expected = GenerationStrategyCreatedRecord(
-            generation_strategy_name="Sobol+GPEI_Nodes",
+            generation_strategy_name="Sobol+MBM_Nodes",
             num_requested_initialization_trials=None,
             num_requested_bayesopt_trials=None,
             num_requested_other_trials=None,

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -196,7 +196,7 @@ def get_generation_strategy(
             search_space=get_search_space(), should_deduplicate=True
         )
         if with_callable_model_kwarg:
-            # pyre-ignore[16]: testing hack to test serialization of callable kwargs
+            # Testing hack to test serialization of callable kwargs
             # in generation steps.
             gs._steps[0].model_kwargs["model_constructor"] = get_sobol
     if with_experiment:

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -135,6 +135,13 @@ Cross Validation
     :undoc-members:
     :show-inheritance:
 
+Model Selection
+~~~~~~~~~~~~~~~~
+.. automodule:: ax.modelbridge.best_model_selector
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Dispatch Utilities
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary:
These were typed as `Optional[Dict[str, Any]]` but immediately made into `Dict[str, Any]` in `__post_init__`. The internal usage also included a bunch of `self.*_kwargs or {}`, presumably to make Pyre happy with the optional field.

This diff updates the type-hints to `Dict[str, Any]` and keeps these arguments as optional during initialization using `field(default_factory=dict)` as the default (which will assign an empty dict as the default). The change is also extended to `GenerationStep`.

I kept the `__post_init__` method in place to keep backwards compatibility with any previous usage of `None`.

Differential Revision: D59403745
