### PR TITLE
Read formatting dependencies from `requirements-fmt.txt` for setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,6 @@ REQUIRES = [
 # pytest-cov requires pytest >= 3.6
 DEV_REQUIRES = [
     "beautifulsoup4",
-    "black==24.2.0",
-    "flake8",
     "Jinja2",
     "pyfakefs",
     "pytest>=4.6",
@@ -52,6 +50,15 @@ DEV_REQUIRES = [
     "lxml",
     "mdformat-myst",
 ]
+
+def read_deps_from_file(filename):
+    """Read in requirements file and return items as list of strings"""
+    root_dir = os.path.dirname(__file__)
+    with open(os.path.join(root_dir, filename), "r") as fh:
+        return [line.strip() for line in fh.readlines() if not line.startswith("#")]
+
+# Read in pinned versions of the formatting tools
+DEV_REQUIRES += read_deps_from_file("requirements-fmt.txt")
 
 MYSQL_REQUIRES = ["SQLAlchemy==1.4.17"]
 

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,13 @@ DEV_REQUIRES = [
     "mdformat-myst",
 ]
 
+
 def read_deps_from_file(filename):
     """Read in requirements file and return items as list of strings"""
     root_dir = os.path.dirname(__file__)
     with open(os.path.join(root_dir, filename), "r") as fh:
         return [line.strip() for line in fh.readlines() if not line.startswith("#")]
+
 
 # Read in pinned versions of the formatting tools
 DEV_REQUIRES += read_deps_from_file("requirements-fmt.txt")


### PR DESCRIPTION
This is the source of truth for the versions of the formatting tools. Rathern than manually pinning things we should just read these in as botorch already does.