### PR TITLE
Split `BenchmarkRunner` into `BenchmarkWithGroundTruthRunner` and `BenchmarkWithoutGroundTruthRunner`

### DIFF
--- a/ax/benchmark/runners/botorch_test.py
+++ b/ax/benchmark/runners/botorch_test.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable
 from typing import Any, Optional, Union
 
 import torch
-from ax.benchmark.runners.base import BenchmarkRunner
+from ax.benchmark.runners.base import BenchmarkWithGroundTruthRunner
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.utils.common.base import Base
@@ -23,7 +23,7 @@ from botorch.utils.transforms import normalize, unnormalize
 from torch import Tensor
 
 
-class BotorchTestProblemRunner(BenchmarkRunner):
+class BotorchTestProblemRunner(BenchmarkWithGroundTruthRunner):
     """A Runner for evaluating Botorch BaseTestProblems.
 
     Given a trial the Runner will evaluate the BaseTestProblem.forward method for each
@@ -75,12 +75,8 @@ class BotorchTestProblemRunner(BenchmarkRunner):
             self.test_problem, ConstrainedBaseTestProblem
         )
         self._is_moo: bool = isinstance(self.test_problem, MultiObjectiveTestProblem)
-        self._outcome_names = outcome_names
+        self.outcome_names = outcome_names
         self._modified_bounds = modified_bounds
-
-    @property
-    def outcome_names(self) -> list[str]:
-        return self._outcome_names
 
     @equality_typechecker
     def __eq__(self, other: Base) -> bool:
@@ -188,7 +184,7 @@ class BotorchTestProblemRunner(BenchmarkRunner):
             "test_problem_module": runner._test_problem_class.__module__,
             "test_problem_class_name": runner._test_problem_class.__name__,
             "test_problem_kwargs": runner._test_problem_kwargs,
-            "outcome_names": runner._outcome_names,
+            "outcome_names": runner.outcome_names,
             "modified_bounds": runner._modified_bounds,
         }
 

--- a/ax/benchmark/runners/surrogate.py
+++ b/ax/benchmark/runners/surrogate.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable
 from typing import Any, Callable, Optional, Union
 
 import torch
-from ax.benchmark.runners.base import BenchmarkRunner
+from ax.benchmark.runners.base import BenchmarkWithGroundTruthRunner
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.observation import ObservationFeatures
@@ -24,7 +24,7 @@ from pyre_extensions import assert_is_instance, none_throws
 from torch import Tensor
 
 
-class SurrogateRunner(BenchmarkRunner):
+class SurrogateRunner(BenchmarkWithGroundTruthRunner):
     def __init__(
         self,
         *,
@@ -68,7 +68,7 @@ class SurrogateRunner(BenchmarkRunner):
         self.get_surrogate_and_datasets = get_surrogate_and_datasets
         self.name = name
         self._surrogate = surrogate
-        self._outcome_names = outcome_names
+        self.outcome_names = outcome_names
         self._datasets = datasets
         self.search_space = search_space
         self.noise_stds = noise_stds
@@ -88,10 +88,6 @@ class SurrogateRunner(BenchmarkRunner):
         if self.get_surrogate_and_datasets is not None:
             self.set_surrogate_and_datasets()
         return none_throws(self._datasets)
-
-    @property
-    def outcome_names(self) -> list[str]:
-        return self._outcome_names
 
     def get_noise_stds(self) -> Union[None, float, dict[str, float]]:
         return self.noise_stds

--- a/ax/benchmark/tests/runners/test_botorch_test_problem.py
+++ b/ax/benchmark/tests/runners/test_botorch_test_problem.py
@@ -125,7 +125,7 @@ class TestBotorchTestProblemRunner(TestCase):
                         "test_problem_module": runner._test_problem_class.__module__,
                         "test_problem_class_name": runner._test_problem_class.__name__,
                         "test_problem_kwargs": runner._test_problem_kwargs,
-                        "outcome_names": runner._outcome_names,
+                        "outcome_names": runner.outcome_names,
                         "modified_bounds": runner._modified_bounds,
                     },
                 )


### PR DESCRIPTION
Summary:
Context: `BenchmarkRunner` has some methods that should be implemented if and only if there is a ground truth and some that are the opposite. It is hard to implement a new `BenchmarkRunner` subclass correctly because without abstract methods in the base class, there won't necessarily be an immediate error for subclasses that don't implement these methods.

This PR:
* Adds subclasses of `BenchmarkRunner`, `BenchmarkWithGroundTruthRunner` and `BenchmarkWithoutGroundTruthRunner`, each of which has only abstract methods that must be overridden and concrete methods that shouldn't need to be.
* Makes `BotorchTestProblemRunner` and `SurrogateRunner` subclasses of `BenchmarkWithGroundTruthRunner`
* Simplifies syntax for `outcome_names`

Differential Revision: D61431979
