### PR TITLE
Make sure is_ax_equal returns a boolean

### DIFF
--- a/ax/utils/common/tests/test_equality.py
+++ b/ax/utils/common/tests/test_equality.py
@@ -14,6 +14,7 @@ from ax.utils.common.equality import (
     dataframe_equals,
     datetime_equals,
     equality_typechecker,
+    is_ax_equal,
     object_attribute_dicts_find_unequal_fields,
     same_elements,
 )
@@ -81,3 +82,8 @@ class EqualityTest(TestCase):
         self.assertEqual(
             object_attribute_dicts_find_unequal_fields(np_0, np_1), ({}, {})
         )
+
+    def test_is_ax_equal_with_different_types(self) -> None:
+        self.assertTrue(is_ax_equal(1, 1.0))
+        self.assertTrue(is_ax_equal(1, np.ones(1)))
+        self.assertFalse(is_ax_equal(1, np.ones(5)))


### PR DESCRIPTION
Summary:
This is an alternative to D61666276 that addresses some of the issues raised there.
Instead of checking for type equality, which is too restrictive, we attempt to cast the output of the equality comparison to a boolean. If the cast or the comparison fails, we return False. This ensures that the output of `is_ax_equal` is always a boolean and can be used in `if` statements.

Also documented some of the special cases used in this method, as its behavior can sometimes be unintuitive.

Differential Revision: D61803910
