### PR TITLE
Support per-metric model specification in MBM

### DIFF
--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -27,6 +27,7 @@ from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.models.torch.botorch_modular.utils import (
     choose_model_class,
     construct_acquisition_and_optimizer_options,
+    ModelConfig,
 )
 from ax.models.torch.utils import _filter_X_observed
 from ax.models.torch_base import TorchOptConfig
@@ -327,7 +328,21 @@ class BoTorchModelTest(TestCase):
         mock_fit.assert_called_with(
             dataset=self.block_design_training_data[0],
             search_space_digest=self.mf_search_space_digest,
-            botorch_model_class=SingleTaskMultiFidelityGP,
+            model_config=ModelConfig(
+                botorch_model_class=None,
+                model_options={},
+                mll_class=ExactMarginalLogLikelihood,
+                mll_options={},
+                input_transform_classes=None,
+                input_transform_options={},
+                outcome_transform_classes=None,
+                outcome_transform_options={},
+                covar_module_class=None,
+                covar_module_options={},
+                likelihood_class=None,
+                likelihood_options={},
+            ),
+            default_botorch_model_class=SingleTaskMultiFidelityGP,
             state_dict=None,
             refit=True,
         )
@@ -727,6 +742,8 @@ class BoTorchModelTest(TestCase):
             input_transform_options=None,
             outcome_transform_classes=None,
             outcome_transform_options=None,
+            model_configs=[],
+            metric_to_model_configs={},
             allow_batched_models=True,
         )
 
@@ -755,6 +772,8 @@ class BoTorchModelTest(TestCase):
             input_transform_options=None,
             outcome_transform_classes=None,
             outcome_transform_options=None,
+            model_configs=[],
+            metric_to_model_configs={},
             allow_batched_models=False,
         )
 

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -306,7 +306,7 @@ class BoTorchModelUtilsTest(TestCase):
                 botorch_model_class=SingleTaskGP,
             )
         )
-        self.assertTrue(
+        self.assertFalse(
             use_model_list(
                 datasets=self.supervised_datasets, botorch_model_class=MultiTaskGP
             )

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -46,6 +46,7 @@ from ax.modelbridge.transition_criterion import (
 )
 from ax.models.torch.botorch_modular.model import SurrogateSpec
 from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.models.torch.botorch_modular.utils import ModelConfig
 from ax.storage.json_store.decoders import (
     batch_trial_from_json,
     botorch_component_from_json,
@@ -229,7 +230,7 @@ def object_from_json(
                 decoder_registry=decoder_registry,
                 class_decoder_registry=class_decoder_registry,
             )
-        elif _class in (SurrogateSpec, Surrogate):
+        elif _class in (SurrogateSpec, Surrogate, ModelConfig):
             if "input_transform" in object_json:
                 (
                     input_transform_classes_json,

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -98,6 +98,7 @@ from ax.modelbridge.transition_criterion import (
 from ax.models.torch.botorch_modular.acquisition import Acquisition
 from ax.models.torch.botorch_modular.model import BoTorchModel, SurrogateSpec
 from ax.models.torch.botorch_modular.surrogate import Surrogate
+from ax.models.torch.botorch_modular.utils import ModelConfig
 from ax.models.winsorization_config import WinsorizationConfig
 from ax.runners.synthetic import SyntheticRunner
 from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
@@ -330,6 +331,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "AuxiliaryExperimentCheck": AuxiliaryExperimentCheck,
     "Models": Models,
     "ModelRegistryBase": ModelRegistryBase,
+    "ModelConfig": ModelConfig,
     "ModelSpec": ModelSpec,
     "MultiObjective": MultiObjective,
     "MultiObjectiveOptimizationConfig": MultiObjectiveOptimizationConfig,

--- a/tutorials/modular_botax.ipynb
+++ b/tutorials/modular_botax.ipynb
@@ -1,13 +1,43 @@
 {
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.5"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5,
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "about-preview",
       "metadata": {
-        "originalKey": "cca773d8-5e94-4b5a-ae54-22295be8936a"
+        "collapsed": false,
+        "executionStartTime": 1730904956474,
+        "executionStopTime": 1730904963470,
+        "id": "about-preview",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "cca773d8-5e94-4b5a-ae54-22295be8936a"
+        },
+        "originalKey": "b3373e27-c3fa-41de-bf4b-3adb0f0571e7",
+        "outputsInitialized": true,
+        "requestMsgId": "b3373e27-c3fa-41de-bf4b-3adb0f0571e7",
+        "serverExecutionDuration": 4351.2808320811
       },
-      "outputs": [],
       "source": [
         "from typing import Any, Dict, Optional, Tuple, Type\n",
         "\n",
@@ -39,13 +69,37 @@
         "# BoTorch components\n",
         "from botorch.models.model import Model\n",
         "from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "I1106 065557.352 _utils_internal.py:321] NCCL_DEBUG env var is set to None\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "I1106 065557.353 _utils_internal.py:339] NCCL_DEBUG is forced to WARN from None\n"
+          ]
+        }
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "northern-affairs",
       "metadata": {
-        "originalKey": "58ea5ebf-ff3a-40b4-8be3-1b85c99d1c4a"
+        "id": "northern-affairs",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "58ea5ebf-ff3a-40b4-8be3-1b85c99d1c4a"
+        },
+        "originalKey": "c9a665ca-497e-4d7c-bbb5-1b9f8d1d311c",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "# Setup and Usage of BoTorch Models in Ax\n",
@@ -70,9 +124,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "pending-support",
       "metadata": {
-        "originalKey": "c06d1b5c-067d-4618-977e-c8269a98bd0a"
+        "id": "pending-support",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "c06d1b5c-067d-4618-977e-c8269a98bd0a"
+        },
+        "originalKey": "4706d02e-6b3f-4161-9e08-f5a31328b1d1",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## 1. Quick-start example\n",
@@ -82,25 +143,53 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "parental-sending",
       "metadata": {
-        "originalKey": "72934cf2-4ecf-483a-93bd-4df88b19a7b8"
+        "collapsed": false,
+        "executionStartTime": 1730904958719,
+        "executionStopTime": 1730904963489,
+        "id": "parental-sending",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "72934cf2-4ecf-483a-93bd-4df88b19a7b8"
+        },
+        "originalKey": "146a9a1b-52e6-4d76-9fc5-79025b392673",
+        "outputsInitialized": true,
+        "requestMsgId": "146a9a1b-52e6-4d76-9fc5-79025b392673",
+        "serverExecutionDuration": 42.191333021037
       },
-      "outputs": [],
       "source": [
         "experiment = get_branin_experiment(with_trial=True)\n",
         "data = get_branin_data(trials=[experiment.trials[0]])"
+      ],
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 11-06 06:56:01] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+          ]
+        }
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "rough-somerset",
       "metadata": {
-        "originalKey": "e571212c-7872-4ebc-b646-8dad8d4266fd"
+        "collapsed": false,
+        "executionStartTime": 1730904959343,
+        "executionStopTime": 1730904964892,
+        "id": "rough-somerset",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "e571212c-7872-4ebc-b646-8dad8d4266fd"
+        },
+        "originalKey": "aa532754-01ad-4441-84c1-2ac7f54ecf1e",
+        "outputsInitialized": true,
+        "requestMsgId": "aa532754-01ad-4441-84c1-2ac7f54ecf1e",
+        "serverExecutionDuration": 870.78339292202
       },
