### PR TITLE
Use Standardize by default for SingleTaskGP

### DIFF
--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -772,7 +772,7 @@ def _get_model(
             train_Yvar=None if all_nan_Yvar else Yvar,
             covar_module=covar_module,
             input_transform=warp_tf,
-            **kwargs,
+            **{"outcome_transform": None, **kwargs},
         )
     else:
         # instantiate multitask GP

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -358,6 +358,17 @@ class Surrogate(Base):
     ) -> None:
         for input_name, input_class, input_options in inputs:
             if input_class is None:
+                # This is a temporary solution until all BoTorch models use
+                # `Standardize` by default, see TODO [T197435440].
+                # After this, we should update `Surrogate` to use `DEFAULT`
+                # (https://fburl.com/code/22f4397e) for both of these args. This will
+                # allow users to explicitly disable the default transforms by passing
+                # in `None`.
+                if (
+                    input_name in ["outcome_transform"]
+                    and input_name in botorch_model_class_args
+                ):
+                    formatted_model_inputs[input_name] = None
                 continue
             if input_name not in botorch_model_class_args:
                 # TODO: We currently only pass in `covar_module` and `likelihood`


### PR DESCRIPTION
Summary: D60080819 recently updated the default `SingleTaskGP` BoTorch priors. One significant change was to remove the use of an outputscale, which may not work well if the outputs aren't standardized. This diff changes the SingleTaskGP to use Standardize by default if no outcome transforms are specified (this allows users to explicitly pass in None if they don't want to use any transforms).

Differential Revision: D60492937
