### PR TITLE
Clean up Acquisition.compute_model_dependencies

### DIFF
--- a/ax/analysis/old/helpers/cross_validation_helpers.py
+++ b/ax/analysis/old/helpers/cross_validation_helpers.py
@@ -141,7 +141,9 @@ def get_plotting_limit_ignore_outliers(
 
     x_np = np.array(x)
     # TODO: replace interpolation->method once it becomes standard.
+    # pyre-fixme[28]: Unexpected keyword argument `interpolation`.
     q1 = np.nanpercentile(x_np, q=25, interpolation="lower").min()
+    # pyre-fixme[28]: Unexpected keyword argument `interpolation`.
     q3 = np.nanpercentile(x_np, q=75, interpolation="higher").max()
     quartile_difference = q3 - q1
 

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -90,6 +90,8 @@ def get_constraint_violated_probabilities(
         list(feasibility_probabilities.values()), axis=0
     )
 
+    # pyre-fixme[7]: Expected `Dict[str, List[float]]` but got `Dict[str,
+    #  ndarray[typing.Any, dtype[typing.Any]]]`.
     return {
         metric_name: 1 - feasibility_probabilities[metric_name]
         for metric_name in feasibility_probabilities

--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -41,9 +41,11 @@ logger: Logger = get_logger(__name__)
 
 
 def compute_score_trace(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     optimization_trace: np.ndarray,
     num_baseline_trials: int,
     problem: BenchmarkProblem,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray:
     """Computes a score trace from the optimization trace."""
 

--- a/ax/benchmark/benchmark_result.py
+++ b/ax/benchmark/benchmark_result.py
@@ -78,9 +78,13 @@ class BenchmarkResult(Base):
     name: str
     seed: int
 
+    # pyre-fixme[24]: Generic type `ndarray` expects 2 type parameters.
     oracle_trace: ndarray
+    # pyre-fixme[24]: Generic type `ndarray` expects 2 type parameters.
     inference_trace: ndarray
+    # pyre-fixme[24]: Generic type `ndarray` expects 2 type parameters.
     optimization_trace: ndarray
+    # pyre-fixme[24]: Generic type `ndarray` expects 2 type parameters.
     score_trace: ndarray
 
     fit_time: float
@@ -156,6 +160,7 @@ class AggregatedBenchmarkResult(Base):
 
 
 def _get_stats(
+    # pyre-fixme[24]: Generic type `ndarray` expects 2 type parameters.
     step_data: Iterable[np.ndarray],
     percentiles: list[float],
 ) -> dict[str, list[float]]:

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -108,6 +108,7 @@ def train_and_evaluate(
             total += labels.size(0)
             correct += (predicted == labels).sum()
 
+    # pyre-fixme[7]: Expected `Tensor` but got `float`.
     return correct / total
 
 
@@ -165,7 +166,11 @@ class PyTorchCNNTorchvisionParamBasedProblem(ParamBasedTestProblem):
         return train_and_evaluate(
             **params,
             device=self.device,
+            # pyre-fixme[16]: `PyTorchCNNTorchvisionParamBasedProblem` has no
+            #  attribute `train_loader`.
             train_loader=self.train_loader,
+            # pyre-fixme[16]: `PyTorchCNNTorchvisionParamBasedProblem` has no
+            #  attribute `test_loader`.
             test_loader=self.test_loader,
         )
 

--- a/ax/benchmark/runners/base.py
+++ b/ax/benchmark/runners/base.py
@@ -72,6 +72,7 @@ class BenchmarkRunner(Runner, ABC):
         """
         ...
 
+    # pyre-fixme[24]: Generic type `ndarray` expects 2 type parameters.
     def evaluate_oracle(self, parameters: Mapping[str, TParamValue]) -> ndarray:
         """
         Evaluate oracle metric values at a parameterization. In the base class,
@@ -149,6 +150,8 @@ class BenchmarkRunner(Runner, ABC):
                 # budget allocation to each arm. This works b/c (i) we assume that
                 # observations per unit sample budget are i.i.d. and (ii) the
                 # normalized weights sum to one.
+                # pyre-fixme[61]: `nlzd_arm_weights` is undefined, or not always
+                #  defined.
                 std = noise_stds_tsr.to(Y_true) / sqrt(nlzd_arm_weights[arm])
                 Ystds[arm.name] = std.tolist()
                 Ys[arm.name] = (Y_true + std * torch.randn_like(Y_true)).tolist()

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -107,8 +107,10 @@ class Experiment(Base):
                 for different purposes (e.g., transfer learning).
         """
         # appease pyre
+        # pyre-fixme[13]: Attribute `_search_space` is never initialized.
         self._search_space: SearchSpace
         self._status_quo: Arm | None = None
+        # pyre-fixme[13]: Attribute `_is_test` is never initialized.
         self._is_test: bool
 
         self._name = name

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -187,7 +187,13 @@ class ObservationData(Base):
     """
 
     def __init__(
-        self, metric_names: list[str], means: np.ndarray, covariance: np.ndarray
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        self,
+        metric_names: list[str],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        means: np.ndarray,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        covariance: np.ndarray,
     ) -> None:
         k = len(metric_names)
         if means.shape != (k,):

--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -41,9 +41,13 @@ REPR_FLAGS_IF_TRUE_ONLY = [
 
 
 class ParameterType(Enum):
+    # pyre-fixme[35]: Target cannot be annotated.
     BOOL: int = 0
+    # pyre-fixme[35]: Target cannot be annotated.
     INT: int = 1
+    # pyre-fixme[35]: Target cannot be annotated.
     FLOAT: int = 2
+    # pyre-fixme[35]: Target cannot be annotated.
     STRING: int = 3
 
     @property
@@ -143,6 +147,7 @@ class Parameter(SortableBase, metaclass=ABCMeta):
             "Only choice hierarchical parameters are currently supported."
         )
 
+    # pyre-fixme[7]: Expected `Parameter` but got implicit return value of `None`.
     def clone(self) -> Parameter:
         # pyre-fixme[7]: Expected `Parameter` but got implicit return value of `None`.
         pass
@@ -214,10 +219,17 @@ class Parameter(SortableBase, metaclass=ABCMeta):
         if flags:
             summary_dict["flags"] = ", ".join(flags)
         if getattr(self, "is_fidelity", False) or getattr(self, "is_task", False):
+            # pyre-fixme[6]: For 2nd argument expected `str` but got `Union[None,
+            #  bool, float, int, str]`.
             summary_dict["target_value"] = self.target_value
         if getattr(self, "is_hierarchical", False):
+            # pyre-fixme[6]: For 2nd argument expected `str` but got
+            #  `Dict[Union[None, bool, float, int, str], List[str]]`.
             summary_dict["dependents"] = self.dependents
 
+        # pyre-fixme[7]: Expected `Dict[str, Union[None, List[Union[None, bool,
+        #  float, int, str]], List[str], bool, float, int, str]]` but got `Dict[str,
+        #  str]`.
         return summary_dict
 
 

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -1102,7 +1102,9 @@ class RobustSearchSpaceDigest:
             Only relevant if paired with a `distribution_sampler`.
     """
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     sample_param_perturbations: Callable[[], np.ndarray] | None = None
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     sample_environmental: Callable[[], np.ndarray] | None = None
     environmental_variables: list[str] = field(default_factory=list)
     multiplicative: bool = False

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -395,7 +395,9 @@ class ObservationsTest(TestCase):
             self.assertEqual(obs.features.parameters, t["updated_parameters"])
             self.assertEqual(obs.features.trial_index, t["trial_index"])
             self.assertEqual(obs.data.metric_names, [t["metric_name"]])
+            # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtype[ty...
             self.assertTrue(np.array_equal(obs.data.means, t["mean_t"]))
+            # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtype[ty...
             self.assertTrue(np.array_equal(obs.data.covariance, t["covariance_t"]))
             self.assertEqual(obs.arm_name, t["arm_name"])
 
@@ -484,7 +486,9 @@ class ObservationsTest(TestCase):
             self.assertEqual(obs.features.parameters, t["updated_parameters"])
             self.assertEqual(obs.features.trial_index, t["trial_index"])
             self.assertEqual(obs.data.metric_names, [t["metric_name"]])
+            # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtype[ty...
             self.assertTrue(np.array_equal(obs.data.means, t["mean_t"]))
+            # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtype[ty...
             self.assertTrue(np.array_equal(obs.data.covariance, t["covariance_t"]))
             self.assertEqual(obs.arm_name, t["arm_name"])
             self.assertEqual(obs.features.metadata, {"timestamp": t["timestamp"]})
@@ -828,8 +832,10 @@ class ObservationsTest(TestCase):
                 0,
             )
             self.assertEqual(obs.data.metric_names, obs_truth["metric_names"][i])
+            # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtype[ty...
             self.assertTrue(np.array_equal(obs.data.means, obs_truth["means"][i]))
             self.assertTrue(
+                # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtyp...
                 np.array_equal(obs.data.covariance, obs_truth["covariance"][i])
             )
             self.assertEqual(obs.arm_name, obs_truth["arm_name"][i])

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -21,6 +21,7 @@ TParameterization = dict[str, TParamValue]
 TParamValueList = list[TParamValue]  # a parameterization without the keys
 TContextStratum = Optional[dict[str, Union[str, float, int]]]
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 TBounds = Optional[tuple[np.ndarray, np.ndarray]]
 TModelMean = dict[str, list[float]]
 TModelCov = dict[str, dict[str, list[float]]]
@@ -29,6 +30,8 @@ TModelPredict = tuple[TModelMean, TModelCov]
 # ( { metric -> mean }, { metric -> { other_metric -> covariance } } ).
 TModelPredictArm = tuple[dict[str, float], Optional[dict[str, dict[str, float]]]]
 
+# pyre-fixme[24]: Generic type `np.floating` expects 1 type parameter.
+# pyre-fixme[24]: Generic type `np.integer` expects 1 type parameter.
 FloatLike = Union[int, float, np.floating, np.integer]
 SingleMetricDataTuple = tuple[FloatLike, Optional[FloatLike]]
 SingleMetricData = Union[FloatLike, tuple[FloatLike, Optional[FloatLike]]]
@@ -70,7 +73,9 @@ TCandidateMetadata = Optional[dict[str, Any]]
 class ComparisonOp(enum.Enum):
     """Class for enumerating comparison operations."""
 
+    # pyre-fixme[35]: Target cannot be annotated.
     GEQ: int = 0
+    # pyre-fixme[35]: Target cannot be annotated.
     LEQ: int = 1
 
 

--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -129,7 +129,11 @@ def _get_missing_arm_trial_pairs(data: Data, metric_name: str) -> set[TArmTrial]
 
 
 def best_feasible_objective(
-    optimization_config: OptimizationConfig, values: dict[str, np.ndarray]
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    optimization_config: OptimizationConfig,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    values: dict[str, np.ndarray],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray:
     """Compute the best feasible objective value found by each iteration.
 

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -54,8 +54,11 @@ class EarlyStoppingTrainingData:
             which data come from the same arm.
     """
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     X: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Y: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Yvar: np.ndarray
     arm_names: list[str | None]
 

--- a/ax/metrics/branin.py
+++ b/ax/metrics/branin.py
@@ -13,17 +13,20 @@ from ax.utils.measurement.synthetic_functions import aug_branin, branin
 
 
 class BraninMetric(NoisyFunctionMetric):
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, x: np.ndarray) -> float:
         x1, x2 = x
         return checked_cast(float, branin(x1=x1, x2=x2))
 
 
 class NegativeBraninMetric(BraninMetric):
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, x: np.ndarray) -> float:
         fpos = super().f(x)
         return -fpos
 
 
 class AugmentedBraninMetric(NoisyFunctionMetric):
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, x: np.ndarray) -> float:
         return checked_cast(float, aug_branin(x))

--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -117,6 +117,7 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
 
     # pyre-fixme[14]: `f` overrides method defined in `NoisyFunctionMapMetric`
     #  inconsistently.
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, x: np.ndarray, timestamp: int) -> Mapping[str, Any]:
         x1, x2 = x
 
@@ -160,6 +161,7 @@ class BraninFidelityMapMetric(NoisyFunctionMapMetric):
             **kwargs,
         )
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, x: np.ndarray) -> Mapping[str, Any]:
         if self.index < len(FIDELITY):
             self.index += 1

--- a/ax/metrics/chemistry.py
+++ b/ax/metrics/chemistry.py
@@ -49,7 +49,9 @@ from ax.utils.common.typeutils import not_none
 
 
 class ChemistryProblemType(Enum):
+    # pyre-fixme[35]: Target cannot be annotated.
     SUZUKI: str = "suzuki"
+    # pyre-fixme[35]: Target cannot be annotated.
     DIRECT_ARYLATION: str = "direct_arylation"
 
 

--- a/ax/metrics/hartmann6.py
+++ b/ax/metrics/hartmann6.py
@@ -13,10 +13,12 @@ from ax.utils.measurement.synthetic_functions import aug_hartmann6, hartmann6
 
 
 class Hartmann6Metric(NoisyFunctionMetric):
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, x: np.ndarray) -> float:
         return checked_cast(float, hartmann6(x))
 
 
 class AugmentedHartmann6Metric(NoisyFunctionMetric):
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, x: np.ndarray) -> float:
         return checked_cast(float, aug_hartmann6(x))

--- a/ax/metrics/l2norm.py
+++ b/ax/metrics/l2norm.py
@@ -11,5 +11,6 @@ from ax.metrics.noisy_function import NoisyFunctionMetric
 
 
 class L2NormMetric(NoisyFunctionMetric):
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, x: np.ndarray) -> float:
         return np.sqrt((x**2).sum())

--- a/ax/metrics/noisy_function.py
+++ b/ax/metrics/noisy_function.py
@@ -104,6 +104,7 @@ class NoisyFunctionMetric(Metric):
         x = np.array([params[p] for p in self.param_names])
         return self.f(x)
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, x: np.ndarray) -> float:
         """The deterministic function that produces the metric outcomes."""
         raise NotImplementedError

--- a/ax/metrics/noisy_function_map.py
+++ b/ax/metrics/noisy_function_map.py
@@ -112,6 +112,7 @@ class NoisyFunctionMapMetric(MapMetric):
                 MetricFetchE(message=f"Failed to fetch {self.name}", exception=e)
             )
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, x: np.ndarray) -> Mapping[str, Any]:
         """The deterministic function that produces the metric outcomes."""
         raise NotImplementedError

--- a/ax/metrics/sklearn.py
+++ b/ax/metrics/sklearn.py
@@ -29,18 +29,24 @@ from sklearn.neural_network import MLPClassifier, MLPRegressor
 
 
 class SklearnModelType(Enum):
+    # pyre-fixme[35]: Target cannot be annotated.
     RF: str = "rf"
+    # pyre-fixme[35]: Target cannot be annotated.
     NN: str = "nn"
 
 
 class SklearnDataset(Enum):
+    # pyre-fixme[35]: Target cannot be annotated.
     DIGITS: str = "digits"
+    # pyre-fixme[35]: Target cannot be annotated.
     BOSTON: str = "boston"
+    # pyre-fixme[35]: Target cannot be annotated.
     CANCER: str = "cancer"
 
 
 @lru_cache(maxsize=8)
 # pyre-fixme[2]: Parameter must be annotated.
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def _get_data(dataset) -> dict[str, np.ndarray]:
     """Return sklearn dataset, loading and caching if necessary."""
     if dataset is SklearnDataset.DIGITS:

--- a/ax/metrics/tests/test_chemistry.py
+++ b/ax/metrics/tests/test_chemistry.py
@@ -19,6 +19,7 @@ from ax.utils.testing.core_stubs import get_trial
 
 
 class DummyEnum(Enum):
+    # pyre-fixme[35]: Target cannot be annotated.
     DUMMY: str = "dummy"
 
 

--- a/ax/metrics/tests/test_sklearn.py
+++ b/ax/metrics/tests/test_sklearn.py
@@ -21,6 +21,7 @@ from sklearn.ensemble import RandomForestClassifier
 
 
 class DummyEnum(Enum):
+    # pyre-fixme[35]: Target cannot be annotated.
     DUMMY: str = "dummy"
 
 

--- a/ax/modelbridge/best_model_selector.py
+++ b/ax/modelbridge/best_model_selector.py
@@ -20,6 +20,7 @@ from ax.modelbridge.model_spec import ModelSpec
 from ax.utils.common.base import Base
 from ax.utils.common.typeutils import not_none
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ARRAYLIKE = Union[np.ndarray, list[float], list[np.ndarray]]
 
 
@@ -43,10 +44,17 @@ class ReductionCriterion(Enum):
     """
 
     # NOTE: Callables need to be wrapped in `partial` to be registered as members.
+    # pyre-fixme[35]: Target cannot be annotated.
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     MEAN: Callable[[ARRAYLIKE], np.ndarray] = partial(np.mean)
+    # pyre-fixme[35]: Target cannot be annotated.
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     MIN: Callable[[ARRAYLIKE], np.ndarray] = partial(np.min)
+    # pyre-fixme[35]: Target cannot be annotated.
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     MAX: Callable[[ARRAYLIKE], np.ndarray] = partial(np.max)
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def __call__(self, array_like: ARRAYLIKE) -> np.ndarray:
         return self.value(array_like)
 

--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -328,6 +328,7 @@ def compute_diagnostics(result: list[CVResult]) -> CVDiagnostics:
     return diagnostics
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def _arrayify_dict_values(d: dict[str, list[float]]) -> dict[str, np.ndarray]:
     """Helper to convert dictionary values to numpy arrays."""
     return {k: np.array(v) for k, v in d.items()}
@@ -402,7 +403,10 @@ def has_good_opt_config_model_fit(
 
 
 def _gen_train_test_split(
-    folds: int, arm_names: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    folds: int,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    arm_names: np.ndarray,
 ) -> Iterable[tuple[set[str], set[str]]]:
     """Return train/test splits of arm names.
 
@@ -535,6 +539,7 @@ def _model_fit_metric(metric_dict: dict[str, dict[str, float]]) -> float:
     return min(metric_dict["coefficient_of_determination"].values())
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def _model_std_quality(std: np.ndarray) -> float:
     """Quantifies quality of the model uncertainty. A value of one means the
     uncertainty is perfectly predictive of the true standard deviation of the error.
@@ -561,6 +566,7 @@ def _model_std_quality(std: np.ndarray) -> float:
 def _predict_on_training_data(
     model_bridge: ModelBridge,
     untransform: bool = False,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> tuple[
     dict[str, np.ndarray],
     dict[str, np.ndarray],
@@ -625,6 +631,7 @@ def _predict_on_training_data(
 def _predict_on_cross_validation_data(
     model_bridge: ModelBridge,
     untransform: bool = False,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> tuple[
     dict[str, np.ndarray],
     dict[str, np.ndarray],

--- a/ax/modelbridge/discrete.py
+++ b/ax/modelbridge/discrete.py
@@ -45,9 +45,13 @@ class DiscreteModelBridge(ModelBridge):
     Requires that all parameters have been transformed to ChoiceParameters.
     """
 
+    # pyre-fixme[13]: Attribute `model` is never initialized.
     model: DiscreteModel
+    # pyre-fixme[13]: Attribute `outcomes` is never initialized.
     outcomes: list[str]
+    # pyre-fixme[13]: Attribute `parameters` is never initialized.
     parameters: list[str]
+    # pyre-fixme[13]: Attribute `search_space` is never initialized.
     search_space: SearchSpace | None
 
     def _fit(

--- a/ax/modelbridge/dispatch_utils.py
+++ b/ax/modelbridge/dispatch_utils.py
@@ -187,6 +187,8 @@ def _suggest_gp_model(
                 all_range_parameters_are_discrete = False
             else:
                 num_param_discrete_values = parameter.cardinality()
+                # pyre-fixme[58]: `*` is not supported for operand types `int` and
+                #  `Union[float, int]`.
                 num_possible_points *= num_param_discrete_values
 
         if should_enumerate_param:

--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -224,7 +224,11 @@ class MapTorchModelBridge(TorchModelBridge):
         )
 
     def _array_to_observation_features(
-        self, X: np.ndarray, candidate_metadata: list[TCandidateMetadata] | None
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        self,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        X: np.ndarray,
+        candidate_metadata: list[TCandidateMetadata] | None,
     ) -> list[ObservationFeatures]:
         """The difference b/t this method and
         TorchModelBridge._array_to_observation_features(...) is

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -304,6 +304,7 @@ def extract_robust_digest(
         # NOTE: Extracting it from `param_names` in case the ordering is different.
         environmental_variables = param_names[num_non_env_vars:]
 
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         def sample_environmental() -> np.ndarray:
             """Get samples from the environmental distributions.
 
@@ -327,10 +328,12 @@ def extract_robust_digest(
         environmental_variables = []
 
     if len(pert_params) > 0:
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         constructor: Callable[[tuple[int, int]], np.ndarray] = (
             np.ones if search_space.multiplicative else np.zeros
         )
 
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         def sample_param_perturbations() -> np.ndarray:
             """Get samples of the input perturbations.
 
@@ -365,6 +368,7 @@ def extract_objective_thresholds(
     objective_thresholds: TRefPoint,
     objective: Objective,
     outcomes: list[str],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray | None:
     """Extracts objective thresholds' values, in the order of `outcomes`.
 
@@ -411,6 +415,7 @@ def extract_objective_thresholds(
     return obj_t
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def extract_objective_weights(objective: Objective, outcomes: list[str]) -> np.ndarray:
     """Extract a weights for objectives.
 
@@ -470,11 +475,17 @@ def extract_outcome_constraints(
 
 
 def validate_and_apply_final_transform(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     objective_weights: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     outcome_constraints: tuple[np.ndarray, np.ndarray] | None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     linear_constraints: tuple[np.ndarray, np.ndarray] | None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     pending_observations: list[np.ndarray] | None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     objective_thresholds: np.ndarray | None = None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     final_transform: Callable[[np.ndarray], Tensor] = torch.tensor,
 ) -> tuple[
     Tensor,
@@ -547,6 +558,7 @@ def pending_observations_as_array_list(
     pending_observations: dict[str, list[ObservationFeatures]],
     outcome_names: list[str],
     param_names: list[str],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> list[np.ndarray] | None:
     """Re-format pending observations.
 
@@ -579,6 +591,7 @@ def pending_observations_as_array_list(
 
 
 def parse_observation_features(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     X: np.ndarray,
     param_names: list[str],
     candidate_metadata: list[TCandidateMetadata] | None = None,
@@ -610,7 +623,9 @@ def parse_observation_features(
 
 
 def transform_callback(
-    param_names: list[str], transforms: MutableMapping[str, Transform]
+    param_names: list[str],
+    transforms: MutableMapping[str, Transform],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> Callable[[np.ndarray], np.ndarray]:
     """A closure for performing the `round trip` transformations.
 
@@ -628,6 +643,7 @@ def transform_callback(
         a function with for performing the roundtrip transform.
     """
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _roundtrip_transform(x: np.ndarray) -> np.ndarray:
         """Inner function for performing aforementioned functionality.
 
@@ -1152,7 +1168,11 @@ def observed_hypervolume(
 
 
 def array_to_observation_data(
-    f: np.ndarray, cov: np.ndarray, outcomes: list[str]
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    f: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    cov: np.ndarray,
+    outcomes: list[str],
 ) -> list[ObservationData]:
     """Convert arrays of model predictions to a list of ObservationData.
 
@@ -1178,6 +1198,7 @@ def array_to_observation_data(
 def observation_data_to_array(
     outcomes: list[str],
     observation_data: list[ObservationData],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> tuple[np.ndarray, np.ndarray]:
     """Convert a list of Observation data to arrays.
 
@@ -1212,14 +1233,20 @@ def observation_data_to_array(
 
 
 def observation_features_to_array(
-    parameters: list[str], obsf: list[ObservationFeatures]
+    parameters: list[str],
+    obsf: list[ObservationFeatures],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray:
     """Convert a list of Observation features to arrays."""
     return np.array([[of.parameters[p] for p in parameters] for of in obsf])
 
 
 def feasible_hypervolume(
-    optimization_config: MultiObjectiveOptimizationConfig, values: dict[str, np.ndarray]
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    optimization_config: MultiObjectiveOptimizationConfig,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    values: dict[str, np.ndarray],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray:
     """Compute the feasible hypervolume each iteration.
 
@@ -1271,6 +1298,7 @@ def feasible_hypervolume(
 
 
 def _array_to_tensor(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     array: np.ndarray | list[float],
     modelbridge: modelbridge_module.base.ModelBridge | None = None,
 ) -> Tensor:

--- a/ax/modelbridge/pairwise.py
+++ b/ax/modelbridge/pairwise.py
@@ -37,6 +37,7 @@ class PairwiseModelBridge(TorchModelBridge):
         """
         if len(observation_features) != len(observation_data):
             raise ValueError("Observation features and data must have the same length!")
+        # pyre-fixme[6]: For 1st argument expected `Union[_SupportsArray[dtype[typing...
         ordered_idx = np.argsort([od.trial_index for od in observation_features])
         observation_features = [observation_features[i] for i in ordered_idx]
         observation_data = [observation_data[i] for i in ordered_idx]

--- a/ax/modelbridge/random.py
+++ b/ax/modelbridge/random.py
@@ -40,7 +40,9 @@ class RandomModelBridge(ModelBridge):
         parameters: Params found in search space on modelbridge init.
     """
 
+    # pyre-fixme[13]: Attribute `model` is never initialized.
     model: RandomModel
+    # pyre-fixme[13]: Attribute `parameters` is never initialized.
     parameters: list[str]
 
     def _fit(

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -201,7 +201,9 @@ class TorchModelBridgeTest(TestCase):
             weights=torch.tensor([1.0], **tkwargs),
             gen_metadata={"foo": 99},
         )
-
+        opt_config = OptimizationConfig(
+            objective=Objective(metric=Metric("y1"), minimize=False),
+        )
         with ExitStack() as es:
             es.enter_context(
                 mock.patch(
@@ -231,9 +233,7 @@ class TorchModelBridgeTest(TestCase):
             gen_run = ma.gen(
                 n=3,
                 search_space=search_space,
-                optimization_config=OptimizationConfig(
-                    objective=Objective(metric=Metric("y1"), minimize=False),
-                ),
+                optimization_config=opt_config,
                 pending_observations={
                     "y2": [
                         ObservationFeatures(
@@ -265,6 +265,7 @@ class TorchModelBridgeTest(TestCase):
         self.assertEqual(gen_opt_config.model_gen_options, {"option": "yes"})
         self.assertIs(gen_opt_config.rounding_func, torch.round)
         self.assertFalse(gen_opt_config.is_moo)
+        self.assertEqual(gen_opt_config.opt_config_metrics, opt_config.metrics)
         self.assertEqual(gen_args["search_space_digest"].target_values, {})
         self.assertEqual(len(gen_run.arms), 1)
         self.assertEqual(gen_run.arms[0].parameters, {"x1": 1.0, "x2": 2.0, "x3": 3.0})

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -92,7 +92,9 @@ class TorchModelBridge(ModelBridge):
     """
 
     model: TorchModel | None = None
+    # pyre-fixme[13]: Attribute `outcomes` is never initialized.
     outcomes: list[str]
+    # pyre-fixme[13]: Attribute `parameters` is never initialized.
     parameters: list[str]
     _default_model_gen_options: TConfig
     _last_observations: list[Observation] | None = None
@@ -283,16 +285,21 @@ class TorchModelBridge(ModelBridge):
         return best_arm, best_point_predictions
 
     def _array_callable_to_tensor_callable(
-        self, array_func: Callable[[np.ndarray], np.ndarray]
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        self,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        array_func: Callable[[np.ndarray], np.ndarray],
     ) -> Callable[[Tensor], Tensor]:
         tensor_func: Callable[[Tensor], Tensor] = lambda x: (
             self._array_to_tensor(array_func(x.detach().cpu().clone().numpy()))
         )
         return tensor_func
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _array_list_to_tensors(self, arrays: list[np.ndarray]) -> list[Tensor]:
         return [self._array_to_tensor(x) for x in arrays]
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _array_to_tensor(self, array: np.ndarray | list[float]) -> Tensor:
         return torch.as_tensor(array, dtype=self.dtype, device=self.device)
 
@@ -765,7 +772,11 @@ class TorchModelBridge(ModelBridge):
         return array_to_observation_data(f=f, cov=cov, outcomes=self.outcomes)
 
     def _array_to_observation_features(
-        self, X: np.ndarray, candidate_metadata: list[TCandidateMetadata] | None
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        self,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        X: np.ndarray,
+        candidate_metadata: list[TCandidateMetadata] | None,
     ) -> list[ObservationFeatures]:
         return parse_observation_features(
             X=X, param_names=self.parameters, candidate_metadata=candidate_metadata

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -93,9 +93,9 @@ class TorchModelBridge(ModelBridge):
 
     model: TorchModel | None = None
     # pyre-fixme[13]: Attribute `outcomes` is never initialized.
-    outcomes: list[str]
+    outcomes: list[str]  # pyre-ignore[13]: These are initialized in _fit.
     # pyre-fixme[13]: Attribute `parameters` is never initialized.
-    parameters: list[str]
+    parameters: list[str]  # pyre-ignore[13]: These are initialized in _fit.
     _default_model_gen_options: TConfig
     _last_observations: list[Observation] | None = None
 
@@ -222,9 +222,7 @@ class TorchModelBridge(ModelBridge):
             objective_thresholds=obj_thresholds,
             objective_weights=torch_opt_config.objective_weights,
             bounds=search_space_digest.bounds,
-            # we should never be in a situation where we call this without there
-            # being an optimization config involved.
-            opt_config_metrics=not_none(torch_opt_config.opt_config_metrics),
+            opt_config_metrics=torch_opt_config.opt_config_metrics,
             fixed_features=torch_opt_config.fixed_features,
         )
 
@@ -710,16 +708,12 @@ class TorchModelBridge(ModelBridge):
             # user-specified objective thresholds are in gen_metadata. Otherwise,
             # if using a hypervolume based acquisition function, then
             # the inferred objective thresholds are in gen_metadata.
-            opt_config_metrics = (
-                torch_opt_config.opt_config_metrics
-                or not_none(self._optimization_config).metrics
-            )
             gen_metadata["objective_thresholds"] = (
                 self._untransform_objective_thresholds(
                     objective_thresholds=gen_metadata["objective_thresholds"],
                     objective_weights=torch_opt_config.objective_weights,
                     bounds=search_space_digest.bounds,
-                    opt_config_metrics=opt_config_metrics,
+                    opt_config_metrics=torch_opt_config.opt_config_metrics,
                     fixed_features=torch_opt_config.fixed_features,
                 )
             )
@@ -841,9 +835,9 @@ class TorchModelBridge(ModelBridge):
                 objective=optimization_config.objective,
                 outcomes=self.outcomes,
             )
-            opt_config_metrics = optimization_config.metrics
         else:
-            objective_thresholds, opt_config_metrics = None, None
+            objective_thresholds = None
+        opt_config_metrics = optimization_config.metrics
 
         pending_array = pending_observations_as_array_list(
             pending_observations, self.outcomes, self.parameters

--- a/ax/modelbridge/transforms/choice_encode.py
+++ b/ax/modelbridge/transforms/choice_encode.py
@@ -225,6 +225,7 @@ class OrderedChoiceEncode(DeprecatedTransformMixin, OrderedChoiceToIntegerRange)
         super().__init__(*args, **kwargs)
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def transform_choice_values(p: ChoiceParameter) -> tuple[np.ndarray, ParameterType]:
     """Transforms the choice values and returns the new parameter type.
 

--- a/ax/modelbridge/transforms/ivw.py
+++ b/ax/modelbridge/transforms/ivw.py
@@ -48,6 +48,7 @@ def ivw_metric_merge(
     # weights is a map from metric name to a vector of the weights for each
     # measurement of that metric. indicies gives the corresponding index in
     # obsd.means for each measurement.
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     weights: dict[str, np.ndarray] = {}
     indicies: dict[str, list[int]] = {}
     for metric_name in set(obsd.metric_names):
@@ -98,7 +99,10 @@ def ivw_metric_merge(
 
 
 def _check_conflicting_means(
-    means_noiseless: np.ndarray, metric_name: str, conflicting_noiseless: str
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    means_noiseless: np.ndarray,
+    metric_name: str,
+    conflicting_noiseless: str,
 ) -> None:
     if np.var(means_noiseless) > 0:
         message = f"Conflicting noiseless measurements for {metric_name}."

--- a/ax/modelbridge/transforms/log_y.py
+++ b/ax/modelbridge/transforms/log_y.py
@@ -102,6 +102,7 @@ class LogY(Transform):
     def _tf_obs_data(
         self,
         observation_data: list[ObservationData],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         transform: Callable[[np.ndarray, np.ndarray], tuple[np.ndarray, np.ndarray]],
     ) -> list[ObservationData]:
         for obsd in observation_data:
@@ -157,10 +158,14 @@ class LogY(Transform):
 
 
 def match_ci_width(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     mean: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     variance: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     transform: Callable[[np.ndarray], np.ndarray],
     level: float = 0.95,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray:
     fac = norm.ppf(1 - (1 - level) / 2)
     d = fac * np.sqrt(variance)
@@ -172,7 +177,11 @@ def match_ci_width(
 
 
 def lognorm_to_norm(
-    mu_ln: np.ndarray, Cov_ln: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    mu_ln: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    Cov_ln: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute mean and covariance of a MVN from those of the associated log-MVN
 
@@ -188,7 +197,11 @@ def lognorm_to_norm(
 
 
 def norm_to_lognorm(
-    mu_n: np.ndarray, Cov_n: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    mu_n: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    Cov_n: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute mean and covariance of a log-MVN from its MVN sufficient statistics
 

--- a/ax/modelbridge/transforms/relativize.py
+++ b/ax/modelbridge/transforms/relativize.py
@@ -170,6 +170,7 @@ class BaseRelativize(Transform, ABC):
     def _get_relative_data_from_obs(
         self,
         obs: Observation,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         rel_op: Callable[..., tuple[np.ndarray, np.ndarray]],
     ) -> ObservationData:
         idx = (
@@ -191,6 +192,7 @@ class BaseRelativize(Transform, ABC):
     def _rel_op_on_observations(
         self,
         observations: list[Observation],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         rel_op: Callable[..., tuple[np.ndarray, np.ndarray]],
     ) -> list[Observation]:
         return [
@@ -206,6 +208,7 @@ class BaseRelativize(Transform, ABC):
         self,
         data: ObservationData,
         status_quo_data: ObservationData,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         rel_op: Callable[..., tuple[np.ndarray, np.ndarray]],
     ) -> ObservationData:
         r"""
@@ -253,7 +256,9 @@ class BaseRelativize(Transform, ABC):
         mean_c: float,
         sem_c: float,
         metric: str,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         rel_op: Callable[..., tuple[np.ndarray, np.ndarray]],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     ) -> tuple[float | np.ndarray, float | np.ndarray]:
         """Compute (un)relativized mean and sem for a single metric."""
         # if the is the status quo

--- a/ax/modelbridge/transforms/rounding.py
+++ b/ax/modelbridge/transforms/rounding.py
@@ -22,6 +22,7 @@ def randomized_round(x: float) -> int:
     return int(z + float(random.random() <= (x - z)))
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def randomized_onehot_round(x: np.ndarray) -> np.ndarray:
     """Randomized rounding of x to a one-hot vector.
     x should be 0 <= x <= 1. If x includes negative values,
@@ -41,6 +42,7 @@ def randomized_onehot_round(x: np.ndarray) -> np.ndarray:
     return z
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def strict_onehot_round(x: np.ndarray) -> np.ndarray:
     """Round x to a one-hot vector by selecting the max element.
     Ties broken randomly."""

--- a/ax/modelbridge/transforms/tests/test_relativize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_relativize_transform.py
@@ -48,6 +48,7 @@ class RelativizeDataTest(TestCase):
         Relativize,
         RelativizeWithConstantControl,
     ]
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     cases: list[tuple[type[Transform], list[tuple[np.ndarray, np.ndarray]]]] = [
         (
             Relativize,
@@ -203,6 +204,7 @@ class RelativizeDataTest(TestCase):
         def _check_transform_observations(
             tf: Transform,
             observations: list[Observation],
+            # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
             expected_mean_and_covar: list[tuple[np.ndarray, np.ndarray]],
         ) -> None:
             results = tf.transform_observations(observations)

--- a/ax/modelbridge/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/modelbridge/transforms/tests/test_transform_to_new_sq.py
@@ -28,6 +28,7 @@ class TransformToNewSQTest(RelativizeDataTest):
     # [Type[TransformToNewSQ]]` is not a subtype of the
     # overridden attribute `List[Type[Transform]]`
     relativize_classes = [TransformToNewSQ]
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     cases: list[tuple[type[Transform], list[tuple[np.ndarray, np.ndarray]]]] = [
         (
             TransformToNewSQ,

--- a/ax/modelbridge/transforms/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_winsorize_transform.py
@@ -688,6 +688,7 @@ def get_default_transform_cutoffs(
     obsd = ObservationData(
         metric_names=["m1"] * obs_data_len,
         means=np.array(range(obs_data_len)),
+        # pyre-fixme[6]: For 1st argument expected `int` but got `SupportsIndex`.
         covariance=np.eye(obs_data_len),
     )
     obs = Observation(features=ObservationFeatures({}), data=obsd)

--- a/ax/modelbridge/transforms/transform_to_new_sq.py
+++ b/ax/modelbridge/transforms/transform_to_new_sq.py
@@ -86,6 +86,7 @@ class TransformToNewSQ(BaseRelativize):
     def _get_relative_data_from_obs(
         self,
         obs: Observation,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         rel_op: Callable[..., tuple[np.ndarray, np.ndarray]],
     ) -> ObservationData:
         idx = (
@@ -104,6 +105,7 @@ class TransformToNewSQ(BaseRelativize):
     def _rel_op_on_observations(
         self,
         observations: list[Observation],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         rel_op: Callable[..., tuple[np.ndarray, np.ndarray]],
     ) -> list[Observation]:
         rel_observations = super()._rel_op_on_observations(
@@ -124,6 +126,7 @@ class TransformToNewSQ(BaseRelativize):
         self,
         data: ObservationData,
         status_quo_data: ObservationData,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         rel_op: Callable[..., tuple[np.ndarray, np.ndarray]],
     ) -> ObservationData:
         r"""
@@ -171,6 +174,7 @@ class TransformToNewSQ(BaseRelativize):
         mean_c: float,
         sem_c: float,
         metric: str,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         rel_op: Callable[..., tuple[np.ndarray, np.ndarray]],
     ) -> tuple[float, float]:
         """Compute (un)transformed mean and sem for a single metric."""
@@ -192,4 +196,6 @@ class TransformToNewSQ(BaseRelativize):
         if rel_op == relativize:
             means_rel = means_rel * abs_target_mean_c + target_mean_c
             sems_rel = sems_rel * abs_target_mean_c
+        # pyre-fixme[7]: Expected `Tuple[float, float]` but got
+        #  `Tuple[ndarray[typing.Any, typing.Any], ndarray[typing.Any, typing.Any]]`.
         return means_rel, sems_rel

--- a/ax/modelbridge/transforms/utils.py
+++ b/ax/modelbridge/transforms/utils.py
@@ -44,6 +44,8 @@ class ClosestLookupDict(dict):
         if not isinstance(key, Number):
             raise ValueError("ClosestLookupDict only allows numerical keys.")
         super().__setitem__(key, val)
+        # pyre-fixme[6]: For 2nd argument expected `Union[bytes, complex, float,
+        #  int, generic, str]` but got `Number`.
         ipos = np.searchsorted(self._keys, key)
         self._keys.insert(ipos, key)
 
@@ -54,6 +56,8 @@ class ClosestLookupDict(dict):
         except KeyError:
             if not self.keys():
                 raise RuntimeError("ClosestLookupDict is empty.")
+            # pyre-fixme[6]: For 2nd argument expected `Union[bytes, complex, float,
+            #  int, generic, str]` but got `Number`.
             ipos = np.searchsorted(self._keys, key)
             if ipos == 0:
                 return super().__getitem__(self._keys[0])

--- a/ax/modelbridge/transforms/winsorize.py
+++ b/ax/modelbridge/transforms/winsorize.py
@@ -344,6 +344,7 @@ def _get_objective_threshold_from_moo_config(
     ]
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def _get_tukey_cutoffs(Y: np.ndarray, lower: bool) -> float:
     """Compute winsorization cutoffs similarly to Tukey boxplots.
 
@@ -386,7 +387,9 @@ def _get_auto_winsorization_cutoffs_outcome_constraint(
     """
     Y = np.array(metric_values)
     # TODO: replace interpolation->method once it becomes standard.
+    # pyre-fixme[28]: Unexpected keyword argument `interpolation`.
     q1 = np.percentile(Y, q=25, interpolation="lower")
+    # pyre-fixme[28]: Unexpected keyword argument `interpolation`.
     q3 = np.percentile(Y, q=75, interpolation="higher")
     lower_cutoff, upper_cutoff = DEFAULT_CUTOFFS
     for oc in outcome_constraints:
@@ -427,6 +430,7 @@ def _quantiles_to_cutoffs(
     elif lower == 0.0:  # Use the default cutoff if there is no winsorization
         cutoff_l = DEFAULT_CUTOFFS[0]
     else:
+        # pyre-fixme[28]: Unexpected keyword argument `interpolation`.
         cutoff_l = np.percentile(Y, lower * 100, interpolation="lower")
 
     if upper == AUTO_WINS_QUANTILE:
@@ -434,6 +438,7 @@ def _quantiles_to_cutoffs(
     elif upper == 0.0:  # Use the default cutoff if there is no winsorization
         cutoff_u = DEFAULT_CUTOFFS[1]
     else:
+        # pyre-fixme[28]: Unexpected keyword argument `interpolation`.
         cutoff_u = np.percentile(Y, (1 - upper) * 100, interpolation="higher")
 
     cutoff_l = min(cutoff_l, bnd_l) if bnd_l is not None else cutoff_l

--- a/ax/models/discrete/full_factorial.py
+++ b/ax/models/discrete/full_factorial.py
@@ -52,7 +52,9 @@ class FullFactorialGenerator(DiscreteModel):
         self,
         n: int,
         parameter_values: list[TParamValueList],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         objective_weights: np.ndarray | None,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         outcome_constraints: tuple[np.ndarray, np.ndarray] | None = None,
         fixed_features: dict[int, TParamValue] | None = None,
         pending_observations: list[list[TParamValueList]] | None = None,

--- a/ax/models/discrete/thompson.py
+++ b/ax/models/discrete/thompson.py
@@ -76,7 +76,9 @@ class ThompsonSampler(DiscreteModel):
         self,
         n: int,
         parameter_values: list[TParamValueList],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         objective_weights: np.ndarray | None,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         outcome_constraints: tuple[np.ndarray, np.ndarray] | None = None,
         fixed_features: dict[int, TParamValue] | None = None,
         pending_observations: list[list[TParamValueList]] | None = None,
@@ -122,6 +124,7 @@ class ThompsonSampler(DiscreteModel):
         return top_arms, top_weights, {"arms_to_weights": list(zip(arms, weights))}
 
     @copy_doc(DiscreteModel.predict)
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def predict(self, X: list[TParamValueList]) -> tuple[np.ndarray, np.ndarray]:
         n = len(X)  # number of parameterizations at which to make predictions
         m = len(self.Ys)  # number of outcomes
@@ -141,7 +144,9 @@ class ThompsonSampler(DiscreteModel):
 
     def _generate_weights(
         self,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         objective_weights: np.ndarray,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         outcome_constraints: tuple[np.ndarray, np.ndarray] | None = None,
     ) -> list[float]:
         samples, fraction_all_infeasible = self._produce_samples(
@@ -173,6 +178,7 @@ class ThompsonSampler(DiscreteModel):
         weights = winner_counts / winner_counts.sum()
         return weights.tolist()
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _generate_samples_per_metric(self, num_samples: int) -> np.ndarray:
         k = len(self.X)
         samples_per_metric = np.zeros(
@@ -190,8 +196,11 @@ class ThompsonSampler(DiscreteModel):
     def _produce_samples(
         self,
         num_samples: int,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         objective_weights: np.ndarray,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         outcome_constraints: tuple[np.ndarray, np.ndarray] | None,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     ) -> tuple[np.ndarray, float]:
         k = len(self.X)
         samples_per_metric = self._generate_samples_per_metric(num_samples=num_samples)

--- a/ax/models/discrete_base.py
+++ b/ax/models/discrete_base.py
@@ -42,6 +42,7 @@ class DiscreteModel(Model):
         """
         pass
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def predict(self, X: list[TParamValueList]) -> tuple[np.ndarray, np.ndarray]:
         """Predict
 
@@ -61,7 +62,9 @@ class DiscreteModel(Model):
         self,
         n: int,
         parameter_values: list[TParamValueList],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         objective_weights: np.ndarray | None,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         outcome_constraints: tuple[np.ndarray, np.ndarray] | None = None,
         fixed_features: dict[int, TParamValue] | None = None,
         pending_observations: list[list[TParamValueList]] | None = None,
@@ -102,6 +105,7 @@ class DiscreteModel(Model):
         Yvars_train: list[list[float]],
         X_test: list[TParamValueList],
         use_posterior_predictive: bool = False,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     ) -> tuple[np.ndarray, np.ndarray]:
         """Do cross validation with the given training and test sets.
 
@@ -133,7 +137,9 @@ class DiscreteModel(Model):
         self,
         n: int,
         parameter_values: list[TParamValueList],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         objective_weights: np.ndarray | None,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         outcome_constraints: tuple[np.ndarray, np.ndarray] | None = None,
         fixed_features: dict[int, TParamValue] | None = None,
         pending_observations: list[list[TParamValueList]] | None = None,

--- a/ax/models/model_utils.py
+++ b/ax/models/model_utils.py
@@ -23,6 +23,7 @@ from botorch.acquisition.risk_measures import RiskMeasureMCObjective
 from torch import Tensor
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 Tensoray = Union[torch.Tensor, np.ndarray]
 
 
@@ -48,18 +49,24 @@ DEFAULT_MAX_RS_DRAWS = 10000
 
 
 def rejection_sample(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     gen_unconstrained: Callable[
         [int, int, np.ndarray, dict[int, float] | None], np.ndarray
     ],
     n: int,
     d: int,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     tunable_feature_indices: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     linear_constraints: tuple[np.ndarray, np.ndarray] | None = None,
     deduplicate: bool = False,
     max_draws: int | None = None,
     fixed_features: dict[int, float] | None = None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     rounding_func: Callable[[np.ndarray], np.ndarray] | None = None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     existing_points: np.ndarray | None = None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> tuple[np.ndarray, int]:
     """Rejection sample in parameter space. Parameter space is typically
     [0, 1] for all tunable parameters.
@@ -156,6 +163,7 @@ def rejection_sample(
         return (points, attempted_draws)
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def check_duplicate(point: np.ndarray, points: np.ndarray) -> bool:
     """Check if a point exists in another array.
 
@@ -173,10 +181,13 @@ def check_duplicate(point: np.ndarray, points: np.ndarray) -> bool:
 
 
 def add_fixed_features(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     tunable_points: np.ndarray,
     d: int,
     fixed_features: dict[int, float] | None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     tunable_feature_indices: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray:
     """Add fixed features to points in tunable space.
 
@@ -201,7 +212,11 @@ def add_fixed_features(
 
 
 def check_param_constraints(
-    linear_constraints: tuple[np.ndarray, np.ndarray], point: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    linear_constraints: tuple[np.ndarray, np.ndarray],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    point: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> tuple[bool, np.ndarray]:
     """Check if a point satisfies parameter constraints.
 
@@ -227,7 +242,9 @@ def check_param_constraints(
 
 
 def tunable_feature_indices(
-    bounds: list[tuple[float, float]], fixed_features: dict[int, float] | None = None
+    bounds: list[tuple[float, float]],
+    fixed_features: dict[int, float] | None = None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray:
     """Get the feature indices of tunable features.
 
@@ -245,7 +262,10 @@ def tunable_feature_indices(
 
 
 def validate_bounds(
-    bounds: list[tuple[float, float]], fixed_feature_indices: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    bounds: list[tuple[float, float]],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    fixed_feature_indices: np.ndarray,
 ) -> None:
     """Ensure the requested space is [0,1]^d.
 
@@ -343,6 +363,7 @@ def best_observed_point(
 
 
 def best_in_sample_point(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Xs: list[torch.Tensor] | list[np.ndarray],
     model: TorchModelLike,
     bounds: list[tuple[float, float]],
@@ -438,6 +459,8 @@ def best_in_sample_point(
         return None
     # Predict objective and P(feas) at these points for Torch models.
     if isinstance(Xs[0], torch.Tensor):
+        # pyre-fixme[16]: Item `ndarray` of `Union[ndarray[typing.Any, typing.Any],
+        #  Tensor]` has no attribute `detach`.
         X_obs = X_obs.detach().clone()
     f, cov = as_array(model.predict(X_obs))
     obj = objective_weights_np @ f.transpose()
@@ -468,6 +491,7 @@ def best_in_sample_point(
         return X_obs[i, :], utility[i]
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def as_array(x: Tensoray | tuple[Tensoray, ...]) -> np.ndarray | tuple[np.ndarray, ...]:
     """Convert every item in a tuple of tensors/arrays into an array.
 
@@ -488,9 +512,12 @@ def as_array(x: Tensoray | tuple[Tensoray, ...]) -> np.ndarray | tuple[np.ndarra
 
 
 def get_observed(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Xs: list[torch.Tensor] | list[np.ndarray],
     objective_weights: Tensoray,
     outcome_constraints: tuple[Tensoray, Tensoray] | None = None,
+    # pyre-fixme[7]: Expected `Union[ndarray[typing.Any, typing.Any], Tensor]` but got
+    #  implicit return value of `None`.
 ) -> Tensoray:
     """Filter points to those that are observed for objective outcomes and outcomes
     that show up in outcome_constraints (if there are any).
@@ -529,6 +556,8 @@ def get_observed(
         #  return value of `None`.
         # pyre-fixme[6]: For 3rd param expected `Optional[_C.dtype]` but got
         #  `Union[np.dtype, _C.dtype]`.
+        # pyre-fixme[16]: Item `ndarray` of `Union[ndarray[typing.Any, typing.Any],
+        #  Tensor]` has no attribute `device`.
         return torch.tensor(list(X_obs_set), device=Xs[0].device, dtype=Xs[0].dtype)
 
 

--- a/ax/models/random/base.py
+++ b/ax/models/random/base.py
@@ -65,6 +65,7 @@ class RandomModel(Model):
         deduplicate: bool = True,
         seed: int | None = None,
         init_position: int = 0,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         generated_points: np.ndarray | None = None,
         fallback_to_sample_polytope: bool = False,
     ) -> None:
@@ -85,10 +86,13 @@ class RandomModel(Model):
         self,
         n: int,
         bounds: list[tuple[float, float]],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         linear_constraints: tuple[np.ndarray, np.ndarray] | None = None,
         fixed_features: dict[int, float] | None = None,
         model_gen_options: TConfig | None = None,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         rounding_func: Callable[[np.ndarray], np.ndarray] | None = None,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     ) -> tuple[np.ndarray, np.ndarray]:
         """Generate new candidates.
 
@@ -200,8 +204,10 @@ class RandomModel(Model):
         self,
         n: int,
         d: int,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         tunable_feature_indices: np.ndarray,
         fixed_features: dict[int, float] | None = None,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     ) -> np.ndarray:
         """Generate n points, from an unconstrained parameter space, using _gen_samples.
 
@@ -225,6 +231,7 @@ class RandomModel(Model):
         )
         return points
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _gen_samples(self, n: int, tunable_d: int) -> np.ndarray:
         """Generate n samples on [0, 1]^d.
 
@@ -238,7 +245,10 @@ class RandomModel(Model):
         raise NotImplementedError("Base RandomModel can't generate samples.")
 
     def _convert_inequality_constraints(
-        self, linear_constraints: tuple[np.ndarray, np.ndarray] | None
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        self,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        linear_constraints: tuple[np.ndarray, np.ndarray] | None,
     ) -> tuple[Tensor, Tensor] | None:
         """Helper method to convert inequality constraints used by the rejection
         sampler to the format required for the polytope sampler.

--- a/ax/models/random/sobol.py
+++ b/ax/models/random/sobol.py
@@ -35,6 +35,7 @@ class SobolGenerator(RandomModel):
         seed: int | None = None,
         init_position: int = 0,
         scramble: bool = True,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         generated_points: np.ndarray | None = None,
         fallback_to_sample_polytope: bool = False,
     ) -> None:
@@ -75,10 +76,13 @@ class SobolGenerator(RandomModel):
         self,
         n: int,
         bounds: list[tuple[float, float]],
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         linear_constraints: tuple[np.ndarray, np.ndarray] | None = None,
         fixed_features: dict[int, float] | None = None,
         model_gen_options: TConfig | None = None,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         rounding_func: Callable[[np.ndarray], np.ndarray] | None = None,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     ) -> tuple[np.ndarray, np.ndarray]:
         """Generate new candidates.
 
@@ -117,6 +121,7 @@ class SobolGenerator(RandomModel):
             self.init_position = not_none(self.engine).num_generated
         return (points, weights)
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _gen_samples(self, n: int, tunable_d: int) -> np.ndarray:
         """Generate n samples.
 

--- a/ax/models/random/uniform.py
+++ b/ax/models/random/uniform.py
@@ -25,6 +25,7 @@ class UniformGenerator(RandomModel):
         deduplicate: bool = True,
         seed: int | None = None,
         init_position: int = 0,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         generated_points: np.ndarray | None = None,
         fallback_to_sample_polytope: bool = False,
     ) -> None:
@@ -40,6 +41,7 @@ class UniformGenerator(RandomModel):
             # Fast-forward the random state by generating & discarding samples.
             self._rs.uniform(size=(self.init_position))
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _gen_samples(self, n: int, tunable_d: int) -> np.ndarray:
         """Generate samples from the scipy uniform distribution.
 

--- a/ax/models/tests/test_model_utils.py
+++ b/ax/models/tests/test_model_utils.py
@@ -61,6 +61,7 @@ class ModelUtilsTest(TestCase):
         )
         X_obs = model.predict.mock_calls[0][1][0]
         self.assertEqual(X_obs.shape, (3, 2))
+        # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtype[typing...
         self.assertTrue(np.array_equal(X_obs[1, :], xbest))  # 1 should be best
 
         # Test with specified utility baseline
@@ -75,6 +76,7 @@ class ModelUtilsTest(TestCase):
         )
         X_obs = model.predict.mock_calls[1][1][0]
         self.assertEqual(X_obs.shape, (3, 2))
+        # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtype[typing...
         self.assertTrue(np.array_equal(X_obs[2, :], xbest))  # 2 should be best
 
         # Test with feasibility threshold
@@ -89,6 +91,7 @@ class ModelUtilsTest(TestCase):
         )
         X_obs = model.predict.mock_calls[2][1][0]
         self.assertEqual(X_obs.shape, (3, 2))
+        # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtype[typing...
         self.assertTrue(np.array_equal(X_obs[0, :], xbest))  # 0 should be best
 
         # Parameter infeasible

--- a/ax/models/tests/test_sobol.py
+++ b/ax/models/tests/test_sobol.py
@@ -43,6 +43,7 @@ class SobolGeneratorTest(TestCase):
         self.assertTrue(
             np.array_equal(
                 state.get("generated_points"),
+                # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtyp...
                 generator.generated_points,
             )
         )
@@ -319,6 +320,7 @@ class SobolGeneratorTest(TestCase):
         self.assertTrue(
             np.array_equal(
                 generator._get_state().get("generated_points"),
+                # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtyp...
                 generator.generated_points,
             )
         )

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -495,6 +495,7 @@ class BotorchModel(TorchModel):
             model=model, X=X_test, use_posterior_predictive=use_posterior_predictive
         )
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def feature_importances(self) -> np.ndarray:
         return get_feature_importances_from_botorch_model(model=self._model)
 
@@ -542,6 +543,7 @@ def get_rounding_func(
 
 def get_feature_importances_from_botorch_model(
     model: Model | ModuleList | None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray:
     """Get feature importances from a list of BoTorch models.
 

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -574,6 +574,8 @@ def recommend_best_observed_point(
     )
     if x_best is None:
         return None
+    # pyre-fixme[16]: Item `ndarray` of `Union[ndarray[typing.Any, typing.Any],
+    #  Tensor]` has no attribute `to`.
     return x_best.to(dtype=model.dtype, device=torch.device("cpu"))
 
 

--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -638,6 +638,7 @@ class BoTorchModel(TorchModel, Base):
         )
 
     @single_surrogate_only
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def feature_importances(self) -> np.ndarray:
         """Compute feature importances from the model.
 

--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -19,7 +19,7 @@ import numpy as np
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata, TGenMetadata
-from ax.exceptions.core import UserInputError
+from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.models.torch.botorch import (
     get_feature_importances_from_botorch_model,
     get_rounding_func,
@@ -616,17 +616,13 @@ class BoTorchModel(TorchModel, Base):
         """
         if not self._botorch_acqf_class:
             if torch_opt_config.risk_measure is not None:
-                # TODO[T131759261]: Implement selection of acqf for robust opt.
-                # This will depend on the properties of the robust search space and
-                # the risk measure being used.
-                raise NotImplementedError
+                raise UnsupportedError(
+                    "Automated selection of `botorch_acqf_class` is not supported "
+                    "for robust optimization with risk measures. Please specify "
+                    "`botorch_acqf_class` as part of `model_kwargs`."
+                )
             self._botorch_acqf_class = choose_botorch_acqf_class(
-                pending_observations=torch_opt_config.pending_observations,
-                outcome_constraints=torch_opt_config.outcome_constraints,
-                linear_constraints=torch_opt_config.linear_constraints,
-                fixed_features=torch_opt_config.fixed_features,
-                objective_thresholds=torch_opt_config.objective_thresholds,
-                objective_weights=torch_opt_config.objective_weights,
+                torch_opt_config=torch_opt_config
             )
 
         return self.acquisition_class(

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -646,6 +646,8 @@ class Surrogate(Base):
             raise ValueError("Could not obtain best in-sample point.")
         best_point, observed_value = best_point_and_observed_value
         return (
+            # pyre-fixme[16]: Item `ndarray` of `Union[ndarray[typing.Any,
+            #  typing.Any], Tensor]` has no attribute `to`.
             best_point.to(dtype=self.dtype, device=torch.device("cpu")),
             observed_value,
         )

--- a/ax/models/torch/randomforest.py
+++ b/ax/models/torch/randomforest.py
@@ -87,8 +87,11 @@ class RandomForest(TorchModel):
 
 
 def _get_rf(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     X: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Y: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Yvar: np.ndarray,
     num_trees: int,
     max_features: str | None,

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import dataclasses
 import itertools
 from contextlib import ExitStack
-from itertools import chain
 from typing import Any
 from unittest import mock
 from unittest.mock import Mock
@@ -250,13 +249,8 @@ class AcquisitionTest(TestCase):
     @mock.patch(
         f"{ACQUISITION_PATH}.get_botorch_objective_and_transform",
     )
-    @mock.patch(
-        f"{CURRENT_PATH}.Acquisition.compute_model_dependencies",
-        return_value={"eta": 0.1},
-    )
     def test_init_with_subset_model_false(
         self,
-        mock_compute_model_deps: Mock,
         mock_get_objective_and_transform: Mock,
         mock_subset_model: Mock,
         mock_get_X: Mock,
@@ -285,13 +279,12 @@ class AcquisitionTest(TestCase):
         self.assertIs(ckwargs["outcome_constraints"], self.outcome_constraints)
         self.assertTrue(torch.equal(ckwargs["X_observed"], self.X[:1]))
         # Check final `acqf` creation
-        model_deps = {"eta": 0.1}
         self.mock_input_constructor.assert_called_once()
         _, ckwargs = self.mock_input_constructor.call_args
         self.assertIs(ckwargs["model"], acquisition.surrogates["surrogate"].model)
         self.assertIs(ckwargs["objective"], botorch_objective)
         self.assertTrue(torch.equal(ckwargs["X_pending"], self.pending_observations[0]))
-        for k, v in chain(self.options.items(), model_deps.items()):
+        for k, v in self.options.items():
             self.assertEqual(ckwargs[k], v)
         self.assertIs(
             ckwargs["constraints"],

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -175,6 +175,7 @@ class BoTorchModelTest(TestCase):
             objective_weights=self.moo_objective_weights,
             objective_thresholds=self.moo_objective_thresholds,
             outcome_constraints=self.moo_outcome_constraints,
+            is_moo=True,
         )
 
     def test_init(self) -> None:
@@ -874,13 +875,13 @@ class BoTorchModelTest(TestCase):
                 torch_opt_config=self.moo_torch_opt_config,
             )
         mock_get_outcome_constraint_transforms.assert_called_once()
-        ckwargs = mock_get_outcome_constraint_transforms.call_args[1]
+        ckwargs = mock_get_outcome_constraint_transforms.call_args.kwargs
         oc = ckwargs["outcome_constraints"]
         self.assertTrue(torch.equal(oc[0], subset_outcome_constraints[0]))
         self.assertTrue(torch.equal(oc[1], subset_outcome_constraints[1]))
 
         # Check input constructor args
-        ckwargs = mock_input_constructor.call_args[1]
+        ckwargs = mock_input_constructor.call_args.kwargs
         expected_kwargs = {
             "constraints",
             "bounds",

--- a/ax/models/torch/tests/test_sebo.py
+++ b/ax/models/torch/tests/test_sebo.py
@@ -138,7 +138,10 @@ class TestSebo(TestCase):
         # Check transformed objective threshold
         self.assertTrue(
             torch.equal(
-                acquisition1.acqf.ref_point[-1], -1 * self.objective_thresholds_sebo[-1]
+                # pyre-fixme[6]: For 2nd argument expected `Tensor` but got `int`.
+                acquisition1.acqf.ref_point[-1],
+                # pyre-fixme[6]: For 2nd argument expected `Tensor` but got `int`.
+                -1 * self.objective_thresholds_sebo[-1],
             )
         )
         self.assertTrue(
@@ -230,6 +233,8 @@ class TestSebo(TestCase):
         )
         # overwrite acqf to validate homotopy
         # pyre-fixme[61]: `p` is undefined, or not always defined.
+        # pyre-fixme[6]: For 1st argument expected `(Tensor) -> Tensor` but got `(x:
+        #  Any) -> int`.
         model = GenericDeterministicModel(f=lambda x: 5 - (x - p) ** 2)
         acqf = PosteriorMean(model=model)
         acquisition.acqf = acqf

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -178,7 +178,11 @@ class SurrogateTest(TestCase):
             fixed_features=self.fixed_features,
         )
         self.ds2 = SupervisedDataset(
+            # pyre-fixme[6]: For 1st argument expected `Union[BotorchContainer,
+            #  Tensor]` but got `int`.
             X=2 * self.Xs[0],
+            # pyre-fixme[6]: For 2nd argument expected `Union[BotorchContainer,
+            #  Tensor]` but got `int`.
             Y=2 * self.Ys[0],
             feature_names=self.feature_names,
             outcome_names=["m2"],

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -26,6 +26,7 @@ from ax.models.torch.botorch_modular.utils import (
     use_model_list,
 )
 from ax.models.torch.utils import _to_inequality_constraints
+from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast, not_none
@@ -178,18 +179,23 @@ class BoTorchModelUtilsTest(TestCase):
             )
 
     def test_choose_botorch_acqf_class(self) -> None:
-        self.assertEqual(qLogNoisyExpectedImprovement, choose_botorch_acqf_class())
-        self.assertEqual(
-            qLogNoisyExpectedHypervolumeImprovement,
-            choose_botorch_acqf_class(objective_thresholds=self.objective_thresholds),
-        )
-        self.assertEqual(
-            qLogNoisyExpectedHypervolumeImprovement,
-            choose_botorch_acqf_class(objective_weights=torch.tensor([0.5, 0.5])),
-        )
         self.assertEqual(
             qLogNoisyExpectedImprovement,
-            choose_botorch_acqf_class(objective_weights=torch.tensor([1.0, 0.0])),
+            choose_botorch_acqf_class(
+                torch_opt_config=TorchOptConfig(
+                    objective_weights=torch.tensor([1.0, 0.0]),
+                    is_moo=False,
+                )
+            ),
+        )
+        self.assertEqual(
+            qLogNoisyExpectedHypervolumeImprovement,
+            choose_botorch_acqf_class(
+                torch_opt_config=TorchOptConfig(
+                    objective_weights=torch.tensor([1.0, -1.0]),
+                    is_moo=True,
+                )
+            ),
         )
 
     def test_construct_acquisition_and_optimizer_options(self) -> None:

--- a/ax/models/torch/utils.py
+++ b/ax/models/torch/utils.py
@@ -362,10 +362,13 @@ def _to_inequality_constraints(
 
 
 def tensor_callable_to_array_callable(
-    tensor_func: Callable[[Tensor], Tensor], device: torch.device
+    tensor_func: Callable[[Tensor], Tensor],
+    device: torch.device,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> Callable[[np.ndarray], np.ndarray]:
     """transfer a tensor callable to an array callable"""
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def array_func(x: np.ndarray) -> np.ndarray:
         return tensor_func(torch.from_numpy(x).to(device)).detach().cpu().numpy()
 

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -87,7 +87,7 @@ class TorchOptConfig:
     pending_observations: list[Tensor] | None = None
     model_gen_options: TConfig = field(default_factory=dict)
     rounding_func: Callable[[Tensor], Tensor] | None = None
-    opt_config_metrics: dict[str, Metric] | None = None
+    opt_config_metrics: dict[str, Metric] = field(default_factory=dict)
     is_moo: bool = False
     risk_measure: RiskMeasureMCObjective | None = None
     fit_out_of_design: bool = False

--- a/ax/plot/contour.py
+++ b/ax/plot/contour.py
@@ -31,6 +31,7 @@ from ax.plot.helper import (
 
 
 # type aliases
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ContourPredictions = tuple[
     PlotData, np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, bool]
 ]
@@ -400,6 +401,7 @@ def interact_contour_plotly(
     param_names = [parameter.name for parameter in range_parameters]
 
     is_log_dict: dict[str, bool] = {}
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     grid_dict: dict[str, np.ndarray] = {}
     for parameter in range_parameters:
         is_log_dict[parameter.name] = parameter.log_scale
@@ -411,11 +413,13 @@ def interact_contour_plotly(
 
     # pyre-fixme[9]: f_dict has type `Dict[str, Dict[str, np.ndarray]]`; used as
     #  `Dict[str, Dict[str, typing.List[Variable[_T]]]]`.
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     f_dict: dict[str, dict[str, np.ndarray]] = {
         param1: {param2: [] for param2 in param_names} for param1 in param_names
     }
     # pyre-fixme[9]: sd_dict has type `Dict[str, Dict[str, np.ndarray]]`; used as
     #  `Dict[str, Dict[str, typing.List[Variable[_T]]]]`.
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     sd_dict: dict[str, dict[str, np.ndarray]] = {
         param1: {param2: [] for param2 in param_names} for param1 in param_names
     }

--- a/ax/plot/feature_importances.py
+++ b/ax/plot/feature_importances.py
@@ -102,6 +102,7 @@ def plot_feature_importance_by_metric(model: ModelBridge) -> AxPlotConfig:
 
 def plot_feature_importance_by_feature_plotly(
     model: ModelBridge | None = None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     sensitivity_values: dict[str, dict[str, float | np.ndarray]] | None = None,
     relative: bool = False,
     caption: str = "",
@@ -193,6 +194,9 @@ def plot_feature_importance_by_feature_plotly(
                         sign_col: (
                             0
                             if factor in categorical_features
+                            # pyre-fixme[16]: Item `bool` of
+                            #  `Union[ndarray[typing.Any, np.dtype[typing.Any]], bool]`
+                            #  has no attribute `astype`.
                             else 2 * (importance >= 0).astype(int) - 1
                         ),
                     }
@@ -276,6 +280,7 @@ def plot_feature_importance_by_feature_plotly(
 
 def plot_feature_importance_by_feature(
     model: ModelBridge | None = None,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     sensitivity_values: dict[str, dict[str, float | np.ndarray]] | None = None,
     relative: bool = False,
     caption: str = "",

--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -460,6 +460,7 @@ def get_range_parameters(
     )
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def get_grid_for_parameter(parameter: RangeParameter, density: int) -> np.ndarray:
     """Get a grid of points along the range of the parameter.
 
@@ -528,6 +529,7 @@ def get_fixed_values(
             elif isinstance(parameter, ChoiceParameter):
                 setx[p_name] = Counter(vals).most_common(1)[0][0]
             elif isinstance(parameter, RangeParameter):
+                # pyre-fixme[6]: For 1st argument expected `Union[_SupportsArray[dtyp...
                 setx[p_name] = parameter.cast(np.mean(vals))
 
     if slice_values is not None:

--- a/ax/plot/pareto_frontier.py
+++ b/ax/plot/pareto_frontier.py
@@ -47,6 +47,7 @@ def _make_label(
     return f"{name}: {estimate}{perc} {ci}<br>"
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def _filter_outliers(Y: np.ndarray, m: float = 2.0) -> np.ndarray:
     std_filter = abs(Y - np.median(Y, axis=0)) < m * np.std(Y, axis=0)
     return Y[np.all(abs(std_filter), axis=1)]
@@ -80,7 +81,9 @@ def scatter_plot_with_hypervolume_trace_plotly(experiment: Experiment) -> go.Fig
 
 
 def scatter_plot_with_pareto_frontier_plotly(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Y: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Y_pareto: np.ndarray | None,
     metric_x: str | None,
     metric_y: str | None,
@@ -238,7 +241,9 @@ def scatter_plot_with_pareto_frontier_plotly(
 
 
 def scatter_plot_with_pareto_frontier(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Y: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Y_pareto: np.ndarray,
     metric_x: str,
     metric_y: str,

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -54,9 +54,11 @@ logger: Logger = get_logger(__name__)
 
 
 def _extract_observed_pareto_2d(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     Y: np.ndarray,
     reference_point: tuple[float, float] | None,
     minimize: bool | tuple[bool, bool] = True,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray:
     if Y.shape[1] != 2:
         raise NotImplementedError("Currently only the 2-dim case is handled.")
@@ -510,6 +512,8 @@ def _extract_pareto_frontier_results(
 
         for metric in metrics:
             if metric not in absolute_metrics and metric in sq_mean:
+                # pyre-fixme[6]: For 2nd argument expected `List[float]` but got
+                #  `ndarray[typing.Any, typing.Any]`.
                 means_out[metric], sems_out[metric] = relativize(
                     means_t=means_out[metric],
                     sems_t=sems_out[metric],
@@ -521,6 +525,8 @@ def _extract_pareto_frontier_results(
     return ParetoFrontierResults(
         param_dicts=param_dicts,
         means=means_out,
+        # pyre-fixme[6]: For 3rd argument expected `Dict[str, List[float]]` but got
+        #  `Dict[str, ndarray[typing.Any, dtype[typing.Any]]]`.
         sems=sems_out,
         primary_metric=primary_metric,
         secondary_metric=secondary_metric,
@@ -547,6 +553,7 @@ def _validate_outcome_constraints(
 
 
 def _build_scalarized_optimization_config(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     weights: np.ndarray,
     primary_objective: Metric,
     secondary_objective: Metric,

--- a/ax/plot/slice.py
+++ b/ax/plot/slice.py
@@ -28,6 +28,7 @@ from plotly import graph_objs as go
 
 
 # type aliases
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 SlicePredictions = tuple[
     PlotData,
     list[dict[str, Union[str, float]]],
@@ -341,6 +342,7 @@ def interact_slice_plotly(
 
         plot_data_dict = {}
         raw_data_dict = {}
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         sd_plt_dict: dict[str, dict[str, np.ndarray]] = {}
 
         cond_name_to_parameters_dict = {}
@@ -376,6 +378,9 @@ def interact_slice_plotly(
             raw_data_dict[metric_name] = rd
             cond_name_to_parameters_dict[metric_name] = cntp
 
+            # pyre-fixme[6]: For 2nd argument expected `Dict[str,
+            #  ndarray[typing.Any, typing.Any]]` but got `ndarray[typing.Any,
+            #  dtype[typing.Any]]`.
             sd_plt_dict[metric_name] = np.sqrt(cov[metric_name][metric_name])
             is_log_dict[metric_name] = ls
 
@@ -471,6 +476,7 @@ def interact_slice_plotly(
     mbuttons = []
     # pyre-fixme[61]: `metrics` is undefined, or not always defined.
     for i, metric in enumerate(metrics):
+        # pyre-fixme[61]: `arm_data` is undefined, or not always defined.
         trace_cnt = 3 + len(arm_data[metric]["out_of_sample"].keys())
         # pyre-fixme[61]: `metrics` is undefined, or not always defined.
         visible = [False] * (len(metrics) * trace_cnt)
@@ -533,6 +539,7 @@ def interact_slice_plotly(
             "autorange": True,
             "tickfont": {"size": 11},
             "tickmode": "auto",
+            # pyre-fixme[61]: `metrics` is undefined, or not always defined.
             "title": metrics[0],
         },
     }

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -131,6 +131,7 @@ class ParetoUtilsTest(TestCase):
             self.assertTrue(np.isnan(pfr.sems["m1"]).all())
             self.assertEqual(len(pfr.arm_names), len(pareto_arms))  # pyre-ignore
             self.assertEqual(pfr.objective_thresholds, {"m1": 0, "m2": 100, "m3": 1000})
+            # pyre-fixme[6]: For 1st argument expected `Union[_SupportsArray[dtype[ty...
             arm_idx = np.argsort(pfr.arm_names)
             for i, idx in enumerate(arm_idx):
                 name = pareto_arms[i]

--- a/ax/plot/trace.py
+++ b/ax/plot/trace.py
@@ -28,7 +28,9 @@ Traces = list[dict[str, Any]]
 
 
 def map_data_single_trace_scatters(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     x: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y: np.ndarray,
     legend_label: str,
     xlabel: str = "Trial progression",
@@ -97,7 +99,9 @@ def map_data_single_trace_scatters(
 def map_data_multiple_metrics_dropdown_plotly(
     title: str,
     metric_names: list[str],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     xs_by_metric: dict[str, list[np.ndarray]],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     ys_by_metric: dict[str, list[np.ndarray]],
     legend_labels_by_metric: dict[str, list[str]],
     stopping_markers_by_metric: dict[str, list[bool]],
@@ -209,6 +213,7 @@ def map_data_multiple_metrics_dropdown_plotly(
 
 
 def mean_trace_scatter(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y: np.ndarray,
     trace_color: tuple[int] = COLORS.STEELBLUE.value,
     legend_label: str = "mean",
@@ -242,6 +247,7 @@ def mean_trace_scatter(
 
 
 def sem_range_scatter(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y: np.ndarray,
     trace_color: tuple[int] = COLORS.STEELBLUE.value,
     legend_label: str = "",
@@ -285,6 +291,7 @@ def sem_range_scatter(
 
 
 def mean_markers_scatter(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y: np.ndarray,
     marker_color: tuple[int] = COLORS.LIGHT_PURPLE.value,
     legend_label: str = "",
@@ -346,6 +353,7 @@ def optimum_objective_scatter(
 
 
 def optimization_trace_single_method_plotly(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y: np.ndarray,
     optimum: float | None = None,
     model_transitions: list[int] | None = None,
@@ -449,6 +457,7 @@ def optimization_trace_single_method_plotly(
 
 
 def _autoset_axis_limits(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y: np.ndarray,
     optimization_direction: str,
     force_include_value: float | None = None,
@@ -481,6 +490,7 @@ def _autoset_axis_limits(
 
 
 def optimization_trace_single_method(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y: np.ndarray,
     optimum: float | None = None,
     model_transitions: list[int] | None = None,
@@ -548,6 +558,7 @@ def optimization_trace_single_method(
 
 
 def optimization_trace_all_methods(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_dict: dict[str, np.ndarray],
     optimum: float | None = None,
     title: str = "",
@@ -630,18 +641,26 @@ def optimization_times(
     fit_res: dict[str, str | list[float]] = {"name": "Fitting"}
     fit_res["mean"] = [np.mean(fit_times[m]) for m in methods]
     fit_res["2sems"] = [
-        2 * np.std(fit_times[m]) / np.sqrt(len(fit_times[m])) for m in methods
+        # pyre-fixme[58]: `*` is not supported for operand types `int` and
+        #  `floating[typing.Any]`.
+        2 * np.std(fit_times[m]) / np.sqrt(len(fit_times[m]))
+        for m in methods
     ]
     gen_res: dict[str, str | list[float]] = {"name": "Generation"}
     gen_res["mean"] = [np.mean(gen_times[m]) for m in methods]
     gen_res["2sems"] = [
-        2 * np.std(gen_times[m]) / np.sqrt(len(gen_times[m])) for m in methods
+        # pyre-fixme[58]: `*` is not supported for operand types `int` and
+        #  `floating[typing.Any]`.
+        2 * np.std(gen_times[m]) / np.sqrt(len(gen_times[m]))
+        for m in methods
     ]
     total_mean: list[float] = []
     total_2sems: list[float] = []
     for m in methods:
         totals = np.array(fit_times[m]) + np.array(gen_times[m])
         total_mean.append(np.mean(totals))
+        # pyre-fixme[58]: `*` is not supported for operand types `int` and
+        #  `floating[typing.Any]`.
         total_2sems.append(2 * np.std(totals) / np.sqrt(len(totals)))
     total_res: dict[str, str | list[float]] = {
         "name": "Total",

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -137,6 +137,7 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
 
     experiment: Experiment
     generation_strategy: GenerationStrategyInterface
+    # pyre-fixme[24]: Generic type `LoggerAdapter` expects 1 type parameter.
     logger: LoggerAdapter
     # Mapping of form {short string identifier -> message to show in reported
     # results}. This is a mapping and not a list to allow for changing of

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -1436,11 +1436,13 @@ class TestAxClient(TestCase):
             if t < 2:
                 ax_client.update_running_trial_with_intermediate_data(
                     0,
+                    # pyre-fixme[6]: For 2nd argument expected `Union[floating[typing...
                     raw_data=[({"t": t}, {"branin": (branin(x, y) + t, 0.0)})],
                 )
             if t == 2:
                 ax_client.complete_trial(
                     0,
+                    # pyre-fixme[6]: For 2nd argument expected `Union[floating[typing...
                     raw_data=[({"t": t}, {"branin": (branin(x, y) + t, 0.0)})],
                 )
             # pyre-fixme[16]: `Data` has no attribute `map_df`.
@@ -1465,6 +1467,7 @@ class TestAxClient(TestCase):
                 raw_data=[
                     # pyre-fixme[61]: `t` is undefined, or not always defined.
                     ({"t": p_t}, {"branin": (branin(x, y) + t, 0.0)})
+                    # pyre-fixme[61]: `t` is undefined, or not always defined.
                     for p_t in range(t + 1)
                 ],
             )

--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -23,6 +23,7 @@ def _branin_evaluation_function(
     # pyre-fixme[2]: Parameter must be annotated.
     parameterization,
     weight=None,  # pyre-fixme[2]: Parameter must be annotated.
+    # pyre-fixme[24]: Generic type `ndarray` expects 2 type parameters.
 ) -> dict[str, tuple[float | ndarray, float]]:
     if any(param_name not in parameterization.keys() for param_name in ["x1", "x2"]):
         raise ValueError("Parametrization does not contain x1 or x2")
@@ -37,6 +38,7 @@ def _branin_evaluation_function_v2(
     # pyre-fixme[2]: Parameter must be annotated.
     parameterization,
     weight=None,  # pyre-fixme[2]: Parameter must be annotated.
+    # pyre-fixme[24]: Generic type `ndarray` expects 2 type parameters.
 ) -> tuple[float | ndarray, float]:
     if any(param_name not in parameterization.keys() for param_name in ["x1", "x2"]):
         raise ValueError("Parametrization does not contain x1 or x2")
@@ -48,6 +50,7 @@ def _branin_evaluation_function_with_unknown_sem(
     # pyre-fixme[2]: Parameter must be annotated.
     parameterization,
     weight=None,  # pyre-fixme[2]: Parameter must be annotated.
+    # pyre-fixme[24]: Generic type `ndarray` expects 2 type parameters.
 ) -> tuple[float | ndarray, None]:
     if any(param_name not in parameterization.keys() for param_name in ["x1", "x2"]):
         raise ValueError("Parametrization does not contain x1 or x2")

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -620,6 +620,8 @@ class BestPointMixin(metaclass=ABCMeta):
         else:
             bins = np.array(bins)  # pyre-ignore[9]
 
+        # pyre-fixme[9]: bins has type `Optional[List[float]]`; used as
+        #  `ndarray[typing.Any, dtype[typing.Any]]`.
         bins = np.expand_dims(bins, axis=0)
 
         # compute for each bin value the largest trial index finished by then
@@ -629,4 +631,6 @@ class BestPointMixin(metaclass=ABCMeta):
         )
         obj_vals = (df["mean"].cummin() if minimize else df["mean"].cummax()).to_numpy()
         best_observed = obj_vals[best_observed_idcs]
+        # pyre-fixme[16]: Item `List` of `Union[List[float], ndarray[typing.Any,
+        #  np.dtype[typing.Any]]]` has no attribute `squeeze`.
         return best_observed.tolist(), bins.squeeze(axis=0).tolist()

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -148,6 +148,7 @@ def _get_objective_trace_plot(
 def _get_objective_v_param_plots(
     experiment: Experiment,
     model: ModelBridge,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     importance: None
     | (dict[str, dict[str, np.ndarray]] | dict[str, dict[str, float]]) = None,
     # Chosen to take ~1min on local benchmarks.
@@ -220,6 +221,8 @@ def _get_objective_v_param_plots(
                     # sort the params by their sensitivity
                     params_to_use = sorted(
                         range_params_sens_for_metric,
+                        # pyre-fixme[6]: For 2nd argument expected `None` but got
+                        #  `(x: Any) -> Union[ndarray[typing.Any, typing.Any], float]`.
                         key=lambda x: range_params_sens_for_metric[x],
                         reverse=True,
                     )[:num_params_per_metric]
@@ -522,7 +525,11 @@ def get_standard_plots(
 
 
 def _transform_progression_to_walltime(
-    progressions: np.ndarray, exp_df: pd.DataFrame, trial_idx: int
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    progressions: np.ndarray,
+    exp_df: pd.DataFrame,
+    trial_idx: int,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray | None:
     try:
         trial_df = exp_df[exp_df["trial_index"] == trial_idx]
@@ -1225,6 +1232,10 @@ def get_figure_and_callback(
             overwrite=True,
         )
 
+    # pyre-fixme[7]: Expected `Tuple[Figure, typing.Callable[[Scheduler], None]]`
+    #  but got `Tuple[FigureWidget,
+    #  typing.Callable(get_figure_and_callback._update_fig_in_place)[[Named(scheduler,
+    #  Scheduler)], None]]`.
     return fig, _update_fig_in_place
 
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -448,7 +448,11 @@ class JSONStoreTest(TestCase):
         with patch.dict(registry_path, mock_registry):
             test_problem = PyTorchCNNTorchvisionParamBasedProblem(name="MNIST")
 
+        # pyre-fixme[16]: `PyTorchCNNTorchvisionParamBasedProblem` has no attribute
+        #  `train_loader`.
         self.assertIsNotNone(test_problem.train_loader)
+        # pyre-fixme[16]: `PyTorchCNNTorchvisionParamBasedProblem` has no attribute
+        #  `test_loader`.
         self.assertIsNotNone(test_problem.test_loader)
 
         as_json = object_to_json(obj=test_problem)

--- a/ax/storage/utils.py
+++ b/ax/storage/utils.py
@@ -15,24 +15,37 @@ from ax.core.formatting_utils import DataType  # noqa F401
 class DomainType(enum.Enum):
     """Class for enumerating domain types."""
 
+    # pyre-fixme[35]: Target cannot be annotated.
     FIXED: int = 0
+    # pyre-fixme[35]: Target cannot be annotated.
     RANGE: int = 1
+    # pyre-fixme[35]: Target cannot be annotated.
     CHOICE: int = 2
+    # pyre-fixme[35]: Target cannot be annotated.
     ENVIRONMENTAL_RANGE: int = 3
 
 
 class MetricIntent(enum.Enum):
     """Class for enumerating metric use types."""
 
+    # pyre-fixme[35]: Target cannot be annotated.
     OBJECTIVE: str = "objective"
+    # pyre-fixme[35]: Target cannot be annotated.
     MULTI_OBJECTIVE: str = "multi_objective"
+    # pyre-fixme[35]: Target cannot be annotated.
     SCALARIZED_OBJECTIVE: str = "scalarized_objective"
     # Additional objective is not yet supported in Ax open-source.
+    # pyre-fixme[35]: Target cannot be annotated.
     ADDITIONAL_OBJECTIVE: str = "additional_objective"
+    # pyre-fixme[35]: Target cannot be annotated.
     OUTCOME_CONSTRAINT: str = "outcome_constraint"
+    # pyre-fixme[35]: Target cannot be annotated.
     SCALARIZED_OUTCOME_CONSTRAINT: str = "scalarized_outcome_constraint"
+    # pyre-fixme[35]: Target cannot be annotated.
     OBJECTIVE_THRESHOLD: str = "objective_threshold"
+    # pyre-fixme[35]: Target cannot be annotated.
     TRACKING: str = "tracking"
+    # pyre-fixme[35]: Target cannot be annotated.
     RISK_MEASURE: str = "risk_measure"
 
 
@@ -43,9 +56,13 @@ class ParameterConstraintType(enum.Enum):
     special types of linear constraints.
     """
 
+    # pyre-fixme[35]: Target cannot be annotated.
     LINEAR: int = 0
+    # pyre-fixme[35]: Target cannot be annotated.
     ORDER: int = 1
+    # pyre-fixme[35]: Target cannot be annotated.
     SUM: int = 2
+    # pyre-fixme[35]: Target cannot be annotated.
     DISTRIBUTION: int = 3
 
 

--- a/ax/utils/common/executils.py
+++ b/ax/utils/common/executils.py
@@ -123,6 +123,8 @@ def retry_on_exception(
                             wait_interval = min(
                                 MAX_WAIT_SECONDS, initial_wait_seconds * 2 ** (i - 1)
                             )
+                            # pyre-fixme[1001]: `asyncio.sleep(wait_interval)` is
+                            #  never awaited.
                             asyncio.sleep(wait_interval)
                         return await func(*args, **kwargs)
                 # If we are here, it means the retries were finished but

--- a/ax/utils/measurement/synthetic_functions.py
+++ b/ax/utils/measurement/synthetic_functions.py
@@ -38,8 +38,11 @@ class SyntheticFunction(ABC):
 
     def __call__(
         self,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         *args: int | float | np.ndarray,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         **kwargs: int | float | np.ndarray,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     ) -> float | np.ndarray:
         """Simplified way to call the synthetic function and pass the argument
         numbers directly, e.g. `branin(2.0, 3.0)`.
@@ -68,6 +71,7 @@ class SyntheticFunction(ABC):
                 x = float(x)
         return checked_cast(float, self.f(np.array(args)))
 
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def f(self, X: np.ndarray) -> float | np.ndarray:
         """Synthetic function implementation.
 
@@ -144,6 +148,7 @@ class SyntheticFunction(ABC):
         return self.informative_failure_on_none(self._fmax)
 
     @abstractmethod
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _f(self, X: np.ndarray) -> float:
         """Implementation of the synthetic function. Must be implemented in subclass.
 
@@ -172,6 +177,7 @@ class FromBotorch(SyntheticFunction):
         return f"{self.__class__.__name__}_{self._botorch_function.__class__.__name__}"
 
     @override
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _f(self, X: np.ndarray) -> float:
         # TODO: support batch evaluation
         return float(self._botorch_function(X=torch.from_numpy(X)).item())
@@ -192,7 +198,9 @@ class Hartmann6(SyntheticFunction):
     _minimums = [(0.20169, 0.150011, 0.476874, 0.275332, 0.311652, 0.6573)]
     _fmin: float = -3.32237
     _fmax = 0.0
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     _alpha: np.ndarray = np.array([1.0, 1.2, 3.0, 3.2])
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     _A: np.ndarray = np.array(
         [
             [10, 3, 17, 3.5, 1.7, 8],
@@ -201,6 +209,7 @@ class Hartmann6(SyntheticFunction):
             [17, 8, 0.05, 10, 0.1, 14],
         ]
     )
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     _P: np.ndarray = 10 ** (-4) * np.array(
         [
             [1312, 1696, 5569, 124, 8283, 5886],
@@ -212,6 +221,7 @@ class Hartmann6(SyntheticFunction):
 
     @override
     @copy_doc(SyntheticFunction._f)
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _f(self, X: np.ndarray) -> float:
         y = 0.0
         for j, alpha_j in enumerate(self._alpha):
@@ -235,6 +245,7 @@ class Aug_Hartmann6(Hartmann6):
 
     @override
     @copy_doc(SyntheticFunction._f)
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _f(self, X: np.ndarray) -> float:
         y = 0.0
         alpha_0 = self._alpha[0] - 0.1 * (1 - X[-1])
@@ -264,6 +275,7 @@ class Branin(SyntheticFunction):
 
     @override
     @copy_doc(SyntheticFunction._f)
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _f(self, X: np.ndarray) -> float:
         x_1 = X[0]
         x_2 = X[1]
@@ -289,6 +301,7 @@ class Aug_Branin(SyntheticFunction):
 
     @override
     @copy_doc(SyntheticFunction._f)
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     def _f(self, X: np.ndarray) -> float:
         x_1 = X[0]
         x_2 = X[1]

--- a/ax/utils/measurement/tests/test_synthetic_functions.py
+++ b/ax/utils/measurement/tests/test_synthetic_functions.py
@@ -21,8 +21,14 @@ from botorch.test_functions import synthetic as botorch_synthetic
 class TestSyntheticFunctions(TestCase):
     def test_branin(self) -> None:
         self.assertEqual(branin.name, "Branin")
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(branin(1, 2), 21.62763539206238)
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(branin(x1=1, x2=2), 21.62763539206238)
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(branin(np.array([1, 2])), 21.62763539206238)
         # pyre-fixme[16]: Item `float` of `Union[float, ndarray]` has no attribute
         #  `__getitem__`.
@@ -30,6 +36,8 @@ class TestSyntheticFunctions(TestCase):
         self.assertAlmostEqual(branin.minimums[0][0], -np.pi)
         self.assertAlmostEqual(branin.fmin, 0.397887, places=6)
         self.assertAlmostEqual(branin.fmax, 308.129, places=3)
+        # pyre-fixme[6]: For 2nd argument expected `_T` but got
+        #  `Union[ndarray[typing.Any, typing.Any], float]`.
         self.assertAlmostEqual(branin.fmax, branin(-5, 0), places=3)
         self.assertEqual(branin.domain[0], (-5, 10))
         self.assertEqual(branin.required_dimensionality, 2)
@@ -40,8 +48,14 @@ class TestSyntheticFunctions(TestCase):
 
     def test_hartmann6(self) -> None:
         self.assertEqual(hartmann6.name, "Hartmann6")
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(hartmann6(1, 2, 3, 4, 5, 6), 0.0)
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(hartmann6(x1=1, x2=2, x3=3, x4=4, x5=5, x6=6), 0.0)
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(hartmann6(np.array([1, 2, 3, 4, 5, 6])), 0.0)
         self.assertAlmostEqual(
             # pyre-fixme[16]: Item `float` of `Union[float, ndarray]` has no
@@ -59,10 +73,19 @@ class TestSyntheticFunctions(TestCase):
 
     def test_aug_hartmann6(self) -> None:
         self.assertEqual(aug_hartmann6.name, "Aug_Hartmann6")
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(aug_hartmann6(1, 2, 3, 4, 5, 6, 1), 0.0)
         self.assertAlmostEqual(
-            aug_hartmann6(x1=1, x2=2, x3=3, x4=4, x5=5, x6=6, x7=1), 0.0
+            # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+            #  SupportsAbs[SupportsRound[object]]]` but got `float`.
+            aug_hartmann6(x1=1, x2=2, x3=3, x4=4, x5=5, x6=6, x7=1),
+            # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+            #  SupportsAbs[SupportsRound[object]]]` but got `float`.
+            0.0,
         )
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(aug_hartmann6(np.array([1, 2, 3, 4, 5, 6, 1])), 0.0)
         self.assertAlmostEqual(
             # pyre-fixme[16]: Item `float` of `Union[float, ndarray]` has no
@@ -82,8 +105,14 @@ class TestSyntheticFunctions(TestCase):
 
     def test_aug_branin(self) -> None:
         self.assertEqual(aug_branin.name, "Aug_Branin")
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(aug_branin(1, 2, 1), 21.62763539206238)
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(aug_branin(x1=1, x2=2, x3=1), 21.62763539206238)
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(aug_branin(np.array([1, 2, 1])), 21.62763539206238)
         self.assertAlmostEqual(
             # pyre-fixme[16]: Item `float` of `Union[float, ndarray]` has no
@@ -105,8 +134,14 @@ class TestSyntheticFunctions(TestCase):
     def test_botorch_ackley(self) -> None:
         ackley = FromBotorch(botorch_synthetic_function=botorch_synthetic.Ackley())
         self.assertEqual(ackley.name, "FromBotorch_Ackley")
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(ackley(1.0, 2.0), 5.422131717799505)
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(ackley(x1=1.0, x2=2.0), 5.422131717799505)
+        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
+        #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(ackley(np.array([1, 2])), 5.422131717799505)
         # pyre-fixme[16]: Item `float` of `Union[float, ndarray]` has no attribute
         #  `__getitem__`.

--- a/ax/utils/sensitivity/sobol_measures.py
+++ b/ax/utils/sensitivity/sobol_measures.py
@@ -833,6 +833,7 @@ def ax_parameter_sens(
     order: str = "first",
     signed: bool = True,
     **sobol_kwargs: Any,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> dict[str, dict[str, np.ndarray]]:
     """
     Compute sensitivity for all metrics on an TorchModelBridge.
@@ -987,7 +988,12 @@ def _get_model_per_metric(
 
 
 def array_with_string_indices_to_dict(
-    rows: list[str], cols: list[str], A: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    rows: list[str],
+    cols: list[str],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    A: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> dict[str, dict[str, np.ndarray]]:
     """
     Args:

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -303,7 +303,16 @@ class SensitivityAnalysisTest(TestCase):
                     for i, row in enumerate(ind_dict):
                         for j, col in enumerate(ind_dict[row]):
                             self.assertAlmostEqual(
-                                ind_dict[row][col], ind_tnsr[i, j].item()
+                                # pyre-fixme[6]: For 2nd argument expected
+                                #  `SupportsRSub[Variable[_T],
+                                #  SupportsAbs[SupportsRound[object]]]` but got
+                                #  `Union[bool, float, int]`.
+                                ind_dict[row][col],
+                                # pyre-fixme[6]: For 2nd argument expected
+                                #  `SupportsRSub[Variable[_T],
+                                #  SupportsAbs[SupportsRound[object]]]` but got
+                                #  `Union[bool, float, int]`.
+                                ind_tnsr[i, j].item(),
                             )
             with self.subTest(order="second"):
                 second_ind_dict = ax_parameter_sens(
@@ -330,13 +339,34 @@ class SensitivityAnalysisTest(TestCase):
                 )
                 # check that the first and second order indices are the same
                 self.assertAlmostEqual(
-                    second_ind_dict["branin"]["x1"], fo_ind_tnsr[0, 0].item()
+                    # pyre-fixme[6]: For 2nd argument expected
+                    #  `SupportsRSub[Variable[_T], SupportsAbs[SupportsRound[object]]]`
+                    #  but got `Union[bool, float, int]`.
+                    second_ind_dict["branin"]["x1"],
+                    # pyre-fixme[6]: For 2nd argument expected
+                    #  `SupportsRSub[Variable[_T], SupportsAbs[SupportsRound[object]]]`
+                    #  but got `Union[bool, float, int]`.
+                    fo_ind_tnsr[0, 0].item(),
                 )
                 self.assertAlmostEqual(
-                    second_ind_dict["branin"]["x2"], fo_ind_tnsr[0, -1].item()
+                    # pyre-fixme[6]: For 2nd argument expected
+                    #  `SupportsRSub[Variable[_T], SupportsAbs[SupportsRound[object]]]`
+                    #  but got `Union[bool, float, int]`.
+                    second_ind_dict["branin"]["x2"],
+                    # pyre-fixme[6]: For 2nd argument expected
+                    #  `SupportsRSub[Variable[_T], SupportsAbs[SupportsRound[object]]]`
+                    #  but got `Union[bool, float, int]`.
+                    fo_ind_tnsr[0, -1].item(),
                 )
                 self.assertAlmostEqual(
-                    second_ind_dict["branin"]["x1 & x2"], so_ind_tnsr[0, 0].item()
+                    # pyre-fixme[6]: For 2nd argument expected
+                    #  `SupportsRSub[Variable[_T], SupportsAbs[SupportsRound[object]]]`
+                    #  but got `Union[bool, float, int]`.
+                    second_ind_dict["branin"]["x1 & x2"],
+                    # pyre-fixme[6]: For 2nd argument expected
+                    #  `SupportsRSub[Variable[_T], SupportsAbs[SupportsRound[object]]]`
+                    #  but got `Union[bool, float, int]`.
+                    so_ind_tnsr[0, 0].item(),
                 )
 
         # Test with signed

--- a/ax/utils/stats/model_fit_stats.py
+++ b/ax/utils/stats/model_fit_stats.py
@@ -30,13 +30,23 @@ class ModelFitMetricProtocol(Protocol):
     """Structural type for model fit metrics."""
 
     def __call__(
-        self, y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        self,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        y_obs: np.ndarray,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        y_pred: np.ndarray,
+        # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+        se_pred: np.ndarray,
     ) -> float: ...
 
 
 def compute_model_fit_metrics(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_obs: Mapping[str, np.ndarray],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_pred: Mapping[str, np.ndarray],
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     se_pred: Mapping[str, np.ndarray],
     fit_metrics_dict: Mapping[str, ModelFitMetricProtocol],
 ) -> dict[str, dict[str, float]]:
@@ -69,8 +79,11 @@ def compute_model_fit_metrics(
 
 
 def coefficient_of_determination(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_obs: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_pred: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     se_pred: np.ndarray | None = None,
     eps: float = 1e-12,
 ) -> float:
@@ -92,8 +105,11 @@ def coefficient_of_determination(
 
 
 def mean_of_the_standardized_error(  # i.e. standardized bias
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_obs: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_pred: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     se_pred: np.ndarray,
 ) -> float:
     """Computes the mean of the error standardized by the predictive standard deviation
@@ -116,8 +132,11 @@ def mean_of_the_standardized_error(  # i.e. standardized bias
 
 
 def std_of_the_standardized_error(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_obs: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_pred: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     se_pred: np.ndarray,
 ) -> float:
     """Standard deviation of the error standardized by the predictive standard deviation
@@ -139,8 +158,11 @@ def std_of_the_standardized_error(
 
 
 def entropy_of_observations(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_obs: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     y_pred: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     se_pred: np.ndarray,
     bandwidth: float = DEFAULT_KDE_BANDWIDTH,
 ) -> float:
@@ -176,6 +198,7 @@ def entropy_of_observations(
     return _entropy_via_kde(y_obs, bandwidth=bandwidth)
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def _entropy_via_kde(y: np.ndarray, bandwidth: float = DEFAULT_KDE_BANDWIDTH) -> float:
     """Computes the entropy of the kernel density estimate of the input data.
 
@@ -193,29 +216,42 @@ def _entropy_via_kde(y: np.ndarray, bandwidth: float = DEFAULT_KDE_BANDWIDTH) ->
 
 
 def _mean_prediction_ci(
-    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_obs: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_pred: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    se_pred: np.ndarray,
 ) -> float:
     # Pyre does not allow float * np.ndarray.
     return float(np.mean(1.96 * 2 * se_pred / np.abs(y_obs)))
 
 
 def _log_likelihood(
-    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_obs: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_pred: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    se_pred: np.ndarray,
 ) -> float:
     return float(np.sum(norm.logpdf(y_obs, loc=y_pred, scale=se_pred)))
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def _mape(y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray) -> float:
     """Mean absolute predictive error"""
     eps = np.finfo(y_obs.dtype).eps
     return float(np.mean(np.abs(y_pred - y_obs) / np.abs(y_obs).clip(min=eps)))
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def _mse(y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray) -> float:
     """Mean squared error"""
     return float(np.mean((y_pred - y_obs) ** 2))
 
 
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 def _wmape(y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray) -> float:
     """Weighted mean absolute predictive error"""
     eps = np.finfo(y_obs.dtype).eps
@@ -223,14 +259,24 @@ def _wmape(y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray) -> float:
 
 
 def _total_raw_effect(
-    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_obs: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_pred: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    se_pred: np.ndarray,
 ) -> float:
     min_y_obs = np.min(y_obs)
     return float((np.max(y_obs) - min_y_obs) / min_y_obs)
 
 
 def _correlation_coefficient(
-    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_obs: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_pred: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    se_pred: np.ndarray,
 ) -> float:
     with np.errstate(invalid="ignore"):
         rho, _ = pearsonr(y_pred, y_obs)
@@ -238,7 +284,12 @@ def _correlation_coefficient(
 
 
 def _rank_correlation(
-    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_obs: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_pred: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    se_pred: np.ndarray,
 ) -> float:
     with np.errstate(invalid="ignore"):
         rho, _ = spearmanr(y_pred, y_obs)
@@ -246,7 +297,12 @@ def _rank_correlation(
 
 
 def _fisher_exact_test_p(
-    y_obs: np.ndarray, y_pred: np.ndarray, se_pred: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_obs: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    y_pred: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    se_pred: np.ndarray,
 ) -> float:
     """Perform a Fisher exact test on the contingency table constructed from
     agreement/disagreement between the predicted and observed data.

--- a/ax/utils/stats/statstools.py
+++ b/ax/utils/stats/statstools.py
@@ -17,11 +17,16 @@ from ax.core.data import Data
 from ax.utils.common.logger import get_logger
 
 logger: Logger = get_logger(__name__)
+# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 num_mixed = Union[np.ndarray, list[float]]
 
 
 def inverse_variance_weight(
-    means: np.ndarray, variances: np.ndarray, conflicting_noiseless: str = "warn"
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    means: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    variances: np.ndarray,
+    conflicting_noiseless: str = "warn",
 ) -> tuple[float, float]:
     """Perform inverse variance weighting.
 
@@ -59,7 +64,12 @@ def inverse_variance_weight(
 
 
 def total_variance(
-    means: np.ndarray, variances: np.ndarray, sample_sizes: np.ndarray
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    means: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    variances: np.ndarray,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
+    sample_sizes: np.ndarray,
 ) -> float:
     """Compute total variance."""
     variances = variances * sample_sizes
@@ -71,7 +81,9 @@ def total_variance(
 
 
 def positive_part_james_stein(
-    means: num_mixed, sems: num_mixed
+    means: num_mixed,
+    sems: num_mixed,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> tuple[np.ndarray, np.ndarray]:
     """Estimation method for Positive-part James-Stein estimator.
 
@@ -134,24 +146,35 @@ def positive_part_james_stein(
         phi_i = 1
     else:
         phi_i = np.minimum(1, sigma2_i / s2)
+    # pyre-fixme[6]: For 1st argument expected `int` but got `floating[typing.Any]`.
+    # pyre-fixme[6]: For 1st argument expected `bool` but got `ndarray[typing.Any,
+    #  dtype[typing.Any]]`.
     mu_hat_i = y_i + phi_i * (ybar - y_i)
     sigma_hat_i = np.sqrt(
+        # pyre-fixme[58]: `-` is not supported for operand types `int` and
+        #  `Union[np.ndarray[typing.Any, np.dtype[typing.Any]], int]`.
         (1 - phi_i) * sigma2_i
         + phi_i * sigma2_i / K
+        # pyre-fixme[58]: `*` is not supported for operand types `int` and
+        #  `Union[np.ndarray[typing.Any, np.dtype[typing.Any]], int]`.
         + 2 * phi_i**2 * (y_i - ybar) ** 2 / (K - 3)
     )
     return mu_hat_i, sigma_hat_i
 
 
 def relativize(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     means_t: np.ndarray | list[float] | float,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     sems_t: np.ndarray | list[float] | float,
     mean_c: float,
     sem_c: float,
     bias_correction: bool = True,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     cov_means: np.ndarray | list[float] | float = 0.0,
     as_percent: bool = False,
     control_as_constant: bool = False,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> tuple[np.ndarray, np.ndarray]:
     """Ratio estimator based on the delta method.
 
@@ -245,14 +268,18 @@ def relativize(
 
 
 def unrelativize(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     means_t: np.ndarray | list[float] | float,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     sems_t: np.ndarray | list[float] | float,
     mean_c: float,
     sem_c: float,
     bias_correction: bool = True,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     cov_means: np.ndarray | list[float] | float = 0.0,
     as_percent: bool = False,
     control_as_constant: bool = False,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Reverse operation of ax.utils.stats.statstools.relativize.
@@ -307,14 +334,21 @@ def unrelativize(
         m_t[means_t == 0.0] = mean_c
         s_t[means_t == 0.0] = sem_c
 
+    # pyre-fixme[7]: Expected `Tuple[ndarray[typing.Any, typing.Any],
+    #  ndarray[typing.Any, typing.Any]]` but got `Tuple[Union[ndarray[typing.Any,
+    #  dtype[typing.Any]], float], Union[ndarray[typing.Any, dtype[typing.Any]],
+    #  float]]`.
     return m_t, s_t
 
 
 def agresti_coull_sem(
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     n_numer: pd.Series | np.ndarray | int,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
     n_denom: pd.Series | np.ndarray | int,
     prior_successes: int = 2,
     prior_failures: int = 2,
+    # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ) -> np.ndarray | float:
     """Compute the Agresti-Coull style standard error for a binomial proportion.
 

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -727,6 +727,9 @@ class transform_2(Transform):
     ) -> list[ObservationFeatures]:
         for obsf in observation_features:
             for pname in obsf.parameters:
+                # pyre-fixme[6]: For 1st argument expected `Union[bytes, complex,
+                #  float, int, generic, str]` but got `Union[None, bool, float, int,
+                #  str]`.
                 obsf.parameters[pname] = np.sqrt(obsf.parameters[pname])
         return observation_features
 

--- a/ax/utils/testing/preference_stubs.py
+++ b/ax/utils/testing/preference_stubs.py
@@ -136,6 +136,9 @@ def get_pbo_experiment(
         objectives=objectives,
         tracking_metric_names=tracking_metric_names,
         is_test=True,
+        # pyre-fixme[6]: For 9th argument expected `Optional[Dict[str, Union[None,
+        #  bool, float, int, str]]]` but got `Optional[Dict[str,
+        #  floating[typing.Any]]]`.
         status_quo=sq,
     )
 


### PR DESCRIPTION
Summary: This does not have any usage since the multi-fidelity acquisition class has been removed. This type of functionality is better served in the acquisition function input constructors, which is what superseeded the previous multi-fidelity functionality. Removing the method helps simplify the, admittedly very complex, Acquisition constructor.

Differential Revision: D64556772
