### PR TITLE
Add EarlyStoppingStrategy support for benchmarking

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -27,11 +27,11 @@ from typing import Set
 
 import numpy as np
 import numpy.typing as npt
-
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_problem import BenchmarkProblem
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
 from ax.benchmark.benchmark_runner import BenchmarkRunner
+from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
 from ax.core.types import TParameterization, TParamValue
 from ax.core.utils import get_model_times
@@ -244,7 +244,12 @@ def benchmark_replication(
                 # problems, because Ax's best-point functionality doesn't know
                 # to predict at the target task or fidelity.
                 continue
-            currently_completed_trials = {t.index for t in experiment.completed_trials}
+
+            currently_completed_trials = {
+                t.index
+                for t in experiment.trials.values()
+                if t.status in (TrialStatus.COMPLETED, TrialStatus.EARLY_STOPPED)
+            }
             newly_completed_trials = (
                 currently_completed_trials - trials_used_for_best_point
             )

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -5,6 +5,7 @@
 
 # pyre-strict
 
+import warnings
 from dataclasses import dataclass
 
 from ax.core.experiment import Experiment
@@ -13,6 +14,7 @@ from ax.core.optimization_config import (
     OptimizationConfig,
 )
 from ax.core.types import TParameterization
+from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.service.utils.best_point_mixin import BestPointMixin
@@ -46,6 +48,7 @@ class BenchmarkMethod(Base):
             and the following arguments are passed to ``SchedulerOptions``.
         run_trials_in_batches: Passed to ``SchedulerOptions``.
         max_pending_trials: Passed to ``SchedulerOptions``.
+        early_stopping_strategy: Passed to ``SchedulerOptions``.
 
     Attributes:
         scheduler_options: ``SchedulerOptions`` that depend on the
@@ -63,10 +66,23 @@ class BenchmarkMethod(Base):
     use_model_predictions_for_best_point: bool = False
     run_trials_in_batches: bool = False
     max_pending_trials: int = 1
+    early_stopping_strategy: BaseEarlyStoppingStrategy | None = None
 
     def __post_init__(self) -> None:
         if self.name == "DEFAULT":
             self.name = self.generation_strategy.name
+        early_stopping_strategy = self.early_stopping_strategy
+        if early_stopping_strategy is not None:
+            seconds_between_polls = early_stopping_strategy.seconds_between_polls
+            if seconds_between_polls > 0:
+                warnings.warn(
+                    "`early_stopping_strategy.seconds_between_polls` is "
+                    f"{seconds_between_polls}, but benchmarking uses 0 seconds "
+                    "between polls. Setting "
+                    "`early_stopping_strategy.seconds_between_polls` to 0.",
+                    stacklevel=1,
+                )
+                early_stopping_strategy.seconds_between_polls = 0
 
     @property
     def scheduler_options(self) -> SchedulerOptions:
@@ -83,6 +99,7 @@ class BenchmarkMethod(Base):
             else TrialType.BATCH_TRIAL,
             batch_size=self.batch_size,
             run_trials_in_batches=self.run_trials_in_batches,
+            early_stopping_strategy=self.early_stopping_strategy,
         )
 
     def get_best_parameters(

--- a/ax/benchmark/benchmark_metric.py
+++ b/ax/benchmark/benchmark_metric.py
@@ -148,7 +148,12 @@ class BenchmarkMapMetric(MapMetric):
             sim_trial = none_throws(
                 backend_simulator.get_sim_trial_by_index(trial.index)
             )
+            # The BackendSimulator distinguishes between queued and running
+            # trials "for testing particular initialization cases", but these
+            # are all "running" to Scheduler.
+            # start_time = none_throws(sim_trial.sim_queued_time)
             start_time = none_throws(sim_trial.sim_start_time)
+
             if sim_trial.sim_completed_time is None:  # Still running
                 max_t = backend_simulator.time - start_time
             else:

--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -5,6 +5,7 @@
 
 # pyre-strict
 
+import warnings
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from math import sqrt
@@ -155,9 +156,15 @@ class BenchmarkRunner(Runner):
                     max_concurrency=self.max_concurrency,
                     # Always use virtual rather than real time for benchmarking
                     internal_clock=0,
-                    use_update_as_start_time=False,
+                    use_update_as_start_time=True,
                 ),
             )
