### PR TITLE
Back out D64110932

### DIFF
--- a/ax/benchmark/runners/base.py
+++ b/ax/benchmark/runners/base.py
@@ -7,7 +7,6 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field, InitVar
 from math import sqrt
 from typing import Any
 
@@ -25,7 +24,6 @@ from numpy import ndarray
 from torch import Tensor
 
 
-@dataclass(kw_only=True)
 class BenchmarkRunner(Runner, ABC):
     """
     A Runner that produces both observed and ground-truth values.
@@ -45,12 +43,19 @@ class BenchmarkRunner(Runner, ABC):
           not over-engineer for that before such a use case arrives.
     """
 
-    outcome_names: list[str]
-    # pyre-fixme[8]: Pyre doesn't understand InitVars
-    search_space_digest: InitVar[SearchSpaceDigest | None] = None
-    target_fidelity_and_task: Mapping[str, float | int] = field(init=False)
-
-    def __post_init__(self, search_space_digest: SearchSpaceDigest | None) -> None:
+    def __init__(
+        self,
+        *,
+        outcome_names: list[str],
+        search_space_digest: SearchSpaceDigest | None = None
+    ) -> None:
+        """
+        Args:
+            outcome_names: Outcome names, needed for going between tensors and
+                data in formats used by Ax.
+            search_space_digest: Used to extract target fidelity and task.
+        """
+        self.outcome_names = outcome_names
         if search_space_digest is not None:
             self.target_fidelity_and_task: dict[str, float | int] = {
                 search_space_digest.feature_names[i]: target

--- a/ax/benchmark/runners/botorch_test.py
+++ b/ax/benchmark/runners/botorch_test.py
@@ -8,7 +8,7 @@
 import importlib
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -56,7 +56,6 @@ class ParamBasedTestProblem(ABC):
         return self.__class__.__name__ == other.__class__.__name__
 
 
-@dataclass(kw_only=True)
 class SyntheticProblemRunner(BenchmarkRunner, ABC):
     """A Runner for evaluating synthetic problems, either BoTorch
     `BaseTestProblem`s or Ax benchmarking `ParamBasedTestProblem`s.
@@ -64,40 +63,70 @@ class SyntheticProblemRunner(BenchmarkRunner, ABC):
     Given a trial, the Runner will evaluate the problem noiselessly for each
     arm in the trial, as well as return some metadata about the underlying
     problem such as the noise_std.
-
-    Args:
-        test_problem_class: A BoTorch `BaseTestProblem` class or Ax
-            `ParamBasedTestProblem` class.
-        test_problem_kwargs: The keyword arguments used for initializing the
-            test problem.
-        outcome_names: The names of the outcomes returned by the problem.
-        modified_bounds: The bounds that are used by the Ax search space
-            while optimizing the problem. If different from the bounds of the
-            test problem, we project the parameters into the test problem
-            bounds before evaluating the test problem.
-            For example, if the test problem is defined on [0, 1] but the Ax
-            search space is integers in [0, 10], an Ax parameter value of
-            5 will correspond to 0.5 while evaluating the test problem.
-            If modified bounds are not provided, the test problem will be
-            evaluated using the raw parameter values.
-        search_space_digest: Used to extract target fidelity and task.
     """
 
-    test_problem_class: type[BaseTestProblem | ParamBasedTestProblem]
-    test_problem_kwargs: dict[str, Any] = field(default_factory=dict)
-    modified_bounds: list[tuple[float, float]] | None = None
-    test_problem: BaseTestProblem | ParamBasedTestProblem = field(init=False)
+    test_problem: BaseTestProblem | ParamBasedTestProblem
+    _is_constrained: bool
+    _test_problem_class: type[BaseTestProblem | ParamBasedTestProblem]
+    _test_problem_kwargs: dict[str, Any] | None
 
-    def __post_init__(self, search_space_digest: SearchSpaceDigest | None) -> None:
-        super().__post_init__(search_space_digest=search_space_digest)
+    def __init__(
+        self,
+        *,
+        test_problem_class: type[BaseTestProblem | ParamBasedTestProblem],
+        test_problem_kwargs: dict[str, Any],
+        outcome_names: list[str],
+        modified_bounds: list[tuple[float, float]] | None = None,
+        search_space_digest: SearchSpaceDigest | None = None,
+    ) -> None:
+        """Initialize the test problem runner.
 
-    @property
-    def _is_moo(self) -> bool:
-        return self.test_problem.num_objectives > 1
+        Args:
+            test_problem_class: A BoTorch `BaseTestProblem` class or Ax
+                `ParamBasedTestProblem` class.
+            test_problem_kwargs: The keyword arguments used for initializing the
+                test problem.
+            outcome_names: The names of the outcomes returned by the problem.
+            modified_bounds: The bounds that are used by the Ax search space
+                while optimizing the problem. If different from the bounds of the
+                test problem, we project the parameters into the test problem
+                bounds before evaluating the test problem.
+                For example, if the test problem is defined on [0, 1] but the Ax
+                search space is integers in [0, 10], an Ax parameter value of
+                5 will correspond to 0.5 while evaluating the test problem.
+                If modified bounds are not provided, the test problem will be
+                evaluated using the raw parameter values.
+            search_space_digest: Used to extract target fidelity and task.
+        """
+        super().__init__(
+            outcome_names=outcome_names, search_space_digest=search_space_digest
+        )
+        self._test_problem_class = test_problem_class
+        self._test_problem_kwargs = test_problem_kwargs
+        self.test_problem = (
+            # pyre-fixme: Invalid class instantiation [45]: Cannot instantiate
+            # abstract class with abstract method `evaluate_true`.
+            test_problem_class(**test_problem_kwargs)
+        )
+        if isinstance(self.test_problem, BaseTestProblem):
+            self.test_problem = self.test_problem.to(dtype=torch.double)
+        # A `ConstrainedBaseTestProblem` is a type of `BaseTestProblem`; a
+        # `ParamBasedTestProblem` is never constrained.
+        self._is_constrained: bool = isinstance(
+            self.test_problem, ConstrainedBaseTestProblem
+        )
+        self._is_moo: bool = self.test_problem.num_objectives > 1
+        self._modified_bounds = modified_bounds
 
-    @property
-    def _is_constrained(self) -> bool:
-        return issubclass(self.test_problem_class, ConstrainedBaseTestProblem)
+    @equality_typechecker
+    def __eq__(self, other: Base) -> bool:
+        if not isinstance(other, type(self)):
+            return False
+
+        return (
+            self.test_problem.__class__.__name__
+            == other.test_problem.__class__.__name__
+        )
 
     def get_noise_stds(self) -> None | float | dict[str, float]:
         noise_std = self.test_problem.noise_std
@@ -145,11 +174,11 @@ class SyntheticProblemRunner(BenchmarkRunner, ABC):
         runner = assert_is_instance(obj, cls)
 
         return {
-            "test_problem_module": runner.test_problem_class.__module__,
-            "test_problem_class_name": runner.test_problem_class.__name__,
-            "test_problem_kwargs": runner.test_problem_kwargs,
+            "test_problem_module": runner._test_problem_class.__module__,
+            "test_problem_class_name": runner._test_problem_class.__name__,
+            "test_problem_kwargs": runner._test_problem_kwargs,
             "outcome_names": runner.outcome_names,
-            "modified_bounds": runner.modified_bounds,
+            "modified_bounds": runner._modified_bounds,
         }
 
     @classmethod
@@ -173,7 +202,6 @@ class SyntheticProblemRunner(BenchmarkRunner, ABC):
         }
 
 
