### PR TITLE
Do not warn when cross validation fails on RandomAdapter

### DIFF
--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -429,6 +429,16 @@ def get_fit_and_std_quality_and_generalization_dict(
             "model_std_generalization": _model_std_quality(np.array(gen_std)),
         }
 
+    # Do not warn if the Adapter does not implment a predict method
+    # (ex. RandomAdapter).
+    except NotImplementedError:
+        return {
+            "model_fit_quality": None,
+            "model_std_quality": None,
+            "model_fit_generalization": None,
+            "model_std_generalization": None,
+        }
+
     except Exception as e:
         warn("Encountered exception in computing model fit quality: " + str(e))
         return {

--- a/ax/modelbridge/tests/test_model_fit_metrics.py
+++ b/ax/modelbridge/tests/test_model_fit_metrics.py
@@ -156,9 +156,14 @@ class TestGetFitAndStdQualityAndGeneralizationDict(TestCase):
         self.sobol = Generators.SOBOL(experiment=self.experiment)
 
     def test_it_returns_empty_data_for_sobol(self) -> None:
-        results = get_fit_and_std_quality_and_generalization_dict(
-            fitted_model_bridge=self.sobol,
-        )
+        with warnings.catch_warnings(record=True) as ws:
+            results = get_fit_and_std_quality_and_generalization_dict(
+                fitted_model_bridge=self.sobol,
+            )
+
+            # Ensure we did not warn since we are using a Sobol Generator
+            self.assertEqual(len(ws), 0)
+
         expected = {
             "model_fit_quality": None,
             "model_std_quality": None,


### PR DESCRIPTION
Summary: This produced a warning for every sobol trial on every experiment, which looked especially bad on the website.

Differential Revision: D70562742


