### PR TITLE
Change SurrogateBenchmarkProblem to TorchModelBridge

### DIFF
--- a/ax/benchmark/problems/surrogate.py
+++ b/ax/benchmark/problems/surrogate.py
@@ -16,7 +16,7 @@ from ax.core.optimization_config import (
 )
 from ax.core.runner import Runner
 from ax.core.search_space import SearchSpace
-from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.modelbridge.torch import TorchModelBridge
 from ax.utils.common.base import Base
 from ax.utils.common.equality import equality_typechecker
 from ax.utils.common.typeutils import checked_cast, not_none
@@ -42,7 +42,7 @@ class SurrogateBenchmarkProblemBase(Base):
         observe_noise_stds: Union[bool, Dict[str, bool]] = False,
         noise_stds: Union[float, Dict[str, float]] = 0.0,
         get_surrogate_and_datasets: Optional[
-            Callable[[], Tuple[Surrogate, List[SupervisedDataset]]]
+            Callable[[], Tuple[TorchModelBridge, List[SupervisedDataset]]]
         ] = None,
         tracking_metrics: Optional[List[BenchmarkMetricBase]] = None,
         _runner: Optional[Runner] = None,
@@ -163,7 +163,7 @@ class SOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
         observe_noise_stds: Union[bool, Dict[str, bool]] = False,
         noise_stds: Union[float, Dict[str, float]] = 0.0,
         get_surrogate_and_datasets: Optional[
-            Callable[[], Tuple[Surrogate, List[SupervisedDataset]]]
+            Callable[[], Tuple[TorchModelBridge, List[SupervisedDataset]]]
         ] = None,
         tracking_metrics: Optional[List[BenchmarkMetricBase]] = None,
         _runner: Optional[Runner] = None,
@@ -210,7 +210,7 @@ class MOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
         observe_noise_stds: Union[bool, Dict[str, bool]] = False,
         noise_stds: Union[float, Dict[str, float]] = 0.0,
         get_surrogate_and_datasets: Optional[
-            Callable[[], Tuple[Surrogate, List[SupervisedDataset]]]
+            Callable[[], Tuple[TorchModelBridge, List[SupervisedDataset]]]
         ] = None,
         tracking_metrics: Optional[List[BenchmarkMetricBase]] = None,
         _runner: Optional[Runner] = None,

--- a/ax/benchmark/tests/runners/test_surrogate_runner.py
+++ b/ax/benchmark/tests/runners/test_surrogate_runner.py
@@ -9,14 +9,9 @@ from unittest.mock import MagicMock
 
 import torch
 from ax.benchmark.problems.surrogate import SurrogateRunner
-from ax.core.arm import Arm
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
-from ax.core.trial import Trial
-from ax.modelbridge.transforms.int_to_float import IntToFloat
-from ax.modelbridge.transforms.log import Log
 from ax.utils.common.testutils import TestCase
-from ax.utils.common.typeutils import checked_cast, not_none
 
 
 class TestSurrogateRunner(TestCase):
@@ -48,38 +43,3 @@ class TestSurrogateRunner(TestCase):
                 self.assertIs(runner.surrogate, surrogate)
                 self.assertEqual(runner.outcome_names, ["dummy_metric"])
                 self.assertEqual(runner.noise_stds, noise_std)
