### PR TITLE
Add surrogate_spec_from_json

### DIFF
--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -257,8 +257,6 @@ def tensor_or_size_from_json(json: dict[str, Any]) -> torch.Tensor | torch.Size:
         )
 
 
-# pyre-fixme[3]: Return annotation cannot contain `Any`.
-# pyre-fixme[2]: Parameter annotation cannot be `Any`.
 def botorch_component_from_json(botorch_class: type[T], json: dict[str, Any]) -> T:
     """Load any instance of `torch.nn.Module` or descendants registered in
     `CLASS_DECODER_REGISTRY` from state dict."""

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -22,6 +22,9 @@ from ax.exceptions.storage import JSONDecodeError, JSONEncodeError
 from ax.modelbridge.generation_node import GenerationStep
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.modelbridge.registry import Models
+from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
+from ax.models.torch.botorch_modular.surrogate import SurrogateSpec
+from ax.models.torch.botorch_modular.utils import ModelConfig
 from ax.storage.json_store.decoder import (
     _DEPRECATED_MODEL_TO_REPLACEMENT,
     generation_strategy_from_json,
@@ -131,6 +134,8 @@ from ax.utils.testing.modeling_stubs import (
 )
 from ax.utils.testing.utils import generic_equals
 from ax.utils.testing.utils_testing_stubs import get_backend_simulator_with_trials
+from botorch.models import SingleTaskGP
+from botorch.models.transforms.outcome import Standardize
 from botorch.sampling.normal import SobolQMCNormalSampler
 
 
@@ -863,6 +868,93 @@ class JSONStoreTest(TestCase):
         }
         expected_object = get_botorch_model_with_surrogate_spec()
         self.assertEqual(object_from_json(object_json), expected_object)
+
+    def test_surrogate_spec_backwards_compatibility(self) -> None:
+        # This is an invalid example that has both deprecated args
+        # and model config specified. Deprecated args will be ignored.
+        object_json = {
+            "__type": "SurrogateSpec",
+            "botorch_model_class": {
+                "__type": "Type[Model]",
+                "index": "MultiTaskGP",
+                "class": "<class 'botorch.models.model.Model'>",
+            },
+            "botorch_model_kwargs": {"dummy": 5},
+            "mll_class": {
+                "__type": "Type[MarginalLogLikelihood]",
+                "index": "ExactMarginalLogLikelihood",
+                "class": (
+                    "<class 'gpytorch.mlls.marginal_log_likelihood."
+                    "MarginalLogLikelihood'>"
+                ),
+            },
+            "mll_kwargs": {},
+            "covar_module_class": None,
+            "covar_module_kwargs": None,
+            "likelihood_class": None,
+            "likelihood_kwargs": None,
+            "input_transform_classes": None,
+            "input_transform_options": None,
+            "outcome_transform_classes": None,
+            "outcome_transform_options": None,
+            "allow_batched_models": True,
+            "model_configs": [
+                {
+                    "__type": "ModelConfig",
+                    "botorch_model_class": {
+                        "__type": "Type[Model]",
+                        "index": "SingleTaskGP",
+                        "class": "<class 'botorch.models.model.Model'>",
+                    },
+                    "model_options": {},
+                    "mll_class": {
+                        "__type": "Type[MarginalLogLikelihood]",
+                        "index": "ExactMarginalLogLikelihood",
+                        "class": (
+                            "<class 'gpytorch.mlls.marginal_log_likelihood."
+                            "MarginalLogLikelihood'>"
+                        ),
+                    },
+                    "mll_options": {},
+                    "input_transform_classes": None,
+                    "input_transform_options": {},
+                    "outcome_transform_classes": [
+                        {
+                            "__type": "Type[OutcomeTransform]",
+                            "index": "Standardize",
+                            "class": (
+                                "<class 'botorch.models.transforms.outcome."
+                                "OutcomeTransform'>"
+                            ),
+                        }
+                    ],
+                    "outcome_transform_options": {},
+                    "covar_module_class": {
+                        "__type": "Type[Kernel]",
+                        "index": "ScaleMaternKernel",
+                        "class": "<class 'gpytorch.kernels.kernel.Kernel'>",
+                    },
+                    "covar_module_options": {},
+                    "likelihood_class": None,
+                    "likelihood_options": {},
+                }
+            ],
+            "metric_to_model_configs": {},
+            "eval_criterion": "Rank correlation",
+            "outcomes": [],
+            "use_posterior_predictive": False,
+        }
+        deserialized_object = object_from_json(object_json)
+        expected_object = SurrogateSpec(
+            model_configs=[
+                ModelConfig(
+                    botorch_model_class=SingleTaskGP,
+                    covar_module_class=ScaleMaternKernel,
+                    outcome_transform_classes=[Standardize],
+                )
+            ]
+        )
+        self.assertEqual(deserialized_object, expected_object)
 
     def test_model_registry_backwards_compatibility(self) -> None:
         # Check that deprecated model registry entries can be loaded.


### PR DESCRIPTION
Summary:
From the introduction of `ModelConfig` up to the removal of deprecated args as attributes in D66553624, we have serialized both `model_configs` and the deprecated args (replaced with their default values) when serializing `surrogate_spec`. This is fine as long as the default values remain unchanged.

D65622788 changes the default value for `input_transform_classes`, which means the old defaults that were serialized now appear as modified values. Deserializing `SurrogateSpec` from the old jsons now errors out since it encounters both non-default deprecated args and `model_configs`.

This diff resolves this issue by discarding the deprecated args from the json if `model_configs` is also found.

Differential Revision: D66558559


