### PR TITLE
Update docstrings and type annotations

### DIFF
--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -26,6 +26,16 @@ class BenchmarkMethod(Base):
     Note: If `BenchmarkMethod.scheduler_options.total_trials` is less than
     `BenchmarkProblem.num_trials` then only the number of trials specified in the
     former will be run.
+
+    Args:
+        name: String description.
+        generation_strategy: The `GenerationStrategy` to use.
+        scheduler_options: `SchedulerOptions` that specify options such as
+            `max_pending_trials`, `timeout_hours`, and `batch_size`. Can be
+            generated with sensible defaults for benchmarking with
+            `get_benchmark_scheduler_options`.
+        distribute_replications: Indicates whether the replications should be
+            run in a distributed manner. Ax itself does not use this attribute.
     """
 
     name: str

--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -95,7 +95,8 @@ class BenchmarkProblem(Base):
         for trial_index, trial in experiment.trials.items():
             for arm in trial.arms:
                 for metric_name, metric_value in zip(
-                    self.runner.outcome_names, self.runner.evaluate_oracle(arm=arm)
+                    self.runner.outcome_names,
+                    self.runner.evaluate_oracle(parameters=arm.parameters),
                 ):
                     records.append(
                         {
@@ -117,6 +118,11 @@ class BenchmarkProblem(Base):
         data = Data(df=pd.DataFrame.from_records(records))
         new_experiment.attach_data(data=data, overwrite_existing_data=True)
         return new_experiment
+
+    @property
+    def is_moo(self) -> bool:
+        """Whether the problem is multi-objective."""
+        return isinstance(self.optimization_config, MultiObjectiveOptimizationConfig)
 
     def get_opt_trace(self, experiment: Experiment) -> np.ndarray:
         """Evaluate the optimization trace of a list of Trials."""

--- a/ax/benchmark/benchmark_result.py
+++ b/ax/benchmark/benchmark_result.py
@@ -28,12 +28,34 @@ PERCENTILES = [0.25, 0.5, 0.75]
 class BenchmarkResult(Base):
     """The result of a single optimization loop from one
     (BenchmarkProblem, BenchmarkMethod) pair.
+
+    Args:
+        name: Name of the benchmark. Should make it possible to determine the
+            problem and the method.
+        seed: Seed used for determinism.
+        optimization_trace: For single-objective problems, element i of the
+            optimization trace is the oracle value of the "best" point, computed
+            after the first i trials have been run. For multi-objective
+            problems, element i of the optimization trace is the hypervolume of
+            oracle values at a set of points, also computed after the first i
+            trials (even if these were ``BatchTrials``).  Oracle values are
+            typically ground-truth (rather than noisy) and evaluated at the
+            target task and fidelity.
+
+        score_trace: The scores associated with the problem, typically either
+            the optimization_trace or inference_value_trace normalized to a
+            0-100 scale for comparability between problems.
+        fit_time: Total time spent fitting models.
+        gen_time: Total time spent generating candidates.
+        experiment: If not ``None``, the Ax experiment associated with the
+            optimization that generated this data. Either ``experiment`` or
+            ``experiment_storage_id`` must be provided.
+        experiment_storage_id: Pointer to location where experiment data can be read.
     """
 
     name: str
     seed: int
 
-    # Tracks best point if single-objective problem, max hypervolume if MOO
     optimization_trace: ndarray
     score_trace: ndarray
 
@@ -41,7 +63,6 @@ class BenchmarkResult(Base):
     gen_time: float
 
     experiment: Optional[Experiment] = None
-    # Pointer to location where experiment data can be read
     experiment_storage_id: Optional[str] = None
 
     def __post_init__(self) -> None:

--- a/ax/benchmark/runners/base.py
+++ b/ax/benchmark/runners/base.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from math import sqrt
 from typing import Any, Union
 
@@ -18,8 +18,10 @@ from ax.core.batch_trial import BatchTrial
 from ax.core.runner import Runner
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.trial import Trial
+from ax.core.types import TParamValue
 
 from ax.utils.common.typeutils import checked_cast
+from numpy import ndarray
 from torch import Tensor
 
 
@@ -65,7 +67,7 @@ class BenchmarkRunner(Runner, ABC):
         """
         ...
 
