### PR TITLE
move is_predictive to adapter property can_predict

### DIFF
--- a/ax/analysis/plotly/arm_effects/insample_effects.py
+++ b/ax/analysis/plotly/arm_effects/insample_effects.py
@@ -168,6 +168,7 @@ def _get_model(
         If use_modeled_effects is True, returns the current model on the generation
         strategy if it is predictive.  Otherwise, returns an empirical Bayes model.
     """
+    # TODO: merge this method into get_adapter helper in the utils file
     trial_data = experiment.lookup_data(trial_indices=[trial_index])
     if trial_data.filter(metric_names=[metric_name]).df.empty:
         raise DataRequiredError(
@@ -183,24 +184,24 @@ def _get_model(
             experiment=experiment,
         )
 
-    model = None
+    adapter = None
     if generation_strategy is not None:
         if generation_strategy.model is None:
             generation_strategy._curr._fit(experiment=experiment)
 
-        model = none_throws(generation_strategy.model)
+        adapter = none_throws(generation_strategy.model)
 
-    if model is None or not is_predictive(model=model):
+    if adapter is None or not is_predictive(adapter=adapter):
         logger.info(
             "Using Empirical Bayes to predict effects because we were unable to find "
-            + " a suitable model on the current Generation Strategy. Current "
-            + f" Generation Strategy is: {generation_strategy} and model is: {model}"
+            + " a suitable adapter on the current Generation Strategy. Current "
+            + f" Generation Strategy is: {generation_strategy} and model is: {adapter}"
         )
         return Generators.EMPIRICAL_BAYES_THOMPSON(
             experiment=experiment, data=trial_data
         )
 
-    return model
+    return adapter
 
 
 def _prepare_data(

--- a/ax/analysis/plotly/arm_effects/predicted_effects.py
+++ b/ax/analysis/plotly/arm_effects/predicted_effects.py
@@ -17,7 +17,7 @@ from ax.analysis.plotly.arm_effects.utils import (
 )
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
-from ax.analysis.plotly.utils import get_adapter, get_nudge_value, is_predictive
+from ax.analysis.plotly.utils import get_adapter, get_nudge_value
 from ax.core import OutcomeConstraint
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.experiment import Experiment
@@ -92,14 +92,8 @@ class PredictedEffectsPlot(PlotlyAnalysis):
             experiment=experiment,
             generation_strategy=generation_strategy,
             adapter=adapter,
+            enforce_supports_predictions=True,
         )
-
-        if not is_predictive(model=adapter):
-            raise UserInputError(
-                "PredictedEffectsPlot requires a GenerationStrategy which is "
-                "in a state where the current model supports prediction.  The current "
-                f"model is {adapter._model_key} and does not support prediction."
-            )
 
         outcome_constraints = (
             []

--- a/ax/analysis/plotly/tests/test_predicted_effects.py
+++ b/ax/analysis/plotly/tests/test_predicted_effects.py
@@ -43,7 +43,7 @@ class TestPredictedEffectsPlot(TestCase):
 
     def test_compute_for_requires_a_gs(self) -> None:
         analysis = PredictedEffectsPlot(metric_name="branin")
-        experiment = get_branin_experiment()
+        experiment = get_branin_experiment(with_batch=True, with_completed_batch=True)
         with self.assertRaisesRegex(UserInputError, "requires a GenerationStrategy"):
             analysis.compute(experiment=experiment)
 

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -97,7 +97,24 @@ class TestScatterPlot(TestCase):
             )
             # candidate points are given an index of -1, check that exists
             self.assertTrue((adhoc_card.df["trial_index"] == -1).any())
-        return
+        with self.subTest("human readable metric names provided"):
+            metric_name_mapping = {
+                self.x_metric_name: "spunky",
+                self.y_metric_name: "sneaky",
+            }
+            adhoc_cards = scatter_plot(
+                adapter=adapter,
+                experiment=self.exp_w_trial_complete,
+                x_metric_name=self.x_metric_name,
+                y_metric_name=self.y_metric_name,
+                metric_name_mapping=metric_name_mapping,
+            )
+            self.assertEqual(len(adhoc_cards), 1)
+            adhoc_card = adhoc_cards[0]
+            self.assertEqual(
+                adhoc_card.title,
+                "Observed spunky vs. sneaky",
+            )
 
     def test_prepare_data(self) -> None:
         observations = [[float(i), float(i + 1)] for i in range(10)]


### PR DESCRIPTION
Summary:
In our analysis utils file we had a method: is_predictive() but this method seems incorrectly placed in our stack and so this diff 
- moves that method to adapter class
- moves the check for is_predictive to the get_adapter method

Differential Revision: D71046045


