### PR TITLE
Use input constructors to determine fixed features to pass to model

### DIFF
--- a/ax/modelbridge/generation_node_input_constructors.py
+++ b/ax/modelbridge/generation_node_input_constructors.py
@@ -33,13 +33,15 @@ class NodeInputConstructors(Enum):
     REMAINING_N = "remaining_n"
     TARGET_TRIAL_FIXED_FEATURES = "set_target_trial"
 
+    # pyre-ignore[3] input constructors can return any type in order to be flexible
+    # and share identical signatures
     def __call__(
         self,
         previous_node: GenerationNode | None,
         next_node: GenerationNode,
         gs_gen_call_kwargs: dict[str, Any],
         experiment: Experiment,
-    ) -> int:
+    ) -> Any:
         """Defines a callable method for the Enum as all values are methods"""
         try:
             method = getattr(sys.modules[__name__], self.value)


### PR DESCRIPTION
Summary:
In previous diffs we added the logic to input constructors to support identification of the target trial, which is a fixed feature, based on an algorithm. In this diff we include grabbing fixed features during generation in both ```gen_for_multiple_trials_with_multiple_nodes``` and ``gen_with_multiple_nodes```. If a user passes in fixed features those will take precedence over algorithmically determined values. We also don't smush together passed in fixed features as we don't have a consistent way of distinguishing target_trial fixed features from other fixed features. For this reason, if a user passes in fixed features it's important that they actually specify **all** fixed features.

The unit tests I add here don't actually use the fixed_features in modeling but ensure that they are passed to the model gen method. In follow up diffs we will:
1. use target trial in dispatch logic
2. expose target trial override in make_candidate_trials
3. add e2e test showing that with this input constructor we can correctly gen from multi-task mbm

Differential Revision: D64288411


