### PR TITLE
Move `outcome_names` from `BenchmarkRunner` to `BenchmarkTestFunction`

### DIFF
--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -47,7 +47,6 @@ class BenchmarkRunner(Runner):
           not over-engineer for that before such a use case arrives.
 
     Args:
-        outcome_names: The names of the outcomes returned by the problem.
         test_function: A ``BenchmarkTestFunction`` from which to generate
             deterministic data before adding noise.
         noise_std: The standard deviation of the noise added to the data. Can be
@@ -55,7 +54,6 @@ class BenchmarkRunner(Runner):
         search_space_digest: Used to extract target fidelity and task.
     """
 
-    outcome_names: list[str]
     test_function: BenchmarkTestFunction
     noise_std: float | list[float] | dict[str, float] = 0.0
     # pyre-fixme[16]: Pyre doesn't understand InitVars
@@ -70,6 +68,11 @@ class BenchmarkRunner(Runner):
             }
         else:
             self.target_fidelity_and_task = {}
+
+    @property
+    def outcome_names(self) -> list[str]:
+        """The names of the outcomes."""
+        return self.test_function.outcome_names
 
     def get_Y_true(self, params: Mapping[str, TParamValue]) -> Tensor:
         """Evaluates the test problem.

--- a/ax/benchmark/benchmark_test_function.py
+++ b/ax/benchmark/benchmark_test_function.py
@@ -21,12 +21,14 @@ class BenchmarkTestFunction(ABC):
     (Noise - if desired - is added by the runner.)
     """
 
+    outcome_names: list[str]
+
     @abstractmethod
     def evaluate_true(self, params: Mapping[str, TParamValue]) -> Tensor:
         """
         Evaluate noiselessly.
 
         Returns:
-            1d tensor of shape (num_outcomes,).
+            1d tensor of shape (len(outcome_names),).
         """
         ...

--- a/ax/benchmark/benchmark_test_functions/botorch_test.py
+++ b/ax/benchmark/benchmark_test_functions/botorch_test.py
@@ -21,6 +21,8 @@ class BoTorchTestFunction(BenchmarkTestFunction):
     Class for generating data from a BoTorch ``BaseTestProblem``.
 
     Args:
+        outcome_names: Names of outcomes. Should have the same length as the
+            dimension of the test function, including constraints.
         botorch_problem: The BoTorch ``BaseTestProblem``.
         modified_bounds: The bounds that are used by the Ax search space
             while optimizing the problem. If different from the bounds of the
@@ -33,6 +35,7 @@ class BoTorchTestFunction(BenchmarkTestFunction):
             evaluated using the raw parameter values.
     """
 
+    outcome_names: list[str]
     botorch_problem: BaseTestProblem
     modified_bounds: list[tuple[float, float]] | None = None
 

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -128,6 +128,7 @@ class PyTorchCNNTorchvisionBenchmarkTestFunction(BenchmarkTestFunction):
     train_loader: InitVar[DataLoader | None] = None
     # pyre-ignore
     test_loader: InitVar[DataLoader | None] = None
+    outcome_names: list[str] = field(default_factory=lambda: ["accuracy"])
 
     def __post_init__(self, train_loader: None, test_loader: None) -> None:
         if self.name not in _REGISTRY:
@@ -208,16 +209,15 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
             ),
         ]
     )
