### PR TITLE
Add parameter name to validation output

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -312,7 +312,9 @@ class RangeParameter(Parameter):
             ParameterType.INT,
             ParameterType.FLOAT,
         ):
-            raise UserInputError("RangeParameter type must be int or float.")
+            raise UserInputError(
+                f"RangeParameter {self.name}type must be int or float."
+            )
 
         upper = float(upper)
         if lower >= upper:
@@ -323,19 +325,19 @@ class RangeParameter(Parameter):
         width: float = upper - lower
         if width < 100 * EPS:
             raise UserInputError(
-                f"Parameter range ({width}) is very small and likely "
+                f"Parameter {self.name}'s range ({width}) is very small and likely "
                 "to cause numerical errors. Consider reparameterizing your "
                 "problem by scaling the parameter."
             )
         if log_scale and logit_scale:
-            raise UserInputError("Can't use both log and logit.")
+            raise UserInputError(f"{self.name} can't use both log and logit.")
         if log_scale and lower <= 0:
-            raise UserInputError("Cannot take log when min <= 0.")
+            raise UserInputError(f"{self.name} cannot take log when min <= 0.")
         if logit_scale and (lower <= 0 or upper >= 1):
-            raise UserInputError("Logit requires lower > 0 and upper < 1")
+            raise UserInputError(f"{self.name} logit requires lower > 0 and upper < 1")
         if not (self.is_valid_type(lower)) or not (self.is_valid_type(upper)):
             raise UserInputError(
-                f"[{lower}, {upper}] is an invalid range for this parameter."
+                f"[{lower}, {upper}] is an invalid range for {self.name}."
             )
 
     @property

--- a/ax/modelbridge/transforms/tests/test_logit_transform.py
+++ b/ax/modelbridge/transforms/tests/test_logit_transform.py
@@ -91,9 +91,9 @@ class LogitTransformTest(TestCase):
     def test_InvalidSettings(self) -> None:
         with self.assertRaises(UserInputError) as cm:
             self._create_logit_parameter(lower=0.1, upper=0.9, log_scale=True)
-        self.assertEqual("Can't use both log and logit.", str(cm.exception))
+        self.assertEqual("x can't use both log and logit.", str(cm.exception))
 
-        str_exc = "Logit requires lower > 0 and upper < 1"
+        str_exc = "x logit requires lower > 0 and upper < 1"
         with self.assertRaises(UserInputError) as cm:
             self._create_logit_parameter(lower=0.0, upper=0.5)
         self.assertEqual(str_exc, str(cm.exception))


### PR DESCRIPTION
Summary: See attached task for motivation. This will make it easier to tell which parameter is malformed in a large search space

Differential Revision: D64978800


