### PR TITLE
Fixing typo in docstring of `get_sobol_botorch_modular_acquisition`

### DIFF
--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -85,11 +85,11 @@ def get_sobol_botorch_modular_acquisition(
         ...     scheduler_options=get_benchmark_scheduler_options(
         ...         batch_size=5,
         ...     ),
-        ...     model_gen_kwargs=model_gen_kwargs={
-        ...             "model_gen_options": {
-        ...                 "optimizer_kwargs": {"sequential": False}
-        ...             }
+        ...     model_gen_kwargs={
+        ...         "model_gen_options": {
+        ...             "optimizer_kwargs": {"sequential": False}
         ...         }
+        ...     },
         ...     num_sobol_trials=1,
         ... )
     """


### PR DESCRIPTION
Summary: This commit fixes a typo.

Reviewed By: esantorella

Differential Revision: D59861328
