### PR TITLE
Get rid of benchmark problem class constructors

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -27,10 +27,7 @@ from typing import Dict, Iterable, List
 import numpy as np
 
 from ax.benchmark.benchmark_method import BenchmarkMethod
-from ax.benchmark.benchmark_problem import (
-    BenchmarkProblemProtocol,
-    BenchmarkProblemWithKnownOptimum,
-)
+from ax.benchmark.benchmark_problem import BenchmarkProblem
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
 from ax.benchmark.metrics.base import BenchmarkMetricBase, GroundTruthMetricMixin
 from ax.core.experiment import Experiment
@@ -53,16 +50,14 @@ logger: Logger = get_logger(__name__)
 def compute_score_trace(
     optimization_trace: np.ndarray,
     num_baseline_trials: int,
-    problem: BenchmarkProblemProtocol,
+    problem: BenchmarkProblem,
 ) -> np.ndarray:
     """Computes a score trace from the optimization trace."""
 
     # Use the first GenerationStep's best found point as baseline. Sometimes (ex. in
     # a timeout) the first GenerationStep will not have not completed and we will not
     # have enough trials; in this case we do not score.
-    if (len(optimization_trace) <= num_baseline_trials) or not isinstance(
-        problem, BenchmarkProblemWithKnownOptimum
-    ):
+    if len(optimization_trace) <= num_baseline_trials:
         return np.full(len(optimization_trace), np.nan)
     optimum = problem.optimal_value
     baseline = optimization_trace[num_baseline_trials - 1]
