### PR TITLE
Have `ParamBasedTestProblemRunner` take a `ParamBasedTestProblem` rather than its class and kwargs; other cleanup

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -375,8 +375,8 @@ def create_problem_from_botorch(
         search_space=search_space,
         optimization_config=optimization_config,
         runner=BotorchTestProblemRunner(
-            test_problem_class=test_problem_class,
-            test_problem_kwargs=test_problem_kwargs,
+            # pyre-ignore[45]: Can't instantiate abstract class
+            test_problem=test_problem_class(**test_problem_kwargs),
             outcome_names=outcome_names,
             search_space_digest=extract_search_space_digest(
                 search_space=search_space,

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -220,8 +220,7 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
         objective_name="accuracy",
     )
     runner = ParamBasedTestProblemRunner(
-        test_problem_class=PyTorchCNNTorchvisionParamBasedProblem,
-        test_problem_kwargs={"name": name},
+        test_problem=PyTorchCNNTorchvisionParamBasedProblem(name=name),
         outcome_names=outcome_names,
     )
     return BenchmarkProblem(

--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -26,12 +26,7 @@ from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
-from botorch.test_functions.synthetic import (
-    Ackley,
-    Hartmann,
-    Rosenbrock,
-    SyntheticTestFunction,
-)
+from botorch.test_functions.synthetic import Ackley, Hartmann, Rosenbrock
 
 
 def _get_problem_from_common_inputs(
@@ -41,7 +36,7 @@ def _get_problem_from_common_inputs(
     metric_name: str,
     lower_is_better: bool,
     observe_noise_sd: bool,
-    test_problem_class: type[SyntheticTestFunction],
+    test_problem_class: type[Hartmann | Ackley | Rosenbrock],
     benchmark_name: str,
     num_trials: int,
     optimal_value: float,

--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -96,14 +96,13 @@ def _get_problem_from_common_inputs(
             minimize=lower_is_better,
         )
     )
-    test_problem_kwargs: dict[str, int | list[tuple[float, float]]] = {"dim": dim}
-    if test_problem_bounds is not None:
-        test_problem_kwargs["bounds"] = test_problem_bounds
+
+    if test_problem_bounds is None:
+        test_problem = test_problem_class(dim=dim)
+    else:
+        test_problem = test_problem_class(dim=dim, bounds=test_problem_bounds)
     runner = BotorchTestProblemRunner(
-        test_problem_class=test_problem_class,
-        test_problem_kwargs=test_problem_kwargs,
-        outcome_names=[metric_name],
-        modified_bounds=bounds,
+        test_problem=test_problem, outcome_names=[metric_name], modified_bounds=bounds
     )
     return BenchmarkProblem(
         name=benchmark_name + ("_observed_noise" if observe_noise_sd else ""),

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -21,6 +21,8 @@ from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import HierarchicalSearchSpace
 from pyre_extensions import none_throws
 
+JENATTON_OPTIMAL_VALUE = 0.1
+
 
 def jenatton_test_function(
     x1: int | None = None,
@@ -56,8 +58,6 @@ class Jenatton(ParamBasedTestProblem):
     noise_std: float | None = None
     negate: bool = False
     num_objectives: int = 1
-    optimal_value: float = 0.1
-    _is_constrained: bool = False
 
     # pyre-fixme[14]: Inconsistent override
     def evaluate_true(self, params: Mapping[str, float | int | None]) -> torch.Tensor:
@@ -131,5 +131,5 @@ def get_jenatton_benchmark_problem(
         ),
         num_trials=num_trials,
         observe_noise_stds=observe_noise_sd,
-        optimal_value=Jenatton.optimal_value,
+        optimal_value=JENATTON_OPTIMAL_VALUE,
     )

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -125,9 +125,7 @@ def get_jenatton_benchmark_problem(
         search_space=search_space,
         optimization_config=optimization_config,
         runner=ParamBasedTestProblemRunner(
-            test_problem_class=Jenatton,
-            test_problem_kwargs={"noise_std": noise_std},
-            outcome_names=[name],
+            test_problem=Jenatton(noise_std=noise_std), outcome_names=[name]
         ),
         num_trials=num_trials,
         observe_noise_stds=observe_noise_sd,

--- a/ax/benchmark/tests/problems/test_mixed_integer_problems.py
+++ b/ax/benchmark/tests/problems/test_mixed_integer_problems.py
@@ -34,11 +34,9 @@ class MixedIntegerProblemsTest(TestCase):
             name = problem_cls.__name__
             problem = constructor()
             self.assertEqual(f"Discrete {name}", problem.name)
-            self.assertEqual(
-                checked_cast(
-                    BotorchTestProblemRunner, problem.runner
-                ).test_problem_class.__name__,
-                name,
+            self.assertIsInstance(
+                checked_cast(BotorchTestProblemRunner, problem.runner).test_problem,
+                problem_cls,
             )
             self.assertEqual(len(problem.search_space.parameters), dim)
             self.assertEqual(

--- a/ax/benchmark/tests/runners/test_botorch_test_problem.py
+++ b/ax/benchmark/tests/runners/test_botorch_test_problem.py
@@ -116,7 +116,6 @@ class TestSyntheticRunner(TestCase):
                     ),
                 )
                 self.assertEqual(runner, runner)
-                self.assertEqual(runner._is_moo, num_objectives > 1)
                 if issubclass(test_problem_class, BaseTestProblem):
                     self.assertEqual(
                         runner.test_problem.dim, test_problem_kwargs["dim"]

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -51,11 +51,7 @@ class TestBenchmarkProblem(TestCase):
             for name in ["Branin", "Currin"]
         ]
         optimization_config = OptimizationConfig(objective=objectives[0])
-        runner = BotorchTestProblemRunner(
-            test_problem_class=Branin,
-            outcome_names=["foo"],
-            test_problem_kwargs={},
-        )
+        runner = BotorchTestProblemRunner(test_problem=Branin(), outcome_names=["foo"])
         with self.assertRaisesRegex(NotImplementedError, "Only `n_best_points=1`"):
             BenchmarkProblem(
                 name="foo",

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -221,18 +222,9 @@ def get_aggregated_benchmark_result() -> AggregatedBenchmarkResult:
     return AggregatedBenchmarkResult.from_benchmark_results([result, result])
 
 
+@dataclass(kw_only=True)
 class TestParamBasedTestProblem(ParamBasedTestProblem):
-    optimal_value: float = 0.0
-
-    def __init__(
-        self,
-        num_objectives: int,
-        noise_std: float | list[float] | None = None,
-        dim: int = 6,
-    ) -> None:
-        self.num_objectives = num_objectives
-        self.noise_std = noise_std
-        self.dim = dim
+    dim: int = 6
 
     # pyre-fixme[14]: Inconsistent override, as dict[str, float] is not a
     # `TParameterization`


### PR DESCRIPTION
Summary:
Now that we are not attempting to serialize these, there is no need to pass a class and kwargs rather than an instantiated object. This will be more ergonomic and make type checking work better.

This diff:
* Has `ParamBasedTestProblemRunner` and `BoTorchTestProblemRunner` take a ` BaseTestProblem` or `ParamBasedTestProblem` as an argument rather than constructing it from its class and keyword arguments
* Updates various call sites

Differential Revision: D64479242
