### PR TITLE
Reap legacy `recommend_best_out_of_sample_point`

### DIFF
--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -23,7 +23,6 @@ from ax.models.torch.botorch import (
 from ax.models.torch.botorch_defaults import (
     get_and_fit_model,
     get_chebyshev_scalarization,
-    recommend_best_out_of_sample_point,
 )
 from ax.models.torch.utils import sample_simplex
 from ax.models.torch_base import TorchOptConfig
@@ -601,28 +600,6 @@ class BotorchModelTest(TestCase):
                     not torch.equal(true_state_dict[k], v)
                     for k, v in chain(model.named_parameters(), model.named_buffers())
                 )
-            )
-
-        # Test that recommend_best_out_of_sample_point errors w/o _get_best_point_acqf
-        model = BotorchModel(best_point_recommender=recommend_best_out_of_sample_point)
-        with mock.patch(FIT_MODEL_MO_PATH) as _mock_fit_model:
-            model.fit(
-                # pyre-fixme[61]: `datasets` is undefined, or not always defined.
-                datasets=datasets,
-                search_space_digest=SearchSpaceDigest(
-                    feature_names=feature_names,
-                    bounds=bounds,
-                    task_features=tfs,
-                ),
-            )
-        with self.assertRaises(RuntimeError):
-            xbest = model.best_point(
-                # pyre-fixme[61]: `search_space_digest` is undefined, or not always
-                #  defined.
-                search_space_digest=search_space_digest,
-                # pyre-fixme[61]: `torch_opt_config` is undefined, or not always
-                #  defined.
-                torch_opt_config=torch_opt_config,
             )
 
     def test_BotorchModel_cuda(self) -> None:

--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -13,13 +13,11 @@ from random import randint
 from typing import Any, Protocol
 
 import torch
-from ax.models.model_utils import best_observed_point, get_observed
-from ax.models.torch.utils import _to_inequality_constraints
+from ax.models.model_utils import best_observed_point
 from ax.models.torch_base import TorchModel
 from ax.models.types import TConfig
 from botorch.acquisition import get_acquisition_function
 from botorch.acquisition.acquisition import AcquisitionFunction
-from botorch.acquisition.fixed_feature import FixedFeatureAcquisitionFunction
 from botorch.acquisition.objective import ConstrainedMCObjective, GenericMCObjective
 from botorch.acquisition.utils import get_infeasible_cost
 from botorch.exceptions.errors import UnsupportedError
@@ -577,107 +575,6 @@ def recommend_best_observed_point(
     # pyre-fixme[16]: Item `ndarray` of `Union[ndarray[typing.Any, typing.Any],
     #  Tensor]` has no attribute `to`.
     return x_best.to(dtype=model.dtype, device=torch.device("cpu"))
-
-
-def recommend_best_out_of_sample_point(
-    model: TorchModel,
-    bounds: list[tuple[float, float]],
-    objective_weights: Tensor,
-    outcome_constraints: tuple[Tensor, Tensor] | None = None,
-    linear_constraints: tuple[Tensor, Tensor] | None = None,
-    fixed_features: dict[int, float] | None = None,
-    model_gen_options: TConfig | None = None,
-    target_fidelities: dict[int, float] | None = None,
-) -> Tensor | None:
-    """
-    Identify the current best point by optimizing the posterior mean of the model.
-    This is "out-of-sample" because it considers un-observed designs as well.
-
-    Return None if no such point can be identified.
-
-    Args:
-        model: A TorchModel.
-        bounds: A list of (lower, upper) tuples for each column of X.
-        objective_weights: The objective is to maximize a weighted sum of
-            the columns of f(x). These are the weights.
-        outcome_constraints: A tuple of (A, b). For k outcome constraints
-            and m outputs at f(x), A is (k x m) and b is (k x 1) such that
-            A f(x) <= b.
-        linear_constraints: A tuple of (A, b). For k linear constraints on
-            d-dimensional x, A is (k x d) and b is (k x 1) such that
-            A x <= b.
-        fixed_features: A map {feature_index: value} for features that
-            should be fixed to a particular value in the best point.
-        model_gen_options: A config dictionary that can contain
-            model-specific options. See `TorchOptConfig` for details.
-        target_fidelities: A map {feature_index: value} of fidelity feature
-            column indices to their respective target fidelities. Used for
-            multi-fidelity optimization.
-
-    Returns:
-        A d-array of the best point, or None if no feasible point exists.
-    """
-    options = model_gen_options or {}
-    fixed_features = fixed_features or {}
-    acf_options = options.get("acquisition_function_kwargs", {})
-    optimizer_options = options.get("optimizer_kwargs", {})
-
-    X_observed = get_observed(
-        Xs=model.Xs,  # pyre-ignore: [16]
-        objective_weights=objective_weights,
-        outcome_constraints=outcome_constraints,
-    )
-
-    if hasattr(model, "_get_best_point_acqf"):
-        acq_function, non_fixed_idcs = model._get_best_point_acqf(  # pyre-ignore: [16]
-            X_observed=X_observed,
-            objective_weights=objective_weights,
-            mc_samples=acf_options.get("mc_samples", 512),
-            fixed_features=fixed_features,
-            target_fidelities=target_fidelities,
-            outcome_constraints=outcome_constraints,
-            seed_inner=acf_options.get("seed_inner", None),
-            qmc=acf_options.get("qmc", True),
-        )
-    else:
-        raise RuntimeError("The model should implement _get_best_point_acqf.")
-
-    inequality_constraints = _to_inequality_constraints(linear_constraints)
-    # TODO: update optimizers to handle inequality_constraints
-    # (including transforming constraints b/c of fixed features)
-    if inequality_constraints is not None:
-        raise UnsupportedError("Inequality constraints are not supported!")
-
-    return_best_only = optimizer_options.get("return_best_only", True)
-    bounds_ = torch.tensor(bounds, dtype=model.dtype, device=model.device)
-    bounds_ = bounds_.transpose(-1, -2)
-    if non_fixed_idcs is not None:
-        bounds_ = bounds_[..., non_fixed_idcs]
-
-    opt_options: dict[str, bool | float | int | str] = {
-        "batch_limit": 8,
-        "maxiter": 200,
-        "method": "L-BFGS-B",
-        "nonnegative": False,
-    }
-    opt_options.update(optimizer_options.get("options", {}))
-    candidates, _ = optimize_acqf(
-        acq_function=acq_function,
-        bounds=bounds_,
-        q=1,
-        num_restarts=optimizer_options.get("num_restarts", 60),
-        raw_samples=optimizer_options.get("raw_samples", 1024),
-        inequality_constraints=inequality_constraints,
-        fixed_features=None,  # handled inside the acquisition function
-        options=opt_options,
-        return_best_only=return_best_only,
-    )
-    rec_point = candidates.detach().cpu()
-    if isinstance(acq_function, FixedFeatureAcquisitionFunction):
-        rec_point = acq_function._construct_X_full(rec_point)
-    if return_best_only:
-        rec_point = rec_point.view(-1)
-    return rec_point
 
 
 def _get_model(


### PR DESCRIPTION
Summary:
Context: `recommend_best_out_of_sample_point` was used with legacy models and would error with any model that did not have an attribute `_get_best_point_acqf`. Currently, no model has that attribute.

This PR: Removes the function

Reviewed By: saitcakmak

Differential Revision: D66551384


