### PR TITLE
Rename `optimize_acqf_mixed.py` to `optimize_mixed.py`

### DIFF
--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -50,7 +50,7 @@ from botorch.optim.optimize import (
     optimize_acqf_discrete_local_search,
     optimize_acqf_mixed,
 )
-from botorch.optim.optimize_acqf_mixed import optimize_acqf_mixed_alternating
+from botorch.optim.optimize_mixed import optimize_acqf_mixed_alternating
 from botorch.utils.constraints import get_outcome_constraint_transforms
 from pyre_extensions import none_throws
 from torch import Tensor

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -54,7 +54,7 @@ from botorch.optim.optimize import (
     optimize_acqf_discrete,
     optimize_acqf_mixed,
 )
-from botorch.optim.optimize_acqf_mixed import optimize_acqf_mixed_alternating
+from botorch.optim.optimize_mixed import optimize_acqf_mixed_alternating
 from botorch.utils.constraints import get_outcome_constraint_transforms
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.testing import MockPosterior


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/2600

The name `optimize_acqf_mixed` conflicts with the optimizer with the same name, which is exposed in `botorch/optim/__init__.py`. This would lead to `botorch.optim.optimize_acqf_mixed` pointing to two different things.

Differential Revision: D65158159
