### PR TITLE
Remove colon from Applications and Integrations

### DIFF
--- a/website/tutorials.json
+++ b/website/tutorials.json
@@ -19,7 +19,7 @@
         "title": "Ask-tell experimentation with early stopping"
       }
     ],
-    "Applications and Integrations:": [
+    "Applications and Integrations": [
       {
         "id": "automl",
         "title": "Ax for AutoML"


### PR DESCRIPTION
Summary: Dont know how that snuck in there. We should either have it on none of them (I like this) or all of them.

Differential Revision: D70564903


