### PR TITLE
Improve header for all cards

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -97,8 +97,15 @@ class AnalysisCard(Base):
 
         By default, this method displays the raw data in a pandas DataFrame.
         """
-        display(Markdown(f"## {self.title}\n\n### {self.subtitle}"))
+        self._display_header()
         display(self.df)
+
+    def _display_header(self) -> None:
+        """
+        Display the title and subtitle of the AnalysisCard. Used in _ipython_display_
+        across all subclasses of AnalysisCard to ensure a uniform look and feel.
+        """
+        display(Markdown(f"**{self.title}**\n\n{self.subtitle}"))
 
 
 def display_cards(

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -32,7 +32,8 @@ class MarkdownAnalysisCard(AnalysisCard):
         IPython display hook. This is called when the AnalysisCard is printed in an
         IPython environment (ex. Jupyter). Here we want to render the Markdown.
         """
-        display(Markdown(f"## {self.title}\n\n### {self.subtitle}\n\n{self.blob}"))
+        self._display_header()
+        display(Markdown(self.blob))
 
 
 class MarkdownAnalysis(Analysis):

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -10,7 +10,7 @@ import pandas as pd
 from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from IPython.display import display, Markdown
+from IPython.display import display
 from plotly import graph_objects as go, io as pio
 
 
@@ -25,7 +25,7 @@ class PlotlyAnalysisCard(AnalysisCard):
         IPython display hook. This is called when the AnalysisCard is printed in an
         IPython environment (ex. Jupyter). Here we want to display the Plotly figure.
         """
-        display(Markdown(f"## {self.title}\n\n### {self.subtitle}"))
+        self._display_header()
         display(self.get_figure())
 
 


### PR DESCRIPTION
Summary:
Previously headers used Markdown headings 2 and 3 for title and subtitle respectively, but this was both too big and caused problems in our website build where Markdown headings are automatically interpreted as items to be added to the side bar.

Changed so the title is now just **bold** and the subtitle is normal paragraph text.

Reviewed By: mgarrard

Differential Revision: D70585345


