### PR TITLE
allow TrialAsTask with less than two trials

### DIFF
--- a/ax/generation_strategy/generation_node_input_constructors.py
+++ b/ax/generation_strategy/generation_node_input_constructors.py
@@ -103,8 +103,10 @@ def get_status_quo(
         raise AxGenerationException(
             f"Attempting to construct status quo input into {next_node} but couldn't "
             "identify the target trial. Often this could be due to no trials on the "
-            f"experiment that are in status {STATUSES_EXPECTING_DATA}. The trials on "
-            f"this experiment are: {experiment.trials}."
+            f"experiment that are in status {STATUSES_EXPECTING_DATA} "
+            f"and have data. The trials on this experiment are: "
+            f"{experiment.trials} and trials with data are: "
+            f"{experiment.lookup_data().df.trial_index.unique()}."
         )
     if experiment.status_quo is None:
         raise AxGenerationException(

--- a/ax/generation_strategy/tests/test_generation_node_input_constructors.py
+++ b/ax/generation_strategy/tests/test_generation_node_input_constructors.py
@@ -281,18 +281,15 @@ class TestGenerationNodeInputConstructors(TestCase):
         self.assertEqual(num_to_gen, 4)
 
     def test_set_target_trial_long_run_wins(self) -> None:
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.LONG_RUN,
-            complete=False,
-            num_arms=1,
-        )
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=False,
-            num_arms=3,
-        )
+        for num_arms, trial_type in zip((1, 3), (Keys.LONG_RUN, Keys.SHORT_RUN)):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=trial_type,
+                complete=False,
+                num_arms=num_arms,
+                with_status_quo=True,
+            )
+        self.experiment.fetch_data()
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
@@ -314,6 +311,7 @@ class TestGenerationNodeInputConstructors(TestCase):
             complete=False,
             num_arms=1,
         )
+        self.experiment.fetch_data()
         with self.assertRaisesRegex(
             AxGenerationException,
             "experiment has no status quo",
@@ -326,20 +324,15 @@ class TestGenerationNodeInputConstructors(TestCase):
             )
 
     def test_status_quo_features(self) -> None:
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.LONG_RUN,
-            complete=False,
-            num_arms=1,
-            with_status_quo=True,
-        )
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.LONG_RUN,
-            complete=False,
-            num_arms=3,
-            with_status_quo=True,
-        )
+        for num_arms in (1, 3):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=Keys.LONG_RUN,
+                complete=False,
+                num_arms=num_arms,
+                with_status_quo=True,
+            )
+        self.experiment.fetch_data()
         sq_ft = NodeInputConstructors.STATUS_QUO_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
