### PR TITLE
Simplify search_space_digest property of BoTorchGenerator

### DIFF
--- a/ax/models/torch/botorch_modular/surrogate.py
+++ b/ax/models/torch/botorch_modular/surrogate.py
@@ -22,6 +22,7 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
 from ax.exceptions.core import AxError, UnsupportedError, UserInputError
+from ax.exceptions.model import ModelError
 from ax.models.model_utils import best_in_sample_point
 from ax.models.torch.botorch_modular.input_constructors.covar_modules import (
     covar_module_argparse,
@@ -777,7 +778,7 @@ class Surrogate(Base):
     @property
     def model(self) -> Model:
         if self._model is None:
-            raise ValueError(
+            raise ModelError(
                 "BoTorch `Model` has not yet been constructed, please fit the "
                 "surrogate first (done via `BoTorchGenerator.fit`)."
             )
@@ -786,7 +787,7 @@ class Surrogate(Base):
     @property
     def training_data(self) -> list[SupervisedDataset]:
         if self._training_data is None:
-            raise ValueError(NOT_YET_FIT_MSG)
+            raise ModelError(NOT_YET_FIT_MSG)
         return self._training_data
 
     @property
@@ -1349,7 +1350,7 @@ class Surrogate(Base):
     @property
     def outcomes(self) -> list[str]:
         if self._outcomes is None:
-            raise RuntimeError("outcomes not initialized. Please call `fit` first.")
+            raise ModelError("`outcomes` was not initialized. Please call `fit` first.")
         return self._outcomes
 
     @outcomes.setter

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -19,6 +19,7 @@ import numpy as np
 import torch
 from ax.core.search_space import RobustSearchSpaceDigest, SearchSpaceDigest
 from ax.exceptions.core import UnsupportedError, UserInputError
+from ax.exceptions.model import ModelError
 from ax.models.model_utils import best_in_sample_point
 from ax.models.torch.botorch_modular.acquisition import Acquisition
 from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
@@ -516,7 +517,7 @@ class SurrogateTest(TestCase):
         for botorch_model_class in [SaasFullyBayesianSingleTaskGP, SingleTaskGP]:
             surrogate, _ = self._get_surrogate(botorch_model_class=botorch_model_class)
             with self.assertRaisesRegex(
-                ValueError, "BoTorch `Model` has not yet been constructed."
+                ModelError, "BoTorch `Model` has not yet been constructed."
             ):
                 surrogate.model
 
@@ -524,7 +525,7 @@ class SurrogateTest(TestCase):
         for botorch_model_class in [SaasFullyBayesianSingleTaskGP, SingleTaskGP]:
             surrogate, _ = self._get_surrogate(botorch_model_class=botorch_model_class)
             with self.assertRaisesRegex(
-                ValueError,
+                ModelError,
                 "Underlying BoTorch `Model` has not yet received its training_data.",
             ):
                 surrogate.training_data
@@ -1542,7 +1543,7 @@ class SurrogateWithModelListTest(TestCase):
         )
         self.assertEqual(model_config.mll_class, self.mll_class)
         with self.assertRaisesRegex(
-            ValueError, "BoTorch `Model` has not yet been constructed"
+            ModelError, "BoTorch `Model` has not yet been constructed"
         ):
             self.surrogate.model
 

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -44,7 +44,7 @@ from torch import Tensor
 
 
 @mock_botorch_optimize
-def get_modelbridge(modular: bool = False, saasbo: bool = False) -> Adapter:
+def get_adapter(modular: bool = False, saasbo: bool = False) -> Adapter:
     exp = get_branin_experiment(with_batch=True)
     exp.trials[0].run()
     if modular:
@@ -64,8 +64,8 @@ def get_modelbridge(modular: bool = False, saasbo: bool = False) -> Adapter:
 class SensitivityAnalysisTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.model = get_modelbridge().model.model
-        self.saas_model = get_modelbridge(saasbo=True).model.surrogate.model
+        self.model = get_adapter().model.model
+        self.saas_model = get_adapter(saasbo=True).model.surrogate.model
 
     def test_DgsmGpMean(self) -> None:
         bounds = torch.tensor([(0.0, 1.0) for _ in range(2)]).t()
@@ -197,12 +197,12 @@ class SensitivityAnalysisTest(TestCase):
         first_order = sensitivity_mean_bootstrap.first_order_indices()
         self.assertEqual(first_order.shape, torch.Size([2, 3]))
 
-        with self.assertRaises(ValueError):
-            sensitivity_mean = SobolSensitivityGPMean(
-                self.model, num_mc_samples=10, bounds=bounds, second_order=False
-            )
-            first_order = sensitivity_mean.first_order_indices()
-            total_order = sensitivity_mean.total_order_indices()
+        sensitivity_mean = SobolSensitivityGPMean(
+            self.model, num_mc_samples=10, bounds=bounds, second_order=False
+        )
+        first_order = sensitivity_mean.first_order_indices()
+        total_order = sensitivity_mean.total_order_indices()
+        with self.assertRaisesRegex(ValueError, "Second order indices"):
             second_order = sensitivity_mean.second_order_indices()
 
         # testing compute_sobol_indices_from_model_list
@@ -240,10 +240,10 @@ class SensitivityAnalysisTest(TestCase):
                     )
                 )
 
