### PR TITLE
fixed params to range

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -900,7 +900,7 @@ class BaseTrial(ABC, SortableBase):
             new_trial.mark_staged()
             return
         # Other statuses require the state first be set to `RUNNING`.
-        new_trial.mark_running(no_runner_required=True)
+        new_trial.mark_running(no_runner_required=True, unsafe=True)
         if self.status == TrialStatus.RUNNING:
             return
         if self.status == TrialStatus.ABANDONED:


### PR DESCRIPTION
Summary: Change fixed params to range in source search spaces to make them compatible with target search spaces. BOTL cannot handle same parameters being of different types in different experiments.

Reviewed By: Balandat

Differential Revision: D65557419


