### PR TITLE
Changes to Adapter constructors, require experiment

### DIFF
--- a/ax/benchmark/problems/surrogate/lcbench/transfer_learning.py
+++ b/ax/benchmark/problems/surrogate/lcbench/transfer_learning.py
@@ -7,7 +7,6 @@
 
 import os
 from collections.abc import Mapping
-
 from typing import Any
 
 import torch
@@ -23,6 +22,7 @@ from ax.exceptions.core import UserInputError
 from ax.modelbridge.registry import Cont_X_trans, Generators, Y_trans
 from ax.modelbridge.torch import TorchAdapter
 from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
+from ax.models.torch.botorch_modular.model import BoTorchGenerator
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.utils.testing.mock import skip_fit_gpytorch_mll_context_manager
 from botorch.models import SingleTaskGP
@@ -133,7 +133,9 @@ def get_lcbench_benchmark_problem(
                 data=obj["data"],
                 transforms=Cont_X_trans + Y_trans,
             )
-        mb.model.surrogate.model.load_state_dict(obj["state_dict"])
+        assert_is_instance(mb.model, BoTorchGenerator).surrogate.model.load_state_dict(
+            obj["state_dict"]
+        )
         return assert_is_instance(mb, TorchAdapter)
 
     name = f"LCBench_Surrogate_{dataset_name}:v1"

--- a/ax/generation_strategy/tests/test_dispatch_utils.py
+++ b/ax/generation_strategy/tests/test_dispatch_utils.py
@@ -22,6 +22,7 @@ from ax.generation_strategy.dispatch_utils import (
 from ax.modelbridge.registry import Generators, MBM_X_trans, Mixed_transforms, Y_trans
 from ax.modelbridge.transforms.log_y import LogY
 from ax.modelbridge.transforms.winsorize import Winsorize
+from ax.models.random.sobol import SobolGenerator
 from ax.models.winsorization_config import WinsorizationConfig
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -35,7 +36,7 @@ from ax.utils.testing.core_stubs import (
     run_branin_experiment_with_generation_strategy,
 )
 from ax.utils.testing.mock import mock_botorch_optimize
-from pyre_extensions import none_throws
+from pyre_extensions import assert_is_instance, none_throws
 
 
 class TestDispatchUtils(TestCase):
@@ -406,7 +407,9 @@ class TestDispatchUtils(TestCase):
         )
         sobol.gen(experiment=get_experiment(), n=1)
         # First model is actually a bridge, second is the Sobol engine.
-        self.assertEqual(none_throws(sobol.model).model.seed, 9)
+        self.assertEqual(
+            assert_is_instance(none_throws(sobol.model).model, SobolGenerator).seed, 9
+        )
 
         with self.subTest("warns if use_saasbo is true"):
             with self.assertLogs(

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -580,10 +580,13 @@ class TestGenerationStrategy(TestCase):
                 )
                 ms = none_throws(g._model_state_after_gen).copy()
                 # Compare the model state to Sobol state.
-                sobol_model = none_throws(gs.model).model
+                sobol_model = assert_is_instance(
+                    none_throws(gs.model).model, SobolGenerator
+                )
                 self.assertTrue(
                     np.array_equal(
-                        ms.pop("generated_points"), sobol_model.generated_points
+                        ms.pop("generated_points"),
+                        none_throws(sobol_model.generated_points),
                     )
                 )
                 # Replace expected seed with the one generated in __init__.
@@ -714,9 +717,9 @@ class TestGenerationStrategy(TestCase):
         """Checks that generation strategy works with custom factory functions.
         No information about the model should be saved on generator run."""
 
-        def get_sobol(search_space: SearchSpace) -> RandomAdapter:
+        def get_sobol(experiment: Experiment) -> RandomAdapter:
             return RandomAdapter(
-                search_space=search_space,
+                experiment=experiment,
                 model=SobolGenerator(),
                 transforms=Cont_X_trans,
             )
@@ -1551,10 +1554,13 @@ class TestGenerationStrategy(TestCase):
                 )
                 ms = none_throws(g._model_state_after_gen).copy()
                 # Compare the model state to Sobol state.
