### PR TITLE
Only load completed map metrics by default

### DIFF
--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -474,7 +474,9 @@ class ObservationsTest(TestCase):
                 MapKeyInfo(key="timestamp", default_value=0.0),
             ],
         )
-        observations = observations_from_data(experiment, data)
+        observations = observations_from_data(
+            experiment, data, load_only_completed_map_metrics=False
+        )
 
         self.assertEqual(len(observations), 3)
 

--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -306,6 +306,7 @@ class Adapter(ABC):  # noqa: B024 -- Adapter doesn't have any abstract methods.
             statuses_to_include=self.statuses_to_fit,
             statuses_to_include_map_metric=self.statuses_to_fit_map_metric,
             map_keys_as_parameters=map_keys_as_parameters,
+            load_only_completed_map_metrics=self._fit_only_completed_map_metrics,
         )
 
     def _transform_data(

--- a/ax/modelbridge/map_torch.py
+++ b/ax/modelbridge/map_torch.py
@@ -201,8 +201,10 @@ class MapTorchAdapter(TorchAdapter):
         `self.parameters_with_map_keys` instead of `self.parameters`.
         """
         self.parameters = list(search_space.parameters.keys())
+        print("MAPTORCH parameters", parameters)
         if parameters is None:
             parameters = self.parameters_with_map_keys
+        print("MAPTORCH parameters", parameters)
         super()._fit(
             model=model,
             search_space=search_space,
@@ -265,6 +267,7 @@ class MapTorchAdapter(TorchAdapter):
             statuses_to_include=self.statuses_to_fit,
             statuses_to_include_map_metric=self.statuses_to_fit_map_metric,
             map_keys_as_parameters=True,
+            load_only_completed_map_metrics=False,
         )
 
     def _compute_in_design(


### PR DESCRIPTION
Summary: This commit ensures that the `Adapter`only loads completed map metrics by default. This makes sure that any method (not-necessarily map-data aware) can be applied by default.

Differential Revision: D70012386


