### PR TITLE
Update nightly cron to use latest BoTorch for website built, use latest linear operator with latest BoTorch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,6 +34,7 @@ jobs:
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         # use latest Botorch
+        uv pip install git+https://github.com/cornellius-gp/linear_operator.git
         uv pip install git+https://github.com/cornellius-gp/gpytorch.git
         uv pip install git+https://github.com/pytorch/botorch.git
         uv pip install -e ".[unittest]"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -45,6 +45,7 @@ jobs:
       contents: write
     with:
       run_tutorials: true
+      pinned_botorch: false
 
   deploy-test-pypi:
 
@@ -68,6 +69,7 @@ jobs:
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         # use latest BoTorch
+        uv pip install git+https://github.com/cornellius-gp/linear_operator.git
         uv pip install git+https://github.com/cornellius-gp/gpytorch.git
         uv pip install git+https://github.com/pytorch/botorch.git
         uv pip install -e ".[dev,mysql,notebook]"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,7 @@ jobs:
     with:
       new_version: ${{ github.event.release.tag_name }}
       run_tutorials: true
+      pinned_botorch: true
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -10,8 +10,16 @@ on:
         required: false
         type: boolean
         default: true
+      pinned_botorch:
+        required: true
+        type: boolean
   workflow_dispatch:
-
+      run_tutorials:
+        required: true
+        type: boolean
+      pinned_botorch:
+        required: true
+        type: boolean
 
 jobs:
 
@@ -39,9 +47,22 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
-    - name: Install dependencies
+
+    - if: ${{ inputs.pinned_botorch }}
+      name: Install dependencies with pinned BoTorch
       run: |
         uv pip install -e ".[tutorial]"
+    - if: ${{ !inputs.pinned_botorch }}
+      name: Install dependencies with latest BoTorch
+      env:
+        ALLOW_BOTORCH_LATEST: true
+        ALLOW_LATEST_GPYTORCH_LINOP: true
+      run: |
+        uv pip install git+https://github.com/cornellius-gp/linear_operator.git
+        uv pip install git+https://github.com/cornellius-gp/gpytorch.git
+        uv pip install git+https://github.com/pytorch/botorch.git
+        uv pip install -e ".[tutorial]"
+
     - if: ${{ inputs.run_tutorials }}
       name: Run Tutorials
       run: |

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -53,6 +53,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
+        uv pip install git+https://github.com/cornellius-gp/linear_operator.git
         uv pip install git+https://github.com/cornellius-gp/gpytorch.git
         uv pip install git+https://github.com/pytorch/botorch.git
         uv pip install -e ${{ ((inputs.minimal_dependencies) && '.[unittest_minimal]') || '.[unittest]' }}

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -46,6 +46,7 @@ jobs:
         ALLOW_BOTORCH_LATEST: true
         ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
+        uv pip install git+https://github.com/cornellius-gp/linear_operator.git
         uv pip install git+https://github.com/cornellius-gp/gpytorch.git
         uv pip install git+https://github.com/pytorch/botorch.git
         uv pip install -e ".[tutorial]"


### PR DESCRIPTION
Summary:
Nightly cron was using pinned BoTorch for the website build, which can lead to failures. Update the workflow to support latest BoTorch.
Updated all workflows that use latest BoTorch to also install latest linear operator package, which may be needed by latest BoTorch.

Differential Revision: D69070370


