### PR TITLE
Publish website and run tutorials, and remove blog link

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -40,6 +40,8 @@ jobs:
     name: Publish latest website
     uses: ./.github/workflows/publish_website.yml
     secrets: inherit
+    with:
+      run_tutorials: true
 
   deploy-test-pypi:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,7 @@ jobs:
     uses: ./.github/workflows/publish_website.yml
     with:
       new_version: ${{ github.event.release.tag_name }}
+      run_tutorials: true
     secrets: inherit
 
   deploy:

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -9,7 +9,7 @@ on:
       run_tutorials:
         required: false
         type: boolean
-        default: false
+        default: true
   workflow_dispatch:
 
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -121,11 +121,6 @@ module.exports={
           "className": "header-github-link",
           "aria-label": "GitHub",
           "position": "right"
-        },
-        {
-          to: 'blog',
-          label: 'Blog',
-          position: 'left'
         }
       ]
     },


### PR DESCRIPTION
## tutorials

We check in the tutorials un-run and run them in CI as a form of integration tests.

This was disabled in my fork to speed up development but we need it back for the official website.

## blog

We removed the blog for now, no need for the navbar link either.