### PR TITLE
In 'best_point' don't require GeneratorRun to have best_arm_predictions to predict from model

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -32,6 +32,7 @@ from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkRe
 from ax.core.experiment import Experiment
 from ax.core.utils import get_model_times
 from ax.service.scheduler import Scheduler
+from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.utils.common.logger import get_logger
 from ax.utils.common.random import with_rng_seed
 
@@ -116,7 +117,15 @@ def benchmark_replication(
     with with_rng_seed(seed=seed):
         scheduler.run_n_trials(max_trials=problem.num_trials)
 
-    optimization_trace = problem.get_opt_trace(experiment=experiment)
+    oracle_experiment = problem.get_oracle_experiment_from_experiment(
+        experiment=experiment
+    )
+    optimization_trace = np.array(
+        BestPointMixin._get_trace(
+            experiment=oracle_experiment,
+            optimization_config=problem.optimization_config,
+        )
+    )
 
     try:
         # Catch any errors that may occur during score computation, such as errors

--- a/ax/benchmark/tests/problems/test_surrogate_problems.py
+++ b/ax/benchmark/tests/problems/test_surrogate_problems.py
@@ -16,8 +16,6 @@ from ax.utils.testing.benchmark_stubs import get_moo_surrogate, get_soo_surrogat
 class TestSurrogateProblems(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        # print max output so errors in 'repr' can be fully shown
-        self.maxDiff = None
 
     def test_conforms_to_api(self) -> None:
         sbp = get_soo_surrogate()
@@ -25,21 +23,6 @@ class TestSurrogateProblems(TestCase):
 
         mbp = get_moo_surrogate()
         self.assertIsInstance(mbp, BenchmarkProblem)
-
-    def test_repr(self) -> None:
-
-        sbp = get_soo_surrogate()
-
-        expected_repr = (
-            "SurrogateBenchmarkProblem(name='test', "
-            "optimization_config=OptimizationConfig(objective=Objective(metric_name="
-            '"branin", '
-            "minimize=True), "
-            "outcome_constraints=[]), num_trials=6, "
-            "observe_noise_stds=True, "
-            "optimal_value=0.0)"
-        )
-        self.assertEqual(repr(sbp), expected_repr)
 
     def test_compute_score_trace(self) -> None:
         soo_problem = get_soo_surrogate()

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -149,15 +149,6 @@ class TestBenchmarkProblem(TestCase):
                 self.assertEqual(
                     test_problem.optimization_config.outcome_constraints, []
                 )
-                expected_repr = (
-                    "BenchmarkProblem(name='Ackley', "
-                    "optimization_config=OptimizationConfig(objective=Objective("
-                    'metric_name="Ackley", '
-                    "minimize=True), outcome_constraints=[]), "
-                    "num_trials=1, "
-                    "observe_noise_stds=False, "
-                    "optimal_value=0.0)"
-                )
             else:
                 outcome_constraint = (
                     test_problem.optimization_config.outcome_constraints[0]
@@ -166,18 +157,6 @@ class TestBenchmarkProblem(TestCase):
                 self.assertEqual(outcome_constraint.op, ComparisonOp.GEQ)
                 self.assertFalse(outcome_constraint.relative)
                 self.assertEqual(outcome_constraint.bound, 0.0)
-                expected_repr = (
-                    "BenchmarkProblem(name='ConstrainedHartmann', "
-                    "optimization_config=OptimizationConfig(objective=Objective("
-                    'metric_name="ConstrainedHartmann", minimize=True), '
-                    "outcome_constraints=[OutcomeConstraint(constraint_slack_0"
-                    " >= 0.0)]), "
-                    "num_trials=1, "
-                    "observe_noise_stds=False, "
-                    "optimal_value=-3.32237)"
-                )
-
-            self.assertEqual(repr(test_problem), expected_repr)
 
     def _test_constrained_from_botorch(
         self,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -79,6 +79,7 @@ from ax.utils.testing.core_stubs import DummyEarlyStoppingStrategy
 from ax.utils.testing.mock import fast_botorch_optimize
 from ax.utils.testing.modeling_stubs import get_observation1, get_observation1trans
 from botorch.test_functions.multi_objective import BraninCurrin
+from pyre_extensions import none_throws
 
 if TYPE_CHECKING:
     from ax.core.types import TTrialEvaluation
@@ -1477,20 +1478,15 @@ class TestAxClient(TestCase):
     )
     def test_get_best_point_no_model_predictions(
         self,
-        # pyre-fixme[2]: Parameter must be annotated.
-        mock_get_best_parameters_from_model_predictions_with_trial_index,
+        mock_get_best_parameters_from_model_predictions_with_trial_index: Mock,
     ) -> None:
         ax_client = get_branin_optimization()
         params, idx = ax_client.get_next_trial()
         ax_client.complete_trial(trial_index=idx, raw_data={"branin": (0, 0.0)})
-        # pyre-fixme[23]: Unable to unpack `Optional[Tuple[int, Dict[str,
-        #  typing.Union[None, bool, float, int, str]], Optional[Tuple[Dict[str, float],
-        #  Optional[Dict[str, typing.Dict[str, float]]]]]]]` into 3 values.
-        best_idx, best_params, _ = ax_client.get_best_trial()
+        best_idx, best_params, _ = none_throws(ax_client.get_best_trial())
         self.assertEqual(best_idx, idx)
         self.assertEqual(best_params, params)
-        # pyre-fixme[16]: `Optional` has no attribute `__getitem__`.
-        self.assertEqual(ax_client.get_best_parameters()[0], params)
+        self.assertEqual(none_throws(ax_client.get_best_parameters())[0], params)
         mock_get_best_parameters_from_model_predictions_with_trial_index.assert_called()
         mock_get_best_parameters_from_model_predictions_with_trial_index.reset_mock()
         ax_client.get_best_parameters(use_model_predictions=False)

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -117,7 +117,14 @@ class TestBestPointUtils(TestCase):
                 mock_model_best_point.assert_called()
 
         # Assert the non-mocked method works correctly as well
-        self.assertIsNotNone(get_best_parameters(exp, Models))
+        best_params = get_best_parameters(exp, Models)
+        self.assertIsNotNone(best_params)
+        # It works even when there are no predictions already stored on the
+        # GeneratorRun
+        for trial in exp.trials.values():
+            trial.generator_run._best_arm_predictions = None
+        best_params_no_gr = get_best_parameters(exp, Models)
+        self.assertEqual(best_params, best_params_no_gr)
 
     def test_best_raw_objective_point(self) -> None:
         exp = get_branin_experiment()

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -237,7 +237,7 @@ def get_best_parameters_from_model_predictions_with_trial_index(
             except ValueError:
                 return _gr_to_prediction_with_trial_index(idx, gr)
 
-            # If model is not TorchModelBridge, just use the best arm frmo the
+            # If model is not TorchModelBridge, just use the best arm from the
             # last good generator run
             if not isinstance(model, TorchModelBridge):
                 return _gr_to_prediction_with_trial_index(idx, gr)

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -224,7 +224,7 @@ def get_best_parameters_from_model_predictions_with_trial_index(
                 # In theory batch_trial can have >1 gr, grab the first
                 gr = trial.generator_run_structs[0].generator_run
 
-        if gr is not None and gr.best_arm_predictions is not None:
+        if gr is not None:
             data = experiment.lookup_data(trial_indices=trial_indices)
 
             try:


### PR DESCRIPTION
Summary:
Context:

`get_best_parameters_from_model_predictions_with_trial_index` will only predict from a model if there are `best_arm_predictions` on the `GeneratorRun`. This doesn't make sense, since it's about to construct and fit a new model and use it to generate predicts. Any existing `best_arm_predictions` are not used.

This PR:
* Removes the `gr.best_arm_predictions is not None` check
* Changes how some imported functions are referenced in `best_point_mixin.py` (doesn't change functionality)

Reviewed By: mpolson64

Differential Revision: D62594017
