### PR TITLE
add metric name mapping

### DIFF
--- a/ax/analysis/plotly/arm_effects/predicted_effects.py
+++ b/ax/analysis/plotly/arm_effects/predicted_effects.py
@@ -17,7 +17,7 @@ from ax.analysis.plotly.arm_effects.utils import (
 )
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
-from ax.analysis.plotly.utils import is_predictive
+from ax.analysis.plotly.utils import get_nudge_value, is_predictive
 from ax.core import OutcomeConstraint
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.experiment import Experiment
@@ -129,22 +129,12 @@ class PredictedEffectsPlot(PlotlyAnalysis):
         fig = prepare_arm_effects_plot(
             df=df, metric_name=self.metric_name, outcome_constraints=outcome_constraints
         )
-
-        level = AnalysisCardLevel.HIGH
-        nudge = -2
-        if experiment.optimization_config is not None:
-            if (
-                self.metric_name
-                in experiment.optimization_config.objective.metric_names
-            ):
-                nudge = 0
-            elif self.metric_name in experiment.optimization_config.metrics:
-                nudge = -1
+        nudge = get_nudge_value(metric_name=self.metric_name, experiment=experiment)
 
         return self._create_plotly_analysis_card(
             title=f"Predicted Effects for {self.metric_name}",
             subtitle="View a candidate trial and its arms' predicted metric values",
-            level=level + nudge,
+            level=AnalysisCardLevel.HIGH + nudge,
             df=df,
             fig=fig,
             category=AnalysisCardCategory.ACTIONABLE,

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -12,6 +12,7 @@ from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
 from ax.analysis.plotly.utils import (
     CONFIDENCE_INTERVAL_BLUE,
+    get_nudge_value,
     MARKER_BLUE,
     select_metric,
 )
@@ -116,22 +117,7 @@ class CrossValidationPlot(PlotlyAnalysis):
 
         fig = _prepare_plot(df=df)
         k_folds_substring = f"{self.folds}-fold" if self.folds > 0 else "leave-one-out"
-        # Nudge the priority if the metric is important to the experiment
-        if (
-            experiment is not None
-            and (optimization_config := experiment.optimization_config) is not None
-            and (objective := optimization_config.objective) is not None
-            and metric_name in objective.metric_names
-        ):
-            nudge = 2
-        elif (
-            experiment is not None
-            and (optimization_config := experiment.optimization_config) is not None
-            and metric_name in optimization_config.outcome_constraints
-        ):
-            nudge = 1
-        else:
-            nudge = 0
+        nudge = get_nudge_value(metric_name=metric_name, experiment=experiment)
 
         # If a human readable metric name is provided, use it in the title
         metric_title = self._refined_metric_name or metric_name

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -10,7 +10,11 @@ import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
-from ax.analysis.plotly.utils import select_metric
+from ax.analysis.plotly.utils import (
+    CONFIDENCE_INTERVAL_BLUE,
+    MARKER_BLUE,
+    select_metric,
+)
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
@@ -282,19 +286,19 @@ def _prepare_plot(
             y=df["predicted"],
             mode="markers",
             marker={
-                "color": "rgba(0, 0, 255, 0.3)",  # partially transparent blue
+                "color": MARKER_BLUE,
             },
             error_x={
                 "type": "data",
                 "array": df["observed_95_ci"],
                 "visible": True,
-                "color": "rgba(0, 0, 255, 0.2)",  # partially transparent blue
+                "color": CONFIDENCE_INTERVAL_BLUE,
             },
             error_y={
                 "type": "data",
                 "array": df["predicted_95_ci"],
                 "visible": True,
-                "color": "rgba(0, 0, 255, 0.2)",  # partially transparent blue
+                "color": CONFIDENCE_INTERVAL_BLUE,
             },
             text=df["arm_name"],
             hovertemplate=(
@@ -304,7 +308,7 @@ def _prepare_plot(
                 + "<extra></extra>"  # Removes the trace name from the hover
             ),
             hoverlabel={
-                "bgcolor": "rgba(0, 0, 255, 0.2)",  # partially transparent blue
+                "bgcolor": CONFIDENCE_INTERVAL_BLUE,
                 "font": {"color": "black"},
             },
         )

--- a/ax/analysis/plotly/tests/test_insample_effects.py
+++ b/ax/analysis/plotly/tests/test_insample_effects.py
@@ -430,7 +430,6 @@ class TestInsampleEffectsPlot(TestCase):
             with self.subTest("objective is high"):
                 # WHEN we compute the analysis for an objective
                 analysis = InSampleEffectsPlot(
-                    # trial_index and use_modeled_effects don't affect the level
                     metric_name=metric,
                     trial_index=0,
                     use_modeled_effects=False,

--- a/ax/analysis/plotly/tests/test_predicted_effects.py
+++ b/ax/analysis/plotly/tests/test_predicted_effects.py
@@ -43,7 +43,7 @@ class TestPredictedEffectsPlot(TestCase):
 
     def test_compute_for_requires_a_gs(self) -> None:
         analysis = PredictedEffectsPlot(metric_name="branin")
-        experiment = get_branin_experiment()
+        experiment = get_branin_experiment(with_batch=True, with_completed_batch=True)
         with self.assertRaisesRegex(UserInputError, "requires a GenerationStrategy"):
             analysis.compute(experiment=experiment)
 

--- a/ax/analysis/plotly/tests/test_predicted_effects.py
+++ b/ax/analysis/plotly/tests/test_predicted_effects.py
@@ -117,12 +117,12 @@ class TestPredictedEffectsPlot(TestCase):
                 self.assertEqual(
                     card.level,
                     (
-                        AnalysisCardLevel.HIGH
+                        AnalysisCardLevel.HIGH + 2
                         if metric == "branin"
                         else (
-                            AnalysisCardLevel.HIGH - 1
+                            AnalysisCardLevel.HIGH + 1
                             if metric == "constraint_branin"
-                            else AnalysisCardLevel.HIGH - 2
+                            else AnalysisCardLevel.HIGH
                         )
                     ),
                 )

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -97,7 +97,24 @@ class TestScatterPlot(TestCase):
             )
             # candidate points are given an index of -1, check that exists
             self.assertTrue((adhoc_card.df["trial_index"] == -1).any())
-        return
+        with self.subTest("human readable metric names provided"):
+            metric_name_mapping = {
+                self.x_metric_name: "spunky",
+                self.y_metric_name: "sneaky",
+            }
+            adhoc_cards = scatter_plot(
+                adapter=adapter,
+                experiment=self.exp_w_trial_complete,
+                x_metric_name=self.x_metric_name,
+                y_metric_name=self.y_metric_name,
+                metric_name_mapping=metric_name_mapping,
+            )
+            self.assertEqual(len(adhoc_cards), 1)
+            adhoc_card = adhoc_cards[0]
+            self.assertEqual(
+                adhoc_card.title,
+                "Observed spunky vs. sneaky",
+            )
 
     def test_prepare_data(self) -> None:
         observations = [[float(i), float(i + 1)] for i in range(10)]

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -133,6 +133,33 @@ def format_constraint_violated_probabilities(
     return constraints_violated_str
 
 
+def get_nudge_value(
+    metric_name: str,
+    experiment: Experiment | None = None,
+    use_modeled_effects: bool = False,
+) -> int:
+    """Get the amount to nudge the level of the plot. Deteremined by metric
+    importance and whether modeled effects are used.
+    """
+    # without an experiment or optimization config, we can't tell if this plot is
+    # relatively more important
+    if experiment is None or experiment.optimization_config is None:
+        return 0
+
+    nudge = 0
+    # More important metrics have a higher nudge
+    if metric_name in experiment.optimization_config.objective.metric_names:
+        nudge += 2
+    elif metric_name in experiment.optimization_config.metrics:
+        nudge += 1
+
+    # Relevant for plots where observed effects and modeled effects can both be shown
+    if use_modeled_effects:
+        nudge += 1
+
+    return nudge
+
+
 def is_predictive(model: Adapter) -> bool:
     """Check if a model is predictive.  Basically, we're checking if
     predict() is implemented.

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -12,6 +12,7 @@ from ax.core.objective import MultiObjective, ScalarizedObjective
 from ax.core.outcome_constraint import ComparisonOp, OutcomeConstraint
 from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.modelbridge.base import Adapter
+
 from botorch.utils.probability.utils import compute_log_prob_feas_from_bounds
 from numpy.typing import NDArray
 
@@ -19,6 +20,12 @@ from numpy.typing import NDArray
 # probability of violating the constraint. But below a certain threshold, we
 # consider probability of violation to be negligible.
 MINIMUM_CONTRAINT_VIOLATION_THRESHOLD = 0.01
+
+# Plotting style constants
+CONFIDENCE_INTERVAL_BLUE = "rgba(0, 0, 255, 0.2)"
+MARKER_BLUE = "rgba(0, 0, 255, 0.3)"  # slightly more opaque than the CI blue
+CANDIDATE_RED = "rgba(220, 20, 60, 0.3)"
+CANDIDATE_CI_RED = "rgba(220, 20, 60, 0.2)"
 
 
 def get_constraint_violated_probabilities(


### PR DESCRIPTION
Summary:
Another nice UX look/feel additiive for the scatter plot is to accept metric mapping to replace long names with human readable names -- this prevents the axes from spilling over.

In the future we should accept and consume this on the UI side as well. But that's a larger discussion related to canonical names

Differential Revision: D70978118