-                sobol_model = none_throws(self.sobol_MBM_GS_nodes.model).model
+                sobol_model = assert_is_instance(
+                    none_throws(self.sobol_MBM_GS_nodes.model).model, SobolGenerator
+                )
                 self.assertTrue(
                     np.array_equal(
-                        ms.pop("generated_points"), sobol_model.generated_points
+                        ms.pop("generated_points"),
+                        none_throws(sobol_model.generated_points),
                     )
                 )
                 # Replace expected seed with the one generated in __init__.

--- a/ax/modelbridge/discrete.py
+++ b/ax/modelbridge/discrete.py
@@ -7,6 +7,10 @@
 # pyre-strict
 
 
+from typing import Mapping, Sequence
+
+from ax.core.data import Data
+from ax.core.experiment import Experiment
 from ax.core.observation import (
     Observation,
     ObservationData,
@@ -28,6 +32,7 @@ from ax.modelbridge.torch import (
     extract_outcome_constraints,
     validate_transformed_optimization_config,
 )
+from ax.modelbridge.transforms.base import Transform
 from ax.models.discrete_base import DiscreteGenerator
 from ax.models.types import TConfig
 
@@ -38,25 +43,56 @@ FIT_MODEL_ERROR = "Model must be fit before {action}."
 class DiscreteAdapter(Adapter):
     """A model bridge for using models based on discrete parameters.
 
-    Requires that all parameters have been transformed to ChoiceParameters.
+    Requires that all parameters to have been transformed to ChoiceParameters.
     """
 
-    # pyre-fixme[13]: Attribute `model` is never initialized.
-    model: DiscreteGenerator
-    # pyre-fixme[13]: Attribute `outcomes` is never initialized.
-    outcomes: list[str]
-    # pyre-fixme[13]: Attribute `parameters` is never initialized.
-    parameters: list[str]
-    # pyre-fixme[13]: Attribute `search_space` is never initialized.
-    search_space: SearchSpace | None
+    def __init__(
+        self,
+        *,
+        experiment: Experiment,
+        model: DiscreteGenerator,
+        search_space: SearchSpace | None = None,
+        data: Data | None = None,
+        transforms: Sequence[type[Transform]] | None = None,
+        transform_configs: Mapping[str, TConfig] | None = None,
+        status_quo_name: str | None = None,
+        status_quo_features: ObservationFeatures | None = None,
+        optimization_config: OptimizationConfig | None = None,
+        expand_model_space: bool = True,
+        fit_out_of_design: bool = False,
+        fit_abandoned: bool = False,
+        fit_tracking_metrics: bool = True,
+        fit_on_init: bool = True,
+        fit_only_completed_map_metrics: bool = True,
+    ) -> None:
+        # These are set in _fit.
+        self.parameters: list[str] = []
+        self.outcomes: list[str] = []
+        super().__init__(
+            experiment=experiment,
+            model=model,
+            search_space=search_space,
+            data=data,
+            transforms=transforms,
+            transform_configs=transform_configs,
+            status_quo_name=status_quo_name,
+            status_quo_features=status_quo_features,
+            optimization_config=optimization_config,
+            expand_model_space=expand_model_space,
+            fit_out_of_design=fit_out_of_design,
+            fit_abandoned=fit_abandoned,
+            fit_tracking_metrics=fit_tracking_metrics,
+            fit_on_init=fit_on_init,
+            fit_only_completed_map_metrics=fit_only_completed_map_metrics,
+        )
+        # Re-assing for more precise typing.
+        self.model: DiscreteGenerator = model
 
     def _fit(
         self,
-        model: DiscreteGenerator,
         search_space: SearchSpace,
         observations: list[Observation],
     ) -> None:
-        self.model = model
         # Convert observations to arrays
         self.parameters = list(search_space.parameters.keys())
         all_metric_names: set[str] = set()

--- a/ax/modelbridge/factory.py
+++ b/ax/modelbridge/factory.py
@@ -74,7 +74,7 @@ def get_sobol(
     """
     return assert_is_instance(
         Generators.SOBOL(
-            search_space=search_space,
+            experiment=Experiment(search_space=search_space),
             seed=seed,
             deduplicate=deduplicate,
             init_position=init_position,
@@ -99,7 +99,9 @@ def get_uniform(
     """
     return assert_is_instance(
         Generators.UNIFORM(
-            search_space=search_space, seed=seed, deduplicate=deduplicate
+            experiment=Experiment(search_space=search_space),
+            seed=seed,
+            deduplicate=deduplicate,
         ),
         RandomAdapter,
     )

--- a/ax/modelbridge/pairwise.py
+++ b/ax/modelbridge/pairwise.py
@@ -45,7 +45,7 @@ class PairwiseAdapter(TorchAdapter):
         (
             Xs,
             Ys,
-            Yvars,
+            _,  # Yvars is not used here.
             candidate_metadata_dict,
             any_candidate_metadata_is_not_none,
             trial_indices,

--- a/ax/modelbridge/tests/test_discrete_modelbridge.py
+++ b/ax/modelbridge/tests/test_discrete_modelbridge.py
@@ -74,14 +74,15 @@ class DiscreteAdapterTest(TestCase):
         self.model_gen_options = {"option": "yes"}
 
     @mock.patch("ax.modelbridge.discrete.DiscreteAdapter.__init__", return_value=None)
-    def test_fit(self, mock_init: Mock) -> None:
+    def test_fit(self, _: Mock) -> None:
         # pyre-fixme[20]: Argument `model` expected.
-        ma = DiscreteAdapter()
-        ma._training_data = self.observations
+        adapter = DiscreteAdapter()
+        adapter._training_data = self.observations
         model = mock.create_autospec(DiscreteGenerator, instance=True)
-        ma._fit(model, self.search_space, self.observations)
-        self.assertEqual(ma.parameters, ["x", "y", "z"])
-        self.assertEqual(sorted(ma.outcomes), ["a", "b"])
+        adapter.model = model
+        adapter._fit(self.search_space, self.observations)
+        self.assertEqual(adapter.parameters, ["x", "y", "z"])
+        self.assertEqual(sorted(adapter.outcomes), ["a", "b"])
         Xs = {
             "a": [[0, "foo", True], [1, "foo", True], [1, "bar", True]],
             "b": [[0, "foo", True], [1, "foo", True]],
@@ -91,23 +92,23 @@ class DiscreteAdapterTest(TestCase):
         parameter_values = [[0.0, 1.0], ["foo", "bar"], [True]]
         model_fit_args = model.fit.mock_calls[0][2]
         for i, x in enumerate(model_fit_args["Xs"]):
-            self.assertEqual(x, Xs[ma.outcomes[i]])
+            self.assertEqual(x, Xs[adapter.outcomes[i]])
         for i, y in enumerate(model_fit_args["Ys"]):
-            self.assertEqual(y, Ys[ma.outcomes[i]])
+            self.assertEqual(y, Ys[adapter.outcomes[i]])
         for i, v in enumerate(model_fit_args["Yvars"]):
-            self.assertEqual(v, Yvars[ma.outcomes[i]])
+            self.assertEqual(v, Yvars[adapter.outcomes[i]])
         self.assertEqual(model_fit_args["parameter_values"], parameter_values)
 
         sq_obs = Observation(
             features=ObservationFeatures({}), data=self.observation_data[0]
         )
         with self.assertRaises(ValueError):
-            ma._fit(model, self.search_space, self.observations + [sq_obs])
+            adapter._fit(self.search_space, self.observations + [sq_obs])
 
     @mock.patch("ax.modelbridge.discrete.DiscreteAdapter.__init__", return_value=None)
     def test_predict(self, mock_init: Mock) -> None:
         # pyre-fixme[20]: Argument `model` expected.
-        ma = DiscreteAdapter()
+        adapter = DiscreteAdapter()
         model = mock.MagicMock(DiscreteGenerator, autospec=True, instance=True)
         model.predict.return_value = (
             np.array([[1.0, -1], [2.0, -2]]),
@@ -115,10 +116,10 @@ class DiscreteAdapterTest(TestCase):
                 (np.array([[1.0, 4.0], [4.0, 6]]), np.array([[2.0, 5.0], [5.0, 7]]))
             ),
         )
-        ma.model = model
-        ma.parameters = ["x", "y", "z"]
-        ma.outcomes = ["a", "b"]
-        observation_data = ma._predict(self.observation_features)
+        adapter.model = model
+        adapter.parameters = ["x", "y", "z"]
+        adapter.outcomes = ["a", "b"]
+        observation_data = adapter._predict(self.observation_features)
         X = [[0, "foo", True], [1, "foo", True], [1, "bar", True]]
         self.assertTrue(model.predict.mock_calls[0][2]["X"], X)
         for i, od in enumerate(observation_data):
@@ -134,11 +135,11 @@ class DiscreteAdapterTest(TestCase):
             ],
         )
         # pyre-fixme[20]: Argument `model` expected.
-        ma = DiscreteAdapter()
+        adapter = DiscreteAdapter()
         # Test validation.
         with self.assertRaisesRegex(UserInputError, "positive integer or -1."):
-            ma._validate_gen_inputs(n=0)
-        ma._validate_gen_inputs(n=-1)
+            adapter._validate_gen_inputs(n=0)
+        adapter._validate_gen_inputs(n=-1)
         # Test rest of gen.
         model = mock.MagicMock(DiscreteGenerator, autospec=True, instance=True)
         best_x = [0.0, 2.0, 1.0]
@@ -147,10 +148,10 @@ class DiscreteAdapterTest(TestCase):
             [1.0, 2.0],
             {"best_x": best_x},
         )
