### PR TITLE
Move stop_trial_run from Scheduler to Experiment

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -376,7 +376,7 @@ class BaseTrial(ABC, SortableBase):
 
     def assign_runner(self) -> BaseTrial:
         """Assigns default experiment runner if trial doesn't already have one."""
-        runner = self._runner or self.experiment.runner_for_trial(self)
+        runner = self.experiment.runner_for_trial(self)
         if runner is not None:
             self._runner = runner.clone()
         return self

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -314,7 +314,11 @@ class MultiTypeExperiment(Experiment):
 
         Looks up the appropriate runner for this trial type in the trial_type_to_runner.
         """
-        return self.runner_for_trial_type(trial_type=none_throws(trial.trial_type))
+        return (
+            trial._runner
+            if trial._runner
+            else self.runner_for_trial_type(trial_type=none_throws(trial.trial_type))
+        )
 
     def runner_for_trial_type(self, trial_type: str) -> Runner | None:
         """The default runner to use for a given trial type.

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
-from ax.core.base_trial import TrialStatus
+from unittest.mock import patch
+
+from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.multi_type_experiment import (
     filter_trials_by_type,
     get_trial_indices_for_statuses,
@@ -204,6 +206,28 @@ class MultiTypeExperimentTest(TestCase):
                 "m5_default_type": "type1",
             },
         )
+
+    def test_stop_trial_runs_multi_type_experiment(self) -> None:
+        # Setup 3 trials with 2 runners
+        self.experiment.new_batch_trial(trial_type="type1")
+        self.experiment.new_batch_trial(trial_type="type2")
+        self.experiment.new_batch_trial(trial_type="type2")
+        runner1 = self.experiment.runner_for_trial_type(trial_type="type1")
+        runner2 = self.experiment.runner_for_trial_type(trial_type="type2")
+
+        with patch.object(
+            runner1, "stop", return_value=None
+        ) as mock_runner_stop1, patch.object(
+            runner2, "stop", return_value=None
+        ) as mock_runner_stop2, patch.object(
+            BaseTrial, "mark_early_stopped"
+        ) as mock_mark_stopped:
+            self.experiment.stop_trial_runs(
+                trials=[self.experiment.trials[0], self.experiment.trials[1]]
+            )
+            mock_runner_stop1.assert_called_once()
+            mock_runner_stop2.assert_called()
+            mock_mark_stopped.assert_called()
 
 
 class MultiTypeExperimentUtilsTest(TestCase):

--- a/ax/exceptions/core.py
+++ b/ax/exceptions/core.py
@@ -95,6 +95,10 @@ class MisconfiguredExperiment(AxError):
     """Raised when experiment has incomplete or incorrect information."""
 
 
+class RunnerNotFoundError(AxError):
+    """Raised when a runner is not found."""
+
+
 class OptimizationComplete(AxError):
     """Raised when you hit SearchSpaceExhausted and GenerationStrategyComplete."""
 

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -919,31 +919,6 @@ class AxSchedulerTestCase(TestCase):
         scheduler.run_n_trials(max_trials=10, ignore_global_stopping_strategy=True)
         self.assertEqual(len(scheduler.experiment.trials), 10)
 
-    def test_stop_trial(self) -> None:
-        gs = self._get_generation_strategy_strategy_for_test(
-            experiment=self.branin_experiment,
-            generation_strategy=self.two_sobol_steps_GS,
-        )
-        # With runners & metrics, `Scheduler.run_all_trials` should run.
-        scheduler = Scheduler(
-            experiment=self.branin_experiment,  # Has runner and metrics.
-            generation_strategy=gs,
-            options=SchedulerOptions(
-                init_seconds_between_polls=0,  # Short between polls so test is fast.
-                **self.scheduler_options_kwargs,
-            ),
-            db_settings=self.db_settings_if_always_needed,
-        )
-        with patch.object(
-            scheduler.runner, "stop", return_value=None
-        ) as mock_runner_stop, patch.object(
-            BaseTrial, "mark_early_stopped"
-        ) as mock_mark_stopped:
-            scheduler.run_n_trials(max_trials=1)
-            scheduler.stop_trial_runs(trials=[scheduler.experiment.trials[0]])
-            mock_runner_stop.assert_called_once()
-            mock_mark_stopped.assert_called_once()
-
     @patch(f"{Scheduler.__module__}.MAX_SECONDS_BETWEEN_REPORTS", 2)
     def test_stop_at_MAX_SECONDS_BETWEEN_REPORTS(self) -> None:
         self.branin_experiment.runner = InfinitePollRunner()


### PR DESCRIPTION
Summary: as titled - `stop_trial_run` should reside within the Experiment class because the components required to stop trials are native attributes of Experiment

Differential Revision: D65777846


