### PR TITLE
Type annotations for discete models: Mark arguments as immutable; copy to prevent mutating

### DIFF
--- a/ax/models/discrete/eb_thompson.py
+++ b/ax/models/discrete/eb_thompson.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import logging
+from collections.abc import Sequence
 
 import numpy as np
 from ax.models.discrete.thompson import ThompsonSampler
@@ -25,18 +26,21 @@ class EmpiricalBayesThompsonSampler(ThompsonSampler):
     """
 
     def _fit_Ys_and_Yvars(
-        self, Ys: list[list[float]], Yvars: list[list[float]], outcome_names: list[str]
+        self,
+        Ys: Sequence[Sequence[float]],
+        Yvars: Sequence[Sequence[float]],
+        outcome_names: Sequence[str],
     ) -> tuple[list[list[float]], list[list[float]]]:
         newYs = []
         newYvars = []
         for i, (Y, Yvar) in enumerate(zip(Ys, Yvars)):
-            newY, newYvar = self._apply_shrinkage(Y, Yvar, i)
+            newY, newYvar = self._apply_shrinkage(Y=Y, Yvar=Yvar, outcome=i)
             newYs.append(newY)
             newYvars.append(newYvar)
         return newYs, newYvars
 
     def _apply_shrinkage(
-        self, Y: list[float], Yvar: list[float], outcome: int
+        self, Y: Sequence[float], Yvar: Sequence[float], outcome: int
     ) -> tuple[list[float], list[float]]:
         npY = np.array(Y)
         npYvar = np.array(Yvar)

--- a/ax/models/discrete/full_factorial.py
+++ b/ax/models/discrete/full_factorial.py
@@ -8,6 +8,7 @@
 
 import itertools
 import logging
+from collections.abc import Sequence
 from functools import reduce
 from operator import mul
 
@@ -48,14 +49,15 @@ class FullFactorialGenerator(DiscreteModel):
         self.check_cardinality = check_cardinality
 
     @copy_doc(DiscreteModel.gen)
+    # pyre-fixme[15]: Inconsistent override in return
     def gen(
         self,
         n: int,
-        parameter_values: list[TParamValueList],
+        parameter_values: Sequence[Sequence[TParamValue]],
         objective_weights: npt.NDArray | None,
         outcome_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
         fixed_features: dict[int, TParamValue] | None = None,
-        pending_observations: list[list[TParamValueList]] | None = None,
+        pending_observations: Sequence[Sequence[Sequence[TParamValue]]] | None = None,
         model_gen_options: TConfig | None = None,
     ) -> tuple[list[TParamValueList], list[float], TGenMetadata]:
         if n != -1:
@@ -66,6 +68,8 @@ class FullFactorialGenerator(DiscreteModel):
             )
 
         if fixed_features:
+            # Make a copy so as to not mutate it
+            parameter_values = list(parameter_values)
             for fixed_feature_index, fixed_feature_value in fixed_features.items():
                 parameter_values[fixed_feature_index] = [fixed_feature_value]
 

--- a/ax/models/discrete_base.py
+++ b/ax/models/discrete_base.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+from collections.abc import Sequence
 
 import numpy.typing as npt
 from ax.core.types import TGenMetadata, TParamValue, TParamValueList
@@ -22,11 +23,11 @@ class DiscreteModel(Model):
 
     def fit(
         self,
-        Xs: list[list[TParamValueList]],
-        Ys: list[list[float]],
-        Yvars: list[list[float]],
-        parameter_values: list[TParamValueList],
-        outcome_names: list[str],
+        Xs: Sequence[Sequence[Sequence[TParamValue]]],
+        Ys: Sequence[Sequence[float]],
+        Yvars: Sequence[Sequence[float]],
+        parameter_values: Sequence[Sequence[TParamValue]],
+        outcome_names: Sequence[str],
     ) -> None:
         """Fit model to m outcomes.
 
