### PR TITLE
Construct `BenchmarkRunner` within `benchmark_replication`; move `evaluate_oracle` from runner to problem

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -64,9 +64,6 @@ class BenchmarkProblem(Base):
         optimization_config: Defines the objective of optimization.
         num_trials: Number of optimization iterations to run. BatchTrials count
             as one trial.
-        observe_noise_stds: If boolean, whether the standard deviation of the
-            observation noise is observed for all metrics. If a dictionary,
-            whether noise levels are observed on a per-metric basis.
         optimal_value: The best ground-truth objective value. Hypervolume for
             multi-objective problems. If the best value is not known, it is
             conventional to set it to a value that is almost certainly better
@@ -94,7 +91,6 @@ class BenchmarkProblem(Base):
     num_trials: int
     test_function: BenchmarkTestFunction
     noise_std: float | list[float] | dict[str, float] = 0.0
-    observe_noise_stds: bool | dict[str, bool] = False
     optimal_value: float
 
     search_space: SearchSpace = field(repr=False)
@@ -429,7 +425,6 @@ def create_problem_from_botorch(
         ),
         noise_std=noise_std,
         num_trials=num_trials,
-        observe_noise_stds=observe_noise_sd,
         optimal_value=optimal_value,
         report_inference_value_as_trace=report_inference_value_as_trace,
     )

--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -47,7 +47,6 @@ class BenchmarkRunner(Runner):
           not over-engineer for that before such a use case arrives.
 
     Args:
-        outcome_names: The names of the outcomes returned by the problem.
         test_function: A ``BenchmarkTestFunction`` from which to generate
             deterministic data before adding noise.
         noise_std: The standard deviation of the noise added to the data. Can be
@@ -55,7 +54,6 @@ class BenchmarkRunner(Runner):
         search_space_digest: Used to extract target fidelity and task.
     """
 
-    outcome_names: list[str]
     test_function: BenchmarkTestFunction
     noise_std: float | list[float] | dict[str, float] = 0.0
     # pyre-fixme[16]: Pyre doesn't understand InitVars
@@ -70,6 +68,11 @@ class BenchmarkRunner(Runner):
             }
         else:
             self.target_fidelity_and_task = {}
+
+    @property
+    def outcome_names(self) -> list[str]:
+        """The names of the outcomes."""
+        return self.test_function.outcome_names
 
     def get_Y_true(self, params: Mapping[str, TParamValue]) -> Tensor:
         """Evaluates the test problem.

--- a/ax/benchmark/benchmark_test_function.py
+++ b/ax/benchmark/benchmark_test_function.py
@@ -21,12 +21,14 @@ class BenchmarkTestFunction(ABC):
     (Noise - if desired - is added by the runner.)
     """
 
+    outcome_names: list[str]
+
     @abstractmethod
     def evaluate_true(self, params: Mapping[str, TParamValue]) -> Tensor:
         """
         Evaluate noiselessly.
 
         Returns:
-            1d tensor of shape (num_outcomes,).
+            1d tensor of shape (len(outcome_names),).
         """
         ...

--- a/ax/benchmark/benchmark_test_functions/botorch_test.py
+++ b/ax/benchmark/benchmark_test_functions/botorch_test.py
@@ -21,6 +21,8 @@ class BoTorchTestFunction(BenchmarkTestFunction):
     Class for generating data from a BoTorch ``BaseTestProblem``.
 
     Args:
+        outcome_names: Names of outcomes. Should have the same length as the
+            dimension of the test function, including constraints.
         botorch_problem: The BoTorch ``BaseTestProblem``.
         modified_bounds: The bounds that are used by the Ax search space
             while optimizing the problem. If different from the bounds of the
@@ -33,6 +35,7 @@ class BoTorchTestFunction(BenchmarkTestFunction):
             evaluated using the raw parameter values.
     """
 