-@dataclass(kw_only=True)
 class BotorchTestProblemRunner(SyntheticProblemRunner):
     """
     A `SyntheticProblemRunner` for BoTorch `BaseTestProblem`s.
@@ -195,14 +223,25 @@ class BotorchTestProblemRunner(SyntheticProblemRunner):
         search_space_digest: Used to extract target fidelity and task.
     """
 
-    test_problem_class: type[BaseTestProblem]
-    test_problem: BaseTestProblem = field(init=False)
-
-    def __post_init__(self, search_space_digest: SearchSpaceDigest | None) -> None:
-        super().__post_init__(search_space_digest)
-        # pyre-fixme[45]: Can't instantiate abstract class `BaseTestProblem`.
-        self.test_problem = self.test_problem_class(**self.test_problem_kwargs).to(
-            torch.double
+    def __init__(
+        self,
+        *,
+        test_problem_class: type[BaseTestProblem],
+        test_problem_kwargs: dict[str, Any],
+        outcome_names: list[str],
+        modified_bounds: list[tuple[float, float]] | None = None,
+        search_space_digest: SearchSpaceDigest | None = None,
+    ) -> None:
+        super().__init__(
+            test_problem_class=test_problem_class,
+            test_problem_kwargs=test_problem_kwargs,
+            outcome_names=outcome_names,
+            modified_bounds=modified_bounds,
+            search_space_digest=search_space_digest,
+        )
+        self.test_problem: BaseTestProblem = self.test_problem.to(dtype=torch.double)
+        self._is_constrained: bool = isinstance(
+            self.test_problem, ConstrainedBaseTestProblem
         )
 
     def get_Y_true(self, params: Mapping[str, TParamValue]) -> Tensor:
@@ -226,10 +265,10 @@ class BotorchTestProblemRunner(SyntheticProblemRunner):
             dtype=torch.double,
         )
 
