### PR TITLE
Enable use of external BenchmarkProblem  registry

### DIFF
--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 import copy
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -236,8 +236,30 @@ BENCHMARK_PROBLEM_REGISTRY = {
 }
 
 
-def get_problem(problem_name: str, **additional_kwargs: Any) -> BenchmarkProblem:
-    entry = BENCHMARK_PROBLEM_REGISTRY[problem_name]
+def get_problem(
+    problem_key: str,
+    registry: Mapping[str, BenchmarkProblemRegistryEntry] | None = None,
+    **additional_kwargs: Any
+) -> BenchmarkProblem:
+    """
+    Generate a benchmark problem from a key, registry, and additional arguments.
+
+    Args:
+        problem_key: The key by which a `BenchmarkProblemRegistryEntry` is
+            looked up in the registry; a problem will then be generated from
+            that entry and `additional_kwargs`. Note that this is not
+            necessarily the same as the `name` attribute of the problem, and
+            that one `problem_key` can generate several different
+            `BenchmarkProblem`s by passing `additional_kwargs`. However, it is a
+            good practice to maintain a 1:1 mapping between `problem_key` and
+            the name.
+        registry: If not provided, uses `BENCHMARK_PROBLEM_REGISTRY` to use
+            problems defined within Ax.
+        additional_kwargs: Additional kwargs to pass to the factory function of
+            the `BenchmarkProblemRegistryEntry`.
+    """
+    registry = BENCHMARK_PROBLEM_REGISTRY if registry is None else registry
+    entry = registry[problem_key]
     kwargs = copy.copy(entry.factory_kwargs)
     kwargs.update(additional_kwargs)
     return entry.factory_fn(**kwargs)

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -78,7 +78,7 @@ class TestMethods(TestCase):
     def _test_benchmark_replication_runs(
         self, scheduler_options: SchedulerOptions, acqf_cls: type[AcquisitionFunction]
     ) -> None:
-        problem = get_problem(problem_name="ackley4")
+        problem = get_problem(problem_key="ackley4")
         method = get_sobol_botorch_modular_acquisition(
             model_cls=SingleTaskGP,
             scheduler_options=scheduler_options,
@@ -92,7 +92,7 @@ class TestMethods(TestCase):
         self.assertEqual(method.name, "test")
         # Only run one non-Sobol trial
         n_total_trials = n_sobol_trials + 1
-        problem = get_problem(problem_name="ackley4", num_trials=n_total_trials)
+        problem = get_problem(problem_key="ackley4", num_trials=n_total_trials)
         result = benchmark_replication(problem=problem, method=method, seed=0)
         self.assertTrue(np.isfinite(result.score_trace).all())
         self.assertEqual(result.optimization_trace.shape, (n_total_trials,))
@@ -131,7 +131,7 @@ class TestMethods(TestCase):
         gs = method.generation_strategy
         self.assertEqual(len(gs._steps), 1)
         self.assertEqual(gs._steps[0].model, Models.SOBOL)
-        problem = get_problem(problem_name="ackley4", num_trials=3)
+        problem = get_problem(problem_key="ackley4", num_trials=3)
         result = benchmark_replication(problem=problem, method=method, seed=0)
         self.assertTrue(np.isfinite(result.score_trace).all())
 
@@ -139,7 +139,7 @@ class TestMethods(TestCase):
         self, use_model_predictions: bool, as_batch: bool
     ) -> None:
         problem = get_problem(
-            problem_name="ackley4", num_trials=2, test_problem_kwargs={"noise_std": 1.0}
+            problem_key="ackley4", num_trials=2, test_problem_kwargs={"noise_std": 1.0}
         )
 
         method = get_sobol_botorch_modular_acquisition(

--- a/ax/benchmark/tests/problems/hpo/test_torchvision.py
+++ b/ax/benchmark/tests/problems/hpo/test_torchvision.py
@@ -38,11 +38,11 @@ class TestPyTorchCNNTorchvision(TestCase):
         ):
 
             self.assertEqual(
-                get_problem(problem_name="hpo_pytorch_cnn_MNIST").name,
+                get_problem(problem_key="hpo_pytorch_cnn_MNIST").name,
                 "HPO_PyTorchCNN_Torchvision::MNIST",
             )
             problem = get_problem(
-                problem_name="hpo_pytorch_cnn_FashionMNIST", num_trials=num_trials
+                problem_key="hpo_pytorch_cnn_FashionMNIST", num_trials=num_trials
             )
 
         self.assertEqual(problem.name, "HPO_PyTorchCNN_Torchvision::FashionMNIST")
