### PR TITLE
Remove parameter constraints when expanding model space in Adapter

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -140,7 +140,8 @@ class Adapter(ABC):  # noqa: B024 -- Adapter doesn't have any abstract methods.
             expand_model_space: If True, expand range parameter bounds in model
                 space to cover given training data. This will make the modeling
                 space larger than the search space if training data fall outside
-                the search space.
+                the search space. Will also include training points that violate
+                parameter constraints in the modeling.
             fit_out_of_design: If specified, all training data are used.
                 Otherwise, only in design points are used.
             fit_abandoned: Whether data for abandoned arms or trials should be
@@ -441,6 +442,8 @@ class Adapter(ABC):  # noqa: B024 -- Adapter doesn't have any abstract methods.
             if isinstance(p, RangeParameter):
                 p.lower = min(p.lower, min(param_vals[p.name]))
                 p.upper = max(p.upper, max(param_vals[p.name]))
+        # Remove parameter constraints from the model space.
+        self._model_space.set_parameter_constraints([])
 
     def _set_status_quo(
         self,


### PR DESCRIPTION
Summary:
By default we expand range parameters in the model space so that the
training data include all modelable data, not just those that fall within the
box bounds.

A similar argument suggests that we should also include training data that
violate parameter constraints in the model. They are modelable and can be used
to improve predictions at points that satisfy parameter constraints.

We do this by simply dropping parameter constraints from the model space, if
the model space is specified to be expanded.

This will also fix https://github.com/facebook/Ax/issues/1568 . The issue there
is that generated points violated parameter constraints due to numerical
issues, and so then were left out of the training data and repeatedly
generated. With this change, those points would be included in the training
data and so likely not re-generated. Note, however, that the purpose of this
change is not just to fix this issue; it is a change that is right because it
better fits the concept of the modeling space.

Reviewed By: sdaulton, saitcakmak

Differential Revision: D69880066


