### PR TITLE
Stop calling float() on single element Series

### DIFF
--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -90,10 +90,12 @@ class DataTest(TestCase):
 
         df = data.df
         self.assertEqual(
-            float(df[df["arm_name"] == "0_0"][df["metric_name"] == "a"]["mean"]), 2.0
+            float(df[df["arm_name"] == "0_0"][df["metric_name"] == "a"]["mean"].item()),
+            2.0,
         )
         self.assertEqual(
-            float(df[df["arm_name"] == "0_1"][df["metric_name"] == "b"]["sem"]), 0.5
+            float(df[df["arm_name"] == "0_1"][df["metric_name"] == "b"]["sem"].item()),
+            0.5,
         )
 
     def test_BadData(self) -> None:

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -48,8 +48,8 @@ class MultiTypeExperimentTest(TestCase):
 
         arm_0_slice = df.loc[df["arm_name"] == "0_0"]
         self.assertNotEqual(
-            float(arm_0_slice[df["trial_index"] == 0]["mean"]),
-            float(arm_0_slice[df["trial_index"] == 1]["mean"]),
+            float(arm_0_slice[df["trial_index"] == 0]["mean"].item()),
+            float(arm_0_slice[df["trial_index"] == 1]["mean"].item()),
         )
         self.assertEqual(len(df), 2 * n)
         self.assertEqual(self.experiment.default_trials, {0})
@@ -60,8 +60,8 @@ class MultiTypeExperimentTest(TestCase):
         df = self.experiment.fetch_data().df
         arm_0_slice = df.loc[df["arm_name"] == "0_0"]
         self.assertAlmostEqual(
-            float(arm_0_slice[df["trial_index"] == 0]["mean"]),
-            float(arm_0_slice[df["trial_index"] == 1]["mean"]),
+            float(arm_0_slice[df["trial_index"] == 0]["mean"].item()),
+            float(arm_0_slice[df["trial_index"] == 1]["mean"].item()),
             places=10,
         )
 


### PR DESCRIPTION
Summary: This practice was causing a deprecation warning: `Calling float on a single element Series is deprecated and will raise a TypeError in the future.`

Differential Revision: D61612829
