### PR TITLE
Fix Parameter Sensitivity Plot Layout

### DIFF
--- a/ax/plot/feature_importances.py
+++ b/ax/plot/feature_importances.py
@@ -244,10 +244,11 @@ def plot_feature_importance_by_feature_plotly(
     longest_label = max(len(f) for f in features)
     longest_metric = max(len(m) for m in sensitivity_values.keys())
     layout = go.Layout(
-        height=len(features) * 20,
+        height=200 + len(features) * 20,
         width=10 * longest_label + max(10 * longest_metric, 400),
         hovermode="closest",
         annotations=compose_annotation(caption=caption),
+        title=f"Parameter Sensitivity by {importance_measure}",
     )
 
     if relative:


### PR DESCRIPTION
Summary:
As titled, fix parameter sensitivity plot layout. 
1) Makes sure the height is enough to show all parameters
2) Shows the title of the plot

sample sweeps with weird sensitivity plot display: f666814066, f666666748, f666034938

Differential Revision: D66395421


