### PR TITLE
Add category to AnalysisCards

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -32,6 +32,14 @@ class AnalysisCardLevel(IntEnum):
     CRITICAL = 40
 
 
+class AnalysisCardCategory(IntEnum):
+    ERROR = 0
+    ACTIONABLE = 1
+    INSIGHT = 2
+    DIAGNOSTIC = 3  # Equivalent to "health check" in online setting
+    INFO = 4
+
+
 class AnalysisCard(Base):
     # Name of the analysis computed, usually the class name of the Analysis which
     # produced the card. Useful for grouping by when querying a large collection of
@@ -44,6 +52,8 @@ class AnalysisCard(Base):
     title: str
     subtitle: str
 
+    # Level of the card with respect to its importance. Higher levels are more
+    # important, and will be displayed first.
     level: int
 
     df: pd.DataFrame  # Raw data produced by the Analysis
@@ -53,6 +63,9 @@ class AnalysisCard(Base):
     # the blob and presenting it to the user (ex. PlotlyAnalysisCard.get_figure()
     # decodes the blob into a go.Figure object).
     blob: str
+    # Type of the card (ex: "insight", "diagnostic"), useful for
+    # grouping the cards to display only one category in notebook environments.
+    category: int
     # How to interpret the blob (ex. "dataframe", "plotly", "markdown")
     blob_annotation = "dataframe"
 
@@ -64,6 +77,7 @@ class AnalysisCard(Base):
         level: int,
         df: pd.DataFrame,
         blob: str,
+        category: int,
         attributes: dict[str, Any] | None = None,
     ) -> None:
         self.name = name
@@ -73,6 +87,7 @@ class AnalysisCard(Base):
         self.df = df
         self.blob = blob
         self.attributes = {} if attributes is None else attributes
+        self.category = category
 
     def _ipython_display_(self) -> None:
         """
@@ -162,6 +177,7 @@ class Analysis(Protocol):
         subtitle: str,
         level: int,
         df: pd.DataFrame,
+        category: int,
     ) -> AnalysisCard:
         """
         Make an AnalysisCard from this Analysis using provided fields and
@@ -175,6 +191,7 @@ class Analysis(Protocol):
             level=level,
             df=df,
             blob=df.to_json(),
+            category=category,
         )
 
     @property

--- a/ax/analysis/healthcheck/can_generate_candidates.py
+++ b/ax/analysis/healthcheck/can_generate_candidates.py
@@ -9,7 +9,7 @@ import json
 from datetime import datetime
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.healthcheck.healthcheck_analysis import (
     HealthcheckAnalysis,
@@ -94,4 +94,5 @@ class CanGenerateCandidatesAnalysis(HealthcheckAnalysis):
                 }
             ),
             level=level,
+            category=AnalysisCardCategory.DIAGNOSTIC,
         )

--- a/ax/analysis/healthcheck/constraints_feasibility.py
+++ b/ax/analysis/healthcheck/constraints_feasibility.py
@@ -9,7 +9,7 @@ import json
 
 import pandas as pd
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.healthcheck.healthcheck_analysis import (
     HealthcheckAnalysis,
@@ -68,6 +68,7 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
         title_status = "Success"
         level = AnalysisCardLevel.LOW
         df = pd.DataFrame({"status": [status]})
+        category = AnalysisCardCategory.DIAGNOSTIC
 
         if experiment is None:
             raise UserInputError(
@@ -83,6 +84,7 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
                 subtitle=subtitle,
                 df=df,
                 level=level,
+                category=category,
             )
 
         if (
@@ -97,6 +99,7 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
                 subtitle=subtitle,
                 df=df,
                 level=level,
+                category=category,
             )
 
         if generation_strategy is None:
@@ -148,6 +151,7 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
             subtitle=subtitle,
             df=df,
             level=level,
+            category=category,
         )
 
 

