### PR TITLE
Stop infeasible values from contributing non-NaN values to optimization trace

### DIFF
--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -44,6 +44,22 @@ class TestBestPointMixin(TestCase):
         opt_conf.objective.minimize = False
         self.assertEqual(get_trace(exp, opt_conf), [11, 11, 11, 15, 15])
 
+        with self.subTest("Single objective with constraints"):
+            # The second metric is the constraint and needs to be >= 0
+            exp = get_experiment_with_observations(
+                observations=[[11, -1], [10, 1], [9, 1], [15, -1], [11, 1]],
+                minimize=False,
+                constrained=True,
+            )
+            self.assertEqual(get_trace(exp), [float("-inf"), 10, 10, 10, 11])
+
+            exp = get_experiment_with_observations(
+                observations=[[11, -1], [10, 1], [9, 1], [15, -1], [11, 1]],
+                minimize=True,
+                constrained=True,
+            )
+            self.assertEqual(get_trace(exp), [float("inf"), 10, 9, 9, 9])
+
         # Scalarized.
         exp = get_experiment_with_observations(
             observations=[[1, 1], [2, 2], [3, 3]],
@@ -63,7 +79,7 @@ class TestBestPointMixin(TestCase):
         ).objective_thresholds = []
         self.assertEqual(get_trace(exp), [0.0, 0.0, 2.0, 8.0, 11.0, 11.0])
 
-        # W/ constraints.
+        # Multi-objective w/ constraints.
         exp = get_experiment_with_observations(
             observations=[[-1, 1, 1], [1, 2, 1], [3, 3, -1], [2, 4, 1], [2, 1, 1]],
             constrained=True,


### PR DESCRIPTION
Summary:
Context: Currently, infeasible trials can increase the optimization trace (T214631737), potentially even beyond what is possible with feasible trials. There is not any generic way to impute a value for them that is worse than any feasible trials, because we generally don't know the worst possible feasible value.

In multi-objective contexts, nothing (weakly) worse than the reference point contributes to hypervolume, so it is fine to preserve the status quo behavior of treating infeasible trials as if they were at the reference point. With a single objective, the best we can do is set the value of that point to -inf or inf.

Since this function takes a cumulative maximum/minimum, it is possible for the trace produced to include non-finite values if the first trial is infeasible.

This function is used in two places:
1. To get a hypervolume trace
2. In benchmarking

(1) is unaffected and I don't forsee any issues with (2), beyond the (intentional) effect that we will start seeing non-finite values. The function that produces baseline values may start producing non-finite values; if those values are used, it could lead to NaNs in scores.

Reviewed By: sdaulton

Differential Revision: D69421757


