### PR TITLE
Fix model fitting logic in MBM w/ model selection

### DIFF
--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -292,7 +292,6 @@ class MapTorchAdapter(TorchAdapter):
         cv_test_points: list[ObservationFeatures],
         parameters: list[str] | None = None,
         use_posterior_predictive: bool = False,
-        **kwargs: Any,
     ) -> list[ObservationData]:
         """Make predictions at cv_test_points using only the data in obs_feats
         and obs_data. The difference from `TorchAdapter._cross_validate`
@@ -308,7 +307,6 @@ class MapTorchAdapter(TorchAdapter):
             cv_test_points=cv_test_points,
             parameters=parameters,  # we pass the map_keys too by default
             use_posterior_predictive=use_posterior_predictive,
-            **kwargs,
         )
         observation_features, observation_data = separate_observations(cv_training_data)
         # Since map_keys are used as features, there can be the possibility that

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -453,7 +453,6 @@ class TorchAdapter(Adapter):
         cv_test_points: list[ObservationFeatures],
         parameters: list[str] | None = None,
         use_posterior_predictive: bool = False,
-        **kwargs: Any,
     ) -> list[ObservationData]:
         """Make predictions at cv_test_points using only the data in obs_feats
         and obs_data.
@@ -479,7 +478,6 @@ class TorchAdapter(Adapter):
             X_test=torch.as_tensor(X_test, dtype=self.dtype, device=self.device),
             search_space_digest=search_space_digest,
             use_posterior_predictive=use_posterior_predictive,
-            **kwargs,
         )
         # Convert array back to ObservationData
         return array_to_observation_data(

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -473,7 +473,6 @@ class LegacyBoTorchGenerator(TorchGenerator):
         datasets: list[SupervisedDataset],
         X_test: Tensor,
         use_posterior_predictive: bool = False,
-        **kwargs: Any,
     ) -> tuple[Tensor, Tensor]:
         if self._model is None:
             raise RuntimeError("Cannot cross-validate model that has not been fitted.")

--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -204,6 +204,7 @@ class BoTorchGenerator(TorchGenerator, Base):
             candidate_metadata=candidate_metadata,
             state_dict=state_dict,
             refit=refit,
