### PR TITLE
Don't pass unused arguments to `optimizer_argparse`

### DIFF
--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -42,6 +42,7 @@ from ax.utils.testing.benchmark_stubs import (
 )
 from ax.utils.testing.core_stubs import get_experiment
 from ax.utils.testing.mock import mock_botorch_optimize
+from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
 from botorch.acquisition.logei import qLogNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.logei import (
     qLogNoisyExpectedHypervolumeImprovement,
@@ -322,6 +323,17 @@ class TestBenchmark(TestCase):
                 ),
                 mnist_problem,
                 "MBM::SingleTaskGP_qLogNEI",
+            ),
+            (
+                get_sobol_botorch_modular_acquisition(
+                    model_cls=SingleTaskGP,
+                    acquisition_cls=qKnowledgeGradient,
+                    distribute_replications=False,
+                ),
+                get_single_objective_benchmark_problem(
+                    observe_noise_sd=False, num_trials=6
+                ),
+                "MBM::SingleTaskGP_qKnowledgeGradient",
             ),
         ]:
             with self.subTest(method=method, problem=problem):

--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -338,8 +338,6 @@ class Acquisition(Base):
         # Prepare arguments for optimizer
         optimizer_options_with_defaults = optimizer_argparse(
             self.acqf,
-            bounds=bounds,
-            q=n,
             optimizer_options=optimizer_options,
             optimizer=optimizer,
         )

