### PR TITLE
Add an `optimal_value` to mixed-integer problems

### DIFF
--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -20,7 +20,7 @@ References
 
 from typing import Dict, List, Optional, Tuple, Type, Union
 
-from ax.benchmark.benchmark_problem import BenchmarkProblem
+from ax.benchmark.benchmark_problem import SingleObjectiveBenchmarkProblem
 from ax.benchmark.metrics.benchmark import BenchmarkMetric
 from ax.benchmark.runners.botorch_test import BotorchTestProblemRunner
 from ax.core.objective import Objective
@@ -36,6 +36,7 @@ from botorch.test_functions.synthetic import (
 
 
 def _get_problem_from_common_inputs(
+    *,
     bounds: List[Tuple[float, float]],
     dim_int: int,
     metric_name: str,
@@ -44,12 +45,18 @@ def _get_problem_from_common_inputs(
     test_problem_class: Type[SyntheticTestFunction],
     benchmark_name: str,
     num_trials: int,
+    optimal_value: float,
     test_problem_bounds: Optional[List[Tuple[float, float]]] = None,
-) -> BenchmarkProblem:
+) -> SingleObjectiveBenchmarkProblem:
     """This is a helper that deduplicates common bits of the below problems.
 
     Args:
-        bounds: The parameter bounds.
+        bounds: The parameter bounds. These will be passed to
+            `BotorchTestProblemRunner` as `modified_bounds`, and the parameters
+            will be renormalized from these bounds to the bounds of the original
+            problem. For example, if `bounds` are [(0, 3)] and the test
+            problem's original bounds are [(0, 2)], then the original problem
+            can be evaluated at 0, 2/3, 4/3, and 2.
         dim_int: The number of integer dimensions. First `dim_int` parameters
             are assumed to be integers.
         metric_name: The name of the metric.
@@ -59,6 +66,12 @@ def _get_problem_from_common_inputs(
         test_problem_class: The BoTorch test problem class.
         benchmark_name: The name of the benchmark problem.
         num_trials: The number of trials.
+        optimal_value: Best attainable value, if known. If unknown, as may be
+            the case for mixed-integer problems, choose a value that is known to
+            be at least as good as the true optimum, to prevent benchmarks from
+            attaining scores of over 100%. One strategy for choosing this value
+            is to choose the overall optimum of the problem without regard to
+            the integer restrictions.
         test_problem_bounds: Optional bounds to evaluate the base test problem on.
             These are passed in as `bounds` while initializing the test problem.
 
@@ -98,12 +111,13 @@ def _get_problem_from_common_inputs(
         outcome_names=[metric_name],
         modified_bounds=bounds,
     )
-    return BenchmarkProblem(
+    return SingleObjectiveBenchmarkProblem(
         name=benchmark_name + ("_observed_noise" if observe_noise_sd else ""),
         search_space=search_space,
         optimization_config=optimization_config,
         runner=runner,
         num_trials=num_trials,
+        optimal_value=optimal_value,
         is_noiseless=True,
         observe_noise_sd=observe_noise_sd,
         has_ground_truth=True,
@@ -114,7 +128,7 @@ def get_discrete_hartmann(
     num_trials: int = 50,
     observe_noise_sd: bool = False,
     bounds: Optional[List[Tuple[float, float]]] = None,
-) -> BenchmarkProblem:
+) -> SingleObjectiveBenchmarkProblem:
     """6D Hartmann problem where first 4 dimensions are discretized."""
     dim_int = 4
     if bounds is None:
@@ -135,6 +149,10 @@ def get_discrete_hartmann(
         test_problem_class=Hartmann,
         benchmark_name="Discrete Hartmann",
         num_trials=num_trials,
+        # The best value we've found so far on this mixed problem is -2.89. The
+        # optimum without regards to the integer constraints is -3.3224, but
+        # that won't be attainable here.
+        optimal_value=-3.0,
     )
 
 
@@ -142,7 +160,7 @@ def get_discrete_ackley(
     num_trials: int = 50,
     observe_noise_sd: bool = False,
     bounds: Optional[List[Tuple[float, float]]] = None,
-) -> BenchmarkProblem:
+) -> SingleObjectiveBenchmarkProblem:
     """13D Ackley problem where first 10 dimensions are discretized.
 
     This also restricts Ackley evaluation bounds to [0, 1].
@@ -165,6 +183,9 @@ def get_discrete_ackley(
         benchmark_name="Discrete Ackley",
         num_trials=num_trials,
         test_problem_bounds=[(0.0, 1.0)] * dim,
+        # Ackley's lowest value is at (0, 0, ..., 0), which is in the search
+        # space, so the restriction to integers doesn't change the optimum
+        optimal_value=0.0,
     )
 
 
@@ -172,7 +193,7 @@ def get_discrete_rosenbrock(
     num_trials: int = 50,
     observe_noise_sd: bool = False,
     bounds: Optional[List[Tuple[float, float]]] = None,
-) -> BenchmarkProblem:
+) -> SingleObjectiveBenchmarkProblem:
     """10D Rosenbrock problem where first 6 dimensions are discretized."""
     dim_int = 6
     if bounds is None:
@@ -189,4 +210,7 @@ def get_discrete_rosenbrock(
         test_problem_class=Rosenbrock,
         benchmark_name="Discrete Rosenbrock",
         num_trials=num_trials,
+        # Rosenbrock's lowest value is at (1, 1, ..., 1), which is in the search
+        # space, so the restriction to integers doesn't change the optimum
+        optimal_value=0.0,
     )

--- a/ax/benchmark/tests/problems/test_mixed_integer_problems.py
+++ b/ax/benchmark/tests/problems/test_mixed_integer_problems.py
@@ -20,15 +20,17 @@ from ax.core.parameter import ParameterType
 from ax.core.trial import Trial
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast, not_none
+from botorch.test_functions.synthetic import Ackley, Hartmann, Rosenbrock
 
 
 class MixedIntegerProblemsTest(TestCase):
     def test_problems(self) -> None:
-        for name, constructor, dim, dim_int in (
-            ("Hartmann", get_discrete_hartmann, 6, 4),
-            ("Ackley", get_discrete_ackley, 13, 10),
-            ("Rosenbrock", get_discrete_rosenbrock, 10, 6),
+        for problem_cls, constructor, dim, dim_int in (
+            (Hartmann, get_discrete_hartmann, 6, 4),
+            (Ackley, get_discrete_ackley, 13, 10),
+            (Rosenbrock, get_discrete_rosenbrock, 10, 6),
         ):
+            name = problem_cls.__name__
             problem = constructor()
             self.assertEqual(f"Discrete {name}", problem.name)
             self.assertEqual(
@@ -56,6 +58,10 @@ class MixedIntegerProblemsTest(TestCase):
                 ).test_problem._bounds,
                 expected_bounds,
             )
+            print(f"{name=}")
+            print(f"{problem.optimal_value=}")
+            print(f"{problem_cls().optimal_value=}")
+            self.assertGreaterEqual(problem.optimal_value, problem_cls().optimal_value)
 
         # Test that they match correctly to the original problems.
         # Hartmann - evaluate at 0 - should correspond to 0.


### PR DESCRIPTION
Summary: The next PR will require all problems to have an  `optimal_value`. See that PR for more context. This PR adds an optimal value to the mixed-integer problems, which are the only problems that currently lack one. This will be better than the true optimal value because the mixed problems have a restricted search space.

Differential Revision: D60144693
