### PR TITLE
Merge _gen_multiple into _gen_with_multiple_nodes

### DIFF
--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -585,7 +585,7 @@ class TestAxClient(TestCase):
         self.assertFalse(is_complete)
 
     @patch(
-        f"{GenerationStrategy.__module__}.GenerationStrategy._gen_multiple",
+        f"{GenerationStrategy.__module__}.GenerationStrategy._gen_with_multiple_nodes",
         side_effect=OptimizationComplete("test error"),
     )
     def test_optimization_complete(self, _mock_gen) -> None:


### PR DESCRIPTION
Summary:
This diff ensures that gen_with_multiple_nodes can function independently by removing the call to _gen_mutliple(..).  This sets us up to fully reap _gen_multiple in a future diff (when we simeltanously replace calls to _gen_multiple with _gen_for_multiple_trials_with_multiple_modesl(..) in diff 4/n


Internal
- 
Tldr:
 {F1973912725} 

See diff 1/n in the stack for context

Reviewed By: lena-kashtelyan

Differential Revision: D67315146


