### PR TITLE
Remove mocks from TorchModelBridgeTest.test_TorchModelBridge

### DIFF
--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -141,6 +141,7 @@ class MapTorchModelBridge(TorchModelBridge):
             status_quo_features=status_quo_features,
             optimization_config=optimization_config,
             fit_out_of_design=fit_out_of_design,
+            fit_abandoned=fit_abandoned,
             fit_on_init=fit_on_init,
             default_model_gen_options=default_model_gen_options,
         )

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -22,7 +22,6 @@ from inspect import isfunction, signature
 from logging import Logger
 from typing import Any, NamedTuple
 
-import torch
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
@@ -145,8 +144,6 @@ MBM_MTGP_trans: list[type[Transform]] = MBM_X_trans + [
     TaskChoiceToIntTaskChoice,
 ]
 
-STANDARD_TORCH_BRIDGE_KWARGS: dict[str, Any] = {"torch_dtype": torch.double}
-
 
 class ModelSetup(NamedTuple):
     """A model setup defines a coupled combination of a model, a model bridge,
@@ -172,13 +169,11 @@ MODEL_KEY_TO_MODEL_SETUP: dict[str, ModelSetup] = {
         bridge_class=TorchModelBridge,
         model_class=ModularBoTorchModel,
         transforms=MBM_X_trans + Y_trans,
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
     "Legacy_GPEI": ModelSetup(
         bridge_class=TorchModelBridge,
         model_class=BotorchModel,
         transforms=Cont_X_trans + Y_trans,
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
     "EB": ModelSetup(
         bridge_class=DiscreteModelBridge,
@@ -209,13 +204,11 @@ MODEL_KEY_TO_MODEL_SETUP: dict[str, ModelSetup] = {
         bridge_class=TorchModelBridge,
         model_class=ModularBoTorchModel,
         transforms=MBM_MTGP_trans,
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
     "BO_MIXED": ModelSetup(
         bridge_class=TorchModelBridge,
         model_class=ModularBoTorchModel,
         transforms=Mixed_transforms + Y_trans,
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
     "SAASBO": ModelSetup(
         bridge_class=TorchModelBridge,
@@ -226,7 +219,6 @@ MODEL_KEY_TO_MODEL_SETUP: dict[str, ModelSetup] = {
                 botorch_model_class=SaasFullyBayesianSingleTaskGP
             )
         },
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
     "SAAS_MTGP": ModelSetup(
         bridge_class=TorchModelBridge,
@@ -237,13 +229,11 @@ MODEL_KEY_TO_MODEL_SETUP: dict[str, ModelSetup] = {
                 botorch_model_class=SaasFullyBayesianMultiTaskGP
             )
         },
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
     "Contextual_SACBO": ModelSetup(
         bridge_class=TorchModelBridge,
         model_class=SACBO,
         transforms=Cont_X_trans + Y_trans,
-        standard_bridge_kwargs=STANDARD_TORCH_BRIDGE_KWARGS,
     ),
 }
 

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -8,7 +8,6 @@
 
 from collections import OrderedDict
 
-import torch
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.modelbridge.discrete import DiscreteModelBridge
@@ -55,6 +54,10 @@ from gpytorch.priors.torch_priors import GammaPrior, LogNormalPrior
 
 
 class ModelRegistryTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.maxDiff = None
+
     @mock_botorch_optimize
     def test_botorch_modular(self) -> None:
         exp = get_branin_experiment(with_batch=True)
@@ -155,7 +158,7 @@ class ModelRegistryTest(TestCase):
             gpei._bridge_kwargs,
             {
                 "transform_configs": None,
-                "torch_dtype": torch.float64,
+                "torch_dtype": None,
                 "torch_device": None,
                 "status_quo_name": None,
                 "status_quo_features": None,

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -914,7 +914,9 @@ class TorchModelBridge(ModelBridge):
             )
         except (KeyError, TypeError):
             raise ValueError("Invalid formatting of observation data.")
-        X = self._transform_observation_features(observation_features)
+        X = self._transform_observation_features(
+            observation_features=observation_features
+        )
         return X, self._array_to_tensor(mean), self._array_to_tensor(cov)
 
     def _untransform_objective_thresholds(

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from logging import Logger
 from typing import Any
+from warnings import warn
 
 import numpy as np
 import numpy.typing as npt
@@ -119,7 +120,19 @@ class TorchModelBridge(ModelBridge):
         fit_on_init: bool = True,
         default_model_gen_options: TConfig | None = None,
     ) -> None:
-        self.dtype: torch.dtype = torch.double if torch_dtype is None else torch_dtype
+        # This warning is being added while we are on 0.4.3, so it will be
+        # released in 0.4.4 or 0.5.0. The `torch_dtype` argument can be removed
+        # in the subsequent minor version. It should also be removed from
+        # `TorchModelBridge` subclasses.
+        if torch_dtype is not None:
+            warn(
+                "The `torch_dtype` argument to `TorchModelBridge` is deprecated"
+                " and will be ignored; data will be in double precision.",
+                DeprecationWarning,
+            )
+
+        # Note: When `torch_dtype` is removed, this attribute can be removed
+        self.dtype: torch.dtype = torch.double
         self.device = torch_device
         # pyre-ignore [4]: Attribute `_default_model_gen_options` of class
         # `TorchModelBridge` must have a type that does not contain `Any`.


### PR DESCRIPTION
Summary: I'm removing mocks (that do not use `wraps`) from Ax unit tests. There were many in this function. However, I left mocks of `fit` and `gen` in place since this is a ModelBridge test that is checking if the correct arguments get passed to and from `Model`, where the fitting and generating happens. `fit` and `gen` ought to be thoroughly tested in `Model` tests (I haven't checked whether that is the case).

Reviewed By: Balandat

Differential Revision: D68030058