--- a/ax/analysis/healthcheck/regression_analysis.py
+++ b/ax/analysis/healthcheck/regression_analysis.py
@@ -8,7 +8,7 @@
 import json
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.healthcheck.healthcheck_analysis import (
     HealthcheckAnalysis,
     HealthcheckAnalysisCard,
@@ -105,6 +105,7 @@ class RegressionAnalysis(HealthcheckAnalysis):
             subtitle=subtitle,
             df=df,
             level=AnalysisCardLevel.LOW,
+            category=AnalysisCardCategory.DIAGNOSTIC,
         )
 
 

--- a/ax/analysis/healthcheck/search_space_analysis.py
+++ b/ax/analysis/healthcheck/search_space_analysis.py
@@ -11,7 +11,7 @@ from typing import Union
 import numpy as np
 import pandas as pd
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.healthcheck.healthcheck_analysis import (
     HealthcheckAnalysis,
     HealthcheckAnalysisCard,
@@ -104,6 +104,7 @@ class SearchSpaceAnalysis(HealthcheckAnalysis):
             df=df,
             level=level,
             attributes={"trial_index": self.trial_index},
+            category=AnalysisCardCategory.DIAGNOSTIC,
         )
 
 

--- a/ax/analysis/healthcheck/should_generate_candidates.py
+++ b/ax/analysis/healthcheck/should_generate_candidates.py
@@ -8,7 +8,7 @@
 import json
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.healthcheck.healthcheck_analysis import (
     HealthcheckAnalysis,
@@ -57,4 +57,5 @@ class ShouldGenerateCandidates(HealthcheckAnalysis):
             ),
             level=AnalysisCardLevel.CRITICAL,
             attributes=self.attributes,
+            category=AnalysisCardCategory.DIAGNOSTIC,
         )

--- a/ax/analysis/healthcheck/tests/test_can_generate_candidates.py
+++ b/ax/analysis/healthcheck/tests/test_can_generate_candidates.py
@@ -8,7 +8,7 @@
 from datetime import datetime, timedelta
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.healthcheck.can_generate_candidates import (
     CanGenerateCandidatesAnalysis,
 )
