### PR TITLE
Add init_position argument to UniformGenerator

### DIFF
--- a/ax/models/random/sobol.py
+++ b/ax/models/random/sobol.py
@@ -6,15 +6,13 @@
 
 # pyre-strict
 
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 import numpy as np
 import torch
-from ax.models.base import Model
 from ax.models.model_utils import tunable_feature_indices
 from ax.models.random.base import RandomModel
 from ax.models.types import TConfig
-from ax.utils.common.docutils import copy_doc
 from ax.utils.common.typeutils import not_none
 from torch.quasirandom import SobolEngine
 
@@ -26,8 +24,6 @@ class SobolGenerator(RandomModel):
     the fit or predict methods.
 
     Attributes:
-        init_position: The initial state of the Sobol generator.
-            Starts at 0 by default.
         scramble: If True, permutes the parameter values among
             the elements of the Sobol sequence. Default is True.
         See base `RandomModel` for a description of remaining attributes.
@@ -35,8 +31,8 @@ class SobolGenerator(RandomModel):
 
     def __init__(
         self,
-        seed: Optional[int] = None,
         deduplicate: bool = True,
+        seed: Optional[int] = None,
         init_position: int = 0,
         scramble: bool = True,
         generated_points: Optional[np.ndarray] = None,
@@ -45,10 +41,10 @@ class SobolGenerator(RandomModel):
         super().__init__(
             deduplicate=deduplicate,
             seed=seed,
+            init_position=init_position,
             generated_points=generated_points,
             fallback_to_sample_polytope=fallback_to_sample_polytope,
         )
-        self.init_position = init_position
         self.scramble = scramble
         # Initialize engine on gen.
         self._engine: Optional[SobolEngine] = None
@@ -120,12 +116,6 @@ class SobolGenerator(RandomModel):
         if self.engine:
             self.init_position = not_none(self.engine).num_generated
         return (points, weights)
-
-    @copy_doc(Model._get_state)
-    def _get_state(self) -> dict[str, Any]:
-        state = super()._get_state()
-        state.update({"init_position": self.init_position})
-        return state
 
     def _gen_samples(self, n: int, tunable_d: int) -> np.ndarray:
         """Generate n samples.

--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -67,6 +67,8 @@ def is_ax_equal(one_val: Any, other_val: Any) -> bool:
     dates, and numpy arrays.  This method and ``same_elements`` function
     as a recursive unit.
     """
+    if type(one_val) is not type(other_val):
+        return False
     if isinstance(one_val, list) and isinstance(other_val, list):
         return same_elements(one_val, other_val)
     elif isinstance(one_val, dict) and isinstance(other_val, dict):

--- a/ax/utils/common/tests/test_equality.py
+++ b/ax/utils/common/tests/test_equality.py
@@ -14,6 +14,7 @@ from ax.utils.common.equality import (
     dataframe_equals,
     datetime_equals,
     equality_typechecker,
+    is_ax_equal,
     object_attribute_dicts_find_unequal_fields,
     same_elements,
 )
@@ -81,3 +82,8 @@ class EqualityTest(TestCase):
         self.assertEqual(
             object_attribute_dicts_find_unequal_fields(np_0, np_1), ({}, {})
         )
+
+    def test_is_ax_equal_with_different_types(self) -> None:
+        self.assertFalse(is_ax_equal(1, np.random.random(5)))
+        self.assertFalse(is_ax_equal(1, np.ones(5)))
+        self.assertFalse(is_ax_equal(1, np.ones(1)))


### PR DESCRIPTION
Summary:
`SobolGenerator` uses `init_position` to ensure that when the model is reconstructed, it resumes candidate generation from where it was left (rather than starting from the beginning of the sequence). Without this, when `deduplicate=False`, the model would generate the same points it has already generated, which would lead to different candidate generation behaviors depending on how often the model was reconstructed. This is undesirable as we want the model to resume generation rather than repeating from scratch.

Prior to this diff, `UniformGenerator` did not have `init_position`, so had this exact issue. We fix it here.

Differential Revision: D61622058