-      "outputs": [],
       "source": [
         "# `Models` automatically selects a model + model bridge combination.\n",
         "# For `BOTORCH_MODULAR`, it will select `BoTorchModel` and `TorchModelBridge`.\n",
@@ -110,13 +199,30 @@
         "    surrogate=Surrogate(SingleTaskGP),  # Optional, will use default if unspecified\n",
         "    botorch_acqf_class=qLogNoisyExpectedImprovement,  # Optional, will use default if unspecified\n",
         ")"
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 11-06 06:56:01] ax.modelbridge.transforms.standardize_y: Outcome branin is constant, within tolerance.\n"
+          ]
+        }
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "hairy-wiring",
       "metadata": {
-        "originalKey": "fba91372-7aa6-456d-a22b-78ab30c26cd8"
+        "id": "hairy-wiring",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "fba91372-7aa6-456d-a22b-78ab30c26cd8"
+        },
+        "originalKey": "46f5c2c7-400d-4d8d-b0b9-a241657b173f",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "Now we can use this model to generate candidates (`gen`), predict outcome at a point (`predict`), or evaluate acquisition function value at a given point (`evaluate_acquisition_function`)."
@@ -124,22 +230,49 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "consecutive-summary",
       "metadata": {
-        "originalKey": "59582fc6-8089-4320-864e-d98ee271d4f7"
+        "collapsed": false,
+        "executionStartTime": 1730904961333,
+        "executionStopTime": 1730904964907,
+        "id": "consecutive-summary",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "59582fc6-8089-4320-864e-d98ee271d4f7"
+        },
+        "originalKey": "c0051dd9-bf05-42bc-b4c3-ae5b99eba696",
+        "outputsInitialized": true,
+        "requestMsgId": "c0051dd9-bf05-42bc-b4c3-ae5b99eba696",
+        "serverExecutionDuration": 284.31268292479
       },
-      "outputs": [],
       "source": [
         "generator_run = model_bridge_with_GPEI.gen(n=1)\n",
         "generator_run.arms[0]"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "Arm(parameters={'x1': -5.0, 'x2': 0.0})"
+          },
+          "metadata": {},
+          "execution_count": 4
+        }
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "diverse-richards",
       "metadata": {
-        "originalKey": "8cfe0fa9-8cce-4718-ba43-e8a63744d626"
+        "id": "diverse-richards",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "8cfe0fa9-8cce-4718-ba43-e8a63744d626"
+        },
+        "originalKey": "804bac30-db07-4444-98a2-7a5f05007495",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "-----\n",
@@ -151,9 +284,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "grand-committee",
       "metadata": {
-        "originalKey": "7037fd14-bcfe-44f9-b915-c23915d2bda9"
+        "id": "grand-committee",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "7037fd14-bcfe-44f9-b915-c23915d2bda9"
+        },
+        "originalKey": "31b54ce5-2590-4617-b10c-d24ed3cce51d",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## 2. BoTorchModel = Surrogate + Acquisition\n",
@@ -163,9 +303,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "thousand-blanket",
       "metadata": {
-        "originalKey": "08b12c6c-14da-4342-95bd-f607a131ce9d"
+        "id": "thousand-blanket",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "08b12c6c-14da-4342-95bd-f607a131ce9d"
+        },
+        "originalKey": "4a4e006e-07fa-4d63-8b9a-31b67075e40e",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "### 2A. Example that uses defaults and requires no options\n",
@@ -175,30 +322,52 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "changing-xerox",
       "metadata": {
-        "originalKey": "b1bca702-07b2-4818-b2b9-2107268c383c"
+        "collapsed": false,
+        "executionStartTime": 1730905022012,
+        "executionStopTime": 1730905022269,
+        "id": "changing-xerox",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "b1bca702-07b2-4818-b2b9-2107268c383c"
+        },
+        "originalKey": "509e30d7-dc32-4190-836f-f221cacbff31",
+        "outputsInitialized": true,
+        "requestMsgId": "509e30d7-dc32-4190-836f-f221cacbff31",
+        "serverExecutionDuration": 1.972567057237
       },
-      "outputs": [],
       "source": [
+        "from ax.models.torch.botorch_modular.utils import ModelConfig\n",
+        "\n",
         "# The surrogate is not specified, so it will be auto-selected\n",
         "# during `model.fit`.\n",
         "GPEI_model = BoTorchModel(botorch_acqf_class=qLogExpectedImprovement)\n",
         "\n",
         "# The acquisition class is not specified, so it will be\n",
         "# auto-selected during `model.gen` or `model.evaluate_acquisition`\n",
-        "GPEI_model = BoTorchModel(surrogate=Surrogate(SingleTaskGP))\n",
+        "GPEI_model = BoTorchModel(\n",
+        "    surrogate=Surrogate(model_configs=[ModelConfig(SingleTaskGP)])\n",
+        ")\n",
         "\n",
         "# Both the surrogate and acquisition class will be auto-selected.\n",
         "GPEI_model = BoTorchModel()"
-      ]
+      ],
+      "execution_count": 7,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
-      "id": "lovely-mechanics",
       "metadata": {
-        "originalKey": "5cec0f06-ae2c-47d3-bd95-441c45762e38"
+        "id": "lovely-mechanics",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "5cec0f06-ae2c-47d3-bd95-441c45762e38"
+        },
+        "originalKey": "7b9fae38-fe5d-4e5b-8b5f-2953c1ef09d2",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "### 2B. Example with all the options\n",
@@ -207,23 +376,36 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "twenty-greek",
       "metadata": {
-        "originalKey": "25b13c48-edb0-4b3f-ba34-4f4a4176162a"
+        "collapsed": false,
+        "executionStartTime": 1730905023369,
+        "executionStopTime": 1730905023622,
+        "id": "twenty-greek",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "25b13c48-edb0-4b3f-ba34-4f4a4176162a"
+        },
+        "originalKey": "a63a4a66-07c7-42b8-8c6b-fda19d9c7f03",
+        "outputsInitialized": true,
+        "requestMsgId": "a63a4a66-07c7-42b8-8c6b-fda19d9c7f03",
+        "serverExecutionDuration": 1.9794970285147
       },
