### PR TITLE
Support MultiTypeExperiment/RealtimeExperiment in Instantiation

### DIFF
--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -171,6 +171,40 @@ class MultiTypeExperimentTest(TestCase):
         ):
             self.experiment.runner_for_trial_type(trial_type="invalid")
 
+    def test_add_tracking_metrics(self) -> None:
+        type1_metrics = [
+            BraninMetric("m3_type1", ["x1", "x2"]),
+            BraninMetric("m4_type1", ["x1", "x2"]),
+        ]
+        type2_metrics = [
+            BraninMetric("m3_type2", ["x1", "x2"]),
+            BraninMetric("m4_type2", ["x1", "x2"]),
+        ]
+        default_type_metrics = [
+            BraninMetric("m5_default_type", ["x1", "x2"]),
+        ]
+        self.experiment.add_tracking_metrics(
+            metrics=type1_metrics + type2_metrics + default_type_metrics,
+            metrics_to_trial_types={
+                "m3_type1": "type1",
+                "m4_type1": "type1",
+                "m3_type2": "type2",
+                "m4_type2": "type2",
+            },
+        )
+        self.assertDictEqual(
+            self.experiment._metric_to_trial_type,
+            {
+                "m1": "type1",
+                "m2": "type2",
+                "m3_type1": "type1",
+                "m4_type1": "type1",
+                "m3_type2": "type2",
+                "m4_type2": "type2",
+                "m5_default_type": "type1",
+            },
+        )
+
 
 class MultiTypeExperimentUtilsTest(TestCase):
     def setUp(self) -> None:

--- a/ax/service/tests/test_instantiation_utils.py
+++ b/ax/service/tests/test_instantiation_utils.py
@@ -17,6 +17,7 @@ from ax.core.parameter import (
     RangeParameter,
 )
 from ax.core.search_space import HierarchicalSearchSpace
+from ax.runners.synthetic import SyntheticRunner
 from ax.service.utils.instantiation import InstantiationBase
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast
@@ -431,3 +432,21 @@ class TestInstantiationtUtils(TestCase):
         self.assertIsInstance(search_space, HierarchicalSearchSpace)
         # pyre-fixme[16]: `SearchSpace` has no attribute `_root`.
         self.assertEqual(search_space._root.name, "root")
+
+    def test_make_multitype_experiment_with_default_trial_type(self) -> None:
+        experiment = InstantiationBase.make_experiment(
+            name="test_make_experiment",
+            parameters=[{"name": "x", "type": "range", "bounds": [0, 1]}],
+            tracking_metric_names=None,
+            default_trial_type="test_trial_type",
+            default_runner=SyntheticRunner(),
+        )
+        self.assertEqual(experiment.__class__.__name__, "MultiTypeExperiment")
+
+    def test_make_single_type_experiment_with_no_default_trial_type(self) -> None:
+        experiment = InstantiationBase.make_experiment(
+            name="test_make_experiment",
+            parameters=[{"name": "x", "type": "range", "bounds": [0, 1]}],
+            tracking_metric_names=None,
+        )
+        self.assertEqual(experiment.__class__.__name__, "Experiment")

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -18,6 +18,7 @@ from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
 from ax.core.experiment import DataType, Experiment
 from ax.core.metric import Metric
+from ax.core.multi_type_experiment import MultiTypeExperiment
 from ax.core.objective import MultiObjective, Objective
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import (
@@ -40,6 +41,7 @@ from ax.core.parameter_constraint import (
     ParameterConstraint,
     validate_constraint_parameters,
 )
+from ax.core.runner import Runner
 from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
 from ax.core.types import ComparisonOp, TParameterization, TParamValue
 from ax.exceptions.core import UnsupportedError
@@ -799,6 +801,8 @@ class InstantiationBase:
         immutable_search_space_and_opt_config: bool = True,
         auxiliary_experiments_by_purpose: None
         | (dict[AuxiliaryExperimentPurpose, list[AuxiliaryExperiment]]) = None,
+        default_trial_type: str | None = None,
+        default_runner: Runner | None = None,
         is_test: bool = False,
     ) -> Experiment:
         """Instantiation wrapper that allows for Ax `Experiment` creation
@@ -854,10 +858,23 @@ class InstantiationBase:
                 improve storage performance.
             auxiliary_experiments_by_purpose: Dictionary of auxiliary experiments for
                 different use cases (e.g., transfer learning).
+            default_trial_type: The default trial type if multiple
+                trial types are intended to be used in the experiment.  If specified,
+                a MultiTypeExperiment will be created. Otherwise, a single-type
+                Experiment will be created.
+            default_runner: The default runner in this experiment.
+                This only applies to MultiTypeExperiment (when default_trial_type
+                is specified).
             is_test: Whether this experiment will be a test experiment (useful for
                 marking test experiments in storage etc). Defaults to False.
 
         """
+        if (default_trial_type is None) != (default_runner is None):
+            raise ValueError(
+                "Must specify both default_trial_type and default_runner if "
+                "using a MultiTypeExperiment."
+            )
+
         status_quo_arm = None if status_quo is None else Arm(parameters=status_quo)
 
         objectives = objectives or cls._get_default_objectives()
@@ -896,6 +913,21 @@ class InstantiationBase:
 
         if owners is not None:
             properties["owners"] = owners
+        if default_trial_type is not None:
+            return MultiTypeExperiment(
+                name=none_throws(name),
+                search_space=cls.make_search_space(parameters, parameter_constraints),
+                default_trial_type=none_throws(default_trial_type),
+                default_runner=none_throws(default_runner),
+                optimization_config=optimization_config,
+                tracking_metrics=tracking_metrics,
+                status_quo=status_quo_arm,
+                description=description,
+                is_test=is_test,
+                experiment_type=experiment_type,
+                properties=properties,
+                default_data_type=default_data_type,
+            )
 
         return Experiment(
             name=name,


### PR DESCRIPTION
Summary:
1. Add support returning MultiTypeExperiment in InstatntiationBase._make_experiment.
2. Add add_tracking_metrics function in MultiTypeExperiment to support batch adding metrics when creating a MultiTypeExperiment.

Differential Revision: D64612495


