### PR TITLE
Introduce `ParamBasedTestProblem` for benchmarking

### DIFF
--- a/ax/benchmark/runners/base.py
+++ b/ax/benchmark/runners/base.py
@@ -5,13 +5,15 @@
 
 # pyre-strict
 
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from math import sqrt
 from typing import Any, Union
 
 import torch
 from ax.core.arm import Arm
-from ax.core.base_trial import BaseTrial
+
+from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.batch_trial import BatchTrial
 from ax.core.runner import Runner
 from ax.core.trial import Trial
@@ -39,10 +41,7 @@ class BenchmarkRunner(Runner, ABC):
           not over-engineer for that before such a use case arrives.
     """
 
-    @abstractproperty
-    def outcome_names(self) -> list[str]:
-        """The names of the outcomes of the problem (in the order of the outcomes)."""
-        pass  # pragma: no cover
+    outcome_names: list[str]
 
     def get_Y_true(self, arm: Arm) -> Tensor:
         """
@@ -132,3 +131,9 @@ class BenchmarkRunner(Runner, ABC):
             "Ys_true": Ys_true,
         }
         return run_metadata
+
+    # This will need to be udpated once asynchronous benchmarks are supported.
+    def poll_trial_status(
+        self, trials: Iterable[BaseTrial]
+    ) -> dict[TrialStatus, set[int]]:
+        return {TrialStatus.COMPLETED: {t.index for t in trials}}

--- a/ax/benchmark/runners/base.py
+++ b/ax/benchmark/runners/base.py
@@ -5,9 +5,9 @@
 
 # pyre-strict
 
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 from math import sqrt
-from typing import Any, Optional, Union
+from typing import Any, Union
 
 import torch
 from ax.core.arm import Arm
@@ -21,45 +21,44 @@ from torch import Tensor
 
 
 class BenchmarkRunner(Runner, ABC):
+    """
+    A Runner that produces both observed and ground-truth values.
 
-    @property
-    @abstractmethod
+    Observed values equal ground-truth values plus noise, with the noise added
+    according to the standard deviations returned by `get_noise_stds()`.
+
+    This runner does require that every benchmark has a ground truth, which
+    won't necessarily be true for real-world problems. Such problems fall into
+    two categories:
+        - If they are deterministic, they can be used with this runner by
+          viewing them as noiseless problems where the observed values are the
+          ground truth. The observed values will be used for tracking the
+          progress of optimization.
+        - If they are not deterministc, they are not supported. It is not
+          conceptually clear how to benchmark such problems, so we decided to
+          not over-engineer for that before such a use case arrives.
+    """
+
+    @abstractproperty
     def outcome_names(self) -> list[str]:
         """The names of the outcomes of the problem (in the order of the outcomes)."""
         pass  # pragma: no cover
 
     def get_Y_true(self, arm: Arm) -> Tensor:
-        """Function returning the ground truth values for a given arm. The
-        synthetic noise is added as part of the Runner's `run()` method.
-        For problems that do not have a ground truth, the Runner must
-        implement the `get_Y_Ystd()` method instead."""
-        raise NotImplementedError(
-            "Must implement method `get_Y_true()` for Runner "
-            f"{self.__class__.__name__} as it does not implement a "
-            "`get_Y_Ystd()` method."
-        )
+        """
+        Return the ground truth values for a given arm.
 
+        Synthetic noise is added as part of the Runner's `run()` method.
+        """
+        ...
+
+    @abstractmethod
     def get_noise_stds(self) -> Union[None, float, dict[str, float]]:
