### PR TITLE
Move savings estimation to ESS and GSS, respectively

### DIFF
--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -208,6 +208,26 @@ class TestBaseEarlyStoppingStrategy(TestCase):
             )[0]
         )
 
+    def test_early_stopping_savings(self) -> None:
+        class FakeStrategy(BaseEarlyStoppingStrategy):
+            def should_stop_trials_early(
+                self,
+                trial_indices: set[int],
+                experiment: Experiment,
+                **kwargs: dict[str, Any],
+            ) -> dict[int, str | None]:
+                return {}
+
+        exp = get_branin_experiment_with_timestamp_map_metric()
+        es_strategy = FakeStrategy(min_progression=3, max_progression=5)
+
+        self.assertEqual(
+            es_strategy.estimate_early_stopping_savings(
+                experiment=exp,
+            ),
+            0,
+        )
+
 
 class TestModelBasedEarlyStoppingStrategy(TestCase):
     def test_get_training_data(self) -> None:

--- a/ax/global_stopping/strategies/base.py
+++ b/ax/global_stopping/strategies/base.py
@@ -86,3 +86,26 @@ class BaseGlobalStoppingStrategy(ABC, Base):
             return False, message
 
         return self._should_stop_optimization(experiment, **kwargs)
+
+    def estimate_global_stopping_savings(
+        self, experiment: Experiment, num_remaining_requested_trials: int
+    ) -> float:
+        """Estimate global stopping savings by considering the number of requested
+        trials versus the number of trials run before the decision to stop was made.
+
+        This is formulated as 1 - (actual_num_trials / total_requested_trials). i.e.
+        0.11 estimated savings indicates we would expect the experiment to have used
+        11% more resources without global stopping present.
+
+        Returns:
+            The estimated resource savings as a fraction of total resource usage.
+        """
+        num_trials = len(experiment.trials)
+
+        if num_remaining_requested_trials == 0:
+            # Note that when no trials were requested, then savings
+            # are 1 - 0 / 0. We resolve the zero division issue by
+            # setting savings to 0 in that case.
+            return 0.0
+
+        return 1 - num_trials / (num_trials + num_remaining_requested_trials)

--- a/ax/global_stopping/tests/test_strategies.py
+++ b/ax/global_stopping/tests/test_strategies.py
@@ -385,3 +385,9 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
         self.assertFalse(constraint_satisfaction(exp.trials[1]))
         self.assertFalse(constraint_satisfaction(exp.trials[2]))
         self.assertFalse(constraint_satisfaction(exp.trials[3]))
+
+    def test_global_stopping_savings(self) -> None:
+        exp = get_experiment_with_data()
+        gss = ImprovementGlobalStoppingStrategy(min_trials=1)
+
+        self.assertEqual(gss.estimate_global_stopping_savings(exp, 1), 0.5)

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -897,7 +897,13 @@ class AxSchedulerTestCase(TestCase):
         )
         scheduler.run_n_trials(max_trials=10)
         self.assertEqual(len(scheduler.experiment.trials), 5)
-        self.assertEqual(scheduler.estimate_global_stopping_savings(), 0.5)
+        self.assertIsNotNone(scheduler.options.global_stopping_strategy)
+        self.assertEqual(
+            scheduler.options.global_stopping_strategy.estimate_global_stopping_savings(
+                scheduler.experiment, scheduler._num_remaining_requested_trials
+            ),
+            0.5,
+        )
 
     def test_ignore_global_stopping(self) -> None:
         gs = self._get_generation_strategy_strategy_for_test(
@@ -1561,7 +1567,13 @@ class AxSchedulerTestCase(TestCase):
             # "type1"
             expected_num_rows = 4
         self.assertEqual(len(fetched_data.map_df), expected_num_rows)
-        self.assertAlmostEqual(scheduler.estimate_early_stopping_savings(), 0.5)
+        self.assertIsNotNone(scheduler.options.early_stopping_strategy)
+        self.assertAlmostEqual(
+            scheduler.options.early_stopping_strategy.estimate_early_stopping_savings(
+                scheduler.experiment
+            ),
+            0.5,
+        )
 
     def test_scheduler_with_metric_with_new_data_after_completion(self) -> None:
         init_test_engine_and_session_factory(force_init=True)


### PR DESCRIPTION
Summary:
Moving the estimation methods to their respective base classes as part of cleanup: https://fburl.com/gdoc/zwgtrnn4

Also rewrote `map_key` setting logic in `estimate_early_stopping_savings` to be more readable

Differential Revision: D65840942


