### PR TITLE
Validate the inputs to ModelBridge.predict

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -627,6 +627,14 @@ class ModelBridge(ABC):  # noqa: B024 -- ModelBridge doesn't have any abstract m
             - Nested dictionary with cov['metric1']['metric2'] a list of
               cov(metric1@x, metric2@x) for x in observation_features.
         """
+        # Make sure that input is a list of ObservationFeatures. If you pass in
+        # arms, the code runs but it doesn't apply the transforms.
+        if not all(
+            isinstance(obsf, ObservationFeatures) for obsf in observation_features
+        ):
+            raise UserInputError(
+                "Input to predict must be a list of `ObservationFeatures`."
+            )
         observation_data = self._predict_observation_data(
             observation_features=observation_features
         )

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -104,6 +104,13 @@ class BaseModelBridgeTest(TestCase):
         with self.assertRaisesRegex(DeprecationWarning, "ModelBridge.update"):
             modelbridge.update(Mock(), Mock())
 
+        # Test prediction with arms.
+        with self.assertRaisesRegex(
+            UserInputError, "Input to predict must be a list of `ObservationFeatures`."
+        ):
+            # pyre-ignore[6]: Intentionally wrong argument type.
+            modelbridge.predict([Arm(parameters={"x": 1.0})])
+
         # Test prediction on out of design features.
         modelbridge._predict = mock.MagicMock(
             "ax.modelbridge.base.ModelBridge._predict",


### PR DESCRIPTION
Summary:
This came out of a puzzling bug in a notebook that took some time to debug. If you pass in a list of `Arm`s, `ModelBridge.predict` runs (since `Arm` also has `parameters`) but it doesn't apply transforms to the parameters (since `Arm.parameters` returns a clone of `Arm._parameters`). This can lead to non-sense predictions without the user realizing there is an issue with their code (in this case an `OverflowError:math range error` flagged the issue to us).

This diff adds a simple validation in `ModelBridge.predict` to check that the input is actually a list of `ObservationFeatures`.

Differential Revision: D64115012


