### PR TITLE
Protocols for user-implementable classes in Ax API

### DIFF
--- a/ax/preview/api/configs.py
+++ b/ax/preview/api/configs.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional
 
+from ax.preview.api.types import TParameterValue
+
 
 # Note: I'm not sold these should be dataclasses, just using this as a placeholder
 
@@ -61,7 +63,7 @@ class ChoiceParameterConfig:
     values: List[float] | List[int] | List[str] | List[bool]
     parameter_type: ParameterType
     is_ordered: bool | None = None
-    dependent_parameters: dict[float | int | str | bool, str] | None = None
+    dependent_parameters: dict[TParameterValue, str] | None = None
 
 
 @dataclass

--- a/ax/preview/api/protocols/__init__.py
+++ b/ax/preview/api/protocols/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/preview/api/protocols/metric.py
+++ b/ax/preview/api/protocols/metric.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+from typing import Any, Mapping
+
+from ax.preview.api.protocols.utils import _APIMetric
+from pyre_extensions import override
+
+
+class IMetric(_APIMetric):
+    """
+    Metrics automate the process of fetching data from external systems. They are used
+    in conjunction with Runners in the run_n_trials method to facilitate closed-loop
+    experimentation.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name=name)
+
+    @override
+    def fetch(
+        self,
+        trial_index: int,
+        trial_metadata: Mapping[str, Any],
+    ) -> tuple[int, float | tuple[float, float]]:
+        """
+        Given trial metadata (the mapping returned from IRunner.run), fetches
+        readings for the metric.
+
+        Readings are returned as a pair (progression, outcome), where progression is
+        an integer representing the progression of the trial (e.g. number of epochs
+        for a training job, timestamp for a time series, etc.), and outcome is either
+        direct reading or a (mean, sem) pair for the metric.
+        """
+        ...

--- a/ax/preview/api/protocols/runner.py
+++ b/ax/preview/api/protocols/runner.py
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+from typing import Any, Mapping
+
+from ax.core.base_trial import TrialStatus
+from ax.preview.api.protocols.utils import _APIRunner
+from ax.preview.api.types import TParameterization
+from pyre_extensions import override
+
+
+class IRunner(_APIRunner):
+    @override
+    def run_trial(
+        self, trial_index: int, parameterization: TParameterization
+    ) -> dict[str, Any]:
+        """
+        Given an index and parameterization, run a trial and return a dictionary of any
+        appropriate metadata. This metadata will be used to identify the trial when
+        polling its status, stopping, fetching data, etc. This may hold information
+        such as the trial's unique identifier on the system its running on, a
+        directory where the trial is logging results to, etc.
+
+        The metadata MUST be JSON-serializable (i.e. dict, list, str, int, float, bool,
+        or None) so that Trials may be properly serialized in Ax.
+        """
+        ...
+
+    @override
+    def poll_trial(
+        self, trial_index: int, trial_metadata: Mapping[str, Any]
+    ) -> TrialStatus:
+        """
+        Given trial index and metadata, poll the status of the trial.
+        """
+        ...
+
+    @override
+    def stop_trial(
+        self, trial_index: int, trial_metadata: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Given trial index and metadata, stop the trial. Returns a dictionary of any
+        appropriate metadata.
+
+        The metadata MUST be JSON-serializable (i.e. dict, list, str, int, float, bool,
+        or None) so that Trials may be properly serialized in Ax.
+        """
+        ...

