### PR TITLE
Rename fast_botorch_optimize -> mock_botorch_optimize

### DIFF
--- a/ax/analysis/plotly/tests/test_cross_validation.py
+++ b/ax/analysis/plotly/tests/test_cross_validation.py
@@ -12,12 +12,12 @@ from ax.exceptions.core import UserInputError
 from ax.service.ax_client import AxClient, ObjectiveProperties
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from pyre_extensions import none_throws
 
 
 class TestCrossValidationPlot(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def setUp(self) -> None:
         super().setUp()
         self.client = AxClient()

--- a/ax/analysis/plotly/tests/test_insample_effects.py
+++ b/ax/analysis/plotly/tests/test_insample_effects.py
@@ -23,7 +23,7 @@ from ax.utils.testing.core_stubs import (
     get_branin_metric,
     get_branin_outcome_constraint,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.utils.probability.utils import compute_log_prob_feas_from_bounds
 from pyre_extensions import none_throws
 
@@ -81,7 +81,7 @@ class TestInsampleEffectsPlot(TestCase):
         with self.assertRaisesRegex(UserInputError, "requires an Experiment"):
             analysis.compute()
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_compute_uses_gs_model_if_possible(self) -> None:
         # GIVEN an experiment and GS with a Botorch model
         experiment = get_branin_experiment(with_status_quo=True)
@@ -306,7 +306,7 @@ class TestInsampleEffectsPlot(TestCase):
             analysis.compute(experiment=experiment, generation_strategy=None)
             # THEN it raises an error
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_compute_requires_data_for_the_metric_on_the_trial_with_a_model(
         self,
     ) -> None:
@@ -351,7 +351,7 @@ class TestInsampleEffectsPlot(TestCase):
             )
             # THEN it raises an error
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_constraints(self) -> None:
         # GIVEN an experiment with metrics and batch trials
         experiment = get_branin_experiment(with_status_quo=True)

--- a/ax/analysis/plotly/tests/test_predicted_effects.py
+++ b/ax/analysis/plotly/tests/test_predicted_effects.py
@@ -28,7 +28,7 @@ from ax.utils.testing.core_stubs import (
     get_branin_metric,
     get_branin_outcome_constraint,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.utils.probability.utils import compute_log_prob_feas_from_bounds
 from pyre_extensions import none_throws
 
@@ -116,7 +116,7 @@ class TestPredictedEffectsPlot(TestCase):
                 experiment=experiment, generation_strategy=generation_strategy
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_compute(self) -> None:
         # GIVEN an experiment with metrics and batch trials
         experiment = get_branin_experiment(with_status_quo=True)
@@ -189,7 +189,7 @@ class TestPredictedEffectsPlot(TestCase):
                     for arm in trial.arms:
                         self.assertIn(arm.name, card.df["arm_name"].unique())
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_compute_multitask(self) -> None:
         # GIVEN an experiment with candidates generated with a multitask model
         experiment = get_branin_experiment(with_status_quo=True)
@@ -260,7 +260,7 @@ class TestPredictedEffectsPlot(TestCase):
             1,
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_it_does_not_plot_abandoned_trials(self) -> None:
         # GIVEN an experiment with candidate and abandoned trials
         experiment = get_branin_experiment()
@@ -297,7 +297,7 @@ class TestPredictedEffectsPlot(TestCase):
                 arm.name,
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_it_works_for_non_batch_experiments(self) -> None:
         # GIVEN an experiment with the default generation strategy
         experiment = get_branin_experiment(with_batch=False)
@@ -333,7 +333,7 @@ class TestPredictedEffectsPlot(TestCase):
                 card.df["arm_name"].unique(),
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_constraints(self) -> None:
         # GIVEN an experiment with metrics and batch trials
         experiment = get_branin_experiment(with_status_quo=True)

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -25,7 +25,7 @@ from ax.service.utils.best_point import (
 from ax.service.utils.scheduler_options import SchedulerOptions
 from ax.utils.common.random import with_rng_seed
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.analytic import LogExpectedImprovement
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
@@ -74,7 +74,7 @@ class TestMethods(TestCase):
             with self.subTest(name=name):
                 self._test_mbm_acquisition(scheduler_options=scheduler_options)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def _test_benchmark_replication_runs(
         self, scheduler_options: SchedulerOptions, acqf_cls: type[AcquisitionFunction]
     ) -> None:

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -41,7 +41,7 @@ from ax.utils.testing.benchmark_stubs import (
     TestDataset,
 )
 from ax.utils.testing.core_stubs import get_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.acquisition.logei import qLogNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.logei import (
     qLogNoisyExpectedHypervolumeImprovement,
@@ -54,7 +54,7 @@ from pyre_extensions import none_throws
 
 
 class TestBenchmark(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_batch(self) -> None:
         batch_size = 5
 
@@ -186,7 +186,7 @@ class TestBenchmark(TestCase):
                 self.assertTrue(np.isfinite(res.score_trace).all())
                 self.assertTrue(np.all(res.score_trace <= 100))
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def _test_replication_with_inference_value(
         self,
         batch_size: int,
@@ -252,7 +252,7 @@ class TestBenchmark(TestCase):
         ):
             get_multi_objective_benchmark_problem(report_inference_value_as_trace=True)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_replication_mbm(self) -> None:
         with patch.dict(
             "ax.benchmark.problems.hpo.torchvision._REGISTRY",
@@ -374,7 +374,7 @@ class TestBenchmark(TestCase):
         for col in ["mean", "P25", "P50", "P75"]:
             self.assertTrue((agg.score_trace[col] <= 100).all())
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_benchmark_multiple_problems_methods(self) -> None:
         aggs = benchmark_multiple_problems_methods(
             problems=[get_single_objective_benchmark_problem(num_trials=6)],

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -66,7 +66,7 @@ from ax.utils.testing.core_stubs import (
     get_status_quo,
     get_test_map_data_experiment,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 DUMMY_RUN_METADATA_KEY = "test_run_metadata_key"
 DUMMY_RUN_METADATA_VALUE = "test_run_metadata_value"
@@ -1477,7 +1477,7 @@ class ExperimentWithMapDataTest(TestCase):
             new_df.drop(["arm_name", "trial_index"], axis=1),
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_batch_with_multiple_generator_runs(self) -> None:
         exp = get_branin_experiment()
         # set seed to avoid transient errors caused by duplicate arms,

--- a/ax/modelbridge/tests/test_cross_validation.py
+++ b/ax/modelbridge/tests/test_cross_validation.py
@@ -33,7 +33,7 @@ from ax.modelbridge.cross_validation import (
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.modeling_stubs import get_observation1trans, get_observation2trans
 
 
@@ -285,7 +285,7 @@ class CrossValidationTest(TestCase):
         with self.assertRaisesRegex(ValueError, "no training data"):
             cross_validate(model=sobol)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_cross_validate_catches_warnings(self) -> None:
         exp = get_branin_experiment(with_batch=True, with_completed_batch=True)
         model = Models.BOTORCH_MODULAR(

--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -36,13 +36,13 @@ from ax.utils.testing.core_stubs import (
     get_search_space_with_choice_parameters,
     run_branin_experiment_with_generation_strategy,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class TestDispatchUtils(TestCase):
     """Tests that dispatching utilities correctly select generation strategies."""
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_choose_generation_strategy(self) -> None:
         expected_transforms = [Winsorize] + Cont_X_trans + Y_trans
         expected_transform_configs = {
@@ -339,7 +339,7 @@ class TestDispatchUtils(TestCase):
             },
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_disable_progbar(self) -> None:
         for disable_progbar in (True, False):
             with self.subTest(str(disable_progbar)):
@@ -369,7 +369,7 @@ class TestDispatchUtils(TestCase):
                     generation_strategy=sobol_saasbo
                 )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_disable_progbar_for_non_saasbo_discards_the_model_kwarg(self) -> None:
         for disable_progbar in (True, False):
             with self.subTest(str(disable_progbar)):
@@ -723,7 +723,7 @@ class TestDispatchUtils(TestCase):
                 5,
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_jit_compile(self) -> None:
         for jit_compile in (True, False):
             with self.subTest(str(jit_compile)):
@@ -753,7 +753,7 @@ class TestDispatchUtils(TestCase):
                     generation_strategy=sobol_saasbo,
                 )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_jit_compile_for_non_saasbo_discards_the_model_kwarg(self) -> None:
         for jit_compile in (True, False):
             with self.subTest(str(jit_compile)):

--- a/ax/modelbridge/tests/test_factory.py
+++ b/ax/modelbridge/tests/test_factory.py
@@ -28,7 +28,7 @@ from ax.utils.testing.core_stubs import (
     get_branin_optimization_config,
     get_factorial_experiment,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 # pyre-fixme[3]: Return type must be annotated.
@@ -52,7 +52,7 @@ def get_multi_obj_exp_and_opt_config():
 
 
 class ModelBridgeFactoryTestSingleObjective(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_sobol_GPEI(self) -> None:
         """Tests sobol + GPEI instantiation."""
         exp = get_branin_experiment()

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -35,7 +35,7 @@ from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.sampling.normal import SobolQMCNormalSampler
 
 logger: Logger = get_logger(__name__)
@@ -168,7 +168,7 @@ class TestGenerationNode(TestCase):
         # pyre-fixme[16]: Optional type has no attribute `get`.
         self.assertEqual(gr._model_kwargs.get("init_position"), 3)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_gen_with_trial_type(self) -> None:
         mbm_short = GenerationNode(
             node_name="test",
@@ -241,7 +241,7 @@ class TestGenerationNode(TestCase):
         )
         self.assertIsNone(sampler.base_samples)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_properties(self) -> None:
         node = GenerationNode(
             node_name="test",
@@ -431,7 +431,7 @@ class TestGenerationNodeWithBestModelSelector(TestCase):
             ),
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_gen(self) -> None:
         self.model_selection_node.fit(
             experiment=self.branin_experiment, data=self.branin_experiment.lookup_data()

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -68,7 +68,7 @@ from ax.utils.testing.core_stubs import (
     get_experiment_with_multi_objective,
     get_hierarchical_search_space_experiment,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class TestGenerationStrategyWithoutModelBridgeMocks(TestCase):
@@ -77,7 +77,7 @@ class TestGenerationStrategyWithoutModelBridgeMocks(TestCase):
     test class that makes use of mocking rather sparingly.
     """
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     @patch(
         "ax.modelbridge.generation_node._extract_model_state_after_gen",
         wraps=_extract_model_state_after_gen,
@@ -1083,7 +1083,7 @@ class TestGenerationStrategy(TestCase):
                         for p in original_pending[m]:
                             self.assertIn(p, pending[m])
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_gen_for_multiple_trials_with_multiple_models_with_fixed_features(
         self,
     ) -> None:

--- a/ax/modelbridge/tests/test_hierarchical_search_space.py
+++ b/ax/modelbridge/tests/test_hierarchical_search_space.py
@@ -29,7 +29,7 @@ from ax.runners.synthetic import SyntheticRunner
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast, not_none
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class TestHierarchicalSearchSpace(TestCase):
@@ -116,7 +116,7 @@ class TestHierarchicalSearchSpace(TestCase):
             ]
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def _test_gen_base(
         self,
         hss: HierarchicalSearchSpace,
@@ -176,7 +176,7 @@ class TestHierarchicalSearchSpace(TestCase):
 
         return experiment
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def _base_test_predict_and_cv(
         self,
         experiment: Experiment,

--- a/ax/modelbridge/tests/test_model_spec.py
+++ b/ax/modelbridge/tests/test_model_spec.py
@@ -19,7 +19,7 @@ from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import not_none
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class BaseModelSpecTest(TestCase):
@@ -35,7 +35,7 @@ class BaseModelSpecTest(TestCase):
 
 
 class ModelSpecTest(BaseModelSpecTest):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_construct(self) -> None:
         ms = ModelSpec(model_enum=Models.BOTORCH_MODULAR)
         with self.assertRaises(UserInputError):
@@ -43,7 +43,7 @@ class ModelSpecTest(BaseModelSpecTest):
         ms.fit(experiment=self.experiment, data=self.data)
         ms.gen(n=1)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     # We can use `extract_search_space_digest` as a surrogate for executing
     # the full TorchModelBridge._fit.
     @mock.patch(

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -39,7 +39,7 @@ from ax.utils.testing.core_stubs import (
     get_branin_optimization_config,
     get_factorial_experiment,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.acquisition.monte_carlo import qExpectedImprovement
 from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
@@ -55,7 +55,7 @@ from gpytorch.priors.torch_priors import GammaPrior, LogNormalPrior
 
 
 class ModelRegistryTest(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_botorch_modular(self) -> None:
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()
@@ -80,7 +80,7 @@ class ModelRegistryTest(TestCase):
         gr = gpei.gen(n=1)
         self.assertIsNotNone(gr.best_arm_predictions)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_SAASBO(self) -> None:
         exp = get_branin_experiment()
         sobol = Models.SOBOL(search_space=exp.search_space)
@@ -102,7 +102,7 @@ class ModelRegistryTest(TestCase):
             saasbo.model.surrogate.botorch_model_class, SaasFullyBayesianSingleTaskGP
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_enum_sobol_GPEI(self) -> None:
         """Tests Sobol and GPEI instantiation through the Models enum."""
         exp = get_branin_experiment()
@@ -286,7 +286,7 @@ class ModelRegistryTest(TestCase):
             ),
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_model_from_generator_run(self) -> None:
         """Tests that it is possible to restore a model from a generator run it
         produced, if `Models` registry was used.
@@ -362,7 +362,7 @@ class ModelRegistryTest(TestCase):
             # Intersection of two sets should be empty
             self.assertEqual(model_args & bridge_args, set())
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_ST_MTGP_LEGACY(self) -> None:
         """Tests single type MTGP instantiation."""
         # Test Single-type MTGP
@@ -390,7 +390,7 @@ class ModelRegistryTest(TestCase):
                 status_quo_features=status_quo_features,
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_ST_MTGP_NEHVI(self) -> None:
         """Tests single type MTGP NEHVI instantiation."""
         exp, status_quo_features = get_branin_experiment_with_status_quo_trials(
@@ -416,7 +416,7 @@ class ModelRegistryTest(TestCase):
         t.set_status_quo_with_weight(status_quo=t.arms[0], weight=0.5)
         t.run().mark_completed()
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_ST_MTGP(self, use_saas: bool = False) -> None:
         """Tests single type MTGP via Modular BoTorch instantiation
         with both single & multi objective optimization."""

--- a/ax/modelbridge/tests/test_robust_modelbridge.py
+++ b/ax/modelbridge/tests/test_robust_modelbridge.py
@@ -22,7 +22,7 @@ from ax.modelbridge.registry import Models
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_robust_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
     qNoisyExpectedHypervolumeImprovement,
@@ -31,7 +31,7 @@ from botorch.models.gp_regression import SingleTaskGP
 
 
 class TestRobust(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_robust(
         self,
         risk_measure: RiskMeasure | None = None,

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -48,7 +48,7 @@ from ax.utils.testing.core_stubs import (
     get_optimization_config_no_constraints,
     get_search_space_for_range_value,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.modeling_stubs import get_observation1, transform_1, transform_2
 from botorch.utils.datasets import (
     ContextualDataset,
@@ -898,7 +898,7 @@ class TorchModelBridgeTest(TestCase):
         )
         self.assertEqual(mb.outcomes, expected_outcomes)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_gen_metadata_untransform(self) -> None:
         experiment = get_experiment_with_observations(
             observations=[[0.0, 1.0], [2.0, 3.0]]

--- a/ax/modelbridge/tests/test_torch_moo_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_moo_modelbridge.py
@@ -49,7 +49,7 @@ from ax.utils.testing.core_stubs import (
     get_non_monolithic_branin_moo_data,
     TEST_SOBOL_SEED,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.modeling_stubs import transform_1, transform_2
 from botorch.utils.multi_objective.pareto import is_non_dominated
 
@@ -66,7 +66,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
         f"{STUBS_PATH}.BraninMetric.is_available_while_running",
         return_value=False,
     )
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def helper_test_pareto_frontier(
         self, _, outcome_constraints: list[OutcomeConstraint] | None
     ) -> None:
@@ -247,7 +247,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
                     outcome_constraints=outcome_constraints
                 )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_pareto_frontier_and_configs_input_validation(self) -> None:
         exp = get_branin_experiment_with_multi_objective(
             has_optimization_config=True, with_batch=True
@@ -428,7 +428,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
         f"{STUBS_PATH}.BraninMetric.is_available_while_running",
         return_value=False,
     )
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_infer_objective_thresholds(self, _, cuda: bool = False) -> None:
         # lightweight test
         exp = get_branin_experiment_with_multi_objective(
@@ -704,7 +704,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
         self.assertFalse(obj_thresholds[0].relative)
         self.assertFalse(obj_thresholds[1].relative)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_status_quo_for_non_monolithic_data(self) -> None:
         exp = get_branin_experiment_with_multi_objective(with_status_quo=True)
         sobol_generator = get_sobol(

--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -22,7 +22,7 @@ from ax.models.torch.botorch_defaults import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast, not_none
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.acquisition.logei import (
     qLogExpectedImprovement,
     qLogNoisyExpectedImprovement,
@@ -237,7 +237,7 @@ class BotorchDefaultsTest(TestCase):
             )
 
     @mock.patch("ax.models.torch.botorch_defaults._get_model", wraps=_get_model)
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     # pyre-fixme[3]: Return type must be annotated.
     # pyre-fixme[2]: Parameter must be annotated.
     def test_task_feature(self, get_model_mock):
@@ -297,7 +297,7 @@ class BotorchDefaultsTest(TestCase):
             )
 
     @mock.patch("ax.models.torch.botorch_defaults._get_model", wraps=_get_model)
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_pass_customized_prior(self, get_model_mock: Mock) -> None:
         x = [torch.zeros(2, 2)]
         y = [torch.zeros(2, 1)]

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -29,7 +29,7 @@ from ax.models.torch.utils import sample_simplex
 from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import not_none
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition.utils import get_infeasible_cost
 from botorch.models import ModelListGP, SingleTaskGP
@@ -195,7 +195,7 @@ class BotorchModelTest(TestCase):
                 0.6,
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_BotorchModel(
         self, dtype: torch.dtype = torch.float, cuda: bool = False
     ) -> None:

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -29,7 +29,7 @@ from ax.models.torch.botorch_moo_defaults import (
 from ax.models.torch.utils import HYPERSPHERE
 from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.acquisition.multi_objective import (
     logei as moo_logei,
     monte_carlo as moo_monte_carlo,
@@ -132,7 +132,7 @@ class BotorchMOOModelTest(TestCase):
                 dtype=dtype, use_noisy=True, use_log=True
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_BotorchMOOModel_with_random_scalarization(
         self,
         dtype: torch.dtype = torch.float,
@@ -262,7 +262,7 @@ class BotorchMOOModelTest(TestCase):
         )
         self.assertTrue(model.use_loocv_pseudo_likelihood)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_BotorchMOOModel_with_chebyshev_scalarization(
         self,
         dtype: torch.dtype = torch.float,
@@ -681,7 +681,7 @@ class BotorchMOOModelTest(TestCase):
             self.assertTrue(torch.equal(obj_t[:2], provided_obj_t[:2].cpu()))
             self.assertTrue(np.isnan(obj_t[2]))
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_BotorchMOOModel_with_random_scalarization_and_outcome_constraints(
         self,
         dtype: torch.dtype = torch.float,
@@ -759,7 +759,7 @@ class BotorchMOOModelTest(TestCase):
             )
             self.assertEqual(n, _mock_sample_simplex.call_count)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_BotorchMOOModel_with_chebyshev_scalarization_and_outcome_constraints(
         self,
         dtype: torch.dtype = torch.float,
@@ -837,7 +837,7 @@ class BotorchMOOModelTest(TestCase):
             # get_chebyshev_scalarization should be called once for generated candidate.
             self.assertEqual(n, _mock_chebyshev_scalarization.call_count)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_BotorchMOOModel_with_qehvi_and_outcome_constraints(
         self,
         dtype: torch.dtype = torch.float,

--- a/ax/models/tests/test_cbo_lcea.py
+++ b/ax/models/tests/test_cbo_lcea.py
@@ -13,14 +13,14 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.cbo_lcea import LCEABO
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.models.contextual import LCEAGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.utils.datasets import SupervisedDataset
 
 
 class LCEABOTest(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_LCEABO(self) -> None:
         train_X = torch.tensor(
             [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]]

--- a/ax/models/tests/test_cbo_lcem.py
+++ b/ax/models/tests/test_cbo_lcem.py
@@ -10,13 +10,13 @@ import numpy as np
 import torch
 from ax.models.torch.cbo_lcem import LCEMBO
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.models.contextual_multioutput import LCEMGP
 from botorch.models.model_list_gp_regression import ModelListGP
 
 
 class LCEMBOTest(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_LCEMBO(self) -> None:
         d = 1
         train_x = torch.rand(10, d)

--- a/ax/models/tests/test_cbo_sac.py
+++ b/ax/models/tests/test_cbo_sac.py
@@ -13,14 +13,14 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.models.torch.cbo_sac import SACBO, SACGP
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.models.contextual import LCEAGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.utils.datasets import SupervisedDataset
 
 
 class SACBOTest(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_SACBO(self) -> None:
         train_X = torch.tensor(
             [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]]

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -31,8 +31,8 @@ from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import (
-    fast_botorch_optimize,
-    fast_botorch_optimize_context_manager,
+    mock_botorch_optimize,
+    mock_botorch_optimize_context_manager,
 )
 from ax.utils.testing.utils import generic_equals
 from botorch.acquisition.acquisition import AcquisitionFunction
@@ -131,7 +131,7 @@ class AcquisitionTest(TestCase):
             bounds=[(0.0, 10.0), (0.0, 10.0), (0.0, 10.0)],
             target_values={2: 1.0},
         )
-        with fast_botorch_optimize_context_manager():
+        with mock_botorch_optimize_context_manager():
             self.surrogate.fit(
                 datasets=self.training_data,
                 search_space_digest=SearchSpaceDigest(
@@ -297,7 +297,7 @@ class AcquisitionTest(TestCase):
             outcome_constraints=self.outcome_constraints
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     @mock.patch(f"{ACQUISITION_PATH}.optimize_acqf", wraps=optimize_acqf)
     def test_optimize(self, mock_optimize_acqf: Mock) -> None:
         acquisition = self.get_acquisition_function(fixed_features=self.fixed_features)
@@ -520,7 +520,7 @@ class AcquisitionTest(TestCase):
         )
 
     # mock `optimize_acqf_discrete_local_search` because it isn't handled by
-    # `fast_botorch_optimize`
+    # `mock_botorch_optimize`
     @mock.patch(
         f"{ACQUISITION_PATH}.optimize_acqf_discrete_local_search",
         return_value=(Mock(), Mock()),
@@ -588,7 +588,7 @@ class AcquisitionTest(TestCase):
             all((X_avoid_true == x).all(dim=-1).any().item() for x in kwargs["X_avoid"])
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_optimize_mixed(self) -> None:
         ssd = SearchSpaceDigest(
             feature_names=["a", "b"],
@@ -626,7 +626,7 @@ class AcquisitionTest(TestCase):
             )
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_optimize_acqf_mixed_alternating(self) -> None:
         ssd = SearchSpaceDigest(
             feature_names=["a", "b", "c"],
@@ -702,7 +702,7 @@ class AcquisitionTest(TestCase):
         acquisition.evaluate(X=self.X)
         mock_evaluate.assert_called_with(X=self.X)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     @mock.patch(  # pyre-ignore
         "ax.models.torch.botorch_moo_defaults._check_posterior_type",
         wraps=lambda y: y,

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -33,7 +33,7 @@ from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition import qLogNoisyExpectedImprovement
 from botorch.acquisition.input_constructors import (
@@ -417,7 +417,7 @@ class BoTorchModelTest(TestCase):
                     kwargs["state_dict"].keys(), expected_state_dict.keys()
                 )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     @mock.patch(
         f"{MODEL_PATH}.construct_acquisition_and_optimizer_options",
         wraps=construct_acquisition_and_optimizer_options,
@@ -566,7 +566,7 @@ class BoTorchModelTest(TestCase):
             search_space_digest=self.mf_search_space_digest,
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_feature_importances(self) -> None:
         for botorch_model_class in [SingleTaskGP, SaasFullyBayesianSingleTaskGP]:
             surrogate = Surrogate(botorch_model_class=botorch_model_class)
@@ -635,7 +635,7 @@ class BoTorchModelTest(TestCase):
         ):
             model.feature_importances()
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_best_point(self) -> None:
         self.model._surrogate = None
         self.model.fit(
@@ -664,7 +664,7 @@ class BoTorchModelTest(TestCase):
                 ),
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     @mock.patch(
         f"{MODEL_PATH}.construct_acquisition_and_optimizer_options",
         return_value=({"num_fantasies": 64}, {"num_restarts": 40, "raw_samples": 1024}),

--- a/ax/models/torch/tests/test_sebo.py
+++ b/ax/models/torch/tests/test_sebo.py
@@ -29,7 +29,7 @@ from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import not_none
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.acquisition.multi_objective.monte_carlo import (
     qNoisyExpectedHypervolumeImprovement,
 )
@@ -47,7 +47,7 @@ SURROGATE_PATH: str = Surrogate.__module__
 
 
 class TestSebo(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def setUp(self) -> None:
         super().setUp()
         tkwargs: dict[str, Any] = {"dtype": torch.double}

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -23,7 +23,7 @@ from ax.models.torch.botorch_modular.utils import choose_model_class, fit_botorc
 from ax.models.torch_base import TorchOptConfig
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.typeutils import checked_cast, not_none
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from ax.utils.testing.utils import generic_equals
 from botorch.models import ModelListGP, SaasFullyBayesianSingleTaskGP, SingleTaskGP
@@ -239,7 +239,7 @@ class SurrogateTest(TestCase):
         )
         self.assertEqual(mock_mll.call_args[1]["some_option"], "some_value")
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_copy_options(self) -> None:
         training_data = self.training_data + [self.ds2]
         d = self.Xs[0].shape[-1]
@@ -356,7 +356,7 @@ class SurrogateTest(TestCase):
             ):
                 surrogate.training_data
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_dtype_and_device_properties(self) -> None:
         for botorch_model_class in [SaasFullyBayesianSingleTaskGP, SingleTaskGP]:
             surrogate, _ = self._get_surrogate(botorch_model_class=botorch_model_class)
@@ -496,7 +496,7 @@ class SurrogateTest(TestCase):
                 surrogate._submodels[key], SingleTaskGPWithDifferentConstructor
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_construct_custom_model(self) -> None:
         # Test error for unsupported covar_module and likelihood.
         surrogate = Surrogate(
@@ -536,7 +536,7 @@ class SurrogateTest(TestCase):
         self.assertEqual(type(model.covar_module), RBFKernel)
         self.assertEqual(model.covar_module.ard_num_dims, 3)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     @patch(f"{SURROGATE_PATH}.predict_from_model")
     def test_predict(self, mock_predict: Mock) -> None:
         for botorch_model_class, use_posterior_predictive in product(
@@ -556,7 +556,7 @@ class SurrogateTest(TestCase):
                 use_posterior_predictive=use_posterior_predictive,
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_best_in_sample_point(self) -> None:
         for botorch_model_class in [SaasFullyBayesianSingleTaskGP, SingleTaskGP]:
             surrogate, _ = self._get_surrogate(botorch_model_class=botorch_model_class)
@@ -599,7 +599,7 @@ class SurrogateTest(TestCase):
                 ):
                     self.assertTrue(generic_equals(ckwargs[attr], getattr(self, attr)))
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_best_out_of_sample_point(self) -> None:
         torch.manual_seed(0)
         for botorch_model_class in [SaasFullyBayesianSingleTaskGP, SingleTaskGP]:
@@ -637,7 +637,7 @@ class SurrogateTest(TestCase):
             self.assertEqual(acqf_value.shape, torch.Size([]))
             # In realistic cases the maximum posterior mean would exceed the
             # sample mean (because the data is standardized), but that might not
-            # be true when using `fast_botorch_optimize`
+            # be true when using `mock_botorch_optimize`
             eps = 1
             self.assertGreaterEqual(
                 acqf_value.item(), assert_is_instance(sample_mean, float) - eps
@@ -651,7 +651,7 @@ class SurrogateTest(TestCase):
             }
             self.assertEqual(surrogate._serialize_attributes_as_kwargs(), expected)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_w_robust_digest(self) -> None:
         surrogate = Surrogate(
             botorch_model_class=SingleTaskGP,
@@ -1036,7 +1036,7 @@ class SurrogateWithModelListTest(TestCase):
                 mll_class=self.mll_class,
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_with_botorch_transforms(self) -> None:
         surrogate = Surrogate(
             botorch_model_class=SingleTaskGPWithDifferentConstructor,
@@ -1116,7 +1116,7 @@ class SurrogateWithModelListTest(TestCase):
         #     expected.pop(attr_name)
         # self.assertEqual(self.surrogate._serialize_attributes_as_kwargs(), expected)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_construct_custom_model(self) -> None:
         noise_constraint = Interval(1e-4, 10.0)
         for submodel_covar_module_options, submodel_likelihood_options in [
@@ -1173,7 +1173,7 @@ class SurrogateWithModelListTest(TestCase):
                     self.assertEqual(type(m_noise_constraint), GreaterThan)
                     self.assertAlmostEqual(m_noise_constraint.lower_bound.item(), 1e-4)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_w_robust_digest(self) -> None:
         surrogate = Surrogate(
             botorch_model_class=SingleTaskGP,

--- a/ax/plot/tests/test_contours.py
+++ b/ax/plot/tests/test_contours.py
@@ -20,11 +20,11 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_high_dimensional_branin_experiment,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class ContoursTest(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_Contours(self) -> None:
         exp = get_branin_experiment(with_str_choice_param=True, with_batch=True)
         exp.trials[0].run()

--- a/ax/plot/tests/test_diagnostic.py
+++ b/ax/plot/tests/test_diagnostic.py
@@ -16,11 +16,11 @@ from ax.plot.diagnostic import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class DiagnosticTest(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def setUp(self) -> None:
         super().setUp()
         exp = get_branin_experiment(with_batch=True)

--- a/ax/plot/tests/test_feature_importances.py
+++ b/ax/plot/tests/test_feature_importances.py
@@ -22,7 +22,7 @@ from ax.plot.feature_importances import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from plotly import graph_objects as go
 
 DUMMY_CAPTION = "test_caption"
@@ -64,7 +64,7 @@ def get_sensitivity_values(ax_model: ModelBridge) -> dict:
 
 
 class FeatureImportancesTest(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_FeatureImportances(self) -> None:
         model = get_modelbridge()
         # Assert that each type of plot can be constructed successfully

--- a/ax/plot/tests/test_fitted_scatter.py
+++ b/ax/plot/tests/test_fitted_scatter.py
@@ -15,11 +15,11 @@ from ax.plot.base import AxPlotConfig
 from ax.plot.scatter import interact_fitted, interact_fitted_plotly
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment, get_branin_metric
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class FittedScatterTest(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_fitted_scatter(self) -> None:
         exp = get_branin_experiment(with_str_choice_param=True, with_batch=True)
         exp.trials[0].run()

--- a/ax/plot/tests/test_slices.py
+++ b/ax/plot/tests/test_slices.py
@@ -17,11 +17,11 @@ from ax.plot.slice import (
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class SlicesTest(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_Slices(self) -> None:
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()

--- a/ax/plot/tests/test_traces.py
+++ b/ax/plot/tests/test_traces.py
@@ -18,11 +18,11 @@ from ax.plot.trace import (
 from ax.service.utils.report_utils import exp_to_df
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class TracesTest(TestCase):
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def setUp(self) -> None:
         super().setUp()
         self.exp = get_branin_experiment(with_batch=True)
@@ -68,7 +68,7 @@ class TracesTest(TestCase):
             else:
                 self.assertIsNone(plot.layout.yaxis.range)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_plot_objective_value_vs_trial_index(self) -> None:
         # Generate some trials with different model types, including batch trial.
         exp = get_branin_experiment(with_batch=True)

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -85,7 +85,7 @@ from ax.utils.testing.core_stubs import (
     get_sobol,
     SpecialGenerationStrategy,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.modeling_stubs import get_generation_strategy
 from pyre_extensions import none_throws
 from sqlalchemy.orm.exc import StaleDataError
@@ -2022,7 +2022,7 @@ class AxSchedulerTestCase(TestCase):
         self.assertTrue(should_stop)
         self.assertEqual(message, "Exceeding the total number of trials.")
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_fitted_model_bridge(self) -> None:
         self.branin_experiment._properties[Keys.IMMUTABLE_SEARCH_SPACE_AND_OPT_CONF] = (
             True
@@ -2329,7 +2329,7 @@ class AxSchedulerTestCase(TestCase):
         self.assertIn(TEST_MEAN, attached_means)
         self.assertEqual(len(attached_means), 2)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_it_works_with_multitask_models(
         self,
     ) -> None:
@@ -2638,7 +2638,7 @@ class AxSchedulerTestCase(TestCase):
         self.assertIn(self.branin_experiment.status_quo, candidate_trial.arms)
         self.assertIsNotNone(checked_cast(BatchTrial, candidate_trial).status_quo)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_generate_candidates_works_for_iteration(self) -> None:
         # GIVEN a scheduler using a GS with MBM.
         gs = self._get_generation_strategy_strategy_for_test(

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -80,7 +80,7 @@ from ax.utils.testing.core_stubs import (
     DummyEarlyStoppingStrategy,
     get_branin_experiment,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.modeling_stubs import get_observation1, get_observation1trans
 from botorch.test_functions.multi_objective import BraninCurrin
 from pyre_extensions import none_throws
@@ -275,7 +275,7 @@ def get_client_with_simple_discrete_moo_problem(
 class TestAxClient(TestCase):
     """Tests service-like API functionality."""
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_interruption(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
@@ -489,7 +489,7 @@ class TestAxClient(TestCase):
         autospec=True,
         return_value={"x": 0.9, "y": 1.1},
     )
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_default_generation_strategy_continuous(self, _a, _b, _c, _d) -> None:
         """
         Test that Sobol+BoTorch is used if no GenerationStrategy is provided.
@@ -538,7 +538,7 @@ class TestAxClient(TestCase):
         autospec=True,
         return_value=([get_observation1(first_metric_name="branin")]),
     )
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_default_generation_strategy_continuous_gen_trials_in_batches(
         self, _
     ) -> None:
@@ -694,7 +694,7 @@ class TestAxClient(TestCase):
         autospec=True,
         return_value={"x": 0.9, "y": 1.1},
     )
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_default_generation_strategy_continuous_for_moo(
         self, _a, _b, _c, _d
     ) -> None:
@@ -1376,7 +1376,7 @@ class TestAxClient(TestCase):
                 outcome_constraints=["test_objective >= 3"],
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_raw_data_format(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
@@ -1397,7 +1397,7 @@ class TestAxClient(TestCase):
             # pyre-fixme[6]: For 2nd param expected `Union[List[Tuple[Dict[str, Union...
             ax_client.update_trial_data(trial_index, raw_data="invalid_data")
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_raw_data_format_with_map_results(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
@@ -1842,7 +1842,7 @@ class TestAxClient(TestCase):
                 outcome_constraints=["some_metric <= 4.0%"],
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_recommended_parallelism(self) -> None:
         ax_client = AxClient()
         with self.assertRaisesRegex(ValueError, "No generation strategy"):
@@ -2305,7 +2305,7 @@ class TestAxClient(TestCase):
         f"{get_pareto_optimal_parameters.__module__}.observed_pareto",
         wraps=observed_pareto,
     )
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def helper_test_get_pareto_optimal_points(
         self,
         mock_observed_pareto: Mock,
@@ -2338,7 +2338,7 @@ class TestAxClient(TestCase):
         solution = 14
 
         # Check model-predicted Pareto frontier using model on GS.
-        # NOTE: model predictions are very poor due to `fast_botorch_optimize`.
+        # NOTE: model predictions are very poor due to `mock_botorch_optimize`.
         # This overwrites the `predict` call to return the original observations,
         # while testing the rest of the code as if we're using predictions.
         # pyre-fixme[16]: `Optional` has no attribute `model`.
@@ -2453,7 +2453,7 @@ class TestAxClient(TestCase):
         self.assertTrue((input_data == pareto_y_list).all())
 
     # Part 1/3 of tests run by helper_test_get_pareto_optimal_points_from_sobol_step
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_pareto_optimal_points_from_sobol_step_no_constraint(self) -> None:
         outcome_constraints = None
         for minimize in [False, True]:
@@ -2462,7 +2462,7 @@ class TestAxClient(TestCase):
             )
 
     # Part 2/3 of tests run by helper_test_get_pareto_optimal_points_from_sobol_step
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_pareto_optimal_points_from_sobol_step_with_constraint_minimize_true(
         self,
     ) -> None:
@@ -2471,7 +2471,7 @@ class TestAxClient(TestCase):
         )
 
     # Part 3/3 of tests run by helper_test_get_pareto_optimal_points_from_sobol_step
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_pareto_optimal_points_from_sobol_step_with_constraint_minimize_false(
         self,
     ) -> None:
@@ -2487,7 +2487,7 @@ class TestAxClient(TestCase):
         f"{get_pareto_optimal_parameters.__module__}.observed_pareto",
         wraps=observed_pareto,
     )
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_pareto_optimal_points_objective_threshold_inference(
         self,
         # pyre-fixme[2]: Parameter must be annotated.
@@ -2638,7 +2638,7 @@ class TestAxClient(TestCase):
             sol, _get_parameterizations_from_pareto_frontier(pareto_mod)
         )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_hypervolume(self) -> None:
         # First check that hypervolume gets returned for observed data
         ax_client, _ = get_branin_currin_optimization_with_N_sobol_trials(num_trials=20)
@@ -2659,7 +2659,7 @@ class TestAxClient(TestCase):
 
         self.assertGreaterEqual(ax_client.get_hypervolume(), 0)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_with_hss(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -40,7 +40,7 @@ from ax.utils.testing.core_stubs import (
     get_experiment_with_observations,
     get_sobol,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 best_point_module: str = _derel_opt_config_wrapper.__module__
 DUMMY_OPTIMIZATION_CONFIG = "test_optimization_config"
@@ -50,7 +50,7 @@ class TestBestPointUtils(TestCase):
     """Testing the best point utilities functionality that is not tested in
     main `AxClient` testing suite (`TestServiceAPI`)."""
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_best_from_model_prediction(self) -> None:
         exp = get_branin_experiment()
 

--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -16,7 +16,7 @@ from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrateg
 from ax.modelbridge.registry import Models
 from ax.service.managed_loop import OptimizationLoop, optimize
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 def _branin_evaluation_function(
@@ -95,7 +95,7 @@ class TestManagedLoop(TestCase):
                 len(loop.experiment.search_space.parameter_constraints) == 0
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_branin(self) -> None:
         """Basic async synthetic function managed loop case."""
         loop = OptimizationLoop.with_evaluation_function(
@@ -123,7 +123,7 @@ class TestManagedLoop(TestCase):
         with self.assertRaisesRegex(ValueError, "Optimization is complete"):
             loop.run_trial()
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_branin_with_active_parameter_constraints(self) -> None:
         """Basic async synthetic function managed loop case."""
         loop = OptimizationLoop.with_evaluation_function(
@@ -154,7 +154,7 @@ class TestManagedLoop(TestCase):
         with self.assertRaisesRegex(ValueError, "Optimization is complete"):
             loop.run_trial()
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_branin_without_objective_name(self) -> None:
         loop = OptimizationLoop.with_evaluation_function(
             parameters=[
@@ -176,7 +176,7 @@ class TestManagedLoop(TestCase):
         self.assertIn("x1", bp)
         self.assertIn("x2", bp)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_branin_with_unknown_sem(self) -> None:
         loop = OptimizationLoop.with_evaluation_function(
             parameters=[
@@ -198,7 +198,7 @@ class TestManagedLoop(TestCase):
         self.assertIn("x1", bp)
         self.assertIn("x2", bp)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_branin_batch(self) -> None:
         """Basic async synthetic function managed loop case."""
 
@@ -275,7 +275,7 @@ class TestManagedLoop(TestCase):
         autospec=True,
         return_value=({"x1": 2.0, "x2": 3.0}, ({"a": 9.0}, {"a": {"a": 3.0}})),
     )
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_optimize_with_predictions(self, _) -> None:
         """Tests optimization as a single call."""
         best, vals, exp, model = optimize(
@@ -300,7 +300,7 @@ class TestManagedLoop(TestCase):
         # pyre-fixme[16]: Optional type has no attribute `__getitem__`.
         self.assertIn("a", vals[1]["a"])
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_optimize_unknown_sem(self) -> None:
         """Tests optimization as a single call."""
         best, vals, exp, model = optimize(

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -60,7 +60,7 @@ from ax.utils.testing.core_stubs import (
     get_multi_type_experiment,
     get_test_map_data_experiment,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.modeling_stubs import get_generation_strategy
 from plotly import graph_objects as go
 
@@ -368,7 +368,7 @@ class ReportUtilsTest(TestCase):
         )
         self.assertDictEqual(expected_output, actual_output)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_standard_plots(self) -> None:
         exp = get_branin_experiment()
         self.assertEqual(
@@ -419,7 +419,7 @@ class ReportUtilsTest(TestCase):
             self.assertEqual(len(plots), num_expected_plots)  # TODO: this failed
             self.assertTrue(all(isinstance(plot, go.Figure) for plot in plots))
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_standard_plots_moo(self) -> None:
         exp = get_branin_experiment_with_multi_objective(with_batch=True)
         exp.optimization_config.objective.objectives[0].minimize = False
@@ -466,7 +466,7 @@ class ReportUtilsTest(TestCase):
                 self.assertTrue(any(expected_msg in msg for msg in created_plots_logs))
         self.assertEqual(len(plots), 6)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_standard_plots_moo_relative_constraints(self) -> None:
         exp = get_branin_experiment_with_multi_objective(with_batch=True)
         exp.optimization_config.objective.objectives[0].minimize = False
@@ -492,7 +492,7 @@ class ReportUtilsTest(TestCase):
         )
         self.assertEqual(len(plots), 8)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_standard_plots_moo_no_objective_thresholds(self) -> None:
         exp = get_branin_experiment_with_multi_objective(with_batch=True)
         exp.optimization_config.objective.objectives[0].minimize = False
@@ -503,7 +503,7 @@ class ReportUtilsTest(TestCase):
         )
         self.assertEqual(len(plots), 8)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_get_standard_plots_map_data(self) -> None:
         exp = get_branin_experiment_with_timestamp_map_metric(with_status_quo=True)
         exp.new_trial().add_arm(exp.status_quo)
@@ -536,7 +536,7 @@ class ReportUtilsTest(TestCase):
                 true_objective_metric_name="not_present",
             )
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_skip_contour_high_dimensional(self) -> None:
         exp = get_high_dimensional_branin_experiment()
         # Initial Sobol points

--- a/ax/telemetry/tests/test_experiment.py
+++ b/ax/telemetry/tests/test_experiment.py
@@ -14,7 +14,7 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_experiment_with_custom_runner_and_metric,
 )
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class TestExperiment(TestCase):
@@ -69,7 +69,7 @@ class TestExperiment(TestCase):
         )
         self.assertEqual(record, expected)
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_bayesopt_trials_are_trials_containing_bayesopt(self) -> None:
         experiment = get_branin_experiment()
         sobol = Models.SOBOL(search_space=experiment.search_space)

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -312,7 +312,7 @@ class TestCase(fake_filesystem_unittest.TestCase):
                     " To specify a reason for a long running test,"
                     + " utilize the @ax_long_test decorator. If your test "
                     + "is long because it's doing modeling, please use the "
-                    + "@fast_botorch_optimize decorator and see if that helps."
+                    + "@mock_botorch_optimize decorator and see if that helps."
                 )
                 raise TimeoutError(message)
             else:

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -35,7 +35,7 @@ from ax.utils.sensitivity.sobol_measures import (
     SobolSensitivityGPSampling,
 )
 from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.models.gpytorch import BatchedMultiOutputGPyTorchModel, GPyTorchModel
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.utils.transforms import unnormalize
@@ -43,7 +43,7 @@ from gpytorch.distributions import MultivariateNormal
 from torch import Tensor
 
 
-@fast_botorch_optimize
+@mock_botorch_optimize
 def get_modelbridge(modular: bool = False, saasbo: bool = False) -> ModelBridge:
     exp = get_branin_experiment(with_batch=True)
     exp.trials[0].run()

--- a/ax/utils/testing/mock.py
+++ b/ax/utils/testing/mock.py
@@ -22,13 +22,14 @@ from torch import Tensor
 
 
 @contextmanager
-def fast_botorch_optimize_context_manager(
+def mock_botorch_optimize_context_manager(
     force: bool = False,
 ) -> Generator[None, None, None]:
-    """A context manager to force botorch to speed up optimization. Currently, the
-    primary tactic is to force the underlying scipy methods to stop after just one
-    iteration.
+    """A context manager that uses mocks to speed up optimization for testing.
+    Currently, the primary tactic is to force the underlying scipy methods to
+    stop after just one iteration.
 
+    Args:
         force: If True will not raise an AssertionError if no mocks are called.
             USE RESPONSIBLY.
     """
@@ -105,17 +106,17 @@ def fast_botorch_optimize_context_manager(
     ):
         raise AssertionError(
             "No mocks were called in the context manager. Please remove unused "
-            "fast_botorch_optimize_context_manager()."
+            "mock_botorch_optimize_context_manager()."
         )
 
 
-def fast_botorch_optimize(f: Callable) -> Callable:
-    """Wraps f in the fast_botorch_optimize_context_manager for use as a decorator."""
+def mock_botorch_optimize(f: Callable) -> Callable:
+    """Wraps `f` in `mock_botorch_optimize_context_manager` for use as a decorator."""
 
     @wraps(f)
     # pyre-fixme[3]: Return type must be annotated.
     def inner(*args: Any, **kwargs: Any):
-        with fast_botorch_optimize_context_manager():
+        with mock_botorch_optimize_context_manager():
             return f(*args, **kwargs)
 
     return inner

--- a/ax/utils/testing/tests/test_utils.py
+++ b/ax/utils/testing/tests/test_utils.py
@@ -13,7 +13,7 @@ from ax.modelbridge.model_spec import ModelSpec
 from ax.modelbridge.registry import Models
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_experiment_with_observations
-from ax.utils.testing.mock import fast_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.utils import generic_equals, run_trials_with_gs
 
 
@@ -51,7 +51,7 @@ class TestUtils(TestCase):
         self.assertTrue(generic_equals({1, 2}, {1, 2}))
         self.assertFalse(generic_equals({1, 2}, {1, 2, 3}))
 
-    @fast_botorch_optimize
+    @mock_botorch_optimize
     def test_run_trials_with_gs(self) -> None:
         experiment = get_experiment_with_observations(
             observations=[[1.0, 5.0], [2.0, 4.0]]


### PR DESCRIPTION
Summary: Renames the decorator to clarify that it mocks the optimization rather than magically speeding things up without consequence.

Reviewed By: Balandat

Differential Revision: D65160586
