### PR TITLE
Derelativize for negative status quo constraint values

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,10 +28,7 @@ jobs:
     - name: Install dependencies
       # Pin ufmt deps so they match intermal pyfmt.
       run: |
-        pip install black==24.2.0
-        pip install usort==1.0.8
-        pip install libcst==1.1.0
-        pip install ufmt
+        pip install -r requirements-fmt.txt
         pip install flake8
     - name: ufmt
       run: |

--- a/ax/core/outcome_constraint.py
+++ b/ax/core/outcome_constraint.py
@@ -49,10 +49,12 @@ class OutcomeConstraint(SortableBase):
         relative: [default ``True``] Whether the provided bound value is relative to
             some status-quo arm's metric value. If False, ``bound`` is interpreted as an
             absolute number, else ``bound`` specifies percent-difference from the
-            observed metric value on the status-quo arm. That is, the bound's absolute
-            value will be ``(1 + bound/100.0) * status_quo_metric_value``. This requires
-            specification of a status-quo arm in ``Experiment``.
-
+            observed metric value on the status-quo arm. That is, the bound's value will
+            be ``(1 + sign * bound/100.0) * status_quo_metric_value``, where `sign` is
+            the sign of status_quo_metric_value. This ensures that a positive relative
+            bound gives rise to an absolute upper bound, even if the status-quo arm has
+            a negative metric value. This requires specification of a status-quo arm in
+            ``Experiment``.
     """
 
     def __init__(
@@ -187,8 +189,14 @@ class ObjectiveThreshold(OutcomeConstraint):
     Attributes:
         metric: Metric to constrain.
         bound: The bound in the constraint.
-        relative: Whether you want to bound on an absolute or relative
-            scale. If relative, bound is the acceptable percent change.
+        relative: Whether you want to bound on an absolute or relative scale. If
+            relative, bound is the acceptable percent change. That is, the bound's value
+            will be ``(1 + sign * bound/100.0) * status_quo_metric_value``, where `sign`
+            is the sign of status_quo_metric_value, ensuring that a positive relative
+            bound gives rise to an absolute upper bound, even if the status-quo arm has
+            a negative metric value. This requires specification of a status-quo arm in
+            ``Experiment``.
+
         op: automatically inferred, but manually overwritable.
             specifies whether metric should be greater or equal to, or less
             than or equal to, some bound.
@@ -243,9 +251,12 @@ class ScalarizedOutcomeConstraint(OutcomeConstraint):
         relative: [default ``True``] Whether the provided bound value is relative to
             some status-quo arm's metric value. If False, ``bound`` is interpreted as an
             absolute number, else ``bound`` specifies percent-difference from the
-            observed metric value on the status-quo arm. That is, the bound's absolute
-            value will be ``(1 + bound/100.0) * status_quo_metric_value``. This requires
-            specification of a status-quo arm in ``Experiment``.
+            observed metric value on the status-quo arm. That is, the bound's value will
+            be ``(1 + sign * bound/100.0) * status_quo_metric_value``, where sign is the
+            sign of status_quo_metric_value. This ensures that a positive relative bound
+            always gives rise to an absolute upper bound, even if the status-quo arm has
+            a negative metric value. This requires specification of a status-quo arm in
+            ``Experiment``.
     """
 
     weights: list[float]

--- a/ax/modelbridge/transforms/derelativize.py
+++ b/ax/modelbridge/transforms/derelativize.py
@@ -105,7 +105,7 @@ class Derelativize(Transform):
                         f"Status-quo metric value not yet available for metric "
                         f"{c.metric.name}."
                     )
-                c.bound = (1 + c.bound / 100.0) * sq_val
+                c.bound = derelativize_bound(bound=c.bound, sq_val=sq_val)
                 c.relative = False
         return optimization_config
 
@@ -117,3 +117,31 @@ class Derelativize(Transform):
         # We intentionally leave outcome constraints derelativized when
         # untransforming.
         return outcome_constraints
