### PR TITLE
Use reduced state for axolotl

### DIFF
--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -656,6 +656,26 @@ class SQAStoreTest(TestCase):
 
         self.assertEqual(gr, gr_decoded_reduced_state)
 
+    def test_load_and_save_generator_run_reduced_state(self) -> None:
+        exp = get_branin_experiment()
+        gs = get_generation_strategy(with_callable_model_kwarg=False)
+        gr = gs.gen(exp)
+        original_gen_metadata = {"foo": "bar"}
+        gr._gen_metadata = original_gen_metadata
+        exp.new_trial(generator_run=gr)
+        save_experiment(exp)
+
+        loaded_reduced_state = load_experiment(
+            experiment_name=exp.name, reduced_state=True
+        )
+        save_experiment(loaded_reduced_state)
+        reloaded_experiment = load_experiment(exp.name, reduced_state=False)
+
+        self.assertEqual(
+            original_gen_metadata,
+            reloaded_experiment.trials[0].generator_runs[0].gen_metadata,
+        )
+
     def test_ExperimentUpdates(self) -> None:
         experiment = get_experiment_with_batch_trial()
         save_experiment(experiment)


### PR DESCRIPTION
Summary:
Somewhat of a hotfix

Seeing some AxService errors (https://fburl.com/tupperware/gffx2flk) in loading PTS experiments where gen metadata has opt config.  It’s trying to decode the gen_metadata here: https://fburl.com/code/udrlyecq.  Originially discovered in https://fburl.com/anp/5w12oinq on `client.attach_iteration_trial`.

The effect was that it created the QE, but didn't save run metadata.  Which blocked the user from fetching data.  This also could be mitigated if we try/catched all errors for axolotl in driver (https://fburl.com/code/kfvl6eb4), but I don't want axolotl to fail silently.

FOLLOW UP: Always use reduced_state in AxService

Question

Reviewed By: Cesar-Cardoso

Differential Revision: D60773593
