### PR TITLE
Build pypi packages with build

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -82,10 +82,10 @@ jobs:
         pip install git+https://github.com/cornellius-gp/gpytorch.git
         pip install git+https://github.com/pytorch/botorch.git
         pip install -e ".[dev,mysql,notebook]"
-        pip install wheel
+        pip install --upgrade build setuptools setuptools_scm wheel
     - name: Build wheel
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel
     - name: Deploy to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,12 +58,12 @@ jobs:
       run: |
         # use stable Botorch
         pip install -e ".[dev,mysql,notebook]"
-        pip install wheel
+        pip install --upgrade build setuptools setuptools_scm wheel
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - name: Build wheel
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel
     - name: Deploy to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
Invoking python setup.py sdist bdist_wheel to build the packages is deprecated. This instead uses the PEP517-compliant build frontend build as per https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/

This also fixes an issue with PEP 625 non-compliance (before this change, the source distribuiton filename would be `ax-platform-x.x.x.tar.gz`; when using `build` as in this change the first hyphen gets properly normalized to an underscore).