### PR TITLE
Abstract away a `FuncEnum` (will use it in `best_model_selector.ReductionCriterion` and `NodeInputConstructors`)

### DIFF
--- a/ax/utils/common/func_enum.py
+++ b/ax/utils/common/func_enum.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from enum import Enum, unique
+from importlib import import_module
+from typing import Any, Callable
+
+from ax.exceptions.core import UnsupportedError
+
+
+@unique
+class FuncEnum(Enum):
+    """A base class for all enums with the following structure: string values that
+    map to names of functions, which reside in the same module as the enum."""
+
+    # pyre-ignore[3]: Input constructors will be used to make different inputs,
+    # so we need to allow `Any` return type here.
+    def __call__(self, **kwargs: Any) -> Any:
+        """Defines a method, by which the members of this enum can be called,
+        e.g. ``MyFunctions.F(**kwargs)``, which will call the corresponding
+        function registered by the name ``F`` in the enum."""
+        return self._get_function_for_value()(**kwargs)
+
+    # pyre-ignore[31]: Expression `typing.Callable[([...], typing.Any)]`
+    # is not a valid type.
+    def _get_function_for_value(self) -> Callable[[...], Any]:
+        """Retrieve the function in this module, name of which corresponds to the
+        value of the enum member."""
+        try:
+            return getattr(import_module(self.__module__), self.value)
+        except AttributeError:
+            raise UnsupportedError(
+                f"{self.value} is not defined as a method in "
+                f"`{self.__module__}`. Please add the method "
+                "to the file."
+            )

--- a/ax/utils/common/tests/test_func_enum.py
+++ b/ax/utils/common/tests/test_func_enum.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.utils.common.func_enum import FuncEnum
+from ax.utils.common.testutils import TestCase
+
+
+def morph_into_salamander(how_soon: int) -> bool:
+    if how_soon <= 0:  # Now is the time!
+        return True
+    else:  # Not morphing yet
+        return False
+
+
+class AnimalAbilities(FuncEnum):
+    # ꒰(˶• ᴗ •˶)꒱
+    AXOLOTL_MORPH = "morph_into_salamander"
+
+
+class EqualityTest(TestCase):
+    def test_basic(self) -> None:
+        self.assertEqual(  # Check underlying function correctness.
+            AnimalAbilities.AXOLOTL_MORPH._get_function_for_value(),
+            morph_into_salamander,
+        )
+
+    def test_call(self) -> None:
+        # Should be too early to morph...
+        self.assertFalse(AnimalAbilities.AXOLOTL_MORPH(how_soon=1))
+        # Should've morphed yesterday!
+        self.assertTrue(AnimalAbilities.AXOLOTL_MORPH(how_soon=-1))

--- a/sphinx/source/utils.rst
+++ b/sphinx/source/utils.rst
@@ -60,9 +60,17 @@ Equality
     :show-inheritance:
 
 Executils
-~~~~~~~~~~~~~~~
+~~~~~~~~~
 
 .. automodule:: ax.utils.common.executils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+FuncEnum
+~~~~~~~~
+
+.. automodule:: ax.utils.common.func_enum
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Summary: Add a base class for any "enums of callables" that will actually play well with storage and provide a consistent and safe way to implement such enums.

Differential Revision: D63914989


