### PR TITLE
Set lower_is_better on objective metrics in configure_optimization

### DIFF
--- a/ax/preview/api/tests/test_client.py
+++ b/ax/preview/api/tests/test_client.py
@@ -162,7 +162,9 @@ class TestClient(TestCase):
         self.assertEqual(
             client._experiment.optimization_config,
             OptimizationConfig(
-                objective=Objective(metric=MapMetric(name="ne"), minimize=True),
+                objective=Objective(
+                    metric=MapMetric(name="ne", lower_is_better=True), minimize=True
+                ),
                 outcome_constraints=[
                     OutcomeConstraint(
                         metric=MapMetric(name="qps"),

--- a/ax/preview/api/utils/instantiation/from_string.py
+++ b/ax/preview/api/utils/instantiation/from_string.py
@@ -211,7 +211,10 @@ def _create_single_objective(expression: Expr) -> Objective:
     # If the expression is a just a Symbol it represents a single metric objective
     if isinstance(expression, Symbol):
         return Objective(
-            metric=MapMetric(name=_unsanitize_dot(str(expression.name))), minimize=False
+            metric=MapMetric(
+                name=_unsanitize_dot(str(expression.name)), lower_is_better=False
+            ),
+            minimize=False,
         )
 
     # If the expression is a Mul it likely represents a single metric objective but
@@ -228,7 +231,10 @@ def _create_single_objective(expression: Expr) -> Objective:
         minimize = bool(expression.as_coefficient(symbol) < 0)
 
         return Objective(
-            metric=MapMetric(name=_unsanitize_dot(str(symbol))), minimize=minimize
+            metric=MapMetric(
+                name=_unsanitize_dot(str(symbol)), lower_is_better=minimize
+            ),
+            minimize=minimize,
         )
 
     # If the expression is an Add it represents a scalarized objective

--- a/ax/preview/api/utils/instantiation/tests/test_from_string.py
+++ b/ax/preview/api/utils/instantiation/tests/test_from_string.py
@@ -35,7 +35,9 @@ class TestFromString(TestCase):
         self.assertEqual(
             only_objective,
             OptimizationConfig(
-                objective=Objective(metric=MapMetric(name="ne"), minimize=False),
+                objective=Objective(
+                    metric=MapMetric(name="ne", lower_is_better=False), minimize=False
+                ),
             ),
         )
 
@@ -45,7 +47,9 @@ class TestFromString(TestCase):
         self.assertEqual(
             with_constraints,
             OptimizationConfig(
-                objective=Objective(metric=MapMetric(name="ne"), minimize=False),
+                objective=Objective(
+                    metric=MapMetric(name="ne", lower_is_better=False), minimize=False
+                ),
                 outcome_constraints=[
                     OutcomeConstraint(
                         metric=MapMetric(name="qps"),
@@ -66,8 +70,14 @@ class TestFromString(TestCase):
             MultiObjectiveOptimizationConfig(
                 objective=MultiObjective(
                     objectives=[
-                        Objective(metric=MapMetric(name="ne"), minimize=True),
-                        Objective(metric=MapMetric(name="qps"), minimize=False),
+                        Objective(
+                            metric=MapMetric(name="ne", lower_is_better=True),
+                            minimize=True,
+                        ),
+                        Objective(
+                            metric=MapMetric(name="qps", lower_is_better=False),
+                            minimize=False,
+                        ),
                     ]
                 ),
                 outcome_constraints=[
@@ -124,13 +134,18 @@ class TestFromString(TestCase):
     def test_parse_objective(self) -> None:
         single_objective = parse_objective(objective_str="ne")
         self.assertEqual(
-            single_objective, Objective(metric=MapMetric(name="ne"), minimize=False)
+            single_objective,
+            Objective(
+                metric=MapMetric(name="ne", lower_is_better=False), minimize=False
+            ),
         )
 
         maximize_single_objective = parse_objective(objective_str="-qps")
         self.assertEqual(
             maximize_single_objective,
-            Objective(metric=MapMetric(name="qps"), minimize=True),
+            Objective(
+                metric=MapMetric(name="qps", lower_is_better=True), minimize=True
+            ),
         )
 
         scalarized_objective = parse_objective(
@@ -154,8 +169,14 @@ class TestFromString(TestCase):
             multiobjective,
             MultiObjective(
                 objectives=[
-                    Objective(metric=MapMetric(name="ne"), minimize=False),
-                    Objective(metric=MapMetric(name="qps"), minimize=True),
+                    Objective(
+                        metric=MapMetric(name="ne", lower_is_better=False),
+                        minimize=False,
+                    ),
+                    Objective(
+                        metric=MapMetric(name="qps", lower_is_better=True),
+                        minimize=True,
+                    ),
                 ]
             ),
         )


### PR DESCRIPTION
Summary:
As titled. Noticed this was not getting set while working on the Ax for AutoML tutorial.

The Scatter plot relies on this being set when drawing the pareto frontier.

Differential Revision: D69611291


