### PR TITLE
Make the message clearer to avoid confusion about a scary and lengthy test stack

### DIFF
--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -428,9 +428,11 @@ class TestCase(fake_filesystem_unittest.TestCase):
             else first != second
         ):
             raise self.failureException(
-                "Encountered unequal objects. "
-                "Attempting in-depth comparison; note that this recurs through the"
-                " attributes of the objects being compared multiple times!\n\n"
+                "Encountered unequal objects. This Ax utility will now attempt an "
+                "in-depth comparison of the objects to print out the actually "
+                "unequal fields within them. Note that the resulting printout is "
+                "a nested comparison, and you'll find the actual unequal fields at "
+                "the very bottom. Don't be scared of the long printout : )\n\n"
                 + _build_comparison_str(
                     first=first, second=second, skip_db_id_check=skip_db_id_check
                 ),


### PR DESCRIPTION
Summary:
We have a pretty convenient feature in Ax' `TestCase`, to deeply compare unequal objects. This can help a lot if you know how to use it, but folks mentioned to me that because the printout is lengthy, folks sometimes get scared of it and don't read it all the way through. Here's my attempt to make it friendlier : )

For illustration, printout (see how it's actually pretty useful if we look all the way through?): 

{F1974874829} 

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: Cesar-Cardoso

Differential Revision: D68987651


