### PR TITLE
Only count launched trials for trials by type

### DIFF
--- a/ax/telemetry/experiment.py
+++ b/ax/telemetry/experiment.py
@@ -270,10 +270,12 @@ class ExperimentCompletedRecord:
             status: len(trials)
             for status, trials in experiment.trials_by_status.items()
         }
+        ignored_statuses = {TrialStatus.STAGED, TrialStatus.CANDIDATE}
 
         model_keys = [
             [gr._model_key for gr in trial.generator_runs]
             for trial in experiment.trials.values()
+            if trial.status not in ignored_statuses
         ]
 
         fit_time, gen_time = get_model_times(experiment=experiment)

--- a/ax/telemetry/tests/test_experiment.py
+++ b/ax/telemetry/tests/test_experiment.py
@@ -79,8 +79,10 @@ class TestExperiment(TestCase):
         trial.mark_completed(unsafe=True)
 
         # create a trial that among other things does bayesopt
+        data = experiment.fetch_data()
         botorch = Models.BOTORCH_MODULAR(
-            experiment=experiment, data=experiment.fetch_data()
+            experiment=experiment,
+            data=data,
         )
         trial = (
             experiment.new_batch_trial()
@@ -89,6 +91,15 @@ class TestExperiment(TestCase):
         )
         trial.add_arm(experiment.arms_by_name["0_0"])
         trial.mark_completed(unsafe=True)
+
+        # create another BO trial but leave it as a candidate
+        botorch = Models.BOTORCH_MODULAR(
+            experiment=experiment,
+            data=data,
+        )
+        trial = experiment.new_batch_trial().add_generator_run(
+            generator_run=botorch.gen(5)
+        )
 
         record = ExperimentCompletedRecord.from_experiment(experiment=experiment)
         self.assertEqual(record.num_initialization_trials, 1)


### PR DESCRIPTION
Summary: Counting candidate trials will be very long when Axolotl is really generating candidate trials, because it will generate candidate trials for online experiments every night that may not be launched.  They should at least be expecting data to be counted.

Differential Revision: D61682298
