### PR TITLE
Fill missing params in ModelBridge

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -251,7 +251,9 @@ class Experiment(Base):
     def status_quo(self, status_quo: Arm | None) -> None:
         if status_quo is not None:
             self.search_space.check_types(
-                parameterization=status_quo.parameters, raise_error=True
+                parameterization=status_quo.parameters,
+                allow_extra_params=False,
+                raise_error=True,
             )
             self.search_space.check_all_parameters_present(
                 parameterization=status_quo.parameters, raise_error=True

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -258,6 +258,7 @@ class SearchSpace(Base):
         self,
         parameterization: TParameterization,
         allow_none: bool = True,
+        allow_extra_params: bool = True,
         raise_error: bool = False,
     ) -> bool:
         """Checks that the given parameterization's types match the search space.
@@ -265,6 +266,7 @@ class SearchSpace(Base):
         Args:
             parameterization: Dict from parameter name to value to validate.
             allow_none: Whether None is a valid parameter value.
+            allow_extra_params: If parameterization can have params not in search space.
             raise_error: If true and parameterization does not belong, raises an error
                 with detailed explanation of why.
 
@@ -273,9 +275,12 @@ class SearchSpace(Base):
         """
         for name, value in parameterization.items():
             if name not in self.parameters:
-                if raise_error:
+                if allow_extra_params:
+                    continue
+                elif raise_error:
                     raise ValueError(f"Parameter {name} not defined in search space")
-                return False
+                else:
+                    return False
 
             if value is None and allow_none:
                 continue

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -319,13 +319,16 @@ class SearchSpaceTest(TestCase):
 
         # Unknown parameter
         p_dict["q"] = 40
-        # pyre-fixme[6]: For 1st param expected `Dict[str, Union[None, bool, float,
-        #  int, str]]` but got `Dict[str, Union[float, str]]`.
-        self.assertFalse(self.ss2.check_types(p_dict))
+        self.assertTrue(self.ss2.check_types(p_dict))  # pyre-fixme[6]
+        self.assertFalse(
+            self.ss2.check_types(p_dict, allow_extra_params=False)  # pyre-fixme[6]
+        )
         with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 1st param expected `Dict[str, Union[None, bool,
-            #  float, int, str]]` but got `Dict[str, Union[float, str]]`.
-            self.ss2.check_types(p_dict, raise_error=True)
+            self.ss2.check_types(
+                p_dict,  # pyre-fixme[6]
+                allow_extra_params=False,
+                raise_error=True,
+            )
 
     def test_CastArm(self) -> None:
         p_dict = {"a": 1.0, "b": 5.0, "c": "foo", "d": True, "e": 0.2, "f": 5}

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -39,6 +39,7 @@ from ax.modelbridge.transforms.choice_encode import (
 )
 from ax.modelbridge.transforms.convert_metric_names import ConvertMetricNames
 from ax.modelbridge.transforms.derelativize import Derelativize
+from ax.modelbridge.transforms.fill_missing_parameters import FillMissingParameters
 from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
 from ax.modelbridge.transforms.int_to_float import IntToFloat
 from ax.modelbridge.transforms.ivw import IVW
