### PR TITLE
Use a dataclass to store data returned by benchmark run

### DIFF
--- a/ax/benchmark/benchmark_trial_metadata.py
+++ b/ax/benchmark/benchmark_trial_metadata.py
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(kw_only=True, frozen=True)
+class BenchmarkTrialMetadata:
+    """
+    Data pertaining to one trial evaluation.
+
+    Args:
+        Ys: A dict mapping arm names to lists of corresponding outcomes,
+            where the order of the outcomes is the same as in `outcome_names`.
+        Ystds: A dict mapping arm names to lists of corresponding outcome
+            noise standard deviations (possibly nan if the noise level is
+            unobserved), where the order of the outcomes is the same as in
+            `outcome_names`.
+        outcome_names: A list of metric names.
+    """
+
+    Ys: Mapping[str, Sequence[float]]
+    Ystds: Mapping[str, Sequence[float]]
+    outcome_names: Sequence[str]

--- a/ax/benchmark/tests/test_benchmark_metric.py
+++ b/ax/benchmark/tests/test_benchmark_metric.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 from ax.benchmark.benchmark_metric import BenchmarkMetric
+from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
 from ax.core.arm import Arm
 from ax.core.batch_trial import BatchTrial
 from ax.core.trial import Trial
@@ -17,15 +18,16 @@ def get_test_trial() -> Trial:
     experiment = get_experiment()
     trial = experiment.new_trial()
     arm = Arm(parameters={"w": 1.0, "x": 1, "y": "foo", "z": True}, name="0_0")
+    outcome_names = ["test_metric1", "test_metric2"]
+
     trial.add_arm(arm)
