### PR TITLE
fix MBM model selection CV bug with uncertainty-based diagnostics

### DIFF
--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -71,7 +71,8 @@ class BoTorchGenerator(TorchGenerator, Base):
             state dict or the state dict of the current BoTorch ``Model`` during
             refitting. If False, model parameters will be reoptimized from
             scratch on refit. NOTE: This setting is ignored during
-            ``cross_validate`` if ``refit_on_cv`` is False.
+            ``cross_validate`` if ``refit_on_cv`` is False. This is also used in
+            Surrogate.model_selection.
     """
 
     acquisition_class: type[Acquisition]
@@ -192,7 +193,9 @@ class BoTorchGenerator(TorchGenerator, Base):
                 else self.surrogate_spec
             )
             self._surrogate = Surrogate(
-                surrogate_spec=surrogate_spec, refit_on_cv=self.refit_on_cv
+                surrogate_spec=surrogate_spec,
+                refit_on_cv=self.refit_on_cv,
+                warm_start_refit=self.warm_start_refit,
             )
 
         # Fit the surrogate.

--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -1189,7 +1189,7 @@ class Surrogate(Base):
         return diag_fn(
             y_obs=Y.view(-1).cpu().numpy(),
             y_pred=pred_Y,
-            se_pred=pred_Yvar,
+            se_pred=np.sqrt(pred_Yvar),
         )
 
     def _discard_cached_model_and_data_if_search_space_digest_changed(

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -785,7 +785,9 @@ class BoTorchGeneratorTest(TestCase):
                 search_space_digest=self.mf_search_space_digest,
                 candidate_metadata=self.candidate_metadata,
             )
-        mock_init.assert_called_with(surrogate_spec=surrogate_spec, refit_on_cv=False)
+        mock_init.assert_called_with(
+            surrogate_spec=surrogate_spec, refit_on_cv=False, warm_start_refit=True
+        )
 
     @mock_botorch_optimize
     def test_surrogate_options_propagation(self) -> None:
@@ -797,7 +799,9 @@ class BoTorchGeneratorTest(TestCase):
                 search_space_digest=self.mf_search_space_digest,
                 candidate_metadata=self.candidate_metadata,
             )
-        mock_init.assert_called_with(surrogate_spec=surrogate_spec, refit_on_cv=False)
+        mock_init.assert_called_with(
+            surrogate_spec=surrogate_spec, refit_on_cv=False, warm_start_refit=True
+        )
 
     @mock_botorch_optimize
     def test_model_list_choice(self) -> None:


### PR DESCRIPTION
Summary: Fixes a bug for model selection criteria that rely on model uncertainty. Previously we passed variance instead of standard deviation.

Differential Revision: D69259144


