### PR TITLE
MapData support

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -68,8 +68,7 @@ def compute_score_trace(
 
 
 def get_benchmark_runner(
-    problem: BenchmarkProblem,
-    max_concurrency: int = 1,
+    problem: BenchmarkProblem, max_concurrency: int = 1
 ) -> BenchmarkRunner:
     """
     Construct a ``BenchmarkRunner`` for the given problem and concurrency.

--- a/ax/benchmark/benchmark_metric.py
+++ b/ax/benchmark/benchmark_metric.py
@@ -7,12 +7,14 @@
 
 from typing import Any
 
-import pandas as pd
 from ax.core.base_trial import BaseTrial
-
 from ax.core.data import Data
+
+from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
 from ax.utils.common.result import Err, Ok
+from pyre_extensions import none_throws
 
 
 class BenchmarkMetric(Metric):
@@ -56,26 +58,120 @@ class BenchmarkMetric(Metric):
                 f"Arguments {set(kwargs)} are not supported in "
                 f"{self.__class__.__name__}.fetch_trial_data."
             )
-        metadata = trial.run_metadata["benchmark_metadata"]
-        # Look up the index based on the outcome name under which we track the data
-        # as part of `metadata`.
-        outcome_index = metadata.outcome_names.index(self.name)
-
+        df = trial.run_metadata["benchmark_metadata"].dfs[self.name]
+        if (df["t"] > 0).any():
+            raise ValueError(
+                f"Trial {trial.index} has data from multiple time steps. This is"
+                " not supported by `BenchmarkMetric`; use `BenchmarkMapMetric`."
+            )
+        df = df.drop(columns=["t"])
+        if not self.observe_noise_sd:
+            df["sem"] = None
         try:
-            records = [
-                {
-                    "arm_name": arm_name,
-                    "metric_name": self.name,
-                    "mean": metadata.Ys[arm_name][outcome_index],
-                    "sem": metadata.Ystds[arm_name][outcome_index]
-                    if self.observe_noise_sd
-                    else float("nan"),
-                    "trial_index": trial.index,
-                }
-                for arm_name in metadata.Ys.keys()
-            ]
-            df = pd.DataFrame.from_records(records)
             return Ok(value=Data(df=df))
+
+        except Exception as e:
+            return Err(
+                MetricFetchE(
+                    message=f"Failed to obtain data for trial {trial.index}",
+                    exception=e,
+                )
+            )
+
+
+class BenchmarkMapMetric(MapMetric):
+    # pyre-fixme: Inconsistent override [15]: `map_key_info` overrides attribute
+    # defined in `MapMetric` inconsistently. Type `MapKeyInfo[int]` is not a
+    # subtype of the overridden attribute `MapKeyInfo[float]`
+    map_key_info: MapKeyInfo[int] = MapKeyInfo(key="t", default_value=0)
+
+    def __init__(
+        self,
+        name: str,
+        # Needed to be boolean (not None) for validation of MOO opt configs
+        lower_is_better: bool,
+        observe_noise_sd: bool = True,
+    ) -> None:
+        """
+        Args:
+            name: Name of the metric.
+            lower_is_better: If `True`, lower metric values are considered better.
+            observe_noise_sd: If `True`, the standard deviation of the observation
+                noise is included in the `sem` column of the the returned data.
+                If `False`, `sem` is set to `None` (meaning that the model will
+                have to infer the noise level).
+        """
+        super().__init__(name=name, lower_is_better=lower_is_better)
+        # Declare `lower_is_better` as bool (rather than optional as in the base class)
+        self.lower_is_better: bool = lower_is_better
+        self.observe_noise_sd: bool = observe_noise_sd
+
+    @classmethod
+    def is_available_while_running(cls) -> bool:
+        return True
+
+    def fetch_trial_data(self, trial: BaseTrial, **kwargs: Any) -> MetricFetchResult:
+        """
+        If the trial has been completed, look up the ``sim_start_time`` and
+        ``sim_completed_time`` on the corresponding ``SimTrial``, and return all
+        data from keys 0, ..., ``sim_completed_time - sim_start_time``. If the
+        trial has not completed, return all data from keys 0, ..., ``sim_runtime
+        - sim_start_time``.
+
+        Args:
+            trial: The trial from which to fetch data.
+            kwargs: Unsupported and will raise an exception.
+
+        Returns:
+            A MetricFetchResult containing the data for the requested metric.
+        """
+        if len(kwargs) > 0:
+            raise NotImplementedError(
+                f"Arguments {set(kwargs)} are not supported in "
+                f"{self.__class__.__name__}.fetch_trial_data."
+            )
+        if len(trial.run_metadata) == 0:
+            return Err(
+                MetricFetchE(
+                    message=f"No metadata available for trial {trial.index}",
+                    exception=None,
+                )
+            )
+
+        metadata = trial.run_metadata["benchmark_metadata"]
+
+        backend_simulator = metadata.backend_simulator
+
+        if backend_simulator is None:
+            max_t = float("inf")
+        else:
+            sim_trial = none_throws(
+                backend_simulator.get_sim_trial_by_index(trial.index)
+            )
+            start_time = none_throws(sim_trial.sim_start_time)
+            if sim_trial.sim_completed_time is None:  # Still running
+                max_t = backend_simulator.time - start_time
+            else:
+                if sim_trial.sim_completed_time > backend_simulator.time:
+                    raise RuntimeError(
+                        "The trial's completion time is in the future! This is "
+                        f"unexpected. {sim_trial.sim_completed_time=}, "
+                        f"{backend_simulator.time=}"
+                    )
+                # Completed, may have stopped early
+                max_t = none_throws(sim_trial.sim_completed_time) - start_time
+
+        df = (
+            metadata.dfs[self.name]
+            .loc[lambda x: x["t"] <= max_t]
+            .rename(columns={"t": self.map_key_info.key})
+        )
+        if not self.observe_noise_sd:
+            df["sem"] = None
+
+        # Could fail if no data
+        try:
+            return Ok(value=MapData(df=df, map_key_infos=[self.map_key_info]))
 
         except Exception as e:
             return Err(

--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -10,20 +10,100 @@ from dataclasses import dataclass, field
 from math import sqrt
 from typing import Any
 
-import torch
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.batch_trial import BatchTrial
 from ax.core.runner import Runner
-from ax.core.trial import Trial
 from ax.core.types import TParamValue
 from ax.exceptions.core import UnsupportedError
 from ax.runners.simulated_backend import SimulatedBackendRunner
 from ax.utils.common.serialization import TClassDecoderRegistry, TDecoderRegistry
 from ax.utils.testing.backend_simulator import BackendSimulator, BackendSimulatorOptions
 from pyre_extensions import assert_is_instance
-from torch import Tensor
+
+
+def _dict_of_arrays_to_df(
+    Y_true_by_arm: Mapping[str, npt.NDArray], outcome_names: Sequence[str]
+) -> pd.DataFrame:
+    """
+    Return a DataFrame with columns ["metric_name", "arm_name",
+    "Y_true", "t"].
+
+    Args:
+        Y_true_by_arm: A mapping from arm name to a 2D arrays each with shape
+            (len(outcome_names), n_time_intervals).
+        outcome_names: The names of the outcomes; will be mapped to the first
+            dimension of each array in ``Y_true_by_arm``.
+    """
+    df = pd.concat(
+        [
+            pd.DataFrame(
+                {
+                    "metric_name": outcome_name,
+                    "arm_name": arm_name,
+                    "Y_true": y_true[i, :],
+                    "t": np.arange(y_true.shape[1]),
+                }
+            )
+            for i, outcome_name in enumerate(outcome_names)
+            for arm_name, y_true in Y_true_by_arm.items()
+        ],
+        ignore_index=True,
+    )
+    return df
+
+
+def _add_noise(
+    df: pd.DataFrame,
+    noise_stds: Mapping[str, float],
+    arm_weights: Mapping[str, float] | None,
+) -> pd.DataFrame:
+    """
+    For each ``Y_true`` in ``df``, with metric name ``metric_name`` and
+    arm name ``arm_name``, add noise with standard deviation
+    ``noise_stds[metric_name] / sqrt_nlzd_arm_weights[arm_name]``,
+    where ``sqrt_nlzd_arm_weights = sqrt(arm_weights[arm_name] /
+    sum(arm_weights.values())])``.
+
+    Args:
+        df: A DataFrame with columns including
+            ["metric_name", "arm_name", "Y_true"].
+        noise_stds: A mapping from metric name to what the standard
+            deviation would be if one arm received the entire
+            sample budget.
+        arm_weights: Either ``None`` if there is only one ``Arm``, or a
+            mapping from ``Arm`` name to the arm's allocation. Using arm
+            weights will increase noise levels, since each ``Arm`` is
+            assumed to receive a fraction of the total sample budget.
+
+    Returns:
+        The original ``df``, now with additional columns ["mean", "sem"].
+    """
+    noiseless = all(v == 0 for v in noise_stds.values())
+    if not noiseless:
+        noise_std_ser = df["metric_name"].map(noise_stds)
+        if arm_weights is not None:
+            nlzd_arm_weights_sqrt = {
+                arm_name: sqrt(weight / sum(arm_weights.values()))
+                for arm_name, weight in arm_weights.items()
+            }
+            arm_weights_ser = df["arm_name"].map(nlzd_arm_weights_sqrt)
+            df["sem"] = noise_std_ser / arm_weights_ser
+
+        else:
+            df["sem"] = noise_std_ser
+
+        df["mean"] = df["Y_true"] + np.random.normal(len(df)) * df["sem"]
+
+    else:
+        df["sem"] = 0.0
+        df["mean"] = df["Y_true"]
+    return df
 
 
 @dataclass(kw_only=True)
@@ -77,7 +157,6 @@ class BenchmarkRunner(Runner):
                     internal_clock=0,
                     use_update_as_start_time=False,
                 ),
-                verbose_logging=False,
             )
             self.simulated_backend_runner = SimulatedBackendRunner(
                 simulator=simulator,
@@ -93,13 +172,18 @@ class BenchmarkRunner(Runner):
         """The names of the outcomes."""
         return self.test_function.outcome_names
 
-    def get_Y_true(self, params: Mapping[str, TParamValue]) -> Tensor:
+    def get_Y_true(self, params: Mapping[str, TParamValue]) -> npt.NDArray:
         """Evaluates the test problem.
 
         Returns:
