### PR TITLE
Remove status quo input constructor

### DIFF
--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -430,13 +430,13 @@ def extend_pending_observations(
 def get_target_trial_index(experiment: Experiment) -> int | None:
     """Get the index of the target trial in the ``Experiment``.
 
-    Find the target trial (among those with data) giving priority in the following
-    order:
+    Find the target trial, among the trials with data for status quo arm, giving
+    priority in the following order:
         1. a running long-run trial. Note if there is a running long-run trial on the
             experiment without data, or if there is no data on the experiment, then
             this will return None.
         2. Most recent trial expecting data with running trials be considered the most
-            recent
+            recent.
 
     In the event of any ties, the tie breaking order is:
         a. longest running trial by duration
@@ -453,8 +453,11 @@ def get_target_trial_index(experiment: Experiment) -> int | None:
     # takes into account the age of the trial, and consider more heavily weighting
     # long run trials.
     df = experiment.lookup_data().df
-    if df.empty:
+    status_quo = experiment.status_quo
+    if df.empty or status_quo is None:
         return None
+    # Filter to only trials with data for status quo arm.
+    df = df[df["arm_name"] == status_quo.name]
     trial_indices_with_data = set(df.trial_index.unique())
     # only consider running trials with data
     running_trials = [

--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -410,15 +410,7 @@ class GenerationNode(SerializationMixin, SortableBase):
             return None
 
         if not skip_fit:
-            self._fit(
-                experiment=experiment,
-                data=data,
-                # pyre-ignore[6] TODO: Handle extracting SQ features differently in a
-                # follow-up commit
-                status_quo_features=input_constructor_values.pop(
-                    "status_quo_features", None
-                ),
-            )
+            self._fit(experiment=experiment, data=data)
         model_gen_kwargs = gs_gen_kwargs.copy()
         model_gen_kwargs.update(input_constructor_values)
         try:
@@ -841,10 +833,6 @@ class GenerationNode(SerializationMixin, SortableBase):
                 experiment=experiment,
                 gen_kwargs=gen_kwargs,
             ),
-            "status_quo_features": self._determine_sq_features_from_node(
-                experiment=experiment,
-                gen_kwargs=gen_kwargs,
-            ),
         }
 
     def _determine_arms_from_node(
@@ -936,37 +924,6 @@ class GenerationNode(SerializationMixin, SortableBase):
                 experiment=experiment,
             )
         return node_fixed_features
-
-    def _determine_sq_features_from_node(
-        self,
-        experiment: Experiment,
-        gen_kwargs: dict[str, Any],
-    ) -> ObservationFeatures | None:
-        """Uses the ``InputConstructors`` on the node to determine the status quo
-        features to pass into the model.
-
-        Args:
-            node_to_gen_from: The node from which to generate from
-            gen_kwargs: The kwargs passed to the ``GenerationStrategy``'s
-                gen call.
-
-        Returns:
-            An object of ObservationFeatures that represents the status quo features
-            to pass into the model.
-        """
-        node_sq_features = None
-        input_constructors_module = gs_module.generation_node_input_constructors
-        purpose_sq_features = (
-            input_constructors_module.InputConstructorPurpose.STATUS_QUO_FEATURES
-        )
-        if purpose_sq_features in self.input_constructors:
-            node_sq_features = self.input_constructors[purpose_sq_features](
-                previous_node=self.previous_node,
-                next_node=self,
-                gs_gen_call_kwargs=gen_kwargs,
-                experiment=experiment,
-            )
-        return node_sq_features
 
 
 class GenerationStep(GenerationNode, SortableBase):

--- a/ax/generation_strategy/generation_node_input_constructors.py
+++ b/ax/generation_strategy/generation_node_input_constructors.py
@@ -18,7 +18,6 @@ from ax.exceptions.generation_strategy import AxGenerationException
 from ax.generation_strategy.generation_node import GenerationNode
 from ax.utils.common.constants import Keys
 from ax.utils.common.func_enum import FuncEnum
-from pyre_extensions import none_throws
 
 
 @unique
@@ -34,7 +33,6 @@ class InputConstructorPurpose(Enum):
 
     N = "n"
     FIXED_FEATURES = "fixed_features"
-    STATUS_QUO_FEATURES = "status_quo_features"
 
 
 class NodeInputConstructors(FuncEnum):
@@ -51,7 +49,6 @@ class NodeInputConstructors(FuncEnum):
     REPEAT_N = "repeat_arm_n"
     REMAINING_N = "remaining_n"
     TARGET_TRIAL_FIXED_FEATURES = "set_target_trial"
-    STATUS_QUO_FEATURES = "get_status_quo"
 
     # pyre-ignore[3]: Input constructors will be used to make different inputs,
     # so we need to allow `Any` return type here.
@@ -75,49 +72,6 @@ class NodeInputConstructors(FuncEnum):
 
 
 # ------------------------- Purpose: `fixed_features` ------------------------- #
-
-
-def get_status_quo(
-    previous_node: GenerationNode | None,
-    next_node: GenerationNode,
-    gs_gen_call_kwargs: dict[str, Any],
-    experiment: Experiment,
-) -> ObservationFeatures | None:
-    """Get the status quo features to pass to the fit of the next node, if applicable.
-
-    Args:
-        previous_node: The previous node in the ``GenerationStrategy``. This is the node
-            that is being transition away from, and is provided for easy access to
-            properties of this node.
-        next_node: The next node in the ``GenerationStrategy``. This is the node that
-            will leverage the inputs defined by this input constructor.
-        gs_gen_call_kwargs: The kwargs passed to the ``GenerationStrategy``'s
-            gen call.
-        experiment: The experiment associated with this ``GenerationStrategy``.
-    Returns:
-        An ``ObservationFeatures`` object that defines the status quo observation
-        features for fitting the model in the next node.
-    """
-    if experiment.status_quo is None:
-        raise AxGenerationException(
-            f"Attempting to construct status quo input into {next_node} but the "
-            "experiment has no status quo. Please set a status quo before "
-            "generating."
-        )
-    target_trial_idx = get_target_trial_index(experiment=experiment)
-    if target_trial_idx is None:
-        raise AxGenerationException(
-            f"Attempting to construct status quo input into {next_node} but couldn't "
-            "identify the target trial. Often this could be due to no trials on the "
-            f"experiment that have status quo arm and are in status "
-            f"{STATUSES_EXPECTING_DATA} and have data. The trials on this experiment "
-            f"are: {experiment.trials} and trials with data are: "
-            f"{experiment.lookup_data().df.trial_index.unique()}."
-        )
-    return ObservationFeatures(
-        parameters=none_throws(experiment.status_quo).parameters,
-        trial_index=target_trial_idx,
-    )
 
 
 def set_target_trial(

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -469,9 +469,7 @@ class TestGenerationNodeWithBestModelSelector(TestCase):
                 self.model_selection_node.model_to_gen_from_name, gr._model_key
             )
         mock_fit.assert_called_with(
-            experiment=self.branin_experiment,
-            data=self.branin_experiment.lookup_data(),
-            status_quo_features=None,
+            experiment=self.branin_experiment, data=self.branin_experiment.lookup_data()
         )
         # Check that the metric aggregation function is called twice, once for each
         # model spec.

--- a/ax/generation_strategy/tests/test_generation_node_input_constructors.py
+++ b/ax/generation_strategy/tests/test_generation_node_input_constructors.py
@@ -287,7 +287,6 @@ class TestGenerationNodeInputConstructors(TestCase):
                 trial_type=trial_type,
                 complete=False,
                 num_arms=num_arms,
-                with_status_quo=True,
             )
         self.experiment.fetch_data()
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
@@ -310,6 +309,7 @@ class TestGenerationNodeInputConstructors(TestCase):
             trial_type=Keys.SHORT_RUN,
             complete=False,
             num_arms=1,
+            with_status_quo=False,
         )
         self.experiment.fetch_data()
         with self.assertRaisesRegex(
@@ -330,7 +330,6 @@ class TestGenerationNodeInputConstructors(TestCase):
                 trial_type=Keys.LONG_RUN,
                 complete=False,
                 num_arms=num_arms,
-                with_status_quo=True,
             )
         self.experiment.fetch_data()
         sq_ft = NodeInputConstructors.STATUS_QUO_FEATURES(
@@ -578,7 +577,7 @@ class TestGenerationNodeInputConstructors(TestCase):
         trial_type: str | None = None,
         complete: bool = True,
         num_arms: int = 1,
-        with_status_quo: bool = False,
+        with_status_quo: bool = True,
     ) -> BatchTrial:
         """Helper function to add a trial to an experiment, takes a trial type and
         whether or not the trial is complete, and number of arms"""

--- a/ax/generation_strategy/tests/test_generation_node_input_constructors.py
+++ b/ax/generation_strategy/tests/test_generation_node_input_constructors.py
@@ -91,10 +91,6 @@ class TestGenerationNodeInputConstructors(TestCase):
                 parameters=EXPECTED_INPUT_CONSTRUCTOR_PARAMETER_ANNOTATIONS,
                 return_annotation="ObservationFeatures | None",
             ),
-            InputConstructorPurpose.STATUS_QUO_FEATURES: inspect.Signature(
-                parameters=EXPECTED_INPUT_CONSTRUCTOR_PARAMETER_ANNOTATIONS,
-                return_annotation="ObservationFeatures | None",
-            ),
         }
 
     def test_all_constructors_have_expected_signature_for_purpose(self) -> None:
@@ -301,46 +297,6 @@ class TestGenerationNodeInputConstructors(TestCase):
                 parameters={},
                 trial_index=0,
             ),
-        )
-
-    def test_status_quo_features_no_sq(self) -> None:
-        self._add_sobol_trial(
-            experiment=self.experiment,
-            trial_type=Keys.SHORT_RUN,
-            complete=False,
-            num_arms=1,
-            with_status_quo=False,
-        )
-        self.experiment.fetch_data()
-        with self.assertRaisesRegex(
-            AxGenerationException,
-            "experiment has no status quo",
-        ):
-            NodeInputConstructors.STATUS_QUO_FEATURES(
-                previous_node=None,
-                next_node=self.sobol_generation_node,
-                gs_gen_call_kwargs={},
-                experiment=self.experiment,
-            )
-
-    def test_status_quo_features(self) -> None:
-        for num_arms in (1, 3):
-            self._add_sobol_trial(
-                experiment=self.experiment,
-                trial_type=Keys.LONG_RUN,
-                complete=False,
-                num_arms=num_arms,
-            )
-        self.experiment.fetch_data()
-        sq_ft = NodeInputConstructors.STATUS_QUO_FEATURES(
-            previous_node=None,
-            next_node=self.sobol_generation_node,
-            gs_gen_call_kwargs={},
-            experiment=self.experiment,
-        )
-        self.assertEqual(
-            sq_ft,
-            ObservationFeatures(parameters={"x1": 0, "x2": 0}, trial_index=1),
         )
 
     def test_set_target_trial_most_arms_long_run_wins(self) -> None:

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -1884,7 +1884,7 @@ class TestGenerationStrategy(TestCase):
         self.assertEqual(trial.generator_runs[0]._generation_node_name, "sobol_4")
 
     def test_gs_with_fixed_features_constructor(self) -> None:
-        exp = get_branin_experiment(with_completed_batch=True)
+        exp = get_branin_experiment(with_completed_batch=True, with_status_quo=True)
         exp.fetch_data()
         sobol_criterion = [
             MinTrials(

--- a/ax/modelbridge/random.py
+++ b/ax/modelbridge/random.py
@@ -127,9 +127,5 @@ class RandomAdapter(Adapter):
     ) -> list[ObservationData]:
         raise NotImplementedError
 
-    def _set_status_quo(
-        self,
-        experiment: Experiment | None,
-        status_quo_features: ObservationFeatures | None,
-    ) -> None:
+    def _set_status_quo(self, experiment: Experiment) -> None:
         pass

--- a/ax/modelbridge/tests/test_torch_moo_modelbridge.py
+++ b/ax/modelbridge/tests/test_torch_moo_modelbridge.py
@@ -44,7 +44,6 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment_with_multi_objective,
     get_hierarchical_search_space,
     get_hss_trials_with_fixed_parameter,
-    get_non_monolithic_branin_moo_data,
     TEST_SOBOL_SEED,
 )
 from ax.utils.testing.mock import mock_botorch_optimize, skip_fit_gpytorch_mll
@@ -704,31 +703,6 @@ class MultiObjectiveTorchAdapterTest(TestCase):
         self.assertEqual(obj_thresholds[1].op, ComparisonOp.LEQ)
         self.assertFalse(obj_thresholds[0].relative)
         self.assertFalse(obj_thresholds[1].relative)
-
-    @mock_botorch_optimize
-    def test_status_quo_for_non_monolithic_data(self) -> None:
-        exp = get_branin_experiment_with_multi_objective(with_status_quo=True)
-        sobol_generator = get_sobol(
-            search_space=exp.search_space,
-        )
-        sobol_run = sobol_generator.gen(n=5)
-        exp.new_batch_trial(sobol_run).set_status_quo_and_optimize_power(
-            status_quo=exp.status_quo
-        ).run()
-
-        # create data where metrics vary in start and end times
-        data = get_non_monolithic_branin_moo_data()
-
-        bridge = TorchAdapter(
-            search_space=exp.search_space,
-            model=MultiObjectiveLegacyBoTorchGenerator(),
-            optimization_config=exp.optimization_config,
-            experiment=exp,
-            data=data,
-            transforms=[],
-        )
-        # pyre-fixme[16]: Optional type has no attribute `arm_name`.
-        self.assertEqual(bridge.status_quo.arm_name, "status_quo")
 
     def test_best_point(self) -> None:
         exp = get_branin_experiment_with_multi_objective(

--- a/ax/modelbridge/tests/test_transform_utils.py
+++ b/ax/modelbridge/tests/test_transform_utils.py
@@ -71,7 +71,7 @@ class TransformUtilsTest(TestCase):
         modelbridge = Adapter(
             experiment=Experiment(
                 search_space=dummy_search_space,
-                status_quo=Arm(parameters={"x": 1.0, "y": 1.0}, name="1_1"),
+                status_quo=Arm(parameters={"x": 2.0, "y": 10.0}, name="1_1"),
             ),
             model=Generator(),
             optimization_config=optimization_config,

--- a/ax/modelbridge/transforms/tests/test_derelativize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_derelativize_transform.py
@@ -122,7 +122,7 @@ class DerelativizeTransformTest(TestCase):
         g = Adapter(
             experiment=Experiment(
                 search_space=search_space,
-                status_quo=Arm(parameters={"x": 1.0, "y": 1.0}, name="1_1"),
+                status_quo=Arm(parameters={"x": 2.0, "y": 10.0}, name="1_1"),
             ),
             model=Generator(),
         )
@@ -204,7 +204,7 @@ class DerelativizeTransformTest(TestCase):
         g = Adapter(
             experiment=Experiment(
                 search_space=search_space,
-                status_quo=Arm(parameters={"x": 1.0, "y": 1.0}, name="1_2"),
+                status_quo=Arm(parameters={"x": None, "y": None}, name="1_2"),
             ),
             model=Generator(),
         )
@@ -253,7 +253,7 @@ class DerelativizeTransformTest(TestCase):
         g = Adapter(
             experiment=Experiment(
                 search_space=search_space,
-                status_quo=Arm(parameters={"x": 1.0, "y": 1.0}, name="1_1"),
+                status_quo=Arm(parameters={"x": 2.0, "y": 10.0}, name="1_1"),
             ),
             model=Generator(),
         )

--- a/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
+++ b/ax/modelbridge/transforms/tests/test_trial_as_task_transform.py
@@ -23,16 +23,18 @@ from ax.utils.testing.core_stubs import get_branin_experiment, get_robust_search
 class TrialAsTaskTransformTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.exp = get_branin_experiment()
+        self.exp = get_branin_experiment(with_status_quo=True, with_batch=True)
         self.modelbridge = Adapter(
             search_space=self.exp.search_space,
             model=Generator(),
             experiment=self.exp,
         )
-        self.exp.new_trial().add_arm(Arm(parameters={"x1": 1, "x2": 1}))
-        self.exp.new_trial().add_arm(Arm(parameters={"x1": 2, "x2": 2}))
-        self.exp.new_trial().add_arm(Arm(parameters={"x1": 3, "x2": 3}))
-        self.exp.new_trial().add_arm(Arm(parameters={"x1": 4, "x2": 4}))
+        self.exp.new_batch_trial().add_arm(
+            Arm(parameters={"x1": 0, "x2": 0}, name="status_quo")
+        ).add_arm(Arm(parameters={"x1": 1, "x2": 1}))
+        self.exp.new_batch_trial().add_arm(
+            Arm(parameters={"x1": 0, "x2": 0}, name="status_quo")
+        ).add_arm(Arm(parameters={"x1": 3, "x2": 3}))
         for t in self.exp.trials.values():
             t.mark_running(no_runner_required=True)
         self.exp.trials[0].mark_completed()

--- a/ax/modelbridge/transforms/tests/test_winsorize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_winsorize_transform.py
@@ -619,7 +619,7 @@ class WinsorizeTransformTest(TestCase):
         modelbridge = Adapter(
             experiment=Experiment(
                 search_space=search_space,
-                status_quo=Arm(parameters={"x": 1.0, "y": 1.0}, name="1_1"),
+                status_quo=Arm(parameters={"x": 2.0, "y": 10.0}, name="1_1"),
             ),
             model=Generator(),
             transforms=[],
@@ -656,8 +656,11 @@ class WinsorizeTransformTest(TestCase):
                 Winsorize(search_space=None, observations=observations, config=config)
 
 
-# pyre-fixme[2]: Parameter must be annotated.
-def get_transform(observation_data, config=None, optimization_config=None) -> Winsorize:
+def get_transform(
+    observation_data: list[ObservationData],
+    config: dict[str, Any] | None = None,
+    optimization_config: OptimizationConfig | None = None,
+) -> Winsorize:
     observations = [
         Observation(features=ObservationFeatures({}), data=obsd)
         for obsd in observation_data

--- a/ax/plot/tests/test_tile_fitted.py
+++ b/ax/plot/tests/test_tile_fitted.py
@@ -119,7 +119,7 @@ class TileObservationsTest(TestCase):
         exp.search_space = SearchSpace(
             parameters=list(exp.search_space.parameters.values())
         )
-        config = tile_observations(experiment=exp, arm_names=["0_1", "0_2"], rel=False)
+        config = tile_observations(experiment=exp, arm_names=["0_0", "0_1"], rel=False)
 
         for key in ["layout", "data"]:
             self.assertIn(key, config.data)
@@ -142,13 +142,13 @@ class TileObservationsTest(TestCase):
         )
 
         # Data
-        self.assertEqual(config.data["data"][0]["x"], ["0_1", "0_2"])
-        self.assertEqual(config.data["data"][0]["y"], [2.0, 2.25])
+        self.assertEqual(config.data["data"][0]["x"], ["0_0", "0_1"])
+        self.assertEqual(config.data["data"][0]["y"], [3.0, 2.0])
         self.assertEqual(config.data["data"][0]["type"], "scatter")
-        self.assertIn("Arm 0_1", config.data["data"][0]["text"][0])
+        self.assertIn("Arm 0_0", config.data["data"][0]["text"][0])
 
         label_dict = {"ax_test_metric": "mapped_name"}
         config = tile_observations(
-            experiment=exp, arm_names=["0_1", "0_2"], rel=False, label_dict=label_dict
+            experiment=exp, arm_names=["0_0", "0_1"], rel=False, label_dict=label_dict
         )
         self.assertEqual(config.data["layout"]["annotations"][0]["text"], "mapped_name")

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -92,6 +92,9 @@ _DEPRECATED_MODEL_KWARGS: tuple[str, ...] = (
     "status_quo_name",
 )
 
+# Deprecated node input constructors, removed from GNodes.
+_DEPRECATED_NODE_INPUT_CONSTRUCTORS: tuple[str, ...] = ("status_quo_features",)
+
 
 @dataclass
 class RegistryKwargs:
@@ -661,14 +664,16 @@ def generation_node_from_json(
     # recursively decode dictionary key values.
     decoded_input_constructors = None
     if "input_constructors" in generation_node_json.keys():
-        decoded_input_constructors = {
-            InputConstructorPurpose[key]: object_from_json(
+        decoded_input_constructors = {}
+        for key, value in generation_node_json.pop("input_constructors").items():
+            if key in _DEPRECATED_NODE_INPUT_CONSTRUCTORS:
+                # Skip deprecated input constructors.
+                continue
+            decoded_input_constructors[InputConstructorPurpose[key]] = object_from_json(
                 value,
                 decoder_registry=decoder_registry,
                 class_decoder_registry=class_decoder_registry,
             )
-            for key, value in generation_node_json.pop("input_constructors").items()
-        }
 
     return GenerationNode(
         node_name=generation_node_json.pop("node_name"),

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -233,12 +233,6 @@ TEST_CASES = [
     ),
     (
         "GenerationStrategy",
-        partial(
-            sobol_gpei_generation_node_gs, with_input_constructors_sq_features=True
-        ),
-    ),
-    (
-        "GenerationStrategy",
         partial(sobol_gpei_generation_node_gs, with_unlimited_gen_mbm=True),
     ),
     (

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -573,7 +573,7 @@ class SQAStoreTest(TestCase):
 
     def test_load_and_save_reduced_state_does_not_lose_abandoned_arms(self) -> None:
         exp = get_experiment_with_batch_trial(constrain_search_space=False)
-        exp.trials[0].mark_arm_abandoned(arm_name="0_0", reason="for this test")
+        self.assertEqual(len(exp.trials[0].abandoned_arms), 1)
         save_experiment(exp)
         loaded_experiment = load_experiment(
             exp.name, reduced_state=True, skip_runners_and_metrics=True
@@ -584,10 +584,7 @@ class SQAStoreTest(TestCase):
             reloaded_experiment.trials[0].abandoned_arms,
             exp.trials[0].abandoned_arms,
         )
-        self.assertEqual(
-            len(reloaded_experiment.trials[0].abandoned_arms),
-            1,
-        )
+        self.assertEqual(len(reloaded_experiment.trials[0].abandoned_arms), 1)
 
     def test_ExperimentSaveAndLoadGRWithOptConfig(self) -> None:
         exp = get_experiment_with_batch_trial(constrain_search_space=False)

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -314,15 +314,16 @@ def get_branin_experiment_with_status_quo_trials(
             with_status_quo=True,
         )
     else:
-        exp = get_branin_experiment()
+        exp = get_branin_experiment(with_status_quo=True)
     sobol = get_sobol(search_space=exp.search_space)
     for _ in range(num_sobol_trials):
         sobol_run = sobol.gen(n=1)
         t = exp.new_batch_trial().add_generator_run(sobol_run)
-        t.set_status_quo_with_weight(status_quo=t.arms[0], weight=0.5)
+        t.set_status_quo_with_weight(status_quo=exp.status_quo, weight=0.5)
+        exp.attach_data(get_branin_data_batch(batch=t))
         t.run().mark_completed()
     status_quo_features = ObservationFeatures(
-        parameters=exp.trials[0].status_quo.parameters,  # pyre-fixme [16]
+        parameters=none_throws(exp.status_quo).parameters,
         trial_index=0,
     )
     return exp, status_quo_features

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -118,24 +118,6 @@ def get_observation_status_quo0(
     )
 
 
-def get_observation_status_quo1(
-    first_metric_name: str = "a",
-    second_metric_name: str = "b",
-) -> Observation:
-    return Observation(
-        features=ObservationFeatures(
-            parameters={"w": 0.85, "x": 1, "y": "baz", "z": False},
-            trial_index=1,
-        ),
-        data=ObservationData(
-            means=np.array([2.0, 4.0]),
-            covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
-            metric_names=[first_metric_name, second_metric_name],
-        ),
-        arm_name="0_0",
-    )
-
-
 def get_observation1trans(
     first_metric_name: str = "a",
     second_metric_name: str = "b",

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -212,7 +212,6 @@ def sobol_gpei_generation_node_gs(
     with_input_constructors_remaining_n: bool = False,
     with_input_constructors_repeat_n: bool = False,
     with_input_constructors_target_trial: bool = False,
-    with_input_constructors_sq_features: bool = False,
     with_unlimited_gen_mbm: bool = False,
     with_trial_type: bool = False,
     with_is_SOO_transition: bool = False,
@@ -235,7 +234,6 @@ def sobol_gpei_generation_node_gs(
                 with_input_constructors_remaining_n,
                 with_input_constructors_repeat_n,
                 with_input_constructors_target_trial,
-                with_input_constructors_sq_features,
             ]
         )
         > 1
@@ -368,11 +366,6 @@ def sobol_gpei_generation_node_gs(
         purpose = InputConstructorPurpose.FIXED_FEATURES
         sobol_node._input_constructors = {
             purpose: NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES,
-        }
-    elif with_input_constructors_sq_features:
-        purpose = InputConstructorPurpose.STATUS_QUO_FEATURES
-        sobol_node._input_constructors = {
-            purpose: NodeInputConstructors.STATUS_QUO_FEATURES,
         }
 
     sobol_mbm_GS_nodes = GenerationStrategy(


### PR DESCRIPTION
Summary:
This is now (D70395177) extracted directly from the experiment in `Adapter._set_status_quo`. A separate input constructor is not needed. The `status_quo_features` input will also be deprecated in the next diff.

The storage code is also updated to discard the deprecated input constructor while decoding JSON objects, to ensure old experiments can be loaded without issues.

Differential Revision: D70516665