@@ -77,7 +72,7 @@ def compute_score_trace(
 
 
 def _create_benchmark_experiment(
-    problem: BenchmarkProblemProtocol, method_name: str
+    problem: BenchmarkProblem, method_name: str
 ) -> Experiment:
     """Creates an empty experiment for the given problem and method.
 
@@ -117,7 +112,7 @@ def _create_benchmark_experiment(
 
 
 def benchmark_replication(
-    problem: BenchmarkProblemProtocol,
+    problem: BenchmarkProblem,
     method: BenchmarkMethod,
     seed: int,
 ) -> BenchmarkResult:
@@ -192,7 +187,7 @@ def benchmark_replication(
 
 
 def benchmark_one_method_problem(
-    problem: BenchmarkProblemProtocol,
+    problem: BenchmarkProblem,
     method: BenchmarkMethod,
     seeds: Iterable[int],
 ) -> AggregatedBenchmarkResult:
@@ -205,7 +200,7 @@ def benchmark_one_method_problem(
 
 
 def benchmark_multiple_problems_methods(
-    problems: Iterable[BenchmarkProblemProtocol],
+    problems: Iterable[BenchmarkProblem],
     methods: Iterable[BenchmarkMethod],
     seeds: Iterable[int],
 ) -> List[AggregatedBenchmarkResult]:
@@ -222,7 +217,7 @@ def benchmark_multiple_problems_methods(
 
 
 def make_ground_truth_metrics(
-    problem: BenchmarkProblemProtocol,
+    problem: BenchmarkProblem,
     include_tracking_metrics: bool = True,
 ) -> Dict[str, Metric]:
     """Makes a ground truth version for each metric defined on the problem.

--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -5,13 +5,8 @@
 
 # pyre-strict
 
-# NOTE: Do not add `from __future__ import annotations` to this file. Adding
-# `annotations` postpones evaluation of types and will break FBLearner's usage of
-# `BenchmarkProblem` as return type annotation, used for serialization and rendering
-# in the UI.
-
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 from ax.benchmark.metrics.base import BenchmarkMetricBase
 
@@ -36,14 +31,6 @@ from botorch.test_functions.base import (
     MultiObjectiveTestProblem,
 )
 from botorch.test_functions.synthetic import SyntheticTestFunction
-
-TBenchmarkProblem = TypeVar("TBenchmarkProblem", bound="BenchmarkProblem")
-TSingleObjectiveBenchmarkProblem = TypeVar(
-    "TSingleObjectiveBenchmarkProblem", bound="SingleObjectiveBenchmarkProblem"
-)
-TMultiObjectiveBenchmarkProblem = TypeVar(
-    "TMultiObjectiveBenchmarkProblem", bound="MultiObjectiveBenchmarkProblem"
-)
 
 
 def _get_name(
@@ -106,122 +93,116 @@ class BenchmarkProblem(Base):
     is_noiseless: bool
 
 
-@dataclass(kw_only=True, repr=True)
 class SingleObjectiveBenchmarkProblem(BenchmarkProblem):
+    """A `BenchmarkProblem` that supports a single objective."""
+
+    pass
+
+
+def create_single_objective_problem_from_botorch(
+    test_problem_class: Type[SyntheticTestFunction],
+    test_problem_kwargs: Dict[str, Any],
+    lower_is_better: bool,
+    num_trials: int,
+    observe_noise_sd: bool = False,
+) -> SingleObjectiveBenchmarkProblem:
     """
-    Benchmark problem with a single objective.
+    Create a BenchmarkProblem from a BoTorch BaseTestProblem using
+    specialized Metrics and Runners. The test problem's result will be
+    computed on the Runner and retrieved by the Metric.
 
-    For argument descriptions, see `BenchmarkProblem`; it additionally takes a
-    `Runner`.
+    Args:
+        test_problem_class: The BoTorch test problem class which will be used
+            to define the `search_space`, `optimization_config`, and `runner`.
+        test_problem_kwargs: Keyword arguments used to instantiate the
+            `test_problem_class`.
+        num_trials: Simply the `num_trials` of the `BenchmarkProblem` created.
+        observe_noise_sd: Whether the standard deviation of the observation noise is
+            observed or not (in which case it must be inferred by the model).
+            This is separate from whether synthetic noise is added to the
+            problem, which is controlled by the `noise_std` of the test problem.
     """
+    # pyre-fixme [45]: Invalid class instantiation
+    test_problem = test_problem_class(**test_problem_kwargs)
+    is_constrained = isinstance(test_problem, ConstrainedBaseTestProblem)
 
-    @classmethod
-    def from_botorch_synthetic(
-        cls: Type[TSingleObjectiveBenchmarkProblem],
-        test_problem_class: Type[SyntheticTestFunction],
-        test_problem_kwargs: Dict[str, Any],
-        lower_is_better: bool,
-        num_trials: int,
-        observe_noise_sd: bool = False,
-    ) -> TSingleObjectiveBenchmarkProblem:
-        """
-        Create a BenchmarkProblem from a BoTorch BaseTestProblem using
-        specialized Metrics and Runners. The test problem's result will be
-        computed on the Runner and retrieved by the Metric.
+    search_space = SearchSpace(
+        parameters=[
+            RangeParameter(
+                name=f"x{i}",
+                parameter_type=ParameterType.FLOAT,
+                lower=lower,
+                upper=upper,
+            )
+            for i, (lower, upper) in enumerate(test_problem._bounds)
+        ]
+    )
 
-        Args:
-            test_problem_class: The BoTorch test problem class which will be used
-                to define the `search_space`, `optimization_config`, and `runner`.
-            test_problem_kwargs: Keyword arguments used to instantiate the
-                `test_problem_class`.
-            num_trials: Simply the `num_trials` of the `BenchmarkProblem` created.
-            observe_noise_sd: Whether the standard deviation of the observation noise is
-                observed or not (in which case it must be inferred by the model).
-                This is separate from whether synthetic noise is added to the
-                problem, which is controlled by the `noise_std` of the test problem.
-        """
+    dim = test_problem_kwargs.get("dim", None)
+    name = _get_name(
+        test_problem=test_problem, observe_noise_sd=observe_noise_sd, dim=dim
+    )
 
-        # pyre-fixme [45]: Invalid class instantiation
-        test_problem = test_problem_class(**test_problem_kwargs)
-        is_constrained = isinstance(test_problem, ConstrainedBaseTestProblem)
+    # TODO: Support constrained MOO problems.
 
-        search_space = SearchSpace(
-            parameters=[
-                RangeParameter(
-                    name=f"x{i}",
-                    parameter_type=ParameterType.FLOAT,
-                    lower=lower,
-                    upper=upper,
-                )
-                for i, (lower, upper) in enumerate(test_problem._bounds)
-            ]
-        )
-
-        dim = test_problem_kwargs.get("dim", None)
-        name = _get_name(
-            test_problem=test_problem, observe_noise_sd=observe_noise_sd, dim=dim
-        )
-
-        # TODO: Support constrained MOO problems.
-
-        objective = Objective(
-            metric=BenchmarkMetric(
-                name=name,
-                lower_is_better=lower_is_better,
-                observe_noise_sd=observe_noise_sd,
-                outcome_index=0,
-            ),
-            minimize=lower_is_better,
-        )
-
-        outcome_names = [name]
-        outcome_constraints = []
-
-        # NOTE: Currently we don't support the case where only some of the
-        # outcomes have noise levels observed.
-
-        if is_constrained:
-            for i in range(test_problem.num_constraints):
-                outcome_name = f"constraint_slack_{i}"
-                outcome_constraints.append(
-                    OutcomeConstraint(
-                        metric=BenchmarkMetric(
-                            name=outcome_name,
-                            lower_is_better=False,  # positive slack = feasible
-                            observe_noise_sd=observe_noise_sd,
-                            outcome_index=i,
-                        ),
-                        op=ComparisonOp.GEQ,
-                        bound=0.0,
-                        relative=False,
-                    )
-                )
-                outcome_names.append(outcome_name)
-
-        optimization_config = OptimizationConfig(
-            objective=objective,
-            outcome_constraints=outcome_constraints,
-        )
-        optimal_value = (
-            test_problem.max_hv
-            if isinstance(test_problem, MultiObjectiveTestProblem)
-            else test_problem.optimal_value
-        )
-        return cls(
+    objective = Objective(
+        metric=BenchmarkMetric(
             name=name,
-            search_space=search_space,
-            optimization_config=optimization_config,
-            runner=BotorchTestProblemRunner(
-                test_problem_class=test_problem_class,
-                test_problem_kwargs=test_problem_kwargs,
-                outcome_names=outcome_names,
-            ),
-            num_trials=num_trials,
-            observe_noise_stds=observe_noise_sd,
-            is_noiseless=test_problem.noise_std in (None, 0.0),
-            has_ground_truth=True,  # all synthetic problems have ground truth
-            optimal_value=optimal_value,
-        )
+            lower_is_better=lower_is_better,
+            observe_noise_sd=observe_noise_sd,
+            outcome_index=0,
+        ),
+        minimize=lower_is_better,
+    )
+
+    outcome_names = [name]
+    outcome_constraints = []
+
+    # NOTE: Currently we don't support the case where only some of the
+    # outcomes have noise levels observed.
+
+    if is_constrained:
+        for i in range(test_problem.num_constraints):
+            outcome_name = f"constraint_slack_{i}"
+            outcome_constraints.append(
+                OutcomeConstraint(
+                    metric=BenchmarkMetric(
+                        name=outcome_name,
+                        lower_is_better=False,  # positive slack = feasible
+                        observe_noise_sd=observe_noise_sd,
+                        outcome_index=i,
+                    ),
+                    op=ComparisonOp.GEQ,
+                    bound=0.0,
+                    relative=False,
+                )
+            )
+            outcome_names.append(outcome_name)
+
+    optimization_config = OptimizationConfig(
+        objective=objective,
+        outcome_constraints=outcome_constraints,
+    )
+    optimal_value = (
+        test_problem.max_hv
+        if isinstance(test_problem, MultiObjectiveTestProblem)
+        else test_problem.optimal_value
+    )
+    return SingleObjectiveBenchmarkProblem(
+        name=name,
+        search_space=search_space,
+        optimization_config=optimization_config,
+        runner=BotorchTestProblemRunner(
+            test_problem_class=test_problem_class,
+            test_problem_kwargs=test_problem_kwargs,
+            outcome_names=outcome_names,
+        ),
+        num_trials=num_trials,
+        observe_noise_stds=observe_noise_sd,
+        is_noiseless=test_problem.noise_std in (None, 0.0),
+        has_ground_truth=True,  # all synthetic problems have ground truth
+        optimal_value=optimal_value,
+    )
 
 
 @dataclass(kw_only=True, repr=True)
@@ -239,82 +220,79 @@ class MultiObjectiveBenchmarkProblem(BenchmarkProblem):
     reference_point: List[float]
     optimization_config: MultiObjectiveOptimizationConfig
 
-    @classmethod
-    def from_botorch_multi_objective(
-        cls: Type[TMultiObjectiveBenchmarkProblem],
-        test_problem_class: Type[MultiObjectiveTestProblem],
-        test_problem_kwargs: Dict[str, Any],
-        # TODO: Figure out whether we should use `lower_is_better` here.
-        num_trials: int,
-        observe_noise_sd: bool = False,
-    ) -> TMultiObjectiveBenchmarkProblem:
-        """Create a BenchmarkProblem from a BoTorch BaseTestProblem using specialized
-        Metrics and Runners. The test problem's result will be computed on the Runner
-        once per trial and each Metric will retrieve its own result by index.
-        """
-        if issubclass(test_problem_class, ConstrainedBaseTestProblem):
-            raise NotImplementedError(
-                "Constrained multi-objective problems are not supported."
-            )
 
-        # pyre-fixme [45]: Invalid class instantiation
-        test_problem = test_problem_class(**test_problem_kwargs)
+def create_multi_objective_problem_from_botorch(
+    test_problem_class: Type[MultiObjectiveTestProblem],
+    test_problem_kwargs: Dict[str, Any],
+    # TODO: Figure out whether we should use `lower_is_better` here.
+    num_trials: int,
+    observe_noise_sd: bool = False,
+) -> MultiObjectiveBenchmarkProblem:
+    """Create a BenchmarkProblem from a BoTorch BaseTestProblem using specialized
+    Metrics and Runners. The test problem's result will be computed on the Runner
+    once per trial and each Metric will retrieve its own result by index.
+    """
+    if issubclass(test_problem_class, ConstrainedBaseTestProblem):
+        raise NotImplementedError(
+            "Constrained multi-objective problems are not supported."
+        )
 
-        problem = SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
-            # pyre-fixme [6]: Passing a multi-objective problem where a
-            # single-objective problem is expected.
-            test_problem_class=test_problem_class,
-            test_problem_kwargs=test_problem_kwargs,
-            lower_is_better=True,  # Seems like we always assume minimization for MOO?
-            num_trials=num_trials,
+    # pyre-fixme [45]: Invalid class instantiation
+    test_problem = test_problem_class(**test_problem_kwargs)
+
+    problem = create_single_objective_problem_from_botorch(
+        # pyre-fixme [6]: Passing a multi-objective problem where a
+        # single-objective problem is expected.
+        test_problem_class=test_problem_class,
+        test_problem_kwargs=test_problem_kwargs,
+        lower_is_better=True,  # Seems like we always assume minimization for MOO?
+        num_trials=num_trials,
+        observe_noise_sd=observe_noise_sd,
+    )
+
+    name = problem.name
+
+    n_obj = test_problem.num_objectives
+    if not observe_noise_sd:
+        noise_sds = [None] * n_obj
+    elif isinstance(test_problem.noise_std, list):
+        noise_sds = test_problem.noise_std
+    else:
+        noise_sds = [checked_cast(float, test_problem.noise_std or 0.0)] * n_obj
+
+    metrics = [
+        BenchmarkMetric(
+            name=f"{name}_{i}",
+            lower_is_better=True,
             observe_noise_sd=observe_noise_sd,
+            outcome_index=i,
         )
-
-        name = problem.name
-
-        n_obj = test_problem.num_objectives
-        if not observe_noise_sd:
-            noise_sds = [None] * n_obj
-        elif isinstance(test_problem.noise_std, list):
-            noise_sds = test_problem.noise_std
-        else:
-            noise_sds = [checked_cast(float, test_problem.noise_std or 0.0)] * n_obj
-
-        metrics = [
-            BenchmarkMetric(
-                name=f"{name}_{i}",
-                lower_is_better=True,
-                observe_noise_sd=observe_noise_sd,
-                outcome_index=i,
+        for i, noise_sd in enumerate(noise_sds)
+    ]
+    optimization_config = MultiObjectiveOptimizationConfig(
+        objective=MultiObjective(
+            objectives=[Objective(metric=metric, minimize=True) for metric in metrics]
+        ),
+        objective_thresholds=[
+            ObjectiveThreshold(
+                metric=metric,
+                bound=test_problem.ref_point[i].item(),
+                relative=False,
+                op=ComparisonOp.LEQ,
             )
-            for i, noise_sd in enumerate(noise_sds)
-        ]
-        optimization_config = MultiObjectiveOptimizationConfig(
-            objective=MultiObjective(
-                objectives=[
-                    Objective(metric=metric, minimize=True) for metric in metrics
-                ]
-            ),
-            objective_thresholds=[
-                ObjectiveThreshold(
-                    metric=metric,
-                    bound=test_problem.ref_point[i].item(),
-                    relative=False,
-                    op=ComparisonOp.LEQ,
-                )
-                for i, metric in enumerate(metrics)
-            ],
-        )
+            for i, metric in enumerate(metrics)
+        ],
+    )
 
-        return cls(
-            name=name,
-            search_space=problem.search_space,
-            optimization_config=optimization_config,
-            runner=problem.runner,
-            num_trials=num_trials,
-            is_noiseless=problem.is_noiseless,
-            observe_noise_stds=observe_noise_sd,
-            has_ground_truth=problem.has_ground_truth,
-            optimal_value=test_problem.max_hv,
-            reference_point=test_problem._ref_point,
-        )
+    return MultiObjectiveBenchmarkProblem(
+        name=name,
+        search_space=problem.search_space,
+        optimization_config=optimization_config,
+        runner=problem.runner,
+        num_trials=num_trials,
+        is_noiseless=problem.is_noiseless,
+        observe_noise_stds=observe_noise_sd,
+        has_ground_truth=problem.has_ground_truth,
+        optimal_value=test_problem.max_hv,
+        reference_point=test_problem._ref_point,
+    )

--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -11,17 +11,7 @@
 # in the UI.
 
 from dataclasses import dataclass, field
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Protocol,
-    runtime_checkable,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 from ax.benchmark.metrics.base import BenchmarkMetricBase
 
@@ -70,33 +60,6 @@ def _get_name(
     observed_noise = "_observed_noise" if observe_noise_sd else ""
     dim_str = "" if dim is None else f"_{dim}d"
     return f"{base_name}{observed_noise}{dim_str}"
-
-
-@runtime_checkable
-class BenchmarkProblemProtocol(Protocol):
-    """
-    Specifies the interface any benchmark problem must adhere to.
-
-    Classes implementing this interface include BenchmarkProblem,
-    SurrogateBenchmarkProblem, and MOOSurrogateBenchmarkProblem.
-    """
-
-    name: str
-    search_space: SearchSpace
-    optimization_config: OptimizationConfig
-    num_trials: int
-    tracking_metrics: List[BenchmarkMetricBase]
-    is_noiseless: bool  # If True, evaluations are deterministic
-    observe_noise_stds: Union[
-        bool, Dict[str, bool]
-    ]  # Whether we observe the observation noise level
-    has_ground_truth: bool  # if True, evals (w/o synthetic noise) are determinstic
-    runner: Runner
-
-
-@runtime_checkable
-class BenchmarkProblemWithKnownOptimum(Protocol):
-    optimal_value: float
 
 
 @dataclass(kw_only=True, repr=True)

--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -11,8 +11,8 @@ from typing import Any, Callable, Dict
 
 from ax.benchmark.benchmark_problem import (
     BenchmarkProblem,
-    MultiObjectiveBenchmarkProblem,
-    SingleObjectiveBenchmarkProblem,
+    create_multi_objective_problem_from_botorch,
+    create_single_objective_problem_from_botorch,
 )
 from ax.benchmark.problems.hd_embedding import embed_higher_dimension
 from ax.benchmark.problems.hpo.torchvision import PyTorchCNNTorchvisionBenchmarkProblem
@@ -29,7 +29,7 @@ class BenchmarkProblemRegistryEntry:
 
 BENCHMARK_PROBLEM_REGISTRY = {
     "ackley4": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Ackley,
             "test_problem_kwargs": {"dim": 4},
@@ -39,7 +39,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         },
     ),
     "branin": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Branin,
             "test_problem_kwargs": {},
@@ -49,7 +49,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         },
     ),
     "branin_currin": BenchmarkProblemRegistryEntry(
-        factory_fn=MultiObjectiveBenchmarkProblem.from_botorch_multi_objective,
+        factory_fn=create_multi_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": BraninCurrin,
             "test_problem_kwargs": {},
@@ -59,7 +59,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
     ),
     "branin_currin30": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n, num_trials: embed_higher_dimension(
-            problem=MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
+            problem=create_multi_objective_problem_from_botorch(
                 test_problem_class=BraninCurrin,
                 test_problem_kwargs={},
                 num_trials=num_trials,
@@ -70,7 +70,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         factory_kwargs={"n": 30, "num_trials": 30},
     ),
     "griewank4": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Griewank,
             "test_problem_kwargs": {"dim": 4},
@@ -80,7 +80,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         },
     ),
     "hartmann3": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Hartmann,
             "test_problem_kwargs": {"dim": 3},
