### PR TITLE
Introduce Experiment.to_df() based on Summary analysis

### DIFF
--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -5,12 +5,10 @@
 
 # pyre-strict
 
-import pandas as pd
 from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from ax.exceptions.core import UserInputError
-from pyre_extensions import none_throws
 
 
 class Summary(Analysis):
@@ -22,14 +20,14 @@ class Summary(Analysis):
     The DataFrame computed will contain one row per arm and the following columns:
         - trial_index: The trial index of the arm
         - arm_name: The name of the arm
-        - status: The status of the trial (e.g. RUNNING, SUCCEDED, FAILED)
+        - trial_status: The status of the trial (e.g. RUNNING, SUCCEDED, FAILED)
         - failure_reason: The reason for the failure, if applicable
         - generation_method: The model_key of the model that generated the arm
         - generation_node: The name of the ``GenerationNode`` that generated the arm
         - **METADATA: Any metadata associated with the trial, as specified by the
             Experiment's runner.run_metadata_report_keys field
         - **METRIC_NAME: The observed mean of the metric specified, for each metric
-        - **PARAMETER_NAME: The value of said parameter for the arm, for each parameter
+        - **PARAMETER_NAME: The parameter value for the arm, for each parameter
     """
 
     def __init__(self, omit_empty_columns: bool = True) -> None:
@@ -42,64 +40,9 @@ class Summary(Analysis):
     ) -> AnalysisCard:
         if experiment is None:
             raise UserInputError("`Summary` analysis requires an `Experiment` input")
-
-        records = []
-        data_df = experiment.lookup_data().df
-        for index, trial in experiment.trials.items():
-            for arm in trial.arms:
-                # Find the observed means for each metric, placing None if not found
-                observed_means = {}
-                for metric in experiment.metrics.keys():
-                    try:
-                        observed_means[metric] = data_df[
-                            (data_df["arm_name"] == arm.name)
-                            & (data_df["metric_name"] == metric)
-                        ]["mean"].item()
-                    except ValueError:
-                        observed_means[metric] = None
-
-                # Find the arm's associated generation method from the trial via the
-                # GeneratorRuns if possible
-                grs = [gr for gr in trial.generator_runs if arm in gr.arms]
-                generation_method = grs[0]._model_key if len(grs) > 0 else None
-                generation_node = grs[0]._generation_node_name if len(grs) > 0 else None
-
-                # Find other metadata from the trial to include from the trial based
-                # on the experiment's runner
-                metadata = (
-                    {
-                        key: value
-                        for key, value in trial.run_metadata.items()
-                        if key
-                        in none_throws(experiment.runner).run_metadata_report_keys
-                    }
-                    if experiment.runner is not None
-                    else {}
-                )
-
-                # Construct the record
-                record = {
-                    "trial_index": index,
-                    "arm_name": arm.name,
-                    "generation_method": generation_method,
-                    "generation_node": generation_node,
-                    "status": trial.status.name,
-                    "fail_reason": trial.run_metadata.get("fail_reason", None),
-                    **metadata,
-                    **arm.parameters,
-                    **observed_means,
-                }
-
-                records.append(record)
-
-        df = pd.DataFrame(records)
-
-        if self.omit_empty_columns:
-            df = df.loc[:, df.notnull().any()]
-
         return self._create_analysis_card(
             title=f"Summary for {experiment.name}",
             subtitle="High-level summary of the `Trial`-s in this `Experiment`",
             level=AnalysisCardLevel.MID,
-            df=df,
+            df=experiment.to_df(omit_empty_columns=self.omit_empty_columns),
         )

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -69,13 +69,13 @@ class TestSummary(TestCase):
             {
                 "trial_index",
                 "arm_name",
+                "trial_status",
                 "generation_method",
                 "generation_node",
-                "status",
-                "x1",
-                "x2",
                 "foo",
                 "bar",
+                "x1",
+                "x2",
             },
         )
 
@@ -89,9 +89,11 @@ class TestSummary(TestCase):
             {
                 "trial_index": {0: 0, 1: 1},
                 "arm_name": {0: "0_0", 1: "1_0"},
+                "trial_status": {0: "COMPLETED", 1: "FAILED"},
                 "generation_method": {0: "Sobol", 1: "Sobol"},
                 "generation_node": {0: "Sobol", 1: "Sobol"},
-                "status": {0: "COMPLETED", 1: "FAILED"},
+                "foo": {0: 1.0, 1: np.nan},  # NaN because trial 1 failed
+                "bar": {0: 2.0, 1: np.nan},
                 "x1": {
                     0: trial_0_parameters["x1"],
                     1: trial_1_parameters["x1"],
@@ -100,8 +102,6 @@ class TestSummary(TestCase):
                     0: trial_0_parameters["x2"],
                     1: trial_1_parameters["x2"],
                 },
-                "foo": {0: 1.0, 1: np.nan},  # NaN because trial 1 failed
-                "bar": {0: 2.0, 1: np.nan},
             }
         )
         self.assertTrue(card.df.equals(expected))
@@ -114,14 +114,14 @@ class TestSummary(TestCase):
             {
                 "trial_index",
                 "arm_name",
+                "trial_status",
+                "fail_reason",
                 "generation_method",
                 "generation_node",
-                "status",
-                "fail_reason",
-                "x1",
-                "x2",
                 "foo",
                 "bar",
+                "x1",
+                "x2",
             },
         )
         self.assertEqual(len(card_no_omit.df), len(experiment.arms_by_name))


### PR DESCRIPTION
Summary:
Introduces `Experiment.to_df`, which will replace `exp_to_df` and `GS.trials_as_df` to present a unified API for summarizing an experiment. The summary will still be available as an analysis card via the `Summary` analysis class.

How does this differ from existing `exp_to_df` and `GS.trials_as_df`:
- `GS.trials_as_df` is rather barebones, and primarily lists the arms, trial status and the node/model that generated the arm. It does not appear to have much usage, so we'll deprecate it.
- The default behavior of `exp_to_df` differs in a few fields. It does not list the node name or metadata, and has an `is_feasible` field (missing here) that is computed in a somewhat strange way (for a boolean field). It also exposes a number of kwargs that can modify its behavior. These seem to be utilized in some plotting related utilities. The plan is to deprecate it in favor of `Experiment.to_df` after figuring out whether the additional options are necessary. If we want to expose an `is_feasible` field, we should come up with a better definition for the field that we utilize consistently across the codebase, such as in best point utilities.

Differential Revision: D68720999