+    outcome_names: list[str]
     botorch_problem: BaseTestProblem
     modified_bounds: list[tuple[float, float]] | None = None
 

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -221,7 +221,6 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
         search_space=search_space,
         optimization_config=optimization_config,
         num_trials=num_trials,
-        observe_noise_stds=False,
         optimal_value=CLASSIFICATION_OPTIMAL_VALUE,
         test_function=test_function,
     )

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -14,7 +14,6 @@ from ax.benchmark.benchmark_problem import (
     BenchmarkProblem,
     get_soo_config_and_outcome_names,
 )
-from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
@@ -217,7 +216,6 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
         observe_noise_sd=False,
         objective_name=test_function.outcome_names[0],
     )
-    runner = BenchmarkRunner(test_function=test_function)
     return BenchmarkProblem(
         name=f"HPO_PyTorchCNN_Torchvision::{name}",
         search_space=search_space,
@@ -225,5 +223,5 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
         num_trials=num_trials,
         observe_noise_stds=False,
         optimal_value=CLASSIFICATION_OPTIMAL_VALUE,
-        runner=runner,
+        test_function=test_function,
     )

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -128,6 +128,7 @@ class PyTorchCNNTorchvisionBenchmarkTestFunction(BenchmarkTestFunction):
     train_loader: InitVar[DataLoader | None] = None
     # pyre-ignore
     test_loader: InitVar[DataLoader | None] = None
+    outcome_names: list[str] = field(default_factory=lambda: ["accuracy"])
 
     def __post_init__(self, train_loader: None, test_loader: None) -> None:
         if self.name not in _REGISTRY:
@@ -208,16 +209,15 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
             ),
         ]
     )