-        """Function returning the standard errors for the synthetic noise
-        to be applied to the observed values. For problems that do not have
-        a ground truth, the Runner must implement the `get_Y_Ystd()` method
-        instead."""
-        raise NotImplementedError(
-            "Must implement method `get_Y_Ystd()` for Runner "
-            f"{self.__class__.__name__} as it does not implement a "
-            "`get_noise_stds()` method."
-        )
-
-    def get_Y_Ystd(self, arm: Arm) -> tuple[Tensor, Optional[Tensor]]:
-        """Function returning the observed values and their standard errors
-        for a given arm. This function is unused for problems that have a
-        ground truth (in this case `get_Y_true()` is used), and is required
-        for problems that do not have a ground truth."""
-        raise NotImplementedError(
-            "Must implement method `get_Y_Ystd()` for Runner "
-            f"{self.__class__.__name__} as it does not implement a "
-            "`get_Y_true()` method."
-        )
+        """
+        Return the standard errors for the synthetic noise to be applied to the
+        observed values.
+        """
+        ...
 
     def run(self, trial: BaseTrial) -> dict[str, Any]:
         """Run the trial by evaluating its parameterization(s).
@@ -110,33 +109,26 @@ class BenchmarkRunner(Runner, ABC):
                 )
 
         for arm in trial.arms:
-            try:
-                # Case where we do have a ground truth
-                Y_true = self.get_Y_true(arm)
-                Ys_true[arm.name] = Y_true.tolist()
-                if noise_stds is None:
-                    # No noise, so just return the true outcome.
-                    Ystds[arm.name] = [0.0] * len(Y_true)
-                    Ys[arm.name] = Y_true.tolist()
-                else:
-                    # We can scale the noise std by the inverse of the relative sample
-                    # budget allocation to each arm. This works b/c (i) we assume that
-                    # observations per unit sample budget are i.i.d. and (ii) the
-                    # normalized weights sum to one.
-                    std = noise_stds_tsr.to(Y_true) / sqrt(nlzd_arm_weights[arm])
-                    Ystds[arm.name] = std.tolist()
-                    Ys[arm.name] = (Y_true + std * torch.randn_like(Y_true)).tolist()
-            except NotImplementedError:
-                # Case where we don't have a ground truth.
-                Y, Ystd = self.get_Y_Ystd(arm)
-                Ys[arm.name] = Y.tolist()
-                Ystds[arm.name] = Ystd.tolist() if Ystd is not None else None
+            # Case where we do have a ground truth
+            Y_true = self.get_Y_true(arm)
+            Ys_true[arm.name] = Y_true.tolist()
+            if noise_stds is None:
+                # No noise, so just return the true outcome.
+                Ystds[arm.name] = [0.0] * len(Y_true)
+                Ys[arm.name] = Y_true.tolist()
+            else:
+                # We can scale the noise std by the inverse of the relative sample
+                # budget allocation to each arm. This works b/c (i) we assume that
+                # observations per unit sample budget are i.i.d. and (ii) the
+                # normalized weights sum to one.
+                std = noise_stds_tsr.to(Y_true) / sqrt(nlzd_arm_weights[arm])
+                Ystds[arm.name] = std.tolist()
+                Ys[arm.name] = (Y_true + std * torch.randn_like(Y_true)).tolist()
 
         run_metadata = {
             "Ys": Ys,
             "Ystds": Ystds,
             "outcome_names": self.outcome_names,
+            "Ys_true": Ys_true,
         }
-        if Ys_true:  # only add key if we actually have a ground truth
-            run_metadata["Ys_true"] = Ys_true
         return run_metadata

--- a/ax/benchmark/runners/botorch_test.py
+++ b/ax/benchmark/runners/botorch_test.py
@@ -6,42 +6,76 @@
 # pyre-strict
 
 import importlib
-from collections.abc import Iterable
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any, Optional, Union
 
 import torch
 from ax.benchmark.runners.base import BenchmarkRunner
 from ax.core.arm import Arm
-from ax.core.base_trial import BaseTrial, TrialStatus
+from ax.core.types import TParameterization
 from ax.utils.common.base import Base
 from ax.utils.common.equality import equality_typechecker
 from ax.utils.common.serialization import TClassDecoderRegistry, TDecoderRegistry
-from ax.utils.common.typeutils import checked_cast
-from botorch.test_functions.base import BaseTestProblem, ConstrainedBaseTestProblem
-from botorch.test_functions.multi_objective import MultiObjectiveTestProblem
+from botorch.test_functions.synthetic import (
+    ConstrainedSyntheticTestFunction,
+    SyntheticTestFunction,
+)
 from botorch.utils.transforms import normalize, unnormalize
+from pyre_extensions import assert_is_instance
 from torch import Tensor
 
 
-class BotorchTestProblemRunner(BenchmarkRunner):
-    """A Runner for evaluating Botorch BaseTestProblems.
-
-    Given a trial the Runner will evaluate the BaseTestProblem.forward method for each
-    arm in the trial, as well as return some metadata about the underlying Botorch
-    problem such as the noise_std. We compute the full result on the Runner (as opposed
-    to the Metric as is typical in synthetic test problems) because the BoTorch problem
-    computes all metrics in one stacked tensor in the MOO case, and we wish to avoid
-    recomputation per metric.
+@dataclass(kw_only=True)
+class ParamBasedTestProblem(ABC):
+    """
+    Similar to a BoTorch test problem, but evaluated using an Ax
+    TParameterization rather than a tensor.
     """
 
