### PR TITLE
Update the default set of Ax transforms used in MBM

### DIFF
--- a/ax/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/modelbridge/tests/test_dispatch_utils.py
@@ -19,8 +19,7 @@ from ax.modelbridge.dispatch_utils import (
     choose_generation_strategy,
     DEFAULT_BAYESIAN_PARALLELISM,
 )
-from ax.modelbridge.factory import Cont_X_trans, Y_trans
-from ax.modelbridge.registry import Mixed_transforms, Models
+from ax.modelbridge.registry import MBM_X_trans, Mixed_transforms, Models, Y_trans
 from ax.modelbridge.transforms.log_y import LogY
 from ax.modelbridge.transforms.winsorize import Winsorize
 from ax.models.winsorization_config import WinsorizationConfig
@@ -44,7 +43,7 @@ class TestDispatchUtils(TestCase):
 
     @mock_botorch_optimize
     def test_choose_generation_strategy(self) -> None:
-        expected_transforms = [Winsorize] + Cont_X_trans + Y_trans
+        expected_transforms = [Winsorize] + MBM_X_trans + Y_trans
         expected_transform_configs = {
             "Winsorize": {"derelativize_with_raw_status_quo": False},
             "Derelativize": {"use_raw_status_quo": False},

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -57,9 +57,8 @@ from ax.modelbridge.generation_strategy import (
 )
 from ax.modelbridge.model_spec import ModelSpec
 from ax.modelbridge.random import RandomModelBridge
-from ax.modelbridge.registry import Models
+from ax.modelbridge.registry import Cont_X_trans, Models
 from ax.runners.synthetic import SyntheticRunner
-
 from ax.service.ax_client import AxClient, ObjectiveProperties
 from ax.service.utils.best_point import (
     get_best_parameters_from_model_predictions_with_trial_index,
@@ -220,7 +219,14 @@ def get_client_with_simple_discrete_moo_problem(
     gs = GenerationStrategy(
         steps=[
             GenerationStep(model=Models.SOBOL, num_trials=3),
-            GenerationStep(model=Models.BOTORCH_MODULAR, num_trials=-1),
+            GenerationStep(
+                model=Models.BOTORCH_MODULAR,
+                num_trials=-1,
+                model_kwargs={
+                    # To avoid search space exhausted errors.
+                    "transforms": Cont_X_trans,
+                },
+            ),
         ]
     )
 


### PR DESCRIPTION
Summary:
This diff adds a new set of transforms (to be used by default in MBM based models) that replaces `IntToFloat` with `LogIntToFloat` and `UnitX` with `Normalize`. The new set of transforms avoid using continuous relaxation for non log-scale discrete parameter, which consistently delivers improved optimization performance on mixed integer benchmark problems.

This diff only updates single task model registry entries. I will follow it up with additional diffs to propagage the changes in multiple stages.

Differential Revision: D66724547


