### PR TITLE
Add previous node to GenerationNode storage

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -88,7 +88,7 @@ class GenerationNode(SerializationMixin, SortableBase):
         input_constructors: A dictionary mapping input constructor purpose enum to the
             input constructor enum. Each input constructor maps to a method which
             encodes the logic for determining dynamic inputs to the ``GenerationNode``
-        previous_node: The previous ``GenerationNode`` name in the
+        previous_node_name: The previous ``GenerationNode`` name in the
             ``GenerationStrategy``, if any. Initialized to None for all nodes, and is
             set during transition from one ``GenerationNode`` to the next. Can be
             overwritten if multiple transitions occur between nodes, and will always
@@ -115,7 +115,7 @@ class GenerationNode(SerializationMixin, SortableBase):
             modelbridge.generation_node_input_constructors.NodeInputConstructors,
         ]
     ]
-    _previous_node: Optional[str] = None
+    _previous_node_name: Optional[str] = None
 
     # [TODO] Handle experiment passing more eloquently by enforcing experiment
     # attribute is set in generation strategies class
@@ -136,7 +136,7 @@ class GenerationNode(SerializationMixin, SortableBase):
                 modelbridge.generation_node_input_constructors.NodeInputConstructors,
             ]
         ] = None,
-        previous_node: Optional[str] = None,
+        previous_node_name: Optional[str] = None,
     ) -> None:
         self._node_name = node_name
         # Check that the model specs have unique model keys.
@@ -152,7 +152,7 @@ class GenerationNode(SerializationMixin, SortableBase):
         self.should_deduplicate = should_deduplicate
         self._transition_criteria = transition_criteria
         self._input_constructors = input_constructors
-        self._previous_node = previous_node
+        self._previous_node_name = previous_node_name
 
     @property
     def node_name(self) -> str:

--- a/ax/modelbridge/generation_node_input_constructors.py
+++ b/ax/modelbridge/generation_node_input_constructors.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from enum import Enum, unique
+from typing import Any, Dict, Optional
+
+from ax.modelbridge.generation_node import GenerationNode
+
+
+def consume_all_n(
+    previous_node: Optional[GenerationNode],
+    next_node: GenerationNode,
+    gs_gen_call_kwargs: Dict[str, Any],
+) -> int:
+    """Generate total requested number of arms from the next node.
+
+    Example: Initial exploration with Sobol will generate all arms from a
+    single sobol node.
+
+    Args:
+        previous_node: The previous node in the ``GenerationStrategy``. This is the node
+            that is being transition away from, and is provided for easy access to
+            properties of this node.
+        next_node: The next node in the ``GenerationStrategy``. This is the node that
+            will leverage the inputs defined by this input constructor.
+        gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
+            gen call.
+    Returns:
+        The total number of requested arms from the next node.
+    """
+    # TODO: @mgarrard handle case where n isn't specified
+    if gs_gen_call_kwargs.get("n") is None:
+        raise NotImplementedError(
+            f"Currently `{consume_all_n.__name__}` only supports cases where n is "
+            "specified"
+        )
+    return gs_gen_call_kwargs.get("n")
+
+
+@unique
+class NodeInputConstructors(Enum):
+    """An enum which maps to a callable method for constructing ``GenerationNode``
+    inputs.
+    """
+
+    ALL_N = consume_all_n
+
+    def __call__(
+        self,
+        previous_node: Optional[GenerationNode],
+        next_node: GenerationNode,
+        gs_gen_call_kwargs: Dict[str, Any],
+    ) -> int:
+        """Defines a callable method for the Enum as all values are methods"""
+        return self(
+            previous_node=previous_node,
+            next_node=next_node,
+            gs_gen_call_kwargs=gs_gen_call_kwargs,
+        )
+
+
+@unique
+class InputConstructorPurpose(Enum):
+    """A simple enum to indicate the purpose of the input constructor.
+
+    Explanation of the different purposes:
+        N: Defines the logic to determine the number of arms to generate from the
+           next ``GenerationNode`` given the total number of arms expected in
+           this trial.
+    """
+
+    N = "n"

--- a/ax/modelbridge/generation_node_input_constructors.py
+++ b/ax/modelbridge/generation_node_input_constructors.py
@@ -99,7 +99,7 @@ def remaining_n(
             "specified"
         )
     # TODO: @mgarrard improve this logic to be more robust
