### PR TITLE
Bring back ax/benchmark/__init__.py

### DIFF
--- a/ax/benchmark/__init__.py
+++ b/ax/benchmark/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/sphinx/source/benchmark.rst
+++ b/sphinx/source/benchmark.rst
@@ -10,11 +10,18 @@ ax.benchmark
 Benchmark
 ---------
 
-
 Benchmark Method
 ~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.benchmark.benchmark_method
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Benchmark Metric
+~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.benchmark.benchmark_metric
     :members:
     :undoc-members:
     :show-inheritance:
@@ -56,38 +63,6 @@ Benchmark Methods Sobol
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.benchmark.methods.sobol
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-Benchmark Metrics Base
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: ax.benchmark.metrics.base
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-Benchmark Metrics Benchmark
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: ax.benchmark.metrics.benchmark
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-Benchmark Metrics Jenatton
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: ax.benchmark.metrics.jenatton
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-Benchmark Metrics Utils
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: ax.benchmark.metrics.utils
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Removing `__init__.py` makes the module not discoverable when installed with `pip`, leading to `ModuleNotFoundError: No module named 'ax.benchmark'`. See https://github.com/pytorch/botorch/actions/runs/10581831529/job/29320089546