### PR TITLE
Remove no-longer-used `GenerationNode.fit` search_space and optimization_config arguments

### DIFF
--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -153,8 +153,6 @@ class TestGenerationNode(TestCase):
         mock_model_spec_fit.assert_called_with(
             experiment=self.branin_experiment,
             data=self.branin_data,
-            search_space=None,
-            optimization_config=None,
         )
 
     def test_gen(self) -> None:

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -408,7 +408,7 @@ class TestGenerationStrategy(TestCase):
                 ]
             )
 
-        exp = Experiment(
+        Experiment(
             name="test", search_space=SearchSpace(parameters=[get_choice_parameter()])
         )
         factorial_thompson_generation_strategy = GenerationStrategy(
@@ -421,8 +421,6 @@ class TestGenerationStrategy(TestCase):
         self.assertFalse(
             factorial_thompson_generation_strategy.uses_non_registered_models
         )
-        with self.assertRaises(ValueError):
-            factorial_thompson_generation_strategy._gen_with_multiple_nodes(exp)
         self.assertEqual(GenerationStep(model=sum, num_trials=1).model_name, "sum")
         with self.assertRaisesRegex(UserInputError, "Maximum parallelism should be"):
             GenerationStrategy(


### PR DESCRIPTION
Summary: As titled. Now the search_space and optimization_config will not be passed and by default will be extracted from the experiment.

Differential Revision: D67803329


