### PR TITLE
Use input constructors during GS

### DIFF
--- a/ax/modelbridge/generation_node_input_constructors.py
+++ b/ax/modelbridge/generation_node_input_constructors.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from enum import Enum, unique
+from typing import Any, Dict, Optional
+
+from ax.modelbridge.generation_node import GenerationNode
+
+
+def consume_all_n(
+    previous_node: Optional[GenerationNode],
+    next_node: GenerationNode,
+    gs_gen_call_kwargs: Dict[str, Any],
+) -> int:
+    """Generate total requested number of arms from the next node.
+
+    Example: Initial exploration with Sobol will generate all arms from a
+    single sobol node.
+
+    Args:
+        previous_node: The previous node in the ``GenerationStrategy``. This is the node
+            that is being transition away from, and is provided for easy access to
+            properties of this node.
+        next_node: The next node in the ``GenerationStrategy``. This is the node that
+            will leverage the inputs defined by this input constructor.
+        gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
+            gen call.
+    Returns:
+        The total number of requested arms from the next node.
+    """
+    # TODO: @mgarrard handle case where n isn't specified
+    if gs_gen_call_kwargs.get("n") is None:
+        raise NotImplementedError(
+            f"Currently `{consume_all_n.__name__}` only supports cases where n is "
+            "specified"
+        )
+    return gs_gen_call_kwargs.get("n")
+
+
+@unique
+class NodeInputConstructors(Enum):
+    """An enum which maps to a callable method for constructing ``GenerationNode``
+    inputs.
+    """
+
+    ALL_N = consume_all_n
+
+    def __call__(
+        self,
+        previous_node: Optional[GenerationNode],
+        next_node: GenerationNode,
+        gs_gen_call_kwargs: Dict[str, Any],
+    ) -> int:
+        """Defines a callable method for the Enum as all values are methods"""
+        return self(
+            previous_node=previous_node,
+            next_node=next_node,
+            gs_gen_call_kwargs=gs_gen_call_kwargs,
+        )
+
+
+@unique
+class InputConstructorPurpose(Enum):
+    """A simple enum to indicate the purpose of the input constructor.
+
+    Explanation of the different purposes:
+        N: Defines the logic to determine the number of arms to generate from the
+           next ``GenerationNode`` given the total number of arms expected in
+           this trial.
+    """
+
+    N = "n"

--- a/ax/modelbridge/generation_node_input_constructors.py
+++ b/ax/modelbridge/generation_node_input_constructors.py
@@ -99,7 +99,7 @@ def remaining_n(
             "specified"
         )
     # TODO: @mgarrard improve this logic to be more robust
-    grs_this_gen = gs_gen_call_kwargs.get("grs")
+    grs_this_gen = gs_gen_call_kwargs.get("grs_this_gen")
     total_n = gs_gen_call_kwargs.get("n")
     # if all arms have been generated, return 0
     return max(total_n - sum(len(gr.arms) for gr in grs_this_gen), 0)

