### PR TITLE
Bug fix: Make MBM acquisition pass the correct args to each BoTorch optimizer; cleanup

### DIFF
--- a/ax/models/torch/botorch_modular/sebo.py
+++ b/ax/models/torch/botorch_modular/sebo.py
@@ -63,7 +63,7 @@ class SEBOAcquisition(Acquisition):
         surrogate = surrogates[Keys.ONLY_SURROGATE]
 
         tkwargs: Dict[str, Any] = {"dtype": surrogate.dtype, "device": surrogate.device}
-        options = options or {}
+        options = {} if options is None else options
         self.penalty_name: str = options.pop("penalty", "L0_norm")
         self.target_point: Tensor = options.pop("target_point", None)
         if self.target_point is None:
@@ -296,9 +296,10 @@ class SEBOAcquisition(Acquisition):
             bounds=bounds,
             q=n,
             optimizer_options=optimizer_options,
+            optimizer="optimize_acqf_homotopy",
         )
 
-        def callback():  # pyre-ignore
+        def callback() -> None:
             if (
                 self.acqf.cache_pending
             ):  # If true, pending points are concatenated with X_baseline

--- a/ax/models/torch/tests/test_optimizer_argparse.py
+++ b/ax/models/torch/tests/test_optimizer_argparse.py
@@ -9,18 +9,23 @@
 from __future__ import annotations
 
 from importlib import reload