-    def evaluate_oracle(self, arm: Arm) -> Tensor:
+    def evaluate_oracle(self, parameters: Mapping[str, TParamValue]) -> ndarray:
         """
         Evaluate oracle metric values at a parameterization. In the base class,
         oracle values are underlying noiseless function values evaluated at the
@@ -76,8 +78,8 @@ class BenchmarkRunner(Runner, ABC):
         preference-learned objective, the values might be true metrics evaluated
         at the true utility function (which would be unobserved in reality).
         """
-        params = {**arm.parameters, **self.target_fidelity_and_task}
-        return self.get_Y_true(arm=Arm(parameters=params))
+        params = {**parameters, **self.target_fidelity_and_task}
+        return self.get_Y_true(arm=Arm(parameters=params)).numpy()
 
     @abstractmethod
     def get_noise_stds(self) -> Union[None, float, dict[str, float]]:

--- a/ax/benchmark/tests/problems/synthetic/hss/test_jenatton.py
+++ b/ax/benchmark/tests/problems/synthetic/hss/test_jenatton.py
@@ -85,7 +85,6 @@ class JenattonTest(TestCase):
             )
 
         for params, value in cases:
-            arm = Arm(parameters=params)
             self.assertAlmostEqual(
                 # pyre-fixme: Incompatible parameter type [6]: In call
                 # `jenatton_test_function`, for 1st positional argument,
@@ -95,7 +94,7 @@ class JenattonTest(TestCase):
                 value,
             )
             self.assertAlmostEqual(
-                benchmark_problem.runner.evaluate_oracle(arm).item(),
+                benchmark_problem.runner.evaluate_oracle(parameters=params)[0],
                 value,
                 places=6,
             )

--- a/ax/benchmark/tests/runners/test_botorch_test_problem.py
+++ b/ax/benchmark/tests/runners/test_botorch_test_problem.py
@@ -10,6 +10,8 @@
 from itertools import product
 from unittest.mock import Mock
 
+import numpy as np
+
 import torch
 from ax.benchmark.runners.botorch_test import (
     BotorchTestProblemRunner,
@@ -150,8 +152,8 @@ class TestSyntheticRunner(TestCase):
                         torch.Size([2]), X.pow(2).sum().item(), dtype=torch.double
                     )
                 self.assertTrue(torch.allclose(Y, expected_Y))
-                oracle = runner.evaluate_oracle(arm=arm)
-                self.assertTrue(torch.equal(Y, oracle))
+                oracle = runner.evaluate_oracle(parameters=arm.parameters)
+                self.assertTrue(np.equal(Y.numpy(), oracle).all())
 
             with self.subTest(f"test `run()`, {test_description}"):
                 trial = Mock(spec=Trial)

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -82,7 +82,8 @@ class TestBenchmarkProblem(TestCase):
             float,
         )
         self.assertAlmostEqual(
-            problem.runner.evaluate_oracle(arm=arm).item(), at_target
+            problem.runner.evaluate_oracle(parameters=arm.parameters)[0],
+            at_target,
         )
         # first term: (-(b - 0.1) * (1 - x3)  + c - r)^2
         # low-fidelity: (-b - 0.1 + c - r)^2

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -435,9 +435,9 @@ class BestPointMixin(metaclass=ABCMeta):
         """Compute the optimization trace at each iteration.
 
         Given an experiment and an optimization config, compute the performance
-        at each iteration. For multi-objective, the performance is compute as the
-        hypervolume. For single objective, the performance is compute as the best
-        observed objective value.
+        at each iteration. For multi-objective, the performance is computed as
+        the hypervolume. For single objective, the performance is computed as
+        the best observed objective value.
 
         An iteration here refers to a completed or early-stopped (batch) trial.
         There will be one performance metric in the trace for each iteration.


### PR DESCRIPTION
Summary:
* Expand docstrings
* `is_moo` syntatactic sugar
* Use mutable annotations where appropriate
* Have `BenchmarkRunner.evaluate_oracle` return a Numpy arrray rather than a tensor (broader detorchification would be good)
*

Differential Revision: D62246721
