### PR TITLE
Remove recording of storage resumption; we can get that from other soures

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -56,7 +56,7 @@ from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.service.utils.with_db_settings_base import DBSettings, WithDBSettingsBase
-from ax.utils.common.constants import Keys, TS_FMT
+from ax.utils.common.constants import Keys
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.executils import retry_on_exception
 from ax.utils.common.logger import (
@@ -304,7 +304,6 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             # provided to this function.
             **kwargs,
         )
-        scheduler._record_experiment_resumption_from_storage()
         return scheduler
 
     @property
@@ -2052,18 +2051,6 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             self.markdown_messages["Optimization complete"] += "\n\n" + completion_msg
         else:
             self.markdown_messages["Optimization complete"] = completion_msg
-
-    def _record_experiment_resumption_from_storage(self) -> None:
-        """Adds a timestamp for resumption-from-storage, to the experiment properties.
-        Useful for debugging purposes and for keeping track of resumption events.
-        """
-        resumption_timestamps = self.experiment._properties.setdefault(
-            Keys.RESUMED_FROM_STORAGE_TS.value, []
-        )
-        resumption_timestamps.append(datetime.strftime(datetime.now(), TS_FMT))
-        self._update_experiment_properties_in_db(
-            experiment_with_updated_properties=self.experiment
-        )
 
     def _fetch_and_process_trials_data_results(
         self,

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -1265,19 +1265,10 @@ class AxSchedulerTestCase(TestCase):
             ),
             db_settings=self.db_settings,
         )
-        # Hack "resumed from storage timestamp" into `exp` to make sure all other fields
-        # are equal, since difference in resumed from storage timestamps is expected.
-        exp._properties[Keys.RESUMED_FROM_STORAGE_TS] = (
-            new_scheduler.experiment._properties[Keys.RESUMED_FROM_STORAGE_TS]
-        )
         self.assertEqual(new_scheduler.experiment, exp)
         self.assertLessEqual(
             len(gs._generator_runs),
             len(new_scheduler.generation_strategy._generator_runs),
-        )
-        self.assertEqual(
-            len(new_scheduler.experiment._properties[Keys.RESUMED_FROM_STORAGE_TS]),
-            1,
         )
 
     def test_from_stored_experiment(self) -> None:


### PR DESCRIPTION
Summary: This is causing unnecessary complexity in testing and hadn't seen much use

Differential Revision: D62258388