-
-                # Check that the transforms are set up correctly.
-                transforms = not_none(runner.transforms)
-                self.assertEqual(len(transforms), 2)
-                self.assertIsInstance(transforms[0], IntToFloat)
-                self.assertIsInstance(transforms[1], Log)
-                self.assertEqual(
-                    checked_cast(IntToFloat, transforms[0]).transform_parameters, {"z"}
-                )
-                self.assertEqual(
-                    checked_cast(Log, transforms[1]).transform_parameters, {"y", "z"}
-                )
-                # Check that evaluation works correctly with the transformed parameters.
-                trial = Trial(experiment=MagicMock())
-                trial.add_arm(Arm({"x": 2.5, "y": 10.0, "z": 1.0}, name="0_0"))
-                run_output = runner.run(trial)
-                self.assertEqual(run_output["outcome_names"], ["dummy_metric"])
-                self.assertEqual(run_output["Ys_true"]["0_0"], [0.1234])
-                self.assertEqual(
-                    run_output["Ystds"]["0_0"],
-                    [
-                        (
-                            noise_std
-                            if not isinstance(noise_std, dict)
-                            else noise_std["dummy_metric"]
-                        )
-                    ],
-                )
-                surrogate.predict.assert_called_once()
-                X = surrogate.predict.call_args[1]["X"]
-                self.assertTrue(
-                    torch.allclose(
-                        X, torch.tensor([[2.5, 1.0, 0.0]], dtype=torch.double)
-                    )
-                )

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -29,7 +29,6 @@ from ax.benchmark.metrics.benchmark import BenchmarkMetric, GroundTruthBenchmark
 from ax.benchmark.problems.registry import get_problem
 from ax.modelbridge.generation_strategy import GenerationNode, GenerationStrategy
 from ax.modelbridge.model_spec import ModelSpec
-from ax.modelbridge.modelbridge_utils import extract_search_space_digest
 from ax.modelbridge.registry import Models
 from ax.service.utils.scheduler_options import SchedulerOptions
 from ax.storage.json_store.load import load_experiment
@@ -44,7 +43,7 @@ from ax.utils.testing.benchmark_stubs import (
     get_sobol_benchmark_method,
     get_soo_surrogate,
 )
-from ax.utils.testing.core_stubs import get_dataset, get_experiment
+from ax.utils.testing.core_stubs import get_experiment
 from ax.utils.testing.mock import fast_botorch_optimize
 from botorch.acquisition.logei import qLogNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
@@ -302,13 +301,6 @@ class TestBenchmark(TestCase):
         ]:
             with self.subTest(name, problem=problem):
                 surrogate, datasets = not_none(problem.get_surrogate_and_datasets)()
-                surrogate.fit(
-                    [get_dataset()],
-                    search_space_digest=extract_search_space_digest(
-                        problem.search_space,
-                        param_names=[*problem.search_space.parameters.keys()],
-                    ),
-                )
                 res = benchmark_replication(problem=problem, method=method, seed=0)
 
                 self.assertEqual(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -611,6 +611,8 @@ def get_branin_experiment_with_multi_objective(
     with_status_quo: bool = False,
     with_fidelity_parameter: bool = False,
     num_objectives: int = 2,
+    with_trial: bool = False,
+    with_completed_trial: bool = False,
 ) -> Experiment:
     exp = Experiment(
         name="branin_test_experiment",
@@ -639,6 +641,18 @@ def get_branin_experiment_with_multi_objective(
         exp.new_batch_trial(optimize_for_power=with_status_quo).add_generator_run(
             sobol_run
         )
+
+    if with_trial or with_completed_trial:
+        sobol_generator = get_sobol(search_space=exp.search_space)
+        sobol_run = sobol_generator.gen(n=1)
+        trial = exp.new_trial(generator_run=sobol_run)
+
+        if with_completed_trial:
+            trial.mark_running(no_runner_required=True)
+            exp.attach_data(
+                get_branin_data_multi_objective(trial_indices=[trial.index])
+            )  # Add data for one trial
+            trial.mark_completed()
 
     return exp
 


### PR DESCRIPTION
Summary:
This diff changes our surrogate benchmark problems to use a `TorchModelBridge` instead of a `Surrogate`

**Why this change?**
Our current surrogate benchmark problems are constructed in the transformed space and thus don't have any transform. Constructing the surrogates in the transformed space doesn't play well with things like HSS and also doesn't allow us to fully utilize methods targeting discrete and mixed search spaces.

This setup also plays much better with how we normally fit models in Ax as, e.g., cross-validation is done on the model bridge. Going forward, constructing a surrogate benchmark problem will end up looking something like this:
1.  Load data
2. Fit an Ax modelbridge
3. Cross-validate the modelbridge to make sure the model fit quality looks good
4. Save the components needed to reconstruct the modelbridge (e.g., state dict)

Reviewed By: saitcakmak

Differential Revision: D59883218
