### PR TITLE
Replace some lingering calls to gs._fit_current_model with curr._fit

### DIFF
--- a/ax/analysis/healthcheck/constraints_feasibility.py
+++ b/ax/analysis/healthcheck/constraints_feasibility.py
@@ -111,7 +111,7 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
         )
 
         if generation_strategy.model is None:
-            generation_strategy._fit_current_model(data=experiment.lookup_data())
+            generation_strategy._curr._fit(experiment=experiment)
 
         model = none_throws(generation_strategy.model)
         if not is_predictive(model=model):

--- a/ax/analysis/plotly/arm_effects/insample_effects.py
+++ b/ax/analysis/plotly/arm_effects/insample_effects.py
@@ -198,7 +198,7 @@ def _get_model(
     model = None
     if generation_strategy is not None:
         if generation_strategy.model is None:
-            generation_strategy._fit_current_model(data=experiment.lookup_data())
+            generation_strategy._curr._fit(experiment=experiment)
 
         model = none_throws(generation_strategy.model)
 

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -92,7 +92,12 @@ class CrossValidationPlot(PlotlyAnalysis):
         )
         # If model is not fit already, fit it
         if generation_strategy.model is None:
-            generation_strategy._fit_current_model(None)
+            if experiment is None:
+                raise UserInputError(
+                    "Unable to find a model on the GenerationStrategy,"
+                    " so Experiment must be provided to fit the model."
+                )
+            generation_strategy._curr._fit(experiment=experiment)
 
         return self._construct_plot(
             adapter=none_throws(generation_strategy.model),

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -64,7 +64,7 @@ class SlicePlot(PlotlyAnalysis):
             raise UserInputError("SlicePlot requires a GenerationStrategy")
 
         if generation_strategy.model is None:
-            generation_strategy._fit_current_model(None)
+            generation_strategy._curr._fit(experiment=experiment)
 
         metric_name = self.metric_name or select_metric(experiment=experiment)
 


### PR DESCRIPTION
Summary:
Lena recently landed a wonderful stack that re-organized our fit calls in GS. This method is now deprecated, and I happened to notice as I was working on some of the analysis files. 



Differential Revision: D70668447


