### PR TITLE
Use `BenchmarkProblem.baseline_value` to compute score

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -447,6 +447,7 @@ def compute_baseline_value_from_sobol(
         num_trials=5,
         test_function=test_function,
         optimal_value=dummy_optimal_value,
+        baseline_value=-dummy_optimal_value,
         target_fidelity_and_task=target_fidelity_and_task,
     )
 

--- a/ax/benchmark/problems/hpo/torchvision.py
+++ b/ax/benchmark/problems/hpo/torchvision.py
@@ -210,11 +210,18 @@ def get_pytorch_cnn_torchvision_benchmark_problem(
     optimization_config = get_soo_opt_config(
         outcome_names=test_function.outcome_names, lower_is_better=False
     )
+    # The baseline value for MNIST was not obtained with
+    # `compute_baseline_value_from_sobol`, as usual, but rather by using
+    # the best of 5 Sobol trials and averaging over seeds 1118-1127, since
+    # that data was readily available.
+    # FashionMNIST was computed using just 5 Sobol trials.
+    baseline_value = 0.16 if name == "FashionMNIST" else 0.21452
     return BenchmarkProblem(
         name=f"HPO_PyTorchCNN_Torchvision::{name}",
         search_space=search_space,
         optimization_config=optimization_config,
         num_trials=num_trials,
         optimal_value=CLASSIFICATION_OPTIMAL_VALUE,
+        baseline_value=baseline_value,
         test_function=test_function,
     )

--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -32,6 +32,7 @@ class BenchmarkProblemRegistryEntry:
     factory_kwargs: dict[str, Any]
 
 
+# Baseline values were obtained with `compute_baseline_value_from_sobol`
 BENCHMARK_PROBLEM_REGISTRY = {
     "ackley4": BenchmarkProblemRegistryEntry(
         factory_fn=create_problem_from_botorch,
@@ -79,6 +80,7 @@ BENCHMARK_PROBLEM_REGISTRY = {
                 test_problem_kwargs={},
                 num_trials=num_trials,
                 observe_noise_sd=False,
+                baseline_value=3.0187520516793587,
             ),
             total_dimensionality=n,
         ),

--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -16,6 +16,11 @@ from ax.benchmark.problems.hpo.torchvision import (
     get_pytorch_cnn_torchvision_benchmark_problem,
 )
 from ax.benchmark.problems.runtime_funcs import int_from_params
+from ax.benchmark.problems.synthetic.discretized.mixed_integer import (
+    get_discrete_ackley,
+    get_discrete_hartmann,
+    get_discrete_rosenbrock,
+)
 from ax.benchmark.problems.synthetic.hss.jenatton import get_jenatton_benchmark_problem
 from botorch.test_functions import synthetic
 from botorch.test_functions.multi_objective import BraninCurrin
@@ -245,6 +250,16 @@ BENCHMARK_PROBLEM_REGISTRY = {
             "num_trials": 50,
             "observe_noise_sd": True,
         },
+    ),
+    "Discrete Hartmann": BenchmarkProblemRegistryEntry(
+        factory_fn=get_discrete_hartmann,
+        factory_kwargs={},
+    ),
+    "Discrete Ackley": BenchmarkProblemRegistryEntry(
+        factory_fn=get_discrete_ackley, factory_kwargs={}
+    ),
+    "Discrete Rosenbrock": BenchmarkProblemRegistryEntry(
+        factory_fn=get_discrete_rosenbrock, factory_kwargs={}
     ),
 }
 

