### PR TITLE
Support use_posterior_predictive argument in predict methods

### DIFF
--- a/ax/modelbridge/discrete.py
+++ b/ax/modelbridge/discrete.py
@@ -116,14 +116,18 @@ class DiscreteAdapter(Adapter):
         )
 
     def _predict(
-        self, observation_features: list[ObservationFeatures]
+        self,
+        observation_features: list[ObservationFeatures],
+        use_posterior_predictive: bool = False,
     ) -> list[ObservationData]:
         # Convert observations to array
         X = [
             [of.parameters[param] for param in self.parameters]
             for of in observation_features
         ]
-        f, cov = self.model.predict(X=X)
+        f, cov = self.model.predict(
+            X=X, use_posterior_predictive=use_posterior_predictive
+        )
         # Convert arrays to observations
         return array_to_observation_data(f=f, cov=cov, outcomes=self.outcomes)
 

--- a/ax/modelbridge/pairwise.py
+++ b/ax/modelbridge/pairwise.py
@@ -84,7 +84,9 @@ class PairwiseAdapter(TorchAdapter):
         return datasets, outcomes, candidate_metadata
 
     def _predict(
-        self, observation_features: list[ObservationFeatures]
+        self,
+        observation_features: list[ObservationFeatures],
+        use_posterior_predictive: bool = False,
     ) -> list[ObservationData]:
         # TODO: Implement `_predict` to enable examining predicted effects
         raise NotImplementedError

--- a/ax/modelbridge/random.py
+++ b/ax/modelbridge/random.py
@@ -111,7 +111,9 @@ class RandomAdapter(Adapter):
         )
 
     def _predict(
-        self, observation_features: list[ObservationFeatures]
+        self,
+        observation_features: list[ObservationFeatures],
+        use_posterior_predictive: bool = False,
     ) -> list[ObservationData]:
         """Apply terminal transform, predict, and reverse terminal transform on
         output.

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -148,12 +148,18 @@ class BaseAdapterTest(TestCase):
         adapter._predict = mock_predict
         adapter.predict([get_observation2().features])
         # Observation features sent to _predict are un-transformed afterwards
-        mock_predict.assert_called_with([get_observation2().features])
+        mock_predict.assert_called_with(
+            observation_features=[get_observation2().features],
+            use_posterior_predictive=False,
+        )
 
         # Check that _single_predict is equivalent here.
         adapter._single_predict([get_observation2().features])
         # Observation features sent to _predict are un-transformed afterwards
-        mock_predict.assert_called_with([get_observation2().features])
+        mock_predict.assert_called_with(
+            observation_features=[get_observation2().features],
+            use_posterior_predictive=False,
+        )
 
         # Test transforms applied on gen
         adapter._gen = mock.MagicMock(

--- a/ax/modelbridge/torch.py
+++ b/ax/modelbridge/torch.py
@@ -758,13 +758,18 @@ class TorchAdapter(Adapter):
         )
 
     def _predict(
-        self, observation_features: list[ObservationFeatures]
+        self,
+        observation_features: list[ObservationFeatures],
+        use_posterior_predictive: bool = False,
     ) -> list[ObservationData]:
         if not self.parameters:
             raise ValueError(FIT_MODEL_ERROR.format(action="_model_predict"))
         # Convert observation features to array
         X = observation_features_to_array(self.parameters, observation_features)
-        f, cov = self.model.predict(X=self._array_to_tensor(X))
+        f, cov = self.model.predict(
+            X=self._array_to_tensor(X),
+            use_posterior_predictive=use_posterior_predictive,
+        )
         f = f.detach().cpu().clone().numpy()
         cov = cov.detach().cpu().clone().numpy()
         if f.shape[-2] != X.shape[-2]:

--- a/ax/modelbridge/transforms/tests/test_derelativize_transform.py
+++ b/ax/modelbridge/transforms/tests/test_derelativize_transform.py
@@ -193,7 +193,7 @@ class DerelativizeTransformTest(TestCase):
                 ),
             ]
         )
-        obsf = mock_predict.mock_calls[0][1][1][0]
+        obsf = mock_predict.call_args.kwargs["observation_features"][0]
         obsf2 = ObservationFeatures(parameters={"x": 2.0, "y": 10.0})
         self.assertTrue(obsf == obsf2)
         self.assertEqual(mock_predict.call_count, 1)

--- a/ax/models/discrete/thompson.py
+++ b/ax/models/discrete/thompson.py
@@ -15,12 +15,11 @@ import numpy as np
 import numpy.typing as npt
 from ax.core.types import TGenMetadata, TParamValue, TParamValueList
 from ax.exceptions.constants import TS_MIN_WEIGHT_ERROR, TS_NO_FEASIBLE_ARMS_ERROR
-from ax.exceptions.core import UnsupportedError
+from ax.exceptions.core import AxWarning, UnsupportedError
 from ax.exceptions.model import ModelError
 from ax.models.discrete_base import DiscreteGenerator
 from ax.models.types import TConfig
 from ax.utils.common.docutils import copy_doc
-
 from pyre_extensions import assert_is_instance, none_throws
 
 
@@ -143,8 +142,15 @@ class ThompsonSampler(DiscreteGenerator):
 
     @copy_doc(DiscreteGenerator.predict)
     def predict(
-        self, X: Sequence[Sequence[TParamValue]]
+        self, X: Sequence[Sequence[TParamValue]], use_posterior_predictive: bool = False
     ) -> tuple[npt.NDArray, npt.NDArray]:
+        if use_posterior_predictive:
+            warnings.warn(
+                f"{self.__class__.__name__} does not support posterior-predictive "
+                "predictions. Ignoring `use_posterior_predictive`. ",
+                AxWarning,
+                stacklevel=2,
+            )
         n = len(X)  # number of parameterizations at which to make predictions
         m = len(none_throws(self.Ys))  # number of outcomes
         f = np.zeros((n, m))  # array of outcome predictions

--- a/ax/models/discrete_base.py
+++ b/ax/models/discrete_base.py
@@ -44,12 +44,16 @@ class DiscreteGenerator(Generator):
         pass
 
     def predict(
-        self, X: Sequence[Sequence[TParamValue]]
+        self, X: Sequence[Sequence[TParamValue]], use_posterior_predictive: bool = False
     ) -> tuple[npt.NDArray, npt.NDArray]:
         """Predict
 
         Args:
             X: List of the j parameterizations at which to make predictions.