-            An `m`-dim tensor of ground truth (noiseless) evaluations.
+            An array of ground truth (noiseless) evaluations, with shape
+            (len(outcome_names), n_intervals) if is_map is True, and
+            (len(outcome_names), 1) otherwise.
         """
-        return torch.atleast_1d(self.test_function.evaluate_true(params=params))
+        result = np.atleast_1d(self.test_function.evaluate_true(params=params).numpy())
+        if result.ndim == 1:
+            return result[:, None]
+        return result
 
     def get_noise_stds(self) -> dict[str, float]:
         noise_std = self.noise_std
@@ -113,7 +197,9 @@ class BenchmarkRunner(Runner):
                 )
             return noise_std
         # list of floats
-        return dict(zip(self.outcome_names, noise_std, strict=True))
+        return dict(
+            zip(self.outcome_names, assert_is_instance(noise_std, list), strict=True)
+        )
 
     def run(self, trial: BaseTrial) -> dict[str, BenchmarkTrialMetadata]:
         """Run the trial by evaluating its parameterization(s).
@@ -125,53 +211,40 @@ class BenchmarkRunner(Runner):
             A dictionary {"benchmark_metadata": metadata}, where ``metadata`` is
             a ``BenchmarkTrialMetadata``.
         """
-        Ys, Ystds = {}, {}
-        noise_stds = self.get_noise_stds()
+        Y_true_by_arm = {
+            arm.name: self.get_Y_true(arm.parameters) for arm in trial.arms
+        }
 
-        noiseless = all(v == 0 for v in noise_stds.values())
-
-        if not noiseless:
-            # extract arm weights to adjust noise levels accordingly
-            if isinstance(trial, BatchTrial):
-                # normalize arm weights (we assume that the noise level is defined)
-                # w.r.t. to a single arm allocated all of the sample budget
-                nlzd_arm_weights = {
-                    arm: weight / sum(trial.arm_weights.values())
-                    for arm, weight in trial.arm_weights.items()
-                }
-            else:
-                nlzd_arm_weights = {assert_is_instance(trial, Trial).arm: 1.0}
-            # generate a tensor of noise levels that we'll reuse below
-            noise_stds_tsr = torch.tensor(
-                [noise_stds[metric_name] for metric_name in self.outcome_names],
-                dtype=torch.double,
-            )
-
-        for arm in trial.arms:
-            # Case where we do have a ground truth
-            Y_true = self.get_Y_true(arm.parameters)
-            if noiseless:
-                # No noise, so just return the true outcome.
-                Ystds[arm.name] = [0.0] * len(Y_true)
-                Ys[arm.name] = Y_true.tolist()
-            else:
-                # We can scale the noise std by the inverse of the relative sample
-                # budget allocation to each arm. This works b/c (i) we assume that
-                # observations per unit sample budget are i.i.d. and (ii) the
-                # normalized weights sum to one.
-                # pyre-fixme[61]: `nlzd_arm_weights` is undefined, or not always
-                #  defined.
-                std = noise_stds_tsr.to(Y_true) / sqrt(nlzd_arm_weights[arm])
-                Ystds[arm.name] = std.tolist()
-                Ys[arm.name] = (Y_true + std * torch.randn_like(Y_true)).tolist()
-
-        metadata = BenchmarkTrialMetadata(
-            Ys=Ys,
-            Ystds=Ystds,
-            outcome_names=self.outcome_names,
+        df = _dict_of_arrays_to_df(
+            Y_true_by_arm=Y_true_by_arm, outcome_names=self.outcome_names
         )
+
+        arm_weights = (
+            {arm.name: w for arm, w in trial.arm_weights.items()}
+            if isinstance(trial, BatchTrial)
+            else None
+        )
+
+        df = _add_noise(
+            df=df, noise_stds=self.get_noise_stds(), arm_weights=arm_weights
+        )
+        df["trial_index"] = trial.index
+        df.drop(columns=["Y_true"], inplace=True)
+
         if self.simulated_backend_runner is not None:
             self.simulated_backend_runner.run(trial=trial)
+
+        dfs = {
+            outcome_name: df[df["metric_name"] == outcome_name]
+            for outcome_name in self.outcome_names
+        }
+
+        metadata = BenchmarkTrialMetadata(
+            dfs=dfs,
+            backend_simulator=None
+            if self.simulated_backend_runner is None
+            else self.simulated_backend_runner.simulator,
+        )
         return {"benchmark_metadata": metadata}
 
     def poll_trial_status(

--- a/ax/benchmark/benchmark_test_function.py
+++ b/ax/benchmark/benchmark_test_function.py
@@ -32,6 +32,8 @@ class BenchmarkTestFunction(ABC):
         Evaluate noiselessly.
 
         Returns:
-            1d tensor of shape (len(outcome_names),).
+            A 2d tensor of shape (len(outcome_names), n_intervals).
+            ``n_intervals`` is only relevant when using time-series data
+            (``MapData``). Otherwise, it is 1.
         """
         ...

