### PR TITLE
Unit tests for benchmarking noisy problems

### DIFF
--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -17,16 +17,19 @@ from ax.benchmark.benchmark_problem import (
     MultiObjectiveBenchmarkProblem,
 )
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
+from ax.benchmark.metrics.benchmark import BenchmarkMetric
 from ax.benchmark.problems.surrogate import (
     MOOSurrogateBenchmarkProblem,
     SOOSurrogateBenchmarkProblem,
 )
 from ax.benchmark.runners.surrogate import SurrogateRunner
 from ax.core.experiment import Experiment
+from ax.core.objective import MultiObjective, Objective
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
 )
+from ax.core.outcome_constraint import ObjectiveThreshold
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
 from ax.modelbridge.torch import TorchModelBridge
@@ -34,7 +37,6 @@ from ax.models.torch.botorch_modular.model import BoTorchModel
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.service.scheduler import SchedulerOptions
 from ax.utils.common.constants import Keys
-from ax.utils.common.typeutils import checked_cast
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_branin_experiment_with_multi_objective,
@@ -60,11 +62,13 @@ def get_single_objective_benchmark_problem(
 
 
 def get_multi_objective_benchmark_problem(
-    observe_noise_sd: bool = False, num_trials: int = 4
+    observe_noise_sd: bool = False,
+    num_trials: int = 4,
+    test_problem_kwargs: Optional[Dict[str, Any]] = None,
 ) -> MultiObjectiveBenchmarkProblem:
     return create_multi_objective_problem_from_botorch(
         test_problem_class=BraninCurrin,
-        test_problem_kwargs={},
+        test_problem_kwargs={} if test_problem_kwargs is None else test_problem_kwargs,
         num_trials=num_trials,
         observe_noise_sd=observe_noise_sd,
     )
@@ -94,41 +98,60 @@ def get_sobol_benchmark_method() -> BenchmarkMethod:
     )
 
 
-def get_soo_surrogate() -> SOOSurrogateBenchmarkProblem:
+def get_soo_surrogate(noise_stds: float = 0.0) -> SOOSurrogateBenchmarkProblem:
+    outcome_name = "branin"
+    observe_noise_stds = True
     experiment = get_branin_experiment(with_completed_trial=True)
-    surrogate = TorchModelBridge(
+
+    optimization_config = OptimizationConfig(
+        objective=Objective(
+            metric=BenchmarkMetric(
+                name=outcome_name,
+                lower_is_better=False,
+                observe_noise_sd=observe_noise_stds,
+            ),
+            minimize=False,
+        )
+    )
+    surrogate = Surrogate(botorch_model_class=SingleTaskGP)
+    model_bridge = TorchModelBridge(
         experiment=experiment,
         search_space=experiment.search_space,
-        model=BoTorchModel(surrogate=Surrogate(botorch_model_class=SingleTaskGP)),
+        model=BoTorchModel(surrogate=surrogate),
         data=experiment.lookup_data(),
         transforms=[],
     )
+    datasets = surrogate.training_data
     runner = SurrogateRunner(
-        name="test",
+        name=outcome_name,
         search_space=experiment.search_space,
-        outcome_names=["branin"],
-        get_surrogate_and_datasets=lambda: (surrogate, []),
+        outcome_names=[outcome_name],
+        get_surrogate_and_datasets=lambda: (model_bridge, datasets),
+        noise_stds=noise_stds,
     )
     return SOOSurrogateBenchmarkProblem(
         name="test",
         search_space=experiment.search_space,
-        optimization_config=checked_cast(
-            OptimizationConfig, experiment.optimization_config
-        ),
+        optimization_config=optimization_config,
         num_trials=6,
-        observe_noise_stds=True,
+        observe_noise_stds=observe_noise_stds,
         optimal_value=0.0,
         runner=runner,
         is_noiseless=runner.is_noiseless,
     )
 
 
-def get_moo_surrogate() -> MOOSurrogateBenchmarkProblem:
+def get_moo_surrogate(noise_stds: float = 0.0) -> MOOSurrogateBenchmarkProblem:
+    observe_noise_stds = True
+    outcome_names = ["branin_a", "branin_b"]
+    # set this to be easy to beat, so hypervolume computations aren't all zero
+    ref_point = [10.0, 10.0]
+    surrogate = Surrogate(botorch_model_class=SingleTaskGP)
     experiment = get_branin_experiment_with_multi_objective(with_completed_trial=True)
-    surrogate = TorchModelBridge(
+    model_bridge = TorchModelBridge(
         experiment=experiment,
         search_space=experiment.search_space,
-        model=BoTorchModel(surrogate=Surrogate(botorch_model_class=SingleTaskGP)),
+        model=BoTorchModel(surrogate=surrogate),
         data=experiment.lookup_data(),
         transforms=[],
     )
@@ -136,19 +159,36 @@ def get_moo_surrogate() -> MOOSurrogateBenchmarkProblem:
     runner = SurrogateRunner(
         name="test",
         search_space=experiment.search_space,
-        outcome_names=["branin_a", "branin_b"],
-        get_surrogate_and_datasets=lambda: (surrogate, []),
+        outcome_names=outcome_names,
+        get_surrogate_and_datasets=lambda: (model_bridge, surrogate.training_data),
+        noise_stds=noise_stds,
     )
+    metrics = [
+        BenchmarkMetric(
+            name=name,
+            lower_is_better=True,
+            observe_noise_sd=observe_noise_stds,
+        )
+        for name in outcome_names
+    ]
+    objectives = [Objective(metric=metric) for metric in metrics]
+    objective_thresholds = [
+        ObjectiveThreshold(metric=metric, bound=ref_p, relative=False)
+        for metric, ref_p in zip(metrics, ref_point)
+    ]
+    optimization_config = MultiObjectiveOptimizationConfig(
+        objective=MultiObjective(objectives=objectives),
+        objective_thresholds=objective_thresholds,
+    )
+
     return MOOSurrogateBenchmarkProblem(
         name="test",
         search_space=experiment.search_space,
-        optimization_config=checked_cast(
-            MultiObjectiveOptimizationConfig, experiment.optimization_config
-        ),
+        optimization_config=optimization_config,
         num_trials=10,
         observe_noise_stds=True,
         optimal_value=1.0,
-        reference_point=[],
+        reference_point=ref_point,
         runner=runner,
         is_noiseless=runner.is_noiseless,
     )


### PR DESCRIPTION
Summary:
Context: some refactoring is coming to enable benchmarking a broader class of problems in which the value that captures optimization progress (such as the ground truth) doesn't match what is observed during optimization (such as noisy measurements).

This PR:
* Adds a property test, asserting that with a noisy problem whose ground truth is always 3, the ground-truth vaules are always 3, and the observed values are not.
* Adds a characterization (golden master) test, asserting that outputs match specific values. Passing this test doesn't indicate correctness per se, but indicates that behavior has not changed since the test was added.
* Fixes stub functions for surrogate problems so that their optimization configs include `BenchmarkMetric`s, which is needed for this to work.

Differential Revision: D60472381
