### PR TITLE
Support Percentile Readings for Tensorboard Metrics

### DIFF
--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -27,7 +27,8 @@ from pyre_extensions import assert_is_instance
 
 logger: Logger = get_logger(__name__)
 
-SMOOTHING_DEFAULT = 0.6  # Default in Tensorboard UI
+# Default in Tensorboard UI (https://fburl.com/workplace/1sq11640)
+SMOOTHING_DEFAULT = 0
 RUN_METADATA_KEY = "tb_log_dir"
 
 try:
@@ -49,6 +50,7 @@ try:
             lower_is_better: bool | None = True,
             smoothing: float = SMOOTHING_DEFAULT,
             cumulative_best: bool = False,
+            percentile: float | None = None,
         ) -> None:
             """
             Args:
@@ -61,12 +63,17 @@ try:
                 cumulative_best: If True, for each trial, apply cumulative best to
                     the curve (i.e., if lower is better, then we return a curve
                     representing the cumulative min of the raw curve).
+                percentile: If not None, return the (rolling) percentile value of the curve.
+                    e.g. if the original curve is [0, 6, 4, 2] and percentile=0.5, then
+                    the returned curve is [0, 3, 4, 3]. Rolling percentile is applied after
+                    any potential smoothing or cumulative_best processing.
             """
             super().__init__(name=name, lower_is_better=lower_is_better)
 
             self.smoothing = smoothing
             self.tag = tag
             self.cumulative_best = cumulative_best
+            self.percentile = percentile
 
         @classmethod
         def is_available_while_running(cls) -> bool:
@@ -183,6 +190,10 @@ try:
                     # Apply smoothing
                     if metric.smoothing > 0:
                         df["mean"] = df["mean"].ewm(alpha=metric.smoothing).mean()
+
+                    # Apply rolling percentile
+                    if metric.percentile is not None:
+                        df["mean"] = df["mean"].expanding().quantile(metric.percentile)
 
                     # Accumulate successfully extracted timeseries
                     res[metric.name] = Ok(


### PR DESCRIPTION
Summary:
As titled, support percentile readings for tensorboard metrics. If `percentile` is specified, `map_df['mean']` will be the (rolling) n-th percentile value up to the most current step.

Note: this also updated the Default smoothing weight to 0.0, which is the new default smoothing in TB

Differential Revision: D68133853


