### PR TITLE
Enable serialization for BackendSimulator

### DIFF
--- a/ax/benchmark/tests/test_benchmark_metric.py
+++ b/ax/benchmark/tests/test_benchmark_metric.py
@@ -210,7 +210,7 @@ class BenchmarkMetricTest(TestCase):
         simulator = BackendSimulator()
         simulator.run_trial(trial_index=0, runtime=0)
         simulator.update()
-        simulator._internal_clock = -1
+        simulator.options.internal_clock = -1
         metadata = BenchmarkTrialMetadata(
             dfs={"test_metric": pd.DataFrame({"t": [3]})}, backend_simulator=simulator
         )

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -58,6 +58,11 @@ from ax.storage.botorch_modular_registry import CLASS_TO_REGISTRY
 from ax.storage.transform_registry import TRANSFORM_REGISTRY
 from ax.utils.common.serialization import serialize_init_args
 from ax.utils.common.typeutils_torch import torch_type_to_str
+from ax.utils.testing.backend_simulator import (
+    BackendSimulator,
+    BackendSimulatorOptions,
+    SimTrial,
+)
 from botorch.models.transforms.input import ChainedInputTransform, InputTransform
 from botorch.sampling.base import MCSampler
 from botorch.utils.types import _DefaultType
@@ -713,3 +718,17 @@ def pathlib_to_dict(path: Path) -> dict[str, Any]:
 
 def default_to_dict(default: _DefaultType) -> dict[str, Any]:
     return {"__type": default.__class__.__name__}