-    trial.update_run_metadata(
-        {
-            "Ys": {"0_0": [1.0, 0.5]},
-            "Ys_true": {"0_0": [1.1, 0.4]},
-            "Ystds": {"0_0": [0.1, 0.1]},
-            "outcome_names": ["test_metric1", "test_metric2"],
-        }
+    metadata = BenchmarkTrialMetadata(
+        Ys={arm.name: [1.0, 0.5]},
+        Ystds={arm.name: [0.1, 0.1]},
+        outcome_names=outcome_names,
     )
+
+    trial.update_run_metadata({"benchmark_metadata": metadata})
     return trial
 
 
@@ -35,77 +37,72 @@ def get_test_batch_trial() -> BatchTrial:
     arm1 = Arm(parameters={"w": 1.0, "x": 1, "y": "foo", "z": True}, name="0_0")
     arm2 = Arm(parameters={"w": 1.0, "x": 2, "y": "foo", "z": True}, name="0_1")
     trial.add_arms_and_weights(arms=[arm1, arm2])
-    trial.update_run_metadata(
-        {
-            "Ys": {"0_0": [1.0, 0.5], "0_1": [2.5, 1.5]},
-            "Ys_true": {"0_0": [1.1, 0.4], "0_1": [2.5, 1.5]},
-            "Ystds": {"0_0": [0.1, 0.1], "0_1": [0.0, 0.0]},
-            "outcome_names": ["test_metric1", "test_metric2"],
-        }
-    )
+
+    Ys = {"0_0": [1.0, 0.5], "0_1": [2.5, 1.5]}
+    Ystds = {"0_0": [0.1, 0.1], "0_1": [0.0, 0.0]}
+    outcome_names = ["test_metric1", "test_metric2"]
+    metadata = BenchmarkTrialMetadata(outcome_names=outcome_names, Ys=Ys, Ystds=Ystds)
+
+    trial.update_run_metadata({"benchmark_metadata": metadata})
     return trial
 
 
 class BenchmarkMetricTest(TestCase):
+    def setUp(self) -> None:
+        self.outcome_names = ["test_metric1", "test_metric2"]
+        self.metric1, self.metric2 = (
+            BenchmarkMetric(name=name, lower_is_better=True)
+            for name in self.outcome_names
+        )
+
     def test_fetch_trial_data(self) -> None:
-        metric1 = BenchmarkMetric(name="test_metric1", lower_is_better=True)
-        metric2 = BenchmarkMetric(name="test_metric2", lower_is_better=True)
         trial = get_test_trial()
         with self.assertRaisesRegex(
             NotImplementedError,
             "Arguments {'foo'} are not supported in BenchmarkMetric",
         ):
-            metric1.fetch_trial_data(trial, foo="bar")
-        df1 = metric1.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
+            self.metric1.fetch_trial_data(trial, foo="bar")
+        df1 = self.metric1.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
         self.assertEqual(len(df1), 1)
-        self.assertDictEqual(
-            df1.iloc[0].to_dict(),
-            {
-                "arm_name": "0_0",
-                "metric_name": "test_metric1",
-                "mean": 1.0,
-                "sem": 0.1,
-                "trial_index": 0,
-            },
-        )
-        df2 = metric2.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
+        expected_results = {
+            "arm_name": "0_0",
+            "metric_name": self.outcome_names[0],
+            "mean": 1.0,
+            "sem": 0.1,
+            "trial_index": 0,
+        }
+        self.assertDictEqual(df1.iloc[0].to_dict(), expected_results)
+        df2 = self.metric2.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
         self.assertEqual(len(df2), 1)
-        self.assertDictEqual(
-            df2.iloc[0].to_dict(),
-            {
-                "arm_name": "0_0",
-                "metric_name": "test_metric2",
-                "mean": 0.5,
-                "sem": 0.1,
-                "trial_index": 0,
-            },
-        )
+        expected_results = {
+            "arm_name": "0_0",
+            "metric_name": self.outcome_names[1],
+            "mean": 0.5,
+            "sem": 0.1,
+            "trial_index": 0,
+        }
+        self.assertDictEqual(df2.iloc[0].to_dict(), expected_results)
 
     def test_fetch_trial_data_batch_trial(self) -> None:
-        metric1 = BenchmarkMetric(name="test_metric1", lower_is_better=True)
-        metric2 = BenchmarkMetric(name="test_metric2", lower_is_better=True)
+        metric1, metric2 = self.metric1, self.metric2
         trial = get_test_batch_trial()
         df1 = metric1.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
         self.assertEqual(len(df1), 2)
-        self.assertDictEqual(
-            df1.to_dict(),
-            {
-                "arm_name": {0: "0_0", 1: "0_1"},
-                "metric_name": {0: "test_metric1", 1: "test_metric1"},
-                "mean": {0: 1.0, 1: 2.5},
-                "sem": {0: 0.1, 1: 0.0},
-                "trial_index": {0: 0, 1: 0},
-            },
-        )
+        expected = {
+            "arm_name": {0: "0_0", 1: "0_1"},
+            "metric_name": {0: "test_metric1", 1: "test_metric1"},
+            "mean": {0: 1.0, 1: 2.5},
+            "sem": {0: 0.1, 1: 0.0},
+            "trial_index": {0: 0, 1: 0},
+        }
+        self.assertDictEqual(df1.to_dict(), expected)
         df2 = metric2.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
         self.assertEqual(len(df2), 2)
-        self.assertDictEqual(
-            df2.to_dict(),
-            {
-                "arm_name": {0: "0_0", 1: "0_1"},
-                "metric_name": {0: "test_metric2", 1: "test_metric2"},
-                "mean": {0: 0.5, 1: 1.5},
-                "sem": {0: 0.1, 1: 0.0},
-                "trial_index": {0: 0, 1: 0},
-            },
-        )
+        expected = {
+            "arm_name": {0: "0_0", 1: "0_1"},
+            "metric_name": {0: "test_metric2", 1: "test_metric2"},
+            "mean": {0: 0.5, 1: 1.5},
+            "sem": {0: 0.1, 1: 0.0},
+            "trial_index": {0: 0, 1: 0},
+        }
+        self.assertDictEqual(df2.to_dict(), expected)

--- a/ax/benchmark/tests/test_benchmark_runner.py
+++ b/ax/benchmark/tests/test_benchmark_runner.py
@@ -236,19 +236,18 @@ class TestBenchmarkRunner(TestCase):
                         return_value=({"branin": [4.2]}, None),
                     )
                 ):
