### PR TITLE
Remove unused function from benchmark_stubs

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -89,7 +89,7 @@ class BenchmarkProblem(Base):
     optimization_config: OptimizationConfig
     num_trials: int
     test_function: BenchmarkTestFunction
-    noise_std: float | list[float] | dict[str, float] = 0.0
+    noise_std: float | Sequence[float] | Mapping[str, float] = 0.0
     optimal_value: float
 
     search_space: SearchSpace = field(repr=False)
@@ -148,41 +148,57 @@ class BenchmarkProblem(Base):
 
 
 def _get_constraints(
-    num_constraints: int, observe_noise_sd: bool
+    constraint_names: Sequence[str], observe_noise_sd: bool
 ) -> list[OutcomeConstraint]:
     """
-    NOTE: Currently we don't support the case where only some of the
-    outcomes have noise levels observed.
-    """
-    outcome_constraints = []
+    Create a list of ``OutcomeConstraint``s.
 
-    for i in range(num_constraints):
-        outcome_name = f"constraint_slack_{i}"
-        outcome_constraints.append(
-            OutcomeConstraint(
-                metric=BenchmarkMetric(
-                    name=outcome_name,
-                    lower_is_better=False,  # positive slack = feasible
-                    observe_noise_sd=observe_noise_sd,
-                ),
-                op=ComparisonOp.GEQ,
-                bound=0.0,
-                relative=False,
-            )
+    Each constraint has a ``BenchmarkMetric``; the metrics names match
+    ``constraint_names``, and each has ``observe_noise_sd=observe_noise_sd``.
+    This doesn't handle the case where only some of the outcomes have noise
+    levels observed.
+    """
+
+    outcome_constraints = [
+        OutcomeConstraint(
+            metric=BenchmarkMetric(
+                name=name,
+                lower_is_better=False,  # positive slack = feasible
+                observe_noise_sd=observe_noise_sd,
+            ),
+            op=ComparisonOp.GEQ,
+            bound=0.0,
+            relative=False,
         )
+        for name in constraint_names
+    ]
     return outcome_constraints
 
 
-def get_soo_config_and_outcome_names(
+def get_soo_opt_config(
     *,
-    num_constraints: int,
-    lower_is_better: bool,
-    observe_noise_sd: bool,
-    objective_name: str,
-) -> tuple[OptimizationConfig, list[str]]:
+    outcome_names: Sequence[str],
+    lower_is_better: bool = True,
+    observe_noise_sd: bool = False,
+) -> OptimizationConfig:
+    """
+    Create a single-objective ``OptimizationConfig``, potentially with
+    constraints.
+
+    Args:
+        outcome_names: Names of the outcomes. If ``outcome_names`` has more than
+            one element, constraints will be created. The first element of
+            ``outcome_names`` will be the name of the ``BenchmarkMetric`` on
+            the objective, and others (if pressent) will be for constraints.
+        lower_is_better: Whether the objective is a minimization problem. This
+            only affects objectives, not constraints; for constraints, higher is
+            better (feasible).
+        observe_noise_sd: Whether the standard deviation of the observation
+            noise is observed. Applies to all objective and constraints.
+    """
     objective = Objective(
         metric=BenchmarkMetric(
-            name=objective_name,
+            name=outcome_names[0],
             lower_is_better=lower_is_better,
             observe_noise_sd=observe_noise_sd,
         ),
@@ -190,55 +206,75 @@ def get_soo_config_and_outcome_names(
     )
 
     outcome_constraints = _get_constraints(
-        num_constraints=num_constraints, observe_noise_sd=observe_noise_sd
+        constraint_names=outcome_names[1:], observe_noise_sd=observe_noise_sd
     )
-    constraint_names = [oc.metric.name for oc in outcome_constraints]
 
-    opt_config = OptimizationConfig(
+    return OptimizationConfig(
         objective=objective, outcome_constraints=outcome_constraints
     )
-    outcome_names = [objective_name] + constraint_names
-    return opt_config, outcome_names
 
 
-def get_moo_opt_config_and_outcome_names(
+def get_moo_opt_config(
     *,
-    num_constraints: int,
-    lower_is_better: bool,
-    observe_noise_sd: bool,
-    objective_names: list[str],
-    ref_point: list[float],
-) -> tuple[MultiObjectiveOptimizationConfig, list[str]]:
-    metrics = [
+    outcome_names: Sequence[str],
+    ref_point: Sequence[float],
+    num_constraints: int = 0,
+    lower_is_better: bool = True,
+    observe_noise_sd: bool = False,
+) -> MultiObjectiveOptimizationConfig:
+    """
+    Create a ``MultiObjectiveOptimizationConfig``, potentially with constraints.
+
+    Args:
+        outcome_names: Names of the outcomes. If ``num_constraints`` is greater
+            than zero, the last ``num_constraints`` elements of
+            ``outcome_names`` will become the names of ``BenchmarkMetric``s on
+            constraints, and the others will correspond to the objectives.
+        ref_point: Objective thresholds for the objective metrics. Note:
+            Although this method requires providing a threshold for each
+            objective, this is not required in general and could be enabled for
+            this method.
+        num_constraints: Number of constraints.
+        lower_is_better: Whether the objectives are lower-is-better. Applies to
+            all objectives and not to constraints. For constraints, higher is
+            better (feasible). Note: Ax allows different metrics to have
+            different values of ``lower_is_better``; that isn't enabled for this
+            method, but could be.
+        observe_noise_sd: Whether the standard deviation of the observation
+        noise is observed. Applies to all objective and constraints.
+    """
+    n_objectives = len(outcome_names) - num_constraints
+    objective_metrics = [
         BenchmarkMetric(
-            name=objective_name,
+            name=outcome_names[i],
             lower_is_better=lower_is_better,
             observe_noise_sd=observe_noise_sd,
         )
-        for objective_name in objective_names
+        for i in range(n_objectives)
     ]
     constraints = _get_constraints(
-        num_constraints=num_constraints, observe_noise_sd=observe_noise_sd
+        constraint_names=outcome_names[n_objectives:],
+        observe_noise_sd=observe_noise_sd,
     )
     optimization_config = MultiObjectiveOptimizationConfig(
         objective=MultiObjective(
             objectives=[
-                Objective(metric=metric, minimize=lower_is_better) for metric in metrics
+                Objective(metric=metric, minimize=lower_is_better)
+                for metric in objective_metrics
             ]
         ),
         objective_thresholds=[
             ObjectiveThreshold(
                 metric=metric,
-                bound=ref_point[i],
+                bound=ref_p,
                 relative=False,
                 op=ComparisonOp.LEQ if metric.lower_is_better else ComparisonOp.GEQ,
             )
-            for i, metric in enumerate(metrics)
+            for ref_p, metric in zip(ref_point, objective_metrics, strict=True)
         ],
         outcome_constraints=constraints,
     )
-    outcome_names = objective_names + [oc.metric.name for oc in constraints]
-    return optimization_config, outcome_names
+    return optimization_config
 
 
 def get_continuous_search_space(bounds: list[tuple[float, float]]) -> SearchSpace:
@@ -315,19 +351,30 @@ def create_problem_from_botorch(
 
     num_constraints = test_problem.num_constraints if is_constrained else 0
     if isinstance(test_problem, MultiObjectiveTestProblem):
-        optimization_config, outcome_names = get_moo_opt_config_and_outcome_names(
+        objective_names = [f"{name}_{i}" for i in range(n_obj)]
+    else:
+        objective_names = [name]
+
+    constraint_names = [f"constraint_slack_{i}" for i in range(num_constraints)]
+    outcome_names = objective_names + constraint_names
+
+    test_function = BoTorchTestFunction(
+        botorch_problem=test_problem, outcome_names=outcome_names
+    )
+
+    if isinstance(test_problem, MultiObjectiveTestProblem):
+        optimization_config = get_moo_opt_config(
             num_constraints=num_constraints,
             lower_is_better=lower_is_better,
             observe_noise_sd=observe_noise_sd,
-            objective_names=[f"{name}_{i}" for i in range(n_obj)],
+            outcome_names=test_function.outcome_names,
             ref_point=test_problem._ref_point,
         )
     else:
-        optimization_config, outcome_names = get_soo_config_and_outcome_names(
-            num_constraints=num_constraints,
+        optimization_config = get_soo_opt_config(
+            outcome_names=test_function.outcome_names,
             lower_is_better=lower_is_better,
             observe_noise_sd=observe_noise_sd,
-            objective_name=name,
         )
 
     optimal_value = (
@@ -335,13 +382,12 @@ def create_problem_from_botorch(
         if isinstance(test_problem, MultiObjectiveTestProblem)
         else test_problem.optimal_value
     )
+
     return BenchmarkProblem(
         name=name,
         search_space=search_space,
         optimization_config=optimization_config,
-        test_function=BoTorchTestFunction(
-            botorch_problem=test_problem, outcome_names=outcome_names
-        ),
+        test_function=test_function,
         noise_std=noise_std,
         num_trials=num_trials,
         optimal_value=optimal_value,

--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -63,7 +63,7 @@ class BenchmarkRunner(Runner):
     """
 
     test_function: BenchmarkTestFunction
-    noise_std: float | list[float] | dict[str, float] = 0.0
+    noise_std: float | Sequence[float] | Mapping[str, float] = 0.0
     trial_runtime_func: Callable[[BaseTrial], int] | None = None
     max_concurrency: int = 1
     simulated_backend_runner: SimulatedBackendRunner | None = field(init=False)

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -10,10 +10,7 @@ from dataclasses import dataclass, field, InitVar
 from functools import lru_cache
 
 import torch
-from ax.benchmark.benchmark_problem import (
-    BenchmarkProblem,
-    get_soo_config_and_outcome_names,
-)
+from ax.benchmark.benchmark_problem import BenchmarkProblem, get_soo_opt_config
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
@@ -210,11 +207,8 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
     )
 
     test_function = PyTorchCNNTorchvisionBenchmarkTestFunction(name=name)
