### PR TITLE
Add a helper to pull out gen kwargs

### DIFF
--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -585,7 +585,7 @@ class TestAxClient(TestCase):
         self.assertFalse(is_complete)
 
     @patch(
-        f"{GenerationStrategy.__module__}.GenerationStrategy._gen_multiple",
+        f"{GenerationStrategy.__module__}.GenerationStrategy._gen_with_multiple_nodes",
         side_effect=OptimizationComplete("test error"),
     )
     def test_optimization_complete(self, _mock_gen) -> None:


### PR DESCRIPTION
Summary:
This diff is purely to improve the code, I could see folks going either way on if this is preferable, so happy to abandon if we don't like it. 

Why I think it's advatageous:
-  Removes some arg passing in already existing helpers by wrapping in gen_kwargs
- Removes that ugly dict creation in the function

Reviewed By: lena-kashtelyan

Differential Revision: D67318518


