### PR TITLE
Add comments to explain AxSchedulerTestCase test inheritance logic

### DIFF
--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -275,7 +275,11 @@ class AxSchedulerTestCase(TestCase):
     by overriding `GENERATION_STRATEGY_INTERFACE_CLASS` and
     `_get_generation_strategy_strategy_for_test()`. You may also need
     to subclass and change some specific tests that don't apply to
-    your specific `GenerationStrategyInterface`."""
+    your specific `GenerationStrategyInterface`.
+
+    IMPORTANT! Any class that inherits from AxSchedulerTestCase will automatically
+    inherit and run its associated tests.
+    """
 
     GENERATION_STRATEGY_INTERFACE_CLASS: type[GenerationStrategyInterface] = (
         GenerationStrategy

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -37,17 +37,18 @@ from ax.utils.testing.core_stubs import (
 
 
 class TestAxScheduler(AxSchedulerTestCase):
-    def test_logging_level_warn(self) -> None:
-        super().test_logging_level_warn()
+    """IMPORTANT! This class inherits AxSchedulerTestCase and will also
+    run its associated tests.
+    """
 
-    def test_logging_level_debug(self) -> None:
-        super().test_logging_level_debug()
-
-    def test_logging_level_is_set(self) -> None:
-        super().test_logging_level_is_set()
+    pass
 
 
 class TestAxSchedulerMultiTypeExperiment(AxSchedulerTestCase):
+    """IMPORTANT! This class inherits AxSchedulerTestCase and will also
+    run its associated tests.
+    """
+
     EXPECTED_SCHEDULER_REPR: str = (
         "Scheduler(experiment=MultiTypeExperiment(branin_test_experiment), "
         "generation_strategy=GenerationStrategy(name='Sobol+BoTorch', "


### PR DESCRIPTION
Summary: This diff is to add comments to explain AxSchedulerTestCase test inheritance logic and removes duplicate calling of tests in `TestAxScheduler`

Differential Revision: D65628941


