### PR TITLE
Check for feasibility in gen_candidates_scipy and error out for infeasible candidates

### DIFF
--- a/ax/modelbridge/tests/test_torch_moo_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_moo_modelbridge.py
@@ -47,7 +47,7 @@ from ax.utils.testing.core_stubs import (
     get_non_monolithic_branin_moo_data,
     TEST_SOBOL_SEED,
 )
-from ax.utils.testing.mock import mock_botorch_optimize
+from ax.utils.testing.mock import mock_botorch_optimize, skip_fit_gpytorch_mll
 from ax.utils.testing.modeling_stubs import transform_1, transform_2
 from botorch.utils.multi_objective.pareto import is_non_dominated
 from pyre_extensions import assert_is_instance, none_throws
@@ -65,7 +65,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
         f"{STUBS_PATH}.BraninMetric.is_available_while_running",
         return_value=False,
     )
-    @mock_botorch_optimize
+    @skip_fit_gpytorch_mll
     def helper_test_pareto_frontier(
         self, _, outcome_constraints: list[OutcomeConstraint] | None
     ) -> None:


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/2737

As titled. Previously, it was possible to return infeasible candidates to the user, with or without warnings alerting the user to the issue. This diff makes it so that the optimizer will error out when infeasible candidates are generated, so that the user can adjust the setup as needed.

Resolves https://github.com/pytorch/botorch/issues/2708

Also includes a couple lint fixes in optimizer tests.

Reviewed By: esantorella

Differential Revision: D69314159