@@ -62,7 +62,7 @@ class TestPyTorchCNNTorchvision(TestCase):
             "ax.benchmark.problems.hpo.torchvision._REGISTRY",
             {problem_name: TestDataset},
         ):
-            problem = get_problem(problem_name=f"hpo_pytorch_cnn_{problem_name}")
+            problem = get_problem(problem_key=f"hpo_pytorch_cnn_{problem_name}")
         # pyre-fixme[6]: complaining that the annotation for Arm.parameters is
         # too broad because it's not immutable
         arm = Arm(parameters=self.parameters, name="0")

--- a/ax/benchmark/tests/problems/test_problems.py
+++ b/ax/benchmark/tests/problems/test_problems.py
@@ -17,7 +17,7 @@ class TestProblems(TestCase):
             if "MNIST" in name:
                 continue  # Skip these as they cause the test to take a long time
 
-            get_problem(problem_name=name)
+            get_problem(problem_key=name)
 
     def test_name(self) -> None:
         expected_names = [
@@ -30,10 +30,31 @@ class TestProblems(TestCase):
             ("levy4", "Levy_4d"),
         ]
         for registry_key, problem_name in expected_names:
-            problem = get_problem(problem_name=registry_key)
+            problem = get_problem(problem_key=registry_key)
             self.assertEqual(problem.name, problem_name)
 
     def test_no_duplicates(self) -> None:
         keys = [elt for elt in BENCHMARK_PROBLEM_REGISTRY.keys() if "MNIST" not in elt]
-        names = {get_problem(problem_name=key).name for key in keys}
+        names = {get_problem(problem_key=key).name for key in keys}
         self.assertEqual(len(keys), len(names))
+
+    def test_external_registry(self) -> None:
+        registry = {
+            "test_problem": BENCHMARK_PROBLEM_REGISTRY["branin"],
+        }
+        problem = get_problem(problem_key="test_problem", registry=registry)
+        self.assertEqual(problem.name, "Branin")
+        with self.assertRaises(KeyError):
+            get_problem(problem_key="branin", registry=registry)
+
+    def test_registry_kwargs_not_mutated(self) -> None:
+        entry = BENCHMARK_PROBLEM_REGISTRY["jenatton"]
+        expected_kws = {"num_trials": 50, "observe_noise_sd": False}
+        self.assertEqual(entry.factory_kwargs, expected_kws)
+        problem = get_problem(problem_key="jenatton", num_trials=5)
+        self.assertEqual(problem.num_trials, 5)
+        self.assertEqual(
+            BENCHMARK_PROBLEM_REGISTRY["jenatton"].factory_kwargs, expected_kws
+        )
+        problem = get_problem(problem_key="jenatton")
+        self.assertEqual(problem.num_trials, 50)

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -260,7 +260,7 @@ class TestBenchmark(TestCase):
             {"MNIST": TestDataset},
         ):
             mnist_problem = get_problem(
-                problem_name="hpo_pytorch_cnn_MNIST", name="MNIST", num_trials=6
+                problem_key="hpo_pytorch_cnn_MNIST", name="MNIST", num_trials=6
             )
         for method, problem, expected_name in [
             (


### PR DESCRIPTION
Summary:
Users may wish to use an exernal registry to accommodate problems defined outside Ax.

This PR:
* Enables use of an externally provided registry.
* Renames `problem_name` to `problem_key` to emphasize that it is not the same as `BenchmarkProblem.name` (unfortunately, since these already differ for existing problems)

Differential Revision: D64241027