@@ -77,6 +78,7 @@ from pyre_extensions import none_throws
 logger: Logger = get_logger(__name__)
 
 Cont_X_trans: list[type[Transform]] = [
+    FillMissingParameters,
     RemoveFixed,
     OrderedChoiceToIntegerRange,
     OneHot,
@@ -89,6 +91,7 @@ Cont_X_trans: list[type[Transform]] = [
 Discrete_X_trans: list[type[Transform]] = [IntRangeToChoice]
 
 Mixed_transforms: list[type[Transform]] = [
+    FillMissingParameters,
     RemoveFixed,
     ChoiceToNumericChoice,
     IntToFloat,

--- a/ax/modelbridge/transforms/fill_missing_parameters.py
+++ b/ax/modelbridge/transforms/fill_missing_parameters.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Optional, TYPE_CHECKING
+
+from ax.core.observation import Observation, ObservationFeatures
+from ax.core.search_space import SearchSpace
+from ax.core.types import TParameterization
+from ax.modelbridge.transforms.base import Transform
+from ax.models.types import TConfig
+from ax.utils.common.typeutils import checked_cast
+from pyre_extensions import none_throws
+
+if TYPE_CHECKING:
+    # import as module to make sphinx-autodoc-typehints happy
+    from ax import modelbridge as modelbridge_module  # noqa F401
+
+
+class FillMissingParameters(Transform):
+    """If a parameter is missing from an arm, fill it with the value from
+    the dict given in the config.
+
+    Config supports two options.
+        fill_values: a dict of {parameter_name: value} to fill in for missing
+            parameters. Required.
+        fill_None: a boolean indicating whether to fill in None values. Default
+            is True. If False, parameters specified as None will remain None,
+            and only parameters absent altogether will be filled.
+    """
+
+    def __init__(
+        self,
+        search_space: SearchSpace | None = None,
+        observations: list[Observation] | None = None,
+        modelbridge: Optional["modelbridge_module.base.ModelBridge"] = None,
+        config: TConfig | None = None,
+    ) -> None:
+        config = config or {}
+        self.fill_values: TParameterization | None = config.get(  # pyre-ignore[8]
+            "fill_values", None
+        )
+        self.fill_None: bool = checked_cast(bool, config.get("fill_None", True))
+
+    def transform_observation_features(
+        self, observation_features: list[ObservationFeatures]
+    ) -> list[ObservationFeatures]:
+        if self.fill_values is None:
+            return observation_features
+        for obsf in observation_features:
+            fill_params = {
+                k: v
+                for k, v in none_throws(self.fill_values).items()
+                if k not in obsf.parameters
+                or (obsf.parameters[k] is None and self.fill_None)
+            }
+            obsf.parameters.update(fill_params)
+        return observation_features

--- a/ax/modelbridge/transforms/tests/test_fill_missing_parameters.py
+++ b/ax/modelbridge/transforms/tests/test_fill_missing_parameters.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from copy import deepcopy
+
+from ax.core.observation import ObservationFeatures
+from ax.modelbridge.transforms.fill_missing_parameters import FillMissingParameters
+from ax.utils.common.testutils import TestCase
+
+
+class FillMissingParametersTransformTest(TestCase):
+    def test_Init(self) -> None:
+        config = {"fill_values": {"x": 2.0, "y": 1.0}}
+        t = FillMissingParameters(config=config)  # pyre-ignore[6]
+        self.assertEqual(t.fill_values, config["fill_values"])
+        self.assertTrue(t.fill_None)
+        config = {"fill_values": {"x": 2.0, "y": 1.0}, "fill_None": False}
+        t = FillMissingParameters(config=config)  # pyre-ignore[6]
+        self.assertFalse(t.fill_None)
+
+    def test_TransformObservationFeatures(self) -> None:
+        observation_features = [
+            ObservationFeatures(parameters={"x": None}),
+            ObservationFeatures(parameters={"x": 0.0}),
+            ObservationFeatures(parameters={"x": 0.0, "y": 2.0}),
+        ]
+        config = {"fill_values": {"x": 2.0, "y": 1.0}}
+        t = FillMissingParameters(config=config)  # pyre-ignore[6]
+        true_1 = [
+            ObservationFeatures(parameters={"x": 2.0, "y": 1.0}),
+            ObservationFeatures(parameters={"x": 0.0, "y": 1.0}),
+            ObservationFeatures(parameters={"x": 0.0, "y": 2.0}),
+        ]
+        obs_ft1 = t.transform_observation_features(deepcopy(observation_features))
+        self.assertEqual(obs_ft1, true_1)
+        config["fill_None"] = False  # pyre-ignore[6]
+        t = FillMissingParameters(config=config)  # pyre-ignore[6]
+        true_2 = [
+            ObservationFeatures(parameters={"x": None, "y": 1.0}),
+            ObservationFeatures(parameters={"x": 0.0, "y": 1.0}),
+            ObservationFeatures(parameters={"x": 0.0, "y": 2.0}),
+        ]
+        obs_ft2 = t.transform_observation_features(deepcopy(observation_features))
+        self.assertEqual(obs_ft2, true_2)
+        # No transformation if no fill values given
+        t = FillMissingParameters(config={})
+        obs_ft3 = t.transform_observation_features(deepcopy(observation_features))
+        self.assertEqual(obs_ft3, observation_features)

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -16,6 +16,7 @@ from ax.modelbridge.transforms.choice_encode import (
 )
 from ax.modelbridge.transforms.convert_metric_names import ConvertMetricNames
 from ax.modelbridge.transforms.derelativize import Derelativize
+from ax.modelbridge.transforms.fill_missing_parameters import FillMissingParameters
 from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
 from ax.modelbridge.transforms.int_to_float import IntToFloat
 from ax.modelbridge.transforms.ivw import IVW
@@ -93,6 +94,7 @@ TRANSFORM_REGISTRY: dict[type[Transform], int] = {
     MergeRepeatedMeasurements: 26,
     TimeAsFeature: 27,
     TransformToNewSQ: 28,
+    FillMissingParameters: 29,
 }
 
 """

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2035,16 +2035,23 @@ def get_branin_data(
     return Data(df=pd.DataFrame.from_records(df_dicts))
 
 
-def get_branin_data_batch(batch: BatchTrial) -> Data:
+def get_branin_data_batch(
+    batch: BatchTrial, fill_vals: dict[str, float] | None = None
+) -> Data:
     means = []
+    fill_vals = fill_vals or {}
     for arm in batch.arms:
-        if arm.parameters["x1"] is None or arm.parameters["x2"] is None:
+        params = arm.parameters
+        for k, v in fill_vals.items():
+            if params.get(k, None) is None:
+                params[k] = v
+        if params["x1"] is None or params["x2"] is None:
             means.append(5.0)
         else:
             means.append(
                 branin(
-                    float(none_throws(arm.parameters["x1"])),
-                    float(none_throws(arm.parameters["x2"])),
+                    float(none_throws(params["x1"])),
+                    float(none_throws(params["x2"])),
                 )
             )
     return Data(

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -206,6 +206,14 @@ Transforms
     :undoc-members:
     :show-inheritance:
 
+`ax.modelbridge.transforms.fill_missing_parameters`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.fill_missing_parameters
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 `ax.modelbridge.transforms.int\_range\_to\_choice`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary:
Adds a kwarg for filling missing parameter values. This allows adding a parameter to the search space, and then arms already on the experiment but missing that parameter can be used in the model as the missing value will be filled.

By default, "missing" means either actually missing or None. So, this will by default also fill in values for a SQ arm that has been set to all None, if those SQ parameter values are provided as the fill values.

Reviewed By: saitcakmak

Differential Revision: D64879754


