### PR TITLE
Add noise to observations of `NoisyFunctionMapMetric` when `noise_sd > 0`

### DIFF
--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -119,7 +119,12 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
                         "metric_name": self.name,
                         "sem": self.noise_sd if noisy else 0.0,
                         "trial_index": trial.index,
-                        "mean": [item["mean"] for item in res],
+                        "mean": [
+                            item["mean"] + self.noise_sd * np.random.randn()
+                            if noisy
+                            else 0.0
+                            for item in res
+                        ],
                         self.map_key_info.key: [
                             item[self.map_key_info.key] for item in res
                         ],

--- a/ax/metrics/noisy_function_map.py
+++ b/ax/metrics/noisy_function_map.py
@@ -100,7 +100,12 @@ class NoisyFunctionMapMetric(MapMetric):
                     "metric_name": self.name,
                     "sem": self.noise_sd if noisy else 0.0,
                     "trial_index": trial.index,
-                    "mean": [item["mean"] for item in res],
+                    "mean": [
+                        item["mean"] + self.noise_sd * np.random.randn()
+                        if noisy
+                        else 0.0
+                        for item in res
+                    ],
                     self.map_key_info.key: [
                         item[self.map_key_info.key] for item in res
                     ],

--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -503,10 +503,11 @@ class Adapter(ABC):  # noqa: B024 -- Adapter doesn't have any abstract methods.
                 # observations of the status quo.
                 # This is useful for getting status_quo_data_by_trial
                 self._status_quo_name = sq_obs[0].arm_name
-                if len(sq_obs) > 1:
+                if len(sq_obs) > 1 and self._fit_only_completed_map_metrics:
+                    # it is expected to have multiple obserations for map data
                     logger.warning(
                         f"Status quo {status_quo_name} found in data with multiple "
-                        "features. Use status_quo_features to specify which to use."
+                        "observations. Use status_quo_features to specify which to use."
                     )
                 else:
                     # if there is a unique status_quo, set it

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -379,12 +379,14 @@ def get_robust_branin_experiment(
 
 def get_map_metric(
     name: str,
+    noise_sd: float = 0.0,
     rate: float | None = None,
     decay_function_name: str = "exp_decay",
 ) -> BraninTimestampMapMetric:
     return BraninTimestampMapMetric(
         name=name,
         param_names=["x1", "x2"],
+        noise_sd=noise_sd,
         rate=rate,
         lower_is_better=True,
         decay_function_name=decay_function_name,
@@ -393,6 +395,7 @@ def get_map_metric(
 
 def get_branin_experiment_with_timestamp_map_metric(
     with_status_quo: bool = False,
+    noise_sd: float = 0.0,
     rate: float | None = None,
     map_tracking_metric: bool = False,
     decay_function_name: str = "exp_decay",
@@ -400,6 +403,7 @@ def get_branin_experiment_with_timestamp_map_metric(
     tracking_metric = (
         get_map_metric(
             name="tracking_branin_map",
+            noise_sd=noise_sd,
             rate=rate,
             decay_function_name=decay_function_name,
         )
@@ -413,6 +417,7 @@ def get_branin_experiment_with_timestamp_map_metric(
             objective=Objective(
                 metric=get_map_metric(
                     name="branin_map",
+                    noise_sd=noise_sd,
                     rate=rate,
                     decay_function_name=decay_function_name,
                 ),


### PR DESCRIPTION
Summary: This commit adds normally distributed noise to the observations of `NoisyFunctionMapMetric` classes, when a `noise_sd` larger than zero is specified.

Differential Revision: D69554195


