### PR TITLE
fix json serialization of metric_to_best_model_config

### DIFF
--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -270,10 +270,9 @@ class BoTorchModel(TorchModel, Base):
         # log what model was used
         metric_to_model_config_name = {
             metric_name: model_config.name or str(model_config)
-            for metric_name_tuple, model_config in (
+            for metric_name, model_config in (
                 self.surrogate.metric_to_best_model_config.items()
             )
-            for metric_name in metric_name_tuple
         }
         gen_metadata["metric_to_model_config_name"] = metric_to_model_config_name
         return TorchGenResults(

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -490,7 +490,7 @@ class SurrogateTest(TestCase):
             key = tuple(outcomes)
             surrogate._submodels[key] = model
             surrogate._last_datasets[key] = self.training_data[0]
-            surrogate.metric_to_best_model_config[key] = (
+            surrogate.metric_to_best_model_config[outcomes[0]] = (
                 surrogate.surrogate_spec.model_configs[0]
             )
 
@@ -908,7 +908,6 @@ class SurrogateTest(TestCase):
                 call_kwargs = mock_model_selection.mock_calls[i].kwargs
                 for k, v in expected_model_selection_kwargs.items():
                     self.assertEqual(call_kwargs[k], v)
-                # pyre-ignore[6]
                 expected_cross_validate_kwargs["dataset"] = training_data[i]
                 # check that each call to cross_validate uses the correct
                 # model config.


### PR DESCRIPTION
Summary: Previously, `metric_to_best_model_config` used a tuple of strings as the key. This did not play well with saving model_kwargs to SQLAlchemy via json. This changes `metric_to_best_model_config` to map strings to model configs.

Reviewed By: bernardbeckerman

Differential Revision: D66511248


