### PR TITLE
Implement predict

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -5,6 +5,8 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 import json
 from collections.abc import Iterable
 from enum import IntEnum
@@ -132,7 +134,7 @@ class Analysis(Protocol):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategyInterface | None = None,
-    ) -> Result[AnalysisCard, ExceptionE]:
+    ) -> Result[AnalysisCard, AnalysisE]:
         """
         Utility method to compute an AnalysisCard as a Result. This can be useful for
         computing many Analyses at once and handling Exceptions later.

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -6,8 +6,10 @@
 # pyre-strict
 
 
+import traceback
+
 import pandas as pd
-from ax.analysis.analysis import Analysis, AnalysisCard
+from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel, AnalysisE
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from IPython.display import display, Markdown
@@ -59,3 +61,23 @@ class MarkdownAnalysis(Analysis):
             df=df,
             blob=message,
         )
+
+
+def markdown_analysis_card_from_analysis_e(
+    analysis_e: AnalysisE,
+) -> MarkdownAnalysisCard:
+    return MarkdownAnalysisCard(
+        name=analysis_e.analysis.name,
+        title=f"{analysis_e.analysis.name} Error",
+        subtitle=f"An error occurred while computing {analysis_e.analysis}",
+        attributes=analysis_e.analysis.attributes,
+        blob="".join(
+            traceback.format_exception(
+                type(analysis_e.exception),
+                analysis_e.exception,
+                analysis_e.exception.__traceback__,
+            )
+        ),
+        df=pd.DataFrame(),
+        level=AnalysisCardLevel.DEBUG,
+    )

--- a/ax/analysis/plotly/tests/__init__.py
+++ b/ax/analysis/plotly/tests/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/analysis/tests/__init__.py
+++ b/ax/analysis/tests/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/analysis/tests/test_utils.py
+++ b/ax/analysis/tests/test_utils.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.analysis.utils import choose_analyses
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import (
+    get_branin_experiment,
+    get_branin_experiment_with_multi_objective,
+)
+
+
+class TestUtils(TestCase):
+    def test_choose_analyses(self) -> None:
+        analyses = choose_analyses(experiment=get_branin_experiment())
+        self.assertEqual(
+            {analysis.name for analysis in analyses},
+            {
+                "ParallelCoordinatesPlot",
+                "InteractionPlot",
+                "Summary",
+                "CrossValidationPlot",
+            },
+        )
+
+        # Multi-objective case
+        analyses = choose_analyses(
+            experiment=get_branin_experiment_with_multi_objective()
+        )
+        self.assertEqual(
+            {analysis.name for analysis in analyses},
+            {"InteractionPlot", "ScatterPlot", "Summary", "CrossValidationPlot"},
+        )

--- a/ax/analysis/utils.py
+++ b/ax/analysis/utils.py
@@ -1,0 +1,76 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+
+from ax.analysis.analysis import Analysis
+from ax.analysis.plotly.cross_validation import CrossValidationPlot
+from ax.analysis.plotly.interaction import InteractionPlot
+from ax.analysis.plotly.parallel_coordinates import ParallelCoordinatesPlot
+from ax.analysis.plotly.scatter import ScatterPlot
+from ax.analysis.summary import Summary
+from ax.core.experiment import Experiment
+from ax.core.objective import MultiObjective, ScalarizedObjective
+
+
+def choose_analyses(experiment: Experiment) -> list[Analysis]:
+    """
+    Choose a default set of Analyses to compute based on the current state of the
+    Experiment.
+    """
+    if (optimization_config := experiment.optimization_config) is None:
+        return []
+
+    if isinstance(optimization_config.objective, MultiObjective) or isinstance(
+        optimization_config.objective, ScalarizedObjective
+    ):
+        # Pareto frontiers for each objective
+        objective_plots = [
+            *[
+                ScatterPlot(x_metric_name=x, y_metric_name=y, show_pareto_frontier=True)
+                for x, y in itertools.combinations(
+                    optimization_config.objective.metric_names, 2
+                )
+            ],
+        ]
+
+        other_scatters = []
+
+        interactions = [
+            InteractionPlot(metric_name=name)
+            for name in optimization_config.objective.metric_names
+        ]
+
+    else:
+        objective_name = optimization_config.objective.metric.name
+        # ParallelCoorindates and leave-one-out cross validation
+        objective_plots = [
+            ParallelCoordinatesPlot(metric_name=objective_name),
+        ]
+
+        # Up to six ScatterPlots for other metrics versus the objective,
+        # prioritizing optimization config metrics over tracking metrics
+        tracking_metric_names = [metric.name for metric in experiment.tracking_metrics]
+        other_scatters = [
+            ScatterPlot(
+                x_metric_name=objective_name,
+                y_metric_name=name,
+                show_pareto_frontier=False,
+            )
+            for name in [
+                *optimization_config.metrics,
+                *tracking_metric_names,
+            ]
+            if name != objective_name
+        ][:6]
+
+        interactions = [InteractionPlot(metric_name=objective_name)]
+
+    # Leave-one-out cross validation for each objective and outcome constraint
+    cv_plots = [
+        CrossValidationPlot(metric_name=name) for name in optimization_config.metrics
+    ]
+
+    return [*objective_plots, *other_scatters, *interactions, *cv_plots, Summary()]

--- a/ax/preview/api/configs.py
+++ b/ax/preview/api/configs.py
@@ -95,7 +95,7 @@ class GenerationStrategyConfig:
 class OrchestrationConfig:
     parallelism: int = 1
     tolerated_trial_failure_rate: float = 0.5
-    seconds_between_polls: float = 1.0
+    initial_seconds_between_polls: int = 1
 
 
 @dataclass

--- a/sphinx/source/analysis.rst
+++ b/sphinx/source/analysis.rst
@@ -159,3 +159,11 @@ Utils
     :members:
     :undoc-members:
     :show-inheritance:
+
+Utils
+~~~~~
+
+.. automodule:: ax.analysis.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Summary:
Implement predict method which given a parameterization checks it is a member of the search space then attempts to call predict using the current fitted model.

Notes:
* We will predict for all metrics. Unfortunately the plumbing is not all there for subsetting the metrics to predict for, but if we want to add an optional arg down the line and add the plumbing because we are seeing genuine demand then we should do that as a fast follow.

Differential Revision: D66679011
