### PR TITLE
Use validate_input_scaling context manager to skip validation / silence warnings during cross validation

### DIFF
--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -24,7 +24,6 @@ from ax.models.torch.botorch import (
 from ax.models.torch.botorch_modular.acquisition import Acquisition
 from ax.models.torch.botorch_modular.surrogate import Surrogate, SurrogateSpec
 from ax.models.torch.botorch_modular.utils import (
-    check_outcome_dataset_match,
     choose_botorch_acqf_class,
     construct_acquisition_and_optimizer_options,
     ModelConfig,
@@ -177,11 +176,6 @@ class BoTorchGenerator(TorchGenerator, Base):
             additional_model_inputs: Additional kwargs to pass to the
                 model input constructor in ``Surrogate.fit``.
         """
-        outcome_names = sum((ds.outcome_names for ds in datasets), [])
-        check_outcome_dataset_match(
-            outcome_names=outcome_names, datasets=datasets, exact_match=True
-        )  # Checks for duplicate outcome names
-
         # Store search space info for later use (e.g. during generation)
         self._search_space_digest = search_space_digest
 

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -12,16 +12,13 @@ from collections import OrderedDict
 import numpy as np
 import torch
 from ax.core.search_space import SearchSpaceDigest
-from ax.exceptions.core import AxError, AxWarning, UnsupportedError
+from ax.exceptions.core import AxWarning, UnsupportedError
 from ax.models.torch.botorch_modular.utils import (
     _get_shared_rows,
-    _tensor_difference,
-    check_outcome_dataset_match,
     choose_botorch_acqf_class,
     choose_model_class,
     construct_acquisition_and_optimizer_options,
     convert_to_block_design,
-    get_subset_datasets,
     subset_state_dict,
     use_model_list,
 )
@@ -351,17 +348,6 @@ class BoTorchGeneratorUtilsTest(TestCase):
             )
         )
 
-    def test_tensor_difference(self) -> None:
-        n, m = 3, 2
-        A = torch.arange(n * m).reshape(n, m)
-        B = torch.cat((A[: n - 1], torch.randn(2, m)), dim=0)
-        # permute B
-        B = B[torch.randperm(len(B))]
-
-        C = _tensor_difference(A=A, B=B)
-
-        self.assertEqual(C.size(dim=0), 2)
-
     def test_get_shared_rows(self) -> None:
         X1 = torch.rand(4, 2)
 
@@ -517,106 +503,6 @@ class BoTorchGeneratorUtilsTest(TestCase):
         self.assertTrue(torch.allclose(ineq_constraints[1][0], torch.tensor([1])))
         self.assertTrue(torch.allclose(ineq_constraints[1][1], torch.tensor([-1])))
         self.assertEqual(ineq_constraints[1][2], -2.0)
-
-    def test_check_check_outcome_dataset_match(self) -> None:
-        ds = self.fixed_noise_datasets[0]
-        # Simple test with one metric & dataset.
-        for exact_match in (True, False):
-            self.assertIsNone(
-                check_outcome_dataset_match(
-                    outcome_names=ds.outcome_names,
-                    datasets=[ds],
-                    exact_match=exact_match,
-                )
-            )
-        # Error with duplicate outcome names.
-        with self.assertRaisesRegex(AxError, "duplicate outcome names"):
-            check_outcome_dataset_match(
-                outcome_names=["y", "y"], datasets=[ds], exact_match=False
-            )
-        ds2 = self.supervised_datasets[0]
-        # Error with duplicate outcomes in datasets.
-        with self.assertRaisesRegex(AxError, "duplicate outcomes"):
-            check_outcome_dataset_match(
-                outcome_names=["y", "y2"], datasets=[ds, ds2], exact_match=False
-            )
-        ds2.outcome_names = ["y2"]
-        # Simple test with two metrics & datasets.
-        for exact_match in (True, False):
-            self.assertIsNone(
-                check_outcome_dataset_match(
-                    outcome_names=["y", "y2"],
-                    datasets=[ds, ds2],
-                    exact_match=exact_match,
-                )
-            )
-        # Exact match required but too many datasets provided.
-        with self.assertRaisesRegex(AxError, "must correspond to an outcome"):
-            check_outcome_dataset_match(
-                outcome_names=["y"],
-                datasets=[ds, ds2],
-                exact_match=True,
-            )
-        # The same check passes if we don't require exact match.
-        self.assertIsNone(
-            check_outcome_dataset_match(
-                outcome_names=["y"],
-                datasets=[ds, ds2],
-                exact_match=False,
-            )
-        )
-        # Error if metric doesn't exist in the datasets.
-        for exact_match in (True, False):
-            with self.assertRaisesRegex(AxError, "but the datasets model"):
-                check_outcome_dataset_match(
-                    outcome_names=["z"],
-                    datasets=[ds, ds2],
-                    exact_match=exact_match,
-                )
-
-    def test_get_subset_datasets(self) -> None:
-        ds = self.fixed_noise_datasets[0]
-        ds2 = self.supervised_datasets[0]
-        ds2.outcome_names = ["y2"]
-        ds3 = SupervisedDataset(
-            X=torch.zeros(1, 2),
-            Y=torch.ones(1, 2),
-            feature_names=["x1", "x2"],
-            outcome_names=["y3", "y4"],
-        )
-        # Test with single dataset.
-        self.assertEqual(
-            [ds], get_subset_datasets(datasets=[ds], subset_outcome_names=["y"])
-        )
-        # Edge case of empty metric list.
-        self.assertEqual(
-            [], get_subset_datasets(datasets=[ds], subset_outcome_names=[])
-        )
-        # Multiple datasets, single metric.
-        self.assertEqual(
-            [ds],
-            get_subset_datasets(datasets=[ds, ds2, ds3], subset_outcome_names=["y"]),
-        )
-        self.assertEqual(
-            [ds2],
-            get_subset_datasets(datasets=[ds, ds2, ds3], subset_outcome_names=["y2"]),
-        )
-        # Multi-output dataset, 1 metric -- not allowed.
-        with self.assertRaisesRegex(UnsupportedError, "multi-outcome dataset"):
-            get_subset_datasets(datasets=[ds, ds2, ds3], subset_outcome_names=["y3"])
-        # Multiple datasets, multiple metrics -- datasets in the same order as metrics.
-        self.assertEqual(
-            [ds2, ds],
-            get_subset_datasets(
-                datasets=[ds, ds2, ds3], subset_outcome_names=["y2", "y"]
-            ),
-        )
-        self.assertEqual(
-            [ds3, ds],
-            get_subset_datasets(
-                datasets=[ds, ds2, ds3], subset_outcome_names=["y3", "y", "y4"]
-            ),
-        )
 
     def test_subset_state_dict(self) -> None:
         m0 = SingleTaskGP(train_X=torch.rand(5, 2), train_Y=torch.rand(5, 1))


### PR DESCRIPTION
Summary: Previously, we were letting these validations happen, knowing that they'd fail, just to filter the raised warnings based on the expected text. BoTorch has a context manager that can disable these warnings, so let's use that instead.

Differential Revision: D69663108


