### PR TITLE
Update cron.yml to resolve deprecation warnings

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -75,6 +75,6 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-        skip_existing: true
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
         verbose: true


### PR DESCRIPTION
Fixes:
Warning: Input 'repository_url' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `repository-url` instead. Warning: Input 'skip_existing' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `skip-existing` instead.