-      "outputs": [],
       "source": [
         "model = BoTorchModel(\n",
         "    # Optional `Surrogate` specification to use instead of default\n",
         "    surrogate=Surrogate(\n",
-        "        # BoTorch `Model` type\n",
-        "        botorch_model_class=SingleTaskGP,\n",
-        "        # Optional, MLL class with which to optimize model parameters\n",
-        "        mll_class=ExactMarginalLogLikelihood,\n",
-        "        # Optional, dictionary of keyword arguments to underlying\n",
-        "        # BoTorch `Model` constructor\n",
-        "        model_options={},\n",
+        "        model_configs=[\n",
+        "            ModelConfig(\n",
+        "                # BoTorch `Model` type\n",
+        "                botorch_model_class=SingleTaskGP,\n",
+        "                # Optional, MLL class with which to optimize model parameters\n",
+        "                mll_class=ExactMarginalLogLikelihood,\n",
+        "                # Optional, dictionary of keyword arguments to underlying\n",
+        "                # BoTorch `Model` constructor\n",
+        "                model_options={},\n",
+        "            )\n",
+        "        ]\n",
         "    ),\n",
         "    # Optional BoTorch `AcquisitionFunction` to use instead of default\n",
         "    botorch_acqf_class=qLogExpectedImprovement,\n",
@@ -238,13 +420,22 @@
         "    refit_on_cv=False,\n",
         "    warm_start_refit=True,\n",
         ")"
-      ]
+      ],
+      "execution_count": 8,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
-      "id": "fourth-material",
       "metadata": {
-        "originalKey": "db0feafe-8af9-40a3-9f67-72c7d1fd808e"
+        "id": "fourth-material",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "db0feafe-8af9-40a3-9f67-72c7d1fd808e"
+        },
+        "originalKey": "7140bb19-09b4-4abe-951d-53902ae07833",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## 2C. `Surrogate` and `Acquisition` Q&A\n",
@@ -258,9 +449,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "violent-course",
       "metadata": {
-        "originalKey": "86018ee5-f7b8-41ae-8e2d-460fe5f0c15b"
+        "id": "violent-course",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "86018ee5-f7b8-41ae-8e2d-460fe5f0c15b"
+        },
+        "originalKey": "71f92895-874d-4fc7-ae87-a5519b18d1a0",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## 3. I know which Botorch `Model` and `AcquisitionFunction` I'd like to combine in Ax. How do set this up?"
@@ -268,11 +466,18 @@
     },
     {
       "cell_type": "markdown",
-      "id": "unlike-football",
       "metadata": {
-        "code_folding": [],
-        "hidden_ranges": [],
-        "originalKey": "b29a846d-d7bc-4143-8318-10170c9b4298",
+        "id": "unlike-football",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "code_folding": [],
+          "hidden_ranges": [],
+          "originalKey": "b29a846d-d7bc-4143-8318-10170c9b4298",
+          "showInput": false
+        },
+        "originalKey": "4af8afa2-5056-46be-b7b9-428127e668cc",
+        "outputsInitialized": false,
         "showInput": false
       },
       "source": [
@@ -286,16 +491,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "dynamic-university",
       "metadata": {
-        "code_folding": [],
-        "hidden_ranges": [],
-        "originalKey": "6c2ea955-c7a4-42ff-a4d7-f787113d4d53"
+        "collapsed": false,
+        "executionStartTime": 1730905050779,
+        "executionStopTime": 1730905051022,
+        "id": "dynamic-university",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "code_folding": [],
+          "hidden_ranges": [],
+          "originalKey": "6c2ea955-c7a4-42ff-a4d7-f787113d4d53"
+        },
+        "originalKey": "1830b3f5-fd8e-4151-97d9-8a2aaa6885f7",
+        "outputsInitialized": true,
+        "requestMsgId": "1830b3f5-fd8e-4151-97d9-8a2aaa6885f7",
+        "serverExecutionDuration": 2.5736939860508
       },
-      "outputs": [],
       "source": [
-        "from botorch.models.model import Model\n",
         "from botorch.utils.datasets import SupervisedDataset\n",
         "\n",
         "\n",
@@ -318,17 +531,30 @@
         "\n",
         "\n",
         "surrogate = Surrogate(\n",
-        "    botorch_model_class=MyModelClass,  # Must implement `construct_inputs`\n",
-        "    # Optional dict of additional keyword arguments to `MyModelClass`\n",
-        "    model_options={},\n",
+        "    model_configs=[\n",
+        "        ModelConfig(\n",
+        "            botorch_model_class=MyModelClass,  # Must implement `construct_inputs`\n",
+        "            # Optional dict of additional keyword arguments to `MyModelClass`\n",
+        "            model_options={},\n",
+        "        )\n",
+        "    ],\n",
         ")"
-      ]
+      ],
+      "execution_count": 9,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
-      "id": "otherwise-context",
       "metadata": {
-        "originalKey": "b9072296-956d-4add-b1f6-e7e0415ba65c"
+        "id": "otherwise-context",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "b9072296-956d-4add-b1f6-e7e0415ba65c"
+        },
+        "originalKey": "5a27fd2c-4c4c-41fe-a634-f6d0ec4f1666",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "NOTE: if you run into a case where base `Surrogate` does not work with your BoTorch `Model`, please let us know in this Github issue: https://github.com/facebook/Ax/issues/363, so we can find the right solution and augment this tutorial."
@@ -336,9 +562,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "northern-invite",
       "metadata": {
-        "originalKey": "335cabdf-2bf6-48e8-ba0c-1404a8ef47f9"
+        "id": "northern-invite",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "335cabdf-2bf6-48e8-ba0c-1404a8ef47f9"
+        },
+        "originalKey": "df06d02b-95cb-4d34-aac6-773231f1a129",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "### 3B. Using an arbitrary BoTorch `AcquisitionFunction` in Ax"
@@ -346,11 +579,18 @@
     },
     {
       "cell_type": "markdown",
-      "id": "surrounded-denial",
       "metadata": {
-        "code_folding": [],
-        "hidden_ranges": [],
-        "originalKey": "e3f0c788-2131-4116-9518-4ae7daeb991f",
+        "id": "surrounded-denial",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "code_folding": [],
+          "hidden_ranges": [],
+          "originalKey": "e3f0c788-2131-4116-9518-4ae7daeb991f",
+          "showInput": false
+        },
+        "originalKey": "d4861847-b757-4fcd-9f35-ba258080812c",
+        "outputsInitialized": false,
         "showInput": false
       },
       "source": [
@@ -363,14 +603,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "interested-search",
       "metadata": {
-        "code_folding": [],
-        "hidden_ranges": [],
-        "originalKey": "6967ce3e-929b-4d9a-8cd1-72bf94f0be3a"
+        "collapsed": false,
+        "executionStartTime": 1730905067704,
+        "executionStopTime": 1730905067939,
+        "id": "interested-search",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "code_folding": [],
+          "hidden_ranges": [],
+          "originalKey": "6967ce3e-929b-4d9a-8cd1-72bf94f0be3a"
+        },
+        "originalKey": "075243f0-c2d6-46fd-9a18-5b77af258abf",
+        "outputsInitialized": true,
+        "requestMsgId": "075243f0-c2d6-46fd-9a18-5b77af258abf",
+        "serverExecutionDuration": 5.0081580411643
       },
