### PR TITLE
Get benchmark test coverage up to 100%

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -70,7 +70,9 @@ def compute_score_trace(
 
 
 def get_benchmark_runner(
-    problem: BenchmarkProblem, max_concurrency: int = 1
+    problem: BenchmarkProblem,
+    max_concurrency: int = 1,
+    first_step_is_instant: bool = False,
 ) -> BenchmarkRunner:
     """
     Construct a ``BenchmarkRunner`` for the given problem and concurrency.
@@ -81,17 +83,22 @@ def get_benchmark_runner(
 
     Args:
         problem: The ``BenchmarkProblem``; provides a ``BenchmarkTestFunction``
-            (used to generate data) and ``trial_runtime_func`` (used to
-            determine the length of trials for the simulator).
+            (used to generate data) and ``step_runtime_function`` (used to
+            determine timing for the simulator).
         max_concurrency: The maximum number of trials that can be run concurrently.
             Typically, ``max_pending_trials`` from ``SchedulerOptions``, which are
             stored on the ``BenchmarkMethod``.
+        first_step_is_instant: Deprecated and provided for backwards
+            compatibility with past behavior of the ``BenchmarkRunner``'s
+            ``SimulatedBackendRunner``.
     """
+
     return BenchmarkRunner(
         test_function=problem.test_function,
         noise_std=problem.noise_std,
-        trial_runtime_func=problem.trial_runtime_func,
+        step_runtime_function=problem.step_runtime_function,
         max_concurrency=max_concurrency,
+        first_step_is_instant=first_step_is_instant,
     )
 
 
@@ -210,6 +217,7 @@ def benchmark_replication(
     method: BenchmarkMethod,
     seed: int,
     strip_runner_before_saving: bool = True,
+    first_step_is_instant: bool = False,
 ) -> BenchmarkResult:
     """
     Run one benchmarking replication (equivalent to one optimization loop).
@@ -226,6 +234,9 @@ def benchmark_replication(
         seed: The seed to use for this replication.
         strip_runner_before_saving: Whether to strip the runner from the
             experiment before saving it. This enables serialization.
+        first_step_is_instant: Deprecated and provided for backwards
+            compatibility with past behavior of the ``BenchmarkRunner``'s
+            ``SimulatedBackendRunner``.
 
     Return:
         ``BenchmarkResult`` object.
@@ -240,7 +251,9 @@ def benchmark_replication(
         include_sq=sq_arm is not None,
     )
     runner = get_benchmark_runner(
-        problem=problem, max_concurrency=scheduler_options.max_pending_trials
+        problem=problem,
+        max_concurrency=scheduler_options.max_pending_trials,
+        first_step_is_instant=first_step_is_instant,
     )
     experiment = Experiment(
         name=f"{problem.name}|{method.name}_{int(time())}",

--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -70,9 +70,7 @@ def compute_score_trace(
 
 
 def get_benchmark_runner(
-    problem: BenchmarkProblem,
-    max_concurrency: int = 1,
-    first_step_is_instant: bool = False,
+    problem: BenchmarkProblem, max_concurrency: int = 1
 ) -> BenchmarkRunner:
     """
     Construct a ``BenchmarkRunner`` for the given problem and concurrency.
@@ -88,9 +86,6 @@ def get_benchmark_runner(
         max_concurrency: The maximum number of trials that can be run concurrently.
             Typically, ``max_pending_trials`` from ``SchedulerOptions``, which are
             stored on the ``BenchmarkMethod``.
-        first_step_is_instant: Deprecated and provided for backwards
-            compatibility with past behavior of the ``BenchmarkRunner``'s
-            ``SimulatedBackendRunner``.
     """
 
     return BenchmarkRunner(
@@ -98,7 +93,6 @@ def get_benchmark_runner(
         noise_std=problem.noise_std,
         step_runtime_function=problem.step_runtime_function,
         max_concurrency=max_concurrency,
-        first_step_is_instant=first_step_is_instant,
     )
 
 
@@ -217,7 +211,6 @@ def benchmark_replication(
     method: BenchmarkMethod,
     seed: int,
     strip_runner_before_saving: bool = True,
-    first_step_is_instant: bool = False,
 ) -> BenchmarkResult:
     """
     Run one benchmarking replication (equivalent to one optimization loop).
@@ -234,9 +227,6 @@ def benchmark_replication(
         seed: The seed to use for this replication.
         strip_runner_before_saving: Whether to strip the runner from the
             experiment before saving it. This enables serialization.
-        first_step_is_instant: Deprecated and provided for backwards
-            compatibility with past behavior of the ``BenchmarkRunner``'s
-            ``SimulatedBackendRunner``.
 
     Return:
         ``BenchmarkResult`` object.
@@ -253,7 +243,6 @@ def benchmark_replication(
     runner = get_benchmark_runner(
         problem=problem,
         max_concurrency=scheduler_options.max_pending_trials,
-        first_step_is_instant=first_step_is_instant,
     )
     experiment = Experiment(
         name=f"{problem.name}|{method.name}_{int(time())}",

--- a/ax/benchmark/benchmark_result.py
+++ b/ax/benchmark/benchmark_result.py
@@ -119,9 +119,6 @@ class AggregatedBenchmarkResult(Base):
     fit_time: list[float]
     gen_time: list[float]
 
-    def __str__(self) -> str:
-        return f"{self.__class__}(name={self.name})"
-
     @classmethod
     def from_benchmark_results(
         cls,

--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -5,8 +5,7 @@
 
 # pyre-strict
 
-import warnings
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from math import sqrt
 from typing import Any
@@ -14,6 +13,7 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+from ax.benchmark.benchmark_step_runtime_function import TBenchmarkStepRuntimeFunction
 
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
@@ -29,18 +29,31 @@ from pyre_extensions import assert_is_instance
 
 
 def _dict_of_arrays_to_df(
-    Y_true_by_arm: Mapping[str, npt.NDArray], outcome_names: Sequence[str]
+    Y_true_by_arm: Mapping[str, npt.NDArray],
+    step_duration_by_arm: Mapping[str, float],
+    outcome_names: Sequence[str],
+    first_step_is_instant: bool,
 ) -> pd.DataFrame:
     """
-    Return a DataFrame with columns ["metric_name", "arm_name",
-    "Y_true", "step"].
+    Return a DataFrame with columns
+    ["metric_name", "arm_name", "Y_true", "step", and "virtual runtime"].
+
+    When the trial produces MapData, the "step" column is 0, 1, 2, ...., and
+    "virtual runtime" contains cumulative time for each element of the
+    progression. When the trial does not produce MapData, the "step" column is
+    just 0, and "virtual runtime" is the total runtime of the trial.
 
     Args:
         Y_true_by_arm: A mapping from arm name to a 2D arrays each with shape
             (len(outcome_names), n_steps).
+        step_duration_by_arm: A mapping from arm name to a number representing
+            the runtime of each step.
         outcome_names: The names of the outcomes; will be mapped to the first
             dimension of each array in ``Y_true_by_arm``.
+        first_step_is_instant: If True, the first step's virtual runtime is 0.
+            Otherwise, it is the typical step duration of that arm.
     """
+    offset = 0 if first_step_is_instant else 1
     df = pd.concat(
         [
             pd.DataFrame(
@@ -49,6 +62,8 @@ def _dict_of_arrays_to_df(
                     "arm_name": arm_name,
                     "Y_true": y_true[i, :],
                     "step": np.arange(y_true.shape[1], dtype=int),
+                    "virtual runtime": (np.arange(y_true.shape[1], dtype=int) + offset)
+                    * step_duration_by_arm[arm_name],
                 }
             )
             for i, outcome_name in enumerate(outcome_names)
@@ -107,6 +122,22 @@ def _add_noise(
     return df
 
 
+def get_total_runtime(
+    trial: BaseTrial,
+    step_runtime_function: TBenchmarkStepRuntimeFunction | None,
+    n_steps: int,
+) -> float:
+    """Get the total runtime of a trial."""
+    # By default, each step takes 1 virtual second.
+    if step_runtime_function is not None:
+        max_step_runtime = max(
+            (step_runtime_function(arm.parameters) for arm in trial.arms)
+        )
+    else:
+        max_step_runtime = 1
+    return n_steps * max_step_runtime
+
+
 @dataclass(kw_only=True)
 class BenchmarkRunner(Runner):
     """
@@ -126,28 +157,31 @@ class BenchmarkRunner(Runner):
           conceptually clear how to benchmark such problems, so we decided to
           not over-engineer for that before such a use case arrives.
 
-    If ``trial_runtime_func`` and ``max_concurrency`` are both left as default,
-    trials run serially and complete immediately. Otherwise, a
-    ``SimulatedBackendRunner`` is constructed to track the status of trials.
+    If ``max_concurrency`` is left as default (1), trials run serially and
+    complete immediately. Otherwise, a ``SimulatedBackendRunner`` is constructed
+    to track the status of trials.
 
     Args:
         test_function: A ``BenchmarkTestFunction`` from which to generate
             deterministic data before adding noise.
         noise_std: The standard deviation of the noise added to the data. Can be
             a list or dict to be per-metric.
-        trial_runtime_func: A callable that takes a trial and returns its
-            runtime, in simulated seconds. If `None`, each trial completes in
-            one simulated second.
+        step_runtime_function: A function that takes in parameters
+            (in ``TParameterization`` format) and returns the runtime of a step.
         max_concurrency: The maximum number of trials that can be running at a
             given time. Typically, this is ``max_pending_trials`` from the
             ``scheduler_options`` on the ``BenchmarkMethod``.
+        first_step_is_instant: Deprecated and provided for backwards
+            compatibility with past behavior of the ``BenchmarkRunner``'s
+            ``SimulatedBackendRunner``.
     """
 
     test_function: BenchmarkTestFunction
     noise_std: float | Sequence[float] | Mapping[str, float] = 0.0
-    trial_runtime_func: Callable[[BaseTrial], int] | None = None
+    step_runtime_function: TBenchmarkStepRuntimeFunction | None = None
     max_concurrency: int = 1
     simulated_backend_runner: SimulatedBackendRunner | None = field(init=False)
+    first_step_is_instant: bool = False
 
     def __post_init__(self) -> None:
         if self.max_concurrency > 1:
@@ -159,17 +193,13 @@ class BenchmarkRunner(Runner):
                     use_update_as_start_time=True,
                 ),
             )
-            if self.trial_runtime_func is None:
-                warnings.warn(
-                    "`trial_runtime_func` is not set and `max_concurrency` > 1."
-                    " Each trial will take one simulated second to run.",
-                    stacklevel=2,
-                )
             self.simulated_backend_runner = SimulatedBackendRunner(
                 simulator=simulator,
-                sample_runtime_func=self.trial_runtime_func
-                if self.trial_runtime_func is not None
-                else lambda _: 1,
+                sample_runtime_func=lambda trial: get_total_runtime(
+                    trial=trial,
+                    step_runtime_function=self.step_runtime_function,
+                    n_steps=self.test_function.n_steps,
+                ),
             )
         else:
             self.simulated_backend_runner = None
@@ -222,8 +252,24 @@ class BenchmarkRunner(Runner):
             arm.name: self.get_Y_true(arm.parameters) for arm in trial.arms
         }
 
+        step_duration_by_arm = {
+            arm.name: 1
+            if self.step_runtime_function is None
+            else self.step_runtime_function(arm.parameters)
+            for arm in trial.arms
+        }
+        for arm_name, duration in step_duration_by_arm.items():
+            if duration < 0:
+                raise ValueError(
+                    "Step duration must be non-negative for each arm. For arm "
+                    f"{arm_name}, duration is {duration}."
+                )
+
         df = _dict_of_arrays_to_df(
-            Y_true_by_arm=Y_true_by_arm, outcome_names=self.outcome_names
+            Y_true_by_arm=Y_true_by_arm,
+            step_duration_by_arm=step_duration_by_arm,
+            outcome_names=self.outcome_names,
+            first_step_is_instant=self.first_step_is_instant,
         )
 
         arm_weights = (

--- a/ax/benchmark/benchmark_step_runtime_function.py
+++ b/ax/benchmark/benchmark_step_runtime_function.py
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+from ax.core.types import TParamValue
+
+
+@runtime_checkable
+class TBenchmarkStepRuntimeFunction(Protocol):
+    def __call__(self, params: Mapping[str, TParamValue]) -> float:
+        """
+        Return the runtime for each step.
+
+        Each step within an arm will take the same amount of time.
+        """
+        ...

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -129,8 +129,8 @@ class PyTorchCNNTorchvisionBenchmarkTestFunction(BenchmarkTestFunction):
     def __post_init__(self, train_loader: None, test_loader: None) -> None:
         if self.name not in _REGISTRY:
             raise UserInputError(
-                f"Unrecognized torchvision dataset {self.name}. Please ensure it "
-                "is listed in ax/benchmark/problems/hop/torchvision.py registry."
+                f"Unrecognized torchvision dataset '{self.name}'. Please ensure"
+                " is listed in ax/benchmark/problems/hpo/torchvision._REGISTRY"
             )
         dataset_fn = _REGISTRY[self.name]
 

--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -15,7 +15,7 @@ from ax.benchmark.problems.hd_embedding import embed_higher_dimension
 from ax.benchmark.problems.hpo.torchvision import (
     get_pytorch_cnn_torchvision_benchmark_problem,
 )
-from ax.benchmark.problems.runtime_funcs import int_from_trial
+from ax.benchmark.problems.runtime_funcs import int_from_params
 from ax.benchmark.problems.synthetic.hss.jenatton import get_jenatton_benchmark_problem
 from botorch.test_functions import synthetic
 from botorch.test_functions.multi_objective import BraninCurrin
@@ -45,7 +45,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
             "num_trials": 40,
             "noise_std": 1.0,
             "observe_noise_sd": False,
-            "trial_runtime_func": int_from_trial,
+            "step_runtime_function": int_from_params,
             "name": "ackley4_async_noisy",
         },
     ),

--- a/ax/benchmark/problems/runtime_funcs.py
+++ b/ax/benchmark/problems/runtime_funcs.py
@@ -5,30 +5,17 @@
 
 # pyre-strict
 
-import random
 from collections.abc import Mapping
 
-from ax.core.trial import Trial
+from ax.core.arm import Arm
 from ax.core.types import TParamValue
-from pyre_extensions import none_throws
 
 
 def int_from_params(
     params: Mapping[str, TParamValue], n_possibilities: int = 10
 ) -> int:
     """
-    Get a random int between 0 and n_possibilities - 1, using parameters for the
-    random seed.
+    Get an int between 0 and n_possibilities - 1, using a hash of the parameters.
     """
-    seed = str(tuple(sorted(params.items())))
-    return random.Random(seed).randrange(n_possibilities)
-
-
-def int_from_trial(trial: Trial, n_possibilities: int = 10) -> int:
-    """
-    Get a random int between 0 and n_possibilities - 1, using the parameters of
-    the trial's first arm for the random seed.
-    """
-    return int_from_params(
-        params=none_throws(trial.arms)[0].parameters, n_possibilities=n_possibilities
-    )
+    arm_hash = Arm.md5hash(parameters=params)
+    return int(arm_hash[-1], 16) % 10

--- a/ax/benchmark/tests/benchmark_test_functions/test_surrogate_test_function.py
+++ b/ax/benchmark/tests/benchmark_test_functions/test_surrogate_test_function.py
@@ -79,3 +79,4 @@ class TestSurrogateTestFunction(TestCase):
         self.assertEqual(runner_1, runner_1a)
         self.assertNotEqual(runner_1, runner_2)
         self.assertNotEqual(runner_1, 1)
+        self.assertNotEqual(runner_1, None)

--- a/ax/benchmark/tests/problems/hpo/test_torchvision.py
+++ b/ax/benchmark/tests/problems/hpo/test_torchvision.py
@@ -12,8 +12,12 @@ from ax.benchmark.benchmark_metric import BenchmarkMetric
 
 from ax.benchmark.benchmark_problem import BenchmarkProblem
 
-from ax.benchmark.problems.hpo.torchvision import CNN
+from ax.benchmark.problems.hpo.torchvision import (
+    CNN,
+    PyTorchCNNTorchvisionBenchmarkTestFunction,
+)
 from ax.benchmark.problems.registry import get_problem
+from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import TestDataset
 from pyre_extensions import assert_is_instance
@@ -70,9 +74,6 @@ class TestPyTorchCNNTorchvision(TestCase):
         test_function = problem.test_function
 
         self.assertEqual(test_function.outcome_names, ["accuracy"])
-        # pyre-fixme[6]: complaining that the annotation for Arm.parameters is
-        # too broad because it's not immutable
-
         expected = 0.21875
         result = test_function.evaluate_true(params=self.parameters)
         self.assertEqual(result.item(), expected)
@@ -92,3 +93,9 @@ class TestPyTorchCNNTorchvision(TestCase):
             ) as mock_CNN:
                 test_function.evaluate_true(params=other_params)
             mock_CNN.assert_called_once()
+
+    def test_load_wrong_name(self) -> None:
+        with self.assertRaisesRegex(
+            UserInputError, "Unrecognized torchvision dataset 'pencil'"
+        ):
+            PyTorchCNNTorchvisionBenchmarkTestFunction(name="pencil")

--- a/ax/benchmark/tests/problems/test_problems.py
+++ b/ax/benchmark/tests/problems/test_problems.py
@@ -5,12 +5,9 @@
 
 # pyre-strict
 
-from unittest.mock import MagicMock
 
 from ax.benchmark.problems.registry import BENCHMARK_PROBLEM_REGISTRY, get_problem
-from ax.benchmark.problems.runtime_funcs import int_from_params, int_from_trial
-from ax.core.arm import Arm
-from ax.core.trial import Trial
+from ax.benchmark.problems.runtime_funcs import int_from_params
 from ax.utils.common.testutils import TestCase
 
 
@@ -66,9 +63,5 @@ class TestProblems(TestCase):
     def test_runtime_funcs(self) -> None:
         parameters = {"x0": 0.5, "x1": -3, "x2": "-4", "x3": False, "x4": None}
         result = int_from_params(params=parameters)
-        expected = 3
+        expected = 1
         self.assertEqual(result, expected)
-        arm = Arm(name="0_0", parameters=parameters)
-        trial = MagicMock(spec=Trial)
-        trial.arms = [arm]
-        self.assertEqual(int_from_trial(trial=trial), expected)

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -6,14 +6,14 @@
 # pyre-strict
 
 from ax.benchmark.benchmark_method import BenchmarkMethod
-from ax.early_stopping.strategies.threshold import ThresholdEarlyStoppingStrategy
-from ax.modelbridge.generation_strategy import (
-    GenerationNode,
-    GenerationStep,
-    GenerationStrategy,
+from ax.benchmark.benchmark_problem import (
+    get_continuous_search_space,
+    get_moo_opt_config,
+    get_soo_opt_config,
 )
-from ax.modelbridge.model_spec import ModelSpec
-from ax.modelbridge.registry import Models
+from ax.benchmark.methods.sobol import get_sobol_generation_strategy
+from ax.core.experiment import Experiment
+from ax.early_stopping.strategies.threshold import ThresholdEarlyStoppingStrategy
 from ax.utils.common.testutils import TestCase
 from pyre_extensions import none_throws
 
@@ -21,28 +21,19 @@ from pyre_extensions import none_throws
 class TestBenchmarkMethod(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        sobol_model_spec = ModelSpec(
-            model_enum=Models.SOBOL, model_kwargs={}, model_gen_kwargs={}
-        )
-        self.gs = GenerationStrategy(
-            nodes=[GenerationNode(node_name="sobol", model_specs=[sobol_model_spec])]
-        )
+        self.gs = get_sobol_generation_strategy()
 
     def test_benchmark_method(self) -> None:
-        gs = GenerationStrategy(
-            steps=[GenerationStep(model=Models.SOBOL, num_trials=10)],
-            name="SOBOL",
-        )
-        method = BenchmarkMethod(name="Sobol10", generation_strategy=gs)
+        method = BenchmarkMethod(name="Sobol10", generation_strategy=self.gs)
+        self.assertEqual(method.name, "Sobol10")
 
         # test that `fit_tracking_metrics` has been correctly set to False
         for step in method.generation_strategy._steps:
             self.assertFalse(none_throws(step.model_kwargs).get("fit_tracking_metrics"))
         self.assertEqual(method.timeout_hours, 4)
 
-        method = BenchmarkMethod(
-            name="Sobol10", generation_strategy=gs, timeout_hours=10
-        )
+        method = BenchmarkMethod(generation_strategy=self.gs, timeout_hours=10)
+        self.assertEqual(method.name, method.generation_strategy.name)
         self.assertEqual(method.timeout_hours, 10)
 
         # test that instantiation works with node-based strategies
@@ -61,3 +52,36 @@ class TestBenchmarkMethod(TestCase):
                 generation_strategy=self.gs,
                 early_stopping_strategy=ess,
             )
+
+    def test_get_best_parameters(self) -> None:
+        """
+        This is tested more thoroughly in `test_benchmark` -- setting up an
+        experiment with data and trials without just running a benchmark is a
+        pain, so in that file, we just run a benchmark.
+        """
+        search_space = get_continuous_search_space(bounds=[(0, 1)])
+        experiment = Experiment(name="test", is_test=True, search_space=search_space)
+        moo_config = get_moo_opt_config(outcome_names=["a", "b"], ref_point=[0, 0])
+
+        method = BenchmarkMethod(generation_strategy=self.gs)
+
+        with self.subTest("MOO not supported"), self.assertRaisesRegex(
+            NotImplementedError, "not currently supported for multi-objective"
+        ):
+            method.get_best_parameters(
+                experiment=experiment, optimization_config=moo_config, n_points=1
+            )
+
+        soo_config = get_soo_opt_config(outcome_names=["a"])
+        with self.subTest("Multiple points not supported"), self.assertRaisesRegex(
+            NotImplementedError, "only n_points=1"
+        ):
+            method.get_best_parameters(
+                experiment=experiment, optimization_config=soo_config, n_points=2
+            )
+
+        with self.subTest("Empty experiment"):
+            result = method.get_best_parameters(
+                experiment=experiment, optimization_config=soo_config, n_points=1
+            )
+            self.assertEqual(result, [])

--- a/ax/benchmark/tests/test_benchmark_metric.py
+++ b/ax/benchmark/tests/test_benchmark_metric.py
@@ -269,3 +269,11 @@ class BenchmarkMetricTest(TestCase):
         metric = BenchmarkMetric(name="test_metric", lower_is_better=True)
         with self.assertRaisesRegex(ValueError, "data from multiple time steps"):
             metric.fetch_trial_data(trial=trial)
+
+    def test_abandoned_arms_not_supported(self) -> None:
+        trial = get_test_trial(batch=True)
+        trial.mark_arm_abandoned("0_0")
+        with self.assertRaisesRegex(
+            NotImplementedError, "does not support abandoned arms"
+        ):
+            self.map_metric1.fetch_trial_data(trial=trial)

--- a/ax/benchmark/tests/test_benchmark_runner.py
+++ b/ax/benchmark/tests/test_benchmark_runner.py
@@ -51,7 +51,7 @@ class TestBenchmarkRunner(TestCase):
         # Initialize
         runner = BenchmarkRunner(
             test_function=Jenatton(outcome_names=["objective"]),
-            trial_runtime_func=lambda trial: trial.index + 1,
+            step_runtime_function=lambda params: params["x1"] + 1,
             max_concurrency=2,
         )
         simulated_backend_runner = none_throws(runner.simulated_backend_runner)
@@ -307,6 +307,7 @@ class TestBenchmarkRunner(TestCase):
                     "sem",
                     "trial_index",
                     "step",
+                    "virtual runtime",
                 },
                 set(obj_df.columns),
             )
@@ -374,10 +375,7 @@ class TestBenchmarkRunner(TestCase):
 
         with self.subTest("with SimulatedBackendRunner"):
             runner = BenchmarkRunner(
-                test_function=test_function,
-                noise_std=0.0,
-                trial_runtime_func=lambda _: 1,
-                max_concurrency=2,
+                test_function=test_function, noise_std=0.0, max_concurrency=2
             )
 
             # pyre-fixme[6]: Incompatible parameter type (because argument is mutable)
@@ -394,10 +392,40 @@ class TestBenchmarkRunner(TestCase):
             self.assertEqual(sim_trial.sim_start_time, 0)
             self.assertEqual(backend_simulator.time, 0)
 
-    def test_warns_if_concurrent_and_trial_runtime_func_is_none(self) -> None:
-        test_function = IdentityTestFunction(outcome_names=["foo"])
-        with self.assertWarnsRegex(Warning, "`trial_runtime_func` is not set"):
-            BenchmarkRunner(
-                test_function=test_function,
-                max_concurrency=2,
-            )
+    def test_heterogeneous_step_runtime(self) -> None:
+        n_steps = 10
+        test_function = IdentityTestFunction(
+            outcome_names=["foo", "bar"], n_steps=n_steps
+        )
+        runner = BenchmarkRunner(
+            test_function=test_function,
+            noise_std=0.0,
+            step_runtime_function=lambda params: params["x0"],
+        )
+        experiment = Experiment(
+            name="test",
+            is_test=True,
+            runner=runner,
+            search_space=Mock(spec=SearchSpace),
+        )
+        trial = BatchTrial(experiment=experiment)
+        arm_0_step_time = 0.5
+        arm_1_step_time = 1.5
+        trial.add_arm(Arm(name="0_0", parameters={"x0": arm_0_step_time}))
+        trial.add_arm(Arm(name="0_1", parameters={"x0": arm_1_step_time}))
+        df = runner.run(trial=trial)["benchmark_metadata"].dfs["foo"]
+        total_runtime = df.groupby("arm_name")["virtual runtime"].max()
+        self.assertEqual(
+            total_runtime.to_dict(),
+            {"0_0": arm_0_step_time * n_steps, "0_1": arm_1_step_time * n_steps},
+        )
+        max_step = df.groupby("arm_name")["step"].max()
+        self.assertEqual(max_step.to_list(), [9, 9])
+
+        with self.subTest("Test runtimes non-negative"):
+            trial = BatchTrial(experiment=experiment)
+            trial.add_arm(Arm(name="0_0", parameters={"x0": -1}))
+            with self.assertRaisesRegex(
+                ValueError, "Step duration must be non-negative"
+            ):
+                runner.run(trial=trial)

--- a/ax/benchmark/tests/test_benchmark_runner.py
+++ b/ax/benchmark/tests/test_benchmark_runner.py
@@ -429,3 +429,11 @@ class TestBenchmarkRunner(TestCase):
                 ValueError, "Step duration must be non-negative"
             ):
                 runner.run(trial=trial)
+
+    def test_wrong_noise_std_keys(self) -> None:
+        test_function = IdentityTestFunction(outcome_names=["foo", "bar"])
+        runner = BenchmarkRunner(test_function=test_function, noise_std={"alpaca": 4})
+        with self.assertRaisesRegex(
+            ValueError, "Noise std must have keys equal to outcome names"
+        ):
+            runner.get_noise_stds()

--- a/ax/core/arm.py
+++ b/ax/core/arm.py
@@ -8,8 +8,9 @@
 
 import hashlib
 import json
+from collections.abc import Mapping
 
-from ax.core.types import TParameterization
+from ax.core.types import TParameterization, TParamValue
 from ax.utils.common.base import SortableBase
 from ax.utils.common.equality import equality_typechecker
 from ax.utils.common.typeutils_nonnative import numpy_type_to_python_type
@@ -73,7 +74,7 @@ class Arm(SortableBase):
         return self.md5hash(self.parameters)
 
     @staticmethod
-    def md5hash(parameters: TParameterization) -> str:
+    def md5hash(parameters: Mapping[str, TParamValue]) -> str:
         """Return unique identifier for arm's parameters.
 
         Args:
@@ -84,8 +85,9 @@ class Arm(SortableBase):
             Hash of arm's parameters.
 
         """
+        new_parameters = {}
         for k, v in parameters.items():
-            parameters[k] = numpy_type_to_python_type(v)
+            new_parameters[k] = numpy_type_to_python_type(v)
         parameters_str = json.dumps(parameters, sort_keys=True)
         return hashlib.md5(parameters_str.encode("utf-8")).hexdigest()
 

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -5,10 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Callable, Iterator
+from typing import Any, Iterator
 
 import numpy as np
 import torch
@@ -21,6 +20,7 @@ from ax.benchmark.benchmark_problem import (
     get_soo_opt_config,
 )
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
+from ax.benchmark.benchmark_step_runtime_function import TBenchmarkStepRuntimeFunction
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.benchmark.benchmark_test_functions.surrogate import SurrogateTestFunction
 from ax.benchmark.problems.synthetic.hss.jenatton import get_jenatton_search_space
@@ -30,7 +30,7 @@ from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import SearchSpace
-from ax.core.trial import BaseTrial, Trial
+from ax.core.trial import Trial
 from ax.core.types import TParameterization, TParamValue
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.modelbridge.external_generation_node import ExternalGenerationNode
@@ -341,7 +341,7 @@ def get_async_benchmark_method(
 
 def get_async_benchmark_problem(
     map_data: bool,
-    trial_runtime_func: Callable[[BaseTrial], int],
+    step_runtime_fn: TBenchmarkStepRuntimeFunction | None = None,
     n_steps: int = 1,
     lower_is_better: bool = False,
 ) -> BenchmarkProblem:
@@ -361,7 +361,7 @@ def get_async_benchmark_problem(
         test_function=test_function,
         num_trials=4,
         optimal_value=19.0,
-        trial_runtime_func=trial_runtime_func,
+        step_runtime_function=step_runtime_fn,
     )
 
 

--- a/sphinx/source/benchmark.rst
+++ b/sphinx/source/benchmark.rst
@@ -66,6 +66,14 @@ Benchmark Test Function
     :undoc-members:
     :show-inheritance:
 
+Benchmark Step Runtime Function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.benchmark.benchmark_step_runtime_function
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Benchmark Trial Metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Summary:
A couple small fixes and a few unit tests. Coverage will still not technically be 100% due to the "..." in abstract methods and protocols

Changes other than adding tests:
* Tidied up torchvision error
* Cleaned up BenchmarkMethod test
* Removed `__str__` method from `BenchmarkResult`; I don't think it is used, and the default repr method it gets from being a dataclass should be fine

Reviewed By: saitcakmak

Differential Revision: D66477878


