### PR TITLE
Pass `botorch_model_class` to `Surrogate._set_formatted_inputs`

### DIFF
--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -1016,7 +1016,10 @@ class SurrogateWithModelListTest(TestCase):
             outcome_transform_classes=[Standardize],
             outcome_transform_options={"Standardize": {"m": 1}},
         )
-        with self.assertRaisesRegex(UserInputError, "The BoTorch model class"):
+        with self.assertRaisesRegex(
+            UserInputError,
+            "The BoTorch model class SingleTaskGPWithDifferentConstructor",
+        ):
             surrogate.fit(
                 datasets=self.supervised_training_data,
                 search_space_digest=SearchSpaceDigest(


### PR DESCRIPTION
Summary:
Context:

`Surrogate._set_formatted_inputs` is used only in the following context:
- A model input constructor sets inputs on the basis of a `botorch_model_class` and a `surrogate`. It checks which inputs are valid based on the `botorch_model_class`
- The input constructor calls `_set_formatted_inputs`; if the inputs are not valid (as per the above bullet), it raises an exception.
- However, `_set_formatted_inputs` uses `surrogate.botorch_model_class` rather than `botorch_model_class`, which may not be the same, and can raise a nonsensical error. Hence there was a unit test raising a puzzling exception that SaasFullyBayesianSingleTaskGP does not support `outcome_transform` (it does), when it should have been saying that `SingleTaskGPWithDifferentConstructor`, the model in question, doesn't support `outcome_transform`.

This PR:

- Passes `botorch_model_class` to `_set_formatted_inputs`
- changes some `list` annotations to `Sequence` to fix type errors

Differential Revision: D61212316
