### PR TITLE
add normalization to warping function

### DIFF
--- a/ax/models/torch/botorch_defaults.py
+++ b/ax/models/torch/botorch_defaults.py
@@ -780,12 +780,18 @@ def get_warping_transform(
     # apply warping to all non-task features, including fidelity features
     if task_feature is not None:
         del indices[task_feature]
+    # Legacy Ax models operate in the unit cube
+    bounds = torch.zeros(2, d, dtype=torch.double)
+    bounds[1] = 1
     # Note: this currently uses the same warping functions for all tasks
     tf = Warp(
+        d=d,
         indices=indices,
         # prior with a median of 1
         concentration1_prior=LogNormalPrior(0.0, 0.75**0.5),
         concentration0_prior=LogNormalPrior(0.0, 0.75**0.5),
         batch_shape=batch_shape,
+        # Legacy Ax models operate in the unit cube
+        bounds=bounds,
     )
     return tf

--- a/ax/models/torch/tests/test_input_transform_argparse.py
+++ b/ax/models/torch/tests/test_input_transform_argparse.py
@@ -183,9 +183,13 @@ class InputTransformArgparseTest(TestCase):
             search_space_digest=self.search_space_digest,
         )
 
-        self.assertEqual(
-            input_transform_kwargs,
-            {"indices": [1, 2]},
+        self.assertEqual(input_transform_kwargs["indices"], [1, 2])
+        self.assertEqual(input_transform_kwargs["d"], 4)
+        self.assertTrue(
+            torch.equal(
+                input_transform_kwargs["bounds"],
+                torch.tensor([[0.0, 0.0, 0.0], [1.0, 2.0, 4.0]]),
+            )
         )
 
         input_transform_kwargs = input_transform_argparse(
@@ -194,8 +198,30 @@ class InputTransformArgparseTest(TestCase):
             search_space_digest=self.search_space_digest,
             input_transform_options={"indices": [0, 1]},
         )
-
-        self.assertEqual(input_transform_kwargs, {"indices": [0, 1]})
+        self.assertEqual(
+            input_transform_kwargs["indices"],
+            [0, 1],
+        )
+        self.assertEqual(input_transform_kwargs["d"], 4)
+        self.assertTrue(
+            torch.equal(
+                input_transform_kwargs["bounds"],
+                torch.tensor([[0.0, 0.0, 0.0], [1.0, 2.0, 4.0]]),
+            )
+        )
+        input_transform_kwargs = input_transform_argparse(
+            Warp,
+            dataset=self.dataset,
+            search_space_digest=self.search_space_digest,
+            input_transform_options={"indices": [0, 1]},
+            torch_dtype=torch.float64,
+        )
+        self.assertTrue(
+            torch.equal(
+                input_transform_kwargs["bounds"],
+                torch.tensor([[0.0, 0.0, 0.0], [1.0, 2.0, 4.0]], dtype=torch.float64),
+            )
+        )
 
     def test_argparse_input_perturbation(self) -> None:
         self.search_space_digest.robust_digest = RobustSearchSpaceDigest(


### PR DESCRIPTION
Summary:
Warping only works on the unit cube. This ensures that inputs are first normalized. This doesn't use `ChainedInputTranform` to avoid nested `ChainedInputTransform`

This is to support linear+warping models in MBM when we aren't using `UnitX`. We’d want to 1) ensure data is in the unit cube before applying `Warp`, 2) then center the warped data at 0 (using Normalize). One way to do this would to apply `Normalize(center=0.5`), `Warp`, `Normalize(center=0.0)`, but we can’t currently specify different options for two different transforms of the same class. So this insteads takes an approach suggested by saitcakmak to include normalization in the `Warp` transform, since we always want inputs to be in the unit cube before warping.

Reviewed By: Balandat

Differential Revision: D68356342