+from itertools import product
 from unittest.mock import patch
 
 from ax.models.torch.botorch_modular import optimizer_argparse as Argparse
 from ax.models.torch.botorch_modular.optimizer_argparse import (
     _argparse_base,
+    BATCH_LIMIT,
     INIT_BATCH_LIMIT,
     MaybeType,
+    NUM_RESTARTS,
     optimizer_argparse,
+    RAW_SAMPLES,
 )
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.analytic import LogExpectedImprovement
 from botorch.acquisition.knowledge_gradient import (
     qKnowledgeGradient,
     qMultiFidelityKnowledgeGradient,
@@ -32,17 +37,50 @@ class DummyAcquisitionFunction(AcquisitionFunction):
 
 
 class OptimizerArgparseTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.default_expected_options = {
+            "optimize_acqf": {
+                "num_restarts": NUM_RESTARTS,
+                "raw_samples": RAW_SAMPLES,
+                "options": {
+                    "init_batch_limit": INIT_BATCH_LIMIT,
+                    "batch_limit": BATCH_LIMIT,
+                },
+                "sequential": True,
+            },
+            "optimize_acqf_discrete_local_search": {
+                "num_restarts": NUM_RESTARTS,
+                "raw_samples": RAW_SAMPLES,
+            },
+            "optimize_acqf_discrete": {},
+            "optimize_acqf_mixed": {
+                "num_restarts": NUM_RESTARTS,
+                "raw_samples": RAW_SAMPLES,
+                "options": {
+                    "init_batch_limit": INIT_BATCH_LIMIT,
+                    "batch_limit": BATCH_LIMIT,
+                },
+            },
+        }
+
     def test_notImplemented(self) -> None:
-        with self.assertRaises(NotImplementedError) as e:
+        with self.assertRaisesRegex(
+            NotImplementedError, "Could not find signature for"
+        ):
             optimizer_argparse[type(None)]  # passing `None` produces a different error
-            self.assertTrue("Could not find signature for" in str(e))
+
+    def test_unsupported_optimizer(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "optimizer=`wishful thinking` is not supported"
+        ):
+            optimizer_argparse(LogExpectedImprovement, optimizer="wishful thinking")
 
     def test_register(self) -> None:
         with patch.dict(optimizer_argparse.funcs, {}):
 
             @optimizer_argparse.register(DummyAcquisitionFunction)
-            # pyre-fixme[3]: Return type must be annotated.
-            def _argparse(acqf: MaybeType[DummyAcquisitionFunction]):
+            def _argparse(acqf: MaybeType[DummyAcquisitionFunction]) -> None:
                 pass
 
             self.assertEqual(optimizer_argparse[DummyAcquisitionFunction], _argparse)
@@ -51,33 +89,67 @@ class OptimizerArgparseTest(TestCase):
         with patch.dict(optimizer_argparse.funcs, {}):
 
             @optimizer_argparse.register(AcquisitionFunction)
-            # pyre-fixme[3]: Return type must be annotated.
-            def _argparse(acqf: MaybeType[DummyAcquisitionFunction]):
+            def _argparse(acqf: MaybeType[DummyAcquisitionFunction]) -> None:
                 pass
 
             self.assertEqual(optimizer_argparse[DummyAcquisitionFunction], _argparse)
 
     def test_optimizer_options(self) -> None:
-        # This has a bespoke test
-        skipped_func = optimizer_argparse[qKnowledgeGradient]
+        # qKG should have a bespoke test
+        # currently there is only one function in fns_to_test
+        fns_to_test = [
+            elt
+            for elt in optimizer_argparse.funcs.values()
+            if elt is not optimizer_argparse[qKnowledgeGradient]
+        ]
         user_options = {"foo": "bar", "num_restarts": 13}
-        for func in optimizer_argparse.funcs.values():
-            if func is skipped_func:
-                continue
-
-            parsed_options = func(None, optimizer_options=user_options)
-            for key, val in user_options.items():
-                self.assertEqual(val, parsed_options.get(key))
+        for func, optimizer in product(
+            fns_to_test,
+            [
+                "optimize_acqf",
+                "optimize_acqf_discrete",
+                "optimize_acqf_mixed",
+                "optimize_acqf_discrete_local_search",
+            ],
+        ):
+            with self.subTest(func=func, optimizer=optimizer):
+                parsed_options = func(
+                    None, optimizer_options=user_options, optimizer=optimizer
+                )
+                self.assertDictEqual(
+                    {**self.default_expected_options[optimizer], **user_options},
+                    parsed_options,
+                )
 
         # Also test sub-options.
-        func = _argparse_base
-        parsed_options = func(
-            None, optimizer_options={"options": {"batch_limit": 10, "maxiter": 20}}
-        )
-        self.assertEqual(
-            parsed_options["options"],
-            {"batch_limit": 10, "init_batch_limit": INIT_BATCH_LIMIT, "maxiter": 20},
-        )
+        inner_options = {"batch_limit": 10, "maxiter": 20}
+        options = {"options": inner_options}
+        for func in fns_to_test:
+            for optimizer in [
+                "optimize_acqf",
+                "optimize_acqf_mixed",
+                "optimize_acqf_discrete",
+            ]:
+                default = self.default_expected_options[optimizer]
+                parsed_options = func(
+                    None, optimizer_options=options, optimizer=optimizer
+                )
+                expected_options = {k: v for k, v in default.items() if k != "options"}
+                if "options" in default:
+                    expected_options["options"] = {
+                        **default["options"],
+                        **inner_options,
+                    }
+                else:
+                    expected_options["options"] = inner_options
+                self.assertDictEqual(expected_options, parsed_options)
+
+            parsed_options = func(
+                None,
+                optimizer_options={"options": {"batch_limit": 10, "maxiter": 20}},
+                optimizer="optimize_acqf_discrete_local_search",
+            )
+            self.assertNotIn("options", parsed_options)
 
     def test_kg(self) -> None:
         with patch(
@@ -87,7 +159,9 @@ class OptimizerArgparseTest(TestCase):
             reload(Argparse)
 
             user_options = {"foo": "bar", "num_restarts": 114}
-            generic_options = _argparse_base(None, optimizer_options=user_options)
+            generic_options = _argparse_base(
+                None, optimizer_options=user_options, optimizer="optimize_acqf"
+            )
             for acqf in (qKnowledgeGradient, qMultiFidelityKnowledgeGradient):
                 with self.subTest(acqf=acqf):
                     options = optimizer_argparse(


### PR DESCRIPTION
Summary:
Motivation: MBM can dispatch to four different BoTorch optimizers depending on the search space. Currently, `optimize_acqf_discrete_local_search` is failing because it is passed the inappropriate argument `sequential`.

This diff
* Makes the logic more clear: First, Acquisition.optimize determines which of the four optimizers is appropriate. then it constructs arguments based on that optimizer. Then it constructs arguments for the optimizers using `optimizer_argparse`. Then it does any optimizer_specific logic and calls the optimizer.
* Fixes optimizer_argparse so that inappropriate arguments such as `sequential` are not passed to optimizers they don't apply to.
* Removes special-casing for qNEHVI and qMES in optimizer_argparse that wasn't actually doing anything
* Extends unit tests for `optimizer_argparse` to check all optimizers
* Reduces the usage and scope of mocks in test_acquisition so that `optimize_acqf` and its variants are actually run as much as possible.

Differential Revision: D59354709
