### PR TITLE
Add AutoTransitionAfterGenCriterion to storage

### DIFF
--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -92,6 +92,7 @@ from ax.modelbridge.model_spec import ModelSpec
 from ax.modelbridge.registry import ModelRegistryBase
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transition_criterion import (
+    AutoTransitionAfterGenCriterion,
     MaxGenerationParallelism,
     MaxTrials,
     MinimumPreferenceOccurances,
@@ -182,6 +183,7 @@ CORE_ENCODER_REGISTRY: Dict[Type, Callable[[Any], Dict[str, Any]]] = {
     AndEarlyStoppingStrategy: logical_early_stopping_strategy_to_dict,
     AugmentedBraninMetric: metric_to_dict,
     AugmentedHartmann6Metric: metric_to_dict,
+    AutoTransitionAfterGenCriterion: transition_criterion_to_dict,
     BatchTrial: batch_to_dict,
     BenchmarkMetric: metric_to_dict,
     BoTorchModel: botorch_model_to_dict,
@@ -287,6 +289,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "AndEarlyStoppingStrategy": AndEarlyStoppingStrategy,
     "AugmentedBraninMetric": AugmentedBraninMetric,
     "AugmentedHartmann6Metric": AugmentedHartmann6Metric,
+    "AutoTransitionAfterGenCriterion": AutoTransitionAfterGenCriterion,
     "Arm": Arm,
     "AggregatedBenchmarkResult": AggregatedBenchmarkResult,
     "BatchTrial": BatchTrial,


### PR DESCRIPTION
Summary: During development, it became clear that I never added AutoTransitionAfterGenCriterion to the encoder/decoder registry. This is a simple diff to add that

Differential Revision: D60419201
