### PR TITLE
Serialize data classes based on their fields only

### DIFF
--- a/ax/storage/json_store/encoder.py
+++ b/ax/storage/json_store/encoder.py
@@ -135,6 +135,7 @@ def object_to_json(  # noqa C901
             },
         }
     elif dataclasses.is_dataclass(obj):
+        field_names = [f.name for f in dataclasses.fields(obj)]
         return {
             "__type": _type.__name__,
             **{
@@ -144,6 +145,7 @@ def object_to_json(  # noqa C901
                     class_encoder_registry=class_encoder_registry,
                 )
                 for k, v in obj.__dict__.items()
+                if k in field_names
             },
         }
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -383,6 +383,25 @@ class JSONStoreTest(TestCase):
                 else:
                     raise e
 
+    def test_EncodeDecode_dataclass_with_initvar(self) -> None:
+        @dataclasses.dataclass
+        class TestDataclass:
+            a_field: int
+            not_a_field: dataclasses.InitVar[int | None] = None
+
+            def __post_init__(self, doesnt_serialize: None) -> None:
+                self.not_a_field = 1
+
+        obj = TestDataclass(a_field=-1)
+        as_json = object_to_json(obj=obj)
+        self.assertEqual(as_json, {"__type": "TestDataclass", "a_field": -1})
+        recovered = object_from_json(
+            object_json=as_json, decoder_registry={"TestDataclass": TestDataclass}
+        )
+        self.assertEqual(recovered.a_field, -1)
+        self.assertEqual(recovered.not_a_field, 1)
+        self.assertEqual(obj, recovered)
+
     def test_EncodeDecodeTorchTensor(self) -> None:
         x = torch.tensor(
             [[1.0, 2.0], [3.0, 4.0]], dtype=torch.float64, device=torch.device("cpu")


### PR DESCRIPTION
Summary:
# Context:

**I think the unit test is the easiest way to understand this!**

There are several cases in Ax where an instance has an attribute that
1) can't or shouldn't be serialized; this is usually subclasses of `torch.nn.Module`, including BoTorch models, but can be other large and complex objects,
2) isn't typically passed at initialization, but rather constructed afterwards, and
3) should be an attribute rather than a property because it's too expensive to construct more than once

These classes have thus required custom serialization logic so that such attributes are not serialized. Classes that have this issue include many benchmarking classes that work with surrogates or neural nets, such as `SurrogateRunner`, `PyTorchCNNTorchvisionRunner`, and `PyTorchCNNTorchvisionBenchmarkProblem`, as well as MBM classes.

A simpler solution is to use dataclasses, by
- specifying features that satisfy (1)-(3) with `InitVar`, and, if they are needed immediately, constructing them in the `__post_init__`
- only serializing fields; `InitVar`s are not fields

This gives more flexibility in what we serialize without taking any away: If an attribute is constructed in the post-init and *should* be serialized, that is still supported by marking it as a `field` and not an `InitVar`. Attributes that are constructed in the init will be serialized, even if they are modified elsewhere.

## Downside
It is not quite the normal usage to use an `InitVar` to define a persistent non-field attribute; instead `InitVar` is intended for something that is needed only for initializing fields. So the usage pattern outlined in the unit test causes Pyre errors, and someone who uses an `InitVar` that way might be surprised that it can't be recovered. However, it might not need to be, since the other fields would be recovered. Also, `InitVar` is a rarely used feature.

# This PR:

* Changes Ax's JSON serialization for dataclasses to exclude non-fields
* Adds a unit test

Differential Revision: D61665461
