### PR TITLE
Remove validate_kwarg_typing and typeguard dependence

### DIFF
--- a/ax/utils/common/tests/test_kwargutils.py
+++ b/ax/utils/common/tests/test_kwargutils.py
@@ -8,115 +8,13 @@
 
 
 from logging import Logger
-from typing import Callable, Optional
 from unittest.mock import patch
 
-from ax.utils.common.kwargs import validate_kwarg_typing, warn_on_kwargs
+from ax.utils.common.kwargs import warn_on_kwargs
 from ax.utils.common.logger import get_logger
 from ax.utils.common.testutils import TestCase
 
 logger: Logger = get_logger("ax.utils.common.kwargs")
-
-
-class TestKwargUtils(TestCase):
-    def test_validate_kwarg_typing(self) -> None:
-        def typed_callable(arg1: int, arg2: Optional[str] = None) -> None:
-            pass
-
-        def typed_callable_with_dict(arg3: int, arg4: dict[str, int]) -> None:
-            pass
-
-        def typed_callable_valid(arg3: int, arg4: Optional[str] = None) -> None:
-            pass
-
-        def typed_callable_dup_keyword(arg2: int, arg4: Optional[str] = None) -> None:
-            pass
-
-        def typed_callable_with_callable(
-            arg1: int, arg2: Callable[[int], dict[str, int]]
-        ) -> None:
-            pass
-
-        def typed_callable_extra_arg(arg1: int, arg2: str, arg3: bool) -> None:
-            pass
-
-        # pass
-        try:
-            kwargs = {"arg1": 1, "arg2": "test", "arg3": 2}
-            validate_kwarg_typing([typed_callable, typed_callable_valid], **kwargs)
-        except Exception:
-            self.assertTrue(False, "Exception raised on valid kwargs")
-
-        # pass with complex data structure
-        try:
-            kwargs = {"arg1": 1, "arg2": "test", "arg3": 2, "arg4": {"k1": 1}}
-            validate_kwarg_typing([typed_callable, typed_callable_with_dict], **kwargs)
-        except Exception:
-            self.assertTrue(False, "Exception raised on valid kwargs")
-
-        # callable as arg (same arg count but diff type)
-        try:
-            kwargs = {"arg1": 1, "arg2": typed_callable}
-            validate_kwarg_typing([typed_callable_with_callable], **kwargs)
-        except Exception:
-            self.assertTrue(False, "Exception raised on valid kwargs")
-
-        # callable as arg (diff arg count)
-        try:
-            kwargs = {"arg1": 1, "arg2": typed_callable_extra_arg}
-            validate_kwarg_typing([typed_callable_with_callable], **kwargs)
-        except Exception:
-            self.assertTrue(False, "Exception raised on valid kwargs")
-
-        # kwargs contains extra keywords
-        with self.assertRaises(ValueError):
-            kwargs = {"arg1": 1, "arg2": "test", "arg3": 3, "arg5": 4}
-            typed_callables = [typed_callable, typed_callable_valid]
-            validate_kwarg_typing(typed_callables, **kwargs)
-
-        # callables have duplicate keywords
-        with patch.object(logger, "debug") as mock_debug:
-            kwargs = {"arg1": 1, "arg2": "test", "arg4": "test_again"}
-            typed_callables = [typed_callable, typed_callable_dup_keyword]
-            validate_kwarg_typing(typed_callables, **kwargs)
-            mock_debug.assert_called_once_with(
-                f"`{typed_callables}` have duplicate keyword argument: arg2."
-            )
-
-        # mismatch types
-        with patch.object(logger, "warning") as mock_warning:
-            kwargs = {"arg1": 1, "arg2": "test", "arg3": "test_again"}
-            typed_callables = [typed_callable, typed_callable_valid]
-            validate_kwarg_typing(typed_callables, **kwargs)
-            expected_message = (
-                f"`{typed_callable_valid}` expected argument `arg3` to be of type"
-                f" {type(1)}. Got test_again (type: {type('test_again')})."
-            )
-            mock_warning.assert_called_once_with(expected_message)
-
-        # mismatch types with Dict
-        with patch.object(logger, "warning") as mock_warning:
-            str_dic = {"k1": "test"}
-            kwargs = {"arg1": 1, "arg2": "test", "arg3": 2, "arg4": str_dic}
-            typed_callables = [typed_callable, typed_callable_with_dict]
-            validate_kwarg_typing(typed_callables, **kwargs)
-            expected_message = (
-                f"`{typed_callable_with_dict}` expected argument `arg4` to be of type"
-                f" dict[str, int]. Got {str_dic} (type: {type(str_dic)})."
-            )
-            mock_warning.assert_called_once_with(expected_message)
-
-        # mismatch types with callable as arg
-        with patch.object(logger, "warning") as mock_warning:
-            kwargs = {"arg1": 1, "arg2": "test_again"}
-            typed_callables = [typed_callable_with_callable]
-            validate_kwarg_typing(typed_callables, **kwargs)
-            expected_message = (
-                f"`{typed_callable_with_callable}` expected argument `arg2` to be of"
-                f" type typing.Callable[[int], dict[str, int]]. "
-                f"Got test_again (type: {type('test_again')})."
-            )
-            mock_warning.assert_called_once_with(expected_message)
 
 
 class TestWarnOnKwargs(TestCase):

--- a/ax/utils/common/typeutils_nonnative.py
+++ b/ax/utils/common/typeutils_nonnative.py
@@ -6,31 +6,9 @@
 
 # pyre-strict
 
-from inspect import signature
-from typing import Any, TypeVar
+from typing import Any
 
 import numpy as np
-from typeguard import check_type
-
-T = TypeVar("T")
-V = TypeVar("V")
-K = TypeVar("K")
-X = TypeVar("X")
-Y = TypeVar("Y")
-
-
-def version_safe_check_type(argname: str, value: T, expected_type: type[T]) -> None:
-    """Excecute the check_type function if it has the expected signature, otherwise
-    warn.  This is done to support newer versions of typeguard with minimal loss
-    of functionality for users that have dependency conflicts"""
-    # Get the signature of the check_type function
-    sig = signature(check_type)
-    # Get the parameters of the check_type function
-    params = sig.parameters
-    # Check if the check_type function has the expected signature
-    params = set(params.keys())
-    if all(arg in params for arg in ["argname", "value", "expected_type"]):
-        check_type(argname, value, expected_type)
 
 
 # pyre-fixme[3]: Return annotation cannot be `Any`.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ REQUIRES = [
     "ipywidgets",
     # Needed for compatibility with ipywidgets >= 8.0.0
     "plotly>=5.12.0",
-    "typeguard",
     "pyre-extensions",
 ]
 


### PR DESCRIPTION
Summary: Proximate motivation: test_validate_kwarg_typing is failing on Github Actions but cannot be reproduced on internal setup

Reviewed By: esantorella

Differential Revision: D61489346
