### PR TITLE
Type annotation: Scheduler.get_pareto_optimal_parameters never returns None

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -469,7 +469,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         optimization_config: Optional[OptimizationConfig] = None,
         trial_indices: Optional[Iterable[int]] = None,
         use_model_predictions: bool = True,
-    ) -> Optional[dict[int, tuple[TParameterization, TModelPredictArm]]]:
+    ) -> dict[int, tuple[TParameterization, TModelPredictArm]]:
         return self._get_pareto_optimal_parameters(
             experiment=self.experiment,
             generation_strategy=self.standard_generation_strategy,

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -134,7 +134,7 @@ class BestPointMixin(metaclass=ABCMeta):
         optimization_config: Optional[OptimizationConfig] = None,
         trial_indices: Optional[Iterable[int]] = None,
         use_model_predictions: bool = True,
-    ) -> Optional[dict[int, tuple[TParameterization, TModelPredictArm]]]:
+    ) -> dict[int, tuple[TParameterization, TModelPredictArm]]:
         """Identifies the best parameterizations tried in the experiment so far,
         using model predictions if ``use_model_predictions`` is true and using
         observed values from the experiment otherwise. By default, uses model
@@ -158,12 +158,13 @@ class BestPointMixin(metaclass=ABCMeta):
                 observed values.
 
         Returns:
-            ``None`` if it was not possible to extract the Pareto frontier,
-            otherwise a mapping from trial index to the tuple of:
+            A mapping from trial index to the tuple of:
             - the parameterization of the arm in that trial,
             - two-item tuple of metric means dictionary and covariance matrix
                 (model-predicted if ``use_model_predictions=True`` and observed
                 otherwise).
+            Raises a `NotImplementedError` if extracting the Pareto frontier is
+            not possible. Note that the returned dict may be empty.
         """
         pass
 


### PR DESCRIPTION
Summary: Fixing a type annotation.

Differential Revision: D62192596
