### PR TITLE
[Website] Use mathjax svg renderer

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -68,7 +68,7 @@ const siteConfig = {
     `${baseUrl}js/plotUtils.js`,
     'https://buttons.github.io/buttons.js',
     `${baseUrl}js/mathjax.js`,
-    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_HTML',
+    'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS_SVG',
   ],
 
   // On page navigation for the current documentation page.


### PR DESCRIPTION
We identified an issue where mathjax would fail to render certain math symbols. This happens on MacOS versions Ventura and later (13+) because of a change in the OS-supplied STIX fonts. We fix this here by changing the renderer from HTML+CSS (which tries to use local STIX fonts) to SVG.

This is a follow up to https://github.com/pytorch/botorch/pull/2481 which solved the same problem on the botorch website. See that PR for more details

| **Before**    | <img width="920" alt="Screenshot 2024-08-23 at 4 40 19 PM" src="https://github.com/user-attachments/assets/6bf1e0ca-e457-4629-956d-29105b50d6e3"> |
| -------- | ------- |
| **After**  | <img width="932" alt="Screenshot 2024-08-23 at 4 40 40 PM" src="https://github.com/user-attachments/assets/c7d804c6-fd3d-4083-beb5-123a9f535862"> |