@@ -90,7 +90,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         },
     ),
     "hartmann6": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Hartmann,
             "test_problem_kwargs": {"dim": 6},
@@ -101,7 +101,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
     ),
     "hartmann30": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n, num_trials: embed_higher_dimension(
-            problem=SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
+            problem=create_single_objective_problem_from_botorch(
                 test_problem_class=synthetic.Hartmann,
                 test_problem_kwargs={"dim": 6},
                 lower_is_better=True,
@@ -131,7 +131,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         factory_kwargs={"num_trials": 50, "observe_noise_sd": False},
     ),
     "levy4": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Levy,
             "test_problem_kwargs": {"dim": 4},
@@ -141,7 +141,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         },
     ),
     "powell4": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Powell,
             "test_problem_kwargs": {"dim": 4},
@@ -151,7 +151,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         },
     ),
     "rosenbrock4": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Rosenbrock,
             "test_problem_kwargs": {"dim": 4},
@@ -161,7 +161,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         },
     ),
     "six_hump_camel": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.SixHumpCamel,
             "test_problem_kwargs": {},
@@ -171,7 +171,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         },
     ),
     "three_hump_camel": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.ThreeHumpCamel,
             "test_problem_kwargs": {},
@@ -182,7 +182,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
     ),
     # Problems where we observe the noise level
     "branin_observed_noise": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Branin,
             "test_problem_kwargs": {},
