### PR TITLE
Fix signatures of TorchModel.cross_validate

### DIFF
--- a/ax/models/tests/test_botorch_model.py
+++ b/ax/models/tests/test_botorch_model.py
@@ -557,6 +557,7 @@ class LegacyBoTorchGeneratorTest(TestCase):
             ]
             mean, variance = model.cross_validate(
                 datasets=combined_datasets,
+                search_space_digest=search_space_digest,
                 X_test=torch.tensor([[1.2, 3.2, 4.2], [2.4, 5.2, 3.2]], **tkwargs),
             )
             self.assertEqual(mean.shape, torch.Size([2, 2]))
@@ -566,6 +567,7 @@ class LegacyBoTorchGeneratorTest(TestCase):
             model.refit_on_cv = True
             mean, variance = model.cross_validate(
                 datasets=combined_datasets,
+                search_space_digest=search_space_digest,
                 X_test=torch.tensor([[1.2, 3.2, 4.2], [2.4, 5.2, 3.2]], **tkwargs),
             )
             self.assertEqual(mean.shape, torch.Size([2, 2]))
@@ -580,7 +582,11 @@ class LegacyBoTorchGeneratorTest(TestCase):
             with self.assertRaisesRegex(
                 RuntimeError, r"Cannot cross-validate model that has not been fitted"
             ):
-                unfit_model.cross_validate(datasets=combined_datasets, X_test=Xs1[0])
+                unfit_model.cross_validate(
+                    datasets=combined_datasets,
+                    search_space_digest=search_space_digest,
+                    X_test=Xs1[0],
+                )
             with self.assertRaisesRegex(
                 RuntimeError,
                 r"Cannot calculate feature_importances without a fitted model",

--- a/ax/models/tests/test_randomforest.py
+++ b/ax/models/tests/test_randomforest.py
@@ -25,14 +25,15 @@ class RandomForestTest(TestCase):
             )
             for i in range(2)
         ]
+        search_space_digest = SearchSpaceDigest(
+            feature_names=["x1", "x2"],
+            bounds=[(0, 1)] * 2,
+        )
 
         m = RandomForest(num_trees=5)
         m.fit(
             datasets=datasets,
-            search_space_digest=SearchSpaceDigest(
-                feature_names=["x1", "x2"],
-                bounds=[(0, 1)] * 2,
-            ),
+            search_space_digest=search_space_digest,
         )
         self.assertEqual(len(m.models), 2)
         # pyre-fixme[16]: `RandomForestRegressor` has no attribute `estimators_`.
@@ -42,6 +43,10 @@ class RandomForestTest(TestCase):
         self.assertEqual(f.shape, torch.Size((5, 2)))
         self.assertEqual(cov.shape, torch.Size((5, 2, 2)))
 
-        f, cov = m.cross_validate(datasets=datasets, X_test=torch.rand(3, 2))
+        f, cov = m.cross_validate(
+            datasets=datasets,
+            search_space_digest=search_space_digest,
+            X_test=torch.rand(3, 2),
+        )
         self.assertEqual(f.shape, torch.Size((3, 2)))
         self.assertEqual(cov.shape, torch.Size((3, 2, 2)))

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -468,10 +468,11 @@ class LegacyBoTorchGenerator(TorchGenerator):
         )
 
     @copy_doc(TorchGenerator.cross_validate)
-    def cross_validate(  # pyre-ignore [14]: `search_space_digest` arg not needed here
+    def cross_validate(
         self,
         datasets: list[SupervisedDataset],
         X_test: Tensor,
+        search_space_digest: SearchSpaceDigest,
         use_posterior_predictive: bool = False,
     ) -> tuple[Tensor, Tensor]:
         if self._model is None:

--- a/ax/models/torch/randomforest.py
+++ b/ax/models/torch/randomforest.py
@@ -66,10 +66,11 @@ class RandomForest(TorchGenerator):
         return _rf_predict(self.models, X)
 
     @copy_doc(TorchGenerator.cross_validate)
-    def cross_validate(  # pyre-ignore [14]: not using metric_names or ssd
+    def cross_validate(
         self,
         datasets: list[SupervisedDataset],
         X_test: Tensor,
+        search_space_digest: SearchSpaceDigest,
         use_posterior_predictive: bool = False,
     ) -> tuple[Tensor, Tensor]:
         Xs, Ys, Yvars = _datasets_to_legacy_inputs(datasets=datasets)


### PR DESCRIPTION
Summary:
Some subclasses were missing SSD input, which leads to errors when called from `TorchAdapter` as
```
        f_test, cov_test = none_throws(self.model).cross_validate(
            datasets=datasets,
            X_test=torch.as_tensor(X_test, dtype=self.dtype, device=self.device),
            search_space_digest=search_space_digest,
            use_posterior_predictive=use_posterior_predictive,
        )
```
This was something raised by pyre but it was being suppressed.

Differential Revision: D69951061