-    optimization_config, _ = get_soo_config_and_outcome_names(
-        num_constraints=0,
-        lower_is_better=False,
-        observe_noise_sd=False,
-        objective_name=test_function.outcome_names[0],
+    optimization_config = get_soo_opt_config(
+        outcome_names=test_function.outcome_names, lower_is_better=False
     )
     return BenchmarkProblem(
         name=f"HPO_PyTorchCNN_Torchvision::{name}",

--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -18,12 +18,8 @@ References
     35, 2022.
 """
 
-from ax.benchmark.benchmark_metric import BenchmarkMetric
-
-from ax.benchmark.benchmark_problem import BenchmarkProblem
+from ax.benchmark.benchmark_problem import BenchmarkProblem, get_soo_opt_config
 from ax.benchmark.benchmark_test_functions.botorch_test import BoTorchTestFunction
-from ax.core.objective import Objective
-from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from botorch.test_functions.synthetic import Ackley, Hartmann, Rosenbrock
@@ -86,15 +82,10 @@ def _get_problem_from_common_inputs(
             for i in range(dim)
         ]
     )
-    optimization_config = OptimizationConfig(
-        objective=Objective(
-            metric=BenchmarkMetric(
-                name=metric_name,
-                lower_is_better=lower_is_better,
-                observe_noise_sd=observe_noise_sd,
-            ),
-            minimize=lower_is_better,
-        )
+    optimization_config = get_soo_opt_config(
+        outcome_names=[metric_name],
+        lower_is_better=lower_is_better,
+        observe_noise_sd=observe_noise_sd,
     )
 
     if test_problem_bounds is None:

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -9,11 +9,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 
 import torch
-from ax.benchmark.benchmark_metric import BenchmarkMetric
-from ax.benchmark.benchmark_problem import BenchmarkProblem
+from ax.benchmark.benchmark_problem import BenchmarkProblem, get_soo_opt_config
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
-from ax.core.objective import Objective
-from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import HierarchicalSearchSpace
 from pyre_extensions import none_throws
@@ -108,15 +105,10 @@ def get_jenatton_benchmark_problem(
     noise_std: float = 0.0,
 ) -> BenchmarkProblem:
     name = "Jenatton" + ("_observed_noise" if observe_noise_sd else "")
-
-    optimization_config = OptimizationConfig(
-        objective=Objective(
-            metric=BenchmarkMetric(
-                name=name, observe_noise_sd=observe_noise_sd, lower_is_better=True
-            ),
-            minimize=True,
-        )
+    optimization_config = get_soo_opt_config(
+        outcome_names=[name], observe_noise_sd=observe_noise_sd
     )
+
     return BenchmarkProblem(
         name=name,
         search_space=get_jenatton_search_space(),

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -13,6 +13,7 @@ from functools import partial
 
 import numpy as np
 import torch
+from ax.benchmark.methods.sobol import get_sobol_benchmark_method
 from ax.core.metric import Metric
 from ax.core.objective import Objective
 from ax.core.runner import Runner
@@ -47,7 +48,6 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import (
     get_aggregated_benchmark_result,
     get_benchmark_result,
-    get_sobol_gpei_benchmark_method,
 )
 from ax.utils.testing.core_stubs import (
     get_abandoned_arm,
@@ -139,7 +139,10 @@ TEST_CASES = [
     ("Arm", get_arm),
     ("AuxiliaryExperiment", get_auxiliary_experiment),
     ("BatchTrial", get_batch_trial),
-    ("BenchmarkMethod", get_sobol_gpei_benchmark_method),
+    (
+        "BenchmarkMethod",
+        lambda: get_sobol_benchmark_method(distribute_replications=True),
+    ),
     ("BenchmarkResult", get_benchmark_result),
     ("BoTorchModel", get_botorch_model),
     ("BoTorchModel", get_botorch_model_with_default_acquisition_class),

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -12,7 +12,6 @@ from typing import Any, Iterator
 
 import numpy as np
 import torch
-from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_problem import (
     BenchmarkProblem,
     create_problem_from_botorch,
@@ -32,17 +31,13 @@ from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
 from ax.core.types import TParameterization, TParamValue
 from ax.modelbridge.external_generation_node import ExternalGenerationNode
-from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
-from ax.modelbridge.registry import Models
 from ax.modelbridge.torch import TorchModelBridge
 from ax.models.torch.botorch_modular.model import BoTorchModel
-from ax.models.torch.botorch_modular.surrogate import Surrogate, SurrogateSpec
-from ax.utils.common.constants import Keys
+from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_branin_experiment_with_multi_objective,
 )
-from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.test_functions.multi_objective import BraninCurrin
 from botorch.test_functions.synthetic import Branin
@@ -155,49 +150,6 @@ def get_moo_surrogate() -> BenchmarkProblem:
         num_trials=10,
         optimal_value=1.0,
         test_function=test_function,
-    )
-
-
-def get_sobol_gpei_benchmark_method() -> BenchmarkMethod:
-    return BenchmarkMethod(
-        name="MBO_SOBOL_GPEI",
-        generation_strategy=GenerationStrategy(
-            name="Modular::Sobol+GPEI",
-            steps=[
-                GenerationStep(
-                    model=Models.SOBOL,
-                    num_trials=3,
-                    model_kwargs={"fit_tracking_metrics": False},
-                    min_trials_observed=3,
-                ),
-                GenerationStep(
-                    model=Models.BOTORCH_MODULAR,
-                    num_trials=-1,
-                    model_kwargs={
-                        "surrogate": Surrogate(
-                            surrogate_spec=SurrogateSpec(
-                                botorch_model_class=SingleTaskGP
-                            )
-                        ),
-                        # TODO: tests should better reflect defaults and not
-                        # re-implement this logic.
-                        "botorch_acqf_class": qNoisyExpectedImprovement,
-                        "model_kwargs": {"fit_tracking_metrics": False},
-                    },
-                    model_gen_kwargs={
-                        "model_gen_options": {
-                            Keys.OPTIMIZER_KWARGS: {
-                                "num_restarts": 50,
-                                "raw_samples": 1024,
-                            },
-                            Keys.ACQF_KWARGS: {
-                                "prune_baseline": True,
-                            },
-                        }
-                    },
-                ),
-            ],
-        ),
     )
 
 


### PR DESCRIPTION
Summary: `get_sobol_gpei_benchmark_method` is used only for testing JSON serialization; instead use a method that's defined elsewhere

Reviewed By: saitcakmak

Differential Revision: D65908525


