### PR TITLE
Remove unnecessary 'datasets' from `SurrogateTestFunction`

### DIFF
--- a/ax/benchmark/benchmark_test_functions/surrogate.py
+++ b/ax/benchmark/benchmark_test_functions/surrogate.py
@@ -15,7 +15,6 @@ from ax.core.types import TParamValue
 from ax.modelbridge.torch import TorchModelBridge
 from ax.utils.common.base import Base
 from ax.utils.common.equality import equality_typechecker
-from botorch.utils.datasets import SupervisedDataset
 from pyre_extensions import none_throws
 from torch import Tensor
 
@@ -30,50 +29,31 @@ class SurrogateTestFunction(BenchmarkTestFunction):
         outcome_names: Names of outcomes to return in `evaluate_true`, if the
             surrogate produces more outcomes than are needed.
         _surrogate: Either `None`, or a `TorchModelBridge` surrogate to use
-            for generating observations. If `None`, `get_surrogate_and_datasets`
+            for generating observations. If `None`, `get_surrogate`
             must not be None and will be used to generate the surrogate when it
             is needed.
-        _datasets: Either `None`, or the `SupervisedDataset`s used to fit
-            the surrogate model. If `None`, `get_surrogate_and_datasets` must
-            not be None and will be used to generate the datasets when they are
-            needed.
-        get_surrogate_and_datasets: Function that returns the surrogate and
-            datasets, to allow for lazy construction. If
-            `get_surrogate_and_datasets` is not provided, `surrogate` and
-            `datasets` must be provided, and vice versa.
+        get_surrogate: Function that returns the surrogate, to allow for lazy
+            construction. If `get_surrogate` is not provided, `surrogate` must
+            be provided and vice versa.
     """
 
     name: str
     outcome_names: list[str]
     _surrogate: TorchModelBridge | None = None
-    _datasets: list[SupervisedDataset] | None = None
-    get_surrogate_and_datasets: (
-        None | Callable[[], tuple[TorchModelBridge, list[SupervisedDataset]]]
-    ) = None
+    get_surrogate: None | Callable[[], TorchModelBridge] = None
 
     def __post_init__(self) -> None:
-        if self.get_surrogate_and_datasets is None and (
-            self._surrogate is None or self._datasets is None
-        ):
+        if self.get_surrogate is None and self._surrogate is None:
             raise ValueError(
-                "If `get_surrogate_and_datasets` is None, `_surrogate` "
-                "and `_datasets` must not be None, and vice versa."
+                "If `get_surrogate` is None, `_surrogate` must not be None, and"
+                " vice versa."
             )
-
-    def set_surrogate_and_datasets(self) -> None:
-        self._surrogate, self._datasets = none_throws(self.get_surrogate_and_datasets)()
 
     @property
     def surrogate(self) -> TorchModelBridge:
         if self._surrogate is None:
-            self.set_surrogate_and_datasets()
+            self._surrogate = none_throws(self.get_surrogate)()
         return none_throws(self._surrogate)
-
-    @property
-    def datasets(self) -> list[SupervisedDataset]:
-        if self._datasets is None:
-            self.set_surrogate_and_datasets()
-        return none_throws(self._datasets)
 
     def evaluate_true(self, params: Mapping[str, TParamValue]) -> Tensor:
         # We're ignoring the uncertainty predictions of the surrogate model here and

--- a/ax/benchmark/tests/benchmark_test_functions/test_surrogate_test_function.py
+++ b/ax/benchmark/tests/benchmark_test_functions/test_surrogate_test_function.py
@@ -28,7 +28,6 @@ class TestSurrogateTestFunction(TestCase):
                     name="test test function",
                     outcome_names=["dummy metric"],
                     _surrogate=surrogate,
-                    _datasets=[],
                 )
                 self.assertEqual(test_function.name, "test test function")
                 self.assertIs(test_function.surrogate, surrogate)
@@ -37,30 +36,22 @@ class TestSurrogateTestFunction(TestCase):
         test_function = get_soo_surrogate_test_function()
 
         self.assertIsNone(test_function._surrogate)
-        self.assertIsNone(test_function._datasets)
 
         # Accessing `surrogate` sets datasets and surrogate
         self.assertIsInstance(test_function.surrogate, TorchModelBridge)
         self.assertIsInstance(test_function._surrogate, TorchModelBridge)
-        self.assertIsInstance(test_function._datasets, list)
-
-        # Accessing `datasets` also sets datasets and surrogate
-        test_function = get_soo_surrogate_test_function()
-        self.assertIsInstance(test_function.datasets, list)
-        self.assertIsInstance(test_function._surrogate, TorchModelBridge)
-        self.assertIsInstance(test_function._datasets, list)
 
         with patch.object(
             test_function,
-            "get_surrogate_and_datasets",
-            wraps=test_function.get_surrogate_and_datasets,
-        ) as mock_get_surrogate_and_datasets:
+            "get_surrogate",
+            wraps=test_function.get_surrogate,
+        ) as mock_get_surrogate:
             test_function.surrogate
-        mock_get_surrogate_and_datasets.assert_not_called()
+        mock_get_surrogate.assert_not_called()
 
     def test_instantiation_raises_with_missing_args(self) -> None:
         with self.assertRaisesRegex(
-            ValueError, "If `get_surrogate_and_datasets` is None, `_surrogate` and "
+            ValueError, "If `get_surrogate` is None, `_surrogate`"
         ):
             SurrogateTestFunction(name="test runner", outcome_names=[])
 
@@ -69,7 +60,6 @@ class TestSurrogateTestFunction(TestCase):
             return SurrogateTestFunction(
                 name=name,
                 _surrogate=MagicMock(),
-                _datasets=[],
                 outcome_names=["dummy_metric"],
             )
 

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -94,16 +94,13 @@ def get_soo_surrogate_test_function(lazy: bool = True) -> SurrogateTestFunction:
     )
     if lazy:
         test_function = SurrogateTestFunction(
-            outcome_names=["branin"],
-            name="test",
-            get_surrogate_and_datasets=lambda: (surrogate, []),
+            outcome_names=["branin"], name="test", get_surrogate=lambda: surrogate
         )
     else:
         test_function = SurrogateTestFunction(
             outcome_names=["branin"],
             name="test",
             _surrogate=surrogate,
-            _datasets=[],
         )
     return test_function
 
@@ -139,9 +136,7 @@ def get_moo_surrogate() -> BenchmarkProblem:
 
     outcome_names = ["branin_a", "branin_b"]
     test_function = SurrogateTestFunction(
-        name="test",
-        outcome_names=outcome_names,
-        get_surrogate_and_datasets=lambda: (surrogate, []),
+        name="test", outcome_names=outcome_names, get_surrogate=lambda: surrogate
     )
     optimization_config = get_moo_opt_config(
         outcome_names=outcome_names,


### PR DESCRIPTION
Summary:
`SurrogateTestFunction` has functionality for lazy-loading datasets, but it turns out to not be needed. If there is any reason to need to access the datasets, they can be found on the surrogate (a `TorchModelBridge`) itself.

This PR removes all `datasets`-related functionality.

Differential Revision: D67056081