@@ -192,7 +192,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         },
     ),
     "branin_currin_observed_noise": BenchmarkProblemRegistryEntry(
-        factory_fn=MultiObjectiveBenchmarkProblem.from_botorch_multi_objective,
+        factory_fn=create_multi_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": BraninCurrin,
             "test_problem_kwargs": {},
@@ -202,7 +202,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
     ),
     "branin_currin30_observed_noise": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n, num_trials: embed_higher_dimension(
-            problem=MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
+            problem=create_multi_objective_problem_from_botorch(
                 test_problem_class=BraninCurrin,
                 test_problem_kwargs={},
                 num_trials=num_trials,
@@ -213,7 +213,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         factory_kwargs={"n": 30, "num_trials": 30},
     ),
     "hartmann6_observed_noise": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Hartmann,
             "test_problem_kwargs": {"dim": 6},
@@ -224,7 +224,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
     ),
     "hartmann30_observed_noise": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n, num_trials: embed_higher_dimension(
-            problem=SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
+            problem=create_single_objective_problem_from_botorch(
                 test_problem_class=synthetic.Hartmann,
                 test_problem_kwargs={"dim": 6},
                 lower_is_better=True,
@@ -240,7 +240,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
         factory_kwargs={"num_trials": 25, "observe_noise_sd": True},
     ),
     "constrained_gramacy_observed_noise": BenchmarkProblemRegistryEntry(
-        factory_fn=SingleObjectiveBenchmarkProblem.from_botorch_synthetic,
+        factory_fn=create_single_objective_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.ConstrainedGramacy,
             "test_problem_kwargs": {},

--- a/ax/benchmark/problems/surrogate.py
+++ b/ax/benchmark/problems/surrogate.py
@@ -5,20 +5,17 @@
 
 # pyre-strict
 
-from typing import Dict, List, Optional, Union
+from dataclasses import dataclass, field
+from typing import List
 
-from ax.benchmark.metrics.base import BenchmarkMetricBase
+from ax.benchmark.benchmark_problem import BenchmarkProblem
 
 from ax.benchmark.runners.surrogate import SurrogateRunner
-from ax.core.optimization_config import (
-    MultiObjectiveOptimizationConfig,
-    OptimizationConfig,
-)
-from ax.core.search_space import SearchSpace
-from ax.utils.common.base import Base
+from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 
 
-class SurrogateBenchmarkProblemBase(Base):
+@dataclass(kw_only=True)
+class SurrogateBenchmarkProblemBase(BenchmarkProblem):
     """
     Base class for SOOSurrogateBenchmarkProblem and MOOSurrogateBenchmarkProblem.
 
@@ -26,132 +23,20 @@ class SurrogateBenchmarkProblemBase(Base):
     constructed lazily and datasets to be downloaded lazily.
     """
 
-    def __init__(
-        self,
-        *,
-        name: str,
-        search_space: SearchSpace,
-        optimization_config: OptimizationConfig,
-        num_trials: int,
-        runner: SurrogateRunner,
-        is_noiseless: bool,
-        observe_noise_stds: Union[bool, Dict[str, bool]] = False,
-        tracking_metrics: Optional[List[BenchmarkMetricBase]] = None,
-    ) -> None:
-        """Construct a `SurrogateBenchmarkProblemBase` instance.
-
-        Args:
-            name: The name of the benchmark problem.
-            search_space: The search space to optimize over.
-            optimization_config: THe optimization config for the problem.
-            num_trials: The number of trials to run.
-            runner: A `SurrogateRunner`, allowing for lazy construction of the
-                surrogate and datasets.
-            observe_noise_stds: Whether or not to observe the observation noise
-                level for each metric. If True/False, observe the the noise standard
-                deviation for all/no metrics. If a dictionary, specify this for
-                individual metrics (metrics not appearing in the dictionary will
-                be assumed to not provide observation noise levels).
-            tracking_metrics: Additional tracking metrics to compute during the
-                optimization (not used to inform the optimization).
-        """
-
-        self.name = name
-        self.search_space = search_space
-        self.optimization_config = optimization_config
-        self.num_trials = num_trials
-        self.observe_noise_stds = observe_noise_stds
-        self.tracking_metrics: List[BenchmarkMetricBase] = tracking_metrics or []
-        self.runner = runner
-        self.is_noiseless = is_noiseless
-
-    @property
-    def has_ground_truth(self) -> bool:
-        # All surrogate-based problems have a ground truth
-        return True
-
-    def __repr__(self) -> str:
-        """
-        Return a string representation that includes only the attributes that
-        print nicely and contain information likely to be useful.
-        """
-        return (
-            f"{self.__class__.__name__}("
-            f"name={self.name}, "
-            f"optimization_config={self.optimization_config}, "
-            f"num_trials={self.num_trials}, "
-            f"is_noiseless={self.is_noiseless}, "
-            f"observe_noise_stds={self.observe_noise_stds}, "
-            f"noise_stds={self.runner.noise_stds}, "
-            f"tracking_metrics={self.tracking_metrics})"
-        )
+    runner: SurrogateRunner = field(repr=False)
 
 
 class SOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
-    """
-    Has the same attributes/properties as a `MultiObjectiveBenchmarkProblem`,
-    but its runner is not constructed until needed, to allow for deferring
-    constructing the surrogate and downloading data. The surrogate is only
-    defined when `runner` is accessed or `set_runner` is called.
-    """
-
-    def __init__(
-        self,
-        optimal_value: float,
-        *,
-        name: str,
-        search_space: SearchSpace,
-        optimization_config: OptimizationConfig,
-        num_trials: int,
-        runner: SurrogateRunner,
-        is_noiseless: bool,
-        observe_noise_stds: Union[bool, Dict[str, bool]] = False,
-    ) -> None:
-        super().__init__(
-            name=name,
-            search_space=search_space,
-            optimization_config=optimization_config,
-            num_trials=num_trials,
-            observe_noise_stds=observe_noise_stds,
-            runner=runner,
-            is_noiseless=is_noiseless,
-        )
-        self.optimal_value = optimal_value
+    pass
 
 
+@dataclass(kw_only=True)
 class MOOSurrogateBenchmarkProblem(SurrogateBenchmarkProblemBase):
     """
     Has the same attributes/properties as a `MultiObjectiveBenchmarkProblem`,
     but its runner is not constructed until needed, to allow for deferring
-    constructing the surrogate and downloading data. The surrogate is only
-    defined when `runner` is accessed or `set_runner` is called.
+    constructing the surrogate and downloading data.
     """
 
     optimization_config: MultiObjectiveOptimizationConfig
-
-    def __init__(
-        self,
-        optimal_value: float,
-        reference_point: List[float],
-        *,
-        name: str,
-        search_space: SearchSpace,
-        optimization_config: MultiObjectiveOptimizationConfig,
-        num_trials: int,
-        runner: SurrogateRunner,
-        is_noiseless: bool,
-        observe_noise_stds: Union[bool, Dict[str, bool]] = False,
-        tracking_metrics: Optional[List[BenchmarkMetricBase]] = None,
-    ) -> None:
-        super().__init__(
-            name=name,
-            search_space=search_space,
-            optimization_config=optimization_config,
-            num_trials=num_trials,
-            observe_noise_stds=observe_noise_stds,
-            tracking_metrics=tracking_metrics,
-            runner=runner,
-            is_noiseless=is_noiseless,
-        )
-        self.reference_point = reference_point
-        self.optimal_value = optimal_value
+    reference_point: List[float]

--- a/ax/benchmark/runners/surrogate.py
+++ b/ax/benchmark/runners/surrogate.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 import warnings
-from typing import Any, Dict, Iterable, List, Optional, Set, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import torch
 from ax.benchmark.runners.base import BenchmarkRunner
@@ -15,20 +15,27 @@ from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.observation import ObservationFeatures
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.torch import TorchModelBridge
+from ax.utils.common.base import Base
+from ax.utils.common.equality import equality_typechecker
 from ax.utils.common.serialization import TClassDecoderRegistry, TDecoderRegistry
 from botorch.utils.datasets import SupervisedDataset
+from pyre_extensions import assert_is_instance, none_throws
 from torch import Tensor
 
 
 class SurrogateRunner(BenchmarkRunner):
     def __init__(
         self,
+        *,
         name: str,
-        surrogate: TorchModelBridge,
-        datasets: List[SupervisedDataset],
         search_space: SearchSpace,
         outcome_names: List[str],
+        surrogate: Optional[TorchModelBridge] = None,
+        datasets: Optional[List[SupervisedDataset]] = None,
         noise_stds: Union[float, Dict[str, float]] = 0.0,
+        get_surrogate_and_datasets: Optional[
+            Callable[[], Tuple[TorchModelBridge, List[SupervisedDataset]]]
+        ] = None,
     ) -> None:
         """Runner for surrogate benchmark problems.
 
@@ -45,14 +52,41 @@ class SurrogateRunner(BenchmarkRunner):
                 is added to all outputs. Alternatively, a dictionary mapping outcome
                 names to noise standard deviations can be provided to specify different
                 noise levels for different outputs.
+            get_surrogate_and_datasets: Function that returns the surrogate and
+                datasets, to allow for lazy construction. If
+                `get_surrogate_and_datasets` is not provided, `surrogate` and
+                `datasets` must be provided, and vice versa.
         """
+        if get_surrogate_and_datasets is None and (
+            surrogate is None or datasets is None
+        ):
+            raise ValueError(
+                "If get_surrogate_and_datasets is not provided, surrogate and "
+                "datasets must be provided, and vice versa."
+            )
+        self.get_surrogate_and_datasets = get_surrogate_and_datasets
         self.name = name
-        self.surrogate = surrogate
+        self._surrogate = surrogate
         self._outcome_names = outcome_names
-        self.datasets = datasets
+        self._datasets = datasets
         self.search_space = search_space
         self.noise_stds = noise_stds
         self.statuses: Dict[int, TrialStatus] = {}
+
+    def set_surrogate_and_datasets(self) -> None:
+        self._surrogate, self._datasets = none_throws(self.get_surrogate_and_datasets)()
+
+    @property
+    def surrogate(self) -> TorchModelBridge:
+        if self.get_surrogate_and_datasets is not None:
+            self.set_surrogate_and_datasets()
+        return none_throws(self._surrogate)
+
+    @property
+    def datasets(self) -> List[SupervisedDataset]:
+        if self.get_surrogate_and_datasets is not None:
+            self.set_surrogate_and_datasets()
+        return none_throws(self._datasets)
 
     @property
     def outcome_names(self) -> List[str]:
@@ -131,3 +165,22 @@ class SurrogateRunner(BenchmarkRunner):
         class_decoder_registry: Optional[TClassDecoderRegistry] = None,
     ) -> Dict[str, Any]:
         return {}
+
+    @property
+    def is_noiseless(self) -> bool:
+        if self.noise_stds is None:
+            return True
+        if isinstance(self.noise_stds, float):
+            return self.noise_stds == 0.0
+        return all(
+            std == 0.0 for std in assert_is_instance(self.noise_stds, dict).values()
+        )
+
+    @equality_typechecker
+    def __eq__(self, other: Base) -> bool:
+        if type(other) is not type(self):
+            return False
+
+        # Checking the whole datasets' equality here would be too expensive to be
+        # worth it; just check names instead
+        return self.name == other.name

--- a/ax/benchmark/tests/problems/test_mixed_integer_problems.py
+++ b/ax/benchmark/tests/problems/test_mixed_integer_problems.py
@@ -58,9 +58,6 @@ class MixedIntegerProblemsTest(TestCase):
                 ).test_problem._bounds,
                 expected_bounds,
             )
