### PR TITLE
Consolidate `observe_noise_stds` and `observe_noise_sd`

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -11,7 +11,7 @@
 # in the UI.
 
 import abc
-from typing import Any, Dict, List, Optional, Protocol, runtime_checkable, Type, Union
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable, Type
 
 from ax.benchmark.metrics.base import BenchmarkMetricBase
 
@@ -66,9 +66,7 @@ class BenchmarkProblemProtocol(Protocol):
     num_trials: int
     tracking_metrics: List[BenchmarkMetricBase]
     is_noiseless: bool  # If True, evaluations are deterministic
-    observe_noise_stds: Union[
-        bool, Dict[str, bool]
-    ]  # Whether we observe the observation noise level
+    observe_noise_sd: bool
     has_ground_truth: bool  # if True, evals (w/o synthetic noise) are determinstic
 
     @abc.abstractproperty
@@ -111,12 +109,6 @@ class BenchmarkProblem(Base):
     @property
     def runner(self) -> Runner:
         return self._runner
-
-    @property
-    def observe_noise_stds(self) -> Union[bool, Dict[str, bool]]:
-        # TODO: Handle cases where some outcomes have noise levels observed
-        # and others do not.
-        return self.observe_noise_sd
 
     @classmethod
     def from_botorch(

--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -314,14 +314,16 @@ class SingleObjectiveBenchmarkProblem(BenchmarkProblem):
 
 
 class MultiObjectiveBenchmarkProblem(BenchmarkProblem):
-    """A BenchmarkProblem support multiple objectives. Rather than knowing each
-    objective's optimal value we track a known maximum hypervolume computed from a
-    given reference point.
+    """
+    A `BenchmarkProblem` that supports multiple objectives.
+
+    For multi-objective problems, `optimal_value` indicates the maximum
+    hypervolume attainable with the given `reference_point`.
     """
 
     def __init__(
         self,
-        maximum_hypervolume: float,
+        optimal_value: float,
         reference_point: List[float],
         *,
         name: str,
@@ -334,7 +336,7 @@ class MultiObjectiveBenchmarkProblem(BenchmarkProblem):
         has_ground_truth: bool = False,
         tracking_metrics: Optional[List[BenchmarkMetricBase]] = None,
     ) -> None:
-        self.maximum_hypervolume = maximum_hypervolume
+        self.optimal_value = optimal_value
         self.reference_point = reference_point
         super().__init__(
             name=name,
@@ -347,10 +349,6 @@ class MultiObjectiveBenchmarkProblem(BenchmarkProblem):
             has_ground_truth=has_ground_truth,
             tracking_metrics=tracking_metrics,
         )
-
-    @property
-    def optimal_value(self) -> float:
-        return self.maximum_hypervolume
 
     @classmethod
     def from_botorch_multi_objective(
@@ -425,6 +423,10 @@ class MultiObjectiveBenchmarkProblem(BenchmarkProblem):
             is_noiseless=problem.is_noiseless,
             observe_noise_sd=observe_noise_sd,
             has_ground_truth=problem.has_ground_truth,
-            maximum_hypervolume=test_problem.max_hv,
+            optimal_value=test_problem.max_hv,
             reference_point=test_problem._ref_point,
         )
+
+    @property
+    def maximum_hypervolume(self) -> float:
+        return self.optimal_value

--- a/ax/benchmark/problems/surrogate.py
+++ b/ax/benchmark/problems/surrogate.py
@@ -39,7 +39,7 @@ class SurrogateBenchmarkProblemBase(Base):
         optimization_config: OptimizationConfig,
         num_trials: int,
         outcome_names: List[str],
-        observe_noise_stds: Union[bool, Dict[str, bool]] = False,
+        observe_noise_sd: bool = False,
         noise_stds: Union[float, Dict[str, float]] = 0.0,
         get_surrogate_and_datasets: Optional[
             Callable[[], Tuple[TorchModelBridge, List[SupervisedDataset]]]
@@ -56,11 +56,8 @@ class SurrogateBenchmarkProblemBase(Base):
             num_trials: The number of trials to run.
             outcome_names: The names of the metrics the benchmark problem
                 produces outcome observations for.
-            observe_noise_stds: Whether or not to observe the observation noise
-                level for each metric. If True/False, observe the the noise standard
-                deviation for all/no metrics. If a dictionary, specify this for
-                individual metrics (metrics not appearing in the dictionary will
-                be assumed to not provide observation noise levels).
+            observe_noise_sd: Whether or not to observe the observation noise
+                level.
             noise_stds: The standard deviation(s) of the observation noise(s).
                 If a single value is provided, it is used for all metrics. Providing
                 a dictionary allows specifying different noise levels for different
@@ -82,7 +79,7 @@ class SurrogateBenchmarkProblemBase(Base):
         self.optimization_config = optimization_config
         self.num_trials = num_trials
         self.outcome_names = outcome_names
-        self.observe_noise_stds = observe_noise_stds
+        self.observe_noise_sd = observe_noise_sd
         self.noise_stds = noise_stds
         self.get_surrogate_and_datasets = get_surrogate_and_datasets
         self.tracking_metrics: List[BenchmarkMetricBase] = tracking_metrics or []
@@ -139,7 +136,7 @@ class SurrogateBenchmarkProblemBase(Base):
             f"optimization_config={self.optimization_config}, "
             f"num_trials={self.num_trials}, "
             f"is_noiseless={self.is_noiseless}, "
-            f"observe_noise_stds={self.observe_noise_stds}, "
+            f"observe_noise_sd={self.observe_noise_sd}, "
             f"noise_stds={self.noise_stds}, "
             f"tracking_metrics={self.tracking_metrics})"
         )
@@ -162,7 +159,7 @@ class SOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
         optimization_config: OptimizationConfig,
         num_trials: int,
         outcome_names: List[str],
-        observe_noise_stds: Union[bool, Dict[str, bool]] = False,
+        observe_noise_sd: bool = False,
         noise_stds: Union[float, Dict[str, float]] = 0.0,
         get_surrogate_and_datasets: Optional[
             Callable[[], Tuple[TorchModelBridge, List[SupervisedDataset]]]
@@ -176,7 +173,7 @@ class SOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
             optimization_config=optimization_config,
             num_trials=num_trials,
             outcome_names=outcome_names,
-            observe_noise_stds=observe_noise_stds,
+            observe_noise_sd=observe_noise_sd,
             noise_stds=noise_stds,
             get_surrogate_and_datasets=get_surrogate_and_datasets,
             tracking_metrics=tracking_metrics,
@@ -205,7 +202,7 @@ class MOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
         optimization_config: MultiObjectiveOptimizationConfig,
         num_trials: int,
         outcome_names: List[str],
-        observe_noise_stds: Union[bool, Dict[str, bool]] = False,
+        observe_noise_sd: bool = False,
         noise_stds: Union[float, Dict[str, float]] = 0.0,
         get_surrogate_and_datasets: Optional[
             Callable[[], Tuple[TorchModelBridge, List[SupervisedDataset]]]
@@ -219,7 +216,7 @@ class MOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
             optimization_config=optimization_config,
             num_trials=num_trials,
             outcome_names=outcome_names,
-            observe_noise_stds=observe_noise_stds,
+            observe_noise_sd=observe_noise_sd,
             noise_stds=noise_stds,
             get_surrogate_and_datasets=get_surrogate_and_datasets,
             tracking_metrics=tracking_metrics,

--- a/ax/benchmark/problems/surrogate.py
+++ b/ax/benchmark/problems/surrogate.py
@@ -27,8 +27,8 @@ class SurrogateBenchmarkProblemBase(Base):
     """
     Base class for SOOSurrogateBenchmarkProblem and MOOSurrogateBenchmarkProblem.
 
-    Allows for lazy creation of objects needed to construct a `runner`,
-    including a surrogate and datasets.
+    Its `runner` is created lazily, when `runner` is accessed or `set_runner` is
+    called, to defer construction of the surrogate and downloading of datasets.
     """
 
     def __init__(
@@ -147,8 +147,10 @@ class SurrogateBenchmarkProblemBase(Base):
 
 class SOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
     """
-    Has the same attributes/properties as a `SingleObjectiveBenchmarkProblem`,
-    but allows for constructing from a surrogate.
+    Has the same attributes/properties as a `MultiObjectiveBenchmarkProblem`,
+    but its runner is not constructed until needed, to allow for deferring
+    constructing the surrogate and downloading data. The surrogate is only
+    defined when `runner` is accessed or `set_runner` is called.
     """
 
     def __init__(
@@ -187,19 +189,15 @@ class MOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
     """
     Has the same attributes/properties as a `MultiObjectiveBenchmarkProblem`,
     but its runner is not constructed until needed, to allow for deferring
-    constructing the surrogate.
-
-    Simple aspects of the problem problem such as its search space
-    are defined immediately, while the surrogate is only defined when [TODO]
-    in order to avoid expensive operations like downloading files and fitting
-    a model.
+    constructing the surrogate and downloading data. The surrogate is only
+    defined when `runner` is accessed or `set_runner` is called.
     """
 
     optimization_config: MultiObjectiveOptimizationConfig
 
     def __init__(
         self,
-        maximum_hypervolume: float,
+        optimal_value: float,
         reference_point: List[float],
         *,
         name: str,
@@ -228,8 +226,4 @@ class MOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
             _runner=_runner,
         )
         self.reference_point = reference_point
-        self.maximum_hypervolume = maximum_hypervolume
-
-    @property
-    def optimal_value(self) -> float:
-        return self.maximum_hypervolume
+        self.optimal_value = optimal_value

--- a/ax/benchmark/tests/problems/test_mixed_integer_problems.py
+++ b/ax/benchmark/tests/problems/test_mixed_integer_problems.py
@@ -58,9 +58,6 @@ class MixedIntegerProblemsTest(TestCase):
                 ).test_problem._bounds,
                 expected_bounds,
             )
-            print(f"{name=}")
-            print(f"{problem.optimal_value=}")
-            print(f"{problem_cls().optimal_value=}")
             self.assertGreaterEqual(problem.optimal_value, problem_cls().optimal_value)
 
         # Test that they match correctly to the original problems.

--- a/ax/benchmark/tests/problems/test_surrogate_problems.py
+++ b/ax/benchmark/tests/problems/test_surrogate_problems.py
@@ -34,7 +34,7 @@ class TestSurrogateProblems(TestCase):
             '"branin", '
             "minimize=False), "
             "outcome_constraints=[]), num_trials=6, is_noiseless=True, "
-            "observe_noise_stds=True, noise_stds=0.0, tracking_metrics=[])"
+            "observe_noise_sd=True, noise_stds=0.0, tracking_metrics=[])"
         )
         self.assertEqual(repr(sbp), expected_repr)
 

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -194,9 +194,7 @@ class TestBenchmarkProblem(TestCase):
         )
 
         # Test hypervolume
-        self.assertEqual(
-            branin_currin_problem.maximum_hypervolume, test_problem._max_hv
-        )
+        self.assertEqual(branin_currin_problem.optimal_value, test_problem._max_hv)
         self.assertEqual(branin_currin_problem.reference_point, test_problem._ref_point)
 
     def test_maximization_problem(self) -> None:

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -165,7 +165,7 @@ def multi_objective_benchmark_problem_to_dict(
         "observe_noise_sd": moo_benchmark_problem.observe_noise_sd,
         "has_ground_truth": moo_benchmark_problem.has_ground_truth,
         "tracking_metrics": moo_benchmark_problem.tracking_metrics,
-        "maximum_hypervolume": moo_benchmark_problem.maximum_hypervolume,
+        "optimal_value": moo_benchmark_problem.optimal_value,
         "reference_point": moo_benchmark_problem.reference_point,
     }
 

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -118,7 +118,7 @@ def get_soo_surrogate() -> SOOSurrogateBenchmarkProblem:
         ),
         num_trials=6,
         outcome_names=["branin"],
-        observe_noise_stds=True,
+        observe_noise_sd=True,
         get_surrogate_and_datasets=lambda: (surrogate, []),
         optimal_value=0.0,
     )
@@ -141,7 +141,7 @@ def get_moo_surrogate() -> MOOSurrogateBenchmarkProblem:
         ),
         num_trials=10,
         outcome_names=["branin_a", "branin_b"],
-        observe_noise_stds=True,
+        observe_noise_sd=True,
         get_surrogate_and_datasets=lambda: (surrogate, []),
         optimal_value=1.0,
         reference_point=[],

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -143,7 +143,7 @@ def get_moo_surrogate() -> MOOSurrogateBenchmarkProblem:
         outcome_names=["branin_a", "branin_b"],
         observe_noise_stds=True,
         get_surrogate_and_datasets=lambda: (surrogate, []),
-        maximum_hypervolume=1.0,
+        optimal_value=1.0,
         reference_point=[],
     )
 


### PR DESCRIPTION
Summary:
Context: `observe_noise_stds` was intended to track whether noise is observed on a metric-by-metric level for multi-objective problems. It should be a dict if noise levels are observed for some metrics and not for others. It can also be boolean and be used for single-objective problems. Confusingly, `observe_noise_sd` can be used for single-objective problems. In practice, these are always boolean and identical, because we have neither problems with partially observed noise nor methods for partially observed noise. It's also confusing to keep track of which is present on which problems and what types it might have.

In the spirit of YAGNI and to facilitate bringing single-objective and multi-objective problems closer together, this PR removes `observe_noise_stds` and replaces it with with `observe_noise_sd` where appropriate. It is alwayas boolean.

If we wind up needing this, we can put it back in, but after more refactoring, the right design might look different.

Note: Similar to D60194654, breaks backward compatibility, including for storage.

Differential Revision: D60202753
