### PR TITLE
Remove generation_method from Summary analysis

### DIFF
--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -28,7 +28,6 @@ class Summary(Analysis):
         - arm_name: The name of the arm
         - trial_status: The status of the trial (e.g. RUNNING, SUCCEDED, FAILED)
         - failure_reason: The reason for the failure, if applicable
-        - generation_method: The model_key of the model that generated the arm
         - generation_node: The name of the ``GenerationNode`` that generated the arm
         - **METADATA: Any metadata associated with the trial, as specified by the
             Experiment's runner.run_metadata_report_keys field

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -71,7 +71,6 @@ class TestSummary(TestCase):
                 "trial_index",
                 "arm_name",
                 "trial_status",
-                "generation_method",
                 "generation_node",
                 "foo",
                 "bar",
@@ -91,7 +90,6 @@ class TestSummary(TestCase):
                 "trial_index": {0: 0, 1: 1},
                 "arm_name": {0: "0_0", 1: "1_0"},
                 "trial_status": {0: "COMPLETED", 1: "FAILED"},
-                "generation_method": {0: "Sobol", 1: "Sobol"},
                 "generation_node": {0: "Sobol", 1: "Sobol"},
                 "foo": {0: 1.0, 1: np.nan},  # NaN because trial 1 failed
                 "bar": {0: 2.0, 1: np.nan},
@@ -117,7 +115,6 @@ class TestSummary(TestCase):
                 "arm_name",
                 "trial_status",
                 "fail_reason",
-                "generation_method",
                 "generation_node",
                 "foo",
                 "bar",

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1852,7 +1852,6 @@ class Experiment(Base):
             - arm_name: The name of the arm
             - trial_status: The status of the trial (e.g. RUNNING, SUCCEDED, FAILED)
             - failure_reason: The reason for the failure, if applicable
-            - generation_method: The model_key of the model that generated the arm
             - generation_node: The name of the ``GenerationNode`` that generated the arm
             - **METADATA: Any metadata associated with the trial, as specified by the
                 Experiment's runner.run_metadata_report_keys field
@@ -1881,7 +1880,6 @@ class Experiment(Base):
                 # Find the arm's associated generation method from the trial via the
                 # GeneratorRuns if possible
                 grs = [gr for gr in trial.generator_runs if arm in gr.arms]
-                generation_method = grs[0]._model_key if len(grs) > 0 else None
                 generation_node = grs[0]._generation_node_name if len(grs) > 0 else None
 
                 # Find other metadata from the trial to include from the trial based
@@ -1902,7 +1900,6 @@ class Experiment(Base):
                     "arm_name": arm.name,
                     "trial_status": trial.status.name,
                     "fail_reason": trial.run_metadata.get("fail_reason", None),
-                    "generation_method": generation_method,
                     "generation_node": generation_node,
                     **metadata,
                     **observed_means,

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1335,7 +1335,6 @@ class ExperimentTest(TestCase):
                 "trial_index": [0, 1, 2],
                 "arm_name": ["0_0", "1_0", "0_0"],
                 "trial_status": ["COMPLETED", "COMPLETED", "CANDIDATE"],
-                "generation_method": ["Sobol", "Sobol", "Sobol"],
                 "name": ["0", "1", None],  # the metadata
                 "m1": [1.0, 3.0, None],
                 "m2": [2.0, 4.0, None],
@@ -1353,7 +1352,6 @@ class ExperimentTest(TestCase):
                 "arm_name",
                 "trial_status",
                 "fail_reason",
-                "generation_method",
                 "generation_node",
                 "name",
                 "m1",


### PR DESCRIPTION
Summary: This is duplicated with GenerationNode and often holds non-useful names anyways

Differential Revision: D71397622


