### PR TITLE
Refer to "time interval" to "epoch" in benchmarking; give `BenchmarkTestFunction` an "epoch" attribute

### DIFF
--- a/ax/benchmark/benchmark_metric.py
+++ b/ax/benchmark/benchmark_metric.py
@@ -93,12 +93,12 @@ class BenchmarkMetric(Metric):
             return _get_no_metadata_err(trial=trial)
 
         df = trial.run_metadata["benchmark_metadata"].dfs[self.name]
-        if (df["t"] > 0).any():
+        if (df["step"] > 0).any():
             raise ValueError(
                 f"Trial {trial.index} has data from multiple time steps. This is"
                 " not supported by `BenchmarkMetric`; use `BenchmarkMapMetric`."
             )
-        df = df.drop(columns=["t"])
+        df = df.drop(columns=["step"])
         if not self.observe_noise_sd:
             df["sem"] = None
         return Ok(value=Data(df=df))
@@ -108,7 +108,7 @@ class BenchmarkMapMetric(MapMetric):
     # pyre-fixme: Inconsistent override [15]: `map_key_info` overrides attribute
     # defined in `MapMetric` inconsistently. Type `MapKeyInfo[int]` is not a
     # subtype of the overridden attribute `MapKeyInfo[float]`
-    map_key_info: MapKeyInfo[int] = MapKeyInfo(key="t", default_value=0)
+    map_key_info: MapKeyInfo[int] = MapKeyInfo(key="step", default_value=0)
 
     def __init__(
         self,
@@ -186,8 +186,8 @@ class BenchmarkMapMetric(MapMetric):
 
         df = (
             metadata.dfs[self.name]
-            .loc[lambda x: x["t"] <= max_t]
-            .rename(columns={"t": self.map_key_info.key})
+            .loc[lambda x: x["step"] <= max_t]
+            .rename(columns={"step": self.map_key_info.key})
         )
         if not self.observe_noise_sd:
             df["sem"] = None

--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -33,11 +33,11 @@ def _dict_of_arrays_to_df(
 ) -> pd.DataFrame:
     """
     Return a DataFrame with columns ["metric_name", "arm_name",
-    "Y_true", "t"].
+    "Y_true", "step"].
 
     Args:
         Y_true_by_arm: A mapping from arm name to a 2D arrays each with shape
-            (len(outcome_names), n_time_intervals).
+            (len(outcome_names), n_steps).
         outcome_names: The names of the outcomes; will be mapped to the first
             dimension of each array in ``Y_true_by_arm``.
     """
@@ -48,7 +48,7 @@ def _dict_of_arrays_to_df(
                     "metric_name": outcome_name,
                     "arm_name": arm_name,
                     "Y_true": y_true[i, :],
-                    "t": np.arange(y_true.shape[1]),
+                    "step": np.arange(y_true.shape[1], dtype=int),
                 }
             )
             for i, outcome_name in enumerate(outcome_names)

--- a/ax/benchmark/benchmark_test_function.py
+++ b/ax/benchmark/benchmark_test_function.py
@@ -22,9 +22,14 @@ class BenchmarkTestFunction(ABC):
 
     Args:
         outcome_names: Names of the outcomes.
+        n_steps: Number of data points produced per metric and per evaluation. 1
+            if data is not time-series. If data is time-series, this will
+            eventually become the number of values on a `MapMetric` for
+            evaluations that run to completion.
     """
 
     outcome_names: Sequence[str]
+    n_steps: int = 1
 
     @abstractmethod
     def evaluate_true(self, params: Mapping[str, TParamValue]) -> Tensor:
@@ -32,8 +37,6 @@ class BenchmarkTestFunction(ABC):
         Evaluate noiselessly.
 
         Returns:
-            A 2d tensor of shape (len(outcome_names), n_intervals).
-            ``n_intervals`` is only relevant when using time-series data
-            (``MapData``). Otherwise, it is 1.
+            A 2d tensor of shape (len(self.outcome_names), self.n_steps).
         """
         ...

--- a/ax/benchmark/tests/benchmark_test_functions/test_botorch_test_function.py
+++ b/ax/benchmark/tests/benchmark_test_functions/test_botorch_test_function.py
@@ -91,3 +91,6 @@ class TestBoTorchTestFunction(TestCase):
             with self.subTest(name=name):
                 self.assertEqual(result.dtype, torch.double)
                 self.assertEqual(result.shape, torch.Size([expected_len[name]]))
