### PR TITLE
expose ability to plot adhoc generated points

### DIFF
--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -10,7 +10,11 @@ import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
-from ax.analysis.plotly.utils import select_metric
+from ax.analysis.plotly.utils import (
+    CONFIDENCE_INTERVAL_BLUE,
+    MARKER_BLUE,
+    select_metric,
+)
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
@@ -282,19 +286,19 @@ def _prepare_plot(
             y=df["predicted"],
             mode="markers",
             marker={
-                "color": "rgba(0, 0, 255, 0.3)",  # partially transparent blue
+                "color": MARKER_BLUE,
             },
             error_x={
                 "type": "data",
                 "array": df["observed_95_ci"],
                 "visible": True,
-                "color": "rgba(0, 0, 255, 0.2)",  # partially transparent blue
+                "color": CONFIDENCE_INTERVAL_BLUE,
             },
             error_y={
                 "type": "data",
                 "array": df["predicted_95_ci"],
                 "visible": True,
-                "color": "rgba(0, 0, 255, 0.2)",  # partially transparent blue
+                "color": CONFIDENCE_INTERVAL_BLUE,
             },
             text=df["arm_name"],
             hovertemplate=(
@@ -304,7 +308,7 @@ def _prepare_plot(
                 + "<extra></extra>"  # Removes the trace name from the hover
             ),
             hoverlabel={
-                "bgcolor": "rgba(0, 0, 255, 0.2)",  # partially transparent blue
+                "bgcolor": CONFIDENCE_INTERVAL_BLUE,
                 "font": {"color": "black"},
             },
         )

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -12,6 +12,7 @@ from ax.core.objective import MultiObjective, ScalarizedObjective
 from ax.core.outcome_constraint import ComparisonOp, OutcomeConstraint
 from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.modelbridge.base import Adapter
+
 from botorch.utils.probability.utils import compute_log_prob_feas_from_bounds
 from numpy.typing import NDArray
 
@@ -19,6 +20,12 @@ from numpy.typing import NDArray
 # probability of violating the constraint. But below a certain threshold, we
 # consider probability of violation to be negligible.
 MINIMUM_CONTRAINT_VIOLATION_THRESHOLD = 0.01
+
+# Plotting style constants
+CONFIDENCE_INTERVAL_BLUE = "rgba(0, 0, 255, 0.2)"
+MARKER_BLUE = "rgba(0, 0, 255, 0.3)"  # slightly more opaque than the CI blue
+CANDIDATE_RED = "rgba(220, 20, 60, 0.3)"
+CANDIDATE_CI_RED = "rgba(220, 20, 60, 0.2)"
 
 
 def get_constraint_violated_probabilities(


### PR DESCRIPTION
Summary:
This diff exposes a method to call scatter plot adhoc in a bento enviroment. It also exposes the ability to pass in a custom gr and adapter, and see the predictions from that gr in the plot. It does not allow for passing in multiple gr from multiple adapters -- rn you will need to call scatter with each model<>gr combo, I think this is a fair limitation for now.

Forthcoming diffs:
- [will backlog] add ability to provide a single metric and get all metrics plotted against that metric
- [will backlog] expose label_dict to map metric name ot human readable name
- [backlogged] relativize the plot data

Differential Revision: D70580029


