### PR TITLE
Use model-recommended best points in ax/service/utils/best_point with discrete models

### DIFF
--- a/ax/modelbridge/discrete.py
+++ b/ax/modelbridge/discrete.py
@@ -170,19 +170,22 @@ class DiscreteModelBridge(ModelBridge):
             pending_observations=pending_array,
             model_gen_options=model_gen_options,
         )
-        observation_features = []
-        for x in X:
-            observation_features.append(
-                ObservationFeatures(
-                    parameters={p: x[i] for i, p in enumerate(self.parameters)}
-                )
+        observation_features = [
+            ObservationFeatures(parameters=dict(zip(self.parameters, x))) for x in X
+        ]
+
+        if "best_x" in gen_metadata:
+            best_observation_features = ObservationFeatures(
+                parameters=dict(zip(self.parameters, gen_metadata["best_x"]))
             )
-        # TODO[drfreund, bletham]: implement best_point identification and
-        # return best_point instead of None
+        else:
+            best_observation_features = None
+
         return GenResults(
             observation_features=observation_features,
             weights=w,
             gen_metadata=gen_metadata,
+            best_observation_features=best_observation_features,
         )
 
     def _cross_validate(

--- a/ax/modelbridge/tests/test_discrete_modelbridge.py
+++ b/ax/modelbridge/tests/test_discrete_modelbridge.py
@@ -38,8 +38,6 @@ class DiscreteModelBridgeTest(TestCase):
         ]
         parameter_constraints = []
 
-        # pyre-fixme[6]: For 1st param expected `List[Parameter]` but got
-        #  `List[Union[ChoiceParameter, FixedParameter]]`.
         self.search_space = SearchSpace(self.parameters, parameter_constraints)
 
         self.observation_features = [
@@ -149,7 +147,12 @@ class DiscreteModelBridgeTest(TestCase):
         ma._validate_gen_inputs(n=-1)
         # Test rest of gen.
         model = mock.MagicMock(DiscreteModel, autospec=True, instance=True)
-        model.gen.return_value = ([[0.0, 2.0, 3.0], [1.0, 1.0, 3.0]], [1.0, 2.0], {})
+        best_x = [0.0, 2.0, 1.0]
+        model.gen.return_value = (
+            [[0.0, 2.0, 3.0], [1.0, 1.0, 3.0]],
+            [1.0, 2.0],
+            {"best_x": best_x},
+        )
         ma.model = model
         ma.parameters = ["x", "y", "z"]
         ma.outcomes = ["a", "b"]
@@ -190,10 +193,12 @@ class DiscreteModelBridgeTest(TestCase):
             {"x": 1.0, "y": 1.0, "z": 3.0},
         )
         self.assertEqual(gen_results.weights, [1.0, 2.0])
+        self.assertEqual(
+            gen_results.best_observation_features,
+            ObservationFeatures(parameters=dict(zip(ma.parameters, best_x))),
+        )
 
         # Test with no constraints, no fixed feature, no pending observations
-        # pyre-fixme[6]: For 1st param expected `List[Parameter]` but got
-        #  `List[Union[ChoiceParameter, FixedParameter]]`.
         search_space = SearchSpace(self.parameters[:2])
         optimization_config.outcome_constraints = []
         ma.parameters = ["x", "y"]

--- a/ax/models/tests/test_thompson.py
+++ b/ax/models/tests/test_thompson.py
@@ -59,6 +59,7 @@ class ThompsonSamplerTest(TestCase):
         ):
             self.assertAlmostEqual(weight, expected_weight, 1)
         self.assertEqual(len(gen_metadata["arms_to_weights"]), 4)
+        self.assertEqual(gen_metadata["best_x"], arms[0])
 
     def test_ThompsonSamplerValidation(self) -> None:
         generator = ThompsonSampler(min_weight=0.01)


### PR DESCRIPTION
Summary:
Context: `GenResults` has a field `best_observation_features` that winds up used by in ax's best-point functions (ax/service/utils/best_point.py). `ThompsonSampler` has an opinion about the best arm, but doesn't pass that information through to `DiscreteModelBridge`, and `DiscreteModelbridge` doesn't look for the best point if it has been passed. 

This unblocks benchmarking the bandits GS, which needs a best-point recommendation for computing inference regret.

This PR:
* Has `DiscreteModelBridge._gen` check `gen_metadata` for a "best_x" and uses it to construct `best_observation_features` if present.
* Adds a type annotation
* Has `ThompsonSampler.gen` return a "best_x" in the `gen_metadata` field

Differential Revision: D67532559