-      "outputs": [],
       "source": [
         "from botorch.acquisition.acquisition import AcquisitionFunction\n",
         "from botorch.acquisition.input_constructors import acqf_input_constructor, MaybeDict\n",
@@ -405,13 +654,31 @@
         "        \"optimizer_options\": {\"sequential\": False},\n",
         "    },\n",
         ")"
+      ],
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "BoTorchModel"
+          },
+          "metadata": {},
+          "execution_count": 10
+        }
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "metallic-imaging",
       "metadata": {
-        "originalKey": "29256ab1-f214-4604-a423-4c7b4b36baa0"
+        "id": "metallic-imaging",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "29256ab1-f214-4604-a423-4c7b4b36baa0"
+        },
+        "originalKey": "b057722d-b8ca-47dd-b2c8-1ff4a71c4863",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "See section 2A for combining the resulting `Surrogate` instance and `Acquisition` type into a `BoTorchModel`. You can also leverage `Models.BOTORCH_MODULAR` for ease of use; more on it in section 4 below or in section 1 quick-start example."
@@ -419,9 +686,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "descending-australian",
       "metadata": {
-        "originalKey": "1d15082f-1df7-4cdb-958b-300483eb7808"
+        "id": "descending-australian",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "1d15082f-1df7-4cdb-958b-300483eb7808"
+        },
+        "originalKey": "a7406f13-1468-487d-ac5e-7d2a45394850",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## 4. Using `Models.BOTORCH_MODULAR` \n",
@@ -433,49 +707,123 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "attached-border",
       "metadata": {
-        "originalKey": "385b2f30-fd86-4d88-8784-f238ea8a6abb"
+        "collapsed": false,
+        "executionStartTime": 1730905070804,
+        "executionStopTime": 1730905071313,
+        "id": "attached-border",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "385b2f30-fd86-4d88-8784-f238ea8a6abb"
+        },
+        "originalKey": "980d8513-8607-4099-8cfe-7c8d7bf5afe9",
+        "outputsInitialized": true,
+        "requestMsgId": "980d8513-8607-4099-8cfe-7c8d7bf5afe9",
+        "serverExecutionDuration": 262.54303695168
       },
-      "outputs": [],
       "source": [
         "model_bridge_with_GPEI = Models.BOTORCH_MODULAR(\n",
         "    experiment=experiment,\n",
         "    data=data,\n",
         ")\n",
         "model_bridge_with_GPEI.gen(1)"
+      ],
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 11-06 06:57:51] ax.modelbridge.transforms.standardize_y: Outcome branin is constant, within tolerance.\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GeneratorRun(1 arms, total weight 1.0)"
+          },
+          "metadata": {},
+          "execution_count": 11
+        }
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "powerful-gamma",
       "metadata": {
-        "originalKey": "89930a31-e058-434b-b587-181931e247b6"
+        "collapsed": false,
+        "executionStartTime": 1730905071744,
+        "executionStopTime": 1730905071981,
+        "id": "powerful-gamma",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "89930a31-e058-434b-b587-181931e247b6"
+        },
+        "originalKey": "6ec047f0-a75e-4733-b4d7-20045627f0b2",
+        "outputsInitialized": true,
+        "requestMsgId": "6ec047f0-a75e-4733-b4d7-20045627f0b2",
+        "serverExecutionDuration": 2.8772989753634
       },
-      "outputs": [],
       "source": [
         "model_bridge_with_GPEI.model.botorch_acqf_class"
+      ],
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "botorch.acquisition.logei.qLogNoisyExpectedImprovement"
+          },
+          "metadata": {},
+          "execution_count": 12
+        }
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "improved-replication",
       "metadata": {
-        "originalKey": "f9a9cb14-20c3-4e1d-93a3-6a35c281ae01"
+        "collapsed": false,
+        "executionStartTime": 1730905076319,
+        "executionStopTime": 1730905076580,
+        "id": "improved-replication",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "f9a9cb14-20c3-4e1d-93a3-6a35c281ae01"
+        },
+        "originalKey": "68caa729-792d-4692-bc4d-4c0b8d03e022",
+        "outputsInitialized": true,
+        "requestMsgId": "68caa729-792d-4692-bc4d-4c0b8d03e022",
+        "serverExecutionDuration": 3.2039729412645
       },