@@ -34,6 +34,7 @@ class TestCanGenerateCandidates(TestCase):
         self.assertEqual(card.title, "Ax Candidate Generation Success")
         self.assertEqual(card.subtitle, "No problems found.")
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
+        self.assertEqual(card.category, AnalysisCardCategory.DIAGNOSTIC)
         pdt.assert_frame_equal(
             card.df,
             pd.DataFrame(

--- a/ax/analysis/healthcheck/tests/test_constraints_feasibility.py
+++ b/ax/analysis/healthcheck/tests/test_constraints_feasibility.py
@@ -10,7 +10,7 @@ import json
 import numpy as np
 import pandas as pd
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.healthcheck.constraints_feasibility import (
     constraints_feasibility,
     ConstraintsFeasibilityAnalysis,
@@ -169,6 +169,7 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
         self.assertEqual(card.name, "ConstraintsFeasibility")
         self.assertEqual(card.title, "Ax Constraints Feasibility Success")
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
+        self.assertEqual(card.category, AnalysisCardCategory.DIAGNOSTIC)
         self.assertEqual(card.subtitle, "All constraints are feasible.")
 
         df_metric_d = pd.DataFrame(

--- a/ax/analysis/healthcheck/tests/test_regression_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_regression_analysis.py
@@ -8,7 +8,7 @@
 
 import numpy as np
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.healthcheck.regression_analysis import RegressionAnalysis
 from ax.core.data import Data
 from ax.utils.common.testutils import TestCase
@@ -42,6 +42,7 @@ class TestRegressionAnalysis(TestCase):
             and "Trial 0" in card.subtitle
         )
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
+        self.assertEqual(card.category, AnalysisCardCategory.DIAGNOSTIC)
 
         df = pd.DataFrame(
             {

--- a/ax/analysis/healthcheck/tests/test_search_space_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_search_space_analysis.py
@@ -7,7 +7,7 @@
 
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.healthcheck.search_space_analysis import (
     boundary_proportions_message,
     search_space_boundary_proportions,
@@ -35,6 +35,7 @@ class TestSearchSpaceAnalysis(TestCase):
         card = ssa.compute(experiment=experiment)
 
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
+        self.assertEqual(card.category, AnalysisCardCategory.DIAGNOSTIC)
         self.assertEqual(card.name, "SearchSpaceAnalysis")
         self.assertEqual(card.title, "Ax Search Space Analysis Warning")
         print(card.subtitle)

--- a/ax/analysis/healthcheck/tests/test_should_generate_candidates.py
+++ b/ax/analysis/healthcheck/tests/test_should_generate_candidates.py
@@ -7,7 +7,7 @@
 
 from random import randint
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckStatus
 from ax.analysis.healthcheck.should_generate_candidates import ShouldGenerateCandidates
 from ax.utils.common.testutils import TestCase
@@ -23,6 +23,7 @@ class TestShouldGenerateCandidates(TestCase):
         ).compute()
         self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
         self.assertEqual(card.level, AnalysisCardLevel.CRITICAL)
+        self.assertEqual(card.category, AnalysisCardCategory.DIAGNOSTIC)
         self.assertEqual(card.subtitle, "Something reassuring")
         self.assertEqual(card.attributes["trial_index"], trial_index)
 
@@ -35,5 +36,6 @@ class TestShouldGenerateCandidates(TestCase):
         ).compute()
         self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
         self.assertEqual(card.level, AnalysisCardLevel.CRITICAL)
+        self.assertEqual(card.category, AnalysisCardCategory.DIAGNOSTIC)
         self.assertEqual(card.subtitle, "Something concerning")
         self.assertEqual(card.attributes["trial_index"], trial_index)

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -9,7 +9,13 @@
 import traceback
 
 import pandas as pd
-from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel, AnalysisE
+from ax.analysis.analysis import (
+    Analysis,
+    AnalysisCard,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+    AnalysisE,
+)
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from IPython.display import display, Markdown
@@ -47,6 +53,7 @@ class MarkdownAnalysis(Analysis):
         level: int,
         df: pd.DataFrame,
         message: str,
+        category: int,
     ) -> MarkdownAnalysisCard:
         """
         Make a MarkdownAnalysisCard from this Analysis using provided fields and
@@ -60,6 +67,7 @@ class MarkdownAnalysis(Analysis):
             level=level,
             df=df,
             blob=message,
+            category=category,
         )
 
 
@@ -80,4 +88,5 @@ def markdown_analysis_card_from_analysis_e(
         ),
         df=pd.DataFrame(),
         level=AnalysisCardLevel.DEBUG,
+        category=AnalysisCardCategory.ERROR,
     )

--- a/ax/analysis/metric_summary.py
+++ b/ax/analysis/metric_summary.py
@@ -5,7 +5,12 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
+from ax.analysis.analysis import (
+    Analysis,
+    AnalysisCard,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
@@ -40,4 +45,5 @@ class MetricSummary(Analysis):
             subtitle="High-level summary of the `Metric`-s in this `Experiment`",
             level=AnalysisCardLevel.MID,
             df=experiment.metric_config_summary_df,
+            category=AnalysisCardCategory.INFO,
         )

--- a/ax/analysis/plotly/arm_effects/insample_effects.py
+++ b/ax/analysis/plotly/arm_effects/insample_effects.py
@@ -9,7 +9,7 @@ from itertools import chain
 from logging import Logger
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.arm_effects.utils import (
     get_predictions_by_arm,
     prepare_arm_effects_plot,
@@ -144,6 +144,7 @@ class InSampleEffectsPlot(PlotlyAnalysis):
             level=level + nudge,
             df=df,
             fig=fig,
+            category=AnalysisCardCategory.INSIGHT,
         )
         return card
 

--- a/ax/analysis/plotly/arm_effects/predicted_effects.py
+++ b/ax/analysis/plotly/arm_effects/predicted_effects.py
@@ -9,7 +9,7 @@ from itertools import chain
 from typing import Any
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.arm_effects.utils import (
     get_predictions_by_arm,
@@ -144,6 +144,7 @@ class PredictedEffectsPlot(PlotlyAnalysis):
             level=level + nudge,
             df=df,
             fig=fig,
+            category=AnalysisCardCategory.ACTIONABLE,
         )
 
 

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -7,7 +7,7 @@
 
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
 from ax.analysis.plotly.utils import select_metric
@@ -124,6 +124,7 @@ class CrossValidationPlot(PlotlyAnalysis):
             level=AnalysisCardLevel.LOW.value + nudge,
             df=df,
             fig=fig,
+            category=AnalysisCardCategory.INSIGHT,
         )
 
 

--- a/ax/analysis/plotly/interaction.py
+++ b/ax/analysis/plotly/interaction.py
@@ -10,7 +10,7 @@ from logging import Logger
 
 import pandas as pd
 import torch
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
 
@@ -259,6 +259,7 @@ class InteractionPlot(PlotlyAnalysis):
             level=AnalysisCardLevel.MID,
             df=sensitivity_df,
             fig=fig,
+            category=AnalysisCardCategory.INSIGHT,
         )
 
     def _get_oak_model(self, experiment: Experiment, metric_name: str) -> TorchAdapter:

--- a/ax/analysis/plotly/parallel_coordinates.py
+++ b/ax/analysis/plotly/parallel_coordinates.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
 from ax.analysis.plotly.utils import select_metric
@@ -61,6 +61,7 @@ class ParallelCoordinatesPlot(PlotlyAnalysis):
             level=AnalysisCardLevel.HIGH,
             df=df,
             fig=fig,
+            category=AnalysisCardCategory.INSIGHT,
         )
 
 

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -47,6 +47,7 @@ class PlotlyAnalysis(Analysis):
         level: int,
         df: pd.DataFrame,
         fig: go.Figure,
+        category: int,
     ) -> PlotlyAnalysisCard:
         """
         Make a PlotlyAnalysisCard from this Analysis using provided fields and
@@ -60,4 +61,5 @@ class PlotlyAnalysis(Analysis):
             level=level,
             df=df,
             blob=pio.to_json(fig),
+            category=category,
         )

--- a/ax/analysis/plotly/progression.py
+++ b/ax/analysis/plotly/progression.py
@@ -8,7 +8,7 @@ from logging import Logger
 
 import numpy as np
 import plotly.express as px
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
 from ax.analysis.plotly.utils import select_metric
@@ -133,6 +133,7 @@ class ProgressionPlot(PlotlyAnalysis):
             level=AnalysisCardLevel.MID,
             df=df,
             fig=fig,
+            category=AnalysisCardCategory.INSIGHT,
         )
 
 

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -7,7 +7,7 @@
 
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
 from ax.core.experiment import Experiment
@@ -75,6 +75,7 @@ class ScatterPlot(PlotlyAnalysis):
             level=AnalysisCardLevel.HIGH,
             df=df,
             fig=fig,
+            category=AnalysisCardCategory.INSIGHT,
         )
 
 

