### PR TITLE
Cleanup map_key_as_features flag

### DIFF
--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -263,7 +263,6 @@ def _observations_from_dataframe(
     map_keys: Iterable[str],
     statuses_to_include: set[TrialStatus],
     statuses_to_include_map_metric: set[TrialStatus],
-    map_keys_as_parameters: bool = False,
 ) -> list[Observation]:
     """Helper method for extracting observations grouped by `cols` from `df`.
 
@@ -278,8 +277,6 @@ def _observations_from_dataframe(
             with statuses in this set.
         statuses_to_include_map_metric: data from MapMetrics will only be included for
             trials with statuses in this set.
-        map_keys_as_parameters: Whether map_keys should be returned as part of
-            the parameters of the Observation objects.
 
     Returns:
         List of Observation objects.
@@ -337,10 +334,7 @@ def _observations_from_dataframe(
             obs_parameters.update(json.loads(fidelities))
 
         for map_key in map_keys:
-            if map_key in obs_parameters or map_keys_as_parameters:
-                obs_parameters[map_key] = features[map_key]
-            else:
-                obs_kwargs[Keys.METADATA][map_key] = features[map_key]
+            obs_kwargs[Keys.METADATA][map_key] = features[map_key]
         d = _filter_data_on_status(
             df=d,
             experiment=experiment,
@@ -460,7 +454,6 @@ def observations_from_data(
     data: Data,
     statuses_to_include: set[TrialStatus] | None = None,
     statuses_to_include_map_metric: set[TrialStatus] | None = None,
-    map_keys_as_parameters: bool = False,
     latest_rows_per_group: int | None = None,
     limit_rows_per_metric: int | None = None,
     limit_rows_per_group: int | None = None,
@@ -480,8 +473,6 @@ def observations_from_data(
             with statuses in this set. Defaults to all statuses except abandoned.
         statuses_to_include_map_metric: data from MapMetrics will only be included for
             trials with statuses in this set. Defaults to all statuses except abandoned.
-        map_keys_as_parameters: Whether map_keys should be returned as part of
-            the parameters of the Observation objects.
         latest_rows_per_group: If specified and data is an instance of MapData,
             uses MapData.latest() with `rows_per_group=latest_rows_per_group` to
             retrieve the most recent rows for each group. Useful in cases where
@@ -527,7 +518,6 @@ def observations_from_data(
         map_keys=map_keys,
         statuses_to_include=statuses_to_include,
         statuses_to_include_map_metric=statuses_to_include_map_metric,
-        map_keys_as_parameters=map_keys_as_parameters,
     )
 
 

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -29,7 +29,7 @@ from ax.modelbridge.modelbridge_utils import (
 from ax.modelbridge.registry import Cont_X_trans, Y_trans
 from ax.modelbridge.torch import TorchAdapter
 from ax.modelbridge.transforms.base import Transform
-from ax.modelbridge.transforms.map_unit_x import MapUnitX
+from ax.modelbridge.transforms.map_key_to_float import MapKeyToFloat
 from ax.models.torch_base import TorchGenerator
 from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
@@ -523,13 +523,14 @@ def get_transform_helper_model(
     Returns: A torch modelbridge.
     """
     if transforms is None:
-        transforms = Cont_X_trans + [MapUnitX] + Y_trans
+        transforms = [MapKeyToFloat] + Cont_X_trans + Y_trans
     return TorchAdapter(
         experiment=experiment,
         search_space=experiment.search_space,
         data=data,
         model=TorchGenerator(),
         transforms=transforms,
+        transform_configs={"MapKeyToFloat": {"default_log_scale": False}},
         data_loader_config=DataLoaderConfig(
             fit_out_of_design=True,
             latest_rows_per_group=None,

--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -18,7 +18,6 @@ from ax.core.arm import Arm
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import extract_arm_predictions, GeneratorRun
-from ax.core.map_data import MapData
 from ax.core.observation import (
     Observation,
     ObservationData,
@@ -331,8 +330,6 @@ class Adapter:
         self, experiment: Experiment, data: Data | None = None
     ) -> list[Observation]:
         data = data if data is not None else experiment.lookup_data()
-        fit_only_completed = self._data_loader_config.fit_only_completed_map_metrics
-        map_keys_as_parameters = not fit_only_completed and isinstance(data, MapData)
         return observations_from_data(
             experiment=experiment,
             data=data,
@@ -341,7 +338,6 @@ class Adapter:
             limit_rows_per_group=self._data_loader_config.limit_rows_per_group,
             statuses_to_include=self.statuses_to_fit,
             statuses_to_include_map_metric=self.statuses_to_fit_map_metric,
-            map_keys_as_parameters=map_keys_as_parameters,
         )
 
     def _transform_data(

--- a/ax/modelbridge/modelbridge_utils.py
+++ b/ax/modelbridge/modelbridge_utils.py
@@ -668,13 +668,8 @@ def transform_callback(
             observation_features = t.transform_observation_features(
                 observation_features
             )
-        # parameters are guaranteed to be float compatible here, but pyre doesn't know
         new_x: list[float] = [
-            # pyre-fixme[6]: Expected `Union[_SupportsIndex, bytearray, bytes, str,
-            #  typing.SupportsFloat]` for 1st param but got `Union[None, bool, float,
-            #  int, str]`.
-            float(observation_features[0].parameters[p])
-            for p in param_names
+            float(observation_features[0].parameters[p]) for p in param_names
         ]
         # turn it back into an array
         return np.array(new_x)

--- a/ax/modelbridge/transforms/utils.py
+++ b/ax/modelbridge/transforms/utils.py
@@ -15,6 +15,7 @@ from numbers import Number
 from typing import Any, TYPE_CHECKING
 
 import numpy as np
+from ax.core.map_metric import MapMetric
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import Parameter
@@ -176,3 +177,23 @@ def derelativize_optimization_config_with_raw_status_quo(
         modelbridge=modelbridge,
         fixed_features=ObservationFeatures(parameters={}),
     )
+
+
+def extract_map_keys_from_opt_config(
+    optimization_config: OptimizationConfig,
+) -> set[str]:
+    """Extract names of the map keys of all map metrics from the optimization config.
+
+    Args:
+        optimization_config: Optimization config.
+
+    Returns:
+        A set of map keys.
+    """
+    map_metrics = {
+        name: metric
+        for name, metric in optimization_config.metrics.items()
+        if isinstance(metric, MapMetric)
+    }
+    map_key_names = {m.map_key_info.key for m in map_metrics.values()}
+    return map_key_names


### PR DESCRIPTION
Summary: This flag was being set based on `fit_only_completed_map_metrics`, which was incompatible with the usage of map data in various applications. In addition, it was extracting features from the metadata and adding them to the parameterization, without adding them to the search space. We're cleaning up this option in favor of `MetadataToFloat` transforms and its subclasses such as `MapKeyToFloat`.

Differential Revision: D71396271


