### PR TITLE
Replace models_enum with GS in best point utils

### DIFF
--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -30,7 +30,6 @@ from ax.exceptions.core import SearchSpaceExhausted, UserInputError
 from ax.generation_strategy.dispatch_utils import choose_generation_strategy
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
-from ax.modelbridge.registry import Generators
 from ax.service.utils.best_point import (
     get_best_parameters_from_model_predictions_with_trial_index,
     get_best_raw_objective_point_with_trial_index,
@@ -251,7 +250,7 @@ class OptimizationLoop:
         of this optimization."""
         # Find latest trial which has a generator_run attached and get its predictions
         best_point = get_best_parameters_from_model_predictions_with_trial_index(
-            experiment=self.experiment, models_enum=Generators
+            experiment=self.experiment, adapter=self.generation_strategy.model
         )
         if best_point is not None:
             _, parameterizations, predictions = best_point

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -413,7 +413,7 @@ class ReportUtilsTest(TestCase):
                     global_sensitivity_analysis=True,
                     true_objective_metric_name="branin",
                 )
-            self.assertEqual(len(plots), num_expected_plots)  # TODO: this failed
+            self.assertEqual(len(plots), num_expected_plots)
             self.assertTrue(all(isinstance(plot, go.Figure) for plot in plots))
 
     @mock_botorch_optimize

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -9,7 +9,6 @@
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping
 from functools import reduce
-
 from logging import Logger
 
 import pandas as pd
@@ -40,11 +39,7 @@ from ax.modelbridge.modelbridge_utils import (
     observed_pareto_frontier as observed_pareto,
     predicted_pareto_frontier as predicted_pareto,
 )
-from ax.modelbridge.registry import (
-    Generators,
-    get_model_from_generator_run,
-    ModelRegistryBase,
-)
+from ax.modelbridge.registry import Generators
 from ax.modelbridge.torch import TorchAdapter
 from ax.modelbridge.transforms.utils import (
     derelativize_optimization_config_with_raw_status_quo,
@@ -184,33 +179,29 @@ def _raw_values_to_model_predict_arm(
 
 def get_best_parameters_from_model_predictions_with_trial_index(
     experiment: Experiment,
-    models_enum: type[ModelRegistryBase],
+    adapter: Adapter | None,
     optimization_config: OptimizationConfig | None = None,
     trial_indices: Iterable[int] | None = None,
 ) -> tuple[int, TParameterization, TModelPredictArm | None] | None:
     """Given an experiment, returns the best predicted parameterization and
     corresponding prediction.
 
-    The best point & predictions are computed using the model from the
-    (first) generator run of the latest trial. If the latest trial doesn't
-    have a generator run, returns None. If the model from the latest trial
-    is not TorchModelBridge or the model construction fails, this will
-    return the best point & the predictions that were saved on the
-    generator run (rather than re-computing them with latest data). If the
-    model fit assessment returns bad fit for any of the metrics, this will
-    fall back to returning the best point based on raw observations.
-
-    Only some models return predictions. For instance GPEI does while Sobol does not.
+    The best point & predictions are computed using the given ``Adapter``
+    and its ``predict`` method (if implemented). If ``adapter`` is not a
+    ``TorchAdapter``, the best point is extracted from the (first) generator run
+    of the latest trial. If the latest trial doesn't have a generator run, returns
+    None. If the model fit assessment returns bad fit for any of the metrics, this
+    will fall back to returning the best point based on raw observations.
 
     TModelPredictArm is of the form:
         ({metric_name: mean}, {metric_name_1: {metric_name_2: cov_1_2}})
 
     Args:
-        experiment: Experiment, on which to identify best raw objective arm.
-        models_enum: Registry of all models that may be in the experiment's
-            generation strategy.
-        optimization_config: Optimization config to use in place of the one stored
-            on the experiment.
+        experiment: ``Experiment``, on which to identify best raw objective arm.
+        adapter: The ``Adapter`` to use to get the model predictions. If None, the
+            best point will be extracted from the generator run of the latest trial.
+        optimization_config: Optional ``OptimizationConfig`` override, to use in place
+            of the one stored on the experiment.
         trial_indices: Indices of trials for which to retrieve data. If None will
             retrieve data from all available trials.
 
@@ -229,74 +220,62 @@ def get_best_parameters_from_model_predictions_with_trial_index(
             "multi-objective optimization configs. This method will return an "
             "arbitrary point on the pareto frontier."
         )
+    gr = None
+    data = experiment.lookup_data(trial_indices=trial_indices)
+    # Extract the latest GR from the experiment.
     for _, trial in sorted(experiment.trials.items(), key=lambda x: x[0], reverse=True):
-        gr = None
         if isinstance(trial, Trial):
             gr = trial.generator_run
         elif isinstance(trial, BatchTrial):
             if len(trial.generator_run_structs) > 0:
                 # In theory batch_trial can have >1 gr, grab the first
                 gr = trial.generator_run_structs[0].generator_run
-
         if gr is not None:
-            data = experiment.lookup_data(trial_indices=trial_indices)
+            break
 
-            try:
-                model = get_model_from_generator_run(
-                    generator_run=gr,
-                    experiment=experiment,
-                    data=data,
-                    models_enum=models_enum,
-                )
-            except ValueError:
-                return _extract_best_arm_from_gr(gr=gr, trials=experiment.trials)
+    if not isinstance(adapter, TorchAdapter):
+        if gr is None:
+            return None
+        return _extract_best_arm_from_gr(gr=gr, trials=experiment.trials)
 
-            # If model is not TorchAdapter, just use the best arm from the
-            # last good generator run
-            if not isinstance(model, TorchAdapter):
-                return _extract_best_arm_from_gr(gr=gr, trials=experiment.trials)
+    # Check to see if the adapter is worth using.
+    cv_results = cross_validate(model=adapter)
+    diagnostics = compute_diagnostics(result=cv_results)
+    assess_model_fit_results = assess_model_fit(diagnostics=diagnostics)
+    objective_name = optimization_config.objective.metric.name
+    # If model fit is bad use raw results
+    if objective_name in assess_model_fit_results.bad_fit_metrics_to_fisher_score:
+        logger.warning("Model fit is poor; falling back on raw data for best point.")
 
-            # Check to see if the model is worth using
-            cv_results = cross_validate(model=model)
-            diagnostics = compute_diagnostics(result=cv_results)
-            assess_model_fit_results = assess_model_fit(diagnostics=diagnostics)
-            objective_name = optimization_config.objective.metric.name
-            # If model fit is bad use raw results
-            if (
-                objective_name
-                in assess_model_fit_results.bad_fit_metrics_to_fisher_score
-            ):
-                logger.warning(
-                    "Model fit is poor; falling back on raw data for best point."
-                )
+        if not _is_all_noiseless(df=data.df, metric_name=objective_name):
+            logger.warning(
+                "Model fit is poor and data on objective metric "
+                + f"{objective_name} is noisy; interpret best points "
+                + "results carefully."
+            )
 
-                if not _is_all_noiseless(df=data.df, metric_name=objective_name):
-                    logger.warning(
-                        "Model fit is poor and data on objective metric "
-                        + f"{objective_name} is noisy; interpret best points "
-                        + "results carefully."
-                    )
+        return get_best_by_raw_objective_with_trial_index(
+            experiment=experiment,
+            optimization_config=optimization_config,
+            trial_indices=trial_indices,
+        )
 
-                return get_best_by_raw_objective_with_trial_index(
-                    experiment=experiment,
-                    optimization_config=optimization_config,
-                    trial_indices=trial_indices,
-                )
+    res = adapter.model_best_point()
+    if res is None:
+        if gr is None:
+            return None
+        return _extract_best_arm_from_gr(gr=gr, trials=experiment.trials)
 
-            res = model.model_best_point()
-            if res is None:
-                return _extract_best_arm_from_gr(gr=gr, trials=experiment.trials)
+    best_arm, best_arm_predictions = res
 
-            best_arm, best_arm_predictions = res
-
-            # Map the arm to the trial index of the first trial that contains it.
-            for trial_index, trial in experiment.trials.items():
-                if best_arm in trial.arms:
-                    return (
-                        trial_index,
-                        none_throws(best_arm).parameters,
-                        best_arm_predictions,
-                    )
+    # Map the arm to the trial index of the first trial that contains it.
+    for trial_index, trial in experiment.trials.items():
+        if best_arm in trial.arms:
+            return (
+                trial_index,
+                none_throws(best_arm).parameters,
+                best_arm_predictions,
+            )
 
     return None
 

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -32,7 +32,6 @@ from ax.modelbridge.modelbridge_utils import (
     predicted_hypervolume,
     validate_and_apply_final_transform,
 )
-from ax.modelbridge.registry import ModelRegistryBase
 from ax.modelbridge.torch import TorchAdapter
 from ax.modelbridge.transforms.derelativize import Derelativize
 from ax.models.torch.botorch_moo_defaults import (
@@ -269,30 +268,17 @@ class BestPointMixin(metaclass=ABCMeta):
                 "Please use `get_pareto_optimal_parameters` for multi-objective "
                 "problems."
             )
-        # TODO[drfreund]: Find a way to include data for last trial in the
-        # calculation of best parameters.
+
         if use_model_predictions:
-            current_model = generation_strategy._curr.model_spec_to_gen_from.model_enum
-            # Cover for the case where source of `self._curr.model` was not a
-            # `Generators` enum but a factory function, in which case we cannot do
-            # `get_model_from_generator_run` (since we don't have model type and inputs
-            # recorded on the generator run.
-            models_enum = (
-                current_model.__class__
-                if isinstance(current_model, ModelRegistryBase)
-                else None
+            res = best_point_utils.get_best_parameters_from_model_predictions_with_trial_index(  # noqa
+                experiment=experiment,
+                adapter=generation_strategy.model,
+                optimization_config=optimization_config,
+                trial_indices=trial_indices,
             )
 
-            if models_enum is not None:
-                res = best_point_utils.get_best_parameters_from_model_predictions_with_trial_index(  # noqa
-                    experiment=experiment,
-                    models_enum=models_enum,
-                    optimization_config=optimization_config,
-                    trial_indices=trial_indices,
-                )
-
-                if res is not None:
-                    return res
+            if res is not None:
+                return res
 
         return best_point_utils.get_best_by_raw_objective_with_trial_index(
             experiment=experiment,


### PR DESCRIPTION
Summary:
Some best point utilities were utilizing a model that is constructed from the last generator run for getting model predictions. In places where we use best point utilities, we typically have access to a generation strategy, which may have an already trained and up to date model, from which we can get predictions from. This diff updates these utilities to leverage the generation strategy instead.

This also eliminates the only use case of `get_model_from_generator_run` helper, unblocking its cleanup (we don't want to keep it for reasons I can't recall at this exact moment. I had started mocking up a version of this diff some time ago, when I had a good reason for it.)

Differential Revision: D70578742


