### PR TITLE
Undo pep585_imports in test_kwargutils

### DIFF
--- a/ax/utils/common/kwargs.py
+++ b/ax/utils/common/kwargs.py
@@ -6,23 +6,22 @@
 
 # pyre-strict
 
-from collections.abc import Iterable
 from inspect import Parameter, signature
 
 from logging import Logger
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils_nonnative import version_safe_check_type
 
 logger: Logger = get_logger(__name__)
 
-TKwargs = dict[str, Any]
+TKwargs = Dict[str, Any]
 
 
 def consolidate_kwargs(
-    kwargs_iterable: Iterable[Optional[dict[str, Any]]], keywords: Iterable[str]
-) -> dict[str, Any]:
+    kwargs_iterable: Iterable[Optional[Dict[str, Any]]], keywords: Iterable[str]
+) -> Dict[str, Any]:
     """Combine an iterable of kwargs into a single dict of kwargs, where kwargs
     by duplicate keys that appear later in the iterable get priority over the
     ones that appear earlier and only kwargs referenced in keywords will be
@@ -45,15 +44,15 @@ def consolidate_kwargs(
 def get_function_argument_names(
     # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
     function: Callable,
-    omit: Optional[list[str]] = None,
-) -> list[str]:
+    omit: Optional[List[str]] = None,
+) -> List[str]:
     """Extract parameter names from function signature."""
     omit = omit or []
     return [p for p in signature(function).parameters.keys() if p not in omit]
 
 
 # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
-def get_function_default_arguments(function: Callable) -> dict[str, Any]:
+def get_function_default_arguments(function: Callable) -> Dict[str, Any]:
     """Extract default arguments from function signature."""
     params = signature(function).parameters
     return {
@@ -62,7 +61,7 @@ def get_function_default_arguments(function: Callable) -> dict[str, Any]:
 
 
 # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
-def validate_kwarg_typing(typed_callables: list[Callable], **kwargs: Any) -> None:
+def validate_kwarg_typing(typed_callables: List[Callable], **kwargs: Any) -> None:
     """Check if keywords in kwargs exist in any of the typed_callables and
     if the type of each keyword value matches the type of corresponding arg in one of
     the callables

--- a/ax/utils/common/tests/test_kwargutils.py
+++ b/ax/utils/common/tests/test_kwargutils.py
@@ -8,7 +8,7 @@
 
 
 from logging import Logger
-from typing import Callable, Optional
+from typing import Callable, Dict, Optional
 from unittest.mock import patch
 
 from ax.utils.common.kwargs import validate_kwarg_typing, warn_on_kwargs
@@ -23,7 +23,7 @@ class TestKwargUtils(TestCase):
         def typed_callable(arg1: int, arg2: Optional[str] = None) -> None:
             pass
 
-        def typed_callable_with_dict(arg3: int, arg4: dict[str, int]) -> None:
+        def typed_callable_with_dict(arg3: int, arg4: Dict[str, int]) -> None:
             pass
 
         def typed_callable_valid(arg3: int, arg4: Optional[str] = None) -> None:
@@ -33,7 +33,7 @@ class TestKwargUtils(TestCase):
             pass
 
         def typed_callable_with_callable(
-            arg1: int, arg2: Callable[[int], dict[str, int]]
+            arg1: int, arg2: Callable[[int], Dict[str, int]]
         ) -> None:
             pass
 
@@ -102,7 +102,7 @@ class TestKwargUtils(TestCase):
             validate_kwarg_typing(typed_callables, **kwargs)
             expected_message = (
                 f"`{typed_callable_with_dict}` expected argument `arg4` to be of type"
-                f" dict[str, int]. Got {str_dic} (type: {type(str_dic)})."
+                f" typing.Dict[str, int]. Got {str_dic} (type: {type(str_dic)})."
             )
             mock_warning.assert_called_once_with(expected_message)
 
@@ -113,7 +113,7 @@ class TestKwargUtils(TestCase):
             validate_kwarg_typing(typed_callables, **kwargs)
             expected_message = (
                 f"`{typed_callable_with_callable}` expected argument `arg2` to be of"
-                f" type typing.Callable[[int], dict[str, int]]. "
+                f" type typing.Callable[[int], typing.Dict[str, int]]. "
                 f"Got test_again (type: {type('test_again')})."
             )
             mock_warning.assert_called_once_with(expected_message)


### PR DESCRIPTION
Summary: For whatever reason validate_kwarg_typing does not play well with this change ONLY IN GITHUB ACTIONS. **Tests pass internally with or without this change.**

Differential Revision: D61480862
