### PR TITLE
Add TransformToNewSQ to transform registry

### DIFF
--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -121,6 +121,7 @@ from ax.utils.testing.modeling_stubs import (
     get_input_transform_type,
     get_observation_features,
     get_outcome_transfrom_type,
+    get_to_new_sq_transform_type,
     get_transform_type,
     sobol_gpei_generation_node_gs,
 )
@@ -258,6 +259,7 @@ TEST_CASES = [
     ("Type[Transform]", get_transform_type),
     ("Type[InputTransform]", get_input_transform_type),
     ("Type[OutcomeTransform]", get_outcome_transfrom_type),
+    ("Type[TransformToNewSQ]", get_to_new_sq_transform_type),
     ("TransitionCriterionList", get_trial_based_criterion),
     ("ThresholdEarlyStoppingStrategy", get_threshold_early_stopping_strategy),
     ("Trial", get_trial),

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -40,6 +40,7 @@ from ax.modelbridge.transforms.standardize_y import StandardizeY
 from ax.modelbridge.transforms.stratified_standardize_y import StratifiedStandardizeY
 from ax.modelbridge.transforms.task_encode import TaskChoiceToIntTaskChoice, TaskEncode
 from ax.modelbridge.transforms.time_as_feature import TimeAsFeature
+from ax.modelbridge.transforms.transform_to_new_sq import TransformToNewSQ
 from ax.modelbridge.transforms.trial_as_task import TrialAsTask
 from ax.modelbridge.transforms.unit_x import UnitX
 from ax.modelbridge.transforms.winsorize import Winsorize
@@ -92,6 +93,7 @@ TRANSFORM_REGISTRY: dict[type[Transform], int] = {
     RelativizeWithConstantControl: 25,
     MergeRepeatedMeasurements: 26,
     TimeAsFeature: 27,
+    TransformToNewSQ: 28,
 }
 
 """

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -36,6 +36,7 @@ from ax.modelbridge.model_spec import ModelSpec
 from ax.modelbridge.registry import Models
 from ax.modelbridge.transforms.base import Transform
 from ax.modelbridge.transforms.int_to_float import IntToFloat
+from ax.modelbridge.transforms.transform_to_new_sq import TransformToNewSQ
 from ax.modelbridge.transition_criterion import (
     AutoTransitionAfterGen,
     IsSingleObjective,
@@ -401,6 +402,10 @@ def get_input_transform_type() -> type[InputTransform]:
 
 def get_outcome_transfrom_type() -> type[OutcomeTransform]:
     return Standardize
+
+
+def get_to_new_sq_transform_type() -> type[TransformToNewSQ]:
+    return TransformToNewSQ
 
 
 def get_experiment_for_value() -> Experiment:


### PR DESCRIPTION
Summary: This is needed for the new online GS which leverage this transform, and we need to be able to load/unload in storage

Differential Revision: D64603480


