### PR TITLE
Remove unused `_init_state` and `reset()` from `BackendSimulator`

### DIFF
--- a/ax/utils/testing/backend_simulator.py
+++ b/ax/utils/testing/backend_simulator.py
@@ -155,7 +155,6 @@ class BackendSimulator:
         self._completed: list[SimTrial] = completed or []
         self._internal_clock: float | None = options.internal_clock
         self._verbose_logging = verbose_logging
-        self._init_state: BackendSimulatorState = self.state()
         self._create_index_to_trial_map()
 
     @property
@@ -213,23 +212,6 @@ class BackendSimulator:
             f"** Completed:\n{format(state.completed)}\n"
             f"-----------\n"
         )
-
-    def reset(self) -> None:
-        """Reset the simulator."""
-        self.max_concurrency = self._init_state.options.max_concurrency
-        self.time_scaling = self._init_state.options.time_scaling
-        self._internal_clock = self._init_state.options.internal_clock
-        # pyre-fixme: Incompatible parameter type [6]: In call
-        # `SimTrial.__init__`, for 1st positional argument, expected `float` but
-        # got `Optional[float]`.
-        self._queued = [SimTrial(**args) for args in self._init_state.queued]
-        # pyre-fixme[6]: as above
-        self._running = [SimTrial(**args) for args in self._init_state.running]
-        # pyre-fixme[6]: as above
-        self._failed = [SimTrial(**args) for args in self._init_state.failed]
-        # pyre-fixme[6]: as above
-        self._completed = [SimTrial(**args) for args in self._init_state.completed]
-        self._create_index_to_trial_map()
 
     def state(self) -> BackendSimulatorState:
         """Return a ``BackendSimulatorState`` containing the state of the simulator."""

--- a/ax/utils/testing/tests/test_backend_simulator.py
+++ b/ax/utils/testing/tests/test_backend_simulator.py
@@ -65,19 +65,6 @@ class BackendSimulatorTest(TestCase):
         self.assertEqual(sim.num_failed, 0)
         self.assertEqual(sim.num_completed, 3)
 
-        # test reset
-        sim.max_concurrency = 3
-        sim.time_scaling = 2.0
-        sim.failure_rate, 0.5
-        sim.reset()
-        self.assertEqual(sim.max_concurrency, 2)
-        self.assertEqual(sim.time_scaling, 1.0)
-        self.assertEqual(sim.failure_rate, 0.0)
-        self.assertEqual(sim.num_queued, 0)
-        self.assertEqual(sim.num_running, 0)
-        self.assertEqual(sim.num_failed, 0)
-        self.assertEqual(sim.num_completed, 0)
-
         # test load state
         sim2 = BackendSimulator.from_state(state)
         self.assertEqual(sim2.max_concurrency, 2)


### PR DESCRIPTION
Summary:
Context: The `BackendSimulator` can be reset to its initial state. This functionality is not used. I would like to be able to serialize and deserialize `BackendSimulator`s in order to permit analysis of past simulations. The presence of `_init_state` makes this much harder, since there are then two states that need to be considered, the initial state and the current state.

This PR:
* Removes the attribute `_init_state` and the method `reset` from `BackendSimulator`

Differential Revision: D66100116


