### PR TITLE
Add framework for input constructor for fixed features

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1455,7 +1455,14 @@ class Experiment(Base):
         The base experiment class only supports None. For experiments
         with multiple trial types, use the MultiTypeExperiment class.
         """
-        return trial_type is None
+        return (
+            trial_type is None
+            # We temporarily allow "short run" and "long run" trial
+            # types in single-type experiments during development of
+            # a new ``GenerationStrategy`` that needs them.
+            or trial_type == Keys.SHORT_RUN
+            or trial_type == Keys.LONG_RUN
+        )
 
     def attach_trial(
         self,

--- a/ax/modelbridge/generation_node_input_constructors.py
+++ b/ax/modelbridge/generation_node_input_constructors.py
@@ -9,6 +9,8 @@ from enum import Enum, unique
 from math import ceil
 from typing import Any
 
+from ax.core import ObservationFeatures
+
 from ax.modelbridge.generation_node import GenerationNode
 
 
@@ -24,6 +26,7 @@ class NodeInputConstructors(Enum):
     ALL_N = "consume_all_n"
     REPEAT_N = "repeat_arm_n"
     REMAINING_N = "remaining_n"
+    TARGET_TRIAL_FIXED_FEATURES = "set_target_trial"
 
     def __call__(
         self,
@@ -58,6 +61,35 @@ class InputConstructorPurpose(Enum):
     """
 
     N = "n"
+    FIXED_FEATURES = "fixed_features"
+
+
+def set_target_trial(
+    previous_node: GenerationNode | None,
+    next_node: GenerationNode,
+    gs_gen_call_kwargs: dict[str, Any],
+) -> ObservationFeatures | None:
+    """Determine the target trial for the next node based on the current state of the
+    ``Experiment``.
+
+     Args:
+        previous_node: The previous node in the ``GenerationStrategy``. This is the node
+            that is being transition away from, and is provided for easy access to
+            properties of this node.
+        next_node: The next node in the ``GenerationStrategy``. This is the node that
+            will leverage the inputs defined by this input constructor.
+        gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
+            gen call.
+    Returns:
+        An ``ObservationFeatures`` object that defines the target trial for the next
+        node.
+    """
+
+    # TODO: @mgarrard implement logic in follow-up diff
+    return ObservationFeatures(
+        parameters={},
+        trial_index=0,
+    )
 
 
 def consume_all_n(

--- a/ax/modelbridge/tests/test_generation_node_input_constructors.py
+++ b/ax/modelbridge/tests/test_generation_node_input_constructors.py
@@ -11,6 +11,7 @@ from typing import Any, get_type_hints
 
 from ax.core.arm import Arm
 from ax.core.generator_run import GeneratorRun
+from ax.core.observation import ObservationFeatures
 from ax.modelbridge.generation_node import GenerationNode
 from ax.modelbridge.generation_node_input_constructors import (
     InputConstructorPurpose,
@@ -133,6 +134,22 @@ class TestGenerationNodeInputConstructors(TestCase):
                 next_node=self.sobol_generation_node,
                 gs_gen_call_kwargs={},
             )
+
+    def test_set_target_trial(self) -> None:
+        """Test that set_target_trial returns the correct trial index."""
+        # should return 1 because 4 arms already exist and 5 are requested
+        target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={},
+        )
+        self.assertEqual(
+            target_trial,
+            ObservationFeatures(
+                parameters={},
+                trial_index=0,
+            ),
+        )
 
 
 class TestInstantiationFromNodeInputConstructor(TestCase):


### PR DESCRIPTION
Summary:
This diff adds the skelton for the input constructor to construct fixed features which will be limited to target trial for now.

In following diffs we'll
1. implement the logic to set target trial
2. save this input constructor in storage
3. use this input constructor

Differential Revision: D64061111