@@ -352,18 +345,14 @@ class TestGenerationNodeInputConstructors(TestCase):
         )
 
     def test_set_target_trial_most_arms_long_run_wins(self) -> None:
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.LONG_RUN,
-            complete=False,
-            num_arms=1,
-        )
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.LONG_RUN,
-            complete=False,
-            num_arms=3,
-        )
+        for num_arms in (1, 3):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=Keys.LONG_RUN,
+                complete=False,
+                num_arms=num_arms,
+            )
+        self.experiment.fetch_data()
         # Test most arms should win
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
@@ -382,18 +371,14 @@ class TestGenerationNodeInputConstructors(TestCase):
     def test_set_target_trial_long_run_ties(self) -> None:
         # if all things are equal we should just pick the first one
         # in the sorted list
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.LONG_RUN,
-            complete=False,
-            num_arms=1,
-        )
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.LONG_RUN,
-            complete=False,
-            num_arms=1,
-        )
+        for _ in range(2):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=Keys.LONG_RUN,
+                complete=False,
+                num_arms=1,
+            )
+        self.experiment.fetch_data()
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
@@ -409,18 +394,14 @@ class TestGenerationNodeInputConstructors(TestCase):
         )
 
     def test_set_target_trial_longest_duration_long_run_wins(self) -> None:
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.LONG_RUN,
-            complete=False,
-            num_arms=1,
-        )
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.LONG_RUN,
-            complete=False,
-            num_arms=1,
-        )
+        for _ in range(2):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=Keys.LONG_RUN,
+                complete=False,
+                num_arms=1,
+            )
+        self.experiment.fetch_data()
         self.experiment.trials[0]._time_run_started = datetime(2000, 1, 2)
         self.experiment.trials[1]._time_run_started = datetime(2000, 1, 1)
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
@@ -438,18 +419,14 @@ class TestGenerationNodeInputConstructors(TestCase):
         )
 
     def test_set_target_trial_running_short_trial_wins(self) -> None:
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.LONG_RUN,
-            complete=True,
-            num_arms=1,
-        )
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=False,
-            num_arms=1,
-        )
+        for trial_type, complete in zip((Keys.LONG_RUN, Keys.SHORT_RUN), (True, False)):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=trial_type,
+                complete=complete,
+                num_arms=1,
+            )
+        self.experiment.fetch_data()
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
@@ -465,18 +442,14 @@ class TestGenerationNodeInputConstructors(TestCase):
         )
 
     def test_set_target_trial_longest_short_wins(self) -> None:
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=False,
-            num_arms=1,
-        )
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=False,
-            num_arms=1,
-        )
+        for _ in range(2):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=Keys.SHORT_RUN,
+                complete=False,
+                num_arms=1,
+            )
+        self.experiment.fetch_data()
         self.experiment.trials[0]._time_run_started = datetime(2000, 1, 2)
         self.experiment.trials[1]._time_run_started = datetime(2000, 1, 1)
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
@@ -494,18 +467,14 @@ class TestGenerationNodeInputConstructors(TestCase):
         )
 
     def test_set_target_trial_most_arms_short_running_wins(self) -> None:
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=False,
-            num_arms=1,
-        )
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=False,
-            num_arms=3,
-        )
+        for num_arms in (1, 3):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=Keys.SHORT_RUN,
+                complete=False,
+                num_arms=num_arms,
+            )
+        self.experiment.fetch_data()
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
@@ -521,18 +490,14 @@ class TestGenerationNodeInputConstructors(TestCase):
         )
 
     def test_set_target_trial_most_arms_complete_short_wins(self) -> None:
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=True,
-            num_arms=1,
-        )
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=True,
-            num_arms=3,
-        )
+        for num_arms in (1, 3):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=Keys.SHORT_RUN,
+                complete=False,
+                num_arms=num_arms,
+            )
+        self.experiment.fetch_data()
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,
@@ -548,18 +513,14 @@ class TestGenerationNodeInputConstructors(TestCase):
         )
 
     def test_set_target_trial_longest_short_complete_wins(self) -> None:
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=True,
-            num_arms=1,
-        )
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=True,
-            num_arms=1,
-        )
+        for _ in range(2):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=Keys.SHORT_RUN,
+                complete=True,
+                num_arms=1,
+            )
+        self.experiment.fetch_data()
         self.experiment.trials[0]._time_run_started = datetime(2000, 1, 2)
         self.experiment.trials[1]._time_run_started = datetime(2000, 1, 1)
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
@@ -587,6 +548,29 @@ class TestGenerationNodeInputConstructors(TestCase):
                 gs_gen_call_kwargs={},
                 experiment=self.experiment,
             )
