### PR TITLE
Test Interaction Plot is still flaky, adding @ax_long_test

### DIFF
--- a/ax/analysis/plotly/tests/test_interaction.py
+++ b/ax/analysis/plotly/tests/test_interaction.py
@@ -11,6 +11,8 @@ from ax.exceptions.core import UserInputError
 from ax.service.ax_client import AxClient, ObjectiveProperties
 from ax.utils.common.testutils import TestCase
 
+from ax.utils.testing.mock import mock_botorch_optimize
+
 
 class TestInteractionPlot(TestCase):
     def setUp(self) -> None:
@@ -43,6 +45,10 @@ class TestInteractionPlot(TestCase):
                 },
             )
 
+    @TestCase.ax_long_test(
+        reason="This test requires fitting an OAK model, which can be time intensive"
+    )
+    @mock_botorch_optimize
     def test_compute(self) -> None:
         analysis = InteractionPlot(metric_name="bar")
 


### PR DESCRIPTION
Summary:
The test interaction plot continues to be flaky, inconsistently. D66963919 initially attempted to fix, but even after landing flakiness conintued. 

See https://www.internalfb.com/intern/test/562950141148215?ref_report_id=0 for the test.

The test runs quickly when ran one at a time, but interestingly running a stress run results in all tests passing or all tests timing out.

# Mitigation

Looking at the profile below, we see that calls to gpytorch/lazy/lazy_evaluated_kernel_tensor and botorch/models/kernels/orthogonal_additive_kernel are resulting in most of the run-time of these tests prior to timing out.

Adding "mock_botorch_optimize" does not help the test cases.

Due to the inconsistent nature of this test due to the fitting of the underlying OAK model and ax_parameter_sens, adding the ax_long_test decorator to mitigate.

Differential Revision: D67107237


