### PR TITLE
Refactor exp_to_df into Summary analysis (#2828)

### DIFF
--- a/ax/analysis/__init__.py
+++ b/ax/analysis/__init__.py
@@ -11,7 +11,8 @@ from ax.analysis.analysis import (
     AnalysisCardLevel,
     display_cards,
 )
+from ax.analysis.summary import Summary
 from ax.analysis.markdown import *  # noqa
 from ax.analysis.plotly import *  # noqa
 
-__all__ = ["Analysis", "AnalysisCard", "AnalysisCardLevel", "display_cards"]
+__all__ = ["Analysis", "AnalysisCard", "AnalysisCardLevel", "display_cards", "Summary"]

--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -1,0 +1,107 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import pandas as pd
+from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
+from ax.core.experiment import Experiment
+from ax.core.generation_strategy_interface import GenerationStrategyInterface
+from ax.exceptions.core import UserInputError
+from pyre_extensions import none_throws
+
+
+class Summary(Analysis):
+    """
+    High-level summary of the Experiment with one row per arm. Any values missing at
+    compute time will be represented as None. Columns where every value is None will
+    be omitted by default.
+
+    The DataFrame computed will contain one row per arm and the following columns:
+        - trial_index: The trial index of the arm
+        - arm_name: The name of the arm
+        - status: The status of the trial (e.g. RUNNING, SUCCEDED, FAILED)
+        - failure_reason: The reason for the failure, if applicable
+        - generation_method: The model_key of the model that generated the arm
+        - generation_node: The name of the ``GenerationNode`` that generated the arm
+        - **METADATA: Any metadata associated with the trial, as specified by the
+            Experiment's runner.run_metadata_report_keys field
+        - **METRIC_NAME: The observed mean of the metric specified, for each metric
+        - **PARAMETER_NAME: The value of said parameter for the arm, for each parameter
+    """
+
+    def __init__(self, omit_empty_columns: bool = True) -> None:
+        self.omit_empty_columns = omit_empty_columns
+
+    def compute(
+        self,
+        experiment: Experiment | None = None,
+        generation_strategy: GenerationStrategyInterface | None = None,
+    ) -> AnalysisCard:
+        if experiment is None:
+            raise UserInputError("`Summary` analysis requires an `Experiment` input")
+
+        records = []
+        data_df = experiment.lookup_data().df
+        for index, trial in experiment.trials.items():
+            for arm in trial.arms:
+                # Find the observed means for each metric, placing None if not found
+                observed_means = {}
+                for metric in experiment.metrics.keys():
+                    try:
+                        observed_means[metric] = data_df[
+                            (data_df["arm_name"] == arm.name)
+                            & (data_df["metric_name"] == metric)
+                        ]["mean"].item()
+                    except ValueError:
+                        observed_means[metric] = None
+
+                # Find the arm's associated generation method from the trial via the
+                # GeneratorRuns if possible
+                grs = [gr for gr in trial.generator_runs if arm in gr.arms]
+                generation_method = grs[0]._model_key if len(grs) > 0 else None
+                generation_node = grs[0]._generation_node_name if len(grs) > 0 else None
+
+                # Find other metadata from the trial to include from the trial based
+                # on the experiment's runner
+                metadata = (
+                    {
+                        key: value
+                        for key, value in trial.run_metadata.items()
+                        if key
+                        in none_throws(experiment.runner).run_metadata_report_keys
+                    }
+                    if experiment.runner is not None
+                    else {}
+                )
+
+                # Construct the record
+                record = {
+                    "trial_index": index,
+                    "arm_name": arm.name,
+                    "generation_method": generation_method,
+                    "generation_node": generation_node,
+                    "status": trial.status.name,
+                    "fail_reason": trial.run_metadata.get("fail_reason", None),
+                    **metadata,
+                    **arm.parameters,
+                    **observed_means,
+                }
+
+                records.append(record)
+
+        df = pd.DataFrame(records)
+
+        if self.omit_empty_columns:
+            df = df.loc[:, df.notnull().all()]
+
+        return AnalysisCard(
+            name=str(self),
+            title=f"Summary for {experiment.name}",
+            subtitle="High-level summary of the `Trial`-s in this `Experiment`",
+            level=AnalysisCardLevel.MID,
+            df=df,
+            blob=str(df),
+        )

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -1,0 +1,84 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.summary import Summary
+from ax.exceptions.core import UserInputError
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_branin_experiment_with_multi_objective
+
+
+class TestSummary(TestCase):
+    def test_compute(self) -> None:
+        analysis = Summary()
+        experiment = get_branin_experiment_with_multi_objective(
+            with_completed_trial=True
+        )
+
+        with self.assertRaisesRegex(UserInputError, "requires an `Experiment`"):
+            analysis.compute()
+
+        card = analysis.compute(experiment=experiment)
+
+        # Test metadata
+        self.assertEqual(card.name, "Summary(omit_empty_columns=True)")
+        self.assertEqual(card.title, "Summary for branin_test_experiment")
+        self.assertEqual(
+            card.subtitle,
+            "High-level summary of the `Trial`-s in this `Experiment`",
+        )
+        self.assertEqual(card.level, AnalysisCardLevel.MID)
+        self.assertIsNotNone(card.blob)
+        self.assertEqual(card.blob_annotation, "dataframe")
+
+        # Test dataframe for accuracy
+        self.assertEqual(
+            {*card.df.columns},
+            {
+                "trial_index",
+                "arm_name",
+                "generation_method",
+                "status",
+                "x1",
+                "x2",
+                "branin_a",
+                "branin_b",
+            },
+        )
+        self.assertEqual(len(card.df), len(experiment.arms_by_name))
+        self.assertEqual(card.df.head()["trial_index"].item(), 0)
+        self.assertEqual(card.df.head()["arm_name"].item(), "0_0")
+        self.assertEqual(card.df.head()["generation_method"].item(), "Sobol")
+        self.assertEqual(card.df.head()["status"].item(), "COMPLETED")
+        self.assertEqual(
+            card.df.head()["x1"].item(), experiment.arms_by_name["0_0"].parameters["x1"]
+        )
+        self.assertEqual(
+            card.df.head()["x2"].item(), experiment.arms_by_name["0_0"].parameters["x2"]
+        )
+        self.assertEqual(card.df.head()["branin_a"].item(), 5.0)
+        self.assertEqual(card.df.head()["branin_b"].item(), 5.0)
+
+        # Test without omitting empty columns
+        analysis_no_omit = Summary(omit_empty_columns=False)
+        card_no_omit = analysis_no_omit.compute(experiment=experiment)
+        self.assertEqual(
+            {*card_no_omit.df.columns},
+            {
+                "trial_index",
+                "arm_name",
+                "generation_method",
+                "generation_node",
+                "status",
+                "fail_reason",
+                "x1",
+                "x2",
+                "branin_a",
+                "branin_b",
+            },
+        )
+        self.assertEqual(len(card_no_omit.df), len(experiment.arms_by_name))

--- a/sphinx/source/analysis.rst
+++ b/sphinx/source/analysis.rst
@@ -71,7 +71,7 @@ Plotly Arm Effects Utils
     :undoc-members:
     :show-inheritance:
 
-Plotly Anaylsis Utils
+Plotly Analysis Utils
 ~~~~~~~~~~~~~~~
 
 .. automodule:: ax.analysis.plotly.utils
@@ -83,6 +83,14 @@ Scatter Plot Analysis
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.analysis.plotly.scatter
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Summary
+~~~~~~~
+
+.. automodule:: ax.analysis.summary
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Summary:

Streamlined version of exp_to_df ported to analysis framework. End goal user experience is to call via either of the following:
```
client.compute_analyses([Summary()]) # A la carte

client.compute_analyses() # Will always appear in default analysis set
```

Current columns include:
- trial_index: The trial index of the arm
- arm_name: The name of the arm
- status: The status of the trial (e.g. RUNNING, SUCCEDED, FAILED)
- failure_reason: The reason for the failure, if applicable
- generation_method: The model_key of the model that generated the arm
- **METADATA: Any metadata associated with the trial, as specified by the Experiment's runner.run_metadata_report_keys field
- **PARAMETER_NAME: The value of said parameter for the arm, for each parameter
- **METRIC_NAME: The observed mean of the metric specified, for each metric

Many options from exp_to_df are not represented in the Summary analysis, but after code searching and consulting with bernardbeckerman none seem to be used in practice.

Possible future plans:
* Incorporate modeled metric values instead of observed (potentially configurable)
* Column for whether an arm is optimal
* Column for whether an arm is constraint violating
* Column for whether an arm's parameterization is in design

Reviewed By: lena-kashtelyan

Differential Revision: D63985460