+            use_posterior_predictive: A boolean indicating if the predictions
+                should be from the posterior predictive (i.e. including
+                observation noise).
+                This option is only supported by the ``BoTorchGenerator``.
 
         Returns:
             2-element tuple containing

--- a/ax/models/model_utils.py
+++ b/ax/models/model_utils.py
@@ -35,11 +35,17 @@ class TorchGeneratorLike(Protocol):
     have a ``predict`` method.
     """
 
-    def predict(self, X: Tensor) -> tuple[Tensor, Tensor]:
+    def predict(
+        self, X: Tensor, use_posterior_predictive: bool = False
+    ) -> tuple[Tensor, Tensor]:
         """Predicts outcomes given an input tensor.
 
         Args:
             X: A ``n x d`` tensor of input parameters.
+            use_posterior_predictive: A boolean indicating if the predictions
+                should be from the posterior predictive (i.e. including
+                observation noise).
+                This option is only supported by the ``BoTorchGenerator``.
 
         Returns:
             Tensor: The predicted posterior mean as an ``n x o``-dim tensor.

--- a/ax/models/torch/botorch.py
+++ b/ax/models/torch/botorch.py
@@ -18,7 +18,7 @@ import numpy.typing as npt
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
-from ax.exceptions.core import DataRequiredError
+from ax.exceptions.core import AxWarning, DataRequiredError
 from ax.models.torch.botorch_defaults import (
     get_and_fit_model,
     get_qLogNEI,
@@ -327,7 +327,16 @@ class LegacyBoTorchGenerator(TorchGenerator):
         )
 
     @copy_doc(TorchGenerator.predict)
-    def predict(self, X: Tensor) -> tuple[Tensor, Tensor]:
+    def predict(
+        self, X: Tensor, use_posterior_predictive: bool = False
+    ) -> tuple[Tensor, Tensor]:
+        if use_posterior_predictive:
+            warnings.warn(
+                f"{self.__class__.__name__} does not support posterior-predictive "
+                "predictions. Ignoring `use_posterior_predictive`. ",
+                AxWarning,
+                stacklevel=2,
+            )
         return self.model_predictor(model=self.model, X=X)  # pyre-ignore [28]
 
     @copy_doc(TorchGenerator.gen)

