### PR TITLE
Remove dispatching functionality from `optimizer_argparse`

### DIFF
--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -42,6 +42,7 @@ from ax.utils.testing.benchmark_stubs import (
 )
 from ax.utils.testing.core_stubs import get_experiment
 from ax.utils.testing.mock import mock_botorch_optimize
+from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
 from botorch.acquisition.logei import qLogNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.logei import (
     qLogNoisyExpectedHypervolumeImprovement,
@@ -322,6 +323,17 @@ class TestBenchmark(TestCase):
                 ),
                 mnist_problem,
                 "MBM::SingleTaskGP_qLogNEI",
+            ),
+            (
+                get_sobol_botorch_modular_acquisition(
+                    model_cls=SingleTaskGP,
+                    acquisition_cls=qKnowledgeGradient,
+                    distribute_replications=False,
+                ),
+                get_single_objective_benchmark_problem(
+                    observe_noise_sd=False, num_trials=6
+                ),
+                "MBM::SingleTaskGP_qKnowledgeGradient",
             ),
         ]:
             with self.subTest(method=method, problem=problem):

--- a/tutorials/modular_botax.ipynb
+++ b/tutorials/modular_botax.ipynb
@@ -355,11 +355,10 @@
       },
       "source": [
         "Steps to set up any `AcquisitionFunction` in Ax are:\n",
-        "1. Define an input constructor function. The purpose of this method is to produce arguments to a acquisition function from a standardized set of inputs passed to BoTorch `AcquisitionFunction`-s from `Acquisition.__init__` in Ax. For example, see [`construct_inputs_qEHVI`](https://github.com/pytorch/botorch/blob/main/botorch/acquisition/input_constructors.py#L477), which creates a fairly complex set of arguments needed by `qExpectedHypervolumeImprovement` –– a popular multi-objective optimization acquisition function offered in Ax and BoTorch. For more examples, see this collection in BoTorch: [botorch/acquisition/input_constructors.py](https://github.com/pytorch/botorch/blob/main/botorch/acquisition/input_constructors.py) \n",
+        "1. Define an input constructor function. The purpose of this method is to produce arguments to an acquisition function from a standardized set of inputs passed to BoTorch `AcquisitionFunction`-s from `Acquisition.__init__` in Ax. For example, see [`construct_inputs_qEHVI`](https://github.com/pytorch/botorch/blob/main/botorch/acquisition/input_constructors.py#L477), which creates a fairly complex set of arguments needed by `qExpectedHypervolumeImprovement` –– a popular multi-objective optimization acquisition function offered in Ax and BoTorch. For more examples, see this collection in BoTorch: [botorch/acquisition/input_constructors.py](https://github.com/pytorch/botorch/blob/main/botorch/acquisition/input_constructors.py) \n",
         "   1. Note that the new input constructor needs to be decorated with `@acqf_input_constructor(AcquisitionFunctionClass)` to register it.\n",
-        "2. (Optional) If a given `AcquisitionFunction` requires specific options passed to the BoTorch `optimize_acqf`, it's possible to add default optimizer options for a given `AcquisitionFunction` to avoid always manually passing them via `acquisition_options`.\n",
-        "3. Specify the BoTorch `AcquisitionFunction` class as `botorch_acqf_class` to `BoTorchModel`\n",
-        "4. (Optional) Pass any additional keyword arguments to acquisition function constructor or to the optimizer function via `acquisition_options` argument to `BoTorchModel`."
+        "2. Specify the BoTorch `AcquisitionFunction` class as `botorch_acqf_class` to `BoTorchModel`\n",
+        "3. (Optional) Pass any additional keyword arguments to acquisition function constructor or to the optimizer function via `acquisition_options` argument to `BoTorchModel`."
       ]
     },
     {
@@ -373,7 +372,6 @@
       },
       "outputs": [],
       "source": [
-        "from ax.models.torch.botorch_modular.optimizer_argparse import optimizer_argparse\n",
         "from botorch.acquisition.acquisition import AcquisitionFunction\n",
         "from botorch.acquisition.input_constructors import acqf_input_constructor, MaybeDict\n",
         "from botorch.utils.datasets import SupervisedDataset\n",
@@ -395,17 +393,7 @@
         "    pass\n",
         "\n",
         "\n",
-        "# 2. Register default optimizer options\n",
-        "@optimizer_argparse.register(MyAcquisitionFunctionClass)\n",
-        "def _argparse_my_acqf(\n",
-        "    acqf: MyAcquisitionFunctionClass, sequential: bool = True\n",
-        ") -> dict:\n",
-        "    return {\n",
-        "        \"sequential\": sequential\n",
-        "    }  # default to sequentially optimizing batches of queries\n",
-        "\n",
-        "\n",
-        "# 3-4. Specifying `botorch_acqf_class` and `acquisition_options`\n",
+        "# 2-3. Specifying `botorch_acqf_class` and `acquisition_options`\n",
         "BoTorchModel(\n",
         "    botorch_acqf_class=MyAcquisitionFunctionClass,\n",
         "    acquisition_options={\n",


### PR DESCRIPTION
Summary:
Context: This dispatcher's only usage is to raise an exception with qKG. There is no need for it to be a dispatcher.

This diff:
* makes `optimizer_argparse` no longer a dispatcher
* Moves the error for qKG into the body of the now-only `optimizer_argparse` function
* Removes special function for qKG
* Changes type annotations so that the first argument is always an `AcquisitionFunction`; it was always used that way, with different types used only in tests.

Reviewed By: saitcakmak, Balandat

Differential Revision: D65231763


