### PR TITLE
Don't test with a test stub when there's a function that does the same thing

### DIFF
--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -68,19 +68,6 @@ def get_multi_objective_benchmark_problem(
     )
 
 
-def get_sobol_benchmark_method() -> BenchmarkMethod:
-    return BenchmarkMethod(
-        name="SOBOL",
-        generation_strategy=GenerationStrategy(
-            steps=[GenerationStep(model=Models.SOBOL, num_trials=-1)],
-            name="SOBOL",
-        ),
-        scheduler_options=SchedulerOptions(
-            total_trials=4, init_seconds_between_polls=0
-        ),
-    )
-
-
 def get_soo_surrogate() -> SurrogateBenchmarkProblem:
     experiment = get_branin_experiment(with_completed_trial=True)
     surrogate = TorchModelBridge(


### PR DESCRIPTION
Summary:
Context:
* There is a `get_sobol_benchmark_method` test stub, which is not needed when a Sobol benchmark method is provided, also called `get_sobol_benchmark_method`. It is better to test that function.
* The latter `get_sobol_benchmark_method` requires an argument `distribute_replications`. (Making this mandatory was an intentional choice, because it is easy to forget it.)

This diff:
* Gets rid of the test stub and uses the non-stub version instead
* Adds `distribute_replications` in a bunch of places. I chose `False` arbitrarily since the argument will have no effect here.

Reviewed By: saitcakmak

Differential Revision: D62157106