-        if self.modified_bounds is not None:
+        if self._modified_bounds is not None:
             # Normalize from modified bounds to unit cube.
             unit_X = normalize(
-                X, torch.tensor(self.modified_bounds, dtype=torch.double).T
+                X, torch.tensor(self._modified_bounds, dtype=torch.double).T
             )
             # Unnormalize from unit cube to original problem bounds.
             X = unnormalize(unit_X, self.test_problem.bounds)
@@ -249,42 +288,37 @@ class BotorchTestProblemRunner(SyntheticProblemRunner):
 
         return Y_true
 
-    @equality_typechecker
-    def __eq__(self, other: Base) -> bool:
-        """
-        Compare equality by comparing dicts, except for `test_problem`.
 
-        Dataclasses are compared by comparing the results of calling asdict on
-        them. However, equality checks don't work as needed with BoTorch test
-        problems, e.g. Branin() == Branin() is False. To get around that, the
-        test problem is stripped from the dictionary. This doesn't make the
-        check less sensitive, as long as the problem has not been modified,
-        because the test problem class and keyword arguments will still be
-        compared.
-        """
-        if not isinstance(other, type(self)):
-            return False
-        self_as_dict = asdict(self)
-        other_as_dict = asdict(other)
-        self_as_dict.pop("test_problem")
-        other_as_dict.pop("test_problem")
-        return self_as_dict == other_as_dict
-
-
-@dataclass(kw_only=True)
 class ParamBasedTestProblemRunner(SyntheticProblemRunner):
     """
     A `SyntheticProblemRunner` for `ParamBasedTestProblem`s. See
     `SyntheticProblemRunner` for more information.
     """
 
-    test_problem_class: type[ParamBasedTestProblem]
-    test_problem: ParamBasedTestProblem = field(init=False)
+    # This could easily be supported, but hasn't been hooked up
+    _is_constrained: bool = False
 
