### PR TITLE
Cleanup in test_botorch_moo_defaults.BotorchMOODefaultsTest

### DIFF
--- a/ax/models/torch/botorch_moo_defaults.py
+++ b/ax/models/torch/botorch_moo_defaults.py
@@ -459,7 +459,9 @@ def _get_EHVI(
     if outcome_constraints is None:
         cons_tfs = None
     else:
-        cons_tfs = get_outcome_constraint_transforms(outcome_constraints)
+        cons_tfs = get_outcome_constraint_transforms(
+            outcome_constraints=outcome_constraints
+        )
     num_objectives = objective_thresholds.shape[0]
     # NOTE: Not using checked_cast here because for Python 3.9, isinstance fails with
     # `TypeError: Subscripted generics cannot be used with class and instance checks`.


### PR DESCRIPTION
Summary:
Context: I was aiming to remove unnecessary mocks here, but there actually weren't any; these mocks are being used to test that arguments are being passed through correctly.

Changes:
* Added some comments
* Stopped instantiating an unneeded model (it was used only for its `model._model` attribute, which is None)
* Pulled out repetitive `posterior`
* Reduced the scope of a context manager by unindenting

Differential Revision: D68233296


