### PR TITLE
Fix TestMetricSummary unit test `test_compute`

### DIFF
--- a/ax/analysis/tests/test_metric_summary.py
+++ b/ax/analysis/tests/test_metric_summary.py
@@ -80,7 +80,7 @@ class TestMetricSummary(TestCase):
                     ),
                 ),
                 "Bound": ["None", ">= 1.0", "<= 0.0", "None"],
-                "Lower is Better": ["None", "None", "None", "None"],
+                "Lower is Better": [False, False, "None", "None"],
             }
         )
         pd.testing.assert_frame_equal(card.df, expected)


### PR DESCRIPTION
Summary: WIth the changes introduced in D69611291, we now set `lower_is_better` on objective metrics in configure_optimization - this change is to update the `test_compute` unit test to reflect this

Differential Revision: D69786858


