### PR TITLE
Improve documentation around validation of opt config in discrete.py

### DIFF
--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -60,7 +60,7 @@ class OptimizationConfig(Base):
         constraints: list[OutcomeConstraint] = (
             [] if outcome_constraints is None else outcome_constraints
         )
-        self._validate_optimization_config(
+        self._validate_transformed_optimization_config(
             objective=objective,
             outcome_constraints=constraints,
             risk_measure=risk_measure,
@@ -104,7 +104,7 @@ class OptimizationConfig(Base):
     @objective.setter
     def objective(self, objective: Objective) -> None:
         """Set objective if not present in outcome constraints."""
-        self._validate_optimization_config(
+        self._validate_transformed_optimization_config(
             objective, self.outcome_constraints, self.risk_measure
         )
         self._objective = objective
@@ -146,7 +146,7 @@ class OptimizationConfig(Base):
     @outcome_constraints.setter
     def outcome_constraints(self, outcome_constraints: list[OutcomeConstraint]) -> None:
         """Set outcome constraints if valid, else raise."""
-        self._validate_optimization_config(
+        self._validate_transformed_optimization_config(
             objective=self.objective,
             outcome_constraints=outcome_constraints,
             risk_measure=self.risk_measure,
@@ -154,7 +154,7 @@ class OptimizationConfig(Base):
         self._outcome_constraints = outcome_constraints
 
     @staticmethod
-    def _validate_optimization_config(
+    def _validate_transformed_optimization_config(
         objective: Objective,
         outcome_constraints: list[OutcomeConstraint] | None = None,
         risk_measure: RiskMeasure | None = None,
@@ -282,7 +282,7 @@ class MultiObjectiveOptimizationConfig(OptimizationConfig):
             [] if outcome_constraints is None else outcome_constraints
         )
         objective_thresholds = objective_thresholds or []
-        self._validate_optimization_config(
+        self._validate_transformed_optimization_config(
             objective=objective,
             outcome_constraints=constraints,
             objective_thresholds=objective_thresholds,
@@ -333,7 +333,7 @@ class MultiObjectiveOptimizationConfig(OptimizationConfig):
     @objective.setter
     def objective(self, objective: MultiObjective | ScalarizedObjective) -> None:
         """Set objective if not present in outcome constraints."""
-        self._validate_optimization_config(
+        self._validate_transformed_optimization_config(
             objective=objective,
             outcome_constraints=self.outcome_constraints,
             objective_thresholds=self.objective_thresholds,
@@ -356,7 +356,7 @@ class MultiObjectiveOptimizationConfig(OptimizationConfig):
         self, objective_thresholds: list[ObjectiveThreshold]
     ) -> None:
         """Set outcome constraints if valid, else raise."""
-        self._validate_optimization_config(
+        self._validate_transformed_optimization_config(
             objective=self.objective,
             objective_thresholds=objective_thresholds,
             risk_measure=self.risk_measure,
@@ -371,7 +371,7 @@ class MultiObjectiveOptimizationConfig(OptimizationConfig):
         return {ot.metric.name: ot for ot in self._objective_thresholds}
 
     @staticmethod
-    def _validate_optimization_config(
+    def _validate_transformed_optimization_config(
         objective: Objective,
         outcome_constraints: list[OutcomeConstraint] | None = None,
         objective_thresholds: list[ObjectiveThreshold] | None = None,

--- a/ax/modelbridge/discrete.py
+++ b/ax/modelbridge/discrete.py
@@ -26,7 +26,7 @@ from ax.modelbridge.modelbridge_utils import (
 from ax.modelbridge.torch import (
     extract_objective_weights,
     extract_outcome_constraints,
-    validate_optimization_config,
+    validate_transformed_optimization_config,
 )
 from ax.models.discrete_base import DiscreteGenerator
 from ax.models.types import TConfig
@@ -124,7 +124,9 @@ class DiscreteAdapter(Adapter):
         """Generate new candidates according to search_space and
         optimization_config.
 
-        The outcome constraints should be transformed to no longer be relative.
+        Any outcome constraints should be transformed to no longer be relative, this
+        can be achieved using either ``Relativize`` or ``Derelativize`` transforms.
+        An error will be raised during validation if transform has not been applied.
         """
         # Validation
         if not self.parameters:
@@ -136,7 +138,7 @@ class DiscreteAdapter(Adapter):
             objective_weights = None
             outcome_constraints = None
         else:
-            validate_optimization_config(optimization_config, self.outcomes)
+            validate_transformed_optimization_config(optimization_config, self.outcomes)
             objective_weights = extract_objective_weights(
                 objective=optimization_config.objective, outcomes=self.outcomes
             )

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -457,7 +457,7 @@ class TorchAdapterTest(TestCase):
 
         # test optimization config validation - raise error when
         # ScalarizedOutcomeConstraint contains a metric that is not in the outcomes
-        with self.assertRaisesRegex(ValueError, "is a relative constraint."):
+        with self.assertRaisesRegex(ValueError, "as a relative constraint."):
             modelbridge.gen(
                 n=1,
                 optimization_config=OptimizationConfig(


### PR DESCRIPTION
Summary:
The documentation in the utils and the general method was not super clear to me and we had to get insight from Sam to understand why this didn't fail if relativize transform was applied.

To me the oriignal documentaion reads as if no relative constraints may exist, but if relativize has been applied now all constraints are relative so really no constraints are relative. So it's really a mix of relative and absolute constraints that create the error

Differential Revision: D69223913


