### PR TITLE
Implement new choose_generation_strategy based on GenerationStrategyConfig

### DIFF
--- a/ax/preview/api/client.py
+++ b/ax/preview/api/client.py
@@ -15,9 +15,7 @@ from ax.analysis.markdown.markdown_analysis import (
     markdown_analysis_card_from_analysis_e,
 )
 from ax.analysis.utils import choose_analyses
-
 from ax.core.base_trial import TrialStatus  # Used as a return type
-
 from ax.core.experiment import Experiment
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
@@ -28,9 +26,7 @@ from ax.core.trial import Trial
 from ax.core.utils import get_pending_observation_features_based_on_trial_status
 from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
 from ax.exceptions.core import UnsupportedError, UserInputError
-from ax.modelbridge.dispatch_utils import choose_generation_strategy
 from ax.modelbridge.generation_strategy import GenerationStrategy
-
 from ax.preview.api.configs import (
     DatabaseConfig,
     ExperimentConfig,
@@ -44,6 +40,7 @@ from ax.preview.api.utils.instantiation.from_config import experiment_from_confi
 from ax.preview.api.utils.instantiation.from_string import (
     optimization_config_from_string,
 )
+from ax.preview.modelbridge.dispatch_utils import choose_generation_strategy
 from ax.service.scheduler import Scheduler, SchedulerOptions
 from ax.utils.common.logger import get_logger
 from ax.utils.common.random import with_rng_seed
@@ -158,18 +155,7 @@ class Client:
         """
 
         generation_strategy = choose_generation_strategy(
-            search_space=self._none_throws_experiment().search_space,
-            optimization_config=self._none_throws_experiment().optimization_config,
-            num_initialization_trials=(
-                generation_strategy_config.initialization_budget
-            ),
-            min_sobol_trials_observed=(
-                generation_strategy_config.min_observed_initialization_trials
-            ),
-            enforce_sequential_optimization=(
-                not generation_strategy_config.allow_exceeding_initialization_budget
-            ),
-            random_seed=generation_strategy_config.initialization_random_seed,
+            gs_config=generation_strategy_config
         )
 
         # Necessary for storage implications, may be removed in the future

--- a/ax/preview/modelbridge/__init__.py
+++ b/ax/preview/modelbridge/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/ax/preview/modelbridge/dispatch_utils.py
+++ b/ax/preview/modelbridge/dispatch_utils.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from ax.core.base_trial import TrialStatus
+from ax.exceptions.core import UnsupportedError
+from ax.modelbridge.generation_strategy import GenerationNode, GenerationStrategy
+from ax.modelbridge.model_spec import ModelSpec
+from ax.modelbridge.registry import Models
+from ax.modelbridge.transition_criterion import MinTrials
+from ax.models.torch.botorch_modular.surrogate import ModelConfig, SurrogateSpec
+from ax.preview.api.configs import GenerationMethod, GenerationStrategyConfig
+from botorch.models.transforms.input import Warp
+from gpytorch.kernels.linear_kernel import LinearKernel
+
+
+def _get_sobol_node(
+    gs_config: GenerationStrategyConfig,
+) -> GenerationNode:
+    """Constructs a Sobol node based on inputs from ``gs_config``.
+    The Sobol generator utilizes `initialization_random_seed` if specified.
+
+    This node always transitions to "MBM", using the following transition criteria:
+    - MinTrials enforcing the initialization budget.
+        - If the initialization budget is not specified, it defaults to 5.
+        - The TC will not block generation if `allow_exceeding_initialization_budget`
+            is set to True.
+        - The TC is currently not restricted to any trial statuses and will
+            count all trials.
+        - `use_existing_trials_for_initialization` controls whether trials previously
+            attached to the experiment are counted as part of the initialization budget.
+    - MinTrials enforcing the minimum number of observed initialization trials.
+        - If `min_observed_initialization_trials` is not specified, it defaults
+            to `max(1, initialization_budget // 2)`.
+        - The TC currently only counts trials in status COMPLETED (with data attached)
+            as observed trials.
+        - `use_existing_trials_for_initialization` controls whether trials previously
+            attached to the experiment are counted as part of the required number of
+            observed initialization trials.
+    """
+    # Set the default options.
+    initialization_budget = gs_config.initialization_budget
+    if initialization_budget is None:
+        initialization_budget = 5
+    min_observed_initialization_trials = gs_config.min_observed_initialization_trials
+    if min_observed_initialization_trials is None:
+        min_observed_initialization_trials = max(1, initialization_budget // 2)
+    # Construct the transition criteria.
+    transition_criteria = [
+        MinTrials(  # This represents the initialization budget.
+            threshold=initialization_budget,
+            transition_to="MBM",
+            block_gen_if_met=(not gs_config.allow_exceeding_initialization_budget),
+            block_transition_if_unmet=True,
+            use_all_trials_in_exp=gs_config.use_existing_trials_for_initialization,
+        ),
+        MinTrials(  # This represents minimum observed trials requirement.
+            threshold=min_observed_initialization_trials,
+            transition_to="MBM",
+            block_gen_if_met=False,
+            block_transition_if_unmet=True,
+            use_all_trials_in_exp=gs_config.use_existing_trials_for_initialization,
+            only_in_statuses=[TrialStatus.COMPLETED],
+            count_only_trials_with_data=True,
+        ),
+    ]
+    return GenerationNode(
+        node_name="Sobol",
+        model_specs=[
+            ModelSpec(
+                model_enum=Models.SOBOL,
+                model_kwargs={"seed": gs_config.initialization_random_seed},
+            )
+        ],
+        transition_criteria=transition_criteria,
+        should_deduplicate=True,
+    )
+
+
+def _get_mbm_node(
+    gs_config: GenerationStrategyConfig,
+) -> GenerationNode:
+    """Constructs an MBM node based on the method specified in ``gs_config``.
+
+    The ``SurrogateSpec`` takes the following form for the given method:
+    - BALANCED: Two model configs: one with MBM defaults, the other with
+        linear kernel with input warping.
+    - FAST: An empty model config that utilizes MBM defaults.
+    """
+    # Construct the surrogate spec.
+    if gs_config.method == GenerationMethod.FAST:
+        model_configs = [ModelConfig(name="MBM defaults")]
+    elif gs_config.method == GenerationMethod.BALANCED:
+        model_configs = [
+            ModelConfig(name="MBM defaults"),
+            ModelConfig(
+                covar_module_class=LinearKernel,
+                input_transform_classes=[Warp],
+                name="LinearKernel with Warp",
+            ),
+        ]
+    else:
+        raise UnsupportedError(f"Unsupported generation method: {gs_config.method}.")
+    torch_device = (
+        None if gs_config.torch_device is None else torch.device(gs_config.torch_device)
+    )
+    return GenerationNode(
+        node_name="MBM",
+        model_specs=[
+            ModelSpec(
+                model_enum=Models.BOTORCH_MODULAR,
+                model_kwargs={
+                    "surrogate_spec": SurrogateSpec(model_configs=model_configs),
+                    "torch_device": torch_device,
+                },
+            )
+        ],
+        should_deduplicate=True,
+    )
+
+
+def choose_generation_strategy(
+    gs_config: GenerationStrategyConfig,
+) -> GenerationStrategy:
+    """Choose a generation strategy based on the properties of the experiment
+    and the inputs provided in ``gs_config``.
+
+    NOTE: The behavior of this function is subject to change. It will be updated to
+    produce best general purpose generation strategies based on benchmarking results.
+
+    Args:
+        gs_config: A ``GenerationStrategyConfig`` object that informs
+            the choice of generation strategy.
+
+    Returns:
+        A generation strategy.
+    """
+    # Handle the random search case.
+    if gs_config.method == GenerationMethod.RANDOM_SEARCH:
+        return GenerationStrategy(
+            name="QuasiRandomSearch",
+            nodes=[
+                GenerationNode(
+                    node_name="Sobol",
+                    model_specs=[
+                        ModelSpec(
+                            model_enum=Models.SOBOL,
+                            model_kwargs={"seed": gs_config.initialization_random_seed},
+                        )
+                    ],
+                )
+            ],
+        )
+    # Construct the nodes.
+    sobol_node = _get_sobol_node(gs_config)
+    # Construct the MBM node.
+    mbm_node = _get_mbm_node(gs_config)
+    method_str = gs_config.method.value
+    return GenerationStrategy(
+        name=f"Sobol+MBM:{method_str}",
+        nodes=[sobol_node, mbm_node],
+    )

--- a/ax/preview/modelbridge/tests/test_dispatch_utils.py
+++ b/ax/preview/modelbridge/tests/test_dispatch_utils.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+from ax.core.base_trial import TrialStatus
+from ax.core.trial import Trial
+from ax.modelbridge.registry import Models
+from ax.modelbridge.transition_criterion import MinTrials
+from ax.models.torch.botorch_modular.surrogate import ModelConfig, SurrogateSpec
+from ax.preview.api.configs import GenerationMethod, GenerationStrategyConfig
+from ax.preview.modelbridge.dispatch_utils import choose_generation_strategy
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import (
+    get_branin_experiment,
+    get_experiment_with_observations,
+)
+from ax.utils.testing.mock import mock_botorch_optimize
+from ax.utils.testing.utils import run_trials_with_gs
+from botorch.models.transforms.input import Warp
+from gpytorch.kernels.linear_kernel import LinearKernel
+from pyre_extensions import assert_is_instance, none_throws
+
+
+class TestDispatchUtils(TestCase):
+    def test_choose_gs_random_search(self) -> None:
+        gs_config = GenerationStrategyConfig(
+            method=GenerationMethod.RANDOM_SEARCH,
+        )
+        gs = choose_generation_strategy(gs_config=gs_config)
+        self.assertEqual(len(gs._nodes), 1)
+        sobol_node = gs._nodes[0]
+        self.assertEqual(len(sobol_node.model_specs), 1)
+        sobol_spec = sobol_node.model_specs[0]
+        self.assertEqual(sobol_spec.model_enum, Models.SOBOL)
+        self.assertEqual(sobol_spec.model_kwargs, {"seed": None})
+        self.assertEqual(sobol_node._transition_criteria, [])
+        # Make sure it generates.
+        run_trials_with_gs(experiment=get_branin_experiment(), gs=gs, num_trials=3)
+
+    @mock_botorch_optimize
+    def test_choose_gs_fast_with_options(self) -> None:
+        gs_config = GenerationStrategyConfig(
+            method=GenerationMethod.FAST,
+            initialization_budget=3,
+            initialization_random_seed=0,
+            use_existing_trials_for_initialization=False,
+            min_observed_initialization_trials=4,
+            allow_exceeding_initialization_budget=True,
+            torch_device="cpu",
+        )
+        gs = choose_generation_strategy(gs_config=gs_config)
+        self.assertEqual(len(gs._nodes), 2)
+        # Check the Sobol node & TC.
+        sobol_node = gs._nodes[0]
+        self.assertTrue(sobol_node.should_deduplicate)
+        self.assertEqual(len(sobol_node.model_specs), 1)
+        sobol_spec = sobol_node.model_specs[0]
+        self.assertEqual(sobol_spec.model_enum, Models.SOBOL)
+        self.assertEqual(sobol_spec.model_kwargs, {"seed": 0})
+        expected_tc = [
+            MinTrials(
+                threshold=3,
+                transition_to="MBM",
+                block_gen_if_met=False,
+                block_transition_if_unmet=True,
+                use_all_trials_in_exp=False,
+            ),
+            MinTrials(
+                threshold=4,
+                transition_to="MBM",
+                block_gen_if_met=False,
+                block_transition_if_unmet=True,
+                use_all_trials_in_exp=False,
+                only_in_statuses=[TrialStatus.COMPLETED],
+                count_only_trials_with_data=True,
+            ),
+        ]
+        self.assertEqual(sobol_node._transition_criteria, expected_tc)
+        # Check the MBM node.
+        mbm_node = gs._nodes[1]
+        self.assertTrue(mbm_node.should_deduplicate)
+        self.assertEqual(len(mbm_node.model_specs), 1)
+        mbm_spec = mbm_node.model_specs[0]
+        self.assertEqual(mbm_spec.model_enum, Models.BOTORCH_MODULAR)
+        expected_ss = SurrogateSpec(model_configs=[ModelConfig(name="MBM defaults")])
+        self.assertEqual(
+            mbm_spec.model_kwargs,
+            {"surrogate_spec": expected_ss, "torch_device": torch.device("cpu")},
+        )
+        self.assertEqual(mbm_node._transition_criteria, [])
+        # Experiment with 2 observations. We should still generate 4 Sobol trials.
+        experiment = get_experiment_with_observations([[1.0], [2.0]])
+        # Mark the existing trials as manual to prevent them from counting for Sobol.
+        for trial in experiment.trials.values():
+            none_throws(
+                assert_is_instance(trial, Trial).generator_run
+            )._model_key = "Manual"
+        # Generate 5 trials and make sure they're from the correct nodes.
+        run_trials_with_gs(experiment=experiment, gs=gs, num_trials=5)
+        self.assertEqual(len(experiment.trials), 7)
+        for trial in experiment.trials.values():
+            model_key = none_throws(
+                assert_is_instance(trial, Trial).generator_run
+            )._model_key
+            if trial.index < 2:
+                self.assertEqual(model_key, "Manual")
+            elif trial.index < 6:
+                self.assertEqual(model_key, "Sobol")
+            else:
+                self.assertEqual(model_key, "BoTorch")
+
+    @mock_botorch_optimize
+    def test_choose_gs_defaults(self) -> None:
+        gs = choose_generation_strategy(gs_config=GenerationStrategyConfig())
+        self.assertEqual(len(gs._nodes), 2)
+        # Check the Sobol node & TC.
+        sobol_node = gs._nodes[0]
+        self.assertTrue(sobol_node.should_deduplicate)
+        self.assertEqual(len(sobol_node.model_specs), 1)
+        sobol_spec = sobol_node.model_specs[0]
+        self.assertEqual(sobol_spec.model_enum, Models.SOBOL)
+        self.assertEqual(sobol_spec.model_kwargs, {"seed": None})
+        expected_tc = [
+            MinTrials(
+                threshold=5,
+                transition_to="MBM",
+                block_gen_if_met=True,
+                block_transition_if_unmet=True,
+                use_all_trials_in_exp=True,
+            ),
+            MinTrials(
+                threshold=2,
+                transition_to="MBM",
+                block_gen_if_met=False,
+                block_transition_if_unmet=True,
+                use_all_trials_in_exp=True,
+                only_in_statuses=[TrialStatus.COMPLETED],
+                count_only_trials_with_data=True,
+            ),
+        ]
+        self.assertEqual(sobol_node._transition_criteria, expected_tc)
+        # Check the MBM node.
+        mbm_node = gs._nodes[1]
+        self.assertTrue(mbm_node.should_deduplicate)
+        self.assertEqual(len(mbm_node.model_specs), 1)
+        mbm_spec = mbm_node.model_specs[0]
+        self.assertEqual(mbm_spec.model_enum, Models.BOTORCH_MODULAR)
+        expected_ss = SurrogateSpec(
+            model_configs=[
+                ModelConfig(name="MBM defaults"),
+                ModelConfig(
+                    covar_module_class=LinearKernel,
+                    input_transform_classes=[Warp],
+                    name="LinearKernel with Warp",
+                ),
+            ]
+        )
+        self.assertEqual(
+            mbm_spec.model_kwargs, {"surrogate_spec": expected_ss, "torch_device": None}
+        )
+        self.assertEqual(mbm_node._transition_criteria, [])
+        # Experiment with 2 observations. We should generate 3 more Sobol trials.
+        experiment = get_experiment_with_observations([[1.0], [2.0]])
+        # Mark the existing trials as manual to prevent them from counting for Sobol.
+        # They'll still count for TC, since we use all trials in the experiment.
+        for trial in experiment.trials.values():
+            none_throws(
+                assert_is_instance(trial, Trial).generator_run
+            )._model_key = "Manual"
+        # Generate 5 trials and make sure they're from the correct nodes.
+        run_trials_with_gs(experiment=experiment, gs=gs, num_trials=5)
+        self.assertEqual(len(experiment.trials), 7)
+        for trial in experiment.trials.values():
+            model_key = none_throws(
+                assert_is_instance(trial, Trial).generator_run
+            )._model_key
+            if trial.index < 2:
+                self.assertEqual(model_key, "Manual")
+            elif trial.index < 5:
+                self.assertEqual(model_key, "Sobol")
+            else:
+                self.assertEqual(model_key, "BoTorch")

--- a/sphinx/source/preview.rst
+++ b/sphinx/source/preview.rst
@@ -77,3 +77,20 @@ From String
     :members:
     :undoc-members:
     :show-inheritance:
+
+
+ModelBridge
+~~~~~~~~~~~
+
+.. automodule:: ax.preview.modelbridge
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Dispatch Utils
+~~~~~~~~~~~~~~
+
+.. automodule:: ax.preview.modelbridge.dispatch_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Summary:
Implements a new `choose_generation_strategy` helper that constructs a `GenerationStrategy` based on options specified in `GenerationStrategyConfig`.

The `choose_generation_strategy` helper will not be part of the API itself, but it will be utilized by the new `Client` via the `configure_generation_strategy` method.

Differential Revision: D67037776


