### PR TITLE
Only support negation implicitly, through BoTorch test problems

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -303,7 +303,6 @@ def create_problem_from_botorch(
     test_problem_kwargs: dict[str, Any],
     noise_std: float | list[float] | None = None,
     constraint_noise_std: float | list[float] | None = None,
-    negate: bool = False,
     num_trials: int,
     lower_is_better: bool = True,
     observe_noise_sd: bool = False,
@@ -327,8 +326,6 @@ def create_problem_from_botorch(
             for all objectives.
         constraint_noise_std: Standard deviation of synthetic noise added to
             constraints.
-        negate: Whether the values produced by the test function should be
-            negated. Does not apply to constraints.
         lower_is_better: Whether this is a minimization problem. For MOO, this
             applies to all objectives.
         num_trials: Simply the `num_trials` of the `BenchmarkProblem` created.
@@ -395,7 +392,6 @@ def create_problem_from_botorch(
                 param_names=list(search_space.parameters.keys()),
             ),
             noise_std=noise_std,
-            negate=negate,
             constraint_noise_std=constraint_noise_std,
         ),
         num_trials=num_trials,

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -124,7 +124,6 @@ class PyTorchCNNTorchvisionParamBasedProblem(ParamBasedTestProblem):
             "cuda" if torch.cuda.is_available() else "cpu"
         )
     )
-    negate: bool = False
     # Using `InitVar` prevents the DataLoaders from being serialized; instead
     # they are reconstructed upon deserialization.
     # Pyre doesn't understand InitVars.

--- a/ax/benchmark/runners/botorch_test.py
+++ b/ax/benchmark/runners/botorch_test.py
@@ -207,6 +207,3 @@ class ParamBasedTestProblemRunner(BenchmarkRunner):
                 dim=-1,
             )
         return Y_true
-
-
-BotorchTestProblemRunner = ParamBasedTestProblemRunner

--- a/ax/benchmark/tests/problems/test_mixed_integer_problems.py
+++ b/ax/benchmark/tests/problems/test_mixed_integer_problems.py
@@ -113,5 +113,5 @@ class MixedIntegerProblemsTest(TestCase):
                 wraps=test_problem.botorch_problem.evaluate_true,
             ) as mock_call:
                 runner.run(trial)
-            actual = mock_call.call_args[0][0]
+            actual = mock_call.call_args.kwargs["X"]
             self.assertTrue(torch.allclose(actual, expected_arg))

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -386,7 +386,6 @@ class TestBenchmarkProblem(TestCase):
             test_problem_class=Branin,
             test_problem_kwargs={},
             num_trials=5,
-            negate=True,
         )
 
         # empty experiment

--- a/ax/storage/tests/test_registry_bundle.py
+++ b/ax/storage/tests/test_registry_bundle.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 from ax.benchmark.benchmark_metric import BenchmarkMetric
-from ax.benchmark.runners.botorch_test import BotorchTestProblemRunner
+from ax.benchmark.runners.botorch_test import ParamBasedTestProblemRunner
 from ax.metrics.branin import BraninMetric
 from ax.runners.synthetic import SyntheticRunner
 from ax.storage.registry_bundle import RegistryBundle
@@ -26,7 +26,7 @@ class RegistryBundleTest(TestCase):
 
         right = RegistryBundle(
             metric_clss={BenchmarkMetric: None},
-            runner_clss={BotorchTestProblemRunner: None},
+            runner_clss={ParamBasedTestProblemRunner: None},
             json_encoder_registry={},
             json_class_encoder_registry={},
             json_decoder_registry={},
@@ -41,4 +41,4 @@ class RegistryBundleTest(TestCase):
         self.assertIn(BraninMetric, combined.encoder_registry)
         self.assertIn(SyntheticRunner, combined.encoder_registry)
         self.assertIn(BenchmarkMetric, combined.encoder_registry)
-        self.assertIn(BotorchTestProblemRunner, combined.encoder_registry)
+        self.assertIn(ParamBasedTestProblemRunner, combined.encoder_registry)


### PR DESCRIPTION
Summary:
Context: Negation is handled quite strangely in benchmark runners, which negate only objectives and not constraints (when `negate=True`). This happens for historical reasons because BoTorch test problems are set up that way. In theory, the `BenchmarkRunner` and its test function should not even need to know what is a constraint vs. an objective; they should just collect the data (D64909689). The `OptimizationConfig` should decide what is a metric and what is a constraint.

This diff makes negation the responsibility of the `ParamBasedTestProblem` (soon to be renamed `TestFunction`). Currently, it is only supported for `BoTorchTestProblem`s, but could be easily added to other problems if needed in the future, which can choose to handle negation as they see fit.

Yes, this is sort of reversing a recent change that moved the `negate` argument from the `ParamBasedTestProblem` to the `Runner`, but this is the first time that negation *behavior* has been handled within the test function.

This diff
* Removes the `negate` argument from `create_problem_from_botorch` and from `ParamBasedTestProblemRunner`, instead implicitly requiring it to be set on the BoTorch `BaseTestProblem`.
* Removes a stray instance of `negate` in `PyTorchCNNTorchvisionParamBasedProblem`, which was already not doing anything
* Removes an error complaining that negate should be set on the runner and not on a Botorch test function
* **Important**: Changes a call to `botorch_problem.evaluate_true(x)` to `self.botorch_problem(x)`, which ensures that negation will be applied in the same way as the runner was applying it.

Differential Revision: D64909689