--- a/ax/benchmark/benchmark_trial_metadata.py
+++ b/ax/benchmark/benchmark_trial_metadata.py
@@ -4,8 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from collections.abc import Mapping, Sequence
+
+from collections.abc import Mapping
 from dataclasses import dataclass
+
+import pandas as pd
+
+from ax.utils.testing.backend_simulator import BackendSimulator
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -14,15 +19,16 @@ class BenchmarkTrialMetadata:
     Data pertaining to one trial evaluation.
 
     Args:
-        Ys: A dict mapping arm names to lists of corresponding outcomes,
-            where the order of the outcomes is the same as in `outcome_names`.
-        Ystds: A dict mapping arm names to lists of corresponding outcome
-            noise standard deviations (possibly nan if the noise level is
-            unobserved), where the order of the outcomes is the same as in
-            `outcome_names`.
-        outcome_names: A list of metric names.
+        df: A dict mapping each metric name to a Pandas DataFrame with columns
+            ["metric_name", "arm_name", "mean", "sem", and "t"]. The "sem" is
+            always present in this df even if noise levels are unobserved;
+            ``BenchmarkMetric`` and ``BenchmarkMapMetric`` hide that data if it
+            should not be observed, and ``BenchmarkMapMetric``s drop data from
+            time periods that that are not observed based on the (simulated)
+            trial progression.
+        backend_simulator: Optionally, the backend simulator that is tracking
+            the trial's status.
     """
 
-    Ys: Mapping[str, Sequence[float]]
-    Ystds: Mapping[str, Sequence[float]]
-    outcome_names: Sequence[str]
+    dfs: Mapping[str, pd.DataFrame]
+    backend_simulator: BackendSimulator | None = None

--- a/ax/benchmark/tests/test_benchmark_metric.py
+++ b/ax/benchmark/tests/test_benchmark_metric.py
@@ -5,43 +5,80 @@
 
 # pyre-strict
 
-from ax.benchmark.benchmark_metric import BenchmarkMetric
+from unittest.mock import Mock
+
+import numpy as np
+import pandas as pd
+from ax.benchmark.benchmark_metric import BenchmarkMapMetric, BenchmarkMetric
 from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
 from ax.core.arm import Arm
 from ax.core.batch_trial import BatchTrial
 from ax.core.trial import Trial
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.backend_simulator import BackendSimulator, BackendSimulatorOptions
 from ax.utils.testing.core_stubs import get_experiment
+from pyre_extensions import none_throws
 
 
-def get_test_trial() -> Trial:
+def get_test_trial(map_data: bool = False, batch: bool = False) -> Trial | BatchTrial:
     experiment = get_experiment()
-    trial = experiment.new_trial()
-    arm = Arm(parameters={"w": 1.0, "x": 1, "y": "foo", "z": True}, name="0_0")
-    outcome_names = ["test_metric1", "test_metric2"]
 
-    trial.add_arm(arm)
-    metadata = BenchmarkTrialMetadata(
-        Ys={arm.name: [1.0, 0.5]},
-        Ystds={arm.name: [0.1, 0.1]},
-        outcome_names=outcome_names,
-    )
-
-    trial.update_run_metadata({"benchmark_metadata": metadata})
-    return trial
-
-
-def get_test_batch_trial() -> BatchTrial:
-    experiment = get_experiment()
-    trial = experiment.new_batch_trial()
     arm1 = Arm(parameters={"w": 1.0, "x": 1, "y": "foo", "z": True}, name="0_0")
     arm2 = Arm(parameters={"w": 1.0, "x": 2, "y": "foo", "z": True}, name="0_1")
-    trial.add_arms_and_weights(arms=[arm1, arm2])
 
-    Ys = {"0_0": [1.0, 0.5], "0_1": [2.5, 1.5]}
-    Ystds = {"0_0": [0.1, 0.1], "0_1": [0.0, 0.0]}
-    outcome_names = ["test_metric1", "test_metric2"]
-    metadata = BenchmarkTrialMetadata(outcome_names=outcome_names, Ys=Ys, Ystds=Ystds)
+    if batch:
+        trial = experiment.new_batch_trial()
+        trial.add_arms_and_weights(arms=[arm1, arm2])
+    else:
+        trial = experiment.new_trial()
+        trial.add_arm(arm=arm1)
+
+    dfs = {
+        "test_metric1": pd.DataFrame(
+            {
+                "arm_name": ["0_0", "0_1"] if batch else ["0_0"],
+                "metric_name": "test_metric1",
+                "mean": [1.0, 2.5] if batch else [1.0],
+                "sem": [0.1, 0.0] if batch else [0.1],
+                "t": 0,
+                "trial_index": 0,
+            }
+        ),
+        "test_metric2": pd.DataFrame(
+            {
+                "arm_name": ["0_0", "0_1"] if batch else ["0_0"],
+                "metric_name": "test_metric2",
+                "mean": [0.5, 1.5] if batch else [0.5],
+                "sem": [0.1, 0.0] if batch else [0.1],
+                "t": 0,
+                "trial_index": 0,
+            }
+        ),
+    }
+
+    if map_data:
+        backend_simulator = BackendSimulator(
+            options=BackendSimulatorOptions(
+                max_concurrency=1,
+                internal_clock=0,
+            ),
+            verbose_logging=False,
+        )
+        n_time_intervals = 3
+        dfs = {
+            k: pd.concat([df] * n_time_intervals).assign(
+                t=np.repeat(np.arange(n_time_intervals), 2 if batch else 1)
+            )
+            for k, df in dfs.items()
+        }
+
+        backend_simulator.run_trial(trial_index=trial.index, runtime=1)
+        metadata = BenchmarkTrialMetadata(
+            dfs=dfs,
+            backend_simulator=backend_simulator,
+        )
+    else:
+        metadata = BenchmarkTrialMetadata(dfs=dfs)
 
     trial.update_run_metadata({"benchmark_metadata": metadata})
     return trial
@@ -54,15 +91,19 @@ class BenchmarkMetricTest(TestCase):
             BenchmarkMetric(name=name, lower_is_better=True)
             for name in self.outcome_names
         )
+        self.map_metric1, self.map_metric2 = (
+            BenchmarkMapMetric(name=name, lower_is_better=True)
+            for name in self.outcome_names
+        )
 
     def test_fetch_trial_data(self) -> None:
         trial = get_test_trial()
         with self.assertRaisesRegex(
             NotImplementedError,
-            "Arguments {'foo'} are not supported in BenchmarkMetric",
+            "Arguments {'foo'} are not supported in Benchmark",
         ):
             self.metric1.fetch_trial_data(trial, foo="bar")
-        df1 = self.metric1.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
+        df1 = self.metric1.fetch_trial_data(trial=trial).value.df
         self.assertEqual(len(df1), 1)
         expected_results = {
             "arm_name": "0_0",
@@ -72,7 +113,7 @@ class BenchmarkMetricTest(TestCase):
             "trial_index": 0,
         }
         self.assertDictEqual(df1.iloc[0].to_dict(), expected_results)
-        df2 = self.metric2.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
+        df2 = self.metric2.fetch_trial_data(trial=trial).value.df
         self.assertEqual(len(df2), 1)
         expected_results = {
             "arm_name": "0_0",
@@ -83,9 +124,58 @@ class BenchmarkMetricTest(TestCase):
         }
         self.assertDictEqual(df2.iloc[0].to_dict(), expected_results)
 
-    def test_fetch_trial_data_batch_trial(self) -> None:
-        metric1, metric2 = self.metric1, self.metric2
-        trial = get_test_batch_trial()
+    def test_fetch_trial_map_data(self) -> None:
+        trial = get_test_trial(map_data=True)
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "Arguments {'foo'} are not supported in Benchmark",
+        ):
+            self.map_metric1.fetch_trial_data(trial, foo="bar")
+
+        map_df1 = self.map_metric1.fetch_trial_data(trial=trial).value.map_df
+        self.assertEqual(len(map_df1), 1)
+        expected_results = {
+            "arm_name": "0_0",
+            "metric_name": self.outcome_names[0],
+            "mean": 1.0,
+            "sem": 0.1,
+            "trial_index": 0,
+            "t": 0,
+        }
+
+        self.assertDictEqual(map_df1.iloc[0].to_dict(), expected_results)
+        map_df2 = self.map_metric2.fetch_trial_data(trial=trial).value.map_df
+        self.assertEqual(len(map_df2), 1)
+        expected_results = {
+            "arm_name": "0_0",
+            "metric_name": self.outcome_names[1],
+            "mean": 0.5,
+            "sem": 0.1,
+            "trial_index": 0,
+            "t": 0,
+        }
+        self.assertDictEqual(map_df2.iloc[0].to_dict(), expected_results)
+
+        backend_simulator = trial.run_metadata["benchmark_metadata"].backend_simulator
+        self.assertEqual(backend_simulator.time, 0)
+        sim_trial = none_throws(backend_simulator.get_sim_trial_by_index(trial.index))
+        self.assertIn(sim_trial, backend_simulator._running)
+        backend_simulator.update()
+        self.assertEqual(backend_simulator.time, 1)
+        self.assertIn(sim_trial, backend_simulator._completed)
+        backend_simulator.update()
+        self.assertIn(sim_trial, backend_simulator._completed)
+        self.assertEqual(backend_simulator.time, 2)
+        map_df1 = self.map_metric1.fetch_trial_data(trial=trial).value.map_df
+        self.assertEqual(len(map_df1), 2)
+        self.assertEqual(set(map_df1["t"].tolist()), {0, 1})
+
+    def _test_fetch_trial_data_batch_trial(self, map_data: bool) -> None:
+        if map_data:
+            metric1, metric2 = self.map_metric1, self.map_metric2
+        else:
+            metric1, metric2 = self.metric1, self.metric2
+        trial = get_test_trial(map_data=map_data, batch=True)
         df1 = metric1.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
         self.assertEqual(len(df1), 2)
         expected = {
@@ -95,6 +185,9 @@ class BenchmarkMetricTest(TestCase):
             "sem": {0: 0.1, 1: 0.0},
             "trial_index": {0: 0, 1: 0},
         }
+        if map_data:
+            expected["t"] = {0: 0, 1: 0}
+
         self.assertDictEqual(df1.to_dict(), expected)
         df2 = metric2.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
         self.assertEqual(len(df2), 2)
@@ -105,4 +198,35 @@ class BenchmarkMetricTest(TestCase):
             "sem": {0: 0.1, 1: 0.0},
             "trial_index": {0: 0, 1: 0},
         }
+        if map_data:
+            expected["t"] = {0: 0, 1: 0}
         self.assertDictEqual(df2.to_dict(), expected)
+
+    def test_fetch_trial_data_batch_trial(self) -> None:
+        self._test_fetch_trial_data_batch_trial(map_data=False)
+        self._test_fetch_trial_data_batch_trial(map_data=True)
+
+    def test_sim_trial_completes_in_future_raises(self) -> None:
+        simulator = BackendSimulator()
+        simulator.run_trial(trial_index=0, runtime=0)
+        simulator.update()
+        simulator._internal_clock = -1
+        metadata = BenchmarkTrialMetadata(
+            dfs={"test_metric": pd.DataFrame({"t": [3]})}, backend_simulator=simulator
+        )
+        trial = Mock(spec=Trial)
+        trial.index = 0
+        trial.run_metadata = {"benchmark_metadata": metadata}
+        metric = BenchmarkMapMetric(name="test_metric", lower_is_better=True)
+        with self.assertRaisesRegex(RuntimeError, "in the future"):
+            metric.fetch_trial_data(trial=trial)
+
+    def test_map_data_without_map_metric_raises(self) -> None:
+        metadata = BenchmarkTrialMetadata(
+            dfs={"test_metric": pd.DataFrame({"t": [0, 1]})},
+        )
+        trial = Mock(spec=Trial)
+        trial.run_metadata = {"benchmark_metadata": metadata}
+        metric = BenchmarkMetric(name="test_metric", lower_is_better=True)
+        with self.assertRaisesRegex(ValueError, "data from multiple time steps"):
+            metric.fetch_trial_data(trial=trial)

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Iterator
 
@@ -293,7 +293,8 @@ class DeterministicGenerationNode(ExternalGenerationNode):
 
 @dataclass(kw_only=True)
 class IdentityTestFunction(BenchmarkTestFunction):
-    outcome_names: list[str] = field(default_factory=lambda: ["objective"])
+    outcome_names: Sequence[str] = field(default_factory=lambda: ["objective"])
+    n_time_intervals: int = 1
 
     # pyre-fixme[14]: Inconsistent override
     def evaluate_true(self, params: Mapping[str, float]) -> torch.Tensor:
@@ -301,7 +302,10 @@ class IdentityTestFunction(BenchmarkTestFunction):
         Args:
             params: A dictionary with key "x0".
         """
