### PR TITLE
Add experiment to input constructor signature

### DIFF
--- a/ax/modelbridge/generation_node_input_constructors.py
+++ b/ax/modelbridge/generation_node_input_constructors.py
@@ -40,6 +40,7 @@ class NodeInputConstructors(Enum):
         previous_node: GenerationNode | None,
         next_node: GenerationNode,
         gs_gen_call_kwargs: dict[str, Any],
+        experiment: Experiment,
     ) -> int:
         """Defines a callable method for the Enum as all values are methods"""
         try:
@@ -54,6 +55,7 @@ class NodeInputConstructors(Enum):
             previous_node=previous_node,
             next_node=next_node,
             gs_gen_call_kwargs=gs_gen_call_kwargs,
+            experiment=experiment,
         )
 
 
@@ -75,6 +77,7 @@ def set_target_trial(
     previous_node: GenerationNode | None,
     next_node: GenerationNode,
     gs_gen_call_kwargs: dict[str, Any],
+    experiment: Experiment,
 ) -> ObservationFeatures | None:
     """Determine the target trial for the next node based on the current state of the
     ``Experiment``.
@@ -87,12 +90,11 @@ def set_target_trial(
             will leverage the inputs defined by this input constructor.
         gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
             gen call.
+        experiment: The experiment associated with this ``GenerationStrategy``.
     Returns:
         An ``ObservationFeatures`` object that defines the target trial for the next
         node.
     """
-    # TODO: @mgarrard add experiment to input constructor signatures
-    experiment = gs_gen_call_kwargs.get("experiment")
     target_trial_idx = _get_target_trial_index(
         experiment=experiment, next_node=next_node
     )
@@ -106,6 +108,7 @@ def consume_all_n(
     previous_node: GenerationNode | None,
     next_node: GenerationNode,
     gs_gen_call_kwargs: dict[str, Any],
+    experiment: Experiment,
 ) -> int:
     """Generate total requested number of arms from the next node.
 
@@ -120,6 +123,7 @@ def consume_all_n(
             will leverage the inputs defined by this input constructor.
         gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
             gen call.
+        experiment: The experiment associated with this ``GenerationStrategy``.
     Returns:
         The total number of requested arms from the next node.
     """
@@ -136,6 +140,7 @@ def repeat_arm_n(
     previous_node: GenerationNode | None,
     next_node: GenerationNode,
     gs_gen_call_kwargs: dict[str, Any],
+    experiment: Experiment,
 ) -> int:
     """Generate a small percentage of arms requested to be used for repeat arms in
     the next trial.
@@ -148,6 +153,7 @@ def repeat_arm_n(
             will leverage the inputs defined by this input constructor.
         gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
             gen call.
+        experiment: The experiment associated with this ``GenerationStrategy``.
     Returns:
         The number of requested arms from the next node
     """
@@ -170,6 +176,7 @@ def remaining_n(
     previous_node: GenerationNode | None,
     next_node: GenerationNode,
     gs_gen_call_kwargs: dict[str, Any],
+    experiment: Experiment,
 ) -> int:
     """Generate the remaining number of arms requested for this trial in gs.gen().
 
@@ -181,6 +188,7 @@ def remaining_n(
             will leverage the inputs defined by this input constructor.
         gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
             gen call.
+        experiment: The experiment associated with this ``GenerationStrategy``.
     Returns:
         The number of requested arms from the next node
     """

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -457,9 +457,7 @@ class GenerationStrategy(GenerationStrategyInterface):
             arms_from_node = self._determine_arms_from_node(
                 node_to_gen_from=node_to_gen_from,
                 arms_per_node=arms_per_node,
-                node_to_gen_from_name=node_to_gen_from_name,
                 n=n,
-                node_names=list(self.nodes_dict.keys()),
                 gen_kwargs=gen_kwargs,
             )
             grs.extend(
@@ -950,8 +948,6 @@ class GenerationStrategy(GenerationStrategyInterface):
         self,
         n: int,
         node_to_gen_from: GenerationNode,
-        node_to_gen_from_name: str,
-        node_names: list[str],
         gen_kwargs: dict[str, Any],
         arms_per_node: dict[str, int] | None = None,
     ) -> int:
@@ -965,8 +961,6 @@ class GenerationStrategy(GenerationStrategyInterface):
                 case this method will also output a generator run with number of
                 arms that can differ from `n`.
             node_to_gen_from: The node from which to generate from
-            node_to_gen_from_name: The name of the node from which to generate from.
-            node_names: The names of all nodes in this generation strategy.
             gs_kwargs: The kwargs passed to the ``GenerationStrategy``'s
             gen call.
             arms_per_node: An optional map from node name to the number of arms to
@@ -982,7 +976,7 @@ class GenerationStrategy(GenerationStrategyInterface):
             # arms_per_node provides a way to manually override input
             # constructors. This should be used with caution, and only
             # if you really know what you're doing. :)
