### PR TITLE
Forbid acqf options in Ax GeneratorSteps

### DIFF
--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -337,8 +337,9 @@ class LegacyBoTorchGenerator(TorchGenerator):
         search_space_digest: SearchSpaceDigest,
         torch_opt_config: TorchOptConfig,
     ) -> TorchGenResults:
+        if Keys.ACQF_KWARGS in self._kwargs:
+            raise NotImplementedError(r"{Keys.ACQF_KWARGS} is not supported.")
         options = torch_opt_config.model_gen_options or {}
-        acf_options = options.get(Keys.ACQF_KWARGS, {})
         optimizer_options = options.get(Keys.OPTIMIZER_KWARGS, {})
 
         if search_space_digest.fidelity_features:
@@ -396,7 +397,6 @@ class LegacyBoTorchGenerator(TorchGenerator):
                 outcome_constraints=outcome_constraints,
                 X_observed=X_observed,
                 X_pending=X_pending,
-                **acf_options,
                 **add_kwargs,
             )
             acquisition_function = assert_is_instance(


### PR DESCRIPTION
Summary:
I removed the option by having a conditional inside our botorch model, as I understand it to only impact this model and other models might use this keyword arg to mean something else.

I also believe that the arg was renamed compared to the Task to `acquisition_function_kwargs` and operated under that assumption.

Differential Revision: D71336403


