### PR TITLE
Add "allow_unmapped" to Ax SQA objects for SQA 2.0 forward compatibility

### DIFF
--- a/ax/storage/sqa_store/db.py
+++ b/ax/storage/sqa_store/db.py
@@ -47,6 +47,8 @@ T = TypeVar("T")
 class SQABase:
     """Metaclass for SQLAlchemy classes corresponding to core Ax classes."""
 
+    __allow_unmapped__ = True
+    __table_args__ = {"extend_existing": True}
     pass
 
 

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from ax.analysis.analysis import AnalysisCardLevel
 
@@ -83,10 +83,10 @@ class SQAParameter(Base):
     upper: Column[Optional[Decimal]] = Column(Float)
 
     # Attributes for Choice Parameters
-    choice_values: Column[Optional[list[TParamValue]]] = Column(JSONEncodedList)
+    choice_values: Column[Optional[List[TParamValue]]] = Column(JSONEncodedList)
     is_ordered: Column[Optional[bool]] = Column(Boolean)
     is_task: Column[Optional[bool]] = Column(Boolean)
-    dependents: Column[Optional[dict[TParamValue, list[str]]]] = Column(
+    dependents: Column[Optional[dict[TParamValue, List[str]]]] = Column(
         JSONEncodedObject
     )
 
@@ -146,7 +146,7 @@ class SQAMetric(Base):
     # of Multi/Scalarized Objective contains all children of the parent metric
     # join_depth argument: used for loading self-referential relationships
     # https://docs.sqlalchemy.org/en/13/orm/self_referential.html#configuring-self-referential-eager-loading
-    scalarized_objective_children_metrics: list[SQAMetric] = relationship(
+    scalarized_objective_children_metrics: List["SQAMetric"] = relationship(
         "SQAMetric",
         cascade="all, delete-orphan",
         lazy=True,
@@ -158,7 +158,7 @@ class SQAMetric(Base):
     scalarized_outcome_constraint_id: Column[Optional[int]] = Column(
         Integer, ForeignKey("metric_v2.id")
     )
-    scalarized_outcome_constraint_children_metrics: list[SQAMetric] = relationship(
+    scalarized_outcome_constraint_children_metrics: List["SQAMetric"] = relationship(
         "SQAMetric",
         cascade="all, delete-orphan",
         lazy=True,
@@ -231,19 +231,19 @@ class SQAGeneratorRun(Base):
     # relationships
     # Use selectin loading for collections to prevent idle timeout errors
     # (https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#selectin-eager-loading)
-    arms: list[SQAArm] = relationship(
+    arms: List[SQAArm] = relationship(
         "SQAArm",
         cascade="all, delete-orphan",
         lazy="selectin",
         order_by=lambda: SQAArm.id,
     )
-    metrics: list[SQAMetric] = relationship(
+    metrics: List[SQAMetric] = relationship(
         "SQAMetric", cascade="all, delete-orphan", lazy="selectin"
     )
-    parameters: list[SQAParameter] = relationship(
+    parameters: List[SQAParameter] = relationship(
         "SQAParameter", cascade="all, delete-orphan", lazy="selectin"
     )
-    parameter_constraints: list[SQAParameterConstraint] = relationship(
+    parameter_constraints: List[SQAParameterConstraint] = relationship(
         "SQAParameterConstraint", cascade="all, delete-orphan", lazy="selectin"
     )
 
@@ -289,17 +289,17 @@ class SQAGenerationStrategy(Base):
 
     id: Column[int] = Column(Integer, primary_key=True)
     name: Column[str] = Column(String(NAME_OR_TYPE_FIELD_LENGTH), nullable=False)
-    steps: Column[list[dict[str, Any]]] = Column(JSONEncodedList, nullable=False)
+    steps: Column[List[dict[str, Any]]] = Column(JSONEncodedList, nullable=False)
     curr_index: Column[int] = Column(Integer, nullable=False)
     experiment_id: Column[Optional[int]] = Column(
         Integer, ForeignKey("experiment_v2.id")
     )
-    nodes: Column[list[dict[str, Any]]] = Column(JSONEncodedList, nullable=True)
+    nodes: Column[List[dict[str, Any]]] = Column(JSONEncodedList, nullable=True)
     curr_node_name: Column[Optional[str]] = Column(
         String(NAME_OR_TYPE_FIELD_LENGTH), nullable=True
     )
 
-    generator_runs: list[SQAGeneratorRun] = relationship(
+    generator_runs: List[SQAGeneratorRun] = relationship(
         "SQAGeneratorRun",
         cascade="all, delete-orphan",
         lazy="selectin",
@@ -347,10 +347,10 @@ class SQATrial(Base):
     # a child, the old one will be deleted.
     # Use selectin loading for collections to prevent idle timeout errors
     # (https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#selectin-eager-loading)
-    abandoned_arms: list[SQAAbandonedArm] = relationship(
+    abandoned_arms: List[SQAAbandonedArm] = relationship(
         "SQAAbandonedArm", cascade="all, delete-orphan", lazy="selectin"
     )
-    generator_runs: list[SQAGeneratorRun] = relationship(
+    generator_runs: List[SQAGeneratorRun] = relationship(
         "SQAGeneratorRun", cascade="all, delete-orphan", lazy="selectin"
     )
     runner: SQARunner = relationship(
@@ -402,7 +402,7 @@ class SQAExperiment(Base):
     # pyre-fixme[8]: Incompatible attribute type [8]: Attribute
     # `auxiliary_experiments_by_purpose` declared in class `SQAExperiment` has
     # type `Optional[Dict[str, List[str]]]` but is used as type `Column[typing.Any]`
-    auxiliary_experiments_by_purpose: Optional[dict[str, list[str]]] = Column(
+    auxiliary_experiments_by_purpose: Optional[dict[str, List[str]]] = Column(
         JSONEncodedTextDict, nullable=True, default={}
     )
 
@@ -412,22 +412,22 @@ class SQAExperiment(Base):
     # a child, the old one will be deleted.
     # Use selectin loading for collections to prevent idle timeout errors
     # (https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#selectin-eager-loading)
-    data: list[SQAData] = relationship(
+    data: List[SQAData] = relationship(
         "SQAData", cascade="all, delete-orphan", lazy="selectin"
     )
-    metrics: list[SQAMetric] = relationship(
+    metrics: List[SQAMetric] = relationship(
         "SQAMetric", cascade="all, delete-orphan", lazy="selectin"
     )
-    parameters: list[SQAParameter] = relationship(
+    parameters: List[SQAParameter] = relationship(
         "SQAParameter", cascade="all, delete-orphan", lazy="selectin"
     )
-    parameter_constraints: list[SQAParameterConstraint] = relationship(
+    parameter_constraints: List[SQAParameterConstraint] = relationship(
         "SQAParameterConstraint", cascade="all, delete-orphan", lazy="selectin"
     )
-    runners: list[SQARunner] = relationship(
+    runners: List[SQARunner] = relationship(
         "SQARunner", cascade="all, delete-orphan", lazy=False
     )
-    trials: list[SQATrial] = relationship(
+    trials: List[SQATrial] = relationship(
         "SQATrial", cascade="all, delete-orphan", lazy="selectin"
     )
     generation_strategy: Optional[SQAGenerationStrategy] = relationship(
@@ -436,6 +436,6 @@ class SQAExperiment(Base):
         uselist=False,
         lazy=True,
     )
-    analysis_cards: list[SQAAnalysisCard] = relationship(
+    analysis_cards: List[SQAAnalysisCard] = relationship(
         "SQAAnalysisCard", cascade="all, delete-orphan", lazy="selectin"
     )

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ DEV_REQUIRES = [
     "numpy<2.0",
 ]
 
-MYSQL_REQUIRES = ["SQLAlchemy==1.4.17"]
+MYSQL_REQUIRES = ["SQLAlchemy==2.0.21"]
 
 NOTEBOOK_REQUIRES = ["jupyter"]
 


### PR DESCRIPTION
Summary:
T163607006 for more context

OSS User trying to use Ax encountered this SQA error when using version 2.0:
```
ArgumentError: Type annotation for "SQAGeneratorRun.arms" can't be correctly interpreted for Annotated Declarative Table form.
ORM annotations should normally make use of the ``Mapped[]`` generic type, or other ORM-compatible generic type, as a container for the actual type, which indicates the intent that the attribute is mapped. Class variables that are not intended to be mapped by the ORM should use ClassVar[].

To allow Annotated Declarative to disregard legacy annotations which don't use Mapped[] to pass,
set "__allow_unmapped__ = True" on the class or a superclass this class. (Background on this error at: https://sqlalche.me/e/20/zlpr)
```
Currently SQA 1.4 is the only supported version internally.

This change follows the suggestion of the error to set "__allow_unmapped__" equal to true, which is also suggested in the SQL alchemy wiki
https://docs.sqlalchemy.org/en/20/changelog/migration_20.html?fbclid=IwZXh0bgNhZW0CMTEAAR083E0mVk0DkKTo9R1AimFUsoZ4iV2ei1BVKFYmH4iQVrMqcS6F6fv7ZUw_aem_S3WfZmTwJIdpYJkQDo2icQ#migration-to-2-0-step-six-add-allow-unmapped-to-explicitly-typed-orm-models

This should fix the issue encountered when using SQA 2.0 in OSS.

Differential Revision: D62261700
