### PR TITLE
log what model is used for each metric

### DIFF
--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -27,6 +27,7 @@ from ax.models.torch.botorch_modular.utils import (
     check_outcome_dataset_match,
     choose_botorch_acqf_class,
     construct_acquisition_and_optimizer_options,
+    ModelConfig,
 )
 from ax.models.torch.utils import _to_inequality_constraints
 from ax.models.torch_base import TorchGenResults, TorchModel, TorchOptConfig
@@ -185,12 +186,14 @@ class BoTorchModel(TorchModel, Base):
 
         # If a surrogate has not been constructed, construct it.
         if self._surrogate is None:
-            if self.surrogate_spec is not None:
-                self._surrogate = Surrogate(
-                    surrogate_spec=self.surrogate_spec, refit_on_cv=self.refit_on_cv
-                )
-            else:
-                self._surrogate = Surrogate(refit_on_cv=self.refit_on_cv)
+            surrogate_spec = (
+                SurrogateSpec(model_configs=[ModelConfig(name="default")])
+                if self.surrogate_spec is None
+                else self.surrogate_spec
+            )
+            self._surrogate = Surrogate(
+                surrogate_spec=surrogate_spec, refit_on_cv=self.refit_on_cv
+            )
 
         # Fit the surrogate.
         for config in self.surrogate.surrogate_spec.model_configs:
@@ -264,6 +267,15 @@ class BoTorchModel(TorchModel, Base):
             torch_opt_config=torch_opt_config,
             expected_acquisition_value=expected_acquisition_value,
         )
+        # log what model was used
+        metric_to_model_config_name = {
+            metric_name: model_config.name or str(model_config)
+            for metric_name_tuple, model_config in (
+                self.surrogate.metric_to_best_model_config.items()
+            )
+            for metric_name in metric_name_tuple
+        }
+        gen_metadata["metric_to_model_config_name"] = metric_to_model_config_name
         return TorchGenResults(
             points=candidates.detach().cpu(),
             weights=weights,

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -372,7 +372,7 @@ def get_model_config_from_deprecated_args(
     # Dict[str, Dict[str, typing.Any]], Sequence[Type[InputTransform]],
     # Sequence[Type[OutcomeTransform]], Type[Union[MarginalLogLikelihood,
     #  Model]], Type[Likelihood], Type[Kernel]]`.
-    return ModelConfig(**model_config_kwargs)
+    return ModelConfig(**model_config_kwargs, name="from deprecated args")
 
 
 @dataclass(frozen=True)

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -101,6 +101,7 @@ class ModelConfig:
             ``likelihood_options`` and gets passed to the model constructor.
             This argument is deprecated in favor of model_configs.
         likelihood_options: Likelihood options.
+        name: Name of the model config. This is used to identify the model config.
     """
 
     botorch_model_class: type[Model] | None = None
@@ -117,6 +118,7 @@ class ModelConfig:
     covar_module_options: dict[str, Any] = field(default_factory=dict)
     likelihood_class: type[Likelihood] | None = None
     likelihood_options: dict[str, Any] = field(default_factory=dict)
+    name: str | None = None
 
 
 def use_model_list(

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -343,6 +343,7 @@ class BoTorchModelTest(TestCase):
                 covar_module_options={},
                 likelihood_class=None,
                 likelihood_options={},
+                name="default",
             ),
             default_botorch_model_class=SingleTaskMultiFidelityGP,
             state_dict=None,
@@ -527,11 +528,15 @@ class BoTorchModelTest(TestCase):
             "_instantiate_acquisition",
             wraps=model._instantiate_acquisition,
         ) as mock_init_acqf:
-            model.gen(
+            gen_results = model.gen(
                 n=1,
                 search_space_digest=search_space_digest,
                 torch_opt_config=self.torch_opt_config,
             )
+        self.assertEqual(
+            gen_results.gen_metadata["metric_to_model_config_name"],
+            {"y": "from deprecated args"},
+        )
         # Assert acquisition initialized with expected arguments
         mock_init_acqf.assert_called_once_with(
             search_space_digest=search_space_digest,


### PR DESCRIPTION
Summary: This reports which model config was used for each metric in gen_metadata.

Differential Revision: D66176489


