### PR TITLE
[Docusaurus] Hide recipes navbar item on unsupported doc versions

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -96,10 +96,11 @@ module.exports={
           "position": "left"
         },
         {
-          "type": "docSidebar",
+          "type": "custom-docSidebar",
           "sidebarId": "recipes",
           "label": "Recipes",
-          "position": "left"
+          "position": "left",
+          "ignoreVersions": ["0.5.0"],
         },
         {
           "href": "https://ax.readthedocs.io/",

--- a/website/src/components/DocSidebarNavbarItem.jsx
+++ b/website/src/components/DocSidebarNavbarItem.jsx
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
+import { useActiveDocContext } from '@docusaurus/plugin-content-docs/client';
+import DocSidebarNavbarItem from '@theme-original/NavbarItem/DocSidebarNavbarItem';
+
+
+/* Custom implementation of DocSidebarNavbarItem that supports conditionally
+ * rendering based on the currently selected docs version.
+ */
+export default function ConditionalDocSidebarNavbarItem(props) {
+  const { ignoreVersions, ...restOfProps } = props;
+
+  const { activeVersion } = useActiveDocContext(props.docsPluginId);
+  if (activeVersion === undefined || ignoreVersions.indexOf(activeVersion.name) !== -1) {
+    return null;
+  }
+
+  return <DocSidebarNavbarItem {...restOfProps} />;
+}

--- a/website/src/theme/NavbarItem/ComponentTypes.js
+++ b/website/src/theme/NavbarItem/ComponentTypes.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
 import DocSidebarNavbarItem from '@site/src/components/DocSidebarNavbarItem.jsx';
 

--- a/website/src/theme/NavbarItem/ComponentTypes.js
+++ b/website/src/theme/NavbarItem/ComponentTypes.js
@@ -1,0 +1,7 @@
+import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import DocSidebarNavbarItem from '@site/src/components/DocSidebarNavbarItem.jsx';
+
+export default {
+  ...ComponentTypes,
+    'custom-docSidebar': DocSidebarNavbarItem,
+};


### PR DESCRIPTION
Fix broken website build: https://github.com/facebook/Ax/actions/runs/13691586221/job/38285664204

Unfortunately the navbar items are not included in Docusaurus's versioning system. This is causing Docusaurus to attempt to show the newly added Recipes navbar item even when viewing the 0.5.0 version (which does not contain recipes) leading to a build failure.

Conditionally adding/removing navbar items is not natively supported by Docusaurus but they do provide a way for us to use our own custom navbar items. Our solution is to create a custom wrapper around the `DocSidebarNavbarItem` that only renders it if the current version is not in a provided list of versions.

Inspired by the official recommendation in this docusaurus github issue: https://github.com/facebook/docusaurus/issues/7227