### PR TITLE
Change time limit for unit tests to 60 seconds and introduce a decorator for long running tests

### DIFF
--- a/ax/utils/common/tests/test_testutils.py
+++ b/ax/utils/common/tests/test_testutils.py
@@ -102,3 +102,14 @@ class TestTestUtils(TestCase):
         self.assertEqual(1, 1)
         with self.assertRaises(RuntimeError):
             self.assertEquals(1, 1)
+
+    def test_ax_long_test_decorator(self) -> None:
+        testReason: str = "testReason"
+
+        @TestCase.ax_long_test(testReason)
+        def decorated_test() -> None:
+            self.assertEqual(testReason, self._long_test_active_reason)
+
+        self.assertEqual(None, self._long_test_active_reason)
+        decorated_test()
+        self.assertEqual(None, self._long_test_active_reason)


### PR DESCRIPTION
Summary:
This diff is to change the time limit for unit tests to 60 seconds and introduce a decorator for long running tests.

We'll use the `ax_long_text` decorator to identify all long running tests, which we can fix over time by creating backlog tasks for test-owners to update these long-running tests with a descriptive message.

This change also introduces this decorator to all tests running over 60 seconds. For now, the provided reason for these long running tests are placeholders.

Differential Revision: D61212556