@@ -42,7 +43,9 @@ class DiscreteModel(Model):
         """
         pass
 
-    def predict(self, X: list[TParamValueList]) -> tuple[npt.NDArray, npt.NDArray]:
+    def predict(
+        self, X: Sequence[Sequence[TParamValue]]
+    ) -> tuple[npt.NDArray, npt.NDArray]:
         """Predict
 
         Args:
@@ -60,13 +63,13 @@ class DiscreteModel(Model):
     def gen(
         self,
         n: int,
-        parameter_values: list[TParamValueList],
+        parameter_values: Sequence[Sequence[TParamValue]],
         objective_weights: npt.NDArray | None,
         outcome_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
         fixed_features: dict[int, TParamValue] | None = None,
-        pending_observations: list[list[TParamValueList]] | None = None,
+        pending_observations: Sequence[Sequence[Sequence[TParamValue]]] | None = None,
         model_gen_options: TConfig | None = None,
-    ) -> tuple[list[TParamValueList], list[float], TGenMetadata]:
+    ) -> tuple[list[Sequence[TParamValue]], list[float], TGenMetadata]:
         """
         Generate new candidates.
 
@@ -97,10 +100,10 @@ class DiscreteModel(Model):
 
     def cross_validate(
         self,
-        Xs_train: list[list[TParamValueList]],
-        Ys_train: list[list[float]],
-        Yvars_train: list[list[float]],
-        X_test: list[TParamValueList],
+        Xs_train: Sequence[Sequence[Sequence[TParamValue]]],
+        Ys_train: Sequence[Sequence[float]],
+        Yvars_train: Sequence[Sequence[float]],
+        X_test: Sequence[Sequence[TParamValue]],
         use_posterior_predictive: bool = False,
     ) -> tuple[npt.NDArray, npt.NDArray]:
         """Do cross validation with the given training and test sets.