-    test_problem: BaseTestProblem
+    num_objectives: int
+    optimal_value: float
+    # Constraints could easily be supported similar to BoTorch test problems,
+    # but haven't been hooked up.
+    _is_constrained: bool = False
+    constraint_noise_std: Optional[Union[float, list[float]]] = None
+    noise_std: Optional[Union[float, list[float]]] = None
+    negate: bool = False
+
+    @abstractmethod
+    def evaluate_true(self, params: TParameterization) -> Tensor: ...
+
+    def evaluate_slack_true(self, params: TParameterization) -> Tensor:
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support constraints."
+        )
+
+    # pyre-fixme: Missing parameter annotation [2]: Parameter `other` must have
+    # a type other than `Any`.
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, type(self)):
+            return False
+        return self.__class__.__name__ == other.__class__.__name__
+
+
+class SyntheticProblemRunner(BenchmarkRunner, ABC):
+    """A Runner for evaluating synthetic problems, either BoTorch
+    `SyntheticTestFunction`s or Ax benchmarking `ParamBasedTestProblem`s.
+
+    Given a trial, the Runner will evaluate the problem noiselessly for each
+    arm in the trial, as well as return some metadata about the underlying
+    problem such as the noise_std.
+    """
+
+    test_problem: Union[SyntheticTestFunction, ParamBasedTestProblem]
     _is_constrained: bool
