### PR TITLE
Fix deprecated node input constructor decoder

### DIFF
--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -94,7 +94,8 @@ _DEPRECATED_MODEL_KWARGS: tuple[str, ...] = (
 )
 
 # Deprecated node input constructors, removed from GNodes.
-_DEPRECATED_NODE_INPUT_CONSTRUCTORS: tuple[str, ...] = ("status_quo_features",)
+# NOTE: These are the enum keys, which are typically upper-case.
+_DEPRECATED_NODE_INPUT_CONSTRUCTORS: tuple[str, ...] = ("STATUS_QUO_FEATURES",)
 
 
 @dataclass


### PR DESCRIPTION
Summary: There was a case mismatch that prevented the backwards compatibility bit from working. We now cast to lower case before comparing the names.

Reviewed By: sdaulton

Differential Revision: D71065973