-    grs_this_gen = gs_gen_call_kwargs.get("grs")
+    grs_this_gen = gs_gen_call_kwargs.get("grs_this_gen")
     total_n = gs_gen_call_kwargs.get("n")
     # if all arms have been generated, return 0
     return max(total_n - sum(len(gr.arms) for gr in grs_this_gen), 0)

--- a/ax/modelbridge/generation_node_input_constructors.py
+++ b/ax/modelbridge/generation_node_input_constructors.py
@@ -58,7 +58,7 @@ def repeat_arm_n(
         gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
             gen call.
     Returns:
-        The number of requested arms from the next node.
+        The number of requested arms from the next node
     """
     if gs_gen_call_kwargs.get("n") is None:
         raise NotImplementedError(
@@ -75,6 +75,36 @@ def repeat_arm_n(
     return ceil(total_n / 10)
 
 
+def remaining_n(
+    previous_node: Optional[GenerationNode],
+    next_node: GenerationNode,
+    gs_gen_call_kwargs: Dict[str, Any],
+) -> int:
+    """Generate the remaining number of arms requested for this trial in gs.gen().
+
+    Args:
+        previous_node: The previous node in the ``GenerationStrategy``. This is the node
+            that is being transition away from, and is provided for easy access to
+            properties of this node.
+        next_node: The next node in the ``GenerationStrategy``. This is the node that
+            will leverage the inputs defined by this input constructor.
+        gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
+            gen call.
+    Returns:
+        The number of requested arms from the next node
+    """
+    if gs_gen_call_kwargs.get("n") is None:
+        raise NotImplementedError(
+            f"Currently `{remaining_n.__name__}` only supports cases where n is "
+            "specified"
+        )
+    # TODO: @mgarrard improve this logic to be more robust
+    grs_this_gen = gs_gen_call_kwargs.get("grs")
+    total_n = gs_gen_call_kwargs.get("n")
+    # if all arms have been generated, return 0
+    return max(total_n - sum(len(gr.arms) for gr in grs_this_gen), 0)
+
+
 @unique
 class NodeInputConstructors(Enum):
     """An enum which maps to a callable method for constructing ``GenerationNode``
@@ -83,6 +113,7 @@ class NodeInputConstructors(Enum):
 
     ALL_N = consume_all_n
     REPEAT_N = repeat_arm_n
+    REMAINING_N = remaining_n
 
     def __call__(
         self,

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -454,7 +454,7 @@ class GenerationStrategy(GenerationStrategyInterface):
             )
             node_to_gen_from = self._nodes[node_names.index(node_to_gen_from_name)]
             if should_transition:
-                node_to_gen_from._previous_node = node_to_gen_from_name
+                node_to_gen_from._previous_node_name = node_to_gen_from_name
             arms_from_node = self._determine_arms_from_node(
                 node_to_gen_from=node_to_gen_from,
                 arms_per_node=arms_per_node,
@@ -904,8 +904,8 @@ class GenerationStrategy(GenerationStrategyInterface):
             arms_from_node = n
         else:
             previous_node = (
-                self._nodes[node_names.index(node_to_gen_from._previous_node)]
-                if node_to_gen_from._previous_node is not None
+                self._nodes[node_names.index(node_to_gen_from._previous_node_name)]
+                if node_to_gen_from._previous_node_name is not None
                 else None
             )
             arms_from_node = node_to_gen_from.input_constructors[

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -82,8 +82,8 @@ class TestGenerationNode(TestCase):
         self.assertIs(node.best_model_selector, model_selector)
 
     def test_input_constructor_none(self) -> None:
-        self.assertIsNone(self.sobol_generation_node.input_constructors)
         self.assertIsNone(self.sobol_generation_node._input_constructors)
+        self.assertEqual(self.sobol_generation_node.input_constructors, {})
 
     def test_input_constructor(self) -> None:
         node = GenerationNode(

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -22,6 +22,10 @@ from ax.modelbridge.generation_node import (
     GenerationStep,
     MISSING_MODEL_SELECTOR_MESSAGE,
 )
+from ax.modelbridge.generation_node_input_constructors import (
+    InputConstructorPurpose,
+    NodeInputConstructors,
+)
 from ax.modelbridge.model_spec import FactoryFunctionModelSpec, ModelSpec
 from ax.modelbridge.registry import Models
 from ax.modelbridge.transition_criterion import MaxTrials
@@ -76,6 +80,25 @@ class TestGenerationNode(TestCase):
         )
         self.assertEqual(node.model_specs, mbm_specs)
         self.assertIs(node.best_model_selector, model_selector)
+
+    def test_input_constructor_none(self) -> None:
+        self.assertIsNone(self.sobol_generation_node.input_constructors)
+        self.assertIsNone(self.sobol_generation_node._input_constructors)
+
+    def test_input_constructor(self) -> None:
+        node = GenerationNode(
+            node_name="test",
+            model_specs=[self.sobol_model_spec],
+            input_constructors={InputConstructorPurpose.N: NodeInputConstructors.ALL_N},
+        )
+        self.assertEqual(
+            node.input_constructors,
+            {InputConstructorPurpose.N: NodeInputConstructors.ALL_N},
+        )
+        self.assertEqual(
+            node._input_constructors,
+            {InputConstructorPurpose.N: NodeInputConstructors.ALL_N},
+        )
 
     def test_fit(self) -> None:
         dat = self.branin_experiment.lookup_data()

--- a/ax/modelbridge/tests/test_generation_node_input_constructors.py
+++ b/ax/modelbridge/tests/test_generation_node_input_constructors.py
@@ -5,11 +5,14 @@
 
 # pyre-strict
 
+from ax.core.arm import Arm
+from ax.core.generator_run import GeneratorRun
 from ax.modelbridge.generation_node import GenerationNode
 from ax.modelbridge.generation_node_input_constructors import NodeInputConstructors
 from ax.modelbridge.model_spec import ModelSpec
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_branin_experiment
 
 
 class TestGenerationNodeInputConstructors(TestCase):
@@ -23,6 +26,13 @@ class TestGenerationNodeInputConstructors(TestCase):
         self.sobol_generation_node = GenerationNode(
             node_name="test", model_specs=[self.sobol_model_spec]
         )
+        self.experiment = get_branin_experiment(with_completed_trial=True)
+        # construct a list of grs that will mock a list of grs that would exist during
+        # a gs.gen call. This list has one single arm GR, and one 3-arm GR.
+        self.grs = [
+            GeneratorRun(arms=[Arm(parameters={"x1": 1, "x2": 5})]),
+            GeneratorRun(arms=[Arm(parameters={"x1": 1, "x2": y}) for y in range(3)]),
+        ]
 
     def test_consume_all_n_constructor(self) -> None:
         """Test that the consume_all_n_constructor returns full n."""
@@ -54,7 +64,37 @@ class TestGenerationNodeInputConstructors(TestCase):
         self.assertEqual(medium_n, 1)
         self.assertEqual(large_n, 2)
 
-    def test_no_n_provided_error(self) -> None:
+    def test_remaining_n_constructor_expect_1(self) -> None:
+        """Test that the remaining_n_constructor returns the remaining n."""
+        # should return 1 becuase 4 arms already exist and 5 are requested
+        expect_1 = NodeInputConstructors.REMAINING_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 5, "grs": self.grs},
+        )
+        self.assertEqual(expect_1, 1)
+
+    def test_remaining_n_constructor_expect_0(self) -> None:
+        # should return 0 becuase 4 arms already exist and 4 are requested
+        expect_0 = NodeInputConstructors.REMAINING_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 4, "grs": self.grs},
+        )
+        self.assertEqual(expect_0, 0)
+
+    def test_remaining_n_constructor_cap_at_zero(self) -> None:
+        # should return 0 becuase 4 arms already exist and 3 are requested
+        # this is a bad state that should never be hit, but ensuring proper
+        # handling here feels like a valid edge case
+        expect_0 = NodeInputConstructors.REMAINING_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 3, "grs": self.grs},
+        )
+        self.assertEqual(expect_0, 0)
+
+    def test_no_n_provided_error_all_n(self) -> None:
         """Test raise error if n is not specified."""
         with self.assertRaisesRegex(
             NotImplementedError,
@@ -65,11 +105,23 @@ class TestGenerationNodeInputConstructors(TestCase):
                 next_node=self.sobol_generation_node,
                 gs_gen_call_kwargs={},
             )