-    optimization_config, outcome_names = get_soo_config_and_outcome_names(
+
+    test_function = PyTorchCNNTorchvisionBenchmarkTestFunction(name=name)
+    optimization_config, _ = get_soo_config_and_outcome_names(
         num_constraints=0,
         lower_is_better=False,
         observe_noise_sd=False,
-        objective_name="accuracy",
+        objective_name=test_function.outcome_names[0],
     )
-    runner = BenchmarkRunner(
-        test_function=PyTorchCNNTorchvisionBenchmarkTestFunction(name=name),
-        outcome_names=outcome_names,
-    )
+    runner = BenchmarkRunner(test_function=test_function)
     return BenchmarkProblem(
         name=f"HPO_PyTorchCNN_Torchvision::{name}",
         search_space=search_space,

--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -104,9 +104,10 @@ def _get_problem_from_common_inputs(
         test_problem = test_problem_class(dim=dim, bounds=test_problem_bounds)
     runner = BenchmarkRunner(
         test_function=BoTorchTestFunction(
-            botorch_problem=test_problem, modified_bounds=bounds
+            botorch_problem=test_problem,
+            modified_bounds=bounds,
+            outcome_names=[metric_name],
         ),
-        outcome_names=[metric_name],
     )
     return BenchmarkProblem(
         name=benchmark_name + ("_observed_noise" if observe_noise_sd else ""),

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -119,7 +119,7 @@ def get_jenatton_benchmark_problem(
         search_space=search_space,
         optimization_config=optimization_config,
         runner=BenchmarkRunner(
-            test_function=Jenatton(), outcome_names=[name], noise_std=noise_std
+            test_function=Jenatton(outcome_names=[name]), noise_std=noise_std
         ),
         num_trials=num_trials,
         observe_noise_stds=observe_noise_sd,

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
@@ -103,7 +103,7 @@ def get_soo_surrogate_test_function(lazy: bool = True) -> SurrogateTestFunction:
 def get_soo_surrogate() -> BenchmarkProblem:
     experiment = get_branin_experiment(with_completed_trial=True)
     test_function = get_soo_surrogate_test_function()
-    runner = BenchmarkRunner(test_function=test_function, outcome_names=["branin"])
+    runner = BenchmarkRunner(test_function=test_function)
 
     observe_noise_sd = True
     objective = Objective(
@@ -140,7 +140,7 @@ def get_moo_surrogate() -> BenchmarkProblem:
         outcome_names=outcome_names,
         get_surrogate_and_datasets=lambda: (surrogate, []),
     )
-    runner = BenchmarkRunner(test_function=test_function, outcome_names=outcome_names)
+    runner = BenchmarkRunner(test_function=test_function)
     observe_noise_sd = True
     optimization_config = MultiObjectiveOptimizationConfig(
         objective=MultiObjective(
@@ -247,8 +247,12 @@ def get_aggregated_benchmark_result() -> AggregatedBenchmarkResult:
 
 @dataclass(kw_only=True)
 class DummyTestFunction(BenchmarkTestFunction):
+    outcome_names: list[str] = field(default_factory=list)
     num_outcomes: int = 1
     dim: int = 6
+
+    def __post_init__(self) -> None:
+        self.outcome_names = [f"objective_{i}" for i in range(self.num_outcomes)]
 
     # pyre-fixme[14]: Inconsistent override, as dict[str, float] is not a
     # `TParameterization`


### PR DESCRIPTION
Summary:
**Context**: This will enable constructing the `BenchmarkRunner` based on the `BenchmarkProblem` and `BenchmarkMethod` rather than asking the user to provide it. In addition to making things simpler (it's weird that a runner is part of a problem!), that will enable the Runner to be aware of aspects of the method, such as parallelism.

This will also enable us to return metrics in a dict format (`{outcome_name: value}`) if we choose to do so in the future. That may be simpler since the data already gets processed into dicts by the runner.

Note that for problems based on BoTorch problems, names are usually already set programmatically, so that logic moves to the test problem.

**This diff**:
* Requires `outcome_names` on `BenchmarkTestFunction`
* Removes `outcome_names` as an argument from `BenchmarkRunner`
* Sets outcome names automatically on `BoTorchTestFunction` when they are not provided, following the convention used elsewhere.

Update usages:
* Remove `outcome_names` from calls to `BenchmarkRunner`
* Add `outcome_names` to calls to `BenchmarkTestFunction`, where needed; they are generally already present on surroagate test functions and can be constructed automatically for BoTorch-based problems.

Differential Revision: D65497700


