### PR TITLE
typing around ThompsonSampler and its subclasses

### DIFF
--- a/ax/models/tests/test_eb_thompson.py
+++ b/ax/models/tests/test_eb_thompson.py
@@ -34,6 +34,10 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
             outcome_names=self.outcome_names,
         )
         self.assertEqual(generator.X, self.Xs[0])
+        print(generator.Ys)
+        print(
+            np.array([[1.3, 2.1, 2.9, 3.7], [0.25, 0.25, 0.25, 0.25]]),
+        )
         self.assertTrue(
             np.allclose(
                 np.array(generator.Ys),

--- a/ax/utils/stats/statstools.py
+++ b/ax/utils/stats/statstools.py
@@ -137,22 +137,13 @@ def positive_part_james_stein(
     sigma2_i = np.power(sems, 2)
     ybar = np.mean(y_i)
     s2 = np.var(y_i - ybar, ddof=3)  # sample variance normalized by K-3
-    if s2 == 0:
-        phi_i = 1
-    else:
-        phi_i = np.minimum(1, sigma2_i / s2)
-    # pyre-fixme[6]: For 1st argument expected `int` but got `floating[typing.Any]`.
-    # pyre-fixme[6]: For 1st argument expected `bool` but got `ndarray[typing.Any,
-    #  dtype[typing.Any]]`.
-    mu_hat_i = y_i + phi_i * (ybar - y_i)
+    phi_i = np.ones_like(sigma2_i) if s2 == 0 else np.minimum(1, sigma2_i / s2)
+    mu_hat_i = y_i + phi_i * np.subtract(ybar, y_i)
+
     sigma_hat_i = np.sqrt(
-        # pyre-fixme[58]: `-` is not supported for operand types `int` and
-        #  `Union[np.ndarray[typing.Any, np.dtype[typing.Any]], int]`.
-        (1 - phi_i) * sigma2_i
+        np.subtract(1.0, phi_i) * sigma2_i
         + phi_i * sigma2_i / K
-        # pyre-fixme[58]: `*` is not supported for operand types `int` and
-        #  `Union[np.ndarray[typing.Any, np.dtype[typing.Any]], int]`.
-        + 2 * phi_i**2 * (y_i - ybar) ** 2 / (K - 3)
+        + np.multiply(2, phi_i**2) * (y_i - ybar) ** 2 / (K - 3)
     )
     return mu_hat_i, sigma_hat_i
 


### PR DESCRIPTION
Summary:
- Added types in ThompsonSampler and EBAshr.
- Added warnings in ThompsonSampler and EBAshr when the objective is a multi-objective. 
Both ThompsonSampler and EBAshr currently handle multi-objective in the same way by multiplying the samples in the case of TS and shrunken estimates in the case of EBAshr with the objective weights that are +/-1 for metrics in the multi-objective. Given different scaling across metrics, multiplying the metric values with the +/-1 weights does not have a meaningful value.

Reviewed By: saitcakmak

Differential Revision: D68297261


