### PR TITLE
Construct `BenchmarkRunner` automatically instead of requring it to be passed to `BenchmarkProblem`

### DIFF
--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -47,7 +47,6 @@ class BenchmarkRunner(Runner):
           not over-engineer for that before such a use case arrives.
 
     Args:
-        outcome_names: The names of the outcomes returned by the problem.
         test_function: A ``BenchmarkTestFunction`` from which to generate
             deterministic data before adding noise.
         noise_std: The standard deviation of the noise added to the data. Can be
@@ -55,7 +54,6 @@ class BenchmarkRunner(Runner):
         search_space_digest: Used to extract target fidelity and task.
     """
 
-    outcome_names: list[str]
     test_function: BenchmarkTestFunction
     noise_std: float | list[float] | dict[str, float] = 0.0
     # pyre-fixme[16]: Pyre doesn't understand InitVars
@@ -70,6 +68,11 @@ class BenchmarkRunner(Runner):
             }
         else:
             self.target_fidelity_and_task = {}
+
+    @property
+    def outcome_names(self) -> list[str]:
+        """The names of the outcomes."""
+        return self.test_function.outcome_names
 
     def get_Y_true(self, params: Mapping[str, TParamValue]) -> Tensor:
         """Evaluates the test problem.

--- a/ax/benchmark/benchmark_test_function.py
+++ b/ax/benchmark/benchmark_test_function.py
@@ -21,12 +21,14 @@ class BenchmarkTestFunction(ABC):
     (Noise - if desired - is added by the runner.)
     """
 
+    outcome_names: list[str]
+
     @abstractmethod
     def evaluate_true(self, params: Mapping[str, TParamValue]) -> Tensor:
         """
         Evaluate noiselessly.
 
         Returns:
-            1d tensor of shape (num_outcomes,).
+            1d tensor of shape (len(outcome_names),).
         """
         ...

--- a/ax/benchmark/benchmark_test_functions/botorch_test.py
+++ b/ax/benchmark/benchmark_test_functions/botorch_test.py
@@ -21,6 +21,8 @@ class BoTorchTestFunction(BenchmarkTestFunction):
     Class for generating data from a BoTorch ``BaseTestProblem``.
 
     Args:
+        outcome_names: Names of outcomes. Should have the same length as the
+            dimension of the test function, including constraints.
         botorch_problem: The BoTorch ``BaseTestProblem``.
         modified_bounds: The bounds that are used by the Ax search space
             while optimizing the problem. If different from the bounds of the
@@ -33,6 +35,7 @@ class BoTorchTestFunction(BenchmarkTestFunction):
             evaluated using the raw parameter values.
     """
 
+    outcome_names: list[str]
     botorch_problem: BaseTestProblem
     modified_bounds: list[tuple[float, float]] | None = None
 

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -14,7 +14,6 @@ from ax.benchmark.benchmark_problem import (
     BenchmarkProblem,
     get_soo_config_and_outcome_names,
 )
-from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
@@ -217,7 +216,6 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
         observe_noise_sd=False,
         objective_name=test_function.outcome_names[0],
     )
-    runner = BenchmarkRunner(test_function=test_function)
     return BenchmarkProblem(
         name=f"HPO_PyTorchCNN_Torchvision::{name}",
         search_space=search_space,
@@ -225,5 +223,5 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
         num_trials=num_trials,
         observe_noise_stds=False,
         optimal_value=CLASSIFICATION_OPTIMAL_VALUE,
-        runner=runner,
+        test_function=test_function,
     )

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -128,6 +128,7 @@ class PyTorchCNNTorchvisionBenchmarkTestFunction(BenchmarkTestFunction):
     train_loader: InitVar[DataLoader | None] = None
     # pyre-ignore
     test_loader: InitVar[DataLoader | None] = None
+    outcome_names: list[str] = field(default_factory=lambda: ["accuracy"])
 
     def __post_init__(self, train_loader: None, test_loader: None) -> None:
         if self.name not in _REGISTRY:
@@ -208,16 +209,15 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
             ),
         ]
     )
