### PR TITLE
Add new GenerationStrategyConfig

### DIFF
--- a/ax/preview/api/client.py
+++ b/ax/preview/api/client.py
@@ -160,12 +160,16 @@ class Client:
         generation_strategy = choose_generation_strategy(
             search_space=self._none_throws_experiment().search_space,
             optimization_config=self._none_throws_experiment().optimization_config,
-            num_trials=generation_strategy_config.num_trials,
             num_initialization_trials=(
-                generation_strategy_config.num_initialization_trials
+                generation_strategy_config.initialization_budget
             ),
-            max_parallelism_cap=generation_strategy_config.maximum_parallelism,
-            random_seed=self._random_seed,
+            min_sobol_trials_observed=(
+                generation_strategy_config.min_observed_initialization_trials
+            ),
+            enforce_sequential_optimization=(
+                not generation_strategy_config.allow_exceeding_initialization_budget
+            ),
+            random_seed=generation_strategy_config.initialization_random_seed,
         )
 
         # Necessary for storage implications, may be removed in the future

--- a/ax/preview/api/configs.py
+++ b/ax/preview/api/configs.py
@@ -7,12 +7,9 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Mapping, Optional, Sequence
+from typing import List, Mapping, Sequence
 
 from ax.preview.api.types import TParameterValue
-
-
-# Note: I'm not sold these should be dataclasses, just using this as a placeholder
 
 
 class ParameterType(Enum):
@@ -83,12 +80,75 @@ class ExperimentConfig:
     owner: str | None = None
 
 
+class GenerationMethod(Enum):
+    """An enum to specify the desired candidate generation method for the experiment.
+    This is used in ``GenerationStrategyConfig``, along with the properties of the
+    experiment, to determine the generation strategy to use for candidate generation.
+
+    NOTE: New options should be rarely added to this enum. This is not intended to be
+    a list of generation strategies for the user to choose from. Instead, this enum
+    should only provide high level guidance to the underlying generation strategy
+    dispatch logic, which is responsible for determinining the exact details.
+
+    Available options are:
+        BALANCED: A balanced generation method that may utilize (per-metric) model
+            selection to achieve a good model accuracy. This method excludes expensive
+            methods, such as the fully Bayesian SAASBO model. Used by default.
+        FAST: A faster generation method that uses the built-in defaults from the
+            Modular BoTorch Model without any model selection.
+        RANDOM_SEARCH: Primarily intended for pure exploration experiments, this
+            method utilizes quasi-random Sobol sequences for candidate generation.
+    """
+
+    BALANCED = "balanced"
+    FAST = "fast"
+    RANDOM_SEARCH = "random_search"
+
+
 @dataclass
 class GenerationStrategyConfig:
-    # This will hold the args to choose_generation_strategy
-    num_trials: Optional[int] = None
-    num_initialization_trials: Optional[int] = None
-    maximum_parallelism: Optional[int] = None
+    """A dataclass used to configure the generation strategy used in the experiment.
+    This is used, along with the properties of the experiment, to determine the
+    generation strategy to use for candidate generation.
+
+    Args:
+        method: The generation method to use. See ``GenerationMethod`` for more details.
+        initialization_budget: The number of trials to use for initialization.
+            If ``None``, a default budget of 5 trials is used.
+        initialization_random_seed: The random seed to use with the Sobol generator
+            that generates the initialization trials.
+        use_existing_trials_for_initialization: Whether to count all trials attached
+            to the experiment as part of the initialization budget. For example,
+            if 2 trials were manually attached to the experiment and this option
+            is set to ``True``, we will only generate `initialization_budget - 2`
+            additional trials for initialization.
+        min_observed_initialization_trials: The minimum required number of
+            initialization trials with observations before the generation strategy
+            is allowed to transition away from the initialization phase.
+            Defaults to `max(1, initialization_budget // 2)`.
+        allow_exceeding_initialization_budget: This option determines the behavior
+            of the generation strategy when the ``initialization_budget`` is exhausted
+            and ``min_observed_initialization_trials`` is not met. If this is ``True``,
+            the generation strategy will generate additional initialization trials when
+            a new trial is requested, exceeding the specified ``initialization_budget``.
+            If this is ``False``, the generation strategy will raise an error and the
+            candidate generation may be continued when additional data is observed
+            for the existing trials.
+        torch_device: The device to use for model fitting and candidate
+            generation in PyTorch / BoTorch based generation nodes.
+            NOTE: This option is not validated. Please ensure that the string
+            input corresponds to a valid device.
+    """
+
+    method: GenerationMethod = GenerationMethod.BALANCED
+    # Initialization options
+    initialization_budget: int | None = None
+    initialization_random_seed: int | None = None
+    use_existing_trials_for_initialization: bool = True
+    min_observed_initialization_trials: int | None = None
+    allow_exceeding_initialization_budget: bool = False
+    # Misc options
+    torch_device: str | None = None
 
 
 @dataclass

--- a/ax/preview/api/tests/test_client.py
+++ b/ax/preview/api/tests/test_client.py
@@ -361,8 +361,7 @@ class TestClient(TestCase):
         client.configure_generation_strategy(
             generation_strategy_config=GenerationStrategyConfig(
                 # Set this to a large number so test runs fast
-                num_initialization_trials=999,
-                maximum_parallelism=5,
+                initialization_budget=999,
             )
         )
 
@@ -383,12 +382,6 @@ class TestClient(TestCase):
         trials = client.get_next_trials(maximum_trials=1, fixed_parameters={"x1": 0.5})
         value = assert_is_instance(trials[3]["x1"], float)
         self.assertEqual(value, 0.5)
-
-        # Test respects max parallelism
-        # Returns 1 even though we asked for 2 because maximum parallelism has been
-        # reached.
-        trials = client.get_next_trials(maximum_trials=2)
-        self.assertEqual(len(trials), 1)
 
     def test_attach_data(self) -> None:
         client = Client()
@@ -929,9 +922,7 @@ class TestClient(TestCase):
         # Set num_initialization_trials=3 so we can reach a predictive GenerationNode
         # quickly
         client.configure_generation_strategy(
-            generation_strategy_config=GenerationStrategyConfig(
-                num_initialization_trials=3
-            )
+            generation_strategy_config=GenerationStrategyConfig(initialization_budget=3)
         )
 
         with self.assertRaisesRegex(ValueError, "but search space has parameters"):


### PR DESCRIPTION
Summary:
Adds the new GenerationStrategyConfig to be used with the future version of the `choose_generation_strategy`.

NOTE: GenerationMode.OPTIMAL is not exposed yet, since the per-metric model selection doesn't yet support mixing fully bayesian & single task models. T209639983

Differential Revision: D67031492


