### PR TITLE
Add LogIntToFloat transform

### DIFF
--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -67,7 +67,7 @@ class SearchSpace(Base):
 
     def __init__(
         self,
-        parameters: list[Parameter],
+        parameters: Sequence[Parameter],
         parameter_constraints: list[ParameterConstraint] | None = None,
     ) -> None:
         """Initialize SearchSpace

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -42,6 +42,7 @@ from ax.models.torch.botorch_modular.utils import (
 )
 from ax.models.torch.utils import (
     _to_inequality_constraints,
+    normalize_indices,
     pick_best_out_of_sample_point_acqf_class,
     predict_from_model,
 )
@@ -69,12 +70,14 @@ from botorch.models.transforms.input import (
     ChainedInputTransform,
     InputPerturbation,
     InputTransform,
+    Normalize,
 )
 from botorch.models.transforms.outcome import ChainedOutcomeTransform, OutcomeTransform
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from botorch.utils.containers import SliceContainer
 from botorch.utils.datasets import MultiTaskDataset, RankingDataset, SupervisedDataset
 from botorch.utils.dispatcher import Dispatcher
+from botorch.utils.types import _DefaultType, DEFAULT
 from gpytorch.kernels import Kernel
 from gpytorch.likelihoods.likelihood import Likelihood
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
@@ -126,7 +129,7 @@ def _extract_model_kwargs(
 
 
 def _make_botorch_input_transform(
-    input_transform_classes: list[type[InputTransform]],
+    input_transform_classes: list[type[InputTransform]] | _DefaultType,
     input_transform_options: dict[str, dict[str, Any]],
     dataset: SupervisedDataset,
     search_space_digest: SearchSpaceDigest,
@@ -134,15 +137,46 @@ def _make_botorch_input_transform(
     """
     Makes a BoTorch input transform from the provided input classes and options.
     """
+    if isinstance(input_transform_classes, _DefaultType):
+        transforms = _construct_default_input_transforms(
+            search_space_digest=search_space_digest, dataset=dataset
+        )
+    else:
+        transforms = _construct_specified_input_transforms(
+            input_transform_classes=input_transform_classes,
+            dataset=dataset,
+            search_space_digest=search_space_digest,
+            input_transform_options=input_transform_options,
+        )
+    if len(transforms) == 0:
+        return None
+    elif len(transforms) > 1:
+        return ChainedInputTransform(
+            **{f"tf{i}": t_i for i, t_i in enumerate(transforms)}
+        )
+    else:
+        return transforms[0]
+
+
+def _construct_specified_input_transforms(
+    input_transform_classes: list[type[InputTransform]],
+    input_transform_options: dict[str, dict[str, Any]],
+    dataset: SupervisedDataset,
+    search_space_digest: SearchSpaceDigest,
+) -> list[InputTransform]:
+    """Constructs a list of input transforms from input transform classes and
+    options provided in ``ModelConfig``.
+    """
     if not (
         isinstance(input_transform_classes, list)
         and all(issubclass(c, InputTransform) for c in input_transform_classes)
     ):
-        raise UserInputError("Expected a list of input transforms.")
+        raise UserInputError(
+            "Expected a list of input transform classes. "
+            f"Got {input_transform_classes=}."
+        )
     if search_space_digest.robust_digest is not None:
         input_transform_classes = [InputPerturbation] + input_transform_classes
-    if len(input_transform_classes) == 0:
-        return None
 
     input_transform_kwargs = [
         input_transform_argparse(
@@ -156,7 +190,7 @@ def _make_botorch_input_transform(
         for transform_class in input_transform_classes
     ]
 
-    input_transforms = [
+    return [
         # pyre-fixme[45]: Cannot instantiate abstract class `InputTransform`.
         transform_class(**single_input_transform_kwargs)
         for transform_class, single_input_transform_kwargs in zip(
@@ -164,15 +198,47 @@ def _make_botorch_input_transform(
         )
     ]
 
-    input_transform_instance = (
-        ChainedInputTransform(
-            **{f"tf{i}": input_transforms[i] for i in range(len(input_transforms))}
-        )
-        if len(input_transforms) > 1
-        else input_transforms[0]
-    )
 
-    return input_transform_instance
+def _construct_default_input_transforms(
+    search_space_digest: SearchSpaceDigest,
+    dataset: SupervisedDataset,
+) -> list[InputTransform]:
+    """Construct the default input transforms for the given search space digest.
+
+    The default transforms are added in this order:
+    - If the search space digest has a robust digest, an ``InputPerturbation`` transform
+        is used.
+    - If the bounds for the non-task features are not [0, 1], a ``Normalize`` transform
+        is used. The transfrom only applies to the non-task features.
+    """
+    transforms = []
+    # Add InputPerturbation if there is a robust digest.
+    if search_space_digest.robust_digest is not None:
+        transforms.append(
+            InputPerturbation(
+                **input_transform_argparse(
+                    InputPerturbation,
+                    dataset=dataset,
+                    search_space_digest=search_space_digest,
+                )
+            )
+        )
+    # Processing for Normalize.
+    bounds = torch.tensor(search_space_digest.bounds, dtype=torch.get_default_dtype()).T
+    indices = list(range(bounds.shape[-1]))
+    # Remove task features.
+    for task_feature in normalize_indices(
+        search_space_digest.task_features, d=bounds.shape[-1]
+    ):
+        indices.remove(task_feature)
+    # Skip the Normalize transform if the bounds are [0, 1].
+    if not (
+        torch.allclose(bounds[0, indices], torch.zeros(len(indices)))
+        and torch.allclose(bounds[1, indices], torch.ones(len(indices)))
+    ):
+        transforms.append(Normalize(d=bounds.shape[-1], indices=indices, bounds=bounds))
+
+    return transforms
 
 
 def _make_botorch_outcome_transform(
@@ -314,10 +380,14 @@ def _raise_deprecation_warning(
         msg += "Please specify {k} via `model_configs`."
     warnings_raised = False
     default_is_dict = {"botorch_model_kwargs", "mll_kwargs"}
+    default_is_default = {"input_transform_classes"}
     for k, v in kwargs.items():
         should_raise = False
         if k in default_is_dict:
             if v not in [{}, None]:
+                should_raise = True
+        elif k in default_is_default:
+            if v != DEFAULT:
                 should_raise = True
         elif (v is not None and k != "mll_class") or (
             k == "mll_class" and v is not ExactMarginalLogLikelihood
@@ -340,7 +410,7 @@ def get_model_config_from_deprecated_args(
     mll_options: dict[str, Any] | None,
     outcome_transform_classes: list[type[OutcomeTransform]] | None,
     outcome_transform_options: dict[str, dict[str, Any]] | None,
-    input_transform_classes: list[type[InputTransform]] | None,
+    input_transform_classes: list[type[InputTransform]] | _DefaultType | None,
     input_transform_options: dict[str, dict[str, Any]] | None,
     covar_module_class: type[Kernel] | None,
     covar_module_options: dict[str, Any] | None,
@@ -348,30 +418,21 @@ def get_model_config_from_deprecated_args(
     likelihood_options: dict[str, Any] | None,
 ) -> ModelConfig:
     """Construct a ModelConfig from deprecated arguments."""
-    model_config_kwargs = {
-        "botorch_model_class": botorch_model_class,
-        "model_options": (model_options or {}).copy(),
-        "mll_class": mll_class,
-        "mll_options": (mll_options or {}).copy(),
-        "outcome_transform_classes": outcome_transform_classes,
-        "outcome_transform_options": outcome_transform_options,
-        "input_transform_classes": input_transform_classes,
-        "input_transform_options": input_transform_options,
-        "covar_module_class": covar_module_class,
-        "covar_module_options": covar_module_options,
-        "likelihood_class": likelihood_class,
-        "likelihood_options": likelihood_options,
-    }
-    model_config_kwargs = {
-        k: v for k, v in model_config_kwargs.items() if v is not None
-    }
-    # pyre-fixme [6]: Incompatible parameter type [6]: In call
-    # `ModelConfig.__init__`, for 1st positional argument, expected
-    # `Dict[str, typing.Any]` but got `Union[Dict[str, typing.Any],
-    # Dict[str, Dict[str, typing.Any]], Sequence[Type[InputTransform]],
-    # Sequence[Type[OutcomeTransform]], Type[Union[MarginalLogLikelihood,
-    #  Model]], Type[Likelihood], Type[Kernel]]`.
-    return ModelConfig(**model_config_kwargs, name="from deprecated args")
+    return ModelConfig(
+        botorch_model_class=botorch_model_class,
+        model_options=(model_options or {}).copy(),
+        mll_class=mll_class or ExactMarginalLogLikelihood,
+        mll_options=(mll_options or {}).copy(),
+        outcome_transform_classes=outcome_transform_classes,
+        outcome_transform_options=(outcome_transform_options or {}).copy(),
+        input_transform_classes=input_transform_classes,
+        input_transform_options=(input_transform_options or {}).copy(),
+        covar_module_class=covar_module_class,
+        covar_module_options=(covar_module_options or {}).copy(),
+        likelihood_class=likelihood_class,
+        likelihood_options=(likelihood_options or {}).copy(),
+        name="from deprecated args",
+    )
 
 
 @dataclass(frozen=True)
@@ -416,6 +477,9 @@ class SurrogateSpec:
         input_transform_classes: List of BoTorch input transforms classes.
             Passed down to the BoTorch ``Model``. Multiple input transforms
             will be chained together using ``ChainedInputTransform``.
+            If `DEFAULT`, a default set of input transforms may be constructed
+            based on the search space digest (in `_construct_default_input_transforms`).
+            To disable this behavior, pass in `input_transform_classes=None`.
             This argument is deprecated in favor of model_configs.
         input_transform_options: Input transform classes kwargs. The keys are
             class string names and the values are dictionaries of input transform
@@ -468,7 +532,9 @@ class SurrogateSpec:
     # pyre-ignore [16]: Pyre doesn't understand InitVars.
     likelihood_kwargs: InitVar[dict[str, Any] | None] = None
     # pyre-ignore [16]: Pyre doesn't understand InitVars.
-    input_transform_classes: InitVar[list[type[InputTransform]] | None] = None
+    input_transform_classes: InitVar[
+        list[type[InputTransform]] | _DefaultType | None
+    ] = DEFAULT
     # pyre-ignore [16]: Pyre doesn't understand InitVars.
     input_transform_options: InitVar[dict[str, dict[str, Any]] | None] = None
     # pyre-ignore [16]: Pyre doesn't understand InitVars.
@@ -577,6 +643,9 @@ class Surrogate(Base):
         input_transform_classes: List of BoTorch input transforms classes.
             Passed down to the BoTorch ``Model``. Multiple input transforms
             will be chained together using ``ChainedInputTransform``.
+            If `DEFAULT`, a default set of input transforms may be constructed
+            based on the search space digest. To disable this behavior, pass
+            in `input_transform_classes=None`.
             This argument is deprecated in favor of model_configs.
         input_transform_options: Input transform classes kwargs. The keys are
             class string names and the values are dictionaries of input transform
@@ -619,7 +688,9 @@ class Surrogate(Base):
         mll_options: dict[str, Any] | None = None,
         outcome_transform_classes: list[type[OutcomeTransform]] | None = None,
         outcome_transform_options: dict[str, dict[str, Any]] | None = None,
-        input_transform_classes: list[type[InputTransform]] | None = None,
+        input_transform_classes: list[type[InputTransform]]
+        | _DefaultType
+        | None = DEFAULT,
         input_transform_options: dict[str, dict[str, Any]] | None = None,
         covar_module_class: type[Kernel] | None = None,
         covar_module_options: dict[str, Any] | None = None,

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -39,6 +39,7 @@ from botorch.models.transforms.input import InputTransform
 from botorch.models.transforms.outcome import OutcomeTransform
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.transforms import is_fully_bayesian
+from botorch.utils.types import _DefaultType, DEFAULT
 from gpytorch.kernels.kernel import Kernel
 from gpytorch.likelihoods import Likelihood
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
@@ -64,7 +65,6 @@ class ModelConfig:
             Note that the corresponding attribute will later be updated to include any
             additional kwargs passed into ``BoTorchModel.fit``.
         mll_class: ``MarginalLogLikelihood`` class to use for model-fitting.
-            This argument is deprecated in favor of model_configs.
         mll_options: Dictionary of options / kwargs for the MLL.
         outcome_transform_classes: List of BoTorch outcome transforms classes. Passed
             down to the BoTorch ``Model``. Multiple outcome transforms can be chained
@@ -81,6 +81,9 @@ class ModelConfig:
         input_transform_classes: List of BoTorch input transforms classes.
             Passed down to the BoTorch ``Model``. Multiple input transforms
             will be chained together using ``ChainedInputTransform``.
+            If `DEFAULT`, a default set of input transforms may be constructed
+            based on the search space digest (in `_construct_default_input_transforms`).
+            To disable this behavior, pass in `input_transform_classes=None`.
         input_transform_options: Input transform classes kwargs. The keys are
             class string names and the values are dictionaries of input transform
             kwargs. For example,
@@ -108,7 +111,7 @@ class ModelConfig:
     model_options: dict[str, Any] = field(default_factory=dict)
     mll_class: type[MarginalLogLikelihood] = ExactMarginalLogLikelihood
     mll_options: dict[str, Any] = field(default_factory=dict)
-    input_transform_classes: list[type[InputTransform]] | None = None
+    input_transform_classes: list[type[InputTransform]] | _DefaultType | None = DEFAULT
     input_transform_options: dict[str, dict[str, Any]] | None = field(
         default_factory=dict
     )

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -54,6 +54,7 @@ from botorch.models.model import Model, ModelList
 from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils.constraints import get_outcome_constraint_transforms
 from botorch.utils.datasets import SupervisedDataset
+from botorch.utils.types import DEFAULT
 from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihood
 from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
 from pyre_extensions import none_throws
@@ -335,7 +336,7 @@ class BoTorchModelTest(TestCase):
                 model_options={},
                 mll_class=ExactMarginalLogLikelihood,
                 mll_options={},
-                input_transform_classes=None,
+                input_transform_classes=DEFAULT,
                 input_transform_options={},
                 outcome_transform_classes=None,
                 outcome_transform_options={},
@@ -635,7 +636,7 @@ class BoTorchModelTest(TestCase):
             )
             model.surrogate.fit(
                 datasets=self.block_design_training_data,
-                search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
+                search_space_digest=self.search_space_digest,
             )
             if botorch_model_class == SaasFullyBayesianSingleTaskGP:
                 mcmc_samples = {
@@ -741,10 +742,7 @@ class BoTorchModelTest(TestCase):
         )
         model.surrogate.fit(
             datasets=self.block_design_training_data,
-            search_space_digest=SearchSpaceDigest(
-                feature_names=[],
-                bounds=[],
-            ),
+            search_space_digest=self.search_space_digest,
         )
         model.evaluate_acquisition_function(
             X=self.X_test,

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -257,8 +257,6 @@ def tensor_or_size_from_json(json: dict[str, Any]) -> torch.Tensor | torch.Size:
         )
 
 
-# pyre-fixme[3]: Return annotation cannot contain `Any`.
-# pyre-fixme[2]: Parameter annotation cannot be `Any`.
 def botorch_component_from_json(botorch_class: type[T], json: dict[str, Any]) -> T:
     """Load any instance of `torch.nn.Module` or descendants registered in
     `CLASS_DECODER_REGISTRY` from state dict."""

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -867,6 +867,7 @@ class JSONStoreTest(TestCase):
             "warm_start_refit": True,
         }
         expected_object = get_botorch_model_with_surrogate_spec()
+        expected_object.surrogate_spec.model_configs[0].input_transform_classes = None
         self.assertEqual(object_from_json(object_json), expected_object)
 
     def test_surrogate_spec_backwards_compatibility(self) -> None:
@@ -951,6 +952,7 @@ class JSONStoreTest(TestCase):
                     botorch_model_class=SingleTaskGP,
                     covar_module_class=ScaleMaternKernel,
                     outcome_transform_classes=[Standardize],
+                    input_transform_classes=None,
                 )
             ]
         )

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -22,6 +22,9 @@ from ax.exceptions.storage import JSONDecodeError, JSONEncodeError
 from ax.modelbridge.generation_node import GenerationStep
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.registry import Models
+from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
+from ax.models.torch.botorch_modular.surrogate import SurrogateSpec
+from ax.models.torch.botorch_modular.utils import ModelConfig
 from ax.storage.json_store.decoder import (
     _DEPRECATED_MODEL_TO_REPLACEMENT,
     generation_strategy_from_json,
@@ -131,6 +134,8 @@ from ax.utils.testing.modeling_stubs import (
 )
 from ax.utils.testing.utils import generic_equals
 from ax.utils.testing.utils_testing_stubs import get_backend_simulator_with_trials
+from botorch.models import SingleTaskGP
+from botorch.models.transforms.outcome import Standardize
 from botorch.sampling.normal import SobolQMCNormalSampler
 
 
@@ -863,6 +868,93 @@ class JSONStoreTest(TestCase):
         }
         expected_object = get_botorch_model_with_surrogate_spec()
         self.assertEqual(object_from_json(object_json), expected_object)
+
+    def test_surrogate_spec_backwards_compatibility(self) -> None:
+        # This is an invalid example that has both deprecated args
+        # and model config specified. Deprecated args will be ignored.
+        object_json = {
+            "__type": "SurrogateSpec",
+            "botorch_model_class": {
+                "__type": "Type[Model]",
+                "index": "MultiTaskGP",
+                "class": "<class 'botorch.models.model.Model'>",
+            },
+            "botorch_model_kwargs": {"dummy": 5},
+            "mll_class": {
+                "__type": "Type[MarginalLogLikelihood]",
+                "index": "ExactMarginalLogLikelihood",
+                "class": (
+                    "<class 'gpytorch.mlls.marginal_log_likelihood."
+                    "MarginalLogLikelihood'>"
+                ),
+            },
+            "mll_kwargs": {},
+            "covar_module_class": None,
+            "covar_module_kwargs": None,
+            "likelihood_class": None,
+            "likelihood_kwargs": None,
+            "input_transform_classes": None,
+            "input_transform_options": None,
+            "outcome_transform_classes": None,
+            "outcome_transform_options": None,
+            "allow_batched_models": True,
+            "model_configs": [
+                {
+                    "__type": "ModelConfig",
+                    "botorch_model_class": {
+                        "__type": "Type[Model]",
+                        "index": "SingleTaskGP",
+                        "class": "<class 'botorch.models.model.Model'>",
+                    },
+                    "model_options": {},
+                    "mll_class": {
+                        "__type": "Type[MarginalLogLikelihood]",
+                        "index": "ExactMarginalLogLikelihood",
+                        "class": (
+                            "<class 'gpytorch.mlls.marginal_log_likelihood."
+                            "MarginalLogLikelihood'>"
+                        ),
+                    },
+                    "mll_options": {},
+                    "input_transform_classes": None,
+                    "input_transform_options": {},
+                    "outcome_transform_classes": [
+                        {
+                            "__type": "Type[OutcomeTransform]",
+                            "index": "Standardize",
+                            "class": (
+                                "<class 'botorch.models.transforms.outcome."
+                                "OutcomeTransform'>"
+                            ),
+                        }
+                    ],
+                    "outcome_transform_options": {},
+                    "covar_module_class": {
+                        "__type": "Type[Kernel]",
+                        "index": "ScaleMaternKernel",
+                        "class": "<class 'gpytorch.kernels.kernel.Kernel'>",
+                    },
+                    "covar_module_options": {},
+                    "likelihood_class": None,
+                    "likelihood_options": {},
+                }
+            ],
+            "metric_to_model_configs": {},
+            "eval_criterion": "Rank correlation",
+            "outcomes": [],
+            "use_posterior_predictive": False,
+        }
+        deserialized_object = object_from_json(object_json)
+        expected_object = SurrogateSpec(
+            model_configs=[
+                ModelConfig(
+                    botorch_model_class=SingleTaskGP,
+                    covar_module_class=ScaleMaternKernel,
+                    outcome_transform_classes=[Standardize],
+                )
+            ]
+        )
+        self.assertEqual(deserialized_object, expected_object)
 
     def test_model_registry_backwards_compatibility(self) -> None:
         # Check that deprecated model registry entries can be loaded.

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -18,7 +18,7 @@ from ax.modelbridge.transforms.convert_metric_names import ConvertMetricNames
 from ax.modelbridge.transforms.derelativize import Derelativize
 from ax.modelbridge.transforms.fill_missing_parameters import FillMissingParameters
 from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
-from ax.modelbridge.transforms.int_to_float import IntToFloat
+from ax.modelbridge.transforms.int_to_float import IntToFloat, LogIntToFloat
 from ax.modelbridge.transforms.ivw import IVW
 from ax.modelbridge.transforms.log import Log
 from ax.modelbridge.transforms.log_y import LogY
@@ -95,6 +95,7 @@ TRANSFORM_REGISTRY: dict[type[Transform], int] = {
     TimeAsFeature: 27,
     TransformToNewSQ: 28,
     FillMissingParameters: 29,
+    LogIntToFloat: 30,
 }
 
 """


### PR DESCRIPTION
Summary:
This is a simple subclass of `IntToFloat` that only transforms log-scale parameters.

Replacing `IntToFloat` with `LogIntToFloat` will avoid unnecessary use of continuous relaxation across the board, and allow us to utilize the various optimizers available in `Acquisition.optimize`.

Differential Revision: D66244582


