### PR TITLE
Add summarize method

### DIFF
--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -28,7 +28,6 @@ class Summary(Analysis):
         - arm_name: The name of the arm
         - trial_status: The status of the trial (e.g. RUNNING, SUCCEDED, FAILED)
         - failure_reason: The reason for the failure, if applicable
-        - generation_method: The model_key of the model that generated the arm
         - generation_node: The name of the ``GenerationNode`` that generated the arm
         - **METADATA: Any metadata associated with the trial, as specified by the
             Experiment's runner.run_metadata_report_keys field

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -71,7 +71,6 @@ class TestSummary(TestCase):
                 "trial_index",
                 "arm_name",
                 "trial_status",
-                "generation_method",
                 "generation_node",
                 "foo",
                 "bar",
@@ -91,7 +90,6 @@ class TestSummary(TestCase):
                 "trial_index": {0: 0, 1: 1},
                 "arm_name": {0: "0_0", 1: "1_0"},
                 "trial_status": {0: "COMPLETED", 1: "FAILED"},
-                "generation_method": {0: "Sobol", 1: "Sobol"},
                 "generation_node": {0: "Sobol", 1: "Sobol"},
                 "foo": {0: 1.0, 1: np.nan},  # NaN because trial 1 failed
                 "bar": {0: 2.0, 1: np.nan},
@@ -117,7 +115,6 @@ class TestSummary(TestCase):
                 "arm_name",
                 "trial_status",
                 "fail_reason",
-                "generation_method",
                 "generation_node",
                 "foo",
                 "bar",

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -834,6 +834,75 @@ class TestClient(TestCase):
             5,
         )
 
+    def test_summarize(self) -> None:
+        client = Client()
+
+        client.configure_experiment(
+            experiment_config=ExperimentConfig(
+                name="test_experiment",
+                parameters=[
+                    RangeParameterConfig(
+                        name="x1",
+                        parameter_type=ParameterType.FLOAT,
+                        bounds=(0, 1),
+                    ),
+                    RangeParameterConfig(
+                        name="x2",
+                        parameter_type=ParameterType.FLOAT,
+                        bounds=(0, 1),
+                    ),
+                ],
+            )
+        )
+        client.configure_optimization(objective="foo, bar")
+
+        # Get two trials and fail one, giving us a ragged structure
+        client.get_next_trials(maximum_trials=2)
+        client.complete_trial(trial_index=0, raw_data={"foo": 1.0, "bar": 2.0})
+        client.mark_trial_failed(trial_index=1)
+
+        summary_df = client.summarize()
+
+        self.assertEqual(
+            {*summary_df.columns},
+            {
+                "trial_index",
+                "arm_name",
+                "trial_status",
+                "generation_node",
+                "foo",
+                "bar",
+                "x1",
+                "x2",
+            },
+        )
+
+        trial_0_parameters = none_throws(
+            assert_is_instance(client._experiment.trials[0], Trial).arm
+        ).parameters
+        trial_1_parameters = none_throws(
+            assert_is_instance(client._experiment.trials[1], Trial).arm
+        ).parameters
+        expected = pd.DataFrame(
+            {
+                "trial_index": {0: 0, 1: 1},
+                "arm_name": {0: "0_0", 1: "1_0"},
+                "trial_status": {0: "COMPLETED", 1: "FAILED"},
+                "generation_node": {0: "Sobol", 1: "Sobol"},
+                "foo": {0: 1.0, 1: np.nan},  # NaN because trial 1 failed
+                "bar": {0: 2.0, 1: np.nan},
+                "x1": {
+                    0: trial_0_parameters["x1"],
+                    1: trial_1_parameters["x1"],
+                },
+                "x2": {
+                    0: trial_0_parameters["x2"],
+                    1: trial_1_parameters["x2"],
+                },
+            }
+        )
+        pd.testing.assert_frame_equal(summary_df, expected)
+
     def test_compute_analyses(self) -> None:
         client = Client()
 

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1852,7 +1852,6 @@ class Experiment(Base):
             - arm_name: The name of the arm
             - trial_status: The status of the trial (e.g. RUNNING, SUCCEDED, FAILED)
             - failure_reason: The reason for the failure, if applicable
-            - generation_method: The model_key of the model that generated the arm
             - generation_node: The name of the ``GenerationNode`` that generated the arm
             - **METADATA: Any metadata associated with the trial, as specified by the
                 Experiment's runner.run_metadata_report_keys field
@@ -1881,7 +1880,6 @@ class Experiment(Base):
                 # Find the arm's associated generation method from the trial via the
                 # GeneratorRuns if possible
                 grs = [gr for gr in trial.generator_runs if arm in gr.arms]
-                generation_method = grs[0]._model_key if len(grs) > 0 else None
                 generation_node = grs[0]._generation_node_name if len(grs) > 0 else None
 
                 # Find other metadata from the trial to include from the trial based
@@ -1902,7 +1900,6 @@ class Experiment(Base):
                     "arm_name": arm.name,
                     "trial_status": trial.status.name,
                     "fail_reason": trial.run_metadata.get("fail_reason", None),
-                    "generation_method": generation_method,
                     "generation_node": generation_node,
                     **metadata,
                     **observed_means,

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1335,7 +1335,6 @@ class ExperimentTest(TestCase):
                 "trial_index": [0, 1, 2],
                 "arm_name": ["0_0", "1_0", "0_0"],
                 "trial_status": ["COMPLETED", "COMPLETED", "CANDIDATE"],
-                "generation_method": ["Sobol", "Sobol", "Sobol"],
                 "name": ["0", "1", None],  # the metadata
                 "m1": [1.0, 3.0, None],
                 "m2": [2.0, 4.0, None],
@@ -1353,7 +1352,6 @@ class ExperimentTest(TestCase):
                 "arm_name",
                 "trial_status",
                 "fail_reason",
-                "generation_method",
                 "generation_node",
                 "name",
                 "m1",


### PR DESCRIPTION
Summary:
Add a convenience function for accessing a DF explaning the experiment state. Note that we do not call this "to_df", which IMO implies some sort of “lossless”-ness and makes it seem more analogous to “to_json” etc

The DataFrame computed will contain one row per arm and the following columns:
            - trial_index: The trial index of the arm
            - arm_name: The name of the arm
            - trial_status: The status of the trial (e.g. RUNNING, SUCCEDED, FAILED)
            - failure_reason: The reason for the failure, if applicable
            - generation_method: The model_key of the model that generated the arm
            - generation_node: The name of the ``GenerationNode`` that generated the arm
            - **METADATA: Any metadata associated with the trial, as specified by the
                Experiment's runner.run_metadata_report_keys field
            - **METRIC_NAME: The observed mean of the metric specified, for each metric
            - **PARAMETER_NAME: The parameter value for the arm, for each parameter

Differential Revision: D70923695


