### PR TITLE
adding experiment to modelbridge and using it in TransferToNewSQ

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -190,6 +190,7 @@ class ModelBridge(ABC):  # noqa: B024 -- ModelBridge doesn't have any abstract m
             experiment is not None and experiment.immutable_search_space_and_opt_config
         )
         self._experiment_properties: dict[str, Any] = {}
+        self._experiment: Experiment | None = experiment
 
         if experiment is not None:
             if self._optimization_config is None:

--- a/ax/modelbridge/transforms/tests/test_relativize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_relativize_transform.py
@@ -277,6 +277,7 @@ class RelativizeDataTest(TestCase):
             ),
             status_quo_name=arm_names[2],
             status_quo_data_by_trial={0: obs_data[0], 1: obs_data[2]},
+            _experiment=None,
         )
 
         for relativize_cls, expected_mean_and_covar in self.cases:

--- a/ax/modelbridge/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/modelbridge/transforms/tests/test_transform_to_new_sq.py
@@ -6,6 +6,8 @@
 # pyre-strict
 
 
+from unittest import mock
+
 import numpy as np
 import numpy.typing as npt
 from ax.core.batch_trial import BatchTrial
@@ -149,11 +151,6 @@ class TransformToNewSQSpecificTest(TestCase):
             experiment=self.exp,
             data=self.exp.lookup_data(),
         )
-        trial_indices = {
-            obs.features.trial_index
-            for obs in observations
-            if obs.features.trial_index is not None
-        }
 
         t = TransformToNewSQ(
             search_space=self.exp.search_space,
@@ -161,4 +158,16 @@ class TransformToNewSQSpecificTest(TestCase):
             modelbridge=self.modelbridge,
         )
 
-        self.assertEqual(t.default_trial_idx, min(trial_indices))
+        self.assertEqual(t.default_trial_idx, 1)
+
+        with mock.patch(
+            "ax.modelbridge.transforms.transform_to_new_sq.get_target_trial_index",
+            return_value=10,
+        ):
+            t = TransformToNewSQ(
+                search_space=self.exp.search_space,
+                observations=observations,
+                modelbridge=self.modelbridge,
+            )
+
+        self.assertEqual(t.default_trial_idx, 10)


### PR DESCRIPTION
Summary:
Target trial index depends on the current experiment state so it varies and cannot be provided explicitly in the transform configs of TransfrormToNewSQ transform. Thus, we need to compute it inside the transform. Since it depends on the experiment, we needed to add save the experiment on the modelbridge.
- Saved experiment in modelbridge._experiment.
- Using the saved experiment to compute target trial index in TransformToNewSQ.

Reviewed By: saitcakmak

Differential Revision: D67775236