-            print(f"{name=}")
-            print(f"{problem.optimal_value=}")
-            print(f"{problem_cls().optimal_value=}")
             self.assertGreaterEqual(problem.optimal_value, problem_cls().optimal_value)
 
         # Test that they match correctly to the original problems.

--- a/ax/benchmark/tests/problems/test_surrogate_problems.py
+++ b/ax/benchmark/tests/problems/test_surrogate_problems.py
@@ -8,7 +8,7 @@
 
 import numpy as np
 from ax.benchmark.benchmark import compute_score_trace
-from ax.benchmark.benchmark_problem import BenchmarkProblemProtocol
+from ax.benchmark.benchmark_problem import BenchmarkProblem
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import get_moo_surrogate, get_soo_surrogate
 
@@ -19,12 +19,12 @@ class TestSurrogateProblems(TestCase):
         # print max output so errors in 'repr' can be fully shown
         self.maxDiff = None
 
-    def test_conforms_to_protocol(self) -> None:
+    def test_conforms_to_api(self) -> None:
         sbp = get_soo_surrogate()
-        self.assertIsInstance(sbp, BenchmarkProblemProtocol)
+        self.assertIsInstance(sbp, BenchmarkProblem)
 
         mbp = get_moo_surrogate()
-        self.assertIsInstance(mbp, BenchmarkProblemProtocol)
+        self.assertIsInstance(mbp, BenchmarkProblem)
 
     def test_repr(self) -> None:
 

