### PR TITLE
Raise error if enum not provided for a value we're trying to encode

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -96,7 +96,7 @@ class Decoder:
         self.config = config
 
     def get_enum_name(
-        self, value: Optional[int], enum: Optional[Enum]
+        self, value: Optional[int], enum: Optional[Union[Enum, Type[Enum]]]
     ) -> Optional[str]:
         """Given an enum value (int) and an enum (of ints), return the
         corresponding enum name. If the value is not present in the enum,

--- a/ax/storage/sqa_store/sqa_config.py
+++ b/ax/storage/sqa_store/sqa_config.py
@@ -8,7 +8,7 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Callable, Dict, Optional, Type, Union
 
 from ax.analysis.analysis_report import AnalysisReport
 from ax.analysis.base_analysis import BaseAnalysis
@@ -87,8 +87,8 @@ class SQAConfig:
     class_to_sqa_class: Dict[Type[Base], Type[SQABase]] = field(
         default_factory=_default_class_to_sqa_class
     )
-    experiment_type_enum: Optional[Enum] = None
-    generator_run_type_enum: Optional[Enum] = GeneratorRunType  # pyre-ignore [8]
+    experiment_type_enum: Optional[Union[Enum, Type[Enum]]] = None
+    generator_run_type_enum: Optional[Union[Enum, Type[Enum]]] = GeneratorRunType
 
     # pyre-fixme[4]: Attribute annotation cannot contain `Any`.
     # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -8,6 +8,7 @@
 
 import logging
 from datetime import datetime
+from enum import Enum
 from logging import Logger
 from typing import Any
 from unittest import mock
@@ -201,6 +202,35 @@ class SQAStoreTest(TestCase):
             self.assertIsNotNone(exp.db_id)
             loaded_experiment = load_experiment(exp.name)
             self.assertEqual(loaded_experiment, exp)
+
+    def test_saving_an_experiment_with_type_requires_an_enum(self) -> None:
+        self.experiment.experiment_type = "TEST"
+        with self.assertRaises(SQAEncodeError):
+            save_experiment(self.experiment)
+
+    def test_saving_an_experiment_with_type_works_with_an_enum(self) -> None:
+        class TestExperimentTypeEnum(Enum):
+            TEST = 0
+
+        self.experiment.experiment_type = "TEST"
+        save_experiment(
+            self.experiment,
+            config=SQAConfig(experiment_type_enum=TestExperimentTypeEnum),
+        )
+        self.assertIsNotNone(self.experiment.db_id)
+
+    def test_saving_an_experiment_with_type_errors_with_missing_enum_value(
+        self,
+    ) -> None:
+        class TestExperimentTypeEnum(Enum):
+            NOT_TEST = 0
+
+        self.experiment.experiment_type = "TEST"
+        with self.assertRaises(SQAEncodeError):
+            save_experiment(
+                self.experiment,
+                config=SQAConfig(experiment_type_enum=TestExperimentTypeEnum),
+            )
 
     def test_LoadExperimentTrialsInBatches(self) -> None:
         for _ in range(4):


### PR DESCRIPTION
Summary:
We probably want to let the user know if they're trying to encode/save a value we're going to drop.  It turns out prior to this diff, a `None` for the enum that would be used to encode the value is treated differently than an actual enum that just happens to be missing the value.  So a missing enum for experiment type would not raise an error if experiment type was passed.

This should debatably only be done in test mode though.  Silent failures are generally bad though and we could cause more problems down the road by not saving data we need to.

Differential Revision: D59925061
