### PR TITLE
Turn warning about two-val choice parameter being considered ordered, into a debug log

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -18,8 +18,11 @@ from warnings import warn
 from ax.core.types import TNumeric, TParamValue, TParamValueList
 from ax.exceptions.core import AxParameterWarning, UserInputError
 from ax.utils.common.base import SortableBase
+from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 from pyre_extensions import assert_is_instance
+
+logger = get_logger(__name__)
 
 # Tolerance for floating point comparisons. This is relatively permissive,
 # and allows for serializing at rather low numerical precision.
@@ -584,7 +587,7 @@ class ChoiceParameter(Parameter):
 
         if is_ordered is False and len(values) == 2:
             is_ordered = True
-            warn(
+            logger.debug(
                 f"Changing `is_ordered` to `True` for `ChoiceParameter` '{name}' since "
                 "there are only two possible values.",
                 AxParameterWarning,

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -525,19 +525,14 @@ class ChoiceParameterTest(TestCase):
             )
             self.assertEqual(p._is_ordered, True)
 
-            # Change `is_ordered` to True and warn
-            with self.assertWarnsRegex(
-                AxParameterWarning,
-                "Changing `is_ordered` to `True` for `ChoiceParameter` 'x' since "
-                "there are only two possible values",
-            ):
-                p = ChoiceParameter(
-                    name="x",
-                    parameter_type=parameter_type,
-                    values=values,  # pyre-ignore
-                    is_ordered=False,
-                )
-                self.assertEqual(p._is_ordered, True)
+            # Change `is_ordered` to True
+            p = ChoiceParameter(
+                name="x",
+                parameter_type=parameter_type,
+                values=values,  # pyre-ignore
+                is_ordered=False,
+            )
+            self.assertEqual(p._is_ordered, True)
 
             # Set to True if `is_ordered` is not specified
             with self.assertWarnsRegex(


### PR DESCRIPTION
Summary: As titled

Reviewed By: saitcakmak

Differential Revision: D64604105


