### PR TITLE
Add trial filter option to scatter plot

### DIFF
--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -33,7 +33,11 @@ class ScatterPlot(PlotlyAnalysis):
     """
 
     def __init__(
-        self, x_metric_name: str, y_metric_name: str, show_pareto_frontier: bool = False
+        self,
+        x_metric_name: str,
+        y_metric_name: str,
+        show_pareto_frontier: bool = False,
+        trial_index: int | None = None,
     ) -> None:
         """
         Args:
@@ -41,12 +45,14 @@ class ScatterPlot(PlotlyAnalysis):
             y_metric_name: The name of the metric to plot on the y-axis.
             show_pareto_frontier: Whether to show the Pareto frontier for the two
                 metrics. Optimization direction is inferred from the Experiment.
+            trial_index: Optional trial index to filter the data to. If not specified,
+                all trials will be included.
         """
 
         self.x_metric_name = x_metric_name
         self.y_metric_name = y_metric_name
-
         self.show_pareto_frontier = show_pareto_frontier
+        self.trial_index = trial_index
 
     def compute(
         self,
@@ -60,6 +66,7 @@ class ScatterPlot(PlotlyAnalysis):
             experiment=experiment,
             x_metric_name=self.x_metric_name,
             y_metric_name=self.y_metric_name,
+            trial_index=self.trial_index,
         )
         fig = _prepare_plot(
             df=df,
@@ -68,6 +75,7 @@ class ScatterPlot(PlotlyAnalysis):
             show_pareto_frontier=self.show_pareto_frontier,
             x_lower_is_better=experiment.metrics[self.x_metric_name].lower_is_better
             or False,
+            trial_index=self.trial_index,
         )
 
         return self._create_plotly_analysis_card(
@@ -81,7 +89,10 @@ class ScatterPlot(PlotlyAnalysis):
 
 
 def _prepare_data(
-    experiment: Experiment, x_metric_name: str, y_metric_name: str
+    experiment: Experiment,
+    x_metric_name: str,
+    y_metric_name: str,
+    trial_index: int | None = None,
 ) -> pd.DataFrame:
     """
     Extract the relevant data from the experiment and prepare it into a dataframe
@@ -91,6 +102,8 @@ def _prepare_data(
         experiment: The experiment to extract data from.
         x_metric_name: The name of the metric to plot on the x-axis.
         y_metric_name: The name of the metric to plot on the y-axis.
+        trial_index: Optional trial index to filter the data to. If not specified,
+                all trials will be included.
     """
 
     # Lookup the data that has already been fetched and attached to the experiment
@@ -104,6 +117,10 @@ def _prepare_data(
     filtered = data[metric_name_mask & status_mask][
         ["trial_index", "arm_name", "metric_name", "mean"]
     ]
+
+    # filter data to trial index if specified
+    if trial_index is not None:
+        filtered = filtered[filtered["trial_index"] == trial_index]
 
     # Pivot the data so that each row is an arm and the columns are the metric names
     pivoted: pd.DataFrame = filtered.pivot_table(
@@ -122,8 +139,7 @@ def _prepare_data(
     # Add a column indicating whether the arm is on the Pareto frontier. This is
     # calculated by comparing each arm to all other arms in the experiment and
     # creating a mask.
-    # If directional guidance is not specified, we assume that we intendt to maximize
-    # the metric.
+    # If directional guidance is not specified, assume higher is better
     x_lower_is_better: bool = experiment.metrics[x_metric_name].lower_is_better or False
     y_lower_is_better: bool = experiment.metrics[y_metric_name].lower_is_better or False
 
@@ -154,6 +170,7 @@ def _prepare_plot(
     y_metric_name: str,
     show_pareto_frontier: bool,
     x_lower_is_better: bool,
+    trial_index: int | None = None,
 ) -> go.Figure:
     """
     Prepare a scatter plot for the given DataFrame.
@@ -171,12 +188,16 @@ def _prepare_plot(
         show_pareto_frontier: Whether to draw the Pareto frontier for the two metrics
         x_lower_is_better: Whether the metric on the x-axis is being minimized (only
             relevant if show_pareto_frontier=True)
+        trial_index: Optional trial index to filter the data to. If not specified,
+                all trials will be included.
     """
     fig = px.scatter(
         df,
         x=x_metric_name,
         y=y_metric_name,
-        color="trial_index",
+        # only show legend + multiple colors if trial index is not specified
+        # indicating all trials are being shown
+        color="trial_index" if trial_index is None else None,
         hover_data=["trial_index", "arm_name", x_metric_name, y_metric_name],
     )
 


### PR DESCRIPTION
Summary:
This diff is the first in a stack of diffs to both improve the utility of the scatter plot overall and expose an adhoc method for using the scatter plot in a notebook environemnt.

This diff adds the ability to apply a trial filter to scatter data, so taht not all trials will be plotted in a single output. This is particularly important for online experimeation usecases, where trials are typically batch trials.

Forthcoming diffs:
- add adhoc method
- expose label_dict to map metric name ot human readable name
- add ci intervals on the plot
- [backlogged] relativize the plot data
- decide if we like the pareto frontier line

Reviewed By: bernardbeckerman

Differential Revision: D70506659


