### PR TITLE
moving regression analysis to oss

### DIFF
--- a/ax/analysis/healthcheck/__init__.py
+++ b/ax/analysis/healthcheck/__init__.py
@@ -17,6 +17,7 @@ from ax.analysis.healthcheck.healthcheck_analysis import (
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
+from ax.analysis.healthcheck.regression_analysis import RegressionAnalysis
 
 from ax.analysis.healthcheck.search_space_analysis import SearchSpaceAnalysis
 from ax.analysis.healthcheck.should_generate_candidates import ShouldGenerateCandidates
@@ -29,4 +30,5 @@ __all__ = [
     "HealthcheckStatus",
     "ShouldGenerateCandidates",
     "SearchSpaceAnalysis",
+    "RegressionAnalysis",
 ]

--- a/ax/analysis/healthcheck/regression_analysis.py
+++ b/ax/analysis/healthcheck/regression_analysis.py
@@ -1,0 +1,164 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import json
+from typing import Tuple
+
+import pandas as pd
+from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.healthcheck.healthcheck_analysis import (
+    HealthcheckAnalysis,
+    HealthcheckAnalysisCard,
+    HealthcheckStatus,
+)
+from ax.analysis.healthcheck.regression_detection_utils import (
+    detect_regressions_by_trial,
+)
+from ax.core.experiment import Experiment
+from ax.core.generation_strategy_interface import GenerationStrategyInterface
+from ax.exceptions.core import UserInputError
+from pyre_extensions import none_throws
+
+
+class RegressionAnalysis(HealthcheckAnalysis):
+    r"""
+    Analysis for detecting the regressing arm, metric pairs across all trials with data.
+    For each metric, the regressions are defined as the arms that have a probability of
+    regression above the threshold. The regression probabilities are calculated as
+    posterior probabilities of the metric being above or below zero (depending if the
+    metric is improving in the negative or positive direction), where the
+    posteriors are with respect to the EBAshr
+    (empirical Bayes Adaptive Shrinkage Model).
+    """
+
+    def __init__(self, prob_threshold: float = 0.95) -> None:
+        r"""
+        Args:
+            prob_theshold: The threshold for the probability of metric regression.
+                Regressions are defined as the arms that have a probability of
+                regression above this threshold.
+
+        Returns None
+        """
+        self.prob_threshold = prob_threshold
+
+    def compute(
+        self,
+        experiment: Experiment | None,
+        generation_strategy: GenerationStrategyInterface | None = None,
+    ) -> HealthcheckAnalysisCard:
+        r"""
+        Detect the regressing arms for all trials that have data.
+
+        Args:
+            experiment: Ax experiment.
+            generation_strategy: Ax generation strategy.
+
+        Returns:
+            A HealthcheckAnalysisCard object with the information on regressing arms
+            and the corresponding metrics the arms regress.
+        """
+        if experiment is None:
+            raise UserInputError("Experiment cannot be None.")
+
+        if experiment.status_quo is None:
+            raise UserInputError(
+                "Experiment must have a status quo arm to run the regression analysis "
+                "since the regressions are relative to the status quo arm."
+            )
+
+        data = none_throws(experiment).lookup_data()
+        thresholds = {
+            metric: (0.0, self.prob_threshold) for metric in experiment.metrics.keys()
+        }
+        regressions_by_trial = detect_regressions_by_trial(
+            experiment=experiment,
+            thresholds=thresholds,
+            data=data,
+        )
+        regressions_by_trial_df, regressions_msg = process_regression_dict(
+            regressions_by_trial=regressions_by_trial
+        )
+
+        if regressions_by_trial_df.shape[0] > 0:
+            df = regressions_by_trial_df
+            status = HealthcheckStatus.WARNING
+            df["status"] = status
+            subtitle = (
+                "The following arms are regressing the following metrics "
+                f"for the respective trials: \n {regressions_msg}"
+            )
+            title_status = "Warning"
+        else:
+            status = HealthcheckStatus.PASS
+            df = pd.DataFrame({"status": [status]})
+            subtitle = "No metric regessions detected."
+            title_status = "Success"
+
+        return HealthcheckAnalysisCard(
+            name="RegressionAnalysis",
+            title=f"Ax Regression Analysis {title_status}",
+            blob=json.dumps({"status": status}),
+            subtitle=subtitle,
+            df=df,
+            level=AnalysisCardLevel.LOW,
+        )
+
+
+def process_regression_dict(
+    regressions_by_trial: dict[int, dict[str, dict[str, float]]],
+) -> Tuple[pd.DataFrame, str]:
+    r"""
+    Process the dictionary of trial indices, regressing arms and metrics into
+        a dataframe and a string.
+
+    Args:
+        regressions_by_trial: A dictionary of the form
+            {trial_index: {arm_name: {metric_name: probability}}}.
+
+    Returns: A tuple containing
+        - A dataFrame with columns ["trial_index", "arm_name", "metric_name",
+            "probability"] and
+        - A string of the form containing trial indices, regressing arms and metrics.
+    """
+    trial_indices = []
+    arm_names = []
+    metric_names = []
+    probabilities = []
+
+    msg = ""
+
+    for trial_index, arm_metric_probs in regressions_by_trial.items():
+        if arm_metric_probs is None or len(arm_metric_probs) == 0:
+            continue
+        msg += f"Trial {trial_index}: \n"
+
+        for arm_name, metrics_probs in arm_metric_probs.items():
+            regressing_metrics = list(metrics_probs.keys())
+            metric_names.extend(regressing_metrics)
+            trial_indices.extend([trial_index] * len(regressing_metrics))
+            probabilities.extend(list(metrics_probs.values()))
+            arm_names.extend([arm_name] * len(regressing_metrics))
+
+            msg += f" - Arm {arm_name}: \n"
+            for metric in regressing_metrics:
+                msg += f"{metric}, "
+            msg = msg[:-2] + " \n"
+
+    regressions_by_trial_df = pd.DataFrame(
+        {
+            "trial_index": trial_indices,
+            "arm_name": arm_names,
+            "metric_name": metric_names,
+            "probability": probabilities,
+        }
+    )
+    if "trial_index" in regressions_by_trial_df.columns:
+        regressions_by_trial_df["trial_index"] = regressions_by_trial_df[
+            "trial_index"
+        ].astype(int)
+    return regressions_by_trial_df, msg

--- a/ax/analysis/healthcheck/regression_detection_utils.py
+++ b/ax/analysis/healthcheck/regression_detection_utils.py
@@ -1,0 +1,197 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from collections import defaultdict
+
+import numpy as np
+import numpy.typing as npt
+
+from ax.core.data import Data
+from ax.core.experiment import Experiment
+from ax.core.observation import observations_from_data
+
+from ax.exceptions.core import DataRequiredError, UserInputError
+from ax.modelbridge.discrete import DiscreteModelBridge
+from ax.modelbridge.registry import rel_EB_ashr_trans
+from ax.models.discrete.eb_ashr import EBAshr
+from pyre_extensions import assert_is_instance
+
+
+def detect_regressions_by_trial(
+    experiment: Experiment,
+    thresholds: dict[str, tuple[float, float]],
+    data: Data | None = None,
+) -> dict[int, dict[str, dict[str, float]]]:
+    r"""
+    Identifies all regressing arms across trial along with the metrics they regress.
+
+    Args:
+        experiment: Ax experiment.
+        thresholds: A dictionary mapping metric names a tuple of
+            (threshold size, threshold probability).
+        data: Experiment data. If None, use the attached experiment data.
+
+    Returns: A dictionary mapping trial indices to
+        dictionaries containing regressing arm names as keys and a dictionary
+        with the corresponding regressed metrics and a tuple of regression sizes and
+        corresponding regression probabilities as values.
+
+    """
+    data = data if data is not None else experiment.lookup_data()
+
+    regressing_arms_metrics_by_trial = {}
+
+    for trial_index, trial_df in data.df.groupby("trial_index"):
+        regressing_arms_metrics_by_trial[trial_index] = detect_regressions_single_trial(
+            experiment=experiment,
+            data=Data(df=trial_df),
+            thresholds=thresholds,
+        )
+
+    return regressing_arms_metrics_by_trial
+
+
+def compute_regression_probabilities_single_trial(
+    experiment: Experiment,
+    size_thresholds: dict[str, float],
+    data: Data | None = None,
+) -> tuple[list[str | None], list[str], npt.NDArray]:
+    r"""
+    Computes the probabilities of regression for all arm metric pairs in a single trial.
+    If a metric has lower_is_better indicator set to True
+    (regresses in positive direction), regression probability is defined as
+    Pr(metric value>=(positive) threshold).
+    If a metric has lower_is_better indicator set to False
+    (regresses in negative direction), regression probability is defined as
+    Pr(metric value<=(negative) threshold).
+
+    Args:
+        experiment: Ax experiment.
+        size_thresholds: A dictionary mapping metric names to threshold sizes.
+        data: Experiment data. If None, use the attached experiment data.
+
+    Returns: A tuple containing
+        - arm names,
+        - metric names, and corresponding
+        - an array of size n x m where n is the number of arms and m is
+            the number of metrics. Each entry contains the probability of
+            regression for that arm-metric pair.
+
+    """
+    data = data if data is not None else experiment.lookup_data()
+
+    if data.df.empty:
+        raise DataRequiredError("Data must be non-empty.")
+
+    if len(set(data.df["trial_index"])) > 1:
+        raise UserInputError("The input data should contain only one trial.")
+
+    # metric names available in the data and also in the given size thresholds dict
+    metric_names = set(size_thresholds.keys()).intersection(set(data.df["metric_name"]))
+
+    if len(metric_names) == 0:
+        raise ValueError(
+            "No common metrics between the provided data and the size thresholds."
+            "Need to provide both data and the size thresholds for metrics of interest."
+        )
+
+    target_data = Data(df=data.df[data.df["metric_name"].isin(metric_names)])
+
+    modelbridge = DiscreteModelBridge(
+        experiment=experiment,
+        search_space=experiment.search_space,
+        data=target_data,
+        model=EBAshr(),
+        transforms=rel_EB_ashr_trans,
+        optimization_config=experiment.optimization_config,
+    )
+
+    metric_names = modelbridge.outcomes
+
+    lower_is_better_indicators = np.array(
+        [-1 if experiment.metrics[m].lower_is_better else 1 for m in metric_names]
+    )
+
+    # if lower is better: outcome constraints: metric <= (positive) threshold
+    # if upper is better: outcome constraints: metric >= (negative) threshold
+    A = -np.diag(lower_is_better_indicators)
+    b = np.array([abs(size_thresholds[metric]) for metric in metric_names])
+
+    _, regression_probabilities = assert_is_instance(
+        modelbridge.model, EBAshr
+    )._get_regression_indicator(
+        objective_weights=np.zeros(len(metric_names)), outcome_constraints=(A, b)
+    )
+
+    observations = observations_from_data(
+        experiment=experiment,
+        data=target_data,
+    )
+
+    arm_names = [
+        observations[i].arm_name for i in range(regression_probabilities.shape[0])
+    ]
+
+    return arm_names, metric_names, regression_probabilities
+
+
+def detect_regressions_single_trial(
+    experiment: Experiment,
+    thresholds: dict[str, tuple[float, float]],
+    data: Data | None = None,
+) -> dict[str | None, dict[str, float]]:
+    r"""
+    Identifies all regressing arms along with the metrics they regress for
+    a single trial.
+
+    Args:
+        experiment: Ax experiment.
+        thresholds: A dictionary mapping metric names a tuple of
+            (threshold size, threshold probability).
+
+    Returns: A dictionary with regressing arms as keys and another dictionary of
+        corresponding regressed metrics and their corresponding regression probabilities
+        as values.
+
+    """
+    data = data if data is not None else experiment.lookup_data()
+
+    if len(set(data.df["trial_index"])) > 1:
+        raise UserInputError("The input data should contain only one trial.")
+
+    # metric names available in the data and also in the given thresholds
+    metric_names = set(thresholds.keys()).intersection(set(data.df["metric_name"]))
+
+    if len(metric_names) == 0:
+        raise ValueError(
+            "No common metrics between the provided data and the thresholds."
+            "Need to provide both data and the size thresholds for metrics of interest."
+        )
+
+    size_thresholds = {metric: thresholds[metric][0] for metric in metric_names}
+
+    (
+        arm_names,
+        metric_names,
+        regression_probabilities,
+    ) = compute_regression_probabilities_single_trial(
+        experiment=experiment,
+        data=Data(df=data.df[data.df["metric_name"].isin(metric_names)]),
+        size_thresholds=size_thresholds,
+    )
+
+    # Regressing arms along with the metrics they regresss
+    regressing_arms_metrics: dict[str | None, dict[str, float]] = defaultdict(dict)
+
+    for i, arm_name in enumerate(arm_names):
+        for j, metric_name in enumerate(metric_names):
+            if regression_probabilities[i, j] >= thresholds[metric_name][1]:
+                regressing_arms_metrics[arm_name].update(
+                    {metric_name: regression_probabilities[i, j]}
+                )
+
+    return regressing_arms_metrics

--- a/ax/analysis/healthcheck/tests/test_regression_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_regression_analysis.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import numpy as np
+import pandas as pd
+from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.healthcheck.regression_analysis import RegressionAnalysis
+from ax.core.data import Data
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_branin_experiment_with_multi_objective
+
+
+class TestRegressionAnalysis(TestCase):
+    def test_regression_analysis(self) -> None:
+        experiment = get_branin_experiment_with_multi_objective(
+            with_batch=True, with_status_quo=True
+        )
+
+        df = pd.DataFrame(
+            {
+                "metric_name": ["branin_a"] * 6 + ["branin_b"] * 6,
+                "arm_name": ["status_quo", "0_0", "0_1", "0_2", "0_3", "0_4"] * 2,
+                "trial_index": [0] * 12,
+                "mean": list(np.arange(7, 1, -1)) + list(np.arange(6, 1, -1)) + [10.0],
+                "sem": [1.0] * 12,
+            }
+        )
+
+        experiment.attach_data(Data(df=df))
+        ra = RegressionAnalysis(prob_threshold=0.90)
+        card = ra.compute(experiment=experiment, generation_strategy=None)
+        self.assertEqual(card.name, "RegressionAnalysis")
+        self.assertEqual(card.title, "Ax Regression Analysis Warning")
+        self.assertTrue(
+            "0_4" in card.subtitle
+            and "branin_b" in card.subtitle
+            and "Trial 0" in card.subtitle
+        )
+        self.assertEqual(card.level, AnalysisCardLevel.LOW)
+
+        df = pd.DataFrame(
+            {
+                "metric_name": ["branin_a"] * 6 + ["branin_b"] * 6,
+                "arm_name": ["status_quo", "0_0", "0_1", "0_2", "0_3", "0_4"] * 2,
+                "trial_index": [0] * 12,
+                "mean": list(np.arange(7, 1, -1)) * 2,
+                "sem": [1.0] * 12,
+            }
+        )
+        experiment.attach_data(Data(df=df))
+        ra = RegressionAnalysis(prob_threshold=0.90)
+        card = ra.compute(experiment=experiment, generation_strategy=None)
+        self.assertEqual(card.name, "RegressionAnalysis")
+        self.assertEqual(card.title, "Ax Regression Analysis Success")
+        self.assertEqual(
+            card.subtitle,
+            "No metric regessions detected.",
+        )
+        self.assertEqual(card.level, AnalysisCardLevel.LOW)

--- a/ax/analysis/healthcheck/tests/test_regression_detection_utils.py
+++ b/ax/analysis/healthcheck/tests/test_regression_detection_utils.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import numpy as np
+import pandas as pd
+from ax.analysis.healthcheck.regression_detection_utils import (
+    detect_regressions_by_trial,
+    detect_regressions_single_trial,
+)
+from ax.core.data import Data
+from ax.modelbridge.factory import get_sobol
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import (
+    get_branin_experiment_with_multi_objective,
+    TEST_SOBOL_SEED,
+)
+
+
+class TestRegressionDetection(TestCase):
+    def test_regression_detection_by_trial(self) -> None:
+        experiment = get_branin_experiment_with_multi_objective(
+            with_batch=True, with_status_quo=True
+        )
+
+        df0 = pd.DataFrame(
+            {
+                "metric_name": ["branin_a"] * 6 + ["branin_b"] * 6,
+                "arm_name": ["status_quo", "0_0", "0_1", "0_2", "0_3", "0_4"] * 2,
+                "trial_index": [0] * 12,
+                "mean": list(np.arange(7, 1, -1)) + list(np.arange(6, 1, -1)) + [10.0],
+                "sem": [1.0] * 12,
+            }
+        )
+
+        # zero size threshold and high probability threshold
+        regressing_arms_metrics = detect_regressions_single_trial(
+            experiment=experiment,
+            thresholds={"branin_a": (0.0, 0.90), "branin_b": (0.0, 0.90)},
+            data=Data(df=df0),
+        )
+        self.assertGreaterEqual(regressing_arms_metrics["0_4"]["branin_b"], 0.90)
+        self.assertEqual(len(list(regressing_arms_metrics.keys())), 1)
+        self.assertEqual(len(list(regressing_arms_metrics["0_4"].keys())), 1)
+        self.assertGreaterEqual(regressing_arms_metrics["0_4"]["branin_b"], 0.90)
+
+        # zero size threshold and different probability threshold
+        regressing_arms_metrics = detect_regressions_single_trial(
+            experiment=experiment,
+            thresholds={"branin_a": (0, 0.10), "branin_b": (0, 0.95)},
+            data=Data(df=df0),
+        )
+        self.assertGreaterEqual(regressing_arms_metrics["0_0"]["branin_a"], 0.10)
+        self.assertEqual(len(list(regressing_arms_metrics.keys())), 1)
+        self.assertEqual(len(list(regressing_arms_metrics["0_0"].keys())), 1)
+
+        # different size thresholds
+        regressing_arms_metrics = detect_regressions_single_trial(
+            experiment=experiment,
+            data=Data(df=df0),
+            thresholds={"branin_a": (10.0, 0.50), "branin_b": (100, 0.50)},
+        )
+        self.assertEqual(len(regressing_arms_metrics), 0)
+
+        # add one more trial
+        sobol_generator = get_sobol(
+            search_space=experiment.search_space, seed=TEST_SOBOL_SEED + 1
+        )
+        sobol_run = sobol_generator.gen(n=3)
+        experiment.new_batch_trial(optimize_for_power=True).add_generator_run(sobol_run)
+
+        df1 = pd.DataFrame(
+            {
+                "metric_name": ["branin_a"] * 4 + ["branin_b"] * 4,
+                "arm_name": ["status_quo", "1_0", "1_1", "1_2"] * 2,
+                "trial_index": [1] * 8,
+                "mean": list(np.arange(5, 1, -1)) + list(np.arange(4, 1, -1)) + [20.0],
+                "sem": [1.0] * 8,
+            }
+        )
+
+        df = pd.concat([df0, df1], ignore_index=True)
+        regressing_arms_metrics_by_trial = detect_regressions_by_trial(
+            experiment=experiment,
+            thresholds={"branin_a": (0.0, 0.90), "branin_b": (0.0, 0.90)},
+            data=Data(df=df),
+        )
+        self.assertGreaterEqual(
+            regressing_arms_metrics_by_trial[0]["0_4"]["branin_b"], 0.90
+        )
+        self.assertEqual(len(list(regressing_arms_metrics_by_trial[0].keys())), 1)
+        self.assertEqual(
+            len(list(regressing_arms_metrics_by_trial[0]["0_4"].keys())), 1
+        )
+        self.assertGreaterEqual(
+            regressing_arms_metrics_by_trial[1]["1_2"]["branin_b"], 0.90
+        )
+        self.assertEqual(len(list(regressing_arms_metrics_by_trial[1].keys())), 1)
+        self.assertEqual(
+            len(list(regressing_arms_metrics_by_trial[1]["1_2"].keys())), 1
+        )

--- a/sphinx/source/analysis.rst
+++ b/sphinx/source/analysis.rst
@@ -40,7 +40,7 @@ Plotly Analysis
     :show-inheritance:
 
 Can Generate Candidates Healthcheck Analysis
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.analysis.healthcheck.can_generate_candidates
     :members:
@@ -48,7 +48,7 @@ Can Generate Candidates Healthcheck Analysis
     :show-inheritance:
 
 Should Generate Candidates Healthcheck Analysis
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.analysis.healthcheck.should_generate_candidates
     :members:
@@ -64,7 +64,7 @@ Healthcheck Analysis
     :show-inheritance:
 
 Constraints Feasibility Analysis
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.analysis.healthcheck.constraints_feasibility
     :members:
@@ -72,16 +72,31 @@ Constraints Feasibility Analysis
     :show-inheritance:
 
 Search Space Analysis
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.analysis.healthcheck.search_space_analysis
     :members:
     :undoc-members:
     :show-inheritance:
 
+Regression Analysis
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.analysis.healthcheck.regression_analysis
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Regression Analysis Utils
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.analysis.healthcheck.regression_detection_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 InSample Effects Analysis
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.analysis.plotly.arm_effects.insample_effects
     :members:
@@ -105,7 +120,7 @@ Predicted Effects Analysis
     :show-inheritance:
 
 Plotly Arm Effects Utils
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.analysis.plotly.arm_effects.utils
     :members:
@@ -113,7 +128,7 @@ Plotly Arm Effects Utils
     :show-inheritance:
 
 Plotly Analysis Utils
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.analysis.plotly.utils
     :members:


### PR DESCRIPTION
Summary:
- Since EBAshr has been moved to OSS in D68562504 and regression analysis healthcheck depends on EBAshr, moving regression detection analysis to Ax OSS as well.
- Deleting regression detection message file since it is unused (it's been replaced by the regression analysis healthcheck).

Reviewed By: saitcakmak

Differential Revision: D68746681


