### PR TITLE
Prevent noisy log from MapData

### DIFF
--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -214,10 +214,22 @@ class MapData(Data):
                     # not add the duplicate.
                     unique_map_key_infos.append(mki)
 
-        df = pd.concat(
-            [pd.DataFrame(columns=[mki.key for mki in unique_map_key_infos])]
-            + [datum.map_df for datum in data]
-        ).fillna(value={mki.key: mki.default_value for mki in unique_map_key_infos})
+        # Avoid concatenating empty dataframes which logs a warning.
+        non_empty_dfs = [datum.map_df for datum in data if not datum.map_df.empty]
+        df = (
+            pd.concat(non_empty_dfs).fillna(
+                value={mki.key: mki.default_value for mki in unique_map_key_infos}
+            )
+            if len(non_empty_dfs) > 0
+            else pd.DataFrame(
+                columns=[*{col for datum in data for col in datum.required_columns()}]
+            )
+        )
+
+        # Esnure that all map keys are present in the dataframe.
+        for mki in unique_map_key_infos:
+            if mki.key not in df.columns:
+                df[mki.key] = mki.default_value
 
         if subset_metrics:
             subset_metrics_mask = df["metric_name"].isin(subset_metrics)


### PR DESCRIPTION
Summary: Tutorial used to be flooded with `/Users/mpolson64/ax/ax/core/map_data.py:216: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.`

Differential Revision: D70273329


