### PR TITLE
load aux experiments with `skip_runners_and_metrics=True`

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -125,7 +125,11 @@ class Decoder:
                 for aux_exp_name in aux_exp_names:
                     auxiliary_experiments_by_purpose[aux_exp_purpose].append(
                         AuxiliaryExperiment(
-                            experiment=load_experiment(aux_exp_name, config=self.config)
+                            experiment=load_experiment(
+                                aux_exp_name,
+                                config=self.config,
+                                skip_runners_and_metrics=True,
+                            )
                         )
                     )
         return auxiliary_experiments_by_purpose

--- a/ax/storage/sqa_store/load.py
+++ b/ax/storage/sqa_store/load.py
@@ -57,7 +57,7 @@ def load_experiment(
         config: `SQAConfig`, from which to retrieve the decoder. Optional,
             defaults to base `SQAConfig`.
         reduced_state: Whether to load experiment with a slightly reduced state
-            (without abandoned arms on experiment and withoug model state,
+            (without abandoned arms on experiment and without model state,
             search space, and optimization config on generator runs).
         skip_runners_and_metrics: If True skip loading runners, and do only a
             minimal load of metrics. This option is intended to enable loading of


### PR DESCRIPTION
Summary:
Load aux experiments with `skip_runners_and_metrics=True` by default.

meta: when an exp is saved with application specific (e.g., PTS) encoder, trying to load metrics with the generic FBDecoder (and OSS one probably as well) will result in fail to load metric error.

Differential Revision: D62661185
