### PR TITLE
Reduce complexity in `wait_for_trials_and_report_results`

### DIFF
--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -5,7 +5,6 @@
 
 # pyre-strict
 
-import warnings
 from dataclasses import dataclass
 
 from ax.core.experiment import Experiment
@@ -64,18 +63,6 @@ class BenchmarkMethod(Base):
     def __post_init__(self) -> None:
         if self.name == "DEFAULT":
             self.name = self.generation_strategy.name
-        early_stopping_strategy = self.early_stopping_strategy
-        if early_stopping_strategy is not None:
-            seconds_between_polls = early_stopping_strategy.seconds_between_polls
-            if seconds_between_polls > 0:
-                warnings.warn(
-                    "`early_stopping_strategy.seconds_between_polls` is "
-                    f"{seconds_between_polls}, but benchmarking uses 0 seconds "
-                    "between polls. Setting "
-                    "`early_stopping_strategy.seconds_between_polls` to 0.",
-                    stacklevel=1,
-                )
-                early_stopping_strategy.seconds_between_polls = 0
 
     def get_best_parameters(
         self,

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -13,7 +13,6 @@ from ax.benchmark.benchmark_problem import (
 )
 from ax.benchmark.methods.sobol import get_sobol_generation_strategy
 from ax.core.experiment import Experiment
-from ax.early_stopping.strategies.threshold import ThresholdEarlyStoppingStrategy
 from ax.utils.common.testutils import TestCase
 from pyre_extensions import none_throws
 
@@ -43,14 +42,6 @@ class TestBenchmarkMethod(TestCase):
                 none_throws(node.model_spec_to_gen_from.model_kwargs).get(
                     "fit_tracking_metrics"
                 )
-            )
-
-    def test_raises_when_ess_polls_with_delay(self) -> None:
-        ess = ThresholdEarlyStoppingStrategy(seconds_between_polls=10)
-        with self.assertWarnsRegex(Warning, "seconds_between_polls"):
-            BenchmarkMethod(
-                generation_strategy=self.gs,
-                early_stopping_strategy=ess,
             )
 
     def test_get_best_parameters(self) -> None:

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -70,7 +70,6 @@ class BaseEarlyStoppingStrategy(ABC, Base):
     def __init__(
         self,
         metric_names: Iterable[str] | None = None,
-        seconds_between_polls: int = 300,
         min_progression: float | None = None,
         max_progression: float | None = None,
         min_curves: int | None = None,
@@ -82,8 +81,6 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         Args:
             metric_names: The names of the metrics the strategy will interact with.
                 If no metric names are provided the objective metric is assumed.
-            seconds_between_polls: How often to poll the early stopping metric to
-                evaluate whether or not the trial should be early stopped.
             min_progression: Only stop trials if the latest progression value
                 (e.g. timestamp, epochs, training data used) is greater than this
                 threshold. Prevents stopping prematurely before enough data is gathered
@@ -103,10 +100,7 @@ class BaseEarlyStoppingStrategy(ABC, Base):
                 should be > 0 to ensure that at least one trial has completed and that
                 we have a reliable approximation for `prog_max`.
         """
-        if seconds_between_polls < 0:
-            raise ValueError("`seconds_between_polls may not be less than 0.")
         self.metric_names = metric_names
-        self.seconds_between_polls = seconds_between_polls
         self.min_progression = min_progression
         self.max_progression = max_progression
         self.min_curves = min_curves
@@ -446,7 +440,6 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
     def __init__(
         self,
         metric_names: Iterable[str] | None = None,
-        seconds_between_polls: int = 300,
         min_progression: float | None = None,
         max_progression: float | None = None,
         min_curves: int | None = None,
@@ -459,8 +452,6 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         Args:
             metric_names: The names of the metrics the strategy will interact with.
                 If no metric names are provided the objective metric is assumed.
-            seconds_between_polls: How often to poll the early stopping metric to
-                evaluate whether or not the trial should be early stopped.
             min_progression: Only stop trials if the latest progression value
                 (e.g. timestamp, epochs, training data used) is greater than this
                 threshold. Prevents stopping prematurely before enough data is gathered
@@ -485,7 +476,6 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         """
         super().__init__(
             metric_names=metric_names,
-            seconds_between_polls=seconds_between_polls,
             min_progression=min_progression,
             max_progression=max_progression,
             min_curves=min_curves,

--- a/ax/early_stopping/strategies/logical.py
+++ b/ax/early_stopping/strategies/logical.py
@@ -19,11 +19,8 @@ class LogicalEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         self,
         left: BaseEarlyStoppingStrategy,
         right: BaseEarlyStoppingStrategy,
-        seconds_between_polls: int = 300,
     ) -> None:
-        super().__init__(
-            seconds_between_polls=seconds_between_polls,
-        )
+        super().__init__()
 
         self.left = left
         self.right = right

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -28,7 +28,6 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
     def __init__(
         self,
         metric_names: Iterable[str] | None = None,
-        seconds_between_polls: int = 300,
         percentile_threshold: float = 50.0,
         min_progression: float | None = 10,
         max_progression: float | None = None,
@@ -42,8 +41,6 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             metric_names: A (length-one) list of name of the metric to observe. If
                 None will default to the objective metric on the Experiment's
                 OptimizationConfig.
-            seconds_between_polls: How often to poll the early stopping metric to
-                evaluate whether or not the trial should be early stopped.
             percentile_threshold: Falling below this threshold compared to other trials
                 at the same step will stop the run. Must be between 0.0 and 100.0.
                 e.g. if percentile_threshold=25.0, the bottom 25% of trials are stopped.
@@ -71,7 +68,6 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         """
         super().__init__(
             metric_names=metric_names,
-            seconds_between_polls=seconds_between_polls,
             trial_indices_to_ignore=trial_indices_to_ignore,
             min_progression=min_progression,
             max_progression=max_progression,

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -25,7 +25,6 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
     def __init__(
         self,
         metric_names: Iterable[str] | None = None,
-        seconds_between_polls: int = 300,
         metric_threshold: float = 0.2,
         min_progression: float | None = 10,
         max_progression: float | None = None,
@@ -39,8 +38,6 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             metric_names: A (length-one) list of name of the metric to observe. If
                 None will default to the objective metric on the Experiment's
                 OptimizationConfig.
-            seconds_between_polls: How often to poll the early stopping metric to
-                evaluate whether or not the trial should be early stopped.
             metric_threshold: The metric threshold that a trial needs to reach by
                 min_progression in order not to be stopped.
             min_progression: Only stop trials if the latest progression value
@@ -64,7 +61,6 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         """
         super().__init__(
             metric_names=metric_names,
-            seconds_between_polls=seconds_between_polls,
             min_progression=min_progression,
             max_progression=max_progression,
             min_curves=min_curves,

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -1479,9 +1479,7 @@ class AxSchedulerTestCase(TestCase):
             generation_strategy=gs,
             options=SchedulerOptions(
                 init_seconds_between_polls=0,
-                early_stopping_strategy=OddIndexEarlyStoppingStrategy(
-                    seconds_between_polls=1
-                ),
+                early_stopping_strategy=OddIndexEarlyStoppingStrategy(),
                 fetch_kwargs={
                     "overwrite_existing_data": False,
                 },
@@ -2933,3 +2931,16 @@ class AxSchedulerTestCase(TestCase):
         self.assertEqual(
             scheduler.markdown_messages["Generation strategy"].priority, 10
         )
+
+    def test_seconds_between_polls_backoff_factor_is_set(self) -> None:
+        options = SchedulerOptions(
+            **self.scheduler_options_kwargs,
+        )
+
+        self.assertEqual(options.seconds_between_polls_backoff_factor, 1.5)
+
+        options_with_ess = SchedulerOptions(
+            early_stopping_strategy=DummyEarlyStoppingStrategy(),
+            **self.scheduler_options_kwargs,
+        )
+        self.assertEqual(options_with_ess.seconds_between_polls_backoff_factor, 1.0)

--- a/ax/service/utils/scheduler_options.py
+++ b/ax/service/utils/scheduler_options.py
@@ -147,3 +147,7 @@ class SchedulerOptions:
     enforce_immutable_search_space_and_opt_config: bool = True
     mt_experiment_trial_type: str | None = None
     force_candidate_generation: bool = False
+
+    def __post_init__(self) -> None:
+        if self.early_stopping_strategy is not None:
+            object.__setattr__(self, "seconds_between_polls_backoff_factor", 1)

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -639,7 +639,6 @@ def percentile_early_stopping_strategy_to_dict(
         "min_progression": strategy.min_progression,
         "min_curves": strategy.min_curves,
         "trial_indices_to_ignore": strategy.trial_indices_to_ignore,
-        "seconds_between_polls": strategy.seconds_between_polls,
         "normalize_progressions": strategy.normalize_progressions,
     }
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2153,7 +2153,6 @@ def get_or_early_stopping_strategy() -> OrEarlyStoppingStrategy:
 class DummyEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
     def __init__(self, early_stop_trials: dict[int, str | None] | None = None) -> None:
         self.early_stop_trials: dict[int, str | None] = early_stop_trials or {}
-        self.seconds_between_polls = 1
 
     def should_stop_trials_early(
         self,


### PR DESCRIPTION
Summary:
This diff contains the following changes:
1. Deprecates ESSs `seconds_between_polls`, as we can leverage SchedulerOption's `init_seconds_between_polls` instead
2. Set SchedulerOption's `seconds_between_polls_backoff_factor` to 1 if an ESS is provided
3. Use a try-catch in `wait_for_completed_trials_and_report_results` when doing `idle_callback`, so it doesn't fail the Scheduler

Differential Revision: D67178422


