### PR TITLE
Don't require n in the signature of gen mfm and multiple nodes methods

### DIFF
--- a/ax/core/generation_strategy_interface.py
+++ b/ax/core/generation_strategy_interface.py
@@ -33,6 +33,10 @@ class GenerationStrategyInterface(ABC, Base):
     # it exists.
     _experiment: Optional[Experiment] = None
 
+    # Constant for default number of arms to generate if `n` is not specified in
+    # `gen` call and "total_concurrent_arms" is not set in experiment properties.
+    DEFAULT_N: int = 1
+
     def __init__(self, name: str) -> None:
         self._name = name
 
@@ -44,7 +48,7 @@ class GenerationStrategyInterface(ABC, Base):
         # TODO[drfreund, danielcohennyc, mgarrard]: Update the format of the arguments
         # below as we find the right one.
         num_generator_runs: int = 1,
-        n: int = 1,
+        n: Optional[int] = None,
     ) -> list[list[GeneratorRun]]:
         """Produce ``GeneratorRun``-s for multiple trials at once with the possibility
         of joining ``GeneratorRun``-s from multiple models into one ``BatchTrial``.

--- a/ax/core/tests/test_generation_strategy_interface.py
+++ b/ax/core/tests/test_generation_strategy_interface.py
@@ -24,7 +24,7 @@ class MyGSI(GenerationStrategyInterface):
         # TODO[drfreund, danielcohennyc, mgarrard]: Update the format of the arguments
         # below as we find the right one.
         num_generator_runs: int = 1,
-        n: int = 1,
+        n: Optional[int] = None,
     ) -> list[list[GeneratorRun]]:
         raise NotImplementedError
 

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1583,13 +1583,15 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         existing_candidate_trials = self.candidate_trials[:n]
         n_new = min(n - len(existing_candidate_trials), max_new_trials)
         new_trials = (
-            self._get_next_trials(num_trials=n_new, n=(self.options.batch_size or 1))
+            self._get_next_trials(num_trials=n_new, n=self.options.batch_size)
             if n_new > 0
             else []
         )
         return existing_candidate_trials, new_trials
 
-    def _get_next_trials(self, num_trials: int = 1, n: int = 1) -> list[BaseTrial]:
+    def _get_next_trials(
+        self, num_trials: int = 1, n: Optional[int] = None
+    ) -> list[BaseTrial]:
         """Produce up to `num_trials` new generator runs from the underlying
         generation strategy and create new trials with them. Logs errors
         encountered during generation.
@@ -1743,7 +1745,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
     def _gen_new_trials_from_generation_strategy(
         self,
         num_trials: int,
-        n: int,
+        n: Optional[int] = None,
     ) -> list[list[GeneratorRun]]:
         """Generates a list ``GeneratorRun``s of length of ``num_trials`` using the
         ``_gen_multiple`` method of the scheduler's ``generation_strategy``, taking

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2442,7 +2442,7 @@ class SpecialGenerationStrategy(GenerationStrategyInterface):
         experiment: Experiment,
         num_generator_runs: int,
         data: Optional[Data] = None,
-        n: int = 1,
+        n: Optional[int] = None,
     ) -> list[list[GeneratorRun]]:
         return []
 


### PR DESCRIPTION
Summary: This is so in the future n can be logically determined inside GS.

Reviewed By: mgarrard

Differential Revision: D63343207