+
+    def test_no_n_provided_error_repeat_n(self) -> None:
         with self.assertRaisesRegex(
             NotImplementedError,
             " `repeat_arm_n` only supports cases where n is specified",
         ):
             _ = NodeInputConstructors.REPEAT_N(
+                previous_node=None,
+                next_node=self.sobol_generation_node,
+                gs_gen_call_kwargs={},
+            )
+
+    def test_no_n_provided_error_remaining_n(self) -> None:
+        with self.assertRaisesRegex(
+            NotImplementedError, "only supports cases where n is specified"
+        ):
+            _ = NodeInputConstructors.REMAINING_N(
                 previous_node=None,
                 next_node=self.sobol_generation_node,
                 gs_gen_call_kwargs={},

--- a/ax/modelbridge/tests/test_generation_node_input_constructors.py
+++ b/ax/modelbridge/tests/test_generation_node_input_constructors.py
@@ -31,16 +31,45 @@ class TestGenerationNodeInputConstructors(TestCase):
             next_node=self.sobol_generation_node,
             gs_gen_call_kwargs={"n": 5},
         )
-
         self.assertEqual(num_to_gen, 5)
 
-    def test_consume_all_n_constructor_no_n(self) -> None:
+    def test_repeat_arm_n_constructor(self) -> None:
+        """Test that the repeat_arm_n_constructor returns a small percentage of n."""
+        small_n = NodeInputConstructors.REPEAT_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 5},
+        )
+        medium_n = NodeInputConstructors.REPEAT_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 8},
+        )
+        large_n = NodeInputConstructors.REPEAT_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 11},
+        )
+        self.assertEqual(small_n, 0)
+        self.assertEqual(medium_n, 1)
+        self.assertEqual(large_n, 2)
+
+    def test_no_n_provided_error(self) -> None:
         """Test raise error if n is not specified."""
         with self.assertRaisesRegex(
             NotImplementedError,
             "`consume_all_n` only supports cases where n is specified",
         ):
             _ = NodeInputConstructors.ALL_N(
+                previous_node=None,
+                next_node=self.sobol_generation_node,
+                gs_gen_call_kwargs={},
+            )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            " `repeat_arm_n` only supports cases where n is specified",
+        ):
+            _ = NodeInputConstructors.REPEAT_N(
                 previous_node=None,
                 next_node=self.sobol_generation_node,
                 gs_gen_call_kwargs={},

--- a/ax/modelbridge/tests/test_generation_node_input_constructors.py
+++ b/ax/modelbridge/tests/test_generation_node_input_constructors.py
@@ -66,31 +66,31 @@ class TestGenerationNodeInputConstructors(TestCase):
 
     def test_remaining_n_constructor_expect_1(self) -> None:
         """Test that the remaining_n_constructor returns the remaining n."""
-        # should return 1 becuase 4 arms already exist and 5 are requested
+        # should return 1 because 4 arms already exist and 5 are requested
         expect_1 = NodeInputConstructors.REMAINING_N(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"n": 5, "grs": self.grs},
+            gs_gen_call_kwargs={"n": 5, "grs_this_gen": self.grs},
         )
         self.assertEqual(expect_1, 1)
 
     def test_remaining_n_constructor_expect_0(self) -> None:
