### PR TITLE
[Docusaurus] Fix broken links

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 The modular design of Ax enables three different usage modes, with different
 balances of structure to flexibility and reproducibility. Navigate to the
-["Tutorials" page](/tutorials) for an in-depth walk-through of each API and
+["Tutorials" page](/docs/tutorials) for an in-depth walk-through of each API and
 usage mode.
 
 **NOTE: We recommend the Service API for the vast majority of use cases.** This
@@ -17,7 +17,7 @@ we are in the process of consolidating Ax usage around it more formally.
 
 From most lightweight to fullest functionality, our APIs are:
 
--   **Loop API** ([tutorial](/tutorials/gpei_hartmann_loop.html)) is intended for
+-   **Loop API** ([tutorial](/docs/tutorials/gpei_hartmann_loop)) is intended for
     synchronous optimization loops, where [trials](glossary.md#trial) can be
     evaluated right away. With this API, optimization can be executed in a single
     call and [experiment](glossary.md#experiment) introspection is available once
@@ -25,7 +25,7 @@ From most lightweight to fullest functionality, our APIs are:
     running a single trial is fast and only one trial should be running at a
     time.**
 -   **[RECOMMENDED] Service API**
-    ([tutorial](/tutorials/gpei_hartmann_service.html)) can be used as a
+    ([tutorial](/docs/tutorials/gpei_hartmann_service)) can be used as a
     lightweight service for parameter-tuning applications where trials might be
     evaluated in parallel and data is available asynchronously (e.g.
     hyperparameter or simulation optimization). It requires little to no knowledge
@@ -38,9 +38,9 @@ From most lightweight to fullest functionality, our APIs are:
     architecture and how things work under the hood.**
     -   In both the Loop and the Service API, it is possible to configure the
         optimization algorithm via an Ax `GenerationStrategy`
-        ([tutorial](/tutorials/generation_strategy.html)), so use of Developer API
+        ([tutorial](/docs/tutorials/generation_strategy)), so use of Developer API
         is not required to control the optimization algorithm in Ax.
--   **Developer API** ([tutorial](/tutorials/gpei_hartmann_developer.html)) is for
+-   **Developer API** ([tutorial](/docs/tutorials/gpei_hartmann_developer)) is for
     ad-hoc use by data scientists, machine learning engineers, and researchers.
     The developer API allows for a great deal of customization and introspection,
     and is recommended for those who plan to use Ax to optimize A/B tests. Using
@@ -49,7 +49,7 @@ From most lightweight to fullest functionality, our APIs are:
     customize or contribute to Ax, or leverage advanced functionality that is not
     exposed in other APIs.**
     -   While not an API, the **`Scheduler`**
-        ([tutorial](/tutorials/scheduler.html)) is an important and distinct
+        ([tutorial](/docs/tutorials/scheduler)) is an important and distinct
         use-case of the Ax Developer API. With the `Scheduler`, it's possible to run
         a configurable, managed closed-loop optimization where trials are deployed
         and polled in an async fashion and no human intervention/oversight is

--- a/docs/core.md
+++ b/docs/core.md
@@ -157,7 +157,7 @@ experiment.new_batch_trial().add_arms_and_weights(arms=[Arm(...), Arm(...)])
 experiment.new_batch_trial().add_generator_run(generator_run=GeneratorRun(...))
 ```
 
-A trial goes through multiple phases during the experimentation cycle, tracked by its [`TrialStatus`](../api/core.html#ax.core.base_trial.TrialStatus) field. These stages are:
+A trial goes through multiple phases during the experimentation cycle, tracked by its [`TrialStatus`](https://ax.readthedocs.io/en/latest/core.html#ax.core.base_trial.TrialStatus) field. These stages are:
 
 -   `CANDIDATE` - Trial has just been created and can still be modified before deployment.
 -   `STAGED` - Relevant for external systems, where the trial configuration has been deployed but not begun the evaluation stage.

--- a/docs/data.md
+++ b/docs/data.md
@@ -6,9 +6,9 @@ title: Data
 
 [Metrics](glossary.md#metric) provide an interface for fetching data for an experiment or trial. Experiment objectives and outcome constraints are special types of metrics, and you can also attach additional metrics for tracking purposes.
 
-Each metric is responsible for fetching its own data. Thus, all metric classes must implement the method `fetch_trial_data`, which accepts a [`Trial`](../api/core.html#ax.core.trial.Trial) and returns an instance of [`Data`](../api/core.html#ax.core.data.Data), a wrapper around a Pandas DataFrame.
+Each metric is responsible for fetching its own data. Thus, all metric classes must implement the method `fetch_trial_data`, which accepts a [`Trial`](https://ax.readthedocs.io/en/latest/core.html#ax.core.trial.Trial) and returns an instance of [`Data`](https://ax.readthedocs.io/en/latest/core.html#ax.core.data.Data), a wrapper around a Pandas DataFrame.
 
-To fetch data for an experiment or trial, use `exp.fetch_data` or `trial.fetch_data`. These methods fetch data for all metrics on the experiment and then combine the results into a new aggregate [`Data`](../api/core.html#ax.core.data.Data) instance.
+To fetch data for an experiment or trial, use `exp.fetch_data` or `trial.fetch_data`. These methods fetch data for all metrics on the experiment and then combine the results into a new aggregate [`Data`](https://ax.readthedocs.io/en/latest/core.html#ax.core.data.Data) instance.
 
 Each row of the final DataFrame represents the evaluation of an arm on a metric. As such, the required columns are: `arm_name`, `metric_name`, `mean`, and `sem`. Additional optional columns are also supported: `trial_index`, `start_time`, and `end_time`.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -5,7 +5,7 @@ sidebar_label: Glossary
 ---
 ### Arm
 
-Mapping from [parameters](glossary.md#parameter) (i.e. a parameterization or parameter configuration) to parameter values. An arm provides the configuration to be tested in an Ax [trial](glossary.md#trial). Also known as "treatment group" or "parameterization", the name 'arm' comes from the [Multi-Armed Bandit](https://en.wikipedia.org/wiki/Multi-armed_bandit) optimization problem, in which a player facing a row of “one-armed bandit” slot machines has to choose which machines to play when and in what order. [`[Arm]`](/api/core.html#module-ax.core.arm)
+Mapping from [parameters](glossary.md#parameter) (i.e. a parameterization or parameter configuration) to parameter values. An arm provides the configuration to be tested in an Ax [trial](glossary.md#trial). Also known as "treatment group" or "parameterization", the name 'arm' comes from the [Multi-Armed Bandit](https://en.wikipedia.org/wiki/Multi-armed_bandit) optimization problem, in which a player facing a row of “one-armed bandit” slot machines has to choose which machines to play when and in what order. [`[Arm]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.arm)
 
 ### Bandit optimization
 
@@ -13,7 +13,7 @@ Machine learning-driven version of A/B testing that dynamically allocates traffi
 
 ### Batch trial
 
-Single step in the [experiment](glossary.md#experiment), contains multiple [arms](glossary.md#arm) that are **deployed and evaluated together**. A batch trial is not just a trial with many arms; it is a trial for which it is important that the arms are evaluated simultaneously, e.g. in an A/B test where the evaluation results are subject to nonstationarity. For cases where multiple arms are evaluated separately and independently of each other, use multiple regular [trials](glossary.md#trial) with a single arm each. [`[BatchTrial]`](/api/core.html#module-ax.core.batch_trial)
+Single step in the [experiment](glossary.md#experiment), contains multiple [arms](glossary.md#arm) that are **deployed and evaluated together**. A batch trial is not just a trial with many arms; it is a trial for which it is important that the arms are evaluated simultaneously, e.g. in an A/B test where the evaluation results are subject to nonstationarity. For cases where multiple arms are evaluated separately and independently of each other, use multiple regular [trials](glossary.md#trial) with a single arm each. [`[BatchTrial]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.batch_trial)
 
 ### Bayesian optimization
 
@@ -21,68 +21,68 @@ Sequential optimization strategy for finding an optimal [arm](glossary.md#arm) i
 
 ### Evaluation function
 
-Function that takes a parameterization and an optional weight as input and outputs a set of metric evaluations ([more details](trial-evaluation.md#evaluation-function)). Used in the [Loop API](api.md).
+Function that takes a parameterization and an optional weight as input and outputs a set of metric evaluations ([more details](/docs/trial-evaluation#evaluating-trial-parameters)). Used in the [Loop API](api.md).
 
 ### Experiment
 
-Object that keeps track of the whole optimization process. Contains a [search space](glossary.md#search-space), [optimization config](glossary.md#optimization-config), and other metadata. [`[Experiment]`](/api/core.html#module-ax.core.experiment)
+Object that keeps track of the whole optimization process. Contains a [search space](glossary.md#search-space), [optimization config](glossary.md#optimization-config), and other metadata. [`[Experiment]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.experiment)
 
 ### Generation strategy
 
-Abstraction that allows to declaratively specify one or multiple models to use in the course of the optimization and automate transition between them (relevant [tutorial](/tutorials/scheduler.html)). [`[GenerationStrategy]`](/api/modelbridge.html#module-ax.modelbridge.generation_strategy)
+Abstraction that allows to declaratively specify one or multiple models to use in the course of the optimization and automate transition between them (relevant [tutorial](/docs/tutorials/scheduler)). [`[GenerationStrategy]`](https://ax.readthedocs.io/en/latest/modelbridge.html#module-ax.modelbridge.generation_strategy)
 
 ### Generator run
 
-Outcome of a single run of the `gen` method of a [model bridge](glossary.md#model-bridge), contains the generated [arms](glossary.md#arm), as well as possibly best [arm](glossary.md#arm) predictions, other [model](glossary.md#model) predictions, fit times etc. [`[GeneratorRun]`](/api/core.html#module-ax.core.generator_run)
+Outcome of a single run of the `gen` method of a [model bridge](glossary.md#model-bridge), contains the generated [arms](glossary.md#arm), as well as possibly best [arm](glossary.md#arm) predictions, other [model](glossary.md#model) predictions, fit times etc. [`[GeneratorRun]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.generator_run)
 
 ### Metric
 
-Interface for fetching data for a specific measurement on an [experiment](glossary.md#experiment) or [trial](glossary.md#trial). [`[Metric]`](/api/core.html#module-ax.core.metric)
+Interface for fetching data for a specific measurement on an [experiment](glossary.md#experiment) or [trial](glossary.md#trial). [`[Metric]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.metric)
 
 ### Model
 
-Algorithm that can be used to generate new points in a [search space](glossary.md#search-space). [`[Model]`](/api/models.html)
+Algorithm that can be used to generate new points in a [search space](glossary.md#search-space). [`[Model]`](https://ax.readthedocs.io/en/latest/models.html)
 
 ### Model bridge
 
-Adapter for interactions with a [model](glossary.md#model) within the Ax ecosystem. [`[ModelBridge]`](/api/modelbridge.html)
+Adapter for interactions with a [model](glossary.md#model) within the Ax ecosystem. [`[ModelBridge]`](https://ax.readthedocs.io/en/latest/modelbridge.html)
 
 ### Objective
 
-The [metric](glossary.md#metric) to be optimized, with an optimization direction (maximize/minimize). [`[Objective]`](/api/core.html#module-ax.core.objective)
+The [metric](glossary.md#metric) to be optimized, with an optimization direction (maximize/minimize). [`[Objective]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.objective)
 
 ### Optimization config
 
-Contains information necessary to run an optimization, i.e. [objective](glossary.md#objective) and [outcome constraints](glossary#outcome-constraints). [`[OptimizationConfig]`](/api/core.html#module-ax.core.optimization_config)
+Contains information necessary to run an optimization, i.e. [objective](glossary.md#objective) and [outcome constraints](/docs/glossary#outcome-constraint). [`[OptimizationConfig]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.optimization_config)
 
 ### Outcome constraint
 
-Constraint on [metric](glossary.md#metric) values, can be an order constraint or a sum constraint; violating [arms](glossary.md#arm) will be considered infeasible. [`[OutcomeConstraint]`](/api/core.html#module-ax.core.outcome_constraint)
+Constraint on [metric](glossary.md#metric) values, can be an order constraint or a sum constraint; violating [arms](glossary.md#arm) will be considered infeasible. [`[OutcomeConstraint]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.outcome_constraint)
 
 ### Parameter
 
-Configurable quantity that can be assigned one of multiple possible values, can be continuous ([`RangeParameter`](../api/core.html#ax.core.parameter.RangeParameter)), discrete ([`ChoiceParameter`](../api/core.html#ax.core.parameter.ChoiceParameter)) or fixed ([`FixedParameter`](../api/core.html#ax.core.parameter.FixedParameter)). [`[Parameter]`](/api/core.html#module-ax.core.parameter)
+Configurable quantity that can be assigned one of multiple possible values, can be continuous ([`RangeParameter`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.RangeParameter)), discrete ([`ChoiceParameter`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.ChoiceParameter)) or fixed ([`FixedParameter`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.FixedParameter)). [`[Parameter]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.parameter)
 
 ### Parameter constraint
 
-Places restrictions on the relationships between [parameters](glossary.md#parameter).  For example `buffer_size1 < buffer_size2` or `buffer_size_1 + buffer_size_2 < 1024`. [`[ParameterConstraint]`](/api/core.html#module-ax.core.parameter_constraint)
+Places restrictions on the relationships between [parameters](glossary.md#parameter).  For example `buffer_size1 < buffer_size2` or `buffer_size_1 + buffer_size_2 < 1024`. [`[ParameterConstraint]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.parameter_constraint)
 
 ### Relative outcome constraint
 
-[Outcome constraint](glossary.md#outcome-constraint) evaluated relative to the [status quo](glossary.md#status-quo) instead of directly on the metric value. [`[OutcomeConstraint]`](/api/core.html#module-ax.core.outcome_constraint)
+[Outcome constraint](glossary.md#outcome-constraint) evaluated relative to the [status quo](glossary.md#status-quo) instead of directly on the metric value. [`[OutcomeConstraint]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.outcome_constraint)
 
 ### Runner
 
-Dispatch abstraction that defines how a given [trial](glossary.md#trial) is to be run (either locally or by dispatching to an external system). [`[Runner]`](/api/core.html#module-ax.core.runner)
+Dispatch abstraction that defines how a given [trial](glossary.md#trial) is to be run (either locally or by dispatching to an external system). [`[Runner]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.runner)
 
 ### Scheduler
 
 Configurable closed-loop optimization manager class, capable of conducting a full experiment by deploying trials, polling their results, and leveraging those results to generate and deploy more
-trials (relevant [tutorial](/tutorials/scheduler.html)). [`[Scheduler]`](https://ax.dev/versions/latest/api/service.html#module-ax.service.scheduler)
+trials (relevant [tutorial](/docs/tutorials/scheduler)). [`[Scheduler]`](https://ax.readthedocs.io/en/latest/service.html#module-ax.service.scheduler)
 
 ### Search space
 
-Continuous, discrete or mixed design space that defines the set of [parameters](glossary.md#parameter) to be tuned in the optimization, and optionally [parameter constraints](glossary.md#parameter-constraint) on these parameters. The parameters of the [arms](glossary.md#arm) to be evaluated in the optimization are drawn from a search space. [`[SearchSpace]`](/api/core.html#module-ax.core.search_space)
+Continuous, discrete or mixed design space that defines the set of [parameters](glossary.md#parameter) to be tuned in the optimization, and optionally [parameter constraints](glossary.md#parameter-constraint) on these parameters. The parameters of the [arms](glossary.md#arm) to be evaluated in the optimization are drawn from a search space. [`[SearchSpace]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.search_space)
 
 ### SEM
 
@@ -90,8 +90,8 @@ Continuous, discrete or mixed design space that defines the set of [parameters](
 
 ### Status quo
 
-An [arm](glossary.md#arm), usually the currently deployed configuration, which provides a baseline for comparing all other [arms](glossary.md#arm). Also known as a control [arm](glossary.md#arm). [`[StatusQuo]`](/api/core.html#ax.core.experiment.Experiment.status_quo)
+An [arm](glossary.md#arm), usually the currently deployed configuration, which provides a baseline for comparing all other [arms](glossary.md#arm). Also known as a control [arm](glossary.md#arm). [`[StatusQuo]`](https://ax.readthedocs.io/en/latest/core.html#ax.core.experiment.Experiment.status_quo)
 
 ### Trial
 
-Single step in the [experiment](glossary.md#experiment), contains a single [arm](glossary.md#arm). In cases where the trial contains multiple [arms](glossary.md#arm) that are deployed simultaneously, we refer to it as a [batch trial](glossary.md#batch-trial). [`[Trial]`](/api/core.html#module-ax.core.trial), [`[BatchTrial]`](/api/core.html#module-ax.core.batch_trial)
+Single step in the [experiment](glossary.md#experiment), contains a single [arm](glossary.md#arm). In cases where the trial contains multiple [arms](glossary.md#arm) that are deployed simultaneously, we refer to it as a [batch trial](glossary.md#batch-trial). [`[Trial]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.trial), [`[BatchTrial]`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.batch_trial)

--- a/docs/models.md
+++ b/docs/models.md
@@ -4,11 +4,11 @@ title: Models
 ---
 ## Using models in Ax
 
-In the optimization algorithms implemented by Ax, models predict the outcomes of metrics within an experiment evaluated at a parameterization, and are used to predict metrics or suggest new parameterizations for trials. Models in Ax are created using factory functions from the [`ax.modelbridge.factory`](../api/modelbridge.html#module-ax.modelbridge.factory). All of these models share a common API with [`predict()`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.predict) to make predictions at new points and [`gen()`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.gen) to generate new candidates to be tested. There are a variety of models available in the factory; here we describe the usage patterns for the primary model types and show how the various Ax utilities can be used with models.
+In the optimization algorithms implemented by Ax, models predict the outcomes of metrics within an experiment evaluated at a parameterization, and are used to predict metrics or suggest new parameterizations for trials. Models in Ax are created using factory functions from the [`ax.modelbridge.factory`](https://ax.readthedocs.io/en/latest/modelbridge.html#module-ax.modelbridge.factory). All of these models share a common API with [`predict()`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.predict) to make predictions at new points and [`gen()`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.gen) to generate new candidates to be tested. There are a variety of models available in the factory; here we describe the usage patterns for the primary model types and show how the various Ax utilities can be used with models.
 
 #### Sobol sequence
 
-The [`get_sobol`](../api/modelbridge.html#ax.modelbridge.factory.get_sobol) function is used to construct a model that produces a quasirandom Sobol sequence when[`gen`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.gen) is called. This code generates a scrambled Sobol sequence of 10 points:
+The [`get_sobol`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.factory.get_sobol) function is used to construct a model that produces a quasirandom Sobol sequence when[`gen`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.gen) is called. This code generates a scrambled Sobol sequence of 10 points:
 
 ```python
 from ax.modelbridge.factory import get_sobol
@@ -17,15 +17,15 @@ m = get_sobol(search_space)
 gr = m.gen(n=10)
 ```
 
-The output of [`gen`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.gen) is a [`GeneratorRun`](../api/core.html#ax.core.generator_run.GeneratorRun) object that contains the generated points, along with metadata about the generation process. The generated arms can be accessed at [`GeneratorRun.arms`](../api/core.html#ax.core.generator_run.GeneratorRun.arms).
+The output of [`gen`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.gen) is a [`GeneratorRun`](https://ax.readthedocs.io/en/latest/core.html#ax.core.generator_run.GeneratorRun) object that contains the generated points, along with metadata about the generation process. The generated arms can be accessed at [`GeneratorRun.arms`](https://ax.readthedocs.io/en/latest/core.html#ax.core.generator_run.GeneratorRun.arms).
 
-Additional arguments can be passed to [`get_sobol`](../api/modelbridge.html#ax.modelbridge.factory.get_sobol) such as `scramble=False` to disable scrambling, and `seed` to set a seed (see [model API](../api/models.html#ax.models.random.sobol.SobolGenerator)).
+Additional arguments can be passed to [`get_sobol`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.factory.get_sobol) such as `scramble=False` to disable scrambling, and `seed` to set a seed (see [model API](https://ax.readthedocs.io/en/latest/models.html#ax.models.random.sobol.SobolGenerator)).
 
-Sobol sequences are typically used to select initialization points, and this model does not implement [`predict`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.predict). It can be used on search spaces with any combination of discrete and continuous parameters.
+Sobol sequences are typically used to select initialization points, and this model does not implement [`predict`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.predict). It can be used on search spaces with any combination of discrete and continuous parameters.
 
 #### Gaussian Process with EI
 
-Gaussian Processes (GPs) are used for [Bayesian Optimization](bayesopt.md) in Ax, the [`Models.BOTORCH_MODULAR`](../api/modelbridge.html#ax.modelbridge.registry.Models) registry entry constructs a modular BoTorch model that fits a GP to the data, and uses qLogNEI (or qLogNEHVI for MOO) acquisition function to generate new points on calls to [`gen`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.gen). This code fits a GP and generates a batch of 5 points which maximizes EI:
+Gaussian Processes (GPs) are used for [Bayesian Optimization](bayesopt.md) in Ax, the [`Models.BOTORCH_MODULAR`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.registry.Models) registry entry constructs a modular BoTorch model that fits a GP to the data, and uses qLogNEI (or qLogNEHVI for MOO) acquisition function to generate new points on calls to [`gen`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.gen). This code fits a GP and generates a batch of 5 points which maximizes EI:
 ```Python
 from ax.modelbridge.registry import Models
 
@@ -33,7 +33,7 @@ m = Models.BOTORCH_MODULAR(experiment=experiment, data=data)
 gr = m.gen(n=5, optimization_config=optimization_config)
 ```
 
-In contrast to [`get_sobol`](../api/modelbridge.html#ax.modelbridge.factory.get_sobol), the GP requires data and is able to make predictions. We make predictions by constructing a list of [`ObservationFeatures`](../api/core.html#ax.core.observation.ObservationFeatures) objects with the parameter values for which we want predictions:
+In contrast to [`get_sobol`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.factory.get_sobol), the GP requires data and is able to make predictions. We make predictions by constructing a list of [`ObservationFeatures`](https://ax.readthedocs.io/en/latest/core.html#ax.core.observation.ObservationFeatures) objects with the parameter values for which we want predictions:
 
 ```python
 from ax.core.observation import ObservationFeatures
@@ -45,9 +45,9 @@ obs_feats = [
 f, cov = m.predict(obs_feats)
 ```
 
-The output of [`predict`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.predict) is the mean estimate of each metric and the covariance (across metrics) for each point.
+The output of [`predict`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.predict) is the mean estimate of each metric and the covariance (across metrics) for each point.
 
-All Ax models that implement [`predict`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.predict) can be used with the built-in plotting utilities, which can produce plots of model predictions on 1-d or 2-d slices of the parameter space:
+All Ax models that implement [`predict`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.predict) can be used with the built-in plotting utilities, which can produce plots of model predictions on 1-d or 2-d slices of the parameter space:
 
 ```python
 from ax.plot.slice import plot_slice
@@ -86,7 +86,7 @@ cv = cross_validate(model)
 diagnostics = compute_diagnostics(cv)
 ```
 
-[`compute_diagnostics`](../api/modelbridge.html#ax.modelbridge.cross_validation.compute_diagnostics) computes a collection of diagnostics of model predictions, such as the correlation between predictions and actual values, and the p-value for a Fisher test of the model's ability to distinguish high values from low. A very useful tool for assessing model performance is to plot the cross validated predictions against the actual observed values:
+[`compute_diagnostics`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.cross_validation.compute_diagnostics) computes a collection of diagnostics of model predictions, such as the correlation between predictions and actual values, and the p-value for a Fisher test of the model's ability to distinguish high values from low. A very useful tool for assessing model performance is to plot the cross validated predictions against the actual observed values:
 
 ```python
 from ax.plot.diagnostic import interact_cross_validation
@@ -96,11 +96,11 @@ render(interact_cross_validation(cv))
 
 <div id="cv" style={{width: "100%"}} />
 
-If the model fits the data well, the values will lie along the diagonal. Poor GP fits tend to produce cross validation plots that are flat with high predictive uncertainty - such fits are unlikely to produce good candidates in [`gen`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.gen).
+If the model fits the data well, the values will lie along the diagonal. Poor GP fits tend to produce cross validation plots that are flat with high predictive uncertainty - such fits are unlikely to produce good candidates in [`gen`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.gen).
 
-By default, this model will apply a number of transformations to the feature space, such as one-hot encoding of [`ChoiceParameters`](../api/core.html#ax.core.parameter.ChoiceParameter) and log transformation of [`RangeParameters`](../api/core.html#ax.core.parameter.RangeParameter) which have `log_scale` set to `True`. Transforms are also applied to the observed outcomes, such as standardizing the data for each metric. See [the section below on Transforms](models.md#Transforms) for a description of the default transforms, and how new transforms can be implemented and included.
+By default, this model will apply a number of transformations to the feature space, such as one-hot encoding of [`ChoiceParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.ChoiceParameter) and log transformation of [`RangeParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.RangeParameter) which have `log_scale` set to `True`. Transforms are also applied to the observed outcomes, such as standardizing the data for each metric. See [the section below on Transforms](/docs/models#transforms) for a description of the default transforms, and how new transforms can be implemented and included.
 
-GPs typically does a good job of modeling continuous parameters ([`RangeParameters`](../api/core.html#ax.core.parameter.RangeParameter)). If the search space contains [`ChoiceParameters`](../api/core.html#ax.core.parameter.ChoiceParameter), they will be one-hot-encoded and the GP fit in the encoded space. A search space with a mix of continuous parameters and [`ChoiceParameters`](../api/core.html#ax.core.parameter.ChoiceParameter) that take a small number of values can be modeled effectively with a GP, but model performance may be poor if there are more than about 20 parameters after one-hot encoding. Cross validation is an effective tool for determining usefulness of the GP on a particular problem.
+GPs typically does a good job of modeling continuous parameters ([`RangeParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.RangeParameter)). If the search space contains [`ChoiceParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.ChoiceParameter), they will be one-hot-encoded and the GP fit in the encoded space. A search space with a mix of continuous parameters and [`ChoiceParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.ChoiceParameter) that take a small number of values can be modeled effectively with a GP, but model performance may be poor if there are more than about 20 parameters after one-hot encoding. Cross validation is an effective tool for determining usefulness of the GP on a particular problem.
 
 In discrete spaces where the GP does not predict well, a multi-armed bandit approach is often preferred, and we now discuss the models suitable for that approach.
 
@@ -116,7 +116,7 @@ For the ordinal variables we can use a standard kernel such as Matérn-5/2, but 
 
 #### Empirical Bayes and Thompson sampling
 
-For [Bandit optimization](banditopt.md), The [`get_empirical_bayes_thompson`](../api/modelbridge.html#ax.modelbridge.factory.get_empirical_bayes_thompson) factory function returns a model that applies [empirical Bayes shrinkage](banditopt.md#empirical-bayes) to a discrete set of arms, and then uses Thompson sampling to construct a policy with the weight that should be allocated to each arms. Here we apply empirical Bayes to the data and use Thompson sampling to generate a policy that is truncated at `n=10` arms:
+For [Bandit optimization](banditopt.md), The [`get_empirical_bayes_thompson`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.factory.get_empirical_bayes_thompson) factory function returns a model that applies [empirical Bayes shrinkage](banditopt.md#empirical-bayes) to a discrete set of arms, and then uses Thompson sampling to construct a policy with the weight that should be allocated to each arms. Here we apply empirical Bayes to the data and use Thompson sampling to generate a policy that is truncated at `n=10` arms:
 
 ```python
 from ax.modelbridge.factory import get_empirical_bayes_thompson
@@ -127,13 +127,13 @@ gr = m.gen(n=10, optimization_config=optimization_config)
 
 The arms and their corresponding weights can be accessed as `gr.arm_weights`.
 
-As with the GP, we can use [`predict`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.predict) to evaluate the model at points of our choosing. However, because this is a purely in-sample model, those points should correspond to arms that were in the data. The model prediction will return the estimate at that point after applying the empirical Bayes shrinkage:
+As with the GP, we can use [`predict`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.predict) to evaluate the model at points of our choosing. However, because this is a purely in-sample model, those points should correspond to arms that were in the data. The model prediction will return the estimate at that point after applying the empirical Bayes shrinkage:
 
 ```python
 f, cov = m.predict([ObservationFeatures(parameters={'x1': 3.14, 'x2': 2.72})])
 ```
 
-We can generate a plot that shows the predictions for each arm with the shrinkage using [`plot_fitted`](../api/plot.html#ax.plot.scatter.plot_fitted), which shows model predictions on all in-sample arms:
+We can generate a plot that shows the predictions for each arm with the shrinkage using [`plot_fitted`](https://ax.readthedocs.io/en/latest/plot.html#ax.plot.scatter.plot_fitted), which shows model predictions on all in-sample arms:
 
 ```python
 from ax.plot.scatter import plot_fitted
@@ -145,7 +145,7 @@ render(plot_fitted(m, metric="metric_a", rel=False))
 
 #### Factorial designs
 
-The factory function [`get_factorial`](../api/modelbridge.html#ax.modelbridge.factory.get_factorial) can be used to construct a factorial design on a set of [`ChoiceParameters`](../api/core.html#ax.core.parameter.ChoiceParameter).
+The factory function [`get_factorial`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.factory.get_factorial) can be used to construct a factorial design on a set of [`ChoiceParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.ChoiceParameter).
 
 ```python
 from ax.modelbridge.factory import get_factorial
@@ -154,45 +154,45 @@ m = get_factorial(search_space)
 gr = m.gen(n=10)
 ```
 
-Like the Sobol sequence, the factorial model is only used to generate points and does not implement [`predict`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.predict).
+Like the Sobol sequence, the factorial model is only used to generate points and does not implement [`predict`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.predict).
 
 ## Deeper dive: organization of the modeling stack
 
-Ax uses a bridge design to provide a unified interface for models, while still allowing for modularity in how different types of models are implemented. The modeling stack consists of two layers: the [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) and the Model.
+Ax uses a bridge design to provide a unified interface for models, while still allowing for modularity in how different types of models are implemented. The modeling stack consists of two layers: the [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) and the Model.
 
-The [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) is the object that is directly used in Ax: model factories return [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) objects, and plotting and cross validation tools operate on a [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge). The [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) defines a unified API for all of the models used in Ax via methods like [`predict`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.predict) and [`gen`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge.gen). Internally, it is responsible for transforming Ax objects like [`Arm`](../api/core.html#ax.core.arm.Arm) and [`Data`](../api/core.html#ax.core.data.Data) into objects which are then consumed downstream by a Model.
+The [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) is the object that is directly used in Ax: model factories return [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) objects, and plotting and cross validation tools operate on a [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge). The [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) defines a unified API for all of the models used in Ax via methods like [`predict`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.predict) and [`gen`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge.gen). Internally, it is responsible for transforming Ax objects like [`Arm`](https://ax.readthedocs.io/en/latest/core.html#ax.core.arm.Arm) and [`Data`](https://ax.readthedocs.io/en/latest/core.html#ax.core.data.Data) into objects which are then consumed downstream by a Model.
 
-Model objects are only used in Ax via a [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge). Each Model object defines an API which does not use Ax objects, allowing for modularity of different model types and making it easy to implement new models. For example, the TorchModel defines an API for a model that operates on torch tensors. There is a 1-to-1 link between [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) objects and Model objects. For instance, the TorchModelBridge takes in Ax objects, converts them to torch tensors, and sends them along to the TorchModel. Similar pairings exist for all of the different model types:
+Model objects are only used in Ax via a [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge). Each Model object defines an API which does not use Ax objects, allowing for modularity of different model types and making it easy to implement new models. For example, the TorchModel defines an API for a model that operates on torch tensors. There is a 1-to-1 link between [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) objects and Model objects. For instance, the TorchModelBridge takes in Ax objects, converts them to torch tensors, and sends them along to the TorchModel. Similar pairings exist for all of the different model types:
 
 | ModelBridge                                                                            | Model                                                                              | Example implementation                                                                     |   |
 | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | - |
-| [`TorchModelBridge`](../api/modelbridge.html#module-ax.modelbridge.torch)       | [`TorchModel`](../api/models.html#ax.models.torch_base.TorchModel)          | [`BotorchModel`](../api/models.html#ax.models.torch.botorch.BotorchModel)           |   |
-| [`DiscreteModelBridge`](../api/modelbridge.html#module-ax.modelbridge.discrete) | [`DiscreteModel`](../api/models.html#ax.models.discrete_base.DiscreteModel) | [`ThompsonSampler`](../api/models.html#ax.models.discrete.thompson.ThompsonSampler) |   |
-| [`RandomModelBridge`](../api/modelbridge.html#module-ax.modelbridge.random)     | [`RandomModel`](../api/models.html#ax.models.random.base.RandomModel)       | [`SobolGenerator`](../api/models.html#ax.models.random.sobol.SobolGenerator)        |   |
+| [`TorchModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#module-ax.modelbridge.torch)       | [`TorchModel`](https://ax.readthedocs.io/en/latest/models.html#ax.models.torch_base.TorchModel)          | [`BotorchModel`](https://ax.readthedocs.io/en/latest/models.html#ax.models.torch.botorch.BotorchModel)           |   |
+| [`DiscreteModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#module-ax.modelbridge.discrete) | [`DiscreteModel`](https://ax.readthedocs.io/en/latest/models.html#ax.models.discrete_base.DiscreteModel) | [`ThompsonSampler`](https://ax.readthedocs.io/en/latest/models.html#ax.models.discrete.thompson.ThompsonSampler) |   |
+| [`RandomModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#module-ax.modelbridge.random)     | [`RandomModel`](https://ax.readthedocs.io/en/latest/models.html#ax.models.random.base.RandomModel)       | [`SobolGenerator`](https://ax.readthedocs.io/en/latest/models.html#ax.models.random.sobol.SobolGenerator)        |   |
 
 This structure allows for different models like the GP in BotorchModel and the Random Forest in RandomForest to share an interface and use common plotting tools at the level of the ModelBridge, while each is implemented using its own torch or numpy structures.
 
-The primary role of the [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) is to act as a transformation layer. This includes transformations to the data, search space, and optimization config such as standardization and log transforms, as well as the final transform from Ax objects into the objects consumed by the Model. We now describe how transforms are implemented and used in the ModelBridge.
+The primary role of the [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) is to act as a transformation layer. This includes transformations to the data, search space, and optimization config such as standardization and log transforms, as well as the final transform from Ax objects into the objects consumed by the Model. We now describe how transforms are implemented and used in the ModelBridge.
 
 ## Transforms
 
-The transformations in the [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) are done by chaining together a set of individual Transform objects. For continuous space models obtained via factory functions ([`get_sobol`](/api/data.html#.data.users.adamobeng.fbsource.fbcode.ax.ax.modelbridge.factory.get_sobol) and [`Models.BOTORCH_MODULAR`](/api/data.html#.data.users.adamobeng.fbsource.fbcode.ax.ax.modelbridge.registry.Models)), the following transforms will be applied by default, in this sequence:
-* [`RemoveFixed`](../api/modelbridge.html#ax.modelbridge.transforms.remove_fixed.RemoveFixed): Remove [`FixedParameters`](../api/core.html#ax.core.parameter.FixedParameter) from the search space.
-* [`OrderedChoiceEncode`](../api/modelbridge.html#ax.modelbridge.transforms.choice_encode.OrderedChoiceEncode): [`ChoiceParameters`](../api/core.html#ax.core.parameter.ChoiceParameter) with `is_ordered` set to `True` are encoded as a sequence of integers.
-* [`OneHot`](../api/modelbridge.html#ax.modelbridge.transforms.one_hot.OneHot): [`ChoiceParameters`](../api/core.html#ax.core.parameter.ChoiceParameter) with `is_ordered` set to `False` are one-hot encoded.
-* [`IntToFloat`](../api/modelbridge.html#ax.modelbridge.transforms.int_to_float.IntToFloat): Integer-valued [`RangeParameters`](../api/core.html#ax.core.parameter.RangeParameter) are converted to have float values.
-* [`Log`](../api/modelbridge.html#ax.modelbridge.transforms.log.Log): [`RangeParameters`](../api/core.html#ax.core.parameter.RangeParameter) with `log_scale` set to `True` are log transformed.
-* [`UnitX`](../api/modelbridge.html#ax.modelbridge.transforms.unit_x.UnitX): All float [`RangeParameters`](../api/core.html#ax.core.parameter.RangeParameter) are mapped to `[0, 1]`.
-* [`Derelativize`](../api/modelbridge.html#ax.modelbridge.transforms.derelativize.Derelativize): Constraints relative to status quo are converted to constraints on raw values.
-* [`StandardizeY`](../api/modelbridge.html#ax.modelbridge.transforms.standardize_y.StandardizeY): The Y values for each metric are standardized (subtract mean, divide by standard deviation).
+The transformations in the [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) are done by chaining together a set of individual Transform objects. For continuous space models obtained via factory functions ([`get_sobol`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.factory.get_sobol) and [`Models.BOTORCH_MODULAR`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.registry.Models)), the following transforms will be applied by default, in this sequence:
+* [`RemoveFixed`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.remove_fixed.RemoveFixed): Remove [`FixedParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.FixedParameter) from the search space.
+* [`OrderedChoiceEncode`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.choice_encode.OrderedChoiceEncode): [`ChoiceParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.ChoiceParameter) with `is_ordered` set to `True` are encoded as a sequence of integers.
+* [`OneHot`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.one_hot.OneHot): [`ChoiceParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.ChoiceParameter) with `is_ordered` set to `False` are one-hot encoded.
+* [`IntToFloat`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.int_to_float.IntToFloat): Integer-valued [`RangeParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.RangeParameter) are converted to have float values.
+* [`Log`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.log.Log): [`RangeParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.RangeParameter) with `log_scale` set to `True` are log transformed.
+* [`UnitX`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.unit_x.UnitX): All float [`RangeParameters`](https://ax.readthedocs.io/en/latest/core.html#ax.core.parameter.RangeParameter) are mapped to `[0, 1]`.
+* [`Derelativize`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.derelativize.Derelativize): Constraints relative to status quo are converted to constraints on raw values.
+* [`StandardizeY`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.standardize_y.StandardizeY): The Y values for each metric are standardized (subtract mean, divide by standard deviation).
 
-Each transform defines both a forward and backwards transform. Arm parameters are passed through the forward transform before being sent along to the Model. The Model works entirely in the transformed space, and when new candidates are generated, they are passed through all of the backwards transforms so the [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) returns points in the original space.
+Each transform defines both a forward and backwards transform. Arm parameters are passed through the forward transform before being sent along to the Model. The Model works entirely in the transformed space, and when new candidates are generated, they are passed through all of the backwards transforms so the [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) returns points in the original space.
 
-New transforms can be implemented by creating a subclass of [`Transform`](../api/modelbridge.html#ax.modelbridge.transforms.base.Transform), which defines the interface for all transforms. There are separate methods for transforming the search space, optimization config, observation features, and observation data. Transforms that operate on only some aspects of the problem do not need to implement all methods, for instance, [`Log`](../api/modelbridge.html#ax.modelbridge.transforms.log.Log) implements only [`transform_observation_features`](../api/modelbridge.html#ax.modelbridge.transforms.log.Log.transform_observation_features) (to log transform the parameters), [`transform_search_space`](../api/modelbridge.html#ax.modelbridge.transforms.log.Log.transform_search_space) (to log transform the search space bounds), and [`untransform_observation_features`](../api/modelbridge.html#ax.modelbridge.transforms.log.Log.untransform_observation_features) (to apply the inverse transform).
+New transforms can be implemented by creating a subclass of [`Transform`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.base.Transform), which defines the interface for all transforms. There are separate methods for transforming the search space, optimization config, observation features, and observation data. Transforms that operate on only some aspects of the problem do not need to implement all methods, for instance, [`Log`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.log.Log) implements only [`transform_observation_features`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.log.Log.transform_observation_features) (to log transform the parameters), [`transform_search_space`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.log.Log.transform_search_space) (to log transform the search space bounds), and [`untransform_observation_features`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.transforms.log.Log.untransform_observation_features) (to apply the inverse transform).
 
 The (ordered) list of transforms to apply is an input to the ModelBridge, and so can easily be altered to add new transforms. It is important that transforms be applied in the right order. For instance, `StandardizeY` and `Winsorize` both transform the observed metric values. Applying them in the order `[StandardizeY, Winsorize]` could produce very different results than `[Winsorize, StandardizeY]`. In the former case, outliers would have already been included in the standardization (a procedure sensitive to outliers), and so the second approach that winsorizes first is preferred.
 
-See [the API reference](../api/modelbridge.html#transforms) for the full collection of implemented transforms.
+See [the API reference](https://ax.readthedocs.io/en/latest/modelbridge.html#transforms) for the full collection of implemented transforms.
 
 ## Implementing new models
 
@@ -200,9 +200,9 @@ The structure of the modeling stack makes it easy to implement new models and us
 
 ### Using an existing Model interface
 
-The easiest way to implement a new model is if it can be adapted to one of the existing Model interfaces: ([`TorchModel`](api/models.html#ax.models.torch_base.TorchModel), [`DiscreteModel`](../api/models.html#ax.models.discrete_base.DiscreteModel), or [`RandomModel`](../api/models.html#ax.models.random.base.RandomModel)). The class definition provides the interface for each of the methods that should be implemented in order for Ax to be able to fully use the new model. Note however that not all methods must need be implemented to use some Ax functionality. For instance, an implementation of [`TorchModel`](../api/models.html#ax.models.torch_base.TorchModel) that implements only [`fit`](../api/models.html#ax.models.torch_base.TorchModel.fit) and [`predict`](../api/models.html#ax.models.torch_base.TorchModel.predict) can be used to fit data and make plots in Ax; however, it will not be able to generate new candidates (requires implementing [`gen`](../api/models.html#ax.models.torch_base.TorchModel.gen)) or be used with Ax's cross validation utility (requires implementing [`cross_validate`](../api/models.html#ax.models.torch_base.TorchModel.cross_validate)).
+The easiest way to implement a new model is if it can be adapted to one of the existing Model interfaces: ([`TorchModel`](https://ax.readthedocs.io/en/latest/models.html#ax.models.torch_base.TorchModel), [`DiscreteModel`](https://ax.readthedocs.io/en/latest/models.html#ax.models.discrete_base.DiscreteModel), or [`RandomModel`](https://ax.readthedocs.io/en/latest/models.html#ax.models.random.base.RandomModel)). The class definition provides the interface for each of the methods that should be implemented in order for Ax to be able to fully use the new model. Note however that not all methods must need be implemented to use some Ax functionality. For instance, an implementation of [`TorchModel`](https://ax.readthedocs.io/en/latest/models.html#ax.models.torch_base.TorchModel) that implements only [`fit`](https://ax.readthedocs.io/en/latest/models.html#ax.models.torch_base.TorchModel.fit) and [`predict`](https://ax.readthedocs.io/en/latest/models.html#ax.models.torch_base.TorchModel.predict) can be used to fit data and make plots in Ax; however, it will not be able to generate new candidates (requires implementing [`gen`](https://ax.readthedocs.io/en/latest/models.html#ax.models.torch_base.TorchModel.gen)) or be used with Ax's cross validation utility (requires implementing [`cross_validate`](https://ax.readthedocs.io/en/latest/models.html#ax.models.torch_base.TorchModel.cross_validate)).
 
-Once the new model has been implemented, it can be used in Ax with the corresponding [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) from the table above. For instance, suppose a new torch-based model was implemented as a subclass of [`TorchModel`](../api/models.html#ax.models.torch_base.TorchModel). We can use that model in Ax like:
+Once the new model has been implemented, it can be used in Ax with the corresponding [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) from the table above. For instance, suppose a new torch-based model was implemented as a subclass of [`TorchModel`](https://ax.readthedocs.io/en/latest/models.html#ax.models.torch_base.TorchModel). We can use that model in Ax like:
 
 ```python
 new_model_obj = NewModel(init_args)  # An instance of the new model class
@@ -215,11 +215,11 @@ m = TorchModelBridge(
 )
 ```
 
-The [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) object `m` can then be used with plotting and cross validation utilities exactly the same way as the built-in models.
+The [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) object `m` can then be used with plotting and cross validation utilities exactly the same way as the built-in models.
 
 ### Creating a new Model interface
 
-If none of the existing Model interfaces work are suitable for the new model type, then a new interface will have to be created. This involves two steps: creating the new model interface and creating the new model bridge. The new model bridge must be a subclass of [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) that implements `ModelBridge._fit`,  `ModelBridge._predict`, `ModelBridge._gen`, and  `ModelBridge._cross_validate`. The implementation of each of these methods will transform the Ax objects in the inputs into objects required for the interface with the new model type. The model bridge will then call out to the new model interface to do the actual modeling work. All of the ModelBridge/Model pairs in the table above provide examples of how this interface can be defined. The main key is that the inputs on the [`ModelBridge`](../api/modelbridge.html#ax.modelbridge.base.ModelBridge) side are fixed, but those inputs can then be transformed in whatever way is desired for the downstream Model interface to be that which is most convenient for implementing the model.
+If none of the existing Model interfaces work are suitable for the new model type, then a new interface will have to be created. This involves two steps: creating the new model interface and creating the new model bridge. The new model bridge must be a subclass of [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) that implements `ModelBridge._fit`,  `ModelBridge._predict`, `ModelBridge._gen`, and  `ModelBridge._cross_validate`. The implementation of each of these methods will transform the Ax objects in the inputs into objects required for the interface with the new model type. The model bridge will then call out to the new model interface to do the actual modeling work. All of the ModelBridge/Model pairs in the table above provide examples of how this interface can be defined. The main key is that the inputs on the [`ModelBridge`](https://ax.readthedocs.io/en/latest/modelbridge.html#ax.modelbridge.base.ModelBridge) side are fixed, but those inputs can then be transformed in whatever way is desired for the downstream Model interface to be that which is most convenient for implementing the model.
 
 <script type="text/javascript" src="assets/slice.js"></script>
 <script type="text/javascript" src="assets/contour.js"></script>

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -36,7 +36,7 @@ experiment = load_experiment(filepath)
 
 ### Customizing
 
-If you add a custom [`Metric`](/api/core.html#module-ax.core.metric) or [`Runner`](../api/core.html#ax.core.runner.Runner) and want to ensure it is saved to JSON properly, create a [`RegistryBundle`](/api/storage.html#ax.storage.registry_bundle.RegistryBundle), which bundles together encoding and decoding logic for use in the various save/load functions as follows:
+If you add a custom [`Metric`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.metric) or [`Runner`](https://ax.readthedocs.io/en/latest/core.html#ax.core.runner.Runner) and want to ensure it is saved to JSON properly, create a [`RegistryBundle`](https://ax.readthedocs.io/en/latest/storage.html#ax.storage.registry_bundle.RegistryBundle), which bundles together encoding and decoding logic for use in the various save/load functions as follows:
 
 ```py
 from ax import Experiment, Metric, Runner, SearchSpace
@@ -138,7 +138,7 @@ experiment = load_experiment(experiment_name)
 
 **Adding a new metric or runner:**
 
-If you add a custom [`Metric`](/api/core.html#module-ax.core.metric) or [`Runner`](../api/core.html#ax.core.runner.Runner) and want to ensure it is saved to SQL properly, create a [`RegistryBundle`](/api/storage.html#ax.storage.registry_bundle.RegistryBundle), which bundles together encoding and decoding logic for use in the various save/load functions as follows:
+If you add a custom [`Metric`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.metric) or [`Runner`](https://ax.readthedocs.io/en/latest/core.html#ax.core.runner.Runner) and want to ensure it is saved to SQL properly, create a [`RegistryBundle`](https://ax.readthedocs.io/en/latest/storage.html#ax.storage.registry_bundle.RegistryBundle), which bundles together encoding and decoding logic for use in the various save/load functions as follows:
 
 ```py
 from ax import Experiment, RangeParameter, ParameterType

--- a/docs/trial-evaluation.md
+++ b/docs/trial-evaluation.md
@@ -4,19 +4,19 @@ title: Trial Evaluation
 ---
 There are 3 paradigms for evaluating [trials](glossary.md#trial) in Ax. Note:
 ensure that you are using the
-[appropriate type of trials](core.md#trial-vs-batched-trial) for your
+[appropriate type of trials](/docs/core#trial-vs-batch-trial) for your
 experiment, before proceeding to trial evaluation.
 
 ## [RECOMMENDED] Service API
 
-The Service API [`AxClient`](/api/service.html#module-ax.service.ax_client)
+The Service API [`AxClient`](https://ax.readthedocs.io/en/latest/service.html#module-ax.service.ax_client)
 exposes
-[`get_next_trial`](/api/service.html#ax.service.ax_client.AxClient.get_next_trial),
+[`get_next_trial`](https://ax.readthedocs.io/en/latest/service.html#ax.service.ax_client.AxClient.get_next_trial),
 as well as
-[`complete_trial`](/api/service.html#ax.service.ax_client.AxClient.complete_trial).
+[`complete_trial`](https://ax.readthedocs.io/en/latest/service.html#ax.service.ax_client.AxClient.complete_trial).
 The user is responsible for evaluating the trial parameters and passing the
 results to
-[`complete_trial`](/api/service.html#ax.service.ax_client.AxClient.complete_trial).
+[`complete_trial`](https://ax.readthedocs.io/en/latest/service.html#ax.service.ax_client.AxClient.complete_trial).
 
 ```python
 ...
@@ -29,9 +29,9 @@ for i in range(25):
 ### Evaluating Trial Parameters
 
 In the Service API, the
-[`complete_trial`](/api/service.html#ax.service.ax_client.AxClient.complete_trial)
+[`complete_trial`](https://ax.readthedocs.io/en/latest/service.html#ax.service.ax_client.AxClient.complete_trial)
 method requires `raw_data` evaluated from the parameters suggested by
-[`get_next_trial`](/api/service.html#ax.service.ax_client.AxClient.get_next_trial).
+[`get_next_trial`](https://ax.readthedocs.io/en/latest/service.html#ax.service.ax_client.AxClient.get_next_trial).
 
 The data can be in the form of:
 
@@ -87,7 +87,7 @@ def branin_evaluation_function_unknown_sem(parameterization):
 
 ## Loop API
 
-The [`optimize`](/api/service.html#ax.service.managed_loop.optimize) function
+The [`optimize`](https://ax.readthedocs.io/en/latest/service.html#ax.service.managed_loop.optimize) function
 requires an `evaluation_function`, which accepts parameters and returns raw data
 in the format described above. It can also accept a `weight` parameter, a
 nullable `float` representing the fraction of available data on which the
@@ -100,12 +100,12 @@ experiments and defaults to `None`.
 ## Developer API
 
 The Developer API is supported by the
-[`Experiment`](/api/core.html#module-ax.core.experiment) class. In this
+[`Experiment`](https://ax.readthedocs.io/en/latest/core.html#module-ax.core.experiment) class. In this
 paradigm, the user specifies:
 
--   [`Runner`](../api/core.html#ax.core.runner.Runner): Defines how to deploy the
+-   [`Runner`](https://ax.readthedocs.io/en/latest/core.html#ax.core.runner.Runner): Defines how to deploy the
     experiment.
--   List of [`Metrics`](../api/core.html#ax.core.metric.Metric): Each defines how
+-   List of [`Metrics`](https://ax.readthedocs.io/en/latest/core.html#ax.core.metric.Metric): Each defines how
     to compute/fetch data for a given objective or outcome.
 
 The experiment requires a `generator_run` to create a new trial or batch trial.
@@ -133,7 +133,7 @@ for i in range(15):
 Similar to a trial evaluation in the Service API, a custom metric computes a
 mean and SEM for each arm of a trial. However, the metric's `fetch_trial_data`
 method will be called automatically by the experiment's
-[`fetch_data`](/api/core.html#ax.core.base_trial.BaseTrial.fetch_data) method.
+[`fetch_data`](https://ax.readthedocs.io/en/latest/core.html#ax.core.base_trial.BaseTrial.fetch_data) method.
 If there are multiple objectives or outcomes that need to be optimized for, each
 needs its own metric.
 
@@ -156,20 +156,20 @@ class MyMetric(Metric):
 ### Adding Your Own Runner
 
 In order to control how the experiment is deployed, you can add your own runner.
-To do so, subclass [`Runner`](../api/core.html#ax.core.runner.Runner) and
-implement the [`run`](../api/core.html#ax.core.runner.Runner.run) method and
-[`staging_required`](../api/core.html#ax.core.runner.Runner.staging_required)
+To do so, subclass [`Runner`](https://ax.readthedocs.io/en/latest/core.html#ax.core.runner.Runner) and
+implement the [`run`](https://ax.readthedocs.io/en/latest/core.html#ax.core.runner.Runner.run) method and
+[`staging_required`](https://ax.readthedocs.io/en/latest/core.html#ax.core.runner.Runner.staging_required)
 property.
 
-The [`run`](../api/core.html#ax.core.runner.Runner.run) method accepts a
-[`Trial`](../api/core.html#ax.core.trial.Trial) and returns a JSON-serializable
+The [`run`](https://ax.readthedocs.io/en/latest/core.html#ax.core.runner.Runner.run) method accepts a
+[`Trial`](https://ax.readthedocs.io/en/latest/core.html#ax.core.trial.Trial) and returns a JSON-serializable
 dictionary of any necessary tracking info to fetch data later from this external
 system. A unique identifier or name for this trial in the external system should
 be stored in this dictionary with the key `"name"`, and this can later be
 accessed via `trial.deployed_name`.
 
 The
-[`staging_required`](../api/core.html#ax.core.runner.Runner.staging_required)
+[`staging_required`](https://ax.readthedocs.io/en/latest/core.html#ax.core.runner.Runner.staging_required)
 indicates whether the trial requires an intermediate staging period before
 evaluation begins. This property returns False by default.
 

--- a/docs/tutorials/index.mdx
+++ b/docs/tutorials/index.mdx
@@ -5,36 +5,36 @@ sidebar_label: Overview
 
 Here you can learn about the structure and applications of Ax from examples.
 
-**Our 3 API tutorials:** [Loop](gpei_hartmann_loop.html), [Service](gpei_hartmann_service.html), and [Developer](gpei_hartmann_developer.html) — are a good place to start. Each tutorial showcases optimization on a constrained Hartmann6 problem, with the Loop API being the simplest to use and the Developer API being the most customizable.
+**Our 3 API tutorials:** [Loop](/docs/tutorials/gpei_hartmann_loop), [Service](/docs/tutorials/gpei_hartmann_service), and [Developer](/docs/tutorials/gpei_hartmann_developer) — are a good place to start. Each tutorial showcases optimization on a constrained Hartmann6 problem, with the Loop API being the simplest to use and the Developer API being the most customizable.
 
-**NOTE: We recommend the [Service API](gpei_hartmann_service.html) for the vast majority of use cases.** This API provides an ideal balance of flexibility and simplicity for most users, and we are in the process of consolidating Ax usage around it more formally.
+**NOTE: We recommend the [Service API](/docs/tutorials/gpei_hartmann_service) for the vast majority of use cases.** This API provides an ideal balance of flexibility and simplicity for most users, and we are in the process of consolidating Ax usage around it more formally.
 
 **Further, we explore the different components available in Ax in more detail.** {' '} The components explored below serve to set up an experiment, visualize its results, configure an optimization algorithm, run an entire experiment in a managed closed loop, and combine BoTorch components in Ax in a modular way.
 
-*   [Visualizations](visualizations.html) illustrates the different plots available to view and understand your results.
+*   [Visualizations](/docs/tutorials/visualizations) illustrates the different plots available to view and understand your results.
 
-*   [GenerationStrategy](generation_strategy.html) steps through setting up a way to specify the optimization algorithm (or multiple). A `GenerationStrategy` is an important component of Service API and the `Scheduler`.
+*   [GenerationStrategy](/docs/tutorials/generation_strategy) steps through setting up a way to specify the optimization algorithm (or multiple). A `GenerationStrategy` is an important component of Service API and the `Scheduler`.
 
-*   [Scheduler](scheduler.html) demonstrates an example of a managed and configurable closed-loop optimization, conducted in an asyncronous fashion. `Scheduler` is a manager abstraction in Ax that deploys trials, polls them, and uses their results to produce more trials.
+*   [Scheduler](/docs/tutorials/scheduler) demonstrates an example of a managed and configurable closed-loop optimization, conducted in an asyncronous fashion. `Scheduler` is a manager abstraction in Ax that deploys trials, polls them, and uses their results to produce more trials.
 
-*   [Modular `BoTorchModel`](modular_botax.html) walks though a new beta-feature — an improved interface between Ax and{' '} [BoTorch](https://botorch.org/) — which allows for combining arbitrary BoTorch components like `AcquisitionFunction`, `Model`, `AcquisitionObjective` etc. into a single{' '} `Model` in Ax.
+*   [Modular `BoTorchModel`](/docs/tutorials/modular_botax) walks though a new beta-feature — an improved interface between Ax and{' '} [BoTorch](https://botorch.org/) — which allows for combining arbitrary BoTorch components like `AcquisitionFunction`, `Model`, `AcquisitionObjective` etc. into a single{' '} `Model` in Ax.
 
 **Our other Bayesian Optimization tutorials include:**
 
-*   [Hyperparameter Optimization for PyTorch](tune_cnn_service.html) provides an example of hyperparameter optimization with Ax and integration with an external ML library.
+*   [Hyperparameter Optimization for PyTorch](/docs/tutorials/tune_cnn_service) provides an example of hyperparameter optimization with Ax and integration with an external ML library.
 
-*   [Hyperparameter Optimization on SLURM via SubmitIt](submitit.html) shows how to use the AxClient to schedule jobs and tune hyperparameters on a Slurm cluster.
+*   [Hyperparameter Optimization on SLURM via SubmitIt](/docs/tutorials/submitit) shows how to use the AxClient to schedule jobs and tune hyperparameters on a Slurm cluster.
 
-*   [Multi-Task Modeling](multi_task.html) illustrates multi-task Bayesian Optimization on a constrained synthetic Hartmann6 problem.
+*   [Multi-Task Modeling](/docs/tutorials/multi_task) illustrates multi-task Bayesian Optimization on a constrained synthetic Hartmann6 problem.
 
-*   [Multi-Objective Optimization](multiobjective_optimization.html) demonstrates Multi-Objective Bayesian Optimization on a synthetic Branin-Currin test function.
+*   [Multi-Objective Optimization](/docs/tutorials/multiobjective_optimization) demonstrates Multi-Objective Bayesian Optimization on a synthetic Branin-Currin test function.
 
-*   [Trial-Level Early Stopping](early_stopping/early_stopping.html) shows how to use trial-level early stopping on an ML training job to save resources and iterate faster.
+*   [Trial-Level Early Stopping](/docs/tutorials/early_stopping) shows how to use trial-level early stopping on an ML training job to save resources and iterate faster.
 
-{/* *   [Benchmarking Suite](benchmarking_suite_example.html) demonstrates how to use the Ax benchmarking suite to compare Bayesian Optimization algorithm performances and generate a comparative report with visualizations. */}
+{/* *   [Benchmarking Suite](/docs/tutorials/benchmarking_suite_example) demonstrates how to use the Ax benchmarking suite to compare Bayesian Optimization algorithm performances and generate a comparative report with visualizations. */}
 
 For experiments done in a real-life setting, refer to our field experiments tutorials:
 
-*   [Bandit Optimization](factorial.html) shows how Thompson Sampling can be used to intelligently reallocate resources to well-performing configurations in real-time.
+*   [Bandit Optimization](/docs/tutorials/factorial) shows how Thompson Sampling can be used to intelligently reallocate resources to well-performing configurations in real-time.
 
-*   [Human-in-the-Loop Optimization](human_in_the_loop/human_in_the_loop.html) walks through manually influencing the course of optimization in real-time.
+*   [Human-in-the-Loop Optimization](/docs/tutorials/human_in_the_loop) walks through manually influencing the course of optimization in real-time.

--- a/tutorials/gpei_hartmann_developer/gpei_hartmann_developer.ipynb
+++ b/tutorials/gpei_hartmann_developer/gpei_hartmann_developer.ipynb
@@ -194,7 +194,7 @@
     "\n",
     "When doing the optimization, we will find points that minimize the objective while obeying the constraints (which in this case means `l2norm < 1.25`).\n",
     "\n",
-    "Note: we are using `Hartmann6Metric` and `L2NormMetric` here, which have built in evaluation functions for testing.  For creating your own cutom metrics, see [8. Defining custom metrics](#8.-Defining-custom-metrics)."
+    "Note: we are using `Hartmann6Metric` and `L2NormMetric` here, which have built in evaluation functions for testing.  For creating your own cutom metrics, see [8. Defining custom metrics](/docs/tutorials/gpei_hartmann_developer/#8-defining-custom-metrics)."
    ]
   },
   {
@@ -319,7 +319,7 @@
     "\n",
     "Run the optimization using the settings defined on the experiment. We will create 5 random sobol points for exploration followed by 15 points generated using the GPEI optimizer.\n",
     "\n",
-    "Instead of a member of the `Models` enum to produce generator runs, users can leverage a `GenerationStrategy`. See the [Generation Strategy Tutorial](https://ax.dev/tutorials/generation_strategy.html) for more info."
+    "Instead of a member of the `Models` enum to produce generator runs, users can leverage a `GenerationStrategy`. See the [Generation Strategy Tutorial](https://ax.dev/docs/tutorials/generation_strategy) for more info."
    ]
   },
   {
@@ -417,7 +417,7 @@
     "showInput": true
    },
    "source": [
-    "The below call to `exp.fetch_data()` also attaches data to the last trial, which because of the way we looped through Botorch trials in [5. Perform Optimization](5.-Perform-Optimization), would otherwise not have data attached.  This is necessary to get `objective_means` in [7. Plot results](7.-Plot-results)."
+    "The below call to `exp.fetch_data()` also attaches data to the last trial, which because of the way we looped through Botorch trials in [5. Perform Optimization](/docs/tutorials/gpei_hartmann_developer/#5-perform-optimization), would otherwise not have data attached.  This is necessary to get `objective_means` in [7. Plot results](/docs/tutorials/gpei_hartmann_developer/#7-plot-results)."
    ]
   },
   {
@@ -496,7 +496,7 @@
     "\n",
     "The only method that needs to be defined for most metric subclasses is `fetch_trial_data`, which defines how a single trial is evaluated, and returns a pandas dataframe.\n",
     " \n",
-    "The `is_available_while_running` method is optional and returns a boolean, specifying whether the trial data can be fetched before the trial is complete.  See [6. Inspect trials' data](6.-Inspect-trials'-data) for more details."
+    "The `is_available_while_running` method is optional and returns a boolean, specifying whether the trial data can be fetched before the trial is complete.  See [6. Inspect trials' data](/docs/tutorials/gpei_hartmann_developer/#6-inspect-trials-data) for more details."
    ]
   },
   {

--- a/tutorials/multiobjective_optimization/multiobjective_optimization.ipynb
+++ b/tutorials/multiobjective_optimization/multiobjective_optimization.ipynb
@@ -15,7 +15,7 @@
     "For Multi-objective optimization (MOO) in the `AxClient`, objectives are specified through the `ObjectiveProperties` dataclass.  An `ObjectiveProperties` requires a boolean `minimize`, and also accepts an optional floating point  `threshold`.  If a `threshold` is not specified, Ax will infer it through the use of heuristics.  If the user knows the region of interest (because they have specs or prior knowledge), then specifying the thresholds is preferable to inferring it. But if the user would need to guess, inferring is preferable.\n",
     "\n",
     "\n",
-    "To learn more about how to choose a threshold, see [Set Objective Thresholds to focus candidate generation in a region of interest](#Set-Objective-Thresholds-to-focus-candidate-generation-in-a-region-of-interest).  See the [Service API Tutorial](/tutorials/gpei_hartmann_service.html) for more infomation on running experiments with the Service API."
+    "To learn more about how to choose a threshold, see [Set Objective Thresholds to focus candidate generation in a region of interest](/docs/tutorials/multiobjective_optimization/#set-objective-thresholds-to-focus-candidate-generation-in-a-region-of-interest).  See the [Service API Tutorial](/docs/tutorials/gpei_hartmann_service) for more infomation on running experiments with the Service API."
    ]
   },
   {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -21,8 +21,8 @@ module.exports={
     "users": [],
     "wrapPagesHTML": true
   },
-  "onBrokenLinks": "log",
-  "onBrokenMarkdownLinks": "log",
+  "onBrokenLinks": "throw",
+  "onBrokenMarkdownLinks": "warn",
   "future": {
     "experimental_faster": true,
   },


### PR DESCRIPTION
## Context

Duplicate of same change in botorch: https://github.com/pytorch/botorch/pull/2720

## Motivation

The recent website upgrade moved the location of tutorials and api reference breaking existing links to those. Here we fix those links and also configure Docusaurus to raise an error on broken links in the future.

## Test Plan

Docusaurus checks for broken links when creating a production build. Running `./scripts/make_docs.sh -b` now results in a clean build with no broken links reported.

## Related PRs
- https://github.com/facebook/Ax/pull/3294

