### PR TITLE
Cast parameter values in Cast.transform_observation_features

### DIFF
--- a/ax/modelbridge/transforms/cast.py
+++ b/ax/modelbridge/transforms/cast.py
@@ -102,6 +102,10 @@ class Cast(Transform):
 
         Returns: transformed observation features
         """
+        observation_features = self._cast_parameter_values(
+            observation_features=observation_features
+        )
+
         if not self.flatten_hss:
             return observation_features
         # Inject the parameters model suggested in the flat search space, which then
@@ -133,10 +137,9 @@ class Cast(Transform):
 
         Returns: observation features in the original space
         """
-        for obsf in observation_features:
-            for p_name, p_value in obsf.parameters.items():
-                if p_name in self.search_space.parameters:
-                    obsf.parameters[p_name] = self.search_space[p_name].cast(p_value)
+        observation_features = self._cast_parameter_values(
+            observation_features=observation_features
+        )
 
         if not self.flatten_hss:
             return observation_features
@@ -147,3 +150,22 @@ class Cast(Transform):
             ).cast_observation_features(observation_features=obs_feats)
             for obs_feats in observation_features
         ]
+
+    def _cast_parameter_values(
+        self, observation_features: list[ObservationFeatures]
+    ) -> list[ObservationFeatures]:
+        """Cast parameter values of the given ``ObseravationFeatures`` to the
+        ``ParameterType`` of the corresponding parameters in the search space.
+
+        NOTE: This is done in-place.
+
+        Args:
+            observation_features: A list of ``ObservationFeatures`` to cast.
+
+        Returns: observation features with casted parameter values.
+        """
+        for obsf in observation_features:
+            for p_name, p_value in obsf.parameters.items():
+                if p_name in self.search_space.parameters:
+                    obsf.parameters[p_name] = self.search_space[p_name].cast(p_value)
+        return observation_features

--- a/ax/modelbridge/transforms/tests/test_cast_transform.py
+++ b/ax/modelbridge/transforms/tests/test_cast_transform.py
@@ -85,6 +85,20 @@ class CastTransformTest(TestCase):
         obs_ft2 = self.t.untransform_observation_features(obs_ft2)
         self.assertEqual(obs_ft2, observation_features)
 
+        # Check that the transform casts the parameter values when necessary.
+        observation_features = [
+            ObservationFeatures(parameters={"a": 1, "b": 2, "c": "a", "d": 2.1})
+        ]
+        expected = [
+            ObservationFeatures(parameters={"a": 1.0, "b": 2.0, "c": "a", "d": 2})
+        ]
+        self.assertEqual(
+            self.t.transform_observation_features(
+                observation_features=observation_features
+            ),
+            expected,
+        )
+
     def test_untransform_observation_features(self) -> None:
         # Verify running the transform on uncasted values properly converts them
         # (e.g. typing, rounding)


### PR DESCRIPTION
Summary:
Casts each parameter value to the ParameterType of the respective parameter in `Cast.transform_observation_features`. This will ensure that the observation features are of the correct type for subsequent operations within the modeling layer. The behavior is consistent with the existing docstring of the transform:

> Cast each param value to the respective parameter's type/format and to a flattened version of the hierarchical search space, if applicable.

Differential Revision: D70494405


