### PR TITLE
pin numpy to < 2.0 until tensorboard cuts a release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,9 @@ DEV_REQUIRES = [
     "torchvision>=0.5.0",
     "nbconvert",
     "jupyter-client==6.1.12",
+    # Replace with `tensorboard >= x.x` once tb cuts a release.
+    # https://github.com/tensorflow/tensorboard/issues/6869#issuecomment-2273718763
+    "numpy<2.0",
 ]
 
 MYSQL_REQUIRES = ["SQLAlchemy==1.4.17"]


### PR DESCRIPTION
Summary: The latest TB version hasn't incorporated numpy2.0-compatible changes (https://github.com/tensorflow/tensorboard/issues/6869#issuecomment-2273718763), and recently unpinned botorch (D60735276) means Ax CI is now failing. This pins numpy to < 2.0 to prevent issues in CI.

Differential Revision: D60917879
