### PR TITLE
Serialization for new metric classes

### DIFF
--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -12,7 +12,12 @@ from typing import Any
 
 import torch
 from ax.benchmark.benchmark_method import BenchmarkMethod
-from ax.benchmark.benchmark_metric import BenchmarkMapMetric, BenchmarkMetric
+from ax.benchmark.benchmark_metric import (
+    BenchmarkMapMetric,
+    BenchmarkMapUnavailableWhileRunningMetric,
+    BenchmarkMetric,
+    BenchmarkTimeVaryingMetric,
+)
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
 from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
 from ax.core import Experiment, ObservationFeatures
@@ -192,6 +197,8 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     BatchTrial: batch_to_dict,
     BenchmarkMetric: metric_to_dict,
     BenchmarkMapMetric: metric_to_dict,
+    BenchmarkTimeVaryingMetric: metric_to_dict,
+    BenchmarkMapUnavailableWhileRunningMetric: metric_to_dict,
     BoTorchModel: botorch_model_to_dict,
     BraninMetric: metric_to_dict,
     BraninTimestampMapMetric: metric_to_dict,
@@ -299,6 +306,10 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "BenchmarkMethod": BenchmarkMethod,
     "BenchmarkMetric": BenchmarkMetric,
     "BenchmarkMapMetric": BenchmarkMapMetric,
+    "BenchmarkTimeVaryingMetric": BenchmarkTimeVaryingMetric,
+    "BenchmarkMapUnavailableWhileRunningMetric": (
+        BenchmarkMapUnavailableWhileRunningMetric
+    ),
     "BenchmarkResult": BenchmarkResult,
     "BenchmarkTrialMetadata": BenchmarkTrialMetadata,
     "BoTorchModel": BoTorchModel,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -51,8 +51,10 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import (
     get_aggregated_benchmark_result,
     get_benchmark_map_metric,
+    get_benchmark_map_unavailable_while_running_metric,
     get_benchmark_metric,
     get_benchmark_result,
+    get_benchmark_time_varying_metric,
 )
 from ax.utils.testing.core_stubs import (
     get_abandoned_arm,
@@ -154,6 +156,11 @@ TEST_CASES = [
     ),
     ("BenchmarkMetric", get_benchmark_metric),
     ("BenchmarkMapMetric", get_benchmark_map_metric),
+    ("BenchmarkTimeVaryingMetric", get_benchmark_time_varying_metric),
+    (
+        "BenchmarkMapUnavailableWhileRunningMetric",
+        get_benchmark_map_unavailable_while_running_metric,
+    ),
     ("BenchmarkResult", get_benchmark_result),
     ("BoTorchModel", get_botorch_model),
     ("BoTorchModel", get_botorch_model_with_default_acquisition_class),

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -12,7 +12,12 @@ from typing import Any, Iterator
 import numpy as np
 import torch
 from ax.benchmark.benchmark_method import BenchmarkMethod
-from ax.benchmark.benchmark_metric import BenchmarkMapMetric, BenchmarkMetric
+from ax.benchmark.benchmark_metric import (
+    BenchmarkMapMetric,
+    BenchmarkMapUnavailableWhileRunningMetric,
+    BenchmarkMetric,
+    BenchmarkTimeVaryingMetric,
+)
 from ax.benchmark.benchmark_problem import (
     BenchmarkProblem,
     create_problem_from_botorch,
@@ -373,3 +378,13 @@ def get_benchmark_metric() -> BenchmarkMetric:
 
 def get_benchmark_map_metric() -> BenchmarkMapMetric:
     return BenchmarkMapMetric(name="test", lower_is_better=True)
+
+
+def get_benchmark_time_varying_metric() -> BenchmarkTimeVaryingMetric:
+    return BenchmarkTimeVaryingMetric(name="test", lower_is_better=True)
+
+
+def get_benchmark_map_unavailable_while_running_metric() -> (
+    BenchmarkMapUnavailableWhileRunningMetric
+):
+    return BenchmarkMapUnavailableWhileRunningMetric(name="test", lower_is_better=True)


### PR DESCRIPTION
Summary: Adds serialization for `BenchmarkTimeVaryingMetric` and `BenchmarkMapUnavailableWhileRunningMetric`, similar to D66429055

Reviewed By: saitcakmak

Differential Revision: D67476621


