### PR TITLE
Remove multi-surrogate support in MBM

### DIFF
--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -30,7 +30,6 @@ from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
 from ax.models.torch.botorch_modular.model import BoTorchModel, SurrogateSpec
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.models.torch.botorch_moo import MultiObjectiveBotorchModel
-from ax.utils.common.constants import Keys
 from ax.utils.common.kwargs import get_function_argument_names
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -74,11 +73,9 @@ class ModelRegistryTest(TestCase):
         self.assertEqual(gpei.model.botorch_acqf_class, qExpectedImprovement)
         self.assertEqual(gpei.model.acquisition_class, Acquisition)
         self.assertEqual(gpei.model.acquisition_options, {"best_f": 0.0})
-        self.assertIsInstance(gpei.model.surrogates[Keys.AUTOSET_SURROGATE], Surrogate)
+        self.assertIsInstance(gpei.model.surrogate, Surrogate)
         # SingleTaskGP should be picked.
-        self.assertIsInstance(
-            gpei.model.surrogates[Keys.AUTOSET_SURROGATE].model, SingleTaskGP
-        )
+        self.assertIsInstance(gpei.model.surrogate.model, SingleTaskGP)
 
         gr = gpei.gen(n=1)
         self.assertIsNotNone(gr.best_arm_predictions)
@@ -96,14 +93,10 @@ class ModelRegistryTest(TestCase):
         self.assertIsInstance(saasbo, TorchModelBridge)
         self.assertEqual(saasbo._model_key, "SAASBO")
         self.assertIsInstance(saasbo.model, BoTorchModel)
-        surrogate_specs = saasbo.model.surrogate_specs
+        surrogate_spec = saasbo.model.surrogate_spec
         self.assertEqual(
-            surrogate_specs,
-            {
-                "SAASBO_Surrogate": SurrogateSpec(
-                    botorch_model_class=SaasFullyBayesianSingleTaskGP
-                )
-            },
+            surrogate_spec,
+            SurrogateSpec(botorch_model_class=SaasFullyBayesianSingleTaskGP),
         )
         self.assertEqual(
             saasbo.model.surrogate.botorch_model_class, SaasFullyBayesianSingleTaskGP

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -265,6 +265,7 @@ class BotorchModel(TorchModel):
             "instead. If you run into a use case that is not supported by MBM, "
             "please raise this with an issue at https://github.com/facebook/Ax",
             DeprecationWarning,
+            stacklevel=2,
         )
         self.model_constructor = model_constructor
         self.model_predictor = model_predictor

--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -336,8 +336,7 @@ class Acquisition(Base):
             )
             return candidates, acqf_values, arm_weights
 
-        # 2. Handle search spaces with discrete features.
-        # 2a. Handle the fully discrete search space.
+        # 2. Handle fully discrete search spaces.
         if optimizer in (
             "optimize_acqf_discrete",
             "optimize_acqf_discrete_local_search",
@@ -384,7 +383,7 @@ class Acquisition(Base):
                 )
             return candidates, acqf_values, arm_weights
 
-        # 2b. Handle mixed search spaces that have discrete and continuous features.
+        # 3. Handle mixed search spaces that have discrete and continuous features.
         # Only sequential optimization is supported for `optimize_acqf_mixed`.
         candidates, acqf_values = optimize_acqf_mixed(
             acq_function=self.acqf,

--- a/ax/models/torch/tests/test_sebo.py
+++ b/ax/models/torch/tests/test_sebo.py
@@ -52,7 +52,7 @@ class TestSebo(TestCase):
         super().setUp()
         tkwargs: dict[str, Any] = {"dtype": torch.double}
         self.botorch_model_class = SingleTaskGP
-        self.surrogates = Surrogate(botorch_model_class=self.botorch_model_class)
+        self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
         self.X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **tkwargs)
         self.target_point = torch.tensor([1.0, 1.0, 1.0], **tkwargs)
         self.Y = torch.tensor([[3.0], [4.0]], **tkwargs)
@@ -67,7 +67,7 @@ class TestSebo(TestCase):
             bounds=[(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)],
             target_values={2: 1.0},
         )