-      "outputs": [],
       "source": [
-        "model_bridge_with_GPEI.model.surrogate.botorch_model_class"
+        "type(model_bridge_with_GPEI.model.surrogate.model)"
+      ],
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "botorch.models.gp_regression.SingleTaskGP"
+          },
+          "metadata": {},
+          "execution_count": 13
+        }
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "connected-sheet",
       "metadata": {
-        "originalKey": "8b6a9ddc-d2d2-4cd5-a6a8-820113f78262"
+        "id": "connected-sheet",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "8b6a9ddc-d2d2-4cd5-a6a8-820113f78262"
+        },
+        "originalKey": "f5c0adbd-00a6-428d-810f-1e7ed0954b08",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "We can use the same `Models.BOTORCH_MODULAR` to set up a model for multi-objective optimization:"
@@ -483,12 +831,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "documentary-jurisdiction",
       "metadata": {
-        "originalKey": "8001de33-d9d9-4888-a5d1-7a59ebeccfd5"
+        "collapsed": false,
+        "executionStartTime": 1730905078786,
+        "executionStopTime": 1730905079551,
+        "id": "documentary-jurisdiction",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "8001de33-d9d9-4888-a5d1-7a59ebeccfd5"
+        },
+        "originalKey": "8ab2462c-c927-4a7c-95cb-c281b9b7f1be",
+        "outputsInitialized": true,
+        "requestMsgId": "8ab2462c-c927-4a7c-95cb-c281b9b7f1be",
+        "serverExecutionDuration": 512.32317101676
       },
-      "outputs": [],
       "source": [
         "model_bridge_with_EHVI = Models.BOTORCH_MODULAR(\n",
         "    experiment=get_branin_experiment_with_multi_objective(\n",
@@ -497,37 +854,116 @@
         "    data=get_branin_data_multi_objective(),\n",
         ")\n",
         "model_bridge_with_EHVI.gen(1)"
+      ],
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 11-06 06:57:59] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 11-06 06:57:59] ax.modelbridge.transforms.standardize_y: Outcome branin_a is constant, within tolerance.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 11-06 06:57:59] ax.modelbridge.transforms.standardize_y: Outcome branin_b is constant, within tolerance.\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "GeneratorRun(1 arms, total weight 1.0)"
+          },
+          "metadata": {},
+          "execution_count": 14
+        }
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "changed-maintenance",
       "metadata": {
-        "originalKey": "dcfdbecc-4a9a-49ac-ad55-0bc04b2ec566"
+        "collapsed": false,
+        "executionStartTime": 1730905079324,
+        "executionStopTime": 1730905079651,
+        "id": "changed-maintenance",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "dcfdbecc-4a9a-49ac-ad55-0bc04b2ec566"
+        },
+        "originalKey": "87247bf1-04f2-4a8a-92f6-18174d70cbb7",
+        "outputsInitialized": true,
+        "requestMsgId": "87247bf1-04f2-4a8a-92f6-18174d70cbb7",
+        "serverExecutionDuration": 3.0141109600663
       },
-      "outputs": [],
       "source": [
         "model_bridge_with_EHVI.model.botorch_acqf_class"
+      ],
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "botorch.acquisition.multi_objective.logei.qLogNoisyExpectedHypervolumeImprovement"
+          },
+          "metadata": {},
+          "execution_count": 15
+        }
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "operating-shelf",
       "metadata": {
-        "originalKey": "16727a51-337d-4715-bf51-9cb6637a950f"
+        "collapsed": false,
+        "executionStartTime": 1730905087115,
+        "executionStopTime": 1730905087362,
+        "id": "operating-shelf",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "16727a51-337d-4715-bf51-9cb6637a950f"
+        },
+        "originalKey": "22fefbbf-68a9-4d5d-ade9-9df425995c3b",
+        "outputsInitialized": true,
+        "requestMsgId": "22fefbbf-68a9-4d5d-ade9-9df425995c3b",
+        "serverExecutionDuration": 3.2659249845892
       },
-      "outputs": [],
       "source": [
-        "model_bridge_with_EHVI.model.surrogate.botorch_model_class"
+        "type(model_bridge_with_EHVI.model.surrogate.model)"
+      ],
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "botorch.models.gp_regression.SingleTaskGP"
+          },
+          "metadata": {},
+          "execution_count": 16
+        }
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "fatal-butterfly",
       "metadata": {
-        "originalKey": "5c64eecc-5ce5-4907-bbcc-5b3cbf4358ae"
+        "id": "fatal-butterfly",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "5c64eecc-5ce5-4907-bbcc-5b3cbf4358ae"
+        },
+        "originalKey": "3ad7c4a7-fe19-44ad-938d-1be4f8b09bfb",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "Furthermore, the quick-start example at the top of this tutorial shows how to specify surrogate and acquisition subcomponents to `Models.BOTORCH_MODULAR`. "
@@ -535,9 +971,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "hearing-interface",
       "metadata": {
-        "originalKey": "a0163432-f0ca-4582-ad84-16c77c99f20b"
+        "id": "hearing-interface",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "a0163432-f0ca-4582-ad84-16c77c99f20b"
+        },
+        "originalKey": "44adf1ce-6d3e-455d-b53c-32d3c42a843f",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## 5. Utilizing `BoTorchModel` in generation strategies\n",
@@ -549,12 +992,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "received-registration",
       "metadata": {
-        "originalKey": "f7eabbcf-607c-4bed-9a0e-6ac6e8b04350"
+        "collapsed": false,
+        "executionStartTime": 1730905104120,
+        "executionStopTime": 1730905104377,
+        "id": "received-registration",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "f7eabbcf-607c-4bed-9a0e-6ac6e8b04350"
+        },
+        "originalKey": "d0303c24-98bb-4c89-87cb-fa32ff498bd4",
+        "outputsInitialized": true,
+        "requestMsgId": "d0303c24-98bb-4c89-87cb-fa32ff498bd4",
+        "serverExecutionDuration": 2.4519630242139
       },