+            if self.trial_runtime_func is None:
+                warnings.warn(
+                    "`trial_runtime_func` is not set and `max_concurrency` > 1."
+                    " Each trial will take one simulated second to run.",
+                    stacklevel=2,
+                )
             self.simulated_backend_runner = SimulatedBackendRunner(
                 simulator=simulator,
                 sample_runtime_func=self.trial_runtime_func

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -30,6 +30,7 @@ from ax.benchmark.problems.registry import get_problem
 from ax.core.map_data import MapData
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
+from ax.early_stopping.strategies.threshold import ThresholdEarlyStoppingStrategy
 from ax.modelbridge.external_generation_node import ExternalGenerationNode
 from ax.modelbridge.generation_strategy import GenerationNode, GenerationStrategy
 from ax.modelbridge.model_spec import ModelSpec
@@ -275,6 +276,7 @@ class TestBenchmark(TestCase):
                 problem = get_async_benchmark_problem(
                     map_data=map_data,
                     trial_runtime_func=trial_runtime_func,
+                    n_time_intervals=30 if map_data else 1,
                 )
 
                 with mock_patch_method_original(
@@ -350,6 +352,90 @@ class TestBenchmark(TestCase):
     def test_replication_async(self) -> None:
         self._test_replication_async(map_data=False)
         self._test_replication_async(map_data=True)
+
+    def test_early_stopping(self) -> None:
+        """
+        Test early stopping with a deterministic generation strategy and ESS
+        that stops if the objective exceeds 0.5 when their progression ("t") hits 2,
+        which happens when 3 epochs have passed (t=[0, 1, 2]).
+
+        Each arm produces values equaling the trial index everywhere on the
+        progression, so Trials 1, 2, and 3 will stop early, and trial 0 will not.
+
+        t=0-2: Trials 0 and 1 run
+        t=2: Trial 1 stops early. Trial 2 gets added to "_queued", and then to
+            "_running", with a queued time of 2 and a sim_start_time of 3.
+        t=3-4: Trials 0 and 2 run.
+        t=4: Trial 0 completes.
+        t=5: Trials 2 and 3 run, then trial 2 gets stopped early.
+        t=6-7: Trial 3 runs by itself then gets stopped early.
+        """
+        min_progression = 2
+        progression_length_if_not_stopped = 5
+        early_stopping_strategy = ThresholdEarlyStoppingStrategy(
+            metric_threshold=0.5,
+            min_progression=min_progression,
+            min_curves=0,
+        )
+
+        method = get_async_benchmark_method(
+            early_stopping_strategy=early_stopping_strategy
+        )
+
+        problem = get_async_benchmark_problem(
+            map_data=True,
+            trial_runtime_func=lambda _: progression_length_if_not_stopped,
+            n_time_intervals=progression_length_if_not_stopped,
+            lower_is_better=True,
+        )
+        result = benchmark_replication(
+            problem=problem, method=method, seed=0, strip_runner_before_saving=False
+        )
+        data = assert_is_instance(none_throws(result.experiment).lookup_data(), MapData)
+        grouped = data.map_df.groupby("trial_index")
+        self.assertEqual(
+            dict(grouped["t"].count()),
+            {
+                0: progression_length_if_not_stopped,
+                # stopping after t=2, so 3 epochs (0, 1, 2) have passed
+                **{i: min_progression + 1 for i in range(1, 4)},
+            },
+        )
+        self.assertEqual(
+            dict(grouped["t"].max()),
+            {
+                0: progression_length_if_not_stopped - 1,
+                **{i: min_progression for i in range(1, 4)},
+            },
+        )
+        map_df = data.map_df
+        simulator = none_throws(
+            assert_is_instance(
+                none_throws(result.experiment).runner, BenchmarkRunner
+            ).simulated_backend_runner
+        ).simulator
+        trials = {
+            trial_index: none_throws(simulator.get_sim_trial_by_index(trial_index))
+            for trial_index in range(4)
+        }
+        start_times = {
+            trial_index: sim_trial.sim_start_time
+            for trial_index, sim_trial in trials.items()
+        }
+        map_df["start_time"] = map_df["trial_index"].map(start_times).astype(int)
+        map_df["absolute_time"] = map_df["t"] + map_df["start_time"]
+        expected_start_end_times = {
+            0: (0, 4),
+            1: (0, 2),
+            2: (3, 5),
+            3: (5, 7),
+        }
+        for trial_index, (start, end) in expected_start_end_times.items():
+            sub_df = map_df[map_df["trial_index"] == trial_index]
+            self.assertEqual(
+                sub_df["absolute_time"].min(), start, msg=f"{trial_index=}"
+            )
+            self.assertEqual(sub_df["absolute_time"].max(), end, msg=f"{trial_index=}")
 
     @mock_botorch_optimize
     def _test_replication_with_inference_value(

--- a/ax/benchmark/tests/test_benchmark_runner.py
+++ b/ax/benchmark/tests/test_benchmark_runner.py
@@ -392,3 +392,11 @@ class TestBenchmarkRunner(TestCase):
             self.assertIsNone(sim_trial.sim_completed_time)
             self.assertEqual(sim_trial.sim_start_time, 0)
             self.assertEqual(backend_simulator.time, 0)
+
+    def test_warns_if_concurrent_and_trial_runtime_func_is_none(self) -> None:
+        test_function = IdentityTestFunction(outcome_names=["foo"])
+        with self.assertWarnsRegex(Warning, "`trial_runtime_func` is not set"):
+            BenchmarkRunner(
+                test_function=test_function,
+                max_concurrency=2,
+            )

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -44,7 +44,7 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             metric_threshold: The metric threshold that a trial needs to reach by
                 min_progression in order not to be stopped.
             min_progression: Only stop trials if the latest progression value
-                (e.g. timestamp, epochs, training data used) is greater than this
+                (e.g. timestamp, epochs, training data used) is worse than this
                 threshold. Prevents stopping prematurely before enough data is gathered
                 to make a decision.
             max_progression: Do not stop trials that have passed `max_progression`.
@@ -53,7 +53,7 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 `min_curves` have completed with curve data attached. That is, if
                 `min_curves` trials are completed but their curve data was not
                 successfully retrieved, further trials may not be early-stopped.
-            trial_indices_to_ignore: Trial indices that should not be early stopped.
+            trial_indices_to_ignore: Trial indices that should not be early-stopped.
             normalize_progressions: Normalizes the progression column of the MapData df
                 by dividing by the max. If the values were originally in [0, `prog_max`]
                 (as we would expect), the transformed values will be in [0, 1]. Useful


### PR DESCRIPTION
Summary:
This PR:
* Adds an `early_stopping_strategy` attribute to `BenchmarkMethod`. It is then passed to `SchedulerOptions`, and gets used by Scheduler (as in the benchmarking code never needs to reference or call the `early_stopping_strategy`)
* Changes `seconds_between_polls` on the ESS to 0, to match `seconds_between_polls` in `SchedulerOptions`. If this were not done, both would be set to the `seconds_between_polls` on the ESS, which by default is 300.  Also, warn if this has been done.

Unrelated change:
* Correct a docstring in `ThresholdEarlyStoppingStrategy` to say it is checking for "worse" rather than "greater" values, since it does seem to account for whether the metric is to be minimized or maximized.

Differential Revision: D66010090


