### PR TITLE
Fix test_init_files

### DIFF
--- a/ax/health_check/__init__.py
+++ b/ax/health_check/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/preview/__init__.py
+++ b/ax/preview/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/preview/api/__init__.py
+++ b/ax/preview/api/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/telemetry/__init__.py
+++ b/ax/telemetry/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/utils/testing/test_init_files.py
+++ b/ax/utils/testing/test_init_files.py
@@ -11,11 +11,16 @@ from glob import glob
 
 from ax.utils.common.testutils import TestCase
 
+DIRS_TO_SKIP = ["ax/fb", "ax/github", "tests"]
+
 
 class InitTest(TestCase):
     def test_InitFiles(self) -> None:
-        """__init__.py files are necessary when not using buck targets"""
-        for root, _dirs, files in os.walk("./ax/ax", topdown=False):
+        """__init__.py files are necessary for the inclusion of the directories
+        in pip builds."""
+        for root, _, files in os.walk("./ax", topdown=False):
+            if any(s in root for s in DIRS_TO_SKIP):
+                continue
             if len(glob(f"{root}/**/*.py", recursive=True)) > 0:
                 with self.subTest(root):
                     self.assertTrue(

--- a/sphinx/source/health_check.rst
+++ b/sphinx/source/health_check.rst
@@ -1,0 +1,19 @@
+.. role:: hidden
+    :class: hidden-section
+
+ax.health_check
+===============
+
+.. automodule:: ax.health_check
+.. currentmodule:: ax.health_check
+
+Ax Experiment Health Checks
+---------------------------
+
+Search Space
+~~~~~~~~~~~~
+
+.. automodule:: ax.health_check.search_space
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -9,14 +9,19 @@ API Reference
 .. toctree::
    :maxdepth: 2
 
+   analysis
    ax
    benchmark
    core
+   early_stopping
    exceptions
+   global_stopping
+   health_check
    metrics
    modelbridge
    models
    plot
+   preview
    runners
    service
    storage

--- a/sphinx/source/preview.rst
+++ b/sphinx/source/preview.rst
@@ -1,0 +1,19 @@
+.. role:: hidden
+    :class: hidden-section
+
+ax.preview
+==========
+
+.. automodule:: ax.preview
+.. currentmodule:: ax.preview
+
+A preview of future Ax API
+--------------------------
+
+Configs
+~~~~~~~
+
+.. automodule:: ax.preview.api.configs
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/sphinx/source/telemetry.rst
+++ b/sphinx/source/telemetry.rst
@@ -7,6 +7,22 @@ ax.telemetry
 .. automodule:: ax.telemetry
 .. currentmodule:: ax.telemetry
 
+AxClient
+~~~~~~~~
+
+.. automodule:: ax.telemetry.ax_client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Common
+~~~~~~
+
+.. automodule:: ax.telemetry.common
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Experiment
 ~~~~~~~~~~
 
@@ -19,6 +35,14 @@ Generation Strategy
 ~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.telemetry.generation_strategy
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Optimization
+~~~~~~~~~~~~
+
+.. automodule:: ax.telemetry.optimization
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Summary:
I randomly came across this test that would've prevented a recent broken release if it has been working. I believe it was written based on the old directory structure (before we moved ax/ax/... to ax/...), and had to be updated to continue working. This diff updates the target directory and adds exclusions for
- ax/fb -- these are only used with buck, so no need to enforce __init__
- ax/github -- these are for github templates and workflows, so no need to have them included in builds. They also live in a separate directory in OSS.
- tests -- I don't have a strong opinion on this one either way

Differential Revision: D65141273


