### PR TITLE
Consolidate unnecessary functions

### DIFF
--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -33,7 +33,7 @@ from ax.modelbridge.base import Adapter
 from ax.modelbridge.registry import Generators
 from ax.service.utils.best_point import (
     get_best_parameters_from_model_predictions_with_trial_index,
-    get_best_raw_objective_point,
+    get_best_raw_objective_point_with_trial_index,
 )
 from ax.service.utils.instantiation import (
     DEFAULT_OBJECTIVE_NAME,
@@ -258,7 +258,7 @@ class OptimizationLoop:
             return parameterizations, predictions
 
         # Could not find through model, default to using raw objective.
-        parameterization, values = get_best_raw_objective_point(
+        _, parameterization, values = get_best_raw_objective_point_with_trial_index(
             experiment=self.experiment
         )
         # For values, grab just the means to conform to TModelPredictArm format.

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -348,7 +348,6 @@ class ReportUtilsTest(TestCase):
         exp.trials[0].run()
         exp.fetch_data()
         relative_df = exp_to_df(exp=exp, show_relative_metrics=True)
-        print(relative_df)
         self.assertTrue(f"{OBJECTIVE_NAME}_%CH" in relative_df.columns.tolist())
         self.assertEqual(relative_df[f"{OBJECTIVE_NAME}_%CH"].values[0], 0.0)
 


### PR DESCRIPTION
Summary:
TLDR: Code deleted, no tests deleted

* `get_best_raw_objective_point` does nothing but return 2 of the 3 return values of `get_best_raw_objective_point_with_trial_index`, so I removed it and replaced it with `get_best_raw_objective_point_with_trial_index`.
*` _filter_feasible_rows` is a simple call to another function plus an exception is and is only used once, so I merged it into the function that calls it.
* `get_best_by_raw_objective` is unused.
* `get_best_parameters` is unused except for tests, and similarly is just a thin wrapper around `get_best_parameters_with_trial_index`, so I removed it.
* But `get_best_parameters_with_trial_index` is itself unused and just a thin wrapper around `get_best_parameters_from_model_predictions_with_trial_index` with a fallback of `get_best_by_raw_objective_with_trial_index`.

Reviewed By: saitcakmak

Differential Revision: D69813967


