### PR TITLE
Restrict get_target_trial_index to only include trials with status quo

### DIFF
--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -430,13 +430,13 @@ def extend_pending_observations(
 def get_target_trial_index(experiment: Experiment) -> int | None:
     """Get the index of the target trial in the ``Experiment``.
 
-    Find the target trial (among those with data) giving priority in the following
-    order:
+    Find the target trial, among the trials with data for status quo arm, giving
+    priority in the following order:
         1. a running long-run trial. Note if there is a running long-run trial on the
             experiment without data, or if there is no data on the experiment, then
             this will return None.
         2. Most recent trial expecting data with running trials be considered the most
-            recent
+            recent.
 
     In the event of any ties, the tie breaking order is:
         a. longest running trial by duration
@@ -453,8 +453,11 @@ def get_target_trial_index(experiment: Experiment) -> int | None:
     # takes into account the age of the trial, and consider more heavily weighting
     # long run trials.
     df = experiment.lookup_data().df
-    if df.empty:
+    status_quo = experiment.status_quo
+    if df.empty or status_quo is None:
         return None
+    # Filter to only trials with data for status quo arm.
+    df = df[df["arm_name"] == status_quo.name]
     trial_indices_with_data = set(df.trial_index.unique())
     # only consider running trials with data
     running_trials = [

--- a/ax/generation_strategy/tests/test_generation_node_input_constructors.py
+++ b/ax/generation_strategy/tests/test_generation_node_input_constructors.py
@@ -287,7 +287,6 @@ class TestGenerationNodeInputConstructors(TestCase):
                 trial_type=trial_type,
                 complete=False,
                 num_arms=num_arms,
-                with_status_quo=True,
             )
         self.experiment.fetch_data()
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
@@ -310,6 +309,7 @@ class TestGenerationNodeInputConstructors(TestCase):
             trial_type=Keys.SHORT_RUN,
             complete=False,
             num_arms=1,
+            with_status_quo=False,
         )
         self.experiment.fetch_data()
         with self.assertRaisesRegex(
@@ -330,7 +330,6 @@ class TestGenerationNodeInputConstructors(TestCase):
                 trial_type=Keys.LONG_RUN,
                 complete=False,
                 num_arms=num_arms,
-                with_status_quo=True,
             )
         self.experiment.fetch_data()
         sq_ft = NodeInputConstructors.STATUS_QUO_FEATURES(
@@ -578,7 +577,7 @@ class TestGenerationNodeInputConstructors(TestCase):
         trial_type: str | None = None,
         complete: bool = True,
         num_arms: int = 1,
-        with_status_quo: bool = False,
+        with_status_quo: bool = True,
     ) -> BatchTrial:
         """Helper function to add a trial to an experiment, takes a trial type and
         whether or not the trial is complete, and number of arms"""

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -1884,7 +1884,7 @@ class TestGenerationStrategy(TestCase):
         self.assertEqual(trial.generator_runs[0]._generation_node_name, "sobol_4")
 
     def test_gs_with_fixed_features_constructor(self) -> None:
-        exp = get_branin_experiment(with_completed_batch=True)
+        exp = get_branin_experiment(with_completed_batch=True, with_status_quo=True)
         exp.fetch_data()
         sobol_criterion = [
             MinTrials(

--- a/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
+++ b/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
@@ -23,16 +23,18 @@ from ax.utils.testing.core_stubs import get_branin_experiment, get_robust_search
 class TrialAsTaskTransformTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.exp = get_branin_experiment()
+        self.exp = get_branin_experiment(with_status_quo=True, with_batch=True)
         self.modelbridge = Adapter(
             search_space=self.exp.search_space,
             model=Generator(),
             experiment=self.exp,
         )
-        self.exp.new_trial().add_arm(Arm(parameters={"x1": 1, "x2": 1}))
-        self.exp.new_trial().add_arm(Arm(parameters={"x1": 2, "x2": 2}))
-        self.exp.new_trial().add_arm(Arm(parameters={"x1": 3, "x2": 3}))
-        self.exp.new_trial().add_arm(Arm(parameters={"x1": 4, "x2": 4}))
+        self.exp.new_batch_trial().add_arm(
+            Arm(parameters={"x1": 0, "x2": 0}, name="status_quo")
+        ).add_arm(Arm(parameters={"x1": 1, "x2": 1}))
+        self.exp.new_batch_trial().add_arm(
+            Arm(parameters={"x1": 0, "x2": 0}, name="status_quo")
+        ).add_arm(Arm(parameters={"x1": 3, "x2": 3}))
         for t in self.exp.trials.values():
             t.mark_running(no_runner_required=True)
         self.exp.trials[0].mark_completed()

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -314,15 +314,16 @@ def get_branin_experiment_with_status_quo_trials(
             with_status_quo=True,
         )
     else:
-        exp = get_branin_experiment()
+        exp = get_branin_experiment(with_status_quo=True)
     sobol = get_sobol(search_space=exp.search_space)
     for _ in range(num_sobol_trials):
         sobol_run = sobol.gen(n=1)
         t = exp.new_batch_trial().add_generator_run(sobol_run)
-        t.set_status_quo_with_weight(status_quo=t.arms[0], weight=0.5)
+        t.set_status_quo_with_weight(status_quo=exp.status_quo, weight=0.5)
+        exp.attach_data(get_branin_data_batch(batch=t))
         t.run().mark_completed()
     status_quo_features = ObservationFeatures(
-        parameters=exp.trials[0].status_quo.parameters,  # pyre-fixme [16]
+        parameters=none_throws(exp.status_quo).parameters,
         trial_index=0,
     )
     return exp, status_quo_features


### PR DESCRIPTION
Summary: This helper is typically used to extract the trial index for the status quo features. To ensure that the constructed SQ features corresponds to an actual (trial, arm), the helper is updated to return only the trials that include the SQ arm (and have data for it, as was previously required).

Differential Revision: D70899731


