### PR TITLE
[Ax] `DataLoaderConfig` - Only load last observation of map data by default

### DIFF
--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -95,6 +95,7 @@ class MapData(Data):
     `experiment.attach_data()` (this requires a description to be set.)
     """
 
+    REQUIRED_COLUMNS = {"trial_index", "arm_name", "metric_name"}
     DEDUPLICATE_BY_COLUMNS = ["trial_index", "arm_name", "metric_name"]
 
     _map_df: pd.DataFrame

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -468,7 +468,6 @@ def observations_from_data(
     latest_rows_per_group: int | None = None,
     limit_rows_per_metric: int | None = None,
     limit_rows_per_group: int | None = None,
-    load_only_completed_map_metrics: bool = True,
 ) -> list[Observation]:
     """Convert Data (or MapData) to observations.
 
@@ -502,8 +501,6 @@ def observations_from_data(
             uses MapData.subsample() with `limit_rows_per_group` on the first
             map_key (map_data.map_keys[0]) to subsample the MapData. Ignored if
             `latest_rows_per_group` is specified.
-        load_only_completed_map_metrics: If True, only loads the last observation
-            for each completed MapMetric.
 
     Returns:
         List of Observation objects.
@@ -514,8 +511,7 @@ def observations_from_data(
         statuses_to_include_map_metric = NON_ABANDONED_STATUSES
     is_map_data = isinstance(data, MapData)
     map_keys = []
-    take_map_branch = is_map_data and not load_only_completed_map_metrics
-    if take_map_branch:
+    if is_map_data:
         data = assert_is_instance(data, MapData)
         map_keys.extend(data.map_keys)
         if latest_rows_per_group is not None:
@@ -530,7 +526,7 @@ def observations_from_data(
         df = data.map_df
     else:
         df = data.df
-    feature_cols = get_feature_cols(data, is_map_data=take_map_branch)
+    feature_cols = get_feature_cols(data, is_map_data=is_map_data)
     return _observations_from_dataframe(
         experiment=experiment,
         df=df,

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -474,9 +474,7 @@ class ObservationsTest(TestCase):
                 MapKeyInfo(key="timestamp", default_value=0.0),
             ],
         )
-        observations = observations_from_data(
-            experiment, data, load_only_completed_map_metrics=False
-        )
+        observations = observations_from_data(experiment, data)
 
         self.assertEqual(len(observations), 3)
 
@@ -493,6 +491,14 @@ class ObservationsTest(TestCase):
             self.assertTrue(np.array_equal(obs.data.covariance, t["covariance_t"]))
             self.assertEqual(obs.arm_name, t["arm_name"])
             self.assertEqual(obs.features.metadata, {"timestamp": t["timestamp"]})
+
+        # testing that we can handle empty data with latest_rows_per_group
+        empty_data = MapData()
+        observations = observations_from_data(
+            experiment,
+            empty_data,
+            latest_rows_per_group=1,
+        )
 
     def test_ObservationsFromDataAbandoned(self) -> None:
         truth = [

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -330,7 +330,6 @@ class UtilsTest(TestCase):
                 ),
             ):
                 pending = get_pending_observation_features(self.experiment)
-                print(pending)
                 self.assertEqual(
                     pending,
                     {

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -951,8 +951,8 @@ class testClampObservationFeatures(TestCase):
         )
         kwargs = mock_observations_from_data.call_args.kwargs
         self.assertTrue(kwargs["map_keys_as_parameters"])
-        # assert `latest_rows_per_group` is not specified or is None
-        self.assertIsNone(kwargs.get("latest_rows_per_group"))
+        # assert `latest_rows_per_group` is 1
+        self.assertEqual(kwargs["latest_rows_per_group"], 1)
         mock_observations_from_data.reset_mock()
 
         # calling without map data calls observations_from_data with

--- a/ax/modelbridge/tests/test_map_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_map_torch_modelbridge.py
@@ -18,6 +18,7 @@ from ax.core.observation import (
 )
 
 from ax.core.trial_status import TrialStatus
+from ax.modelbridge.base import DataLoaderConfig
 from ax.modelbridge.map_torch import MapTorchAdapter
 from ax.models.torch_base import TorchGenerator, TorchGenResults
 from ax.utils.common.constants import Keys
@@ -50,7 +51,10 @@ class MapTorchAdapterTest(TestCase):
             data=experiment.lookup_data(),
             model=model,
             transforms=[],
-            fit_out_of_design=True,
+            data_loader_config=DataLoaderConfig(
+                fit_out_of_design=True,
+                latest_rows_per_group=None,
+            ),
             default_model_gen_options={"target_map_values": {"timestamp": 4.0}},
         )
         # Check that indices are set correctly.

--- a/ax/modelbridge/tests/test_registry.py
+++ b/ax/modelbridge/tests/test_registry.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.exceptions.core import UserInputError
+from ax.modelbridge.base import DataLoaderConfig
 from ax.modelbridge.discrete import DiscreteAdapter
 from ax.modelbridge.random import RandomAdapter
 from ax.modelbridge.registry import (
@@ -167,14 +168,21 @@ class ModelRegistryTest(TestCase):
                 "optimization_config": None,
                 "transforms": Cont_X_trans + Y_trans,
                 "expand_model_space": True,
-                "fit_out_of_design": False,
-                "fit_abandoned": False,
                 "fit_tracking_metrics": True,
                 "fit_on_init": True,
                 "default_model_gen_options": None,
-                "fit_only_completed_map_metrics": True,
+                "data_loader_config": None,
+                # now passed through the data loader config
+                "fit_only_completed_map_metrics": None,
+                "fit_out_of_design": None,
+                "fit_abandoned": None,
             },
         )