-        # should return 0 becuase 4 arms already exist and 4 are requested
+        # should return 0 because 4 arms already exist and 4 are requested
         expect_0 = NodeInputConstructors.REMAINING_N(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"n": 4, "grs": self.grs},
+            gs_gen_call_kwargs={"n": 4, "grs_this_gen": self.grs},
         )
         self.assertEqual(expect_0, 0)
 
     def test_remaining_n_constructor_cap_at_zero(self) -> None:
-        # should return 0 becuase 4 arms already exist and 3 are requested
+        # should return 0 because 4 arms already exist and 3 are requested
         # this is a bad state that should never be hit, but ensuring proper
         # handling here feels like a valid edge case
         expect_0 = NodeInputConstructors.REMAINING_N(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"n": 3, "grs": self.grs},
+            gs_gen_call_kwargs={"n": 3, "grs_this_gen": self.grs},
         )
         self.assertEqual(expect_0, 0)
 

--- a/ax/modelbridge/tests/test_generation_node_input_constructors.py
+++ b/ax/modelbridge/tests/test_generation_node_input_constructors.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.modelbridge.generation_node import GenerationNode
+from ax.modelbridge.generation_node_input_constructors import NodeInputConstructors
+from ax.modelbridge.model_spec import ModelSpec
+from ax.modelbridge.registry import Models
+from ax.utils.common.testutils import TestCase
+
+
+class TestGenerationNodeInputConstructors(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.sobol_model_spec = ModelSpec(
+            model_enum=Models.SOBOL,
+            model_kwargs={"init_position": 3},
+            model_gen_kwargs={"some_gen_kwarg": "some_value"},
+        )
+        self.sobol_generation_node = GenerationNode(
+            node_name="test", model_specs=[self.sobol_model_spec]
+        )
+
+    def test_consume_all_n_constructor(self) -> None:
+        """Test that the consume_all_n_constructor returns full n."""
+        num_to_gen = NodeInputConstructors.ALL_N(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={"n": 5},
+        )
+
+        self.assertEqual(num_to_gen, 5)
+
+    def test_consume_all_n_constructor_no_n(self) -> None:
+        """Test raise error if n is not specified."""
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "`consume_all_n` only supports cases where n is specified",
+        ):
+            _ = NodeInputConstructors.ALL_N(
+                previous_node=None,
+                next_node=self.sobol_generation_node,
+                gs_gen_call_kwargs={},
+            )

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -1213,7 +1213,7 @@ class TestGenerationStrategy(TestCase):
             ],
         )
         for node in gs._nodes:
