### PR TITLE
Check for type equality in is_ax_equal

### DIFF
--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -67,6 +67,8 @@ def is_ax_equal(one_val: Any, other_val: Any) -> bool:
     dates, and numpy arrays.  This method and ``same_elements`` function
     as a recursive unit.
     """
+    if type(one_val) is not type(other_val):
+        return False
     if isinstance(one_val, list) and isinstance(other_val, list):
         return same_elements(one_val, other_val)
     elif isinstance(one_val, dict) and isinstance(other_val, dict):

--- a/ax/utils/common/tests/test_equality.py
+++ b/ax/utils/common/tests/test_equality.py
@@ -14,6 +14,7 @@ from ax.utils.common.equality import (
     dataframe_equals,
     datetime_equals,
     equality_typechecker,
+    is_ax_equal,
     object_attribute_dicts_find_unequal_fields,
     same_elements,
 )
@@ -81,3 +82,8 @@ class EqualityTest(TestCase):
         self.assertEqual(
             object_attribute_dicts_find_unequal_fields(np_0, np_1), ({}, {})
         )
+
+    def test_is_ax_equal_with_different_types(self) -> None:
+        self.assertFalse(is_ax_equal(1, np.random.random(5)))
+        self.assertFalse(is_ax_equal(1, np.ones(5)))
+        self.assertFalse(is_ax_equal(1, np.ones(1)))


### PR DESCRIPTION
Summary: Prior to this, if you compared a float with an ndarray, you'd get a boolean ndarray, which would lead to `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`.

Differential Revision: D61666276
