### PR TITLE
Fixing timeouts for analysis::test_compute

### DIFF
--- a/ax/analysis/plotly/tests/test_interaction.py
+++ b/ax/analysis/plotly/tests/test_interaction.py
@@ -10,11 +10,9 @@ from ax.analysis.plotly.interaction import InteractionPlot
 from ax.exceptions.core import UserInputError
 from ax.service.ax_client import AxClient, ObjectiveProperties
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.mock import mock_botorch_optimize
 
 
 class TestInteractionPlot(TestCase):
-    @mock_botorch_optimize
     def setUp(self) -> None:
         super().setUp()
         self.client = AxClient()
@@ -36,7 +34,7 @@ class TestInteractionPlot(TestCase):
             objectives={"bar": ObjectiveProperties(minimize=True)},
         )
 
-        for _ in range(10):
+        for _ in range(2):
             parameterization, trial_index = self.client.get_next_trial()
             self.client.complete_trial(
                 trial_index=trial_index,


### PR DESCRIPTION
Summary:
Encountered flaky oncall task:

"Test ax/analysis/plotly:interaction_tests - ax.analysis.plotly.tests.test_interaction.TestInteractionPlot: test_compute flaky for ae"



## Fixing

1. To speed up the test, changed the number of executed trials from 10 to 2. What the test checks for does not depend on the number of trials, so the functionality is unchanged. 

2. Changing the num trials from 10 to 2 led to the following error:
```
ax.analysis.plotly.tests.test_interaction.TestInteractionPlot
  test_compute: AssertionError: No mocks were called in the context manager. Please remove unused mock_botorch_optimize_context_manager().
```
Removed the `mock_botorch_optimize` context manager to fix.

Reviewed By: mpolson64

Differential Revision: D66963919


