### PR TITLE
Add "display=True" arg to compute_analyses

### DIFF
--- a/ax/preview/api/client.py
+++ b/ax/preview/api/client.py
@@ -11,7 +11,11 @@ from typing import Any, Sequence
 
 import numpy as np
 
-from ax.analysis.analysis import Analysis, AnalysisCard  # Used as a return type
+from ax.analysis.analysis import (  # Used as a return type
+    Analysis,
+    AnalysisCard,
+    display_cards,
+)
 from ax.analysis.markdown.markdown_analysis import (
     markdown_analysis_card_from_analysis_e,
 )
@@ -607,6 +611,7 @@ class Client(WithDBSettingsBase):
     def compute_analyses(
         self,
         analyses: Sequence[Analysis] | None = None,
+        display: bool = True,
     ) -> list[AnalysisCard]:
         """
         Compute AnalysisCards (data about the optimization for end-user consumption)
@@ -620,6 +625,12 @@ class Client(WithDBSettingsBase):
 
         Saves to database on completion if storage_config is present.
 
+        Args:
+            analyses: A list of Analysis classes to run. If None Ax will choose which
+                analyses to run based on the state of the experiment.
+            display: Whether to display the AnalysisCards if executed in an interactive
+                environment (e.g. Jupyter). Defaults to True. If not in an interactive
+                environment this setting has no effect.
         Returns:
             A list of AnalysisCards.
         """
@@ -646,6 +657,11 @@ class Client(WithDBSettingsBase):
             for result in results
         ]
 
+        # Display the AnalysisCards if requested and if the user is in a notebook
+        if display:
+            display_cards(cards=cards)
+
+        # Save the AnalysisCards to the database if possible
         self._save_analysis_cards_to_db_if_possible(
             experiment=self._experiment, analysis_cards=cards
         )


### PR DESCRIPTION
Summary:
As titled. Previously users would have to call
```
cards = client.compute_analyses()
display_cards(display)
```
or worse
```
cards = client.compute_analyses(display=False)
for card in analysis_cards:
    card._ipython_display_()
```
if they were not privy to the display_cards method. I noticed this while reviewing our tutorials.

Now that can call `client.compute_analyses()` and have all the cards displayed, or `client.compute_analyses(display=False)` to access legacy behavior.


This should provide a good default experience for our users, and an escape hatch for users who dont want this functionality. Note that when called in a non-interactive environment the display_cards call is a no-op

Differential Revision: D67799963


