### PR TITLE
Improve TB error message when 'scalars' is missing from multiplexer

### DIFF
--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -119,8 +119,10 @@ try:
                     metric.name: Err(
                         MetricFetchE(
                             message=(
-                                "No 'scalar' data found for trial in multiplexer "
-                                f"{mul=}"
+                                "Tensorboard multiplexer is empty. This can happen if "
+                                "TB data is not populated at the time of fetch. Check "
+                                "the corresponding logs to confirm that Tensorboard "
+                                "data is available."
                             ),
                             exception=None,
                         )


### PR DESCRIPTION
Summary: Previous message was hard for users to interpret, leading them to contact support.

Reviewed By: sunnyshen321

Differential Revision: D68292863


