### PR TITLE
Sphinx: Fix api generation after PEP604 codemod

### DIFF
--- a/ax/modelbridge/transforms/time_as_feature.py
+++ b/ax/modelbridge/transforms/time_as_feature.py
@@ -6,6 +6,8 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 from logging import Logger
 from time import time
 from typing import Optional, TYPE_CHECKING

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -6,6 +6,8 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 import itertools
 import logging
 from collections import defaultdict

--- a/ax/utils/stats/statstools.py
+++ b/ax/utils/stats/statstools.py
@@ -6,6 +6,8 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 from logging import Logger
 from typing import Union
 

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -251,10 +251,8 @@ set_type_checking_flag = True
 
 # Mock SQLAlchemy base; otherwise have issues with trying to register same
 # class (with same table) multiple times through autodocs
-# Also mock Pandas to avoid circular imports due to TYPE_CHECKING = True
 autodoc_mock_imports = [
     "sqlalchemy",
-    "pandas",
     "plotly",
     "tensorboard",
     "__test_modules__",


### PR DESCRIPTION
I don't think we should need to be using `__future__.annotations` given that we're using python 3.10+, but we're seeing Sphinx complain *a lot* about these particular files after the PEP604 codemod we performed in https://github.com/facebook/Ax/commit/33333d2cc22b51c9d3fa9c060c151e62b15810a1

After using `__future__.annotations` our Sphinx generation began breaking because `parse_version(pd.__version__)` is not resolving to a real version number. I'm not seeing any immediate issues from not mocking pandas, the mocking was [introduced 5 years ago](https://www.internalfb.com/diff/D20198261?dst_version_fbid=336946477251580&transaction_fbid=197042131569907) so hopefully the circular dependency issue it was mitigating has been fixed now.

All the api documentation is rendering correctly for me now with `./scripts/make_docs.sh`

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/8440adbf-aea9-4633-9888-63474eb3f512">
