### PR TITLE
Remove seconds_between_polls argument from early_stopping tutorial notebook

### DIFF
--- a/tutorials/early_stopping/early_stopping.ipynb
+++ b/tutorials/early_stopping/early_stopping.ipynb
@@ -358,8 +358,6 @@
         "    min_curves=5,\n",
         "    # specify, e.g., [0, 1] if the first two trials should never be stopped\n",
         "    trial_indices_to_ignore=None,\n",
-        "    # check for new data every 10 seconds\n",
-        "    seconds_between_polls=10,\n",
         "    normalize_progressions=True,\n",
         ")"
       ]


### PR DESCRIPTION
Summary:
As part of D67178422, we deprecated ESSs `seconds_between_polls`, as we can leverage SchedulerOption's `init_seconds_between_polls` instead

A tutorial notebook was not updated to reflect this change, leading to a failure in our website publishing github jobs: https://github.com/facebook/Ax/actions/runs/12645491959/job/35234720575

Differential Revision: D67902374


