### PR TITLE
Isolate the "no feasible points" error to objective threshold inference during MOO

### DIFF
--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -18,7 +18,7 @@ from ax.models.torch.botorch_defaults import (
     _get_model,
     get_and_fit_model,
     get_warping_transform,
-    NO_FEASIBLE_POINTS_MESSAGE,
+    NO_OBSERVED_POINTS_MESSAGE,
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast, not_none
@@ -399,7 +399,7 @@ class BotorchDefaultsTest(TestCase):
             for acqf_con, exp_con in zip(acqf_constraints, expected_constraints):
                 self.assertTrue(torch.allclose(acqf_con(samples), exp_con(samples)))
 
-            with self.assertRaisesRegex(ValueError, NO_FEASIBLE_POINTS_MESSAGE):
+            with self.assertRaisesRegex(ValueError, NO_OBSERVED_POINTS_MESSAGE):
                 _get_acquisition_func(
                     model=model,
                     acquisition_function_name=acqf_name,

--- a/ax/models/tests/test_botorch_moo_defaults.py
+++ b/ax/models/tests/test_botorch_moo_defaults.py
@@ -13,6 +13,7 @@ from unittest import mock
 import numpy as np
 import torch
 from ax.core.search_space import SearchSpaceDigest
+from ax.models.torch.botorch_defaults import NO_OBSERVED_POINTS_MESSAGE
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
 from ax.models.torch.botorch_moo_defaults import (
     get_outcome_constraint_transforms,
@@ -234,9 +235,7 @@ class BotorchMOODefaultsTest(TestCase):
         weights = torch.ones(2)
         objective_thresholds = torch.zeros(2)
         mm = MockModel(MockPosterior())
-        with self.assertRaisesRegex(
-            ValueError, "There are no feasible observed points."
-        ):
+        with self.assertRaisesRegex(ValueError, NO_OBSERVED_POINTS_MESSAGE):
             get_qLogEHVI(
                 model=mm,
                 objective_weights=weights,
@@ -261,9 +260,7 @@ class BotorchMOODefaultsTest(TestCase):
         model = MultiObjectiveBotorchModel()
         weights = torch.ones(2)
         objective_thresholds = torch.zeros(2)
-        with self.assertRaisesRegex(
-            ValueError, "There are no feasible observed points."
-        ):
+        with self.assertRaisesRegex(ValueError, NO_OBSERVED_POINTS_MESSAGE):
             get_qLogNEHVI(
                 # pyre-fixme[6]: For 1st param expected `Model` but got
                 #  `Optional[Model]`.

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -50,9 +50,9 @@ from torch import Tensor
 
 
 MIN_OBSERVED_NOISE_LEVEL = 1e-6
-NO_FEASIBLE_POINTS_MESSAGE = (
-    "There are no feasible observed points.  This likely means that one "
-    "or more outcome constraints or objective thresholds is set too strictly.  "
+NO_OBSERVED_POINTS_MESSAGE = (
+    "There are no observed points meeting all parameter "
+    "constraints or have all necessary metrics attached."
 )
 
 
@@ -402,7 +402,7 @@ def _get_acquisition_func(
         raise NotImplementedError(f"{acquisition_function_name=} not implemented yet.")
 
     if X_observed is None:
-        raise ValueError(NO_FEASIBLE_POINTS_MESSAGE)
+        raise ValueError(NO_OBSERVED_POINTS_MESSAGE)
     # construct Objective module
     if chebyshev_scalarization:
         with torch.no_grad():

--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -33,7 +33,7 @@ from typing import cast, Optional, Union
 
 import torch
 from ax.exceptions.core import AxError
-from ax.models.torch.botorch_defaults import NO_FEASIBLE_POINTS_MESSAGE
+from ax.models.torch.botorch_defaults import NO_OBSERVED_POINTS_MESSAGE
 from ax.models.torch.utils import (
     _get_X_pending_and_observed,
     get_outcome_constraint_transforms,
@@ -80,6 +80,12 @@ TFrontierEvaluator = Callable[
     ],
     tuple[Tensor, Tensor, Tensor],
 ]
+
+NO_FEASIBLE_POINTS_MESSAGE = (
+    " Cannot infer objective thresholds due to no observed feasible points. "
+    " This likely means that one or more outcome constraints is set too strictly.  "
+    " Consider adding thresholds to your objectives to bypass this error."
+)
 
 
 def get_weighted_mc_objective_and_objective_thresholds(
@@ -262,7 +268,7 @@ def _get_NEHVI(
     seed: int | None = None,
 ) -> qNoisyExpectedHypervolumeImprovement | qLogNoisyExpectedHypervolumeImprovement:
     if X_observed is None:
-        raise ValueError(NO_FEASIBLE_POINTS_MESSAGE)
+        raise ValueError(NO_OBSERVED_POINTS_MESSAGE)
     # construct Objective module
     (
         objective,
@@ -439,7 +445,7 @@ def _get_EHVI(
     seed: int | None = None,
 ) -> qExpectedHypervolumeImprovement | qLogExpectedHypervolumeImprovement:
     if X_observed is None:
-        raise ValueError(NO_FEASIBLE_POINTS_MESSAGE)
+        raise ValueError(NO_OBSERVED_POINTS_MESSAGE)
     # construct Objective module
     (
         objective,


### PR DESCRIPTION
Summary:
### The problem

For a MMO problem, if no thresholds are provided on the objectives, we try to infer them during gen().  If there are outcome constraints, and none of the observed data points are feasible, we cannot infer the thresholds and error out. This is reproduced in N5821958.

However, the error makes it look like candidate generation failed, when in fact it is the inference of the thresholds.  We could simply suggest the users to provide thresholds if they can and the error will be gone.

### The caveats

The same error message are being referenced in multiple places.
In particular, it is being used in PosteriorMeanPriorSampler, and acquisition functions for non-MBM models.  However, in those cases, we do not actually filter for feasibility/outcome constraints.  Instead, we only filter for points where all metrics (objectives and outcome constraints) are attached, and sometimes parameter constraints as well.  So in such cases, the error should happen very rarely, and the error message is misleading at best.

### This diff

Change the error message to a more actionable when incurred during reference point inference.  And change the error from all other places mentioned above to "no observed points" error message.

Differential Revision: D64691734