--- a/ax/modelbridge/generation_node_input_constructors.py
+++ b/ax/modelbridge/generation_node_input_constructors.py
@@ -58,7 +58,7 @@ def repeat_arm_n(
         gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
             gen call.
     Returns:
-        The number of requested arms from the next node.
+        The number of requested arms from the next node
     """
     if gs_gen_call_kwargs.get("n") is None:
         raise NotImplementedError(
@@ -75,6 +75,36 @@ def repeat_arm_n(
     return ceil(total_n / 10)
 
 
+def remaining_n(
+    previous_node: Optional[GenerationNode],
+    next_node: GenerationNode,
+    gs_gen_call_kwargs: Dict[str, Any],
+) -> int:
+    """Generate the remaining number of arms requested for this trial in gs.gen().
+
+    Args:
+        previous_node: The previous node in the ``GenerationStrategy``. This is the node
+            that is being transition away from, and is provided for easy access to
+            properties of this node.
+        next_node: The next node in the ``GenerationStrategy``. This is the node that
+            will leverage the inputs defined by this input constructor.
+        gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
+            gen call.
+    Returns:
+        The number of requested arms from the next node
+    """
+    if gs_gen_call_kwargs.get("n") is None:
+        raise NotImplementedError(
+            f"Currently `{remaining_n.__name__}` only supports cases where n is "
+            "specified"
+        )
+    # TODO: @mgarrard improve this logic to be more robust
+    grs_this_gen = gs_gen_call_kwargs.get("grs")
+    total_n = gs_gen_call_kwargs.get("n")
+    # if all arms have been generated, return 0
+    return max(total_n - sum(len(gr.arms) for gr in grs_this_gen), 0)
+
+
 @unique
 class NodeInputConstructors(Enum):
     """An enum which maps to a callable method for constructing ``GenerationNode``
@@ -83,6 +113,7 @@ class NodeInputConstructors(Enum):
 
     ALL_N = consume_all_n
     REPEAT_N = repeat_arm_n
+    REMAINING_N = remaining_n
 
     def __call__(
         self,

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -82,8 +82,8 @@ class TestGenerationNode(TestCase):
         self.assertIs(node.best_model_selector, model_selector)
 
     def test_input_constructor_none(self) -> None:
-        self.assertIsNone(self.sobol_generation_node.input_constructors)
         self.assertIsNone(self.sobol_generation_node._input_constructors)
+        self.assertEqual(self.sobol_generation_node.input_constructors, {})
 
     def test_input_constructor(self) -> None:
         node = GenerationNode(

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -22,6 +22,10 @@ from ax.modelbridge.generation_node import (
     GenerationStep,
     MISSING_MODEL_SELECTOR_MESSAGE,
 )
+from ax.modelbridge.generation_node_input_constructors import (
+    InputConstructorPurpose,
+    NodeInputConstructors,
+)
 from ax.modelbridge.model_spec import FactoryFunctionModelSpec, ModelSpec
 from ax.modelbridge.registry import Models
 from ax.modelbridge.transition_criterion import MaxTrials
@@ -76,6 +80,25 @@ class TestGenerationNode(TestCase):
         )
         self.assertEqual(node.model_specs, mbm_specs)
         self.assertIs(node.best_model_selector, model_selector)
+
+    def test_input_constructor_none(self) -> None:
+        self.assertIsNone(self.sobol_generation_node.input_constructors)
+        self.assertIsNone(self.sobol_generation_node._input_constructors)
+
+    def test_input_constructor(self) -> None:
+        node = GenerationNode(
+            node_name="test",
+            model_specs=[self.sobol_model_spec],
+            input_constructors={InputConstructorPurpose.N: NodeInputConstructors.ALL_N},
+        )
+        self.assertEqual(
+            node.input_constructors,
+            {InputConstructorPurpose.N: NodeInputConstructors.ALL_N},
+        )
+        self.assertEqual(
+            node._input_constructors,
+            {InputConstructorPurpose.N: NodeInputConstructors.ALL_N},
+        )
 
     def test_fit(self) -> None:
         dat = self.branin_experiment.lookup_data()

--- a/ax/modelbridge/tests/test_generation_node_input_constructors.py
+++ b/ax/modelbridge/tests/test_generation_node_input_constructors.py
@@ -5,11 +5,14 @@
 
 # pyre-strict
 
+from ax.core.arm import Arm
+from ax.core.generator_run import GeneratorRun
 from ax.modelbridge.generation_node import GenerationNode
 from ax.modelbridge.generation_node_input_constructors import NodeInputConstructors
 from ax.modelbridge.model_spec import ModelSpec
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_branin_experiment
 
 
 class TestGenerationNodeInputConstructors(TestCase):
@@ -23,6 +26,13 @@ class TestGenerationNodeInputConstructors(TestCase):
         self.sobol_generation_node = GenerationNode(
             node_name="test", model_specs=[self.sobol_model_spec]
         )
+        self.experiment = get_branin_experiment(with_completed_trial=True)
+        # construct a list of grs that will mock a list of grs that would exist during
+        # a gs.gen call. This list has one single arm GR, and one 3-arm GR.
+        self.grs = [
+            GeneratorRun(arms=[Arm(parameters={"x1": 1, "x2": 5})]),
+            GeneratorRun(arms=[Arm(parameters={"x1": 1, "x2": y}) for y in range(3)]),
+        ]
 
     def test_consume_all_n_constructor(self) -> None:
         """Test that the consume_all_n_constructor returns full n."""
@@ -54,7 +64,37 @@ class TestGenerationNodeInputConstructors(TestCase):
         self.assertEqual(medium_n, 1)
         self.assertEqual(large_n, 2)
 
-    def test_no_n_provided_error(self) -> None:
+    def test_remaining_n_constructor_expect_1(self) -> None:
+        """Test that the remaining_n_constructor returns the remaining n."""
+        # should return 1 becuase 4 arms already exist and 5 are requested
+        expect_1 = NodeInputConstructors.REMAINING_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 5, "grs": self.grs},
+        )
+        self.assertEqual(expect_1, 1)
+
+    def test_remaining_n_constructor_expect_0(self) -> None:
+        # should return 0 becuase 4 arms already exist and 4 are requested
+        expect_0 = NodeInputConstructors.REMAINING_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 4, "grs": self.grs},
+        )
+        self.assertEqual(expect_0, 0)
+
+    def test_remaining_n_constructor_cap_at_zero(self) -> None:
+        # should return 0 becuase 4 arms already exist and 3 are requested
+        # this is a bad state that should never be hit, but ensuring proper
+        # handling here feels like a valid edge case
+        expect_0 = NodeInputConstructors.REMAINING_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 3, "grs": self.grs},
+        )
+        self.assertEqual(expect_0, 0)
+
+    def test_no_n_provided_error_all_n(self) -> None:
         """Test raise error if n is not specified."""
         with self.assertRaisesRegex(
             NotImplementedError,
@@ -65,11 +105,23 @@ class TestGenerationNodeInputConstructors(TestCase):
                 next_node=self.sobol_generation_node,
                 gs_gen_call_kwargs={},
             )
