### PR TITLE
Add CI to scatter plot

### DIFF
--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -13,7 +13,7 @@ from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCar
 from ax.core.experiment import Experiment
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from plotly import express as px, graph_objects as go
+from plotly import graph_objects as go
 
 
 class ScatterPlot(PlotlyAnalysis):
@@ -105,7 +105,6 @@ def _prepare_data(
         trial_index: Optional trial index to filter the data to. If not specified,
                 all trials will be included.
     """
-
     # Lookup the data that has already been fetched and attached to the experiment
     data = experiment.lookup_data().df
 
@@ -115,7 +114,7 @@ def _prepare_data(
         lambda trial_index: experiment.trials[trial_index].status.is_completed
     )
     filtered = data[metric_name_mask & status_mask][
-        ["trial_index", "arm_name", "metric_name", "mean"]
+        ["trial_index", "arm_name", "metric_name", "mean", "sem"]
     ]
 
     # filter data to trial index if specified
@@ -123,9 +122,14 @@ def _prepare_data(
         filtered = filtered[filtered["trial_index"] == trial_index]
 
     # Pivot the data so that each row is an arm and the columns are the metric names
-    pivoted: pd.DataFrame = filtered.pivot_table(
+    # and the SEMs for each metric.
+    pivoted_mean: pd.DataFrame = filtered.pivot_table(
         index=["trial_index", "arm_name"], columns="metric_name", values="mean"
     ).dropna()
+    pivoted_sem: pd.DataFrame = filtered.pivot_table(
+        index=["trial_index", "arm_name"], columns="metric_name", values="sem"
+    ).dropna()
+    pivoted = pivoted_mean.join(pivoted_sem, rsuffix="_sem")
     pivoted.reset_index(inplace=True)
     pivoted.columns.name = None
 
@@ -143,21 +147,19 @@ def _prepare_data(
     x_lower_is_better: bool = experiment.metrics[x_metric_name].lower_is_better or False
     y_lower_is_better: bool = experiment.metrics[y_metric_name].lower_is_better or False
 
-    def is_optimal(row: pd.Series) -> bool:
-        x_mask = (
-            (pivoted[x_metric_name] < row[x_metric_name])
-            if x_lower_is_better
-            else (pivoted[x_metric_name] > row[x_metric_name])
-        )
-        y_mask = (
-            (pivoted[y_metric_name] < row[y_metric_name])
-            if y_lower_is_better
-            else (pivoted[y_metric_name] > row[y_metric_name])
-        )
-        return not (x_mask & y_mask).any()
-
     pivoted["is_optimal"] = pivoted.apply(
-        is_optimal,
+        lambda row: not (
+            (
+                (pivoted[x_metric_name] < row[x_metric_name])
+                if x_lower_is_better
+                else (pivoted[x_metric_name] > row[x_metric_name])
+            )
+            & (
+                (pivoted[y_metric_name] < row[y_metric_name])
+                if y_lower_is_better
+                else (pivoted[y_metric_name] > row[y_metric_name])
+            )
+        ).any(),
         axis=1,
     )
 
@@ -181,6 +183,8 @@ def _prepare_plot(
             - arm_name: The name of the arm
             - X_METRIC_NAME: The observed mean of some metric to plot on the x-axis
             - Y_METRIC_NAME: The observed mean of the metric to plot on the y-axis
+            - X_METRIC_NAME_SEM: The SEM of the observed mean of the x-axis metric
+            - Y_METRIC_NAME_SEM: The SEM of the observed mean of the y-axis metric
             - is_optimal: Whether the arm is on the Pareto frontier (this can be
                 omitted if show_pareto_frontier=False)
         x_metric_name: The name of the metric to plot on the x-axis
@@ -191,14 +195,42 @@ def _prepare_plot(
         trial_index: Optional trial index to filter the data to. If not specified,
                 all trials will be included.
     """
-    fig = px.scatter(
-        df,
-        x=x_metric_name,
-        y=y_metric_name,
-        # only show legend + multiple colors if trial index is not specified
-        # indicating all trials are being shown
-        color="trial_index" if trial_index is None else None,
-        hover_data=["trial_index", "arm_name", x_metric_name, y_metric_name],
+    fig = go.Figure(
+        go.Scatter(
+            x=df[x_metric_name],
+            y=df[y_metric_name],
+            mode="markers",
+            marker={
+                "color": "rgba(0, 0, 255, 0.3)",  # partially transparent blue
+            },
+            error_x={
+                "type": "data",
+                "array": df[f"{x_metric_name}_sem"] * 1.96,
+                "visible": True,
+                "color": "rgba(0, 0, 255, 0.2)",  # Semi-transparent blue
+            },
+            error_y={
+                "type": "data",
+                "array": df[f"{y_metric_name}_sem"] * 1.96,
+                "visible": True,
+                "color": "rgba(0, 0, 255, 0.2)",  # Semi-transparent blue
+            },
+            hoverlabel={
+                "bgcolor": "rgba(0, 0, 255, 0.2)",  # partially transparent blue
+                "font": {"color": "black"},
+            },
+            hoverinfo="text",
+            text=df.apply(
+                lambda row: (
+                    f"Trial: {row['trial_index']}<br>"
+                    + f"Arm: {row['arm_name']}<br>"
+                    + f"{x_metric_name}: {row[x_metric_name]}<br>"
+                    + f"{y_metric_name}: {row[y_metric_name]}"
+                ),
+                axis=1,
+            ),
+            showlegend=False,
+        )
     )
 
     if show_pareto_frontier:

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -41,7 +41,15 @@ class TestScatterPlot(TestCase):
         self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
         self.assertEqual(
             {*card.df.columns},
-            {"arm_name", "trial_index", "branin_a", "branin_b", "is_optimal"},
+            {
+                "arm_name",
+                "trial_index",
+                "branin_a",
+                "branin_b",
+                "branin_a_sem",
+                "branin_b_sem",
+                "is_optimal",
+            },
         )
         self.assertIsNotNone(card.blob)
         self.assertEqual(card.blob_annotation, "plotly")
@@ -49,7 +57,7 @@ class TestScatterPlot(TestCase):
     def test_prepare_data(self) -> None:
         observations = [[float(i), float(i + 1)] for i in range(10)]
         experiment = get_experiment_with_observations(
-            observations=observations,
+            observations=observations, with_sem=True
         )
         # Mark one trial as failed to ensure that it gets filtered out.
         experiment.trials[9].mark_failed(unsafe=True)
@@ -78,6 +86,8 @@ class TestScatterPlot(TestCase):
                     "arm_name",
                     "m1",
                     "m2",
+                    "m1_sem",
+                    "m2_sem",
                     "is_optimal",
                 },
             )
