### PR TITLE
Provide more informative warning messages in `InputDataWarning`

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -904,7 +904,7 @@ class ModelBridge(ABC):  # noqa: B024 -- ModelBridge doesn't have any abstract m
             # users with this warning, we filter it out.
             warnings.filterwarnings(
                 "ignore",
-                message="Data is not standardized",
+                message=r"Data \(outcome observations\) not standardized",
                 category=InputDataWarning,
             )
             cv_predictions = self._cross_validate(

--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -184,7 +184,7 @@ def cross_validate(
                 # To avoid confusing users with this warning, we filter it out.
                 warnings.filterwarnings(
                     "ignore",
-                    message="Data is not standardized",
+                    message=r"Data \(outcome observations\) not standardized",
                     category=InputDataWarning,
                 )
                 cv_test_predictions = model._cross_validate(

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -225,7 +225,7 @@ class BaseModelBridgeTest(TestCase):
             nonlocal called
             called = True
             warnings.warn(
-                "Data is not standardized",
+                "Data (outcome observations) not standardized",
                 InputDataWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/2489

Provide more informative warning messages when `InputDataWarning`s are raised to specify whether it pertains to input features or output targets.

Updated unit tests accordingly to ensure coverage.

Differential Revision: D61797434
