### PR TITLE
`BraninMapMetric` with power law decay

### DIFF
--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from random import random
 from typing import Any
 
@@ -25,7 +25,6 @@ from ax.metrics.noisy_function_map import NoisyFunctionMapMetric
 from ax.utils.common.result import Err, Ok
 from ax.utils.common.typeutils import checked_cast
 from ax.utils.measurement.synthetic_functions import branin
-from pyre_extensions import none_throws
 
 FIDELITY = [0.1, 0.4, 0.7, 1.0]
 
@@ -39,12 +38,15 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
         lower_is_better: bool | None = None,
         rate: float | None = None,
         cache_evaluations: bool = True,
+        decay_function_name: str = "exp_decay",
     ) -> None:
-        """A Branin map metric with an optional multiplicative factor
-        of `1 + exp(-rate * t)` where `t` is the runtime of the trial.
-        If the multiplicative factor is used, then at `t = 0`, the function
-        is twice the usual value, while as `t` becomes large, the values
-        approach the standard Branin values.
+        """A Branin map metric with an optional multiplicative factor of
+        `1 + decay_function(rate * t)` where `t` is the runtime of the trial.
+        `decay_function` is a function of the form `f: float -> float`, either
+        an exponential decay or a power law decay, and `rate` is the parameter that
+        controls the rate of decay. The functions decay to zero as `t` increases.
+        If the multiplicative factor is used, the function is `1 + f(0)` times the usual
+        value at `t = 0`, and approaches standard Branin values as `t` grows large.
 
         Args:
             name: Name of the metric.
@@ -53,8 +55,24 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
             noise_sd: Scale of normal noise added to the function result.
             lower_is_better: Flag for metrics which should be minimized.
             rate: Parameter of the multiplicative factor.
+            decay_function_name: The name of the function used to decay the
+                multiplicative factor. Options: "exp_decay", and "pow_decay".
         """
         self.rate = rate
+        self.decay_function_name = decay_function_name
+
+        def _exp_decay(x: float) -> float:
+            return math.exp(-x)
+
+        def _pow_decay(x: float) -> float:
+            return max(x, 1e-3) ** (-1 / np.pi)
+
+        decay_functions = {"exp_decay": _exp_decay, "pow_decay": _pow_decay}
+
+        self._decay_function: Callable[[float], float] = decay_functions[
+            decay_function_name
+        ]
+
         # pyre-fixme[4]: Attribute must be annotated.
         self._trial_index_to_timestamp = defaultdict(int)
 
@@ -123,7 +141,7 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
         x1, x2 = x
 
         if self.rate is not None:
-            weight = 1.0 + np.exp(-none_throws(self.rate) * timestamp)
+            weight = 1.0 + self._decay_function(self.rate * timestamp)
         else:
             weight = 1.0
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -371,12 +371,17 @@ def get_robust_branin_experiment(
     return exp
 
 
-def get_map_metric(name: str, rate: float | None = None) -> BraninTimestampMapMetric:
+def get_map_metric(
+    name: str,
+    rate: float | None = None,
+    decay_function_name: str = "exp_decay",
+) -> BraninTimestampMapMetric:
     return BraninTimestampMapMetric(
         name=name,
         param_names=["x1", "x2"],
         rate=rate,
         lower_is_better=True,
+        decay_function_name=decay_function_name,
     )
 
 
@@ -384,9 +389,14 @@ def get_branin_experiment_with_timestamp_map_metric(
     with_status_quo: bool = False,
     rate: float | None = None,
     map_tracking_metric: bool = False,
+    decay_function_name: str = "exp_decay",
 ) -> Experiment:
     tracking_metric = (
-        get_map_metric(name="tracking_branin_map", rate=rate)
+        get_map_metric(
+            name="tracking_branin_map",
+            rate=rate,
+            decay_function_name=decay_function_name,
+        )
         if map_tracking_metric
         else BraninMetric(name="branin", param_names=["x1", "x2"], lower_is_better=True)
     )
@@ -395,7 +405,12 @@ def get_branin_experiment_with_timestamp_map_metric(
         search_space=get_branin_search_space(),
         optimization_config=OptimizationConfig(
             objective=Objective(
-                metric=get_map_metric(name="branin_map", rate=rate), minimize=True
+                metric=get_map_metric(
+                    name="branin_map",
+                    rate=rate,
+                    decay_function_name=decay_function_name,
+                ),
+                minimize=True,
             )
         ),
         tracking_metrics=[tracking_metric],


### PR DESCRIPTION
Summary: Adds flexibility to specify a power law decay function for `BraninMapMetric`.

Reviewed By: saitcakmak

Differential Revision: D67304462


