### PR TITLE
Use `_gen_multiple` for now, as before, in applications of the `Scheduler` that run `Trials`

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -31,6 +31,7 @@ from ax.utils.common.serialization import (
 from ax.utils.common.typeutils import checked_cast, not_none
 
 TBaseData = TypeVar("TBaseData", bound="BaseData")
+DF_REPR_MAX_LENGTH = 1000
 
 
 class BaseData(Base, SerializationMixin):
@@ -210,10 +211,9 @@ class BaseData(Base, SerializationMixin):
 
     @property
     def true_df(self) -> pd.DataFrame:
-        """Return the `DataFrame` being used as the source of truth (avoid using
+        """Return the ``DataFrame`` being used as the source of truth (avoid using
         except for caching).
         """
-
         return self._df
 
     @property
@@ -409,6 +409,13 @@ class BaseData(Base, SerializationMixin):
         """
         cls = type(self)
         return cls(df=df, **cls.serialize_init_args(self))
+
+    def __repr__(self) -> str:
+        """String representation of the subclass, inheriting from this base."""
+        df_markdown = self.df.to_markdown()
+        if len(df_markdown) > DF_REPR_MAX_LENGTH:
+            df_markdown = df_markdown[:DF_REPR_MAX_LENGTH] + "..."
+        return f"{self.__class__.__name__}(df=\n{df_markdown})"
 
 
 class Data(BaseData):

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -22,7 +22,12 @@ import ax.core.observation as observation
 import pandas as pd
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
-from ax.core.base_trial import BaseTrial, DEFAULT_STATUSES_TO_WARM_START, TrialStatus
+from ax.core.base_trial import (
+    BaseTrial,
+    DEFAULT_STATUSES_TO_WARM_START,
+    STATUSES_EXPECTING_DATA,
+    TrialStatus,
+)
 from ax.core.batch_trial import BatchTrial, LifecycleStage
 from ax.core.data import Data
 from ax.core.formatting_utils import DATA_TYPE_LOOKUP, DataType
@@ -1055,6 +1060,18 @@ class Experiment(Base):
     def running_trial_indices(self) -> set[int]:
         """Indices of running trials, associated with the experiment."""
         return self._trial_indices_by_status[TrialStatus.RUNNING]
+
+    @property
+    def trial_indices_expecting_data(self) -> set[int]:
+        """Set of indices of trials, statuses of which indicate that we expect
+        these trials to have data, either already or in the future.
+        """
+        return set.union(
+            *(
+                self.trial_indices_by_status[status]
+                for status in STATUSES_EXPECTING_DATA
+            )
+        )
 
     @property
     def default_data_type(self) -> DataType:

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import random
+from unittest.mock import patch
 
 import pandas as pd
 from ax.core.data import (
@@ -17,6 +18,39 @@ from ax.core.data import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.timeutils import current_timestamp_in_millis
+
+REPR_1000: str = (
+    "Data(df=\n"
+    + "|    |   arm_name | metric_name   |   mean |   sem |   trial_index "
+    + "| start_time          | end_time            |\n"
+    + "|---:|-----------:|:--------------|-------:|------:|--------------:"
+    + "|:--------------------|:--------------------|\n"
+    + "|  0 |        0_0 | a             |    2   |   0.2 |             1 "
+    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    + "|  1 |        0_0 | b             |    1.8 |   0.3 |             1 "
+    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    + "|  2 |        0_1 | a             |    4   |   0.6 |             1 "
+    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    + "|  3 |        0_1 | b             |    3.7 |   0.5 |             1 "
+    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    + "|  4 |        0_2 | a             |    0.5 | nan   |             1 "
+    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    + "|  5 |        0_2 | b             |    3   | nan   |             1 "
+    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |)"
+)
+
+REPR_500: str = (
+    "Data(df=\n"
+    + "|    |   arm_name | metric_name   |   mean |   sem |   trial_index "
+    + "| start_time          | end_time            |\n"
+    + "|---:|-----------:|:--------------|-------:|------:|--------------:"
+    + "|:--------------------|:--------------------|\n"
+    + "|  0 |        0_0 | a             |    2   |   0.2 |             1 "
+    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    + "|  1 |        0_0 | b             |    1.8 |   0.3 |             1 "
+    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    + "|  2 |        0_1 | a             |    4   |   0...)"
+)
 
 
 class DataTest(TestCase):
@@ -97,6 +131,17 @@ class DataTest(TestCase):
             float(df[df["arm_name"] == "0_1"][df["metric_name"] == "b"]["sem"].item()),
             0.5,
         )
+
+    def test_repr(self) -> None:
+        self.assertEqual(
+            str(Data(df=self.df)),
+            REPR_1000,
+        )
+        with patch(f"{Data.__module__}.DF_REPR_MAX_LENGTH", 500):
+            self.assertEqual(
+                str(Data(df=self.df)),
+                REPR_500,
+            )
 
     def test_clone(self) -> None:
         data = Data(df=self.df, description="test")

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -850,7 +850,8 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
     def should_consider_optimization_complete(self) -> tuple[bool, str]:
         """Whether this scheduler should consider this optimization complete and not
         run more trials (and conclude the optimization via ``_complete_optimization``).
-        An optimization is considered complete when a generation strategy signalled
+
+        NOTE: An optimization is considered complete when a generation strategy signaled
         completion or when the ``completion_criterion`` on this scheduler
         evaluates to ``True``. The ``completion_criterion`` method is also responsible
         for checking global_stopping_strategy's decision as well. Alongside the stop
@@ -860,7 +861,10 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
         if self._optimization_complete:
             return True, ""
 
-        return self.completion_criterion()
+        should_complete, completion_message = self.completion_criterion()
+        if should_complete:
+            self.logger.info(f"Completing the optimization: {completion_message}.")
+        return should_complete, completion_message
 
     def should_abort_optimization(self) -> bool:
         """Checks whether this scheduler has reached some intertuption / abort


### PR DESCRIPTION
Summary: We have yet to restore the behavior where unnecessary model refitting is skipped by default, in `gen_for_multiple_trials_from_multiple_models`. In order to avoid any slowdowns that may come from this, let us continue using the old `_gen_multiple` behavior for all `Trial`-based applications, for now.

Reviewed By: mgarrard

Differential Revision: D64243368


