### PR TITLE
Don't discard abandoned arms on reduced state

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -956,13 +956,12 @@ class Decoder:
                         new_generator_run_structs.append(struct)
                 generator_run_structs = new_generator_run_structs
             trial._generator_run_structs = generator_run_structs
-            if not reduced_state:
-                trial._abandoned_arms_metadata = {
-                    abandoned_arm_sqa.name: self.abandoned_arm_from_sqa(
-                        abandoned_arm_sqa=abandoned_arm_sqa
-                    )
-                    for abandoned_arm_sqa in trial_sqa.abandoned_arms
-                }
+            trial._abandoned_arms_metadata = {
+                abandoned_arm_sqa.name: self.abandoned_arm_from_sqa(
+                    abandoned_arm_sqa=abandoned_arm_sqa
+                )
+                for abandoned_arm_sqa in trial_sqa.abandoned_arms
+            }
             trial._refresh_arms_by_name()  # Trigger cache build
         else:
             trial = Trial(

--- a/ax/storage/sqa_store/load.py
+++ b/ax/storage/sqa_store/load.py
@@ -279,7 +279,6 @@ def _get_experiment_sqa_reduced_state(
     large experiments, in cases where model state history is not required.
     """
     options = get_query_options_to_defer_immutable_duplicates()
-    options.append(lazyload("abandoned_arms"))
     options.extend(get_query_options_to_defer_large_model_cols())
 
     return _get_experiment_sqa(


### PR DESCRIPTION
Summary:
Reduced state does still have use for leaving out gen metadata, but I don't know of any use cases with such a huge amount of abandoned arms this will make a difference (considering it can never make more than a 50% difference).

It also affects the contents/functionality of the experiment by making it look like arms are not abandoned and should be used on trials.  And loading and saving with reduced state loses records that arms were abandoned, which creates problems in experimentation.  See N6450800

Differential Revision: D68514688