+
+    def test_no_n_provided_error_repeat_n(self) -> None:
         with self.assertRaisesRegex(
             NotImplementedError,
             " `repeat_arm_n` only supports cases where n is specified",
         ):
             _ = NodeInputConstructors.REPEAT_N(
+                previous_node=None,
+                next_node=self.sobol_generation_node,
+                gs_gen_call_kwargs={},
+            )
+
+    def test_no_n_provided_error_remaining_n(self) -> None:
+        with self.assertRaisesRegex(
+            NotImplementedError, "only supports cases where n is specified"
+        ):
+            _ = NodeInputConstructors.REMAINING_N(
                 previous_node=None,
                 next_node=self.sobol_generation_node,
                 gs_gen_call_kwargs={},

--- a/ax/modelbridge/tests/test_generation_node_input_constructors.py
+++ b/ax/modelbridge/tests/test_generation_node_input_constructors.py
@@ -31,16 +31,45 @@ class TestGenerationNodeInputConstructors(TestCase):
             next_node=self.sobol_generation_node,
             gs_gen_call_kwargs={"n": 5},
         )
-
         self.assertEqual(num_to_gen, 5)
 
-    def test_consume_all_n_constructor_no_n(self) -> None:
+    def test_repeat_arm_n_constructor(self) -> None:
+        """Test that the repeat_arm_n_constructor returns a small percentage of n."""
+        small_n = NodeInputConstructors.REPEAT_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 5},
+        )
+        medium_n = NodeInputConstructors.REPEAT_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 8},
+        )
+        large_n = NodeInputConstructors.REPEAT_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 11},
+        )
+        self.assertEqual(small_n, 0)
+        self.assertEqual(medium_n, 1)
+        self.assertEqual(large_n, 2)
+
+    def test_no_n_provided_error(self) -> None:
         """Test raise error if n is not specified."""
         with self.assertRaisesRegex(
             NotImplementedError,
             "`consume_all_n` only supports cases where n is specified",
         ):
             _ = NodeInputConstructors.ALL_N(
+                previous_node=None,
+                next_node=self.sobol_generation_node,
+                gs_gen_call_kwargs={},
+            )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            " `repeat_arm_n` only supports cases where n is specified",
+        ):
+            _ = NodeInputConstructors.REPEAT_N(
                 previous_node=None,
                 next_node=self.sobol_generation_node,
                 gs_gen_call_kwargs={},

--- a/ax/modelbridge/tests/test_generation_node_input_constructors.py
+++ b/ax/modelbridge/tests/test_generation_node_input_constructors.py
@@ -66,31 +66,31 @@ class TestGenerationNodeInputConstructors(TestCase):
 
     def test_remaining_n_constructor_expect_1(self) -> None:
         """Test that the remaining_n_constructor returns the remaining n."""
-        # should return 1 becuase 4 arms already exist and 5 are requested
+        # should return 1 because 4 arms already exist and 5 are requested
         expect_1 = NodeInputConstructors.REMAINING_N(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"n": 5, "grs": self.grs},
+            gs_gen_call_kwargs={"n": 5, "grs_this_gen": self.grs},
         )
         self.assertEqual(expect_1, 1)
 
     def test_remaining_n_constructor_expect_0(self) -> None:
