### PR TITLE
Move `TrialStatus` out to its own file (preliminary cleanup)

### DIFF
--- a/ax/analysis/healthcheck/tests/test_can_generate_candidates.py
+++ b/ax/analysis/healthcheck/tests/test_can_generate_candidates.py
@@ -13,7 +13,7 @@ from ax.analysis.healthcheck.can_generate_candidates import (
     CanGenerateCandidatesAnalysis,
 )
 from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckStatus
-from ax.core.base_trial import TrialStatus
+from ax.core.trial_status import TrialStatus
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
 from pandas import testing as pdt

--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -35,11 +35,11 @@ from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.benchmark.methods.sobol import get_sobol_generation_strategy
 from ax.core.arm import Arm
-from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
 from ax.core.objective import MultiObjective
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
+from ax.core.trial_status import TrialStatus
 from ax.core.types import TParameterization, TParamValue
 from ax.core.utils import get_model_times
 from ax.service.scheduler import Scheduler

--- a/ax/benchmark/tests/test_benchmark_runner.py
+++ b/ax/benchmark/tests/test_benchmark_runner.py
@@ -25,11 +25,11 @@ from ax.benchmark.problems.synthetic.hss.jenatton import (
     Jenatton,
 )
 from ax.core.arm import Arm
-from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import BatchTrial
 from ax.core.experiment import Experiment
 from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
