### PR TITLE
Remove link to the Raytune Tutorial

### DIFF
--- a/website/pages/tutorials/index.js
+++ b/website/pages/tutorials/index.js
@@ -123,15 +123,6 @@ class TutorialHome extends React.Component {
             </ul>
             <ul>
               <li>
-                <a href="raytune_pytorch_cnn.html">
-                  Hyperparameter Optimization via Raytune
-                </a>
-                &nbsp; provides an example of parallelized hyperparameter
-                optimization using Ax + Raytune.
-              </li>
-            </ul>
-            <ul>
-              <li>
                 <a href="multi_task.html">Multi-Task Modeling</a>
                 &nbsp; illustrates multi-task Bayesian Optimization on a
                 constrained synthetic Hartmann6 problem.

--- a/website/tutorials.json
+++ b/website/tutorials.json
@@ -41,10 +41,6 @@
       "title": "Hyperparameter Optimization on SLURM via SubmitIt"
     },
     {
-      "id": "raytune_pytorch_cnn",
-      "title": "Hyperparameter Optimization via Raytune"
-    },
-    {
       "id": "multi_task",
       "title": "Multi-Task Modeling"
     },


### PR DESCRIPTION
Summary:
Follow up to https://github.com/facebook/Ax/issues/2090?fbclid=IwAR2wIKU6wq2vv5tZlcyoNwa1LU4HtBSNKQG3UBT7tLUL8-Atv_SjPBgcHFE#issuecomment-2040602613

Right now the Raytune tutorial goes to a 404 - which isn't great. Liz suggested removing this tutorial while we get it fixed.

Differential Revision: D56048964
