### PR TITLE
Added documentation for `ax.utils.common.deprecation` module to address GitHub Actions Test Failure

### DIFF
--- a/sphinx/source/utils.rst
+++ b/sphinx/source/utils.rst
@@ -35,6 +35,14 @@ Decorator
     :undoc-members:
     :show-inheritance:
 
+Deprecation
+~~~~~~~~~~~
+
+.. automodule:: ax.utils.common.deprecation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Docutils
 ~~~~~~~~
 


### PR DESCRIPTION
Summary: This addresses T199733564 by adding missing documentation for the `ax.utils.common.deprecation` module introduced in D61601511.

Differential Revision: D61727254
