### PR TITLE
Update GenerationNode repr w/ brief node and model spec strings

### DIFF
--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -679,15 +679,40 @@ class GenerationNode(SerializationMixin, SortableBase):
             return -1
         return min(gen_blocking_criterion_delta_from_threshold)
 
+    def _brief_transition_criteria_repr(self) -> str:
+        """Returns a brief string representation of the
+        transition criteria for this node.
+
+        Returns:
+            str: A string representation of the transition criteria for this node.
+        """
+        if self.transition_criteria is None:
+            return "None"
+        tc_list = ", ".join(
+            [
+                f"{tc.__class__.__name__}(transition_to='{str(tc.transition_to)}')"
+                for tc in self.transition_criteria
+            ]
+        )
+        return f"[{tc_list}]"
+
     def __repr__(self) -> str:
         "String representation of this GenerationNode"
         # add model specs
-        str_rep = f"{self.__class__.__name__}(model_specs="
-        model_spec_str = str(self.model_specs).replace("\n", " ").replace("\t", "")
-        str_rep += model_spec_str
+        str_rep = f"{self.__class__.__name__}"
+        str_rep += f"(node_name='{self.node_name}'"
 
-        str_rep += f", node_name={self.node_name}"
-        str_rep += f", transition_criteria={str(self.transition_criteria)}"
+        str_rep += ", model_specs="
+        model_spec_str = (
+            ", ".join([spec._brief_repr() for spec in self.model_specs])
+            .replace("\n", " ")
+            .replace("\t", "")
+        )
+        str_rep += f"[{model_spec_str}]"
+
+        str_rep += (
+            f", transition_criteria={str(self._brief_transition_criteria_repr())}"
+        )
 
         return f"{str_rep})"
 

--- a/ax/generation_strategy/model_spec.py
+++ b/ax/generation_strategy/model_spec.py
@@ -296,6 +296,16 @@ class GeneratorSpec(SortableBase, SerializationMixin):
         if self._fitted_model is None:
             raise UserInputError("No fitted model found. Call fit() to generate one")
 
+    def _brief_repr(self) -> str:
+        """Returns a brief string representation of this model spec.
+        Includes just name and override, but not the various kwargs"""
+        return (
+            "GeneratorSpec("
+            f"\tmodel_enum={self.model_enum.value}, "
+            f"\tmodel_key_override={self.model_key_override}"
+            ")"
+        )
+
     def __repr__(self) -> str:
         model_kwargs = json.dumps(
             self.model_kwargs, sort_keys=True, cls=GeneratorSpecJSONEncoder

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -311,16 +311,10 @@ class TestGenerationNode(TestCase):
 
         self.assertEqual(
             string_rep,
-            "GenerationNode(model_specs=[GeneratorSpec(model_enum=BoTorch,"
-            " model_kwargs={}, model_gen_kwargs={}, model_cv_kwargs={},"
-            " model_key_override=None)], node_name=test, "
-            "transition_criteria=[MinTrials({'threshold': 5, "
-            "'only_in_statuses': [<enum 'TrialStatus'>.RUNNING], "
-            "'not_in_statuses': None, 'transition_to': None, "
-            "'block_transition_if_unmet': True, 'block_gen_if_met': False, "
-            "'use_all_trials_in_exp': False, "
-            "'continue_trial_generation': False, "
-            "'count_only_trials_with_data': False})])",
+            "GenerationNode(node_name='test', "
+            "model_specs=[GeneratorSpec(model_enum=BoTorch, "
+            "model_key_override=None)], "
+            "transition_criteria=[MinTrials(transition_to='None')])",
         )
 
     def test_single_fixed_features(self) -> None:

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -477,9 +477,9 @@ class TestGenerationStrategy(TestCase):
         self.assertEqual(
             str(gs3),
             "GenerationStrategy(name='test', nodes=[GenerationNode("
+            "node_name='test', "
             "model_specs=[GeneratorSpec(model_enum=Sobol, "
-            "model_kwargs={}, model_gen_kwargs={}, model_cv_kwargs={},"
-            " model_key_override=None)], node_name=test, "
+            "model_key_override=None)], "
             "transition_criteria=[])])",
         )
 

--- a/ax/generation_strategy/tests/test_model_spec.py
+++ b/ax/generation_strategy/tests/test_model_spec.py
@@ -215,6 +215,23 @@ class GeneratorSpecTest(BaseGeneratorSpecTest):
         self.assertIn("test_cv_kwargs", repr_str)
         self.assertIn("test_model_key_override", repr_str)
 
+    def test_brief_rep(self) -> None:
+        ms = GeneratorSpec(
+            model_enum=Generators.BOTORCH_MODULAR,
+            model_kwargs={"test_model_kwargs": 1},
+            model_gen_kwargs={"test_gen_kwargs": 1},
+            model_cv_kwargs={"test_cv_kwargs": 1},
+        )
+        ms.model_key_override = "test_model_key_override"
+
+        repr_str = ms._brief_repr()
+
+        self.assertNotIn("\n", repr_str)
+        self.assertNotIn("test_model_kwargs", repr_str)
+        self.assertNotIn("test_gen_kwargs", repr_str)
+        self.assertNotIn("test_cv_kwargs", repr_str)
+        self.assertIn("test_model_key_override", repr_str)
+
 
 class FactoryFunctionGeneratorSpecTest(BaseGeneratorSpecTest):
     def test_construct(self) -> None:


### PR DESCRIPTION
Summary:
1. Adjust GenNode.repr to only print `TransitionCriterionClass(transition_to=<transition_to>)` (can use tc.class.name for this), omitting other TransitionCriteria settings

2. Adds a brief repr of ModelSpec repr to ignore its kwargs

3. Reorders Generation Node args to node_name first, Model Specs after, then transition criteria last. 
4. Adds ' tick marks to "node_name" arg
5. Update the corresponding unit tests


Note: Added a specific brief repr method to GenerationNode instead of changing TransitionCriteria's repr, 
Additionally, added brief repr for model spec following prior feedback.

Differential Revision: D69260519