-            arms_from_node = arms_per_node[node_to_gen_from_name]
+            arms_from_node = arms_per_node[node_to_gen_from.node_name]
         elif InputConstructorPurpose.N not in node_to_gen_from.input_constructors:
             # if the node does not have an input constructor for N, then we
             # assume a default of generating n arms from this node.

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -993,6 +993,7 @@ class GenerationStrategy(GenerationStrategyInterface):
                 previous_node=previous_node,
                 next_node=node_to_gen_from,
                 gs_gen_call_kwargs=gen_kwargs,
+                experiment=self.experiment,
             )
 
         return arms_from_node

--- a/ax/modelbridge/tests/test_generation_node_input_constructors.py
+++ b/ax/modelbridge/tests/test_generation_node_input_constructors.py
@@ -53,6 +53,7 @@ class TestGenerationNodeInputConstructors(TestCase):
             previous_node=None,
             next_node=self.sobol_generation_node,
             gs_gen_call_kwargs={"n": 5},
+            experiment=self.experiment,
         )
         self.assertEqual(num_to_gen, 5)
 
@@ -62,16 +63,19 @@ class TestGenerationNodeInputConstructors(TestCase):
             previous_node=None,
             next_node=self.sobol_generation_node,
             gs_gen_call_kwargs={"n": 5},
+            experiment=self.experiment,
         )
         medium_n = NodeInputConstructors.REPEAT_N(
             previous_node=None,
             next_node=self.sobol_generation_node,
             gs_gen_call_kwargs={"n": 8},
+            experiment=self.experiment,
         )
         large_n = NodeInputConstructors.REPEAT_N(
             previous_node=None,
             next_node=self.sobol_generation_node,
             gs_gen_call_kwargs={"n": 11},
+            experiment=self.experiment,
         )
         self.assertEqual(small_n, 0)
         self.assertEqual(medium_n, 1)
@@ -84,6 +88,7 @@ class TestGenerationNodeInputConstructors(TestCase):
             previous_node=None,
             next_node=self.sobol_generation_node,
             gs_gen_call_kwargs={"n": 5, "grs_this_gen": self.grs},
+            experiment=self.experiment,
         )
         self.assertEqual(expect_1, 1)
 
@@ -93,6 +98,7 @@ class TestGenerationNodeInputConstructors(TestCase):
             previous_node=None,
             next_node=self.sobol_generation_node,
             gs_gen_call_kwargs={"n": 4, "grs_this_gen": self.grs},
+            experiment=self.experiment,
         )
         self.assertEqual(expect_0, 0)
 
@@ -104,6 +110,7 @@ class TestGenerationNodeInputConstructors(TestCase):
             previous_node=None,
             next_node=self.sobol_generation_node,
             gs_gen_call_kwargs={"n": 3, "grs_this_gen": self.grs},
+            experiment=self.experiment,
         )
         self.assertEqual(expect_0, 0)
 
@@ -117,6 +124,7 @@ class TestGenerationNodeInputConstructors(TestCase):
                 previous_node=None,
                 next_node=self.sobol_generation_node,
                 gs_gen_call_kwargs={},
+                experiment=self.experiment,
             )
 
     def test_no_n_provided_error_repeat_n(self) -> None:
@@ -128,6 +136,7 @@ class TestGenerationNodeInputConstructors(TestCase):
                 previous_node=None,
                 next_node=self.sobol_generation_node,
                 gs_gen_call_kwargs={},
+                experiment=self.experiment,
             )
 
     def test_no_n_provided_error_remaining_n(self) -> None:
@@ -138,6 +147,7 @@ class TestGenerationNodeInputConstructors(TestCase):
                 previous_node=None,
                 next_node=self.sobol_generation_node,
                 gs_gen_call_kwargs={},
+                experiment=self.experiment,
             )
 
     def test_set_target_trial_long_run_wins(self) -> None:
