### PR TITLE
Eliminate bug that added dynamic behavior on `GS.__repr__`

### DIFF
--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -183,6 +183,10 @@ class GenerationNode(SerializationMixin, SortableBase):
                 f"Trial type must be either {Keys.SHORT_RUN} or {Keys.LONG_RUN},"
                 f" got {trial_type}."
             )
+        # If possible, assign `_model_spec_to_gen_from` right away, for use in
+        # `__repr__`
+        if len(model_specs) == 1:
+            self._model_spec_to_gen_from = model_specs[0]
         self.model_specs = model_specs
         self.best_model_selector = best_model_selector
         self.should_deduplicate = should_deduplicate

--- a/ax/generation_strategy/generation_strategy.py
+++ b/ax/generation_strategy/generation_strategy.py
@@ -482,10 +482,11 @@ class GenerationStrategy(Base):
         of the fields should be identical.
         """
         self._model = None
-        for s in self._nodes:
-            s._model_spec_to_gen_from = None
+        for n in self._nodes:
+            if len(n.model_specs) > 1:
+                n._model_spec_to_gen_from = None
             if not self.is_node_based:
-                s._previous_node_name = None
+                n._previous_node_name = None
 
     @step_based_gs_only
     def _validate_and_set_step_sequence(self, steps: list[GenerationStep]) -> None:
@@ -631,9 +632,10 @@ class GenerationStrategy(Base):
                 ):
                     num_trials = criterion.threshold
 
-            try:
-                model_name = step.model_spec_to_gen_from.model_key
-            except TypeError:
+            model_spec = step._model_spec_to_gen_from
+            if model_spec is not None:
+                model_name = model_spec.model_key
+            else:
                 model_name = "model with unknown name"
 
             step_str_rep += f"{model_name} for {num_trials} trials, "

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -279,7 +279,7 @@ class TestGenerationNode(TestCase):
                 ),
             ],
         )
-        self.assertIsNone(node.model_to_gen_from_name)
+        self.assertEqual(node.model_to_gen_from_name, "BoTorch")
         node._fit(
             experiment=self.branin_experiment,
             data=self.branin_data,

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -1671,8 +1671,7 @@ class SQAStoreTest(TestCase):
         save_generation_strategy(generation_strategy=generation_strategy)
         # Also try restoring this generation strategy by its ID in the DB.
         new_generation_strategy = load_generation_strategy_by_id(
-            # pyre-fixme[6]: For 1st param expected `int` but got `Optional[int]`.
-            gs_id=generation_strategy._db_id
+            gs_id=none_throws(generation_strategy._db_id)
         )
         # Some fields of the reloaded GS are not expected to be set (both will be
         # set during next model fitting call), so we unset them on the original GS as
@@ -1689,9 +1688,9 @@ class SQAStoreTest(TestCase):
 
         # Check that we can encode and decode the generation strategy *after*
         # it has generated some trials and been updated with some data.
-        # Since we now need to `gen`, we remove the fake callable kwarg we added,
-        # since model does not expect it.
-        generation_strategy = get_generation_strategy(with_generation_nodes=True)
+        generation_strategy = get_generation_strategy(
+            with_generation_nodes=True, with_callable_model_kwarg=False
+        )
         experiment.new_trial(generation_strategy.gen(experiment=experiment))
         generation_strategy.gen(experiment, data=get_branin_data())
         save_experiment(experiment)

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -174,15 +174,8 @@ def get_generation_strategy(
 ) -> GenerationStrategy:
     if with_generation_nodes:
         gs = sobol_gpei_generation_node_gs()
-        gs._nodes[0]._model_spec_to_gen_from = GeneratorSpec(
-            model_enum=Generators.SOBOL,
-            model_kwargs={"init_position": 3},
-            model_gen_kwargs={"some_gen_kwarg": "some_value"},
-        )
         if with_callable_model_kwarg:
-            # pyre-ignore[16]: testing hack to test serialization of callable kwargs
-            # in generation steps.
-            gs._nodes[0]._model_spec_to_gen_from.model_kwargs["model_constructor"] = (
+            gs._curr.model_spec_to_gen_from.model_kwargs["model_constructor"] = (
                 get_sobol
             )
     else:


### PR DESCRIPTION
Summary: Fixes a gnarly bug where calling `GS.__repr__` was altering one of the underlying fields

Reviewed By: saitcakmak, SebastianAment

Differential Revision: D70814279


