### PR TITLE
Updates baseline and optimal values for LCBench early-stopping benchmark problems

### DIFF
--- a/ax/benchmark/problems/surrogate/lcbench/early_stopping.py
+++ b/ax/benchmark/problems/surrogate/lcbench/early_stopping.py
@@ -17,12 +17,11 @@ import pandas as pd
 import torch
 from ax.benchmark.benchmark_problem import BenchmarkProblem
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
-from ax.benchmark.problems.surrogate.lcbench.data import load_lcbench_data
-from ax.benchmark.problems.surrogate.lcbench.transfer_learning import (
-    BASELINE_VALUES,
-    DEFAULT_AND_OPTIMAL_VALUES,
-    DEFAULT_NUM_TRIALS,
+from ax.benchmark.problems.surrogate.lcbench.data import (
+    DATASET_NAMES,
+    load_lcbench_data,
 )
+from ax.benchmark.problems.surrogate.lcbench.transfer_learning import DEFAULT_NUM_TRIALS
 from ax.benchmark.problems.surrogate.lcbench.utils import (
     DEFAULT_METRIC_NAME,
     get_lcbench_log_scale_parameter_names,
@@ -45,6 +44,81 @@ from sklearn.preprocessing import FunctionTransformer, MinMaxScaler
 logger: Logger = get_logger(__name__)
 
 TRegressorProtocol = TypeVar("TRegressorProtocol", bound="RegressorProtocol")
+
+BASELINE_VALUES: dict[str, float] = {
+    "APSFailure": 97.75948131763847,
+    "Amazon_employee_access": 93.39364177908142,
+    "Australian": 88.1445880383116,
+    "Fashion-MNIST": 84.75904272864778,
+    "KDDCup09_appetency": 96.13544312868322,
+    "MiniBooNE": 85.8639428612948,
+    "adult": 79.50334987749676,
+    "airlines": 58.96099030718572,
+    "albert": 63.885932360810884,
+    "bank-marketing": 83.72755317459641,
+    "blood-transfusion-service-center": 62.651717620524835,
+    "car": 78.59464531457958,
+    "christine": 72.22719165860138,
+    "cnae-9": 92.24923138962973,
+    "connect-4": 63.808749677494774,
+    "covertype": 61.61393200315512,
+    "credit-g": 70.45312807563056,
+    "dionis": 53.71071232033245,
+    "fabert": 64.44304132875557,
+    "helena": 18.239085505279544,
+    "higgs": 64.74999655474926,
+    "jannis": 57.82155396833136,
+    "jasmine": 80.48475426337272,
+    "jungle_chess_2pcs_raw_endgame_complete": 65.58537332961572,
+    "kc1": 77.28692486000287,
+    "kr-vs-kp": 93.63368446446995,
+    "mfeat-factors": 94.72758417873838,
+    "nomao": 93.73968374826451,
+    "numerai28.6": 51.60281273196557,
+    "phoneme": 75.20979771001986,
+    "segment": 78.81992685291081,
+    "shuttle": 96.45744339531132,
+    "sylvine": 91.15923021902736,
+    "vehicle": 67.40729695042013,
+    "volkert": 49.204981948803855,
+}
+OPTIMAL_VALUES: dict[str, float] = {
+    "APSFailure": 98.97643280029295,
+    "Amazon_employee_access": 94.1208953857422,
+    "Australian": 92.1568603515625,
+    "Fashion-MNIST": 89.417236328125,
+    "KDDCup09_appetency": 98.33574676513672,
+    "MiniBooNE": 90.79180908203124,
+    "adult": 84.11111450195312,
+    "airlines": 63.999061584472656,
+    "albert": 66.25859832763672,
+    "bank-marketing": 88.8466567993164,
+    "blood-transfusion-service-center": 80.1204833984375,
+    "car": 96.8668441772461,
+    "christine": 75.04173278808594,
+    "cnae-9": 97.48954010009766,
+    "connect-4": 74.20671844482422,
+    "covertype": 77.28044128417969,
+    "credit-g": 77.47747802734375,
+    "dionis": 87.68419647216797,
+    "fabert": 67.32564544677734,
+    "helena": 29.10163116455078,
+    "higgs": 71.88652801513672,
+    "jannis": 66.58744812011719,
+    "jasmine": 82.60211944580078,
+    "jungle_chess_2pcs_raw_endgame_complete": 84.13723754882812,
+    "kc1": 87.36616516113281,
+    "kr-vs-kp": 99.00990295410156,
+    "mfeat-factors": 97.96839904785156,
+    "nomao": 96.2865753173828,
+    "numerai28.6": 52.32661819458008,
+    "phoneme": 82.09204864501953,
+    "segment": 90.60665130615234,
+    "shuttle": 99.76605987548828,
+    "sylvine": 94.97354125976562,
+    "vehicle": 81.9148941040039,
+    "volkert": 64.02699279785156,
+}
 
 
 class RegressorProtocol(Protocol):
@@ -219,14 +293,12 @@ def get_lcbench_early_stopping_benchmark_problem(
         An LCBench surrogate benchmark problem.
     """
 
-    if dataset_name not in DEFAULT_AND_OPTIMAL_VALUES:
-        raise UserInputError(
-            f"`dataset_name` must be one of {sorted(DEFAULT_AND_OPTIMAL_VALUES)}"
-        )
+    if dataset_name not in DATASET_NAMES:
+        raise UserInputError(f"`dataset_name` must be one of {sorted(DATASET_NAMES)}")
 
     name = f"LCBench_Surrogate_{dataset_name}_{metric_name}:v1"
 
-    _, optimal_value = DEFAULT_AND_OPTIMAL_VALUES[dataset_name]
+    optimal_value = OPTIMAL_VALUES[dataset_name]
     baseline_value = BASELINE_VALUES[dataset_name]
 
     search_space: SearchSpace = get_lcbench_search_space()


### PR DESCRIPTION
Summary:
## Context

For the LCBench *early-stopping* surrogate benchmark problems, we were previously using baseline and optimal values computed specifically for the vanilla (single-output/single-fidelity) LCBench surrogate benchmark problems, which is based on GP surrogate models, while the *early-stopping* surrogate benchmarks are based on random forests. Therefore, we should not expect the baseline and optimal values to transfer.

## Changes

We 1) use N6522262 to compute the baseline values specifically for the  *early-stopping* surrogate benchmarks based on random forests and 2) set the best observed objective value for each dataset as the optimal value. We define `BASELINE_VALUES` and `OPTIMAL_VALUE` dicts consisting of these values and remove the dependency on the analogous dicts defined for the vanilla GP-based LCBench surrogate benchmarks.

Differential Revision: D69150124


