### PR TITLE
Make run_trials_with_gs into a standalone test helper

### DIFF
--- a/ax/utils/testing/tests/test_utils.py
+++ b/ax/utils/testing/tests/test_utils.py
@@ -8,8 +8,12 @@
 
 import numpy as np
 import torch
+from ax.modelbridge.generation_strategy import GenerationNode, GenerationStrategy
+from ax.modelbridge.model_spec import ModelSpec
+from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.utils import generic_equals
+from ax.utils.testing.core_stubs import get_experiment_with_observations
+from ax.utils.testing.utils import generic_equals, run_trials_with_gs
 
 
 class TestUtils(TestCase):
@@ -45,3 +49,30 @@ class TestUtils(TestCase):
         self.assertFalse(generic_equals(np.ones(2), np.zeros(2)))
         self.assertTrue(generic_equals({1, 2}, {1, 2}))
         self.assertFalse(generic_equals({1, 2}, {1, 2, 3}))
+
+    def test_run_n_trials(self) -> None:
+        experiment = get_experiment_with_observations(
+            observations=[[1.0, 5.0], [2.0, 4.0]]
+        )
+        # There are 2 trials with observations for 2 metrics.
+        self.assertEqual(len(experiment.trials), 2)
+        self.assertEqual(len(experiment.lookup_data().df), 4)
+        gs = GenerationStrategy(
+            nodes=[
+                GenerationNode(
+                    node_name="MBM",
+                    model_specs=[
+                        ModelSpec(
+                            model_enum=Models.BOTORCH_MODULAR,
+                        )
+                    ],
+                )
+            ]
+        )
+        run_trials_with_gs(experiment=experiment, gs=gs, num_trials=2)
+        self.assertEqual(len(experiment.trials), 4)
+        self.assertEqual(len(experiment.lookup_data().df), 8)
+        for idx in [2, 3]:
+            self.assertEqual(
+                experiment.trials[idx].generator_runs[0]._generation_node_name, "MBM"
+            )

--- a/ax/utils/testing/utils.py
+++ b/ax/utils/testing/utils.py
@@ -5,10 +5,17 @@
 
 # pyre-strict
 
+import random
 from typing import Any
 
 import numpy as np
+import pandas as pd
 import torch
+from ax.core.data import Data
+from ax.core.experiment import Experiment
+from ax.exceptions.core import UnsupportedError
+from ax.modelbridge.generation_strategy import GenerationStrategy
+from pyre_extensions import none_throws
 from torch import Tensor
 
 
@@ -32,3 +39,41 @@ def generic_equals(first: Any, second: Any) -> bool:
                 return False
         return True
     return first == second
+
+
+def run_trials_with_gs(
+    experiment: Experiment, gs: GenerationStrategy, num_trials: int
+) -> None:
+    r"""Runs and completes `num_trials` trials for the given experiment with the
+    given GS. The trials are completed with random metric values between 0 and 1.
+
+    Args:
+        experiment: The experiment to run trials on. Must have an optimization config.
+        gs: The generation strategy to use.
+        num_trials: The number of trials to run.
+    """
+    if experiment.optimization_config is None:
+        raise UnsupportedError(  # pragma: no cover
+            "`run_trials_with_gs` requires the experiment to have "
+            "an optimization config."
+        )
+    existing_trials = len(experiment.trials)
+    for i in range(existing_trials, existing_trials + num_trials):
+        trial = experiment.new_trial(generator_run=gs.gen(experiment=experiment))
+        data = Data(
+            df=pd.DataFrame.from_records(
+                [
+                    {
+                        "arm_name": arm.name,
+                        "metric_name": m,
+                        "mean": random.random(),
+                        "sem": None,
+                        "trial_index": i,
+                    }
+                    for m in none_throws(experiment.optimization_config).metrics
+                    for arm in trial.arms
+                ]
+            )
+        )
+        experiment.attach_data(data)
+        trial.run().complete()


### PR DESCRIPTION
Summary: This is useful for testing generation strategies without having to write repetitive boilerplate to advance them to the node of interest. It runs the specified number of trials using with the given experiment & GS, and completes the trials with dummy observations.

Differential Revision: D64044818


