### PR TITLE
[Docusaurus] Be more specific about archived versions

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -116,7 +116,7 @@ module.exports={
               },
               {
                 href: 'https://archive.ax.dev/versions.html',
-                label: '0.x.x',
+                label: '<= 0.4.1',
               },
             ],
         },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -116,7 +116,7 @@ module.exports={
               },
               {
                 href: 'https://archive.ax.dev/versions.html',
-                label: '<= 0.4.1',
+                label: '<= 0.4.3',
               },
             ],
         },


### PR DESCRIPTION
The upgrade website has been released so we know exactly which versions are only available in the archive. Also `0.x.x` is not accurate anyways