### PR TITLE
Filter out of design points in best point selection

### DIFF
--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -922,7 +922,7 @@ def predicted_pareto_frontier(
     """
     if observation_features is None:
         observation_features, _, arm_names = _get_modelbridge_training_data(
-            modelbridge=modelbridge
+            modelbridge=modelbridge, in_design_only=True
         )
     else:
         arm_names = None
@@ -963,7 +963,7 @@ def observed_pareto_frontier(
     """
     # Get observation_data from current training data
     obs_feats, obs_data, arm_names = _get_modelbridge_training_data(
-        modelbridge=modelbridge
+        modelbridge=modelbridge, in_design_only=True
     )
 
     pareto_observations = pareto_frontier(
@@ -1300,9 +1300,16 @@ def _array_to_tensor(
 
 
 def _get_modelbridge_training_data(
-    modelbridge: modelbridge_module.torch.TorchAdapter,
+    modelbridge: modelbridge_module.torch.TorchAdapter, in_design_only: bool = False
 ) -> tuple[list[ObservationFeatures], list[ObservationData], list[str | None]]:
+    """
+    Get training data for modelbridge, optionally filtering out out-of-design points.
+    """
     obs = modelbridge.get_training_data()
+
+    if in_design_only:
+        obs = [obs[i] for i in range(len(obs)) if modelbridge.training_in_design[i]]
+
     return _unpack_observations(obs=obs)
 
 

--- a/ax/modelbridge/tests/test_modelbridge_utils.py
+++ b/ax/modelbridge/tests/test_modelbridge_utils.py
@@ -13,6 +13,7 @@ import numpy.typing as npt
 import torch
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
@@ -22,6 +23,7 @@ from ax.core.types import ComparisonOp
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.modelbridge_utils import (
     _array_to_tensor,
+    _get_modelbridge_training_data,
     extract_risk_measure,
     extract_robust_digest,
     extract_search_space_digest,
@@ -31,22 +33,17 @@ from ax.modelbridge.modelbridge_utils import (
     transform_search_space,
 )
 from ax.modelbridge.registry import Cont_X_trans, Y_trans
+from ax.modelbridge.torch import TorchAdapter
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_robust_search_space, get_search_space
 from botorch.acquisition.risk_measures import VaR
 from botorch.utils.datasets import ContextualDataset, SupervisedDataset
 from pyre_extensions import none_throws
+from torch import Tensor
 
 
 class TestAdapterUtils(TestCase):
     def test__array_to_tensor(self) -> None:
-        from ax.modelbridge import Adapter
-
-        @dataclass
-        class MockAdapter(Adapter):
-            def _array_to_tensor(self, array: npt.NDArray | list[float]):
-                return _array_to_tensor(array=array)
-
         mock_modelbridge = MockAdapter()
         arr = [0.0]
         res = _array_to_tensor(array=arr)
@@ -368,3 +365,81 @@ class TestAdapterUtils(TestCase):
             )
             with self.assertRaisesRegex(UserInputError, "Log and Logit"):
                 extract_search_space_digest(ss, list(ss.parameters))
+
+    def test_get_in_desing_modelbridge_training_data(self) -> None:
+        adapter = MockAdapter()
+
+        # Add training data to adapter.
+        adapter._training_data = [
+            Observation(
+                features=ObservationFeatures(
+                    parameters={"x": 2.0, "y": 10.0}, trial_index=0
+                ),
+                data=ObservationData(
+                    means=np.array([2.0, 4.0]),
+                    covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
+                    metric_names=["a", "b"],
+                ),
+                arm_name="0_0",
+            ),
+            Observation(
+                features=ObservationFeatures(
+                    parameters={"x": 20.0, "y": 1.0}, trial_index=0
+                ),
+                data=ObservationData(
+                    means=np.array([20.0, 40.0]),
+                    covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
+                    metric_names=["a", "b"],
+                ),
+                arm_name="1_0",
+            ),
+        ]
+
+        # Test _get_modelbridge_training_data and
+        # _get_in_design_modelbridge_training_data return the same observations when
+        # all are is in-design.
+        adapter._training_in_design = [True, True]
+        obs_feats, obs_data, arm_names = _get_modelbridge_training_data(
+            modelbridge=adapter
+        )
+        in_design_obs_feats, in_design_obs_data, in_design_arm_names = (
+            _get_modelbridge_training_data(modelbridge=adapter, in_design_only=True)
+        )
+        self.assertEqual(obs_feats, in_design_obs_feats)
+        self.assertEqual(obs_data, in_design_obs_data)
+        self.assertEqual(arm_names, in_design_arm_names)
+
+        # Test results are different when some data is out-of-design.
+        adapter._training_in_design = [False, True]
+        obs_feats, obs_data, arm_names = _get_modelbridge_training_data(
+            modelbridge=adapter
+        )
+        in_design_obs_feats, in_design_obs_data, in_design_arm_names = (
+            _get_modelbridge_training_data(modelbridge=adapter, in_design_only=True)
+        )
+        self.assertEqual(len(obs_feats), 2)
+        self.assertEqual(len(obs_data), 2)
+        self.assertEqual(len(arm_names), 2)
+
+        self.assertEqual(len(in_design_obs_feats), 1)
+        self.assertEqual(len(in_design_obs_data), 1)
+        self.assertEqual(len(in_design_arm_names), 1)
+
+        self.assertEqual(obs_feats[1], in_design_obs_feats[0])
+        self.assertEqual(obs_data[1], in_design_obs_data[0])
+        self.assertEqual(arm_names[1], in_design_arm_names[0])
+
+        # Test nothing is returned when all are out-of-design.
+        adapter._training_in_design = [False, False]
+        in_design_obs_feats, in_design_obs_data, in_design_arm_names = (
+            _get_modelbridge_training_data(modelbridge=adapter, in_design_only=True)
+        )
+        self.assertEqual(len(in_design_obs_feats), 0)
+        self.assertEqual(len(in_design_obs_data), 0)
+        self.assertEqual(len(in_design_arm_names), 0)
+
+
+@dataclass
+class MockAdapter(TorchAdapter):
+    def _array_to_tensor(self, array: npt.NDArray | list[float]) -> Tensor:
+        return _array_to_tensor(array=array)

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -190,6 +190,20 @@ class TestBestPointMixin(TestCase):
         )
         self.assertEqual(get_best(exp), 6)
 
+        # Exclude out of design arms
+        exp = get_experiment_with_observations(
+            observations=[[11], [10], [9], [15], [5]],
+            parameterizations=[
+                {"x": 0.0, "y": 0.0},
+                {"x": 0.1, "y": 0.0},
+                {"x": 10.0, "y": 10.0},  # out of design
+                {"x": 0.2, "y": 0.0},
+                {"x": 10.1, "y": 10.0},  # out of design
+            ],
+            minimize=True,
+        )
+        self.assertEqual(get_best(exp), 10)  # 5 and 9 are out of design
+
     def test_extract_Y_from_data(self) -> None:
         # Single objective, minimize.
         exp = get_experiment_with_observations(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 from logging import Logger
 from math import prod
 from pathlib import Path
-from typing import Any, cast, Union
+from typing import Any, cast, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -816,6 +816,7 @@ def get_experiment_with_observations(
     constrained: bool = False,
     with_tracking_metrics: bool = False,
     search_space: SearchSpace | None = None,
+    parameterizations: Sequence[TParameterization] | None = None,
     with_sem: bool = False,
 ) -> Experiment:
     if observations:
@@ -892,8 +893,13 @@ def get_experiment_with_observations(
     )
     sobol_generator = get_sobol(search_space=search_space)
     for i, obs in enumerate(observations):
-        # Create a dummy trial to add the observation.
-        trial = exp.new_trial(generator_run=sobol_generator.gen(n=1))
+        if parameterizations is not None:
+            trial = exp.new_trial(
+                generator_run=GeneratorRun(arms=[Arm(parameters=parameterizations[i])])
+            )
+        else:
+            trial = exp.new_trial(generator_run=sobol_generator.gen(1))
+
         data = Data(
             df=pd.DataFrame.from_records(
                 [


### PR DESCRIPTION
Summary:
Prereq for solving https://github.com/facebook/Ax/issues/3269

This situation may arise when a user attaches a custom arm (say a baseline or data from a previous experiment) which is intentionally out of design. If a user specifies they are only interested in searching over a specific space we should not return points outside of that space when they request the best trial or pareto frontier.

Differential Revision: D70920707


