### PR TITLE
Add adapter to compute method

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -16,6 +16,7 @@ from typing import Any, Protocol
 import pandas as pd
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
 from ax.utils.common.result import Err, ExceptionE, Ok, Result
@@ -146,6 +147,7 @@ class Analysis(Protocol):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> AnalysisCard:
         # Note: when implementing compute always prefer experiment.lookup_data() to
         # experiment.fetch_data() to avoid unintential data fetching within the report

--- a/ax/analysis/healthcheck/can_generate_candidates.py
+++ b/ax/analysis/healthcheck/can_generate_candidates.py
@@ -18,6 +18,7 @@ from ax.analysis.healthcheck.healthcheck_analysis import (
 )
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 from pyre_extensions import none_throws
 
 
@@ -47,6 +48,7 @@ class CanGenerateCandidatesAnalysis(HealthcheckAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> HealthcheckAnalysisCard:
         status = HealthcheckStatus.PASS
         subtitle = self.reason

--- a/ax/analysis/healthcheck/constraints_feasibility.py
+++ b/ax/analysis/healthcheck/constraints_feasibility.py
@@ -37,9 +37,8 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
     def __init__(self, prob_threshold: float = 0.95) -> None:
         r"""
         Args:
-            prob_theshold: The threshold for the probability of constraint violation.
+            prob_threhshold: Threshold for the probability of constraint violation.
 
-        Returns None
         """
         self.prob_threshold = prob_threshold
 
@@ -47,6 +46,7 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> HealthcheckAnalysisCard:
         r"""
         Compute the feasibility of the constraints for the experiment.
@@ -54,9 +54,7 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
         Args:
             experiment: Ax experiment.
             generation_strategy: Ax generation strategy.
-            prob_threhshold: Threshold for the probability of constraint violation.
-                Constraints are considered feasible if the probability of constraint
-                violation is below the threshold for at least one arm.
+            adapter: Ax modelbridge adapter
 
         Returns:
             A HealthcheckAnalysisCard object with the information on infeasible metrics,

--- a/ax/analysis/healthcheck/healthcheck_analysis.py
+++ b/ax/analysis/healthcheck/healthcheck_analysis.py
@@ -10,6 +10,7 @@ from enum import IntEnum
 from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 
 
 class HealthcheckStatus(IntEnum):
@@ -34,4 +35,5 @@ class HealthcheckAnalysis(Analysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> HealthcheckAnalysisCard: ...

--- a/ax/analysis/healthcheck/regression_analysis.py
+++ b/ax/analysis/healthcheck/regression_analysis.py
@@ -20,6 +20,7 @@ from ax.analysis.healthcheck.regression_detection_utils import (
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 from pyre_extensions import none_throws
 
 
@@ -41,7 +42,6 @@ class RegressionAnalysis(HealthcheckAnalysis):
                 Regressions are defined as the arms that have a probability of
                 regression above this threshold.
 
-        Returns None
         """
         self.prob_threshold = prob_threshold
 
@@ -49,6 +49,7 @@ class RegressionAnalysis(HealthcheckAnalysis):
         self,
         experiment: Experiment | None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> HealthcheckAnalysisCard:
         r"""
         Detect the regressing arms for all trials that have data.
@@ -56,6 +57,7 @@ class RegressionAnalysis(HealthcheckAnalysis):
         Args:
             experiment: Ax experiment.
             generation_strategy: Ax generation strategy.
+            adapter: Ax modelbridge adapter
 
         Returns:
             A HealthcheckAnalysisCard object with the information on regressing arms

--- a/ax/analysis/healthcheck/search_space_analysis.py
+++ b/ax/analysis/healthcheck/search_space_analysis.py
@@ -25,6 +25,7 @@ from ax.core.search_space import SearchSpace
 from ax.core.types import TParameterization
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 from pyre_extensions import assert_is_instance
 
 
@@ -55,17 +56,8 @@ class SearchSpaceAnalysis(HealthcheckAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> HealthcheckAnalysisCard:
-        r"""
-        Args:
-            experiment: Ax experiment.
-            generation_strategy: Ax generation strategy.
-
-        Returns:
-            A HealthcheckAnalysisCard object with the information on the parameters
-            and parameter constraints whose boundaries are recommended to be expanded.
-        """
-
         if experiment is None:
             raise UserInputError("SearchSpaceAnalysis requires an Experiment.")
 

--- a/ax/analysis/healthcheck/should_generate_candidates.py
+++ b/ax/analysis/healthcheck/should_generate_candidates.py
@@ -17,6 +17,7 @@ from ax.analysis.healthcheck.healthcheck_analysis import (
 )
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 
 
 class ShouldGenerateCandidates(HealthcheckAnalysis):
@@ -34,6 +35,7 @@ class ShouldGenerateCandidates(HealthcheckAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> HealthcheckAnalysisCard:
         status = (
             HealthcheckStatus.PASS

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -18,6 +18,7 @@ from ax.analysis.analysis import (
 )
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 from IPython.display import display, Markdown
 
 
@@ -45,6 +46,7 @@ class MarkdownAnalysis(Analysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> MarkdownAnalysisCard: ...
 
     def _create_markdown_analysis_card(

--- a/ax/analysis/metric_summary.py
+++ b/ax/analysis/metric_summary.py
@@ -14,6 +14,7 @@ from ax.analysis.analysis import (
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 
 
 class MetricSummary(Analysis):
@@ -35,6 +36,7 @@ class MetricSummary(Analysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> AnalysisCard:
         if experiment is None:
             raise UserInputError(

--- a/ax/analysis/plotly/arm_effects/insample_effects.py
+++ b/ax/analysis/plotly/arm_effects/insample_effects.py
@@ -77,6 +77,7 @@ class InSampleEffectsPlot(PlotlyAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
         if experiment is None:
             raise UserInputError("InSampleEffectsPlot requires an Experiment.")

--- a/ax/analysis/plotly/arm_effects/predicted_effects.py
+++ b/ax/analysis/plotly/arm_effects/predicted_effects.py
@@ -68,6 +68,7 @@ class PredictedEffectsPlot(PlotlyAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
         if experiment is None:
             raise UserInputError("PredictedEffectsPlot requires an Experiment.")

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -83,6 +83,7 @@ class CrossValidationPlot(PlotlyAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
         if generation_strategy is None:
             raise UserInputError("CrossValidation requires a GenerationStrategy")

--- a/ax/analysis/plotly/interaction.py
+++ b/ax/analysis/plotly/interaction.py
@@ -27,6 +27,7 @@ from ax.analysis.plotly.utils import select_metric
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 from ax.modelbridge.registry import Generators
 from ax.modelbridge.torch import TorchAdapter
 from ax.models.torch.botorch_modular.surrogate import Surrogate
@@ -90,6 +91,7 @@ class InteractionPlot(PlotlyAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
         """
         Compute Sobol index sensitivity for one metric of an experiment. Sensitivity

--- a/ax/analysis/plotly/parallel_coordinates.py
+++ b/ax/analysis/plotly/parallel_coordinates.py
@@ -16,6 +16,7 @@ from ax.analysis.plotly.utils import select_metric
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 from plotly import graph_objects as go
 
 
@@ -46,6 +47,7 @@ class ParallelCoordinatesPlot(PlotlyAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
         if experiment is None:
             raise UserInputError("ParallelCoordinatesPlot requires an Experiment")

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -10,6 +10,7 @@ import pandas as pd
 from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 from IPython.display import display
 from plotly import graph_objects as go, io as pio
 
@@ -38,6 +39,7 @@ class PlotlyAnalysis(Analysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard: ...
 
     def _create_plotly_analysis_card(

--- a/ax/analysis/plotly/progression.py
+++ b/ax/analysis/plotly/progression.py
@@ -17,6 +17,7 @@ from ax.core.map_data import MapData
 from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 from ax.utils.common.logger import get_logger
 from plotly import graph_objects as go
 from pyre_extensions import assert_is_instance
@@ -58,6 +59,7 @@ class ProgressionPlot(PlotlyAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
         if experiment is None:
             raise UserInputError("ProgressionPlot requires an Experiment")

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -13,6 +13,7 @@ from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCar
 from ax.core.experiment import Experiment
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 from plotly import graph_objects as go
 
 
@@ -58,6 +59,7 @@ class ScatterPlot(PlotlyAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
         if experiment is None:
             raise UserInputError("ScatterPlot requires an Experiment")

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -13,7 +13,7 @@ from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCar
 from ax.core.experiment import Experiment
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from plotly import express as px, graph_objects as go
+from plotly import graph_objects as go
 
 
 class ScatterPlot(PlotlyAnalysis):
@@ -105,7 +105,6 @@ def _prepare_data(
         trial_index: Optional trial index to filter the data to. If not specified,
                 all trials will be included.
     """
-
     # Lookup the data that has already been fetched and attached to the experiment
     data = experiment.lookup_data().df
 
@@ -115,7 +114,7 @@ def _prepare_data(
         lambda trial_index: experiment.trials[trial_index].status.is_completed
     )
     filtered = data[metric_name_mask & status_mask][
-        ["trial_index", "arm_name", "metric_name", "mean"]
+        ["trial_index", "arm_name", "metric_name", "mean", "sem"]
     ]
 
     # filter data to trial index if specified
@@ -123,9 +122,14 @@ def _prepare_data(
         filtered = filtered[filtered["trial_index"] == trial_index]
 
     # Pivot the data so that each row is an arm and the columns are the metric names
-    pivoted: pd.DataFrame = filtered.pivot_table(
+    # and the SEMs for each metric.
+    pivoted_mean: pd.DataFrame = filtered.pivot_table(
         index=["trial_index", "arm_name"], columns="metric_name", values="mean"
     ).dropna()
+    pivoted_sem: pd.DataFrame = filtered.pivot_table(
+        index=["trial_index", "arm_name"], columns="metric_name", values="sem"
+    ).dropna()
+    pivoted = pivoted_mean.join(pivoted_sem, rsuffix="_sem")
     pivoted.reset_index(inplace=True)
     pivoted.columns.name = None
 
@@ -143,21 +147,19 @@ def _prepare_data(
     x_lower_is_better: bool = experiment.metrics[x_metric_name].lower_is_better or False
     y_lower_is_better: bool = experiment.metrics[y_metric_name].lower_is_better or False
 
-    def is_optimal(row: pd.Series) -> bool:
-        x_mask = (
-            (pivoted[x_metric_name] < row[x_metric_name])
-            if x_lower_is_better
-            else (pivoted[x_metric_name] > row[x_metric_name])
-        )
-        y_mask = (
-            (pivoted[y_metric_name] < row[y_metric_name])
-            if y_lower_is_better
-            else (pivoted[y_metric_name] > row[y_metric_name])
-        )
-        return not (x_mask & y_mask).any()
-
     pivoted["is_optimal"] = pivoted.apply(
-        is_optimal,
+        lambda row: not (
+            (
+                (pivoted[x_metric_name] < row[x_metric_name])
+                if x_lower_is_better
+                else (pivoted[x_metric_name] > row[x_metric_name])
+            )
+            & (
+                (pivoted[y_metric_name] < row[y_metric_name])
+                if y_lower_is_better
+                else (pivoted[y_metric_name] > row[y_metric_name])
+            )
+        ).any(),
         axis=1,
     )
 
@@ -181,6 +183,8 @@ def _prepare_plot(
             - arm_name: The name of the arm
             - X_METRIC_NAME: The observed mean of some metric to plot on the x-axis
             - Y_METRIC_NAME: The observed mean of the metric to plot on the y-axis
+            - X_METRIC_NAME_SEM: The SEM of the observed mean of the x-axis metric
+            - Y_METRIC_NAME_SEM: The SEM of the observed mean of the y-axis metric
             - is_optimal: Whether the arm is on the Pareto frontier (this can be
                 omitted if show_pareto_frontier=False)
         x_metric_name: The name of the metric to plot on the x-axis
@@ -191,14 +195,42 @@ def _prepare_plot(
         trial_index: Optional trial index to filter the data to. If not specified,
                 all trials will be included.
     """
-    fig = px.scatter(
-        df,
-        x=x_metric_name,
-        y=y_metric_name,
-        # only show legend + multiple colors if trial index is not specified
-        # indicating all trials are being shown
-        color="trial_index" if trial_index is None else None,
-        hover_data=["trial_index", "arm_name", x_metric_name, y_metric_name],
+    fig = go.Figure(
+        go.Scatter(
+            x=df[x_metric_name],
+            y=df[y_metric_name],
+            mode="markers",
+            marker={
+                "color": "rgba(0, 0, 255, 0.3)",  # partially transparent blue
+            },
+            error_x={
+                "type": "data",
+                "array": df[f"{x_metric_name}_sem"] * 1.96,
+                "visible": True,
+                "color": "rgba(0, 0, 255, 0.2)",  # Semi-transparent blue
+            },
+            error_y={
+                "type": "data",
+                "array": df[f"{y_metric_name}_sem"] * 1.96,
+                "visible": True,
+                "color": "rgba(0, 0, 255, 0.2)",  # Semi-transparent blue
+            },
+            hoverlabel={
+                "bgcolor": "rgba(0, 0, 255, 0.2)",  # partially transparent blue
+                "font": {"color": "black"},
+            },
+            hoverinfo="text",
+            text=df.apply(
+                lambda row: (
+                    f"Trial: {row['trial_index']}<br>"
+                    + f"Arm: {row['arm_name']}<br>"
+                    + f"{x_metric_name}: {row[x_metric_name]}<br>"
+                    + f"{y_metric_name}: {row[y_metric_name]}"
+                ),
+                axis=1,
+            ),
+            showlegend=False,
+        )
     )
 
     if show_pareto_frontier:

--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -62,6 +62,7 @@ class ContourPlot(PlotlyAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
         if experiment is None:
             raise UserInputError("ContourPlot requires an Experiment")
@@ -70,7 +71,7 @@ class ContourPlot(PlotlyAnalysis):
             raise UserInputError("ContourPlot requires a GenerationStrategy")
 
         if generation_strategy.model is None:
-            generation_strategy._fit_current_model(None)
+            generation_strategy._curr._fit(experiment=experiment)
 
         metric_name = self.metric_name or select_metric(experiment=experiment)
 

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -56,6 +56,7 @@ class SlicePlot(PlotlyAnalysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
         if experiment is None:
             raise UserInputError("SlicePlot requires an Experiment")

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -41,7 +41,15 @@ class TestScatterPlot(TestCase):
         self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
         self.assertEqual(
             {*card.df.columns},
-            {"arm_name", "trial_index", "branin_a", "branin_b", "is_optimal"},
+            {
+                "arm_name",
+                "trial_index",
+                "branin_a",
+                "branin_b",
+                "branin_a_sem",
+                "branin_b_sem",
+                "is_optimal",
+            },
         )
         self.assertIsNotNone(card.blob)
         self.assertEqual(card.blob_annotation, "plotly")
@@ -49,7 +57,7 @@ class TestScatterPlot(TestCase):
     def test_prepare_data(self) -> None:
         observations = [[float(i), float(i + 1)] for i in range(10)]
         experiment = get_experiment_with_observations(
-            observations=observations,
+            observations=observations, with_sem=True
         )
         # Mark one trial as failed to ensure that it gets filtered out.
         experiment.trials[9].mark_failed(unsafe=True)
@@ -78,6 +86,8 @@ class TestScatterPlot(TestCase):
                     "arm_name",
                     "m1",
                     "m2",
+                    "m1_sem",
+                    "m2_sem",
                     "is_optimal",
                 },
             )
@@ -95,6 +105,7 @@ class TestScatterPlot(TestCase):
                     self.assertTrue(row["is_optimal"])
                 else:
                     self.assertFalse(row["is_optimal"])
+
         with self.subTest("Test trial filter applied"):
             data = _prepare_data(
                 experiment=experiment,

--- a/ax/analysis/search_space_summary.py
+++ b/ax/analysis/search_space_summary.py
@@ -14,6 +14,7 @@ from ax.analysis.analysis import (
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 
 
 class SearchSpaceSummary(Analysis):
@@ -36,6 +37,7 @@ class SearchSpaceSummary(Analysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> AnalysisCard:
         if experiment is None:
             raise UserInputError(

--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -14,6 +14,7 @@ from ax.analysis.analysis import (
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
 
 
 class Summary(Analysis):
@@ -42,6 +43,7 @@ class Summary(Analysis):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
     ) -> AnalysisCard:
         if experiment is None:
             raise UserInputError("`Summary` analysis requires an `Experiment` input")

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -781,6 +781,7 @@ def get_experiment_with_observations(
     constrained: bool = False,
     with_tracking_metrics: bool = False,
     search_space: SearchSpace | None = None,
+    with_sem: bool = False,
 ) -> Experiment:
     if observations:
         multi_objective = (len(observations[0]) - constrained) > 1
@@ -865,7 +866,7 @@ def get_experiment_with_observations(
                         "arm_name": f"{i}_0",
                         "metric_name": f"m{j + 1}",
                         "mean": o,
-                        "sem": None,
+                        "sem": 0.1 if with_sem else None,
                         "trial_index": i,
                     }
                     for j, o in enumerate(obs)


### PR DESCRIPTION
Summary:
Per our meeting yesterday, we decided to expand the compute method arguments to include adapter. This allows for a bit more flexibility in leveraging a custom adapater instead of the generation strategy.

In follow up diffs we'll add validation between adapter and GS where applicable.

Differential Revision: D70716921


