### PR TITLE
Prepare for "Fix type-safety of `torch.nn.Module` instances": fbcode/a*

### DIFF
--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -391,10 +391,14 @@ def create_problem_from_botorch(
 
     num_constraints = test_problem.num_constraints if is_constrained else 0
     if isinstance(test_problem, MultiObjectiveTestProblem):
+        # pyre-fixme[6]: For 1st argument expected `SupportsIndex` but got
+        #  `Union[Tensor, Module]`.
         objective_names = [f"{name}_{i}" for i in range(n_obj)]
     else:
         objective_names = [name]
 
+    # pyre-fixme[6]: For 1st argument expected `SupportsIndex` but got `Union[int,
+    #  Tensor, Module]`.
     constraint_names = [f"constraint_slack_{i}" for i in range(num_constraints)]
     outcome_names = objective_names + constraint_names
 
@@ -404,6 +408,8 @@ def create_problem_from_botorch(
 
     if isinstance(test_problem, MultiObjectiveTestProblem):
         optimization_config = get_moo_opt_config(
+            # pyre-fixme[6]: For 1st argument expected `int` but got `Union[int,
+            #  Tensor, Module]`.
             num_constraints=num_constraints,
             lower_is_better=lower_is_better,
             observe_noise_sd=observe_noise_sd,
@@ -430,6 +436,8 @@ def create_problem_from_botorch(
         test_function=test_function,
         noise_std=noise_std,
         num_trials=num_trials,
+        # pyre-fixme[6]: For 7th argument expected `float` but got `Union[float,
+        #  Tensor, Module]`.
         optimal_value=optimal_value,
         report_inference_value_as_trace=report_inference_value_as_trace,
         trial_runtime_func=trial_runtime_func,

--- a/ax/models/tests/test_botorch_defaults.py
+++ b/ax/models/tests/test_botorch_defaults.py
@@ -68,8 +68,13 @@ class BotorchDefaultsTest(TestCase):
         self.assertIsInstance(model, SingleTaskGP)
         self.assertIsInstance(model.likelihood, FixedNoiseGaussianLikelihood)
         self.assertEqual(
-            model.covar_module.lengthscale_prior.loc, math.log(2.0) / 2 + 2**0.5
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `lengthscale_prior`.
+            model.covar_module.lengthscale_prior.loc,
+            math.log(2.0) / 2 + 2**0.5,
         )
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `lengthscale_prior`.
         self.assertEqual(model.covar_module.lengthscale_prior.scale, 3**0.5)
         model = _get_model(X=x, Y=y, Yvar=unknown_var, task_feature=1)
         self.assertIs(type(model), MultiTaskGP)  # Don't accept subclasses.
@@ -101,15 +106,25 @@ class BotorchDefaultsTest(TestCase):
         #  Union[Type[LKJCovariancePrior], float, GammaPrior]]`.
         model = _get_model(X=x, Y=y, Yvar=partial_var.clone(), task_feature=1, **kwargs)
         self.assertIsInstance(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `IndexKernelPrior`.
             model.task_covar_module.IndexKernelPrior,
             LKJCovariancePrior,
         )
         self.assertEqual(
-            model.task_covar_module.IndexKernelPrior.sd_prior.concentration, 2.0
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `IndexKernelPrior`.
+            model.task_covar_module.IndexKernelPrior.sd_prior.concentration,
+            2.0,
         )
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `IndexKernelPrior`.
         self.assertEqual(model.task_covar_module.IndexKernelPrior.sd_prior.rate, 0.44)
         self.assertEqual(
-            model.task_covar_module.IndexKernelPrior.correlation_prior.eta, 0.6
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `IndexKernelPrior`.
+            model.task_covar_module.IndexKernelPrior.correlation_prior.eta,
+            0.6,
         )
 
         kwargs2 = {"prior": {"type": LKJCovariancePrior}}
@@ -125,15 +140,23 @@ class BotorchDefaultsTest(TestCase):
             **kwargs2,
         )
         self.assertIsInstance(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `IndexKernelPrior`.
             model.task_covar_module.IndexKernelPrior,
             LKJCovariancePrior,
         )
         self.assertEqual(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `IndexKernelPrior`.
             model.task_covar_module.IndexKernelPrior.sd_prior.concentration,
             1.0,
         )
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `IndexKernelPrior`.
         self.assertEqual(model.task_covar_module.IndexKernelPrior.sd_prior.rate, 0.15)
         self.assertEqual(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `IndexKernelPrior`.
             model.task_covar_module.IndexKernelPrior.correlation_prior.eta,
             0.5,
         )
@@ -170,8 +193,13 @@ class BotorchDefaultsTest(TestCase):
         model = _get_model(X=x, Y=y, Yvar=var, **deepcopy(kwargs6))  # pyre-ignore
         self.assertIsInstance(model, SingleTaskGP)
         self.assertEqual(
-            model.covar_module.base_kernel.lengthscale_prior.concentration, 12.0
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `base_kernel`.
+            model.covar_module.base_kernel.lengthscale_prior.concentration,
+            12.0,
         )
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `base_kernel`.
         self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
         model = _get_model(
             X=x,
@@ -183,10 +211,17 @@ class BotorchDefaultsTest(TestCase):
         self.assertIs(type(model), MultiTaskGP)
         self.assertIsInstance(model.likelihood, GaussianLikelihood)
         self.assertEqual(
-            model.covar_module.base_kernel.lengthscale_prior.concentration, 12.0
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `base_kernel`.
+            model.covar_module.base_kernel.lengthscale_prior.concentration,
+            12.0,
         )
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `base_kernel`.
         self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
         self.assertIsInstance(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `IndexKernelPrior`.
             model.task_covar_module.IndexKernelPrior,
             LKJCovariancePrior,
         )
@@ -200,11 +235,19 @@ class BotorchDefaultsTest(TestCase):
         self.assertIsInstance(model, MultiTaskGP)
         self.assertIsInstance(model.likelihood, FixedNoiseGaussianLikelihood)
         self.assertEqual(
-            model.covar_module.base_kernel.lengthscale_prior.concentration, 12.0
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `base_kernel`.
+            model.covar_module.base_kernel.lengthscale_prior.concentration,
+            12.0,
         )
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `base_kernel`.
         self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
         self.assertIsInstance(
-            model.task_covar_module.IndexKernelPrior, LKJCovariancePrior
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `IndexKernelPrior`.
+            model.task_covar_module.IndexKernelPrior,
+            LKJCovariancePrior,
         )
         # test passing customized prior
         kwargs7 = {
@@ -326,11 +369,19 @@ class BotorchDefaultsTest(TestCase):
         self.assertIsInstance(model.likelihood, FixedNoiseGaussianLikelihood)
 
         self.assertEqual(
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `base_kernel`.
             model.covar_module.base_kernel.lengthscale_prior.concentration,
             12.0,
         )
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `base_kernel`.
         self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `outputscale_prior`.
         self.assertEqual(model.covar_module.outputscale_prior.concentration, 2.0)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `outputscale_prior`.
         self.assertEqual(model.covar_module.outputscale_prior.rate, 12.0)
 
         model = get_and_fit_model(
@@ -344,6 +395,8 @@ class BotorchDefaultsTest(TestCase):
             refit_model=False,
             **kwarg,  # pyre-ignore
         )
+        # pyre-fixme[29]: `Union[(self: Tensor) -> Any, Tensor, Module]` is not a
+        #  function.
         for m in model.models:
             self.assertIs(type(m), MultiTaskGP)
             self.assertIsInstance(m.likelihood, FixedNoiseGaussianLikelihood)
@@ -397,6 +450,8 @@ class BotorchDefaultsTest(TestCase):
             self.assertIsNotNone(acqf_constraints)
 
             # while the function pointer is different, return value has to be the same
+            # pyre-fixme[6]: For 1st argument expected `Iterable[_T1]` but got
+            #  `Union[Tensor, Module]`.
             for acqf_con, exp_con in zip(acqf_constraints, expected_constraints):
                 self.assertTrue(torch.allclose(acqf_con(samples), exp_con(samples)))
 
@@ -437,7 +492,11 @@ class BotorchDefaultsTest(TestCase):
             acqf_constraints = acqf._constraints
             self.assertIsNotNone(acqf_constraints)
             self.assertIsInstance(acqf.objective, PenalizedMCObjective)
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `penalty_objective`.
             self.assertIsInstance(acqf.objective.penalty_objective, L1PenaltyObjective)
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `regularization_parameter`.
             self.assertEqual(acqf.objective.regularization_parameter, 0.1)
 
         acqf_name = "qSR"

--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -767,6 +767,7 @@ class BotorchModelTest(TestCase):
         train_X = torch.rand(5, 3, **tkwargs)
         train_Y = train_X.sum(dim=-1, keepdim=True)
         simple_gp = SingleTaskGP(train_X=train_X, train_Y=train_Y)
+        # pyre-fixme[16]: `Module` has no attribute `lengthscale`.
         simple_gp.covar_module.lengthscale = torch.tensor([1, 3, 5], **tkwargs)
         importances = get_feature_importances_from_botorch_model(simple_gp)
         self.assertTrue(np.allclose(importances, np.array([15 / 23, 5 / 23, 3 / 23])))

--- a/ax/models/tests/test_torch_model_utils.py
+++ b/ax/models/tests/test_torch_model_utils.py
@@ -233,10 +233,15 @@ class SubsetModelTestMultiTask(TestCase):
         obj_weights[1] = 0
         subset_model_results = subset_model(model, obj_weights)
         models = subset_model_results.model.models
+        # pyre-fixme[6]: For 1st argument expected
+        #  `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Tensor, Module]`.
         self.assertEqual(len(models), 2)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIs(models[0], m1)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(models[1], SingleTaskGP)
         # check that second model is the second output of m2
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertTrue(torch.equal(models[1].train_targets, m2.train_targets[1]))
 
     def test_nested_model_list_gp(self) -> None:
@@ -260,6 +265,10 @@ class SubsetModelTestMultiTask(TestCase):
         obj_weights[2] = 1
         subset_model_results = subset_model(model, obj_weights)
         models = subset_model_results.model.models
+        # pyre-fixme[6]: For 1st argument expected
+        #  `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Tensor, Module]`.
         self.assertEqual(len(models), 2)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIs(models[0], m1)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIs(models[1], m2b)

--- a/ax/models/torch/botorch_modular/sebo.py
+++ b/ax/models/torch/botorch_modular/sebo.py
@@ -126,6 +126,7 @@ class SEBOAcquisition(Acquisition):
         )
 
         # update objective threshold for deterministic model (penalty term)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.acqf.ref_point[-1] = self.sparsity_threshold * -1
         self._objective_thresholds[-1] = self.sparsity_threshold  # pyre-ignore
 
@@ -302,6 +303,8 @@ class SEBOAcquisition(Acquisition):
         batch_initial_conditions = get_batch_initial_conditions(
             acq_function=self.acqf,
             raw_samples=optimizer_options_with_defaults["raw_samples"],
+            # pyre-fixme[6]: For 3rd argument expected `Tensor` but got
+            #  `Union[Tensor, Module]`.
             X_pareto=self.acqf.X_baseline,
             target_point=self.target_point,
             bounds=bounds,

--- a/ax/models/torch/tests/test_kernels.py
+++ b/ax/models/torch/tests/test_kernels.py
@@ -30,9 +30,15 @@ class KernelsTest(TestCase):
         self.assertTrue(isinstance(covar.base_kernel, MaternKernel))
         self.assertTrue(isinstance(covar.base_kernel, MaternKernel))
         self.assertEqual(covar.base_kernel.ard_num_dims, 10)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `rate`.
         self.assertEqual(covar.base_kernel.lengthscale_prior.rate, 3.0)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `concentration`.
         self.assertEqual(covar.base_kernel.lengthscale_prior.concentration, 6.0)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `rate`.
         self.assertEqual(covar.outputscale_prior.rate, 0.15)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `concentration`.
         self.assertEqual(covar.outputscale_prior.concentration, 2.0)
         self.assertEqual(covar.base_kernel.batch_shape[0], 2)
 
@@ -66,8 +72,11 @@ class KernelsTest(TestCase):
                 ),
                 temporal_lengthscale_constraint=tls_constraint,
             )
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             self.assertTrue(isinstance(covar.base_kernel.kernels[0], MaternKernel))
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             self.assertTrue(isinstance(covar.base_kernel.kernels[1], PeriodicKernel))
+            # pyre-fixme[23]: Unable to unpack `Tensor | Module` into 2 values.
             matern, periodic = covar.base_kernel.kernels
 
             self.assertEqual(matern.ard_num_dims, matern_ard_num_dims)

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -646,6 +646,7 @@ class BoTorchModelTest(TestCase):
                     "mean": torch.randn(3, **self.tkwargs),
                     "noise": torch.rand(3, **self.tkwargs),
                 }
+                # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
                 model.surrogate.model.load_mcmc_samples(mcmc_samples)
                 importances = model.feature_importances()
                 self.assertTrue(
@@ -654,6 +655,8 @@ class BoTorchModelTest(TestCase):
                 self.assertEqual(importances.shape, (1, 1, 3))
                 saas_model = deepcopy(model.surrogate.model)
             else:
+                # pyre-fixme[16]: `Tensor` has no attribute `lengthscale`.
+                # pyre-fixme[16]: `Module` has no attribute `lengthscale`.
                 model.surrogate.model.covar_module.lengthscale = torch.tensor(
                     [1, 2, 3], **self.tkwargs
                 )

--- a/ax/models/torch/tests/test_sebo.py
+++ b/ax/models/torch/tests/test_sebo.py
@@ -156,18 +156,23 @@ class TestSebo(TestCase):
         surrogate = acquisition1.surrogate
         model_list = none_throws(surrogate._model)
         self.assertIsInstance(model_list, ModelList)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(model_list.models[0], SingleTaskGP)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(model_list.models[1], GenericDeterministicModel)
 
         # Check right penalty term is instantiated
         self.assertEqual(acquisition1.penalty_name, "L0_norm")
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(model_list.models[1]._f, L0Approximation)
         # `a` needs to be set to something small for the pruning to work as expected
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertEqual(model_list.models[-1]._f.a, 1e-6)
 
         # Check transformed objective threshold
         self.assertTrue(
             torch.equal(
+                # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slic...
                 acquisition1.acqf.ref_point[-1],
                 -self.objective_thresholds_sebo[-1],
             )
@@ -187,7 +192,9 @@ class TestSebo(TestCase):
         self.assertEqual(acquisition2.penalty_name, "L1_norm")
         surrogate = acquisition2.surrogate
         model_list = none_throws(surrogate._model)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(model_list.models[1]._f, functools.partial)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIs(model_list.models[1]._f.func, L1_norm_func)
 
         # assert error raise when constructing non L0/L1 penalty terms
@@ -282,6 +289,7 @@ class TestSebo(TestCase):
             fixed_features=self.fixed_features,
             options={"penalty": "L0_norm", "target_point": self.target_point},
         )
+        # pyre-fixme[16]: `AcquisitionFunction` has no attribute `cache_pending`.
         acquisition2.acqf.cache_pending = torch.tensor(False)
         acquisition2.optimize(
             n=2,

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -344,6 +344,7 @@ class SurrogateTest(TestCase):
         botorch_model = surrogate.model
         self.assertIsInstance(botorch_model.input_transform, Normalize)
         self.assertIsInstance(botorch_model.outcome_transform, Standardize)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `_m`.
         self.assertEqual(botorch_model.outcome_transform._m, self.Ys[0].shape[-1])
 
         # Error handling if the model does not support transforms.
@@ -588,6 +589,8 @@ class SurrogateTest(TestCase):
         noise_constraint.eval()  # For the equality check.
         self.assertEqual(
             # Checking equality of __dict__'s since Interval does not define __eq__.
+            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+            #  `noise_covar`.
             model.likelihood.noise_covar.raw_noise_constraint.__dict__,
             noise_constraint.__dict__,
         )
@@ -596,6 +599,8 @@ class SurrogateTest(TestCase):
             LeaveOneOutPseudoLikelihood,
         )
         self.assertEqual(type(model.covar_module), RBFKernel)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `ard_num_dims`.
         self.assertEqual(model.covar_module.ard_num_dims, 3)
 
     def test_construct_custom_model_with_config(self) -> None:
@@ -628,15 +633,24 @@ class SurrogateTest(TestCase):
         # first two metrics
         self.assertIsInstance(surrogate.model, ModelListGP)
         submodels = surrogate.model.models
+        # pyre-fixme[6]: For 1st argument expected
+        #  `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Tensor, Module]`.
         self.assertEqual(len(submodels), 4)
+        # pyre-fixme[29]: `Union[(self: Tensor) -> Any, Tensor, Module]` is not a
+        #  function.
         for m in submodels:
             self.assertIsInstance(m, SingleTaskGP)
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(surrogate.model.models[1].covar_module, ScaleKernel)
         self.assertIsInstance(
-            surrogate.model.models[1].covar_module.base_kernel, MaternKernel
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
+            surrogate.model.models[1].covar_module.base_kernel,
+            MaternKernel,
         )
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(surrogate.model.models[0].covar_module, RBFKernel)
         # test model use model_configs for the third metric
+        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(surrogate.model.models[2].covar_module, LinearKernel)
 
     @mock_botorch_optimize
@@ -1126,18 +1140,22 @@ class SurrogateTest(TestCase):
         self.assertEqual(surrogate.model._ignore_X_dims_scaling_check, [0])
         covar_module = checked_cast(Kernel, surrogate.model.covar_module)
         self.assertEqual(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             covar_module.kernels[0].base_kernel.kernels[1].active_dims.tolist(),
             [0],
         )
         self.assertEqual(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             covar_module.kernels[0].base_kernel.kernels[0].active_dims.tolist(),
             [1, 2],
         )
         self.assertEqual(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             covar_module.kernels[1].base_kernel.kernels[1].active_dims.tolist(),
             [0],
         )
         self.assertEqual(
+            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             covar_module.kernels[1].base_kernel.kernels[0].active_dims.tolist(),
             [1, 2],
         )
@@ -1490,6 +1508,7 @@ class SurrogateWithModelListTest(TestCase):
                 task_features=[],
             ),
         )
+        # pyre-fixme[9]: models has type `ModuleList`; used as `Union[Tensor, Module]`.
         models: torch.nn.modules.container.ModuleList = surrogate.model.models
         for i in range(2):
             self.assertIsInstance(models[i].outcome_transform, Standardize)
@@ -1606,6 +1625,8 @@ class SurrogateWithModelListTest(TestCase):
                 robust_digest=robust_digest,
             ),
         )
+        # pyre-fixme[29]: `Union[(self: Tensor) -> Any, Tensor, Module]` is not a
+        #  function.
         for m in surrogate.model.models:
             intf = checked_cast(InputPerturbation, m.input_transform)
             self.assertIsInstance(intf, InputPerturbation)

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -619,6 +619,7 @@ def botorch_input_transform_to_init_args(
         return {k: botorch_component_to_dict(v) for k, v in input_transform.items()}
     else:
         try:
+            # pyre-fixme[29]: `Union[Tensor, Module]` is not a function.
             return input_transform.get_init_args()  # pyre-fixme [16]
         except AttributeError:
             raise JSONEncodeError(


### PR DESCRIPTION
Summary:
In D52890934 we are tightening the type signature on attributes on nn Module.  To do this, we need to
first apply Pyre fixme to all sites that were relying on the old Any.  This diff shards out all changes
to files that begin with a.

Differential Revision: D66233582


