### PR TITLE
Add a noisy and asynchronous benchmark

### DIFF
--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -76,7 +76,8 @@ class BenchmarkRunner(Runner):
                     # Always use virtual rather than real time for benchmarking
                     internal_clock=0,
                     use_update_as_start_time=False,
-                )
+                ),
+                verbose_logging=False,
             )
             self.simulated_backend_runner = SimulatedBackendRunner(
                 simulator=simulator,

--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -15,6 +15,7 @@ from ax.benchmark.problems.hd_embedding import embed_higher_dimension
 from ax.benchmark.problems.hpo.torchvision import (
     get_pytorch_cnn_torchvision_benchmark_problem,
 )
+from ax.benchmark.problems.runtime_funcs import async_runtime_func_from_pi
 from ax.benchmark.problems.synthetic.hss.jenatton import get_jenatton_benchmark_problem
 from botorch.test_functions import synthetic
 from botorch.test_functions.multi_objective import BraninCurrin
@@ -34,6 +35,18 @@ BENCHMARK_PROBLEM_REGISTRY = {
             "test_problem_kwargs": {"dim": 4},
             "num_trials": 40,
             "observe_noise_sd": False,
+        },
+    ),
+    "ackley4_async_noisy": BenchmarkProblemRegistryEntry(
+        factory_fn=create_problem_from_botorch,
+        factory_kwargs={
+            "test_problem_class": synthetic.Ackley,
+            "test_problem_kwargs": {"dim": 4},
+            "num_trials": 40,
+            "noise_std": 1.0,
+            "observe_noise_sd": False,
+            "trial_runtime_func": async_runtime_func_from_pi,
+            "name": "ackley4_async_noisy",
         },
     ),
     "branin": BenchmarkProblemRegistryEntry(

--- a/ax/benchmark/problems/runtime_funcs.py
+++ b/ax/benchmark/problems/runtime_funcs.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.core.trial import Trial
+
+
+def async_runtime_func_from_pi(trial: Trial) -> int:
+    # First 49 digits of pi, not including the decimal
+    pi_digits_str = "3141592653589793115997963468544185161590576171875"
+    idx = trial.index % len(pi_digits_str)
+    return int(pi_digits_str[idx])

--- a/sphinx/source/benchmark.rst
+++ b/sphinx/source/benchmark.rst
@@ -138,6 +138,13 @@ Benchmark Problems PyTorchCNN TorchVision
     :undoc-members:
     :show-inheritance:
 
+Benchmark Problems Runtime Functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.benchmark.problems.runtime_funcs
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Benchmark Test Functions: BoTorch Test
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Summary:
Adds a benchmark that runs the Ackley4 problem with
* Up to 3 pending points
* A noise standard deviation of 1.0
* 40 trials (Chosen to typically result in making some real progress, as judged by the inference trace, but not a lot. That way, this can be used for regression detection, but there is also room for improvement and it isn't running for longer than necessary. Score should be around ~20%.)
* 10 replications

Other changes (some cleanup from enabling asynchronicity and minor fixes):
* Pull out `get_sobol_mbm_generation_strategy` from `get_sobol_botorch_modular_acquisition` (which should really be called `get_sobol_botorch_modular_method`). `get_sobol_botorch_modular_acquisition` is now unneeded, as `get_sobol_botorch_modular_acquisition(generation_strategy=get_sobol_mbm_generation_strategy(), **kwargs)` is equivalent to `BenchmarkMethod(generation_strategy=get_sobol_mbm_generation_strategy(), **kwargs)`.
* Disable verbose logging to prevent logspew from the simulated backend runner

Reviewed By: Balandat

Differential Revision: D65712886


