### PR TITLE
Add an exception for logit scale parameters in parameter_to_sqa

### DIFF
--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -238,6 +238,12 @@ class Encoder:
         # pyre-fixme[9]: Expected `Base` for 1st...typing.Type[Parameter]`.
         parameter_class: SQAParameter = self.config.class_to_sqa_class[Parameter]
         if isinstance(parameter, RangeParameter):
+            if parameter.logit_scale:
+                raise NotImplementedError(
+                    "Cannot encode logit-scale parameter to SQLAlchemy because "
+                    "the DB schema does not have a corresponding column. "
+                    "Please reach out to the AE team if you need this feature. "
+                )
             # pyre-fixme[29]: `SQAParameter` is not a function.
             return parameter_class(
                 id=parameter.db_id,

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -16,7 +16,6 @@ from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
 import pandas as pd
-
 from ax.analysis.analysis import AnalysisCard, AnalysisCardLevel
 from ax.analysis.markdown.markdown_analysis import MarkdownAnalysisCard
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
@@ -1249,6 +1248,18 @@ class SQAStoreTest(TestCase):
         sqa_parameter.domain_type = 5
         with self.assertRaises(SQADecodeError):
             self.decoder.parameter_from_sqa(sqa_parameter)
+
+    def test_logit_scale(self) -> None:
+        with self.assertRaisesRegex(NotImplementedError, "logit-scale"):
+            self.encoder.parameter_to_sqa(
+                parameter=RangeParameter(
+                    name="foo",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.1,
+                    upper=0.99,
+                    logit_scale=True,
+                )
+            )
 
     def test_ParameterConstraintValidation(self) -> None:
         sqa_parameter_constraint = SQAParameterConstraint(


### PR DESCRIPTION
Summary: The DB schema does not support logit-scale, so we have been silently ignoring the attribute. This adds an exception to make this explicit to avoid silent bugs.

Differential Revision: D65619262


