### PR TITLE
Fix sqa storage issue for input_constructors

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from logging import Logger
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 # Module-level import to avoid circular dependency b/w this file and
 # generation_strategy.py
@@ -109,7 +109,7 @@ class GenerationNode(SerializationMixin, SortableBase):
     _model_spec_to_gen_from: Optional[ModelSpec] = None
     # TODO: @mgarrard should this be a dict criterion_class name -> criterion mapping?
     _transition_criteria: Sequence[TransitionCriterion]
-    _input_constructors: Dict[
+    _input_constructors: dict[
         modelbridge.generation_node_input_constructors.InputConstructorPurpose,
         modelbridge.generation_node_input_constructors.NodeInputConstructors,
     ]
@@ -129,7 +129,7 @@ class GenerationNode(SerializationMixin, SortableBase):
         should_deduplicate: bool = False,
         transition_criteria: Optional[Sequence[TransitionCriterion]] = None,
         input_constructors: Optional[
-            Dict[
+            dict[
                 modelbridge.generation_node_input_constructors.InputConstructorPurpose,
                 modelbridge.generation_node_input_constructors.NodeInputConstructors,
             ]
@@ -204,7 +204,7 @@ class GenerationNode(SerializationMixin, SortableBase):
     @property
     def input_constructors(
         self,
-    ) -> Dict[
+    ) -> dict[
         modelbridge.generation_node_input_constructors.InputConstructorPurpose,
         modelbridge.generation_node_input_constructors.NodeInputConstructors,
     ]:

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -443,7 +443,12 @@ def generation_node_to_dict(generation_node: GenerationNode) -> dict[str, Any]:
         "transition_criteria": generation_node.transition_criteria,
         "model_spec_to_gen_from": generation_node._model_spec_to_gen_from,
         "previous_node_name": generation_node._previous_node_name,
-        "input_constructors": generation_node.input_constructors,
+        # need to manually encode input constructors because the key is an enum.
+        # Our encoding and decoding logic in object_to_json and object_from_json
+        # doesn't recursively encode/decode the keys of dictionaries.
+        "input_constructors": {
+            key.name: value for key, value in generation_node.input_constructors.items()
+        },
     }
 
 

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -123,7 +123,10 @@ from ax.utils.testing.core_stubs import (
     get_sum_constraint2,
     get_synthetic_runner,
 )
-from ax.utils.testing.modeling_stubs import get_generation_strategy
+from ax.utils.testing.modeling_stubs import (
+    get_generation_strategy,
+    sobol_gpei_generation_node_gs,
+)
 from plotly import graph_objects as go, io as pio
 
 logger: Logger = get_logger(__name__)
@@ -1500,6 +1503,61 @@ class SQAStoreTest(TestCase):
             not_none(new_generation_strategy._experiment)._name, experiment._name
         )
 
+    def test_EncodeDecodeGenerationNodeGSWithAdvancedSettings(self) -> None:
+        """Test to ensure that GenerationNode based GenerationStrategies are
+        able to be encoded/decoded correctly. This test adds transition criteria
+        and input constructors to the nodes in the generation strategy.
+        """
+        generation_strategy = sobol_gpei_generation_node_gs(
+            with_input_constructors_all_n=True
+        )
+
+        # Try restoring this generation strategy by its ID in the DB.
+        save_generation_strategy(generation_strategy=generation_strategy)
+        new_generation_strategy = load_generation_strategy_by_id(
+            # pyre-fixme[6]: For 1st param expected `int` but got `Optional[int]`.
+            gs_id=generation_strategy._db_id
+        )
+
+        # Some fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._unset_non_persistent_state_fields()
+        self.assertEqual(generation_strategy, new_generation_strategy)
+        self.assertIsNone(generation_strategy._experiment)
+        experiment = get_branin_experiment()
+        save_experiment(experiment)
+
+        # Check that we can encode and decode the generation strategy *after*
+        # it has generated some trials and been updated with some data.
+        # Since we now need to `gen`, we remove the fake callable kwarg we added,
+        # since model does not expect it.
+        generation_strategy = sobol_gpei_generation_node_gs(
+            with_input_constructors_all_n=True
+        )
+        experiment.new_trial(generation_strategy.gen(experiment=experiment))
+        generation_strategy.gen(experiment, data=get_branin_data())
+        save_experiment(experiment)
+        save_generation_strategy(generation_strategy=generation_strategy)
+
+        # Try restoring the generation strategy using the experiment its
+        # attached to.
+        new_generation_strategy = load_generation_strategy_by_experiment_name(
+            experiment_name=experiment.name
+        )
+        # Some fields of the reloaded GS are not expected to be set (both will be
+        # set during next model fitting call), so we unset them on the original GS as
+        # well.
+        generation_strategy._unset_non_persistent_state_fields()
+        self.assertEqual(generation_strategy, new_generation_strategy)
+        self.assertIsInstance(
+            new_generation_strategy._nodes[0].model_spec_to_gen_from.model_enum, Models
+        )
+        self.assertEqual(len(new_generation_strategy._generator_runs), 2)
+        self.assertEqual(
+            not_none(new_generation_strategy._experiment)._name, experiment._name
+        )
+
     def test_EncodeDecodeGenerationNodeBasedGenerationStrategy(self) -> None:
         """Test to ensure that GenerationNode based GenerationStrategies are
         able to be encoded/decoded correctly.
@@ -1537,7 +1595,7 @@ class SQAStoreTest(TestCase):
         experiment.new_trial(generation_strategy.gen(experiment=experiment))
         generation_strategy.gen(experiment, data=get_branin_data())
         save_experiment(experiment)
-        # TODO @mgarrard passes up until this point
+
         save_generation_strategy(generation_strategy=generation_strategy)
         # Try restoring the generation strategy using the experiment its
         # attached to.


### PR DESCRIPTION
Summary: I recently added storage for input constructors, and our json tests pass for this because json is able to eloquently handle the enum of inputconstructorpurpose since the enum value is a string, however, it looks like sqa storage is not able to do this.

Differential Revision: D63442156
