### PR TITLE
Fix candidate generation healthcheck text

### DIFF
--- a/ax/analysis/healthcheck/can_generate_candidates.py
+++ b/ax/analysis/healthcheck/can_generate_candidates.py
@@ -21,7 +21,7 @@ from pyre_extensions import none_throws
 
 
 class CanGenerateCandidatesAnalysis(HealthcheckAnalysis):
-    REASON_PREFIX: str = "This experiment cannot generate candidates.\nREASON:"
+    REASON_PREFIX: str = "This experiment cannot generate candidates.\nREASON: "
     LAST_RUN_TEMPLATE: str = "\nLAST TRIAL RUN: {days} day(s) ago"
 
     def __init__(


### PR DESCRIPTION
Summary:
We're missing a space



Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D64627037


