### PR TITLE
fix bug in UnitX when transforming new search space

### DIFF
--- a/ax/modelbridge/transforms/unit_x.py
+++ b/ax/modelbridge/transforms/unit_x.py
@@ -68,14 +68,16 @@ class UnitX(Transform):
 
     def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         for p_name, p in search_space.parameters.items():
-            if p_name in self.bounds and isinstance(p, RangeParameter):
+            if (p_bounds := self.bounds.get(p_name)) is not None and isinstance(
+                p, RangeParameter
+            ):
                 p.update_range(
-                    lower=self.target_lb,
-                    upper=self.target_lb + self.target_range,
+                    lower=self._normalize_value(value=p.lower, bounds=p_bounds),
+                    upper=self._normalize_value(value=p.upper, bounds=p_bounds),
                 )
                 if p.target_value is not None:
                     p._target_value = self._normalize_value(
-                        p.target_value, self.bounds[p_name]  # pyre-ignore[6]
+                        value=p.target_value, bounds=p_bounds  # pyre-ignore [6]
                     )
         new_constraints: List[ParameterConstraint] = []
         for c in search_space.parameter_constraints:


### PR DESCRIPTION
Summary:
This fixes a significant bug, where a new search space (other than the search space passed to `UnitX.__init__`) that is passed to `UnitX._transform_search_space` is not actually transformed.

A common setting where this comes up is passing a new search space to `Modelbridge.gen` to generate candidates from a particular part of the searchspace. E.g. if the original search space bounds for `x` were [2.0, 5.0] and I want to generate candidates from the restricted search space [3.0, 4.0] by passing a search space to `Modelbridge.gen`, the new search space previously ignored.

Differential Revision: D60855920