--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -8,7 +8,7 @@
 import math
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
 from ax.analysis.plotly.surface.utils import (
@@ -106,6 +106,7 @@ class ContourPlot(PlotlyAnalysis):
             level=AnalysisCardLevel.LOW,
             df=df,
             fig=fig,
+            category=AnalysisCardCategory.INSIGHT,
         )
 
 

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -8,7 +8,7 @@
 import math
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
 from ax.analysis.plotly.surface.utils import (
@@ -93,6 +93,7 @@ class SlicePlot(PlotlyAnalysis):
             level=AnalysisCardLevel.LOW,
             df=df,
             fig=fig,
+            category=AnalysisCardCategory.INSIGHT,
         )
 
 

--- a/ax/analysis/plotly/surface/tests/test_contour.py
+++ b/ax/analysis/plotly/surface/tests/test_contour.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.surface.contour import ContourPlot
 from ax.exceptions.core import UserInputError
 from ax.service.ax_client import AxClient, ObjectiveProperties
@@ -71,6 +71,7 @@ class TestContourPlot(TestCase):
             "2D contour of the surrogate model's predicted outcomes for bar",
         )
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
+        self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
         self.assertEqual(
             {*card.df.columns},
             {

--- a/ax/analysis/plotly/surface/tests/test_slice.py
+++ b/ax/analysis/plotly/surface/tests/test_slice.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.surface.slice import SlicePlot
 from ax.exceptions.core import UserInputError
 from ax.service.ax_client import AxClient, ObjectiveProperties
@@ -61,6 +61,7 @@ class TestSlicePlot(TestCase):
             "1D slice of the surrogate model's predicted outcomes for bar",
         )
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
+        self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
         self.assertEqual(
             {*card.df.columns},
             {

--- a/ax/analysis/plotly/tests/test_cross_validation.py
+++ b/ax/analysis/plotly/tests/test_cross_validation.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.cross_validation import CrossValidationPlot
 from ax.core.trial import Trial
 from ax.exceptions.core import UserInputError
@@ -57,6 +57,7 @@ class TestCrossValidationPlot(TestCase):
             "Out-of-sample predictions using leave-one-out CV",
         )
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
+        self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
         self.assertEqual(
             {*card.df.columns},
             {"arm_name", "observed", "observed_sem", "predicted", "predicted_sem"},

--- a/ax/analysis/plotly/tests/test_insample_effects.py
+++ b/ax/analysis/plotly/tests/test_insample_effects.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import torch
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.arm_effects.insample_effects import InSampleEffectsPlot
 from ax.analysis.plotly.arm_effects.utils import get_predictions_by_arm
 from ax.exceptions.core import DataRequiredError, UserInputError
@@ -134,6 +134,7 @@ class TestInsampleEffectsPlot(TestCase):
         )
         # +2 because it's on objective, +1 because it's modeled
         self.assertEqual(card.level, AnalysisCardLevel.MID + 3)
+        self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
 
     def test_compute_modeled_can_use_ebts_for_no_gs(self) -> None:
         # GIVEN an experiment with a trial with data

--- a/ax/analysis/plotly/tests/test_interaction.py
+++ b/ax/analysis/plotly/tests/test_interaction.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.interaction import InteractionPlot
 from ax.exceptions.core import UserInputError
 from ax.service.ax_client import AxClient, ObjectiveProperties
@@ -72,6 +72,7 @@ class TestInteractionPlot(TestCase):
             "slice or contour plots",
         )
         self.assertEqual(card.level, AnalysisCardLevel.MID)
+        self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
         self.assertEqual(
             {*card.df.columns},
             {"feature", "sensitivity"},

--- a/ax/analysis/plotly/tests/test_parallel_coordinates.py
+++ b/ax/analysis/plotly/tests/test_parallel_coordinates.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.parallel_coordinates import (
     _get_parameter_dimension,
     ParallelCoordinatesPlot,
@@ -37,6 +37,7 @@ class TestParallelCoordinatesPlot(TestCase):
             "View arm parameterizations with their respective metric values",
         )
         self.assertEqual(card.level, AnalysisCardLevel.HIGH)
+        self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
         self.assertEqual({*card.df.columns}, {"arm_name", "branin", "x1", "x2"})
         self.assertIsNotNone(card.blob)
         self.assertEqual(card.blob_annotation, "plotly")

--- a/ax/analysis/plotly/tests/test_predicted_effects.py
+++ b/ax/analysis/plotly/tests/test_predicted_effects.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import torch
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.arm_effects.predicted_effects import PredictedEffectsPlot
 from ax.analysis.plotly.arm_effects.utils import get_predictions_by_arm
 from ax.core.observation import ObservationFeatures
@@ -126,6 +126,7 @@ class TestPredictedEffectsPlot(TestCase):
                         )
                     ),
                 )
