### PR TITLE
use most recent trial in TransformToNewSQ by default

### DIFF
--- a/ax/modelbridge/transforms/transform_to_new_sq.py
+++ b/ax/modelbridge/transforms/transform_to_new_sq.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from logging import Logger
 
 from math import sqrt
 from typing import TYPE_CHECKING
@@ -22,12 +23,14 @@ from ax.core.search_space import SearchSpace
 from ax.core.utils import get_target_trial_index
 from ax.modelbridge.transforms.relativize import BaseRelativize, get_metric_index
 from ax.models.types import TConfig
+from ax.utils.common.logger import get_logger
 from ax.utils.stats.statstools import relativize, unrelativize
 from pyre_extensions import assert_is_instance, none_throws
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
     from ax import modelbridge as modelbridge_module  # noqa F401
+logger: Logger = get_logger(__name__)
 
 
 class TransformToNewSQ(BaseRelativize):
@@ -73,6 +76,13 @@ class TransformToNewSQ(BaseRelativize):
             target_trial_index = get_target_trial_index(
                 experiment=modelbridge._experiment
             )
+            trials_indices_with_sq_data = self.status_quo_data_by_trial.keys()
+            if target_trial_index not in trials_indices_with_sq_data:
+                target_trial_index = max(trials_indices_with_sq_data)
+                logger.info(
+                    "No SQ data for target trial. Failing back to "
+                    f"{target_trial_index}."
+                )
 
         if target_trial_index is not None:
             self.default_trial_idx: int = assert_is_instance(


### PR DESCRIPTION
Summary: see title. This ensures that status_quo_data_by_trial contains the target trial index by default.

Differential Revision: D67875128


