### PR TITLE
Fix missing metric cols in Summary

### DIFF
--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -95,7 +95,7 @@ class Summary(Analysis):
         df = pd.DataFrame(records)
 
         if self.omit_empty_columns:
-            df = df.loc[:, df.notnull().all()]
+            df = df.loc[:, df.notnull().any()]
 
         return self._create_analysis_card(
             title=f"Summary for {experiment.name}",

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -5,28 +5,56 @@
 
 # pyre-strict
 
+import numpy as np
+import pandas as pd
 from ax.analysis.analysis import AnalysisCardLevel
 from ax.analysis.summary import Summary
+from ax.core.trial import Trial
 from ax.exceptions.core import UserInputError
+from ax.preview.api.client import Client
+from ax.preview.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_branin_experiment_with_multi_objective
+from pyre_extensions import assert_is_instance, none_throws
 
 
 class TestSummary(TestCase):
     def test_compute(self) -> None:
-        analysis = Summary()
-        experiment = get_branin_experiment_with_multi_objective(
-            with_completed_trial=True
+        client = Client()
+        client.configure_experiment(
+            experiment_config=ExperimentConfig(
+                name="test_experiment",
+                parameters=[
+                    RangeParameterConfig(
+                        name="x1",
+                        parameter_type=ParameterType.FLOAT,
+                        bounds=(0, 1),
+                    ),
+                    RangeParameterConfig(
+                        name="x2",
+                        parameter_type=ParameterType.FLOAT,
+                        bounds=(0, 1),
+                    ),
+                ],
+            )
         )
+        client.configure_optimization(objective="foo, bar")
+
+        # Get two trials and fail one, giving us a ragged structure
+        client.get_next_trials(maximum_trials=2)
+        client.complete_trial(trial_index=0, raw_data={"foo": 1.0, "bar": 2.0})
+        client.mark_trial_failed(trial_index=1)
+
+        analysis = Summary()
 
         with self.assertRaisesRegex(UserInputError, "requires an `Experiment`"):
             analysis.compute()
 
+        experiment = client._experiment
         card = analysis.compute(experiment=experiment)
 
         # Test metadata
         self.assertEqual(card.name, "Summary")
-        self.assertEqual(card.title, "Summary for branin_test_experiment")
+        self.assertEqual(card.title, "Summary for test_experiment")
         self.assertEqual(
             card.subtitle,
             "High-level summary of the `Trial`-s in this `Experiment`",
@@ -42,26 +70,41 @@ class TestSummary(TestCase):
                 "trial_index",
                 "arm_name",
                 "generation_method",
+                "generation_node",
                 "status",
                 "x1",
                 "x2",
-                "branin_a",
-                "branin_b",
+                "foo",
+                "bar",
             },
         )
-        self.assertEqual(len(card.df), len(experiment.arms_by_name))
-        self.assertEqual(card.df.head()["trial_index"].item(), 0)
-        self.assertEqual(card.df.head()["arm_name"].item(), "0_0")
-        self.assertEqual(card.df.head()["generation_method"].item(), "Sobol")
-        self.assertEqual(card.df.head()["status"].item(), "COMPLETED")
-        self.assertEqual(
-            card.df.head()["x1"].item(), experiment.arms_by_name["0_0"].parameters["x1"]
+
+        trial_0_parameters = none_throws(
+            assert_is_instance(experiment.trials[0], Trial).arm
+        ).parameters
+        trial_1_parameters = none_throws(
+            assert_is_instance(experiment.trials[1], Trial).arm
+        ).parameters
+        expected = pd.DataFrame(
+            {
+                "trial_index": {0: 0, 1: 1},
+                "arm_name": {0: "0_0", 1: "1_0"},
+                "generation_method": {0: "Sobol", 1: "Sobol"},
+                "generation_node": {0: "Sobol", 1: "Sobol"},
+                "status": {0: "COMPLETED", 1: "FAILED"},
+                "x1": {
+                    0: trial_0_parameters["x1"],
+                    1: trial_1_parameters["x1"],
+                },
+                "x2": {
+                    0: trial_0_parameters["x2"],
+                    1: trial_1_parameters["x2"],
+                },
+                "foo": {0: 1.0, 1: np.nan},  # NaN because trial 1 failed
+                "bar": {0: 2.0, 1: np.nan},
+            }
         )
-        self.assertEqual(
-            card.df.head()["x2"].item(), experiment.arms_by_name["0_0"].parameters["x2"]
-        )
-        self.assertEqual(card.df.head()["branin_a"].item(), 5.0)
-        self.assertEqual(card.df.head()["branin_b"].item(), 5.0)
+        self.assertTrue(card.df.equals(expected))
 
         # Test without omitting empty columns
         analysis_no_omit = Summary(omit_empty_columns=False)
@@ -77,8 +120,8 @@ class TestSummary(TestCase):
                 "fail_reason",
                 "x1",
                 "x2",
-                "branin_a",
-                "branin_b",
+                "foo",
+                "bar",
             },
         )
         self.assertEqual(len(card_no_omit.df), len(experiment.arms_by_name))


### PR DESCRIPTION
Summary:
Pointed out to me by Sait: If any metric value is missing/None (which can happen if a trial fails) we're dropping the whole column from the summary -- we actually only want to drop a column if EVERY value is None.

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: saitcakmak

Differential Revision: D68632100


