### PR TITLE
Enable gen fallback model spec for GenerationNode

### DIFF
--- a/ax/generation_strategy/generation_strategy.py
+++ b/ax/generation_strategy/generation_strategy.py
@@ -43,12 +43,6 @@ logger: Logger = get_logger(__name__)
 
 
 MAX_CONDITIONS_GENERATED = 10000
-MAX_GEN_DRAWS = 5
-MAX_GEN_DRAWS_EXCEEDED_MESSAGE = (
-    f"GenerationStrategy exceeded `MAX_GEN_DRAWS` of {MAX_GEN_DRAWS} while trying to "
-    "generate a unique parameterization. This indicates that the search space has "
-    "likely been fully explored, or that the sweep has converged."
-)
 T = TypeVar("T")
 
 

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -153,8 +153,6 @@ class TestGenerationNode(TestCase):
         mock_model_spec_fit.assert_called_with(
             experiment=self.branin_experiment,
             data=self.branin_data,
-            search_space=None,
-            optimization_config=None,
         )
 
     def test_gen(self) -> None:

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -408,7 +408,7 @@ class TestGenerationStrategy(TestCase):
                 ]
             )
 
-        exp = Experiment(
+        Experiment(
             name="test", search_space=SearchSpace(parameters=[get_choice_parameter()])
         )
         factorial_thompson_generation_strategy = GenerationStrategy(
@@ -421,8 +421,6 @@ class TestGenerationStrategy(TestCase):
         self.assertFalse(
             factorial_thompson_generation_strategy.uses_non_registered_models
         )
-        with self.assertRaises(ValueError):
-            factorial_thompson_generation_strategy._gen_with_multiple_nodes(exp)
         self.assertEqual(GenerationStep(model=sum, num_trials=1).model_name, "sum")
         with self.assertRaisesRegex(UserInputError, "Maximum parallelism should be"):
             GenerationStrategy(

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -263,7 +263,7 @@ def get_client_with_simple_discrete_moo_problem(
             metrics = [-m for m in metrics]
         y0, y1, y2 = metrics
         raw_data = {"y0": (y0, 0.0), "y1": (y1, 0.0), "y2": (y2, 0.0)}
-        # pyre-fixme [6]: In call `AxClient.complete_trial`, for 2nd parameter
+        # pyre-fixme[6]: In call `AxClient.complete_trial`, for 2nd parameter
         #  `raw_data`
         #  expected `Union[Dict[str, Union[Tuple[Union[float, floating, integer],
         #  Union[None, float, floating, integer]], float, floating, integer]],
@@ -1778,7 +1778,7 @@ class TestAxClient(TestCase):
             RandomAdapter, "_fit", autospec=True, side_effect=RandomAdapter._fit
         ) as mock_fit:
             ax_client.get_next_trial()
-            mock_fit.assert_called_once()
+            self.assertEqual(mock_fit.call_count, 1)
             features = mock_fit.call_args_list[0][1]["observations"][0].features
             # we're asserting it's actually created real Timestamp objects
             # for the observation features
@@ -1800,7 +1800,7 @@ class TestAxClient(TestCase):
             RandomAdapter, "_fit", autospec=True, side_effect=RandomAdapter._fit
         ) as mock_fit:
             ax_client.get_next_trial()
-            mock_fit.assert_called_once()
+            self.assertEqual(mock_fit.call_count, 1)
             features = mock_fit.call_args_list[0][1]["observations"][0].features
             # we're asserting it's actually created real Timestamp objects
             # for the observation features


### PR DESCRIPTION
Summary: Allowing for gen fallback (default to sobol) upon running into specified error in GenerationNode.gen()

Differential Revision: D67232696


