### PR TITLE
add option to clear trial type when cloning experiments and trials

### DIFF
--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -568,6 +568,7 @@ class BatchTrial(BaseTrial):
         self,
         experiment: core.experiment.Experiment | None = None,
         include_sq: bool = True,
+        clear_trial_type: bool = False,
     ) -> BatchTrial:
         """Clone the trial and attach it to a specified experiment.
         If None provided, attach it to the current experiment.
@@ -576,6 +577,7 @@ class BatchTrial(BaseTrial):
             experiment: The experiment to which the cloned trial will belong.
                 If unspecified, uses the current experiment.
             include_sq: Whether to include status quo in the cloned trial.
+            clear_trial_type: Whether to clear the trial type of the cloned trial.
 
         Returns:
             A new instance of the trial.
@@ -583,7 +585,8 @@ class BatchTrial(BaseTrial):
         use_old_experiment = experiment is None
         experiment = self._experiment if experiment is None else experiment
         new_trial = experiment.new_batch_trial(
-            trial_type=self._trial_type, ttl_seconds=self._ttl_seconds
+            trial_type=None if clear_trial_type else self._trial_type,
+            ttl_seconds=self._ttl_seconds,
         )
         for struct in self._generator_run_structs:
             if use_old_experiment:

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1644,6 +1644,7 @@ class Experiment(Base):
         properties: dict[str, Any] | None = None,
         trial_indices: list[int] | None = None,
         data: Data | None = None,
+        clear_trial_type: bool = False,
     ) -> Experiment:
         r"""
         Return a copy of this experiment with some attributes replaced.
@@ -1673,6 +1674,8 @@ class Experiment(Base):
             data: If specified, attach this data to the cloned experiment. If None,
                 clones the latest data attached to the original experiment if
                 the experiment has any data.
+            clear_trial_type: If True, all cloned trials on the cloned experiment have
+                `trial_type` set to `None`.
         """
         search_space = (
             self.search_space.clone() if (search_space is None) else search_space
@@ -1739,7 +1742,9 @@ class Experiment(Base):
         for trial_index in trial_indices_to_keep.intersection(original_trial_indices):
             trial = self.trials[trial_index]
             if isinstance(trial, BatchTrial) or isinstance(trial, Trial):
-                new_trial = trial.clone_to(cloned_experiment)
+                new_trial = trial.clone_to(
+                    cloned_experiment, clear_trial_type=clear_trial_type
+                )
                 new_index = new_trial.index
                 trial_data, timestamp = self.lookup_data_for_trial(trial_index)
                 # Clone the data to avoid overwriting the original in the DB.

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -453,6 +453,9 @@ class BatchTrialTest(TestCase):
         self.assertEqual(new_batch_trial_0, batch)
         self.assertEqual(new_batch_trial_1, batch)
 
+        # check that trial_type is cloned correctly
+        self.assertEqual(new_batch_trial_0.trial_type, "foo")
+
         # make sure modifying the cloned batch trial does not affect original one
         new_batch_trial_1.add_arm(
             Arm(name="new_arm", parameters={"w": 2.6, "x": 2, "y": "baz", "z": True})
@@ -472,6 +475,9 @@ class BatchTrialTest(TestCase):
         new_batch_trial._index = batch.index
         new_batch_trial._time_created = batch._time_created
         self.assertEqual(new_batch_trial, batch)
+        # test cloning with clear_trial_type=True
+        new_batch_trial = batch.clone_to(clear_trial_type=True)
+        self.assertIsNone(new_batch_trial.trial_type)
 
     def test_Runner(self) -> None:
         # Verify BatchTrial without runner will fail

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1157,6 +1157,20 @@ class ExperimentTest(TestCase):
         cloned_experiment._time_created = experiment._time_created
         self.assertEqual(cloned_experiment, experiment)
 
+        # test clear_trial_type
+        experiment = get_branin_experiment(
+            with_batch=True,
+            num_batch_trial=1,
+            with_completed_batch=True,
+        )
+        experiment.trials[0]._trial_type = "foo"
+        with self.assertRaisesRegex(
+            ValueError, "Experiment does not support trial_type foo."
+        ):
+            experiment.clone_with()
+        cloned_experiment = experiment.clone_with(clear_trial_type=True)
+        self.assertIsNone(cloned_experiment.trials[0].trial_type)
+
     def test_metric_summary_df(self) -> None:
         experiment = Experiment(
             name="test_experiment",

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -383,6 +383,13 @@ class TrialTest(TestCase):
         self.assertTrue(new_trial.status.is_completed)
         self.assertFalse(self.trial.status.is_completed)
 
+        # check that trial_type is cloned correctly
+        self.assertEqual(new_trial.trial_type, "foo")
+
+        # test clear_trial_type
+        new_trial = self.trial.clone_to(clear_trial_type=True)
+        self.assertIsNone(new_trial.trial_type)
+
     def test_update_trial_status_on_clone(self) -> None:
         for status in [
             TrialStatus.CANDIDATE,

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -333,6 +333,7 @@ class Trial(BaseTrial):
     def clone_to(
         self,
         experiment: core.experiment.Experiment | None = None,
+        clear_trial_type: bool = False,
     ) -> Trial:
         """Clone the trial and attach it to the specified experiment.
         If no experiment is provided, the original experiment will be used.
@@ -340,13 +341,16 @@ class Trial(BaseTrial):
         Args:
             experiment: The experiment to which the cloned trial will belong.
                 If unspecified, uses the current experiment.
+            clear_trial_type: If True, all cloned trials on the cloned experiment have
+                `trial_type` set to `None`.
 
         Returns:
             A new instance of the trial.
         """
         experiment = self._experiment if experiment is None else experiment
         new_trial = experiment.new_trial(
-            ttl_seconds=self.ttl_seconds, trial_type=self.trial_type
+            ttl_seconds=self.ttl_seconds,
+            trial_type=None if clear_trial_type else self.trial_type,
         )
         if self.generator_run is not None:
             new_trial.add_generator_run(self.generator_run.clone())


### PR DESCRIPTION
Summary: This is helpful for creating an Experiment that is a clone of a MultiTypeExperiment, but only considers a single trial type.

Reviewed By: Balandat

Differential Revision: D67695412


