### PR TITLE
Update make_candidate_trials to set the trial type

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1455,7 +1455,14 @@ class Experiment(Base):
         The base experiment class only supports None. For experiments
         with multiple trial types, use the MultiTypeExperiment class.
         """
-        return trial_type is None
+        return (
+            trial_type is None
+            # We temporarily allow "short run" and "long run" trial
+            # types in single-type experiments during development of
+            # a new ``GenerationStrategy`` that needs them.
+            or trial_type == Keys.SHORT_RUN
+            or trial_type == Keys.LONG_RUN
+        )
 
     def attach_trial(
         self,


### PR DESCRIPTION
Summary: This diff adds functionality for AxBatchClient to leverage the GR gen_metadata, which may include a trial_type, to set that trial type on a newly created trial. We also add validation that all GRs for a singular trial should indicate the same trial type

Differential Revision: D64066430


