### PR TITLE
Implement attach_trial and attach_baseline

### DIFF
--- a/ax/preview/api/client.py
+++ b/ax/preview/api/client.py
@@ -455,31 +455,53 @@ class Client:
     # -------------------- Section 2.3 Marking trial status manually ----------------
     def mark_trial_failed(self, trial_index: int) -> None:
         """
-        Manually mark a trial as FAILED. FAILED trials may be re-suggested by
-        get_next_trials.
+        Manually mark a trial as FAILED. FAILED trials typically may be re-suggested by
+        get_next_trials, though this is controlled by the GenerationStrategy.
 
         Saves to database on completion if db_config is present.
         """
-        ...
+        self._none_throws_experiment().trials[trial_index].mark_failed()
+
+        if self._db_config is not None:
+            # TODO[mpolson64] Save to database
+            ...
 
     def mark_trial_abandoned(self, trial_index: int) -> None:
         """
-        Manually mark a trial as ABANDONED. ABANDONED trials may be re-suggested by
+        Manually mark a trial as ABANDONED. ABANDONED trials are typically not able to
+        be re-suggested by get_next_trials, though this is controlled by the
+        GenerationStrategy.
+
+        Saves to database on completion if db_config is present.
+        """
+        self._none_throws_experiment().trials[trial_index].mark_abandoned()
+
+        if self._db_config is not None:
+            # TODO[mpolson64] Save to database
+            ...
+
+    def mark_trial_early_stopped(
+        self, trial_index: int, raw_data: TOutcome, progression: int | None = None
+    ) -> None:
+        """
+        Manually mark a trial as EARLY_STOPPED while attaching the most recent data.
+        This is used when the user has decided (with or without Ax's recommendation) to
+        stop the trial early. EARLY_STOPPED trials will not be re-suggested by
         get_next_trials.
 
         Saves to database on completion if db_config is present.
         """
-        ...
 
-    def mark_trial_early_stopped(self, trial_index: int) -> None:
-        """
-        Manually mark a trial as EARLY_STOPPED. This is used when the user has decided
-        (with or without Ax's recommendation) to stop the trial early. EARLY_STOPPED
-        trials will not be re-suggested by get_next_trials.
+        # First attach the new data
+        self.attach_data(
+            trial_index=trial_index, raw_data=raw_data, progression=progression
+        )
 
-        Saves to database on completion if db_config is present.
-        """
-        ...
+        self._none_throws_experiment().trials[trial_index].mark_early_stopped()
+
+        if self._db_config is not None:
+            # TODO[mpolson64] Save to database
+            ...
 
     def run_trials(self, maximum_trials: int, options: OrchestrationConfig) -> None:
         """

--- a/ax/preview/api/client.py
+++ b/ax/preview/api/client.py
@@ -16,7 +16,6 @@ from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from ax.core.metric import Metric
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.runner import Runner
-from ax.core.search_space import SearchSpace
 from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
 from ax.exceptions.core import UnsupportedError
 from ax.modelbridge.dispatch_utils import choose_generation_strategy
@@ -41,6 +40,7 @@ from typing_extensions import Self
 class Client:
     _experiment: Experiment | None = None
     _generation_strategy: GenerationStrategyInterface | None = None
+    _early_stopping_strategy: BaseEarlyStoppingStrategy | None = None
 
     def __init__(
         self,
@@ -181,51 +181,82 @@ class Client:
     # -------------------- Section 1.2: Set (not API) -------------------------------
     def set_experiment(self, experiment: Experiment) -> None:
         """
+        This method is not part of the API and is provided (without guarantees of
+        method signature stability) for the convenience of some developers, power
+        users, and partners.
+
         Overwrite the existing Experiment with the provided Experiment.
 
         Saves to database on completion if db_config is present.
         """
-        ...
+        self._experiment = experiment
 
-    def set_search_space(self, search_space: SearchSpace) -> None:
-        """
-        Overwrite the existing SearchSpace with the provided SearchSpace.
-
-        Saves to database on completion if db_config is present.
-        """
-        ...
+        if self.db_config is not None:
+            # TODO[mpolson64] Save to database
+            ...
 
     def set_optimization_config(self, optimization_config: OptimizationConfig) -> None:
         """
+        This method is not part of the API and is provided (without guarantees of
+        method signature stability) for the convenience of some developers, power
+        users, and partners.
+
         Overwrite the existing OptimizationConfig with the provided OptimizationConfig.
 
         Saves to database on completion if db_config is present.
         """
-        ...
+        self._none_throws_experiment().optimization_config = optimization_config
+
+        if self.db_config is not None:
+            # TODO[mpolson64] Save to database
+            ...
 
     def set_generation_strategy(
         self, generation_strategy: GenerationStrategyInterface
     ) -> None:
         """
+        This method is not part of the API and is provided (without guarantees of
+        method signature stability) for the convenience of some developers, power
+        users, and partners.
+
         Overwrite the existing GenerationStrategy with the provided GenerationStrategy.
 
         Saves to database on completion if db_config is present.
         """
-        ...
+        self._generation_strategy = generation_strategy
+        none_throws(
+            self._generation_strategy
+        )._experiment = self._none_throws_experiment()
+
+        if self.db_config is not None:
+            # TODO[mpolson64] Save to database
+            ...
 
     def set_early_stopping_strategy(
         self, early_stopping_strategy: BaseEarlyStoppingStrategy
     ) -> None:
         """
+        This method is not part of the API and is provided (without guarantees of
+        method signature stability) for the convenience of some developers, power
+        users, and partners.
+
         Overwrite the existing EarlyStoppingStrategy with the provided
         EarlyStoppingStrategy.
 
         Saves to database on completion if db_config is present.
         """
-        ...
+        self._early_stopping_strategy = early_stopping_strategy
+
+        if self.db_config is not None:
+            # TODO[mpolson64] Save to database
+            ...
 
     def set_runner(self, runner: Runner) -> None:
         """
+        This method is not part of the API and is provided (without guarantees of
+        method signature stability) for the convenience of some developers and power
+        users.
+
         Attaches a Runner to the Experiment.
 
         Saves to database on completion if db_config is present.