-            self.assertIsNone(node._previous_node)
+            self.assertIsNone(node._previous_node_name)
 
     def test_gs_with_generation_nodes(self) -> None:
         "Simple test of a SOBOL + MBM GenerationStrategy composed of GenerationNodes"

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -671,6 +671,11 @@ def generation_node_from_json(
             if "transition_criteria" in generation_node_json.keys()
             else None
         ),
+        previous_node_name=(
+            generation_node_json.pop("previous_node_name")
+            if "previous_node_name" in generation_node_json.keys()
+            else None
+        ),
     )
 
 

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -442,6 +442,7 @@ def generation_node_to_dict(generation_node: GenerationNode) -> dict[str, Any]:
         "should_deduplicate": generation_node.should_deduplicate,
         "transition_criteria": generation_node.transition_criteria,
         "model_spec_to_gen_from": generation_node._model_spec_to_gen_from,
+        "previous_node_name": generation_node._previous_node_name,
     }
 
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -184,6 +184,10 @@ TEST_CASES = [
         "GenerationStrategy",
         partial(sobol_gpei_generation_node_gs, with_auto_transition=True),
     ),
+    (
+        "GenerationStrategy",
+        partial(sobol_gpei_generation_node_gs, with_previous_node=True),
+    ),
     ("GeneratorRun", get_generator_run),
     ("Hartmann6Metric", get_hartmann_metric),
     ("HierarchicalSearchSpace", get_hierarchical_search_space),

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -214,6 +214,7 @@ def get_generation_strategy(
 def sobol_gpei_generation_node_gs(
     with_model_selection: bool = False,
     with_auto_transition: bool = False,
+    with_previous_node: bool = False,
 ) -> GenerationStrategy:
     """Returns a basic SOBOL+MBM GS using GenerationNodes for testing.
 
@@ -301,6 +302,11 @@ def sobol_gpei_generation_node_gs(
             model_specs=mbm_model_specs,
             best_model_selector=best_model_selector,
         )
+
+    # in an actual GS, this would be set during transition, manually setting here for
+    # testing purposes
+    if with_previous_node:
+        mbm_node._previous_node_name = sobol_node.node_name
 
     sobol_mbm_GS_nodes = GenerationStrategy(
         name="Sobol+MBM_Nodes",

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -38,6 +38,12 @@ Transition Criterion
     :undoc-members:
     :show-inheritance:
 
+Generation Node Input Constructors
+.. automodule:: ax.modelbridge.generation_node_input_constructors
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Registry
 ~~~~~~~~
 .. automodule:: ax.modelbridge.registry


### PR DESCRIPTION
Summary:
In the previous diff we added a previous node property to Generation Node, this diff adds storage for that property so it can persist on load of Generation Strategy

Follow up diffs:
- storage for input constructors --> let's do this once we all like the 3 input constructors
- update the input constructors to handle the case where n isn't provided as a kwarg
- add tests for real world scenario per Liz suggestion
- add test to enforce signature across input constructors per Liz/Sait/Daniel suggestion

Differential Revision: D62531632
