### PR TITLE
Remove multi-surrogate support from Acquisition classes

### DIFF
--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -626,7 +626,7 @@ class BoTorchModel(TorchModel, Base):
             )
 
         return self.acquisition_class(
-            surrogates=self.surrogates,
+            surrogate=self.surrogate,
             botorch_acqf_class=self.botorch_acqf_class,
             search_space_digest=search_space_digest,
             torch_opt_config=torch_opt_config,

--- a/ax/models/torch/botorch_modular/sebo.py
+++ b/ax/models/torch/botorch_modular/sebo.py
@@ -21,7 +21,6 @@ from ax.models.torch.botorch_modular.acquisition import Acquisition
 from ax.models.torch.botorch_modular.optimizer_argparse import optimizer_argparse
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.models.torch_base import TorchOptConfig
-from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import not_none
 from botorch.acquisition.acquisition import AcquisitionFunction
@@ -58,16 +57,12 @@ class SEBOAcquisition(Acquisition):
 
     def __init__(
         self,
-        surrogates: dict[str, Surrogate],
+        surrogate: Surrogate,
         search_space_digest: SearchSpaceDigest,
         torch_opt_config: TorchOptConfig,
         botorch_acqf_class: type[AcquisitionFunction],
         options: dict[str, Any] | None = None,
     ) -> None:
-        if len(surrogates) > 1:
-            raise ValueError("SEBO does not support support multiple surrogates.")
-        surrogate = surrogates[Keys.ONLY_SURROGATE]
-
         tkwargs: dict[str, Any] = {"dtype": surrogate.dtype, "device": surrogate.device}
         options = {} if options is None else options
         self.penalty_name: str = options.pop("penalty", "L0_norm")
@@ -123,7 +118,7 @@ class SEBOAcquisition(Acquisition):
         if self.penalty_name == "L0_norm":
             self.deterministic_model._f.a.fill_(1e-6)
         super().__init__(
-            surrogates={"sebo": surrogate_f},
+            surrogate=surrogate_f,
             search_space_digest=search_space_digest,
             torch_opt_config=torch_opt_config_sebo,
             botorch_acqf_class=qLogNoisyExpectedHypervolumeImprovement,

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -692,8 +692,8 @@ class Surrogate(Base):
         # Avoiding circular import between `Surrogate` and `Acquisition`.
         from ax.models.torch.botorch_modular.acquisition import Acquisition
 
-        acqf = Acquisition(  # TODO: For multi-fidelity, might need diff. class.
-            surrogates={"self": self},
+        acqf = Acquisition(
+            surrogate=self,
             botorch_acqf_class=acqf_class,
             search_space_digest=search_space_digest,
             torch_opt_config=torch_opt_config,

--- a/ax/models/torch/tests/test_sebo.py
+++ b/ax/models/torch/tests/test_sebo.py
@@ -119,7 +119,7 @@ class TestSebo(TestCase):
     ) -> SEBOAcquisition:
         return SEBOAcquisition(
             botorch_acqf_class=qNoisyExpectedHypervolumeImprovement,
-            surrogates={Keys.ONLY_SURROGATE: self.surrogates},
+            surrogate=self.surrogates,
             search_space_digest=self.search_space_digest,
             torch_opt_config=dataclasses.replace(
                 torch_opt_config or self.torch_opt_config,
@@ -133,7 +133,7 @@ class TestSebo(TestCase):
             options={"target_point": self.target_point},
         )
         # Check that determinstic metric is added to surrogate
-        surrogate = acquisition1.surrogates["sebo"]
+        surrogate = acquisition1.surrogate
         model_list = not_none(surrogate._model)
         self.assertIsInstance(model_list, ModelList)
         self.assertIsInstance(model_list.models[0], SingleTaskGP)
@@ -167,7 +167,7 @@ class TestSebo(TestCase):
             options={"penalty": "L1_norm", "target_point": self.target_point},
         )
         self.assertEqual(acquisition2.penalty_name, "L1_norm")
-        surrogate = acquisition2.surrogates["sebo"]
+        surrogate = acquisition2.surrogate
         model_list = not_none(surrogate._model)
         self.assertIsInstance(model_list.models[1]._f, functools.partial)
         self.assertIs(model_list.models[1]._f.func, L1_norm_func)
@@ -179,21 +179,6 @@ class TestSebo(TestCase):
             self.get_acquisition_function(
                 fixed_features=self.fixed_features,
                 options={"penalty": "L2_norm", "target_point": self.target_point},
-            )
-
-        # assert error raise if multiple surrogates are given
-        with self.assertRaisesRegex(
-            ValueError, "SEBO does not support support multiple surrogates."
-        ):
-            SEBOAcquisition(
-                botorch_acqf_class=qNoisyExpectedHypervolumeImprovement,
-                surrogates={
-                    Keys.ONLY_SURROGATE: self.surrogates,
-                    "sebo2": self.surrogates,
-                },
-                search_space_digest=self.search_space_digest,
-                torch_opt_config=self.torch_opt_config,
-                options=self.options,
             )
 
         # assert error raise if target point is not given


### PR DESCRIPTION
Summary:
Multiple surrogates is not supported by any Acquisition classes and is being deprecated. This diff replaces the `surrogates: dict[str, Surrogate]` input to `Acquisition` classes with a simple `surrogate: Surrogate` input and cleans up the relevant code.

A following diff will remove multiple-surrogate support from the `BoTorchModel` class.

Differential Revision: D64875386


