### PR TITLE
Replace AnalysisCardLevel with int

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 from collections.abc import Iterable
-from enum import Enum
+from enum import IntEnum
 from logging import Logger
 from typing import Any, Protocol
 
@@ -21,12 +21,12 @@ from IPython.display import display
 logger: Logger = get_logger(__name__)
 
 
-class AnalysisCardLevel(Enum):
+class AnalysisCardLevel(IntEnum):
     DEBUG = 0
-    LOW = 1
-    MID = 2
-    HIGH = 3
-    CRITICAL = 4
+    LOW = 10
+    MID = 20
+    HIGH = 30
+    CRITICAL = 40
 
 
 class AnalysisCard(Base):
@@ -41,7 +41,7 @@ class AnalysisCard(Base):
     title: str
     subtitle: str
 
-    level: AnalysisCardLevel
+    level: int
 
     df: pd.DataFrame  # Raw data produced by the Analysis
 
@@ -58,7 +58,7 @@ class AnalysisCard(Base):
         name: str,
         title: str,
         subtitle: str,
-        level: AnalysisCardLevel,
+        level: int,
         df: pd.DataFrame,
         blob: str,
         attributes: dict[str, Any] | None = None,
@@ -148,7 +148,7 @@ class Analysis(Protocol):
         self,
         title: str,
         subtitle: str,
-        level: AnalysisCardLevel,
+        level: int,
         df: pd.DataFrame,
     ) -> AnalysisCard:
         """

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -7,7 +7,7 @@
 
 
 import pandas as pd
-from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
+from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from IPython.display import display, Markdown
@@ -42,7 +42,7 @@ class MarkdownAnalysis(Analysis):
         self,
         title: str,
         subtitle: str,
-        level: AnalysisCardLevel,
+        level: int,
         df: pd.DataFrame,
         message: str,
     ) -> MarkdownAnalysisCard:

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -7,7 +7,7 @@
 
 
 import pandas as pd
-from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
+from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from IPython.display import display
@@ -43,7 +43,7 @@ class PlotlyAnalysis(Analysis):
         self,
         title: str,
         subtitle: str,
-        level: AnalysisCardLevel,
+        level: int,
         df: pd.DataFrame,
         fig: go.Figure,
     ) -> PlotlyAnalysisCard:

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -14,7 +14,7 @@ from logging import Logger
 from typing import Any, cast, Union
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCard, AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCard
 
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
@@ -1052,7 +1052,7 @@ class Decoder:
             name=analysis_card_sqa.name,
             title=analysis_card_sqa.title,
             subtitle=analysis_card_sqa.subtitle,
-            level=AnalysisCardLevel(analysis_card_sqa.level),
+            level=analysis_card_sqa.level,
             df=read_json(analysis_card_sqa.dataframe_json),
             blob=analysis_card_sqa.blob,
             attributes=(

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -12,8 +12,6 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
-from ax.analysis.analysis import AnalysisCardLevel
-
 from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import LifecycleStage
 from ax.core.parameter import ParameterType
@@ -341,9 +339,7 @@ class SQAAnalysisCard(Base):
     name: Column[str] = Column(String(NAME_OR_TYPE_FIELD_LENGTH), nullable=False)
     title: Column[str] = Column(String(LONG_STRING_FIELD_LENGTH), nullable=False)
     subtitle: Column[str] = Column(Text, nullable=False)
-    level: Column[AnalysisCardLevel] = Column(
-        IntEnum(AnalysisCardLevel), nullable=False
-    )
+    level: Column[int] = Column(Integer, nullable=False)
     dataframe_json: Column[str] = Column(Text(LONGTEXT_BYTES), nullable=False)
     blob: Column[str] = Column(Text(LONGTEXT_BYTES), nullable=False)
     blob_annotation: Column[str] = Column(


### PR DESCRIPTION
Summary: After discussion we decided we wanted more granular control over priority levels. We encourage all Analysis authors to continue using AnalysisCardLevel as a starting point, but if necessary they can adjust by adding or subtracting an integer.

Differential Revision: D64261171