-    optimization_config, outcome_names = get_soo_config_and_outcome_names(
+
+    test_function = PyTorchCNNTorchvisionBenchmarkTestFunction(name=name)
+    optimization_config, _ = get_soo_config_and_outcome_names(
         num_constraints=0,
         lower_is_better=False,
         observe_noise_sd=False,
-        objective_name="accuracy",
+        objective_name=test_function.outcome_names[0],
     )
-    runner = BenchmarkRunner(
-        test_function=PyTorchCNNTorchvisionBenchmarkTestFunction(name=name),
-        outcome_names=outcome_names,
-    )
+    runner = BenchmarkRunner(test_function=test_function)
     return BenchmarkProblem(
         name=f"HPO_PyTorchCNN_Torchvision::{name}",
         search_space=search_space,

--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -21,7 +21,6 @@ References
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 
 from ax.benchmark.benchmark_problem import BenchmarkProblem
-from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_functions.botorch_test import BoTorchTestFunction
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
@@ -102,18 +101,16 @@ def _get_problem_from_common_inputs(
         test_problem = test_problem_class(dim=dim)
     else:
         test_problem = test_problem_class(dim=dim, bounds=test_problem_bounds)
-    runner = BenchmarkRunner(
-        test_function=BoTorchTestFunction(
-            botorch_problem=test_problem,
-            modified_bounds=bounds,
-            outcome_names=[metric_name],
-        ),
+    test_function = BoTorchTestFunction(
+        botorch_problem=test_problem,
+        modified_bounds=bounds,
+        outcome_names=[metric_name],
     )
     return BenchmarkProblem(
         name=benchmark_name + ("_observed_noise" if observe_noise_sd else ""),
         search_space=search_space,
         optimization_config=optimization_config,
-        runner=runner,
+        test_function=test_function,
         num_trials=num_trials,
         optimal_value=optimal_value,
         observe_noise_stds=observe_noise_sd,

--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -104,9 +104,10 @@ def _get_problem_from_common_inputs(
         test_problem = test_problem_class(dim=dim, bounds=test_problem_bounds)
     runner = BenchmarkRunner(
         test_function=BoTorchTestFunction(
-            botorch_problem=test_problem, modified_bounds=bounds
+            botorch_problem=test_problem,
+            modified_bounds=bounds,
+            outcome_names=[metric_name],
         ),
-        outcome_names=[metric_name],
     )
     return BenchmarkProblem(
         name=benchmark_name + ("_observed_noise" if observe_noise_sd else ""),

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -119,7 +119,7 @@ def get_jenatton_benchmark_problem(
         search_space=search_space,
         optimization_config=optimization_config,
         runner=BenchmarkRunner(
-            test_function=Jenatton(), outcome_names=[name], noise_std=noise_std
+            test_function=Jenatton(outcome_names=[name]), noise_std=noise_std
         ),
         num_trials=num_trials,
         observe_noise_stds=observe_noise_sd,

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 import torch
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 from ax.benchmark.benchmark_problem import BenchmarkProblem
-from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
@@ -118,9 +117,8 @@ def get_jenatton_benchmark_problem(
         name=name,
         search_space=search_space,
         optimization_config=optimization_config,
-        runner=BenchmarkRunner(
-            test_function=Jenatton(outcome_names=[name]), noise_std=noise_std
-        ),
+        test_function=Jenatton(outcome_names=[name]),
+        noise_std=noise_std,
         num_trials=num_trials,
         observe_noise_stds=observe_noise_sd,
         optimal_value=JENATTON_OPTIMAL_VALUE,

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -14,7 +14,6 @@ import torch
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 
 from ax.benchmark.benchmark_problem import BenchmarkProblem, create_problem_from_botorch
-from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_functions.botorch_test import BoTorchTestFunction
 from ax.core.objective import MultiObjective, Objective
 from ax.core.optimization_config import (
@@ -53,10 +52,8 @@ class TestBenchmarkProblem(TestCase):
             for name in ["Branin", "Currin"]
         ]
         optimization_config = OptimizationConfig(objective=objectives[0])
-        runner = BenchmarkRunner(
-            test_function=BoTorchTestFunction(
-                botorch_problem=Branin(), outcome_names=["Branin"]
-            ),
+        test_function = BoTorchTestFunction(
+            botorch_problem=Branin(), outcome_names=["Branin"]
         )
         with self.assertRaisesRegex(NotImplementedError, "Only `n_best_points=1`"):
             BenchmarkProblem(
@@ -65,7 +62,7 @@ class TestBenchmarkProblem(TestCase):
                 num_trials=1,
                 optimal_value=0.0,
                 search_space=SearchSpace(parameters=[]),
-                runner=runner,
+                test_function=test_function,
                 n_best_points=2,
             )
 
@@ -80,7 +77,7 @@ class TestBenchmarkProblem(TestCase):
                 num_trials=1,
                 optimal_value=0.0,
                 search_space=SearchSpace(parameters=[]),
-                runner=runner,
+                test_function=test_function,
                 n_best_points=1,
                 report_inference_value_as_trace=True,
             )
@@ -90,10 +87,8 @@ class TestBenchmarkProblem(TestCase):
             Objective(metric=BenchmarkMetric(name, lower_is_better=True))
             for name in ["Branin", "Currin"]
         ]
-        runner = BenchmarkRunner(
-            test_function=BoTorchTestFunction(
-                botorch_problem=Branin(), outcome_names=["Branin"]
-            )
+        test_function = BoTorchTestFunction(
+            botorch_problem=Branin(), outcome_names=["Branin"]
         )
         opt_config = MultiObjectiveOptimizationConfig(
             objective=MultiObjective(objectives)
@@ -110,7 +105,7 @@ class TestBenchmarkProblem(TestCase):
                 num_trials=1,
                 optimal_value=0.0,
                 search_space=SearchSpace(parameters=[]),
-                runner=runner,
+                test_function=test_function,
             )
 
         opt_config = OptimizationConfig(
@@ -135,7 +130,7 @@ class TestBenchmarkProblem(TestCase):
                 num_trials=1,
                 optimal_value=0.0,
                 search_space=SearchSpace(parameters=[]),
-                runner=runner,
+                test_function=test_function,
             )
 
     def _test_multi_fidelity_or_multi_task(self, fidelity_or_task: str) -> None:

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -15,7 +15,6 @@ from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 from ax.benchmark.benchmark_problem import BenchmarkProblem, create_problem_from_botorch
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
-from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.benchmark.benchmark_test_functions.surrogate import SurrogateTestFunction
 from ax.core.experiment import Experiment
@@ -103,7 +102,6 @@ def get_soo_surrogate_test_function(lazy: bool = True) -> SurrogateTestFunction:
 def get_soo_surrogate() -> BenchmarkProblem:
     experiment = get_branin_experiment(with_completed_trial=True)
     test_function = get_soo_surrogate_test_function()
-    runner = BenchmarkRunner(test_function=test_function)
 
     observe_noise_sd = True
     objective = Objective(
@@ -120,7 +118,7 @@ def get_soo_surrogate() -> BenchmarkProblem:
         num_trials=6,
         observe_noise_stds=observe_noise_sd,
         optimal_value=0.0,
-        runner=runner,
+        test_function=test_function,
     )
 
 
@@ -140,7 +138,6 @@ def get_moo_surrogate() -> BenchmarkProblem:
         outcome_names=outcome_names,
         get_surrogate_and_datasets=lambda: (surrogate, []),
     )
-    runner = BenchmarkRunner(test_function=test_function)
     observe_noise_sd = True
     optimization_config = MultiObjectiveOptimizationConfig(
         objective=MultiObjective(
@@ -169,7 +166,7 @@ def get_moo_surrogate() -> BenchmarkProblem:
         num_trials=10,
         observe_noise_stds=True,
         optimal_value=1.0,
-        runner=runner,
+        test_function=test_function,
     )
 
 

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
@@ -103,7 +103,7 @@ def get_soo_surrogate_test_function(lazy: bool = True) -> SurrogateTestFunction:
 def get_soo_surrogate() -> BenchmarkProblem:
     experiment = get_branin_experiment(with_completed_trial=True)
     test_function = get_soo_surrogate_test_function()
-    runner = BenchmarkRunner(test_function=test_function, outcome_names=["branin"])
+    runner = BenchmarkRunner(test_function=test_function)
 
     observe_noise_sd = True
     objective = Objective(
@@ -140,7 +140,7 @@ def get_moo_surrogate() -> BenchmarkProblem:
         outcome_names=outcome_names,
         get_surrogate_and_datasets=lambda: (surrogate, []),
     )
-    runner = BenchmarkRunner(test_function=test_function, outcome_names=outcome_names)
+    runner = BenchmarkRunner(test_function=test_function)
     observe_noise_sd = True
     optimization_config = MultiObjectiveOptimizationConfig(
         objective=MultiObjective(
@@ -247,8 +247,12 @@ def get_aggregated_benchmark_result() -> AggregatedBenchmarkResult:
 
 @dataclass(kw_only=True)
 class DummyTestFunction(BenchmarkTestFunction):
+    outcome_names: list[str] = field(default_factory=list)
     num_outcomes: int = 1
     dim: int = 6
+
+    def __post_init__(self) -> None:
+        self.outcome_names = [f"objective_{i}" for i in range(self.num_outcomes)]
 
     # pyre-fixme[14]: Inconsistent override, as dict[str, float] is not a
     # `TParameterization`


### PR DESCRIPTION
Summary:
**Context**:

This is an intermediate step. In this diff, we no longer require a user constructing a `BenchmarkProblem` to construct a `BenchmarkRunner`, instead asking the user for the arguments to `BenchmarkRunner`, `test_function` and `noise_std`. (It also requires a `search_space_digest`, which can be computed from the `search_space` on the problem.) In the next diff, the `BenchmarkRunner` will move off the `BenchmarkProblem` entirely. That will eventually allow the runner to depend on attributes that live on `BenchmarkMethod`, such as parallelism, in turn unblocking asynchronous benchmarking.

**This diff**:
* Adds arguments `test_function` and `noise_std` to `BenchmarkProblem`
* Removes argument `runner` from `BenchmarkProblem`
* Automatically constructs the runner in the `BenchmarkProblem`'s post-init
* Updates call sites

Differential Revision: D65498908


