### PR TITLE
[Docusaurus] Render Recipes nav item iff available in current version context

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -100,7 +100,6 @@ module.exports={
           "sidebarId": "recipes",
           "label": "Recipes",
           "position": "left",
-          "ignoreVersions": ["0.5.0"],
         },
         {
           "href": "https://ax.readthedocs.io/",

--- a/website/src/components/DocSidebarNavbarItem.jsx
+++ b/website/src/components/DocSidebarNavbarItem.jsx
@@ -6,20 +6,22 @@
  */
 
 import React from "react";
-import { useActiveDocContext } from '@docusaurus/plugin-content-docs/client';
+import { useDocsVersionCandidates } from '@docusaurus/plugin-content-docs/client';
 import DocSidebarNavbarItem from '@theme-original/NavbarItem/DocSidebarNavbarItem';
 
 
-/* Custom implementation of DocSidebarNavbarItem that supports conditionally
- * rendering based on the currently selected docs version.
+/**
+ * Custom implementation of DocSidebarNavbarItem that only renders if the
+ * sidebar exists in the current version context.
+ *
+ * DocSidebarNavbarItem assumes that the provided sidebarId exists in every
+ * version of the docs but this is not true in our case since we have added new
+ * sidebars not present in previous versions.
  */
 export default function ConditionalDocSidebarNavbarItem(props) {
-  const { ignoreVersions, ...restOfProps } = props;
-
-  const { activeVersion } = useActiveDocContext(props.docsPluginId);
-  if (activeVersion === undefined || ignoreVersions.indexOf(activeVersion.name) !== -1) {
+  const docsVersionCandidates = useDocsVersionCandidates(props.docsPluginId);
+  if (docsVersionCandidates?.length > 0 && !docsVersionCandidates[0]?.sidebars?.hasOwnProperty(props.sidebarId)) {
     return null;
   }
-
-  return <DocSidebarNavbarItem {...restOfProps} />;
+  return <DocSidebarNavbarItem {...props} />;
 }


### PR DESCRIPTION
In https://github.com/facebook/Ax/pull/3475 we added custom support for rendering navbar items based on the currently selected docs version, but this does not work on non-docs pages. Specifically, the landing page is a "page" not a "doc" (pages are not versioned, only docs) so when on that page we lose context for the currently selected version. Even if we update our logic to render the navbar item when there is no version context, Docusaurus throws an error because it searches through all the possible versions assuming that the targeted sidebar exists in all of them (in our case it does not since the recipes section is newly added)

Docusaurus is also aware of this issue of version context only being available on docs pages, and they use the method `useDocsVersionCandidates()` to determine version candidates that a doc/sidebar a navbar item should point to when the exact selected version is not known. Unfortunately they assume that the doc/sidebar is present in every version so we use that same method to return early if the targeted sidebar is not present in the top version candidate.

| Before (recipes missing) | After (recipes present) |
|--------|--------|
| <img width="1661" alt="SCR-20250318-lzpi" src="https://github.com/user-attachments/assets/2c5612cf-1d97-45b6-ac8f-f0b4dcb95f49" /> | <img width="1659" alt="SCR-20250318-lzgr" src="https://github.com/user-attachments/assets/ea162136-a2d2-41ce-ad96-5c308574241c" /> |