-      "outputs": [],
       "source": [
         "from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy\n",
         "from ax.modelbridge.modelbridge_utils import get_pending_observation_features\n",
@@ -576,19 +1028,30 @@
         "            # No limit on how many generator runs will be produced\n",
         "            num_trials=-1,\n",
         "            model_kwargs={  # Kwargs to pass to `BoTorchModel.__init__`\n",
-        "                \"surrogate\": Surrogate(SingleTaskGP),\n",
+        "                \"surrogate\": Surrogate(\n",
+        "                    model_configs=[ModelConfig(botorch_model_class=SingleTaskGP)]\n",
+        "                ),\n",
         "                \"botorch_acqf_class\": qLogNoisyExpectedImprovement,\n",
         "            },\n",
         "        ),\n",
         "    ]\n",
         ")"
-      ]
+      ],
+      "execution_count": 17,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
-      "id": "logical-windsor",
       "metadata": {
-        "originalKey": "212c4543-220e-4605-8f72-5f86cf52f722"
+        "id": "logical-windsor",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "212c4543-220e-4605-8f72-5f86cf52f722"
+        },
+        "originalKey": "ba3783ee-3d88-4e44-ad07-77de3c50f84d",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "Set up an experiment and generate 10 trials in it, adding synthetic data to experiment after each one:"
@@ -596,24 +1059,58 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "viral-cheese",
       "metadata": {
-        "originalKey": "30cfcdd7-721d-4f89-b851-7a94140dfad6"
+        "collapsed": false,
+        "executionStartTime": 1730905105295,
+        "executionStopTime": 1730905105570,
+        "id": "viral-cheese",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "30cfcdd7-721d-4f89-b851-7a94140dfad6"
+        },
+        "originalKey": "e8aa4013-eb6f-4f50-a5f0-f963369495ed",
+        "outputsInitialized": true,
+        "requestMsgId": "e8aa4013-eb6f-4f50-a5f0-f963369495ed",
+        "serverExecutionDuration": 4.1721769375727
       },
-      "outputs": [],
       "source": [
         "experiment = get_branin_experiment(minimize=True)\n",
         "\n",
         "assert len(experiment.trials) == 0\n",
         "experiment.search_space"
+      ],
+      "execution_count": 18,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 11-06 06:58:25] ax.core.experiment: The is_test flag has been set to True. This flag is meant purely for development and integration testing purposes. If you are running a live experiment, please set this flag to False\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "SearchSpace(parameters=[RangeParameter(name='x1', parameter_type=FLOAT, range=[-5.0, 10.0]), RangeParameter(name='x2', parameter_type=FLOAT, range=[0.0, 15.0])], parameter_constraints=[])"
+          },
+          "metadata": {},
+          "execution_count": 18
+        }
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "incident-newspaper",
       "metadata": {
-        "originalKey": "2807d7ce-8a6b-423c-b5f5-32edba09c78e"
+        "id": "incident-newspaper",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "2807d7ce-8a6b-423c-b5f5-32edba09c78e"
+        },
+        "originalKey": "df2e90f5-4132-4d87-989b-e6d47c748ddc",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## 5a. Specifying `pending_observations`\n",
@@ -624,12 +1121,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "casual-spread",
       "metadata": {
-        "originalKey": "58aafd65-a366-4b66-a1b1-31b207037a2e"
+        "collapsed": false,
+        "executionStartTime": 1730905107391,
+        "executionStopTime": 1730905109351,
+        "id": "casual-spread",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "58aafd65-a366-4b66-a1b1-31b207037a2e"
+        },
+        "originalKey": "36ca75ec-b37c-498c-a487-5652cd3dc34b",
+        "outputsInitialized": true,
+        "requestMsgId": "36ca75ec-b37c-498c-a487-5652cd3dc34b",
+        "serverExecutionDuration": 1696.8911510194
       },
-      "outputs": [],
       "source": [
         "for _ in range(10):\n",
         "    # Produce a new generator run and attach it to experiment as a trial\n",
@@ -648,13 +1154,58 @@
         "    trial.mark_completed()\n",
         "\n",
         "    print(f\"Completed trial #{trial.index}, suggested by {generator_run._model_key}.\")"
+      ],
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Completed trial #0, suggested by Sobol.\nCompleted trial #1, suggested by Sobol.\nCompleted trial #2, suggested by Sobol.\nCompleted trial #3, suggested by Sobol.\nCompleted trial #4, suggested by Sobol.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Completed trial #5, suggested by BoTorch.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Completed trial #6, suggested by BoTorch.\nCompleted trial #7, suggested by BoTorch.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Completed trial #8, suggested by BoTorch.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Completed trial #9, suggested by BoTorch.\n"
+          ]
+        }
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "circular-vermont",
       "metadata": {
-        "originalKey": "9d3b86bf-b691-4315-8b8f-60504b37818c"
+        "id": "circular-vermont",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "9d3b86bf-b691-4315-8b8f-60504b37818c"
+        },
+        "originalKey": "6a78ef13-fbaa-4cae-934b-d57f5807fe25",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "Now we examine the experiment and observe the trials that were added to it and produced by the generation strategy:"
@@ -662,21 +1213,200 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "significant-particular",
       "metadata": {
-        "originalKey": "ca12913d-e3fd-4617-a247-e3432665bac1"
+        "collapsed": false,
+        "executionStartTime": 1730905108832,
+        "executionStopTime": 1730905109399,
+        "id": "significant-particular",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "ca12913d-e3fd-4617-a247-e3432665bac1"
+        },
+        "originalKey": "68d567be-27d6-4244-b22f-d6c53ed2d303",
+        "outputsInitialized": true,
+        "requestMsgId": "68d567be-27d6-4244-b22f-d6c53ed2d303",
+        "serverExecutionDuration": 32.219067099504
       },
