### PR TITLE
Add should_skip property to GenerationNode

### DIFF
--- a/ax/modelbridge/generation_node.py
+++ b/ax/modelbridge/generation_node.py
@@ -96,6 +96,8 @@ class GenerationNode(SerializationMixin, SortableBase):
             set during transition from one ``GenerationNode`` to the next. Can be
             overwritten if multiple transitions occur between nodes, and will always
             store the most recent previous ``GenerationNode`` name.
+        should_skip: Whether to skip this node during generation time. Defaults to
+            False, and can only currently be set to True via ``NodeInputConstructors``
 
     Note for developers: by "model" here we really mean an Ax ModelBridge object, which
     contains an Ax Model under the hood. We call it "model" here to simplify and focus
@@ -118,6 +120,7 @@ class GenerationNode(SerializationMixin, SortableBase):
     ]
     _previous_node_name: str | None = None
     _trial_type: str | None = None
+    _should_skip: bool = False
 
     # [TODO] Handle experiment passing more eloquently by enforcing experiment
     # attribute is set in generation strategies class

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -1380,7 +1380,7 @@ class TestGenerationStrategy(TestCase):
             # check first call is 6 (from the previous trial having 6 arms)
             self.assertEqual(len(list(pending_in_each_gen)[0][1]["m1"]), 6)
 
-    def test_gs_initializes_all_previous_node_to_none(self) -> None:
+    def test_gs_initializes_default_props_correctly(self) -> None:
         """Test that all previous nodes are initialized to None"""
         node_1 = GenerationNode(
             node_name="node_1",
@@ -1401,13 +1401,18 @@ class TestGenerationStrategy(TestCase):
                 node_3,
             ],
         )
-        with self.subTest("after initialization all should be none"):
+        with self.subTest("after initialization all previous nodes should be none"):
             for node in gs._nodes:
                 self.assertIsNone(node._previous_node_name)
                 self.assertIsNone(node.previous_node)
-        with self.subTest("check previous node nodes after being set"):
+        with self.subTest("check previous node after it is set"):
             gs._nodes[1]._previous_node_name = "node_1"
             self.assertEqual(gs._nodes[1].previous_node, node_1)
+        with self.subTest(
+            "after initialization all nodes should have should_skip set to False"
+        ):
+            for node in gs._nodes:
+                self.assertFalse(node._should_skip)
 
     def test_gs_with_generation_nodes(self) -> None:
         "Simple test of a SOBOL + MBM GenerationStrategy composed of GenerationNodes"


### PR DESCRIPTION
Summary:
There are some cases where the input constructor returns n=o, specifically for repeat arms, this is currently causing an issue in generaiton strategy gen method because if we don't generate from a node we can't meet the TC, and move forward, however, we don't actually want to generate from that node.

This simply exposes a prop on gen node to expose this, and default it to false

Following diffs will:
- update TC.is_met() to accept a GenNode instead of just the name
- update input constructor to properly set should skip
- update the gs to appropiately handle resetting to false after a gen is completed

Differential Revision: D64444258


