### PR TITLE
Update ModelBasedESS to use TorchAdapter instead of MapTorchAdapter

### DIFF
--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -240,7 +240,7 @@ class TestModelBasedEarlyStoppingStrategy(TestCase):
                 return {}
 
         experiment = get_test_map_data_experiment(
-            num_trials=3, num_fetches=2, num_complete=3
+            num_trials=3, num_fetches=4, num_complete=3
         )
         training_data = FakeStrategy().get_training_data(
             experiment,
@@ -252,6 +252,8 @@ class TestModelBasedEarlyStoppingStrategy(TestCase):
         # check that the default Ax transform is applied, i.e., that the
         # parameters are normalized to [0, 1]
         self.assertTrue(np.all((X[:, :2] >= 0.0) & (X[:, :2] <= 1.0)))
+        # Check that the map dimension is also normalized to [0, 1].
+        self.assertTrue(np.all((X[:, 2] >= 0.0) & (X[:, 2] <= 1.0)))
 
 
 class TestPercentileEarlyStoppingStrategy(TestCase):


### PR DESCRIPTION
Summary: Using the options available on `DataLoaderConfig`, we can extract the same data using the `TorchAdapter`, and eliminate the dependency on `MapTorchAdapter` (which we will be deprecating).

We can transition this onto `MapKeyToFloat` down the line, once we clean up `map_keys_as_parameters` logic within the `Adapter`.

Differential Revision: D70645611


