### PR TITLE
Add previous node property to GenerationNode

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -239,6 +239,15 @@ class GenerationNode(SerializationMixin, SortableBase):
         return self.should_transition_to_next_node(raise_data_required_error=False)[0]
 
     @property
+    def previous_node(self) -> GenerationNode | None:
+        """Returns the previous ``GenerationNode``, if any."""
+        return (
+            self.generation_strategy.nodes_dict[self._previous_node_name]
+            if self._previous_node_name is not None
+            else None
+        )
+
+    @property
     def _unique_id(self) -> str:
         """Returns a unique (w.r.t. parent class: ``GenerationStrategy``) id
         for this GenerationNode. Used for SQL storage.

--- a/ax/modelbridge/generation_strategy.py
+++ b/ax/modelbridge/generation_strategy.py
@@ -967,7 +967,7 @@ class GenerationStrategy(GenerationStrategyInterface):
             node_fixed_features = node_to_gen_from.input_constructors[
                 InputConstructorPurpose.FIXED_FEATURES
             ](
-                previous_node=None,  # not needed for this constructor
+                previous_node=node_to_gen_from.previous_node,
                 next_node=node_to_gen_from,
                 gs_gen_call_kwargs=gen_kwargs,
                 experiment=self.experiment,
@@ -1018,15 +1018,10 @@ class GenerationStrategy(GenerationStrategyInterface):
             # assume a default of generating n arms from this node.
             arms_from_node = n if n is not None else self.DEFAULT_N
         else:
-            previous_node = (
-                self.nodes_dict[node_to_gen_from._previous_node_name]
-                if node_to_gen_from._previous_node_name is not None
-                else None
-            )
             arms_from_node = node_to_gen_from.input_constructors[
                 InputConstructorPurpose.N
             ](
-                previous_node=previous_node,
+                previous_node=node_to_gen_from.previous_node,
                 next_node=node_to_gen_from,
                 gs_gen_call_kwargs=gen_kwargs,
                 experiment=self.experiment,

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -49,6 +49,11 @@ class TestGenerationNode(TestCase):
             model_kwargs={"init_position": 3},
             model_gen_kwargs={"some_gen_kwarg": "some_value"},
         )
+        self.mbm_model_spec = ModelSpec(
+            model_enum=Models.BOTORCH_MODULAR,
+            model_kwargs={},
+            model_gen_kwargs={},
+        )
         self.sobol_generation_node = GenerationNode(
             node_name="test", model_specs=[self.sobol_model_spec]
         )
@@ -291,11 +296,7 @@ class TestGenerationNode(TestCase):
         node = GenerationNode(
             node_name="test",
             model_specs=[
-                ModelSpec(
-                    model_enum=Models.BOTORCH_MODULAR,
-                    model_kwargs={},
-                    model_gen_kwargs={},
-                ),
+                self.mbm_model_spec,
             ],
             transition_criteria=[
                 MaxTrials(threshold=5, only_in_statuses=[TrialStatus.RUNNING])

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -1328,8 +1328,13 @@ class TestGenerationStrategy(TestCase):
                 node_3,
             ],
         )
-        for node in gs._nodes:
-            self.assertIsNone(node._previous_node_name)
+        with self.subTest("after initialization all should be none"):
+            for node in gs._nodes:
+                self.assertIsNone(node._previous_node_name)
+                self.assertIsNone(node.previous_node)
+        with self.subTest("check previous node nodes after being set"):
+            gs._nodes[1]._previous_node_name = "node_1"
+            self.assertEqual(gs._nodes[1].previous_node, node_1)
 
     def test_gs_with_generation_nodes(self) -> None:
         "Simple test of a SOBOL + MBM GenerationStrategy composed of GenerationNodes"


### PR DESCRIPTION
Summary:
In a previous diff Lena and Daniel suggested that having a property on the generation node which returns the actual generation node object and not just the name makes things a bit cleaner in GS.

This does just that

Reviewed By: esantorella

Differential Revision: D64402184


