### PR TITLE
Update gen_for_multiple_trials_with_multiple_models to call into gen_with_multiple_nodes

### DIFF
--- a/ax/core/generation_strategy_interface.py
+++ b/ax/core/generation_strategy_interface.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from typing import Any
+
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
+from ax.core.observation import ObservationFeatures
 from ax.exceptions.core import AxError, UnsupportedError
 from ax.utils.common.base import Base
 from ax.utils.common.typeutils import not_none
@@ -43,10 +46,10 @@ class GenerationStrategyInterface(ABC, Base):
         self,
         experiment: Experiment,
         data: Data | None = None,
-        # TODO[drfreund, danielcohennyc, mgarrard]: Update the format of the arguments
-        # below as we find the right one.
-        num_generator_runs: int = 1,
+        pending_observations: dict[str, list[ObservationFeatures]] | None = None,
         n: int | None = None,
+        num_trials: int = 1,
+        arms_per_node: dict[str, int] | None = None,
     ) -> list[list[GeneratorRun]]:
         """Produce ``GeneratorRun``-s for multiple trials at once with the possibility
         of joining ``GeneratorRun``-s from multiple models into one ``BatchTrial``.
@@ -60,14 +63,22 @@ class GenerationStrategyInterface(ABC, Base):
             data: Optional data to be passed to the underlying model's ``gen``, which
                 is called within this method and actually produces the resulting
                 generator run. By default, data is all data on the ``experiment``.
-            n: Integer representing how many trials should be in the generator run
-                produced by this method. NOTE: Some underlying models may ignore
-                the ``n`` and produce a model-determined number of arms. In that
-                case this method will also output a generator run with number of
-                arms that can differ from ``n``.
             pending_observations: A map from metric name to pending
                 observations for that metric, used by some models to avoid
                 resuggesting points that are currently being evaluated.
+            n: Integer representing how many total arms should be in the generator
+                runs produced by this method. NOTE: Some underlying models may ignore
+                the `n` and produce a model-determined number of arms. In that
+                case this method will also output generator runs with number of
+                arms that can differ from `n`.
+            num_trials: Number of trials to generate generator runs for in this call.
+                If not provided, defaults to 1.
+            arms_per_node: An optional map from node name to the number of arms to
+                generate from that node. If not provided, will default to the number
+                of arms specified in the node's ``InputConstructors`` or n if no
+                ``InputConstructors`` are defined on the node. We expect either n or
+                arms_per_node to be provided, but not both, and this is an advanced
+                argument that should only be used by advanced users.
 
         Returns:
             A list of lists of ``GeneratorRun``-s. Each outer list item represents
@@ -77,6 +88,49 @@ class GenerationStrategyInterface(ABC, Base):
         # When implementing your subclass' override for this method, don't forget
         # to consider using "pending points", corresponding to arms in trials that
         # are currently running / being evaluated/
+        ...
+
+    def _gen_multiple(
+        self,
+        experiment: Experiment,
+        num_generator_runs: int,
+        data: Data | None = None,
+        n: int = 1,
+        pending_observations: dict[str, list[ObservationFeatures]] | None = None,
+        **model_gen_kwargs: Any,
+    ) -> list[GeneratorRun]:
+        """Produce multiple generator runs at once, to be made into multiple
+        trials on the experiment.
+
+        NOTE: This is used to ensure that maximum parallelism and number
+        of trials per node are not violated when producing many generator
+        runs from this generation strategy in a row. Without this function,
+        if one generates multiple generator runs without first making any
+        of them into running trials, generation strategy cannot enforce that it only
+        produces as many generator runs as are allowed by the parallelism
+        limit and the limit on number of trials in current node.
+
+        Args:
+            experiment: Experiment, for which the generation strategy is producing
+                a new generator run in the course of `gen`, and to which that
+                generator run will be added as trial(s). Information stored on the
+                experiment (e.g., trial statuses) is used to determine which model
+                will be used to produce the generator run returned from this method.
+            data: Optional data to be passed to the underlying model's `gen`, which
+                is called within this method and actually produces the resulting
+                generator run. By default, data is all data on the `experiment`.
+            n: Integer representing how many arms should be in the generator run
+                produced by this method. NOTE: Some underlying models may ignore
+                the ``n`` and produce a model-determined number of arms. In that
+                case this method will also output a generator run with number of
+                arms that can differ from ``n``.
+            pending_observations: A map from metric name to pending
+                observations for that metric, used by some models to avoid
+                resuggesting points that are currently being evaluated.
+            model_gen_kwargs: Keyword arguments that are passed through to
+                ``GenerationNode.gen``, which will pass them through to
+                ``ModelSpec.gen``, which will pass them to ``ModelBridge.gen``.
+        """
         ...
 
     @abstractmethod

--- a/ax/core/tests/test_generation_strategy_interface.py
+++ b/ax/core/tests/test_generation_strategy_interface.py
@@ -10,6 +10,7 @@ from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from ax.core.generator_run import GeneratorRun
+from ax.core.observation import ObservationFeatures
 from ax.exceptions.core import AxError, UnsupportedError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_experiment, SpecialGenerationStrategy
@@ -20,10 +21,10 @@ class MyGSI(GenerationStrategyInterface):
         self,
         experiment: Experiment,
         data: Data | None = None,
-        # TODO[drfreund, danielcohennyc, mgarrard]: Update the format of the arguments
-        # below as we find the right one.
-        num_generator_runs: int = 1,
+        pending_observations: dict[str, list[ObservationFeatures]] | None = None,
         n: int | None = None,
+        num_trials: int = 1,
+        arms_per_node: dict[str, int] | None = None,
     ) -> list[list[GeneratorRun]]:
         raise NotImplementedError
 

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1882,10 +1882,11 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         ``_gen_multiple`` method of the scheduler's ``generation_strategy``, taking
         into account any ``pending`` observations.
         """
+        self.generation_strategy.experiment = self.experiment
         # TODO: pass self.trial_type to GS.gen for multi-type experiments
         return self.generation_strategy.gen_for_multiple_trials_with_multiple_models(
             experiment=self.experiment,
-            num_generator_runs=num_trials,
+            num_trials=num_trials,
             n=n,
         )
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2443,9 +2443,11 @@ class SpecialGenerationStrategy(GenerationStrategyInterface):
     def gen_for_multiple_trials_with_multiple_models(
         self,
         experiment: Experiment,
-        num_generator_runs: int,
         data: Data | None = None,
+        pending_observations: dict[str, list[ObservationFeatures]] | None = None,
         n: int | None = None,
+        num_trials: int = 1,
+        arms_per_node: dict[str, int] | None = None,
     ) -> list[list[GeneratorRun]]:
         return []
 


### PR DESCRIPTION
Summary:
This should be a no-op on the logic, since we aren't actually using quickbo anywhere, but this diff makes gen_with_multiple_nodes a sub-method of gen_multiple_trials_with_multiple_models and makes the later the primary entry point into GS. We update the method in all locations it's defined.

We also ensure that pending points are handled correctly by gen_multiple_trials_with_multiple_models, and ensure backwards compatability with all live GS.

Differential Revision: D63657844


