### PR TITLE
improve isSubDict to not key error on missing field

### DIFF
--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -500,7 +500,7 @@ class TestCase(fake_filesystem_unittest.TestCase):
             superdict: A larger dictionary which should contain all keys of subdict
                 and the same values as subdict for the corresponding keys.
         """
-        intersection_dict = {k: superdict[k] for k in subdict}
+        intersection_dict = {k: superdict[k] for k in subdict if k in superdict}
         if consider_nans_equal and not almost_equal:
             raise ValueError(
                 "`consider_nans_equal` can only be used with `almost_equal`"


### PR DESCRIPTION
Summary: If the superDict is missing a key from the subDict, it just gives a single key error.  The communication is poor and it hides other inequalities.

Differential Revision: D67057678


