### PR TITLE
pass constraints feasibility when the experiments or opt configs are not specified

### DIFF
--- a/ax/analysis/healthcheck/constraints_feasibility.py
+++ b/ax/analysis/healthcheck/constraints_feasibility.py
@@ -77,9 +77,14 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
             )
 
         if experiment.optimization_config is None:
-            raise UserInputError(
-                "ConstraintsFeasibilityAnalysis requires an Experiment with an "
-                "optimization config."
+            subtitle = "No optimization config is specified."
+            return HealthcheckAnalysisCard(
+                name="ConstraintsFeasibility",
+                title=f"Ax Constraints Feasibility {title_status}",
+                blob=json.dumps({"status": status}),
+                subtitle=subtitle,
+                df=df,
+                level=level,
             )
 
         if (


### PR DESCRIPTION
Summary: Changing status from fail to pass in the constraints feasibility health check when  experiment.optimization_config isn't specified.

Reviewed By: danielcohenlive

Differential Revision: D68279145