-        return torch.tensor(params["x0"], dtype=torch.float64)
+        value = params["x0"]
+        return torch.full(
+            (len(self.outcome_names), self.n_time_intervals), value, dtype=torch.float64
+        )
 
 
 def get_discrete_search_space() -> SearchSpace:


### PR DESCRIPTION
Summary:
**`BenchmarkMapMetric`**
* A `MapMetric`, returning `MapData`.
* Receives an entire learning curve and looks to the backend simulator to see whether to return partial data, if the trial has still been running or has been early-stopped.

**`BenchmarkMapTestFunction`**
* Now produces a 2d tensor rather than a 1d tensor, with the second dimension being the progression along the learning curve or time series.
* Always produces the entire learning curve or time series. If we only observe partial data, `BenchmarkMapMetric` will handle that.

**`LearningCurveTestFunction`**
A `BenchmarkTestFunction` that decays smoothly to the value of some underlying base test function. This may not be interesting to benchmark, but is useful for testing. We may want to delete this.

**`BenchmarkRunner`**
* Always produces the entire learning curve or time series. If we only observe partial data, `BenchmarkMapMetric` will handle that.
* Now works with numpy arrays rather than torch tensors. This may be controversial, but results eventually wind up as numpy arrays, and Ax always needs numpy as a dependency and doesn't always need torch, so I figure the more we can avoid torch, the better.
* Adds IID noise to each element of a time series. We can add more sophisticated noise generators in the future.

**`benchmark_problem.py`**
Adds an option to generate a `LearningCurveTestFunction` from a BoTorch problem. We may want to delete this if we don't want to keep `LearningCurveTestFunction` around.

**`BenchmarkTrialMetadata`**
Now stores `Ys` and `Ystds` as numpy arrays rather than lists of floats.

Differential Revision: D64198634