--- a/ax/benchmark/tests/problems/test_surrogate_problems.py
+++ b/ax/benchmark/tests/problems/test_surrogate_problems.py
@@ -16,6 +16,7 @@ from ax.utils.testing.benchmark_stubs import get_moo_surrogate, get_soo_surrogat
 class TestSurrogateProblems(TestCase):
     def setUp(self) -> None:
         super().setUp()
+        # print max output so errors in 'repr' can be fully shown
         self.maxDiff = None
 
     def test_conforms_to_protocol(self) -> None:
@@ -30,12 +31,13 @@ class TestSurrogateProblems(TestCase):
         sbp = get_soo_surrogate()
 
         expected_repr = (
-            "SOOSurrogateBenchmarkProblem(name=test, "
+            "SOOSurrogateBenchmarkProblem(name='test', "
             "optimization_config=OptimizationConfig(objective=Objective(metric_name="
             '"branin", '
             "minimize=False), "
-            "outcome_constraints=[]), num_trials=6, is_noiseless=True, "
-            "observe_noise_stds=True, noise_stds=0.0, tracking_metrics=[])"
+            "outcome_constraints=[]), num_trials=6, "
+            "observe_noise_stds=True, has_ground_truth=True, "
+            "tracking_metrics=[], optimal_value=0.0, is_noiseless=True)"
         )
         self.assertEqual(repr(sbp), expected_repr)
 

--- a/ax/benchmark/tests/problems/test_surrogate_problems.py
+++ b/ax/benchmark/tests/problems/test_surrogate_problems.py
@@ -9,12 +9,15 @@
 import numpy as np
 from ax.benchmark.benchmark import compute_score_trace
 from ax.benchmark.benchmark_problem import BenchmarkProblemProtocol
