### PR TITLE
storage for auxiliary sources

### DIFF
--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -188,7 +188,13 @@ class Encoder:
             aux_exps,
         ) in experiment.auxiliary_experiments_by_purpose.items():
             aux_exp_type = aux_exp_type_enum.value
-            aux_exp_jsons = [aux_exp.experiment.name for aux_exp in aux_exps]
+            aux_exp_jsons = [
+                {
+                    "__type": aux_exp.__class__.__name__,
+                    "experiment_name": aux_exp.experiment.name,
+                }
+                for aux_exp in aux_exps
+            ]
             auxiliary_experiments_by_purpose[aux_exp_type] = aux_exp_jsons
 
         properties = experiment._properties

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -371,7 +371,7 @@ class SQAExperiment(Base):
     # pyre-fixme[8]: Incompatible attribute type [8]: Attribute
     # `auxiliary_experiments_by_purpose` declared in class `SQAExperiment` has
     # type `Optional[Dict[str, List[str]]]` but is used as type `Column[typing.Any]`
-    auxiliary_experiments_by_purpose: dict[str, List[str]] | None = Column(
+    auxiliary_experiments_by_purpose: dict[str, List[dict[str, Any]]] | None = Column(
         JSONEncodedTextDict, nullable=True, default={}
     )
 


### PR DESCRIPTION
Summary: Adding proper encoder and decoder for auxiliary_experiments_by_purpose argument of Experiment object. Previously, auxiliary_experiments_by_purpose used to include only AuxiliaryExperiment object that had an easy encoder and decoder via experiment name. But after allowing AuxiliarySources to be added in auxiliary_experiments_by_purpose we need to encode and decode AuxiliarySource objects as well.

Reviewed By: saitcakmak

Differential Revision: D68542281


