### PR TITLE
Don't pass batch size so scheduler can use total concurrent arms for PTS

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1830,7 +1830,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         """
         new_trials = self._get_next_trials(
             num_trials=num_trials,
-            n=self.options.batch_size or 1,
+            n=self.options.batch_size,
         )
         if len(new_trials) > 0:
             new_generator_runs = [gr for t in new_trials for gr in t.generator_runs]


### PR DESCRIPTION
Summary: as per title

Differential Revision: D63835518