--- a/ax/models/torch/botorch_modular/optimizer_argparse.py
+++ b/ax/models/torch/botorch_modular/optimizer_argparse.py
@@ -25,20 +25,9 @@ def optimizer_argparse(
     acqf: AcquisitionFunction,
     *,
     optimizer: str,
-    sequential: bool = True,
-    num_restarts: int = NUM_RESTARTS,
-    raw_samples: int = RAW_SAMPLES,
-    init_batch_limit: int = INIT_BATCH_LIMIT,
-    batch_limit: int = BATCH_LIMIT,
     optimizer_options: dict[str, Any] | None = None,
-    **ignore: Any,
 ) -> dict[str, Any]:
     """Extract the kwargs to be passed to a BoTorch optimizer.
-
-    NOTE: Since `optimizer_options` is how the user would typically pass in these
-    options, it takes precedence over other arguments. E.g., if both `num_restarts`
-    and `optimizer_options["num_restarts"]` are provided, this will use
-    `num_restarts` from `optimizer_options`.
 
     Args:
         acqf: The acquisition function being optimized.
@@ -50,24 +39,10 @@ def optimizer_argparse(
             - "optimize_acqf_homotopy",
             - "optimize_acqf_mixed",
             - "optimize_acqf_mixed_alternating".
-        sequential: Whether we choose one candidate at a time in a sequential
-            manner. `sequential=False` is not supported by optimizers other than
-            `optimize_acqf` and will lead to an error.
-        num_restarts: The number of starting points for multistart acquisition
-            function optimization. Ignored if the optimizer is
-            `optimize_acqf_discrete`.
-        raw_samples: The number of samples for initialization. Ignored if the
-            optimizer is `optimize_acqf_discrete`.
-        init_batch_limit: The size of mini-batches used to evaluate the `raw_samples`.
-            This helps reduce peak memory usage. Ignored if the optimizer is
-            `optimize_acqf_discrete` or `optimize_acqf_discrete_local_search`.
-        batch_limit: The size of mini-batches used while optimizing the `acqf`.
-            This helps reduce peak memory usage. Ignored if the optimizer is
-            `optimize_acqf_discrete` or `optimize_acqf_discrete_local_search`.
-        optimizer_options: An optional dictionary of optimizer options. This may
-            include overrides for the above options (some of these under an `options`
-            dictionary) or any other option that is accepted by the optimizer. See
-            the docstrings in `botorch/optim/optimize.py` for supported options.
+        optimizer_options: An optional dictionary of optimizer options (some of
+            these under an `options` dictionary); default values will be used
+            where not specified. See the docstrings in
+            `botorch/optim/optimize.py` for supported options.
             Example:
                 >>> optimizer_options = {
                 >>>     "num_restarts": 20,
@@ -108,8 +83,8 @@ def optimizer_argparse(
         options = {}
     else:
         options = {
-            "num_restarts": num_restarts,
-            "raw_samples": raw_samples,
+            "num_restarts": NUM_RESTARTS,
+            "raw_samples": RAW_SAMPLES,
         }
 
     if optimizer in [
@@ -119,8 +94,8 @@ def optimizer_argparse(
         "optimize_acqf_mixed_alternating",
     ]:
         options["options"] = {
-            "init_batch_limit": init_batch_limit,
-            "batch_limit": batch_limit,
+            "init_batch_limit": INIT_BATCH_LIMIT,
+            "batch_limit": BATCH_LIMIT,
             **provided_options.get("options", {}),
         }
     # Error out if options are specified for an optimizer that does not support the arg.
@@ -130,9 +105,7 @@ def optimizer_argparse(
         )
 
     if optimizer == "optimize_acqf":
-        options["sequential"] = sequential
-    elif sequential is False:
-        raise UnsupportedError(f"`{optimizer=}` does not support `sequential=False`.")
+        options["sequential"] = True
 
     options.update(**{k: v for k, v in provided_options.items() if k != "options"})
     return options

--- a/ax/models/torch/botorch_modular/sebo.py
+++ b/ax/models/torch/botorch_modular/sebo.py
@@ -282,8 +282,6 @@ class SEBOAcquisition(Acquisition):
         # Prepare arguments for optimizer
         optimizer_options_with_defaults = optimizer_argparse(
             self.acqf,
-            bounds=bounds,
-            q=n,
             optimizer_options=optimizer_options,
             optimizer="optimize_acqf_homotopy",
         )

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -315,8 +315,6 @@ class AcquisitionTest(TestCase):
             )
         mock_optimizer_argparse.assert_called_once_with(
             acquisition.acqf,
-            bounds=mock.ANY,
-            q=n,
             optimizer_options=self.optimizer_options,
             optimizer="optimize_acqf",
         )
@@ -410,8 +408,6 @@ class AcquisitionTest(TestCase):
             )
         mock_optimizer_argparse.assert_called_once_with(
             acquisition.acqf,
-            bounds=mock.ANY,
-            q=n,
             optimizer_options=None,
             optimizer="optimize_acqf_discrete",
         )
@@ -459,8 +455,6 @@ class AcquisitionTest(TestCase):
             )
         mock_optimizer_argparse.assert_called_once_with(
             acquisition.acqf,
-            bounds=mock.ANY,
-            q=3,
             optimizer_options=None,
             optimizer="optimize_acqf_discrete",
         )
@@ -551,8 +545,6 @@ class AcquisitionTest(TestCase):
             )
         mock_optimizer_argparse.assert_called_once_with(
             acquisition.acqf,
-            bounds=mock.ANY,
-            q=3,
             optimizer_options=self.optimizer_options,
             optimizer="optimize_acqf_discrete_local_search",
         )

--- a/ax/models/torch/tests/test_optimizer_argparse.py
+++ b/ax/models/torch/tests/test_optimizer_argparse.py
@@ -132,19 +132,6 @@ class OptimizerArgparseTest(TestCase):
                     optimizer=optimizer,
                 )
 
-        # `sequential=False` with optimizers other than `optimize_acqf`.
-        for optimizer in [
-            "optimize_acqf_homotopy",
-            "optimize_acqf_mixed",
-            "optimize_acqf_mixed_alternating",
-            "optimize_acqf_discrete",
-            "optimize_acqf_discrete_local_search",
-        ]:
-            with self.assertRaisesRegex(
-                UnsupportedError, "does not support `sequential=False`"
-            ):
-                optimizer_argparse(self.acqf, sequential=False, optimizer=optimizer)
-
     def test_kg(self) -> None:
         user_options = {"foo": "bar", "num_restarts": 114}
         generic_options = optimizer_argparse(
@@ -158,11 +145,7 @@ class OptimizerArgparseTest(TestCase):
         ):
             with self.subTest(acqf=acqf):
                 options = optimizer_argparse(
-                    acqf,
-                    q=None,
-                    bounds=None,
-                    optimizer_options=user_options,
-                    optimizer="optimize_acqf",
+                    acqf, optimizer_options=user_options, optimizer="optimize_acqf"
                 )
                 self.assertEqual(options, generic_options)
 

--- a/tutorials/modular_botax.ipynb
+++ b/tutorials/modular_botax.ipynb
@@ -355,11 +355,10 @@
       },
       "source": [
         "Steps to set up any `AcquisitionFunction` in Ax are:\n",
-        "1. Define an input constructor function. The purpose of this method is to produce arguments to a acquisition function from a standardized set of inputs passed to BoTorch `AcquisitionFunction`-s from `Acquisition.__init__` in Ax. For example, see [`construct_inputs_qEHVI`](https://github.com/pytorch/botorch/blob/main/botorch/acquisition/input_constructors.py#L477), which creates a fairly complex set of arguments needed by `qExpectedHypervolumeImprovement` –– a popular multi-objective optimization acquisition function offered in Ax and BoTorch. For more examples, see this collection in BoTorch: [botorch/acquisition/input_constructors.py](https://github.com/pytorch/botorch/blob/main/botorch/acquisition/input_constructors.py) \n",
+        "1. Define an input constructor function. The purpose of this method is to produce arguments to an acquisition function from a standardized set of inputs passed to BoTorch `AcquisitionFunction`-s from `Acquisition.__init__` in Ax. For example, see [`construct_inputs_qEHVI`](https://github.com/pytorch/botorch/blob/main/botorch/acquisition/input_constructors.py#L477), which creates a fairly complex set of arguments needed by `qExpectedHypervolumeImprovement` –– a popular multi-objective optimization acquisition function offered in Ax and BoTorch. For more examples, see this collection in BoTorch: [botorch/acquisition/input_constructors.py](https://github.com/pytorch/botorch/blob/main/botorch/acquisition/input_constructors.py) \n",
         "   1. Note that the new input constructor needs to be decorated with `@acqf_input_constructor(AcquisitionFunctionClass)` to register it.\n",
-        "2. (Optional) If a given `AcquisitionFunction` requires specific options passed to the BoTorch `optimize_acqf`, it's possible to add default optimizer options for a given `AcquisitionFunction` to avoid always manually passing them via `acquisition_options`.\n",
-        "3. Specify the BoTorch `AcquisitionFunction` class as `botorch_acqf_class` to `BoTorchModel`\n",
-        "4. (Optional) Pass any additional keyword arguments to acquisition function constructor or to the optimizer function via `acquisition_options` argument to `BoTorchModel`."
+        "2. Specify the BoTorch `AcquisitionFunction` class as `botorch_acqf_class` to `BoTorchModel`\n",
+        "3. (Optional) Pass any additional keyword arguments to acquisition function constructor or to the optimizer function via `acquisition_options` argument to `BoTorchModel`."
       ]
     },
     {
@@ -373,7 +372,6 @@
       },
       "outputs": [],
       "source": [
-        "from ax.models.torch.botorch_modular.optimizer_argparse import optimizer_argparse\n",
         "from botorch.acquisition.acquisition import AcquisitionFunction\n",
         "from botorch.acquisition.input_constructors import acqf_input_constructor, MaybeDict\n",
         "from botorch.utils.datasets import SupervisedDataset\n",
@@ -395,17 +393,7 @@
         "    pass\n",
         "\n",
         "\n",
-        "# 2. Register default optimizer options\n",
-        "@optimizer_argparse.register(MyAcquisitionFunctionClass)\n",
-        "def _argparse_my_acqf(\n",
-        "    acqf: MyAcquisitionFunctionClass, sequential: bool = True\n",
-        ") -> dict:\n",
-        "    return {\n",
-        "        \"sequential\": sequential\n",
-        "    }  # default to sequentially optimizing batches of queries\n",
-        "\n",
-        "\n",
-        "# 3-4. Specifying `botorch_acqf_class` and `acquisition_options`\n",
+        "# 2-3. Specifying `botorch_acqf_class` and `acquisition_options`\n",
         "BoTorchModel(\n",
         "    botorch_acqf_class=MyAcquisitionFunctionClass,\n",
         "    acquisition_options={\n",


### PR DESCRIPTION
Summary:
Context:
- The only arguments ever passed to `optimizer_argparse` are `acqf`, `optimizer_options`, and `optimizer`, `q`, and `bounds`. The latter two are always ignored.
- `optimizer_argparse` accepts a bunch of arguments that are never passed to it... and never should be, because, as the docstring explains, `optimizer_options` is the right place to pass those.

Reviewed By: saitcakmak, Balandat

Differential Revision: D65233328


