### PR TITLE
Minor updates to default behavior of MapKeyToFLoat

### DIFF
--- a/ax/modelbridge/transforms/map_key_to_float.py
+++ b/ax/modelbridge/transforms/map_key_to_float.py
@@ -8,10 +8,11 @@
 
 from typing import Optional, TYPE_CHECKING
 
-from ax.core.map_metric import MapMetric
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.search_space import SearchSpace
+from ax.exceptions.core import UserInputError
 from ax.modelbridge.transforms.metadata_to_float import MetadataToFloat
+from ax.modelbridge.transforms.utils import extract_map_keys_from_opt_config
 from ax.models.types import TConfig
 
 if TYPE_CHECKING:
@@ -22,9 +23,9 @@ if TYPE_CHECKING:
 class MapKeyToFloat(MetadataToFloat):
     """
     This transform extracts the entry from the metadata field of the observation
-    features corresponding to the `parameters` specified in the transform config,
-    or the default map key (`MapMetric.map_key_info.key`) if not specified,
-    and inserts it into the parameter field.
+    features corresponding to the `parameters` specified in the transform config
+    and inserts it into the parameter field. If no parameters are specified in the
+    config, the transform will extract all map key names from the optimization config.
 
     Inheriting from the `MetadataToFloat` transform, this transform
     also adds a range (float) parameter to the search space.
@@ -36,8 +37,8 @@ class MapKeyToFloat(MetadataToFloat):
     Transform is done in-place.
     """
 
+    # NOTE: This will be ignored if the lower bound is <= 0.
     DEFAULT_LOG_SCALE: bool = True
-    DEFAULT_MAP_KEY: str = MapMetric.map_key_info.key
 
     def __init__(
         self,
@@ -47,9 +48,22 @@ class MapKeyToFloat(MetadataToFloat):
         config: TConfig | None = None,
     ) -> None:
         config = config or {}
-        # Use the default map key if nothing is specified in the config.
         if "parameters" not in config:
-            config["parameters"] = {self.DEFAULT_MAP_KEY: {}}
+            # Extract map keys from the optimization config, if no parameters are
+            # specified in the config.
+            if modelbridge is not None and modelbridge._optimization_config is not None:
+                config["parameters"] = {
+                    key: {}
+                    for key in extract_map_keys_from_opt_config(
+                        optimization_config=modelbridge._optimization_config
+                    )
+                }
+            else:
+                raise UserInputError(
+                    f"{self.__class__.__name__} requires either `parameters` to be "
+                    "specified in the transform config or a modelbridge with an "
+                    "optimization config, from which the map keys can be extracted."
+                )
         super().__init__(
             search_space=search_space,
             observations=observations,

--- a/ax/modelbridge/transforms/metadata_to_float.py
+++ b/ax/modelbridge/transforms/metadata_to_float.py
@@ -39,7 +39,10 @@ class MetadataToFloat(Transform):
 
     It allows the user to specify the `config` with `parameters` as the key, where
     each entry maps a metadata key to a dictionary of keyword arguments for the
-    corresponding RangeParameter constructor.
+    corresponding RangeParameter constructor. The `config` can also be used to
+    override `default_log_scale` for all parameters. Note that any parameter
+    with a lower bound <= 0 will not be set to log scale regardless of the
+    specified log scale setting.
 
     Transform is done in-place.
     """
@@ -64,6 +67,7 @@ class MetadataToFloat(Transform):
         self.parameters: dict[str, dict[str, Any]] = assert_is_instance(
             config.get("parameters", {}), dict
         )
+        default_log_scale = config.get("default_log_scale", self.DEFAULT_LOG_SCALE)
 
         self._parameter_list: list[RangeParameter] = []
         for name in self.parameters:
@@ -76,7 +80,7 @@ class MetadataToFloat(Transform):
             lower: float = self.parameters[name].get("lower", min(values))
             upper: float = self.parameters[name].get("upper", max(values))
 
-            log_scale = self.parameters[name].get("log_scale", self.DEFAULT_LOG_SCALE)
+            log_scale = self.parameters[name].get("log_scale", default_log_scale)
             logit_scale = self.parameters[name].get(
                 "logit_scale", self.DEFAULT_LOGIT_SCALE
             )
@@ -92,7 +96,7 @@ class MetadataToFloat(Transform):
                 parameter_type=ParameterType.FLOAT,
                 lower=lower,
                 upper=upper,
-                log_scale=log_scale,
+                log_scale=log_scale and lower > 0.0,
                 logit_scale=logit_scale,
                 digits=digits,
                 is_fidelity=is_fidelity,

--- a/ax/modelbridge/transforms/utils.py
+++ b/ax/modelbridge/transforms/utils.py
@@ -15,6 +15,7 @@ from numbers import Number
 from typing import Any, TYPE_CHECKING
 
 import numpy as np
+from ax.core.map_metric import MapMetric
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import Parameter
@@ -176,3 +177,23 @@ def derelativize_optimization_config_with_raw_status_quo(
         modelbridge=modelbridge,
         fixed_features=ObservationFeatures(parameters={}),
     )
+
+
+def extract_map_keys_from_opt_config(
+    optimization_config: OptimizationConfig,
+) -> set[str]:
+    """Extract names of the map keys of all map metrics from the optimization config.
+
+    Args:
+        optimization_config: Optimization config.
+
+    Returns:
+        A set of map keys.
+    """
+    map_metrics = {
+        name: metric
+        for name, metric in optimization_config.metrics.items()
+        if isinstance(metric, MapMetric)
+    }
+    map_key_names = {m.map_key_info.key for m in map_metrics.values()}
+    return map_key_names


### PR DESCRIPTION
Summary:
- Instead of using the default map key `step` if `parameters` is not specified, we now extract the map keys from `Adapter._optimization_config`. Now, either a config or an adapter with optimization config is required.
- Instead of erroring out if the lowest observed value is <=0 (and log is True by default), we simply not set log if the lower bound is <=0.
- Also allows overwriting `default_log_scale` using the config, rather than having to do it for each parameter one by one.

Differential Revision: D71398837


