### PR TITLE
Remove logspew from percentile es

### DIFF
--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -255,46 +255,6 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         )
         return False, reason
 
-    @staticmethod
-    def _log_and_return_completed_trials(
-        logger: logging.Logger, num_completed: int, min_curves: float
-    ) -> tuple[bool, str]:
-        """Helper function for logging/constructing a reason when min number of
-        completed trials is not yet reached."""
-        logger.info(
-            f"The number of completed trials ({num_completed}) is less than "
-            "the minimum number of curves needed for early stopping "
-            f"({min_curves}). Not early stopping."
-        )
-        reason = (
-            f"Need {min_curves} completed trials, but only {num_completed} "
-            "completed trials so far."
-        )
-        return False, reason
-
-    @staticmethod
-    def _log_and_return_num_trials_with_data(
-        logger: logging.Logger,
-        trial_index: int,
-        trial_last_progression: float,
-        num_trials_with_data: int,
-        min_curves: int,
-    ) -> tuple[bool, str]:
-        """Helper function for logging/constructing a reason when min number of
-        trials with data is not yet reached."""
-        logger.info(
-            f"The number of trials with data ({num_trials_with_data}) "
-            f"at trial {trial_index}'s last progression ({trial_last_progression}) "
-            "is less than the specified minimum number for early stopping "
-            f"({min_curves}). Not early stopping."
-        )
-        reason = (
-            f"Number of trials with data ({num_trials_with_data}) at "
-            f"last progression ({trial_last_progression}) is less than the "
-            f"specified minimum number for early stopping ({min_curves})."
-        )
-        return False, reason
-
     def is_eligible_any(
         self,
         trial_indices: set[int],
@@ -315,11 +275,6 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         # check that there are sufficient completed trials
         num_completed = len(experiment.trial_indices_by_status[TrialStatus.COMPLETED])
         if self.min_curves is not None and num_completed < self.min_curves:
-            self._log_and_return_completed_trials(
-                logger=logger,
-                num_completed=num_completed,
-                min_curves=none_throws(self.min_curves),
-            )
             return False
 
         # check that at least one trial has reached `self.min_progression`
@@ -327,15 +282,11 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         any_last_prog = 0
         if not df_trials[map_key].empty:
             any_last_prog = df_trials[map_key].max()
-        logger.info(
-            f"Last progression of any candidate for trial stopping is {any_last_prog}."
-        )
+
         if self.min_progression is not None and any_last_prog < self.min_progression:
-            logger.info(
-                f"No trials have reached {self.min_progression}. "
-                "Not stopping any trials."
-            )
+            # No trials have reached `self.min_progression`, not stopping any trials
             return False
+
         return True
 
     def is_eligible(
@@ -392,9 +343,6 @@ class BaseEarlyStoppingStrategy(ABC, Base):
 
             # check for min/max progression
             trial_last_prog = df_trial[map_key].max()
-            logger.info(
-                f"Last progression of Trial {trial_index} is {trial_last_prog}."
-            )
             if (
                 self.min_progression is not None
                 and trial_last_prog < self.min_progression

--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -98,12 +98,9 @@ def align_partial_results(
                     # do forward fill (with valid observations) to handle instances
                     # where one task only has data for early progressions
                     df_interp = df_interp.fillna(method="pad")
-            except ValueError as e:
+            except ValueError:
                 df_interp = df_ridx
-                logger.info(
-                    f"Got exception `{e}` during interpolation. "
-                    "Using uninterpolated values instead."
-                )
+
             # renaming column to trial index, append results
             dfs_mean[metric].append(df_interp["mean"].rename(tidx))
             if has_sem:


### PR DESCRIPTION
Summary:
Playing whack-a-mode with some logs while developing tutorials. Logs are in an unacceptable state and take up more than 99% of the page real estate before this diff, producing multiple logs per progression call to `should_stop_trial_early` regardless of whether anything happened. We do not need this much visibility on whether or not we decide to kill a trial.

In the tutorials we're working on (ex N6570044 we were seeing thousands of logs before this change, now we see a couple dozen).

Changes:
* No longer log if there havent been enough completed trials to make an ES decision
* No longer log if no trials have met minimum observed progressions
* No longer log the value of every trial before we make an ES decision (this happened twice)
* No longer log at the beginning of ever ES decision that we are about to make an ES decision
* No longer log when we consider stopping a trial and chose not to (only log if we actually decide it should stop)
* [RFC] No longer log if an error happened during interpolation and we decide to use uninterpolated values instead (its not clear to me how important this error is -- fwiw in the tutorial we run into this very frequently -- if its a real actionable issue we need to fix it)

Differential Revision: D69616469


