### PR TITLE
Avoid recursive auxiliary experiment loading

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -129,6 +129,7 @@ class Decoder:
                                 aux_exp_name,
                                 config=self.config,
                                 skip_runners_and_metrics=True,
+                                load_auxiliary_experiments=False,
                             )
                         )
                     )
@@ -138,6 +139,7 @@ class Decoder:
         self,
         experiment_sqa: SQAExperiment,
         ax_object_field_overrides: Optional[dict[str, Any]] = None,
+        load_auxiliary_experiments: bool = True,
     ) -> Experiment:
         """First step of conversion within experiment_from_sqa."""
         opt_config, tracking_metrics = self.opt_config_and_tracking_metrics_from_sqa(
@@ -180,9 +182,13 @@ class Decoder:
         default_data_type = experiment_sqa.default_data_type
 
         auxiliary_experiments_by_purpose = (
-            self._auxiliary_experiments_by_purpose_from_experiment_sqa(
-                experiment_sqa=experiment_sqa
+            (
+                self._auxiliary_experiments_by_purpose_from_experiment_sqa(
+                    experiment_sqa=experiment_sqa
+                )
             )
+            if load_auxiliary_experiments
+            else {}
         )
 
         return Experiment(
@@ -258,6 +264,7 @@ class Decoder:
         experiment_sqa: SQAExperiment,
         reduced_state: bool = False,
         ax_object_field_overrides: Optional[dict[str, Any]] = None,
+        load_auxiliary_experiments: bool = True,
     ) -> Experiment:
         """Convert SQLAlchemy Experiment to Ax Experiment.
 
@@ -270,13 +277,16 @@ class Decoder:
                 to override values loaded objects will all be instantiated with fields
                 set to override value
                 current valid object types are: "runner"
+            load_auxiliary_experiment: whether to load auxiliary experiments.
         """
         subclass = (experiment_sqa.properties or {}).get(Keys.SUBCLASS)
         if subclass == "MultiTypeExperiment":
             experiment = self._init_mt_experiment_from_sqa(experiment_sqa)
         else:
             experiment = self._init_experiment_from_sqa(
-                experiment_sqa, ax_object_field_overrides=ax_object_field_overrides
+                experiment_sqa,
+                ax_object_field_overrides=ax_object_field_overrides,
+                load_auxiliary_experiments=load_auxiliary_experiments,
             )
         trials = [
             self.trial_from_sqa(

--- a/ax/storage/sqa_store/load.py
+++ b/ax/storage/sqa_store/load.py
@@ -49,6 +49,7 @@ def load_experiment(
     reduced_state: bool = False,
     load_trials_in_batches_of_size: Optional[int] = None,
     skip_runners_and_metrics: bool = False,
+    load_auxiliary_experiments: bool = True,
 ) -> Experiment:
     """Load experiment by name.
 
@@ -65,6 +66,7 @@ def load_experiment(
             on a registry. Note that even though the intention is to skip loading
             of metrics, this option converts the loaded metrics into a base
             metric avoiding conversion related to custom properties of the metric.
+        load_auxiliary_experiments: whether to load auxiliary experiments.
     """
     config = SQAConfig() if config is None else config
     decoder = Decoder(config=config)
@@ -74,6 +76,7 @@ def load_experiment(
         reduced_state=reduced_state,
         load_trials_in_batches_of_size=load_trials_in_batches_of_size,
         skip_runners_and_metrics=skip_runners_and_metrics,
+        load_auxiliary_experiments=load_auxiliary_experiments,
     )
 
 
@@ -84,6 +87,7 @@ def _load_experiment(
     load_trials_in_batches_of_size: Optional[int] = None,
     ax_object_field_overrides: Optional[dict[str, Any]] = None,
     skip_runners_and_metrics: bool = False,
+    load_auxiliary_experiments: bool = True,
 ) -> Experiment:
     """Load experiment by name, using given Decoder instance.
 
@@ -100,7 +104,7 @@ def _load_experiment(
             to override values loaded objects will all be instantiated with fields
             set to override value
             current valid object types are: "runner"
-
+        load_auxiliary_experiments: whether to load auxiliary experiments.
     """
 
     # pyre-ignore Incompatible variable type [9]: exp_sqa_class is declared to have type
@@ -167,6 +171,7 @@ def _load_experiment(
         experiment_sqa=experiment_sqa,
         reduced_state=reduced_state,
         ax_object_field_overrides=ax_object_field_overrides,
+        load_auxiliary_experiments=load_auxiliary_experiments,
     )
 
 


### PR DESCRIPTION
Summary:
When loading an experiment with aux experiments that eventually recursively point to the experiment itself, we will trigger a "maximum recursion depth exceeded" error.

In this diff, we prevent loading auxiliary experiments recursively to avoid this error.

Differential Revision: D63367943
