### PR TITLE
Make parameters ordered in SearchSpace

### DIFF
--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import math
 import warnings
+from collections import OrderedDict
 from collections.abc import Hashable, Mapping
 from dataclasses import dataclass, field
 from functools import reduce
@@ -79,7 +80,9 @@ class SearchSpace(Base):
         if len({p.name for p in parameters}) < len(parameters):
             raise ValueError("Parameter names must be unique.")
 
-        self._parameters: dict[str, Parameter] = {p.name: p for p in parameters}
+        self._parameters: OrderedDict[str, Parameter] = OrderedDict(
+            [(p.name, p) for p in parameters]
+        )
         self.set_parameter_constraints(parameter_constraints or [])
 
     @property


### PR DESCRIPTION
Summary:
This PR: Changes `SearchSpace.parameters` from a `dict` to an `OrderedDict`.

Context: In benchmarking, the order of parameters matters because parameters can be converted to a tensor. In the current Python version, this should work even without using `OrderedDict` because dicts are insertion-ordered, but this isn't an officially supported language feature or guaranteed to last.

One downside is that by annotating the parameters as an `OrderedDict`, we can't also annotate them as an immutable `Mapping`. For now, this is fine, because the parameters are mutated, so we can't annotate them as immutable anyway.

Differential Revision: D63641392
