### PR TITLE
Don't plot abandoned arms for arm effects plots

### DIFF
--- a/ax/analysis/plotly/arm_effects/insample_effects.py
+++ b/ax/analysis/plotly/arm_effects/insample_effects.py
@@ -285,6 +285,7 @@ def _prepare_data(
             metric_name=metric_name,
             outcome_constraints=outcome_constraints,
             gr=gr,
+            abandoned_arms={a.name for a in trial.abandoned_arms},
         )
         for gr in trial.generator_runs
     ]

--- a/ax/analysis/plotly/arm_effects/predicted_effects.py
+++ b/ax/analysis/plotly/arm_effects/predicted_effects.py
@@ -185,6 +185,7 @@ def _prepare_data(
                 metric_name=metric_name,
                 outcome_constraints=outcome_constraints,
                 gr=gr,
+                abandoned_arms={a.name for a in candidate_trial.abandoned_arms},
             )
             for gr in candidate_trial.generator_runs
         ]


### PR DESCRIPTION
Summary: We were getting an error plotting insample observed effects, which turned out to be because we'd abandoned arms before collecting data.  It then turned out that we're also plotting abandoned arms in the predicted effects plot.

Reviewed By: Cesar-Cardoso

Differential Revision: D68499032


