### PR TITLE
fix EBTS bug where gen returned less than n total weight

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -205,7 +205,7 @@ def get_benchmark_scheduler_options(
     Returns:
         ``SchedulerOptions``
     """
-    if method.batch_size > 1 or include_sq:
+    if method.batch_size is None or method.batch_size > 1 or include_sq:
         trial_type = TrialType.BATCH_TRIAL
     else:
         trial_type = TrialType.TRIAL

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -55,7 +55,7 @@ class BenchmarkMethod(Base):
     distribute_replications: bool = False
     use_model_predictions_for_best_point: bool = False
 
-    batch_size: int = 1
+    batch_size: int | None = 1
     run_trials_in_batches: bool = False
     max_pending_trials: int = 1
     early_stopping_strategy: BaseEarlyStoppingStrategy | None = None

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -899,4 +899,4 @@ class TorchAdapterTest(TestCase):
         self.assertNotEqual(modelbridge._model_space, modelbridge._search_space)
         # Generate candidates.
         gr = modelbridge.gen(n=3)
-        self.assertEqual(len(gr.arms), 3)
+        self.assertEqual(sum(gr.weights), 3)

--- a/ax/models/discrete/full_factorial.py
+++ b/ax/models/discrete/full_factorial.py
@@ -60,13 +60,6 @@ class FullFactorialGenerator(DiscreteGenerator):
         pending_observations: Sequence[Sequence[Sequence[TParamValue]]] | None = None,
         model_gen_options: TConfig | None = None,
     ) -> tuple[list[TParamValueList], list[float], TGenMetadata]:
-        if n != -1:
-            logger.warning(
-                "FullFactorialGenerator will ignore the specified value of n. "
-                "The generator automatically determines how many arms to "
-                "generate."
-            )
-
         if fixed_features:
             # Make a copy so as to not mutate it
             parameter_values = list(parameter_values)
@@ -74,6 +67,12 @@ class FullFactorialGenerator(DiscreteGenerator):
                 parameter_values[fixed_feature_index] = [fixed_feature_value]
 
         num_arms = reduce(mul, [len(values) for values in parameter_values], 1)
+        if n != num_arms:
+            logger.warning(
+                "FullFactorialGenerator will ignore the specified value of n. "
+                "The generator automatically determines how many arms to "
+                "generate."
+            )
         if self.check_cardinality and num_arms > self.max_cardinality:
             raise ValueError(
                 f"FullFactorialGenerator generated {num_arms} arms, "

--- a/ax/models/tests/test_eb_thompson.py
+++ b/ax/models/tests/test_eb_thompson.py
@@ -75,7 +75,7 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
             )
             self.assertEqual(arms, [[4, 4], [3, 3], [2, 2], [1, 1]])
             for weight, expected_weight in zip(
-                weights, [4 * i for i in [0.66, 0.25, 0.07, 0.02]]
+                weights, [5 * i for i in [0.66, 0.25, 0.07, 0.02]]
             ):
                 self.assertAlmostEqual(weight, expected_weight, delta=0.1)
 
@@ -95,7 +95,7 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
         )
         self.assertEqual(arms, [[3, 3], [2, 2], [1, 1]])
         for weight, expected_weight in zip(
-            weights, [3 * i for i in [0.74, 0.21, 0.05]]
+            weights, [5 * i for i in [0.74, 0.21, 0.05]]
         ):
             self.assertAlmostEqual(weight, expected_weight, delta=0.1)
 

--- a/ax/models/tests/test_full_factorial.py
+++ b/ax/models/tests/test_full_factorial.py
@@ -38,14 +38,14 @@ class FullFactorialGeneratorTest(TestCase):
                 objective_weights=np.ones(1),
             )
 
-        # Raise error because n != -1
+        # Raise error because n != num_arms
         generator = FullFactorialGenerator()
         parameter_values = [[1, 2], ["foo", "bar"]]
         with self.assertLogs(
             FullFactorialGenerator.__module__, logging.WARNING
         ) as logger:
             generated_points, weights, _ = generator.gen(
-                n=5,
+                n=-1,
                 parameter_values=parameter_values,
                 objective_weights=np.ones(1),
             )

--- a/ax/models/tests/test_thompson.py
+++ b/ax/models/tests/test_thompson.py
@@ -90,6 +90,7 @@ class ThompsonSamplerTest(TestCase):
             generator.gen(5, self.parameter_values, objective_weights=None)
 
     def test_ThompsonSamplerMinWeight(self) -> None:
+        np.random.seed(0)
         generator = ThompsonSampler(min_weight=0.01)
         generator.fit(
             Xs=self.Xs,
@@ -99,7 +100,7 @@ class ThompsonSamplerTest(TestCase):
             outcome_names=self.outcome_names,
         )
         arms, weights, _ = generator.gen(
-            n=5,
+            n=3,
             parameter_values=self.parameter_values,
             objective_weights=np.ones(1),
         )
@@ -223,3 +224,20 @@ class ThompsonSamplerTest(TestCase):
             " not lead to a meaningful result.",
             str(warning_list[0].message),
         )
+
+    def test_ThompsonSamplerNonPositiveN(self) -> None:
+        generator = ThompsonSampler(min_weight=0.0)
+        generator.fit(
+            Xs=self.Xs,
+            Ys=self.Ys,
+            Yvars=self.Yvars,
+            parameter_values=self.parameter_values,
+            outcome_names=self.outcome_names,
+        )
+        for n in (-1, 0):
+            with self.assertRaisesRegex(ValueError, "ThompsonSampler requires n > 0"):
+                generator.gen(
+                    n=n,
+                    parameter_values=self.parameter_values,
+                    objective_weights=np.ones(1),
+                )

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 from collections.abc import Iterable, MutableMapping
 from datetime import datetime, timedelta
 from logging import Logger
+from math import prod
 from pathlib import Path
 from typing import Any, cast
 
@@ -559,7 +560,12 @@ def get_factorial_experiment(
 
     if with_batch:
         factorial_generator = get_factorial(search_space=exp.search_space)
-        factorial_run = factorial_generator.gen(n=-1)
+        # compute cardinality of discrete search space
+        n = prod(
+            len(assert_is_instance(p, ChoiceParameter).values)
+            for p in exp.search_space.parameters.values()
+        )
+        factorial_run = factorial_generator.gen(n=n)
         exp.new_batch_trial(optimize_for_power=with_status_quo).add_generator_run(
             factorial_run
         )

--- a/tutorials/factorial/factorial.ipynb
+++ b/tutorials/factorial/factorial.ipynb
@@ -322,6 +322,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from math import prod\n",
+    "n = prod(len(p.values) for p in search_space.parameters.values())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "executionStartTime": 1626985056428,
     "executionStopTime": 1626985056466,
@@ -332,8 +342,10 @@
    "source": [
     "factorial = Generators.FACTORIAL(search_space=exp.search_space)\n",
     "factorial_run = factorial.gen(\n",
-    "    n=-1\n",
-    ")  # Number of arms to generate is derived from the search space.\n",
+    "    # Number of arms to generate is derived from the search space. \n",
+    "    # So n passed here will be overwritten by internal logic.\n",
+    "    n=n \n",
+    ")  \n",
     "print(len(factorial_run.arms))"
    ]
   },
@@ -433,7 +445,7 @@
     "    trial.mark_completed()\n",
     "    thompson = Generators.THOMPSON(experiment=exp, data=trial.fetch_data(), min_weight=0.01)\n",
     "    models.append(thompson)\n",
-    "    thompson_run = thompson.gen(n=-1)\n",
+    "    thompson_run = thompson.gen(n=n)\n",
     "    trial = exp.new_batch_trial(optimize_for_power=True).add_generator_run(thompson_run)"
    ]
   },
@@ -626,6 +638,13 @@
     "\n",
     "render(plot_marginal_effects(models[0], \"success_metric\"))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Summary:
This could happen if enought `weights` were zero here than the length of `weights` became less than `n`: https://www.internalfb.com/code/fbsource/[b9c286a9f21709eb4c964c3c24bb629b2b218c86]/fbcode/ax/models/discrete/thompson.py?lines=109-113.

The `AlmostEqual` is needed to deal with numerical precision (e.g. 9.0000000002)

Reviewed By: danielcohenlive

Differential Revision: D69253157


