### PR TITLE
Use `optimize_acqf_mixed_alternating` in `Acquisition.optimize`

### DIFF
--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from functools import reduce
 from logging import Logger
 from random import choice, uniform
+from typing import Sequence
 
 import numpy as np
 import pandas as pd
@@ -714,7 +715,7 @@ class HierarchicalSearchSpace(SearchSpace):
         ):
             raise RuntimeError(
                 error_msg_prefix
-                + f"Parameters {applicable_paramers- set(parameters.keys())} are"
+                + f"Parameters {applicable_paramers - set(parameters.keys())} are"
                 " missing."
             )
 
@@ -1074,7 +1075,7 @@ class SearchSpaceDigest:
     bounds: list[tuple[int | float, int | float]]
     ordinal_features: list[int] = field(default_factory=list)
     categorical_features: list[int] = field(default_factory=list)
-    discrete_choices: Mapping[int, list[int | float]] = field(default_factory=dict)
+    discrete_choices: Mapping[int, Sequence[int | float]] = field(default_factory=dict)
     task_features: list[int] = field(default_factory=list)
     fidelity_features: list[int] = field(default_factory=list)
     target_values: dict[int, int | float] = field(default_factory=dict)


### PR DESCRIPTION
Summary:
This diff updates `Acquisition.optimize` to utilize `optimize_acqf_mixed_alternating` when
- there are no categorical features (except for those handled by transforms),
- all ordinal features are integer valued,
- and there are more than `ALTERNATING_OPTIMIZER_THRESHOLD` combinations of discrete choices.
`optimize_acqf_mixed_alternating` will be more efficient than `optimize_acqf_mixed` when there are many combinations of discrete choices. The other conditions are current limitations of the optimizer.

The current choice of `ALTERNATING_OPTIMIZER_THRESHOLD = 10` is somewhat arbitrary.

Reviewed By: susanxia1006

Differential Revision: D65066344


