### PR TITLE
Remove status quo weight override from COPY_DB_IDS_ATTRS_TO_SKIP

### DIFF
--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -350,6 +350,7 @@ class BatchTrial(BaseTrial):
     def unset_status_quo(self) -> None:
         """Set the status quo to None."""
         self._status_quo = None
+        self._status_quo_weight_override = None
         self._refresh_arms_by_name()
 
     @immutable_once_run
@@ -362,8 +363,11 @@ class BatchTrial(BaseTrial):
         result in the weight being additive over all generator runs.
         """
         # Assign a name to this arm if none exists
-        if weight is not None and weight <= 0.0:
-            raise ValueError("Status quo weight must be positive.")
+        if weight is not None:
+            if weight <= 0.0:
+                raise ValueError("Status quo weight must be positive.")
+            if status_quo is None:
+                raise ValueError("Cannot set weight because status quo is not defined.")
 
         if status_quo is not None:
             self.experiment.search_space.check_types(

--- a/ax/storage/sqa_store/utils.py
+++ b/ax/storage/sqa_store/utils.py
@@ -38,10 +38,6 @@ COPY_DB_IDS_ATTRS_TO_SKIP = {
     "_steps",
     "analysis_scheduler",
     "_nodes",
-    # ``status_quo_weight_override`` is a field on ``BatchTrial`` not in the
-    # "trial_v2" table
-    # TODO(T193258337)
-    "_status_quo_weight_override",
 }
 SKIP_ATTRS_ERROR_SUFFIX = "Consider adding to COPY_DB_IDS_ATTRS_TO_SKIP if appropriate."
 


### PR DESCRIPTION
Summary:
Encoder and decoder both deal with `_status_quo_weight_override`.  In decoder in happens through the status quo generator run.  The problem is when a trial has a `_status_quo_weight_override`, but no status quo.  The solution in this diff is to make it impossible (unless you use protected fields directly) to have a `_status_quo_weight_override` without a `status_quo`.

## How could this be wrong?
If the user needs to store a status quo weight override on the trial for later but does not yet have a status quo.  But I don't know why they could only calculate the weight now and not later.

Differential Revision: D60413211