+
+
+def backend_simulator_to_dict(
+    backend_simulator: BackendSimulator,
+) -> dict[str, str | BackendSimulatorOptions | list[SimTrial] | bool]:
+    return {
+        "__type": backend_simulator.__class__.__name__,
+        "options": backend_simulator.options,
+        "queued": backend_simulator._queued,
+        "running": backend_simulator._running,
+        "failed": backend_simulator._failed,
+        "completed": backend_simulator._completed,
+        "verbose_logging": backend_simulator._verbose_logging,
+    }

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -114,6 +114,7 @@ from ax.storage.json_store.decoders import (
 from ax.storage.json_store.encoders import (
     arm_to_dict,
     auxiliary_experiment_to_dict,
+    backend_simulator_to_dict,
     batch_to_dict,
     best_model_selector_to_dict,
     botorch_component_to_dict,
@@ -163,6 +164,11 @@ from ax.storage.json_store.encoders import (
 from ax.storage.utils import DomainType, ParameterConstraintType
 from ax.utils.common.constants import Keys
 from ax.utils.common.serialization import TDecoderRegistry
+from ax.utils.testing.backend_simulator import (
+    BackendSimulator,
+    BackendSimulatorOptions,
+    SimTrial,
+)
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.models.model import Model
 from botorch.models.transforms.input import ChainedInputTransform, Normalize, Round
@@ -182,6 +188,7 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     AuxiliaryExperiment: auxiliary_experiment_to_dict,
     AndEarlyStoppingStrategy: logical_early_stopping_strategy_to_dict,
     AutoTransitionAfterGen: transition_criterion_to_dict,
+    BackendSimulator: backend_simulator_to_dict,
     BatchTrial: batch_to_dict,
     BenchmarkMetric: metric_to_dict,
     BoTorchModel: botorch_model_to_dict,
@@ -285,6 +292,8 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "AuxiliaryExperimentPurpose": AuxiliaryExperimentPurpose,
     "Arm": Arm,
     "AggregatedBenchmarkResult": AggregatedBenchmarkResult,
+    "BackendSimulator": BackendSimulator,
+    "BackendSimulatorOptions": BackendSimulatorOptions,
     "BatchTrial": BatchTrial,
     "BenchmarkMethod": BenchmarkMethod,
     "BenchmarkMetric": BenchmarkMetric,
@@ -367,6 +376,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "ScalarizedObjective": ScalarizedObjective,
     "SchedulerOptions": SchedulerOptions,
     "SearchSpace": SearchSpace,
+    "SimTrial": SimTrial,
     "SingleDiagnosticBestModelSelector": SingleDiagnosticBestModelSelector,
     "SklearnDataset": SklearnDataset,
     "SklearnMetric": SklearnMetric,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -128,6 +128,7 @@ from ax.utils.testing.modeling_stubs import (
     sobol_gpei_generation_node_gs,
 )
 from ax.utils.testing.utils import generic_equals
+from ax.utils.testing.utils_testing_stubs import get_backend_simulator_with_trials
 from botorch.sampling.normal import SobolQMCNormalSampler
 
 
@@ -138,6 +139,7 @@ TEST_CASES = [
     ("AndEarlyStoppingStrategy", get_and_early_stopping_strategy),
     ("Arm", get_arm),
     ("AuxiliaryExperiment", get_auxiliary_experiment),
+    ("BackendSimulator", get_backend_simulator_with_trials),
     ("BatchTrial", get_batch_trial),
     (
         "BenchmarkMethod",

--- a/ax/utils/testing/backend_simulator.py
+++ b/ax/utils/testing/backend_simulator.py
@@ -155,7 +155,6 @@ class BackendSimulator:
         self._completed: list[SimTrial] = completed or []
         self._internal_clock: float | None = options.internal_clock
         self._verbose_logging = verbose_logging
-        self._init_state: BackendSimulatorState = self.state()
         self._create_index_to_trial_map()
 
     @property
@@ -213,23 +212,6 @@ class BackendSimulator:
             f"** Completed:\n{format(state.completed)}\n"
             f"-----------\n"
         )
-
-    def reset(self) -> None:
-        """Reset the simulator."""
-        self.max_concurrency = self._init_state.options.max_concurrency
-        self.time_scaling = self._init_state.options.time_scaling
-        self._internal_clock = self._init_state.options.internal_clock
-        # pyre-fixme: Incompatible parameter type [6]: In call
-        # `SimTrial.__init__`, for 1st positional argument, expected `float` but
-        # got `Optional[float]`.
-        self._queued = [SimTrial(**args) for args in self._init_state.queued]
-        # pyre-fixme[6]: as above
-        self._running = [SimTrial(**args) for args in self._init_state.running]
-        # pyre-fixme[6]: as above
-        self._failed = [SimTrial(**args) for args in self._init_state.failed]
-        # pyre-fixme[6]: as above
-        self._completed = [SimTrial(**args) for args in self._init_state.completed]
-        self._create_index_to_trial_map()
 
     def state(self) -> BackendSimulatorState:
         """Return a ``BackendSimulatorState`` containing the state of the simulator."""

--- a/ax/utils/testing/backend_simulator.py
+++ b/ax/utils/testing/backend_simulator.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from logging import Logger
 
 from ax.core.base_trial import TrialStatus
+from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
 from pyre_extensions import none_throws
 
@@ -112,7 +113,7 @@ class BackendSimulatorState:
     completed: list[dict[str, float | None]]
 
 
-class BackendSimulator:
+class BackendSimulator(Base):
     """Simulator for a backend deployment with concurrent dispatch and a queue."""
 
     def __init__(

--- a/ax/utils/testing/tests/test_backend_simulator.py
+++ b/ax/utils/testing/tests/test_backend_simulator.py
@@ -65,19 +65,6 @@ class BackendSimulatorTest(TestCase):
         self.assertEqual(sim.num_failed, 0)
         self.assertEqual(sim.num_completed, 3)
 
-        # test reset
-        sim.max_concurrency = 3
-        sim.time_scaling = 2.0
-        sim.failure_rate, 0.5
-        sim.reset()
-        self.assertEqual(sim.max_concurrency, 2)
-        self.assertEqual(sim.time_scaling, 1.0)
-        self.assertEqual(sim.failure_rate, 0.0)
-        self.assertEqual(sim.num_queued, 0)
-        self.assertEqual(sim.num_running, 0)
-        self.assertEqual(sim.num_failed, 0)
-        self.assertEqual(sim.num_completed, 0)
-
         # test load state
         sim2 = BackendSimulator.from_state(state)
         self.assertEqual(sim2.max_concurrency, 2)

--- a/ax/utils/testing/tests/test_backend_simulator.py
+++ b/ax/utils/testing/tests/test_backend_simulator.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 from ax.core.base_trial import TrialStatus
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.backend_simulator import BackendSimulator, BackendSimulatorOptions
+from ax.utils.testing.utils_testing_stubs import get_backend_simulator_with_trials
 
 
 class BackendSimulatorTest(TestCase):
@@ -22,9 +23,10 @@ class BackendSimulatorTest(TestCase):
 
         # test init
         sim = BackendSimulator(options=options)
-        self.assertEqual(sim.max_concurrency, 2)
-        self.assertEqual(sim.time_scaling, 1.0)
-        self.assertEqual(sim.failure_rate, 0.0)
+        options = sim.options
+        self.assertEqual(options.max_concurrency, 2)
+        self.assertEqual(options.time_scaling, 1.0)
+        self.assertEqual(options.failure_rate, 0.0)
         self.assertEqual(sim.num_queued, 0)
         self.assertEqual(sim.num_running, 0)
         self.assertEqual(sim.num_failed, 0)
@@ -90,13 +92,7 @@ class BackendSimulatorTest(TestCase):
         self.assertEqual(sim3.num_completed, 0)
 
     def test_backend_simulator_internal_clock(self) -> None:
-        options = BackendSimulatorOptions(
-            internal_clock=0.0, use_update_as_start_time=True, max_concurrency=2
-        )
-        sim = BackendSimulator(options=options)
-        sim.run_trial(0, 2)
-        sim.run_trial(1, 1)
-        sim.run_trial(2, 10)
+        sim = get_backend_simulator_with_trials()
         self.assertEqual(len(sim.all_trials), 3)
         self.assertEqual(sim.time, 0.0)
         self.assertEqual(sim.num_queued, 1)

--- a/ax/utils/testing/utils_testing_stubs.py
+++ b/ax/utils/testing/utils_testing_stubs.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+from ax.utils.testing.backend_simulator import BackendSimulator, BackendSimulatorOptions
+
+
+def get_backend_simulator_with_trials() -> BackendSimulator:
+    options = BackendSimulatorOptions(
+        internal_clock=0.0, use_update_as_start_time=True, max_concurrency=2
+    )
+    sim = BackendSimulator(options=options)
+    sim.run_trial(0, 2)
+    sim.run_trial(1, 1)
+    sim.run_trial(2, 10)
+    return sim

--- a/sphinx/source/utils.rst
+++ b/sphinx/source/utils.rst
@@ -297,13 +297,20 @@ Modeling Stubs
     :show-inheritance:
 
 Preference Stubs
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.utils.testing.preference_stubs
     :members:
     :undoc-members:
     :show-inheritance:
 
+Utils Testing Stubs
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.utils.testing.utils_testing_stubs
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Mocking
 ~~~~~~~


### PR DESCRIPTION
Summary:
Context: For benchmarking, we would like to be able to store a `BackendSimulator` and reload and inspect it later. So it needs to be serializable.

This PR:
* Enable serialization and deserialization for `BackendSimulator` and the dataclasses it depends on, `SimTrial` and `BackendSimulatorOptions`
* Adds a test stub which is then used in multiple tests, including one for serialization

Differential Revision: D66102399