-        ma.model = model
-        ma.parameters = ["x", "y", "z"]
-        ma.outcomes = ["a", "b"]
-        gen_results = ma._gen(
+        adapter.model = model
+        adapter.parameters = ["x", "y", "z"]
+        adapter.outcomes = ["a", "b"]
+        gen_results = adapter._gen(
             n=3,
             search_space=self.search_space,
             optimization_config=optimization_config,
@@ -189,14 +190,14 @@ class DiscreteAdapterTest(TestCase):
         self.assertEqual(gen_results.weights, [1.0, 2.0])
         self.assertEqual(
             gen_results.best_observation_features,
-            ObservationFeatures(parameters=dict(zip(ma.parameters, best_x))),
+            ObservationFeatures(parameters=dict(zip(adapter.parameters, best_x))),
         )
 
         # Test with no constraints, no fixed feature, no pending observations
         search_space = SearchSpace(self.parameters[:2])
         optimization_config.outcome_constraints = []
-        ma.parameters = ["x", "y"]
-        ma._gen(
+        adapter.parameters = ["x", "y"]
+        adapter._gen(
             n=3,
             search_space=search_space,
             optimization_config=optimization_config,
@@ -217,7 +218,7 @@ class DiscreteAdapterTest(TestCase):
             ],
         )
         with self.assertRaises(ValueError):
-            ma._gen(
+            adapter._gen(
                 n=3,
                 search_space=search_space,
                 optimization_config=optimization_config,
@@ -229,7 +230,7 @@ class DiscreteAdapterTest(TestCase):
     @mock.patch("ax.modelbridge.discrete.DiscreteAdapter.__init__", return_value=None)
     def test_cross_validate(self, mock_init: Mock) -> None:
         # pyre-fixme[20]: Argument `model` expected.
-        ma = DiscreteAdapter()
+        adapter = DiscreteAdapter()
         model = mock.MagicMock(DiscreteGenerator, autospec=True, instance=True)
         model.cross_validate.return_value = (
             np.array([[1.0, -1], [2.0, -2]]),
@@ -237,10 +238,10 @@ class DiscreteAdapterTest(TestCase):
                 (np.array([[1.0, 4.0], [4.0, 6]]), np.array([[2.0, 5.0], [5.0, 7]]))
             ),
         )
-        ma.model = model
-        ma.parameters = ["x", "y", "z"]
-        ma.outcomes = ["a", "b"]
-        observation_data = ma._cross_validate(
+        adapter.model = model
+        adapter.parameters = ["x", "y", "z"]
+        adapter.outcomes = ["a", "b"]
+        observation_data = adapter._cross_validate(
             search_space=self.search_space,
             cv_training_data=self.observations,
             cv_test_points=self.observation_features,

--- a/ax/modelbridge/tests/test_factory.py
+++ b/ax/modelbridge/tests/test_factory.py
@@ -6,6 +6,11 @@
 
 # pyre-strict
 
+from ax.core.experiment import Experiment
+from ax.core.optimization_config import (
+    MultiObjectiveOptimizationConfig,
+    OptimizationConfig,
+)
 from ax.core.outcome_constraint import ComparisonOp, ObjectiveThreshold
 from ax.modelbridge.discrete import DiscreteAdapter
 from ax.modelbridge.factory import (
@@ -24,13 +29,12 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment_with_multi_objective,
     get_factorial_experiment,
 )
+from pyre_extensions import assert_is_instance, none_throws
 
 
-# pyre-fixme[3]: Return type must be annotated.
-def get_multi_obj_exp_and_opt_config():
+def get_multi_obj_exp_and_opt_config() -> tuple[Experiment, OptimizationConfig]:
     multi_obj_exp = get_branin_experiment_with_multi_objective(with_batch=True)
-    # pyre-fixme[16]: Optional type has no attribute `objective`.
-    metrics = multi_obj_exp.optimization_config.objective.metrics
+    metrics = none_throws(multi_obj_exp.optimization_config).objective.metrics
     multi_objective_thresholds = [
         ObjectiveThreshold(
             metric=metrics[0], bound=5.0, relative=False, op=ComparisonOp.LEQ
@@ -39,14 +43,13 @@ def get_multi_obj_exp_and_opt_config():
             metric=metrics[1], bound=10.0, relative=False, op=ComparisonOp.LEQ
         ),
     ]
-    # pyre-fixme[16]: Optional type has no attribute `clone_with_args`.
-    optimization_config = multi_obj_exp.optimization_config.clone_with_args(
-        objective_thresholds=multi_objective_thresholds
-    )
+    optimization_config = assert_is_instance(
+        multi_obj_exp.optimization_config, MultiObjectiveOptimizationConfig
+    ).clone_with_args(objective_thresholds=multi_objective_thresholds)
     return multi_obj_exp, optimization_config
 
 
-class AdapterFactoryTestSingleObjective(TestCase):
+class TestAdapterFactorySingleObjective(TestCase):
     def test_model_kwargs(self) -> None:
         """Tests that model kwargs are passed correctly."""
         exp = get_branin_experiment()

--- a/ax/modelbridge/tests/test_hierarchical_search_space.py
+++ b/ax/modelbridge/tests/test_hierarchical_search_space.py
@@ -152,7 +152,7 @@ class TestHierarchicalSearchSpace(TestCase):
             runner=SyntheticRunner(),
         )
 
-        sobol = Generators.SOBOL(search_space=hss)
+        sobol = Generators.SOBOL(experiment=experiment)
         for _ in range(num_sobol_trials):
             trial = experiment.new_trial(generator_run=sobol.gen(n=1))
             trial.run().mark_completed()

--- a/ax/modelbridge/tests/test_model_fit_metrics.py
+++ b/ax/modelbridge/tests/test_model_fit_metrics.py
@@ -153,7 +153,7 @@ class TestGetFitAndStdQualityAndGeneralizationDict(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.experiment = get_branin_experiment()
-        self.sobol = Generators.SOBOL(search_space=self.experiment.search_space)
+        self.sobol = Generators.SOBOL(experiment=self.experiment)
 
     def test_it_returns_empty_data_for_sobol(self) -> None:
         results = get_fit_and_std_quality_and_generalization_dict(

--- a/ax/modelbridge/tests/test_torch_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_modelbridge.py
@@ -67,8 +67,6 @@ def _get_modelbridge_from_experiment(
 ) -> TorchAdapter:
     return TorchAdapter(
         experiment=experiment,
-        search_space=experiment.search_space,
-        data=experiment.lookup_data(),
         model=BoTorchGenerator(),
         transforms=transforms or [],
         torch_device=device,
@@ -84,13 +82,13 @@ class TorchAdapterTest(TestCase):
             min=0.0, max=5.0, parameter_names=feature_names
         )
         experiment = Experiment(search_space=search_space, name="test")
-        model_bridge = _get_modelbridge_from_experiment(
+        adapter = _get_modelbridge_from_experiment(
             experiment=experiment,
             device=device,
             fit_on_init=False,
         )
-        self.assertEqual(model_bridge.device, device)
-        self.assertIsNone(model_bridge._last_observations)
+        self.assertEqual(adapter.device, device)
+        self.assertIsNone(adapter._last_observations)
         tkwargs: dict[str, Any] = {"dtype": torch.double, "device": device}
         # Test `_fit`.
         X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **tkwargs)
@@ -129,12 +127,10 @@ class TorchAdapterTest(TestCase):
         ]
         observations = recombine_observations(observation_features, observation_data)
 
-        model = BoTorchGenerator()
+        model = adapter.model
         with mock.patch.object(model, "fit", wraps=model.fit) as mock_fit:
-            model_bridge._fit(
-                model=model, search_space=search_space, observations=observations
-            )
-        model_fit_args = mock_fit.mock_calls[0][2]
+            adapter._fit(search_space=search_space, observations=observations)
+        model_fit_args = mock_fit.call_args.kwargs
         self.assertEqual(model_fit_args["datasets"], list(datasets.values()))
 
         expected_ssd = SearchSpaceDigest(
@@ -142,14 +138,10 @@ class TorchAdapterTest(TestCase):
         )
         self.assertEqual(model_fit_args["search_space_digest"], expected_ssd)
         self.assertIsNone(model_fit_args["candidate_metadata"])
-        self.assertEqual(model_bridge._last_observations, observations)
+        self.assertEqual(adapter._last_observations, observations)
 
         with mock.patch(f"{TorchAdapter.__module__}.logger.debug") as mock_logger:
-            model_bridge._fit(
-                model=model,
-                search_space=search_space,
-                observations=observations,
-            )
+            adapter._fit(search_space=search_space, observations=observations)
         mock_logger.assert_called_once_with(
             "The observations are identical to the last set of observations "
             "used to fit the model. Skipping model fitting."
@@ -170,7 +162,7 @@ class TorchAdapterTest(TestCase):
         with mock.patch.object(
             model, "predict", return_value=predict_return_value
         ) as mock_predict:
-            pr_obs_data = model_bridge._predict(
+            pr_obs_data = adapter._predict(
                 observation_features=observation_features[:1]
             )
         self.assertTrue(torch.equal(mock_predict.mock_calls[0][2]["X"], X[:1]))
@@ -209,7 +201,7 @@ class TorchAdapterTest(TestCase):
                 # silence a warning about inability to generate unique candidates
                 mock.patch(f"{Adapter.__module__}.logger.warning")
             )
-            gen_run = model_bridge.gen(
+            gen_run = adapter.gen(
                 n=3,
                 search_space=search_space,
                 optimization_config=opt_config,
@@ -262,7 +254,7 @@ class TorchAdapterTest(TestCase):
             "cross_validate",
             return_value=predict_return_value,
         ) as mock_cross_validate:
-            cv_obs_data = model_bridge._cross_validate(
+            cv_obs_data = adapter._cross_validate(
                 search_space=search_space,
                 cv_training_data=observations,
                 cv_test_points=cv_test_points,
@@ -276,12 +268,12 @@ class TorchAdapterTest(TestCase):
         # Transform observations
         # This functionality is likely to be deprecated (T134940274)
         # so this is not a thorough test.
-        model_bridge.transform_observations(observations=observations)
+        adapter.transform_observations(observations=observations)
 
         # Transform observation features
         obsf = [ObservationFeatures(parameters={"x": 1.0, "y": 2.0})]
-        model_bridge.parameters = ["x", "y"]
-        X = model_bridge._transform_observation_features(observation_features=obsf)
+        adapter.parameters = ["x", "y"]
+        X = adapter._transform_observation_features(observation_features=obsf)
         self.assertTrue(torch.equal(X, torch.tensor([[1.0, 2.0]], **tkwargs)))
 
     def test_TorchAdapter_cuda(self) -> None:

--- a/ax/modelbridge/tests/test_transform_utils.py
+++ b/ax/modelbridge/tests/test_transform_utils.py
@@ -9,7 +9,6 @@
 from unittest import mock
 
 import numpy as np
-from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
@@ -19,6 +18,7 @@ from ax.modelbridge.transforms.utils import (
     ClosestLookupDict,
     derelativize_optimization_config_with_raw_status_quo,
 )
+from ax.models.base import Generator
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_multi_objective_optimization_config
 
@@ -68,11 +68,8 @@ class TransformUtilsTest(TestCase):
             ]
         )
         modelbridge = Adapter(
-            search_space=dummy_search_space,
-            model=None,
-            transforms=[],
-            experiment=Experiment(dummy_search_space, "test"),
-            data=Data(),
+            experiment=Experiment(search_space=dummy_search_space),
+            model=Generator(),
             optimization_config=optimization_config,
             status_quo_name="1_1",
         )

--- a/ax/modelbridge/tests/test_utils.py
+++ b/ax/modelbridge/tests/test_utils.py
@@ -56,7 +56,7 @@ class TestAdapterUtils(TestCase):
             arm=self.trial.arm, trial_index=self.trial.index
         )
         self.hss_exp = get_hierarchical_search_space_experiment()
-        self.hss_sobol = Generators.SOBOL(search_space=self.hss_exp.search_space)
+        self.hss_sobol = Generators.SOBOL(experiment=self.hss_exp)
         self.hss_gr = self.hss_sobol.gen(n=1)
         self.hss_trial = self.hss_exp.new_trial(self.hss_gr)
         self.hss_arm = none_throws(self.hss_trial.arm)

--- a/ax/modelbridge/transforms/tests/test_derelativize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_derelativize_transform.py
@@ -12,7 +12,6 @@ from unittest import mock
 from unittest.mock import Mock, patch
 
 import numpy as np
-from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.metric import Metric
 from ax.core.objective import Objective
@@ -25,6 +24,7 @@ from ax.core.types import ComparisonOp
 from ax.exceptions.core import DataRequiredError
 from ax.modelbridge.base import Adapter
 from ax.modelbridge.transforms.derelativize import Derelativize
+from ax.models.base import Generator
 from ax.utils.common.testutils import TestCase
 
 
@@ -119,11 +119,8 @@ class DerelativizeTransformTest(TestCase):
             ]
         )
         g = Adapter(
-            search_space=search_space,
-            model=None,
-            transforms=[],
-            experiment=Experiment(search_space, "test"),
-            data=Data(),
+            experiment=Experiment(search_space=search_space),
+            model=Generator(),
             status_quo_name="1_1",
         )
 
@@ -202,11 +199,8 @@ class DerelativizeTransformTest(TestCase):
         # Test with relative constraint, out-of-design status quo
         mock_predict.side_effect = RuntimeError()
         g = Adapter(
-            search_space=search_space,
-            model=None,
-            transforms=[],
-            experiment=Experiment(search_space, "test"),
-            data=Data(),
+            experiment=Experiment(search_space=search_space),
+            model=Generator(),
             status_quo_name="1_2",
         )
         oc = OptimizationConfig(
@@ -252,11 +246,8 @@ class DerelativizeTransformTest(TestCase):
 
         # Raises error if predict fails with in-design status quo
         g = Adapter(
-            search_space=search_space,
-            model=None,
-            transforms=[],
-            experiment=Experiment(search_space, "test"),
-            data=Data(),
+            experiment=Experiment(search_space=search_space),
+            model=Generator(),
             status_quo_name="1_1",
         )
         oc = OptimizationConfig(
@@ -311,13 +302,7 @@ class DerelativizeTransformTest(TestCase):
             t2.transform_optimization_config(deepcopy(oc_scalarized_only), g, None)
 
         # Raises error with relative constraint, no status quo.
-        g = Adapter(
-            search_space=search_space,
-            model=None,
-            transforms=[],
-            experiment=Experiment(search_space, "test"),
-            data=Data(),
-        )
+        g = Adapter(experiment=Experiment(search_space=search_space), model=Generator())
         with self.assertRaises(DataRequiredError):
             t.transform_optimization_config(deepcopy(oc), g, None)
 
@@ -325,7 +310,7 @@ class DerelativizeTransformTest(TestCase):
         with self.assertRaises(ValueError):
             t.transform_optimization_config(deepcopy(oc), None, None)
 
-    def test_Errors(self) -> None:
+    def test_errors(self) -> None:
         t = Derelativize(
             search_space=None,
             observations=[],
@@ -339,8 +324,14 @@ class DerelativizeTransformTest(TestCase):
         search_space = SearchSpace(
             parameters=[RangeParameter("x", ParameterType.FLOAT, 0, 20)]
         )
-        g = Adapter(search_space, None, [])
+        adapter = Adapter(
+            experiment=Experiment(search_space=search_space), model=Generator()
+        )
         with self.assertRaises(ValueError):
-            t.transform_optimization_config(oc, None, None)
+            t.transform_optimization_config(
+                optimization_config=oc, modelbridge=None, fixed_features=None
+            )
         with self.assertRaises(DataRequiredError):
-            t.transform_optimization_config(oc, g, None)
+            t.transform_optimization_config(
+                optimization_config=oc, modelbridge=adapter, fixed_features=None
+            )

--- a/ax/modelbridge/transforms/tests/test_relativize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_relativize_transform.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock
 import numpy as np
 import numpy.typing as npt
 from ax.core import BatchTrial
+from ax.core.experiment import Experiment
 from ax.core.observation import (
     Observation,
     ObservationData,
@@ -91,7 +92,7 @@ class RelativizeDataTest(TestCase):
     ) -> None:
         for relativize_cls in self.relativize_classes:
             # modelbridge has no status quo
-            sobol = Generators.SOBOL(search_space=get_search_space())
+            sobol = Generators.SOBOL(experiment=get_branin_experiment())
             self.assertIsNone(sobol.status_quo)
             with self.assertRaisesRegex(
                 AssertionError, f"{relativize_cls.__name__} requires status quo data."
@@ -457,7 +458,7 @@ class RelativizeDataOptConfigTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         search_space = get_search_space()
-        gr = Generators.SOBOL(search_space=search_space).gen(n=1)
+        gr = Generators.SOBOL(experiment=Experiment(search_space=search_space)).gen(n=1)
         self.model = Mock(
             search_space=search_space,
             status_quo=Mock(

--- a/ax/modelbridge/transforms/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_winsorize_transform.py
@@ -38,6 +38,7 @@ from ax.modelbridge.transforms.winsorize import (
     AUTO_WINS_QUANTILE,
     Winsorize,
 )
+from ax.models.base import Generator
 from ax.models.winsorization_config import WinsorizationConfig
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -601,10 +602,9 @@ class WinsorizeTransformTest(TestCase):
             ],
         )
         modelbridge = Adapter(
-            search_space=search_space,
-            model=None,
+            experiment=Experiment(search_space=search_space),
+            model=Generator(),
             transforms=[],
-            experiment=Experiment(search_space, "test"),
             data=Data(),
             optimization_config=oc,
         )
@@ -619,10 +619,9 @@ class WinsorizeTransformTest(TestCase):
             )
 
         modelbridge = Adapter(
-            search_space=search_space,
-            model=None,
+            experiment=Experiment(search_space=search_space),
+            model=Generator(),
             transforms=[],
-            experiment=Experiment(search_space, "test"),
             data=Data(),
             status_quo_name="1_1",
             optimization_config=oc,
@@ -692,7 +691,9 @@ def get_default_transform_cutoffs(
         covariance=np.eye(obs_data_len),
     )
     obs = Observation(features=ObservationFeatures({}), data=obsd)
-    modelbridge = _wrap_optimization_config_in_modelbridge(optimization_config)
+    modelbridge = _wrap_optimization_config_in_modelbridge(
+        optimization_config=optimization_config
+    )
     transform = Winsorize(
         search_space=None,
         observations=[deepcopy(obs)],
@@ -708,7 +709,7 @@ def _wrap_optimization_config_in_modelbridge(
     optimization_config: OptimizationConfig,
 ) -> Adapter:
     return Adapter(
-        search_space=SearchSpace(parameters=[]),
-        model=1,
+        experiment=Experiment(search_space=SearchSpace(parameters=[])),
+        model=Generator(),
         optimization_config=optimization_config,
     )


### PR DESCRIPTION
Summary:
The motivation for this change is to bring us closer to relying on the `experiment` as the source of truth about the experiment state & attributes within the modeling layer. We currently support many inputs that are extracted from the `experiment`, just to be passed in alongside it. By making `experiment` a required input, we open the possibility of removing these extra inputs and extracting them directly from `experiment` where they're needed.

Makes the following changes to Adapter constructors:
- Requires keyword-only arguments. Positional inputs are no-longer supported.
- Makes `experiment` required and `search_space` optional.
- Re-orders inputs for consistency across sub-classes.

In addition:
- Removes `model` input to `Adapter._fit`. This is a private method that is only called through `fit_if_implemented` (with `self.model`). Accepting multiple inputs for the same argument only makes the code harder to reason about.
- Removes class level attributes, some of which weren't initialized in `__init__`, leading to pyre complaints. All attributes are now initialized in `__init__`. This also eliminates misleading "optional" type hints with `None` default for `model`, which is never `None` in practice.
- Removes `Adapter.update`, which has been deprecated for quite some time.
- Initializing a Generator from registry with only `search_space` is being deprecated. It is temporarily supported using a dummy experiment for random & discrete adapters, which previously did not require an `experiment`.

Differential Revision: D70103442