--- a/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
+++ b/ax/benchmark/problems/synthetic/discretized/mixed_integer.py
@@ -36,6 +36,7 @@ def _get_problem_from_common_inputs(
     benchmark_name: str,
     num_trials: int,
     optimal_value: float,
+    baseline_value: float,
     test_problem_bounds: list[tuple[float, float]] | None = None,
 ) -> BenchmarkProblem:
     """This is a helper that deduplicates common bits of the below problems.
@@ -62,6 +63,7 @@ def _get_problem_from_common_inputs(
             attaining scores of over 100%. One strategy for choosing this value
             is to choose the overall optimum of the problem without regard to
             the integer restrictions.
+        baseline_value: Will be passed to the `BenchmarkProblem`.
         test_problem_bounds: Optional bounds to evaluate the base test problem on.
             These are passed in as `bounds` while initializing the test problem.
 
@@ -104,6 +106,7 @@ def _get_problem_from_common_inputs(
         test_function=test_function,
         num_trials=num_trials,
         optimal_value=optimal_value,
+        baseline_value=baseline_value,
     )
 
 
@@ -136,6 +139,8 @@ def get_discrete_hartmann(
         # optimum without regards to the integer constraints is -3.3224, but
         # that won't be attainable here.
         optimal_value=-3.0,
+        # Baseline values were obtained with `compute_baseline_value_from_sobol`
+        baseline_value=-0.6755184773211834,
     )
 
 
@@ -169,6 +174,7 @@ def get_discrete_ackley(
         # Ackley's lowest value is at (0, 0, ..., 0), which is in the search
         # space, so the restriction to integers doesn't change the optimum
         optimal_value=0.0,
+        baseline_value=3.1869268815137968,
     )
 
 
@@ -196,4 +202,5 @@ def get_discrete_rosenbrock(
         # Rosenbrock's lowest value is at (1, 1, ..., 1), which is in the search
         # space, so the restriction to integers doesn't change the optimum
         optimal_value=0.0,
+        baseline_value=705714.2851460224,
     )

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -16,6 +16,8 @@ from ax.core.search_space import HierarchicalSearchSpace
 from pyre_extensions import none_throws
 
 JENATTON_OPTIMAL_VALUE = 0.1
+# Baseline value was obtained with `compute_baseline_value_from_sobol`
+JENATTON_BASELINE_VALUE = 0.5797074938368603
 
 
 def jenatton_test_function(
@@ -117,4 +119,5 @@ def get_jenatton_benchmark_problem(
         noise_std=noise_std,
         num_trials=num_trials,
         optimal_value=JENATTON_OPTIMAL_VALUE,
+        baseline_value=JENATTON_BASELINE_VALUE,
     )

--- a/ax/benchmark/tests/problems/test_problems.py
+++ b/ax/benchmark/tests/problems/test_problems.py
@@ -29,6 +29,9 @@ class TestProblems(TestCase):
             ("branin_currin_observed_noise", "BraninCurrin_observed_noise"),
             ("branin_currin30_observed_noise", "BraninCurrin_observed_noise_30d"),
             ("levy4", "Levy_4d"),
+        ] + [
+            (name, name)
+            for name in ["Discrete Ackley", "Discrete Hartmann", "Discrete Rosenbrock"]
         ]
         for registry_key, problem_name in expected_names:
             problem = get_problem(problem_key=registry_key)

--- a/ax/benchmark/tests/problems/test_problems.py
+++ b/ax/benchmark/tests/problems/test_problems.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 
+from ax.benchmark.benchmark_problem import BenchmarkProblem
 from ax.benchmark.problems.registry import BENCHMARK_PROBLEM_REGISTRY, get_problem
 from ax.benchmark.problems.runtime_funcs import int_from_params
 from ax.utils.common.testutils import TestCase
@@ -18,7 +19,8 @@ class TestProblems(TestCase):
             if "MNIST" in name:
                 continue  # Skip these as they cause the test to take a long time
 
-            get_problem(problem_key=name)
+            problem = get_problem(problem_key=name)
+            self.assertIsInstance(problem, BenchmarkProblem, msg=name)
 
     def test_name(self) -> None:
         expected_names = [

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -697,6 +697,7 @@ class TestBenchmark(TestCase):
             test_problem_class=Branin,
             test_problem_kwargs={},
             num_trials=1000,  # Unachievable num_trials
+            baseline_value=100,
         )
 
         generation_strategy = get_sobol_botorch_modular_acquisition(
@@ -853,11 +854,9 @@ class TestBenchmark(TestCase):
         problem = create_problem_from_botorch(
             test_problem_class=AugmentedBranin,
             test_problem_kwargs={},
-            # pyre-fixme: Incompatible parameter type [6]: In call
-            # `SearchSpace.__init__`, for 1st positional argument, expected
-            # `List[Parameter]` but got `List[RangeParameter]`.
             search_space=SearchSpace(parameters),
             num_trials=3,
+            baseline_value=3.0,
         )
         params = {"x0": 1.0, "x1": 0.0, "x2": 0.0}
         at_target = assert_is_instance(

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -196,25 +196,25 @@ class TestBenchmark(TestCase):
 
     def test_compute_score_trace(self) -> None:
         opt_trace = np.array([1, 0, -1, 2, float("nan"), 4])
-        num_baseline_trials = 2
 
         with self.subTest("Higher is better"):
             optimal_value = 5
+            baseline_value = 1
             expected_trace = np.array([0, -25, -50, 25, float("nan"), 75.0])
             trace = compute_score_trace(
                 optimization_trace=opt_trace,
-                num_baseline_trials=num_baseline_trials,
+                baseline_value=baseline_value,
                 optimal_value=optimal_value,
             )
             self.assertTrue(np.array_equal(trace, expected_trace, equal_nan=True))
 
         with self.subTest("Lower is better"):
             optimal_value = -1
-            # baseline should be 0
+            baseline_value = 0
             expected_trace = np.array([-100, 0, 100, -200, float("nan"), -400])
             trace = compute_score_trace(
                 optimization_trace=opt_trace,
-                num_baseline_trials=num_baseline_trials,
+                baseline_value=baseline_value,
                 optimal_value=optimal_value,
             )
             self.assertTrue(np.array_equal(trace, expected_trace, equal_nan=True))
@@ -751,7 +751,7 @@ class TestBenchmark(TestCase):
         res = benchmark_replication(problem=problem, method=method, seed=0)
 
         self.assertEqual(problem.num_trials, len(none_throws(res.experiment).trials))
-        self.assertTrue(np.isnan(res.score_trace).all())
+        self.assertFalse(np.isnan(res.score_trace).any())
 
     def test_get_oracle_experiment_from_params(self) -> None:
         problem = create_problem_from_botorch(

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -956,7 +956,6 @@ class TestBenchmark(TestCase):
                 n_repeats=1,
             )
             self.assertEqual(result, 0)
-        return
 
         with self.subTest("SOO, MapData"):
             map_test_function = IdentityTestFunction(n_steps=2)

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -60,6 +60,7 @@ class TestBenchmarkProblem(TestCase):
                 optimization_config=optimization_config,
                 num_trials=1,
                 optimal_value=0.0,
+                baseline_value=1.0,
                 search_space=SearchSpace(parameters=[]),
                 test_function=test_function,
                 n_best_points=2,
@@ -76,6 +77,7 @@ class TestBenchmarkProblem(TestCase):
                 num_trials=1,
                 optimal_value=0.0,
                 search_space=SearchSpace(parameters=[]),
+                baseline_value=1.0,
                 test_function=test_function,
                 n_best_points=1,
                 report_inference_value_as_trace=True,
@@ -102,9 +104,10 @@ class TestBenchmarkProblem(TestCase):
                 name="foo",
                 optimization_config=opt_config,
                 num_trials=1,
-                optimal_value=0.0,
+                optimal_value=1.0,
                 search_space=SearchSpace(parameters=[]),
                 test_function=test_function,
+                baseline_value=0.0,
             )
 
         opt_config = OptimizationConfig(
@@ -130,6 +133,7 @@ class TestBenchmarkProblem(TestCase):
                 optimal_value=0.0,
                 search_space=SearchSpace(parameters=[]),
                 test_function=test_function,
+                baseline_value=1.0,
             )
 
     def test_single_objective_from_botorch(self) -> None:
@@ -138,6 +142,7 @@ class TestBenchmarkProblem(TestCase):
                 test_problem_class=botorch_test_problem.__class__,
                 test_problem_kwargs={},
                 num_trials=1,
+                baseline_value=100.0,
             )
 
             # Test search space
@@ -317,6 +322,7 @@ class TestBenchmarkProblem(TestCase):
             lower_is_better=False,
             num_trials=1,
             test_problem_kwargs={},
+            baseline_value=-8,
         )
         self.assertFalse(test_problem.optimization_config.objective.minimize)
 
@@ -326,7 +332,7 @@ class TestBenchmarkProblem(TestCase):
         ):
             create_problem_from_botorch(
                 test_problem_class=Branin,
-                lower_is_better=False,
+                lower_is_better=True,
                 num_trials=1,
                 test_problem_kwargs={},
                 status_quo_params={"x0": 20.0, "x1": 20.0},

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -65,6 +65,7 @@ def get_single_objective_benchmark_problem(
         report_inference_value_as_trace=report_inference_value_as_trace,
         noise_std=noise_std,
         status_quo_params=status_quo_params,
+        baseline_value=3,
     )
 
 
@@ -80,6 +81,7 @@ def get_multi_objective_benchmark_problem(
         num_trials=num_trials,
         observe_noise_sd=observe_noise_sd,
         report_inference_value_as_trace=report_inference_value_as_trace,
+        baseline_value=0.0,
     )
 
 
@@ -120,6 +122,7 @@ def get_soo_surrogate() -> BenchmarkProblem:
         optimization_config=optimization_config,
         num_trials=6,
         optimal_value=0.0,
+        baseline_value=3.0,
         test_function=test_function,
     )
 
@@ -150,6 +153,7 @@ def get_moo_surrogate() -> BenchmarkProblem:
         optimization_config=optimization_config,
         num_trials=10,
         optimal_value=1.0,
+        baseline_value=0.0,
         test_function=test_function,
     )
 
@@ -357,7 +361,8 @@ def get_async_benchmark_problem(
         optimization_config=optimization_config,
         test_function=test_function,
         num_trials=4,
-        optimal_value=19.0,
+        baseline_value=19 if lower_is_better else 0,
+        optimal_value=0 if lower_is_better else 19,
         step_runtime_function=step_runtime_fn,
     )
 


### PR DESCRIPTION
Summary: These baseline values were introduced in a previous diff but not used to compute scores.

Reviewed By: saitcakmak

Differential Revision: D67054919


