### PR TITLE
Simplify passing 'use_model_predictions' for best-point selection

### DIFF
--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -48,7 +48,7 @@ def get_sobol_botorch_modular_acquisition(
     name: Optional[str] = None,
     num_sobol_trials: int = 5,
     model_gen_kwargs: Optional[dict[str, Any]] = None,
-    best_point_kwargs: dict[str, bool] | None = None,
+    use_model_predictions_for_best_point: bool = False,
 ) -> BenchmarkMethod:
     """Get a `BenchmarkMethod` that uses Sobol followed by MBM.
 
@@ -65,7 +65,7 @@ def get_sobol_botorch_modular_acquisition(
             `BatchTrial`s.
         model_gen_kwargs: Passed to the BoTorch `GenerationStep` and ultimately
             to the BoTorch `Model`.
-        best_point_kwargs: Passed to the created `BenchmarkMethod`.
+        use_model_predictions_for_best_point: Passed to the created `BenchmarkMethod`.
 
     Example:
         >>> # A simple example
@@ -140,5 +140,5 @@ def get_sobol_botorch_modular_acquisition(
         generation_strategy=generation_strategy,
         scheduler_options=scheduler_options or get_benchmark_scheduler_options(),
         distribute_replications=distribute_replications,
-        best_point_kwargs={} if best_point_kwargs is None else best_point_kwargs,
+        use_model_predictions_for_best_point=use_model_predictions_for_best_point,
     )

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -146,7 +146,7 @@ class TestMethods(TestCase):
             model_cls=SingleTaskGP,
             acquisition_cls=qLogExpectedImprovement,
             distribute_replications=False,
-            best_point_kwargs={"use_model_predictions": use_model_predictions},
+            use_model_predictions_for_best_point=use_model_predictions,
             num_sobol_trials=1,
         )
 
@@ -191,10 +191,7 @@ class TestMethods(TestCase):
         self.assertEqual(len(best_params), 1)
 
     def test_get_best_parameters(self) -> None:
-        for use_model_predictions, as_batch in product(
-            [False, True],
-            [False, True],
-        ):
+        for use_model_predictions, as_batch in product([False, True], [False, True]):
             with self.subTest(f"{use_model_predictions=}, {as_batch=}"):
                 self._test_get_best_parameters(
                     use_model_predictions=use_model_predictions, as_batch=as_batch

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -237,7 +237,7 @@ class TestBenchmark(TestCase):
             model_cls=SingleTaskGP,
             acquisition_cls=qLogNoisyExpectedImprovement,
             distribute_replications=False,
-            best_point_kwargs={"use_model_predictions": use_model_predictions},
+            use_model_predictions_for_best_point=use_model_predictions,
             num_sobol_trials=3,
         )
 

--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Sequence
-from dataclasses import dataclass
 from logging import Logger
 from typing import Any, Callable, Optional, Union
 
@@ -39,7 +38,7 @@ from ax.modelbridge.transition_criterion import (
     TransitionCriterion,
     TrialBasedCriterion,
 )
-from ax.utils.common.base import Base, SortableBase
+from ax.utils.common.base import SortableBase
 from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import SerializationMixin
 from ax.utils.common.typeutils import not_none
@@ -640,7 +639,6 @@ class GenerationNode(SerializationMixin, SortableBase):
         return f"{str_rep})"
 
 
-@dataclass
 class GenerationStep(GenerationNode, SortableBase):
     """One step in the generation strategy, corresponds to a single model.
     Describes the model, how many trials will be generated with this model, what
@@ -731,7 +729,9 @@ class GenerationStep(GenerationNode, SortableBase):
         if use_update:
             raise DeprecationWarning("`GenerationStep.use_update` is deprecated.")
         # These are here for backwards compatibility. Prior to implementation of
-        # custom __init__, these were the fields of the dataclass.
+        # the __init__ method, these were the fields of the dataclass. GenerationStep
+        # storage utilizes these attributes, so we need to store them. Once we start
+        # using GenerationNode storage, we can clean up these attributes.
         self.index = index
         self.model = model
         self.num_trials = num_trials
@@ -866,11 +866,3 @@ class GenerationStep(GenerationNode, SortableBase):
         )
         gr._generation_step_index = self.index
         return gr
-
-    def __eq__(self, other: Base) -> bool:
-        # We need to override `__eq__` to make sure we inherit the one from
-        # the base class and not the one from dataclasses library, since we
-        # want to be comparing equality of generation steps in the same way
-        # as we compare equality of other Ax objects (and we want all the
-        # same special-casing to apply).
-        return SortableBase.__eq__(self, other=other)


### PR DESCRIPTION
Summary:
Context: Currently, a `BenchmarkMethod` has `best_point_kwargs` that are passed to `BestPointMixin`. When passing kwargs like this, it's hard to make sure defaults are correct, and in fact MBM benchmarks were inadvertently using model predictions because they were passing `best_point_kwargs={}`, overriding the default that was filled in when best_point_kwargs are not passed at all.

This is unnecessarily complex, because the only argument currently supported in `best_point_kwargs` is `use_model_predictions`.

This PR:
* Changes passing `best_point_kwargs` to just passing a boolean

Reviewed By: saitcakmak

Differential Revision: D63653755
