### PR TITLE
Evaluate oracle at target task and fidelity

### DIFF
--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -9,11 +9,7 @@ import copy
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from ax.benchmark.benchmark_problem import (
-    BenchmarkProblem,
-    create_multi_objective_problem_from_botorch,
-    create_single_objective_problem_from_botorch,
-)
+from ax.benchmark.benchmark_problem import BenchmarkProblem, create_problem_from_botorch
 from ax.benchmark.problems.hd_embedding import embed_higher_dimension
 from ax.benchmark.problems.hpo.torchvision import (
     get_pytorch_cnn_torchvision_benchmark_problem,
@@ -31,27 +27,25 @@ class BenchmarkProblemRegistryEntry:
 
 BENCHMARK_PROBLEM_REGISTRY = {
     "ackley4": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Ackley,
             "test_problem_kwargs": {"dim": 4},
-            "lower_is_better": True,
             "num_trials": 40,
             "observe_noise_sd": False,
         },
     ),
     "branin": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Branin,
             "test_problem_kwargs": {},
-            "lower_is_better": True,
             "num_trials": 30,
             "observe_noise_sd": False,
         },
     ),
     "branin_currin": BenchmarkProblemRegistryEntry(
-        factory_fn=create_multi_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": BraninCurrin,
             "test_problem_kwargs": {},
@@ -61,7 +55,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
     ),
     "branin_currin30": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n, num_trials: embed_higher_dimension(
-            problem=create_multi_objective_problem_from_botorch(
+            problem=create_problem_from_botorch(
                 test_problem_class=BraninCurrin,
                 test_problem_kwargs={},
                 num_trials=num_trials,
@@ -72,41 +66,37 @@ BENCHMARK_PROBLEM_REGISTRY = {
         factory_kwargs={"n": 30, "num_trials": 30},
     ),
     "griewank4": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Griewank,
             "test_problem_kwargs": {"dim": 4},
-            "lower_is_better": True,
             "num_trials": 40,
             "observe_noise_sd": False,
         },
     ),
     "hartmann3": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Hartmann,
             "test_problem_kwargs": {"dim": 3},
-            "lower_is_better": True,
             "num_trials": 30,
             "observe_noise_sd": False,
         },
     ),
     "hartmann6": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Hartmann,
             "test_problem_kwargs": {"dim": 6},
-            "lower_is_better": True,
             "num_trials": 35,
             "observe_noise_sd": False,
         },
     ),
     "hartmann30": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n, num_trials: embed_higher_dimension(
-            problem=create_single_objective_problem_from_botorch(
+            problem=create_problem_from_botorch(
                 test_problem_class=synthetic.Hartmann,
                 test_problem_kwargs={"dim": 6},
-                lower_is_better=True,
                 num_trials=num_trials,
                 observe_noise_sd=False,
             ),
@@ -133,68 +123,62 @@ BENCHMARK_PROBLEM_REGISTRY = {
         factory_kwargs={"num_trials": 50, "observe_noise_sd": False},
     ),
     "levy4": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Levy,
             "test_problem_kwargs": {"dim": 4},
-            "lower_is_better": True,
             "num_trials": 40,
             "observe_noise_sd": False,
         },
     ),
     "powell4": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Powell,
             "test_problem_kwargs": {"dim": 4},
-            "lower_is_better": True,
             "num_trials": 40,
             "observe_noise_sd": False,
         },
     ),
     "rosenbrock4": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Rosenbrock,
             "test_problem_kwargs": {"dim": 4},
-            "lower_is_better": True,
             "num_trials": 40,
             "observe_noise_sd": False,
         },
     ),
     "six_hump_camel": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.SixHumpCamel,
             "test_problem_kwargs": {},
-            "lower_is_better": True,
             "num_trials": 30,
             "observe_noise_sd": False,
         },
     ),
     "three_hump_camel": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.ThreeHumpCamel,
             "test_problem_kwargs": {},
-            "lower_is_better": True,
             "num_trials": 30,
             "observe_noise_sd": False,
         },
     ),
     # Problems where we observe the noise level
     "branin_observed_noise": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Branin,
             "test_problem_kwargs": {},