+
+
+def derelativize_bound(
+    bound: float,
+    sq_val: float,
+) -> float:
+    """Derelativize a bound. Note that a positive `bound` makes the derelativized bound
+    larger than `sq_val`, i.e. `bound < sq_val`, regardless of the sign of `sq_val`.
+
+    Args:
+        bound: The bound to derelativize in percentage terms, so a bound of 1
+            corresponds to a 1% increase compared to the status quo.
+        sq_val: The status quo value.
+
+    Returns:
+        The derelativized bound.
+
+    Examples:
+        >>> derelativize_bound(bound=1.0, sq_val=10.0)
+        10.1
+        >>> derelativize_bound(bound=-1.0, sq_val=10.0)
+        9.9
+        >>> derelativize_bound(bound=1.0, sq_val=-10.0)
+        -9.9
+        >>> derelativize_bound(bound=-1.0, sq_val=-10.0)
+        -10.1
+    """
+    return (1 + np.sign(sq_val) * bound / 100.0) * sq_val

--- a/ax/modelbridge/transforms/ivw.py
+++ b/ax/modelbridge/transforms/ivw.py
@@ -54,6 +54,8 @@ def ivw_metric_merge(
         indcs = [i for i, mn in enumerate(obsd.metric_names) if mn == metric_name]
         indicies[metric_name] = indcs
         # Extract variances for observations of this metric
+        # NOTE: This only extracts the diagonal of the covariance matrix, and would not
+        # lead to a maximum variance reduction in the presence of correlated noise.
         sigma2s = obsd.covariance[indcs, indcs]
         # Check for noiseless observations
         idx_noiseless = np.where(sigma2s == 0.0)[0]

--- a/ax/modelbridge/transforms/tests/test_derelativize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_derelativize_transform.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+from contextlib import ExitStack
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import Mock, patch
@@ -34,17 +35,31 @@ class DerelativizeTransformTest(TestCase):
         self.addCleanup(m.stop)
         m.start()
 
-    @mock.patch(
-        "ax.modelbridge.base.observations_from_data",
-        autospec=True,
-        return_value=(
-            [
+    def test_DerelativizeTransform(self) -> None:
+        for negative_metrics in [False, True]:
+            sq_sign = -1.0 if negative_metrics else 1.0
+            observed_means = sq_sign * np.array([1.0, 2.0, 6.0])
+            sq_b_observed = np.mean(observed_means[1:])
+            predicted_means = sq_sign * np.array([3.0, 5.0])
+            sq_b_predicted = predicted_means[-1]
+            predict_return_value = [
+                ObservationData(
+                    means=predicted_means,
+                    covariance=np.array([[1.0, 0.0], [0.0, 1.0]]),
+                    metric_names=["a", "b"],
+                )
+            ]
+            observations_from_data_return_value = [
                 Observation(
                     features=ObservationFeatures(parameters={"x": 2.0, "y": 10.0}),
                     data=ObservationData(
-                        means=np.array([1.0, 2.0, 6.0]),
+                        means=observed_means,
                         covariance=np.array(
-                            [[1.0, 2.0, 0.0], [3.0, 4.0, 0.0], [0.0, 0.0, 4.0]]
+                            [
+                                [1.0, 2.0, 0.0],
+                                [3.0, 4.0, 0.0],
+                                [0.0, 0.0, 4.0],
+                            ]
                         ),
                         metric_names=["a", "b", "b"],
                     ),
@@ -53,36 +68,52 @@ class DerelativizeTransformTest(TestCase):
                 Observation(
                     features=ObservationFeatures(parameters={"x": None, "y": None}),
                     data=ObservationData(
-                        means=np.array([1.0, 2.0, 6.0]),
+                        means=observed_means,
                         covariance=np.array(
-                            [[1.0, 2.0, 0.0], [3.0, 4.0, 0.0], [0.0, 0.0, 4.0]]
+                            [
+                                [1.0, 2.0, 0.0],
+                                [3.0, 4.0, 0.0],
+                                [0.0, 0.0, 4.0],
+                            ]
                         ),
                         metric_names=["a", "b", "b"],
                     ),
                     arm_name="1_2",
                 ),
             ]
-        ),
-    )
-    @mock.patch("ax.modelbridge.base.ModelBridge._fit", autospec=True)
-    @mock.patch(
-        "ax.modelbridge.base.ModelBridge._predict",
-        autospec=True,
-        return_value=(
-            [
-                ObservationData(
-                    means=np.array([3.0, 5.0]),
-                    covariance=np.array([[1.0, 0.0], [0.0, 1.0]]),
-                    metric_names=["a", "b"],
+            with ExitStack() as es:
+                mock_predict = es.enter_context(
+                    mock.patch(
+                        "ax.modelbridge.base.ModelBridge._predict",
+                        autospec=True,
+                        return_value=predict_return_value,
+                    )
                 )
-            ]
-        ),
-    )
-    def test_DerelativizeTransform(
+                mock_fit = es.enter_context(
+                    mock.patch("ax.modelbridge.base.ModelBridge._fit", autospec=True)
+                )
+                mock_observations_from_data = es.enter_context(
+                    mock.patch(
+                        "ax.modelbridge.base.observations_from_data",
+                        autospec=True,
+                        return_value=observations_from_data_return_value,
+                    )
+                )
+                self._test_DerelativizeTransform(
+                    mock_predict=mock_predict,
+                    mock_fit=mock_fit,
+                    mock_observations_from_data=mock_observations_from_data,
+                    sq_b_observed=sq_b_observed,
+                    sq_b_predicted=sq_b_predicted,
+                )
+
+    def _test_DerelativizeTransform(
         self,
         mock_predict: Mock,
         mock_fit: Mock,
         mock_observations_from_data: Mock,
+        sq_b_observed: float,
+        sq_b_predicted: float,
     ) -> None:
         t = Derelativize(search_space=None, observations=[])
 
@@ -123,6 +154,7 @@ class DerelativizeTransformTest(TestCase):
         self.assertTrue(oc == oc2)
 
         # Test with relative constraint, in-design status quo
+        relative_bound = -10
         oc = OptimizationConfig(
             objective=objective,
             outcome_constraints=[
@@ -130,18 +162,20 @@ class DerelativizeTransformTest(TestCase):
                     Metric("a"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 OutcomeConstraint(
-                    Metric("b"), ComparisonOp.LEQ, bound=-10, relative=True
+                    Metric("b"), ComparisonOp.LEQ, bound=relative_bound, relative=True
                 ),
                 ScalarizedOutcomeConstraint(
                     metrics=[Metric("a"), Metric("b")],
                     weights=[0.0, 1.0],
                     op=ComparisonOp.LEQ,
-                    bound=-10,
+                    bound=relative_bound,
                     relative=True,
                 ),
             ],
         )
         oc2 = t.transform_optimization_config(oc, g, None)
+        sq_val = sq_b_predicted
+        absolute_bound = (1 + np.sign(sq_val) * relative_bound / 100.0) * sq_val
         self.assertTrue(
             oc2.outcome_constraints
             == [
@@ -149,13 +183,13 @@ class DerelativizeTransformTest(TestCase):
                     Metric("a"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 OutcomeConstraint(
-                    Metric("b"), ComparisonOp.LEQ, bound=4.5, relative=False
+                    Metric("b"), ComparisonOp.LEQ, bound=absolute_bound, relative=False
                 ),
                 ScalarizedOutcomeConstraint(
                     metrics=[Metric("a"), Metric("b")],
                     weights=[0.0, 1.0],
                     op=ComparisonOp.LEQ,
-                    bound=4.5,
+                    bound=absolute_bound,
                     relative=False,
                 ),
             ]
@@ -188,18 +222,20 @@ class DerelativizeTransformTest(TestCase):
                     Metric("a"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 OutcomeConstraint(
-                    Metric("b"), ComparisonOp.LEQ, bound=-10, relative=True
+                    Metric("b"), ComparisonOp.LEQ, bound=relative_bound, relative=True
                 ),
                 ScalarizedOutcomeConstraint(
                     metrics=[Metric("a"), Metric("b")],
                     weights=[0.0, 1.0],
                     op=ComparisonOp.LEQ,
-                    bound=-10,
+                    bound=relative_bound,
                     relative=True,
                 ),
             ],
         )
         oc2 = t.transform_optimization_config(oc, g, None)
+        sq_val = sq_b_observed
+        absolute_bound = (1 + np.sign(sq_val) * relative_bound / 100.0) * sq_val
         self.assertTrue(
             oc2.outcome_constraints
             == [
@@ -207,13 +243,13 @@ class DerelativizeTransformTest(TestCase):
                     Metric("a"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 OutcomeConstraint(
-                    Metric("b"), ComparisonOp.LEQ, bound=3.6, relative=False
+                    Metric("b"), ComparisonOp.LEQ, bound=absolute_bound, relative=False
                 ),
                 ScalarizedOutcomeConstraint(
                     metrics=[Metric("a"), Metric("b")],
                     weights=[0.0, 1.0],
                     op=ComparisonOp.LEQ,
-                    bound=3.6,
+                    bound=absolute_bound,
                     relative=False,
                 ),
             ]

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -35,6 +35,7 @@ from ax.modelbridge.modelbridge_utils import (
 )
 from ax.modelbridge.registry import Models
 from ax.modelbridge.torch import TorchModelBridge
+from ax.modelbridge.transforms.derelativize import derelativize_bound
 from ax.modelbridge.transforms.search_space_to_float import SearchSpaceToFloat
 from ax.models.torch_base import TorchModel
 from ax.utils.common.logger import get_logger
@@ -267,10 +268,11 @@ def get_observed_pareto_frontiers(
                     sq_sem=np.nan,
                 )[0][0]
         elif name in objective_thresholds and rel_objth[name]:
-            # Metric is not rel but obj th is, so need to derelativize obj th
-            objective_thresholds[name] = (
-                1 + objective_thresholds[name] / 100.0
-            ) * sq_means[name]
+            # Metric is not relative but objective threshold is, so we need to
+            # derelativize the objective threshold.
+            objective_thresholds[name] = derelativize_bound(
+                bound=objective_thresholds[name], sq_val=sq_means[name]
+            )
 
     absolute_metrics = [name for name, val in metric_is_rel.items() if not val]
     # Construct ParetoFrontResults for each pair

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -86,7 +86,7 @@ class ParetoUtilsTest(TestCase):
                 minimize=True,
             ),
         ]
-        bounds = [0, -100, 1000]
+        bounds = [0, 100, 1000]
         rels = [True, True, False]
         objective_thresholds = [
             ObjectiveThreshold(
@@ -130,9 +130,7 @@ class ParetoUtilsTest(TestCase):
             self.assertEqual(len(pfr.means["m1"]), len(pareto_arms))
             self.assertTrue(np.isnan(pfr.sems["m1"]).all())
             self.assertEqual(len(pfr.arm_names), len(pareto_arms))  # pyre-ignore
-            self.assertEqual(
-                pfr.objective_thresholds, {"m1": 0, "m2": -100, "m3": 1000}
-            )
+            self.assertEqual(pfr.objective_thresholds, {"m1": 0, "m2": 100, "m3": 1000})
             arm_idx = np.argsort(pfr.arm_names)
             for i, idx in enumerate(arm_idx):
                 name = pareto_arms[i]
@@ -145,7 +143,7 @@ class ParetoUtilsTest(TestCase):
         self.assertEqual(pfr.absolute_metrics, [])
         self.assertEqual(
             pfr.objective_thresholds,
-            {"m1": 0, "m2": -100, "m3": (1000 / sq_val - 1) * 100},
+            {"m1": 0, "m2": 100, "m3": (1000 / sq_val - 1) * 100},
         )
         pfrs = get_observed_pareto_frontiers(
             experiment=experiment, data=data, rel=False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.usort]
 first_party_detection = false
+
+[tool.ufmt]
+formatter = "ruff-api"


### PR DESCRIPTION
Summary:

This commit ensures that a relative constraint of `< b`, where `b` is a positive number, yields an absolute upper bound that is *larger* than the status quo *even if* the value of the status quo is *negative*.

Differential Revision: D63638706


