### PR TITLE
Move Models registry backwards compatibility support into storage layer

### DIFF
--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -17,7 +17,6 @@ from generator run, use `get_model_from_generator_run` utility from this module.
 
 from __future__ import annotations
 
-import warnings
 from enum import Enum
 from inspect import isfunction, signature
 from logging import Logger
@@ -406,6 +405,10 @@ class Models(ModelRegistryBase):
     For instance, `Models.SOBOL(search_space=search_space, scramble=False)`
     will instantiate a `RandomModelBridge(search_space=search_space)`
     with a `SobolGenerator(scramble=False)` underlying model.
+
+    NOTE: If you deprecate a model, please add its replacement to
+    `ax.storage.json_store.decoder._DEPRECATED_MODEL_TO_REPLACEMENT` to ensure
+    backwards compatibility of the storage layer.
     """
 
     SOBOL = "Sobol"
@@ -420,72 +423,6 @@ class Models(ModelRegistryBase):
     ST_MTGP = "ST_MTGP"
     BO_MIXED = "BO_MIXED"
     CONTEXT_SACBO = "Contextual_SACBO"
-
-    @classmethod
-    @property
-    def ST_MTGP_LEGACY(cls) -> Models:
-        return _deprecated_model_with_warning(
-            old_model_str="ST_MTGP_LEGACY", new_model=cls.ST_MTGP
-        )
-
-    @classmethod
-    @property
-    def ST_MTGP_NEHVI(cls) -> Models:
-        return _deprecated_model_with_warning(
-            old_model_str="ST_MTGP_NEHVI", new_model=cls.ST_MTGP
-        )
-
-    @classmethod
-    @property
-    def MOO(cls) -> Models:
-        return _deprecated_model_with_warning(
-            old_model_str="MOO", new_model=cls.BOTORCH_MODULAR
-        )
-
-    @classmethod
-    @property
-    def GPEI(cls) -> Models:
-        return _deprecated_model_with_warning(
-            old_model_str="GPEI", new_model=cls.BOTORCH_MODULAR
-        )
-
-    @classmethod
-    @property
-    def FULLYBAYESIAN(cls) -> Models:
-        return _deprecated_model_with_warning(
-            old_model_str="FULLYBAYESIAN", new_model=cls.SAASBO
-        )
-
-    @classmethod
-    @property
-    def FULLYBAYESIANMOO(cls) -> Models:
-        return _deprecated_model_with_warning(
-            old_model_str="FULLYBAYESIANMOO", new_model=cls.SAASBO
-        )
-
-    @classmethod
-    @property
-    def FULLYBAYESIAN_MTGP(cls) -> Models:
-        return _deprecated_model_with_warning(
-            old_model_str="FULLYBAYESIAN_MTGP", new_model=cls.SAAS_MTGP
-        )
-
-    @classmethod
-    @property
-    def FULLYBAYESIANMOO_MTGP(cls) -> Models:
-        return _deprecated_model_with_warning(
-            old_model_str="FULLYBAYESIANMOO_MTGP", new_model=cls.SAAS_MTGP
-        )
-
-
-def _deprecated_model_with_warning(old_model_str: str, new_model: Models) -> Models:
-    warnings.warn(
-        f"{old_model_str} is deprecated and replaced by {new_model}. "
-        f"Please use {new_model}. This will become an error in a future release.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-    return new_model
 
 
 def get_model_from_generator_run(

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -446,32 +446,6 @@ class ModelRegistryTest(TestCase):
     def test_SAAS_MTGP(self) -> None:
         self.test_ST_MTGP(use_saas=True)
 
-    def test_deprecated_models(self) -> None:
-        """Tests that deprecated models raise a warning and point to correct models.
-
-        Due to differences in internal and external Python, this test runs the
-        same check in a couple different ways.
-        """
-        for old_model_str, new_model in [
-            ("ST_MTGP_NEHVI", Models.ST_MTGP),
-            ("ST_MTGP_LEGACY", Models.ST_MTGP),
-            ("MOO", Models.BOTORCH_MODULAR),
-            ("GPEI", Models.BOTORCH_MODULAR),
-            ("FULLYBAYESIAN", Models.SAASBO),
-            ("FULLYBAYESIANMOO", Models.SAASBO),
-            ("FULLYBAYESIAN_MTGP", Models.SAAS_MTGP),
-            ("FULLYBAYESIANMOO_MTGP", Models.SAAS_MTGP),
-        ]:
-            with self.assertWarnsRegex(
-                DeprecationWarning, "deprecated and replaced by"
-            ):
-                try:
-                    self.assertEqual(new_model, getattr(Models, old_model_str))
-                except AssertionError:
-                    self.assertEqual(
-                        new_model, getattr(Models, old_model_str).fget(Models)
-                    )
-
     def test_extract_model_state_after_gen(self) -> None:
         # Test with actual state.
         exp = get_branin_experiment()


### PR DESCRIPTION
Summary: The deprecated models have been raising a `DeprecationWarning` for about a year, so loss of the ability to call `Models.FULLYBAYESIAN` is not the backwards compatibility we want to support here. We're rather interested in being able to load old experiments from the DB. Having the BC support in storage layer enables this and eliminates the need for lots of class properties (deprecated in Py3.13) on `Models`.

Differential Revision: D65608756


