### PR TITLE
Add concept of recoverable errors respected by Scheduler

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -2041,11 +2041,14 @@ class Scheduler(AnalysisBase, BestPointMixin):
                 )
 
                 # If the fetch failure was for a metric in the optimization config (an
-                # objective or constraint) the trial as failed
+                # objective or constraint) mark the trial as failed
                 optimization_config = self.experiment.optimization_config
                 if (
                     optimization_config is not None
                     and metric_name in optimization_config.metrics.keys()
+                    and not self.experiment.metrics[
+                        metric_name
+                    ].is_reconverable_fetch_e(metric_fetch_e=metric_fetch_e)
                 ):
                     status = self._mark_err_trial_status(
                         trial=self.experiment.trials[trial_index],


### PR DESCRIPTION
Summary:
The motivation is that some metrics are flaky and we don't want to fail the trial just because we encountered one exception fetching.  Especially trials with `period_of_new_data_after_trial_completion()` > 0.

This alternative to implementing this on the metric is that the set of recoverable errors should be a scheduler option, and it's more a matter of scheduler use case than metric.

Reviewed By: Cesar-Cardoso

Differential Revision: D68273328


