### PR TITLE
Fix DBSettings type hints & resulting import errors

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -72,7 +72,7 @@ from ax.service.utils.instantiation import (
     InstantiationBase,
     ObjectiveProperties,
 )
-from ax.service.utils.with_db_settings_base import DBSettings
+from ax.service.utils.with_db_settings_base import TDBSettings
 from ax.storage.json_store.decoder import (
     generation_strategy_from_json,
     object_from_json,
@@ -182,7 +182,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
     def __init__(
         self,
         generation_strategy: GenerationStrategy | None = None,
-        db_settings: DBSettings | None = None,
+        db_settings: TDBSettings = None,
         enforce_sequential_optimization: bool = True,
         random_seed: int | None = None,
         torch_device: torch.device | None = None,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -2031,7 +2031,7 @@ class TestAxClient(TestCase):
 
     @patch.dict(sys.modules, {"ax.storage.sqa_store.structs": None})
     @patch.dict(sys.modules, {"sqalchemy": None})
-    @patch("ax.service.ax_client.DBSettings", None)
+    @patch("ax.service.ax_client.TDBSettings", None)
     def test_no_sqa(self) -> None:
         # Make sure we couldn't import sqa_store.structs (this could happen when
         # SQLAlchemy is not installed).

--- a/ax/service/utils/with_db_settings_base.py
+++ b/ax/service/utils/with_db_settings_base.py
@@ -9,11 +9,9 @@
 import re
 import time
 from collections.abc import Iterable, Sequence
-
 from logging import INFO, Logger
 
 from ax.analysis.analysis import AnalysisCard
-
 from ax.core.base_trial import BaseTrial
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
@@ -75,10 +73,13 @@ try:  # We don't require SQLAlchemy by default.
     from sqlalchemy.exc import OperationalError
     from sqlalchemy.orm.exc import StaleDataError
 
+    TDBSettings = DBSettings | None
+
     # We retry on `OperationalError` if saving to DB.
     RETRY_EXCEPTION_TYPES = (OperationalError, StaleDataError)
 except (ModuleNotFoundError, IncompatibleDependencyVersion, TypeError):
     DBSettings = None
+    TDBSettings = None
     Decoder = None
     Encoder = None
     SQAConfig = None
@@ -93,11 +94,11 @@ class WithDBSettingsBase:
     if `db_settings` property is set to a non-None value on the instance.
     """
 
-    _db_settings: DBSettings | None = None
+    _db_settings: TDBSettings = None
 
     def __init__(
         self,
-        db_settings: DBSettings | None = None,
+        db_settings: TDBSettings = None,
         logging_level: int = INFO,
         suppress_all_errors: bool = False,
     ) -> None:
@@ -117,7 +118,7 @@ class WithDBSettingsBase:
         logger.setLevel(logging_level)
 
     @staticmethod
-    def _get_default_db_settings() -> DBSettings | None:
+    def _get_default_db_settings() -> TDBSettings:
         """Overridable method to get default db_settings
         if none are passed in __init__
         """


### PR DESCRIPTION
Summary:
`with_db_settings_base` imports `DBSettings` only if sqlalchemy is available and sets it to `None` otherwise. `None | None` is not a valid type hint (even though `Optional[None]` appears to be), and leads to import time errors when importing AxClient (if sqlalchemy is not installed).

This diff introduces a type variable `TDBSettings` to replace `DBSettings | None`, which should prevent these errors.

Example failure: https://github.com/pytorch/botorch/actions/runs/13404405548/job/37441576260

Differential Revision: D69828785


