### PR TITLE
BUG FIX: Only construct surrogate once in SurrogateRunner

### DIFF
--- a/ax/benchmark/runners/surrogate.py
+++ b/ax/benchmark/runners/surrogate.py
@@ -78,13 +78,13 @@ class SurrogateRunner(BenchmarkRunner):
 
     @property
     def surrogate(self) -> TorchModelBridge:
-        if self.get_surrogate_and_datasets is not None:
+        if self._surrogate is None:
             self.set_surrogate_and_datasets()
         return none_throws(self._surrogate)
 
     @property
     def datasets(self) -> list[SupervisedDataset]:
-        if self.get_surrogate_and_datasets is not None:
+        if self._datasets is None:
             self.set_surrogate_and_datasets()
         return none_throws(self._datasets)
 

--- a/ax/benchmark/tests/runners/test_surrogate_runner.py
+++ b/ax/benchmark/tests/runners/test_surrogate_runner.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 from ax.benchmark.runners.surrogate import SurrogateRunner
@@ -55,7 +55,7 @@ class TestSurrogateRunner(TestCase):
         self.assertIsNone(runner._surrogate)
         self.assertIsNone(runner._datasets)
 
-        # Accessing `surrogat` sets datasets and surrogate
+        # Accessing `surrogate` sets datasets and surrogate
         self.assertIsInstance(runner.surrogate, TorchModelBridge)
         self.assertIsInstance(runner._surrogate, TorchModelBridge)
         self.assertIsInstance(runner._datasets, list)
@@ -65,6 +65,14 @@ class TestSurrogateRunner(TestCase):
         self.assertIsInstance(runner.datasets, list)
         self.assertIsInstance(runner._surrogate, TorchModelBridge)
         self.assertIsInstance(runner._datasets, list)
+
+        with patch.object(
+            runner,
+            "get_surrogate_and_datasets",
+            wraps=runner.get_surrogate_and_datasets,
+        ) as mock_get_surrogate_and_datasets:
+            runner.surrogate
+        mock_get_surrogate_and_datasets.assert_not_called()
 
     def test_instantiation_raises_with_missing_args(self) -> None:
         with self.assertRaisesRegex(


### PR DESCRIPTION
Summary:
Context:

`SurrogateRunner` constructs surrogates and datasets lazily, because this operation is slow and can be pointless to do in advance since surrogates cannot be serialized anyway. Currently, the surrogate is re-constructed whenever it is accessed. It should only be constructed the first time it is accessed.

This PR:
* Fixes the check for whether the surrogate needs to be constructed
* Adds a unit test

Reviewed By: saitcakmak

Differential Revision: D61855164
