### PR TITLE
Improve ergonomics around early stopping

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -621,8 +621,16 @@ class BaseTrial(ABC, SortableBase):
         Returns:
             The trial instance.
         """
-        if self._status != TrialStatus.RUNNING:
-            raise ValueError("Can only early stop trial that is currently running.")
+        if not unsafe:
+            if self._status != TrialStatus.RUNNING:
+                raise ValueError("Can only early stop trial that is currently running.")
+
+            if self.lookup_data().df.empty:
+                raise UnsupportedError(
+                    "Cannot mark trial early stopped without data. Please mark trial "
+                    "abandoned instead."
+                )
+
         self._status = TrialStatus.EARLY_STOPPED
         self._time_completed = datetime.now()
         return self
@@ -822,4 +830,4 @@ class BaseTrial(ABC, SortableBase):
         if self.status == TrialStatus.FAILED:
             new_trial.mark_failed(reason=self.failed_reason)
             return
-        new_trial.mark_as(self.status)
+        new_trial.mark_as(self.status, unsafe=True)

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -404,6 +404,12 @@ class BatchTrialTest(TestCase):
     def test_EarlyStoppedBatchTrial(self) -> None:
         self.batch.runner = SyntheticRunner()
         self.batch.run()
+        self.batch.attach_batch_trial_data(
+            raw_data={
+                self.batch.arms[0].name: {"m1": 1.0, "m2": 2.0},
+                self.batch.arms[1].name: {"m1": 3.0, "m2": 4.0},
+            }
+        )
         self.batch.mark_early_stopped()
 
         self.assertEqual(self.batch.status, TrialStatus.EARLY_STOPPED)

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1298,7 +1298,9 @@ class ExperimentTest(TestCase):
         self.assertEqual(experiment.trial_indices_expecting_data, {2, 4})
         experiment.trials[4].mark_failed()
         self.assertEqual(experiment.trial_indices_expecting_data, {2})
-        experiment.trials[5].mark_running(no_runner_required=True).mark_early_stopped()
+        experiment.trials[5].mark_running(no_runner_required=True).mark_early_stopped(
+            unsafe=True
+        )
         self.assertEqual(experiment.trial_indices_expecting_data, {2, 5})
 
     def test_stop_trial(self) -> None:

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -205,6 +205,11 @@ class TrialTest(TestCase):
                     kwargs["reason"] = "test_reason_abandon"
                 if status == TrialStatus.FAILED:
                     kwargs["reason"] = "test_reason_failed"
+
+                # Trial must have data before it can be marked EARLY_STOPPED
+                if status == TrialStatus.EARLY_STOPPED:
+                    self.trial.update_trial_data(raw_data={"m1": 1.0, "m2": 2.0})
+
                 self.trial.mark_as(status=status, **kwargs)
                 self.assertTrue(self.trial.status == status)
 
@@ -254,6 +259,7 @@ class TrialTest(TestCase):
             self.trial._runner = DummyStopRunner()
             self.trial.mark_running()
             self.assertEqual(self.trial.status, TrialStatus.RUNNING)
+            self.trial.update_trial_data(raw_data={"m1": 1.0, "m2": 2.0})
             self.trial.stop(new_status=new_status, reason=reason)
             self.assertEqual(self.trial.status, new_status)
             self.assertEqual(

--- a/ax/preview/api/client.py
+++ b/ax/preview/api/client.py
@@ -560,23 +560,16 @@ class Client(WithDBSettingsBase):
             experiment=self._experiment, trial=self._experiment.trials[trial_index]
         )
 
-    def mark_trial_early_stopped(
-        self, trial_index: int, raw_data: TOutcome, progression: int | None = None
-    ) -> None:
+    def mark_trial_early_stopped(self, trial_index: int) -> None:
         """
-        Manually mark a trial as EARLY_STOPPED while attaching the most recent data.
-        This is used when the user has decided (with or without Ax's recommendation) to
-        stop the trial early. EARLY_STOPPED trials will not be re-suggested by
-        get_next_trials.
+        Manually mark a trial as EARLY_STOPPED. This is used when the user has decided
+        (with or without Ax's recommendation) to stop the trial after some data has
+        been attached but before the trial is completed. Note that if data has not been
+        attached for the trial yet users should instead call ``mark_trial_abandoned``.
+        EARLY_STOPPED trials will not be re-suggested by ``get_next_trials``.
 
         Saves to database on completion if storage_config is present.
         """
-
-        # First attach the new data
-        self.attach_data(
-            trial_index=trial_index, raw_data=raw_data, progression=progression
-        )
-
         self._experiment.trials[trial_index].mark_early_stopped()
 
         self._save_or_update_trial_in_db_if_possible(

--- a/ax/preview/api/tests/test_client.py
+++ b/ax/preview/api/tests/test_client.py
@@ -687,9 +687,16 @@ class TestClient(TestCase):
         client.configure_optimization(objective="foo")
 
         trial_index = [*client.get_next_trials(maximum_trials=1).keys()][0]
-        client.mark_trial_early_stopped(
+
+        with self.assertRaisesRegex(
+            UnsupportedError, "Cannot mark trial early stopped"
+        ):
+            client.mark_trial_early_stopped(trial_index=trial_index)
+
+        client.attach_data(
             trial_index=trial_index, raw_data={"foo": 0.0}, progression=1
         )
+        client.mark_trial_early_stopped(trial_index=trial_index)
         self.assertEqual(
             client._experiment.trials[trial_index].status,
             TrialStatus.EARLY_STOPPED,

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -157,7 +157,7 @@ class TestBestPointUtils(TestCase):
         with self.subTest("Only early-stopped trials"):
             exp = get_experiment_with_map_data()
             exp.trials[0].mark_running(no_runner_required=True)
-            exp.trials[0].mark_early_stopped()
+            exp.trials[0].mark_early_stopped(unsafe=True)
             with self.assertRaisesRegex(
                 ValueError, "Cannot identify best point if no trials are completed."
             ):
@@ -414,7 +414,7 @@ class TestBestPointUtils(TestCase):
                 no_runner_required=True
             )
             if i in [3, 8, 10]:
-                trial.mark_early_stopped()
+                trial.mark_early_stopped(unsafe=True)
             else:
                 trial.mark_completed()
 


### PR DESCRIPTION
Summary: As discussed in Ax/Botorch sync. mark_trial_early_stopped signuture is brought in line with other mark_trial_STATUS methods and BaseTrial now validates that data must be present on a trial when marking it early stopped. This Exception from BaseTrial is a ValueError to stay in line with convention in that module, but is wrapped in an Ax UnsupportedError in Client where we expect exceptions to be Ax classes.

Reviewed By: lena-kashtelyan

Differential Revision: D70397779


