### PR TITLE
Allow extra parameters in SearchSpace.check_types

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -251,7 +251,9 @@ class Experiment(Base):
     def status_quo(self, status_quo: Arm | None) -> None:
         if status_quo is not None:
             self.search_space.check_types(
-                parameterization=status_quo.parameters, raise_error=True
+                parameterization=status_quo.parameters,
+                allow_extra_params=False,
+                raise_error=True,
             )
             self.search_space.check_all_parameters_present(
                 parameterization=status_quo.parameters, raise_error=True

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -258,6 +258,7 @@ class SearchSpace(Base):
         self,
         parameterization: TParameterization,
         allow_none: bool = True,
+        allow_extra_params: bool = True,
         raise_error: bool = False,
     ) -> bool:
         """Checks that the given parameterization's types match the search space.
@@ -265,6 +266,7 @@ class SearchSpace(Base):
         Args:
             parameterization: Dict from parameter name to value to validate.
             allow_none: Whether None is a valid parameter value.
+            allow_extra_params: If parameterization can have params not in search space.
             raise_error: If true and parameterization does not belong, raises an error
                 with detailed explanation of why.
 
@@ -273,9 +275,12 @@ class SearchSpace(Base):
         """
         for name, value in parameterization.items():
             if name not in self.parameters:
-                if raise_error:
+                if allow_extra_params:
+                    continue
+                elif raise_error:
                     raise ValueError(f"Parameter {name} not defined in search space")
-                return False
+                else:
+                    return False
 
             if value is None and allow_none:
                 continue

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -319,13 +319,16 @@ class SearchSpaceTest(TestCase):
 
         # Unknown parameter
         p_dict["q"] = 40
-        # pyre-fixme[6]: For 1st param expected `Dict[str, Union[None, bool, float,
-        #  int, str]]` but got `Dict[str, Union[float, str]]`.
-        self.assertFalse(self.ss2.check_types(p_dict))
+        self.assertTrue(self.ss2.check_types(p_dict))  # pyre-fixme[6]
+        self.assertFalse(
+            self.ss2.check_types(p_dict, allow_extra_params=False)  # pyre-fixme[6]
+        )
         with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 1st param expected `Dict[str, Union[None, bool,
-            #  float, int, str]]` but got `Dict[str, Union[float, str]]`.
-            self.ss2.check_types(p_dict, raise_error=True)
+            self.ss2.check_types(
+                p_dict,  # pyre-fixme[6]
+                allow_extra_params=False,
+                raise_error=True,
+            )
 
     def test_CastArm(self) -> None:
         p_dict = {"a": 1.0, "b": 5.0, "c": "foo", "d": True, "e": 0.2, "f": 5}


### PR DESCRIPTION
Summary:
Allows (by default) extra parameters to be present when checking
types. So the behavior will be to verify the types of any parameters that are
in the search space, and ignore parameters that aren't. This allows creating
trials with parameters that are not on the experiment search space, since
otherwise we run into an error here:

https://www.internalfb.com/code/fbsource/[43d49d6a8a5f0b60658ffc89c695a278e3427a1f]/fbcode/ax/core/batch_trial.py?lines=298

The strategy in the stack of diffs here is:

1, D64968959. Kill MultiSearchSpace so we don't have to keep it up-to-date with this.
2, D64879753. Allow attaching arms with different parameter sets to the same experiment. This is important because when we add a new parameter p to the search space, we want to keep the old arms as-is. So we'll have a mix of old arms without p, and new arms with p.
3, D64879754. Once we have an experiment with arms of different parameter sets on the experiment, we need to be able to use them all in the same model. Currently, we could either give the old SS to the model, in which case the new arms would be OOD; or we could give the new SS to the model, in which case the old arms would be OOD. What we want to be able to do is provide the value of new p so that the old arms can become in-design for the new SS. This is done by providing the model with the value of new p for the old arms, so it can fill it in and everything becomes in-design for new SS.
4, D64879752. Now we have new and old arms attached to the experiment, and we can use them all in the model by filling missing parameter values. A somewhat orthogonal but closely related issue is that when we want to restrict range parameter values for the current optimization more than what we used in the original search space that those arms were generated for. We have talked many times about doing soft checks on range parameters and adapting the "modeling space" to be different than the "search space", which is what is done here.

Reviewed By: saitcakmak, Balandat, lena-kashtelyan

Differential Revision: D64879753


