### PR TITLE
only fetch metric for specified trial_type in Scheduler for MT Experiment

### DIFF
--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -131,6 +131,10 @@ class MultiTypeExperiment(Experiment):
             self._metric_to_trial_type[metric_name] = none_throws(
                 self.default_trial_type
             )
+        # prune metrics that are no longer attached to the experiment
+        for metric_name in list(self._metric_to_trial_type.keys()):
+            if metric_name not in self.metrics:
+                del self._metric_to_trial_type[metric_name]
 
     def update_runner(self, trial_type: str, runner: Runner) -> "MultiTypeExperiment":
         """Update the default runner for an existing trial_type.
@@ -328,6 +332,19 @@ class MultiTypeExperiment(Experiment):
         if not self.supports_trial_type(trial_type):
             raise ValueError(f"Trial type `{trial_type}` is not supported.")
         return self._trial_type_to_runner[trial_type]
+
+    def metrics_for_trial_type(self, trial_type: str) -> list[Metric]:
+        """The default runner to use for a given trial type.
+
+        Looks up the appropriate runner for this trial type in the trial_type_to_runner.
+        """
+        if not self.supports_trial_type(trial_type):
+            raise ValueError(f"Trial type `{trial_type}` is not supported.")
+        return [
+            self.metrics[metric_name]
+            for metric_name, metric_trial_type in self._metric_to_trial_type.items()
+            if metric_trial_type == trial_type
+        ]
 
     def supports_trial_type(self, trial_type: str | None) -> bool:
         """Whether this experiment allows trials of the given type.

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -159,10 +159,8 @@ class MultiTypeExperimentTest(TestCase):
         self.experiment.optimization_config = OptimizationConfig(
             Objective(BraninMetric("m3", ["x1", "x2"]), minimize=True)
         )
-        # TODO: improve consistency of metric mappings
         self.assertDictEqual(
-            self.experiment._metric_to_trial_type,
-            {"m1": "type1", "m2": "type2", "m3": "type1"},
+            self.experiment._metric_to_trial_type, {"m2": "type2", "m3": "type1"}
         )
 
     def test_runner_for_trial_type(self) -> None:

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -2147,6 +2147,11 @@ class Scheduler(WithDBSettingsBase, BestPointMixin):
             ):
                 # to avoid error https://fburl.com/code/ilix4okj
                 kwargs["overwrite_existing_data"] = False
+            if self.trial_type is not None:
+                metrics = assert_is_instance(
+                    self.experiment, MultiTypeExperiment
+                ).metrics_for_trial_type(trial_type=none_throws(self.trial_type))
+                kwargs["metrics"] = metrics
             results = self.experiment.fetch_trials_data_results(
                 trial_indices=trial_indices,
                 **kwargs,


### PR DESCRIPTION
Summary: This updates the `Scheduler` to only fetch metrics for `Scheduler.trial_type` when the experiment is a `MultiTypeExperiment`.

Reviewed By: Balandat

Differential Revision: D66661144


