### PR TITLE
Add validation when calling wrong get_best_* for current optimization config

### DIFF
--- a/ax/preview/api/client.py
+++ b/ax/preview/api/client.py
@@ -693,6 +693,21 @@ class Client(WithDBSettingsBase):
                 each parameterization)
         """
 
+        if self._experiment.optimization_config is None:
+            raise UnsupportedError(
+                "No optimization config has been set. Please configure the "
+                "optimization before calling get_best_parameterization."
+            )
+
+        if self._experiment.optimization_config.is_moo_problem:
+            raise UnsupportedError(
+                "The client is currently configured to jointly optimize "
+                f"{self._experiment.optimization_config}. "
+                "Multi-objective optimization does not return a single best "
+                "parameterization -- it returns a Pareto frontier. Please call "
+                "get_pareto_frontier instead."
+            )
+
         if len(self._experiment.trials) < 1:
             raise UnsupportedError(
                 "No trials have been run yet. Please run at least one trial before "
@@ -737,6 +752,20 @@ class Client(WithDBSettingsBase):
                 - The name of the best arm (each trial has a unique name associated
                     with each parameterization).
         """
+        if self._experiment.optimization_config is None:
+            raise UnsupportedError(
+                "No optimization config has been set. Please configure the "
+                "optimization before calling get_pareto_frontier."
+            )
+
+        if not self._experiment.optimization_config.is_moo_problem:
+            raise UnsupportedError(
+                "The client is currently configured to optimize "
+                f"{self._experiment.optimization_config.objective}. "
+                "Single-objective optimization does not return a Pareto frontier -- "
+                "it returns a single best point. Please call "
+                "get_best_parameterization instead."
+            )
 
         if len(self._experiment.trials) < 1:
             raise UnsupportedError(

--- a/ax/preview/api/tests/test_client.py
+++ b/ax/preview/api/tests/test_client.py
@@ -886,6 +886,12 @@ class TestClient(TestCase):
                 name="foo",
             )
         )
+
+        with self.assertRaisesRegex(
+            UnsupportedError, "No optimization config has been set"
+        ):
+            client.get_best_parameterization()
+
         client.configure_optimization(objective="foo")
         # Set initialization_budget=3 so we can reach a predictive GenerationNode
         # quickly
@@ -943,6 +949,13 @@ class TestClient(TestCase):
         )
         self.assertEqual({*prediction.keys()}, {"foo"})
 
+        # Try calling after setting OptimizationConfig to MOO problem
+        client.configure_optimization("foo, bar")
+        with self.assertRaisesRegex(
+            UnsupportedError, "Please call get_pareto_frontier"
+        ):
+            client.get_best_parameterization()
+
     @mock_botorch_optimize
     def test_get_pareto_frontier(self) -> None:
         client = Client()
@@ -957,6 +970,12 @@ class TestClient(TestCase):
                 name="foo",
             )
         )
+
+        with self.assertRaisesRegex(
+            UnsupportedError, "No optimization config has been set"
+        ):
+            client.get_pareto_frontier()
+
         client.configure_optimization(objective="foo, bar")
         # Set initialization_budget=3 so we can reach a predictive GenerationNode
         # quickly
@@ -1029,6 +1048,13 @@ class TestClient(TestCase):
                 )
             )
             self.assertEqual({*prediction.keys()}, {"foo", "bar"})
+
+        # Try calling after setting OptimizationConfig to single objective problem
+        client.configure_optimization("foo")
+        with self.assertRaisesRegex(
+            UnsupportedError, "Please call get_best_parameterization"
+        ):
+            client.get_pareto_frontier()
 
     @mock_botorch_optimize
     def test_predict(self) -> None:


### PR DESCRIPTION
Summary: As titled. Raise an exception if you try and call get_best_parameterization with MOO OC or vice versa

Differential Revision: D69596638


