### PR TITLE
Remove custom axis labels for CrossValidation Plot

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -16,7 +16,7 @@ from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
 from ax.utils.common.result import Err, ExceptionE, Ok, Result
-from IPython.display import display
+from IPython.display import display, Markdown
 
 logger: Logger = get_logger(__name__)
 
@@ -79,15 +79,23 @@ class AnalysisCard(Base):
 
         By default, this method displays the raw data in a pandas DataFrame.
         """
+        display(Markdown(f"## {self.title}\n\n### {self.subtitle}"))
         display(self.df)
 
 
-def display_cards(cards: Iterable[AnalysisCard]) -> None:
+def display_cards(
+    cards: Iterable[AnalysisCard], minimum_level: int = AnalysisCardLevel.LOW
+) -> None:
     """
     Display a collection of AnalysisCards in IPython environments (ex. Jupyter).
+
+    Args:
+        cards: Collection of AnalysisCards to display.
+        minimum_level: Minimum level of cards to display.
     """
-    for card in cards:
-        display(card)
+    for card in sorted(cards, key=lambda x: x.level, reverse=True):
+        if card.level >= minimum_level:
+            display(card)
 
 
 class Analysis(Protocol):

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -24,7 +24,7 @@ class MarkdownAnalysisCard(AnalysisCard):
         IPython display hook. This is called when the AnalysisCard is printed in an
         IPython environment (ex. Jupyter). Here we want to render the Markdown.
         """
-        display(Markdown(self.blob))
+        display(Markdown(f"## {self.title}\n\n### {self.subtitle}\n\n{self.blob}"))
 
 
 class MarkdownAnalysis(Analysis):

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -169,10 +169,6 @@ def _prepare_plot(df: pd.DataFrame, metric_name: str) -> go.Figure:
         y="predicted",
         error_x="observed_sem",
         error_y="predicted_sem",
-        labels={
-            "observed": f"Observed {metric_name}",
-            "predicted": f"Predicted {metric_name}",
-        },
         hover_data=["arm_name", "observed", "predicted"],
     )
 

--- a/ax/analysis/plotly/parallel_coordinates.py
+++ b/ax/analysis/plotly/parallel_coordinates.py
@@ -81,7 +81,7 @@ def _prepare_data(experiment: Experiment, metric: str) -> pd.DataFrame:
         for arm in trial.arms
     ]
 
-    return pd.DataFrame.from_records(records)
+    return pd.DataFrame.from_records(records).dropna()
 
 
 def _prepare_plot(df: pd.DataFrame, metric_name: str) -> go.Figure:
@@ -96,10 +96,7 @@ def _prepare_plot(df: pd.DataFrame, metric_name: str) -> go.Figure:
 
     return go.Figure(
         go.Parcoords(
-            line={
-                "color": df[metric_name],
-                "showscale": True,
-            },
+            line={"color": df[metric_name], "showscale": True},
             dimensions=[
                 *parameter_dimensions,
                 {

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -10,7 +10,7 @@ import pandas as pd
 from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
-from IPython.display import display
+from IPython.display import display, Markdown
 from plotly import graph_objects as go, io as pio
 
 
@@ -25,6 +25,7 @@ class PlotlyAnalysisCard(AnalysisCard):
         IPython display hook. This is called when the AnalysisCard is printed in an
         IPython environment (ex. Jupyter). Here we want to display the Plotly figure.
         """
+        display(Markdown(f"## {self.title}\n\n### {self.subtitle}"))
         display(self.get_figure())
 
 


### PR DESCRIPTION
Summary:
Instead of having "Observed {metric_name}" just show "observed" (and same for predicted). In plots where the metric name is long the custom labels were unweildy. {F1937529521}

This should not be a regression to UX since D64495780 makes the title and subtitle get displayed in bento as well.

Reviewed By: danielcohenlive

Differential Revision: D64609346


