### PR TITLE
Remove support(?) for multiple surrogates from Acquisition

### DIFF
--- a/ax/models/torch/botorch_modular/sebo.py
+++ b/ax/models/torch/botorch_modular/sebo.py
@@ -204,7 +204,7 @@ class SEBOAcquisition(Acquisition):
             model_gen_options=torch_opt_config.model_gen_options,
             rounding_func=torch_opt_config.rounding_func,
             opt_config_metrics=torch_opt_config.opt_config_metrics,
-            is_moo=torch_opt_config.is_moo,
+            is_moo=True,  # SEBO adds an objective, so it'll always be MOO.
         )
 
     def optimize(

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock
 import numpy as np
 import torch
 from ax.core.search_space import SearchSpaceDigest
-from ax.exceptions.core import AxWarning, SearchSpaceExhausted
+from ax.exceptions.core import AxWarning, SearchSpaceExhausted, UnsupportedError
 from ax.models.torch.botorch_modular.acquisition import Acquisition
 from ax.models.torch.botorch_modular.optimizer_argparse import optimizer_argparse
 from ax.models.torch.botorch_modular.surrogate import Surrogate
@@ -776,6 +776,7 @@ class AcquisitionTest(TestCase):
             objective_weights=moo_objective_weights,
             outcome_constraints=outcome_constraints,
             objective_thresholds=moo_objective_thresholds,
+            is_moo=True,
         )
         acquisition = Acquisition(
             surrogates={"surrogate": self.surrogate},
@@ -860,3 +861,18 @@ class AcquisitionTest(TestCase):
 
     def test_init_no_X_observed(self) -> None:
         self.test_init_moo(with_no_X_observed=True, with_outcome_constraints=False)
+
+    def test_init_multiple_surrogates(self) -> None:
+        with self.assertRaisesRegex(
+            UnsupportedError, "currently only supports a single surrogate"
+        ):
+            Acquisition(
+                surrogates={
+                    "surrogate_1": self.surrogate,
+                    "surrogate_2": self.surrogate,
+                },
+                search_space_digest=self.search_space_digest,
+                torch_opt_config=self.torch_opt_config,
+                botorch_acqf_class=self.botorch_acqf_class,
+                options=self.options,
+            )


### PR DESCRIPTION
Summary:
The current implementation of `Acqusition.__init__` technically supports multiple surrogates. It combines the models from each surrogate into a `ModelDict` before passing them down to acquisition input constructors. `ModelDict` was added some time ago with the goal of using it to support failure aware BO, but those methods never got implemented and there is no current use case that supports it.

In its current form, the support for multiple surrugates is completely superficial and does not bring much value. It requires complex handling of arguments like `X_pending` and `X_observed`, which itself comes with TODOs to fix or improve it.

This diff removes support for multiple surrogates from `Acquisition` and cleans up some of the complicated argument handling that was necessitated by it. If we decide to support multiple surrogates again at a later date, we can do so with a better thought out design and implement it more cleanly.

Differential Revision: D64610244


