### PR TITLE
Change blob type to str

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 from enum import Enum
-from typing import Any, Optional, Protocol
+from typing import Optional, Protocol
 
 import pandas as pd
 from ax.core.experiment import Experiment
@@ -33,9 +33,11 @@ class AnalysisCard:
 
     df: pd.DataFrame  # Raw data produced by the Analysis
 
-    # pyre-ignore[4] We explicitly want to allow any type here, blob is narrowed in
-    # AnalysisCard's subclasses
-    blob: Any  # Data processed and ready for end-user consumption
+    # Blob is the data processed for end-user consumption, encoded as a string,
+    # typically JSON. Subclasses of Analysis can define their own methods for consuming
+    # the blob and presenting it to the user (ex. PlotlyAnalysisCard.get_figure()
+    # decodes the blob into a go.Figure object).
+    blob: str
 
     # How to interpret the blob (ex. "dataframe", "plotly", "markdown")
     blob_annotation = "dataframe"
@@ -47,9 +49,7 @@ class AnalysisCard:
         subtitle: str,
         level: AnalysisCardLevel,
         df: pd.DataFrame,
-        # pyre-ignore[2] We explicitly want to allow any type here, blob is narrowed in
-        # AnalysisCard's subclasses
-        blob: Any,
+        blob: str,
     ) -> None:
         self.name = name
         self.title = title

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -7,21 +7,12 @@
 
 from typing import Optional
 
-import pandas as pd
-from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
+from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.modelbridge.generation_strategy import GenerationStrategy
 
 
 class MarkdownAnalysisCard(AnalysisCard):
-    name: str
-
-    title: str
-    subtitle: str
-    level: AnalysisCardLevel
-
-    df: pd.DataFrame
-    blob: str
     blob_annotation = "markdown"
 
     def get_markdown(self) -> str:

--- a/ax/analysis/plotly/parallel_coordinates/parallel_coordinates.py
+++ b/ax/analysis/plotly/parallel_coordinates/parallel_coordinates.py
@@ -14,7 +14,7 @@ from ax.core.experiment import Experiment
 from ax.core.objective import MultiObjective, ScalarizedObjective
 from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.modelbridge.generation_strategy import GenerationStrategy
-from plotly import graph_objects as go
+from plotly import graph_objects as go, io as pio
 
 
 class ParallelCoordinatesPlot(PlotlyAnalysis):
@@ -59,7 +59,7 @@ class ParallelCoordinatesPlot(PlotlyAnalysis):
             subtitle="View arm parameterizations with their respective metric values",
             level=AnalysisCardLevel.HIGH,
             df=df,
-            blob=fig,
+            blob=pio.to_json(fig),
         )
 
 

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -7,26 +7,17 @@
 
 from typing import Optional
 
-import pandas as pd
-from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
+from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.modelbridge.generation_strategy import GenerationStrategy
-from plotly import graph_objects as go
+from plotly import graph_objects as go, io as pio
 
 
 class PlotlyAnalysisCard(AnalysisCard):
-    name: str
-
-    title: str
-    subtitle: str
-    level: AnalysisCardLevel
-
-    df: pd.DataFrame
-    blob: go.Figure
     blob_annotation = "plotly"
 
     def get_figure(self) -> go.Figure:
-        return self.blob
+        return pio.from_json(self.blob)
 
 
 class PlotlyAnalysis(Analysis):


### PR DESCRIPTION
Summary:
Change the blob on AnalysisCard to always be a string rather than Any. This does not change anything for the base Anaysis or MarkdownAnalysis, but changes the dataflow on PlotlyAnalysis to use pio.to_json and pio.from_json during compute (both are very cheap).

Doing things this way allows us to decode any AnaysisCard is the same regardless of its subclass and the `card == decoded(encoded))` relatioship holds.

Reviewed By: Cesar-Cardoso

Differential Revision: D60538382
