### PR TITLE
Change top level `__init__.py` to reflect API

### DIFF
--- a/ax/__init__.py
+++ b/ax/__init__.py
@@ -6,70 +6,29 @@
 
 # pyre-strict
 
-from ax.core import (
-    Arm,
-    BatchTrial,
-    ChoiceParameter,
-    ComparisonOp,
-    Data,
-    Experiment,
-    FixedParameter,
-    GeneratorRun,
-    Metric,
-    MultiObjective,
-    MultiObjectiveOptimizationConfig,
-    Objective,
-    ObjectiveThreshold,
-    OptimizationConfig,
-    OrderConstraint,
-    OutcomeConstraint,
-    Parameter,
-    ParameterConstraint,
+from ax.api.client import Client
+from ax.api.configs import (
+    ChoiceParameterConfig,
+    ExperimentConfig,
+    GenerationStrategyConfig,
+    OrchestrationConfig,
+    ParameterScaling,
     ParameterType,
-    RangeParameter,
-    Runner,
-    SearchSpace,
-    SumConstraint,
-    Trial,
+    RangeParameterConfig,
+    StorageConfig,
 )
-from ax.modelbridge import Generators
-from ax.service import OptimizationLoop, optimize
-from ax.storage import json_load, json_save
-
-try:
-    pass
-except Exception:  # pragma: no cover
-    __version__ = "Unknown"
-
+from ax.api.types import TOutcome, TParameterization
 
 __all__ = [
-    "Arm",
-    "BatchTrial",
-    "ChoiceParameter",
-    "ComparisonOp",
-    "Data",
-    "Experiment",
-    "FixedParameter",
-    "GeneratorRun",
-    "Metric",
-    "Generators",
-    "MultiObjective",
-    "MultiObjectiveOptimizationConfig",
-    "Objective",
-    "ObjectiveThreshold",
-    "OptimizationConfig",
-    "OptimizationLoop",
-    "OrderConstraint",
-    "OutcomeConstraint",
-    "Parameter",
-    "ParameterConstraint",
+    "Client",
+    "ChoiceParameterConfig",
+    "ExperimentConfig",
+    "GenerationStrategyConfig",
+    "OrchestrationConfig",
+    "ParameterScaling",
     "ParameterType",
-    "RangeParameter",
-    "Runner",
-    "SearchSpace",
-    "SumConstraint",
-    "Trial",
-    "optimize",
-    "json_save",
-    "json_load",
+    "RangeParameterConfig",
+    "StorageConfig",
+    "TOutcome",
+    "TParameterization",
 ]

--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -12,6 +12,9 @@ import inspect
 import logging
 from collections.abc import Iterable
 
+# Manual import to avoid strange error, see Diff for details.
+import ax.generation_strategy.generation_node_input_constructors  # noqa
+
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import BatchTrial

--- a/scripts/import_ax.py
+++ b/scripts/import_ax.py
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import ax
-from ax.service.ax_client import AxClient
+from ax.api.client import Client
 
 
 if __name__ == "__main__":
     assert ax is not None
-    assert AxClient is not None
+    assert Client is not None


### PR DESCRIPTION
Summary: This allows `from ax import *` to import the API objects (Client, configs, and types)

Differential Revision: D71402459
