### PR TITLE
Create Scheduler.generate_candidates() function

### DIFF
--- a/ax/exceptions/generation_strategy.py
+++ b/ax/exceptions/generation_strategy.py
@@ -73,3 +73,10 @@ class GenerationStrategyMisconfiguredException(AxGenerationException):
             + "check the documentation, and adjust the configuration accordingly. "
             + f"{error_info}"
         )
+
+
+class OptimizationConfigRequired(ValueError):
+    """Error indicating that candidate generation cannot be completed
+    because an optimization config was not provided."""
+
+    pass

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -38,6 +38,7 @@ from ax.core.outcome_constraint import (
 from ax.core.search_space import SearchSpace
 from ax.core.types import TCandidateMetadata, TModelPredictArm
 from ax.exceptions.core import DataRequiredError, UnsupportedError
+from ax.exceptions.generation_strategy import OptimizationConfigRequired
 from ax.modelbridge.base import gen_arms, GenResults, ModelBridge
 from ax.modelbridge.modelbridge_utils import (
     array_to_observation_data,
@@ -804,7 +805,7 @@ class TorchModelBridge(ModelBridge):
             search_space=search_space, param_names=self.parameters
         )
         if optimization_config is None:
-            raise ValueError(
+            raise OptimizationConfigRequired(
                 f"{self.__class__.__name__} requires an OptimizationConfig "
                 "to be specified"
             )


### PR DESCRIPTION
Summary:
Add `Scheduler.generate_candidates()` method which calls
- poll and fetch
- get next trial
- eventaully gen report
- save new trials

Differential Revision: D59606488
