### PR TITLE
Handling empty metadata in `MapKeyToFloat`

### DIFF
--- a/ax/modelbridge/transforms/map_key_to_float.py
+++ b/ax/modelbridge/transforms/map_key_to_float.py
@@ -72,8 +72,9 @@ class MapKeyToFloat(MetadataToFloat):
         )
 
     def _transform_observation_feature(self, obsf: ObservationFeatures) -> None:
-        if not obsf.parameters:
-            for p in self._parameter_list:
-                obsf.parameters[p.name] = p.upper
+        if len(obsf.parameters) == 0:
+            obsf.parameters = {p.name: p.upper for p in self._parameter_list}
             return
+        if obsf.metadata is None or len(obsf.metadata) == 0:
+            obsf.metadata = {p.name: p.upper for p in self._parameter_list}
         super()._transform_observation_feature(obsf)


### PR DESCRIPTION
Summary: **Context:** In some situations in the MapKeyToFloat transform we encounter observation features with an empty `metadata` dict. This appears to originate only from the pending observations where, for the most part, the `metadata` dict is non-empty. To enable the improvements to how we leverage early-stopped trial data in the parallel setting we are

Differential Revision: D70901701


