### PR TITLE
More informative error when trying to find a best point and no trials are completed

### DIFF
--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -33,7 +33,7 @@ from ax.modelbridge.base import Adapter
 from ax.modelbridge.registry import Generators
 from ax.service.utils.best_point import (
     get_best_parameters_from_model_predictions_with_trial_index,
-    get_best_raw_objective_point,
+    get_best_raw_objective_point_with_trial_index,
 )
 from ax.service.utils.instantiation import (
     DEFAULT_OBJECTIVE_NAME,
@@ -258,7 +258,7 @@ class OptimizationLoop:
             return parameterizations, predictions
 
         # Could not find through model, default to using raw objective.
-        parameterization, values = get_best_raw_objective_point(
+        _, parameterization, values = get_best_raw_objective_point_with_trial_index(
             experiment=self.experiment
         )
         # For values, grab just the means to conform to TModelPredictArm format.

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -46,6 +46,7 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_branin_metric,
     get_branin_search_space,
+    get_experiment_with_map_data,
     get_experiment_with_observations,
     get_sobol,
 )
@@ -153,6 +154,15 @@ class TestBestPointUtils(TestCase):
         self.assertIsNotNone(predict_arm)
 
     def test_best_raw_objective_point(self) -> None:
+        with self.subTest("Only early-stopped trials"):
+            exp = get_experiment_with_map_data()
+            exp.trials[0].mark_running(no_runner_required=True)
+            exp.trials[0].mark_early_stopped()
+            with self.assertRaisesRegex(
+                ValueError, "Cannot identify best point if no trials are completed."
+            ):
+                get_best_raw_objective_point_with_trial_index(experiment=exp)
+
         exp = get_branin_experiment()
         with self.assertRaisesRegex(
             ValueError, "Cannot identify best point if experiment contains no data."

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -348,7 +348,6 @@ class ReportUtilsTest(TestCase):
         exp.trials[0].run()
         exp.fetch_data()
         relative_df = exp_to_df(exp=exp, show_relative_metrics=True)
-        print(relative_df)
         self.assertTrue(f"{OBJECTIVE_NAME}_%CH" in relative_df.columns.tolist())
         self.assertEqual(relative_df[f"{OBJECTIVE_NAME}_%CH"].values[0], 0.0)
 

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -108,6 +108,8 @@ def get_best_raw_objective_point_with_trial_index(
     completed_indices = {
         t.index for t in experiment.trials_by_status[TrialStatus.COMPLETED]
     }
+    if len(completed_indices) == 0:
+        raise ValueError("Cannot identify best point if no trials are completed.")
     completed_df = dat.df[dat.df["trial_index"].isin(completed_indices)]
 
     is_feasible = _is_row_feasible(


### PR DESCRIPTION
Summary:
Context:

A confusing error appears when best-point utilities receive an experiment whose only trials have been early-stopped. It will skip a check for empty data (because there are trials, just early-stopped ones) and then will notice there are no feasible trials and error out with  "No points satisfied all outcome constraints within 95 percent confidence interval"


This PR: Adds an error message

Differential Revision: D69489730