--- a/ax/models/torch/randomforest.py
+++ b/ax/models/torch/randomforest.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 
 import numpy as np
@@ -15,6 +16,7 @@ import numpy.typing as npt
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
+from ax.exceptions.core import AxWarning
 from ax.models.torch.utils import _datasets_to_legacy_inputs
 from ax.models.torch_base import TorchGenerator
 from ax.utils.common.docutils import copy_doc
@@ -64,7 +66,16 @@ class RandomForest(TorchGenerator):
             )
 
     @copy_doc(TorchGenerator.predict)
-    def predict(self, X: Tensor) -> tuple[Tensor, Tensor]:
+    def predict(
+        self, X: Tensor, use_posterior_predictive: bool = False
+    ) -> tuple[Tensor, Tensor]:
+        if use_posterior_predictive:
+            warnings.warn(
+                f"{self.__class__.__name__} does not support posterior-predictive "
+                "predictions. Ignoring `use_posterior_predictive`. ",
+                AxWarning,
+                stacklevel=2,
+            )
         return _rf_predict(self.models, X)
 
     @copy_doc(TorchGenerator.cross_validate)

--- a/ax/models/torch_base.py
+++ b/ax/models/torch_base.py
@@ -138,11 +138,17 @@ class TorchGenerator(BaseGenerator):
         """
         pass
 
-    def predict(self, X: Tensor) -> tuple[Tensor, Tensor]:
+    def predict(
+        self, X: Tensor, use_posterior_predictive: bool = False
+    ) -> tuple[Tensor, Tensor]:
         """Predict
 
         Args:
             X: (j x d) tensor of the j points at which to make predictions.
+            use_posterior_predictive: A boolean indicating if the predictions
+                should be from the posterior predictive (i.e. including
+                observation noise).
+                This option is only supported by the ``BoTorchGenerator``.
 
         Returns:
             2-element tuple containing

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -301,7 +301,9 @@ def get_branin_experiment(
 
         if with_completed_trial:
             trial.mark_running(no_runner_required=True)
-            exp.attach_data(get_branin_data(trials=[trial]))  # Add data for one trial
+            exp.attach_data(
+                get_branin_data(trials=[trial], metrics=exp.metrics)
+            )  # Add data for one trial
             trial.mark_completed()
 
     return exp
@@ -2111,14 +2113,17 @@ def get_map_key_info() -> MapKeyInfo:
 def get_branin_data(
     trial_indices: Iterable[int] | None = None,
     trials: Iterable[Trial] | None = None,
+    metrics: Iterable[str] | None = None,
 ) -> Data:
     if trial_indices and trials:
         raise ValueError("Expected `trial_indices` or `trials`, not both.")
+    if metrics is None:
+        metrics = ["branin"]
     if trials:
         df_dicts = [
             {
                 "trial_index": trial.index,
-                "metric_name": "branin",
+                "metric_name": metric,
                 "arm_name": none_throws(assert_is_instance(trial, Trial).arm).name,
                 "mean": branin(
                     float(none_throws(none_throws(trial.arm).parameters["x1"])),
@@ -2127,17 +2132,19 @@ def get_branin_data(
                 "sem": 0.0,
             }
             for trial in trials
+            for metric in metrics
         ]
     else:
         df_dicts = [
             {
                 "trial_index": trial_index,
-                "metric_name": "branin",
+                "metric_name": metric,
                 "arm_name": f"{trial_index}_0",
                 "mean": 5.0,
                 "sem": 0.0,
             }
             for trial_index in (trial_indices or [0])
+            for metric in metrics
         ]
     return Data(df=pd.DataFrame.from_records(df_dicts))
 


### PR DESCRIPTION
Summary: This will allow us to make predictions with observation noise included. We already support this for cross validation. This diff extends the API support to all predict methods on Adapter & Generator classes. Functionally, this is only supported by `BoTorchGenerator` and others will simply warn when posterior predictive is requested.

Differential Revision: D71552963


