### PR TITLE
Add additional validation to transition criterion to not allow `transition_to` to be undefined except for MaxGenParallelism

### DIFF
--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -632,6 +632,17 @@ class GenerationStrategy(GenerationStrategyInterface):
         for node in self._nodes:
             for next_node, tcs in node.transition_edges.items():
                 contains_a_transition_to_argument = True
+                if next_node is None:
+                    # TODO: @mgarrard remove MaxGenerationParallelism check when
+                    # we update TransitionCriterion always define `transition_to`
+                    for tc in tcs:
+                        if "MaxGenerationParallelism" not in tc.criterion_class:
+                            raise GenerationStrategyMisconfiguredException(
+                                error_info="Only MaxGenerationParallelism transition"
+                                " criterion can have a null `transition_to` argument,"
+                                f" but {tc.criterion_class} does not define "
+                                f"`transition_to` on {node.node_name}."
+                            )
                 if next_node is not None and next_node not in node_names:
                     raise GenerationStrategyMisconfiguredException(
                         error_info=f"`transition_to` argument "

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -152,7 +152,9 @@ class TestGenerationStrategy(TestCase):
         self.gpei_criterion = [
             MaxTrials(
                 threshold=2,
-                transition_to=None,
+                # this self-pointing isn't representative of real-world, but is
+                # useful for testing attributes likes repr etc
+                transition_to="GPEI_node",
                 block_gen_if_met=True,
                 only_in_statuses=None,
                 not_in_statuses=[TrialStatus.FAILED, TrialStatus.ABANDONED],

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -228,10 +228,12 @@ def sobol_gpei_generation_node_gs(
             not_in_statuses=[TrialStatus.FAILED, TrialStatus.ABANDONED],
         )
     ]
+    # self-transitioning for mbm criterion isn't representative of real-world, but is
+    # useful for testing attributes likes repr etc
     mbm_criterion = [
         MaxTrials(
             threshold=2,
-            transition_to=None,
+            transition_to="MBM_node",
             block_gen_if_met=True,
             only_in_statuses=None,
             not_in_statuses=[TrialStatus.FAILED, TrialStatus.ABANDONED],
@@ -240,7 +242,7 @@ def sobol_gpei_generation_node_gs(
         # we wanted to have an instance of them to test for storage compatibility.
         MinTrials(
             threshold=0,
-            transition_to=None,
+            transition_to="MBM_node",
             block_gen_if_met=False,
             only_in_statuses=[TrialStatus.CANDIDATE],
             not_in_statuses=None,


### PR DESCRIPTION
Summary:
This recently came up in a conversation with Lena/Sait when debugging an issue with transition logic (it ended up being related to the GeneratorRun node_name property being improperly set), but we should still add additional validation.

All TC should define a `transition_to` arg unless it's MaxGenParallelism. We update the logic to raise an error, and we update associated tests.

In the future, we want to reconfigure TC to never allow undefined `transition_to` so we also add a TODO

Differential Revision: D59740485
