### PR TITLE
Standardize AnalysisCard.name and AnalysisCard.attributes

### DIFF
--- a/ax/analysis/healthcheck/healthcheck_analysis.py
+++ b/ax/analysis/healthcheck/healthcheck_analysis.py
@@ -7,9 +7,9 @@
 import json
 from enum import IntEnum
 
-from ax.analysis.analysis import AnalysisCard
+from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
-from ax.modelbridge.generation_strategy import GenerationStrategy
+from ax.core.generation_strategy_interface import GenerationStrategyInterface
 
 
 class HealthcheckStatus(IntEnum):
@@ -25,7 +25,7 @@ class HealthcheckAnalysisCard(AnalysisCard):
         return HealthcheckStatus(json.loads(self.blob)["status"])
 
 
-class HealthcheckAnalysis:
+class HealthcheckAnalysis(Analysis):
     """
     An analysis that performs a health check.
     """
@@ -33,5 +33,5 @@ class HealthcheckAnalysis:
     def compute(
         self,
         experiment: Experiment | None = None,
-        generation_strategy: GenerationStrategy | None = None,
+        generation_strategy: GenerationStrategyInterface | None = None,
     ) -> HealthcheckAnalysisCard: ...

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -6,7 +6,8 @@
 # pyre-strict
 
 
-from ax.analysis.analysis import Analysis, AnalysisCard
+import pandas as pd
+from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from IPython.display import display, Markdown
@@ -36,3 +37,25 @@ class MarkdownAnalysis(Analysis):
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategyInterface | None = None,
     ) -> MarkdownAnalysisCard: ...
+
+    def _create_markdown_analysis_card(
+        self,
+        title: str,
+        subtitle: str,
+        level: AnalysisCardLevel,
+        df: pd.DataFrame,
+        message: str,
+    ) -> MarkdownAnalysisCard:
+        """
+        Make a MarkdownAnalysisCard from this Analysis using provided fields and
+        details about the Analysis class.
+        """
+        return MarkdownAnalysisCard(
+            name=self.__class__.__name__,
+            attributes=self.__dict__,
+            title=title,
+            subtitle=subtitle,
+            level=level,
+            df=df,
+            blob=message,
+        )

--- a/ax/analysis/plotly/arm_effects/insample_effects.py
+++ b/ax/analysis/plotly/arm_effects/insample_effects.py
@@ -25,7 +25,6 @@ from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.registry import Models
 from ax.modelbridge.transforms.derelativize import Derelativize
 from ax.utils.common.logger import get_logger
-from plotly import io as pio
 from pyre_extensions import none_throws
 
 logger: Logger = get_logger(__name__)
@@ -128,8 +127,7 @@ class InSampleEffectsPlot(PlotlyAnalysis):
             f"{'predicted' if self.use_modeled_effects else 'observed'} "
             "metric values"
         )
