### PR TITLE
Do not expand ChoiceParameters in ModelBridge._set_model_space

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -32,7 +32,7 @@ from ax.core.observation import (
     separate_observations,
 )
 from ax.core.optimization_config import OptimizationConfig
-from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
+from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import (
     TCandidateMetadata,
@@ -432,8 +432,6 @@ class ModelBridge(ABC):  # noqa: B024 -- ModelBridge doesn't have any abstract m
             if isinstance(p, RangeParameter):
                 p.lower = min(p.lower, min(param_vals[p.name]))
                 p.upper = max(p.upper, max(param_vals[p.name]))
-            elif isinstance(p, ChoiceParameter) and not p.is_ordered:
-                p.set_values(values=list(set(p.values).union(set(param_vals[p.name]))))
 
     def _set_status_quo(
         self,

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -849,8 +849,6 @@ def get_high_dimensional_branin_experiment(
     with_batch: bool = False, with_status_quo: bool = False
 ) -> Experiment:
     search_space = SearchSpace(
-        # pyre-fixme[6]: In call `SearchSpace.__init__`, for 1st parameter `parameters`
-        # expected `List[Parameter]` but got `List[RangeParameter]`.
         parameters=[
             RangeParameter(
                 name=f"x{i}",
@@ -1021,7 +1019,7 @@ def get_large_ordinal_search_space(
     n_continuous_range_parameters: int,
 ) -> SearchSpace:
     return SearchSpace(
-        parameters=[  # pyre-ignore[6]
+        parameters=[
             RangeParameter(
                 name=f"x{i}",
                 parameter_type=ParameterType.FLOAT,
@@ -1072,12 +1070,14 @@ def get_search_space_for_range_value(min: float = 3.0, max: float = 6.0) -> Sear
 
 
 def get_search_space_for_range_values(
-    min: float = 3.0, max: float = 6.0
+    min: float = 3.0, max: float = 6.0, parameter_names: list[str] | None = None
 ) -> SearchSpace:
+    if parameter_names is None:
+        parameter_names = ["x", "y"]
     return SearchSpace(
         [
-            RangeParameter("x", ParameterType.FLOAT, min, max),
-            RangeParameter("y", ParameterType.FLOAT, min, max),
+            RangeParameter(name, ParameterType.FLOAT, min, max)
+            for name in parameter_names
         ]
     )
 


### PR DESCRIPTION
Summary: Expanding unordered choice parameters leads to OneHot transform (constructed using `model_space`) creating additional OH_params that do not exist in the transformed `search_space`, which leads to errors in `extract_search_space_digest`.

Differential Revision: D67063486


