### PR TITLE
Silence input data warnings in tests

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -904,7 +904,7 @@ class ModelBridge(ABC):  # noqa: B024 -- ModelBridge doesn't have any abstract m
             # users with this warning, we filter it out.
             warnings.filterwarnings(
                 "ignore",
-                message=r"Data \(outcome observations\) not standardized",
+                message=r"Data \(outcome observations\) is not standardized",
                 category=InputDataWarning,
             )
             cv_predictions = self._cross_validate(

--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -184,7 +184,7 @@ def cross_validate(
                 # To avoid confusing users with this warning, we filter it out.
                 warnings.filterwarnings(
                     "ignore",
-                    message=r"Data \(outcome observations\) not standardized",
+                    message=r"Data \(outcome observations\) is not standardized",
                     category=InputDataWarning,
                 )
                 cv_test_predictions = model._cross_validate(

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -225,7 +225,7 @@ class BaseModelBridgeTest(TestCase):
             nonlocal called
             called = True
             warnings.warn(
-                "Data (outcome observations) not standardized",
+                "Data (outcome observations) is not standardized",
                 InputDataWarning,
                 stacklevel=2,
             )

--- a/ax/utils/common/tests/test_testutils.py
+++ b/ax/utils/common/tests/test_testutils.py
@@ -8,9 +8,13 @@
 
 import io
 import sys
+import warnings
 
+import torch
 from ax.utils.common.base import Base
 from ax.utils.common.testutils import TestCase
+from botorch.exceptions.warnings import InputDataWarning
+from botorch.models.gp_regression import SingleTaskGP
 
 
 # pyre-fixme[3]: Return type must be annotated.
@@ -19,7 +23,7 @@ def _f():
     raise e
 
 
-F_FAILURE_LINENO = 19  # Line # for the error in `_f`.
+F_FAILURE_LINENO = 23  # Line # for the error in `_f`.
 
 
 def _g() -> None:
@@ -113,3 +117,13 @@ class TestTestUtils(TestCase):
         self.assertEqual(None, self._long_test_active_reason)
         decorated_test()
         self.assertEqual(None, self._long_test_active_reason)
+
+    def test_warning_filtering(self) -> None:
+        with warnings.catch_warnings(record=True) as ws:
+            # Model with unstandardized float data, which would typically raise
+            # multiple warnings.
+            SingleTaskGP(
+                train_X=torch.rand(5, 2, dtype=torch.float) * 10,
+                train_Y=torch.rand(5, 1, dtype=torch.float) * 10,
+            )
+        self.assertFalse(any(w.category == InputDataWarning for w in ws))

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -364,7 +364,12 @@ class TestCase(fake_filesystem_unittest.TestCase):
         # BoTorch input standardization warnings.
         warnings.filterwarnings(
             "ignore",
-            message="Input data is not",
+            message=r"Data \(outcome observations\) is not standardized ",
+            category=InputDataWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=r"Data \(input features\) is not",
             category=InputDataWarning,
         )
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/2508

This logic broke since D61797434 updated the warning messages, leading to too many of these warnings in test outputs again.

Differential Revision: D62200731
