### PR TITLE
Compute ground-truth optimization trace on BenchmarkProblem

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -151,6 +151,9 @@ def benchmark_replication(
         scheduler.get_trace(optimization_config=analysis_opt_config)
     )
 
+    new_optimization_trace = problem.get_opt_trace(experiment=experiment)
+    np.testing.assert_allclose(optimization_trace, new_optimization_trace)
+
     try:
         # Catch any errors that may occur during score computation, such as errors
         # while accessing "steps" in node based generation strategies. The error

--- a/ax/benchmark/tests/problems/synthetic/hss/test_jenatton.py
+++ b/ax/benchmark/tests/problems/synthetic/hss/test_jenatton.py
@@ -14,7 +14,6 @@ from ax.benchmark.problems.synthetic.hss.jenatton import (
     get_jenatton_benchmark_problem,
     jenatton_test_function,
 )
-from ax.benchmark.runners.base import BenchmarkRunner
 from ax.benchmark.runners.botorch_test import ParamBasedTestProblemRunner
 from ax.core.arm import Arm
 from ax.core.data import Data
@@ -96,9 +95,7 @@ class JenattonTest(TestCase):
                 value,
             )
             self.assertAlmostEqual(
-                assert_is_instance(benchmark_problem.runner, BenchmarkRunner)
-                .get_Y_true(arm)
-                .item(),
+                benchmark_problem.runner.evaluate_oracle(arm).item(),
                 value,
                 places=6,
             )

--- a/ax/benchmark/tests/problems/test_surrogate_problems.py
+++ b/ax/benchmark/tests/problems/test_surrogate_problems.py
@@ -34,7 +34,7 @@ class TestSurrogateProblems(TestCase):
             "SOOSurrogateBenchmarkProblem(name='test', "
             "optimization_config=OptimizationConfig(objective=Objective(metric_name="
             '"branin", '
-            "minimize=False), "
+            "minimize=True), "
             "outcome_constraints=[]), num_trials=6, "
             "observe_noise_stds=True, has_ground_truth=True, "
             "tracking_metrics=[], optimal_value=0.0, is_noiseless=True)"


### PR DESCRIPTION
Summary: This currently doesn't change behavior, but enables more flexibility by redefining `Problem.get_ground_truth_opt_trace` or `BenchmarkRunner.get_Y_true`. This is currently duplicative with the tracking metrics setup, which will be reaped in D61432000; these should be combined. This diff has both ways of computing the optimization trace running, along with an assertion that they give the same results.

Reviewed By: saitcakmak

Differential Revision: D61404056