+
+    def test_n_steps_is_one(self) -> None:
+        self.assertEqual(self.botorch_test_problems["base Hartmann"].n_steps, 1)

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -250,7 +250,7 @@ class TestBenchmark(TestCase):
             # same effect as completing after 1 second (third case), because a
             # new trial can't start until the next time increment.
             # With MapData, trials complete at the same times as without
-            # MapData, but an extra epoch accrues in the third case.
+            # MapData, but an extra step accrues in the third case.
             "Trials complete at same time": [0, 0, 1, 1],
             "Complete out of order": [0, 0, 1, 2],
         }
@@ -276,7 +276,7 @@ class TestBenchmark(TestCase):
                 problem = get_async_benchmark_problem(
                     map_data=map_data,
                     trial_runtime_func=trial_runtime_func,
-                    n_time_intervals=30 if map_data else 1,
+                    n_steps=30 if map_data else 1,
                 )
 
                 with mock_patch_method_original(
@@ -357,7 +357,7 @@ class TestBenchmark(TestCase):
         """
         Test early stopping with a deterministic generation strategy and ESS
         that stops if the objective exceeds 0.5 when their progression ("t") hits 2,
-        which happens when 3 epochs have passed (t=[0, 1, 2]).
+        which happens when 3 steps have passed (t=[0, 1, 2]).
 
         Each arm produces values equaling the trial index everywhere on the
         progression, so Trials 1, 2, and 3 will stop early, and trial 0 will not.
@@ -385,7 +385,7 @@ class TestBenchmark(TestCase):
         problem = get_async_benchmark_problem(
             map_data=True,
             trial_runtime_func=lambda _: progression_length_if_not_stopped,
-            n_time_intervals=progression_length_if_not_stopped,
+            n_steps=progression_length_if_not_stopped,
             lower_is_better=True,
         )
         result = benchmark_replication(
@@ -394,15 +394,15 @@ class TestBenchmark(TestCase):
         data = assert_is_instance(none_throws(result.experiment).lookup_data(), MapData)
         grouped = data.map_df.groupby("trial_index")
         self.assertEqual(
-            dict(grouped["t"].count()),
+            dict(grouped["step"].count()),
             {
                 0: progression_length_if_not_stopped,
-                # stopping after t=2, so 3 epochs (0, 1, 2) have passed
+                # stopping after step=2, so 3 steps (0, 1, 2) have passed
                 **{i: min_progression + 1 for i in range(1, 4)},
             },
         )
         self.assertEqual(
-            dict(grouped["t"].max()),
+            dict(grouped["step"].max()),
             {
                 0: progression_length_if_not_stopped - 1,
                 **{i: min_progression for i in range(1, 4)},
@@ -423,7 +423,7 @@ class TestBenchmark(TestCase):
             for trial_index, sim_trial in trials.items()
         }
         map_df["start_time"] = map_df["trial_index"].map(start_times).astype(int)
-        map_df["absolute_time"] = map_df["t"] + map_df["start_time"]
+        map_df["absolute_time"] = map_df["step"] + map_df["start_time"]
         expected_start_end_times = {
             0: (0, 4),
             1: (0, 2),

--- a/ax/benchmark/tests/test_benchmark_metric.py
+++ b/ax/benchmark/tests/test_benchmark_metric.py
@@ -51,7 +51,7 @@ def get_test_trial(
                 "metric_name": "test_metric1",
                 "mean": [1.0, 2.5] if batch else [1.0],
                 "sem": [0.1, 0.0] if batch else [0.1],
-                "t": 0,
+                "step": 0,
                 "trial_index": 0,
             }
         ),
@@ -61,7 +61,7 @@ def get_test_trial(
                 "metric_name": "test_metric2",
                 "mean": [0.5, 1.5] if batch else [0.5],
                 "sem": [0.1, 0.0] if batch else [0.1],
-                "t": 0,
+                "step": 0,
                 "trial_index": 0,
             }
         ),
@@ -75,10 +75,10 @@ def get_test_trial(
             ),
             verbose_logging=False,
         )
-        n_time_intervals = 3
+        n_steps = 3
         dfs = {
-            k: pd.concat([df] * n_time_intervals).assign(
-                t=np.repeat(np.arange(n_time_intervals), 2 if batch else 1)
+            k: pd.concat([df] * n_steps).assign(
+                step=np.repeat(np.arange(n_steps), 2 if batch else 1)
             )
             for k, df in dfs.items()
         }
@@ -162,7 +162,7 @@ class BenchmarkMetricTest(TestCase):
             "mean": 1.0,
             "sem": 0.1,
             "trial_index": 0,
-            "t": 0,
+            "step": 0,
         }
 
         self.assertDictEqual(map_df1.iloc[0].to_dict(), expected_results)
@@ -174,7 +174,7 @@ class BenchmarkMetricTest(TestCase):
             "mean": 0.5,
             "sem": 0.1,
             "trial_index": 0,
-            "t": 0,
+            "step": 0,
         }
         self.assertDictEqual(map_df2.iloc[0].to_dict(), expected_results)
 
@@ -190,7 +190,7 @@ class BenchmarkMetricTest(TestCase):
         self.assertEqual(backend_simulator.time, 2)
         map_df1 = self.map_metric1.fetch_trial_data(trial=trial).value.map_df
         self.assertEqual(len(map_df1), 2)
-        self.assertEqual(set(map_df1["t"].tolist()), {0, 1})
+        self.assertEqual(set(map_df1["step"].tolist()), {0, 1})
 
     def _test_fetch_trial_data_batch_trial(self, map_data: bool) -> None:
         if map_data:
@@ -198,7 +198,7 @@ class BenchmarkMetricTest(TestCase):
         else:
             metric1, metric2 = self.metric1, self.metric2
         trial = get_test_trial(map_data=map_data, batch=True)
-        df1 = metric1.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
+        df1 = metric1.fetch_trial_data(trial=trial).value.df
         self.assertEqual(len(df1), 2)
         expected = {
             "arm_name": {0: "0_0", 1: "0_1"},
@@ -208,10 +208,10 @@ class BenchmarkMetricTest(TestCase):
             "trial_index": {0: 0, 1: 0},
         }
         if map_data:
-            expected["t"] = {0: 0, 1: 0}
+            expected["step"] = {0: 0, 1: 0}
 
         self.assertDictEqual(df1.to_dict(), expected)
-        df2 = metric2.fetch_trial_data(trial=trial).value.df  # pyre-ignore [16]
+        df2 = metric2.fetch_trial_data(trial=trial).value.df
         self.assertEqual(len(df2), 2)
         expected = {
             "arm_name": {0: "0_0", 1: "0_1"},
@@ -221,7 +221,7 @@ class BenchmarkMetricTest(TestCase):
             "trial_index": {0: 0, 1: 0},
         }
         if map_data:
-            expected["t"] = {0: 0, 1: 0}
+            expected["step"] = {0: 0, 1: 0}
         self.assertDictEqual(df2.to_dict(), expected)
 
     def test_fetch_trial_data_batch_trial(self) -> None:
@@ -245,7 +245,7 @@ class BenchmarkMetricTest(TestCase):
 
     def test_map_data_without_map_metric_raises(self) -> None:
         metadata = BenchmarkTrialMetadata(
-            dfs={"test_metric": pd.DataFrame({"t": [0, 1]})},
+            dfs={"test_metric": pd.DataFrame({"step": [0, 1]})},
         )
         trial = Mock(spec=Trial)
         trial.run_metadata = {"benchmark_metadata": metadata}

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -297,7 +297,7 @@ class DeterministicGenerationNode(ExternalGenerationNode):
 @dataclass(kw_only=True)
 class IdentityTestFunction(BenchmarkTestFunction):
     outcome_names: Sequence[str] = field(default_factory=lambda: ["objective"])
-    n_time_intervals: int = 1
+    n_steps: int = 1
 
     # pyre-fixme[14]: Inconsistent override
     def evaluate_true(self, params: Mapping[str, float]) -> torch.Tensor:
@@ -307,7 +307,7 @@ class IdentityTestFunction(BenchmarkTestFunction):
         """
         value = params["x0"]
         return torch.full(
-            (len(self.outcome_names), self.n_time_intervals), value, dtype=torch.float64
+            (len(self.outcome_names), self.n_steps), value, dtype=torch.float64
         )
 
 
@@ -345,11 +345,11 @@ def get_async_benchmark_method(
 def get_async_benchmark_problem(
     map_data: bool,
     trial_runtime_func: Callable[[BaseTrial], int],
-    n_time_intervals: int = 1,
+    n_steps: int = 1,
     lower_is_better: bool = False,
 ) -> BenchmarkProblem:
     search_space = get_discrete_search_space()
-    test_function = IdentityTestFunction(n_time_intervals=n_time_intervals)
+    test_function = IdentityTestFunction(n_steps=n_steps)
     optimization_config = get_soo_opt_config(
         outcome_names=["objective"],
         use_map_metric=map_data,


### PR DESCRIPTION
Summary:
I find this clearer, since "time interval" is vauge and could in theory refer to many different periods of time. The downside is that "epoch" may make less sense outside the context of AutoML.

The new attribute is not needed yet, but will be in the next diff.

Differential Revision: D66397779


