### PR TITLE
Delete some unneeded tests

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -32,6 +32,7 @@ from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkRe
 from ax.core.experiment import Experiment
 from ax.core.utils import get_model_times
 from ax.service.scheduler import Scheduler
+from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.utils.common.logger import get_logger
 from ax.utils.common.random import with_rng_seed
 
@@ -116,7 +117,15 @@ def benchmark_replication(
     with with_rng_seed(seed=seed):
         scheduler.run_n_trials(max_trials=problem.num_trials)
 
-    optimization_trace = problem.get_opt_trace(experiment=experiment)
+    oracle_experiment = problem.get_oracle_experiment_from_experiment(
+        experiment=experiment
+    )
+    optimization_trace = np.array(
+        BestPointMixin._get_trace(
+            experiment=oracle_experiment,
+            optimization_config=problem.optimization_config,
+        )
+    )
 
     try:
         # Catch any errors that may occur during score computation, such as errors

--- a/ax/benchmark/tests/problems/test_surrogate_problems.py
+++ b/ax/benchmark/tests/problems/test_surrogate_problems.py
@@ -16,8 +16,6 @@ from ax.utils.testing.benchmark_stubs import get_moo_surrogate, get_soo_surrogat
 class TestSurrogateProblems(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        # print max output so errors in 'repr' can be fully shown
-        self.maxDiff = None
 
     def test_conforms_to_api(self) -> None:
         sbp = get_soo_surrogate()
@@ -25,21 +23,6 @@ class TestSurrogateProblems(TestCase):
 
         mbp = get_moo_surrogate()
         self.assertIsInstance(mbp, BenchmarkProblem)
-
-    def test_repr(self) -> None:
-
-        sbp = get_soo_surrogate()
-
-        expected_repr = (
-            "SurrogateBenchmarkProblem(name='test', "
-            "optimization_config=OptimizationConfig(objective=Objective(metric_name="
-            '"branin", '
-            "minimize=True), "
-            "outcome_constraints=[]), num_trials=6, "
-            "observe_noise_stds=True, "
-            "optimal_value=0.0)"
-        )
-        self.assertEqual(repr(sbp), expected_repr)
 
     def test_compute_score_trace(self) -> None:
         soo_problem = get_soo_surrogate()

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -149,15 +149,6 @@ class TestBenchmarkProblem(TestCase):
                 self.assertEqual(
                     test_problem.optimization_config.outcome_constraints, []
                 )
-                expected_repr = (
-                    "BenchmarkProblem(name='Ackley', "
-                    "optimization_config=OptimizationConfig(objective=Objective("
-                    'metric_name="Ackley", '
-                    "minimize=True), outcome_constraints=[]), "
-                    "num_trials=1, "
-                    "observe_noise_stds=False, "
-                    "optimal_value=0.0)"
-                )
             else:
                 outcome_constraint = (
                     test_problem.optimization_config.outcome_constraints[0]
@@ -166,18 +157,6 @@ class TestBenchmarkProblem(TestCase):
                 self.assertEqual(outcome_constraint.op, ComparisonOp.GEQ)
                 self.assertFalse(outcome_constraint.relative)
                 self.assertEqual(outcome_constraint.bound, 0.0)
-                expected_repr = (
-                    "BenchmarkProblem(name='ConstrainedHartmann', "
-                    "optimization_config=OptimizationConfig(objective=Objective("
-                    'metric_name="ConstrainedHartmann", minimize=True), '
-                    "outcome_constraints=[OutcomeConstraint(constraint_slack_0"
-                    " >= 0.0)]), "
-                    "num_trials=1, "
-                    "observe_noise_stds=False, "
-                    "optimal_value=-3.32237)"
-                )
-
-            self.assertEqual(repr(test_problem), expected_repr)
 
     def _test_constrained_from_botorch(
         self,

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -237,7 +237,7 @@ def get_best_parameters_from_model_predictions_with_trial_index(
             except ValueError:
                 return _gr_to_prediction_with_trial_index(idx, gr)
 
-            # If model is not TorchModelBridge, just use the best arm frmo the
+            # If model is not TorchModelBridge, just use the best arm from the
             # last good generator run
             if not isinstance(model, TorchModelBridge):
                 return _gr_to_prediction_with_trial_index(idx, gr)


### PR DESCRIPTION
Summary:
Context: There used to be more `BenchmarkProblem` subclasses, and they used to implement their own '__repr__' methods, so there were tests for the custom repr methods. Now `BenchmarkProblem` and its subclass `SurrogateBenchmarkProblem` get their `__repr__` methods from being data classes. These tests have become annoying because they break with any change to `BenchmarkProblem, even if just changing the order of arguments.

This PR:
* Removes two `test_repr` methods.

Reviewed By: Balandat

Differential Revision: D62518032