-from ax.core.runner import Runner
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import get_moo_surrogate, get_soo_surrogate
 
 
 class TestSurrogateProblems(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.maxDiff = None
+
     def test_conforms_to_protocol(self) -> None:
         sbp = get_soo_surrogate()
         self.assertIsInstance(sbp, BenchmarkProblemProtocol)
@@ -22,11 +25,9 @@ class TestSurrogateProblems(TestCase):
         mbp = get_moo_surrogate()
         self.assertIsInstance(mbp, BenchmarkProblemProtocol)
 
-    def test_lazy_instantiation(self) -> None:
+    def test_repr(self) -> None:
 
-        # test instantiation from init
         sbp = get_soo_surrogate()
-        # test __repr__ method
 
         expected_repr = (
             "SOOSurrogateBenchmarkProblem(name=test, "
@@ -37,23 +38,6 @@ class TestSurrogateProblems(TestCase):
             "observe_noise_stds=True, noise_stds=0.0, tracking_metrics=[])"
         )
         self.assertEqual(repr(sbp), expected_repr)
-
-        self.assertIsNone(sbp._runner)
-        # sets runner
-        self.assertIsInstance(sbp.runner, Runner)
-
-        self.assertIsNotNone(sbp._runner)
-        self.assertIsNotNone(sbp.runner)
-
-        # repeat for MOO
-        sbp = get_moo_surrogate()
-
-        self.assertIsNone(sbp._runner)
-        # sets runner
-        self.assertIsInstance(sbp.runner, Runner)
-
-        self.assertIsNotNone(sbp._runner)
-        self.assertIsNotNone(sbp.runner)
 
     def test_compute_score_trace(self) -> None:
         soo_problem = get_soo_surrogate()

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -21,7 +21,7 @@ from ax.benchmark.benchmark_method import (
     BenchmarkMethod,
     get_benchmark_scheduler_options,
 )
-from ax.benchmark.benchmark_problem import SingleObjectiveBenchmarkProblem
+from ax.benchmark.benchmark_problem import create_single_objective_problem_from_botorch
 from ax.benchmark.benchmark_result import BenchmarkResult
 from ax.benchmark.methods.modular_botorch import get_sobol_botorch_modular_acquisition
 from ax.benchmark.metrics.base import GroundTruthMetricMixin
@@ -439,7 +439,7 @@ class TestBenchmark(TestCase):
                 self.assertTrue((agg.score_trace[col] <= 100).all())
 
     def test_timeout(self) -> None:
-        problem = SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
+        problem = create_single_objective_problem_from_botorch(
             test_problem_class=Branin,
             test_problem_kwargs={},
             lower_is_better=True,

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -27,6 +27,7 @@ from ax.benchmark.methods.modular_botorch import get_sobol_botorch_modular_acqui
 from ax.benchmark.metrics.base import GroundTruthMetricMixin
 from ax.benchmark.metrics.benchmark import BenchmarkMetric, GroundTruthBenchmarkMetric
 from ax.benchmark.problems.registry import get_problem
+from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.modelbridge.generation_strategy import GenerationNode, GenerationStrategy
 from ax.modelbridge.model_spec import ModelSpec
 from ax.modelbridge.registry import Models
@@ -36,7 +37,6 @@ from ax.storage.json_store.save import save_experiment
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast, not_none
 from ax.utils.testing.benchmark_stubs import (
-    get_constrained_multi_objective_benchmark_problem,
     get_moo_surrogate,
     get_multi_objective_benchmark_problem,
     get_single_objective_benchmark_problem,
@@ -162,9 +162,10 @@ class TestBenchmark(TestCase):
         gt_opt_cfg = make_ground_truth_optimization_config(experiment)
         self.assertIs(gt_opt_cfg.objective.metric, gt_metric)
 
-        # Test behavior with MOO problem and outcome constraints
-        problem = get_constrained_multi_objective_benchmark_problem(
-            observe_noise_sd=False
+        # Test behavior with MOO problem
+        problem = get_multi_objective_benchmark_problem(observe_noise_sd=False)
+        self.assertIsInstance(
+            problem.optimization_config, MultiObjectiveOptimizationConfig
         )
         experiment = _create_benchmark_experiment(
             problem=problem, method_name="test_method"

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -300,7 +300,6 @@ class TestBenchmark(TestCase):
             ("moo", get_moo_surrogate()),
         ]:
             with self.subTest(name, problem=problem):
-                surrogate, datasets = not_none(problem.get_surrogate_and_datasets)()
                 res = benchmark_replication(problem=problem, method=method, seed=0)
 
                 self.assertEqual(

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -8,15 +8,18 @@
 from typing import List, Optional, Union
 
 from ax.benchmark.benchmark_problem import (
-    MultiObjectiveBenchmarkProblem,
-    SingleObjectiveBenchmarkProblem,
+    create_multi_objective_problem_from_botorch,
+    create_single_objective_problem_from_botorch,
 )
 from ax.benchmark.metrics.benchmark import BenchmarkMetric
 from ax.benchmark.runners.botorch_test import BotorchTestProblemRunner
 from ax.core.types import ComparisonOp
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast
-from botorch.test_functions.multi_objective import BraninCurrin, ConstrainedBraninCurrin
+from ax.utils.testing.benchmark_stubs import (
+    get_constrained_multi_objective_benchmark_problem,
+)
+from botorch.test_functions.multi_objective import BraninCurrin
 from botorch.test_functions.synthetic import (
     Ackley,
     ConstrainedGramacy,
@@ -34,7 +37,7 @@ class TestBenchmarkProblem(TestCase):
 
     def test_single_objective_from_botorch(self) -> None:
         for botorch_test_problem in [Ackley(), ConstrainedHartmann(dim=6)]:
-            test_problem = SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
+            test_problem = create_single_objective_problem_from_botorch(
                 test_problem_class=botorch_test_problem.__class__,
                 test_problem_kwargs={},
                 lower_is_better=True,
@@ -131,7 +134,7 @@ class TestBenchmarkProblem(TestCase):
         objective_noise_std: Optional[float],
         constraint_noise_std: Optional[Union[float, List[float]]],
     ) -> None:
-        ax_problem = SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
+        ax_problem = create_single_objective_problem_from_botorch(
             test_problem_class=ConstrainedGramacy,
             test_problem_kwargs={
                 "noise_std": objective_noise_std,
@@ -167,12 +170,10 @@ class TestBenchmarkProblem(TestCase):
 
     def test_moo_from_botorch(self) -> None:
         test_problem = BraninCurrin()
-        branin_currin_problem = (
-            MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
-                test_problem_class=test_problem.__class__,
-                test_problem_kwargs={},
-                num_trials=1,
-            )
+        branin_currin_problem = create_multi_objective_problem_from_botorch(
+            test_problem_class=test_problem.__class__,
+            test_problem_kwargs={},
+            num_trials=1,
         )
 
         # Test search space
@@ -209,14 +210,10 @@ class TestBenchmarkProblem(TestCase):
             NotImplementedError,
             "Constrained multi-objective problems are not supported.",
         ):
-            MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
-                test_problem_class=ConstrainedBraninCurrin,
-                test_problem_kwargs={},
-                num_trials=1,
-            )
+            get_constrained_multi_objective_benchmark_problem()
 
     def test_maximization_problem(self) -> None:
-        test_problem = SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
+        test_problem = create_single_objective_problem_from_botorch(
             test_problem_class=Cosine8,
             lower_is_better=False,
             num_trials=1,

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -147,6 +147,7 @@ def benchmark_problem_to_dict(benchmark_problem: BenchmarkProblem) -> Dict[str, 
         "observe_noise_stds": benchmark_problem.observe_noise_stds,
         "has_ground_truth": benchmark_problem.has_ground_truth,
         "tracking_metrics": benchmark_problem.tracking_metrics,
+        "optimal_value": benchmark_problem.optimal_value,
     }
 
 

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, Optional
 import numpy as np
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_problem import (
+    create_multi_objective_problem_from_botorch,
+    create_single_objective_problem_from_botorch,
     MultiObjectiveBenchmarkProblem,
     SingleObjectiveBenchmarkProblem,
 )
@@ -44,7 +46,7 @@ from botorch.test_functions.synthetic import Branin
 
 
 def get_benchmark_problem() -> SingleObjectiveBenchmarkProblem:
-    return SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
+    return create_single_objective_problem_from_botorch(
         test_problem_class=Branin,
         test_problem_kwargs={},
         lower_is_better=True,
@@ -57,7 +59,7 @@ def get_single_objective_benchmark_problem(
     num_trials: int = 4,
     test_problem_kwargs: Optional[Dict[str, Any]] = None,
 ) -> SingleObjectiveBenchmarkProblem:
-    return SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
+    return create_single_objective_problem_from_botorch(
         test_problem_class=Branin,
         test_problem_kwargs=test_problem_kwargs or {},
         lower_is_better=True,
@@ -69,7 +71,7 @@ def get_single_objective_benchmark_problem(
 def get_multi_objective_benchmark_problem(
     observe_noise_sd: bool = False, num_trials: int = 4
 ) -> MultiObjectiveBenchmarkProblem:
-    return MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
+    return create_multi_objective_problem_from_botorch(
         test_problem_class=BraninCurrin,
         test_problem_kwargs={},
         num_trials=num_trials,
@@ -80,7 +82,7 @@ def get_multi_objective_benchmark_problem(
 def get_constrained_multi_objective_benchmark_problem(
     observe_noise_sd: bool = False, num_trials: int = 4
 ) -> MultiObjectiveBenchmarkProblem:
-    return MultiObjectiveBenchmarkProblem.from_botorch_multi_objective(
+    return create_multi_objective_problem_from_botorch(
         test_problem_class=ConstrainedBraninCurrin,
         test_problem_kwargs={},
         num_trials=num_trials,

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Optional
 import numpy as np
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_problem import (
-    BenchmarkProblem,
     MultiObjectiveBenchmarkProblem,
     SingleObjectiveBenchmarkProblem,
 )
@@ -44,8 +43,8 @@ from botorch.test_functions.multi_objective import BraninCurrin, ConstrainedBran
 from botorch.test_functions.synthetic import Branin
 
 
-def get_benchmark_problem() -> BenchmarkProblem:
-    return BenchmarkProblem.from_botorch(
+def get_benchmark_problem() -> SingleObjectiveBenchmarkProblem:
+    return SingleObjectiveBenchmarkProblem.from_botorch_synthetic(
         test_problem_class=Branin,
         test_problem_kwargs={},
         lower_is_better=True,

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -20,6 +20,7 @@ from ax.benchmark.problems.surrogate import (
     MOOSurrogateBenchmarkProblem,
     SOOSurrogateBenchmarkProblem,
 )
+from ax.benchmark.runners.surrogate import SurrogateRunner
 from ax.core.experiment import Experiment
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
@@ -110,6 +111,12 @@ def get_soo_surrogate() -> SOOSurrogateBenchmarkProblem:
         data=experiment.lookup_data(),
         transforms=[],
     )
+    runner = SurrogateRunner(
+        name="test",
+        search_space=experiment.search_space,
+        outcome_names=["branin"],
+        get_surrogate_and_datasets=lambda: (surrogate, []),
+    )
     return SOOSurrogateBenchmarkProblem(
         name="test",
         search_space=experiment.search_space,
@@ -117,10 +124,10 @@ def get_soo_surrogate() -> SOOSurrogateBenchmarkProblem:
             OptimizationConfig, experiment.optimization_config
         ),
         num_trials=6,
-        outcome_names=["branin"],
         observe_noise_stds=True,
-        get_surrogate_and_datasets=lambda: (surrogate, []),
         optimal_value=0.0,
+        runner=runner,
+        is_noiseless=runner.is_noiseless,
     )
 
 
@@ -133,6 +140,13 @@ def get_moo_surrogate() -> MOOSurrogateBenchmarkProblem:
         data=experiment.lookup_data(),
         transforms=[],
     )
+
+    runner = SurrogateRunner(
+        name="test",
+        search_space=experiment.search_space,
+        outcome_names=["branin_a", "branin_b"],
+        get_surrogate_and_datasets=lambda: (surrogate, []),
+    )
     return MOOSurrogateBenchmarkProblem(
         name="test",
         search_space=experiment.search_space,
@@ -140,11 +154,11 @@ def get_moo_surrogate() -> MOOSurrogateBenchmarkProblem:
             MultiObjectiveOptimizationConfig, experiment.optimization_config
         ),
         num_trials=10,
-        outcome_names=["branin_a", "branin_b"],
         observe_noise_stds=True,
-        get_surrogate_and_datasets=lambda: (surrogate, []),
         optimal_value=1.0,
         reference_point=[],
+        runner=runner,
+        is_noiseless=runner.is_noiseless,
     )
 
 


### PR DESCRIPTION
Summary:
Context: Benchmark problems are sometimes created with class methods `SingleObjectiveBenchmarkProblem.from_botorch`, `SingleObjectiveBenchmarkProblem.from_botorch_synthetic`, and `MultiObjectiveBenchmarkProblem.from_botorch_multi_objective`, the former two now being identical. This creates the need for some tricky type annotations; to me, replacing these with functions is obviously cleaner. This will make it easier to consolidate classes in the future.

This PR:
* Replaces `SingleObjectiveBenchmarkProblem.from_botorch` and `SingleObjectiveBenchmarkProblem.from_botorch_synthetic` with `create_single_objective_problem_from_botorch`
* Replaces `MultiObjectiveBenchmarkProblem.from_botorch_multi_objective` with `create_multi_objective_problem_from_botorch`

Differential Revision: D60284484
