### PR TITLE
Make benchmark runners into dataclasses

### DIFF
--- a/ax/benchmark/runners/base.py
+++ b/ax/benchmark/runners/base.py
@@ -7,6 +7,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field, InitVar
 from math import sqrt
 from typing import Any
 
@@ -24,6 +25,7 @@ from numpy import ndarray
 from torch import Tensor
 
 
+@dataclass(kw_only=True)
 class BenchmarkRunner(Runner, ABC):
     """
     A Runner that produces both observed and ground-truth values.
@@ -43,19 +45,12 @@ class BenchmarkRunner(Runner, ABC):
           not over-engineer for that before such a use case arrives.
     """
 
-    def __init__(
-        self,
-        *,
-        outcome_names: list[str],
-        search_space_digest: SearchSpaceDigest | None = None
-    ) -> None:
-        """
-        Args:
-            outcome_names: Outcome names, needed for going between tensors and
-                data in formats used by Ax.
-            search_space_digest: Used to extract target fidelity and task.
-        """
-        self.outcome_names = outcome_names
+    outcome_names: list[str]
+    # pyre-fixme[8]: Pyre doesn't understand InitVars
+    search_space_digest: InitVar[SearchSpaceDigest | None] = None
+    target_fidelity_and_task: Mapping[str, float | int] = field(init=False)
+
+    def __post_init__(self, search_space_digest: SearchSpaceDigest | None) -> None:
         if search_space_digest is not None:
             self.target_fidelity_and_task: dict[str, float | int] = {
                 search_space_digest.feature_names[i]: target

--- a/ax/benchmark/tests/problems/test_mixed_integer_problems.py
+++ b/ax/benchmark/tests/problems/test_mixed_integer_problems.py
@@ -37,7 +37,7 @@ class MixedIntegerProblemsTest(TestCase):
             self.assertEqual(
                 checked_cast(
                     BotorchTestProblemRunner, problem.runner
-                )._test_problem_class.__name__,
+                ).test_problem_class.__name__,
                 name,
             )
             self.assertEqual(len(problem.search_space.parameters), dim)

--- a/ax/benchmark/tests/runners/test_botorch_test_problem.py
+++ b/ax/benchmark/tests/runners/test_botorch_test_problem.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 
+from dataclasses import replace
 from itertools import product
 from unittest.mock import Mock
 
@@ -101,14 +102,20 @@ class TestSyntheticRunner(TestCase):
                     runner._is_constrained,
                     issubclass(test_problem_class, ConstrainedBaseTestProblem),
                 )
-                self.assertEqual(runner._modified_bounds, modified_bounds)
+                self.assertEqual(runner.modified_bounds, modified_bounds)
                 if noise_std is not None:
                     self.assertEqual(runner.get_noise_stds(), noise_std)
                 else:
                     self.assertIsNone(runner.get_noise_stds())
 
-                # check equality with different class
-                self.assertNotEqual(runner, Hartmann(dim=6))
+                # check equality
+                self.assertNotEqual(
+                    runner,
+                    replace(
+                        runner,
+                        test_problem_kwargs={**test_problem_kwargs, "noise_std": 200.0},
+                    ),
+                )
                 self.assertEqual(runner, runner)
                 self.assertEqual(runner._is_moo, num_objectives > 1)
                 if issubclass(test_problem_class, BaseTestProblem):
@@ -180,11 +187,11 @@ class TestSyntheticRunner(TestCase):
                 self.assertEqual(
                     serialize_init_args,
                     {
-                        "test_problem_module": runner._test_problem_class.__module__,
-                        "test_problem_class_name": runner._test_problem_class.__name__,
-                        "test_problem_kwargs": runner._test_problem_kwargs,
+                        "test_problem_module": runner.test_problem_class.__module__,
+                        "test_problem_class_name": runner.test_problem_class.__name__,
+                        "test_problem_kwargs": runner.test_problem_kwargs,
                         "outcome_names": runner.outcome_names,
-                        "modified_bounds": runner._modified_bounds,
+                        "modified_bounds": runner.modified_bounds,
                     },
                 )
                 # test deserialize args

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -250,7 +250,15 @@ TEST_CASES = [
     ("SchedulerOptions", get_default_scheduler_options),
     ("SchedulerOptions", get_scheduler_options_batch_trial),
     ("SearchSpace", get_search_space),
-    ("SingleObjectiveBenchmarkProblem", get_single_objective_benchmark_problem),
+    (
+        "SingleObjectiveBenchmarkProblem",
+        lambda: get_single_objective_benchmark_problem(
+            test_problem_kwargs={
+                "noise_std": 2.0,
+                "bounds": [(-10.0, 10.0) for _ in range(2)],
+            }
+        ),
+    ),
     ("SumConstraint", get_sum_constraint1),
     ("SumConstraint", get_sum_constraint2),
     ("Surrogate", get_surrogate),


### PR DESCRIPTION
Summary:
Context: Using dataclasses makes things easier , and will make things *much* easier if we eventually rework serialization for BenchmarkRunners to not rely on SerializationMixin (as in D64061291). It also allows for stricter equality checks in a natural way.

This PR:
* Makes `BenchmarkRunner`, `SyntheticProblemRunner`, into dataclasses, without changing their init signatures or making substantive changes to their attributes.
* Renames attributes with underscores like `_test_problem_class` to `test_problem_class`, so that the attributes match what is used for initialization, to make these work as dataclasses
* Introduces a stricter equality check that uses `dataclasses.asdict`

Note: I had hoped to make this into frozen dataclasses, but this doesn't combine well with setting attributes in the post-init. That can be done but ia little opaque; see even though this is not really mutating the object after initialization, see https://stackoverflow.com/questions/53756788/how-to-set-the-value-of-dataclass-field-in-post-init-when-frozen-true

Differential Revision: D64110932