-    def __post_init__(self, search_space_digest: SearchSpaceDigest | None) -> None:
-        super().__post_init__(search_space_digest=search_space_digest)
-        # pyre-fixme[45]: Can't instantiate abstract class `ParamBasedTestProblem`.
-        self.test_problem = self.test_problem_class(**self.test_problem_kwargs)
+    def __init__(
+        self,
+        *,
+        test_problem_class: type[ParamBasedTestProblem],
+        test_problem_kwargs: dict[str, Any],
+        outcome_names: list[str],
+        modified_bounds: list[tuple[float, float]] | None = None,
+        search_space_digest: SearchSpaceDigest | None = None,
+    ) -> None:
+        if modified_bounds is not None:
+            raise NotImplementedError(
+                f"modified_bounds is not supported for {test_problem_class.__name__}"
+            )
+        super().__init__(
+            test_problem_class=test_problem_class,
+            test_problem_kwargs=test_problem_kwargs,
+            outcome_names=outcome_names,
+            modified_bounds=modified_bounds,
+            search_space_digest=search_space_digest,
+        )
+        self.test_problem: ParamBasedTestProblem = self.test_problem
 
     def get_Y_true(self, params: Mapping[str, TParamValue]) -> Tensor:
         """Evaluates the test problem.

--- a/ax/benchmark/tests/problems/test_mixed_integer_problems.py
+++ b/ax/benchmark/tests/problems/test_mixed_integer_problems.py
@@ -37,7 +37,7 @@ class MixedIntegerProblemsTest(TestCase):
             self.assertEqual(
                 checked_cast(
                     BotorchTestProblemRunner, problem.runner
-                ).test_problem_class.__name__,
+                )._test_problem_class.__name__,
                 name,
             )
             self.assertEqual(len(problem.search_space.parameters), dim)

--- a/ax/benchmark/tests/runners/test_botorch_test_problem.py
+++ b/ax/benchmark/tests/runners/test_botorch_test_problem.py
@@ -7,7 +7,6 @@
 # pyre-strict
 
 
-from dataclasses import replace
 from itertools import product
 from unittest.mock import Mock
 
@@ -102,20 +101,14 @@ class TestSyntheticRunner(TestCase):
                     runner._is_constrained,
                     issubclass(test_problem_class, ConstrainedBaseTestProblem),
                 )
-                self.assertEqual(runner.modified_bounds, modified_bounds)
+                self.assertEqual(runner._modified_bounds, modified_bounds)
                 if noise_std is not None:
                     self.assertEqual(runner.get_noise_stds(), noise_std)
                 else:
                     self.assertIsNone(runner.get_noise_stds())
 
-                # check equality
-                self.assertNotEqual(
-                    runner,
-                    replace(
-                        runner,
-                        test_problem_kwargs={**test_problem_kwargs, "noise_std": 200.0},
-                    ),
-                )
+                # check equality with different class
+                self.assertNotEqual(runner, Hartmann(dim=6))
                 self.assertEqual(runner, runner)
                 self.assertEqual(runner._is_moo, num_objectives > 1)
                 if issubclass(test_problem_class, BaseTestProblem):
@@ -187,11 +180,11 @@ class TestSyntheticRunner(TestCase):
                 self.assertEqual(
                     serialize_init_args,
                     {
-                        "test_problem_module": runner.test_problem_class.__module__,
-                        "test_problem_class_name": runner.test_problem_class.__name__,
-                        "test_problem_kwargs": runner.test_problem_kwargs,
+                        "test_problem_module": runner._test_problem_class.__module__,
+                        "test_problem_class_name": runner._test_problem_class.__name__,
+                        "test_problem_kwargs": runner._test_problem_kwargs,
                         "outcome_names": runner.outcome_names,
-                        "modified_bounds": runner.modified_bounds,
+                        "modified_bounds": runner._modified_bounds,
                     },
                 )
                 # test deserialize args

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -148,6 +148,10 @@ TEST_CASES = [
     ("BoTorchModel", get_botorch_model),
     ("BoTorchModel", get_botorch_model_with_default_acquisition_class),
     ("BoTorchModel", get_botorch_model_with_surrogate_specs),
+    (
+        "BoTorchTestProblemRunner",
+        lambda: get_single_objective_benchmark_problem().runner,
+    ),
     ("BraninMetric", get_branin_metric),
     ("ChainedInputTransform", get_chained_input_transform),
     ("ChoiceParameter", get_choice_parameter),
@@ -241,6 +245,7 @@ TEST_CASES = [
         "PercentileEarlyStoppingStrategy",
         get_percentile_early_stopping_strategy_with_non_objective_metric_name,
     ),
+    ("ParamBasedTestProblemRunner", lambda: get_jenatton_benchmark_problem().runner),
     ("ParameterConstraint", get_parameter_constraint),
     ("ParameterDistribution", get_parameter_distribution),
     ("RangeParameter", get_range_parameter),
@@ -250,15 +255,7 @@ TEST_CASES = [
     ("SchedulerOptions", get_default_scheduler_options),
     ("SchedulerOptions", get_scheduler_options_batch_trial),
     ("SearchSpace", get_search_space),
-    (
-        "SingleObjectiveBenchmarkProblem",
-        lambda: get_single_objective_benchmark_problem(
-            test_problem_kwargs={
-                "noise_std": 2.0,
-                "bounds": [(-10.0, 10.0) for _ in range(2)],
-            }
-        ),
-    ),
+    ("SingleObjectiveBenchmarkProblem", get_single_objective_benchmark_problem),
     ("SumConstraint", get_sum_constraint1),
     ("SumConstraint", get_sum_constraint2),
     ("Surrogate", get_surrogate),


### PR DESCRIPTION
Summary: Reverts D64110932, which broke serialization and deserialization for `ParamBasedTestProblemRunner`. I am working on a change to make serializing BenchmarkProblems and BenchmarkRunners unsupported and unavailable, so it makes more sense to do that and then make these into dataclasses once serialization is not an issue.

Reviewed By: Balandat

Differential Revision: D64240260