+                self.assertEqual(card.category, AnalysisCardCategory.ACTIONABLE)
                 # AND THEN it has the right rows and columns in the dataframe
                 self.assertEqual(
                     {*card.df.columns},

--- a/ax/analysis/plotly/tests/test_progression.py
+++ b/ax/analysis/plotly/tests/test_progression.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.progression import (
     _calculate_wallclock_timeseries,
     ProgressionPlot,
@@ -36,6 +36,7 @@ class TestProgression(TestCase):
             "Observe how the metric changes as each trial progresses",
         )
         self.assertEqual(card.level, AnalysisCardLevel.MID)
+        self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
         self.assertEqual(
             {*card.df.columns},
             {"trial_index", "arm_name", "branin_map", "progression", "wallclock_time"},

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.scatter import _prepare_data, ScatterPlot
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.modelbridge.registry import Generators
@@ -38,6 +38,7 @@ class TestScatterPlot(TestCase):
             "Compare arms by their observed metric values",
         )
         self.assertEqual(card.level, AnalysisCardLevel.HIGH)
+        self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
         self.assertEqual(
             {*card.df.columns},
             {"arm_name", "trial_index", "branin_a", "branin_b", "is_optimal"},

--- a/ax/analysis/search_space_summary.py
+++ b/ax/analysis/search_space_summary.py
@@ -5,7 +5,12 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
+from ax.analysis.analysis import (
+    Analysis,
+    AnalysisCard,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
@@ -41,4 +46,5 @@ class SearchSpaceSummary(Analysis):
             subtitle="High-level summary of the `Parameter`-s in this `Experiment`",
             level=AnalysisCardLevel.MID,
             df=experiment.search_space.summary_df,
+            category=AnalysisCardCategory.INFO,
         )

--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -5,7 +5,12 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel
+from ax.analysis.analysis import (
+    Analysis,
+    AnalysisCard,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
@@ -45,4 +50,5 @@ class Summary(Analysis):
             subtitle="High-level summary of the `Trial`-s in this `Experiment`",
             level=AnalysisCardLevel.MID,
             df=experiment.to_df(omit_empty_columns=self.omit_empty_columns),
+            category=AnalysisCardCategory.INFO,
         )

--- a/ax/analysis/tests/test_metric_summary.py
+++ b/ax/analysis/tests/test_metric_summary.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.metric_summary import MetricSummary
 from ax.core.metric import Metric
 from ax.exceptions.core import UserInputError
@@ -48,6 +48,7 @@ class TestMetricSummary(TestCase):
             "High-level summary of the `Metric`-s in this `Experiment`",
         )
         self.assertEqual(card.level, AnalysisCardLevel.MID)
+        self.assertEqual(card.category, AnalysisCardCategory.INFO)
         self.assertIsNotNone(card.blob)
         self.assertEqual(card.blob_annotation, "dataframe")
 

--- a/ax/analysis/tests/test_search_space_summary.py
+++ b/ax/analysis/tests/test_search_space_summary.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.search_space_summary import SearchSpaceSummary
 from ax.exceptions.core import UserInputError
 from ax.preview.api.client import Client
@@ -58,6 +58,7 @@ class TestSearchSpaceSummary(TestCase):
             "High-level summary of the `Parameter`-s in this `Experiment`",
         )
         self.assertEqual(card.level, AnalysisCardLevel.MID)
