### PR TITLE
Error out if Logit scale parameters are not transformed in ModelBridge

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -231,8 +231,12 @@ def extract_search_space_digest(
             discrete_choices[i] = p.values  # pyre-ignore [6]
             bounds.append((min(p.values), max(p.values)))  # pyre-ignore [6]
         elif isinstance(p, RangeParameter):
-            if p.log_scale:
-                raise ValueError(f"{p} is log scale")
+            if p.log_scale or p.logit_scale:
+                raise UserInputError(
+                    "Log and Logit scale parameters must be transformed using the "
+                    "corresponding transform within the `ModelBridge`. After applying "
+                    f"the transforms, we have {p.log_scale=} and {p.logit_scale=}."
+                )
             if p.parameter_type == ParameterType.INT:
                 ordinal_features.append(i)
                 d_choices = list(range(int(p.lower), int(p.upper) + 1))

--- a/ax/modelbridge/tests/test_modelbridge_utils.py
+++ b/ax/modelbridge/tests/test_modelbridge_utils.py
@@ -24,6 +24,7 @@ from ax.modelbridge.modelbridge_utils import (
     _array_to_tensor,
     extract_risk_measure,
     extract_robust_digest,
+    extract_search_space_digest,
     feasible_hypervolume,
     process_contextual_datasets,
     RISK_MEASURE_NAME_TO_CLASS,
@@ -348,3 +349,22 @@ class TestModelBridgeUtils(TestCase):
         self.assertEqual(len(contextual_datasets), 3)
         for d in contextual_datasets:
             self.assertIsInstance(d, ContextualDataset)
+
+    def test_extract_search_space_digest(self) -> None:
+        # This is also tested as part of broader TorchModelBridge tests.
+        # Test log & logit scale parameters.
+        for log_scale, logit_scale in [(True, False), (False, True)]:
+            ss = SearchSpace(
+                parameters=[
+                    RangeParameter(
+                        name="x1",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.1,
+                        upper=0.9,
+                        log_scale=log_scale,
+                        logit_scale=logit_scale,
+                    )
+                ]
+            )
+            with self.assertRaisesRegex(UserInputError, "Log and Logit"):
+                extract_search_space_digest(ss, list(ss.parameters))


### PR DESCRIPTION
Summary: For log-scale parameters, we had an error but a similar error was missing for logit-scale parameters, which would make it possible to silently ignore the `logit_scale` option for these parameters. Extended the error to cover both parameter types.

Differential Revision: D65682314


