### PR TITLE
Add mixed integer problems to registry

### DIFF
--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -16,6 +16,11 @@ from ax.benchmark.problems.hpo.torchvision import (
     get_pytorch_cnn_torchvision_benchmark_problem,
 )
 from ax.benchmark.problems.runtime_funcs import int_from_params
+from ax.benchmark.problems.synthetic.discretized.mixed_integer import (
+    get_discrete_ackley,
+    get_discrete_hartmann,
+    get_discrete_rosenbrock,
+)
 from ax.benchmark.problems.synthetic.hss.jenatton import get_jenatton_benchmark_problem
 from botorch.test_functions import synthetic
 from botorch.test_functions.multi_objective import BraninCurrin
@@ -245,6 +250,16 @@ BENCHMARK_PROBLEM_REGISTRY = {
             "num_trials": 50,
             "observe_noise_sd": True,
         },
+    ),
+    "Discrete Hartmann": BenchmarkProblemRegistryEntry(
+        factory_fn=get_discrete_hartmann,
+        factory_kwargs={},
+    ),
+    "Discrete Ackley": BenchmarkProblemRegistryEntry(
+        factory_fn=get_discrete_ackley, factory_kwargs={}
+    ),
+    "Discrete Rosenbrock": BenchmarkProblemRegistryEntry(
+        factory_fn=get_discrete_rosenbrock, factory_kwargs={}
     ),
 }
 

--- a/ax/benchmark/tests/problems/test_problems.py
+++ b/ax/benchmark/tests/problems/test_problems.py
@@ -29,6 +29,9 @@ class TestProblems(TestCase):
             ("branin_currin_observed_noise", "BraninCurrin_observed_noise"),
             ("branin_currin30_observed_noise", "BraninCurrin_observed_noise_30d"),
             ("levy4", "Levy_4d"),
+        ] + [
+            (name, name)
+            for name in ["Discrete Ackley", "Discrete Hartmann", "Discrete Rosenbrock"]
         ]
         for registry_key, problem_name in expected_names:
             problem = get_problem(problem_key=registry_key)

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -956,7 +956,6 @@ class TestBenchmark(TestCase):
                 n_repeats=1,
             )
             self.assertEqual(result, 0)
-        return
 
         with self.subTest("SOO, MapData"):
             map_test_function = IdentityTestFunction(n_steps=2)


### PR DESCRIPTION
Summary: This makes it easier to access problems programmatically, as I have been doing while adding baseline values.

Differential Revision: D67052992


