### PR TITLE
Remove internal type shed for plotly

### DIFF
--- a/ax/analysis/old/helpers/cross_validation_helpers.py
+++ b/ax/analysis/old/helpers/cross_validation_helpers.py
@@ -174,6 +174,7 @@ def diagonal_trace(min_: float, max_: float, visible: bool = True) -> dict[str, 
         max_: maximum to be used for ending point of line.
         visible: if True, trace is set to visible.
     """
+    # pyre-fixme[7]: Expected `Dict[str, typing.Any]` but got `Scatter`.
     return go.Scatter(
         x=[min_, max_],
         y=[min_, max_],

--- a/ax/analysis/old/helpers/layout_helpers.py
+++ b/ax/analysis/old/helpers/layout_helpers.py
@@ -107,4 +107,5 @@ def layout_format(
         width=530,
         height=500,
     )
+    # pyre-fixme[7]: Expected `Type[Figure]` but got `Layout`.
     return layout

--- a/ax/analysis/old/helpers/scatter_helpers.py
+++ b/ax/analysis/old/helpers/scatter_helpers.py
@@ -232,6 +232,7 @@ def error_dot_plot_trace_from_df(
 
     trace.update(visible=visible)
     trace.update(showlegend=False)
+    # pyre-fixme[7]: Expected `Dict[str, typing.Any]` but got `Scatter`.
     return trace
 
 
@@ -309,4 +310,5 @@ def error_scatter_trace_from_df(
 
     trace.update(visible=visible)
     trace.update(showlegend=True)
+    # pyre-fixme[7]: Expected `Dict[str, typing.Any]` but got `Scatter`.
     return trace

--- a/ax/analysis/old/tests/test_cross_validation_plot.py
+++ b/ax/analysis/old/tests/test_cross_validation_plot.py
@@ -27,7 +27,6 @@ class TestCrossValidationPlot(TestCase):
 
     def test_cross_validation_plot(self) -> None:
         plot = CrossValidationPlot(experiment=self.exp, model=self.model).get_fig()
-        # pyre-ignore [16]
         x_range = plot.layout.updatemenus[0].buttons[0].args[1]["xaxis.range"]
         y_range = plot.layout.updatemenus[0].buttons[0].args[1]["yaxis.range"]
         self.assertTrue((len(x_range) == 2) and (x_range[0] < x_range[1]))

--- a/ax/plot/bandit_rollout.py
+++ b/ax/plot/bandit_rollout.py
@@ -75,4 +75,5 @@ def plot_bandit_rollout(experiment: Experiment) -> AxPlotConfig:
         del bandit["index"]  # Have to delete index or figure creation causes error
     fig = go.Figure(data=bandits, layout=layout)
 
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)

--- a/ax/plot/contour.py
+++ b/ax/plot/contour.py
@@ -316,6 +316,8 @@ def plot_contour(
         AxPlotConfig: contour plot of objective vs. parameter values
     """
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=plot_contour_plotly(
             model=model,
             param_x=param_x,
@@ -925,6 +927,8 @@ def interact_contour(
         AxPlotConfig: interactive plot of objective vs. parameters
     """
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=interact_contour_plotly(
             model=model,
             metric_name=metric_name,

--- a/ax/plot/diagnostic.py
+++ b/ax/plot/diagnostic.py
@@ -71,6 +71,7 @@ def _diagonal_trace(min_: float, max_: float, visible: bool = True) -> dict[str,
         visible: if True, trace is set to visible.
 
     """
+    # pyre-fixme[7]: Expected `Dict[str, typing.Any]` but got `Scatter`.
     return go.Scatter(
         x=[min_, max_],
         y=[min_, max_],
@@ -479,6 +480,7 @@ def interact_empirical_model_validation(batch: BatchTrial, data: Data) -> AxPlot
 
     fig = _obs_vs_pred_dropdown_plot(data=plot_data, rel=False)
     fig["layout"]["title"] = "Cross-validation"
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -541,6 +543,8 @@ def interact_cross_validation(
     Returns an AxPlotConfig
     """
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=interact_cross_validation_plotly(
             cv_results=cv_results,
             show_context=show_context,
@@ -601,7 +605,7 @@ def tile_cross_validation(
             y_raw.append(arm.y[metric])
             se_raw.append(arm.se[metric])
         min_, max_ = _get_min_max_with_errors(y_raw, y_hat, se_raw, se_hat)
-        fig.append_trace(  # pyre-ignore[16]
+        fig.append_trace(
             _diagonal_trace(min_, max_), int(np.floor(i / 2)) + 1, i % 2 + 1
         )
         fig.append_trace(
@@ -645,6 +649,7 @@ def tile_cross_validation(
             title="Predicted Outcome", mirror=True, linecolor="black", linewidth=0.5
         )
 
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -687,4 +692,5 @@ def interact_batch_comparison(
         ylabel=y_label,
     )
     fig["layout"]["title"] = "Repeated arms across trials"
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)

--- a/ax/plot/feature_importances.py
+++ b/ax/plot/feature_importances.py
@@ -40,7 +40,7 @@ def plot_feature_importance_plotly(df: pd.DataFrame, title: str) -> go.Figure:
     )
 
     for idx, item in enumerate(data):
-        fig.append_trace(item, idx + 1, 1)  # pyre-ignore[16]
+        fig.append_trace(item, idx + 1, 1)
     fig.layout.showlegend = False
     fig.layout.margin = go.layout.Margin(
         l=8 * min(max(len(idx) for idx in df.index), 75)  # noqa E741
@@ -53,7 +53,10 @@ def plot_feature_importance(df: pd.DataFrame, title: str) -> AxPlotConfig:
     """Wrapper method to convert plot_feature_importance_plotly to
     AxPlotConfig"""
     return AxPlotConfig(
-        data=plot_feature_importance_plotly(df, title), plot_type=AxPlotTypes.GENERIC
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
+        data=plot_feature_importance_plotly(df, title),
+        plot_type=AxPlotTypes.GENERIC,
     )
 
 
@@ -90,6 +93,8 @@ def plot_feature_importance_by_metric(model: ModelBridge) -> AxPlotConfig:
     """Wrapper method to convert plot_feature_importance_by_metric_plotly to
     AxPlotConfig"""
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=plot_feature_importance_by_metric_plotly(model),
         plot_type=AxPlotTypes.GENERIC,
     )
@@ -282,6 +287,8 @@ def plot_feature_importance_by_feature(
     """Wrapper method to convert `plot_feature_importance_by_feature_plotly` to
     AxPlotConfig"""
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=plot_feature_importance_by_feature_plotly(
             model=model,
             sensitivity_values=sensitivity_values,
@@ -328,6 +335,8 @@ def plot_relative_feature_importance(model: ModelBridge) -> AxPlotConfig:
     """Wrapper method to convert plot_relative_feature_importance_plotly to
     AxPlotConfig"""
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=plot_relative_feature_importance_plotly(model),
         plot_type=AxPlotTypes.GENERIC,
     )

--- a/ax/plot/marginal_effects.py
+++ b/ax/plot/marginal_effects.py
@@ -61,7 +61,7 @@ def plot_marginal_effects(model: ModelBridge, metric: str) -> AxPlotConfig:
         shared_yaxes=True,
     )
     for idx, item in enumerate(data):
-        fig.append_trace(item, 1, idx + 1)  # pyre-ignore[16]
+        fig.append_trace(item, 1, idx + 1)
     fig.layout.showlegend = False
     # fig.layout.margin = go.layout.Margin(l=2, r=2)
     fig.layout.title = "Marginal Effects by Factor"
@@ -69,4 +69,5 @@ def plot_marginal_effects(model: ModelBridge, metric: str) -> AxPlotConfig:
         "title": "% higher than experiment average",
         "hoverformat": ".{}f".format(DECIMALS),
     }
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)

--- a/ax/plot/parallel_coordinates.py
+++ b/ax/plot/parallel_coordinates.py
@@ -86,4 +86,5 @@ def plot_parallel_coordinates(
         experiment=experiment, ignored_names=ignored_names
     )
 
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)

--- a/ax/plot/pareto_frontier.py
+++ b/ax/plot/pareto_frontier.py
@@ -247,6 +247,8 @@ def scatter_plot_with_pareto_frontier(
     minimize: bool = True,
 ) -> AxPlotConfig:
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=scatter_plot_with_pareto_frontier_plotly(
             Y=Y,
             Y_pareto=Y_pareto,
@@ -411,6 +413,7 @@ def plot_pareto_frontier(
     )
 
     fig = go.Figure(data=[trace], layout=layout)
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -519,6 +522,7 @@ def plot_multiple_pareto_frontiers(
     )
 
     fig = go.Figure(data=traces, layout=layout)
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -625,6 +629,7 @@ def interact_pareto_frontier(
     )
 
     fig = go.Figure(data=traces, layout=layout)
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -767,6 +772,7 @@ def interact_multiple_pareto_frontier(
     )
 
     fig = go.Figure(data=traces, layout=layout)
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 

--- a/ax/plot/scatter.py
+++ b/ax/plot/scatter.py
@@ -294,6 +294,7 @@ def _error_scatter_trace(
         trace.update(legendgroup=legendgroup)
     if showlegend is not None:
         trace.update(showlegend=showlegend)
+    # pyre-fixme[7]: Expected `Dict[str, typing.Any]` but got `Scatter`.
     return trace
 
 
@@ -535,6 +536,7 @@ def plot_multiple_metrics(
         legend={"x": 1 + layout_offset_x},
     )
     fig = go.Figure(data=traces, layout=layout)
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -772,6 +774,7 @@ def plot_objective_vs_constraints(
     )
 
     fig = go.Figure(data=plot_data, layout=layout)
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -867,7 +870,7 @@ def lattice_multiple_metrics(
                     visible=True,
                     show_arm_details_on_hover=show_arm_details_on_hover,
                 )
-                fig.append_trace(obs_insample_trace, j, i)  # pyre-ignore[16]
+                fig.append_trace(obs_insample_trace, j, i)
                 fig.append_trace(predicted_insample_trace, j, i)
 
                 # iterate over models here
@@ -1068,6 +1071,7 @@ def lattice_multiple_metrics(
     for xaxis in boxplot_xaxes:
         fig["layout"][xaxis]["showticklabels"] = False
 
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -1291,6 +1295,7 @@ def plot_fitted(
     )
 
     fig = go.Figure(data=traces, layout=layout)
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -1403,9 +1408,7 @@ def tile_fitted(
             "zerolinecolor": "red",
         }
         for d in data:
-            fig.append_trace(  # pyre-ignore[16]
-                d, int(np.floor(i / ncols)) + 1, i % ncols + 1
-            )
+            fig.append_trace(d, int(np.floor(i / ncols)) + 1, i % ncols + 1)
 
     order_options = [
         {"args": [name_order_args], "label": "Name", "method": "relayout"},
@@ -1469,6 +1472,7 @@ def tile_fitted(
         },
     )
 
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     fig = resize_subtitles(figure=fig, size=10)
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
@@ -1660,6 +1664,8 @@ def interact_fitted(
     """
 
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=interact_fitted_plotly(
             model=model,
             generator_runs_dict=generator_runs_dict,

--- a/ax/plot/slice.py
+++ b/ax/plot/slice.py
@@ -273,6 +273,8 @@ def plot_slice(
         AxPlotConfig: plot of objective vs. parameter value
     """
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=plot_slice_plotly(
             model=model,
             param_name=param_name,
@@ -570,6 +572,8 @@ def interact_slice(
     """
 
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=interact_slice_plotly(
             model=model,
             generator_runs_dict=generator_runs_dict,

--- a/ax/plot/table_view.py
+++ b/ax/plot/table_view.py
@@ -161,4 +161,5 @@ def table_view_plot(
     )
     fig = go.Figure(data=[trace], layout=layout)
     # pyre-fixme[7]: Expected `Tuple[DataFrame]` but got `AxPlotConfig`.
+    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)

--- a/ax/plot/tests/test_contours.py
+++ b/ax/plot/tests/test_contours.py
@@ -78,6 +78,4 @@ class ContoursTest(TestCase):
             plot = interact_contour_plotly(
                 model, list(model.metric_names)[0], parameters_to_use=parameters_to_use
             )
-            # pyre-ignore[16]: `plotly.graph_objs.graph_objs.Figure`
-            # has no attribute `layout`.
             self.assertEqual(len(plot.layout.updatemenus[0].buttons), i)

--- a/ax/plot/tests/test_diagnostic.py
+++ b/ax/plot/tests/test_diagnostic.py
@@ -39,7 +39,6 @@ class DiagnosticTest(TestCase):
             plot = interact_cross_validation_plotly(
                 cv, label_dict=label_dict, autoset_axis_limits=autoset_axis_limits
             )
-            # pyre-ignore [16]
             x_range = plot.layout.updatemenus[0].buttons[0].args[1]["xaxis.range"]
             y_range = plot.layout.updatemenus[0].buttons[0].args[1]["yaxis.range"]
             if autoset_axis_limits:

--- a/ax/plot/tests/test_feature_importances.py
+++ b/ax/plot/tests/test_feature_importances.py
@@ -74,7 +74,6 @@ class FeatureImportancesTest(TestCase):
             model=model, caption=DUMMY_CAPTION
         )
         self.assertIsInstance(plot, go.Figure)
-        # pyre-fixme[16]: `Figure` has no attribute `layout`.
         self.assertEqual(len(plot.layout.annotations), 1)
         self.assertEqual(plot.layout.annotations[0].text, DUMMY_CAPTION)
         plot = plot_feature_importance_by_feature(model=model)

--- a/ax/plot/tests/test_traces.py
+++ b/ax/plot/tests/test_traces.py
@@ -58,7 +58,7 @@ class TracesTest(TestCase):
                 optimization_direction=optimization_direction,
                 autoset_axis_limits=True,
             )
-            self.assertIsNone(plot.layout.xaxis.range)  # pyre-ignore
+            self.assertIsNone(plot.layout.xaxis.range)
             if optimization_direction == "minimize":
                 self.assertAlmostEqual(plot.layout.yaxis.range[0], 0.525)
                 self.assertAlmostEqual(plot.layout.yaxis.range[1], 6.225)

--- a/ax/plot/trace.py
+++ b/ax/plot/trace.py
@@ -526,6 +526,8 @@ def optimization_trace_single_method(
         AxPlotConfig: plot of the optimization trace with IQR
     """
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=optimization_trace_single_method_plotly(
             y=y,
             optimum=optimum,
@@ -602,7 +604,10 @@ def optimization_trace_all_methods(
     )
 
     return AxPlotConfig(
-        data=go.Figure(layout=layout, data=data), plot_type=AxPlotTypes.GENERIC
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
+        data=go.Figure(layout=layout, data=data),
+        plot_type=AxPlotTypes.GENERIC,
     )
 
 
@@ -672,7 +677,10 @@ def optimization_times(
     )
 
     return AxPlotConfig(
-        data=go.Figure(layout=layout, data=data), plot_type=AxPlotTypes.GENERIC
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
+        data=go.Figure(layout=layout, data=data),
+        plot_type=AxPlotTypes.GENERIC,
     )
 
 
@@ -717,6 +725,8 @@ def get_running_trials_per_minute(
     )
 
     return AxPlotConfig(
+        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
+        #  `Figure`.
         data=go.Figure(
             layout=go.Layout(title="Number of running trials during experiment"),
             data=[scatter],
@@ -791,7 +801,6 @@ def plot_objective_value_vs_trial_index(
         color="Legend",
         line_shape="hv",
     )
-    # pyre-ignore[16]: `go.graph_objs.Figure` has no attribute add_trace.
     fig = scatter.add_trace(line.data[0])
     if autoset_axis_limits:
         layout_yaxis_range = _autoset_axis_limits(

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -503,7 +503,7 @@ class ReportUtilsTest(TestCase):
         self.assertTrue(all(isinstance(plot, go.Figure) for plot in plots))
         self.assertIn(
             "Objective branin_map vs. True Objective Metric branin",
-            [p.layout.title.text for p in plots],  # pyre-ignore[16]
+            [p.layout.title.text for p in plots],
         )
 
         with self.assertRaisesRegex(

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -481,7 +481,6 @@ def get_standard_plots(
             )
             logger.debug("Finished feature importance plot.")
             feature_importance_plot.layout.title = "[ADVANCED] " + str(
-                # pyre-fixme[16]: go.Figure has no attribute `layout`
                 feature_importance_plot.layout.title.text
             )
             output_plot_list.append(feature_importance_plot)
@@ -1182,8 +1181,8 @@ def get_figure_and_callback(
             )
             return
         fig.update(
-            data=new_fig._data,  # pyre-ignore[16]
-            layout=new_fig._layout,  # pyre-ignore[16]
+            data=new_fig._data,
+            layout=new_fig._layout,
             overwrite=True,
         )
 
@@ -1193,7 +1192,7 @@ def get_figure_and_callback(
 def _warn_and_create_warning_plot(warning_msg: str) -> go.Figure:
     logger.warning(warning_msg)
     return (
-        go.Figure()  # pyre-ignore[16]
+        go.Figure()
         .add_annotation(text=warning_msg, showarrow=False, font={"size": 20})
         .update_xaxes(showgrid=False, showticklabels=False, zeroline=False)
         .update_yaxes(showgrid=False, showticklabels=False, zeroline=False)


### PR DESCRIPTION
Summary: Recent versions of plotly ship with type annotations, so we can remove outdated internal type shed stubs. This fixes a lot of false positive errors and only introduces a relatively small amount of false positive errors.

Reviewed By: stroxler

Differential Revision: D61731048