+        self.assertEqual(card.category, AnalysisCardCategory.INFO)
         self.assertIsNotNone(card.blob)
         self.assertEqual(card.blob_annotation, "dataframe")
 

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.summary import Summary
 from ax.core.trial import Trial
 from ax.exceptions.core import UserInputError
@@ -60,6 +60,7 @@ class TestSummary(TestCase):
             "High-level summary of the `Trial`-s in this `Experiment`",
         )
         self.assertEqual(card.level, AnalysisCardLevel.MID)
+        self.assertEqual(card.category, AnalysisCardCategory.INFO)
         self.assertIsNotNone(card.blob)
         self.assertEqual(card.blob_annotation, "dataframe")
 

--- a/ax/service/utils/analysis_base.py
+++ b/ax/service/utils/analysis_base.py
@@ -9,7 +9,13 @@ from collections.abc import Iterable
 
 import pandas as pd
 
-from ax.analysis.analysis import Analysis, AnalysisCard, AnalysisCardLevel, AnalysisE
+from ax.analysis.analysis import (
+    Analysis,
+    AnalysisCard,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+    AnalysisE,
+)
 from ax.analysis.markdown.markdown_analysis import MarkdownAnalysisCard
 from ax.analysis.plotly.parallel_coordinates import ParallelCoordinatesPlot
 from ax.core.experiment import Experiment
