### PR TITLE
Opt-out test file that hangs Pyre

### DIFF
--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-strict
+# pyre-ignore-all-errors
 
 from unittest.mock import patch
 


### PR DESCRIPTION
Summary: There's one function in one file that currently chokes Pyre. Opt it out from type checking until we figure out a fix.

Differential Revision: D65000955