-                    res = runner.run(trial=trial)
-                self.assertEqual({"Ys", "Ystds", "outcome_names"}, res.keys())
-                self.assertEqual({"0_0"}, res["Ys"].keys())
+                    res = runner.run(trial=trial)["benchmark_metadata"]
+                self.assertEqual({"0_0"}, res.Ys.keys())
 
                 if isinstance(noise_std, list):
-                    self.assertEqual(res["Ystds"]["0_0"], noise_std)
+                    self.assertEqual(res.Ystds["0_0"], noise_std)
                     if all((n == 0 for n in noise_std)):
-                        self.assertEqual(res["Ys"]["0_0"], Y.tolist())
+                        self.assertEqual(res.Ys["0_0"], Y.tolist())
                 else:  # float
-                    self.assertEqual(res["Ystds"]["0_0"], [noise_std] * len(Y))
+                    self.assertEqual(res.Ystds["0_0"], [noise_std] * len(Y))
                     if noise_std == 0:
-                        self.assertEqual(res["Ys"]["0_0"], Y.tolist())
-                self.assertEqual(res["outcome_names"], outcome_names)
+                        self.assertEqual(res.Ys["0_0"], Y.tolist())
+                self.assertEqual(res.outcome_names, outcome_names)
 
             with self.subTest(f"test `poll_trial_status()`, {test_description}"):
                 self.assertEqual(
@@ -288,8 +287,7 @@ class TestBenchmarkRunner(TestCase):
             trial.arms = [arm]
             trial.arm = arm
             trial.index = 0
-            res = runner.run(trial=trial)
-            self.assertSetEqual(set(res.keys()), {"Ys", "Ystds", "outcome_names"})
-            self.assertSetEqual(set(res["Ys"].keys()), {"0_0"})
-            self.assertEqual(res["Ystds"]["0_0"], [0.1, 0.05])
-            self.assertEqual(res["outcome_names"], ["objective_0", "constraint"])
+            res = runner.run(trial=trial)["benchmark_metadata"]
+            self.assertEqual({arm.name}, res.Ys.keys())
+            self.assertEqual(res.Ystds[arm.name], [0.1, 0.05])
+            self.assertEqual(res.outcome_names, ["objective_0", "constraint"])

--- a/ax/runners/simulated_backend.py
+++ b/ax/runners/simulated_backend.py
@@ -54,7 +54,7 @@ class SimulatedBackendRunner(Runner):
             trial_status[status].add(t_index)
         return dict(trial_status)
 
-    def run(self, trial: BaseTrial) -> dict[str, Any]:
+    def run(self, trial: BaseTrial) -> dict[str, float]:
         """Start a trial on the BackendSimulator.
 
         Args:

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -14,6 +14,7 @@ import torch
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
+from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
 from ax.core import Experiment, ObservationFeatures
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
@@ -288,6 +289,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "BenchmarkMethod": BenchmarkMethod,
     "BenchmarkMetric": BenchmarkMetric,
     "BenchmarkResult": BenchmarkResult,
+    "BenchmarkTrialMetadata": BenchmarkTrialMetadata,
     "BoTorchModel": BoTorchModel,
     "BraninMetric": BraninMetric,
     "BraninTimestampMapMetric": BraninTimestampMapMetric,

--- a/sphinx/source/benchmark.rst
+++ b/sphinx/source/benchmark.rst
@@ -66,6 +66,14 @@ Benchmark Test Function
     :undoc-members:
     :show-inheritance:
 
+Benchmark Trial Metadata
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.benchmark.benchmark_trial_metadata
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Benchmark Methods Modular BoTorch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary:
## `benchmark/dataclasses.py`
Introduces a small dataclass to store `Ys`, `Ystds`, and `outcome_names`, rather than keeping them in a dict. This helps with typing

## `BenchmarkRunner`, `BenchmarkMetric`:
* Now uses the above dataclasses

Reviewed By: saitcakmak

Differential Revision: D65280187
