### PR TITLE
Have scheduler give clearer error message when it has no metrics

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1874,14 +1874,15 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             raise UnsupportedError(
                 "`Scheduler` requires that experiment specifies a `Runner`."
             )
-        msg = (
-            "`Scheduler` requires that experiment specifies metrics "
-            "with implemented fetching logic."
-        )
         metrics_are_invalid = False
         if not experiment.metrics:
+            msg = "`Scheduler` requires that `experiment.metrics` not be None."
             metrics_are_invalid = True
         else:
+            msg = (
+                "`Scheduler` requires that experiment specifies metrics "
+                "with implemented fetching logic."
+            )
             base_metrics = {
                 m_name for m_name, m in experiment.metrics.items() if type(m) is Metric
             }

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -426,16 +426,29 @@ class AxSchedulerTestCase(TestCase):
 
     def test_init_with_no_impl_with_runner(self) -> None:
         self.branin_experiment_no_impl_runner_or_metrics.runner = self.runner
+        generation_strategy = self._get_generation_strategy_strategy_for_test(
+            experiment=self.branin_experiment_no_impl_runner_or_metrics,
+            generation_strategy=self.sobol_GPEI_GS,
+        )
         with self.assertRaisesRegex(
             UnsupportedError,
             ".*Metrics {'branin'} do not implement fetching logic.",
         ):
             Scheduler(
                 experiment=self.branin_experiment_no_impl_runner_or_metrics,
-                generation_strategy=self._get_generation_strategy_strategy_for_test(
-                    experiment=self.branin_experiment_no_impl_runner_or_metrics,
-                    generation_strategy=self.sobol_GPEI_GS,
-                ),
+                generation_strategy=generation_strategy,
+                options=SchedulerOptions(total_trials=10),
+                db_settings=self.db_settings_if_always_needed,
+            )
+
+        self.branin_experiment_no_impl_runner_or_metrics._optimization_config = None
+        with self.assertRaisesRegex(
+            UnsupportedError,
+            "`Scheduler` requires that `experiment.metrics` not be None.",
+        ):
+            Scheduler(
+                experiment=self.branin_experiment_no_impl_runner_or_metrics,
+                generation_strategy=generation_strategy,
                 options=SchedulerOptions(total_trials=10),
                 db_settings=self.db_settings_if_always_needed,
             )


### PR DESCRIPTION
Summary: Scheduler used to complain about metrics not implementing fetching logic either when there are metrics but they don't implement fetching logic or when there are no metrics. Now the latter situation gives an error that the metrics must not be None.

Reviewed By: Balandat

Differential Revision: D63151740
