### PR TITLE
Change type of json decoder registries to include callables

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -91,6 +91,7 @@ from ax.storage.json_store.registry import (
     CORE_CLASS_ENCODER_REGISTRY,
     CORE_DECODER_REGISTRY,
     CORE_ENCODER_REGISTRY,
+    TDecoderRegistry,
 )
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.executils import retry_on_exception
@@ -1424,9 +1425,7 @@ class AxClient(WithDBSettingsBase, BestPointMixin, InstantiationBase):
     def from_json_snapshot(
         cls: Type[AxClientSubclass],
         serialized: Dict[str, Any],
-        # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-        #  `typing.Type` to avoid runtime subscripting errors.
-        decoder_registry: Optional[Dict[str, Type]] = None,
+        decoder_registry: Optional[TDecoderRegistry] = None,
         # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
         class_decoder_registry: Optional[
             Dict[str, Callable[[Dict[str, Any]], Any]]

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -164,7 +164,9 @@ def object_from_json(
             )
             raise JSONDecodeError(err)
 
-        _class = decoder_registry[_type]
+        # pyre-fixme[9, 24]: Generic type `type` expects 1 type parameter, use
+        # `typing.Type[<base type>]` to avoid runtime subscripting errors.
+        _class: Type = decoder_registry[_type]
 
         if isclass(_class) and issubclass(_class, Enum):
             # to access enum members by name, use item access

--- a/ax/storage/json_store/load.py
+++ b/ax/storage/json_store/load.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 import json
-from typing import Any, Callable, Dict, Type
+from typing import Any, Callable, Dict
 
 from ax.core.experiment import Experiment
 from ax.storage.json_store.decoder import object_from_json
@@ -15,13 +15,12 @@ from ax.storage.json_store.registry import (
     CORE_CLASS_DECODER_REGISTRY,
     CORE_DECODER_REGISTRY,
 )
+from ax.utils.common.serialization import TDecoderRegistry
 
 
 def load_experiment(
     filepath: str,
-    # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-    #  `typing.Type` to avoid runtime subscripting errors.
-    decoder_registry: Dict[str, Type] = CORE_DECODER_REGISTRY,
+    decoder_registry: TDecoderRegistry = CORE_DECODER_REGISTRY,
     # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
     class_decoder_registry: Dict[
         str, Callable[[Dict[str, Any]], Any]

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -161,6 +161,7 @@ from ax.storage.json_store.encoders import (
     winsorization_config_to_dict,
 )
 from ax.storage.utils import DomainType, ParameterConstraintType
+from ax.utils.common.serialization import TDecoderRegistry
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.models.model import Model
 from botorch.models.transforms.input import ChainedInputTransform, Normalize, Round
@@ -279,8 +280,7 @@ CORE_CLASS_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
 
 # TODO Clean up type signature. Decoders should be allowed to be any method from some
 # splattable inputs to the resultant class, not just Types with kwarg inits.
-# pyre-fixme[9, 24]
-CORE_DECODER_REGISTRY: Dict[str, Type] = {
+CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "AbandonedArm": AbandonedArm,
     "AndEarlyStoppingStrategy": AndEarlyStoppingStrategy,
     "AugmentedBraninMetric": AugmentedBraninMetric,

--- a/ax/storage/metric_registry.py
+++ b/ax/storage/metric_registry.py
@@ -19,7 +19,11 @@ from ax.metrics.hartmann6 import Hartmann6Metric
 from ax.metrics.noisy_function import NoisyFunctionMetric
 from ax.metrics.sklearn import SklearnMetric
 from ax.storage.json_store.encoders import metric_to_dict
-from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
+from ax.storage.json_store.registry import (
+    CORE_DECODER_REGISTRY,
+    CORE_ENCODER_REGISTRY,
+    TDecoderRegistry,
+)
 from ax.storage.utils import stable_hash
 from ax.utils.common.logger import get_logger
 
@@ -54,15 +58,13 @@ def register_metrics(
     encoder_registry: Dict[
         Type, Callable[[Any], Dict[str, Any]]
     ] = CORE_ENCODER_REGISTRY,
-    # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-    #  `typing.Type` to avoid runtime subscripting errors.
-    decoder_registry: Dict[str, Type] = CORE_DECODER_REGISTRY,
+    decoder_registry: TDecoderRegistry = CORE_DECODER_REGISTRY,
     # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use `typing.Type` to
     #  avoid runtime subscripting errors.
 ) -> Tuple[
     Dict[Type[Metric], int],
     Dict[Type, Callable[[Any], Dict[str, Any]]],
-    Dict[str, Type],
+    TDecoderRegistry,
 ]:
     """Add custom metric classes to the SQA and JSON registries.
     For the SQA registry, if no int is specified, use a hash of the class name.

--- a/ax/storage/registry_bundle.py
+++ b/ax/storage/registry_bundle.py
@@ -17,6 +17,7 @@ from ax.storage.json_store.registry import (
     CORE_CLASS_ENCODER_REGISTRY,
     CORE_DECODER_REGISTRY,
     CORE_ENCODER_REGISTRY,
+    TDecoderRegistry,
 )
 from ax.storage.metric_registry import register_metrics
 from ax.storage.runner_registry import register_runners
@@ -61,9 +62,7 @@ class RegistryBundleBase(ABC):
         # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
         #  `typing.Type` to avoid runtime subscripting errors.
         json_class_encoder_registry: Dict[Type, Callable[[Any], Dict[str, Any]]],
-        # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-        #  `typing.Type` to avoid runtime subscripting errors.
-        json_decoder_registry: Dict[str, Type],
+        json_decoder_registry: TDecoderRegistry,
         # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
         json_class_decoder_registry: Dict[str, Callable[[Dict[str, Any]], Any]],
     ) -> None:
@@ -105,9 +104,7 @@ class RegistryBundleBase(ABC):
         return self._encoder_registry
 
     @property
-    # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-    #  `typing.Type` to avoid runtime subscripting errors.
-    def decoder_registry(self) -> Dict[str, Type]:
+    def decoder_registry(self) -> TDecoderRegistry:
         return self._decoder_registry
 
     @property
@@ -183,9 +180,7 @@ class RegistryBundle(RegistryBundleBase):
         json_class_encoder_registry: Dict[
             Type, Callable[[Any], Dict[str, Any]]
         ] = CORE_CLASS_ENCODER_REGISTRY,
-        # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-        #  `typing.Type` to avoid runtime subscripting errors.
-        json_decoder_registry: Dict[str, Type] = CORE_DECODER_REGISTRY,
+        json_decoder_registry: TDecoderRegistry = CORE_DECODER_REGISTRY,
         # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
         json_class_decoder_registry: Dict[
             str, Callable[[Dict[str, Any]], Any]

--- a/ax/storage/runner_registry.py
+++ b/ax/storage/runner_registry.py
@@ -12,7 +12,11 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type
 from ax.core.runner import Runner
 from ax.runners.synthetic import SyntheticRunner
 from ax.storage.json_store.encoders import runner_to_dict
-from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
+from ax.storage.json_store.registry import (
+    CORE_DECODER_REGISTRY,
+    CORE_ENCODER_REGISTRY,
+    TDecoderRegistry,
+)
 from ax.storage.utils import stable_hash
 from ax.utils.common.logger import get_logger
 
@@ -40,16 +44,14 @@ def register_runner(
     encoder_registry: Dict[
         Type, Callable[[Any], Dict[str, Any]]
     ] = CORE_ENCODER_REGISTRY,
-    # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-    #  `typing.Type` to avoid runtime subscripting errors.
-    decoder_registry: Dict[str, Type] = CORE_DECODER_REGISTRY,
+    decoder_registry: TDecoderRegistry = CORE_DECODER_REGISTRY,
     val: Optional[int] = None,
     # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use `typing.Type` to
     #  avoid runtime subscripting errors.
 ) -> Tuple[
     Dict[Type[Runner], int],
     Dict[Type, Callable[[Any], Dict[str, Any]]],
-    Dict[str, Type],
+    TDecoderRegistry,
 ]:
     """Add a custom runner class to the SQA and JSON registries.
     For the SQA registry, if no int is specified, use a hash of the class name.
@@ -73,15 +75,13 @@ def register_runners(
     encoder_registry: Dict[
         Type, Callable[[Any], Dict[str, Any]]
     ] = CORE_ENCODER_REGISTRY,
-    # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-    #  `typing.Type` to avoid runtime subscripting errors.
-    decoder_registry: Dict[str, Type] = CORE_DECODER_REGISTRY,
+    decoder_registry: TDecoderRegistry = CORE_DECODER_REGISTRY,
     # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use `typing.Type` to
     #  avoid runtime subscripting errors.
 ) -> Tuple[
     Dict[Type[Runner], int],
     Dict[Type, Callable[[Any], Dict[str, Any]]],
-    Dict[str, Type],
+    TDecoderRegistry,
 ]:
     """Add custom runner classes to the SQA and JSON registries.
     For the SQA registry, if no int is specified, use a hash of the class name.

--- a/ax/storage/sqa_store/sqa_config.py
+++ b/ax/storage/sqa_store/sqa_config.py
@@ -29,6 +29,7 @@ from ax.storage.json_store.registry import (
     CORE_CLASS_ENCODER_REGISTRY,
     CORE_DECODER_REGISTRY,
     CORE_ENCODER_REGISTRY,
+    TDecoderRegistry,
 )
 from ax.storage.metric_registry import CORE_METRIC_REGISTRY
 from ax.storage.runner_registry import CORE_RUNNER_REGISTRY
@@ -101,9 +102,8 @@ class SQAConfig:
     json_class_encoder_registry: Dict[Type, Callable[[Any], Dict[str, Any]]] = field(
         default_factory=lambda: CORE_CLASS_ENCODER_REGISTRY
     )
-    # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
-    #  `typing.Type` to avoid runtime subscripting errors.
-    json_decoder_registry: Dict[str, Type] = field(
+
+    json_decoder_registry: TDecoderRegistry = field(
         default_factory=lambda: CORE_DECODER_REGISTRY
     )
     # pyre-fixme[4]: Attribute annotation cannot contain `Any`.

--- a/ax/utils/common/serialization.py
+++ b/ax/utils/common/serialization.py
@@ -11,12 +11,11 @@ from __future__ import annotations
 import inspect
 import pydoc
 from types import FunctionType
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 
-# pyre-fixme[24]: Generic type `type` expects 1 type parameter, use `typing.Type` to
-# avoid runtime subscripting errors.
-TDecoderRegistry = Dict[str, Type]
+T = TypeVar("T")
+TDecoderRegistry = Dict[str, Union[Type[T], Callable[..., T]]]
 # pyre-fixme[33]: `TClassDecoderRegistry` cannot alias to a type containing `Any`.
 TClassDecoderRegistry = Dict[str, Callable[[Dict[str, Any]], Any]]
 


### PR DESCRIPTION
Summary:
I'm getting this error.  I'm just fixing it because keeps coming up locally
```
ax/fb/generation_strategy/external_nodes/amos.py:626:4 Incompatible parameter type [6]: In call `RegistryBundle.__init__`, for argument `json_decoder_registry`, expected `Dict[str, Type[typing.Any]]` but got `Dict[str, Union[typing.Callable(amos_generation_node_from_dict)[[Named(name, str), Named(metric_equation_map, Dict[str, Type[Equation]]), Named(strict_updates, bool), Named(transition_criteria, List[TransitionCriterion]), Named(allow_parameter_prefix, bool), Named(experiment, Optional[Experiment], default)], AMOSGenerationNode], Type[typing.Any]]]`.
```

Differential Revision: D59352865