+            repeat_model_selection_if_dataset_changed=True,
         )
 
     def predict(
@@ -356,13 +357,12 @@ class BoTorchGenerator(TorchGenerator, Base):
             # remaining observations will not pass the input scaling checks.
             # To avoid confusing users with warnings, we disable these checks.
             with validate_input_scaling(False):
-                self.fit(
+                self.surrogate.fit(
                     datasets=datasets,
                     search_space_digest=search_space_digest,
-                    # pyre-fixme [6]: state_dict() has a generic dict[str, Any]
-                    # return type but it is actually an OrderedDict[str, Tensor].
                     state_dict=state_dict,
                     refit=self.refit_on_cv,
+                    repeat_model_selection_if_dataset_changed=False,
                 )
             X_test_prediction = self.predict(
                 X=X_test,

--- a/ax/models/torch/botorch_modular/model.py
+++ b/ax/models/torch/botorch_modular/model.py
@@ -67,7 +67,7 @@ class BoTorchGenerator(TorchGenerator, Base):
         surrogate: In lieu of ``SurrogateSpec``, an instance of ``Surrogate`` may
             be provided. In most cases, ``surrogate_spec`` should be used instead.
         refit_on_cv: Whether to reoptimize model parameters during call to
-            ``BoTorchmodel.cross_validate``.
+            ``BoTorchGenerator.cross_validate``.
         warm_start_refit: Whether to load parameters from either the provided
             state dict or the state dict of the current BoTorch ``Model`` during
             refitting. If False, model parameters will be reoptimized from
@@ -330,7 +330,6 @@ class BoTorchGenerator(TorchGenerator, Base):
         X_test: Tensor,
         search_space_digest: SearchSpaceDigest,
         use_posterior_predictive: bool = False,
-        **additional_model_inputs: Any,
     ) -> tuple[Tensor, Tensor]:
         current_surrogate = self.surrogate
         # If we should be refitting but not warm-starting the refit, set
@@ -364,7 +363,6 @@ class BoTorchGenerator(TorchGenerator, Base):
                     # return type but it is actually an OrderedDict[str, Tensor].
                     state_dict=state_dict,
                     refit=self.refit_on_cv,
-                    **additional_model_inputs,
                 )
             X_test_prediction = self.predict(
                 X=X_test,

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from logging import Logger
-from typing import Any
+from typing import Any, Mapping
 
 import torch
 from ax.core.search_space import SearchSpaceDigest
@@ -409,7 +409,7 @@ def fit_botorch_model(
 
 
 def subset_state_dict(
-    state_dict: OrderedDict[str, Tensor],
+    state_dict: Mapping[str, Tensor],
     submodel_index: int,
 ) -> OrderedDict[str, Tensor]:
     """Get the state dict for a submodel from the state dict of a model list.

--- a/ax/models/torch/tests/test_surrogate.py
+++ b/ax/models/torch/tests/test_surrogate.py
@@ -700,7 +700,7 @@ class SurrogateTest(TestCase):
                     search_space_digest=self.search_space_digest,
                     model_config=surrogate.surrogate_spec.model_configs[0],
                     default_botorch_model_class=SingleTaskGP,
-                    state_dict={},  # pyre-ignore [6]
+                    state_dict={},
                     refit=True,
                 )
                 if warm_start_refit:
@@ -1117,6 +1117,57 @@ class SurrogateTest(TestCase):
         self.assertIsInstance(model.models[0].covar_module, MaternKernel)
         # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(model.models[1].covar_module, RBFKernel)
+
+    def test_fit_multiple_model_configs_multiple_iterations(self) -> None:
+        """This test reproduces multiple iterations of model fitting in a
+        typical experiment, where fit is called, model is used to generate
+        candidates (this step is skipped), and fit is called again with
+        the new data. This test checks that the model fitting fits all
+        model specs and picks the best model corresponding to the new data.
+        `fit_botorch_model` is mocked to provide easy access to which models
+        are being fit.
+        """
+        model_configs = [
+            ModelConfig(covar_module_class=RBFKernel),
+            ModelConfig(covar_module_class=LinearKernel),
+        ]
+        surrogate = Surrogate(surrogate_spec=SurrogateSpec(model_configs=model_configs))
+        X = torch.rand(5, 3, **self.tkwargs)
+        Y = torch.rand(5, 1, **self.tkwargs)
+        ds1 = SupervisedDataset(
+            X=X[:4],
+            Y=Y[:4],
+            feature_names=self.feature_names,
+            outcome_names=self.metric_names,
+        )
+        ds2 = SupervisedDataset(
+            X=X,
+            Y=Y,
+            feature_names=self.feature_names,
+            outcome_names=self.metric_names,
+        )
+        with patch(
+            f"{SURROGATE_PATH}.fit_botorch_model",
+            side_effect=lambda model, **_: model.eval(),
+        ) as mock_fit:
+            surrogate.fit(
+                datasets=[ds1],
+                search_space_digest=self.search_space_digest,
+            )
+        # Should be called twice, since we have two model configs.
+        self.assertEqual(mock_fit.call_count, 2)
+        # Fit again with updated data.
+        with patch(
+            f"{SURROGATE_PATH}.fit_botorch_model",
+            side_effect=lambda model, **_: model.eval(),
+        ) as mock_fit:
+            surrogate.fit(
+                datasets=[ds2],
+                search_space_digest=self.search_space_digest,
+            )
+        # Should be called twice, since we have two model configs
+        # and the data is updated.
+        self.assertEqual(mock_fit.call_count, 2)
 
     def test_exception_for_multiple_model_configs_and_multioutcome_dataset(
         self,
@@ -1687,10 +1738,6 @@ class SurrogateWithModelListTest(TestCase):
                 datasets=datasets,
                 search_space_digest=search_space_digest,
                 refit=False,
-                # pyre-fixme: Incompatible parameter type [6]: In call
-                # `Surrogate.fit`, for argument `state_dict`, expected
-                # `Optional[OrderedDict[str, Tensor]]` but got `Dict[str,
-                # typing.Any]`
                 state_dict=state_dict,
             )
 


### PR DESCRIPTION
Summary:
There was a bug in MBM with model selection, where once the best config is identified (in first `fit`), it would be re-used from there on without repeating the model selection, even if the dataset has changed. There are two cases we need to consider here:
- During cross-validation (Adapter/Generator-level), we are trying to evaluate the quality of the model as fitted, with the selected best config. The dataset will change between subsequent calls, but we do not want to invalidate best config.
- During model fitting ((Adapter/Generator-level `fit` call), we want to repeat model selection if the dataset changed, to ensure we have the best model for the up-to-date data.
Since both codepaths call `Surrogate.fit`, adding a kwarg to control this behavior seemed like a natural choice. With this change, `repeat_model_selection_if_dataset_changed` controls whether the model selection is repeated in `Surrogate.fit`.

Reviewed By: sdaulton

Differential Revision: D69620020


