### PR TITLE
Allow removal of parameters with different values in RemoveFixed transform

### DIFF
--- a/ax/modelbridge/transforms/remove_fixed.py
+++ b/ax/modelbridge/transforms/remove_fixed.py
@@ -48,14 +48,8 @@ class RemoveFixed(Transform):
         self, observation_features: list[ObservationFeatures]
     ) -> list[ObservationFeatures]:
         for obsf in observation_features:
-            for p_name, fixed_p in self.fixed_parameters.items():
-                if p_name in obsf.parameters:
-                    if obsf.parameters[p_name] != fixed_p.value:
-                        raise ValueError(
-                            f"Fixed parameter {p_name} with out of design value: "
-                            f"{obsf.parameters[p_name]} passed to `RemoveFixed`."
-                        )
-                    obsf.parameters.pop(p_name)
+            for p_name in self.fixed_parameters:
+                obsf.parameters.pop(p_name, None)
         return observation_features
 
     def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:

--- a/ax/modelbridge/transforms/tests/test_remove_fixed_transform.py
+++ b/ax/modelbridge/transforms/tests/test_remove_fixed_transform.py
@@ -58,12 +58,15 @@ class RemoveFixedTransformTest(TestCase):
         observation_features = [
             ObservationFeatures(parameters={"a": 2.2, "b": "b", "c": "a"})
         ]
-        observation_features_invalid = [
+        observation_features_different = [
             ObservationFeatures(parameters={"a": 2.2, "b": "b", "c": "b"})
         ]
-        # Fixed parameter out of design!
-        with self.assertRaises(ValueError):
-            self.t.transform_observation_features(observation_features_invalid)
+        # Fixed parameter is out of design. It will still get removed.
+        t_obs = self.t.transform_observation_features(observation_features)
+        t_obs_different = self.t.transform_observation_features(
+            observation_features_different
+        )
+        self.assertEqual(t_obs, t_obs_different)
 
     def test_TransformSearchSpace(self) -> None:
         ss2 = self.search_space.clone()


### PR DESCRIPTION
Summary:
Previously, the `RemoveFixed.transform_observation_features` transform checked that the parameter being removed had the same value as the fixed parameter in the search space used to initialize the transform.
This diff removes this check to allow removal of any observation parameter with the same name. This will allow the transform to operate on observations from two similar but non-identical search spaces.

Differential Revision: D63322396