+        self.assertIsInstance(gpei._data_loader_config, DataLoaderConfig)
+        self.assertEqual(gpei._data_loader_config.fit_only_completed_map_metrics, True)
+        self.assertEqual(gpei._data_loader_config.fit_out_of_design, False)
+        self.assertEqual(gpei._data_loader_config.fit_abandoned, False)
+
         prior_kwargs = {"lengthscale_prior": GammaPrior(6.0, 6.0)}
         gpei = Generators.LEGACY_BOTORCH(
             experiment=exp,

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -41,7 +41,7 @@ from ax.core.search_space import SearchSpace
 from ax.core.types import TCandidateMetadata, TModelPredictArm
 from ax.exceptions.core import DataRequiredError, UnsupportedError
 from ax.exceptions.generation_strategy import OptimizationConfigRequired
-from ax.modelbridge.base import Adapter, gen_arms, GenResults
+from ax.modelbridge.base import Adapter, DataLoaderConfig, gen_arms, GenResults
 from ax.modelbridge.modelbridge_utils import (
     array_to_observation_data,
     extract_objective_thresholds,
@@ -103,13 +103,14 @@ class TorchAdapter(Adapter):
         status_quo_features: ObservationFeatures | None = None,
         optimization_config: OptimizationConfig | None = None,
         expand_model_space: bool = True,
-        fit_out_of_design: bool = False,
-        fit_abandoned: bool = False,
         fit_tracking_metrics: bool = True,
         fit_on_init: bool = True,
-        fit_only_completed_map_metrics: bool = True,
         default_model_gen_options: TConfig | None = None,
         torch_device: torch.device | None = None,
+        data_loader_config: DataLoaderConfig | None = None,
+        fit_out_of_design: bool | None = None,
+        fit_abandoned: bool | None = None,
+        fit_only_completed_map_metrics: bool | None = None,
     ) -> None:
         """In addition to common arguments documented in the base ``Adapter`` class,
         ``TorchAdapter`` accepts the following arguments.
@@ -120,6 +121,12 @@ class TorchAdapter(Adapter):
                 `model_gen_options` passed to the `Adapter.gen` method.
             torch_device: The device to use for any torch tensors and operations
                 on these tensors.
+            data_loader_options: A dictionary of options for loading data.
+            fit_out_of_design: Overwrites `data_loader_config.fit_out_of_design` if
+                not None.
+            fit_abandoned: Overwrites `data_loader_config.fit_abandoned` if not None.
+            fit_only_completed_map_metrics: If not None, overwrites
+                `data_loader_config.fit_only_completed_map_metrics`.
         """
         self.device: torch.device | None = torch_device
         self._default_model_gen_options: TConfig = default_model_gen_options or {}
@@ -150,10 +157,11 @@ class TorchAdapter(Adapter):
             status_quo_features=status_quo_features,
             optimization_config=optimization_config,
             expand_model_space=expand_model_space,
-            fit_out_of_design=fit_out_of_design,
-            fit_abandoned=fit_abandoned,
             fit_tracking_metrics=fit_tracking_metrics,
             fit_on_init=fit_on_init,
+            data_loader_config=data_loader_config,
+            fit_out_of_design=fit_out_of_design,
+            fit_abandoned=fit_abandoned,
             fit_only_completed_map_metrics=fit_only_completed_map_metrics,
         )
 
@@ -883,7 +891,7 @@ class TorchAdapter(Adapter):
             opt_config_metrics=opt_config_metrics,
             is_moo=optimization_config.is_moo_problem,
             risk_measure=risk_measure,
-            fit_out_of_design=self._fit_out_of_design,
+            fit_out_of_design=self._data_loader_config.fit_out_of_design,
         )
         return search_space_digest, torch_opt_config
 


### PR DESCRIPTION
Summary: This commit ensures that the `Adapter` only loads a single observation by default, even for map metrics. This makes sure that any method (not-necessarily map-data aware) can be applied by default.

Differential Revision: D69992533