-        # testing ax sensitivity utils
-        # model_bridge = cast(TorchAdapter, get_modelbridge())
+    def test_SobolGPMean_SAASBO_Ax_utils(self) -> None:
+        num_mc_samples = 10
         for modular in [False, True]:
-            model_bridge = cast(TorchAdapter, get_modelbridge(modular=modular))
+            model_bridge = cast(TorchAdapter, get_adapter(modular=modular))
             with self.assertRaisesRegex(
                 NotImplementedError,
                 "but only TorchAdapter is supported",
@@ -254,10 +254,7 @@ class SensitivityAnalysisTest(TestCase):
             with patch.object(model_bridge, "model", return_value=None):
                 with self.assertRaisesRegex(
                     NotImplementedError,
-                    (
-                        r"but only Union\[BotorchGenerator, ModularBoTorchGenerator\] "
-                        r"is supported"
-                    ),
+                    "but only BotorchGenerator and ModularBoTorchGenerator",
                 ):
                     ax_parameter_sens(model_bridge, model_bridge.outcomes)
 
@@ -358,7 +355,7 @@ class SensitivityAnalysisTest(TestCase):
                 )
 
         # Test with signed
-        model_bridge = get_modelbridge(modular=True)
+        model_bridge = get_adapter(modular=True)
 
         # adding a categorical feature
         cat_model_bridge = copy.deepcopy(model_bridge)
@@ -486,7 +483,7 @@ class SensitivityAnalysisTest(TestCase):
         self.assertFalse(torch.allclose(Brnd, B))
 
     def test_Sobol_raises(self) -> None:
-        bridge = get_modelbridge(modular=True)
+        bridge = get_adapter(modular=True)
         with self.assertRaisesRegex(
             NotImplementedError,
             "Order third and fourth is not supported. Plese choose one of"


### PR DESCRIPTION
Summary:
The `search_space_digest` property existed with a stated motivation to be used during `gen`, but `gen` receives the `search_space_digest` from the `Adapter` when called. `gen` was then mixing the two to create a hybrid, which was confusing.

This diff removes the duplicate (of `Surrogate._last_search_space_digest`) `BoTorchGenerator._search_space_digest`, updating `BoTorchGenerator.search_space_digest` to return it from the underlying surrogate. `search_space_digest` is retained as a property for use by low level utilities (like Sobol sensitivity) that may utilize information about the transformed search space that was used to construct the underlying BoTorch models.

Also updated a couple error types from `ValueError -> ModelError`.

Differential Revision: D69634327


