### PR TITLE
Create ax/analysis/plotly/parallel_coordinates/__init__.py

### DIFF
--- a/ax/analysis/plotly/parallel_coordinates/__init__.py
+++ b/ax/analysis/plotly/parallel_coordinates/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
I believe this is the root cause of the module not found errors: https://github.com/pytorch/botorch/actions/runs/10494294567/job/29070223575?fbclid=IwZXh0bgNhZW0CMTEAAR0STaNC60ySHOHuufC68-0TeVYfIfgWeVyoT85JDOF4G1-7rekaP3QpGkE_aem_eqZc_2xXNAdTkgEmmCsYfw