### PR TITLE
Support ST/MT model selection

### DIFF
--- a/ax/models/torch/tests/test_covar_modules_argparse.py
+++ b/ax/models/torch/tests/test_covar_modules_argparse.py
@@ -92,6 +92,7 @@ class CovarModuleArgparseTest(TestCase):
                 "outputscale_prior_concentration": 2.0,
                 "outputscale_prior_rate": 0.15,
                 "batch_shape": torch.Size([2]),
+                "active_dims": None,
             },
             {
                 "ard_num_dims": 9,
@@ -100,6 +101,7 @@ class CovarModuleArgparseTest(TestCase):
                 "outputscale_prior_concentration": 2.0,
                 "outputscale_prior_rate": 0.15,
                 "batch_shape": torch.Size([]),
+                "active_dims": None,
             },
         ]
 

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -76,6 +76,7 @@ from botorch.models.transforms.outcome import (
     ChainedOutcomeTransform,
     OutcomeTransform,
     Standardize,
+    StratifiedStandardize,
 )
 from botorch.sampling.normal import SobolQMCNormalSampler
 
@@ -194,6 +195,7 @@ Mapping of BoTorch `OutcomeTransform` classes to class name strings.
 OUTCOME_TRANSFORM_REGISTRY: dict[type[OutcomeTransform], str] = {
     ChainedOutcomeTransform: "ChainedOutcomeTransform",
     Standardize: "Standardize",
+    StratifiedStandardize: "StratifiedStandardize",
 }
 
 """


### PR DESCRIPTION
Summary:
This enables ST/MT model selection by 1) removing the `task_feature` argument to `SingleTaskGP.construct_inputs` if a ST model is used, 2) setting `active_dims` to remove the task feature from the kernel computation and the "remove_task_features" option is passed to `covar_module_options`.

This doesn't currently remove the task feature kernel computation for models that don't use a provided `covar_module` (e.g. ST GP, without a specified covar_module, or a SAAS model). The SAAS model should be able to learn that parameter is irrelevant though.

Differential Revision: D69469846


