### PR TITLE
Add qLogNParEGO to ACQUISITION_FUNCTION_REGISTRY

### DIFF
--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -47,6 +47,7 @@ from botorch.acquisition.multi_objective.monte_carlo import (
     qExpectedHypervolumeImprovement,
     qNoisyExpectedHypervolumeImprovement,
 )
+from botorch.acquisition.multi_objective.parego import qLogNParEGO
 from botorch.acquisition.preference import AnalyticExpectedUtilityOfBestOption
 from botorch.models import SaasFullyBayesianSingleTaskGP
 from botorch.models.contextual import LCEAGP
@@ -144,6 +145,7 @@ ACQUISITION_FUNCTION_REGISTRY: dict[type[AcquisitionFunction], str] = {
     qLogNoisyExpectedImprovement: "qLogNoisyExpectedImprovement",
     qLogExpectedHypervolumeImprovement: "qLogExpectedHypervolumeImprovement",
     qLogNoisyExpectedHypervolumeImprovement: "qLogNoisyExpectedHypervolumeImprovement",
+    qLogNParEGO: "qLogNParEGO",
 }
 
 


### PR DESCRIPTION
Summary:
ParEGO AxSweeps currently fail due to the following error:

```
ValueError: Class `qLogNParEGO` not in Type[AcquisitionFunction] registry, please add it. BoTorch object registries are located in `ax/storage/botorch_modular_registry.py`. Please see our storage tutorial (https://ax.dev/docs/storage.html) for more details ('Customizing' section will be relevant for saving Ax object subclasses).
```

This rectifies by following the error's recommendation.

Differential Revision: D62280737
