### PR TITLE
Sphinx: Stop relying on bundled JS

### DIFF
--- a/scripts/make_docs.sh
+++ b/scripts/make_docs.sh
@@ -83,8 +83,6 @@ if [[ $ONLY_DOCUSAURUS == false ]]; then
 
   # move JS files from /sphinx/build/html/_static/*:
   cp "${SPHINX_JS_DIR}documentation_options.js" "${DOCUSAURUS_JS_DIR}documentation_options.js"
-  cp "${SPHINX_JS_DIR}jquery.js" "${DOCUSAURUS_JS_DIR}jquery.js"
-  cp "${SPHINX_JS_DIR}underscore.js" "${DOCUSAURUS_JS_DIR}underscore.js"
   cp "${SPHINX_JS_DIR}doctools.js" "${DOCUSAURUS_JS_DIR}doctools.js"
   cp "${SPHINX_JS_DIR}language_data.js" "${DOCUSAURUS_JS_DIR}language_data.js"
   cp "${SPHINX_JS_DIR}searchtools.js" "${DOCUSAURUS_JS_DIR}searchtools.js"


### PR DESCRIPTION
Sphinx stopped bundling JS in Sphinx 6. Our current setup was expecting these files to exist so we update our assumptions here.

This was missed when [upgrading our Sphinx version](https://github.com/facebook/Ax/pull/2835) because building new sphinx docs `make html` does not clear out the contents from previous builds, so in my testing the build folder still contained these removed files from previous builds. Note to self: always run `make clean` when testing changes to sphinx.