### PR TITLE
[GHA] Creating a new version only tracks relevant files to git

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -75,7 +75,7 @@ jobs:
         yarn
         yarn docusaurus docs:version ${{ inputs.new_version }}
 
-        git add --all
+        git add versioned_docs/ versioned_sidebars/ versions.json
         git commit -m "Create version ${{ inputs.new_version }} of site in Docusaurus"
         git push --force origin HEAD:docusaurus-versions
     - name: Build website


### PR DESCRIPTION
Fixes an issue where unrelated files were getting added to the `docusaurus-versions` branch. In particular the changes from running tutorials (the tutorials themselves, the dbs) were getting persisted and causing problems for future runs of the tutorials.