### PR TITLE
Add checks that only Range parameters can have ParameterConstraints instantiated

### DIFF
--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -210,7 +210,7 @@ class ExperimentTest(TestCase):
 
         # Try (and fail) to create an experiment with constraints on choice
         # paramaters
-        with self.assertRaises(UnsupportedError):
+        with self.assertRaises(ValueError):
             ax_client.create_experiment(
                 name="experiment",
                 parameters=[
@@ -231,7 +231,7 @@ class ExperimentTest(TestCase):
 
         # Try (and fail) to create an experiment with constraints on fixed
         # parameters
-        with self.assertRaises(UnsupportedError):
+        with self.assertRaises(ValueError):
             ax_client.create_experiment(
                 name="experiment",
                 parameters=[

--- a/ax/service/tests/test_instantiation_utils.py
+++ b/ax/service/tests/test_instantiation_utils.py
@@ -51,7 +51,20 @@ class TestInstantiationtUtils(TestCase):
                 "x1 + x2 <= not_numerical_bound",
                 # pyre-fixme[6]: For 2nd param expected `Dict[str, Parameter]` but
                 #  got `Dict[str, None]`.
-                {"x1": None, "x2": None},
+                {
+                    "x1": RangeParameter(
+                        name="x1",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=2.0,
+                    ),
+                    "x2": RangeParameter(
+                        name="x2",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=2.0,
+                    ),
+                },
             )
         with self.assertRaisesRegex(ValueError, "Outcome constraint bound"):
             InstantiationBase.outcome_constraint_from_str("m1 <= not_numerical_bound")
@@ -92,7 +105,14 @@ class TestInstantiationtUtils(TestCase):
             "x1 <= 0",
             # pyre-fixme[6]: For 2nd param expected `Dict[str, Parameter]` but
             #  got `Dict[str, None]`.
-            {"x1": None, "x2": None},
+            {
+                "x1": RangeParameter(
+                    name="x1", parameter_type=ParameterType.FLOAT, lower=0.1, upper=2.0
+                ),
+                "x2": RangeParameter(
+                    name="x2", parameter_type=ParameterType.FLOAT, lower=0.1, upper=2.0
+                ),
+            },
         )
         self.assertEqual(one_val_constraint.bound, 0.0)
         self.assertEqual(one_val_constraint.constraint_dict, {"x1": 1.0})
@@ -100,7 +120,14 @@ class TestInstantiationtUtils(TestCase):
             "-0.5*x1 >= -0.1",
             # pyre-fixme[6]: For 2nd param expected `Dict[str, Parameter]` but
             #  got `Dict[str, None]`.
-            {"x1": None, "x2": None},
+            {
+                "x1": RangeParameter(
+                    name="x1", parameter_type=ParameterType.FLOAT, lower=0.1, upper=2.0
+                ),
+                "x2": RangeParameter(
+                    name="x2", parameter_type=ParameterType.FLOAT, lower=0.1, upper=2.0
+                ),
+            },
         )
         self.assertEqual(one_val_constraint.bound, 0.1)
         self.assertEqual(one_val_constraint.constraint_dict, {"x1": 0.5})
@@ -128,28 +155,122 @@ class TestInstantiationtUtils(TestCase):
                 "x1 - e*x2 + x3 <= 3",
                 # pyre-fixme[6]: For 2nd param expected `Dict[str, Parameter]` but
                 #  got `Dict[str, None]`.
-                {"x1": None, "x2": None, "x3": None},
+                {
+                    "x1": RangeParameter(
+                        name="x1",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                    "x2": RangeParameter(
+                        name="x2",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                    "x3": RangeParameter(
+                        name="x3",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                },
             )
         with self.assertRaisesRegex(ValueError, "A linear constraint should be"):
             InstantiationBase.constraint_from_str(
                 "x1 - 2 *x2 + 3 *x3 <= 3",
                 # pyre-fixme[6]: For 2nd param expected `Dict[str, Parameter]` but
                 #  got `Dict[str, None]`.
-                {"x1": None, "x2": None, "x3": None},
+                {
+                    "x1": RangeParameter(
+                        name="x1",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                    "x2": RangeParameter(
+                        name="x2",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                    "x3": RangeParameter(
+                        name="x3",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                },
             )
         with self.assertRaisesRegex(ValueError, "A linear constraint should be"):
             InstantiationBase.constraint_from_str(
                 "x1 - 2* x2 + 3* x3 <= 3",
                 # pyre-fixme[6]: For 2nd param expected `Dict[str, Parameter]` but
                 #  got `Dict[str, None]`.
-                {"x1": None, "x2": None, "x3": None},
+                {
+                    "x1": RangeParameter(
+                        name="x1",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                    "x2": RangeParameter(
+                        name="x2",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                    "x3": RangeParameter(
+                        name="x3",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                },
             )
         with self.assertRaisesRegex(ValueError, "A linear constraint should be"):
             InstantiationBase.constraint_from_str(
                 "x1 - 2 * x2 + 3*x3 <= 3",
                 # pyre-fixme[6]: For 2nd param expected `Dict[str, Parameter]` but
                 #  got `Dict[str, None]`.
-                {"x1": None, "x2": None, "x3": None},
+                {
+                    "x1": RangeParameter(
+                        name="x1",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                    "x2": RangeParameter(
+                        name="x2",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                    "x3": RangeParameter(
+                        name="x3",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=4.0,
+                    ),
+                },
+            )
+
+        with self.assertRaisesRegex(
+            ValueError, "Parameter constraints not supported for ChoiceParameter"
+        ):
+            InstantiationBase.constraint_from_str(
+                "x1 + x2 <= 3",
+                {
+                    "x1": RangeParameter(
+                        name="x1",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=2.0,
+                    ),
+                    "x2": ChoiceParameter(
+                        name="x2", parameter_type=ParameterType.FLOAT, values=[0, 1, 2]
+                    ),
+                },
             )
 
     def test_add_tracking_metrics(self) -> None:

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -35,7 +35,11 @@ from ax.core.parameter import (
     RangeParameter,
     TParameterType,
 )
-from ax.core.parameter_constraint import OrderConstraint, ParameterConstraint
+from ax.core.parameter_constraint import (
+    OrderConstraint,
+    ParameterConstraint,
+    validate_constraint_parameters,
+)
 from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
 from ax.core.types import ComparisonOp, TParameterization, TParamValue
 from ax.exceptions.core import UnsupportedError
@@ -403,6 +407,9 @@ class InstantiationBase:
             assert (
                 right in parameter_names
             ), f"Parameter {right} not in {parameter_names}."
+            validate_constraint_parameters(
+                parameters=[parameters[left], parameters[right]]
+            )
             return (
                 OrderConstraint(
                     lower_parameter=parameters[left], upper_parameter=parameters[right]
@@ -451,9 +458,12 @@ class InstantiationBase:
                         multiplier = -1.0
                     else:
                         multiplier = 1.0
+
                 assert (
                     parameter in parameter_names
                 ), f"Parameter {parameter} not in {parameter_names}."
+                validate_constraint_parameters(parameters=[parameters[parameter]])
+
                 parameter_weight[parameter] = operator_sign * multiplier
             # for operators
             else:


### PR DESCRIPTION
Summary: As titled. This is a little janky but will do for now, a clearner validation scheme will be set up with via the Ax API workstream.

Differential Revision: D64784254