-      "outputs": [],
       "source": [
         "exp_to_df(experiment)"
+      ],
+      "execution_count": 20,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[WARNING 11-06 06:58:29] ax.service.utils.report_utils: Column reason missing for all trials. Not appending column.\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "   trial_index arm_name trial_status  ...     branin         x1         x2\n0            0      0_0    COMPLETED  ...  79.581199   1.380743  12.280850\n1            1      1_0    COMPLETED  ...  17.366840   6.989676   1.438049\n2            2      2_0    COMPLETED  ...  61.299075   6.097525   7.568626\n3            3      3_0    COMPLETED  ...  71.268812  -3.293570   4.231312\n4            4      4_0    COMPLETED  ...   3.831238  -2.268755  10.230113\n5            5      5_0    COMPLETED  ...   4.246417  -3.354258  10.886093\n6            6      6_0    COMPLETED  ...   6.712767   9.467421   0.000000\n7            7      7_0    COMPLETED  ...  17.508300  -5.000000  15.000000\n8            8      8_0    COMPLETED  ...   2.507635  10.000000   2.251628\n9            9      9_0    COMPLETED  ...   1.318731   8.983844   2.177537\n\n[10 rows x 7 columns]",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>trial_index</th>\n      <th>arm_name</th>\n      <th>trial_status</th>\n      <th>generation_method</th>\n      <th>branin</th>\n      <th>x1</th>\n      <th>x2</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>0</td>\n      <td>0_0</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n      <td>79.581199</td>\n      <td>1.380743</td>\n      <td>12.280850</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>1</td>\n      <td>1_0</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n      <td>17.366840</td>\n      <td>6.989676</td>\n      <td>1.438049</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2</td>\n      <td>2_0</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n      <td>61.299075</td>\n      <td>6.097525</td>\n      <td>7.568626</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3</td>\n      <td>3_0</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n      <td>71.268812</td>\n      <td>-3.293570</td>\n      <td>4.231312</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>4</td>\n      <td>4_0</td>\n      <td>COMPLETED</td>\n      <td>Sobol</td>\n      <td>3.831238</td>\n      <td>-2.268755</td>\n      <td>10.230113</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>5</td>\n      <td>5_0</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n      <td>4.246417</td>\n      <td>-3.354258</td>\n      <td>10.886093</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>6</td>\n      <td>6_0</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n      <td>6.712767</td>\n      <td>9.467421</td>\n      <td>0.000000</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>7</td>\n      <td>7_0</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n      <td>17.508300</td>\n      <td>-5.000000</td>\n      <td>15.000000</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>8</td>\n      <td>8_0</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n      <td>2.507635</td>\n      <td>10.000000</td>\n      <td>2.251628</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>9</td>\n      <td>9_0</td>\n      <td>COMPLETED</td>\n      <td>BoTorch</td>\n      <td>1.318731</td>\n      <td>8.983844</td>\n      <td>2.177537</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+            "application/vnd.dataresource+json": {
+              "schema": {
+                "fields": [
+                  {
+                    "name": "index",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "trial_index",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "arm_name",
+                    "type": "string"
+                  },
+                  {
+                    "name": "trial_status",
+                    "type": "string"
+                  },
+                  {
+                    "name": "generation_method",
+                    "type": "string"
+                  },
+                  {
+                    "name": "branin",
+                    "type": "number"
+                  },
+                  {
+                    "name": "x1",
+                    "type": "number"
+                  },
+                  {
+                    "name": "x2",
+                    "type": "number"
+                  }
+                ],
+                "primaryKey": [
+                  "index"
+                ],
+                "pandas_version": "1.4.0"
+              },
+              "data": [
+                {
+                  "index": 0,
+                  "trial_index": 0,
+                  "arm_name": "0_0",
+                  "trial_status": "COMPLETED",
+                  "generation_method": "Sobol",
+                  "branin": 79.5811993025,
+                  "x1": 1.3807432353,
+                  "x2": 12.2808498144
+                },
+                {
+                  "index": 1,
+                  "trial_index": 1,
+                  "arm_name": "1_0",
+                  "trial_status": "COMPLETED",
+                  "generation_method": "Sobol",
+                  "branin": 17.3668397479,
+                  "x1": 6.9896756578,
+                  "x2": 1.4380489429
+                },
+                {
+                  "index": 2,
+                  "trial_index": 2,
+                  "arm_name": "2_0",
+                  "trial_status": "COMPLETED",
+                  "generation_method": "Sobol",
+                  "branin": 61.2990749448,
+                  "x1": 6.097525456,
+                  "x2": 7.5686264969
+                },
+                {
+                  "index": 3,
+                  "trial_index": 3,
+                  "arm_name": "3_0",
+                  "trial_status": "COMPLETED",
+                  "generation_method": "Sobol",
+                  "branin": 71.268812081,
+                  "x1": -3.2935703546,
+                  "x2": 4.231311623
+                },
+                {
+                  "index": 4,
+                  "trial_index": 4,
+                  "arm_name": "4_0",
+                  "trial_status": "COMPLETED",
+                  "generation_method": "Sobol",
+                  "branin": 3.8312383283,
+                  "x1": -2.2687551333,
+                  "x2": 10.2301133936
+                },
+                {
+                  "index": 5,
+                  "trial_index": 5,
+                  "arm_name": "5_0",
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch",
+                  "branin": 4.2464169491,
+                  "x1": -3.3542581623,
+                  "x2": 10.8860926765
+                },
+                {
+                  "index": 6,
+                  "trial_index": 6,
+                  "arm_name": "6_0",
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch",
+                  "branin": 6.7127667696,
+                  "x1": 9.4674207228,
+                  "x2": 0
+                },
+                {
+                  "index": 7,
+                  "trial_index": 7,
+                  "arm_name": "7_0",
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch",
+                  "branin": 17.5082995158,
+                  "x1": -5,
+                  "x2": 15
+                },
+                {
+                  "index": 8,
+                  "trial_index": 8,
+                  "arm_name": "8_0",
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch",
+                  "branin": 2.5076350936,
+                  "x1": 10,
+                  "x2": 2.2516281613
+                },
+                {
+                  "index": 9,
+                  "trial_index": 9,
+                  "arm_name": "9_0",
+                  "trial_status": "COMPLETED",
+                  "generation_method": "BoTorch",
+                  "branin": 1.3187305399,
+                  "x1": 8.983844442,
+                  "x2": 2.1775366828
+                }
+              ]
+            }
+          },
+          "metadata": {},
+          "execution_count": 20
+        }
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "obvious-transparency",
       "metadata": {
-        "originalKey": "c25da720-6d3d-4f16-b878-24f2d2755783"
+        "id": "obvious-transparency",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "c25da720-6d3d-4f16-b878-24f2d2755783"
+        },
+        "originalKey": "633c66af-a89f-4f03-a88b-866767d0a52f",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## 6. Customizing a `Surrogate` or `Acquisition`\n",
@@ -688,12 +1418,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "organizational-balance",
       "metadata": {
-        "originalKey": "e7f8e413-f01e-4f9d-82c1-4912097637af"
+        "collapsed": false,
+        "executionStartTime": 1730905111356,
+        "executionStopTime": 1730905111601,
+        "id": "organizational-balance",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "e7f8e413-f01e-4f9d-82c1-4912097637af"
+        },
+        "originalKey": "8fb45ee5-b75f-459e-afd2-5f7e7c7d4693",
+        "outputsInitialized": true,
+        "requestMsgId": "8fb45ee5-b75f-459e-afd2-5f7e7c7d4693",
+        "serverExecutionDuration": 2.4916339898482
       },
