### PR TITLE
Add generation node string to base trial

### DIFF
--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -12,7 +12,12 @@ from unittest import mock
 from unittest.mock import Mock, patch
 
 import pandas as pd
-from ax.core.base_trial import BaseTrial, TrialStatus
+from ax.core.base_trial import (
+    BaseTrial,
+    MANUAL_GENERATION_METHOD_STR,
+    TrialStatus,
+    UNKNOWN_GENERATION_METHOD_STR,
+)
 from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun, GeneratorRunType
 from ax.core.runner import Runner
@@ -87,10 +92,13 @@ class TrialTest(TestCase):
         self.assertEqual(
             self.trial.generator_run.generator_run_type, GeneratorRunType.MANUAL.name
         )
+        self.assertEqual(self.trial.generation_method_str, MANUAL_GENERATION_METHOD_STR)
 
         # Test empty arms
+        t = self.experiment.new_trial()
         with self.assertRaises(AttributeError):
-            self.experiment.new_trial().arm_weights
+            t.arm_weights
+        self.assertEqual(t.generation_method_str, UNKNOWN_GENERATION_METHOD_STR)
 
         self.trial.mark_running(no_runner_required=True)
         self.assertTrue(self.trial.status.is_running)

--- a/ax/utils/common/constants.py
+++ b/ax/utils/common/constants.py
@@ -93,4 +93,5 @@ class Keys(str, Enum):
     TASK_FEATURES = "task_features"
     TRIAL_COMPLETION_TIMESTAMP = "trial_completion_timestamp"
     WARM_START_REFITTING = "warm_start_refitting"
+    WARMSTART_TRIAL_MODEL_KEY = "generation_model_key"
     X_BASELINE = "X_baseline"


### PR DESCRIPTION
Summary: This will help expose the methods used to generate trials to the user, e.g., via experiment.to_df, matching legacy behavior in exp_to_df.

Reviewed By: saitcakmak

Differential Revision: D68909600


