### PR TITLE
Add should generate health check for the trial

### DIFF
--- a/ax/analysis/healthcheck/__init__.py
+++ b/ax/analysis/healthcheck/__init__.py
@@ -13,10 +13,12 @@ from ax.analysis.healthcheck.healthcheck_analysis import (
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
+from ax.analysis.healthcheck.should_generate_candidates import ShouldGenerateCandidates
 
 __all__ = [
     "CanGenerateCandidatesAnalysis",
     "HealthcheckAnalysis",
     "HealthcheckAnalysisCard",
     "HealthcheckStatus",
+    "ShouldGenerateCandidates",
 ]

--- a/ax/analysis/healthcheck/should_generate_candidates.py
+++ b/ax/analysis/healthcheck/should_generate_candidates.py
@@ -1,0 +1,58 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+
+import pandas as pd
+from ax.analysis.analysis import AnalysisCardLevel
+
+from ax.analysis.healthcheck.healthcheck_analysis import (
+    HealthcheckAnalysis,
+    HealthcheckAnalysisCard,
+    HealthcheckStatus,
+)
+from ax.core.experiment import Experiment
+from ax.core.generation_strategy_interface import GenerationStrategyInterface
+
+
+class ShouldGenerateCandidates(HealthcheckAnalysis):
+    def __init__(
+        self,
+        should_generate: bool,
+        reason: str,
+        trial_index: int,
+    ) -> None:
+        self.should_generate = should_generate
+        self.reason = reason
+        self.trial_index = trial_index
+
+    def compute(
+        self,
+        experiment: Experiment | None = None,
+        generation_strategy: GenerationStrategyInterface | None = None,
+    ) -> HealthcheckAnalysisCard:
+        status = (
+            HealthcheckStatus.PASS
+            if self.should_generate
+            else HealthcheckStatus.WARNING
+        )
+        return HealthcheckAnalysisCard(
+            name=self.name,
+            title=f"Ready to Generate Candidates for Trial {self.trial_index}",
+            blob=json.dumps(
+                {
+                    "status": status,
+                }
+            ),
+            subtitle=self.reason,
+            df=pd.DataFrame(
+                {
+                    "status": [status],
+                    "reason": [self.reason],
+                }
+            ),
+            level=AnalysisCardLevel.CRITICAL,
+            attributes=self.attributes,
+        )

--- a/ax/analysis/healthcheck/tests/test_should_generate_candidates.py
+++ b/ax/analysis/healthcheck/tests/test_should_generate_candidates.py
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from random import randint
+
+from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckStatus
+from ax.analysis.healthcheck.should_generate_candidates import ShouldGenerateCandidates
+from ax.utils.common.testutils import TestCase
+
+
+class TestShouldGenerateCandidates(TestCase):
+    def test_should(self) -> None:
+        trial_index = randint(0, 10)
+        card = ShouldGenerateCandidates(
+            should_generate=True,
+            reason="Something reassuring",
+            trial_index=trial_index,
+        ).compute()
+        self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
+        self.assertEqual(card.level, AnalysisCardLevel.CRITICAL)
+        self.assertEqual(card.subtitle, "Something reassuring")
+        self.assertEqual(card.attributes["trial_index"], trial_index)
+
+    def test_should_not(self) -> None:
+        trial_index = randint(0, 10)
+        card = ShouldGenerateCandidates(
+            should_generate=False,
+            reason="Something concerning",
+            trial_index=trial_index,
+        ).compute()
+        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+        self.assertEqual(card.level, AnalysisCardLevel.CRITICAL)
+        self.assertEqual(card.subtitle, "Something concerning")
+        self.assertEqual(card.attributes["trial_index"], trial_index)

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -51,8 +51,8 @@ class MarkdownAnalysis(Analysis):
         details about the Analysis class.
         """
         return MarkdownAnalysisCard(
-            name=self.__class__.__name__,
-            attributes=self.__dict__,
+            name=self.name,
+            attributes=self.attributes,
             title=title,
             subtitle=subtitle,
             level=level,

--- a/ax/analysis/plotly/arm_effects/insample_effects.py
+++ b/ax/analysis/plotly/arm_effects/insample_effects.py
@@ -129,15 +129,14 @@ class InSampleEffectsPlot(PlotlyAnalysis):
         max_trial_index = max(experiment.trial_indices_expecting_data, default=0)
         nudge -= min(max_trial_index - self.trial_index, 9)
 
-        plot_type = "Modeled" if self.use_modeled_effects else "Observed"
         subtitle = (
             "View a trial and its arms' "
-            f"{'predicted' if self.use_modeled_effects else 'observed'} "
+            f"{self._plot_type_string.lower()} "
             "metric values"
         )
         card = self._create_plotly_analysis_card(
             title=(
-                f"{plot_type} Effects for {self.metric_name} "
+                f"{self._plot_type_string} Effects for {self.metric_name} "
                 f"on trial {self.trial_index}"
             ),
             subtitle=subtitle,
@@ -145,8 +144,15 @@ class InSampleEffectsPlot(PlotlyAnalysis):
             df=df,
             fig=fig,
         )
-        card.name = f"{plot_type}EffectsPlot"
         return card
+
+    @property
+    def name(self) -> str:
+        return f"{self._plot_type_string}EffectsPlot"
+
+    @property
+    def _plot_type_string(self) -> str:
+        return "Modeled" if self.use_modeled_effects else "Observed"
 
 
 def _get_max_observed_trial_index(model: ModelBridge) -> int | None:

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -53,8 +53,8 @@ class PlotlyAnalysis(Analysis):
         details about the Analysis class.
         """
         return PlotlyAnalysisCard(
-            name=self.__class__.__name__,
-            attributes=self.__dict__,
+            name=self.name,
+            attributes=self.attributes,
             title=title,
             subtitle=subtitle,
             level=level,

--- a/ax/analysis/plotly/tests/test_insample_effects.py
+++ b/ax/analysis/plotly/tests/test_insample_effects.py
@@ -172,7 +172,7 @@ class TestInsampleEffectsPlot(TestCase):
         self.assertEqual(card.name, "ModeledEffectsPlot")
         self.assertEqual(card.title, "Modeled Effects for branin on trial 0")
         self.assertEqual(
-            card.subtitle, "View a trial and its arms' predicted metric values"
+            card.subtitle, "View a trial and its arms' modeled metric values"
         )
         # +2 because it's on objective, +1 because it's modeled
         self.assertEqual(card.level, AnalysisCardLevel.MID + 3)
@@ -218,7 +218,7 @@ class TestInsampleEffectsPlot(TestCase):
         self.assertEqual(card.name, "ModeledEffectsPlot")
         self.assertEqual(card.title, "Modeled Effects for branin on trial 0")
         self.assertEqual(
-            card.subtitle, "View a trial and its arms' predicted metric values"
+            card.subtitle, "View a trial and its arms' modeled metric values"
         )
         # +2 because it's on objective, +1 because it's modeled
         self.assertEqual(card.level, AnalysisCardLevel.MID + 3)

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1024,7 +1024,7 @@ class Decoder:
         analysis_card_sqa: SQAAnalysisCard,
     ) -> AnalysisCard:
         """Convert SQLAlchemy Analysis to Ax Analysis Object."""
-        return AnalysisCard(
+        card = AnalysisCard(
             name=analysis_card_sqa.name,
             title=analysis_card_sqa.title,
             subtitle=analysis_card_sqa.subtitle,
@@ -1037,6 +1037,8 @@ class Decoder:
                 else json.loads(analysis_card_sqa.attributes)
             ),
         )
+        card.db_id = analysis_card_sqa.id
+        return card
 
     def _metric_from_sqa_util(self, metric_sqa: SQAMetric) -> Metric:
         """Convert SQLAlchemy Metric to Ax Metric"""

--- a/sphinx/source/analysis.rst
+++ b/sphinx/source/analysis.rst
@@ -47,6 +47,14 @@ Can Generate Candidates Healthcheck Analysis
     :undoc-members:
     :show-inheritance:
 
+Should Generate Candidates Healthcheck Analysis
+~~~~~~~~~~~~~~~
+
+.. automodule:: ax.analysis.healthcheck.should_generate_candidates
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Healthcheck Analysis
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary: Create a should generate candidates healthcheck to surface warnings when we only generated because `force_candidate_generation=True` was passed.

Reviewed By: Cesar-Cardoso

Differential Revision: D65295234


