### PR TITLE
Implement an __init__ method for GenerationStep

### DIFF
--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -294,8 +294,16 @@ class TestGenerationStep(TestCase):
         )
 
     def test_properties(self) -> None:
-        self.assertEqual(self.sobol_generation_step.model_spec, self.model_spec)
-        self.assertEqual(self.sobol_generation_step._unique_id, "-1")
+        step = self.sobol_generation_step
+        self.assertEqual(step.model_spec, self.model_spec)
+        self.assertEqual(step._unique_id, "-1")
+        # Make sure that model_kwargs and model_gen_kwargs are synchronized
+        # to the underlying model spec.
+        spec = step.model_spec
+        spec.model_kwargs.update({"new_kwarg": 1})
+        spec.model_gen_kwargs.update({"new_gen_kwarg": 1})
+        self.assertEqual(step.model_kwargs, spec.model_kwargs)
+        self.assertEqual(step.model_gen_kwargs, spec.model_gen_kwargs)
 
 
 class TestGenerationNodeWithBestModelSelector(TestCase):


### PR DESCRIPTION
Summary:
Dataclasses by default generate an `__init__` method based on the fields specified in dataclass definition. This is generally quite convenient but it leads to some issues in the case of `GenerationStep`.
Some of the inputs to `GenerationStep` constructor is used to construct the underlying `ModelSpec`. With the default constructor, certain attributes that we would expect to be identical, such as `GenerationStep.model_kwargs` and `ModelSpec.model_kwargs`, can go out of sync if one of them is updated after initialization.
Because dataclass fields are class attributes (including `InitVar`s), we cannot define properties with the same name linking the attributes directly to the attributes of the underlying `ModelSpec`. Implementing a custom `__init__` method lifts this restriction.

Note that I didn't add setters for `model_kwargs` and `model_gen_kwargs`. I found only one place in the codebase where they were being updated, so it didn't seem necessary.

Differential Revision: D63497022