@@ -89,6 +95,7 @@ class AnalysisBase(WithDBSettingsBase):
                         blob=traceback_str,
                         df=pd.DataFrame(),
                         level=AnalysisCardLevel.DEBUG,
+                        category=AnalysisCardCategory.ERROR,
                     )
                 )
 

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1061,6 +1061,7 @@ class Decoder:
                 if analysis_card_sqa.attributes == ""
                 else json.loads(analysis_card_sqa.attributes)
             ),
+            category=analysis_card_sqa.category,
         )
         card.db_id = analysis_card_sqa.id
         return card

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -1103,4 +1103,5 @@ class Encoder:
             time_created=timestamp,
             experiment_id=experiment_id,
             attributes=json.dumps(analysis_card.attributes),
+            category=analysis_card.category,
         )

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -351,6 +351,7 @@ class SQAAnalysisCard(Base):
         Integer, ForeignKey("experiment_v2.id"), nullable=False
     )
     attributes: Column[str] = Column(Text(LONGTEXT_BYTES), nullable=False)
+    category: Column[int] = Column(Integer, nullable=False)
 
 
 class SQAExperiment(Base):

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -17,7 +17,7 @@ from unittest import mock
 from unittest.mock import MagicMock, Mock, patch
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCard, AnalysisCardLevel
+from ax.analysis.analysis import AnalysisCard, AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.markdown.markdown_analysis import MarkdownAnalysisCard
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
 from ax.core.arm import Arm
@@ -2209,6 +2209,7 @@ class SQAStoreTest(TestCase):
             df=test_df,
             blob="test blob",
             attributes={"foo": "bar"},
+            category=AnalysisCardCategory.DIAGNOSTIC,
         )
         markdown_analysis_card = MarkdownAnalysisCard(
             name="test_markdown_analysis_card",
@@ -2218,6 +2219,7 @@ class SQAStoreTest(TestCase):
             df=test_df,
             blob="This is some **really cool** markdown",
             attributes={"foo": "baz"},
+            category=AnalysisCardCategory.DIAGNOSTIC,
         )
         plotly_analysis_card = PlotlyAnalysisCard(
             name="test_plotly_analysis_card",
@@ -2227,6 +2229,7 @@ class SQAStoreTest(TestCase):
             df=test_df,
             blob=pio.to_json(go.Figure()),
             attributes={"foo": "bad"},
+            category=AnalysisCardCategory.DIAGNOSTIC,
         )
         with self.subTest("test_save_analysis_cards"):
             save_experiment(self.experiment)


### PR DESCRIPTION
Summary:
We've had a few instances come up in meetings last week that I think will make having a category useful:
1. Allow us to group similar analysis together in the UI so everything isn't shown in one tab
2. Allow for easy grouping of analysis in bento notebooks

Additionally, as I was implementing this, there is a TODO on base_client to find a good hueristic for which analysis to show, I think implementing that hueristic will be much easier with category.

I think this is useful enough to warrant the addition because it is distinct from level- which indicates importance - and category should still be ranked by level.

Reviewed By: mpolson64, Cesar-Cardoso

Differential Revision: D69726341