@@ -234,6 +265,10 @@ class Client:
 
     def set_metrics(self, metrics: Sequence[Metric]) -> None:
         """
+        This method is not part of the API and is provided (without guarantees of
+        method signature stability) for the convenience of some developers, power
+        users, and partners.
+
         Finds equivallently named Metric that already exists on the Experiment and
         replaces it with the Metric provided, or adds the Metric provided to the
         Experiment as tracking metrics.

--- a/ax/preview/api/configs.py
+++ b/ax/preview/api/configs.py
@@ -7,7 +7,7 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional
+from typing import List, Mapping, Optional, Sequence
 
 from ax.preview.api.types import TParameterValue
 
@@ -63,18 +63,14 @@ class ChoiceParameterConfig:
     values: List[float] | List[int] | List[str] | List[bool]
     parameter_type: ParameterType
     is_ordered: bool | None = None
-    dependent_parameters: dict[TParameterValue, str] | None = None
+    dependent_parameters: Mapping[TParameterValue, Sequence[str]] | None = None
 
 
 @dataclass
 class ExperimentConfig:
     """
-    ExperimentConfig allows users to specify the SearchSpace and OptimizationConfig of
-    an Experiment and validates their inputs jointly.
-
-    This will also be the construct that handles transforming string-based inputs (the
-    objective, parameter constraints, and output constraints) into their corresponding
-    Ax class using SymPy.
+    ExperimentConfig allows users to specify the SearchSpace of an experiment along
+    with other metadata.
     """
 
     name: str

--- a/ax/preview/api/tests/test_client.py
+++ b/ax/preview/api/tests/test_client.py
@@ -379,6 +379,74 @@ class TestClient(TestCase):
         trials = client.get_next_trials(maximum_trials=2)
         self.assertEqual(len(trials), 1)
 
+    def test_mark_trial_failed(self) -> None:
+        client = Client()
+
+        client.configure_experiment(
+            ExperimentConfig(
+                parameters=[
+                    RangeParameterConfig(
+                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                    ),
+                ],
+                name="foo",
+            )
+        )
+        client.configure_optimization(objective="foo")
+
+        trial_index = [*client.get_next_trials(maximum_trials=1).keys()][0]
+        client.mark_trial_failed(trial_index=trial_index)
+        self.assertEqual(
+            none_throws(client._experiment).trials[trial_index].status,
+            TrialStatus.FAILED,
+        )
+
+    def test_mark_trial_abandoned(self) -> None:
+        client = Client()
+
+        client.configure_experiment(
+            ExperimentConfig(
+                parameters=[
+                    RangeParameterConfig(
+                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                    ),
+                ],
+                name="foo",
+            )
+        )
+        client.configure_optimization(objective="foo")
+
+        trial_index = [*client.get_next_trials(maximum_trials=1).keys()][0]
+        client.mark_trial_abandoned(trial_index=trial_index)
+        self.assertEqual(
+            none_throws(client._experiment).trials[trial_index].status,
+            TrialStatus.ABANDONED,
+        )
+
+    def test_mark_trial_early_stopped(self) -> None:
+        client = Client()
+
+        client.configure_experiment(
+            ExperimentConfig(
+                parameters=[
+                    RangeParameterConfig(
+                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                    ),
+                ],
+                name="foo",
+            )
+        )
+        client.configure_optimization(objective="foo")
+
+        trial_index = [*client.get_next_trials(maximum_trials=1).keys()][0]
+        client.mark_trial_early_stopped(
+            trial_index=trial_index, raw_data={"foo": 0.0}, progression=1
+        )
+        self.assertEqual(
+            none_throws(client._experiment).trials[trial_index].status,
+            TrialStatus.EARLY_STOPPED,
+        )
+
 
 class DummyRunner(IRunner):
     @override

--- a/ax/preview/api/tests/test_client.py
+++ b/ax/preview/api/tests/test_client.py
@@ -1,0 +1,156 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.core.experiment import Experiment
+from ax.core.metric import Metric
+from ax.core.objective import Objective
+from ax.core.optimization_config import OptimizationConfig
+from ax.core.outcome_constraint import ComparisonOp, OutcomeConstraint
+from ax.core.parameter import (
+    ChoiceParameter,
+    ParameterType as CoreParameterType,
+    RangeParameter,
+)
+from ax.core.parameter_constraint import ParameterConstraint
+from ax.core.search_space import SearchSpace
+from ax.exceptions.core import UnsupportedError
+from ax.preview.api.client import Client
+from ax.preview.api.configs import (
+    ChoiceParameterConfig,
+    ExperimentConfig,
+    ParameterType,
+    RangeParameterConfig,
+)
+from ax.utils.common.testutils import TestCase
+from pyre_extensions import none_throws
+
+
+class TestClient(TestCase):
+    def test_configure_experiment(self) -> None:
+        client = Client()
+
+        float_parameter = RangeParameterConfig(
+            name="float_param",
+            parameter_type=ParameterType.FLOAT,
+            bounds=(0, 1),
+        )
+        int_parameter = RangeParameterConfig(
+            name="int_param",
+            parameter_type=ParameterType.INT,
+            bounds=(0, 1),
+        )
+        choice_parameter = ChoiceParameterConfig(
+            name="choice_param",
+            parameter_type=ParameterType.STRING,
+            values=["a", "b", "c"],
+        )
+
+        experiment_config = ExperimentConfig(
+            name="test_experiment",
+            parameters=[float_parameter, int_parameter, choice_parameter],
+            parameter_constraints=["int_param <= float_param"],
+            description="test description",
+            owner="miles",
+        )
+
+        client.configure_experiment(experiment_config=experiment_config)
+        self.assertEqual(
+            client._experiment,
+            Experiment(
+                search_space=SearchSpace(
+                    parameters=[
+                        RangeParameter(
+                            name="float_param",
+                            parameter_type=CoreParameterType.FLOAT,
+                            lower=0,
+                            upper=1,
+                        ),
+                        RangeParameter(
+                            name="int_param",
+                            parameter_type=CoreParameterType.INT,
+                            lower=0,
+                            upper=1,
+                        ),
+                        ChoiceParameter(
+                            name="choice_param",
+                            parameter_type=CoreParameterType.STRING,
+                            values=["a", "b", "c"],
+                            is_ordered=False,
+                            sort_values=False,
+                        ),
+                    ],
+                    parameter_constraints=[
+                        ParameterConstraint(
+                            constraint_dict={"int_param": 1, "float_param": -1}, bound=0
+                        )
+                    ],
+                ),
+                name="test_experiment",
+                description="test description",
+                properties={"owners": ["miles"]},
+            ),
+        )
+
+        with self.assertRaisesRegex(UnsupportedError, "Experiment already configured"):
+            client.configure_experiment(experiment_config=experiment_config)
+
+    def test_configure_optimization(self) -> None:
+        client = Client()
+
+        float_parameter = RangeParameterConfig(
+            name="float_param",
+            parameter_type=ParameterType.FLOAT,
+            bounds=(0, 1),
+        )
+        int_parameter = RangeParameterConfig(
+            name="int_param",
+            parameter_type=ParameterType.INT,
+            bounds=(0, 1),
+        )
+        choice_parameter = ChoiceParameterConfig(
+            name="choice_param",
+            parameter_type=ParameterType.STRING,
+            values=["a", "b", "c"],
+        )
+
+        experiment_config = ExperimentConfig(
+            name="test_experiment",
+            parameters=[float_parameter, int_parameter, choice_parameter],
+            parameter_constraints=["int_param <= float_param"],
+            description="test description",
+            owner="miles",
+        )
+
+        client.configure_experiment(experiment_config=experiment_config)
+
+        client.configure_optimization(
+            objective="-ne",
+            outcome_constraints=["qps >= 0"],
+        )
+
+        self.assertEqual(
+            none_throws(client._experiment).optimization_config,
+            OptimizationConfig(
+                objective=Objective(metric=Metric(name="ne"), minimize=True),
+                outcome_constraints=[
+                    OutcomeConstraint(
+                        metric=Metric(name="qps"),
+                        op=ComparisonOp.GEQ,
+                        bound=0.0,
+                        relative=False,
+                    )
+                ],
+            ),
+        )
+
+        empty_client = Client()
+
+        with self.assertRaisesRegex(AssertionError, "Experiment not set"):
+            empty_client.configure_optimization(
+                objective="ne",
+                outcome_constraints=["qps >= 0"],
+            )

--- a/ax/preview/api/tests/test_client.py
+++ b/ax/preview/api/tests/test_client.py
@@ -26,6 +26,12 @@ from ax.preview.api.configs import (
     RangeParameterConfig,
 )
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import (
+    get_branin_experiment,
+    get_branin_optimization_config,
+    get_percentile_early_stopping_strategy,
+)
+from ax.utils.testing.modeling_stubs import get_generation_strategy
 from pyre_extensions import none_throws
 
 
@@ -154,3 +160,45 @@ class TestClient(TestCase):
                 objective="ne",
                 outcome_constraints=["qps >= 0"],
             )
+
+    def test_set_experiment(self) -> None:
+        client = Client()
+        experiment = get_branin_experiment()
+
+        client.set_experiment(experiment=experiment)
+
+        self.assertEqual(client._experiment, experiment)
+
+    def test_set_optimization_config(self) -> None:
+        client = Client()
+        optimization_config = get_branin_optimization_config()
+
+        with self.assertRaisesRegex(AssertionError, "Experiment not set"):
+            client.set_optimization_config(optimization_config=optimization_config)
+
+        client.set_experiment(experiment=get_branin_experiment())
+        client.set_optimization_config(
+            optimization_config=optimization_config,
+        )
+
+        self.assertEqual(
+            none_throws(client._experiment).optimization_config, optimization_config
+        )
+
+    def test_set_generation_strategy(self) -> None:
+        client = Client()
+        client.set_experiment(experiment=get_branin_experiment())
+
+        generation_strategy = get_generation_strategy()
+
+        client.set_generation_strategy(generation_strategy=generation_strategy)
+        self.assertEqual(client._generation_strategy, generation_strategy)
+
+    def test_set_early_stopping_strategy(self) -> None:
+        client = Client()
+        early_stopping_strategy = get_percentile_early_stopping_strategy()
+
+        client.set_early_stopping_strategy(
+            early_stopping_strategy=early_stopping_strategy
+        )
+        self.assertEqual(client._early_stopping_strategy, early_stopping_strategy)

--- a/ax/preview/api/utils/__init__.py
+++ b/ax/preview/api/utils/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/preview/api/utils/instantiation/__init__.py
+++ b/ax/preview/api/utils/instantiation/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/preview/api/utils/instantiation/from_config.py
+++ b/ax/preview/api/utils/instantiation/from_config.py
@@ -9,6 +9,8 @@
 import numpy as np
 
 from ax.core.experiment import Experiment
+
+from ax.core.formatting_utils import DataType
 from ax.core.parameter import (
     ChoiceParameter,
     FixedParameter,
@@ -126,6 +128,7 @@ def experiment_from_config(config: ExperimentConfig) -> Experiment:
         name=config.name,
         description=config.description,
         properties={"owners": [config.owner]},
+        default_data_type=DataType.MAP_DATA,
     )
 
 

--- a/ax/preview/api/utils/instantiation/from_config.py
+++ b/ax/preview/api/utils/instantiation/from_config.py
@@ -1,0 +1,146 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import numpy as np
+
+from ax.core.experiment import Experiment
+from ax.core.parameter import (
+    ChoiceParameter,
+    FixedParameter,
+    Parameter,
+    ParameterType as CoreParameterType,
+    RangeParameter,
+)
+from ax.core.parameter_constraint import validate_constraint_parameters
+from ax.core.search_space import SearchSpace
+from ax.exceptions.core import UserInputError
+from ax.preview.api.configs import (
+    ChoiceParameterConfig,
+    ExperimentConfig,
+    ParameterScaling,
+    ParameterType,
+    RangeParameterConfig,
+)
+from ax.preview.api.utils.instantiation.from_string import parse_parameter_constraint
+
+
+def parameter_from_config(
+    config: RangeParameterConfig | ChoiceParameterConfig,
+) -> Parameter:
+    """
+    Create a RangeParameter, ChoiceParameter, or FixedParameter from a ParameterConfig.
+    """
+
+    if isinstance(config, RangeParameterConfig):
+        lower, upper = config.bounds
+
+        # TODO[mpolson64] Add support for RangeParameterConfig.step_size native to
+        # RangeParameter instead of converting to ChoiceParameter
+        if (step_size := config.step_size) is not None:
+            if not (
+                config.scaling == ParameterScaling.LINEAR or config.scaling is None
+            ):
+                raise UserInputError(
+                    "Non-linear parameter scaling is not supported when using "
+                    "step_size."
+                )
+
+            if (upper - lower) % step_size != 0:
+                raise UserInputError(
+                    "The range of the parameter must be evenly divisible by the "
+                    "step size."
+                )
+
+            return ChoiceParameter(
+                name=config.name,
+                parameter_type=_parameter_type_converter(config.parameter_type),
+                values=[*np.arange(lower, upper + step_size, step_size)],
+                is_ordered=True,
+            )
+
+        return RangeParameter(
+            name=config.name,
+            parameter_type=_parameter_type_converter(config.parameter_type),
+            lower=lower,
+            upper=upper,
+            log_scale=config.scaling == ParameterScaling.LOG,
+        )
+
+    else:
+        # If there is only one value, create a FixedParameter instead of a
+        # ChoiceParameter
+        if len(config.values) == 1:
+            return FixedParameter(
+                name=config.name,
+                parameter_type=_parameter_type_converter(config.parameter_type),
+                value=config.values[0],
+                # pyre-fixme[6] Variance issue caused by FixedParameter.dependents
+                # using List instead of immutable container type.
+                dependents=config.dependent_parameters,
+            )
+
+        return ChoiceParameter(
+            name=config.name,
+            parameter_type=_parameter_type_converter(config.parameter_type),
+            # pyre-fixme[6] Variance issue caused by ChoiceParameter.value using List
+            # instead of immutable container type.
+            values=config.values,
+            is_ordered=config.is_ordered,
+            # pyre-fixme[6] Variance issue caused by ChoiceParameter.dependents using
+            # List instead of immutable container type.
+            dependents=config.dependent_parameters,
+        )
+
+
+def experiment_from_config(config: ExperimentConfig) -> Experiment:
+    """Create an Experiment from an ExperimentConfig."""
+    parameters = [
+        parameter_from_config(config=parameter_config)
+        for parameter_config in config.parameters
+    ]
+
+    constraints = [
+        parse_parameter_constraint(constraint_str=constraint_str)
+        for constraint_str in config.parameter_constraints
+    ]
+
+    # Ensure that all ParameterConstraints are valid and acting on existing parameters
+    for constraint in constraints:
+        validate_constraint_parameters(
+            parameters=[
+                parameter
+                for parameter in parameters
+                if parameter.name in constraint.constraint_dict.keys()
+            ]
+        )
+
+    search_space = SearchSpace(parameters=parameters, parameter_constraints=constraints)
+
+    return Experiment(
+        search_space=search_space,
+        name=config.name,
+        description=config.description,
+        properties={"owners": [config.owner]},
+    )
+
+
+def _parameter_type_converter(parameter_type: ParameterType) -> CoreParameterType:
+    """
+    Convert from an API ParameterType to a core Ax ParameterType.
+    """
+
+    if parameter_type == ParameterType.BOOL:
+        return CoreParameterType.BOOL
+    elif parameter_type == ParameterType.FLOAT:
+        return CoreParameterType.FLOAT
+    elif parameter_type == ParameterType.INT:
+        return CoreParameterType.INT
+    elif parameter_type == ParameterType.STRING:
+        return CoreParameterType.STRING
+    else:
+        raise UserInputError(f"Unsupported parameter type {parameter_type}.")

--- a/ax/preview/api/utils/instantiation/from_string.py
+++ b/ax/preview/api/utils/instantiation/from_string.py
@@ -1,0 +1,263 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Sequence
+
+from ax.core.metric import Metric
+from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
+from ax.core.optimization_config import (
+    MultiObjectiveOptimizationConfig,
+    OptimizationConfig,
+)
+from ax.core.outcome_constraint import (
+    ComparisonOp,
+    ObjectiveThreshold,
+    OutcomeConstraint,
+    ScalarizedOutcomeConstraint,
+)
+from ax.core.parameter_constraint import ParameterConstraint
+from ax.exceptions.core import UserInputError
+from sympy.core.add import Add
+from sympy.core.expr import Expr
+from sympy.core.mul import Mul
+from sympy.core.relational import GreaterThan, LessThan
+from sympy.core.symbol import Symbol
+from sympy.core.sympify import sympify
+
+
+def optimization_config_from_string(
+    objective_str: str, outcome_constraint_strs: Sequence[str] | None = None
+) -> OptimizationConfig:
+    """
+    Create an OptimizationConfig from objective and outcome constraint strings.
+
+    Note that outcome constraints may not be placed on the objective metric except in
+    the multi-objective case where they will be converted to objective thresholds.
+    """
+
+    objective = parse_objective(objective_str=objective_str)
+
+    if outcome_constraint_strs is not None:
+        outcome_constraints = [
+            parse_outcome_constraint(constraint_str=constraint_str)
+            for constraint_str in outcome_constraint_strs
+        ]
+    else:
+        outcome_constraints = None
+
+    if isinstance(objective, MultiObjective):
+        # Convert OutcomeConstraints to ObjectiveThresholds if relevant
+        objective_metric_names = {metric.name for metric in objective.metrics}
+        true_outcome_constraints = []
+        objective_thresholds: list[ObjectiveThreshold] = []
+        for outcome_constraint in outcome_constraints or []:
+            if (
+                not isinstance(outcome_constraint, ScalarizedOutcomeConstraint)
+                and outcome_constraint.metric.name in objective_metric_names
+            ):
+                objective_thresholds.append(
+                    ObjectiveThreshold(
+                        metric=outcome_constraint.metric,
+                        bound=outcome_constraint.bound,
+                        relative=outcome_constraint.relative,
+                        op=outcome_constraint.op,
+                    )
+                )
+            else:
+                true_outcome_constraints.append(outcome_constraint)
+
+        return MultiObjectiveOptimizationConfig(
+            objective=objective,
+            outcome_constraints=true_outcome_constraints,
+            objective_thresholds=objective_thresholds,
+        )
+
+    # Ensure that outcome constraints are not placed on the objective metric
+    objective_metric_names = {metric.name for metric in objective.metrics}
+    for outcome_constraint in outcome_constraints or []:
+        if outcome_constraint.metric.name in objective_metric_names:
+            raise UserInputError(
+                "Outcome constraints may not be placed on the objective metric "
+                f"except in the multi-objective case, found {objective_str} and "
+                f"{outcome_constraint_strs}"
+            )
+
+    return OptimizationConfig(
+        objective=objective,
+        outcome_constraints=outcome_constraints,
+    )
+
+
+def parse_parameter_constraint(constraint_str: str) -> ParameterConstraint:
+    """
+    Parse a parameter constraint string into a ParameterConstraint object using SymPy.
+    Currently only supports linear constraints of the form "a * x + b * y >= k" or
+    "a * x + b * y <= k".
+    """
+    coefficient_dict = _extract_coefficient_dict_from_inequality(
+        inequality_str=constraint_str
+    )
+
+    # Iterate through the coefficients to extract the parameter names and weights and
+    # the bound
+    constraint_dict = {}
+    bound = 0
+    for term, coefficient in coefficient_dict.items():
+        if term.is_symbol:
+            constraint_dict[term.name] = coefficient
+        elif term.is_number:
+            # Invert because we are "moving" the bound to the right hand side
+            bound = -1 * coefficient
+        else:
+            raise UserInputError(
+                "Only linear inequality parameter constraints are supported, found "
+                f"{constraint_str}"
+            )
+
+    return ParameterConstraint(constraint_dict=constraint_dict, bound=bound)
+
+
+def parse_objective(objective_str: str) -> Objective:
+    """
+    Parse an objective string into an Objective object using SymPy.
+
+    Currently only supports linear objectives of the form "a * x + b * y" and tuples of
+    linear objectives.
+    """
+    # Parse the objective string into a SymPy expression
+    expression = sympify(objective_str)
+
+    if isinstance(expression, tuple):  # Multi-objective
+        return MultiObjective(
+            objectives=[
+                _create_single_objective(expression=term) for term in expression
+            ]
+        )
+
+    return _create_single_objective(expression=expression)
+
+
+def parse_outcome_constraint(constraint_str: str) -> OutcomeConstraint:
+    """
+    Parse an outcome constraint string into an OutcomeConstraint object using SymPy.
+    Currently only supports linear constraints of the form "a * x + b * y >= k" or
+    "a * x + b * y <= k".
+
+    To indicate a relative constraint (i.e. performance relative to some baseline)
+    multiply your bound by "baseline". For example "qps >= 0.95 * baseline" will
+    constrain such that the QPS is at least 95% of the baseline arm's QPS.
+    """
+    coefficient_dict = _extract_coefficient_dict_from_inequality(
+        inequality_str=constraint_str
+    )
+
+    # Iterate through the coefficients to extract the parameter names and weights and
+    # the bound
+    constraint_dict: dict[str, float] = {}
+    bound = 0
+    is_relative = False
+    for term, coefficient in coefficient_dict.items():
+        if term.is_symbol:
+            if term.name == "baseline":
+                # Invert because we are "moving" the bound to the right hand side
+                bound = -1 * coefficient
+                is_relative = True
+            else:
+                constraint_dict[term.name] = coefficient
+        elif term.is_number:
+            # Invert because we are "moving" the bound to the right hand side
+            bound = -1 * coefficient
+        else:
+            raise UserInputError(
+                "Only linear outcome constraints are supported, found "
+                f"{constraint_str}"
+            )
+
+    if len(constraint_dict) == 1:
+        term, coefficient = next(iter(constraint_dict.items()))
+
+        return OutcomeConstraint(
+            metric=Metric(name=term),
+            op=ComparisonOp.LEQ if coefficient > 0 else ComparisonOp.GEQ,
+            bound=bound / coefficient,
+            relative=is_relative,
+        )
+
+    names, coefficients = zip(*constraint_dict.items())
+    return ScalarizedOutcomeConstraint(
+        metrics=[Metric(name=name) for name in names],
+        op=ComparisonOp.LEQ,
+        weights=[*coefficients],
+        bound=bound,
+        relative=is_relative,
+    )
+
+
+def _create_single_objective(expression: Expr) -> Objective:
+    """
+    Create an Objective or ScalarizedObjective from a linear SymPy expression.
+
+    All expressions are assumed to represent maximization objectives.
+    """
+
+    # If the expression is a just a Symbol it represents a single metric objective
+    if isinstance(expression, Symbol):
+        return Objective(metric=Metric(name=str(expression.name)), minimize=False)
+
+    # If the expression is a Mul it likely represents a single metric objective but
+    # some additional validation is required
+    if isinstance(expression, Mul):
+        symbol, *other_symbols = expression.free_symbols
+        if len(other_symbols) > 0:
+            raise UserInputError(
+                f"Only linear objectives are supported, found {expression}."
+            )
+
+        # Since the objectives 1 * loss and 2 * loss are equivalent, we can just use
+        # the sign from the coefficient rather than its value
+        minimize = bool(expression.as_coefficient(symbol) < 0)
+
+        return Objective(metric=Metric(name=str(symbol)), minimize=minimize)
+
+    # If the expression is an Add it represents a scalarized objective
+    elif isinstance(expression, Add):
+        names, coefficients = zip(*expression.as_coefficients_dict().items())
+        return ScalarizedObjective(
+            metrics=[Metric(name=str(name)) for name in names],
+            weights=[float(coefficient) for coefficient in coefficients],
+            minimize=False,
+        )
+
+    raise UserInputError(f"Only linear objectives are supported, found {expression}.")
+
+
+def _extract_coefficient_dict_from_inequality(
+    inequality_str: str,
+) -> dict[Symbol, float]:
+    """
+    Use SymPy to parse a string into an inequality, invert if necessary to enforce a
+    less-than relationship, move all terms to the left side, and return the
+    coefficients as a dictionary. This is useful for parsing parameter and outcome
+    constraints.
+    """
+    # Parse the constraint string into a SymPy inequality
+    inequality = sympify(inequality_str)
+
+    # Check the SymPy object is a valid inequality
+    if not isinstance(inequality, GreaterThan | LessThan):
+        raise UserInputError(f"Expected an inequality, found {inequality_str}")
+
+    # Move all terms to the left side of the inequality and invert if necessary to
+    # enforce a less-than relationship
+    if isinstance(inequality, LessThan):
+        expression = inequality.lhs - inequality.rhs
+    else:
+        expression = inequality.rhs - inequality.lhs
+
+    return {
+        key: float(value) for key, value in expression.as_coefficients_dict().items()
+    }

--- a/ax/preview/api/utils/instantiation/tests/test_from_config.py
+++ b/ax/preview/api/utils/instantiation/tests/test_from_config.py
@@ -1,0 +1,277 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.core.experiment import Experiment
+from ax.core.parameter import (
+    ChoiceParameter,
+    FixedParameter,
+    ParameterType as CoreParameterType,
+    RangeParameter,
+)
+from ax.core.parameter_constraint import ParameterConstraint
+from ax.core.search_space import SearchSpace
+from ax.exceptions.core import UserInputError
+from ax.preview.api.configs import (
+    ChoiceParameterConfig,
+    ExperimentConfig,
+    ParameterScaling,
+    ParameterType,
+    RangeParameterConfig,
+)
+from ax.preview.api.utils.instantiation.from_config import (
+    _parameter_type_converter,
+    experiment_from_config,
+    parameter_from_config,
+)
+from ax.utils.common.testutils import TestCase
+
+
+class TestFromConfig(TestCase):
+    def test_create_range_parameter(self) -> None:
+        float_config = RangeParameterConfig(
+            name="float_param",
+            parameter_type=ParameterType.FLOAT,
+            bounds=(0, 1),
+        )
+
+        self.assertEqual(
+            parameter_from_config(config=float_config),
+            RangeParameter(
+                name="float_param",
+                parameter_type=CoreParameterType.FLOAT,
+                lower=0,
+                upper=1,
+            ),
+        )
+
+        float_config_with_log_scaling = RangeParameterConfig(
+            name="float_param_with_log_scaling",
+            parameter_type=ParameterType.FLOAT,
+            bounds=(1e-10, 1),
+            scaling=ParameterScaling.LOG,
+        )
+
+        self.assertEqual(
+            parameter_from_config(config=float_config_with_log_scaling),
+            RangeParameter(
+                name="float_param_with_log_scaling",
+                parameter_type=CoreParameterType.FLOAT,
+                lower=1e-10,
+                upper=1,
+                log_scale=True,
+            ),
+        )
+
+        int_config = RangeParameterConfig(
+            name="int_param",
+            parameter_type=ParameterType.INT,
+            bounds=(0, 1),
+        )
+
+        self.assertEqual(
+            parameter_from_config(config=int_config),
+            RangeParameter(
+                name="int_param",
+                parameter_type=CoreParameterType.INT,
+                lower=0,
+                upper=1,
+            ),
+        )
+
+        step_size_config = RangeParameterConfig(
+            name="step_size_param",
+            parameter_type=ParameterType.FLOAT,
+            bounds=(0, 100),
+            step_size=10,
+        )
+
+        self.assertEqual(
+            parameter_from_config(config=step_size_config),
+            ChoiceParameter(
+                name="step_size_param",
+                parameter_type=CoreParameterType.FLOAT,
+                values=[
+                    0.0,
+                    10.0,
+                    20.0,
+                    30.0,
+                    40.0,
+                    50.0,
+                    60.0,
+                    70.0,
+                    80.0,
+                    90.0,
+                    100.0,
+                ],
+                is_ordered=True,
+            ),
+        )
+
+        with self.assertRaisesRegex(
+            UserInputError,
+            "Non-linear parameter scaling is not supported when using step_size",
+        ):
+            parameter_from_config(
+                config=RangeParameterConfig(
+                    name="step_size_param_with_scaling",
+                    parameter_type=ParameterType.FLOAT,
+                    bounds=(0, 100),
+                    step_size=10,
+                    scaling=ParameterScaling.LOG,
+                )
+            )
+
+    def test_create_choice_parameter(self) -> None:
+        choice_config = ChoiceParameterConfig(
+            name="choice_param",
+            parameter_type=ParameterType.STRING,
+            values=["a", "b", "c"],
+        )
+
+        self.assertEqual(
+            parameter_from_config(config=choice_config),
+            ChoiceParameter(
+                name="choice_param",
+                parameter_type=CoreParameterType.STRING,
+                values=["a", "b", "c"],
+            ),
+        )
+
+        choice_config_with_order = ChoiceParameterConfig(
+            name="choice_param_with_order",
+            parameter_type=ParameterType.STRING,
+            values=["a", "b", "c"],
+            is_ordered=True,
+        )
+        self.assertEqual(
+            parameter_from_config(config=choice_config_with_order),
+            ChoiceParameter(
+                name="choice_param_with_order",
+                parameter_type=CoreParameterType.STRING,
+                values=["a", "b", "c"],
+                is_ordered=True,
+            ),
+        )
+
+        choice_config_with_dependents = ChoiceParameterConfig(
+            name="choice_param_with_dependents",
+            parameter_type=ParameterType.STRING,
+            values=["a", "b", "c"],
+            dependent_parameters={
+                "a": ["a1", "a2"],
+                "b": ["b1", "b2", "b3"],
+            },
+        )
+        self.assertEqual(
+            parameter_from_config(config=choice_config_with_dependents),
+            ChoiceParameter(
+                name="choice_param_with_dependents",
+                parameter_type=CoreParameterType.STRING,
+                values=["a", "b", "c"],
+                dependents={
+                    "a": ["a1", "a2"],
+                    "b": ["b1", "b2", "b3"],
+                },
+            ),
+        )
+
+        single_element_choice_config = ChoiceParameterConfig(
+            name="single_element_choice_param",
+            parameter_type=ParameterType.STRING,
+            values=["a"],
+        )
+        self.assertEqual(
+            parameter_from_config(config=single_element_choice_config),
+            FixedParameter(
+                name="single_element_choice_param",
+                parameter_type=CoreParameterType.STRING,
+                value="a",
+            ),
+        )
+
+    def test_experiment_from_config(self) -> None:
+        float_parameter = RangeParameterConfig(
+            name="float_param",
+            parameter_type=ParameterType.FLOAT,
+            bounds=(0, 1),
+        )
+        int_parameter = RangeParameterConfig(
+            name="int_param",
+            parameter_type=ParameterType.INT,
+            bounds=(0, 1),
+        )
+        choice_parameter = ChoiceParameterConfig(
+            name="choice_param",
+            parameter_type=ParameterType.STRING,
+            values=["a", "b", "c"],
+        )
+
+        experiment_config = ExperimentConfig(
+            name="test_experiment",
+            parameters=[float_parameter, int_parameter, choice_parameter],
+            parameter_constraints=["int_param <= float_param"],
+            description="test description",
+            owner="miles",
+        )
+
+        self.assertEqual(
+            experiment_from_config(config=experiment_config),
+            Experiment(
+                search_space=SearchSpace(
+                    parameters=[
+                        RangeParameter(
+                            name="float_param",
+                            parameter_type=CoreParameterType.FLOAT,
+                            lower=0,
+                            upper=1,
+                        ),
+                        RangeParameter(
+                            name="int_param",
+                            parameter_type=CoreParameterType.INT,
+                            lower=0,
+                            upper=1,
+                        ),
+                        ChoiceParameter(
+                            name="choice_param",
+                            parameter_type=CoreParameterType.STRING,
+                            values=["a", "b", "c"],
+                            is_ordered=False,
+                            sort_values=False,
+                        ),
+                    ],
+                    parameter_constraints=[
+                        ParameterConstraint(
+                            constraint_dict={"int_param": 1, "float_param": -1}, bound=0
+                        )
+                    ],
+                ),
+                name="test_experiment",
+                description="test description",
+                properties={"owners": ["miles"]},
+            ),
+        )
+
+    def test_parameter_type_converter(self) -> None:
+        self.assertEqual(
+            _parameter_type_converter(parameter_type=ParameterType.BOOL),
+            CoreParameterType.BOOL,
+        )
+        self.assertEqual(
+            _parameter_type_converter(parameter_type=ParameterType.INT),
+            CoreParameterType.INT,
+        )
+        self.assertEqual(
+            _parameter_type_converter(parameter_type=ParameterType.FLOAT),
+            CoreParameterType.FLOAT,
+        )
+        self.assertEqual(
+            _parameter_type_converter(parameter_type=ParameterType.STRING),
+            CoreParameterType.STRING,
+        )
+        with self.assertRaisesRegex(UserInputError, "Unsupported parameter type"):
+            # pyre-ignore[6] Testing a bad input on purpose
+            _parameter_type_converter(parameter_type="bad")

--- a/ax/preview/api/utils/instantiation/tests/test_from_config.py
+++ b/ax/preview/api/utils/instantiation/tests/test_from_config.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 from ax.core.experiment import Experiment
+from ax.core.formatting_utils import DataType
 from ax.core.parameter import (
     ChoiceParameter,
     FixedParameter,
@@ -252,6 +253,7 @@ class TestFromConfig(TestCase):
                 name="test_experiment",
                 description="test description",
                 properties={"owners": ["miles"]},
+                default_data_type=DataType.MAP_DATA,
             ),
         )
 

--- a/ax/preview/api/utils/instantiation/tests/test_from_string.py
+++ b/ax/preview/api/utils/instantiation/tests/test_from_string.py
@@ -1,0 +1,213 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.core.metric import Metric
+from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
+from ax.core.optimization_config import (
+    MultiObjectiveOptimizationConfig,
+    OptimizationConfig,
+)
+from ax.core.outcome_constraint import (
+    ComparisonOp,
+    ObjectiveThreshold,
+    OutcomeConstraint,
+    ScalarizedOutcomeConstraint,
+)
+from ax.core.parameter_constraint import ParameterConstraint
+from ax.exceptions.core import UserInputError
+from ax.preview.api.utils.instantiation.from_string import (
+    optimization_config_from_string,
+    parse_objective,
+    parse_outcome_constraint,
+    parse_parameter_constraint,
+)
+from ax.utils.common.testutils import TestCase
+
+
+class TestFromString(TestCase):
+    def test_optimization_config_from_string(self) -> None:
+        only_objective = optimization_config_from_string(objective_str="ne")
+        self.assertEqual(
+            only_objective,
+            OptimizationConfig(
+                objective=Objective(metric=Metric(name="ne"), minimize=False),
+            ),
+        )
+
+        with_constraints = optimization_config_from_string(
+            objective_str="ne", outcome_constraint_strs=["qps >= 0"]
+        )
+        self.assertEqual(
+            with_constraints,
+            OptimizationConfig(
+                objective=Objective(metric=Metric(name="ne"), minimize=False),
+                outcome_constraints=[
+                    OutcomeConstraint(
+                        metric=Metric(name="qps"),
+                        op=ComparisonOp.GEQ,
+                        bound=0.0,
+                        relative=False,
+                    )
+                ],
+            ),
+        )
+
+        with_constraints_and_objective_threshold = optimization_config_from_string(
+            objective_str="-ne, qps",
+            outcome_constraint_strs=["qps >= 1000", "flops <= 1000000"],
+        )
+        self.assertEqual(
+            with_constraints_and_objective_threshold,
+            MultiObjectiveOptimizationConfig(
+                objective=MultiObjective(
+                    objectives=[
+                        Objective(metric=Metric(name="ne"), minimize=True),
+                        Objective(metric=Metric(name="qps"), minimize=False),
+                    ]
+                ),
+                outcome_constraints=[
+                    OutcomeConstraint(
+                        metric=Metric(name="flops"),
+                        op=ComparisonOp.LEQ,
+                        bound=1000000.0,
+                        relative=False,
+                    )
+                ],
+                objective_thresholds=[
+                    ObjectiveThreshold(
+                        metric=Metric(name="qps"),
+                        op=ComparisonOp.GEQ,
+                        bound=1000.0,
+                        relative=False,
+                    )
+                ],
+            ),
+        )
+
+    def test_parse_paramter_constraint(self) -> None:
+        constraint = parse_parameter_constraint(constraint_str="x1 + x2 <= 1")
+        self.assertEqual(
+            constraint,
+            ParameterConstraint(constraint_dict={"x1": 1, "x2": 1}, bound=1.0),
+        )
+
+        with_coefficients = parse_parameter_constraint(
+            constraint_str="2 * x1 + 3 * x2 <= 1"
+        )
+        self.assertEqual(
+            with_coefficients,
+            ParameterConstraint(constraint_dict={"x1": 2, "x2": 3}, bound=1.0),
+        )
+
+        flipped_sign = parse_parameter_constraint(constraint_str="x1 + x2 >= 1")
+        self.assertEqual(
+            flipped_sign,
+            ParameterConstraint(constraint_dict={"x1": -1, "x2": -1}, bound=-1.0),
+        )
+
+        weird = parse_parameter_constraint(constraint_str="x1 + x2 <= 1.5 * x3 + 2")
+        self.assertEqual(
+            weird,
+            ParameterConstraint(
+                constraint_dict={"x1": 1, "x2": 1, "x3": -1.5}, bound=2.0
+            ),
+        )
+
+        with self.assertRaisesRegex(UserInputError, "Only linear"):
+            parse_parameter_constraint(constraint_str="x1 * x2 <= 1")
+
+    def test_parse_objective(self) -> None:
+        single_objective = parse_objective(objective_str="ne")
+        self.assertEqual(
+            single_objective, Objective(metric=Metric(name="ne"), minimize=False)
+        )
+
+        maximize_single_objective = parse_objective(objective_str="-qps")
+        self.assertEqual(
+            maximize_single_objective,
+            Objective(metric=Metric(name="qps"), minimize=True),
+        )
+
+        scalarized_objective = parse_objective(
+            objective_str="0.5 * ne1 + 0.3 * ne2 + 0.2 * ne3"
+        )
+        self.assertEqual(
+            scalarized_objective,
+            ScalarizedObjective(
+                metrics=[Metric(name="ne1"), Metric(name="ne2"), Metric(name="ne3")],
+                weights=[0.5, 0.3, 0.2],
+                minimize=False,
+            ),
+        )
+
+        multiobjective = parse_objective(objective_str="ne, -qps")
+        self.assertEqual(
+            multiobjective,
+            MultiObjective(
+                objectives=[
+                    Objective(metric=Metric(name="ne"), minimize=False),
+                    Objective(metric=Metric(name="qps"), minimize=True),
+                ]
+            ),
+        )
+
+        with self.assertRaisesRegex(UserInputError, "Only linear"):
+            parse_objective(objective_str="ne * qps")
+
+    def test_parse_outcome_constraint(self) -> None:
+        constraint = parse_outcome_constraint(constraint_str="flops <= 1000000")
+        self.assertEqual(
+            constraint,
+            OutcomeConstraint(
+                metric=Metric(name="flops"),
+                op=ComparisonOp.LEQ,
+                bound=1000000.0,
+                relative=False,
+            ),
+        )
+
+        flipped_sign = parse_outcome_constraint(constraint_str="flops >= 1000000.0")
+        self.assertEqual(
+            flipped_sign,
+            OutcomeConstraint(
+                metric=Metric(name="flops"),
+                op=ComparisonOp.GEQ,
+                bound=1000000.0,
+                relative=False,
+            ),
+        )
+
+        relative = parse_outcome_constraint(constraint_str="flops <= 105 * baseline")
+        self.assertEqual(
+            relative,
+            OutcomeConstraint(
+                metric=Metric(name="flops"),
+                op=ComparisonOp.LEQ,
+                bound=105.0,
+                relative=True,
+            ),
+        )
+
+        scalarized = parse_outcome_constraint(
+            constraint_str="0.5 * flops1 + 0.3 * flops2 <= 1000000"
+        )
+        self.assertEqual(
+            scalarized,
+            ScalarizedOutcomeConstraint(
+                metrics=[Metric(name="flops1"), Metric(name="flops2")],
+                weights=[0.5, 0.3],
+                op=ComparisonOp.LEQ,
+                bound=1000000.0,
+                relative=False,
+            ),
+        )
+
+        with self.assertRaisesRegex(UserInputError, "Expected an inequality"):
+            parse_outcome_constraint(constraint_str="flops == 1000000")
+
+        with self.assertRaisesRegex(UserInputError, "Only linear"):
+            parse_outcome_constraint(constraint_str="flops * flops <= 1000000")

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ REQUIRES = [
     # Needed for compatibility with ipywidgets >= 8.0.0
     "plotly>=5.12.0",
     "pyre-extensions",
+    "sympy",
 ]
 
 # pytest-cov requires pytest >= 3.6

--- a/sphinx/source/preview.rst
+++ b/sphinx/source/preview.rst
@@ -61,3 +61,19 @@ Types
     :members:
     :undoc-members:
     :show-inheritance:
+
+From Config
+~~~~~~~~~~~
+
+.. automodule:: ax.preview.api.utils.instantiation.from_config
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+From String
+~~~~~~~~~~~
+
+.. automodule:: ax.preview.api.utils.instantiation.from_string
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Summary:
Implement a method for attaching a single arm trial and a special helper method to attach a single arm trial, name it "baseline", and attach its arm as the status quo

RFC: Is this behavior actually what we want attach_baseline to do? Or does it make more sense just to set the status quo arm and not attach anything? IMO it makes sense to attach the trial in the single-arm trial setting, but in the batch trial setting we want to attach this arm to every trial, no? That being said Im not sure we want to bifurcate behavior like this. Curious to hear what you all think.

Reviewed By: lena-kashtelyan

Differential Revision: D66664475