@@ -132,11 +135,11 @@ class DiscreteModel(Model):
     def best_point(
         self,
         n: int,
-        parameter_values: list[TParamValueList],
+        parameter_values: Sequence[Sequence[TParamValue]],
         objective_weights: npt.NDArray | None,
         outcome_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
         fixed_features: dict[int, TParamValue] | None = None,
-        pending_observations: list[list[TParamValueList]] | None = None,
+        pending_observations: Sequence[Sequence[Sequence[TParamValue]]] | None = None,
         model_gen_options: TConfig | None = None,
     ) -> TParamValueList | None:
         """Obtains the point that has the best value according to the model

--- a/ax/models/tests/test_eb_thompson.py
+++ b/ax/models/tests/test_eb_thompson.py
@@ -27,17 +27,9 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
     def test_EmpiricalBayesThompsonSamplerFit(self) -> None:
         generator = EmpiricalBayesThompsonSampler(min_weight=0.0)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=self.Xs,
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )
@@ -58,17 +50,9 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
     def test_EmpiricalBayesThompsonSamplerGen(self) -> None:
         generator = EmpiricalBayesThompsonSampler(min_weight=0.0)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=self.Xs,
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )
@@ -86,8 +70,6 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
         ):
             arms, weights, _ = generator.gen(
                 n=5,
-                # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-                #  float, int, str]]]` but got `List[List[int]]`.
                 parameter_values=self.parameter_values,
                 objective_weights=np.array([1, 0]),
             )
@@ -100,24 +82,14 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
     def test_EmpiricalBayesThompsonSamplerWarning(self) -> None:
         generator = EmpiricalBayesThompsonSampler(min_weight=0.0)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=[x[:-1] for x in self.Xs],
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=[y[:-1] for y in self.Ys],
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=[y[:-1] for y in self.Yvars],
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )
         arms, weights, _ = generator.gen(
             n=5,
-            # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             objective_weights=np.array([1, 0]),
         )
@@ -132,14 +104,8 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
         with self.assertRaises(ValueError):
             generator.fit(
                 Xs=[[[1, 1], [2, 2], [3, 3], [4, 4]], [[1, 1], [2, 2], [4, 4]]],
-                # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-                #  `List[List[int]]`.
                 Ys=self.Ys,
-                # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-                #  `List[List[int]]`.
                 Yvars=self.Yvars,
-                # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-                #  float, int, str]]]` but got `List[List[int]]`.
                 parameter_values=self.parameter_values,
                 outcome_names=self.outcome_names,
             )
@@ -147,17 +113,9 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
     def test_EmpiricalBayesThompsonSamplerPredict(self) -> None:
         generator = EmpiricalBayesThompsonSampler(min_weight=0.0)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=self.Xs,
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )

--- a/ax/models/tests/test_full_factorial.py
+++ b/ax/models/tests/test_full_factorial.py
@@ -20,8 +20,6 @@ class FullFactorialGeneratorTest(TestCase):
         parameter_values = [[1, 2], ["foo", "bar"]]
         generated_points, weights, _ = generator.gen(
             n=-1,
-            # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[Union[List[int], List[str]]]`.
             parameter_values=parameter_values,
             objective_weights=np.ones(1),
         )
@@ -36,9 +34,6 @@ class FullFactorialGeneratorTest(TestCase):
         with self.assertRaises(ValueError):
             generated_points, weights, _ = generator.gen(
                 n=-1,
-                # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-                #  float, int, str]]]` but got `List[Union[List[bool], List[int],
-                #  List[str]]]`.
                 parameter_values=parameter_values,
                 objective_weights=np.ones(1),
             )
@@ -51,8 +46,6 @@ class FullFactorialGeneratorTest(TestCase):
         ) as logger:
             generated_points, weights, _ = generator.gen(
                 n=5,
-                # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-                #  float, int, str]]]` but got `List[Union[List[int], List[str]]]`.
                 parameter_values=parameter_values,
                 objective_weights=np.ones(1),
             )
@@ -67,8 +60,6 @@ class FullFactorialGeneratorTest(TestCase):
         parameter_values = [[1, 2], ["foo", "bar"]]
         generated_points, weights, _ = generator.gen(
             n=-1,
-            # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[Union[List[int], List[str]]]`.
             parameter_values=parameter_values,
             objective_weights=np.ones(1),
             fixed_features={1: "foo"},

--- a/ax/models/tests/test_thompson.py
+++ b/ax/models/tests/test_thompson.py
@@ -32,24 +32,14 @@ class ThompsonSamplerTest(TestCase):
     def test_ThompsonSampler(self) -> None:
         generator = ThompsonSampler(min_weight=0.0)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=self.Xs,
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )
         arms, weights, gen_metadata = generator.gen(
             n=3,
-            # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             objective_weights=np.ones(1),
         )
@@ -68,14 +58,8 @@ class ThompsonSamplerTest(TestCase):
         with self.assertRaises(ValueError):
             generator.fit(
                 Xs=[[[1, 1], [2, 2], [3, 3], [4, 4]], [[1, 1], [2, 2], [4, 4]]],
-                # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-                #  `List[List[int]]`.
                 Ys=self.Ys,
-                # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-                #  `List[List[int]]`.
                 Yvars=self.Yvars,
-                # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-                #  float, int, str]]]` but got `List[List[int]]`.
                 parameter_values=self.parameter_values,
                 outcome_names=self.outcome_names,
             )
@@ -84,14 +68,8 @@ class ThompsonSamplerTest(TestCase):
         with self.assertRaises(ValueError):
             generator.fit(
                 Xs=[[[1, 1], [2, 2], [2, 2]]],
-                # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-                #  `List[List[int]]`.
                 Ys=self.Ys,
-                # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-                #  `List[List[int]]`.
                 Yvars=self.Yvars,
-                # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-                #  float, int, str]]]` but got `List[List[int]]`.
                 parameter_values=self.parameter_values,
                 outcome_names=self.outcome_names,
             )
@@ -99,45 +77,27 @@ class ThompsonSamplerTest(TestCase):
         # these are not the same observations, so should not error
         generator.fit(
             Xs=[[[1, 1], [2.0, 2], [2, 2]]],
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )
 
         # requires objective weights
         with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             generator.gen(5, self.parameter_values, objective_weights=None)
 
     def test_ThompsonSamplerMinWeight(self) -> None:
         generator = ThompsonSampler(min_weight=0.01)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=self.Xs,
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )
         arms, weights, _ = generator.gen(
             n=5,
-            # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             objective_weights=np.ones(1),
         )
@@ -150,24 +110,14 @@ class ThompsonSamplerTest(TestCase):
     def test_ThompsonSamplerUniformWeights(self) -> None:
         generator = ThompsonSampler(min_weight=0.0, uniform_weights=True)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=self.Xs,
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )
         arms, weights, _ = generator.gen(
             n=3,
-            # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             objective_weights=np.ones(1),
         )
@@ -178,25 +128,15 @@ class ThompsonSamplerTest(TestCase):
     def test_ThompsonSamplerInfeasible(self) -> None:
         generator = ThompsonSampler(min_weight=0.9)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=self.Xs,
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )
         with self.assertRaises(ModelError):
             generator.gen(
                 n=3,
-                # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-                #  float, int, str]]]` but got `List[List[int]]`.
                 parameter_values=self.parameter_values,
                 objective_weights=np.ones(1),
             )
@@ -204,24 +144,14 @@ class ThompsonSamplerTest(TestCase):
     def test_ThompsonSamplerOutcomeConstraints(self) -> None:
         generator = ThompsonSampler(min_weight=0.0)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=self.multiple_metrics_Xs,
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.multiple_metrics_Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.multiple_metrics_Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )
         arms, weights, _ = generator.gen(
             n=4,
-            # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             objective_weights=np.array([1, 0]),
             outcome_constraints=(
@@ -240,25 +170,15 @@ class ThompsonSamplerTest(TestCase):
     def test_ThompsonSamplerOutcomeConstraintsInfeasible(self) -> None:
         generator = ThompsonSampler(min_weight=0.0)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=self.multiple_metrics_Xs,
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.multiple_metrics_Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.multiple_metrics_Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )
         with self.assertRaises(ModelError):
             generator.gen(
                 n=3,
-                # pyre-fixme[6]: For 2nd param expected `List[List[Union[None, bool,
-                #  float, int, str]]]` but got `List[List[int]]`.
                 parameter_values=self.parameter_values,
                 objective_weights=np.ones(2),
                 outcome_constraints=(np.array([[0, 1]]), np.array([[-10]])),
@@ -267,17 +187,9 @@ class ThompsonSamplerTest(TestCase):
     def test_ThompsonSamplerPredict(self) -> None:
         generator = ThompsonSampler(min_weight=0.0)
         generator.fit(
-            # pyre-fixme[6]: For 1st param expected `List[List[List[Union[None,
-            #  bool, float, int, str]]]]` but got `List[List[List[int]]]`.
             Xs=self.Xs,
-            # pyre-fixme[6]: For 2nd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Ys=self.Ys,
-            # pyre-fixme[6]: For 3rd param expected `List[List[float]]` but got
-            #  `List[List[int]]`.
             Yvars=self.Yvars,
-            # pyre-fixme[6]: For 4th param expected `List[List[Union[None, bool,
-            #  float, int, str]]]` but got `List[List[int]]`.
             parameter_values=self.parameter_values,
             outcome_names=self.outcome_names,
         )


### PR DESCRIPTION
Summary:
Context: The pyre-fixmes were ignoring me.

This PR:
- Make one copy of parameters in `full_factorial` to prevent it being mutated
- Mark many parameters as immutable by changing list to `Sequence` or `Iterable`
- Removes pyre-fixmes

Differential Revision: D67726297


