### PR TITLE
Storage support for ScaleMaternKernel & DEFAULT

### DIFF
--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -40,6 +40,7 @@ from ax.utils.common.typeutils import checked_cast
 from ax.utils.common.typeutils_torch import torch_type_from_str
 from botorch.models.transforms.input import ChainedInputTransform, InputTransform
 from botorch.models.transforms.outcome import ChainedOutcomeTransform, OutcomeTransform
+from botorch.utils.types import _DefaultType, DEFAULT
 
 logger: logging.Logger = get_logger(__name__)
 
@@ -319,3 +320,11 @@ def pathlib_from_json(pathsegments: Union[str, Iterable[str]]) -> Path:
         return Path(pathsegments)
 
     return Path(*pathsegments)
+
+
+def default_from_json(json: Dict[str, Any]) -> _DefaultType:
+    if json != {}:
+        raise JSONDecodeError(
+            f"Expected empty json object for ``DEFAULT``, got {json=}"
+        )
+    return DEFAULT

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -68,6 +68,7 @@ from ax.utils.common.serialization import serialize_init_args
 from ax.utils.common.typeutils import not_none
 from ax.utils.common.typeutils_torch import torch_type_to_str
 from botorch.models.transforms.input import ChainedInputTransform, InputTransform
+from botorch.utils.types import _DefaultType
 from torch import Tensor
 
 
@@ -764,3 +765,7 @@ def risk_measure_to_dict(
 
 def pathlib_to_dict(path: Path) -> Dict[str, Any]:
     return {"__type": path.__class__.__name__, "pathsegments": [str(path)]}
+
+
+def default_to_dict(default: _DefaultType) -> Dict[str, Any]:
+    return {"__type": default.__class__.__name__}

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -108,6 +108,7 @@ from ax.runners.synthetic import SyntheticRunner
 from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.storage.json_store.decoders import (
     class_from_json,
+    default_from_json,
     input_transform_type_from_json,
     outcome_transform_type_from_json,
     pathlib_from_json,
@@ -123,6 +124,7 @@ from ax.storage.json_store.encoders import (
     botorch_modular_to_dict,
     choice_parameter_to_dict,
     data_to_dict,
+    default_to_dict,
     experiment_to_dict,
     fixed_parameter_to_dict,
     generation_node_to_dict,
@@ -169,6 +171,7 @@ from ax.utils.common.serialization import TDecoderRegistry
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.models.model import Model
 from botorch.models.transforms.input import ChainedInputTransform, Normalize, Round
+from botorch.utils.types import DEFAULT
 from gpytorch.constraints import Interval
 from gpytorch.likelihoods.likelihood import Likelihood
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
@@ -281,6 +284,7 @@ CORE_CLASS_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     MarginalLogLikelihood: botorch_modular_to_dict,  # BoTorch component
     Model: botorch_modular_to_dict,  # BoTorch component
     Transform: transform_type_to_dict,  # Ax general (not just MBM) component
+    DEFAULT: default_to_dict,  # BoTorch DEFAULT, used in MBM.
 }
 
 # TODO Clean up type signature. Decoders should be allowed to be any method from some
@@ -403,6 +407,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
 CORE_CLASS_DECODER_REGISTRY: Dict[str, Callable[[Dict[str, Any]], Any]] = {
     "Type[Acquisition]": class_from_json,
     "Type[AcquisitionFunction]": class_from_json,
+    "Type[Kernel]": class_from_json,
     "Type[Likelihood]": class_from_json,
     "Type[torch.nn.Module]": class_from_json,
     "Type[MarginalLogLikelihood]": class_from_json,
@@ -410,4 +415,5 @@ CORE_CLASS_DECODER_REGISTRY: Dict[str, Callable[[Dict[str, Any]], Any]] = {
     "Type[Transform]": transform_type_from_json,
     "Type[InputTransform]": input_transform_type_from_json,
     "Type[OutcomeTransform]": outcome_transform_type_from_json,
+    "_DefaultType": default_from_json,
 }

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -102,6 +102,7 @@ from ax.modelbridge.transition_criterion import (
     TrialBasedCriterion,
 )
 from ax.models.torch.botorch_modular.acquisition import Acquisition
+from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
 from ax.models.torch.botorch_modular.model import BoTorchModel, SurrogateSpec
 from ax.models.torch.botorch_modular.sebo import SEBOAcquisition
 from ax.models.torch.botorch_modular.surrogate import Surrogate
@@ -119,6 +120,7 @@ from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.model import Model
 from botorch.models.transforms.input import ChainedInputTransform, Normalize, Round
 from botorch.utils.datasets import SupervisedDataset
+from botorch.utils.types import DEFAULT
 from gpytorch.constraints import Interval
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
@@ -2219,6 +2221,19 @@ def get_surrogate() -> Surrogate:
     return Surrogate(
         botorch_model_class=get_model_type(),
         mll_class=get_mll_type(),
+    )
+
+
+def get_surrogate_spec_with_default() -> SurrogateSpec:
+    return SurrogateSpec(
+        botorch_model_class=SingleTaskGP,
+        covar_module_class=ScaleMaternKernel,
+        covar_module_kwargs={
+            "ard_num_dims": DEFAULT,
+            "lengthscale_prior": GammaPrior(6.0, 3.0),
+            "outputscale_prior": GammaPrior(2.0, 0.15),
+            "batch_shape": DEFAULT,
+        },
     )
 
 


### PR DESCRIPTION
Summary: Turns out these weren't in the storage registries, so they couldn't be serialized.

Differential Revision: D59891434
