### PR TITLE
[GHA] Specify permissions when deviating from defaults

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -39,7 +39,10 @@ jobs:
   publish-latest-website:
     name: Publish latest website
     uses: ./.github/workflows/publish_website.yml
-    secrets: inherit
+    permissions:
+      pages: write
+      id-token: write
+      contents: write
     with:
       run_tutorials: true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,10 @@ jobs:
     with:
       new_version: ${{ github.event.release.tag_name }}
       run_tutorials: true
-    secrets: inherit
+    permissions:
+      pages: write
+      id-token: write
+      contents: write
 
   deploy:
     needs: tests-and-coverage-pinned # only run if test step succeeds

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -17,6 +17,8 @@ jobs:
 
   build-website:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Context

Duplicate of change made in botorch: https://github.com/pytorch/botorch/pull/2721

## Motivation

The `publish_website.yml` workflow requires write permissions to
1. create new docusaurus versions by pushing a commit to `docusaurus-versions` branch
2. push new website to gh-pages

This was not an issue in the fork that introduced these changes because Meta's organization / the official repo has more restrictive permissions than the defaults. More restrictive default permissions are definitely the way to go, here we elevate permissions only when necessary.

## Test Plan

I made the default permissions in my fork more restrictive such that the same workflows would fail then verified that this change results in successful workflow runs. https://github.com/CristianLara/botorch/actions/runs/13107635487/job/36565023833