-        self.surrogates.fit(
+        self.surrogate.fit(
             datasets=self.training_data,
             search_space_digest=self.search_space_digest,
         )
@@ -119,7 +119,7 @@ class TestSebo(TestCase):
     ) -> SEBOAcquisition:
         return SEBOAcquisition(
             botorch_acqf_class=qNoisyExpectedHypervolumeImprovement,
-            surrogate=self.surrogates,
+            surrogate=self.surrogate,
             search_space_digest=self.search_space_digest,
             torch_opt_config=dataclasses.replace(
                 torch_opt_config or self.torch_opt_config,

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -56,7 +56,6 @@ from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.models.winsorization_config import WinsorizationConfig
 from ax.storage.botorch_modular_registry import CLASS_TO_REGISTRY
 from ax.storage.transform_registry import TRANSFORM_REGISTRY
-from ax.utils.common.constants import Keys
 from ax.utils.common.serialization import serialize_init_args
 from ax.utils.common.typeutils_torch import torch_type_to_str
 from botorch.models.transforms.input import ChainedInputTransform, InputTransform
@@ -530,14 +529,8 @@ def botorch_model_to_dict(model: BoTorchModel) -> dict[str, Any]:
         "__type": model.__class__.__name__,
         "acquisition_class": model.acquisition_class,
         "acquisition_options": model.acquisition_options or {},
-        "surrogate": (
-            model._surrogates[Keys.ONLY_SURROGATE]
-            if Keys.ONLY_SURROGATE in model._surrogates
-            else None
-        ),
-        "surrogate_specs": (
-            model.surrogate_specs if len(model.surrogate_specs) > 0 else None
-        ),
+        "surrogate": (model._surrogate if model.surrogate_spec is None else None),
+        "surrogate_spec": model.surrogate_spec,
         "botorch_acqf_class": model._botorch_acqf_class,
         "refit_on_cv": model.refit_on_cv,
         "warm_start_refit": model.warm_start_refit,

--- a/ax/utils/sensitivity/sobol_measures.py
+++ b/ax/utils/sensitivity/sobol_measures.py
@@ -8,13 +8,10 @@
 import itertools
 from collections.abc import Callable
 from copy import deepcopy
-
 from typing import Any
 
 import numpy as np
-
 import torch
-
 from ax.modelbridge.torch import TorchModelBridge
 from ax.models.torch.botorch import BotorchModel
 from ax.models.torch.botorch_modular.model import BoTorchModel as ModularBoTorchModel
@@ -941,12 +938,12 @@ def _get_torch_model(
     """
     if not isinstance(model_bridge, TorchModelBridge):
         raise NotImplementedError(
-            f"{type(model_bridge) = }, but only TorchModelBridge is supported."
+            f"{type(model_bridge)=}, but only TorchModelBridge is supported."
         )
     model = model_bridge.model  # should be of type TorchModel
     if not (isinstance(model, BotorchModel) or isinstance(model, ModularBoTorchModel)):
         raise NotImplementedError(
-            f"{type(model_bridge.model) = }, but only "
+            f"{type(model_bridge.model)=}, but only "
             "Union[BotorchModel, ModularBoTorchModel] is supported."
         )
     return model
@@ -971,19 +968,18 @@ def _get_model_per_metric(
             )
         return [gp_model.models[i] for i in model_idx]
     else:  # isinstance(model, ModularBoTorchModel):
+        surrogate = model.surrogate
+        outcomes = surrogate.outcomes
         model_list = []
         for m in metrics:  # for each metric, find a corresponding surrogate
-            for label, outcomes in model.outcomes_by_surrogate_label.items():
-                if m in outcomes:
-                    i = outcomes.index(m)
-                    metric_model = model.surrogates[label].model
-                    # since model is a ModularBoTorchModel, metric_model will be a
-                    # `botorch.models.model.Model` object, which have the `num_outputs`
-                    # property and `subset_outputs` method.
-                    if metric_model.num_outputs > 1:  # subset to relevant output
-                        metric_model = metric_model.subset_output([i])
-                    model_list.append(metric_model)
-                    continue  # found surrogate for `m`, so we can move on to next `m`.
+            i = outcomes.index(m)
+            metric_model = surrogate.model
+            # since model is a ModularBoTorchModel, metric_model will be a
+            # `botorch.models.model.Model` object, which have the `num_outputs`
+            # property and `subset_outputs` method.
+            if metric_model.num_outputs > 1:  # subset to relevant output
+                metric_model = metric_model.subset_output([i])
+            model_list.append(metric_model)
         return model_list
 
 

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -65,9 +65,7 @@ class SensitivityAnalysisTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.model = get_modelbridge().model.model
-        self.saas_model = (
-            get_modelbridge(saasbo=True).model.surrogates["SAASBO_Surrogate"].model
-        )
+        self.saas_model = get_modelbridge(saasbo=True).model.surrogate.model
 
     def test_DgsmGpMean(self) -> None:
         bounds = torch.tensor([(0.0, 1.0) for _ in range(2)]).t()

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2217,6 +2217,12 @@ def get_botorch_model_with_surrogate_specs() -> BoTorchModel:
     )
 
 
+def get_botorch_model_with_surrogate_spec() -> BoTorchModel:
+    return BoTorchModel(
+        surrogate_spec=SurrogateSpec(botorch_model_kwargs={"some_option": "some_value"})
+    )
+
+
 def get_surrogate() -> Surrogate:
     return Surrogate(
         botorch_model_class=get_model_type(),


### PR DESCRIPTION
Summary:
MBM with multiple surrogates was never supported e2e and is being deprecated. This diff:
- Adds a new `surrogate_spec: Surrogate` input to `BoTorchModel`, to replace `surrogate_specs: dict[str, Surrogate]` input.
- Raises a `DeprecationWarning` (as an exception) if `surrogate_specs` is passed in with multiple elements.
- Cleans up the code that was necessary to support multiple surrogates.

Differential Revision: D64875988


