### PR TITLE
Deprecate `no_bayesian_optimization` argument in favor of `force_random_search`

### DIFF
--- a/ax/utils/common/deprecation.py
+++ b/ax/utils/common/deprecation.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import warnings
+from typing import Optional, Type
+
+
+def _validate_force_random_search(
+    no_bayesian_optimization: Optional[bool] = None,
+    force_random_search: bool = False,
+    exception_cls: Type[Exception] = ValueError,
+) -> None:
+    """Helper function to validate interaction between `force_random_search`
+    and `no_bayesian_optimization` (supported until deprecation in [T199632397])
+    """
+    if no_bayesian_optimization is not None:
+        # users are effectively permitted to continue using
+        # `no_bayesian_optimization` so long as it doesn't
+        # conflict with `force_random_search`
+        if no_bayesian_optimization != force_random_search:
+            raise exception_cls(
+                "Conflicting values for `force_random_search` "
+                "and `no_bayesian_optimization`! "
+                "Please only specify `force_random_search`."
+            )
+        warnings.warn(
+            "`no_bayesian_optimization` is deprecated. Please use "
+            "`force_random_search` in the future.",
+            DeprecationWarning,
+            stacklevel=2,
+        )


### PR DESCRIPTION
Summary:
This deprecates the `no_bayesian_optimization` argument in favor of `force_random_search`. It is a "soft" deprecation in which we continue to provide support for the `no_bayesian_optimization` argument, but we turn it into an *optional* one and raise a deprecation warning when it is specified explicitly by the user.

If this soft deprecation does not start any fires in the coming few weeks, we will move forward with a "hard" deprecation in follow-up task [insert link to task here].

- In the `GenerationStrategyConfig` dataclass we turned `no_bayesian_optimization` into an [init-only variable](https://docs.python.org/3/library/dataclasses.html#init-only-variables) (so it no longer become a "field").
- Everywhere that it appears as an argument, `no_bayesian_optimization` is now an *optional* argument with a default value of `None`. Whenever it is not `None`, we raise a deprecation warning and, whenever its value conflicts with `force_random_search` (non-optional, default `False`), we raise a `ValueError`.

Differential Revision: D61601511