-    optimization_config, outcome_names = get_soo_config_and_outcome_names(
+
+    test_function = PyTorchCNNTorchvisionBenchmarkTestFunction(name=name)
+    optimization_config, _ = get_soo_config_and_outcome_names(
         num_constraints=0,
         lower_is_better=False,
         observe_noise_sd=False,
-        objective_name="accuracy",
+        objective_name=test_function.outcome_names[0],
     )
-    runner = BenchmarkRunner(
-        test_function=PyTorchCNNTorchvisionBenchmarkTestFunction(name=name),
-        outcome_names=outcome_names,
-    )
+    runner = BenchmarkRunner(test_function=test_function)
     return BenchmarkProblem(
         name=f"HPO_PyTorchCNN_Torchvision::{name}",
         search_space=search_space,

--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -113,7 +113,6 @@ def _get_problem_from_common_inputs(
         test_function=test_function,
         num_trials=num_trials,
         optimal_value=optimal_value,
-        observe_noise_stds=observe_noise_sd,
     )
 
 

--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -21,7 +21,6 @@ References
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 
 from ax.benchmark.benchmark_problem import BenchmarkProblem
-from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_functions.botorch_test import BoTorchTestFunction
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
@@ -102,18 +101,16 @@ def _get_problem_from_common_inputs(
         test_problem = test_problem_class(dim=dim)
     else:
         test_problem = test_problem_class(dim=dim, bounds=test_problem_bounds)
-    runner = BenchmarkRunner(
-        test_function=BoTorchTestFunction(
-            botorch_problem=test_problem,
-            modified_bounds=bounds,
-            outcome_names=[metric_name],
-        ),
+    test_function = BoTorchTestFunction(
+        botorch_problem=test_problem,
+        modified_bounds=bounds,
+        outcome_names=[metric_name],
     )
     return BenchmarkProblem(
         name=benchmark_name + ("_observed_noise" if observe_noise_sd else ""),
         search_space=search_space,
         optimization_config=optimization_config,
-        runner=runner,
+        test_function=test_function,
         num_trials=num_trials,
         optimal_value=optimal_value,
         observe_noise_stds=observe_noise_sd,

--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -104,9 +104,10 @@ def _get_problem_from_common_inputs(
         test_problem = test_problem_class(dim=dim, bounds=test_problem_bounds)
     runner = BenchmarkRunner(
         test_function=BoTorchTestFunction(
-            botorch_problem=test_problem, modified_bounds=bounds
+            botorch_problem=test_problem,
+            modified_bounds=bounds,
+            outcome_names=[metric_name],
         ),
-        outcome_names=[metric_name],
     )
     return BenchmarkProblem(
         name=benchmark_name + ("_observed_noise" if observe_noise_sd else ""),

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -119,7 +119,7 @@ def get_jenatton_benchmark_problem(
         search_space=search_space,
         optimization_config=optimization_config,
         runner=BenchmarkRunner(
-            test_function=Jenatton(), outcome_names=[name], noise_std=noise_std
+            test_function=Jenatton(outcome_names=[name]), noise_std=noise_std
         ),
         num_trials=num_trials,
         observe_noise_stds=observe_noise_sd,

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 import torch
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 from ax.benchmark.benchmark_problem import BenchmarkProblem
-from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
@@ -118,9 +117,8 @@ def get_jenatton_benchmark_problem(
         name=name,
         search_space=search_space,
         optimization_config=optimization_config,
-        runner=BenchmarkRunner(
-            test_function=Jenatton(outcome_names=[name]), noise_std=noise_std
-        ),
+        test_function=Jenatton(outcome_names=[name]),
+        noise_std=noise_std,
         num_trials=num_trials,
         observe_noise_stds=observe_noise_sd,
         optimal_value=JENATTON_OPTIMAL_VALUE,

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -120,6 +120,5 @@ def get_jenatton_benchmark_problem(
         test_function=Jenatton(outcome_names=[name]),
         noise_std=noise_std,
         num_trials=num_trials,
-        observe_noise_stds=observe_noise_sd,
         optimal_value=JENATTON_OPTIMAL_VALUE,
     )

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -6,11 +6,10 @@
 # pyre-strict
 
 
-from itertools import product
 from unittest.mock import patch
 
 import numpy as np
-from ax.benchmark.benchmark import benchmark_replication
+from ax.benchmark.benchmark import benchmark_replication, get_benchmark_runner
 from ax.benchmark.benchmark_method import get_benchmark_scheduler_options
 from ax.benchmark.methods.modular_botorch import get_sobol_botorch_modular_acquisition
 from ax.benchmark.methods.sobol import get_sobol_benchmark_method
@@ -135,9 +134,7 @@ class TestMethods(TestCase):
         result = benchmark_replication(problem=problem, method=method, seed=0)
         self.assertTrue(np.isfinite(result.score_trace).all())
 
-    def _test_get_best_parameters(
-        self, use_model_predictions: bool, as_batch: bool
-    ) -> None:
+    def _test_get_best_parameters(self, use_model_predictions: bool) -> None:
         problem = get_problem(problem_key="ackley4", num_trials=2, noise_std=1.0)
 
         method = get_sobol_botorch_modular_acquisition(
@@ -152,7 +149,7 @@ class TestMethods(TestCase):
             name="test",
             search_space=problem.search_space,
             optimization_config=problem.optimization_config,
-            runner=problem.runner,
+            runner=get_benchmark_runner(problem=problem),
         )
 
         scheduler = Scheduler(
@@ -189,8 +186,8 @@ class TestMethods(TestCase):
         self.assertEqual(len(best_params), 1)
 
     def test_get_best_parameters(self) -> None:
-        for use_model_predictions, as_batch in product([False, True], [False, True]):
-            with self.subTest(f"{use_model_predictions=}, {as_batch=}"):
+        for use_model_predictions in [False, True]:
+            with self.subTest(f"{use_model_predictions=}"):
                 self._test_get_best_parameters(
-                    use_model_predictions=use_model_predictions, as_batch=as_batch
+                    use_model_predictions=use_model_predictions
                 )

--- a/ax/benchmark/tests/problems/hpo/test_torchvision.py
+++ b/ax/benchmark/tests/problems/hpo/test_torchvision.py
@@ -8,6 +8,8 @@
 from random import choice
 from unittest.mock import MagicMock, patch
 
+from ax.benchmark.benchmark_metric import BenchmarkMetric
+
 from ax.benchmark.benchmark_problem import BenchmarkProblem
 
 from ax.benchmark.problems.hpo.torchvision import CNN
@@ -16,6 +18,7 @@ from ax.core.arm import Arm
 from ax.core.trial import Trial
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import TestDataset
+from pyre_extensions import assert_is_instance
 
 
 class TestPyTorchCNNTorchvision(TestCase):
@@ -53,7 +56,10 @@ class TestPyTorchCNNTorchvision(TestCase):
         )
         self.assertFalse(problem.optimization_config.objective.minimize)
         self.assertEqual(problem.num_trials, num_trials)
-        self.assertFalse(problem.observe_noise_stds)
+        metric = assert_is_instance(
+            problem.optimization_config.objective.metric, BenchmarkMetric
+        )
+        self.assertFalse(metric.observe_noise_sd)
 
     def test_deterministic(self) -> None:
         problem_name = choice(["MNIST", "FashionMNIST"])

--- a/ax/benchmark/tests/problems/synthetic/hss/test_jenatton.py
+++ b/ax/benchmark/tests/problems/synthetic/hss/test_jenatton.py
@@ -5,7 +5,6 @@
 
 # pyre-strict
 
-import math
 from random import random
 
 from ax.benchmark.benchmark_metric import BenchmarkMetric
@@ -14,10 +13,6 @@ from ax.benchmark.problems.synthetic.hss.jenatton import (
     get_jenatton_benchmark_problem,
     jenatton_test_function,
 )
-from ax.core.arm import Arm
-from ax.core.data import Data
-from ax.core.experiment import Experiment
-from ax.core.trial import Trial
 from ax.core.types import TParameterization
 from ax.utils.common.testutils import TestCase
 from pyre_extensions import assert_is_instance
@@ -92,7 +87,7 @@ class JenattonTest(TestCase):
                 value,
             )
             self.assertAlmostEqual(
-                benchmark_problem.runner.evaluate_oracle(parameters=params)[0],
+                benchmark_problem.test_function.evaluate_true(params=params).item(),
                 value,
                 places=6,
             )
@@ -105,7 +100,7 @@ class JenattonTest(TestCase):
         self.assertEqual(metric.name, "Jenatton")
         self.assertTrue(objective.minimize)
         self.assertTrue(metric.lower_is_better)
-        self.assertEqual(problem.runner.noise_std, 0.0)
+        self.assertEqual(problem.noise_std, 0.0)
         self.assertFalse(assert_is_instance(metric, BenchmarkMetric).observe_noise_sd)
 
         problem = get_jenatton_benchmark_problem(
@@ -114,59 +109,5 @@ class JenattonTest(TestCase):
         objective = problem.optimization_config.objective
         metric = objective.metric
         self.assertTrue(metric.lower_is_better)
-        self.assertEqual(problem.runner.noise_std, 0.1)
+        self.assertEqual(problem.noise_std, 0.1)
         self.assertTrue(assert_is_instance(metric, BenchmarkMetric).observe_noise_sd)
-
-    def test_fetch_trial_data(self) -> None:
-        problem = get_jenatton_benchmark_problem()
-        arm = Arm(parameters={"x1": 0, "x2": 1, "x5": 2.0, "r8": 0.05}, name="0_0")
-
-        experiment = Experiment(
-            search_space=problem.search_space,
-            name="Jenatton",
-            optimization_config=problem.optimization_config,
-        )
-
-        trial = Trial(experiment=experiment)
-        trial.add_arm(arm)
-        metadata = problem.runner.run(trial=trial)
-        trial.update_run_metadata(metadata)
-
-        expected_metadata = {
-            "Ys": {"0_0": [4.25]},
-            "Ystds": {"0_0": [0.0]},
-            "outcome_names": ["Jenatton"],
-        }
-        self.assertEqual(metadata, expected_metadata)
-
-        metric = problem.optimization_config.objective.metric
-
-        df = assert_is_instance(metric.fetch_trial_data(trial=trial).value, Data).df
-        self.assertEqual(len(df), 1)
-        res_dict = df.iloc[0].to_dict()
-        self.assertEqual(res_dict["arm_name"], "0_0")
-        self.assertEqual(res_dict["metric_name"], "Jenatton")
-        self.assertEqual(res_dict["mean"], 4.25)
-        self.assertTrue(math.isnan(res_dict["sem"]))
-        self.assertEqual(res_dict["trial_index"], 0)
-
-        problem = get_jenatton_benchmark_problem(noise_std=0.1, observe_noise_sd=True)
-        experiment = Experiment(
-            search_space=problem.search_space,
-            name="Jenatton",
-            optimization_config=problem.optimization_config,
-        )
-
-        trial = Trial(experiment=experiment)
-        trial.add_arm(arm)
-        metadata = problem.runner.run(trial=trial)
-        trial.update_run_metadata(metadata)
-
-        metric = problem.optimization_config.objective.metric
-        df = assert_is_instance(metric.fetch_trial_data(trial=trial).value, Data).df
-        self.assertEqual(len(df), 1)
-        res_dict = df.iloc[0].to_dict()
-        self.assertEqual(res_dict["arm_name"], "0_0")
-        self.assertNotEqual(res_dict["mean"], 4.25)
-        self.assertAlmostEqual(res_dict["sem"], 0.1)
-        self.assertEqual(res_dict["trial_index"], 0)

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -173,7 +173,7 @@ class TestBenchmarkProblem(TestCase):
             float,
         )
         self.assertAlmostEqual(
-            problem.runner.evaluate_oracle(parameters=params)[0],
+            problem.evaluate_oracle(parameters=params)[0],
             at_target,
         )
         # first term: (-(b - 0.1) * (1 - x3)  + c - r)^2
@@ -182,7 +182,7 @@ class TestBenchmarkProblem(TestCase):
         t = -5.1 / (4 * math.pi**2) + 5 / math.pi - 6
         expected_change = (t + 0.1) ** 2 - t**2
         self.assertAlmostEqual(
-            problem.runner.get_Y_true(params=params).item(),
+            problem.test_function.evaluate_true(params=params).item(),
             at_target + expected_change,
         )
 
@@ -259,12 +259,11 @@ class TestBenchmarkProblem(TestCase):
             observe_noise_sd=observe_noise_sd,
             noise_std=noise_std,
         )
-        runner = ax_problem.runner
-        test_problem = assert_is_instance(runner.test_function, BoTorchTestFunction)
+        test_problem = assert_is_instance(ax_problem.test_function, BoTorchTestFunction)
         botorch_problem = assert_is_instance(
             test_problem.botorch_problem, ConstrainedBaseTestProblem
         )
-        self.assertEqual(runner.noise_std, noise_std)
+        self.assertEqual(ax_problem.noise_std, noise_std)
         opt_config = ax_problem.optimization_config
         outcome_constraints = opt_config.outcome_constraints
         self.assertEqual(

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -14,7 +14,6 @@ import torch
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 
 from ax.benchmark.benchmark_problem import BenchmarkProblem, create_problem_from_botorch
-from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_functions.botorch_test import BoTorchTestFunction
 from ax.core.objective import MultiObjective, Objective
 from ax.core.optimization_config import (
@@ -53,10 +52,8 @@ class TestBenchmarkProblem(TestCase):
             for name in ["Branin", "Currin"]
         ]
         optimization_config = OptimizationConfig(objective=objectives[0])
-        runner = BenchmarkRunner(
-            test_function=BoTorchTestFunction(
-                botorch_problem=Branin(), outcome_names=["Branin"]
-            ),
+        test_function = BoTorchTestFunction(
+            botorch_problem=Branin(), outcome_names=["Branin"]
         )
         with self.assertRaisesRegex(NotImplementedError, "Only `n_best_points=1`"):
             BenchmarkProblem(
@@ -65,7 +62,7 @@ class TestBenchmarkProblem(TestCase):
                 num_trials=1,
                 optimal_value=0.0,
                 search_space=SearchSpace(parameters=[]),
-                runner=runner,
+                test_function=test_function,
                 n_best_points=2,
             )
 
@@ -80,7 +77,7 @@ class TestBenchmarkProblem(TestCase):
                 num_trials=1,
                 optimal_value=0.0,
                 search_space=SearchSpace(parameters=[]),
-                runner=runner,
+                test_function=test_function,
                 n_best_points=1,
                 report_inference_value_as_trace=True,
             )
@@ -90,10 +87,8 @@ class TestBenchmarkProblem(TestCase):
             Objective(metric=BenchmarkMetric(name, lower_is_better=True))
             for name in ["Branin", "Currin"]
         ]
-        runner = BenchmarkRunner(
-            test_function=BoTorchTestFunction(
-                botorch_problem=Branin(), outcome_names=["Branin"]
-            )
+        test_function = BoTorchTestFunction(
+            botorch_problem=Branin(), outcome_names=["Branin"]
         )
         opt_config = MultiObjectiveOptimizationConfig(
             objective=MultiObjective(objectives)
@@ -110,7 +105,7 @@ class TestBenchmarkProblem(TestCase):
                 num_trials=1,
                 optimal_value=0.0,
                 search_space=SearchSpace(parameters=[]),
-                runner=runner,
+                test_function=test_function,
             )
 
         opt_config = OptimizationConfig(
@@ -135,7 +130,7 @@ class TestBenchmarkProblem(TestCase):
                 num_trials=1,
                 optimal_value=0.0,
                 search_space=SearchSpace(parameters=[]),
-                runner=runner,
+                test_function=test_function,
             )
 
     def _test_multi_fidelity_or_multi_task(self, fidelity_or_task: str) -> None:

--- a/ax/benchmark/tests/test_benchmark_runner.py
+++ b/ax/benchmark/tests/test_benchmark_runner.py
@@ -12,8 +12,6 @@ from dataclasses import replace
 from itertools import product
 from unittest.mock import Mock, patch
 
-import numpy as np
-
 import torch
 from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_functions.botorch_test import BoTorchTestFunction
@@ -146,7 +144,6 @@ class TestBenchmarkRunner(TestCase):
                     )
                 ):
                     Y = runner.get_Y_true(params=params)
-                    oracle = runner.evaluate_oracle(parameters=params)
 
                 if (
                     isinstance(test_function, BoTorchTestFunction)
@@ -180,7 +177,6 @@ class TestBenchmarkRunner(TestCase):
                         torch.Size([2]), X.pow(2).sum().item(), dtype=torch.double
                     )
                 self.assertTrue(torch.allclose(Y, expected_Y))
-                self.assertTrue(np.equal(Y.numpy(), oracle).all())
 
             with self.subTest(f"test `run()`, {test_description}"):
                 trial = Mock(spec=Trial)

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -15,7 +15,6 @@ from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 from ax.benchmark.benchmark_problem import BenchmarkProblem, create_problem_from_botorch
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
-from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.benchmark.benchmark_test_functions.surrogate import SurrogateTestFunction
 from ax.core.experiment import Experiment
@@ -103,7 +102,6 @@ def get_soo_surrogate_test_function(lazy: bool = True) -> SurrogateTestFunction:
 def get_soo_surrogate() -> BenchmarkProblem:
     experiment = get_branin_experiment(with_completed_trial=True)
     test_function = get_soo_surrogate_test_function()
-    runner = BenchmarkRunner(test_function=test_function)
 
     observe_noise_sd = True
     objective = Objective(
@@ -120,7 +118,7 @@ def get_soo_surrogate() -> BenchmarkProblem:
         num_trials=6,
         observe_noise_stds=observe_noise_sd,
         optimal_value=0.0,
-        runner=runner,
+        test_function=test_function,
     )
 
 
@@ -140,7 +138,6 @@ def get_moo_surrogate() -> BenchmarkProblem:
         outcome_names=outcome_names,
         get_surrogate_and_datasets=lambda: (surrogate, []),
     )
-    runner = BenchmarkRunner(test_function=test_function)
     observe_noise_sd = True
     optimization_config = MultiObjectiveOptimizationConfig(
         objective=MultiObjective(
@@ -169,7 +166,7 @@ def get_moo_surrogate() -> BenchmarkProblem:
         num_trials=10,
         observe_noise_stds=True,
         optimal_value=1.0,
-        runner=runner,
+        test_function=test_function,
     )
 
 

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -116,7 +116,6 @@ def get_soo_surrogate() -> BenchmarkProblem:
         search_space=experiment.search_space,
         optimization_config=optimization_config,
         num_trials=6,
-        observe_noise_stds=observe_noise_sd,
         optimal_value=0.0,
         test_function=test_function,
     )
@@ -164,7 +163,6 @@ def get_moo_surrogate() -> BenchmarkProblem:
         search_space=experiment.search_space,
         optimization_config=optimization_config,
         num_trials=10,
-        observe_noise_stds=True,
         optimal_value=1.0,
         test_function=test_function,
     )

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
@@ -103,7 +103,7 @@ def get_soo_surrogate_test_function(lazy: bool = True) -> SurrogateTestFunction:
 def get_soo_surrogate() -> BenchmarkProblem:
     experiment = get_branin_experiment(with_completed_trial=True)
     test_function = get_soo_surrogate_test_function()
-    runner = BenchmarkRunner(test_function=test_function, outcome_names=["branin"])
+    runner = BenchmarkRunner(test_function=test_function)
 
     observe_noise_sd = True
     objective = Objective(
@@ -140,7 +140,7 @@ def get_moo_surrogate() -> BenchmarkProblem:
         outcome_names=outcome_names,
         get_surrogate_and_datasets=lambda: (surrogate, []),
     )
-    runner = BenchmarkRunner(test_function=test_function, outcome_names=outcome_names)
+    runner = BenchmarkRunner(test_function=test_function)
     observe_noise_sd = True
     optimization_config = MultiObjectiveOptimizationConfig(
         objective=MultiObjective(
@@ -247,8 +247,12 @@ def get_aggregated_benchmark_result() -> AggregatedBenchmarkResult:
 
 @dataclass(kw_only=True)
 class DummyTestFunction(BenchmarkTestFunction):
+    outcome_names: list[str] = field(default_factory=list)
     num_outcomes: int = 1
     dim: int = 6
+
+    def __post_init__(self) -> None:
+        self.outcome_names = [f"objective_{i}" for i in range(self.num_outcomes)]
 
     # pyre-fixme[14]: Inconsistent override, as dict[str, float] is not a
     # `TParameterization`


### PR DESCRIPTION
Summary:
Context:

Moving the runner off of the `BenchmarkProblem` and instead constructing it within `BenchmarkReplication`: In addition to making it simpler for the user to specify the problem and making the code flatter and easier to understand, this will enable the runner to depend on both the `BenchmarkProblem` and `BenchmarkMethod`, so that it can take advantage of the parallelism stored on the runner.

Moving `evaluate_oracle` from the runner to the problem is the right thing to do in principle, since ideally the runner would only need to be used within the BayesOpt loop. Also, there could conceivably be a world where the oracle value is the "best" value (e.g. the lowest point on a learning curve), and that woulud need to depend on the `OptimizationConfig`, which the `BenchmarkProblem` wouldn't need to know about.

This diff:
* Removes `runner` from `BenchmarkProblem`
* Starts constructing the runner in `benchmark_replication`
* Moves `evaluate_oracle` from runner to problem; moves `target_fidelity_and_task` from runner to problem in order to make that possible

Reviewed By: saitcakmak

Differential Revision: D65503068
