### PR TITLE
Replace usage of exp_to_df with Experiment.to_df

### DIFF
--- a/ax/modelbridge/tests/test_torch_moo_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_moo_modelbridge.py
@@ -37,7 +37,6 @@ from ax.models.torch.botorch_moo_defaults import (
     infer_objective_thresholds,
     pareto_frontier_evaluator,
 )
-from ax.service.utils.report_utils import exp_to_df
 from ax.utils.common.random import set_rng_seed
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -546,7 +545,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
             self.assertEqual(obj_thresholds[1].op, ComparisonOp.LEQ)
             self.assertFalse(obj_thresholds[0].relative)
             self.assertFalse(obj_thresholds[1].relative)
-            df = exp_to_df(exp)
+            df = exp.to_df()
             Y = np.stack([df.branin_a.values, df.branin_b.values]).T
             Y = torch.from_numpy(Y)
             Y[:, 0] *= -1
@@ -616,7 +615,7 @@ class MultiObjectiveTorchModelBridgeTest(TestCase):
         self.assertEqual(obj_thresholds[1].op, ComparisonOp.LEQ)
         self.assertFalse(obj_thresholds[0].relative)
         self.assertFalse(obj_thresholds[1].relative)
-        df = exp_to_df(exp)
+        df = exp.to_df()
         trial_mask = df.trial_index == 1
         Y = np.stack([df.branin_a.values[trial_mask], df.branin_b.values[trial_mask]]).T
         Y = torch.from_numpy(Y)

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -73,7 +73,6 @@ from ax.service.utils.instantiation import (
     InstantiationBase,
     ObjectiveProperties,
 )
-from ax.service.utils.report_utils import exp_to_df
 from ax.service.utils.with_db_settings_base import DBSettings
 from ax.storage.json_store.decoder import (
     generation_strategy_from_json,
@@ -920,7 +919,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         one-arm trials, which is the case in base ``AxClient``; will correspond
         to arms in trials in the batch-trial case).
         """
-        return exp_to_df(exp=self.experiment)
+        return self.experiment.to_df()
 
     def get_max_parallelism(self) -> list[tuple[int, int]]:
         """Retrieves maximum number of trials that can be scheduled in parallel


### PR DESCRIPTION
Summary: Updates some use cases of `exp_to_df` to utilize `Experiment.to_df`. This diff handles most usage that doesn't rely on the kwargs exposed on `exp_to_df`. The remaining usage will be updated after adding the necessary options to `Experiment.to_df`.

Differential Revision: D68774600