-      "outputs": [],
       "source": [
         "from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform\n",
         "from botorch.acquisition.risk_measures import RiskMeasureMCObjective\n",
@@ -711,13 +1450,22 @@
         "        risk_measure: Optional[RiskMeasureMCObjective] = None,\n",
         "    ) -> Tuple[Optional[MCAcquisitionObjective], Optional[PosteriorTransform]]:\n",
         "        ...  # Produce the desired `MCAcquisitionObjective` and `PosteriorTransform` instead of the default"
-      ]
+      ],
+      "execution_count": 21,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
-      "id": "theoretical-horizon",
       "metadata": {
-        "originalKey": "7299f0fc-e19e-4383-99de-ef7a9a987fe9"
+        "id": "theoretical-horizon",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "7299f0fc-e19e-4383-99de-ef7a9a987fe9"
+        },
+        "originalKey": "0ec8606d-9d5b-4bcb-ad7e-f54839ad6f9b",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "Then to use the new subclass in `BoTorchModel`, just specify `acquisition_class` argument along with `botorch_acqf_class` (to `BoTorchModel` directly or to `Models.BOTORCH_MODULAR`, which just passes the relevant arguments to `BoTorchModel` under the hood, as discussed in section 4):"
@@ -725,12 +1473,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "approximate-rolling",
       "metadata": {
-        "originalKey": "07fe169a-78de-437e-9857-7c99cc48eedc"
+        "collapsed": false,
+        "executionStartTime": 1730905113131,
+        "executionStopTime": 1730905113387,
+        "id": "approximate-rolling",
+        "isAgentGenerated": false,
+        "language": "python",
+        "metadata": {
+          "originalKey": "07fe169a-78de-437e-9857-7c99cc48eedc"
+        },
+        "originalKey": "d2cbf675-77f6-4bbe-9eb6-42a6834ccaab",
+        "outputsInitialized": true,
+        "requestMsgId": "d2cbf675-77f6-4bbe-9eb6-42a6834ccaab",
+        "serverExecutionDuration": 12.22031598445
       },
-      "outputs": [],
       "source": [
         "Models.BOTORCH_MODULAR(\n",
         "    experiment=experiment,\n",
@@ -738,13 +1495,38 @@
         "    acquisition_class=CustomObjectiveAcquisition,\n",
         "    botorch_acqf_class=MyAcquisitionFunctionClass,\n",
         ")"
+      ],
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[INFO 11-06 06:58:33] ax.modelbridge.transforms.standardize_y: Outcome branin is constant, within tolerance.\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": "TorchModelBridge(model=BoTorchModel)"
+          },
+          "metadata": {},
+          "execution_count": 22
+        }
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "representative-implement",
       "metadata": {
-        "originalKey": "608d5f0d-4528-4aa6-869d-db38fcbfb256"
+        "id": "representative-implement",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "608d5f0d-4528-4aa6-869d-db38fcbfb256"
+        },
+        "originalKey": "cdcfb2bc-3016-4681-9fff-407f28321c3f",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "To use a custom `Surrogate` subclass, pass the `surrogate` argument of that type:\n",
@@ -759,9 +1541,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "framed-intermediate",
       "metadata": {
-        "originalKey": "64f1289e-73c7-4cc5-96ee-5091286a8361"
+        "id": "framed-intermediate",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "64f1289e-73c7-4cc5-96ee-5091286a8361"
+        },
+        "originalKey": "ff03d674-f584-403f-ba65-f1bab921845b",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "------"
@@ -769,9 +1558,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "metropolitan-feedback",
       "metadata": {
-        "originalKey": "d1e37569-dd0d-4561-b890-2f0097a345e0"
+        "id": "metropolitan-feedback",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "d1e37569-dd0d-4561-b890-2f0097a345e0"
+        },
+        "originalKey": "f71fcfa1-fc59-4bfb-84d6-b94ea5298bfa",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## Appendix 1: Methods available on `BoTorchModel`\n",
@@ -787,14 +1583,22 @@
         "* `update` updates surrogate model with training data and optionally reoptimizes model parameters via `Surrogate.update`,\n",
         "* `cross_validate` re-fits the surrogate model to subset of training data and makes predictions for test data,\n",
         "* `evaluate_acquisition_function` instantiates an acquisition function and evaluates it for a given point.\n",
-        "------\n"
+        "------\n",
+        ""
       ]
     },
     {
       "cell_type": "markdown",
-      "id": "possible-transsexual",
       "metadata": {
-        "originalKey": "b02f928c-57d9-4b2a-b4fe-c6d28d368b12"
+        "id": "possible-transsexual",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "b02f928c-57d9-4b2a-b4fe-c6d28d368b12"
+        },
+        "originalKey": "91cedde4-8911-441f-af05-eb124581cbbc",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## Appendix 2: Default surrogate models and acquisition functions\n",
@@ -812,9 +1616,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "continuous-strain",
       "metadata": {
-        "originalKey": "76ae9852-9d21-43d6-bf75-bb087a474dd6"
+        "id": "continuous-strain",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "76ae9852-9d21-43d6-bf75-bb087a474dd6"
+        },
+        "originalKey": "c8b0f933-8df6-479b-aa61-db75ca877624",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "## Appendix 3: Handling storage errors that arise from objects that don't have serialization logic in A\n",
@@ -824,9 +1635,16 @@
     },
     {
       "cell_type": "markdown",
-      "id": "broadband-voice",
       "metadata": {
-        "originalKey": "6487b68e-b808-4372-b6ba-ab02ce4826bc"
+        "id": "broadband-voice",
+        "isAgentGenerated": false,
+        "language": "markdown",
+        "metadata": {
+          "originalKey": "6487b68e-b808-4372-b6ba-ab02ce4826bc"
+        },
+        "originalKey": "4d82f49a-3a8b-42f0-a4f5-5c079b793344",
+        "outputsInitialized": false,
+        "showInput": false
       },
       "source": [
         "The two options for handling this error are:\n",
@@ -834,26 +1652,5 @@
         "2. specifying serialization logic for a given object that needs to occur among the `Model` or `AcquisitionFunction` options. Tutorial for this is in the works, but in the meantime you can [post an issue on the Ax GitHub](https://github.com/facebook/Ax/issues) to get help with this."
       ]
     }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.5"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  ]
 }


### PR DESCRIPTION
Summary:
Enables using different models for different metrics.

* Adds ModelConfig dataclass to specify a single botorch model configuration
* Adds a list of ModelConfigs to SurrogateSpec
* Adds a dictionary mapping metric names to list of ModelConfigs to enable per-metric model specification
* Lists of model configs are used to enable per-metric model selection across multiple ModelConfigs in a subsequent diff.

Reviewed By: saitcakmak

Differential Revision: D64793595
