### PR TITLE
Remove `experiment.fetch_trial_data` from the Dev API tutorial

### DIFF
--- a/tutorials/gpei_hartmann_developer/gpei_hartmann_developer.ipynb
+++ b/tutorials/gpei_hartmann_developer/gpei_hartmann_developer.ipynb
@@ -386,38 +386,7 @@
     "To fetch trial data, we need to run it and mark it completed. For most metrics in Ax, data is only available once the status of the trial is `COMPLETED`, since in real-worlds scenarios, metrics can typically only be fetched after the trial finished running.\n",
     "\n",
     "NOTE: Metrics classes may implement the `is_available_while_running` method. When this method returns `True`, data is available when trials are either `RUNNING` or `COMPLETED`. This can be used to obtain intermediate results from A/B test trials and other online experiments, or when metric values are available immediately, like in the case of synthetic problem metrics.\n",
-    "\n",
-    "We can also use the `fetch_trials_data` function to get evaluation data for a specific trials in the experiment, like so:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "code_folding": [],
-    "executionStartTime": 1646323714950,
-    "executionStopTime": 1646323715210,
-    "hidden_ranges": [],
-    "originalKey": "65113ac3-956a-4fcc-abf7-a9d45f8ecb72",
-    "requestMsgId": "65113ac3-956a-4fcc-abf7-a9d45f8ecb72"
-   },
-   "outputs": [],
-   "source": [
-    "trial_data = exp.fetch_trials_data([NUM_SOBOL_TRIALS + NUM_BOTORCH_TRIALS - 1])\n",
-    "trial_data.df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "code_folding": [],
-    "customInput": null,
-    "hidden_ranges": [],
-    "originalKey": "74fa0cc5-075c-4b34-98b9-cbf74ad5bb26",
-    "showInput": true
-   },
-   "source": [
-    "The below call to `exp.fetch_data()` also attaches data to the last trial, which because of the way we looped through Botorch trials in [5. Perform Optimization](/docs/tutorials/gpei_hartmann_developer/#5-perform-optimization), would otherwise not have data attached.  This is necessary to get `objective_means` in [7. Plot results](/docs/tutorials/gpei_hartmann_developer/#7-plot-results)."
+     "The below call to `exp.fetch_data()` also attaches data to the last trial, which because of the way we looped through Botorch trials in [5. Perform Optimization](/docs/tutorials/gpei_hartmann_developer/#5-perform-optimization), would otherwise not have data attached.  This is necessary to get `objective_means` in [7. Plot results](/docs/tutorials/gpei_hartmann_developer/#7-plot-results)."
    ]
   },
   {


### PR DESCRIPTION
Summary:
Remove the highlighted bit from the tutorial in preparation for D69313269

 {F1975035862} 





Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: saitcakmak

Differential Revision: D69338861


