### PR TITLE
Unpin SQLAlchemy dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ DEV_REQUIRES = [
     "numpy<2.0",
 ]
 
-MYSQL_REQUIRES = ["SQLAlchemy==1.4.17"]
+MYSQL_REQUIRES = ["SQLAlchemy"]
 
 NOTEBOOK_REQUIRES = ["jupyter"]
 


### PR DESCRIPTION
As per #3008 this shouldn't be necessary anymore. Removing this pin as This is very restrictive and can cause problem for users' environments.