### PR TITLE
Rewrite flaky test_compute for Interaction plot

### DIFF
--- a/ax/analysis/plotly/tests/test_interaction.py
+++ b/ax/analysis/plotly/tests/test_interaction.py
@@ -76,5 +76,13 @@ class TestInteractionPlot(TestCase):
         self.assertEqual(card.blob_annotation, "plotly")
 
         fig = card.get_figure()
-        # Ensure all subplots are present
-        self.assertEqual(len(fig.data), 6)
+
+        # Ensure there is at least one of each type of plot in the figure (we cannot
+        # check for the exact number of subplots because we added by trace and there
+        # may be many traces per subplot).
+        trace_names = [trace.__class__.__name__ for trace in fig.data]
+        self.assertIn("Bar", trace_names)
+        self.assertTrue(
+            any("Scatter" in name for name in trace_names)
+            or any("Contour" in name for name in trace_names)
+        )


### PR DESCRIPTION
Summary:
Unfortunately we cannot count the number of subplots present by taking the length of fig.data because data holds the *TRACES* not the subplots themselves, and each subplot may hold one or more traces. This was causing the test to be flaky.

Instead now we are just checking that at least one trace came from a bar plot and that the other plots were either Scatter (slice) or Contour

Reviewed By: paschai

Differential Revision: D66472847


