### PR TITLE
When constructing parameters from lists of names and values, ensure that names and values have the same length

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -614,7 +614,7 @@ def parse_observation_features(
     for i, x in enumerate(X):
         observation_features.append(
             ObservationFeatures(
-                parameters=dict(zip(param_names, x)),
+                parameters=dict(zip(param_names, x, strict=True)),
                 metadata=candidate_metadata[i] if candidate_metadata else None,
             )
         )

--- a/ax/modelbridge/tests/test_map_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_map_torch_modelbridge.py
@@ -71,7 +71,7 @@ class MapTorchModelBridgeTest(TestCase):
         # Test _gen
         model = mock.MagicMock(TorchModel, autospec=True, instance=True)
         model.gen.return_value = TorchGenResults(
-            points=torch.tensor([[0.0, 0.0]]),
+            points=torch.tensor([[0.0, 0.0, 0.0]]),
             weights=torch.tensor([1.0]),
             gen_metadata={},
         )
@@ -79,6 +79,7 @@ class MapTorchModelBridgeTest(TestCase):
             torch.tensor([[0.0, 0.0]]),
             torch.tensor([[[1.0, 0.0], [0.0, 1.0]]]),
         )
+        model.best_point.return_value = torch.tensor([0.0, 0.0])
         modelbridge.model = model
         gen_results = modelbridge._gen(
             n=1,
@@ -93,7 +94,8 @@ class MapTorchModelBridgeTest(TestCase):
             {"map_dim_to_target": {2: 4.0}},
         )
         self.assertEqual(
-            gen_results.observation_features[0].parameters, {"x1": 0.0, "x2": 0.0}
+            gen_results.observation_features[0].parameters,
+            {"x1": 0.0, "x2": 0.0, "timestamp": 0.0},
         )
 
         # Test _predict

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -223,6 +223,7 @@ class TorchModelBridgeTest(TestCase):
             weights=torch.tensor([1.0], **tkwargs),
             gen_metadata={"foo": 99},
         )
+        model.best_point.return_value = torch.tensor([1.0, 2.0, 3.0], **tkwargs)
         opt_config = OptimizationConfig(
             objective=Objective(metric=Metric("y1"), minimize=False),
         )
@@ -428,11 +429,6 @@ class TorchModelBridgeTest(TestCase):
         )
 
     @mock.patch(
-        f"{ModelBridge.__module__}.observations_from_data",
-        autospec=True,
-        return_value=([get_observation1()]),
-    )
-    @mock.patch(
         f"{ModelBridge.__module__}.unwrap_observation_data",
         autospec=True,
         return_value=(2, 2),
@@ -451,7 +447,7 @@ class TorchModelBridgeTest(TestCase):
     @mock.patch(
         f"{TorchModel.__module__}.TorchModel.gen",
         return_value=TorchGenResults(
-            points=torch.tensor([[1, 2]]),
+            points=torch.tensor([[1]]),
             weights=torch.tensor([1.0]),
         ),
         autospec=True,
@@ -463,7 +459,6 @@ class TorchModelBridgeTest(TestCase):
         _mock_predict,
         _mock_gen_arms,
         _mock_unwrap,
-        _mock_obs_from_data,
     ) -> None:
         exp = Experiment(search_space=get_search_space_for_range_value(), name="test")
         oc = OptimizationConfig(
@@ -491,7 +486,7 @@ class TorchModelBridgeTest(TestCase):
 
         with mock.patch(
             f"{TorchModel.__module__}.TorchModel.best_point",
-            return_value=torch.tensor([1.0, 2.0]),
+            return_value=torch.tensor([1.0]),
             autospec=True,
         ):
             run = modelbridge.gen(n=1, optimization_config=oc)
@@ -871,7 +866,7 @@ class TorchModelBridgeTest(TestCase):
             },
         ):
             gen_return_value = TorchGenResults(
-                points=torch.tensor([[1.0, 2.0, 3.0]]),
+                points=torch.tensor([[1.0, 2.0]]),
                 weights=torch.tensor([1.0]),
                 gen_metadata={Keys.EXPECTED_ACQF_VAL: [1.0], **additional_metadata},
             )

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -736,7 +736,9 @@ class TorchModelBridge(ModelBridge):
         best_obsf = None
         if xbest is not None:
             best_obsf = ObservationFeatures(
-                parameters={p: float(xbest[i]) for i, p in enumerate(self.parameters)}
+                parameters={
+                    p: float(x) for p, x in zip(self.parameters, xbest, strict=True)
+                }
             )
 
         return GenResults(


### PR DESCRIPTION
Summary:
Context: There is code like

`parameters={p: float(xbest[i]) for i, p in enumerate(self.parameters)}`

If `xbest` is longer than `self.parameters` (which indicates a problem), the extra elements in `xbest` will be silently discarded. The new behavior will generate an exception.

I did not check everywhere that this might be a problem, just in the places where it was causing trouble for me.

This PR:
* Updates two places where  parameters are constructed to use `dict(zip(..., strict=True))`

Reviewed By: Balandat

Differential Revision: D68035646


