### PR TITLE
Use uv package manager in GHA

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,9 +17,13 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-
+    env:
+      # `uv pip ...` requires venv by default. This skips that requirement.
+      UV_SYSTEM_PYTHON: 1
     steps:
     - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -30,9 +34,9 @@ jobs:
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         # use latest Botorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ".[unittest]"
+        uv pip install git+https://github.com/cornellius-gp/gpytorch.git
+        uv pip install git+https://github.com/pytorch/botorch.git
+        uv pip install -e ".[unittest]"
     - name: Validate Sphinx
       run: |
         python scripts/validate_sphinx.py -p "${pwd}"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -49,11 +49,15 @@ jobs:
   deploy-test-pypi:
 
     runs-on: ubuntu-latest
-
+    env:
+      # `uv pip ...` requires venv by default. This skips that requirement.
+      UV_SYSTEM_PYTHON: 1
     steps:
     - uses: actions/checkout@v4
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -64,10 +68,10 @@ jobs:
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         # use latest BoTorch
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ".[dev,mysql,notebook]"
-        pip install --upgrade build setuptools setuptools_scm wheel
+        uv pip install git+https://github.com/cornellius-gp/gpytorch.git
+        uv pip install git+https://github.com/pytorch/botorch.git
+        uv pip install -e ".[dev,mysql,notebook]"
+        uv pip install --upgrade build setuptools setuptools_scm wheel
     - name: Build wheel
       run: |
         python -m build --sdist --wheel

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,8 +67,13 @@ jobs:
   deploy:
     needs: tests-and-coverage-pinned # only run if test step succeeds
     runs-on: ubuntu-latest
+    env:
+      # `uv pip ...` requires venv by default. This skips that requirement.
+      UV_SYSTEM_PYTHON: 1
     steps:
     - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -76,8 +81,8 @@ jobs:
     - name: Install dependencies
       run: |
         # use stable Botorch
-        pip install -e ".[dev,mysql,notebook]"
-        pip install --upgrade build setuptools setuptools_scm wheel
+        uv pip install -e ".[dev,mysql,notebook]"
+        uv pip install --upgrade build setuptools setuptools_scm wheel
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - name: Build wheel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,16 +12,20 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    env:
+      # `uv pip ...` requires venv by default. This skips that requirement.
+      UV_SYSTEM_PYTHON: 1
     steps:
       - uses: actions/checkout@v4
-
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
       - name: Install dependencies
-        run: pip install pre-commit
+        run: uv pip install pre-commit
 
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      # `uv pip ...` requires venv by default. This skips that requirement.
+      UV_SYSTEM_PYTHON: 1
     steps:
     - uses: actions/checkout@v4
       with:
@@ -30,13 +33,15 @@ jobs:
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git merge origin/main
         # To avoid a large number of commits we don't push this sync commit to github until a new release.
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - name: Install dependencies
       run: |
-        pip install -e ".[tutorial]"
+        uv pip install -e ".[tutorial]"
     - if: ${{ inputs.run_tutorials }}
       name: Run Tutorials
       run: |

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -27,9 +27,13 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12"]
       fail-fast: false
-
+    env:
+      # `uv pip ...` requires venv by default. This skips that requirement.
+      UV_SYSTEM_PYTHON: 1
     steps:
     - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -41,7 +45,7 @@ jobs:
         # The brackets returns '.[unittest_minimal]' if using minimal dependencies and '.[unittest]'
         # otherwise. This saves us from needing 4 install dependencies blocks by supporting two
         # different installation options in one line.
-        pip install -e ${{ ((inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
+        uv pip install -e ${{ ((inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
 
     - if: ${{ !inputs.pinned_botorch }}
       name: Install dependencies with latest BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
@@ -49,9 +53,9 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ${{ ((inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
+        uv pip install git+https://github.com/cornellius-gp/gpytorch.git
+        uv pip install git+https://github.com/pytorch/botorch.git
+        uv pip install -e ${{ ((inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}
 
     - name: Import Ax
       run: |

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -23,8 +23,13 @@ jobs:
   build-tutorials:
     name: Tutorials
     runs-on: ubuntu-latest
+    env:
+      # `uv pip ...` requires venv by default. This skips that requirement.
+      UV_SYSTEM_PYTHON: 1
     steps:
     - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -33,7 +38,7 @@ jobs:
     - if: ${{ inputs.pinned_botorch }}
       name: Install dependencies with pinned BoTorch
       run: |
-        pip install -e ".[tutorial]"
+        uv pip install -e ".[tutorial]"
 
     - if: ${{ !inputs.pinned_botorch }}
       name: Install dependencies with latest BoTorch
@@ -41,9 +46,9 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
-        pip install git+https://github.com/cornellius-gp/gpytorch.git
-        pip install git+https://github.com/pytorch/botorch.git
-        pip install -e ".[tutorial]"
+        uv pip install git+https://github.com/cornellius-gp/gpytorch.git
+        uv pip install git+https://github.com/pytorch/botorch.git
+        uv pip install -e ".[tutorial]"
 
     - if: ${{ inputs.smoke_test }}
       name: Run tutorials with smoke test


### PR DESCRIPTION
Replicates https://github.com/pytorch/botorch/pull/2713 for Ax.
`uv` is much faster than `pip`, which leads to a couple minutes of speed up in each workflow, which can add up to meaningful compute savings over many CI runs we do every day.

Test plan: Successful CI run

Compared to a previous CI run
Before - 155 secs of setup time (until test & coverage step): https://github.com/facebook/Ax/actions/runs/13040634315/job/36381474759
After - 48 secs of setup time (until test & coverage step): https://github.com/facebook/Ax/actions/runs/13061685440/job/36445887187