-    _test_problem_class: type[BaseTestProblem]
+    _test_problem_class: type[Union[SyntheticTestFunction, ParamBasedTestProblem]]
     _test_problem_kwargs: Optional[dict[str, Any]]
 
     def __init__(
         self,
-        test_problem_class: type[BaseTestProblem],
+        *,
+        test_problem_class: type[Union[SyntheticTestFunction, ParamBasedTestProblem]],
         test_problem_kwargs: dict[str, Any],
         outcome_names: list[str],
         modified_bounds: Optional[list[tuple[float, float]]] = None,
@@ -49,7 +83,8 @@ class BotorchTestProblemRunner(BenchmarkRunner):
         """Initialize the test problem runner.
 
         Args:
-            test_problem_class: The BoTorch test problem class.
+            test_problem_class: A BoTorch `SyntheticTestFunction` class or Ax
+                `ParamBasedTestProblem` class.
             test_problem_kwargs: The keyword arguments used for initializing the
                 test problem.
             outcome_names: The names of the outcomes returned by the problem.
@@ -63,28 +98,27 @@ class BotorchTestProblemRunner(BenchmarkRunner):
                 If modified bounds are not provided, the test problem will be
                 evaluated using the raw parameter values.
         """
-
         self._test_problem_class = test_problem_class
         self._test_problem_kwargs = test_problem_kwargs
-
-        # pyre-fixme [45]: Invalid class instantiation
-        self.test_problem = test_problem_class(**test_problem_kwargs).to(
-            dtype=torch.double
+        self.test_problem = (
+            # pyre-fixme: Invalid class instantiation [45]: Cannot instantiate
+            # abstract class with abstract method `evaluate_true`.
+            test_problem_class(**test_problem_kwargs)
         )
+        if isinstance(self.test_problem, SyntheticTestFunction):
+            self.test_problem = self.test_problem.to(dtype=torch.double)
+        # A `ConstrainedSyntheticTestFunction` is a type of `SyntheticTestFunction`; a
+        # `ParamBasedTestProblem` is never constrained.
         self._is_constrained: bool = isinstance(
-            self.test_problem, ConstrainedBaseTestProblem
+            self.test_problem, ConstrainedSyntheticTestFunction
         )
-        self._is_moo: bool = isinstance(self.test_problem, MultiObjectiveTestProblem)
-        self._outcome_names = outcome_names
+        self._is_moo: bool = self.test_problem.num_objectives > 1
+        self.outcome_names = outcome_names
         self._modified_bounds = modified_bounds
-
-    @property
-    def outcome_names(self) -> list[str]:
-        return self._outcome_names
 
     @equality_typechecker
     def __eq__(self, other: Base) -> bool:
-        if not isinstance(other, BotorchTestProblemRunner):
+        if not isinstance(other, type(self)):
             return False
 
         return (
@@ -129,66 +163,19 @@ class BotorchTestProblemRunner(BenchmarkRunner):
 
         return noise_std_dict
 
-    def get_Y_true(self, arm: Arm) -> Tensor:
-        """Converts X to original bounds -- only if modified bounds were provided --
-        and evaluates the test problem. See `__init__` docstring for details.
-
-        Args:
-            X: A `batch_shape x d`-dim tensor of point(s) at which to evaluate the
-                test problem.
-
-        Returns:
-            A `batch_shape x m`-dim tensor of ground truth (noiseless) evaluations.
-        """
-        X = torch.tensor(
-            [
-                value
-                for _key, value in [*arm.parameters.items()][: self.test_problem.dim]
-            ],
-            dtype=torch.double,
-        )
-
-        if self._modified_bounds is not None:
-            # Normalize from modified bounds to unit cube.
-            unit_X = normalize(
-                X, torch.tensor(self._modified_bounds, dtype=torch.double).T
-            )
-            # Unnormalize from unit cube to original problem bounds.
-            X = unnormalize(unit_X, self.test_problem.bounds)
-
-        Y_true = self.test_problem.evaluate_true(X).view(-1)
-        # `BaseTestProblem.evaluate_true()` does not negate the outcome
-        if self.test_problem.negate:
-            Y_true = -Y_true
-
-        if self._is_constrained:
-            # Convention: Concatenate objective and black box constraints. `view()`
-            # makes the inputs 1d, so the resulting `Y_true` are also 1d.
-            Y_true = torch.cat(
-                [Y_true, self.test_problem.evaluate_slack_true(X).view(-1)],
-                dim=-1,
-            )
-
-        return Y_true
-
-    def poll_trial_status(
-        self, trials: Iterable[BaseTrial]
-    ) -> dict[TrialStatus, set[int]]:
-        return {TrialStatus.COMPLETED: {t.index for t in trials}}
-
     @classmethod
     # pyre-fixme [2]: Parameter `obj` must have a type other than `Any``
     def serialize_init_args(cls, obj: Any) -> dict[str, Any]:
         """Serialize the properties needed to initialize the runner.
         Used for storage.
         """
-        runner = checked_cast(BotorchTestProblemRunner, obj)
+        runner = assert_is_instance(obj, cls)
 
         return {
             "test_problem_module": runner._test_problem_class.__module__,
             "test_problem_class_name": runner._test_problem_class.__name__,
             "test_problem_kwargs": runner._test_problem_kwargs,
-            "outcome_names": runner._outcome_names,
+            "outcome_names": runner.outcome_names,
             "modified_bounds": runner._modified_bounds,
         }
 
@@ -211,3 +198,134 @@ class BotorchTestProblemRunner(BenchmarkRunner):
             "outcome_names": args["outcome_names"],
             "modified_bounds": args["modified_bounds"],
         }
+
+
+class BotorchTestProblemRunner(SyntheticProblemRunner):
+    """
+    A `SyntheticProblemRunner` for BoTorch `SyntheticTestFunction`s.
+
+    Args:
+        test_problem_class: A BoTorch `SyntheticTestFunction` class.
+        test_problem_kwargs: The keyword arguments used for initializing the
+            test problem.
+        outcome_names: The names of the outcomes returned by the problem.
+        modified_bounds: The bounds that are used by the Ax search space
+            while optimizing the problem. If different from the bounds of the
+            test problem, we project the parameters into the test problem
+            bounds before evaluating the test problem.
+            For example, if the test problem is defined on [0, 1] but the Ax
+            search space is integers in [0, 10], an Ax parameter value of
+            5 will correspond to 0.5 while evaluating the test problem.
+            If modified bounds are not provided, the test problem will be
+            evaluated using the raw parameter values.
+    """
+
+    def __init__(
+        self,
+        *,
+        test_problem_class: type[SyntheticTestFunction],
+        test_problem_kwargs: dict[str, Any],
+        outcome_names: list[str],
+        modified_bounds: Optional[list[tuple[float, float]]] = None,
+    ) -> None:
+        super().__init__(
+            test_problem_class=test_problem_class,
+            test_problem_kwargs=test_problem_kwargs,
+            outcome_names=outcome_names,
+            modified_bounds=modified_bounds,
+        )
+        self.test_problem: SyntheticTestFunction = self.test_problem.to(
+            dtype=torch.double
+        )
+        self._is_constrained: bool = isinstance(
+            self.test_problem, ConstrainedSyntheticTestFunction
+        )
+
+    def get_Y_true(self, arm: Arm) -> Tensor:
+        """
+        Convert the arm to a tensor and evaluate it on the base test problem.
+
+        Convert the tensor to original bounds -- only if modified bounds were
+        provided -- and evaluates the test problem. See the docstring for
+        `modified_bounds` in `BotorchTestProblemRunner.__init__` for details.
+
+        Args:
+            arm: Arm to evaluate. It will be converted to a
+                `batch_shape x d`-dim tensor of point(s) at which to evaluate the
+                test problem.
+
+        Returns:
+            A `batch_shape x m`-dim tensor of ground truth (noiseless) evaluations.
+        """
+        X = torch.tensor(
+            [
+                value
+                for _key, value in [*arm.parameters.items()][: self.test_problem.dim]
+            ],
+            dtype=torch.double,
+        )
+
+        if self._modified_bounds is not None:
+            # Normalize from modified bounds to unit cube.
+            unit_X = normalize(
+                X, torch.tensor(self._modified_bounds, dtype=torch.double).T
+            )
+            # Unnormalize from unit cube to original problem bounds.
+            X = unnormalize(unit_X, self.test_problem.bounds)
+
+        Y_true = self.test_problem.evaluate_true(X).view(-1)
+        # `SyntheticTestFunction.evaluate_true()` does not negate the outcome
+        if self.test_problem.negate:
+            Y_true = -Y_true
+
+        if self._is_constrained:
+            # Convention: Concatenate objective and black box constraints. `view()`
+            # makes the inputs 1d, so the resulting `Y_true` are also 1d.
+            Y_true = torch.cat(
+                [Y_true, self.test_problem.evaluate_slack_true(X).view(-1)],
+                dim=-1,
+            )
+
+        return Y_true
+
+
+class ParamBasedTestProblemRunner(SyntheticProblemRunner):
+    """
+    A `SyntheticProblemRunner` for `ParamBasedTestProblem`s. See
+    `SyntheticProblemRunner` for more information.
+    """
+
+    # This could easily be supported, but hasn't been hooked up
+    _is_constrained: bool = False
+
+    def __init__(
+        self,
+        *,
+        test_problem_class: type[ParamBasedTestProblem],
+        test_problem_kwargs: dict[str, Any],
+        outcome_names: list[str],
+        modified_bounds: Optional[list[tuple[float, float]]] = None,
+    ) -> None:
+        if modified_bounds is not None:
+            raise NotImplementedError(
+                f"modified_bounds is not supported for {test_problem_class.__name__}"
+            )
+        super().__init__(
+            test_problem_class=test_problem_class,
+            test_problem_kwargs=test_problem_kwargs,
+            outcome_names=outcome_names,
+            modified_bounds=modified_bounds,
+        )
+        self.test_problem: ParamBasedTestProblem = self.test_problem
+
+    def get_Y_true(self, arm: Arm) -> Tensor:
+        """Evaluates the test problem.
+
+        Returns:
+            A `batch_shape x m`-dim tensor of ground truth (noiseless) evaluations.
+        """
+        Y_true = self.test_problem.evaluate_true(arm.parameters).view(-1)
+        # `ParamBasedTestProblem.evaluate_true()` does not negate the outcome
+        if self.test_problem.negate:
+            Y_true = -Y_true
+        return Y_true

--- a/ax/benchmark/runners/surrogate.py
+++ b/ax/benchmark/runners/surrogate.py
@@ -6,7 +6,6 @@
 # pyre-strict
 
 import warnings
-from collections.abc import Iterable
 from typing import Any, Callable, Optional, Union
 
 import torch
@@ -68,7 +67,7 @@ class SurrogateRunner(BenchmarkRunner):
         self.get_surrogate_and_datasets = get_surrogate_and_datasets
         self.name = name
         self._surrogate = surrogate
-        self._outcome_names = outcome_names
+        self.outcome_names = outcome_names
         self._datasets = datasets
         self.search_space = search_space
         self.noise_stds = noise_stds
@@ -88,10 +87,6 @@ class SurrogateRunner(BenchmarkRunner):
         if self.get_surrogate_and_datasets is not None:
             self.set_surrogate_and_datasets()
         return none_throws(self._datasets)
-
-    @property
-    def outcome_names(self) -> list[str]:
-        return self._outcome_names
 
     def get_noise_stds(self) -> Union[None, float, dict[str, float]]:
         return self.noise_stds
@@ -134,11 +129,6 @@ class SurrogateRunner(BenchmarkRunner):
         run_metadata = super().run(trial=trial)
         run_metadata["outcome_names"] = self.outcome_names
         return run_metadata
-
-    def poll_trial_status(
-        self, trials: Iterable[BaseTrial]
-    ) -> dict[TrialStatus, set[int]]:
-        return {TrialStatus.COMPLETED: {t.index for t in trials}}
 
     @classmethod
     # pyre-fixme[2]: Parameter annotation cannot be `Any`.

--- a/ax/benchmark/tests/runners/test_botorch_test_problem.py
+++ b/ax/benchmark/tests/runners/test_botorch_test_problem.py
@@ -8,35 +8,79 @@
 
 
 from itertools import product
-from typing import Union
 from unittest.mock import Mock
 
 import torch
-from ax.benchmark.runners.botorch_test import BotorchTestProblemRunner
+from ax.benchmark.runners.botorch_test import (
+    BotorchTestProblemRunner,
+    ParamBasedTestProblemRunner,
+)
 from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
 from ax.core.trial import Trial
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast
-from botorch.test_functions.base import ConstrainedBaseTestProblem
+from ax.utils.testing.benchmark_stubs import TestParamBasedTestProblem
+from botorch.test_functions.base import BaseTestProblem, ConstrainedBaseTestProblem
 from botorch.test_functions.synthetic import ConstrainedHartmann, Hartmann
 from botorch.utils.transforms import normalize
+from pyre_extensions import assert_is_instance
 
 
-class TestBotorchTestProblemRunner(TestCase):
-    def test_botorch_test_problem_runner(self) -> None:
-        for test_problem_class, modified_bounds, noise_std in product(
-            (Hartmann, ConstrainedHartmann), (None, [(0.0, 2.0)] * 6), (None, 0.1)
+class TestSyntheticRunner(TestCase):
+    def test_synthetic_runner(self) -> None:
+        botorch_cases = [
+            (
+                BotorchTestProblemRunner,
+                test_problem_class,
+                {"dim": 6},
+                modified_bounds,
+                noise_std,
+            )
+            for test_problem_class, modified_bounds, noise_std in product(
+                (Hartmann, ConstrainedHartmann),
+                (None, [(0.0, 2.0)] * 6),
+                (None, 0.1),
+            )
+        ]
+        param_based_cases = [
+            (
+                ParamBasedTestProblemRunner,
+                TestParamBasedTestProblem,
+                {"num_objectives": num_objectives, "dim": 6},
+                None,
+                noise_std,
+            )
+            for num_objectives, noise_std in product((1, 2), (None, 0.0, 1.0))
+        ]
+        for (
+            runner_cls,
+            test_problem_class,
+            test_problem_kwargs,
+            modified_bounds,
+            noise_std,
+        ) in (
+            botorch_cases + param_based_cases
         ):
-            test_problem = test_problem_class(dim=6).to(dtype=torch.double)
-            test_problem_kwargs: dict[str, Union[int, float]] = {"dim": 6}
             if noise_std is not None:
+                # pyre-fixme[6]: Incompatible parameter type: Expected int, got float
                 test_problem_kwargs["noise_std"] = noise_std
-            outcome_names = ["objective"]
+
+            num_objectives = (
+                test_problem_kwargs["num_objectives"]
+                if "num_objectives" in test_problem_kwargs
+                else 1
+            )
+            outcome_names = [f"objective_{i}" for i in range(num_objectives)]
             if test_problem_class == ConstrainedHartmann:
                 outcome_names = outcome_names + ["constraint"]
 
-            runner = BotorchTestProblemRunner(
+            runner = runner_cls(
+                # pyre-fixme[6]: Incompatible parameter type: In call
+                # `BotorchTestProblemRunner.__init__`, for argument
+                # `test_problem_class`, expected `Type[BaseTestProblem]` but got
+                # `Union[Type[ConstrainedHartmann], Type[Hartmann],
+                # Type[TestParamBasedTestProblem]]`.
                 test_problem_class=test_problem_class,
                 test_problem_kwargs=test_problem_kwargs,
                 outcome_names=outcome_names,
@@ -51,11 +95,9 @@ class TestBotorchTestProblemRunner(TestCase):
 
             with self.subTest(f"Test basic construction, {test_description}"):
                 self.assertIsInstance(runner.test_problem, test_problem_class)
-                self.assertEqual(runner.test_problem.dim, test_problem_kwargs["dim"])
-                self.assertEqual(runner.test_problem.bounds.dtype, torch.double)
                 self.assertEqual(
                     runner._is_constrained,
-                    isinstance(test_problem, ConstrainedBaseTestProblem),
+                    issubclass(test_problem_class, ConstrainedBaseTestProblem),
                 )
                 self.assertEqual(runner._modified_bounds, modified_bounds)
                 if noise_std is not None:
@@ -66,6 +108,17 @@ class TestBotorchTestProblemRunner(TestCase):
                 # check equality with different class
                 self.assertNotEqual(runner, Hartmann(dim=6))
                 self.assertEqual(runner, runner)
+                self.assertEqual(runner._is_moo, num_objectives > 1)
+                if issubclass(test_problem_class, BaseTestProblem):
+                    self.assertEqual(
+                        runner.test_problem.dim, test_problem_kwargs["dim"]
+                    )
+                    self.assertEqual(
+                        assert_is_instance(
+                            runner.test_problem, BaseTestProblem
+                        ).bounds.dtype,
+                        torch.double,
+                    )
 
             with self.subTest(f"test `get_Y_true()`, {test_description}"):
                 X = torch.rand(1, 6, dtype=torch.double)
@@ -80,16 +133,22 @@ class TestBotorchTestProblemRunner(TestCase):
                     )
                 else:
                     X_tf = X
-                obj = test_problem.evaluate_true(X_tf)
-                if test_problem.negate:
-                    obj = -obj
-                if runner._is_constrained:
-                    expected_Y = torch.cat(
-                        [obj.view(-1), test_problem.evaluate_slack(X_tf).view(-1)],
-                        dim=-1,
-                    )
+                test_problem = runner.test_problem
+                if issubclass(test_problem_class, BaseTestProblem):
+                    obj = test_problem.evaluate_true(X_tf)
+                    if test_problem.negate:
+                        obj = -obj
+                    if runner._is_constrained:
+                        expected_Y = torch.cat(
+                            [obj.view(-1), test_problem.evaluate_slack(X_tf).view(-1)],
+                            dim=-1,
+                        )
+                    else:
+                        expected_Y = obj
                 else:
-                    expected_Y = obj
+                    expected_Y = torch.full(
+                        torch.Size([2]), X.pow(2).sum().item(), dtype=torch.double
+                    )
                 self.assertTrue(torch.allclose(Y, expected_Y))
 
             with self.subTest(f"test `run()`, {test_description}"):
@@ -116,21 +175,19 @@ class TestBotorchTestProblemRunner(TestCase):
                 )
 
             with self.subTest(f"test `serialize_init_args()`, {test_description}"):
-                serialize_init_args = BotorchTestProblemRunner.serialize_init_args(
-                    obj=runner
-                )
+                serialize_init_args = runner_cls.serialize_init_args(obj=runner)
                 self.assertEqual(
                     serialize_init_args,
                     {
                         "test_problem_module": runner._test_problem_class.__module__,
                         "test_problem_class_name": runner._test_problem_class.__name__,
                         "test_problem_kwargs": runner._test_problem_kwargs,
-                        "outcome_names": runner._outcome_names,
+                        "outcome_names": runner.outcome_names,
                         "modified_bounds": runner._modified_bounds,
                     },
                 )
                 # test deserialize args
-                deserialize_init_args = BotorchTestProblemRunner.deserialize_init_args(
+                deserialize_init_args = runner_cls.deserialize_init_args(
                     serialize_init_args
                 )
                 self.assertEqual(

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -23,7 +23,10 @@ from ax.benchmark.problems.hpo.torchvision import (
     PyTorchCNNTorchvisionBenchmarkProblem,
     PyTorchCNNTorchvisionRunner,
 )
-from ax.benchmark.runners.botorch_test import BotorchTestProblemRunner
+from ax.benchmark.runners.botorch_test import (
+    BotorchTestProblemRunner,
+    ParamBasedTestProblemRunner,
+)
 from ax.benchmark.runners.surrogate import SurrogateRunner
 from ax.core import Experiment, ObservationFeatures
 from ax.core.arm import Arm
@@ -238,6 +241,7 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     OrEarlyStoppingStrategy: logical_early_stopping_strategy_to_dict,
     OrderConstraint: order_parameter_constraint_to_dict,
     OutcomeConstraint: outcome_constraint_to_dict,
+    ParamBasedTestProblemRunner: runner_to_dict,
     ParameterConstraint: parameter_constraint_to_dict,
     ParameterDistribution: parameter_distribution_to_dict,
     pathlib.Path: pathlib_to_dict,
@@ -363,6 +367,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "OrEarlyStoppingStrategy": OrEarlyStoppingStrategy,
     "OrderConstraint": OrderConstraint,
     "OutcomeConstraint": OutcomeConstraint,
+    "ParamBasedTestProblemRunner": ParamBasedTestProblemRunner,
     "ParameterConstraint": ParameterConstraint,
     "ParameterConstraintType": ParameterConstraintType,
     "ParameterDistribution": ParameterDistribution,

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -6,9 +6,10 @@
 
 # pyre-strict
 
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import numpy as np
+import torch
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_problem import (
     BenchmarkProblem,
@@ -21,6 +22,7 @@ from ax.benchmark.problems.surrogate import (
     MOOSurrogateBenchmarkProblem,
     SOOSurrogateBenchmarkProblem,
 )
+from ax.benchmark.runners.botorch_test import ParamBasedTestProblem
 from ax.benchmark.runners.surrogate import SurrogateRunner
 from ax.core.experiment import Experiment
 from ax.core.optimization_config import (
@@ -218,3 +220,23 @@ def get_benchmark_result() -> BenchmarkResult:
 def get_aggregated_benchmark_result() -> AggregatedBenchmarkResult:
     result = get_benchmark_result()
     return AggregatedBenchmarkResult.from_benchmark_results([result, result])
+
+
+class TestParamBasedTestProblem(ParamBasedTestProblem):
+    optimal_value: float = 0.0
+
+    def __init__(
+        self,
+        num_objectives: int,
+        noise_std: Optional[Union[float, list[float]]] = None,
+        dim: int = 6,
+    ) -> None:
+        self.num_objectives = num_objectives
+        self.noise_std = noise_std
+        self.dim = dim
+
+    # pyre-fixme[14]: Inconsistent override, as dict[str, float] is not a
+    # `TParameterization`
+    def evaluate_true(self, params: dict[str, float]) -> torch.Tensor:
+        value = sum(elt**2 for elt in params.values())
+        return value * torch.ones(self.num_objectives, dtype=torch.double)


### PR DESCRIPTION
Summary:
Context:

In a future refactor that will enable more flexible and powerful best-point functionality, every BenchmarkProblem's runner will be able to produce an "oracle" value (possibly the ground truth) for any arm, in-sample or not, with a function like `BenchmarkRunner.evaluate_oracle(arm=arm)`, with the problem handling computation and the runner formatting results.  However, the current `BenchmarkRunner` and `BenchmarkMetric` setup currently doesn't cover every benchmark. Consolidating on `BenchmarkRunner` and `BenchmarkMetric` will enable the refactor, make it easier to universalize functionality like handling of constraints, noise, and inference regret, and will also allow for deleting some LOC for more custom problems.

Current `BenchmarkRunner`s only handle problems that can consume tensor-valued arguments: BoTorch synthetic problems and surrogate problems. This isn't a good fit for problems like Jenatton that have a hierarchical search space and can have some parameters not passed. Because Ax always passes parameters and only sometimes represents them as tensors, a `TParameterization` is a more natural abstraction to handle parameters than a tensor.

This PR:
- Introduces `ParamBasedTestProblem`, which is like a BoTorch synthetic test problem but consumes a `TParameterization` rather than a tensor
- Added `ParamBasedProblemRunner`, which shares a base class `SyntheticProblemRunner` and most functionality with  `BotorchTestProblemRunner` (so it is a `BenchmarkRunner` and supports both observed and unboserved noise).

Differential Revision: D60996475
