### PR TITLE
Bug fix: Correctly add noise to benchmark problems

### DIFF
--- a/ax/benchmark/benchmark_runner.py
+++ b/ax/benchmark/benchmark_runner.py
@@ -110,7 +110,7 @@ def _add_noise(
         else:
             df["sem"] = noise_std_ser
 
-        df["mean"] = df["Y_true"] + np.random.normal(len(df)) * df["sem"]
+        df["mean"] = df["Y_true"] + np.random.normal(loc=0, scale=df["sem"])
 
     else:
         df["sem"] = 0.0


### PR DESCRIPTION
Summary:
There was this piece of incorrect logic:

```
df["mean"] = df["Y_true"] + np.random.normal(len(df)) * df["sem"]
```

`len(df)` is not the size/shape parameter; it's the mean. So this generates one single normal draw with mean `len(df)` and variance 1, then multiplies it by `df["sem"]`.

This diff fixes that.

Reviewed By: saitcakmak

Differential Revision: D67521651