@@ -156,7 +166,8 @@ class TestGenerationNodeInputConstructors(TestCase):
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"experiment": self.experiment},
+            gs_gen_call_kwargs={},
+            experiment=self.experiment,
         )
         self.assertEqual(
             target_trial,
@@ -183,7 +194,8 @@ class TestGenerationNodeInputConstructors(TestCase):
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"experiment": self.experiment},
+            gs_gen_call_kwargs={},
+            experiment=self.experiment,
         )
         self.assertEqual(
             target_trial,
@@ -211,7 +223,8 @@ class TestGenerationNodeInputConstructors(TestCase):
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"experiment": self.experiment},
+            gs_gen_call_kwargs={},
+            experiment=self.experiment,
         )
         self.assertEqual(
             target_trial,
@@ -239,7 +252,8 @@ class TestGenerationNodeInputConstructors(TestCase):
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"experiment": self.experiment},
+            gs_gen_call_kwargs={},
+            experiment=self.experiment,
         )
         self.assertEqual(
             target_trial,
@@ -265,7 +279,8 @@ class TestGenerationNodeInputConstructors(TestCase):
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"experiment": self.experiment},
+            gs_gen_call_kwargs={},
+            experiment=self.experiment,
         )
         self.assertEqual(
             target_trial,
@@ -293,7 +308,8 @@ class TestGenerationNodeInputConstructors(TestCase):
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"experiment": self.experiment},
+            gs_gen_call_kwargs={},
+            experiment=self.experiment,
         )
         self.assertEqual(
             target_trial,
@@ -319,7 +335,8 @@ class TestGenerationNodeInputConstructors(TestCase):
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"experiment": self.experiment},
+            gs_gen_call_kwargs={},
+            experiment=self.experiment,
         )
         self.assertEqual(
             target_trial,
@@ -345,7 +362,8 @@ class TestGenerationNodeInputConstructors(TestCase):
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"experiment": self.experiment},
+            gs_gen_call_kwargs={},
+            experiment=self.experiment,
         )
         self.assertEqual(
             target_trial,
@@ -373,7 +391,8 @@ class TestGenerationNodeInputConstructors(TestCase):
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={"experiment": self.experiment},
+            gs_gen_call_kwargs={},
+            experiment=self.experiment,
         )
         self.assertEqual(
             target_trial,
@@ -391,7 +410,8 @@ class TestGenerationNodeInputConstructors(TestCase):
             NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
                 previous_node=None,
                 next_node=self.sobol_generation_node,
-                gs_gen_call_kwargs={"experiment": self.experiment},
+                gs_gen_call_kwargs={},
+                experiment=self.experiment,
             )
 
     def _add_sobol_trial(
@@ -442,7 +462,13 @@ class TestInstantiationFromNodeInputConstructor(TestCase):
                 self.assertEqual(
                     Counter(list(func_parameters.keys())),
                     Counter(
-                        ["previous_node", "next_node", "gs_gen_call_kwargs", "return"]
+                        [
+                            "previous_node",
+                            "next_node",
+                            "gs_gen_call_kwargs",
+                            "experiment",
+                            "return",
+                        ]
                     ),
                 )
                 self.assertEqual(
@@ -452,4 +478,5 @@ class TestInstantiationFromNodeInputConstructor(TestCase):
                 # pyre-ignore [16]: Undefined attribute [16]: `dict` has no attribute
                 # `__getitem__`.¸
                 self.assertEqual(func_parameters["gs_gen_call_kwargs"], dict[str, Any])
+                self.assertEqual(func_parameters["experiment"], Experiment)
                 self.assertEqual(method_signature, inspect.signature(constructor))

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -212,6 +212,12 @@ TEST_CASES = [
     ),
     (
         "GenerationStrategy",
+        partial(
+            sobol_gpei_generation_node_gs, with_input_constructors_target_trial=True
+        ),
+    ),
+    (
+        "GenerationStrategy",
         partial(sobol_gpei_generation_node_gs, with_unlimited_gen_mbm=True),
     ),
     (

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -226,6 +226,7 @@ def sobol_gpei_generation_node_gs(
     with_input_constructors_all_n: bool = False,
     with_input_constructors_remaining_n: bool = False,
     with_input_constructors_repeat_n: bool = False,
+    with_input_constructors_target_trial: bool = False,
     with_unlimited_gen_mbm: bool = False,
     with_trial_type: bool = False,
     with_is_SOO_transition: bool = False,
@@ -241,6 +242,21 @@ def sobol_gpei_generation_node_gs(
             "Only one of with_auto_transition, with_unlimited_gen_mbm, "
             "with_is_SOO_transition can be set to True."
         )
+    if (
+        sum(
+            [
+                with_input_constructors_all_n,
+                with_input_constructors_remaining_n,
+                with_input_constructors_repeat_n,
+                with_input_constructors_target_trial,
+            ]
+        )
+        > 1
+    ):
+        raise UserInputError(
+            "Only one of the input_constructors kwargs can be set to True."
+        )
+
     sobol_criterion = [
         MaxTrials(
             threshold=5,
@@ -360,6 +376,11 @@ def sobol_gpei_generation_node_gs(
     elif with_input_constructors_repeat_n:
         sobol_node._input_constructors = {
             InputConstructorPurpose.N: NodeInputConstructors.REPEAT_N,
+        }
+    elif with_input_constructors_target_trial:
+        purpose = InputConstructorPurpose.FIXED_FEATURES
+        sobol_node._input_constructors = {
+            purpose: NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES,
         }
 
     sobol_mbm_GS_nodes = GenerationStrategy(


### PR DESCRIPTION
Summary: In a previous diff both Daniel and Lena suggested adding experiment to the method signatures for input constructors, at the time we only had a single input constructor that needed the exp object, but in coming diffs we'll grab it for other input constructors. If we continue to rely on gs_kwargs to get it, we have to do null checks etc, and this is much better.

Differential Revision: D64308015


