### PR TITLE
Update model_spec.__repr__

### DIFF
--- a/ax/modelbridge/model_spec.py
+++ b/ax/modelbridge/model_spec.py
@@ -308,10 +308,11 @@ class ModelSpec(SortableBase, SerializationMixin):
         )
         return (
             "ModelSpec("
-            f"\tmodel_enum={self.model_enum.value},\n"
-            f"\tmodel_kwargs={model_kwargs},\n"
-            f"\tmodel_gen_kwargs={model_gen_kwargs},\n"
-            f"\tmodel_cv_kwargs={model_cv_kwargs},\n"
+            f"\tmodel_enum={self.model_enum.value}, "
+            f"\tmodel_kwargs={model_kwargs}, "
+            f"\tmodel_gen_kwargs={model_gen_kwargs}, "
+            f"\tmodel_cv_kwargs={model_cv_kwargs}, "
+            f"\tmodel_key_override={self.model_key_override}"
             ")"
         )
 

--- a/ax/modelbridge/tests/test_generation_node.py
+++ b/ax/modelbridge/tests/test_generation_node.py
@@ -303,20 +303,19 @@ class TestGenerationNode(TestCase):
             ],
         )
         string_rep = str(node)
+
         self.assertEqual(
             string_rep,
-            (
-                "GenerationNode(model_specs=[ModelSpec(model_enum=BoTorch,"
-                " model_kwargs={}, model_gen_kwargs={}, model_cv_kwargs={},"
-                " )], node_name=test, "
-                "transition_criteria=[MinTrials({'threshold': 5, "
-                "'only_in_statuses': [<enum 'TrialStatus'>.RUNNING], "
-                "'not_in_statuses': None, 'transition_to': None, "
-                "'block_transition_if_unmet': True, 'block_gen_if_met': False, "
-                "'use_all_trials_in_exp': False, "
-                "'continue_trial_generation': False, "
-                "'count_only_trials_with_data': False})])"
-            ),
+            "GenerationNode(model_specs=[ModelSpec(model_enum=BoTorch,"
+            " model_kwargs={}, model_gen_kwargs={}, model_cv_kwargs={},"
+            " model_key_override=None)], node_name=test, "
+            "transition_criteria=[MinTrials({'threshold': 5, "
+            "'only_in_statuses': [<enum 'TrialStatus'>.RUNNING], "
+            "'not_in_statuses': None, 'transition_to': None, "
+            "'block_transition_if_unmet': True, 'block_gen_if_met': False, "
+            "'use_all_trials_in_exp': False, "
+            "'continue_trial_generation': False, "
+            "'count_only_trials_with_data': False})])",
         )
 
     def test_single_fixed_features(self) -> None:

--- a/ax/modelbridge/tests/test_generation_strategy.py
+++ b/ax/modelbridge/tests/test_generation_strategy.py
@@ -474,7 +474,7 @@ class TestGenerationStrategy(TestCase):
             "GenerationStrategy(name='test', nodes=[GenerationNode("
             "model_specs=[ModelSpec(model_enum=Sobol, "
             "model_kwargs={}, model_gen_kwargs={}, model_cv_kwargs={},"
-            " )], node_name=test, "
+            " model_key_override=None)], node_name=test, "
             "transition_criteria=[])])",
         )
 

--- a/ax/modelbridge/tests/test_model_spec.py
+++ b/ax/modelbridge/tests/test_model_spec.py
@@ -186,6 +186,23 @@ class ModelSpecTest(BaseModelSpecTest):
         self.assertIsInstance(gen_metadata["model_fit_generalization"], float)
         self.assertIsInstance(gen_metadata["model_std_generalization"], float)
 
+    def test_spec_string_representation(self) -> None:
+        ms = ModelSpec(
+            model_enum=Models.BOTORCH_MODULAR,
+            model_kwargs={"test_model_kwargs": 1},
+            model_gen_kwargs={"test_gen_kwargs": 1},
+            model_cv_kwargs={"test_cv_kwargs": 1},
+        )
+        ms.model_key_override = "test_model_key_override"
+
+        repr_str = repr(ms)
+
+        self.assertNotIn("\n", repr_str)
+        self.assertIn("test_model_kwargs", repr_str)
+        self.assertIn("test_gen_kwargs", repr_str)
+        self.assertIn("test_cv_kwargs", repr_str)
+        self.assertIn("test_model_key_override", repr_str)
+
 
 class FactoryFunctionModelSpecTest(BaseModelSpecTest):
     def test_construct(self) -> None:


### PR DESCRIPTION
Summary:
This change updates the model spec repr in the following ways:
1. Remove \n-s from ModelSpec.__repr__ (having \n-s in there is inconvenient for any other object's __repr__ that needs to include ModelSpec-s as part of the parent object representation)
2. Also add model_key_override to the str representation
3. Adds a corresponding unit test

Note that the generation_node has built in logic to remove new line characters from model_spec, so removing \n won't impact its string representation. 
https://www.internalfb.com/code/fbsource/[50013458b05c]/fbcode/ax/modelbridge/generation_node.py?lines=675
This change generalizes the removal of new lines from ModelSpec.

Reviewed By: bernardbeckerman

Differential Revision: D67153538


