### PR TITLE
Update Acquisition.optimize to use mixed optimizer if discrete parameters have high cardinality

### DIFF
--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -55,8 +55,11 @@ from pyre_extensions import none_throws
 from torch import Tensor
 
 
-MAX_CHOICES_ENUMERATE = 100_000  # For fully discrete search spaces.
-ALTERNATING_OPTIMIZER_THRESHOLD = 10  # For mixed search spaces.
+# For fully discrete search spaces.
+MAX_CHOICES_ENUMERATE = 100_000
+MAX_CARDINALITY_FOR_LOCAL_SEARCH = 100
+# For mixed search spaces.
+ALTERNATING_OPTIMIZER_THRESHOLD = 10
 
 logger: Logger = get_logger(__name__)
 
@@ -299,14 +302,23 @@ class Acquisition(Base):
         else:
             fully_discrete = len(discrete_choices) == len(ssd.feature_names)
             if fully_discrete:
+                # One of the three optimizers may be used depending on the number of
+                # discrete choices and the cardinality of individual parameters.
                 # If there are less than `MAX_CHOICES_ENUMERATE` choices, we will
-                # evaluate all of them and pick the best. Otherwise, we will use
-                # local search.
-                total_discrete_choices = reduce(
-                    operator.mul, [float(len(c)) for c in discrete_choices.values()]
-                )
+                # evaluate all of them and pick the best.
+                # If there are more than `MAX_CARDINALITY_FOR_LOCAL_SEARCH` choices
+                # for any given parameter, we will use discrete local search.
+                # Otherwise, we will use the mixed alternating optimizer, which may use
+                # continuous relaxation for the high cardinality parameters, while
+                # using local search for the remaining parameters.
+                cardinalities = [len(c) for c in discrete_choices.values()]
+                max_cardinality = max(cardinalities)
+                total_discrete_choices = reduce(operator.mul, cardinalities)
                 if total_discrete_choices > MAX_CHOICES_ENUMERATE:
-                    optimizer = "optimize_acqf_discrete_local_search"
+                    if max_cardinality <= MAX_CARDINALITY_FOR_LOCAL_SEARCH:
+                        optimizer = "optimize_acqf_discrete_local_search"
+                    else:
+                        optimizer = "optimize_acqf_mixed_alternating"
                 else:
                     optimizer = "optimize_acqf_discrete"
                     # `raw_samples` and `num_restarts` are not supported by


### PR DESCRIPTION
Summary:
`optimize_acqf_discrete_local_search` is not suitable for parameters with high cardinality, since it generates the neighbors by changing the value of one parameter at a time and trying out all possible values for that parameter. This can quickly get very expensive with high cardinality parameters.

This diff updates the dispatch logic to utilize the mixed alternating optimizer in cases with high cardinality discrete parameters. The optimizer will internally use continuous relaxation for high cardinality parameters while using nearest neighbor search for the low cardinality discrete parameters.

Reviewed By: bernardbeckerman

Differential Revision: D68357373