--- a/ax/preview/api/protocols/utils.py
+++ b/ax/preview/api/protocols/utils.py
@@ -1,0 +1,162 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import json
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Any, Iterable, Mapping
+
+import pandas as pd
+
+from ax.core.base_trial import BaseTrial, TrialStatus
+from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_metric import MapMetric
+from ax.core.metric import MetricFetchE, MetricFetchResult
+from ax.core.runner import Runner
+from ax.core.trial import Trial
+from ax.exceptions.storage import JSONEncodeError
+from ax.preview.api.types import TParameterization
+from ax.utils.common.result import Err, Ok
+from pyre_extensions import assert_is_instance, none_throws, override
+
+
+class _APIMetric(MapMetric, ABC):
+    """
+    This Metric provides implmementations for the essential MapMetric methods expected
+    by the Ax Scheduler, shimming between our IMetric and MapMetric interfaces.
+
+    Users should never instantiate or subclass this class directly.
+
+    Ideally we will be able to remove this class in the future, once we have stablized
+    structure of ax.core.Metric to be more in line with our long term vision for Ax.
+    """
+
+    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="progression", default_value=0.0)
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name=name)
+
+    @abstractmethod
+    def fetch(
+        self,
+        trial_index: int,
+        trial_metadata: Mapping[str, Any],
+    ) -> tuple[int, float | tuple[float, float]]: ...
+
+    @override
+    def fetch_trial_data(self, trial: BaseTrial, **kwargs: Any) -> MetricFetchResult:
+        """
+        Fetch data for a single trial for this metric by calling the user-implemented
+        fetch method.
+        """
+        trial = assert_is_instance(trial, Trial)
+
+        try:
+            progression, outcome = self.fetch(
+                trial_index=trial.index, trial_metadata=trial.run_metadata
+            )
+
+            if isinstance(outcome, float):
+                mean = outcome
+                sem = float("nan")
+            else:
+                mean, sem = outcome
+
+            record = {
+                "trial_index": trial.index,
+                "arm_name": none_throws(trial.arm).name,
+                "metric_name": self.name,
+                self.map_key_info.key: progression,
+                "mean": mean,
+                "sem": sem,
+            }
+            return Ok(
+                value=MapData(
+                    df=pd.DataFrame.from_records([record]),
+                    map_key_infos=[self.map_key_info],
+                )
+            )
+        except Exception as e:
+            return Err(
+                value=MetricFetchE(message=f"Failed to fetch {self.name}", exception=e)
+            )
+
+
+class _APIRunner(Runner, ABC):
+    """
+    This Runner provides implementations for the essential Runner methods expected
+    by the Ax Scheduler, shimming between our IRunner and Runner interfaces.
+
+    Users should never instantiate or subclass this class directly.
+
+    Ideally we will be able to remove this class in the future, once we have stablized
+    structure of ax.core.Runner to be more in line with our long term vision for Ax.
+    """
+
+    @abstractmethod
+    def run_trial(
+        self, trial_index: int, parameterization: TParameterization
+    ) -> dict[str, Any]: ...
+
+    @abstractmethod
+    def poll_trial(
+        self, trial_index: int, trial_metadata: Mapping[str, Any]
+    ) -> TrialStatus: ...
+
+    @abstractmethod
+    def stop_trial(
+        self, trial_index: int, trial_metadata: Mapping[str, Any]
+    ) -> dict[str, Any]: ...
+
+    @override
+    def run(self, trial: BaseTrial) -> dict[str, Any]:
+        """
+        Runs a trial by calling the user-implemented run_trial method, returning
+        appropriate metadata.
+        """
+        metadata = self.run_trial(
+            trial_index=trial.index,
+            # pyre-ignore[6] Arms in core Ax may have None in their parameters
+            parameterization=none_throws(
+                assert_is_instance(trial, Trial).arm
+            ).parameters,
+        )
+
+        # Runtime validate metadata is JSON serializable to avoid issues when
+        # serializing the Trial.
+        try:
+            json.dumps(metadata)
+            return metadata
+        except TypeError:
+            raise JSONEncodeError(
+                f"Metadata must be JSON serializable, received {metadata}"
+            )
+
+    @override
+    def poll_trial_status(
+        self, trials: Iterable[BaseTrial]
+    ) -> dict[TrialStatus, set[int]]:
+        """
+        Polls the status of trials by calling the user-implemented poll_trial method.
+        """
+        res = defaultdict(set)
+        for trial in trials:
+            status = self.poll_trial(
+                trial_index=trial.index, trial_metadata=trial.run_metadata
+            )
+
+            res[status].add(trial.index)
+
+        return res
+
+    @override
+    def stop(self, trial: BaseTrial, reason: str | None = None) -> dict[str, Any]:
+        """Stops a trial by calling the user-implemented stop_trial method"""
+        return self.stop_trial(
+            trial_index=trial.index, trial_metadata=trial.run_metadata
+        )

--- a/ax/preview/api/types.py
+++ b/ax/preview/api/types.py
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Mapping
+
+TParameterValue = int | float | str | bool
+TParameterization = Mapping[str, TParameterValue]
+
+# Metric name => mean | (mean, sem)
+TOutcome = Mapping[str, float | tuple[float, float]]

--- a/sphinx/source/preview.rst
+++ b/sphinx/source/preview.rst
@@ -10,10 +10,45 @@ ax.preview
 A preview of future Ax API
 --------------------------
 
+
+IMetric
+~~~~~~~
+
+.. automodule:: ax.preview.api.protocols.metric
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+IRunner
+~~~~~~~
+
+.. automodule:: ax.preview.api.protocols.runner
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Utils
+~~~~~~~
+
+.. automodule:: ax.preview.api.protocols.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Configs
 ~~~~~~~
 
 .. automodule:: ax.preview.api.configs
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Types
+~~~~~
+
+.. automodule:: ax.preview.api.types
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Summary: Users may wish to implement their own Metrics and Runners when using the run_n_trials method.

Differential Revision: D63836189


