### PR TITLE
Handle `outcome_names` argument of `BenchmarkRunner` in base class and remove unused `SearchSpace`

### DIFF
--- a/ax/benchmark/runners/base.py
+++ b/ax/benchmark/runners/base.py
@@ -43,13 +43,19 @@ class BenchmarkRunner(Runner, ABC):
           not over-engineer for that before such a use case arrives.
     """
 
-    outcome_names: list[str]
-
-    def __init__(self, search_space_digest: SearchSpaceDigest | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        outcome_names: list[str],
+        search_space_digest: SearchSpaceDigest | None = None
+    ) -> None:
         """
         Args:
+            outcome_names: Outcome names, needed for going between tensors and
+                data in formats used by Ax.
             search_space_digest: Used to extract target fidelity and task.
         """
+        self.outcome_names = outcome_names
         if search_space_digest is not None:
             self.target_fidelity_and_task: dict[str, float | int] = {
                 search_space_digest.feature_names[i]: target

--- a/ax/benchmark/runners/botorch_test.py
+++ b/ax/benchmark/runners/botorch_test.py
@@ -98,7 +98,9 @@ class SyntheticProblemRunner(BenchmarkRunner, ABC):
                 evaluated using the raw parameter values.
             search_space_digest: Used to extract target fidelity and task.
         """
-        super().__init__(search_space_digest=search_space_digest)
+        super().__init__(
+            outcome_names=outcome_names, search_space_digest=search_space_digest
+        )
         self._test_problem_class = test_problem_class
         self._test_problem_kwargs = test_problem_kwargs
         self.test_problem = (
@@ -114,7 +116,6 @@ class SyntheticProblemRunner(BenchmarkRunner, ABC):
             self.test_problem, ConstrainedBaseTestProblem
         )
         self._is_moo: bool = self.test_problem.num_objectives > 1
-        self.outcome_names = outcome_names
         self._modified_bounds = modified_bounds
 
     @equality_typechecker

--- a/ax/benchmark/runners/surrogate.py
+++ b/ax/benchmark/runners/surrogate.py
@@ -13,7 +13,7 @@ import torch
 from ax.benchmark.runners.base import BenchmarkRunner
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.observation import ObservationFeatures
-from ax.core.search_space import SearchSpace, SearchSpaceDigest
+from ax.core.search_space import SearchSpaceDigest
 from ax.modelbridge.torch import TorchModelBridge
 from ax.utils.common.base import Base
 from ax.utils.common.equality import equality_typechecker
@@ -28,7 +28,6 @@ class SurrogateRunner(BenchmarkRunner):
         self,
         *,
         name: str,
-        search_space: SearchSpace,
         outcome_names: list[str],
         surrogate: TorchModelBridge | None = None,
         datasets: list[SupervisedDataset] | None = None,
@@ -44,8 +43,6 @@ class SurrogateRunner(BenchmarkRunner):
             name: The name of the runner.
             surrogate: The modular BoTorch model `Surrogate` to use for
                 generating observations.
-            search_space: The search space of the problem (used for
-                parameter transforms).
             datasets: The data sets used to fit the surrogate model.
             outcome_names: The names of the outcomes of the Surrogate.
             noise_stds: Noise standard deviations to add to the surrogate output(s).
@@ -67,13 +64,13 @@ class SurrogateRunner(BenchmarkRunner):
                 "If get_surrogate_and_datasets is not provided, surrogate and "
                 "datasets must be provided, and vice versa."
             )
-        super().__init__(search_space_digest=search_space_digest)
+        super().__init__(
+            search_space_digest=search_space_digest, outcome_names=outcome_names
+        )
         self.get_surrogate_and_datasets = get_surrogate_and_datasets
         self.name = name
         self._surrogate = surrogate
-        self.outcome_names = outcome_names
         self._datasets = datasets
-        self.search_space = search_space
         self.noise_stds = noise_stds
         self.statuses: dict[int, TrialStatus] = {}
 

--- a/ax/benchmark/tests/runners/test_surrogate_runner.py
+++ b/ax/benchmark/tests/runners/test_surrogate_runner.py
@@ -40,7 +40,6 @@ class TestSurrogateRunner(TestCase):
                     name="test runner",
                     surrogate=surrogate,
                     datasets=[],
-                    search_space=self.search_space,
                     outcome_names=["dummy_metric"],
                     noise_stds=noise_std,
                 )
@@ -80,7 +79,6 @@ class TestSurrogateRunner(TestCase):
         ):
             SurrogateRunner(
                 name="test runner",
-                search_space=self.search_space,
                 outcome_names=[],
                 noise_stds=0.0,
             )
@@ -92,7 +90,6 @@ class TestSurrogateRunner(TestCase):
                 name=name,
                 surrogate=MagicMock(),
                 datasets=[],
-                search_space=self.search_space,
                 outcome_names=["dummy_metric"],
                 noise_stds=0.0,
             )

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -83,7 +83,6 @@ def get_soo_surrogate() -> SurrogateBenchmarkProblem:
     )
     runner = SurrogateRunner(
         name="test",
-        search_space=experiment.search_space,
         outcome_names=["branin"],
         get_surrogate_and_datasets=lambda: (surrogate, []),
     )
@@ -119,7 +118,6 @@ def get_moo_surrogate() -> SurrogateBenchmarkProblem:
 
     runner = SurrogateRunner(
         name="test",
-        search_space=experiment.search_space,
         outcome_names=["branin_a", "branin_b"],
         get_surrogate_and_datasets=lambda: (surrogate, []),
     )


### PR DESCRIPTION
Summary:
* All `BenchmarkRunner` subclasses treat `outcome_names` the same, so there is no reason to have it as an abstract property in the base class.
* The `SearchSpace` attribute of `SurrogateRunner` is not used.

Differential Revision: D64074648


