### PR TITLE
Simulated benchmark runner

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -117,7 +117,7 @@ def benchmark_replication(
 
     is_mf_or_mt = len(problem.target_fidelity_and_task) > 0
     # Run the optimization loop.
-    timeout_hours = scheduler.options.timeout_hours
+    timeout_hours = method.timeout_hours
     remaining_hours = timeout_hours
     with with_rng_seed(seed=seed):
         start = monotonic()

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -21,38 +21,67 @@ from ax.utils.common.base import Base
 from pyre_extensions import none_throws
 
 
-@dataclass(frozen=True)
+@dataclass(kw_only=True)
 class BenchmarkMethod(Base):
     """Benchmark method, represented in terms of Ax generation strategy (which tells us
     which models to use when) and scheduler options (which tell us extra execution
     information like maximum parallelism, early stopping configuration, etc.).
 
-    Note: If `BenchmarkMethod.scheduler_options.total_trials` is less than
-    `BenchmarkProblem.num_trials` then only the number of trials specified in the
-    former will be run.
-
     Args:
         name: String description.
         generation_strategy: The `GenerationStrategy` to use.
-        scheduler_options: `SchedulerOptions` that specify options such as
-            `max_pending_trials`, `timeout_hours`, and `batch_size`. Can be
-            generated with sensible defaults for benchmarking with
-            `get_benchmark_scheduler_options`.
+        timeout_hours: Number of hours after which to stop a benchmark
+            replication.
         distribute_replications: Indicates whether the replications should be
             run in a distributed manner. Ax itself does not use this attribute.
-        use_model_predictions_for_best_point: Whether to use model predictions
-            with `get_pareto_optimal_parameters` (if multi-objective) or
-            `BestPointMixin._get_best_trial` (if single-objective). However,
-            note that if multi-objective, best-point selection is not currently
-            supported and `get_pareto_optimal_parameters` will raise a
-            `NotImplementedError`.
+        use_model_predictions_for_best_point: Whether to use model
+            predictions with ``get_pareto_optimal_parameters`` (if
+            multi-objective) or `BestPointMixin._get_best_trial` (if
+            single-objective). However, note that if multi-objective,
+            best-point selection is not currently supported and
+            ``get_pareto_optimal_parameters`` will raise a
+            ``NotImplementedError``.
+        batch_size: Number of arms per trial. If greater than 1, trials are
+            ``BatchTrial``s; otherwise, they are ``Trial``s. Defaults to 1. This
+            and the following arguments are passed to ``SchedulerOptions``.
+        run_trials_in_batches: Passed to ``SchedulerOptions``.
+
+    Attributes:
+        scheduler_options: ``SchedulerOptions`` that depend on the
+            ``batch_size`` of the method. No ``timeout_hours`` can be passed to
+            these ``SchedulerOptions``, because ``timeout_hours`` here means the
+            total amount of time to run a benchmark replication and not the time
+            per call to ``Scheduler.run_n_trials``.
     """
 
-    name: str
+    name: str = "DEFAULT"
     generation_strategy: GenerationStrategy
-    scheduler_options: SchedulerOptions
+    batch_size: int = 1
+    timeout_hours: float = 4.0
     distribute_replications: bool = False
     use_model_predictions_for_best_point: bool = False
+    run_trials_in_batches: bool = False
+
+    def __post_init__(self) -> None:
+        if self.name == "DEFAULT":
+            self.name = self.generation_strategy.name
+
+    @property
+    def scheduler_options(self) -> SchedulerOptions:
+        return SchedulerOptions(
+            # No new candidates can be generated while any are pending.
+            # If batched, an entire batch must finish before the next can be
+            # generated.
+            max_pending_trials=1,
+            # Do not throttle, as is often necessary when polling real endpoints
+            init_seconds_between_polls=0,
+            min_seconds_before_poll=0,
+            trial_type=TrialType.TRIAL
+            if self.batch_size == 1
+            else TrialType.BATCH_TRIAL,
+            batch_size=self.batch_size,
+            run_trials_in_batches=self.run_trials_in_batches,
+        )
 
     def get_best_parameters(
         self,
@@ -107,33 +136,3 @@ class BenchmarkMethod(Base):
 
         i, params, prediction = none_throws(result)
         return [params]
-
-
-def get_benchmark_scheduler_options(
-    timeout_hours: int = 4,
-    batch_size: int = 1,
-) -> SchedulerOptions:
-    """The typical SchedulerOptions used in benchmarking.
-
-    Currently, regardless of batch size, all pending trials must complete before
-    new ones are generated. That is, when batch_size > 1, the design is "batch
-    sequential", and when batch_size = 1, the design is "fully sequential."
-
-    Args:
-        timeout_hours: The maximum amount of time (in hours) to run each
-            benchmark replication. Defaults to 4 hours.
-        batch_size: Number of trials to generate at once.
-    """
-
-    return SchedulerOptions(
-        # No new candidates can be generated while any are pending.
-        # If batched, an entire batch must finish before the next can be
-        # generated.
-        max_pending_trials=1,
-        # Do not throttle, as is often necessary when polling real endpoints
-        init_seconds_between_polls=0,
-        min_seconds_before_poll=0,
-        timeout_hours=timeout_hours,
-        trial_type=TrialType.TRIAL if batch_size == 1 else TrialType.BATCH_TRIAL,
-        batch_size=batch_size,
-    )

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -45,6 +45,7 @@ class BenchmarkMethod(Base):
             ``BatchTrial``s; otherwise, they are ``Trial``s. Defaults to 1. This
             and the following arguments are passed to ``SchedulerOptions``.
         run_trials_in_batches: Passed to ``SchedulerOptions``.
+        max_pending_trials: Passed to ``SchedulerOptions``.
 
     Attributes:
         scheduler_options: ``SchedulerOptions`` that depend on the
@@ -61,6 +62,7 @@ class BenchmarkMethod(Base):
     distribute_replications: bool = False
     use_model_predictions_for_best_point: bool = False
     run_trials_in_batches: bool = False
+    max_pending_trials: int = 1
 
     def __post_init__(self) -> None:
         if self.name == "DEFAULT":
@@ -72,7 +74,7 @@ class BenchmarkMethod(Base):
             # No new candidates can be generated while any are pending.
             # If batched, an entire batch must finish before the next can be
             # generated.
-            max_pending_trials=1,
+            max_pending_trials=self.max_pending_trials,
             # Do not throttle, as is often necessary when polling real endpoints
             init_seconds_between_polls=0,
             min_seconds_before_poll=0,

--- a/ax/benchmark/methods/sobol.py
+++ b/ax/benchmark/methods/sobol.py
@@ -6,18 +6,14 @@
 # pyre-strict
 
 
-from ax.benchmark.benchmark_method import (
-    BenchmarkMethod,
-    get_benchmark_scheduler_options,
-)
+from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 from ax.modelbridge.registry import Models
-from ax.service.scheduler import SchedulerOptions
 
 
 def get_sobol_benchmark_method(
     distribute_replications: bool,
-    scheduler_options: SchedulerOptions | None = None,
+    batch_size: int = 1,
 ) -> BenchmarkMethod:
     generation_strategy = GenerationStrategy(
         name="Sobol",
@@ -25,8 +21,7 @@ def get_sobol_benchmark_method(
     )
 
     return BenchmarkMethod(
-        name=generation_strategy.name,
         generation_strategy=generation_strategy,
-        scheduler_options=scheduler_options or get_benchmark_scheduler_options(),
+        batch_size=batch_size,
         distribute_replications=distribute_replications,
     )

--- a/ax/benchmark/methods/sobol.py
+++ b/ax/benchmark/methods/sobol.py
@@ -11,17 +11,21 @@ from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrateg
 from ax.modelbridge.registry import Models
 
 
+def get_sobol_generation_strategy() -> GenerationStrategy:
+    return GenerationStrategy(
+        name="Sobol",
+        steps=[
+            GenerationStep(model=Models.SOBOL, num_trials=-1),
+        ],
+    )
+
+
 def get_sobol_benchmark_method(
     distribute_replications: bool,
     batch_size: int = 1,
 ) -> BenchmarkMethod:
-    generation_strategy = GenerationStrategy(
-        name="Sobol",
-        steps=[GenerationStep(model=Models.SOBOL, num_trials=-1)],
-    )
-
     return BenchmarkMethod(
-        generation_strategy=generation_strategy,
+        generation_strategy=get_sobol_generation_strategy(),
         batch_size=batch_size,
         distribute_replications=distribute_replications,
     )

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -61,11 +61,7 @@ class Jenatton(BenchmarkTestFunction):
         return torch.tensor(value, dtype=torch.double)
 
 
-def get_jenatton_benchmark_problem(
-    num_trials: int = 50,
-    observe_noise_sd: bool = False,
-    noise_std: float = 0.0,
-) -> BenchmarkProblem:
+def get_jenatton_search_space() -> HierarchicalSearchSpace:
     search_space = HierarchicalSearchSpace(
         parameters=[
             ChoiceParameter(
@@ -103,6 +99,14 @@ def get_jenatton_benchmark_problem(
             ),
         ]
     )
+    return search_space
+
+
+def get_jenatton_benchmark_problem(
+    num_trials: int = 50,
+    observe_noise_sd: bool = False,
+    noise_std: float = 0.0,
+) -> BenchmarkProblem:
     name = "Jenatton" + ("_observed_noise" if observe_noise_sd else "")
 
     optimization_config = OptimizationConfig(
@@ -115,7 +119,7 @@ def get_jenatton_benchmark_problem(
     )
     return BenchmarkProblem(
         name=name,
-        search_space=search_space,
+        search_space=get_jenatton_search_space(),
         optimization_config=optimization_config,
         test_function=Jenatton(outcome_names=[name]),
         noise_std=noise_std,

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -5,10 +5,7 @@
 
 # pyre-strict
 
-from ax.benchmark.benchmark_method import (
-    BenchmarkMethod,
-    get_benchmark_scheduler_options,
-)
+from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.modelbridge.generation_strategy import (
     GenerationNode,
     GenerationStep,
@@ -26,26 +23,22 @@ class TestBenchmarkMethod(TestCase):
             steps=[GenerationStep(model=Models.SOBOL, num_trials=10)],
             name="SOBOL",
         )
-        options = get_benchmark_scheduler_options()
-        method = BenchmarkMethod(
-            name="Sobol10", generation_strategy=gs, scheduler_options=options
-        )
+        method = BenchmarkMethod(name="Sobol10", generation_strategy=gs)
 
         # test that `fit_tracking_metrics` has been correctly set to False
         for step in method.generation_strategy._steps:
             self.assertFalse(none_throws(step.model_kwargs).get("fit_tracking_metrics"))
 
-        self.assertEqual(method.scheduler_options, options)
+        options = method.scheduler_options
         self.assertEqual(options.max_pending_trials, 1)
         self.assertEqual(options.init_seconds_between_polls, 0)
         self.assertEqual(options.min_seconds_before_poll, 0)
-        self.assertEqual(options.timeout_hours, 4)
+        self.assertEqual(method.timeout_hours, 4)
 
-        options = get_benchmark_scheduler_options(timeout_hours=10)
         method = BenchmarkMethod(
-            name="Sobol10", generation_strategy=gs, scheduler_options=options
+            name="Sobol10", generation_strategy=gs, timeout_hours=10
         )
-        self.assertEqual(method.scheduler_options.timeout_hours, 10)
+        self.assertEqual(method.timeout_hours, 10)
 
         # test that instantiation works with node-based strategies
         sobol_model_spec = ModelSpec(
@@ -55,9 +48,7 @@ class TestBenchmarkMethod(TestCase):
             nodes=[GenerationNode(node_name="sobol", model_specs=[sobol_model_spec])]
         )
 
-        method = BenchmarkMethod(
-            name="Sobol10", generation_strategy=node_gs, scheduler_options=options
-        )
+        method = BenchmarkMethod(name="Sobol10", generation_strategy=node_gs)
         for node in method.generation_strategy._nodes:
             self.assertFalse(
                 none_throws(node.model_spec_to_gen_from.model_kwargs).get(

--- a/ax/utils/testing/backend_simulator.py
+++ b/ax/utils/testing/backend_simulator.py
@@ -371,7 +371,7 @@ class BackendSimulator:
             completed=[t.trial_index for t in self._completed],
         )
 
-    def lookup_trial_index_status(self, trial_index: int) -> TrialStatus | None:
+    def lookup_trial_index_status(self, trial_index: int) -> TrialStatus:
         """Lookup the trial status of a ``trial_index``.
 
         Args:
@@ -389,7 +389,7 @@ class BackendSimulator:
             return TrialStatus.COMPLETED
         elif trial_index in sim_status.failed:
             return TrialStatus.FAILED
-        return None
+        raise ValueError(f"Trial {trial_index} not found in simulator.")
 
     def get_sim_trial_by_index(self, trial_index: int) -> SimTrial | None:
         """Get a ``SimTrial`` by ``trial_index``.

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -28,7 +28,6 @@ from ax.modelbridge.registry import Models
 from ax.modelbridge.torch import TorchModelBridge
 from ax.models.torch.botorch_modular.model import BoTorchModel
 from ax.models.torch.botorch_modular.surrogate import Surrogate, SurrogateSpec
-from ax.service.scheduler import SchedulerOptions
 from ax.utils.common.constants import Keys
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
@@ -207,9 +206,6 @@ def get_sobol_gpei_benchmark_method() -> BenchmarkMethod:
                     },
                 ),
             ],
-        ),
-        scheduler_options=SchedulerOptions(
-            total_trials=4, init_seconds_between_polls=0
         ),
     )
 

--- a/ax/utils/testing/tests/test_backend_simulator.py
+++ b/ax/utils/testing/tests/test_backend_simulator.py
@@ -147,3 +147,5 @@ class BackendSimulatorTest(TestCase):
             sim.get_sim_trial_by_index(trial_index=2).sim_completed_time,
             2.0,
         )
+        with self.assertRaisesRegex(ValueError, "Trial 100 not found in simulator"):
+            sim.lookup_trial_index_status(trial_index=100)


### PR DESCRIPTION
Summary:
Context:

This enables running asynchronous benchmarks, which will be needed for realistic AutoML benchmarks.

This diff:
* Gives `BenchmarkRunner` an optional `SimulatedBackendRunner`, which shadows the real runner by tracking the progress of simulated trials. It uses a simulated "internal" clock, so that the simulation plays out deterministically, with real runtime having no bearing.
* Updates the `create_problem_from_botorch` helper function to take an argument `max_n_concurrent_trials` and to have each trial take 1 period.
* Updates `benchmark_replication` to be able to start more than one trial at the same time, with `Scheduler.run_n_trials`. These will have the same start time according to the simulated runner.

TODO: It is unfortunate that we need to set `BenchmarkProblem.max_n_concurrent_trials` to match `SchedulerOptions.max_pending_trials`. I will see if we can combine those, or at least add validation that they match. I am not sure if concurrency should live on the `BenchmarkProblem` or the `BenchmarkMethod`

Differential Revision: D64899934


