### PR TITLE
Set Scheduler logging level appropriately

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -65,12 +65,7 @@ from ax.service.utils.with_db_settings_base import DBSettings, WithDBSettingsBas
 from ax.utils.common.constants import Keys
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.executils import retry_on_exception
-from ax.utils.common.logger import (
-    build_file_handler,
-    get_logger,
-    make_indices_str,
-    set_stderr_log_level,
-)
+from ax.utils.common.logger import build_file_handler, get_logger, make_indices_str
 from ax.utils.common.timeutils import current_timestamp_in_millis
 from ax.utils.common.typeutils import checked_cast
 from pyre_extensions import assert_is_instance, none_throws
@@ -2045,8 +2040,9 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
     def _set_logger(self, options: SchedulerOptions) -> None:
         """Set up the logger with appropriate logging levels."""
         cls_name = self.__class__.__name__
-        logger = get_logger(name=f"{__name__}.{cls_name}@{hex(id(self))}")
-        set_stderr_log_level(options.logging_level)
+        logger = get_logger(
+            name=f"{__name__}.{cls_name}@{hex(id(self))}", level=options.logging_level
+        )
         if options.log_filepath is not None:
             handler = build_file_handler(
                 filepath=none_throws(options.log_filepath),

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -37,7 +37,14 @@ from ax.utils.testing.core_stubs import (
 
 
 class TestAxScheduler(AxSchedulerTestCase):
-    pass
+    def test_logging_level_warn(self) -> None:
+        super().test_logging_level_warn()
+
+    def test_logging_level_debug(self) -> None:
+        super().test_logging_level_debug()
+
+    def test_logging_level_is_set(self) -> None:
+        super().test_logging_level_is_set()
 
 
 class TestAxSchedulerMultiTypeExperiment(AxSchedulerTestCase):


### PR DESCRIPTION
Summary:
Currently, setting the `logging_level` in `SchedulerOptions` actually sets the **root stream handler's level** - this shouldn't be the case, as the correct intention is to set the logging level of the Scheduler logger. 

This diff is to correct the level handling for the Scheduler logger.

Differential Revision: D65555729


