### PR TITLE
Use old 'Set' typing method for sphinx

### DIFF
--- a/scripts/validate_sphinx.py
+++ b/scripts/validate_sphinx.py
@@ -8,6 +8,7 @@ import argparse
 import os
 import pkgutil
 import re
+from typing import Set
 
 
 # Paths are relative to top-level Ax directory (which is passed into fxn below)
@@ -30,7 +31,7 @@ EXCLUDE_MODULES = {
 
 # NOTE: Can't use set[str] here due to internal call site of this module
 # on an ancient (<py3.9) python version.
-def parse_rst(rst_filename: str) -> set[str]:
+def parse_rst(rst_filename: str) -> Set[str]:
     """Extract automodule directives from rst."""
     ret = set()
     with open(rst_filename, "r") as f:


### PR DESCRIPTION
Summary:
Our conveyors are failing because of a github error: https://www.internalfb.com/sandcastle/workflow/1103381908710640190

Make this old Set type to make ancient machine settings happy

Reviewed By: mpolson64

Differential Revision: D64980148


