### PR TITLE
Allow different steps to take different lengths of time based on parameterization in benchmarking

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -70,7 +70,9 @@ def compute_score_trace(
 
 
 def get_benchmark_runner(
-    problem: BenchmarkProblem, max_concurrency: int = 1
+    problem: BenchmarkProblem,
+    max_concurrency: int = 1,
+    first_step_is_instant: bool = False,
 ) -> BenchmarkRunner:
     """
     Construct a ``BenchmarkRunner`` for the given problem and concurrency.
@@ -81,17 +83,22 @@ def get_benchmark_runner(
 
     Args:
         problem: The ``BenchmarkProblem``; provides a ``BenchmarkTestFunction``
-            (used to generate data) and ``trial_runtime_func`` (used to
-            determine the length of trials for the simulator).
+            (used to generate data) and ``step_runtime_function`` (used to
+            determine timing for the simulator).
         max_concurrency: The maximum number of trials that can be run concurrently.
             Typically, ``max_pending_trials`` from ``SchedulerOptions``, which are
             stored on the ``BenchmarkMethod``.
+        first_step_is_instant: Deprecated and provided for backwards
+            compatibility with past behavior of the ``BenchmarkRunner``'s
+            ``SimulatedBackendRunner``.
     """
+
     return BenchmarkRunner(
         test_function=problem.test_function,
         noise_std=problem.noise_std,
-        trial_runtime_func=problem.trial_runtime_func,
+        step_runtime_function=problem.step_runtime_function,
         max_concurrency=max_concurrency,
+        first_step_is_instant=first_step_is_instant,
     )
 
 
@@ -210,6 +217,7 @@ def benchmark_replication(
     method: BenchmarkMethod,
     seed: int,
     strip_runner_before_saving: bool = True,
+    first_step_is_instant: bool = False,
 ) -> BenchmarkResult:
     """
     Run one benchmarking replication (equivalent to one optimization loop).
@@ -226,6 +234,9 @@ def benchmark_replication(
         seed: The seed to use for this replication.
         strip_runner_before_saving: Whether to strip the runner from the
             experiment before saving it. This enables serialization.
+        first_step_is_instant: Deprecated and provided for backwards
+            compatibility with past behavior of the ``BenchmarkRunner``'s
+            ``SimulatedBackendRunner``.
 
     Return:
         ``BenchmarkResult`` object.
@@ -240,7 +251,9 @@ def benchmark_replication(
         include_sq=sq_arm is not None,
     )
     runner = get_benchmark_runner(
-        problem=problem, max_concurrency=scheduler_options.max_pending_trials
+        problem=problem,
+        max_concurrency=scheduler_options.max_pending_trials,
+        first_step_is_instant=first_step_is_instant,
     )
     experiment = Experiment(
         name=f"{problem.name}|{method.name}_{int(time())}",

--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -5,8 +5,7 @@
 
 # pyre-strict
 
-import warnings
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from math import sqrt
 from typing import Any
@@ -14,6 +13,7 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+from ax.benchmark.benchmark_step_runtime_function import TBenchmarkStepRuntimeFunction
 
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
@@ -29,18 +29,31 @@ from pyre_extensions import assert_is_instance
 
 
 def _dict_of_arrays_to_df(
-    Y_true_by_arm: Mapping[str, npt.NDArray], outcome_names: Sequence[str]
+    Y_true_by_arm: Mapping[str, npt.NDArray],
+    step_duration_by_arm: Mapping[str, float],
+    outcome_names: Sequence[str],
+    first_step_is_instant: bool,
 ) -> pd.DataFrame:
     """
-    Return a DataFrame with columns ["metric_name", "arm_name",
-    "Y_true", "step"].
+    Return a DataFrame with columns
+    ["metric_name", "arm_name", "Y_true", "step", and "virtual runtime"].
+
+    When the trial produces MapData, the "step" column is 0, 1, 2, ...., and
+    "virtual runtime" contains cumulative time for each element of the
+    progression. When the trial does not produce MapData, the "step" column is
+    just 0, and "virtual runtime" is the total runtime of the trial.
 
     Args:
         Y_true_by_arm: A mapping from arm name to a 2D arrays each with shape
             (len(outcome_names), n_steps).
+        step_duration_by_arm: A mapping from arm name to a number representing
+            the runtime of each step.
         outcome_names: The names of the outcomes; will be mapped to the first
             dimension of each array in ``Y_true_by_arm``.
+        first_step_is_instant: If True, the first step's virtual runtime is 0.
+            Otherwise, it is the typical step duration of that arm.
     """
+    offset = 0 if first_step_is_instant else 1
     df = pd.concat(
         [
             pd.DataFrame(
@@ -49,6 +62,8 @@ def _dict_of_arrays_to_df(
                     "arm_name": arm_name,
                     "Y_true": y_true[i, :],
                     "step": np.arange(y_true.shape[1], dtype=int),
+                    "virtual runtime": (np.arange(y_true.shape[1], dtype=int) + offset)
+                    * step_duration_by_arm[arm_name],
                 }
             )
             for i, outcome_name in enumerate(outcome_names)
@@ -107,6 +122,22 @@ def _add_noise(
     return df
 
 
+def get_total_runtime(
+    trial: BaseTrial,
+    step_runtime_function: TBenchmarkStepRuntimeFunction | None,
+    n_steps: int,
+) -> float:
+    """Get the total runtime of a trial."""
+    # By default, each step takes 1 virtual second.
+    if step_runtime_function is not None:
+        max_step_runtime = max(
+            (step_runtime_function(arm.parameters) for arm in trial.arms)
+        )
+    else:
+        max_step_runtime = 1
+    return n_steps * max_step_runtime
+
+
 @dataclass(kw_only=True)
 class BenchmarkRunner(Runner):
     """
@@ -126,28 +157,31 @@ class BenchmarkRunner(Runner):
           conceptually clear how to benchmark such problems, so we decided to
           not over-engineer for that before such a use case arrives.
 
-    If ``trial_runtime_func`` and ``max_concurrency`` are both left as default,
-    trials run serially and complete immediately. Otherwise, a
-    ``SimulatedBackendRunner`` is constructed to track the status of trials.
+    If ``max_concurrency`` is left as default (1), trials run serially and
+    complete immediately. Otherwise, a ``SimulatedBackendRunner`` is constructed
+    to track the status of trials.
 
     Args:
         test_function: A ``BenchmarkTestFunction`` from which to generate
             deterministic data before adding noise.
         noise_std: The standard deviation of the noise added to the data. Can be
             a list or dict to be per-metric.
-        trial_runtime_func: A callable that takes a trial and returns its
-            runtime, in simulated seconds. If `None`, each trial completes in
-            one simulated second.
+        step_runtime_function: A function that takes in parameters
+            (in ``TParameterization`` format) and returns the runtime of a step.
         max_concurrency: The maximum number of trials that can be running at a
             given time. Typically, this is ``max_pending_trials`` from the
             ``scheduler_options`` on the ``BenchmarkMethod``.
+        first_step_is_instant: Deprecated and provided for backwards
+            compatibility with past behavior of the ``BenchmarkRunner``'s
+            ``SimulatedBackendRunner``.
     """
 
     test_function: BenchmarkTestFunction
     noise_std: float | Sequence[float] | Mapping[str, float] = 0.0
-    trial_runtime_func: Callable[[BaseTrial], int] | None = None
+    step_runtime_function: TBenchmarkStepRuntimeFunction | None = None
     max_concurrency: int = 1
     simulated_backend_runner: SimulatedBackendRunner | None = field(init=False)
+    first_step_is_instant: bool = False
 
     def __post_init__(self) -> None:
         if self.max_concurrency > 1:
@@ -159,17 +193,13 @@ class BenchmarkRunner(Runner):
                     use_update_as_start_time=True,
                 ),
             )
-            if self.trial_runtime_func is None:
-                warnings.warn(
-                    "`trial_runtime_func` is not set and `max_concurrency` > 1."
-                    " Each trial will take one simulated second to run.",
-                    stacklevel=2,
-                )
             self.simulated_backend_runner = SimulatedBackendRunner(
                 simulator=simulator,
-                sample_runtime_func=self.trial_runtime_func
-                if self.trial_runtime_func is not None
-                else lambda _: 1,
+                sample_runtime_func=lambda trial: get_total_runtime(
+                    trial=trial,
+                    step_runtime_function=self.step_runtime_function,
+                    n_steps=self.test_function.n_steps,
+                ),
             )
         else:
             self.simulated_backend_runner = None
@@ -222,8 +252,24 @@ class BenchmarkRunner(Runner):
             arm.name: self.get_Y_true(arm.parameters) for arm in trial.arms
         }
 
+        step_duration_by_arm = {
+            arm.name: 1
+            if self.step_runtime_function is None
+            else self.step_runtime_function(arm.parameters)
+            for arm in trial.arms
+        }
+        for arm_name, duration in step_duration_by_arm.items():
+            if duration < 0:
+                raise ValueError(
+                    "Step duration must be non-negative for each arm. For arm "
+                    f"{arm_name}, duration is {duration}."
+                )
+
         df = _dict_of_arrays_to_df(
-            Y_true_by_arm=Y_true_by_arm, outcome_names=self.outcome_names
+            Y_true_by_arm=Y_true_by_arm,
+            step_duration_by_arm=step_duration_by_arm,
+            outcome_names=self.outcome_names,
+            first_step_is_instant=self.first_step_is_instant,
         )
 
         arm_weights = (

--- a/ax/benchmark/benchmark_step_runtime_function.py
+++ b/ax/benchmark/benchmark_step_runtime_function.py
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+from ax.core.types import TParamValue
+
+
+@runtime_checkable
+class TBenchmarkStepRuntimeFunction(Protocol):
+    def __call__(self, params: Mapping[str, TParamValue]) -> float:
+        """
+        Return the runtime for each step.
+
+        Each step within an arm will take the same amount of time.
+        """
+        ...

--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -15,7 +15,7 @@ from ax.benchmark.problems.hd_embedding import embed_higher_dimension
 from ax.benchmark.problems.hpo.torchvision import (
     get_pytorch_cnn_torchvision_benchmark_problem,
 )
-from ax.benchmark.problems.runtime_funcs import int_from_trial
+from ax.benchmark.problems.runtime_funcs import int_from_params
 from ax.benchmark.problems.synthetic.hss.jenatton import get_jenatton_benchmark_problem
 from botorch.test_functions import synthetic
 from botorch.test_functions.multi_objective import BraninCurrin
@@ -45,7 +45,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
             "num_trials": 40,
             "noise_std": 1.0,
             "observe_noise_sd": False,
-            "trial_runtime_func": int_from_trial,
+            "step_runtime_function": int_from_params,
             "name": "ackley4_async_noisy",
         },
     ),

--- a/ax/benchmark/problems/runtime_funcs.py
+++ b/ax/benchmark/problems/runtime_funcs.py
@@ -5,30 +5,17 @@
 
 # pyre-strict
 
-import random
 from collections.abc import Mapping
 
-from ax.core.trial import Trial
+from ax.core.arm import Arm
 from ax.core.types import TParamValue
-from pyre_extensions import none_throws
 
 
 def int_from_params(
     params: Mapping[str, TParamValue], n_possibilities: int = 10
 ) -> int:
     """
-    Get a random int between 0 and n_possibilities - 1, using parameters for the
-    random seed.
+    Get an int between 0 and n_possibilities - 1, using a hash of the parameters.
     """
-    seed = str(tuple(sorted(params.items())))
-    return random.Random(seed).randrange(n_possibilities)
-
-
-def int_from_trial(trial: Trial, n_possibilities: int = 10) -> int:
-    """
-    Get a random int between 0 and n_possibilities - 1, using the parameters of
-    the trial's first arm for the random seed.
-    """
-    return int_from_params(
-        params=none_throws(trial.arms)[0].parameters, n_possibilities=n_possibilities
-    )
+    arm_hash = Arm.md5hash(parameters=params)
+    return int(arm_hash[-1], 16) % 10

--- a/ax/benchmark/tests/problems/test_problems.py
+++ b/ax/benchmark/tests/problems/test_problems.py
@@ -5,12 +5,9 @@
 
 # pyre-strict
 
-from unittest.mock import MagicMock
 
 from ax.benchmark.problems.registry import BENCHMARK_PROBLEM_REGISTRY, get_problem
-from ax.benchmark.problems.runtime_funcs import int_from_params, int_from_trial
-from ax.core.arm import Arm
-from ax.core.trial import Trial
+from ax.benchmark.problems.runtime_funcs import int_from_params
 from ax.utils.common.testutils import TestCase
 
 
@@ -66,9 +63,5 @@ class TestProblems(TestCase):
     def test_runtime_funcs(self) -> None:
         parameters = {"x0": 0.5, "x1": -3, "x2": "-4", "x3": False, "x4": None}
         result = int_from_params(params=parameters)
-        expected = 3
+        expected = 1
         self.assertEqual(result, expected)
-        arm = Arm(name="0_0", parameters=parameters)
-        trial = MagicMock(spec=Trial)
-        trial.arms = [arm]
-        self.assertEqual(int_from_trial(trial=trial), expected)

--- a/ax/benchmark/tests/test_benchmark_runner.py
+++ b/ax/benchmark/tests/test_benchmark_runner.py
@@ -51,7 +51,7 @@ class TestBenchmarkRunner(TestCase):
         # Initialize
         runner = BenchmarkRunner(
             test_function=Jenatton(outcome_names=["objective"]),
-            trial_runtime_func=lambda trial: trial.index + 1,
+            step_runtime_function=lambda params: params["x1"] + 1,
             max_concurrency=2,
         )
         simulated_backend_runner = none_throws(runner.simulated_backend_runner)
@@ -307,6 +307,7 @@ class TestBenchmarkRunner(TestCase):
                     "sem",
                     "trial_index",
                     "step",
+                    "virtual runtime",
                 },
                 set(obj_df.columns),
             )
@@ -374,10 +375,7 @@ class TestBenchmarkRunner(TestCase):
 
         with self.subTest("with SimulatedBackendRunner"):
             runner = BenchmarkRunner(
-                test_function=test_function,
-                noise_std=0.0,
-                trial_runtime_func=lambda _: 1,
-                max_concurrency=2,
+                test_function=test_function, noise_std=0.0, max_concurrency=2
             )
 
             # pyre-fixme[6]: Incompatible parameter type (because argument is mutable)
@@ -394,10 +392,40 @@ class TestBenchmarkRunner(TestCase):
             self.assertEqual(sim_trial.sim_start_time, 0)
             self.assertEqual(backend_simulator.time, 0)
 
-    def test_warns_if_concurrent_and_trial_runtime_func_is_none(self) -> None:
-        test_function = IdentityTestFunction(outcome_names=["foo"])
-        with self.assertWarnsRegex(Warning, "`trial_runtime_func` is not set"):
-            BenchmarkRunner(
-                test_function=test_function,
-                max_concurrency=2,
-            )
+    def test_heterogeneous_step_runtime(self) -> None:
+        n_steps = 10
+        test_function = IdentityTestFunction(
+            outcome_names=["foo", "bar"], n_steps=n_steps
+        )
+        runner = BenchmarkRunner(
+            test_function=test_function,
+            noise_std=0.0,
+            step_runtime_function=lambda params: params["x0"],
+        )
+        experiment = Experiment(
+            name="test",
+            is_test=True,
+            runner=runner,
+            search_space=Mock(spec=SearchSpace),
+        )
+        trial = BatchTrial(experiment=experiment)
+        arm_0_step_time = 0.5
+        arm_1_step_time = 1.5
+        trial.add_arm(Arm(name="0_0", parameters={"x0": arm_0_step_time}))
+        trial.add_arm(Arm(name="0_1", parameters={"x0": arm_1_step_time}))
+        df = runner.run(trial=trial)["benchmark_metadata"].dfs["foo"]
+        total_runtime = df.groupby("arm_name")["virtual runtime"].max()
+        self.assertEqual(
+            total_runtime.to_dict(),
+            {"0_0": arm_0_step_time * n_steps, "0_1": arm_1_step_time * n_steps},
+        )
+        max_step = df.groupby("arm_name")["step"].max()
+        self.assertEqual(max_step.to_list(), [9, 9])
+
+        with self.subTest("Test runtimes non-negative"):
+            trial = BatchTrial(experiment=experiment)
+            trial.add_arm(Arm(name="0_0", parameters={"x0": -1}))
+            with self.assertRaisesRegex(
+                ValueError, "Step duration must be non-negative"
+            ):
+                runner.run(trial=trial)

--- a/ax/core/arm.py
+++ b/ax/core/arm.py
@@ -8,8 +8,9 @@
 
 import hashlib
 import json
+from collections.abc import Mapping
 
-from ax.core.types import TParameterization
+from ax.core.types import TParameterization, TParamValue
 from ax.utils.common.base import SortableBase
 from ax.utils.common.equality import equality_typechecker
 from ax.utils.common.typeutils_nonnative import numpy_type_to_python_type
@@ -73,7 +74,7 @@ class Arm(SortableBase):
         return self.md5hash(self.parameters)
 
     @staticmethod
-    def md5hash(parameters: TParameterization) -> str:
+    def md5hash(parameters: Mapping[str, TParamValue]) -> str:
         """Return unique identifier for arm's parameters.
 
         Args:
@@ -84,8 +85,9 @@ class Arm(SortableBase):
             Hash of arm's parameters.
 
         """
+        new_parameters = {}
         for k, v in parameters.items():
-            parameters[k] = numpy_type_to_python_type(v)
+            new_parameters[k] = numpy_type_to_python_type(v)
         parameters_str = json.dumps(parameters, sort_keys=True)
         return hashlib.md5(parameters_str.encode("utf-8")).hexdigest()
 

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -5,10 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Callable, Iterator
+from typing import Any, Iterator
 
 import numpy as np
 import torch
@@ -21,6 +20,7 @@ from ax.benchmark.benchmark_problem import (
     get_soo_opt_config,
 )
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
+from ax.benchmark.benchmark_step_runtime_function import TBenchmarkStepRuntimeFunction
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.benchmark.benchmark_test_functions.surrogate import SurrogateTestFunction
 from ax.benchmark.problems.synthetic.hss.jenatton import get_jenatton_search_space
@@ -30,7 +30,7 @@ from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import SearchSpace
-from ax.core.trial import BaseTrial, Trial
+from ax.core.trial import Trial
 from ax.core.types import TParameterization, TParamValue
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.modelbridge.external_generation_node import ExternalGenerationNode
@@ -341,7 +341,7 @@ def get_async_benchmark_method(
 
 def get_async_benchmark_problem(
     map_data: bool,
-    trial_runtime_func: Callable[[BaseTrial], int],
+    step_runtime_fn: TBenchmarkStepRuntimeFunction | None = None,
     n_steps: int = 1,
     lower_is_better: bool = False,
 ) -> BenchmarkProblem:
@@ -361,7 +361,7 @@ def get_async_benchmark_problem(
         test_function=test_function,
         num_trials=4,
         optimal_value=19.0,
-        trial_runtime_func=trial_runtime_func,
+        step_runtime_function=step_runtime_fn,
     )
 
 

--- a/sphinx/source/benchmark.rst
+++ b/sphinx/source/benchmark.rst
@@ -66,6 +66,14 @@ Benchmark Test Function
     :undoc-members:
     :show-inheritance:
 
+Benchmark Step Runtime Function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.benchmark.benchmark_step_runtime_function
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Benchmark Trial Metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary:
**Note**: There was a nasty off-by-one issue, where the first step always completed immediately with MapData but not with non-map Data. Correcting this would have led to many test failures and would have blown up the size of this diff, but I did not want to reproduce the old logic in new code, so I added an argument `first_step_is_instant` (default False, legacy behavior True) to allow those tests to pass, and will update them in a future diff. See the "offset" in `benchmark_runner._dict_of_arrays_to_df` to see what is going on.

**Context**: In AutoML applications, realistically, different learning curves will run at different rates. However, we do not generally expect much variation within one learning curve. So far, in benchmarks, all steps have taken one virtual second. To allow them to run at different rates, we need to disambiguate the "steps" from time. This also allows for some (simulated) online evaluations to take longer than others; all must have the same number of steps, but the time between steps can be higher for longer-running evaluations.

# Changes in this PR

This PR enables different arms with MapData to run at different rates, including different arms within the same `BatchTrial`.

For ease of use, the total duration of the trial no longer needs to be specified by passing a `sample_runtime_func` to the `BenchmarkProblem`; instead, it is inferred from the number of steps and how long each takes.

**Detailed changes**
* Give `BenchmarkRunner` an argument and attribute `step_runtime_function`, replacing `trial_runtime_func`, and update various references. The reason `trial_runtime_func` existed was that it was similar to the `sample_runtime_func` attribute on the `BackendSimulator`.
* Add a type `TBenchmarkStepRuntimeFunction` defining the expected type of the `step_runtime_function` (a callable that consumes `params` and returns a float)
* Update `async_runtime_func_from_pi` to operate on parameters rather than a trial index
* Update the asynchronous problem in the registry to use that function
* As discussed above, give `BenchmarkRunner` and functions upstream of it an argument `first_step_is_instant` which allows for backward-compatible behavior. This should be removed in the next diff (which will require more test updates)

Differential Revision: D66313060


