### PR TITLE
[Docusaurus] Disable experimental optimizations

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -14,6 +14,7 @@ on:
         required: true
         type: boolean
   workflow_dispatch:
+    inputs:
       run_tutorials:
         required: true
         type: boolean

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -30,9 +30,6 @@ module.exports={
   },
   "onBrokenLinks": "throw",
   "onBrokenMarkdownLinks": "warn",
-  "future": {
-    "experimental_faster": true,
-  },
   "presets": [
     [
       "@docusaurus/preset-classic",

--- a/website/package.json
+++ b/website/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "examples": "docusaurus-examples",
-    "start": "DOCUSAURUS_IGNORE_SSG_WARNINGS=true docusaurus start",
-    "build": "DOCUSAURUS_IGNORE_SSG_WARNINGS=true docusaurus build",
+    "start": "docusaurus start",
+    "build": "docusaurus build",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",
@@ -16,7 +16,6 @@
   "devDependencies": {},
   "dependencies": {
     "@docusaurus/core": "3.6.3",
-    "@docusaurus/faster": "3.6.3",
     "@docusaurus/plugin-client-redirects": "3.6.3",
     "@docusaurus/preset-classic": "3.6.3",
     "clsx": "^1.1.1",


### PR DESCRIPTION
I previously added this to resolve issues with building when we have many versions of our docs. While this works locally we've been seeing [failures to build in GHA](https://github.com/facebook/Ax/actions/runs/13164146992/job/36740052914). Some debugging pointed to this being the issue, so let's disable for now. The Docusaurus team is actively working on speeding up build time and plans to roll out these optimizations as they become more stable.

I tested this by adding a test workflow to build the website using these changes in a separate PR for debugging
- PR: https://github.com/facebook/Ax/pull/3303
- Successful workflow run: https://github.com/facebook/Ax/actions/runs/13206354540/job/36870297699

See this commit for when I added these options: https://github.com/CristianLara/Ax/commit/d04a3b202a48f900e9cb7b6ff5849b8ecdbb5d6e

See Docusaurus's "faster" initiative: https://github.com/facebook/docusaurus/issues/10556