### PR TITLE
Don't round parameters once they are in log space

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -422,7 +422,7 @@ class RangeParameter(Parameter):
         self._upper = cast_upper
         return self
 
-    def set_digits(self, digits: int) -> RangeParameter:
+    def set_digits(self, digits: int | None) -> RangeParameter:
         self._digits = digits
 
         # Re-scale min and max to new digits definition

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -621,7 +621,7 @@ def transform_callback(
 ) -> Callable[[npt.NDArray], npt.NDArray]:
     """A closure for performing the `round trip` transformations.
 
-    The function round points by de-transforming points back into
+    The function rounds points by de-transforming points back into
     the original space (done by applying transforms in reverse), and then
     re-transforming them.
     This function is specifically for points which are formatted as numpy

--- a/ax/modelbridge/transforms/log.py
+++ b/ax/modelbridge/transforms/log.py
@@ -58,6 +58,9 @@ class Log(Transform):
     def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         for p_name, p in search_space.parameters.items():
             if p_name in self.transform_parameters and isinstance(p, RangeParameter):
+                # Don't round in log space
+                if p.digits is not None:
+                    p.set_digits(digits=None)
                 p.set_log_scale(False).update_range(
                     lower=math.log10(p.lower), upper=math.log10(p.upper)
                 )

--- a/ax/modelbridge/transforms/tests/test_log_transform.py
+++ b/ax/modelbridge/transforms/tests/test_log_transform.py
@@ -16,6 +16,7 @@ from ax.exceptions.core import UnsupportedError
 from ax.modelbridge.transforms.log import Log
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_robust_search_space
+from pyre_extensions import assert_is_instance
 
 
 class LogTransformTest(TestCase):
@@ -29,6 +30,7 @@ class LogTransformTest(TestCase):
                     upper=3,
                     parameter_type=ParameterType.FLOAT,
                     log_scale=True,
+                    digits=3,
                 ),
                 RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),
                 ChoiceParameter(
@@ -74,10 +76,10 @@ class LogTransformTest(TestCase):
     def test_TransformSearchSpace(self) -> None:
         ss2 = deepcopy(self.search_space)
         ss2 = self.t.transform_search_space(ss2)
-        # pyre-fixme[16]: `Parameter` has no attribute `lower`.
-        self.assertEqual(ss2.parameters["x"].lower, math.log10(1))
-        # pyre-fixme[16]: `Parameter` has no attribute `upper`.
-        self.assertEqual(ss2.parameters["x"].upper, math.log10(3))
+        param = assert_is_instance(ss2.parameters["x"], RangeParameter)
+        self.assertEqual(param.lower, math.log10(1))
+        self.assertEqual(param.upper, math.log10(3))
+        self.assertIsNone(param.digits)
         t2 = Log(
             search_space=self.search_space_with_target,
             observations=[],


### PR DESCRIPTION
Summary:
Context: Currently, when `RangeParameter`s with `digits` set and `log_scale=True` are modeled, their bounds are logged and then rounded. The rounding can lead to generating candidates that are outside the search space.

This PR:
* Sets the 'digits' attribute on such parameters to `None` within `Log._transform_search_space`

Reviewed By: bernardbeckerman, saitcakmak

Differential Revision: D66670173


