### PR TITLE
Remove unneeded `optimal_value` and `_is_constrained` from `ParamBasedTestProblem` and `_is_constrained` and `_is_moo` from `SyntheticProblemRunner`

### DIFF
--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -26,12 +26,7 @@ from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
-from botorch.test_functions.synthetic import (
-    Ackley,
-    Hartmann,
-    Rosenbrock,
-    SyntheticTestFunction,
-)
+from botorch.test_functions.synthetic import Ackley, Hartmann, Rosenbrock
 
 
 def _get_problem_from_common_inputs(
@@ -41,7 +36,7 @@ def _get_problem_from_common_inputs(
     metric_name: str,
     lower_is_better: bool,
     observe_noise_sd: bool,
-    test_problem_class: type[SyntheticTestFunction],
+    test_problem_class: type[Hartmann | Ackley | Rosenbrock],
     benchmark_name: str,
     num_trials: int,
     optimal_value: float,

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -21,6 +21,8 @@ from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import HierarchicalSearchSpace
 from pyre_extensions import none_throws
 
+JENATTON_OPTIMAL_VALUE = 0.1
+
 
 def jenatton_test_function(
     x1: int | None = None,
@@ -56,8 +58,6 @@ class Jenatton(ParamBasedTestProblem):
     noise_std: float | None = None
     negate: bool = False
     num_objectives: int = 1
-    optimal_value: float = 0.1
-    _is_constrained: bool = False
 
     # pyre-fixme[14]: Inconsistent override
     def evaluate_true(self, params: Mapping[str, float | int | None]) -> torch.Tensor:
@@ -131,5 +131,5 @@ def get_jenatton_benchmark_problem(
         ),
         num_trials=num_trials,
         observe_noise_stds=observe_noise_sd,
-        optimal_value=Jenatton.optimal_value,
+        optimal_value=JENATTON_OPTIMAL_VALUE,
     )

--- a/ax/benchmark/tests/runners/test_botorch_test_problem.py
+++ b/ax/benchmark/tests/runners/test_botorch_test_problem.py
@@ -116,7 +116,6 @@ class TestSyntheticRunner(TestCase):
                     ),
                 )
                 self.assertEqual(runner, runner)
-                self.assertEqual(runner._is_moo, num_objectives > 1)
                 if issubclass(test_problem_class, BaseTestProblem):
                     self.assertEqual(
                         runner.test_problem.dim, test_problem_kwargs["dim"]

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -221,18 +222,9 @@ def get_aggregated_benchmark_result() -> AggregatedBenchmarkResult:
     return AggregatedBenchmarkResult.from_benchmark_results([result, result])
 
 
+@dataclass(kw_only=True)
 class TestParamBasedTestProblem(ParamBasedTestProblem):
-    optimal_value: float = 0.0
-
-    def __init__(
-        self,
-        num_objectives: int,
-        noise_std: float | list[float] | None = None,
-        dim: int = 6,
-    ) -> None:
-        self.num_objectives = num_objectives
-        self.noise_std = noise_std
-        self.dim = dim
+    dim: int = 6
 
     # pyre-fixme[14]: Inconsistent override, as dict[str, float] is not a
     # `TParameterization`


### PR DESCRIPTION
Summary:
Context: Several parameters have become redundant during refactoring. Also, a `ParamBasedTestProblem` should be as minimal as possible, as the only benchmark class that needs to be repeatedly subclassed.

`optimal_value` does not need to be defined on a `ParamBasedTestProblem`, since it is also defined on the `Problem`; logically, it should be with the problem, because the optimal value depends on the search space and optimization config. A `ParamBasedTestProblem` should only generate data.

`_is_moo` and `_is_constrained` are helper functions that are not very helpful, with `_is_constrained` being redundant.

This diff:
* Removes `optimal_value` from `ParamBasedTestProblem`, which is defined redundantly on the `BenchmarkProblem`
* Removes `_is_moo` from `SyntheticRunner`, which only has one usage which isn't very helpful
* Removes `_is_constrained` from `ParamBasedTestProblem`, which is defined redundantly on `SyntheticRunner`
* Removes custom equality check from `ParamBasedTestProblem`, so it can just use dataclass equality method.
* Makes some minor fixes
* Makes the equality method for `ParamBasedTestProblem` more rigorous by removing it, so it uses the dataclass equality check

Differential Revision: D64572527