-        # should return 0 becuase 4 arms already exist and 4 are requested
+        # should return 0 because 4 arms already exist and 4 are requested
         expect_0 = NodeInputConstructors.REMAINING_N(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"n": 4, "grs": self.grs},
+            gs_gen_call_kwargs={"n": 4, "grs_this_gen": self.grs},
         )
         self.assertEqual(expect_0, 0)
 
     def test_remaining_n_constructor_cap_at_zero(self) -> None:
-        # should return 0 becuase 4 arms already exist and 3 are requested
+        # should return 0 because 4 arms already exist and 3 are requested
         # this is a bad state that should never be hit, but ensuring proper
         # handling here feels like a valid edge case
         expect_0 = NodeInputConstructors.REMAINING_N(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"n": 3, "grs": self.grs},
+            gs_gen_call_kwargs={"n": 3, "grs_this_gen": self.grs},
         )
         self.assertEqual(expect_0, 0)
 

--- a/ax/modelbridge/tests/test_generation_node_input_constructors.py
+++ b/ax/modelbridge/tests/test_generation_node_input_constructors.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.modelbridge.generation_node import GenerationNode
+from ax.modelbridge.generation_node_input_constructors import NodeInputConstructors
+from ax.modelbridge.model_spec import ModelSpec
+from ax.modelbridge.registry import Models
+from ax.utils.common.testutils import TestCase
+
+
+class TestGenerationNodeInputConstructors(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.sobol_model_spec = ModelSpec(
+            model_enum=Models.SOBOL,
+            model_kwargs={"init_position": 3},
+            model_gen_kwargs={"some_gen_kwarg": "some_value"},
+        )
+        self.sobol_generation_node = GenerationNode(
+            node_name="test", model_specs=[self.sobol_model_spec]
+        )
+
+    def test_consume_all_n_constructor(self) -> None:
+        """Test that the consume_all_n_constructor returns full n."""
+        num_to_gen = NodeInputConstructors.ALL_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 5},
+        )
+
+        self.assertEqual(num_to_gen, 5)
+
+    def test_consume_all_n_constructor_no_n(self) -> None:
+        """Test raise error if n is not specified."""
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "`consume_all_n` only supports cases where n is specified",
+        ):
+            _ = NodeInputConstructors.ALL_N(
+                previous_node=None,
+                next_node=self.sobol_generation_node,
+                gs_gen_call_kwargs={},
+            )

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -38,6 +38,12 @@ Transition Criterion
     :undoc-members:
     :show-inheritance:
 
+Generation Node Input Constructors
+.. automodule:: ax.modelbridge.generation_node_input_constructors
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Registry
 ~~~~~~~~
 .. automodule:: ax.modelbridge.registry


### PR DESCRIPTION
Summary:
This diff adds support for leveraging the input constructors during gs.gen_with_multiple_nodes(..), as part of this we also add _previous_node param on gennodes. We presist the arms_per_node argument as we believe this is likely useful for researchers and developers internally, but this should never be exposed at api level to not cause confusion.

we also add a e2e style unit test

Follow up diffs:
- storage --> let's do this once we all like the 3 input constructors
- update the input constructors to handle the case where n isn't provided as a kwarg
- add tests for real world scenario per Liz suggestion
- add test to enforce signature across input constructors per Liz/Sait/Daniel suggestion

Differential Revision: D62316641