-        return PlotlyAnalysisCard(
-            name=f"{plot_type}EffectsPlot",
+        return self._create_plotly_analysis_card(
             title=(
                 f"{plot_type} Effects for {self.metric_name} "
                 f"on trial {self.trial_index}"
@@ -137,8 +135,7 @@ class InSampleEffectsPlot(PlotlyAnalysis):
             subtitle=subtitle,
             level=level,
             df=df,
-            blob=pio.to_json(fig),
-            attributes={"trial_index": self.trial_index},
+            fig=fig,
         )
 
 

--- a/ax/analysis/plotly/arm_effects/predicted_effects.py
+++ b/ax/analysis/plotly/arm_effects/predicted_effects.py
@@ -24,7 +24,6 @@ from ax.modelbridge.base import ModelBridge
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.transforms.derelativize import Derelativize
 from ax.utils.common.typeutils import checked_cast
-from plotly import io as pio
 from pyre_extensions import none_throws
 
 
@@ -132,14 +131,12 @@ class PredictedEffectsPlot(PlotlyAnalysis):
         else:
             level = AnalysisCardLevel.MID
 
-        return PlotlyAnalysisCard(
-            name="PredictedEffectsPlot",
+        return self._create_plotly_analysis_card(
             title=f"Predicted Effects for {self.metric_name}",
             subtitle="View a candidate trial and its arms' predicted metric values",
             level=level,
             df=df,
-            blob=pio.to_json(fig),
-            attributes={"trial_index": candidate_trial.index},
+            fig=fig,
         )
 
 

--- a/ax/analysis/plotly/parallel_coordinates.py
+++ b/ax/analysis/plotly/parallel_coordinates.py
@@ -16,7 +16,7 @@ from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from ax.core.objective import MultiObjective, ScalarizedObjective
 from ax.exceptions.core import UnsupportedError, UserInputError
-from plotly import graph_objects as go, io as pio
+from plotly import graph_objects as go
 
 
 class ParallelCoordinatesPlot(PlotlyAnalysis):
@@ -55,13 +55,12 @@ class ParallelCoordinatesPlot(PlotlyAnalysis):
         df = _prepare_data(experiment=experiment, metric=metric_name)
         fig = _prepare_plot(df=df, metric_name=metric_name)
 
-        return PlotlyAnalysisCard(
-            name=str(self),
+        return self._create_plotly_analysis_card(
             title=f"Parallel Coordinates for {metric_name}",
             subtitle="View arm parameterizations with their respective metric values",
             level=AnalysisCardLevel.HIGH,
             df=df,
-            blob=pio.to_json(fig),
+            fig=fig,
         )
 
 

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -6,7 +6,8 @@
 # pyre-strict
 
 
-from ax.analysis.analysis import Analysis, AnalysisCard
+import pandas as pd
+from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from IPython.display import display
@@ -37,3 +38,25 @@ class PlotlyAnalysis(Analysis):
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategyInterface | None = None,
     ) -> PlotlyAnalysisCard: ...
+
+    def _create_plotly_analysis_card(
+        self,
+        title: str,
+        subtitle: str,
+        level: AnalysisCardLevel,
+        df: pd.DataFrame,
+        fig: go.Figure,
+    ) -> PlotlyAnalysisCard:
+        """
+        Make a PlotlyAnalysisCard from this Analysis using provided fields and
+        details about the Analysis class.
+        """
+        return PlotlyAnalysisCard(
+            name=self.__class__.__name__,
+            attributes=self.__dict__,
+            title=title,
+            subtitle=subtitle,
+            level=level,
+            df=df,
+            blob=pio.to_json(fig),
+        )

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -14,7 +14,7 @@ from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCar
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from ax.exceptions.core import DataRequiredError, UserInputError
-from plotly import express as px, graph_objects as go, io as pio
+from plotly import express as px, graph_objects as go
 
 
 class ScatterPlot(PlotlyAnalysis):
@@ -70,13 +70,12 @@ class ScatterPlot(PlotlyAnalysis):
             or False,
         )
 
-        return PlotlyAnalysisCard(
-            name=str(self),
+        return self._create_plotly_analysis_card(
             title=f"Observed {self.x_metric_name} vs. {self.y_metric_name}",
             subtitle="Compare arms by their observed metric values",
             level=AnalysisCardLevel.HIGH,
             df=df,
-            blob=pio.to_json(fig),
+            fig=fig,
         )
 
 

--- a/ax/analysis/plotly/tests/test_insample_effects.py
+++ b/ax/analysis/plotly/tests/test_insample_effects.py
@@ -172,7 +172,7 @@ class TestInsampleEffectsPlot(TestCase):
             self.assertIn(arm.name, card.df["arm_name"].unique())
 
         # AND THEN the card is labeled correctly
-        self.assertEqual(card.name, "ModeledEffectsPlot")
+        self.assertEqual(card.name, "InSampleEffectsPlot")
         self.assertEqual(card.title, "Modeled Effects for branin on trial 0")
         self.assertEqual(
             card.subtitle, "View a trial and its arms' predicted metric values"
@@ -218,7 +218,7 @@ class TestInsampleEffectsPlot(TestCase):
             self.assertIn(arm.name, card.df["arm_name"].unique())
 
         # AND THEN the card is labeled correctly
-        self.assertEqual(card.name, "ModeledEffectsPlot")
+        self.assertEqual(card.name, "InSampleEffectsPlot")
         self.assertEqual(card.title, "Modeled Effects for branin on trial 0")
         self.assertEqual(
             card.subtitle, "View a trial and its arms' predicted metric values"
@@ -275,7 +275,7 @@ class TestInsampleEffectsPlot(TestCase):
             )
 
         # AND THEN the card is labeled correctly
-        self.assertEqual(card.name, "RawEffectsPlot")
+        self.assertEqual(card.name, "InSampleEffectsPlot")
         self.assertEqual(card.title, "Raw Effects for branin on trial 0")
         self.assertEqual(
             card.subtitle, "View a trial and its arms' observed metric values"

--- a/ax/analysis/plotly/tests/test_parallel_coordinates.py
+++ b/ax/analysis/plotly/tests/test_parallel_coordinates.py
@@ -30,7 +30,7 @@ class TestParallelCoordinatesPlot(TestCase):
             analysis.compute()
 
         card = analysis.compute(experiment=experiment)
-        self.assertEqual(card.name, "ParallelCoordinatesPlot(metric_name=branin)")
+        self.assertEqual(card.name, "ParallelCoordinatesPlot")
         self.assertEqual(card.title, "Parallel Coordinates for branin")
         self.assertEqual(
             card.subtitle,

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -31,13 +31,7 @@ class TestParallelCoordinatesPlot(TestCase):
             analysis.compute()
 
         card = analysis.compute(experiment=experiment)
-        self.assertEqual(
-            card.name,
-            (
-                "ScatterPlot(x_metric_name=branin_a, y_metric_name=branin_b, "
-                "show_pareto_frontier=True)"
-            ),
-        )
+        self.assertEqual(card.name, "ScatterPlot")
         self.assertEqual(card.title, "Observed branin_a vs. branin_b")
         self.assertEqual(
             card.subtitle,

--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -97,11 +97,9 @@ class Summary(Analysis):
         if self.omit_empty_columns:
             df = df.loc[:, df.notnull().all()]
 
-        return AnalysisCard(
-            name=str(self),
+        return self._create_analysis_card(
             title=f"Summary for {experiment.name}",
             subtitle="High-level summary of the `Trial`-s in this `Experiment`",
             level=AnalysisCardLevel.MID,
             df=df,
-            blob=str(df),
         )

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -25,7 +25,7 @@ class TestSummary(TestCase):
         card = analysis.compute(experiment=experiment)
 
         # Test metadata
-        self.assertEqual(card.name, "Summary(omit_empty_columns=True)")
+        self.assertEqual(card.name, "Summary")
         self.assertEqual(card.title, "Summary for branin_test_experiment")
         self.assertEqual(
             card.subtitle,

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -2617,7 +2617,7 @@ class AxSchedulerTestCase(TestCase):
             self.assertTrue(
                 any(
                     (
-                        "Failed to compute ParallelCoordinatesPlot(metric_name=None): "
+                        "Failed to compute ParallelCoordinatesPlot: "
                         "No data found for metric "
                     )
                     in msg
@@ -2645,7 +2645,7 @@ class AxSchedulerTestCase(TestCase):
         cards = scheduler.compute_analyses(analyses=[ParallelCoordinatesPlot()])
 
         self.assertEqual(len(cards), 1)
-        self.assertEqual(cards[0].name, "ParallelCoordinatesPlot(metric_name=None)")
+        self.assertEqual(cards[0].name, "ParallelCoordinatesPlot")
 
     def test_validate_options_not_none_mt_trial_type(
         self, msg: str | None = None


### PR DESCRIPTION
Summary: Added new method Analysis._create_analysis_card and a corresponding method on the other Analysis types to standardize the way we collect data while constructing Cards. These utitlity methods make it so Card.name will always be the class name of the Analysis that computes the Card and Card.attributes will always hold the attributes present on the Analysis

Differential Revision: D64255296


