### PR TITLE
Replace None with np.nan in BenchmarkMetric.fetch_trial_data

### DIFF
--- a/ax/benchmark/benchmark_metric.py
+++ b/ax/benchmark/benchmark_metric.py
@@ -89,12 +89,11 @@ enumerates use cases.
 from abc import abstractmethod
 from typing import Any
 
+import numpy as np
 from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
-
 from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
-
 from ax.core.map_data import MapData, MapKeyInfo
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
@@ -198,7 +197,7 @@ class BenchmarkMetricBase(Metric):
             available_data = df[df["virtual runtime"] <= max_t]
 
         if not self.observe_noise_sd:
-            available_data.loc[:, "sem"] = None
+            available_data.loc[:, "sem"] = np.nan
         return self._df_to_result(df=available_data.drop(columns=["virtual runtime"]))
 
     @abstractmethod


### PR DESCRIPTION
Summary:
This leads to a future warning in later versions pandas:
```
/opt/anaconda3/envs/profiling/lib/python3.12/site-packages/ax/benchmark/benchmark_metric.py:201: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value 'None' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.
  available_data.loc[:, "sem"] = None
```

Differential Revision: D67720091


