### PR TITLE
Add longtest decorator to pairwise model tests

### DIFF
--- a/ax/modelbridge/tests/test_pairwise_modelbridge.py
+++ b/ax/modelbridge/tests/test_pairwise_modelbridge.py
@@ -38,6 +38,9 @@ class PairwiseModelBridgeTest(TestCase):
         self.experiment = experiment
         self.data = experiment.lookup_data()
 
+    @TestCase.ax_long_test(
+        reason="TODO[T199510629] Fix: break up test into one test per case"
+    )
     def test_PairwiseModelBridge(self) -> None:
         surrogate = Surrogate(
             botorch_model_class=PairwiseGP,


### PR DESCRIPTION
Summary: Sam fixed the logic in the test yesterday, thanks sam!, but now it's timing out this adds it to the backlog to be fixed.

Reviewed By: danielcohenlive, mpolson64

Differential Revision: D62036700
