### PR TITLE
Make BenchmarkRunners into dataclasses

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -189,6 +189,9 @@ def benchmark_replication(
         score_trace = np.full(len(optimization_trace), np.nan)
 
     fit_time, gen_time = get_model_times(experiment=experiment)
+    # Strip runner from experiment before returning, so that the experiment can
+    # be serialized (the runner can't be)
+    experiment.runner = None
 
     return BenchmarkResult(
         name=scheduler.experiment.name,

--- a/ax/benchmark/runners/base.py
+++ b/ax/benchmark/runners/base.py
@@ -18,6 +18,8 @@ from ax.core.runner import Runner
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.trial import Trial
 from ax.core.types import TParamValue
+from ax.exceptions.core import UnsupportedError
+from ax.utils.common.serialization import TClassDecoderRegistry, TDecoderRegistry
 
 from ax.utils.common.typeutils import checked_cast
 from numpy import ndarray
@@ -165,3 +167,31 @@ class BenchmarkRunner(Runner, ABC):
         self, trials: Iterable[BaseTrial]
     ) -> dict[TrialStatus, set[int]]:
         return {TrialStatus.COMPLETED: {t.index for t in trials}}
+
+    @classmethod
+    # pyre-fixme [2]: Parameter `obj` must have a type other than `Any``
+    def serialize_init_args(cls, obj: Any) -> dict[str, Any]:
+        """
+        It is tricky to use SerializationMixin with instances that have Ax
+        objects as attributes, as BenchmarkRunners do. Therefore, serialization
+        is not supported.
+        """
+        raise UnsupportedError(
+            "serialize_init_args is not a supported method for BenchmarkRunners."
+        )
+
+    @classmethod
+    def deserialize_init_args(
+        cls,
+        args: dict[str, Any],
+        decoder_registry: TDecoderRegistry | None = None,
+        class_decoder_registry: TClassDecoderRegistry | None = None,
+    ) -> dict[str, Any]:
+        """
+        It is tricky to use SerializationMixin with instances that have Ax
+        objects as attributes, as BenchmarkRunners do. Therefore, serialization
+        is not supported.
+        """
+        raise UnsupportedError(
+            "deserialize_init_args is not a supported method for BenchmarkRunners."
+        )

--- a/ax/benchmark/runners/base.py
+++ b/ax/benchmark/runners/base.py
@@ -7,11 +7,11 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field, InitVar
 from math import sqrt
 from typing import Any
 
 import torch
-
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.batch_trial import BatchTrial
 from ax.core.runner import Runner
@@ -26,6 +26,7 @@ from numpy import ndarray
 from torch import Tensor
 
 
+@dataclass(kw_only=True)
 class BenchmarkRunner(Runner, ABC):
     """
     A Runner that produces both observed and ground-truth values.
@@ -45,19 +46,12 @@ class BenchmarkRunner(Runner, ABC):
           not over-engineer for that before such a use case arrives.
     """
 
-    def __init__(
-        self,
-        *,
-        outcome_names: list[str],
-        search_space_digest: SearchSpaceDigest | None = None,
-    ) -> None:
-        """
-        Args:
-            outcome_names: Outcome names, needed for going between tensors and
-                data in formats used by Ax.
-            search_space_digest: Used to extract target fidelity and task.
-        """
-        self.outcome_names = outcome_names
+    outcome_names: list[str]
+    # pyre-fixme[8]: Pyre doesn't understand InitVars
+    search_space_digest: InitVar[SearchSpaceDigest | None] = None
+    target_fidelity_and_task: Mapping[str, float | int] = field(init=False)
+
+    def __post_init__(self, search_space_digest: SearchSpaceDigest | None) -> None:
         if search_space_digest is not None:
             self.target_fidelity_and_task: dict[str, float | int] = {
                 search_space_digest.feature_names[i]: target

--- a/ax/benchmark/runners/botorch_test.py
+++ b/ax/benchmark/runners/botorch_test.py
@@ -5,7 +5,6 @@
 
 # pyre-strict
 
-import importlib
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -17,10 +16,8 @@ from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TParamValue
 from ax.utils.common.base import Base
 from ax.utils.common.equality import equality_typechecker
-from ax.utils.common.serialization import TClassDecoderRegistry, TDecoderRegistry
 from botorch.test_functions.synthetic import BaseTestProblem, ConstrainedBaseTestProblem
 from botorch.utils.transforms import normalize, unnormalize
-from pyre_extensions import assert_is_instance
 from torch import Tensor
 
 
@@ -164,42 +161,6 @@ class SyntheticProblemRunner(BenchmarkRunner, ABC):
                 noise_std_dict[self.outcome_names[i]] = noise_std_
 
         return noise_std_dict
-
-    @classmethod
-    # pyre-fixme [2]: Parameter `obj` must have a type other than `Any``
-    def serialize_init_args(cls, obj: Any) -> dict[str, Any]:
-        """Serialize the properties needed to initialize the runner.
-        Used for storage.
-        """
-        runner = assert_is_instance(obj, cls)
-
-        return {
-            "test_problem_module": runner._test_problem_class.__module__,
-            "test_problem_class_name": runner._test_problem_class.__name__,
-            "test_problem_kwargs": runner._test_problem_kwargs,
-            "outcome_names": runner.outcome_names,
-            "modified_bounds": runner._modified_bounds,
-        }
-
-    @classmethod
-    def deserialize_init_args(
-        cls,
-        args: dict[str, Any],
-        decoder_registry: TDecoderRegistry | None = None,
-        class_decoder_registry: TClassDecoderRegistry | None = None,
-    ) -> dict[str, Any]:
-        """Given a dictionary, deserialize the properties needed to initialize the
-        runner. Used for storage.
-        """
-
-        module = importlib.import_module(args["test_problem_module"])
-
-        return {
-            "test_problem_class": getattr(module, args["test_problem_class_name"]),
-            "test_problem_kwargs": args["test_problem_kwargs"],
-            "outcome_names": args["outcome_names"],
-            "modified_bounds": args["modified_bounds"],
-        }
 
 
 class BotorchTestProblemRunner(SyntheticProblemRunner):

--- a/ax/benchmark/runners/botorch_test.py
+++ b/ax/benchmark/runners/botorch_test.py
@@ -7,7 +7,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 import torch
@@ -53,6 +53,7 @@ class ParamBasedTestProblem(ABC):
         return self.__class__.__name__ == other.__class__.__name__
 
 
+@dataclass(kw_only=True)
 class SyntheticProblemRunner(BenchmarkRunner, ABC):
     """A Runner for evaluating synthetic problems, either BoTorch
     `BaseTestProblem`s or Ax benchmarking `ParamBasedTestProblem`s.
@@ -60,70 +61,37 @@ class SyntheticProblemRunner(BenchmarkRunner, ABC):
     Given a trial, the Runner will evaluate the problem noiselessly for each
     arm in the trial, as well as return some metadata about the underlying
     problem such as the noise_std.
+
+    Args:
+        test_problem_class: A BoTorch `BaseTestProblem` class or Ax
+            `ParamBasedTestProblem` class.
+        test_problem_kwargs: The keyword arguments used for initializing the
+            test problem.
+        outcome_names: The names of the outcomes returned by the problem.
+        modified_bounds: The bounds that are used by the Ax search space
+            while optimizing the problem. If different from the bounds of the
+            test problem, we project the parameters into the test problem
+            bounds before evaluating the test problem.
+            For example, if the test problem is defined on [0, 1] but the Ax
+            search space is integers in [0, 10], an Ax parameter value of
+            5 will correspond to 0.5 while evaluating the test problem.
+            If modified bounds are not provided, the test problem will be
+            evaluated using the raw parameter values.
+        search_space_digest: Used to extract target fidelity and task.
     """
 
-    test_problem: BaseTestProblem | ParamBasedTestProblem
-    _is_constrained: bool
-    _test_problem_class: type[BaseTestProblem | ParamBasedTestProblem]
-    _test_problem_kwargs: dict[str, Any] | None
+    test_problem_class: type[BaseTestProblem | ParamBasedTestProblem]
+    test_problem_kwargs: dict[str, Any] = field(default_factory=dict)
+    modified_bounds: list[tuple[float, float]] | None = None
+    test_problem: BaseTestProblem | ParamBasedTestProblem = field(init=False)
 
-    def __init__(
-        self,
-        *,
-        test_problem_class: type[BaseTestProblem | ParamBasedTestProblem],
-        test_problem_kwargs: dict[str, Any],
-        outcome_names: list[str],
-        modified_bounds: list[tuple[float, float]] | None = None,
-        search_space_digest: SearchSpaceDigest | None = None,
-    ) -> None:
-        """Initialize the test problem runner.
+    @property
+    def _is_moo(self) -> bool:
+        return self.test_problem.num_objectives > 1
 
-        Args:
-            test_problem_class: A BoTorch `BaseTestProblem` class or Ax
-                `ParamBasedTestProblem` class.
-            test_problem_kwargs: The keyword arguments used for initializing the
-                test problem.
-            outcome_names: The names of the outcomes returned by the problem.
-            modified_bounds: The bounds that are used by the Ax search space
-                while optimizing the problem. If different from the bounds of the
-                test problem, we project the parameters into the test problem
-                bounds before evaluating the test problem.
-                For example, if the test problem is defined on [0, 1] but the Ax
-                search space is integers in [0, 10], an Ax parameter value of
-                5 will correspond to 0.5 while evaluating the test problem.
-                If modified bounds are not provided, the test problem will be
-                evaluated using the raw parameter values.
-            search_space_digest: Used to extract target fidelity and task.
-        """
-        super().__init__(
-            outcome_names=outcome_names, search_space_digest=search_space_digest
-        )
-        self._test_problem_class = test_problem_class
-        self._test_problem_kwargs = test_problem_kwargs
-        self.test_problem = (
-            # pyre-fixme: Invalid class instantiation [45]: Cannot instantiate
-            # abstract class with abstract method `evaluate_true`.
-            test_problem_class(**test_problem_kwargs)
-        )
-        if isinstance(self.test_problem, BaseTestProblem):
-            self.test_problem = self.test_problem.to(dtype=torch.double)
-        # A `ConstrainedBaseTestProblem` is a type of `BaseTestProblem`; a
-        # `ParamBasedTestProblem` is never constrained.
-        self._is_constrained: bool = isinstance(
-            self.test_problem, ConstrainedBaseTestProblem
-        )
-        self._is_moo: bool = self.test_problem.num_objectives > 1
-        self._modified_bounds = modified_bounds
-
-    @equality_typechecker
-    def __eq__(self, other: Base) -> bool:
-        if not isinstance(other, type(self)):
-            return False
-
-        return (
-            self.test_problem.__class__.__name__
-            == other.test_problem.__class__.__name__
-        )
+    @property
+    def _is_constrained(self) -> bool:
+        return issubclass(self.test_problem_class, ConstrainedBaseTestProblem)
 
     def get_noise_stds(self) -> None | float | dict[str, float]:
         noise_std = self.test_problem.noise_std
@@ -163,6 +131,7 @@ class SyntheticProblemRunner(BenchmarkRunner, ABC):
         return noise_std_dict
 
 
+@dataclass(kw_only=True)
 class BotorchTestProblemRunner(SyntheticProblemRunner):
     """
     A `SyntheticProblemRunner` for BoTorch `BaseTestProblem`s.
@@ -184,25 +153,14 @@ class BotorchTestProblemRunner(SyntheticProblemRunner):
         search_space_digest: Used to extract target fidelity and task.
     """
 
-    def __init__(
-        self,
-        *,
-        test_problem_class: type[BaseTestProblem],
-        test_problem_kwargs: dict[str, Any],
-        outcome_names: list[str],
-        modified_bounds: list[tuple[float, float]] | None = None,
-        search_space_digest: SearchSpaceDigest | None = None,
-    ) -> None:
-        super().__init__(
-            test_problem_class=test_problem_class,
-            test_problem_kwargs=test_problem_kwargs,
-            outcome_names=outcome_names,
-            modified_bounds=modified_bounds,
-            search_space_digest=search_space_digest,
-        )
-        self.test_problem: BaseTestProblem = self.test_problem.to(dtype=torch.double)
-        self._is_constrained: bool = isinstance(
-            self.test_problem, ConstrainedBaseTestProblem
+    test_problem_class: type[BaseTestProblem]
+    test_problem: BaseTestProblem = field(init=False)
+
+    def __post_init__(self, search_space_digest: SearchSpaceDigest | None) -> None:
+        super().__post_init__(search_space_digest=search_space_digest)
+        # pyre-fixme[45]: Can't instantiate abstract class `BaseTestProblem`.
+        self.test_problem = self.test_problem_class(**self.test_problem_kwargs).to(
+            torch.double
         )
 
     def get_Y_true(self, params: Mapping[str, TParamValue]) -> Tensor:
@@ -226,10 +184,10 @@ class BotorchTestProblemRunner(SyntheticProblemRunner):
             dtype=torch.double,
         )
 
-        if self._modified_bounds is not None:
+        if self.modified_bounds is not None:
             # Normalize from modified bounds to unit cube.
             unit_X = normalize(
-                X, torch.tensor(self._modified_bounds, dtype=torch.double).T
+                X, torch.tensor(self.modified_bounds, dtype=torch.double).T
             )
             # Unnormalize from unit cube to original problem bounds.
             X = unnormalize(unit_X, self.test_problem.bounds)
@@ -249,37 +207,42 @@ class BotorchTestProblemRunner(SyntheticProblemRunner):
 
         return Y_true
 
+    @equality_typechecker
+    def __eq__(self, other: Base) -> bool:
+        """
+        Compare equality by comparing dicts, except for `test_problem`.
 
+        Dataclasses are compared by comparing the results of calling asdict on
+        them. However, equality checks don't work as needed with BoTorch test
+        problems, e.g. Branin() == Branin() is False. To get around that, the
+        test problem is stripped from the dictionary. This doesn't make the
+        check less sensitive, as long as the problem has not been modified,
+        because the test problem class and keyword arguments will still be
+        compared.
+        """
+        if not isinstance(other, type(self)):
+            return False
+        self_as_dict = asdict(self)
+        other_as_dict = asdict(other)
+        self_as_dict.pop("test_problem")
+        other_as_dict.pop("test_problem")
+        return self_as_dict == other_as_dict
+
+
+@dataclass(kw_only=True)
 class ParamBasedTestProblemRunner(SyntheticProblemRunner):
     """
     A `SyntheticProblemRunner` for `ParamBasedTestProblem`s. See
     `SyntheticProblemRunner` for more information.
     """
 
-    # This could easily be supported, but hasn't been hooked up
-    _is_constrained: bool = False
+    test_problem_class: type[ParamBasedTestProblem]
+    test_problem: ParamBasedTestProblem = field(init=False)
 
-    def __init__(
-        self,
-        *,
-        test_problem_class: type[ParamBasedTestProblem],
-        test_problem_kwargs: dict[str, Any],
-        outcome_names: list[str],
-        modified_bounds: list[tuple[float, float]] | None = None,
-        search_space_digest: SearchSpaceDigest | None = None,
-    ) -> None:
-        if modified_bounds is not None:
-            raise NotImplementedError(
-                f"modified_bounds is not supported for {test_problem_class.__name__}"
-            )
-        super().__init__(
-            test_problem_class=test_problem_class,
-            test_problem_kwargs=test_problem_kwargs,
-            outcome_names=outcome_names,
-            modified_bounds=modified_bounds,
-            search_space_digest=search_space_digest,
-        )
-        self.test_problem: ParamBasedTestProblem = self.test_problem
+    def __post_init__(self, search_space_digest: SearchSpaceDigest | None) -> None:
+        super().__post_init__(search_space_digest=search_space_digest)
+        # pyre-fixme[45]: Can't instantiate abstract class `ParamBasedTestProblem`.
+        self.test_problem = self.test_problem_class(**self.test_problem_kwargs)
 
     def get_Y_true(self, params: Mapping[str, TParamValue]) -> Tensor:
         """Evaluates the test problem.

--- a/ax/benchmark/runners/surrogate.py
+++ b/ax/benchmark/runners/surrogate.py
@@ -5,7 +5,6 @@
 
 # pyre-strict
 
-import warnings
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -17,7 +16,6 @@ from ax.core.search_space import SearchSpaceDigest
 from ax.modelbridge.torch import TorchModelBridge
 from ax.utils.common.base import Base
 from ax.utils.common.equality import equality_typechecker
-from ax.utils.common.serialization import TClassDecoderRegistry, TDecoderRegistry
 from botorch.utils.datasets import SupervisedDataset
 from pyre_extensions import assert_is_instance, none_throws
 from torch import Tensor
@@ -131,33 +129,6 @@ class SurrogateRunner(BenchmarkRunner):
         run_metadata = super().run(trial=trial)
         run_metadata["outcome_names"] = self.outcome_names
         return run_metadata
-
-    @classmethod
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
-    def serialize_init_args(cls, obj: Any) -> dict[str, Any]:
-        """Serialize the properties needed to initialize the runner.
-        Used for storage.
-
-        WARNING: Because of issues with consistently saving and loading BoTorch and
-        GPyTorch modules the SurrogateRunner cannot be serialized at this time.
-        At load time the runner will be replaced with a SyntheticRunner.
-        """
-        warnings.warn(
-            "Because of issues with consistently saving and loading BoTorch and "
-            f"GPyTorch modules, {cls.__name__} cannot be serialized at this time. "
-            "At load time the runner will be replaced with a SyntheticRunner.",
-            stacklevel=3,
-        )
-        return {}
-
-    @classmethod
-    def deserialize_init_args(
-        cls,
-        args: dict[str, Any],
-        decoder_registry: TDecoderRegistry | None = None,
-        class_decoder_registry: TClassDecoderRegistry | None = None,
-    ) -> dict[str, Any]:
-        return {}
 
     @property
     def is_noiseless(self) -> bool:

--- a/ax/benchmark/tests/problems/test_mixed_integer_problems.py
+++ b/ax/benchmark/tests/problems/test_mixed_integer_problems.py
@@ -37,7 +37,7 @@ class MixedIntegerProblemsTest(TestCase):
             self.assertEqual(
                 checked_cast(
                     BotorchTestProblemRunner, problem.runner
-                )._test_problem_class.__name__,
+                ).test_problem_class.__name__,
                 name,
             )
             self.assertEqual(len(problem.search_space.parameters), dim)

--- a/ax/benchmark/tests/runners/test_botorch_test_problem.py
+++ b/ax/benchmark/tests/runners/test_botorch_test_problem.py
@@ -20,6 +20,7 @@ from ax.benchmark.runners.botorch_test import (
 from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
 from ax.core.trial import Trial
+from ax.exceptions.core import UnsupportedError
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast
 from ax.utils.testing.benchmark_stubs import TestParamBasedTestProblem
@@ -174,30 +175,14 @@ class TestSyntheticRunner(TestCase):
                 )
 
             with self.subTest(f"test `serialize_init_args()`, {test_description}"):
-                serialize_init_args = runner_cls.serialize_init_args(obj=runner)
-                self.assertEqual(
-                    serialize_init_args,
-                    {
-                        "test_problem_module": runner._test_problem_class.__module__,
-                        "test_problem_class_name": runner._test_problem_class.__name__,
-                        "test_problem_kwargs": runner._test_problem_kwargs,
-                        "outcome_names": runner.outcome_names,
-                        "modified_bounds": runner._modified_bounds,
-                    },
-                )
-                # test deserialize args
-                deserialize_init_args = runner_cls.deserialize_init_args(
-                    serialize_init_args
-                )
-                self.assertEqual(
-                    deserialize_init_args,
-                    {
-                        "test_problem_class": test_problem_class,
-                        "test_problem_kwargs": test_problem_kwargs,
-                        "outcome_names": outcome_names,
-                        "modified_bounds": modified_bounds,
-                    },
-                )
+                with self.assertRaisesRegex(
+                    UnsupportedError, "serialize_init_args is not a supported method"
+                ):
+                    runner_cls.serialize_init_args(obj=runner)
+                with self.assertRaisesRegex(
+                    UnsupportedError, "deserialize_init_args is not a supported method"
+                ):
+                    runner_cls.deserialize_init_args({})
 
     def test_botorch_test_problem_runner_heterogeneous_noise(self) -> None:
         runner = BotorchTestProblemRunner(

--- a/ax/benchmark/tests/runners/test_botorch_test_problem.py
+++ b/ax/benchmark/tests/runners/test_botorch_test_problem.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 
+from dataclasses import replace
 from itertools import product
 from unittest.mock import Mock
 
@@ -100,14 +101,20 @@ class TestSyntheticRunner(TestCase):
                     runner._is_constrained,
                     issubclass(test_problem_class, ConstrainedBaseTestProblem),
                 )
-                self.assertEqual(runner._modified_bounds, modified_bounds)
+                self.assertEqual(runner.modified_bounds, modified_bounds)
                 if noise_std is not None:
                     self.assertEqual(runner.get_noise_stds(), noise_std)
                 else:
                     self.assertIsNone(runner.get_noise_stds())
 
-                # check equality with different class
-                self.assertNotEqual(runner, Hartmann(dim=6))
+                # check equality
+                self.assertNotEqual(
+                    runner,
+                    replace(
+                        runner,
+                        test_problem_kwargs={**test_problem_kwargs, "noise_std": 200.0},
+                    ),
+                )
                 self.assertEqual(runner, runner)
                 self.assertEqual(runner._is_moo, num_objectives > 1)
                 if issubclass(test_problem_class, BaseTestProblem):

--- a/ax/benchmark/tests/runners/test_surrogate_runner.py
+++ b/ax/benchmark/tests/runners/test_surrogate_runner.py
@@ -38,8 +38,8 @@ class TestSurrogateRunner(TestCase):
                 surrogate.dtype = torch.double
                 runner = SurrogateRunner(
                     name="test runner",
-                    surrogate=surrogate,
-                    datasets=[],
+                    _surrogate=surrogate,
+                    _datasets=[],
                     outcome_names=["dummy_metric"],
                     noise_stds=noise_std,
                 )
@@ -75,20 +75,16 @@ class TestSurrogateRunner(TestCase):
 
     def test_instantiation_raises_with_missing_args(self) -> None:
         with self.assertRaisesRegex(
-            ValueError, "If get_surrogate_and_datasets is not provided, surrogate and "
+            ValueError, "If `get_surrogate_and_datasets` is None, `_surrogate` and "
         ):
-            SurrogateRunner(
-                name="test runner",
-                outcome_names=[],
-                noise_stds=0.0,
-            )
+            SurrogateRunner(name="test runner", outcome_names=[], noise_stds=0.0)
 
     def test_equality(self) -> None:
         def _construct_runner(name: str) -> SurrogateRunner:
             return SurrogateRunner(
                 name=name,
-                surrogate=MagicMock(),
-                datasets=[],
+                _surrogate=MagicMock(),
+                _datasets=[],
                 outcome_names=["dummy_metric"],
                 noise_stds=0.0,
             )

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -13,14 +13,7 @@ from typing import Any
 import torch
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_metric import BenchmarkMetric
-from ax.benchmark.benchmark_problem import BenchmarkProblem
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
-from ax.benchmark.problems.hpo.torchvision import PyTorchCNNTorchvisionParamBasedProblem
-from ax.benchmark.runners.botorch_test import (
-    BotorchTestProblemRunner,
-    ParamBasedTestProblemRunner,
-)
-from ax.benchmark.runners.surrogate import SurrogateRunner
 from ax.core import Experiment, ObservationFeatures
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
@@ -190,7 +183,6 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     BatchTrial: batch_to_dict,
     BenchmarkMetric: metric_to_dict,
     BoTorchModel: botorch_model_to_dict,
-    BotorchTestProblemRunner: runner_to_dict,
     BraninMetric: metric_to_dict,
     BraninTimestampMapMetric: metric_to_dict,
     ChainedInputTransform: botorch_component_to_dict,
@@ -236,7 +228,6 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     OrEarlyStoppingStrategy: logical_early_stopping_strategy_to_dict,
     OrderConstraint: order_parameter_constraint_to_dict,
     OutcomeConstraint: outcome_constraint_to_dict,
-    ParamBasedTestProblemRunner: runner_to_dict,
     ParameterConstraint: parameter_constraint_to_dict,
     ParameterDistribution: parameter_distribution_to_dict,
     pathlib.Path: pathlib_to_dict,
@@ -257,7 +248,6 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     SobolQMCNormalSampler: botorch_component_to_dict,
     SumConstraint: sum_parameter_constraint_to_dict,
     Surrogate: surrogate_to_dict,
-    SurrogateRunner: runner_to_dict,
     SyntheticRunner: runner_to_dict,
     ThresholdEarlyStoppingStrategy: threshold_early_stopping_strategy_to_dict,
     Trial: trial_to_dict,
@@ -296,10 +286,8 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "BatchTrial": BatchTrial,
     "BenchmarkMethod": BenchmarkMethod,
     "BenchmarkMetric": BenchmarkMetric,
-    "BenchmarkProblem": BenchmarkProblem,
     "BenchmarkResult": BenchmarkResult,
     "BoTorchModel": BoTorchModel,
-    "BotorchTestProblemRunner": BotorchTestProblemRunner,
     "BraninMetric": BraninMetric,
     "BraninTimestampMapMetric": BraninTimestampMapMetric,
     "ChainedInputTransform": ChainedInputTransform,
@@ -344,7 +332,6 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "ModelRegistryBase": ModelRegistryBase,
     "ModelSpec": ModelSpec,
     "MultiObjective": MultiObjective,
-    "MultiObjectiveBenchmarkProblem": BenchmarkProblem,  # backward compatibility
     "MultiObjectiveOptimizationConfig": MultiObjectiveOptimizationConfig,
     "MultiTypeExperiment": MultiTypeExperiment,
     "NegativeBraninMetric": NegativeBraninMetric,
@@ -357,7 +344,6 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "OrEarlyStoppingStrategy": OrEarlyStoppingStrategy,
     "OrderConstraint": OrderConstraint,
     "OutcomeConstraint": OutcomeConstraint,
-    "ParamBasedTestProblemRunner": ParamBasedTestProblemRunner,
     "ParameterConstraint": ParameterConstraint,
     "ParameterConstraintType": ParameterConstraintType,
     "ParameterDistribution": ParameterDistribution,
@@ -369,7 +355,6 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "PurePosixPath": pathlib_from_json,
     "PureWindowsPath": pathlib_from_json,
     "PercentileEarlyStoppingStrategy": PercentileEarlyStoppingStrategy,
-    "PyTorchCNNTorchvisionParamBasedProblem": PyTorchCNNTorchvisionParamBasedProblem,
     "RangeParameter": RangeParameter,
     "ReductionCriterion": ReductionCriterion,
     "RiskMeasure": RiskMeasure,

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -205,7 +205,6 @@ def get_benchmark_result() -> BenchmarkResult:
             name="test_benchmarking_experiment",
             search_space=problem.search_space,
             optimization_config=problem.optimization_config,
-            runner=problem.runner,
             is_test=True,
         ),
         inference_trace=np.ones(4),


### PR DESCRIPTION
Summary:
Context: D64110932 didn't work because of serialization, but now we don't serialize runners anymore.

This diff:
* Largely the same as D64110932, but also makes `SurrogateRunner` into a dataclass and makes its equality check stricter

Reviewed By: saitcakmak

Differential Revision: D64360228


