### PR TITLE
Update documentation

### DIFF
--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -48,22 +48,16 @@ class BenchmarkMethod(Base):
             and the following arguments are passed to ``SchedulerOptions``.
         run_trials_in_batches: Passed to ``SchedulerOptions``.
         max_pending_trials: Passed to ``SchedulerOptions``.
-        early_stopping_strategy: Passed to ``SchedulerOptions``.
-
-    Attributes:
-        scheduler_options: ``SchedulerOptions`` that depend on the
-            ``batch_size`` of the method. No ``timeout_hours`` can be passed to
-            these ``SchedulerOptions``, because ``timeout_hours`` here means the
-            total amount of time to run a benchmark replication and not the time
-            per call to ``Scheduler.run_n_trials``.
     """
 
     name: str = "DEFAULT"
     generation_strategy: GenerationStrategy
-    batch_size: int = 1
+
     timeout_hours: float = 4.0
     distribute_replications: bool = False
     use_model_predictions_for_best_point: bool = False
+
+    batch_size: int = 1
     run_trials_in_batches: bool = False
     max_pending_trials: int = 1
     early_stopping_strategy: BaseEarlyStoppingStrategy | None = None

--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -332,7 +332,9 @@ def create_problem_from_botorch(
         test_problem_class: The BoTorch test problem class which will be used
             to define the `search_space`, `optimization_config`, and `runner`.
         test_problem_kwargs: Keyword arguments used to instantiate the
-            `test_problem_class`.
+            `test_problem_class`. This should *not* include `noise_std` or
+            `negate`, since these are handled through Ax benchmarking (as the
+            `noise_std` and `lower_is_better` arguments to `BenchmarkProblem`).
         noise_std: Standard deviation of synthetic noise added to outcomes. If a
             float, the same noise level is used for all objectives.
         lower_is_better: Whether this is a minimization problem. For MOO, this
@@ -354,6 +356,18 @@ def create_problem_from_botorch(
             See ``BenchmarkResult`` for more information.
         trial_runtime_func: A function that takes a trial and returns how long
             it takes to run that trial.
+
+    Example:
+        >>> from ax.benchmark.benchmark_problem import create_problem_from_botorch
+        >>> from botorch.test_functions.synthetic import Branin
+        >>> problem = create_problem_from_botorch(
+        ...    test_problem_class=Branin,
+        ...    test_problem_kwargs={},
+        ...    noise_std=0.1,
+        ...    num_trials=10,
+        ...    observe_noise_sd=True,
+        ...    trial_runtime_func=lambda trial: trial.index,
+        ... )
     """
     # pyre-fixme [45]: Invalid class instantiation
     test_problem = test_problem_class(**test_problem_kwargs)


### PR DESCRIPTION
Summary:
Changes:
* Removed `Attributes` block from `BenchmarkMethod` since it is incorrect: The actual attributes are identical to the arguments, and the listed attribute (`scheduler_options`) is actually a property.
* Expanded on docstring in `BenchmarkProblem`

Differential Revision: D66012030


