### PR TITLE
BilogY transform

### DIFF
--- a/ax/modelbridge/transforms/bilog_y.py
+++ b/ax/modelbridge/transforms/bilog_y.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+from logging import Logger
+from typing import Callable, TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+from ax.core.observation import Observation, ObservationData
+from ax.core.outcome_constraint import OutcomeConstraint
+from ax.core.search_space import SearchSpace
+from ax.exceptions.core import DataRequiredError
+from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.log_y import match_ci_width
+from ax.models.types import TConfig
+from ax.utils.common.logger import get_logger
+
+if TYPE_CHECKING:
+    # import as module to make sphinx-autodoc-typehints happy
+    from ax import modelbridge as modelbridge_module  # noqa F401
+
+
+logger: Logger = get_logger(__name__)
+
+
+class BilogY(Transform):
+    """Apply a bilog-transform to the outcome constraint metrics.
+
+    The bilog transform was introduced in
+    https://proceedings.mlr.press/v130/eriksson21a/eriksson21a.pdf, with the key idea
+    being to magnify the region around the outcome constraint constraint boundary,
+    thus making it easier to model that part of the metric space. We use a matching
+    procedure based on the width of the CIs to transform thevariance observations.
+    This transform is applied in-place.
+
+    We define the transform as: f(y) = bound + sign(y - bound) * log(|y - bound| + 1)
+    where bound is the outcome constraint bound. This has the properties:
+        1. It magnifies the region around y=bound, which makes it easier to
+            model the constraint boundary.
+        2. f(bound) = bound, so we don't have to modify the optimization config.
+    """
+
+    def __init__(
+        self,
+        search_space: SearchSpace | None = None,
+        observations: list[Observation] | None = None,
+        modelbridge: modelbridge_module.base.Adapter | None = None,
+        config: TConfig | None = None,
+    ) -> None:
+        """Initialize the ``BilogY`` transform.
+
+        Args:
+            search_space: The search space of the experiment. Unused.
+            observations: A list of observations from the experiment.
+            modelbridge: The `Adapter` within which the transform is used.
+        """
+        if observations is None or len(observations) == 0:
+            raise DataRequiredError("BilogY requires observations.")
+        if modelbridge is not None and modelbridge._optimization_config is not None:
+            ocs: list[OutcomeConstraint] = (
+                modelbridge._optimization_config.outcome_constraints
+                if modelbridge
+                else []
+            )
+            if any(oc.relative for oc in ocs):
+                raise ValueError(
+                    "BilogY cannot be used with relative outcome constraints."
+                )
+            self.metric_to_bound: dict[str, float] = {
+                oc.metric.name: oc.bound for oc in ocs
+            }
+        else:
+            self.metric_to_bound = {}
+
+    def _transform_observation_data(
+        self,
+        observation_data: list[ObservationData],
+    ) -> list[ObservationData]:
+        """Apply bilog to observation data in place."""
+        return self._reusable_transform(
+            observation_data=observation_data,
+            transform=bilog_transform,
+        )
+
+    def _untransform_observation_data(
+        self,
+        observation_data: list[ObservationData],
+    ) -> list[ObservationData]:
+        """Apply inverse bilog to observation data in place."""
+        return self._reusable_transform(
+            observation_data=observation_data,
+            transform=inv_bilog_transform,
+        )
+
+    def _reusable_transform(
+        self,
+        observation_data: list[ObservationData],
+        # pyre-fixme[11]: Annotation `npt.NDarray` is not defined as a type.
+        transform: Callable[[npt.NDArray, npt.NDarray], npt.NDarray],
+    ) -> list[ObservationData]:
+        for obsd in observation_data:
+            for i, m in enumerate(obsd.metric_names):
+                if m in self.metric_to_bound.keys():
+                    bound = self.metric_to_bound[m]
+                    obsd.means[i], obsd.covariance[i, i] = match_ci_width(
+                        mean=obsd.means[i],
+                        variance=obsd.covariance[i, i],
+                        transform=lambda y, bound=bound: transform(y, bound=bound),
+                    )
+        return observation_data
+
+
+def bilog_transform(y: npt.NDarray, bound: npt.NDarray) -> npt.NDarray:
+    """Bilog transform: f(y) = bound + sign(y - bound) * log(|y - bound| + 1)"""
+    return bound + np.sign(y - bound) * np.log(np.abs(y - bound) + 1)
+
+
+def inv_bilog_transform(y: npt.NDarray, bound: npt.NDarray) -> npt.NDarray:
+    """Inverse bilog transform: f(y) = bound + sign(y - bound) * expm1(|y - bound|)"""
+    return bound + np.sign(y - bound) * np.expm1((y - bound) * np.sign(y - bound))

