### PR TITLE
Add potential SQL deprecation warning at Encoder instantiation time

### DIFF
--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -83,6 +83,11 @@ class Encoder:
     """
 
     def __init__(self, config: SQAConfig) -> None:
+        logger.error(
+            "ATTENTION: The Ax team is considering deprecating SQLAlchemy storage. "
+            "If you are currently using SQLAlchemy storage, please reach out to us "
+            "via GitHub Issues here: https://github.com/facebook/Ax/issues/2975"
+        )
         self.config = config
 
     @classmethod


### PR DESCRIPTION
Summary: We are considering deprecating SQLAlchechemy support in Ax due in large part to a perceived lack of usage by our OSS community. If you are using this feature please let us know as soon as possible via Github Issues.

Reviewed By: lena-kashtelyan

Differential Revision: D64781681


