### PR TITLE
[Sphinx] Fix rst underline length warnings

### DIFF
--- a/sphinx/source/core.rst
+++ b/sphinx/source/core.rst
@@ -54,7 +54,7 @@ Core Classes
 
 
 `AuxiliaryExperiment`
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.core.auxiliary
     :members:
@@ -205,7 +205,7 @@ Core Classes
 
 
 `TrialStatus`
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. automodule:: ax.core.trial_status
     :members:

--- a/sphinx/source/generation_strategy.rst
+++ b/sphinx/source/generation_strategy.rst
@@ -2,7 +2,7 @@
     :class: hidden-section
 
 ax.generation_strategy
-==============
+======================
 
 .. automodule:: ax.generation_strategy
 .. currentmodule:: ax.generation_strategy
@@ -26,28 +26,28 @@ Generation Node
     :show-inheritance:
 
 External Generation Node
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: ax.generation_strategy.external_generation_node
     :members:
     :undoc-members:
     :show-inheritance:
 
 Transition Criterion
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 .. automodule:: ax.generation_strategy.transition_criterion
     :members:
     :undoc-members:
     :show-inheritance:
 
 Generation Node Input Constructors
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: ax.generation_strategy.generation_node_input_constructors
     :members:
     :undoc-members:
     :show-inheritance:
 
 GeneratorSpec
-~~~~~~~~~
+~~~~~~~~~~~~~
 .. automodule:: ax.generation_strategy.model_spec
     :members:
     :undoc-members:

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -26,7 +26,7 @@ Generation Node
     :show-inheritance:
 
 External Generation Node
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: ax.modelbridge.external_generation_node
     :members:
     :undoc-members:
@@ -59,7 +59,7 @@ Factory
     :show-inheritance:
 
 GeneratorSpec
-~~~~~~~~~
+~~~~~~~~~~~~~
 .. automodule:: ax.modelbridge.model_spec
     :members:
     :undoc-members:
@@ -207,7 +207,7 @@ Transforms
     :show-inheritance:
 
 `ax.modelbridge.transforms.fill_missing_parameters`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.modelbridge.transforms.fill_missing_parameters
     :members:
@@ -377,7 +377,7 @@ Transforms
     :show-inheritance:
 
 `ax.modelbridge.transforms.time\_as\_feature`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.modelbridge.transforms.time_as_feature
     :members:
@@ -385,7 +385,7 @@ Transforms
     :show-inheritance:
 
 `ax.modelbridge.transforms.transform\_to\_new\_sq`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.modelbridge.transforms.transform_to_new_sq
     :members:

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -9,7 +9,7 @@ ax.models
 
 
 Base Generators & Utilities
------------------------
+---------------------------
 
 ax.models.base
 ~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ ax.models.winsorization\_config module
 
 
 Discrete Generators
----------------
+-------------------
 
 ax.models.discrete.eb\_thompson module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -96,7 +96,7 @@ ax.models.discrete.eb\_ashr module
     :show-inheritance:
 
 ax.models.discrete.ashr\_utils module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.models.discrete.ashr_utils
     :members:
@@ -105,7 +105,7 @@ ax.models.discrete.ashr\_utils module
 
 
 Random Generators
--------------
+-----------------
 
 ax.models.random.base module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -132,7 +132,7 @@ ax.models.random.sobol module
     :show-inheritance:
 
 Torch Generators & Utilities
-------------------------
+----------------------------
 
 ax.models.torch.botorch module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/sphinx/source/utils.rst
+++ b/sphinx/source/utils.rst
@@ -148,7 +148,7 @@ Typeutils
     :show-inheritance:
 
 Typeutils Non-Native
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.utils.common.typeutils_nonnative
     :members:


### PR DESCRIPTION
## These changes

Fixes errors like
```shell
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [docutils]
/home/runner/work/Ax/Ax/sphinx/source/modelbridge.rst:388: WARNING: Title underline too short.
```

From the [official RST documentation](https://docutils.sourceforge.io/docs/user/rst/quickstart.html#sections):
> The underline/overline must be at least as long as the title text.

## Next steps

We currently ignore warnings and errors in our sphinx build. There's more work needed to fix all the current warnings and errors before we can start blocking deploys on this. We currently build sphinx for testing in the "Build and Test Workflow" https://github.com/facebook/Ax/actions/runs/13395675240/job/37413955185#step:7:207

I took a stab at fixing other errors but the loop of
1. attempt fix
2. rebuild sphinx docs to reveal errors
3. grep logs to see if fix resolved our specific error

is painfully slow. I tried using a [flake8-rst extension](https://github.com/peterjc/flake8-rst-docstrings) to reveal the errors in my editor but they didn't match the output of sphinx.

Creating a backlog task for the remaining work