### PR TITLE
add status quo name property to MB

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -454,6 +454,14 @@ class ModelBridge(ABC):  # noqa: B024 -- ModelBridge doesn't have any abstract m
         return self._status_quo
 
     @property
+    def status_quo_name(self) -> str | None:
+        """Name of status quo, if any."""
+        if self._status_quo is not None:
+            if self._status_quo.arm_name is not None:
+                return self._status_quo.arm_name
+        return self._status_quo_name
+
+    @property
     def metric_names(self) -> set[str]:
         """Metric names present in training data."""
         return self._metric_names

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -510,6 +510,7 @@ class BaseModelBridgeTest(TestCase):
             status_quo_name="1_1",
         )
         self.assertEqual(modelbridge.status_quo, get_observation1())
+        self.assertEqual(modelbridge.status_quo_name, "1_1")
 
         # Alternatively, we can specify by features
         modelbridge = ModelBridge(
@@ -522,6 +523,7 @@ class BaseModelBridgeTest(TestCase):
             status_quo_features=get_observation1().features,
         )
         self.assertEqual(modelbridge.status_quo, get_observation1())
+        self.assertEqual(modelbridge.status_quo_name, "1_1")
 
         # Alternatively, we can specify on experiment
         # Put a dummy arm with SQ name 1_1 on the dummy experiment.
@@ -532,6 +534,7 @@ class BaseModelBridgeTest(TestCase):
         # pyre-fixme[6]: For 5th param expected `Optional[Data]` but got `int`.
         modelbridge = ModelBridge(get_search_space_for_value(), 0, [], exp, 0)
         self.assertEqual(modelbridge.status_quo, get_observation1())
+        self.assertEqual(modelbridge.status_quo_name, "1_1")
 
         # Errors if features and name both specified
         with self.assertRaises(ValueError):
@@ -557,6 +560,7 @@ class BaseModelBridgeTest(TestCase):
             status_quo_name="1_0",
         )
         self.assertIsNone(modelbridge.status_quo)
+        self.assertIsNone(modelbridge.status_quo_name)
         modelbridge = ModelBridge(
             get_search_space_for_value(),
             0,

--- a/ax/modelbridge/transforms/tests/test_relativize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_relativize_transform.py
@@ -271,6 +271,7 @@ class RelativizeDataTest(TestCase):
             status_quo=Mock(
                 data=obs_data[2], features=obs_features[2], arm_name=arm_names[2]
             ),
+            status_quo_name=arm_names[2],
             status_quo_data_by_trial={0: obs_data[0], 1: obs_data[2]},
         )
 

--- a/ax/modelbridge/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/modelbridge/transforms/tests/test_transform_to_new_sq.py
@@ -73,11 +73,12 @@ class TransformToNewSQSpecificTest(TestCase):
             status_quo_name="status_quo",
         )
 
-    def test_modelbridge_without_status_quo(self) -> None:
+    def test_modelbridge_without_status_quo_name(self) -> None:
         self.modelbridge._status_quo = None
+        self.modelbridge._status_quo_name = None
 
         with self.assertRaisesRegex(
-            ValueError, "Status quo must be set on modelbridge for TransformToNewSQ."
+            ValueError, "TransformToNewSQ requires status quo data."
         ):
             TransformToNewSQ(
                 search_space=None,

--- a/ax/modelbridge/transforms/transform_to_new_sq.py
+++ b/ax/modelbridge/transforms/transform_to_new_sq.py
@@ -20,8 +20,9 @@ from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.search_space import SearchSpace
 from ax.modelbridge.transforms.relativize import BaseRelativize, get_metric_index
 from ax.models.types import TConfig
-from ax.utils.common.typeutils import checked_cast, not_none
+from ax.utils.common.typeutils import checked_cast
 from ax.utils.stats.statstools import relativize, unrelativize
+from pyre_extensions import none_throws
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
@@ -54,9 +55,8 @@ class TransformToNewSQ(BaseRelativize):
             modelbridge=modelbridge,
             config=config,
         )
-        self.status_quo: Observation = not_none(
-            self.modelbridge.status_quo,
-            f"Status quo must be set on modelbridge for {self.__class__.__name__}.",
+        self._status_quo_name: str = none_throws(
+            none_throws(modelbridge).status_quo_name
         )
         if config is not None:
             target_trial_index = config.get("target_trial_index")
@@ -115,7 +115,7 @@ class TransformToNewSQ(BaseRelativize):
             for obs in rel_observations
             # drop SQ observations
             if (
-                obs.arm_name != self.status_quo.arm_name
+                obs.arm_name != self._status_quo_name
                 or obs.features.trial_index == self.default_trial_idx
             )
         ]

--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -391,12 +391,11 @@ def get_plot_data(
         fixed_features=fixed_features,
         scalarized_metric_config=scalarized_metric_config,
     )
-    status_quo_name = None if model.status_quo is None else model.status_quo.arm_name
     plot_data = PlotData(
         metrics=list(metrics_plot),
         in_sample=in_sample_plot,
         out_of_sample=out_of_sample_plot,
-        status_quo_name=status_quo_name,
+        status_quo_name=model.status_quo_name,
     )
     return plot_data, raw_data, cond_name_to_parameters
 


### PR DESCRIPTION
Summary: This adds a status quo name property that can be set by passing status quo_name in the absence of having a status_quo set on the MB. This may happen in the case that each BatchTrial has a status_quo observation.

Reviewed By: danielcohenlive

Differential Revision: D63998413


