### PR TITLE
Use experiment._properties["total_concurrent_arms"] for determining n

### DIFF
--- a/ax/core/generation_strategy_interface.py
+++ b/ax/core/generation_strategy_interface.py
@@ -33,6 +33,10 @@ class GenerationStrategyInterface(ABC, Base):
     # it exists.
     _experiment: Optional[Experiment] = None
 
+    # Constant for default number of arms to generate if `n` is not specified in
+    # `gen` call and "total_concurrent_arms" is not set in experiment properties.
+    DEFAULT_N: int = 1
+
     def __init__(self, name: str) -> None:
         self._name = name
 
@@ -44,7 +48,7 @@ class GenerationStrategyInterface(ABC, Base):
         # TODO[drfreund, danielcohennyc, mgarrard]: Update the format of the arguments
         # below as we find the right one.
         num_generator_runs: int = 1,
-        n: int = 1,
+        n: Optional[int] = None,
     ) -> list[list[GeneratorRun]]:
         """Produce ``GeneratorRun``-s for multiple trials at once with the possibility
         of joining ``GeneratorRun``-s from multiple models into one ``BatchTrial``.

--- a/ax/core/tests/test_generation_strategy_interface.py
+++ b/ax/core/tests/test_generation_strategy_interface.py
@@ -24,7 +24,7 @@ class MyGSI(GenerationStrategyInterface):
         # TODO[drfreund, danielcohennyc, mgarrard]: Update the format of the arguments
         # below as we find the right one.
         num_generator_runs: int = 1,
-        n: int = 1,
+        n: Optional[int] = None,
     ) -> list[list[GeneratorRun]]:
         raise NotImplementedError
 

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -55,6 +55,7 @@ from ax.modelbridge.transition_criterion import (
     MinTrials,
 )
 from ax.models.random.sobol import SobolGenerator
+from ax.utils.common.constants import Keys
 from ax.utils.common.equality import same_elements
 from ax.utils.common.mock import mock_patch_method_original
 from ax.utils.common.testutils import TestCase
@@ -922,6 +923,19 @@ class TestGenerationStrategy(TestCase):
                             for p in original_pending[m]:
                                 self.assertIn(p, pending[m])
 
+    def test_gen_for_multiple_uses_total_concurrent_arms_for_a_default(
+        self,
+    ) -> None:
+        exp = get_branin_experiment()
+        gs = self.sobol_GS
+        gs.experiment = exp
+        exp._properties[Keys.EXPERIMENT_TOTAL_CONCURRENT_ARMS.value] = 3
+        grs = gs.gen_for_multiple_trials_with_multiple_models(exp, num_generator_runs=2)
+        self.assertEqual(len(grs), 2)
+        for gr_list in grs:
+            self.assertEqual(len(gr_list), 1)
+            self.assertEqual(len(gr_list[0].arms), 3)
+
     def test_gen_for_multiple_trials_with_multiple_models(self) -> None:
         exp = get_experiment_with_multi_objective()
         sobol_MBM_gs = self.sobol_MBM_step_GS
@@ -1470,6 +1484,15 @@ class TestGenerationStrategy(TestCase):
         )
         self.assertEqual(trial.generator_runs[0]._generation_node_name, "sobol_4")
         self.assertEqual(len(trial.generator_runs[0].arms), 4)
+
+    def test_gen_with_multiple_uses_total_concurrent_arms_for_a_default(self) -> None:
+        exp = get_branin_experiment()
+        gs = self.sobol_GS
+        gs.experiment = exp
+        exp._properties[Keys.EXPERIMENT_TOTAL_CONCURRENT_ARMS.value] = 3
+        grs = gs.gen_with_multiple_nodes(exp)
+        self.assertEqual(len(grs), 1)
+        self.assertEqual(len(grs[0].arms), 3)
 
     def test_node_gs_with_auto_transitions(self) -> None:
         """Test that node-based generation strategies which leverage

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1583,13 +1583,15 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         existing_candidate_trials = self.candidate_trials[:n]
         n_new = min(n - len(existing_candidate_trials), max_new_trials)
         new_trials = (
-            self._get_next_trials(num_trials=n_new, n=(self.options.batch_size or 1))
+            self._get_next_trials(num_trials=n_new, n=self.options.batch_size)
             if n_new > 0
             else []
         )
         return existing_candidate_trials, new_trials
 
-    def _get_next_trials(self, num_trials: int = 1, n: int = 1) -> list[BaseTrial]:
+    def _get_next_trials(
+        self, num_trials: int = 1, n: Optional[int] = None
+    ) -> list[BaseTrial]:
         """Produce up to `num_trials` new generator runs from the underlying
         generation strategy and create new trials with them. Logs errors
         encountered during generation.
@@ -1743,7 +1745,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
     def _gen_new_trials_from_generation_strategy(
         self,
         num_trials: int,
-        n: int,
+        n: Optional[int] = None,
     ) -> list[list[GeneratorRun]]:
         """Generates a list ``GeneratorRun``s of length of ``num_trials`` using the
         ``_gen_multiple`` method of the scheduler's ``generation_strategy``, taking

--- a/ax/utils/common/constants.py
+++ b/ax/utils/common/constants.py
@@ -61,6 +61,7 @@ class Keys(str, Enum):
     CURRENT_VALUE = "current_value"
     EXPAND = "expand"
     EXPECTED_ACQF_VAL = "expected_acquisition_value"
+    EXPERIMENT_TOTAL_CONCURRENT_ARMS = "total_concurrent_arms"
     FIDELITY_FEATURES = "fidelity_features"
     FIDELITY_WEIGHTS = "fidelity_weights"
     FRAC_RANDOM = "frac_random"

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2442,7 +2442,7 @@ class SpecialGenerationStrategy(GenerationStrategyInterface):
         experiment: Experiment,
         num_generator_runs: int,
         data: Optional[Data] = None,
-        n: int = 1,
+        n: Optional[int] = None,
     ) -> list[list[GeneratorRun]]:
         return []
 


### PR DESCRIPTION
Summary: In GS.gen_for_multiple_trials_with_multiple_models and GS.gen_with_multiple_nodes

Reviewed By: lena-kashtelyan

Differential Revision: D63422137
