### PR TITLE
Remove duplicate build tutorials job from nightly cron

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -29,13 +29,6 @@ jobs:
       minimal_dependencies: false
     secrets: inherit
 
-  build-tutorials:
-    name: Build tutorials with latest BoTorch
-    uses: ./.github/workflows/reusable_tutorials.yml
-    with:
-      smoke_test: false
-      pinned_botorch: false
-
   publish-latest-website:
     name: Publish latest website
     uses: ./.github/workflows/publish_website.yml


### PR DESCRIPTION
Cron runs `publish_website` with `run_tutorials: true`, which runs all tutorials. The `build_tutorials` step duplicates this.