### PR TITLE
drop duplicates when obtaining status quo mean and sem in relativize_data

### DIFF
--- a/ax/utils/stats/statstools.py
+++ b/ax/utils/stats/statstools.py
@@ -414,7 +414,9 @@ def relativize_data(
     for grp in grouped_df.groups.keys():
         subgroup_df = grouped_df.get_group(grp)
         is_sq = subgroup_df["arm_name"] == status_quo_name
-        sq_mean, sq_sem = subgroup_df[is_sq][["mean", "sem"]].values.flatten()
+        sq_mean, sq_sem = (
+            subgroup_df[is_sq][["mean", "sem"]].drop_duplicates().values.flatten()
+        )
 
         # rm status quo from final df to relativize
         if not include_sq:


### PR DESCRIPTION
Summary: Drop duplicates during relativization in case of duplicated entries in data

Reviewed By: danielcohenlive

Differential Revision: D62210747
