### PR TITLE
Fix trial_as_task for pending points

### DIFF
--- a/ax/modelbridge/transforms/choice_encode.py
+++ b/ax/modelbridge/transforms/choice_encode.py
@@ -121,7 +121,8 @@ class ChoiceToNumericChoice(Transform):
                     # pyre: pval is declared to have type `int` but is used as
                     # pyre-fixme[9]: type `Union[bool, float, str]`.
                     pval: int = obsf.parameters[p_name]
-                    obsf.parameters[p_name] = reverse_transform[pval]
+                    if pval in reverse_transform:
+                        obsf.parameters[p_name] = reverse_transform[pval]
         return observation_features
 
 


### PR DESCRIPTION
Summary:
## The Change
If trial indices are not in the level dict, we set TRIAL_PARAM to the max in level_dict, which is the max observed trial index.  We may choose to replace this with the target trial in a follow up.

We then have to ensure the trial_index is not set to something it shouldn't be in `TrialAsTask.untransform_observation_features()` and `ChoiceToNumericChoice.untransform_observation_features()`, which seem to be from generated points and come out as floats.  I'm less certain about why this is.  There may be another error in the modeling stack, but in the meantime it would block candidate generation.

## The Promlem

Reviewed By: lena-kashtelyan

Differential Revision: D67766937