--- a/ax/modelbridge/transforms/tests/test_bilog_y.py
+++ b/ax/modelbridge/transforms/tests/test_bilog_y.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from ax.core.observation import observations_from_data
+from ax.exceptions.core import DataRequiredError
+from ax.modelbridge.base import Adapter
+from ax.modelbridge.transforms.bilog_y import (
+    bilog_transform,
+    BilogY,
+    inv_bilog_transform,
+)
+from ax.models.base import Generator
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_branin_experiment
+
+
+class BilogYTest(TestCase):
+    def setUp(self) -> None:
+        self.exp = get_branin_experiment(
+            with_status_quo=True,
+            with_completed_batch=True,
+            with_absolute_constraint=True,
+        )
+        self.data = self.exp.fetch_data()
+
+    def get_mb(self) -> Adapter:
+        return Adapter(
+            search_space=self.exp.search_space,
+            model=Generator(),
+            experiment=self.exp,
+            data=self.exp.lookup_data(),
+        )
+
+    def test_Init(self) -> None:
+        observations = observations_from_data(
+            experiment=self.exp, data=self.exp.lookup_data()
+        )
+        t = BilogY(
+            search_space=self.exp.search_space,
+            observations=observations,
+            modelbridge=self.get_mb(),
+        )
+        self.assertEqual(t.metric_to_bound, {"branin_e": -0.25})
+
+    def test_Bilog(self) -> None:
+        self.assertAlmostEqual(
+            float(bilog_transform(y=7.3, bound=3)), 4.667706820558076
+        )
+        self.assertAlmostEqual(
+            float(bilog_transform(y=7.3, bound=10)), 8.691667180349821
+        )
+        self.assertAlmostEqual(
+            float(inv_bilog_transform(y=4.3, bound=3)), 5.669296667619244
+        )
+        self.assertAlmostEqual(
+            float(inv_bilog_transform(y=2.3, bound=3)), 1.9862472925295231
+        )
+        self.assertAlmostEqual(
+            float(inv_bilog_transform(bilog_transform(y=0.3, bound=3), bound=3)),
+            0.3,
+        )
+        self.assertAlmostEqual(
+            float(bilog_transform(inv_bilog_transform(y=0.3, bound=3), bound=3)),
+            0.3,
+        )
+
+    def test_TransformUntransform(self) -> None:
+        bound = self.exp.optimization_config.outcome_constraints[0].bound
+        observations = observations_from_data(
+            experiment=self.exp, data=self.exp.lookup_data()
+        )
+        t = BilogY(
+            search_space=self.exp.search_space,
+            observations=observations,
+            modelbridge=self.get_mb(),
+        )
+
+        # Transform
+        transformed_data = t._transform_observation_data(
+            deepcopy([obs.data for obs in observations])
+        )
+        for obs, transform_obs in zip(observations, transformed_data):
+            # Non-constraints should be the same
+            self.assertEqual(transform_obs.metric_names, ["branin", "branin_e"])
+            self.assertEqual(transform_obs.means[0], obs.data.means[0])
+            self.assertEqual(transform_obs.covariance[0, 0], obs.data.covariance[0, 0])
+            # Make sure the bilog transform with ci width matching was applied
+            self.assertAlmostEqual(
+                transform_obs.means[1], bilog_transform(obs.data.means[1], bound=bound)
+            )
+            self.assertTrue(  # The transformed variance should be smaller
+                (transform_obs.covariance[1, 1] < obs.data.covariance[1, 1]).all()
+            )
+
+        # Untransform
+        untransformed_data = t._untransform_observation_data(deepcopy(transformed_data))
+        for obs, untransform_obs, transform_obs in zip(
+            observations, untransformed_data, transformed_data
+        ):
+            # Non-constraints should be the same
+            self.assertEqual(untransform_obs.metric_names, ["branin", "branin_e"])
+            self.assertEqual(untransform_obs.means[0], obs.data.means[0])
+            self.assertEqual(
+                untransform_obs.covariance[0, 0], obs.data.covariance[0, 0]
+            )
+            # Make sure the inverse bilog transform with ci width matching was applied
+            self.assertAlmostEqual(
+                untransform_obs.means[1],
+                inv_bilog_transform(transform_obs.means[1], bound=bound),
+            )
+            # And that we are back where we started as invf(f(x)) = x
+            self.assertAlmostEqual(
+                obs.data.means[1],
+                inv_bilog_transform(transform_obs.means[1], bound=bound),
+            )
+            self.assertAlmostEqual(
+                untransform_obs.covariance[1, 1], obs.data.covariance[1, 1]
+            )
+
+    def test_TransformOptimizationConfig(self) -> None:
+        t = BilogY(
+            search_space=self.exp.search_space,
+            observations=observations_from_data(
+                experiment=self.exp, data=self.exp.lookup_data()
+            ),
+            modelbridge=self.get_mb(),
+        )
+        oc = self.exp.optimization_config
+        # This should be a no-op
+        new_oc = t.transform_optimization_config(optimization_config=oc)
+        self.assertEqual(new_oc, oc)
+
+    def test_TransformSearchSpace(self) -> None:
+        t = BilogY(
+            search_space=self.exp.search_space,
+            observations=observations_from_data(
+                experiment=self.exp, data=self.exp.lookup_data()
+            ),
+            modelbridge=self.get_mb(),
+        )
+        # This should be a no-op
+        new_ss = t.transform_search_space(self.exp.search_space)
+        self.assertEqual(new_ss, self.exp.search_space)
+
+    def test_ModelBridgeIsNone(self) -> None:
+        t = BilogY(
+            search_space=self.exp.search_space,
+            observations=observations_from_data(
+                experiment=self.exp, data=self.exp.lookup_data()
+            ),
+            modelbridge=None,
+        )
+        self.assertEqual(t.metric_to_bound, {})
+
+    def test_Raises(self) -> None:
+        exp = get_branin_experiment(with_status_quo=True, with_batch=True)
+        with self.assertRaisesRegex(DataRequiredError, "BilogY requires observations."):
+            BilogY(
+                search_space=exp.search_space,
+                observations=observations_from_data(
+                    experiment=exp, data=exp.lookup_data()
+                ),
+                modelbridge=None,
+            )
+        # Relative constraints should raise
+        exp = get_branin_experiment(
+            with_status_quo=True,
+            with_completed_batch=True,
+            with_relative_constraint=True,
+        )
+        with self.assertRaisesRegex(
+            ValueError, "BilogY cannot be used with relative outcome constraints."
+        ):
+            BilogY(
+                search_space=exp.search_space,
+                observations=observations_from_data(
+                    experiment=exp, data=exp.lookup_data()
+                ),
+                modelbridge=Adapter(
+                    search_space=exp.search_space,
+                    model=Generator(),
+                    experiment=exp,
+                    data=exp.lookup_data(),
+                ),
+            )

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -8,6 +8,7 @@
 
 
 from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.bilog_y import BilogY
 from ax.modelbridge.transforms.choice_encode import (
     ChoiceEncode,
     ChoiceToNumericChoice,
@@ -98,6 +99,7 @@ TRANSFORM_REGISTRY: dict[type[Transform], int] = {
     FillMissingParameters: 29,
     LogIntToFloat: 30,
     MapKeyToFloat: 31,
+    BilogY: 32,
 }
 
 """

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -257,6 +257,7 @@ def get_branin_experiment(
     with_completed_trial: bool = False,
     num_arms_per_trial: int = 15,
     with_relative_constraint: bool = False,
+    with_absolute_constraint: bool = False,
 ) -> Experiment:
     search_space = search_space or get_branin_search_space(
         with_fidelity_parameter=with_fidelity_parameter,
@@ -270,7 +271,9 @@ def get_branin_experiment(
         search_space=search_space,
         optimization_config=(
             get_branin_optimization_config(
-                minimize=minimize, with_relative_constraint=with_relative_constraint
+                minimize=minimize,
+                with_relative_constraint=with_relative_constraint,
+                with_absolute_constraint=with_absolute_constraint,
             )
             if has_optimization_config or with_relative_constraint
             else None
@@ -1786,13 +1789,21 @@ def get_optimization_config_no_constraints(
 
 
 def get_branin_optimization_config(
-    minimize: bool = False, with_relative_constraint: bool = False
+    minimize: bool = False,
+    with_relative_constraint: bool = False,
+    with_absolute_constraint: bool = False,
 ) -> OptimizationConfig:
     outcome_constraint = []
     if with_relative_constraint:
         outcome_constraint.append(
             get_outcome_constraint(
                 metric=get_branin_metric(name="branin_d"), relative=True
+            )
+        )
+    if with_absolute_constraint:
+        outcome_constraint.append(
+            get_outcome_constraint(
+                metric=get_branin_metric(name="branin_e"), relative=False
             )
         )
     return OptimizationConfig(

--- a/sphinx/source/modelbridge.rst
+++ b/sphinx/source/modelbridge.rst
@@ -166,6 +166,14 @@ Transforms
     :undoc-members:
     :show-inheritance:
 
+`ax.modelbridge.transforms.bilog_y`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.bilog_y
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 `ax.modelbridge.transforms.cast`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -320,6 +328,14 @@ Transforms
     :undoc-members:
     :show-inheritance:
 
+`ax.modelbridge.transforms.relativize`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: ax.modelbridge.transforms.relativize
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 `ax.modelbridge.transforms.rounding`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -412,14 +428,6 @@ Transforms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: ax.modelbridge.transforms.winsorize
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-`ax.modelbridge.transforms.relativize`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. automodule:: ax.modelbridge.transforms.relativize
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Summary:
This adds a bilog transform that is applied automatically to all outcome constraints. The key idea of the bilog transform is to apply a two-sided log-transform that magnifies the constraint boundary, thus making it easier to model that part of the metric space. We modify the transform slightly compared to what is in https://proceedings.mlr.press/v130/eriksson21a/eriksson21a.pdf so that `f(bound) = bound`. This is convenient since it means we don't have to transform the optimization config.

The transform and inverse transforms take the form:
`f(y) = bound + sign(y - bound) log(1 + |y - bound|)`
`f^{-1}(y) = bound + sign(y - bound) (exp((y - bound) sign(y - bound)) - 1)`

The transform is illustrated in the figure below where the constraint bound is `y=5`
![bilog](https://github.com/user-attachments/assets/fdab0d1c-d671-47d9-8362-ef31a1652a86)

Reviewed By: Balandat

Differential Revision: D71446538