+
+    def test_target_trial_latest_trial_no_data(self) -> None:
+        for _ in range(2):
+            self._add_sobol_trial(
+                experiment=self.experiment,
+                trial_type=Keys.SHORT_RUN,
+                complete=True,
+                num_arms=1,
+            )
+        self.experiment.fetch_trials_data(trial_indices=[0])
+        target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
+            previous_node=None,
+            next_node=self.sobol_generation_node,
+            gs_gen_call_kwargs={},
+            experiment=self.experiment,
+        )
+        self.assertEqual(
+            target_trial,
+            ObservationFeatures(
+                parameters={},
+                trial_index=0,
+            ),
+        )
 
     def _add_sobol_trial(
         self,

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -1866,7 +1866,8 @@ class TestGenerationStrategy(TestCase):
         self.assertEqual(trial.generator_runs[0]._generation_node_name, "sobol_4")
 
     def test_gs_with_fixed_features_constructor(self) -> None:
-        exp = get_branin_experiment()
+        exp = get_branin_experiment(with_completed_batch=True)
+        exp.fetch_data()
         sobol_criterion = [
             MinTrials(
                 threshold=1,

--- a/ax/modelbridge/transforms/stratified_standardize_y.py
+++ b/ax/modelbridge/transforms/stratified_standardize_y.py
@@ -99,7 +99,9 @@ class StratifiedStandardizeY(Transform):
             ]
             if len(task_parameters) == 0:
                 raise ValueError(
-                    "Must specify parameter for stratified standardization"
+                    "Must specify parameter for stratified standardization. This can "
+                    "happen if TrialAsTask is a no-op, due to there only being a single"
+                    " task level."
                 )
             elif len(task_parameters) != 1:
                 raise ValueError(

--- a/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
+++ b/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
@@ -9,30 +9,40 @@
 from copy import deepcopy
 
 import numpy as np
+from ax.core.arm import Arm
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
-from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
-from ax.core.search_space import SearchSpace
+from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.exceptions.core import UnsupportedError
+from ax.modelbridge.base import Adapter
 from ax.modelbridge.transforms.trial_as_task import TrialAsTask
+from ax.models.base import Generator
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_robust_search_space
+from ax.utils.testing.core_stubs import get_branin_experiment, get_robust_search_space
 
 
 class TrialAsTaskTransformTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.search_space = SearchSpace(
-            parameters=[
-                RangeParameter(
-                    "x", lower=1, upper=4, parameter_type=ParameterType.FLOAT
-                )
-            ]
+        self.exp = get_branin_experiment()
+        self.modelbridge = Adapter(
+            search_space=self.exp.search_space,
+            model=Generator(),
+            experiment=self.exp,
         )
+        self.exp.new_trial().add_arm(Arm(parameters={"x1": 1, "x2": 1}))
+        self.exp.new_trial().add_arm(Arm(parameters={"x1": 2, "x2": 2}))
+        self.exp.new_trial().add_arm(Arm(parameters={"x1": 3, "x2": 3}))
+        self.exp.new_trial().add_arm(Arm(parameters={"x1": 4, "x2": 4}))
+        for t in self.exp.trials.values():
+            t.mark_running(no_runner_required=True)
+        self.exp.trials[0].mark_completed()
+        self.exp.fetch_data()
+
         self.training_feats = [
-            ObservationFeatures({"x": 1}, trial_index=0),
-            ObservationFeatures({"x": 2}, trial_index=0),
-            ObservationFeatures({"x": 3}, trial_index=1),
-            ObservationFeatures({"x": 4}, trial_index=2),
+            ObservationFeatures({"x1": 1, "x2": 1}, trial_index=0),
+            ObservationFeatures({"x1": 2, "x2": 2}, trial_index=0),
+            ObservationFeatures({"x1": 3, "x2": 3}, trial_index=1),
+            ObservationFeatures({"x1": 4, "x2": 4}, trial_index=2),
         ]
         self.training_obs = [
             Observation(
@@ -45,8 +55,9 @@ class TrialAsTaskTransformTest(TestCase):
         ]
 
         self.t = TrialAsTask(
-            search_space=self.search_space,
+            search_space=self.exp.search_space,
             observations=self.training_obs,
+            modelbridge=self.modelbridge,
         )
         self.bm = {
             "bp1": {0: "v1", 1: "v2", 2: "v3"},
@@ -54,13 +65,15 @@ class TrialAsTaskTransformTest(TestCase):
         }
 
         self.t2 = TrialAsTask(
-            search_space=self.search_space,
+            search_space=self.exp.search_space,
             observations=self.training_obs,
+            modelbridge=self.modelbridge,
             config={"trial_level_map": self.bm},
         )
         self.t3 = TrialAsTask(
-            search_space=self.search_space,
+            search_space=self.exp.search_space,
             observations=self.training_obs,
+            modelbridge=self.modelbridge,
             config={"trial_level_map": {}},
         )
         # test string trial indices
@@ -69,8 +82,9 @@ class TrialAsTaskTransformTest(TestCase):
             for p_name, value_dict in self.bm.items()
         }
         self.t4 = TrialAsTask(
-            search_space=self.search_space,
+            search_space=self.exp.search_space,
             observations=self.training_obs,
+            modelbridge=self.modelbridge,
             config={"trial_level_map": self.bm2, "target_trial": 2},
         )
 
@@ -79,29 +93,32 @@ class TrialAsTaskTransformTest(TestCase):
             self.t.trial_level_map, {"TRIAL_PARAM": {i: str(i) for i in range(3)}}
         )
         self.assertEqual(self.t.inverse_map, {str(i): i for i in range(3)})
-        self.assertEqual(self.t.target_values, {"TRIAL_PARAM": "0"})
+        # based on `get_target_trial_index``, the longest running trial is trial 1
+        self.assertEqual(self.t.target_values, {"TRIAL_PARAM": "1"})
         self.assertEqual(self.t2.trial_level_map, self.bm)
         self.assertIsNone(self.t2.inverse_map)
-        self.assertEqual(self.t2.target_values, {"bp1": "v1", "bp2": "u1"})
+        self.assertEqual(self.t2.target_values, {"bp1": "v2", "bp2": "u1"})
         # check that strings were converted to integers
         self.assertEqual(self.t4.trial_level_map, self.bm)
         self.assertIsNone(self.t4.inverse_map)
         self.assertEqual(self.t4.target_values, {"bp1": "v3", "bp2": "u2"})
         # Test validation
-        obsf = ObservationFeatures({"x": 2})
+        obsf = ObservationFeatures({"x1": 2, "x2": 2})
         obs = Observation(
             data=ObservationData([], np.array([]), np.empty((0, 0))), features=obsf
         )
         with self.assertRaises(ValueError):
             TrialAsTask(
-                search_space=self.search_space,
+                search_space=self.exp.search_space,
                 observations=self.training_obs + [obs],
+                modelbridge=self.modelbridge,
             )
-        bm = {"p": {0: "x1", 1: "x2"}}
+        bm = {"p": {0: "y", 1: "z"}}
         with self.assertRaises(ValueError):
             TrialAsTask(
-                search_space=self.search_space,
+                search_space=self.exp.search_space,
                 observations=self.training_obs,
+                modelbridge=self.modelbridge,
                 config={"trial_level_map": bm},
             )
 
@@ -109,16 +126,16 @@ class TrialAsTaskTransformTest(TestCase):
         obs_ft1 = deepcopy(self.training_feats)
         obs_ft2 = deepcopy(self.training_feats)
         obs_ft_trans1 = [
-            ObservationFeatures({"x": 1, "TRIAL_PARAM": "0"}),
-            ObservationFeatures({"x": 2, "TRIAL_PARAM": "0"}),
-            ObservationFeatures({"x": 3, "TRIAL_PARAM": "1"}),
-            ObservationFeatures({"x": 4, "TRIAL_PARAM": "2"}),
+            ObservationFeatures({"x1": 1, "x2": 1, "TRIAL_PARAM": "0"}),
+            ObservationFeatures({"x1": 2, "x2": 2, "TRIAL_PARAM": "0"}),
+            ObservationFeatures({"x1": 3, "x2": 3, "TRIAL_PARAM": "1"}),
+            ObservationFeatures({"x1": 4, "x2": 4, "TRIAL_PARAM": "2"}),
         ]
         obs_ft_trans2 = [
-            ObservationFeatures({"x": 1, "bp1": "v1", "bp2": "u1"}),
-            ObservationFeatures({"x": 2, "bp1": "v1", "bp2": "u1"}),
-            ObservationFeatures({"x": 3, "bp1": "v2", "bp2": "u1"}),
-            ObservationFeatures({"x": 4, "bp1": "v3", "bp2": "u2"}),
+            ObservationFeatures({"x1": 1, "x2": 1, "bp1": "v1", "bp2": "u1"}),
+            ObservationFeatures({"x1": 2, "x2": 2, "bp1": "v1", "bp2": "u1"}),
+            ObservationFeatures({"x1": 3, "x2": 3, "bp1": "v2", "bp2": "u1"}),
+            ObservationFeatures({"x1": 4, "x2": 4, "bp1": "v3", "bp2": "u2"}),
         ]
         obs_ft1 = self.t.transform_observation_features(obs_ft1)
         self.assertEqual(obs_ft1, obs_ft_trans1)
@@ -136,22 +153,22 @@ class TrialAsTaskTransformTest(TestCase):
         obs_ft_no_trial_index = deepcopy(self.training_feats)
         obs_ft_no_trial_index.append(
             ObservationFeatures(
-                {"x": 20},
+                {"x1": 20, "x2": 20},
             )
         )
         obs_ft_trans = [
-            ObservationFeatures({"x": 1, "TRIAL_PARAM": "0"}),
-            ObservationFeatures({"x": 2, "TRIAL_PARAM": "0"}),
-            ObservationFeatures({"x": 3, "TRIAL_PARAM": "1"}),
-            ObservationFeatures({"x": 4, "TRIAL_PARAM": "2"}),
-            ObservationFeatures({"x": 20, "TRIAL_PARAM": "2"}),
+            ObservationFeatures({"x1": 1, "x2": 1, "TRIAL_PARAM": "0"}),
+            ObservationFeatures({"x1": 2, "x2": 2, "TRIAL_PARAM": "0"}),
+            ObservationFeatures({"x1": 3, "x2": 3, "TRIAL_PARAM": "1"}),
+            ObservationFeatures({"x1": 4, "x2": 4, "TRIAL_PARAM": "2"}),
+            ObservationFeatures({"x1": 20, "x2": 20, "TRIAL_PARAM": "2"}),
         ]
         obs_ft_trans2 = [
-            ObservationFeatures({"x": 1, "bp1": "v1", "bp2": "u1"}),
-            ObservationFeatures({"x": 2, "bp1": "v1", "bp2": "u1"}),
-            ObservationFeatures({"x": 3, "bp1": "v2", "bp2": "u1"}),
-            ObservationFeatures({"x": 4, "bp1": "v3", "bp2": "u2"}),
-            ObservationFeatures({"x": 20, "bp1": "v3", "bp2": "u2"}),
+            ObservationFeatures({"x1": 1, "x2": 1, "bp1": "v1", "bp2": "u1"}),
+            ObservationFeatures({"x1": 2, "x2": 2, "bp1": "v1", "bp2": "u1"}),
+            ObservationFeatures({"x1": 3, "x2": 3, "bp1": "v2", "bp2": "u1"}),
+            ObservationFeatures({"x1": 4, "x2": 4, "bp1": "v3", "bp2": "u2"}),
+            ObservationFeatures({"x1": 20, "x2": 20, "bp1": "v3", "bp2": "u2"}),
         ]
 
         # test can transform and untransform with no config
@@ -173,9 +190,9 @@ class TrialAsTaskTransformTest(TestCase):
         self.assertEqual(obs_ft4, obs_ft_no_trial_index)
 
     def test_TransformSearchSpace(self) -> None:
-        ss2 = deepcopy(self.search_space)
+        ss2 = deepcopy(self.exp.search_space)
         ss2 = self.t.transform_search_space(ss2)
-        self.assertEqual(set(ss2.parameters.keys()), {"x", "TRIAL_PARAM"})
+        self.assertEqual(set(ss2.parameters.keys()), {"x1", "x2", "TRIAL_PARAM"})
         p = ss2.parameters["TRIAL_PARAM"]
         self.assertEqual(p.parameter_type, ParameterType.STRING)
         # pyre-fixme[16]: `Parameter` has no attribute `values`.
@@ -184,17 +201,17 @@ class TrialAsTaskTransformTest(TestCase):
         self.assertTrue(p.is_task)
         # pyre-fixme[16]: `Parameter` has no attribute `is_ordered`.
         self.assertFalse(p.is_ordered)
-        self.assertEqual(p.target_value, "0")
-        ss2 = deepcopy(self.search_space)
+        self.assertEqual(p.target_value, "1")
+        ss2 = deepcopy(self.exp.search_space)
         ss2 = self.t2.transform_search_space(ss2)
-        self.assertEqual(set(ss2.parameters.keys()), {"x", "bp1", "bp2"})
+        self.assertEqual(set(ss2.parameters.keys()), {"x1", "x2", "bp1", "bp2"})
         p = ss2.parameters["bp1"]
         self.assertTrue(isinstance(p, ChoiceParameter))
         self.assertEqual(p.parameter_type, ParameterType.STRING)
         self.assertEqual(set(p.values), {"v1", "v2", "v3"})
         self.assertTrue(p.is_task)
         self.assertFalse(p.is_ordered)
-        self.assertEqual(p.target_value, "v1")
+        self.assertEqual(p.target_value, "v2")
         p = ss2.parameters["bp2"]
         self.assertTrue(isinstance(p, ChoiceParameter))
         self.assertEqual(p.parameter_type, ParameterType.STRING)
@@ -203,8 +220,9 @@ class TrialAsTaskTransformTest(TestCase):
         self.assertTrue(p.is_ordered)  # 2 choices so always ordered
         self.assertEqual(p.target_value, "u1")
         t = TrialAsTask(
-            search_space=self.search_space,
+            search_space=self.exp.search_space,
             observations=self.training_obs,
+            modelbridge=self.modelbridge,
             config={
                 "trial_level_map": {
                     "trial_index": {0: 10, 1: 11, 2: 12},
@@ -212,7 +230,7 @@ class TrialAsTaskTransformTest(TestCase):
                 "target_trial": 1,
             },
         )
-        ss2 = deepcopy(self.search_space)
+        ss2 = deepcopy(self.exp.search_space)
         ss2 = t.transform_search_space(ss2)
         p = ss2.parameters["trial_index"]
         self.assertEqual(p.parameter_type, ParameterType.INT)
@@ -228,4 +246,5 @@ class TrialAsTaskTransformTest(TestCase):
             TrialAsTask(
                 search_space=rss,
                 observations=[],
+                modelbridge=self.modelbridge,
             )

--- a/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
+++ b/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
@@ -248,3 +248,59 @@ class TrialAsTaskTransformTest(TestCase):
                 observations=[],
                 modelbridge=self.modelbridge,
             )
+
+    def test_less_than_two_trials(self) -> None:
+        # test transform is a no-op with less than two trials
+        exp = get_branin_experiment()
+        exp.new_trial().add_arm(Arm(parameters={"x": 1}))
+        modelbridge = Adapter(
+            search_space=exp.search_space,
+            model=Generator(),
+            experiment=exp,
+        )
+        training_obs = self.training_obs[:1]
+        t = TrialAsTask(
+            search_space=exp.search_space,
+            observations=training_obs,
+            modelbridge=modelbridge,
+        )
+        self.assertEqual(t.trial_level_map, {})
+        training_feats = [training_obs[0].features]
+        training_feats_clone = deepcopy(training_feats)
+        self.assertEqual(
+            t.transform_observation_features(training_feats_clone), training_feats
+        )
+        self.assertEqual(
+            t.untransform_observation_features(training_feats), training_feats_clone
+        )
+        ss2 = exp.search_space.clone()
+        self.assertEqual(t.transform_search_space(ss2), exp.search_space)
+
+    def test_less_than_two_levels(self) -> None:
+        # test transform is a no-op with less than two trials
+        exp = get_branin_experiment()
+        exp.new_trial().add_arm(Arm(parameters={"x": 1}))
+        exp.new_trial().add_arm(Arm(parameters={"x": 2}))
+        modelbridge = Adapter(
+            search_space=exp.search_space,
+            model=Generator(),
+            experiment=exp,
+        )
+        training_obs = self.training_obs[:1]
+        t = TrialAsTask(
+            search_space=exp.search_space,
+            observations=training_obs,
+            modelbridge=modelbridge,
+            config={"trial_level_map": {"t": {0: "v1", 1: "v1"}}},
+        )
+        self.assertEqual(t.trial_level_map, {})
+        training_feats = [training_obs[0].features]
+        training_feats_clone = deepcopy(training_feats)
+        self.assertEqual(
+            t.transform_observation_features(training_feats_clone), training_feats
+        )
+        self.assertEqual(
+            t.untransform_observation_features(training_feats), training_feats_clone
+        )
+        ss2 = exp.search_space.clone()
+        self.assertEqual(t.transform_search_space(ss2), exp.search_space)

--- a/ax/service/tests/scheduler_test_utils.py
+++ b/ax/service/tests/scheduler_test_utils.py
@@ -1296,11 +1296,7 @@ class AxSchedulerTestCase(TestCase):
         self.assertEqual(exp, self.branin_experiment)
         exp = none_throws(exp)
         self.assertEqual(
-            # pyre-fixme[16]: Add `_generator_runs` back to GSI interface or move
-            # interface to node-level from strategy-level (the latter is likely the
-            # better option) TODO
-            len(gs._generator_runs),
-            len(none_throws(loaded_gs)._generator_runs),
+            len(gs._generator_runs), len(none_throws(loaded_gs)._generator_runs)
         )
         scheduler.run_all_trials()
         # Check that experiment and GS were saved and test reloading with reduced state.
@@ -2450,18 +2446,12 @@ class AxSchedulerTestCase(TestCase):
             experiment=self.branin_experiment,
             generation_strategy=GenerationStrategy(
                 steps=[
-                    GenerationStep(
-                        model=Generators.SOBOL,
-                        num_trials=1,
-                    ),
-                    GenerationStep(
-                        model=Generators.BOTORCH_MODULAR,
-                        num_trials=1,
-                    ),
+                    GenerationStep(model=Generators.SOBOL, num_trials=1),
+                    GenerationStep(model=Generators.BOTORCH_MODULAR, num_trials=1),
                     GenerationStep(
                         model=Generators.BOTORCH_MODULAR,
                         model_kwargs={
-                            # this will cause and error if the model
+                            # this will cause an error if the model
                             # doesn't get fixed features
                             "transforms": MBM_MTGP_trans,
                             "transform_configs": {

--- a/ax/utils/common/mock.py
+++ b/ax/utils/common/mock.py
@@ -34,5 +34,10 @@ def mock_patch_method_original(
         return original_method(self, *args, **kwargs)
 
     patcher = patch(mock_path, autospec=True, side_effect=side_effect)
-    yield patcher.start()
+    try:
+        yield patcher.start()
+    except Exception as e:
+        # tear down the patch if the `original_method` fails
+        patcher.stop()
+        raise e
     patcher.stop()


### PR DESCRIPTION
Summary:
The transform is a no-op in that case.

This is necessary to enable STGP vs MTGP model selection without adding additional nodes to the GS, thus creating further complication of the GS DAG.

Reviewed By: mgarrard

Differential Revision: D69496509