-            "lower_is_better": True,
             "num_trials": 20,
             "observe_noise_sd": True,
         },
     ),
     "branin_currin_observed_noise": BenchmarkProblemRegistryEntry(
-        factory_fn=create_multi_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": BraninCurrin,
             "test_problem_kwargs": {},
@@ -204,7 +188,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
     ),
     "branin_currin30_observed_noise": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n, num_trials: embed_higher_dimension(
-            problem=create_multi_objective_problem_from_botorch(
+            problem=create_problem_from_botorch(
                 test_problem_class=BraninCurrin,
                 test_problem_kwargs={},
                 num_trials=num_trials,
@@ -215,21 +199,19 @@ BENCHMARK_PROBLEM_REGISTRY = {
         factory_kwargs={"n": 30, "num_trials": 30},
     ),
     "hartmann6_observed_noise": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.Hartmann,
             "test_problem_kwargs": {"dim": 6},
-            "lower_is_better": True,
             "num_trials": 50,
             "observe_noise_sd": True,
         },
     ),
     "hartmann30_observed_noise": BenchmarkProblemRegistryEntry(
         factory_fn=lambda n, num_trials: embed_higher_dimension(
-            problem=create_single_objective_problem_from_botorch(
+            problem=create_problem_from_botorch(
                 test_problem_class=synthetic.Hartmann,
                 test_problem_kwargs={"dim": 6},
-                lower_is_better=True,
                 num_trials=num_trials,
                 observe_noise_sd=True,
             ),
@@ -242,11 +224,10 @@ BENCHMARK_PROBLEM_REGISTRY = {
         factory_kwargs={"num_trials": 25, "observe_noise_sd": True},
     ),
     "constrained_gramacy_observed_noise": BenchmarkProblemRegistryEntry(
-        factory_fn=create_single_objective_problem_from_botorch,
+        factory_fn=create_problem_from_botorch,
         factory_kwargs={
             "test_problem_class": synthetic.ConstrainedGramacy,
             "test_problem_kwargs": {},
-            "lower_is_better": True,
             "num_trials": 50,
             "observe_noise_sd": True,
         },

--- a/ax/benchmark/runners/botorch_test.py
+++ b/ax/benchmark/runners/botorch_test.py
@@ -13,6 +13,7 @@ from typing import Any, Optional, Union
 import torch
 from ax.benchmark.runners.base import BenchmarkRunner
 from ax.core.arm import Arm
+from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TParameterization
 from ax.utils.common.base import Base
 from ax.utils.common.equality import equality_typechecker
@@ -76,6 +77,7 @@ class SyntheticProblemRunner(BenchmarkRunner, ABC):
         test_problem_kwargs: dict[str, Any],
         outcome_names: list[str],
         modified_bounds: Optional[list[tuple[float, float]]] = None,
+        search_space_digest: SearchSpaceDigest | None = None,
     ) -> None:
         """Initialize the test problem runner.
 
@@ -94,7 +96,9 @@ class SyntheticProblemRunner(BenchmarkRunner, ABC):
                 5 will correspond to 0.5 while evaluating the test problem.
                 If modified bounds are not provided, the test problem will be
                 evaluated using the raw parameter values.
+            search_space_digest: Used to extract target fidelity and task.
         """
+        super().__init__(search_space_digest=search_space_digest)
         self._test_problem_class = test_problem_class
         self._test_problem_kwargs = test_problem_kwargs
         self.test_problem = (
@@ -215,6 +219,7 @@ class BotorchTestProblemRunner(SyntheticProblemRunner):
             5 will correspond to 0.5 while evaluating the test problem.
             If modified bounds are not provided, the test problem will be
             evaluated using the raw parameter values.
+        search_space_digest: Used to extract target fidelity and task.
     """
 
     def __init__(
@@ -224,12 +229,14 @@ class BotorchTestProblemRunner(SyntheticProblemRunner):
         test_problem_kwargs: dict[str, Any],
         outcome_names: list[str],
         modified_bounds: Optional[list[tuple[float, float]]] = None,
+        search_space_digest: SearchSpaceDigest | None = None,
     ) -> None:
         super().__init__(
             test_problem_class=test_problem_class,
             test_problem_kwargs=test_problem_kwargs,
             outcome_names=outcome_names,
             modified_bounds=modified_bounds,
+            search_space_digest=search_space_digest,
         )
         self.test_problem: BaseTestProblem = self.test_problem.to(dtype=torch.double)
         self._is_constrained: bool = isinstance(
@@ -300,6 +307,7 @@ class ParamBasedTestProblemRunner(SyntheticProblemRunner):
         test_problem_kwargs: dict[str, Any],
         outcome_names: list[str],
         modified_bounds: Optional[list[tuple[float, float]]] = None,
+        search_space_digest: SearchSpaceDigest | None = None,
     ) -> None:
         if modified_bounds is not None:
             raise NotImplementedError(
@@ -310,6 +318,7 @@ class ParamBasedTestProblemRunner(SyntheticProblemRunner):
             test_problem_kwargs=test_problem_kwargs,
             outcome_names=outcome_names,
             modified_bounds=modified_bounds,
+            search_space_digest=search_space_digest,
         )
         self.test_problem: ParamBasedTestProblem = self.test_problem
 

--- a/ax/benchmark/runners/surrogate.py
+++ b/ax/benchmark/runners/surrogate.py
@@ -13,7 +13,7 @@ from ax.benchmark.runners.base import BenchmarkRunner
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.observation import ObservationFeatures
-from ax.core.search_space import SearchSpace
+from ax.core.search_space import SearchSpace, SearchSpaceDigest
 from ax.modelbridge.torch import TorchModelBridge
 from ax.utils.common.base import Base
 from ax.utils.common.equality import equality_typechecker
@@ -36,6 +36,7 @@ class SurrogateRunner(BenchmarkRunner):
         get_surrogate_and_datasets: Optional[
             Callable[[], tuple[TorchModelBridge, list[SupervisedDataset]]]
         ] = None,
+        search_space_digest: SearchSpaceDigest | None = None,
     ) -> None:
         """Runner for surrogate benchmark problems.
 
@@ -56,6 +57,8 @@ class SurrogateRunner(BenchmarkRunner):
                 datasets, to allow for lazy construction. If
                 `get_surrogate_and_datasets` is not provided, `surrogate` and
                 `datasets` must be provided, and vice versa.
+            search_space_digest: Used to get the target task and fidelity at
+                which the oracle is evaluated.
         """
         if get_surrogate_and_datasets is None and (
             surrogate is None or datasets is None
@@ -64,6 +67,7 @@ class SurrogateRunner(BenchmarkRunner):
                 "If get_surrogate_and_datasets is not provided, surrogate and "
                 "datasets must be provided, and vice versa."
             )
+        super().__init__(search_space_digest=search_space_digest)
         self.get_surrogate_and_datasets = get_surrogate_and_datasets
         self.name = name
         self._surrogate = surrogate

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -19,7 +19,7 @@ from ax.benchmark.benchmark_method import (
     BenchmarkMethod,
     get_benchmark_scheduler_options,
 )
-from ax.benchmark.benchmark_problem import create_single_objective_problem_from_botorch
+from ax.benchmark.benchmark_problem import create_problem_from_botorch
 from ax.benchmark.benchmark_result import BenchmarkResult
 from ax.benchmark.methods.modular_botorch import get_sobol_botorch_modular_acquisition
 from ax.benchmark.problems.registry import get_problem
@@ -368,10 +368,9 @@ class TestBenchmark(TestCase):
                 self.assertTrue((agg.score_trace[col] <= 100).all())
 
     def test_timeout(self) -> None:
-        problem = create_single_objective_problem_from_botorch(
+        problem = create_problem_from_botorch(
             test_problem_class=Branin,
             test_problem_kwargs={},
-            lower_is_better=True,
             num_trials=1000,  # Unachievable num_trials
         )
 

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -12,11 +12,7 @@ import numpy as np
 import torch
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_metric import BenchmarkMetric
-from ax.benchmark.benchmark_problem import (
-    BenchmarkProblem,
-    create_multi_objective_problem_from_botorch,
-    create_single_objective_problem_from_botorch,
-)
+from ax.benchmark.benchmark_problem import BenchmarkProblem, create_problem_from_botorch
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
 from ax.benchmark.problems.surrogate import SurrogateBenchmarkProblem
 from ax.benchmark.runners.botorch_test import ParamBasedTestProblem
@@ -40,7 +36,7 @@ from ax.utils.testing.core_stubs import (
 )
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.models.gp_regression import SingleTaskGP
-from botorch.test_functions.multi_objective import BraninCurrin, ConstrainedBraninCurrin
+from botorch.test_functions.multi_objective import BraninCurrin
 from botorch.test_functions.synthetic import Branin
 from pyre_extensions import assert_is_instance
 from torch.utils.data import Dataset
@@ -51,10 +47,9 @@ def get_single_objective_benchmark_problem(
     num_trials: int = 4,
     test_problem_kwargs: Optional[dict[str, Any]] = None,
 ) -> BenchmarkProblem:
-    return create_single_objective_problem_from_botorch(
+    return create_problem_from_botorch(
         test_problem_class=Branin,
         test_problem_kwargs=test_problem_kwargs or {},
-        lower_is_better=True,
         num_trials=num_trials,
         observe_noise_sd=observe_noise_sd,
     )
@@ -65,21 +60,11 @@ def get_multi_objective_benchmark_problem(
     num_trials: int = 4,
     test_problem_class: type[BraninCurrin] = BraninCurrin,
 ) -> BenchmarkProblem:
-    return create_multi_objective_problem_from_botorch(
+    return create_problem_from_botorch(
         test_problem_class=test_problem_class,
         test_problem_kwargs={},
         num_trials=num_trials,
         observe_noise_sd=observe_noise_sd,
-    )
-
-
-def get_constrained_multi_objective_benchmark_problem(
-    observe_noise_sd: bool = False, num_trials: int = 4
-) -> BenchmarkProblem:
-    return get_multi_objective_benchmark_problem(
-        observe_noise_sd=observe_noise_sd,
-        num_trials=num_trials,
-        test_problem_class=ConstrainedBraninCurrin,
     )
 
 


### PR DESCRIPTION
Summary:
`BenchmarkRunner.evaluate_oracle` now evaluates at the target task and fidelity.

A weakness of this solution is that it requires passing the search space to the runner. Generally, there is too much information that must be on both the problem and the runner; this could be addressed by making the problem an attribute of the runner rather than the other way around.

Reviewed By: sdaulton

Differential Revision: D61884295
