### PR TITLE
Add _ipython_display_ to AnalysisCards

### DIFF
--- a/ax/analysis/__init__.py
+++ b/ax/analysis/__init__.py
@@ -5,8 +5,13 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
+from ax.analysis.analysis import (
+    Analysis,
+    AnalysisCard,
+    AnalysisCardLevel,
+    display_cards,
+)
 from ax.analysis.markdown import *  # noqa
 from ax.analysis.plotly import *  # noqa
 
-__all__ = ["Analysis", "AnalysisCard", "AnalysisCardLevel"]
+__all__ = ["Analysis", "AnalysisCard", "AnalysisCardLevel", "display_cards"]

--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -7,7 +7,7 @@
 
 from enum import Enum
 from logging import Logger
-from typing import Optional, Protocol
+from typing import Iterable, Optional, Protocol
 
 import pandas as pd
 from ax.core.experiment import Experiment
@@ -15,6 +15,7 @@ from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
 from ax.utils.common.result import Err, ExceptionE, Ok, Result
+from IPython.display import display
 
 logger: Logger = get_logger(__name__)
 
@@ -63,6 +64,24 @@ class AnalysisCard(Base):
         self.level = level
         self.df = df
         self.blob = blob
+
+    def _ipython_display_(self) -> None:
+        """
+        IPython display hook. This is called when the AnalysisCard is printed in an
+        IPython environment (ex. Jupyter). This method should be implemented by
+        subclasses of Analysis to display the AnalysisCard in a useful way.
+
+        By default, this method displays the raw data in a pandas DataFrame.
+        """
+        display(self.df)
+
+
+def display_cards(cards: Iterable[AnalysisCard]) -> None:
+    """
+    Display a collection of AnalysisCards in IPython environments (ex. Jupyter).
+    """
+    for card in cards:
+        display(card)
 
 
 class Analysis(Protocol):

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -10,6 +10,7 @@ from typing import Optional
 from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
+from IPython.display import display, Markdown
 
 
 class MarkdownAnalysisCard(AnalysisCard):
@@ -17,6 +18,13 @@ class MarkdownAnalysisCard(AnalysisCard):
 
     def get_markdown(self) -> str:
         return self.blob
+
+    def _ipython_display_(self) -> None:
+        """
+        IPython display hook. This is called when the AnalysisCard is printed in an
+        IPython environment (ex. Jupyter). Here we want to render the Markdown.
+        """
+        display(Markdown(self.blob))
 
 
 class MarkdownAnalysis(Analysis):

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -10,6 +10,7 @@ from typing import Optional
 from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
+from IPython.display import display
 from plotly import graph_objects as go, io as pio
 
 
@@ -18,6 +19,13 @@ class PlotlyAnalysisCard(AnalysisCard):
 
     def get_figure(self) -> go.Figure:
         return pio.from_json(self.blob)
+
+    def _ipython_display_(self) -> None:
+        """
+        IPython display hook. This is called when the AnalysisCard is printed in an
+        IPython environment (ex. Jupyter). Here we want to display the Plotly figure.
+        """
+        display(self.get_figure())
 
 
 class PlotlyAnalysis(Analysis):


### PR DESCRIPTION
Summary:
Adding _ipython_display_ allows display(...) to inteligently consume and output the cards in a way that is beneficial for the user.

By overriding this method in each of our Card subclasses we can call the the same display(...) method and the notebook will correctly select whether to show the dataframe, plotly plot, or markdown text.

Note that passing diplay a list of cards will not result in display being called for each element, so I've also added a display_cards method that iterates through the list for the user.

Differential Revision: D63649339
