### PR TITLE
Remove redundant MultiObjectiveOptimizationConfig.metrics definition

### DIFF
--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -123,12 +123,12 @@ class OptimizationConfig(Base):
     def metrics(self) -> dict[str, Metric]:
         constraint_metrics = {
             oc.metric.name: oc.metric
-            for oc in self._outcome_constraints
+            for oc in self.all_constraints
             if not isinstance(oc, ScalarizedOutcomeConstraint)
         }
         scalarized_constraint_metrics = {
             metric.name: metric
-            for oc in self._outcome_constraints
+            for oc in self.all_constraints
             if isinstance(oc, ScalarizedOutcomeConstraint)
             for metric in oc.metrics
         }
@@ -345,26 +345,6 @@ class MultiObjectiveOptimizationConfig(OptimizationConfig):
     def all_constraints(self) -> list[OutcomeConstraint]:
         """Get all constraints and thresholds."""
         return self.outcome_constraints + self.objective_thresholds
-
-    @property
-    def metrics(self) -> dict[str, Metric]:
-        constraint_metrics = {
-            oc.metric.name: oc.metric
-            for oc in self.all_constraints
-            if not isinstance(oc, ScalarizedOutcomeConstraint)
-        }
-        scalarized_constraint_metrics = {
-            metric.name: metric
-            for oc in self.all_constraints
-            if isinstance(oc, ScalarizedOutcomeConstraint)
-            for metric in oc.metrics
-        }
-        objective_metrics = {metric.name: metric for metric in self.objective.metrics}
-        return {
-            **constraint_metrics,
-            **scalarized_constraint_metrics,
-            **objective_metrics,
-        }
 
     @property
     def objective_thresholds(self) -> list[ObjectiveThreshold]:


### PR DESCRIPTION
Summary: The base property can use `all_constraints`, which makes the redefined property redundant.

Differential Revision: D65888209


