### PR TITLE
Fix incorrect status quo update warning

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -257,16 +257,15 @@ class Experiment(Base):
             while name in arms_by_name:
                 name = f"status_quo_e{sq_idx}"
                 sq_idx += 1
-
             self._name_and_store_arm_if_not_exists(arm=status_quo, proposed_name=name)
-            logger.warning(
-                "Experiment's status_quo is updated. "
-                "Generally the status_quo should not be changed after being set."
-            )
 
         # If old status_quo not present in any trials,
         # remove from _arms_by_signature
         if self._status_quo is not None:
+            logger.warning(
+                "Experiment's status_quo is updated. "
+                "Generally the status_quo should not be changed after being set."
+            )
             persist_old_sq = False
             for trial in self._trials.values():
                 # pyre-fixme[16]: `Optional` has no attribute `name`.

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -373,8 +373,11 @@ class ExperimentTest(TestCase):
         self.assertEqual(len(self.experiment.arms_by_name), 1)
 
         # Change status quo, verify still just 1 arm
-        sq_parameters["w"] = 3.6
-        self.experiment.status_quo = Arm(sq_parameters)
+        with patch("ax.core.experiment.logger.warning") as mock_logger:
+            sq_parameters["w"] = 3.6
+            self.experiment.status_quo = Arm(sq_parameters)
+        mock_logger.assert_called_once()
+        self.assertIn("status_quo is updated", mock_logger.call_args.args[0])
         self.assertEqual(len(self.experiment.arms_by_signature), 1)
         self.assertEqual(len(self.experiment.arms_by_name), 1)
 


### PR DESCRIPTION
Summary:
This is something Ben brought up as something to improve a couple months ago. Right now, with almost everything we do in any of the clients there is a warning about status quo being updated, even though it is often not being updated. It turns out this is because of the incorrect positioning of the warning in the status quo setter.

In this diff I
1) move the logger warning to be under the self._status_quo is None check
2) added a unit test modification

Differential Revision: D59894197