@@ -95,6 +105,7 @@ class TestScatterPlot(TestCase):
                     self.assertTrue(row["is_optimal"])
                 else:
                     self.assertFalse(row["is_optimal"])
+
         with self.subTest("Test trial filter applied"):
             data = _prepare_data(
                 experiment=experiment,

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -781,6 +781,7 @@ def get_experiment_with_observations(
     constrained: bool = False,
     with_tracking_metrics: bool = False,
     search_space: SearchSpace | None = None,
+    with_sem: bool = False,
 ) -> Experiment:
     if observations:
         multi_objective = (len(observations[0]) - constrained) > 1
@@ -865,7 +866,7 @@ def get_experiment_with_observations(
                         "arm_name": f"{i}_0",
                         "metric_name": f"m{j + 1}",
                         "mean": o,
-                        "sem": None,
+                        "sem": 0.1 if with_sem else None,
                         "trial_index": i,
                     }
                     for j, o in enumerate(obs)


### PR DESCRIPTION
Summary: This diff adds a 95% CI interval to the scatter plot code. We also do a few other updates: (1) remove color matching for each trial -- i think this is actually not that helpful and we may want to use colors to seperate from modeled vs insample predictions in the future. The hovers take care of the info about trials. (2) adds opacity to CI intervals, and markers for cleaner view (3) cleans up the hover template

Reviewed By: mpolson64

Differential Revision: D70540038


