### PR TITLE
Derelativize for negative status quo constraint values

### DIFF
--- a/ax/modelbridge/transforms/derelativize.py
+++ b/ax/modelbridge/transforms/derelativize.py
@@ -105,7 +105,7 @@ class Derelativize(Transform):
                         f"Status-quo metric value not yet available for metric "
                         f"{c.metric.name}."
                     )
-                c.bound = (1 + c.bound / 100.0) * sq_val
+                c.bound = derelativize_bound(bound=c.bound, sq_val=sq_val)
                 c.relative = False
         return optimization_config
 
@@ -117,3 +117,19 @@ class Derelativize(Transform):
         # We intentionally leave outcome constraints derelativized when
         # untransforming.
         return outcome_constraints
+
+
+def derelativize_bound(
+    bound: float,
+    sq_val: float,
+) -> float:
+    """Derelativize a bound.
+
+    Args:
+        bound: The bound to derelativize.
+        sq_val: The status quo value.
+
+    Returns:
+        The derelativized bound.
+    """
+    return (1 + np.sign(sq_val) * bound / 100.0) * sq_val

--- a/ax/modelbridge/transforms/ivw.py
+++ b/ax/modelbridge/transforms/ivw.py
@@ -54,6 +54,8 @@ def ivw_metric_merge(
         indcs = [i for i, mn in enumerate(obsd.metric_names) if mn == metric_name]
         indicies[metric_name] = indcs
         # Extract variances for observations of this metric
+        # NOTE: This only extracts the diagonal of the covariance matrix, and would not
+        # lead to a maximum variance reduction in the presence correlated noise.
         sigma2s = obsd.covariance[indcs, indcs]
         # Check for noiseless observations
         idx_noiseless = np.where(sigma2s == 0.0)[0]

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -35,6 +35,7 @@ from ax.modelbridge.modelbridge_utils import (
 )
 from ax.modelbridge.registry import Models
 from ax.modelbridge.torch import TorchModelBridge
+from ax.modelbridge.transforms.derelativize import derelativize_bound
 from ax.modelbridge.transforms.search_space_to_float import SearchSpaceToFloat
 from ax.models.torch_base import TorchModel
 from ax.utils.common.logger import get_logger
@@ -267,10 +268,11 @@ def get_observed_pareto_frontiers(
                     sq_sem=np.nan,
                 )[0][0]
         elif name in objective_thresholds and rel_objth[name]:
-            # Metric is not rel but obj th is, so need to derelativize obj th
-            objective_thresholds[name] = (
-                1 + objective_thresholds[name] / 100.0
-            ) * sq_means[name]
+            # Metric is not relative but objective threshold is, so we need to
+            # derelativize the objective threshold.
+            objective_thresholds[name] = derelativize_bound(
+                bound=objective_thresholds[name], sq_val=sq_means[name]
+            )
 
     absolute_metrics = [name for name, val in metric_is_rel.items() if not val]
     # Construct ParetoFrontResults for each pair

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -86,7 +86,7 @@ class ParetoUtilsTest(TestCase):
                 minimize=True,
             ),
         ]
-        bounds = [0, -100, 1000]
+        bounds = [0, 100, 1000]
         rels = [True, True, False]
         objective_thresholds = [
             ObjectiveThreshold(
@@ -130,9 +130,7 @@ class ParetoUtilsTest(TestCase):
             self.assertEqual(len(pfr.means["m1"]), len(pareto_arms))
             self.assertTrue(np.isnan(pfr.sems["m1"]).all())
             self.assertEqual(len(pfr.arm_names), len(pareto_arms))  # pyre-ignore
-            self.assertEqual(
-                pfr.objective_thresholds, {"m1": 0, "m2": -100, "m3": 1000}
-            )
+            self.assertEqual(pfr.objective_thresholds, {"m1": 0, "m2": 100, "m3": 1000})
             arm_idx = np.argsort(pfr.arm_names)
             for i, idx in enumerate(arm_idx):
                 name = pareto_arms[i]
@@ -145,7 +143,7 @@ class ParetoUtilsTest(TestCase):
         self.assertEqual(pfr.absolute_metrics, [])
         self.assertEqual(
             pfr.objective_thresholds,
-            {"m1": 0, "m2": -100, "m3": (1000 / sq_val - 1) * 100},
+            {"m1": 0, "m2": 100, "m3": (1000 / sq_val - 1) * 100},
         )
         pfrs = get_observed_pareto_frontiers(
             experiment=experiment, data=data, rel=False


### PR DESCRIPTION
Summary: This commit ensures that a relative constraint of `< b`, where `b` is a positive number, yields an absolute upper bound that is *larger* than the status quo *even if* the value of the status quo is *negative*.

Differential Revision: D63638706