+from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.benchmark_stubs import (

--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -12,7 +12,6 @@ from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Callable
 from copy import deepcopy
 from datetime import datetime, timedelta
-from enum import Enum
 from typing import Any, TYPE_CHECKING
 
 from ax.core.arm import Arm
@@ -23,6 +22,7 @@ from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric, MetricFetchResult
 from ax.core.runner import Runner
+from ax.core.trial_status import TrialStatus
 from ax.core.types import TCandidateMetadata, TEvaluationOutcome
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.base import SortableBase
@@ -32,144 +32,6 @@ from pyre_extensions import none_throws
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
     from ax import core  # noqa F401
-
-
-class TrialStatus(int, Enum):
-    """Enum of trial status.
-
-    General lifecycle of a trial is:::
-
-        CANDIDATE --> STAGED --> RUNNING --> COMPLETED
-                  ------------->         --> FAILED (retryable)
-                                         --> EARLY_STOPPED (deemed unpromising)
-                  -------------------------> ABANDONED (non-retryable)
-
-    Trial is marked as a ``CANDIDATE`` immediately upon its creation.
-
-    Trials may be abandoned at any time prior to completion or failure.
-    The difference between abandonment and failure is that the ``FAILED`` state
-    is meant to express a possibly transient or retryable error, so trials in
-    that state may be re-run and arm(s) in them may be resuggested by Ax models
-    to be added to new trials.
-
-    ``ABANDONED`` trials on the other end, indicate
-    that the trial (and arms(s) in it) should not be rerun or added to new
-    trials. A trial might be marked ``ABANDONED`` as a result of human-initiated
-    action (if some trial in experiment is poorly-performing, deterministically
-    failing etc., and should not be run again in the experiment). It might also
-    be marked ``ABANDONED`` in an automated way if the trial's execution
-    encounters an error that indicates that the arm(s) in the trial should bot
-    be evaluated in the experiment again (e.g. the parameterization in a given
-    arm deterministically causes trial evaluation to fail). Note that it's also
-    possible to abandon a single arm in a `BatchTrial` via
-    ``batch.mark_arm_abandoned``.
-
-    Early-stopped refers to trials that were deemed
-    unpromising by an early-stopping strategy and therefore terminated.
-
-    Additionally, when trials are deployed, they may be in an intermediate
-    staged state (e.g. scheduled but waiting for resources) or immediately
-    transition to running. Note that ``STAGED`` trial status is not always
-    applicable and depends on the ``Runner`` trials are deployed with
-    (and whether a ``Runner`` is present at all; for example, in Ax Service
-    API, trials are marked as ``RUNNING`` immediately when generated from
-    ``get_next_trial``, skipping the ``STAGED`` status).
-
-    NOTE: Data for abandoned trials (or abandoned arms in batch trials) is
-    not passed to the model as part of training data, unless ``fit_abandoned``
-    option is specified to model bridge. Additionally, data from MapMetrics is
-    typically excluded unless the corresponding trial is completed.
-    """
-
-    CANDIDATE = 0
-    STAGED = 1
-    FAILED = 2
-    COMPLETED = 3
-    RUNNING = 4
-    ABANDONED = 5
-    DISPATCHED = 6  # Deprecated.
-    EARLY_STOPPED = 7
-
-    @property
-    def is_terminal(self) -> bool:
-        """True if trial is completed."""
-        return (
-            self == TrialStatus.ABANDONED
-            or self == TrialStatus.COMPLETED
-            or self == TrialStatus.FAILED
-            or self == TrialStatus.EARLY_STOPPED
-        )
-
-    @property
-    def expecting_data(self) -> bool:
-        """True if trial is expecting data."""
-        return self in STATUSES_EXPECTING_DATA
-
-    @property
-    def is_deployed(self) -> bool:
-        """True if trial has been deployed but not completed."""
-        return self == TrialStatus.STAGED or self == TrialStatus.RUNNING
-
-    @property
-    def is_failed(self) -> bool:
-        """True if this trial is a failed one."""
-        return self == TrialStatus.FAILED
-
-    @property
-    def is_abandoned(self) -> bool:
-        """True if this trial is an abandoned one."""
-        return self == TrialStatus.ABANDONED
-
-    @property
-    def is_candidate(self) -> bool:
-        """True if this trial is a candidate."""
-        return self == TrialStatus.CANDIDATE
-
-    @property
-    def is_completed(self) -> bool:
-        """True if this trial is a successfully completed one."""
-        return self == TrialStatus.COMPLETED
-
-    @property
-    def is_running(self) -> bool:
-        """True if this trial is a running one."""
-        return self == TrialStatus.RUNNING
-
-    @property
-    def is_early_stopped(self) -> bool:
-        """True if this trial is an early stopped one."""
-        return self == TrialStatus.EARLY_STOPPED
-
-    def __format__(self, fmt: str) -> str:
-        """Define `__format__` to avoid pulling the `__format__` from the `int`
-        mixin (since its better for statuses to show up as `RUNNING` than as
-        just an int that is difficult to interpret).
-
-        E.g. batch trial representation with the overridden method is:
-        "BatchTrial(experiment_name='test', index=0, status=TrialStatus.CANDIDATE)".
-
-        Docs on enum formatting: https://docs.python.org/3/library/enum.html#others.
-        """
-        return f"{self!s}"
-
-    def __repr__(self) -> str:
-        return f"{self.__class__}.{self.name}"
-
-
-DEFAULT_STATUSES_TO_WARM_START: list[TrialStatus] = [
-    TrialStatus.RUNNING,
-    TrialStatus.COMPLETED,
-    TrialStatus.ABANDONED,
-    TrialStatus.EARLY_STOPPED,
-]
-
-NON_ABANDONED_STATUSES: set[TrialStatus] = set(TrialStatus) - {TrialStatus.ABANDONED}
-
-STATUSES_EXPECTING_DATA: list[TrialStatus] = [
-    TrialStatus.RUNNING,
-    TrialStatus.COMPLETED,
-    TrialStatus.EARLY_STOPPED,
-]
 
 
 def immutable_once_run(func: Callable) -> Callable:

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -22,12 +22,7 @@ import ax.core.observation as observation
 import pandas as pd
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
-from ax.core.base_trial import (
-    BaseTrial,
-    DEFAULT_STATUSES_TO_WARM_START,
-    STATUSES_EXPECTING_DATA,
-    TrialStatus,
-)
+from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import BatchTrial, LifecycleStage
 from ax.core.data import Data
 from ax.core.formatting_utils import DATA_TYPE_LOOKUP, DataType
@@ -41,6 +36,11 @@ from ax.core.parameter import Parameter
 from ax.core.runner import Runner
 from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
 from ax.core.trial import Trial
+from ax.core.trial_status import (
+    DEFAULT_STATUSES_TO_WARM_START,
+    STATUSES_EXPECTING_DATA,
+    TrialStatus,
+)
 from ax.core.types import ComparisonOp, TParameterization
 from ax.exceptions.core import (
     AxError,

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -19,11 +19,11 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from ax.core.arm import Arm
-from ax.core.base_trial import NON_ABANDONED_STATUSES, TrialStatus
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
 from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
+from ax.core.trial_status import NON_ABANDONED_STATUSES, TrialStatus
 from ax.core.types import TCandidateMetadata, TParameterization
 from ax.utils.common.base import Base
 from ax.utils.common.constants import Keys

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -13,12 +13,12 @@ from unittest.mock import patch, PropertyMock
 
 import numpy as np
 from ax.core.arm import Arm
-from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import BatchTrial, GeneratorRunStruct
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun, GeneratorRunType
 from ax.core.parameter import FixedParameter, ParameterType
 from ax.core.search_space import SearchSpace
+from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UnsupportedError
 from ax.runners.synthetic import SyntheticRunner
 from ax.utils.common.testutils import TestCase

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -12,7 +12,6 @@ from unittest.mock import Mock, patch, PropertyMock
 import numpy as np
 import pandas as pd
 from ax.core.arm import Arm
-from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun
@@ -29,6 +28,7 @@ from ax.core.observation import (
     separate_observations,
 )
 from ax.core.trial import Trial
+from ax.core.trial_status import TrialStatus
 from ax.core.types import TParameterization
 from ax.utils.common.testutils import TestCase
 from pyre_extensions import none_throws

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -12,7 +12,6 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 from ax.core.arm import Arm
-from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
@@ -20,6 +19,7 @@ from ax.core.objective import Objective
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint
+from ax.core.trial_status import TrialStatus
 from ax.core.types import ComparisonOp
 from ax.core.utils import (
     best_feasible_objective,

--- a/ax/core/trial_status.py
+++ b/ax/core/trial_status.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TrialStatus(int, Enum):
+    """Enum of trial status.
+
+    General lifecycle of a trial is:::
+
+        CANDIDATE --> STAGED --> RUNNING --> COMPLETED
+                  ------------->         --> FAILED (retryable)
+                                         --> EARLY_STOPPED (deemed unpromising)
+                  -------------------------> ABANDONED (non-retryable)
+
+    Trial is marked as a ``CANDIDATE`` immediately upon its creation.
+
+    Trials may be abandoned at any time prior to completion or failure.
+    The difference between abandonment and failure is that the ``FAILED`` state
+    is meant to express a possibly transient or retryable error, so trials in
+    that state may be re-run and arm(s) in them may be resuggested by Ax models
+    to be added to new trials.
+
+    ``ABANDONED`` trials on the other end, indicate
+    that the trial (and arms(s) in it) should not be rerun or added to new
+    trials. A trial might be marked ``ABANDONED`` as a result of human-initiated
+    action (if some trial in experiment is poorly-performing, deterministically
+    failing etc., and should not be run again in the experiment). It might also
+    be marked ``ABANDONED`` in an automated way if the trial's execution
+    encounters an error that indicates that the arm(s) in the trial should bot
+    be evaluated in the experiment again (e.g. the parameterization in a given
+    arm deterministically causes trial evaluation to fail). Note that it's also
+    possible to abandon a single arm in a `BatchTrial` via
+    ``batch.mark_arm_abandoned``.
+
+    Early-stopped refers to trials that were deemed
+    unpromising by an early-stopping strategy and therefore terminated.
+
+    Additionally, when trials are deployed, they may be in an intermediate
+    staged state (e.g. scheduled but waiting for resources) or immediately
+    transition to running. Note that ``STAGED`` trial status is not always
+    applicable and depends on the ``Runner`` trials are deployed with
+    (and whether a ``Runner`` is present at all; for example, in Ax Service
+    API, trials are marked as ``RUNNING`` immediately when generated from
+    ``get_next_trial``, skipping the ``STAGED`` status).
+
+    NOTE: Data for abandoned trials (or abandoned arms in batch trials) is
+    not passed to the model as part of training data, unless ``fit_abandoned``
+    option is specified to model bridge. Additionally, data from MapMetrics is
+    typically excluded unless the corresponding trial is completed.
+    """
+
+    CANDIDATE = 0
+    STAGED = 1
+    FAILED = 2
+    COMPLETED = 3
+    RUNNING = 4
+    ABANDONED = 5
+    DISPATCHED = 6  # Deprecated.
+    EARLY_STOPPED = 7
+
+    @property
+    def is_terminal(self) -> bool:
+        """True if trial is completed."""
+        return (
+            self == TrialStatus.ABANDONED
+            or self == TrialStatus.COMPLETED
+            or self == TrialStatus.FAILED
+            or self == TrialStatus.EARLY_STOPPED
+        )
+
+    @property
+    def expecting_data(self) -> bool:
+        """True if trial is expecting data."""
+        return self in STATUSES_EXPECTING_DATA
+
+    @property
+    def is_deployed(self) -> bool:
+        """True if trial has been deployed but not completed."""
+        return self == TrialStatus.STAGED or self == TrialStatus.RUNNING
+
+    @property
+    def is_failed(self) -> bool:
+        """True if this trial is a failed one."""
+        return self == TrialStatus.FAILED
+
+    @property
+    def is_abandoned(self) -> bool:
+        """True if this trial is an abandoned one."""
+        return self == TrialStatus.ABANDONED
+
+    @property
+    def is_candidate(self) -> bool:
+        """True if this trial is a candidate."""
+        return self == TrialStatus.CANDIDATE
+
+    @property
+    def is_completed(self) -> bool:
+        """True if this trial is a successfully completed one."""
+        return self == TrialStatus.COMPLETED
+
+    @property
+    def is_running(self) -> bool:
+        """True if this trial is a running one."""
+        return self == TrialStatus.RUNNING
+
+    @property
+    def is_early_stopped(self) -> bool:
+        """True if this trial is an early stopped one."""
+        return self == TrialStatus.EARLY_STOPPED
+
+    def __format__(self, fmt: str) -> str:
+        """Define `__format__` to avoid pulling the `__format__` from the `int`
+        mixin (since its better for statuses to show up as `RUNNING` than as
+        just an int that is difficult to interpret).
+
+        E.g. batch trial representation with the overridden method is:
+        "BatchTrial(experiment_name='test', index=0, status=TrialStatus.CANDIDATE)".
+
+        Docs on enum formatting: https://docs.python.org/3/library/enum.html#others.
+        """
+        return f"{self!s}"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__}.{self.name}"
+
+
+DEFAULT_STATUSES_TO_WARM_START: list[TrialStatus] = [
+    TrialStatus.RUNNING,
+    TrialStatus.COMPLETED,
+    TrialStatus.ABANDONED,
+    TrialStatus.EARLY_STOPPED,
+]
+
+NON_ABANDONED_STATUSES: set[TrialStatus] = set(TrialStatus) - {TrialStatus.ABANDONED}
+
+STATUSES_EXPECTING_DATA: list[TrialStatus] = [
+    TrialStatus.RUNNING,
+    TrialStatus.COMPLETED,
+    TrialStatus.EARLY_STOPPED,
+]

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -14,12 +14,12 @@ from logging import Logger
 
 import numpy.typing as npt
 import pandas as pd
-from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
 from ax.core.objective import MultiObjective
+from ax.core.trial_status import TrialStatus
 
 from ax.early_stopping.utils import estimate_early_stopping_savings
 from ax.modelbridge.map_torch import MapTorchAdapter

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -11,10 +11,10 @@ from typing import Any, cast
 
 import numpy as np
 from ax.core import OptimizationConfig
-from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
 from ax.core.objective import MultiObjective
+from ax.core.trial_status import TrialStatus
 from ax.early_stopping.strategies import (
     BaseEarlyStoppingStrategy,
     ModelBasedEarlyStoppingStrategy,

--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -10,9 +10,9 @@ from collections import defaultdict
 from logging import Logger
 
 import pandas as pd
-from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
+from ax.core.trial_status import TrialStatus
 from ax.utils.common.logger import get_logger
 from pyre_extensions import assert_is_instance
 

--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -14,13 +14,13 @@ from logging import Logger
 from typing import Any, TYPE_CHECKING
 
 from ax.core.arm import Arm
-from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
+from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UserInputError
 from ax.exceptions.generation_strategy import GenerationStrategyRepeatedPoints
 from ax.generation_strategy.best_model_selector import BestModelSelector

--- a/ax/generation_strategy/generation_node_input_constructors.py
+++ b/ax/generation_strategy/generation_node_input_constructors.py
@@ -11,8 +11,8 @@ from math import ceil, floor
 from typing import Any
 
 from ax.core import ObservationFeatures
-from ax.core.base_trial import STATUSES_EXPECTING_DATA
 from ax.core.experiment import Experiment
+from ax.core.trial_status import STATUSES_EXPECTING_DATA
 from ax.core.utils import get_target_trial_index
 from ax.exceptions.generation_strategy import AxGenerationException
 

--- a/ax/generation_strategy/generation_strategy.py
+++ b/ax/generation_strategy/generation_strategy.py
@@ -16,12 +16,12 @@ from logging import Logger
 from typing import Any, TypeVar
 
 import pandas as pd
-from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generation_strategy_interface import GenerationStrategyInterface
 from ax.core.generator_run import GeneratorRun
 from ax.core.observation import ObservationFeatures
+from ax.core.trial_status import TrialStatus
 from ax.core.utils import extend_pending_observations, extract_pending_observations
 from ax.exceptions.core import DataRequiredError, UnsupportedError, UserInputError
 from ax.exceptions.generation_strategy import (

--- a/ax/generation_strategy/tests/test_aepsych_criterion.py
+++ b/ax/generation_strategy/tests/test_aepsych_criterion.py
@@ -8,8 +8,8 @@
 from unittest.mock import patch
 
 import pandas as pd
-from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
+from ax.core.trial_status import TrialStatus
 from ax.generation_strategy.generation_strategy import (
     GenerationStep,
     GenerationStrategy,

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -10,9 +10,9 @@ from logging import Logger
 from unittest.mock import MagicMock, patch
 
 import torch
-
-from ax.core.base_trial import TrialStatus
 from ax.core.observation import ObservationFeatures
+
+from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.best_model_selector import (
     ReductionCriterion,

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -13,12 +13,12 @@ from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
 from ax.core.arm import Arm
-from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, FixedParameter, Parameter, ParameterType
 from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
+from ax.core.trial_status import TrialStatus
 from ax.core.utils import (
     get_pending_observation_features_based_on_trial_status as get_pending,
 )

--- a/ax/generation_strategy/tests/test_transition_criterion.py
+++ b/ax/generation_strategy/tests/test_transition_criterion.py
@@ -12,8 +12,8 @@ from unittest.mock import patch
 
 import pandas as pd
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
-from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
+from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import (
     GenerationNode,

--- a/ax/generation_strategy/transition_criterion.py
+++ b/ax/generation_strategy/transition_criterion.py
@@ -15,9 +15,9 @@ from typing import TYPE_CHECKING
 from ax.core import MultiObjectiveOptimizationConfig
 
 from ax.core.auxiliary import AuxiliaryExperimentPurpose
-
-from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
+
+from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.exceptions.generation_strategy import MaxParallelismReachedException
 

--- a/ax/global_stopping/strategies/base.py
+++ b/ax/global_stopping/strategies/base.py
@@ -9,8 +9,9 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
+
+from ax.core.trial_status import TrialStatus
 from ax.utils.common.base import Base
 
 

--- a/ax/global_stopping/tests/test_strategies.py
+++ b/ax/global_stopping/tests/test_strategies.py
@@ -10,7 +10,6 @@
 import numpy as np
 import pandas as pd
 from ax.core.arm import Arm
-from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
 from ax.core.experiment import Experiment
@@ -24,6 +23,7 @@ from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
+from ax.core.trial_status import TrialStatus
 from ax.core.types import ComparisonOp
 from ax.global_stopping.strategies.improvement import (
     constraint_satisfaction,

--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -19,7 +19,6 @@ from logging import Logger
 from typing import Any
 
 from ax.core.arm import Arm
-from ax.core.base_trial import NON_ABANDONED_STATUSES, TrialStatus
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import extract_arm_predictions, GeneratorRun
@@ -34,6 +33,7 @@ from ax.core.observation import (
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
+from ax.core.trial_status import NON_ABANDONED_STATUSES, TrialStatus
 from ax.core.types import (
     TCandidateMetadata,
     TModelCov,

--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -11,7 +11,6 @@ import numpy as np
 import numpy.typing as npt
 
 import torch
-from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
 from ax.core.experiment import Experiment
@@ -25,6 +24,7 @@ from ax.core.observation import (
 )
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
+from ax.core.trial_status import TrialStatus
 from ax.core.types import TCandidateMetadata
 from ax.modelbridge.base import GenResults
 from ax.modelbridge.modelbridge_utils import (

--- a/ax/modelbridge/tests/test_map_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_map_torch_modelbridge.py
@@ -11,13 +11,13 @@ from unittest import mock
 import numpy as np
 
 import torch
-
-from ax.core.base_trial import TrialStatus
 from ax.core.observation import (
     ObservationData,
     ObservationFeatures,
     recombine_observations,
 )
+
+from ax.core.trial_status import TrialStatus
 from ax.modelbridge.map_torch import MapTorchAdapter
 from ax.models.torch_base import TorchGenerator, TorchGenResults
 from ax.utils.common.constants import Keys

--- a/ax/preview/api/client.py
+++ b/ax/preview/api/client.py
@@ -20,7 +20,6 @@ from ax.analysis.markdown.markdown_analysis import (
     markdown_analysis_card_from_analysis_e,
 )
 from ax.analysis.utils import choose_analyses
-from ax.core.base_trial import TrialStatus  # Used as a return type
 from ax.core.experiment import Experiment
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
@@ -28,6 +27,7 @@ from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.runner import Runner
 from ax.core.trial import Trial
+from ax.core.trial_status import TrialStatus  # Used as a return type
 from ax.core.utils import get_pending_observation_features_based_on_trial_status
 from ax.early_stopping.strategies import (
     BaseEarlyStoppingStrategy,

--- a/ax/preview/api/protocols/runner.py
+++ b/ax/preview/api/protocols/runner.py
@@ -8,7 +8,7 @@
 
 from typing import Any, Mapping
 
-from ax.core.base_trial import TrialStatus
+from ax.core.trial_status import TrialStatus
 from ax.preview.api.protocols.utils import _APIRunner
 from ax.preview.api.types import TParameterization
 from pyre_extensions import override

--- a/ax/preview/api/tests/test_client.py
+++ b/ax/preview/api/tests/test_client.py
@@ -11,7 +11,6 @@ import numpy as np
 
 import pandas as pd
 from ax.analysis.plotly.parallel_coordinates import ParallelCoordinatesPlot
-from ax.core.base_trial import TrialStatus
 
 from ax.core.experiment import Experiment
 from ax.core.formatting_utils import DataType
@@ -28,6 +27,7 @@ from ax.core.parameter import (
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
+from ax.core.trial_status import TrialStatus
 from ax.early_stopping.strategies import PercentileEarlyStoppingStrategy
 from ax.exceptions.core import UnsupportedError
 from ax.preview.api.client import Client

--- a/ax/preview/modelbridge/dispatch_utils.py
+++ b/ax/preview/modelbridge/dispatch_utils.py
@@ -7,7 +7,7 @@
 # pyre-unsafe
 
 import torch
-from ax.core.base_trial import TrialStatus
+from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UnsupportedError
 from ax.generation_strategy.generation_strategy import (
     GenerationNode,

--- a/ax/preview/modelbridge/tests/test_preview_dispatch_utils.py
+++ b/ax/preview/modelbridge/tests/test_preview_dispatch_utils.py
@@ -6,8 +6,8 @@
 
 
 import torch
-from ax.core.base_trial import TrialStatus
 from ax.core.trial import Trial
+from ax.core.trial_status import TrialStatus
 from ax.generation_strategy.transition_criterion import MinTrials
 from ax.modelbridge.registry import Generators
 from ax.models.torch.botorch_modular.surrogate import ModelConfig, SurrogateSpec

--- a/ax/runners/tests/test_single_running_trial_mixin.py
+++ b/ax/runners/tests/test_single_running_trial_mixin.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 
-from ax.core.base_trial import TrialStatus
+from ax.core.trial_status import TrialStatus
 from ax.runners.single_running_trial_mixin import SingleRunningTrialMixin
 from ax.runners.synthetic import SyntheticRunner
 from ax.utils.common.testutils import TestCase

--- a/ax/service/tests/test_with_db_settings_base.py
+++ b/ax/service/tests/test_with_db_settings_base.py
@@ -10,8 +10,9 @@ import random
 import string
 from unittest.mock import patch
 
-from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
+
+from ax.core.trial_status import TrialStatus
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.service.utils.with_db_settings_base import (
     try_load_generation_strategy,

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -21,7 +21,6 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import plotly.graph_objects as go
-from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRunType
@@ -33,6 +32,7 @@ from ax.core.objective import MultiObjective, ScalarizedObjective
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import Parameter
 from ax.core.trial import BaseTrial
+from ax.core.trial_status import TrialStatus
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -17,7 +17,6 @@ from typing import Any, TYPE_CHECKING, TypeVar
 
 import torch
 from ax.core.arm import Arm
-from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import (
     AbandonedArm,
     BatchTrial,
@@ -27,6 +26,7 @@ from ax.core.batch_trial import (
 from ax.core.generator_run import GeneratorRun
 from ax.core.runner import Runner
 from ax.core.trial import Trial
+from ax.core.trial_status import TrialStatus
 from ax.exceptions.storage import JSONDecodeError
 from ax.modelbridge.transforms.base import Transform
 from ax.storage.botorch_modular_registry import (

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -23,7 +23,6 @@ from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
 from ax.core import Experiment, ObservationFeatures
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
-from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import (
     AbandonedArm,
     BatchTrial,
@@ -58,6 +57,7 @@ from ax.core.parameter_distribution import ParameterDistribution
 from ax.core.risk_measures import RiskMeasure
 from ax.core.search_space import HierarchicalSearchSpace, RobustSearchSpace, SearchSpace
 from ax.core.trial import Trial
+from ax.core.trial_status import TrialStatus
 from ax.core.types import ComparisonOp
 from ax.early_stopping.strategies import (
     PercentileEarlyStoppingStrategy,

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -12,9 +12,10 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any, List
 
-from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import LifecycleStage
 from ax.core.parameter import ParameterType
+
+from ax.core.trial_status import TrialStatus
 from ax.core.types import (
     ComparisonOp,
     TModelPredict,

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -21,7 +21,6 @@ from ax.analysis.markdown.markdown_analysis import MarkdownAnalysisCard
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
-from ax.core.base_trial import TrialStatus
 from ax.core.batch_trial import LifecycleStage
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
@@ -30,6 +29,7 @@ from ax.core.objective import MultiObjective, Objective
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.runner import Runner
+from ax.core.trial_status import TrialStatus
 from ax.core.types import ComparisonOp
 from ax.exceptions.core import ObjectNotFoundError
 from ax.exceptions.storage import JSONDecodeError, SQADecodeError, SQAEncodeError

--- a/ax/utils/testing/backend_simulator.py
+++ b/ax/utils/testing/backend_simulator.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 
 from logging import Logger
 
-from ax.core.base_trial import TrialStatus
+from ax.core.trial_status import TrialStatus
 from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
 from pyre_extensions import none_throws

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -10,12 +10,12 @@ from logging import Logger
 from typing import Any
 
 import numpy as np
-from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import FixedParameter, RangeParameter
 from ax.core.search_space import SearchSpace
+from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.best_model_selector import (
     ReductionCriterion,

--- a/ax/utils/testing/tests/test_backend_simulator.py
+++ b/ax/utils/testing/tests/test_backend_simulator.py
@@ -8,7 +8,7 @@
 
 from unittest.mock import Mock, patch
 
-from ax.core.base_trial import TrialStatus
+from ax.core.trial_status import TrialStatus
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.backend_simulator import BackendSimulator, BackendSimulatorOptions
 from ax.utils.testing.utils_testing_stubs import get_backend_simulator_with_trials

--- a/sphinx/source/core.rst
+++ b/sphinx/source/core.rst
@@ -204,6 +204,15 @@ Core Classes
     :show-inheritance:
 
 
+`TrialStatus`
+~~~~~~~~~~~~
+
+.. automodule:: ax.core.trial_status
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Core Types
 ----------
 


### PR DESCRIPTION
Summary:
**The goal of this stack was to make trials store arms directly, and not have a weird intermediate step where in fact trials store generator runs, which in turn store arms.** We didn't like that setup because:
a. it was confusing and we always had to caveat it,
b. it made it awkward to add or remove arms from (batch)trials,
c. it made us create things like `GeneratorRun(generator_run_type="MANUAL")`, which is pretty ugly,
d. it made us return things like "list of lists of generator runs" from `GenerationStrategy.gen` (since we need that call to produce GRs for multiple trials, where each trial itself might need multiple GRs, e.g. in OnlineExp case).
*More detail on the motivation in [this proposal](https://fb.workplace.com/groups/659814077526772/permalink/2499116463596515/)*.

{F1974983717}

Once saitcakmak and I started thinking through how this might work ([related discussion in this doc](https://docs.google.com/document/d/1MbHzClqVISjKjQ81kuTQWopzX0pzCb7GeIpxRAvGT7E/edit?tab=t.0)), we concluded that **we liked the ideas of a) storing all `GR`s on the `Experiment`, using unique indices and b) leveraging those unique indices everywhere else to connect other abstractions to `GR`s**, e.g. `Arms` or `Trial`s (if needed). We do something similar with `Trial`s on `Experiment` now and thing that works pretty well.

However, we encountered a conundrum: **if we were to return `Arm`s from `GS.gen` like we previously wanted** (whereby we'd returned list of lists of arms from that call, with each list of arms intended as a trial), we also needed to keep track of which `GenNodes` produced those `Arm`s (or which `GR`s those arms came from, since the `GR`s have `GenNode`s' names stored on them. And if we were to capture this info during `GS.gen` (for which we will need to know what index a given `GR` will have on the `Experiment`), **we'd end up adding `GR`s to the `Experiment` during that call, which is a pretty big and likely unintuitive side effect** (and we might end up storing "garbage/debugging" `GR`s we generated manually and never intended to add to any trial). *Sigh*.

And then we realized that there might be a way out of this: **what if `GS.gen` actually returned `Trial`s? –– that is the core idea of this RfC stack** After all, we always find ourselves saying things like "GS generated a new ~trial~ –– jk, a `GR` that is destined to become a `Trial`." So what it it could actually make `Trial`s? The only change this would require is that **those `Trial`-s are not automatically added to an `Experiment`, but rather that can be done in a separate step** (this is drafted in step 3 below and will need much beautifying before it can go in).

One aspect to pay attention to: for the internal machinery of `GenerationStrategy` to function in a well-oiled way, it needs to know which `Trial`s have arms that come from given `GenerationNodes` (many `TransitionCriteria` are based on this information, e.g. "move to BO after 5 Sobol trials.") To this end, we also capture a mapping from each `Trial`'s `Arm`s, to indices of `GR`s that produced those arms (and the `GR`s know which `GenNode` made them).

Contents of this stack:

1. [D69223588]**[THIS DIFF] Preliminary cleanup, pulls `TrialStatus` out into its own file.** It's still importable from where it used to live (base_trial.py)
2. [D69221377] Add `Experiment._generator_runs`: this will track all GRs produced for this experiment, arms from which made it to trials attached to the experiment (aside: this should allow us to no longer track all GRs on the GS!)
3. [D69221378] Removes the requirement that trials are created only as they are attached to the experiment; i.e. allows us to make trials that are not yet attached to anything. Step 5 will make use of this.
4. [D69223783] We have an old `attach_trial` method on the experiment, used only internally. I think we could rename it to `attach_custom_trial` or something else –– the meaning of this method is "attach this purely manually generated parameterization." Maybe a better name will be `attach_custom_arm_as_trial` or something like that.
5. [D69223800] Implements a new `Experiment.attach_trial` which, given a trial that is not yet attached to anything, adds it to the experiment.
6. [D69223911] **Adds a `GenerationStrategy.gen_next_trials` method (the main `gen` to rule them all), which creates trials and not GRs like the GS always did.** These trials are not automatically attached to the experiment and their GRs are only added to `Experiment._generator_runs` iff the trial actually gets attached via `Experiment.attach_trial`.
7. (More like 7-N; will add if we like the proposal): Storage updates and other downstream updates related to this core change.

Differential Revision: D69223588
