### PR TITLE
Change default mapdata value in data_and_evaluations_from_raw_data

### DIFF
--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -230,7 +230,7 @@ class MapData(Data):
             for key in map_dict.keys()
         }
         map_key_infos = map_key_infos or [
-            MapKeyInfo(key=key, default_value=0.0) for key in map_keys
+            MapKeyInfo(key=key, default_value=np.nan) for key in map_keys
         ]
 
         if {mki.key for mki in map_key_infos} != map_keys:


### PR DESCRIPTION
Summary:
Infer map_key_infos with default value NaN from the shape of the data in data_and_evaluations_from_raw_data. This method  is used in trial.update_trial_data which in turn is used in AxClient and the preview API.

Ultimately we want to make this change to prevent 0 from sneaking into MapData when a user calls Client.attach_data without a progression -- we would prefer a NaN to be there signifying no data is present.

Differential Revision: D66765038


