### PR TITLE
Change compute to return a collection of cards instead of a single card

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -11,7 +11,7 @@ import json
 from collections.abc import Iterable
 from enum import IntEnum
 from logging import Logger
-from typing import Any, Protocol
+from typing import Any, Protocol, Sequence
 
 import pandas as pd
 from ax.core.experiment import Experiment
@@ -148,7 +148,7 @@ class Analysis(Protocol):
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> AnalysisCard:
+    ) -> Sequence[AnalysisCard]:
         # Note: when implementing compute always prefer experiment.lookup_data() to
         # experiment.fetch_data() to avoid unintential data fetching within the report
         # generation.
@@ -158,7 +158,7 @@ class Analysis(Protocol):
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
-    ) -> Result[AnalysisCard, AnalysisE]:
+    ) -> Result[Sequence[AnalysisCard], AnalysisE]:
         """
         Utility method to compute an AnalysisCard as a Result. This can be useful for
         computing many Analyses at once and handling Exceptions later.

--- a/ax/analysis/healthcheck/can_generate_candidates.py
+++ b/ax/analysis/healthcheck/can_generate_candidates.py
@@ -7,6 +7,7 @@
 
 import json
 from datetime import datetime
+from typing import Sequence
 
 import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
@@ -19,7 +20,7 @@ from ax.analysis.healthcheck.healthcheck_analysis import (
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
-from pyre_extensions import none_throws
+from pyre_extensions import none_throws, override
 
 
 class CanGenerateCandidatesAnalysis(HealthcheckAnalysis):
@@ -44,12 +45,13 @@ class CanGenerateCandidatesAnalysis(HealthcheckAnalysis):
         self.reason = reason
         self.days_till_fail = days_till_fail
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> HealthcheckAnalysisCard:
+    ) -> Sequence[HealthcheckAnalysisCard]:
         status = HealthcheckStatus.PASS
         subtitle = (
             "The candidate generation health check notifies users "
@@ -85,21 +87,23 @@ class CanGenerateCandidatesAnalysis(HealthcheckAnalysis):
         else:
             subtitle += f"{self.reason}"
 
-        return HealthcheckAnalysisCard(
-            name="CanGenerateCandidates",
-            title=f"Ax Candidate Generation {title_status}",
-            blob=json.dumps(
-                {
-                    "status": status,
-                }
-            ),
-            subtitle=subtitle,
-            df=pd.DataFrame(
-                {
-                    "status": [status],
-                    "reason": [self.reason],
-                }
-            ),
-            level=level,
-            category=AnalysisCardCategory.DIAGNOSTIC,
-        )
+        return [
+            HealthcheckAnalysisCard(
+                name="CanGenerateCandidates",
+                title=f"Ax Candidate Generation {title_status}",
+                blob=json.dumps(
+                    {
+                        "status": status,
+                    }
+                ),
+                subtitle=subtitle,
+                df=pd.DataFrame(
+                    {
+                        "status": [status],
+                        "reason": [self.reason],
+                    }
+                ),
+                level=level,
+                category=AnalysisCardCategory.DIAGNOSTIC,
+            )
+        ]

--- a/ax/analysis/healthcheck/constraints_feasibility.py
+++ b/ax/analysis/healthcheck/constraints_feasibility.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 import json
+from typing import Sequence
 
 import pandas as pd
 
@@ -24,7 +25,7 @@ from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
 from ax.modelbridge.transforms.derelativize import Derelativize
-from pyre_extensions import assert_is_instance
+from pyre_extensions import assert_is_instance, override
 
 
 class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
@@ -42,12 +43,13 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
         """
         self.prob_threshold = prob_threshold
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> HealthcheckAnalysisCard:
+    ) -> Sequence[HealthcheckAnalysisCard]:
         r"""
         Compute the feasibility of the constraints for the experiment.
 
@@ -75,30 +77,34 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
 
         if experiment.optimization_config is None:
             subtitle = "No optimization config is specified."
-            return HealthcheckAnalysisCard(
-                name="ConstraintsFeasibility",
-                title=f"Ax Constraints Feasibility {title_status}",
-                blob=json.dumps({"status": status}),
-                subtitle=subtitle,
-                df=df,
-                level=level,
-                category=category,
-            )
+            return [
+                HealthcheckAnalysisCard(
+                    name="ConstraintsFeasibility",
+                    title=f"Ax Constraints Feasibility {title_status}",
+                    blob=json.dumps({"status": status}),
+                    subtitle=subtitle,
+                    df=df,
+                    level=level,
+                    category=category,
+                )
+            ]
 
         if (
             experiment.optimization_config.outcome_constraints is None
             or len(experiment.optimization_config.outcome_constraints) == 0
         ):
             subtitle = "No constraints are specified."
-            return HealthcheckAnalysisCard(
-                name="ConstraintsFeasibility",
-                title=f"Ax Constraints Feasibility {title_status}",
-                blob=json.dumps({"status": status}),
-                subtitle=subtitle,
-                df=df,
-                level=level,
-                category=category,
-            )
+            return [
+                HealthcheckAnalysisCard(
+                    name="ConstraintsFeasibility",
+                    title=f"Ax Constraints Feasibility {title_status}",
+                    blob=json.dumps({"status": status}),
+                    subtitle=subtitle,
+                    df=df,
+                    level=level,
+                    category=category,
+                )
+            ]
 
         adapter = get_adapter(
             analysis_name=self.name,
@@ -135,15 +141,17 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
                 "status",
             ] = status
 
-        return HealthcheckAnalysisCard(
-            name="ConstraintsFeasibility",
-            title=f"Ax Constraints Feasibility {title_status}",
-            blob=json.dumps({"status": status}),
-            subtitle=subtitle,
-            df=df,
-            level=level,
-            category=category,
-        )
+        return [
+            HealthcheckAnalysisCard(
+                name="ConstraintsFeasibility",
+                title=f"Ax Constraints Feasibility {title_status}",
+                blob=json.dumps({"status": status}),
+                subtitle=subtitle,
+                df=df,
+                level=level,
+                category=category,
+            )
+        ]
 
 
 def constraints_feasibility(

--- a/ax/analysis/healthcheck/healthcheck_analysis.py
+++ b/ax/analysis/healthcheck/healthcheck_analysis.py
@@ -6,11 +6,13 @@
 # pyre-strict
 import json
 from enum import IntEnum
+from typing import Sequence
 
 from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
+from pyre_extensions import override
 
 
 class HealthcheckStatus(IntEnum):
@@ -31,9 +33,10 @@ class HealthcheckAnalysis(Analysis):
     An analysis that performs a health check.
     """
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> HealthcheckAnalysisCard: ...
+    ) -> Sequence[HealthcheckAnalysisCard]: ...

--- a/ax/analysis/healthcheck/regression_analysis.py
+++ b/ax/analysis/healthcheck/regression_analysis.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 import json
+from typing import Sequence
 
 import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
@@ -21,7 +22,7 @@ from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
-from pyre_extensions import none_throws
+from pyre_extensions import none_throws, override
 
 
 class RegressionAnalysis(HealthcheckAnalysis):
@@ -45,12 +46,13 @@ class RegressionAnalysis(HealthcheckAnalysis):
         """
         self.prob_threshold = prob_threshold
 
+    @override
     def compute(
         self,
         experiment: Experiment | None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> HealthcheckAnalysisCard:
+    ) -> Sequence[HealthcheckAnalysisCard]:
         r"""
         Detect the regressing arms for all trials that have data.
 
@@ -110,15 +112,17 @@ class RegressionAnalysis(HealthcheckAnalysis):
             subtitle = subtitle_base + "No metric regessions detected."
             title_status = "Success"
 
-        return HealthcheckAnalysisCard(
-            name="RegressionAnalysis",
-            title=f"Ax Regression Analysis {title_status}",
-            blob=json.dumps({"status": status}),
-            subtitle=subtitle,
-            df=df,
-            level=AnalysisCardLevel.LOW,
-            category=AnalysisCardCategory.DIAGNOSTIC,
-        )
+        return [
+            HealthcheckAnalysisCard(
+                name="RegressionAnalysis",
+                title=f"Ax Regression Analysis {title_status}",
+                blob=json.dumps({"status": status}),
+                subtitle=subtitle,
+                df=df,
+                level=AnalysisCardLevel.LOW,
+                category=AnalysisCardCategory.DIAGNOSTIC,
+            )
+        ]
 
 
 def process_regression_dict(

--- a/ax/analysis/healthcheck/search_space_analysis.py
+++ b/ax/analysis/healthcheck/search_space_analysis.py
@@ -6,7 +6,7 @@
 # pyre-strict
 
 import json
-from typing import Union
+from typing import Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -26,7 +26,7 @@ from ax.core.types import TParameterization
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
-from pyre_extensions import assert_is_instance
+from pyre_extensions import assert_is_instance, override
 
 
 class SearchSpaceAnalysis(HealthcheckAnalysis):
@@ -52,12 +52,13 @@ class SearchSpaceAnalysis(HealthcheckAnalysis):
         self.trial_index = trial_index
         self.boundary_proportion_threshold = boundary_proportion_threshold
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> HealthcheckAnalysisCard:
+    ) -> Sequence[HealthcheckAnalysisCard]:
         if experiment is None:
             raise UserInputError("SearchSpaceAnalysis requires an Experiment.")
 
@@ -94,16 +95,18 @@ class SearchSpaceAnalysis(HealthcheckAnalysis):
         else:
             additional_subtitle = "Search space does not need to be updated."
 
-        return HealthcheckAnalysisCard(
-            name="SearchSpaceAnalysis",
-            title=f"Ax Search Space Analysis {title_status}",
-            blob=json.dumps({"status": status}),
-            subtitle=subtitle_base + additional_subtitle,
-            df=df,
-            level=level,
-            attributes={"trial_index": self.trial_index},
-            category=AnalysisCardCategory.DIAGNOSTIC,
-        )
+        return [
+            HealthcheckAnalysisCard(
+                name="SearchSpaceAnalysis",
+                title=f"Ax Search Space Analysis {title_status}",
+                blob=json.dumps({"status": status}),
+                subtitle=subtitle_base + additional_subtitle,
+                df=df,
+                level=level,
+                attributes={"trial_index": self.trial_index},
+                category=AnalysisCardCategory.DIAGNOSTIC,
+            )
+        ]
 
 
 def search_space_boundary_proportions(

--- a/ax/analysis/healthcheck/should_generate_candidates.py
+++ b/ax/analysis/healthcheck/should_generate_candidates.py
@@ -6,6 +6,7 @@
 # pyre-unsafe
 
 import json
+from typing import Sequence
 
 import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
@@ -18,6 +19,7 @@ from ax.analysis.healthcheck.healthcheck_analysis import (
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
+from pyre_extensions import override
 
 
 class ShouldGenerateCandidates(HealthcheckAnalysis):
@@ -31,33 +33,36 @@ class ShouldGenerateCandidates(HealthcheckAnalysis):
         self.reason = reason
         self.trial_index = trial_index
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> HealthcheckAnalysisCard:
+    ) -> Sequence[HealthcheckAnalysisCard]:
         status = (
             HealthcheckStatus.PASS
             if self.should_generate
             else HealthcheckStatus.WARNING
         )
-        return HealthcheckAnalysisCard(
-            name=self.name,
-            title=f"Ready to Generate Candidates for Trial {self.trial_index}",
-            blob=json.dumps(
-                {
-                    "status": status,
-                }
-            ),
-            subtitle=self.reason,
-            df=pd.DataFrame(
-                {
-                    "status": [status],
-                    "reason": [self.reason],
-                }
-            ),
-            level=AnalysisCardLevel.CRITICAL,
-            attributes=self.attributes,
-            category=AnalysisCardCategory.DIAGNOSTIC,
-        )
+        return [
+            HealthcheckAnalysisCard(
+                name=self.name,
+                title=f"Ready to Generate Candidates for Trial {self.trial_index}",
+                blob=json.dumps(
+                    {
+                        "status": status,
+                    }
+                ),
+                subtitle=self.reason,
+                df=pd.DataFrame(
+                    {
+                        "status": [status],
+                        "reason": [self.reason],
+                    }
+                ),
+                level=AnalysisCardLevel.CRITICAL,
+                attributes=self.attributes,
+                category=AnalysisCardCategory.DIAGNOSTIC,
+            )
+        ]

--- a/ax/analysis/healthcheck/tests/test_can_generate_candidates.py
+++ b/ax/analysis/healthcheck/tests/test_can_generate_candidates.py
@@ -23,7 +23,7 @@ class TestCanGenerateCandidates(TestCase):
     def test_passes_if_can_generate(self) -> None:
         # GIVEN we can generate candidates
         # WHEN we run the healthcheck
-        card = CanGenerateCandidatesAnalysis(
+        (card,) = CanGenerateCandidatesAnalysis(
             can_generate_candidates=True,
             reason="No problems found.",
             days_till_fail=0,
@@ -58,7 +58,7 @@ class TestCanGenerateCandidates(TestCase):
         trial.mark_running(no_runner_required=True)
         trial._time_run_started = datetime.now() - timedelta(days=1)
         # WHEN we run the healthcheck
-        card = CanGenerateCandidatesAnalysis(
+        (card,) = CanGenerateCandidatesAnalysis(
             can_generate_candidates=False,
             reason="The data is borked.",
             days_till_fail=2,
@@ -94,7 +94,7 @@ class TestCanGenerateCandidates(TestCase):
         trial = experiment.trials[0]
         self.assertEqual(trial.status, TrialStatus.CANDIDATE)
         # WHEN we run the healthcheck
-        card = CanGenerateCandidatesAnalysis(
+        (card,) = CanGenerateCandidatesAnalysis(
             can_generate_candidates=False,
             reason="The data is gone.",
             days_till_fail=2,
@@ -130,7 +130,7 @@ class TestCanGenerateCandidates(TestCase):
         trial._time_run_started = datetime.now() - timedelta(days=3)
         trial.mark_completed()
         # WHEN we run the healthcheck
-        card = CanGenerateCandidatesAnalysis(
+        (card,) = CanGenerateCandidatesAnalysis(
             can_generate_candidates=False,
             reason="The data is old.",
             days_till_fail=1,

--- a/ax/analysis/healthcheck/tests/test_constraints_feasibility.py
+++ b/ax/analysis/healthcheck/tests/test_constraints_feasibility.py
@@ -163,7 +163,7 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
     def test_compute(self) -> None:
         self.setUp()
         cfa = ConstraintsFeasibilityAnalysis()
-        card = cfa.compute(
+        (card,) = cfa.compute(
             experiment=self.experiment, generation_strategy=self.generation_strategy
         )
         self.assertEqual(card.name, "ConstraintsFeasibility")
@@ -191,7 +191,7 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
         generation_strategy.experiment = experiment
         generation_strategy._curr._fit(experiment=experiment)
         cfa = ConstraintsFeasibilityAnalysis()
-        card = cfa.compute(
+        (card,) = cfa.compute(
             experiment=experiment, generation_strategy=generation_strategy
         )
         self.assertEqual(card.name, "ConstraintsFeasibility")
@@ -215,7 +215,7 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
             outcome_constraints=[],
         )
         cfa = ConstraintsFeasibilityAnalysis()
-        card = cfa.compute(
+        (card,) = cfa.compute(
             experiment=experiment, generation_strategy=generation_strategy
         )
         self.assertEqual(card.name, "ConstraintsFeasibility")
@@ -227,7 +227,7 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
     def test_no_optimization_config(self) -> None:
         experiment = get_branin_experiment(has_optimization_config=False)
         cfa = ConstraintsFeasibilityAnalysis()
-        card = cfa.compute(experiment=experiment, generation_strategy=None)
+        (card,) = cfa.compute(experiment=experiment, generation_strategy=None)
         self.assertEqual(card.name, "ConstraintsFeasibility")
         self.assertEqual(card.title, "Ax Constraints Feasibility Success")
         self.assertEqual(card.level, AnalysisCardLevel.LOW)

--- a/ax/analysis/healthcheck/tests/test_regression_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_regression_analysis.py
@@ -33,7 +33,7 @@ class TestRegressionAnalysis(TestCase):
 
         experiment.attach_data(Data(df=df))
         ra = RegressionAnalysis(prob_threshold=0.90)
-        card = ra.compute(experiment=experiment, generation_strategy=None)
+        (card,) = ra.compute(experiment=experiment, generation_strategy=None)
         self.assertEqual(card.name, "RegressionAnalysis")
         self.assertEqual(card.title, "Ax Regression Analysis Warning")
         self.assertTrue(
@@ -55,7 +55,7 @@ class TestRegressionAnalysis(TestCase):
         )
         experiment.attach_data(Data(df=df))
         ra = RegressionAnalysis(prob_threshold=0.90)
-        card = ra.compute(experiment=experiment, generation_strategy=None)
+        (card,) = ra.compute(experiment=experiment, generation_strategy=None)
         self.assertEqual(card.name, "RegressionAnalysis")
         self.assertEqual(card.title, "Ax Regression Analysis Success")
         self.assertEqual(

--- a/ax/analysis/healthcheck/tests/test_search_space_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_search_space_analysis.py
@@ -32,7 +32,7 @@ class TestSearchSpaceAnalysis(TestCase):
         ]
         experiment.new_batch_trial(generator_run=GeneratorRun(arms=arms))
         ssa = SearchSpaceAnalysis(trial_index=0)
-        card = ssa.compute(experiment=experiment)
+        (card,) = ssa.compute(experiment=experiment)
 
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
         self.assertEqual(card.category, AnalysisCardCategory.DIAGNOSTIC)
@@ -56,7 +56,7 @@ class TestSearchSpaceAnalysis(TestCase):
         ]
         experiment.new_batch_trial(generator_run=GeneratorRun(arms=arms))
         ssa = SearchSpaceAnalysis(trial_index=1)
-        card = ssa.compute(experiment=experiment)
+        (card,) = ssa.compute(experiment=experiment)
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
         self.assertEqual(card.name, "SearchSpaceAnalysis")
         self.assertEqual(card.title, "Ax Search Space Analysis Success")
@@ -77,7 +77,7 @@ class TestSearchSpaceAnalysis(TestCase):
         ]
         experiment.new_batch_trial(generator_run=GeneratorRun(arms=arms))
         ssa = SearchSpaceAnalysis(trial_index=2)
-        card = ssa.compute(experiment=experiment)
+        (card,) = ssa.compute(experiment=experiment)
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
         self.assertEqual(card.name, "SearchSpaceAnalysis")
         self.assertEqual(card.title, "Ax Search Space Analysis Warning")

--- a/ax/analysis/healthcheck/tests/test_should_generate_candidates.py
+++ b/ax/analysis/healthcheck/tests/test_should_generate_candidates.py
@@ -16,7 +16,7 @@ from ax.utils.common.testutils import TestCase
 class TestShouldGenerateCandidates(TestCase):
     def test_should(self) -> None:
         trial_index = randint(0, 10)
-        card = ShouldGenerateCandidates(
+        (card,) = ShouldGenerateCandidates(
             should_generate=True,
             reason="Something reassuring",
             trial_index=trial_index,
@@ -29,7 +29,7 @@ class TestShouldGenerateCandidates(TestCase):
 
     def test_should_not(self) -> None:
         trial_index = randint(0, 10)
-        card = ShouldGenerateCandidates(
+        (card,) = ShouldGenerateCandidates(
             should_generate=False,
             reason="Something concerning",
             trial_index=trial_index,

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -7,6 +7,7 @@
 
 
 import traceback
+from typing import Sequence
 
 import pandas as pd
 from ax.analysis.analysis import (
@@ -20,6 +21,7 @@ from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
 from IPython.display import display, Markdown
+from pyre_extensions import override
 
 
 class MarkdownAnalysisCard(AnalysisCard):
@@ -42,12 +44,13 @@ class MarkdownAnalysis(Analysis):
     An Analysis that computes a paragraph of Markdown formatted text.
     """
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> MarkdownAnalysisCard: ...
+    ) -> Sequence[MarkdownAnalysisCard]: ...
 
     def _create_markdown_analysis_card(
         self,
@@ -76,20 +79,22 @@ class MarkdownAnalysis(Analysis):
 
 def markdown_analysis_card_from_analysis_e(
     analysis_e: AnalysisE,
-) -> MarkdownAnalysisCard:
-    return MarkdownAnalysisCard(
-        name=analysis_e.analysis.name,
-        title=f"{analysis_e.analysis.name} Error",
-        subtitle=f"An error occurred while computing {analysis_e.analysis}",
-        attributes=analysis_e.analysis.attributes,
-        blob="".join(
-            traceback.format_exception(
-                type(analysis_e.exception),
-                analysis_e.exception,
-                analysis_e.exception.__traceback__,
-            )
-        ),
-        df=pd.DataFrame(),
-        level=AnalysisCardLevel.DEBUG,
-        category=AnalysisCardCategory.ERROR,
-    )
+) -> list[MarkdownAnalysisCard]:
+    return [
+        MarkdownAnalysisCard(
+            name=analysis_e.analysis.name,
+            title=f"{analysis_e.analysis.name} Error",
+            subtitle=f"An error occurred while computing {analysis_e.analysis}",
+            attributes=analysis_e.analysis.attributes,
+            blob="".join(
+                traceback.format_exception(
+                    type(analysis_e.exception),
+                    analysis_e.exception,
+                    analysis_e.exception.__traceback__,
+                )
+            ),
+            df=pd.DataFrame(),
+            level=AnalysisCardLevel.DEBUG,
+            category=AnalysisCardCategory.ERROR,
+        )
+    ]

--- a/ax/analysis/metric_summary.py
+++ b/ax/analysis/metric_summary.py
@@ -5,6 +5,8 @@
 
 # pyre-strict
 
+from typing import Sequence
+
 from ax.analysis.analysis import (
     Analysis,
     AnalysisCard,
@@ -15,6 +17,7 @@ from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
+from pyre_extensions import override
 
 
 class MetricSummary(Analysis):
@@ -32,20 +35,23 @@ class MetricSummary(Analysis):
             if provided.
     """
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> AnalysisCard:
+    ) -> Sequence[AnalysisCard]:
         if experiment is None:
             raise UserInputError(
                 "`MetricSummary` analysis requires an `Experiment` input"
             )
-        return self._create_analysis_card(
-            title=f"MetricSummary for `{experiment.name}`",
-            subtitle="High-level summary of the `Metric`-s in this `Experiment`",
-            level=AnalysisCardLevel.MID,
-            df=experiment.metric_config_summary_df,
-            category=AnalysisCardCategory.INFO,
-        )
+        return [
+            self._create_analysis_card(
+                title=f"MetricSummary for `{experiment.name}`",
+                subtitle="High-level summary of the `Metric`-s in this `Experiment`",
+                level=AnalysisCardLevel.MID,
+                df=experiment.metric_config_summary_df,
+                category=AnalysisCardCategory.INFO,
+            )
+        ]

--- a/ax/analysis/plotly/arm_effects/insample_effects.py
+++ b/ax/analysis/plotly/arm_effects/insample_effects.py
@@ -7,6 +7,7 @@
 
 from itertools import chain
 from logging import Logger
+from typing import Sequence
 
 import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
@@ -26,7 +27,7 @@ from ax.modelbridge.base import Adapter
 from ax.modelbridge.registry import Generators
 from ax.modelbridge.transforms.derelativize import Derelativize
 from ax.utils.common.logger import get_logger
-from pyre_extensions import none_throws
+from pyre_extensions import none_throws, override
 
 logger: Logger = get_logger(__name__)
 
@@ -73,12 +74,13 @@ class InSampleEffectsPlot(PlotlyAnalysis):
         self.trial_index = trial_index
         self.use_modeled_effects = use_modeled_effects
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard:
+    ) -> Sequence[PlotlyAnalysisCard]:
         if experiment is None:
             raise UserInputError("InSampleEffectsPlot requires an Experiment.")
 
@@ -128,18 +130,19 @@ class InSampleEffectsPlot(PlotlyAnalysis):
             "perfectly match raw observations."
         )
 
-        card = self._create_plotly_analysis_card(
-            title=(
-                f"{self._plot_type_string} Effects for {self.metric_name} "
-                f"on trial {self.trial_index}"
-            ),
-            subtitle=subtitle,
-            level=AnalysisCardLevel.MID + nudge,
-            df=df,
-            fig=fig,
-            category=AnalysisCardCategory.INSIGHT,
-        )
-        return card
+        return [
+            self._create_plotly_analysis_card(
+                title=(
+                    f"{self._plot_type_string} Effects for {self.metric_name} "
+                    f"on trial {self.trial_index}"
+                ),
+                subtitle=subtitle,
+                level=AnalysisCardLevel.MID + nudge,
+                df=df,
+                fig=fig,
+                category=AnalysisCardCategory.INSIGHT,
+            )
+        ]
 
     @property
     def name(self) -> str:

--- a/ax/analysis/plotly/arm_effects/predicted_effects.py
+++ b/ax/analysis/plotly/arm_effects/predicted_effects.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 
 from itertools import chain
-from typing import Any
+from typing import Any, Sequence
 
 import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
@@ -25,7 +25,7 @@ from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
 from ax.modelbridge.transforms.derelativize import Derelativize
-from pyre_extensions import none_throws
+from pyre_extensions import none_throws, override
 
 
 class PredictedEffectsPlot(PlotlyAnalysis):
@@ -64,12 +64,13 @@ class PredictedEffectsPlot(PlotlyAnalysis):
         """
         self.metric_name = metric_name
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard:
+    ) -> Sequence[PlotlyAnalysisCard]:
         if experiment is None:
             raise UserInputError("PredictedEffectsPlot requires an Experiment.")
 
@@ -117,22 +118,24 @@ class PredictedEffectsPlot(PlotlyAnalysis):
         )
         nudge = get_nudge_value(metric_name=self.metric_name, experiment=experiment)
 
-        return self._create_plotly_analysis_card(
-            title=f"Predicted Effects for {self.metric_name}",
-            subtitle=(
-                "The predicted effects plot provides a visualization of the "
-                "estimated metric effects for each arm in the upcoming trial. "
-                "This plot helps in anticipating the potential outcomes and "
-                "performance of different arms based on the model's predictions. "
-                "Note that flat predictions across arms indicate that the model "
-                "has not picked up on sufficient signal in the data, and instead "
-                "is just predicting the mean."
-            ),
-            level=AnalysisCardLevel.HIGH + nudge,
-            df=df,
-            fig=fig,
-            category=AnalysisCardCategory.ACTIONABLE,
-        )
+        return [
+            self._create_plotly_analysis_card(
+                title=f"Predicted Effects for {self.metric_name}",
+                subtitle=(
+                    "The predicted effects plot provides a visualization of the "
+                    "estimated metric effects for each arm in the upcoming trial. "
+                    "This plot helps in anticipating the potential outcomes and "
+                    "performance of different arms based on the model's predictions. "
+                    "Note that flat predictions across arms indicate that the model "
+                    "has not picked up on sufficient signal in the data, and instead "
+                    "is just predicting the mean."
+                ),
+                level=AnalysisCardLevel.HIGH + nudge,
+                df=df,
+                fig=fig,
+                category=AnalysisCardCategory.ACTIONABLE,
+            )
+        ]
 
 
 def _prepare_data(

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -6,6 +6,8 @@
 # pyre-strict
 
 
+from typing import Sequence
+
 import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
@@ -91,7 +93,7 @@ class CrossValidationPlot(PlotlyAnalysis):
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard:
+    ) -> Sequence[PlotlyAnalysisCard]:
         adapter_for_analysis = get_adapter(
             analysis_name=self.name,
             experiment=experiment,
@@ -136,27 +138,29 @@ class CrossValidationPlot(PlotlyAnalysis):
                 "used for validation"
             )
         )
-        return self._create_plotly_analysis_card(
-            title=f"Cross Validation for {metric_title}",
-            subtitle=(
-                "The cross-validation plot displays the model fit for each "
-                f"metric in the experiment. It employs a {k_folds_substring} "
-                f"approach, where {cv_description}. The plot shows the "
-                "predicted outcome for the validation set on the y-axis against "
-                "its actual value on the x-axis. Points that align closely with "
-                "the dotted diagonal line indicate a strong model fit, signifying "
-                "accurate predictions. Additionally, the plot includes 95% "
-                "confidence intervals that provide insight into the noise in "
-                "observations and the uncertainty in model predictions. A "
-                "horizontal, flat line of predictions indicates that the model "
-                "has not picked up on sufficient signal in the data, and instead "
-                "is just predicting the mean."
-            ),
-            level=AnalysisCardLevel.LOW.value + nudge,
-            df=df,
-            fig=fig,
-            category=AnalysisCardCategory.INSIGHT,
-        )
+        return [
+            self._create_plotly_analysis_card(
+                title=f"Cross Validation for {metric_title}",
+                subtitle=(
+                    "The cross-validation plot displays the model fit for each "
+                    f"metric in the experiment. It employs a {k_folds_substring} "
+                    f"approach, where {cv_description}. The plot shows the "
+                    "predicted outcome for the validation set on the y-axis against "
+                    "its actual value on the x-axis. Points that align closely with "
+                    "the dotted diagonal line indicate a strong model fit, signifying "
+                    "accurate predictions. Additionally, the plot includes 95% "
+                    "confidence intervals that provide insight into the noise in "
+                    "observations and the uncertainty in model predictions. A "
+                    "horizontal, flat line of predictions indicates that the model "
+                    "has not picked up on sufficient signal in the data, and instead "
+                    "is just predicting the mean."
+                ),
+                level=AnalysisCardLevel.LOW.value + nudge,
+                df=df,
+                fig=fig,
+                category=AnalysisCardCategory.INSIGHT,
+            )
+        ]
 
 
 def cross_validation_adhoc_compute(
@@ -208,7 +212,7 @@ def cross_validation_adhoc_compute(
             else metric_name
         )
         plots.append(
-            CrossValidationPlot(
+            *CrossValidationPlot(
                 metric_name=metric_name,
                 folds=folds,
                 untransform=untransform,

--- a/ax/analysis/plotly/interaction.py
+++ b/ax/analysis/plotly/interaction.py
@@ -7,6 +7,7 @@
 
 
 from logging import Logger
+from typing import Sequence
 
 import pandas as pd
 import torch
@@ -40,7 +41,7 @@ from gpytorch.kernels import RBFKernel
 from gpytorch.priors import LogNormalPrior
 from plotly import express as px, graph_objects as go
 from plotly.subplots import make_subplots
-from pyre_extensions import assert_is_instance
+from pyre_extensions import assert_is_instance, override
 
 logger: Logger = get_logger(__name__)
 
@@ -87,12 +88,13 @@ class InteractionPlot(PlotlyAnalysis):
         self.seed = seed
         self.torch_device = torch_device
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard:
+    ) -> Sequence[PlotlyAnalysisCard]:
         """
         Compute Sobol index sensitivity for one metric of an experiment. Sensitivity
         is comptuted by component, where a compoent may be either one variable
@@ -264,14 +266,16 @@ class InteractionPlot(PlotlyAnalysis):
             "the experiment's results."
         )
 
-        return self._create_plotly_analysis_card(
-            title=f"Interaction Analysis for {metric_name}",
-            subtitle=subtitle,
-            level=AnalysisCardLevel.MID,
-            df=sensitivity_df,
-            fig=fig,
-            category=AnalysisCardCategory.INSIGHT,
-        )
+        return [
+            self._create_plotly_analysis_card(
+                title=f"Interaction Analysis for {metric_name}",
+                subtitle=subtitle,
+                level=AnalysisCardLevel.MID,
+                df=sensitivity_df,
+                fig=fig,
+                category=AnalysisCardCategory.INSIGHT,
+            )
+        ]
 
     def _get_oak_model(self, experiment: Experiment, metric_name: str) -> TorchAdapter:
         """

--- a/ax/analysis/plotly/parallel_coordinates.py
+++ b/ax/analysis/plotly/parallel_coordinates.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from typing import Any
+from typing import Any, Sequence
 
 import numpy as np
 import pandas as pd
@@ -18,6 +18,7 @@ from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
 from plotly import graph_objects as go
+from pyre_extensions import override
 
 
 class ParallelCoordinatesPlot(PlotlyAnalysis):
@@ -43,12 +44,13 @@ class ParallelCoordinatesPlot(PlotlyAnalysis):
 
         self.metric_name = metric_name
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard:
+    ) -> Sequence[PlotlyAnalysisCard]:
         if experiment is None:
             raise UserInputError("ParallelCoordinatesPlot requires an Experiment")
 
@@ -57,24 +59,26 @@ class ParallelCoordinatesPlot(PlotlyAnalysis):
         df = _prepare_data(experiment=experiment, metric=metric_name)
         fig = _prepare_plot(df=df, metric_name=metric_name)
 
-        return self._create_plotly_analysis_card(
-            title=f"Parallel Coordinates for {metric_name}",
-            subtitle=(
-                "The parallel coordinates plot displays multi-dimensional "
-                "data by representing each parameter as a parallel axis. This "
-                "plot helps in assessing how thoroughly the search space has "
-                "been explored and in identifying patterns or clusterings associated "
-                "with high-performing (good) or low-performing (bad) arms. By "
-                "tracing lines across the axes, one can observe correlations and "
-                "interactions between parameters, gaining insights into the "
-                "relationships that contribute to the success or failure of "
-                "different configurations within the experiment."
-            ),
-            level=AnalysisCardLevel.HIGH,
-            df=df,
-            fig=fig,
-            category=AnalysisCardCategory.INSIGHT,
-        )
+        return [
+            self._create_plotly_analysis_card(
+                title=f"Parallel Coordinates for {metric_name}",
+                subtitle=(
+                    "The parallel coordinates plot displays multi-dimensional "
+                    "data by representing each parameter as a parallel axis. This "
+                    "plot helps in assessing how thoroughly the search space has "
+                    "been explored and in identifying patterns or clusterings "
+                    "associated with high-performing (good) or low-performing (bad) "
+                    "arms. By tracing lines across the axes, one can observe "
+                    "correlations and interactions between parameters, gaining "
+                    "insights into the relationships that contribute to the success "
+                    "or failure of different configurations within the experiment."
+                ),
+                level=AnalysisCardLevel.HIGH,
+                df=df,
+                fig=fig,
+                category=AnalysisCardCategory.INSIGHT,
+            )
+        ]
 
 
 def _prepare_data(experiment: Experiment, metric: str) -> pd.DataFrame:

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -6,6 +6,8 @@
 # pyre-strict
 
 
+from typing import Sequence
+
 import pandas as pd
 from ax.analysis.analysis import Analysis, AnalysisCard
 from ax.core.experiment import Experiment
@@ -13,6 +15,7 @@ from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
 from IPython.display import display
 from plotly import graph_objects as go, io as pio
+from pyre_extensions import override
 
 
 class PlotlyAnalysisCard(AnalysisCard):
@@ -35,12 +38,13 @@ class PlotlyAnalysis(Analysis):
     An Analysis that computes a Plotly figure.
     """
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard: ...
+    ) -> Sequence[PlotlyAnalysisCard]: ...
 
     def _create_plotly_analysis_card(
         self,

--- a/ax/analysis/plotly/progression.py
+++ b/ax/analysis/plotly/progression.py
@@ -5,6 +5,7 @@
 
 # pyre-strict
 from logging import Logger
+from typing import Sequence
 
 import numpy as np
 import plotly.express as px
@@ -20,7 +21,7 @@ from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
 from ax.utils.common.logger import get_logger
 from plotly import graph_objects as go
-from pyre_extensions import assert_is_instance
+from pyre_extensions import assert_is_instance, override
 
 logger: Logger = get_logger(__name__)
 
@@ -55,12 +56,13 @@ class ProgressionPlot(PlotlyAnalysis):
         self._metric_name = metric_name
         self._by_wallclock_time = by_wallclock_time
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard:
+    ) -> Sequence[PlotlyAnalysisCard]:
         if experiment is None:
             raise UserInputError("ProgressionPlot requires an Experiment")
 
@@ -135,20 +137,22 @@ class ProgressionPlot(PlotlyAnalysis):
                 )
             )
 
-        return self._create_plotly_analysis_card(
-            title=f"{metric_name} by {x_axis_name.replace('_', ' ')}",
-            subtitle=(
-                "The progression plot tracks the evolution of each metric "
-                "over the course of the experiment. This visualization is "
-                "typically used to monitor the improvement of metrics over "
-                "Trial iterations, but can also be useful in informing decisions "
-                "about early stopping for Trials."
-            ),
-            level=AnalysisCardLevel.MID,
-            df=df,
-            fig=fig,
-            category=AnalysisCardCategory.INSIGHT,
-        )
+        return [
+            self._create_plotly_analysis_card(
+                title=f"{metric_name} by {x_axis_name.replace('_', ' ')}",
+                subtitle=(
+                    "The progression plot tracks the evolution of each metric "
+                    "over the course of the experiment. This visualization is "
+                    "typically used to monitor the improvement of metrics over "
+                    "Trial iterations, but can also be useful in informing decisions "
+                    "about early stopping for Trials."
+                ),
+                level=AnalysisCardLevel.MID,
+                df=df,
+                fig=fig,
+                category=AnalysisCardCategory.INSIGHT,
+            )
+        ]
 
 
 def _calculate_wallclock_timeseries(

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -5,6 +5,8 @@
 
 # pyre-strict
 
+from typing import Sequence
+
 import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
@@ -23,6 +25,7 @@ from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
 from ax.modelbridge.prediction_utils import predict_at_point
 from plotly import graph_objects as go
+from pyre_extensions import override
 
 
 class ScatterPlot(PlotlyAnalysis):
@@ -76,12 +79,13 @@ class ScatterPlot(PlotlyAnalysis):
         self._fixed_features = fixed_features
         self._metric_name_mapping = metric_name_mapping
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard:
+    ) -> Sequence[PlotlyAnalysisCard]:
         if experiment is None:
             raise UserInputError("ScatterPlot requires an Experiment")
 
@@ -115,21 +119,23 @@ class ScatterPlot(PlotlyAnalysis):
             or False,
         )
 
-        return self._create_plotly_analysis_card(
-            title=f"Observed {x_metric_name} vs. {y_metric_name}",
-            subtitle=(
-                "The scatter plot displays individual data points "
-                "representing either observed or predicted values "
-                "from the model for two selected metrics. Each point on the plot "
-                "corresponds to an arm in a Trial. This visualization is particularly "
-                "useful for understanding the trade-off between two metrics in the "
-                "experiment."
-            ),
-            level=AnalysisCardLevel.HIGH,
-            df=df,
-            fig=fig,
-            category=AnalysisCardCategory.INSIGHT,
-        )
+        return [
+            self._create_plotly_analysis_card(
+                title=f"Observed {x_metric_name} vs. {y_metric_name}",
+                subtitle=(
+                    "The scatter plot displays individual data points "
+                    "representing either observed or predicted values "
+                    "from the model for two selected metrics. Each point on the plot "
+                    "corresponds to an arm in a Trial. This visualization is "
+                    "particularly useful for understanding the trade-off between two "
+                    "metrics in the experiment."
+                ),
+                level=AnalysisCardLevel.HIGH,
+                df=df,
+                fig=fig,
+                category=AnalysisCardCategory.INSIGHT,
+            )
+        ]
 
 
 def scatter_plot(
@@ -164,7 +170,7 @@ def scatter_plot(
     """
     # returning as a list enables easier UX for displaying the cards in a notebook
     return [
-        ScatterPlot(
+        *ScatterPlot(
             x_metric_name=x_metric_name,
             y_metric_name=y_metric_name,
             show_pareto_frontier=False,  # Not supported for adhoc use

--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 import math
+from typing import Sequence
 
 import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
@@ -23,7 +24,7 @@ from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
 from plotly import graph_objects as go
-from pyre_extensions import none_throws
+from pyre_extensions import none_throws, override
 
 
 class ContourPlot(PlotlyAnalysis):
@@ -59,12 +60,13 @@ class ContourPlot(PlotlyAnalysis):
         self.metric_name = metric_name
         self._display_sampled = display_sampled
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard:
+    ) -> Sequence[PlotlyAnalysisCard]:
         if experiment is None:
             raise UserInputError("ContourPlot requires an Experiment")
 
@@ -98,26 +100,29 @@ class ContourPlot(PlotlyAnalysis):
             display_sampled=self._display_sampled,
         )
 
-        return self._create_plotly_analysis_card(
-            title=(
-                f"{self.x_parameter_name}, {self.y_parameter_name} vs. {metric_name}"
-            ),
-            subtitle=(
-                "The contour plot visualizes the predicted outcomes "
-                f"for {metric_name} across a two-dimensional parameter space, "
-                "with other parameters held fixed at their status_quo value "
-                "(or mean value if status_quo is unavailable). This plot helps "
-                "in identifying regions of optimal performance and understanding "
-                "how changes in the selected parameters influence the predicted "
-                "outcomes. Contour lines represent levels of constant predicted "
-                "values, providing insights into the gradient and potential optima "
-                "within the parameter space."
-            ),
-            level=AnalysisCardLevel.LOW,
-            df=df,
-            fig=fig,
-            category=AnalysisCardCategory.INSIGHT,
-        )
+        return [
+            self._create_plotly_analysis_card(
+                title=(
+                    f"{self.x_parameter_name}, {self.y_parameter_name} vs. "
+                    f"{metric_name}"
+                ),
+                subtitle=(
+                    "The contour plot visualizes the predicted outcomes "
+                    f"for {metric_name} across a two-dimensional parameter space, "
+                    "with other parameters held fixed at their status_quo value "
+                    "(or mean value if status_quo is unavailable). This plot helps "
+                    "in identifying regions of optimal performance and understanding "
+                    "how changes in the selected parameters influence the predicted "
+                    "outcomes. Contour lines represent levels of constant predicted "
+                    "values, providing insights into the gradient and potential optima "
+                    "within the parameter space."
+                ),
+                level=AnalysisCardLevel.LOW,
+                df=df,
+                fig=fig,
+                category=AnalysisCardCategory.INSIGHT,
+            )
+        ]
 
 
 def _prepare_data(

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 import math
+from typing import Sequence
 
 import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
@@ -23,7 +24,7 @@ from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
 from plotly import express as px, graph_objects as go
-from pyre_extensions import none_throws
+from pyre_extensions import none_throws, override
 
 
 class SlicePlot(PlotlyAnalysis):
@@ -57,12 +58,13 @@ class SlicePlot(PlotlyAnalysis):
         self.metric_name = metric_name
         self._display_sampled = display_sampled
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard:
+    ) -> Sequence[PlotlyAnalysisCard]:
         if experiment is None:
             raise UserInputError("SlicePlot requires an Experiment")
 
@@ -91,22 +93,24 @@ class SlicePlot(PlotlyAnalysis):
             display_sampled=self._display_sampled,
         )
 
-        return self._create_plotly_analysis_card(
-            title=f"{self.parameter_name} vs. {metric_name}",
-            subtitle=(
-                "The slice plot provides a one-dimensional view of predicted "
-                f"outcomes for {metric_name} as a function of a single parameter, "
-                "while keeping all other parameters fixed at their status_quo "
-                "value (or mean value if status_quo is unavailable). "
-                "This visualization helps in understanding the sensitivity and "
-                "impact of changes in the selected parameter on the predicted "
-                "metric outcomes."
-            ),
-            level=AnalysisCardLevel.LOW,
-            df=df,
-            fig=fig,
-            category=AnalysisCardCategory.INSIGHT,
-        )
+        return [
+            self._create_plotly_analysis_card(
+                title=f"{self.parameter_name} vs. {metric_name}",
+                subtitle=(
+                    "The slice plot provides a one-dimensional view of predicted "
+                    f"outcomes for {metric_name} as a function of a single parameter, "
+                    "while keeping all other parameters fixed at their status_quo "
+                    "value (or mean value if status_quo is unavailable). "
+                    "This visualization helps in understanding the sensitivity and "
+                    "impact of changes in the selected parameter on the predicted "
+                    "metric outcomes."
+                ),
+                level=AnalysisCardLevel.LOW,
+                df=df,
+                fig=fig,
+                category=AnalysisCardCategory.INSIGHT,
+            )
+        ]
 
 
 def _prepare_data(

--- a/ax/analysis/plotly/surface/tests/test_contour.py
+++ b/ax/analysis/plotly/surface/tests/test_contour.py
@@ -60,7 +60,7 @@ class TestContourPlot(TestCase):
         with self.assertRaisesRegex(UserInputError, "requires a GenerationStrategy"):
             analysis.compute(experiment=self.client.experiment)
 
-        card = analysis.compute(
+        (card,) = analysis.compute(
             experiment=self.client.experiment,
             generation_strategy=self.client.generation_strategy,
         )

--- a/ax/analysis/plotly/surface/tests/test_slice.py
+++ b/ax/analysis/plotly/surface/tests/test_slice.py
@@ -50,7 +50,7 @@ class TestSlicePlot(TestCase):
         with self.assertRaisesRegex(UserInputError, "requires a GenerationStrategy"):
             analysis.compute(experiment=self.client.experiment)
 
-        card = analysis.compute(
+        (card,) = analysis.compute(
             experiment=self.client.experiment,
             generation_strategy=self.client.generation_strategy,
         )

--- a/ax/analysis/plotly/tests/test_cross_validation.py
+++ b/ax/analysis/plotly/tests/test_cross_validation.py
@@ -50,7 +50,7 @@ class TestCrossValidationPlot(TestCase):
         with self.assertRaisesRegex(UserInputError, "requires a GenerationStrategy"):
             analysis.compute()
 
-        card = analysis.compute(generation_strategy=self.client.generation_strategy)
+        (card,) = analysis.compute(generation_strategy=self.client.generation_strategy)
         self.assertEqual(
             card.name,
             "CrossValidationPlot",
@@ -103,7 +103,7 @@ class TestCrossValidationPlot(TestCase):
             ):
                 analysis.compute(generation_strategy=self.client.generation_strategy)
         with self.subTest("infer from experiment"):
-            card = analysis.compute(
+            (card,) = analysis.compute(
                 generation_strategy=self.client.generation_strategy,
                 experiment=self.client.experiment,
             )
@@ -112,7 +112,7 @@ class TestCrossValidationPlot(TestCase):
 
     def test_it_can_specify_trial_index_correctly(self) -> None:
         analysis = CrossValidationPlot(metric_name="bar", trial_index=9)
-        card = analysis.compute(generation_strategy=self.client.generation_strategy)
+        (card,) = analysis.compute(generation_strategy=self.client.generation_strategy)
         for t in self.client.experiment.trials.values():
             # Skip the last trial because the model was used to generate it
             # and therefore hasn't observed it

--- a/ax/analysis/plotly/tests/test_insample_effects.py
+++ b/ax/analysis/plotly/tests/test_insample_effects.py
@@ -63,7 +63,7 @@ class TestInsampleEffectsPlot(TestCase):
             f"{get_predictions_by_arm.__module__}.predict_at_point",
             wraps=predict_at_point,
         ) as predict_at_point_spy:
-            card = analysis.compute(
+            (card,) = analysis.compute(
                 experiment=experiment, generation_strategy=generation_strategy
             )
         # THEN it uses the model from the GS
@@ -106,7 +106,7 @@ class TestInsampleEffectsPlot(TestCase):
             f"{get_predictions_by_arm.__module__}.predict_at_point",
             wraps=predict_at_point,
         ) as predict_at_point_spy:
-            card = analysis.compute(
+            (card,) = analysis.compute(
                 experiment=experiment, generation_strategy=generation_strategy
             )
         # THEN it uses the empirical bayes model
@@ -164,7 +164,7 @@ class TestInsampleEffectsPlot(TestCase):
             f"{get_predictions_by_arm.__module__}.predict_at_point",
             wraps=predict_at_point,
         ) as predict_at_point_spy:
-            card = analysis.compute(experiment=experiment, generation_strategy=None)
+            (card,) = analysis.compute(experiment=experiment, generation_strategy=None)
         # THEN it uses the empirical bayes model
         models_used_for_prediction = [
             call[1]["model"]._model_key for call in predict_at_point_spy.call_args_list
@@ -227,7 +227,7 @@ class TestInsampleEffectsPlot(TestCase):
             f"{get_predictions_by_arm.__module__}.predict_at_point",
             wraps=predict_at_point,
         ) as predict_at_point_spy:
-            card = analysis.compute(
+            (card,) = analysis.compute(
                 experiment=experiment, generation_strategy=generation_strategy
             )
         # THEN it uses the thompson model
@@ -382,7 +382,7 @@ class TestInsampleEffectsPlot(TestCase):
                 f"{compute_log_prob_feas_from_bounds.__module__}.log_ndtr",
                 side_effect=lambda t: torch.as_tensor([[0.25]] * t.size()[0]).log(),
             ):
-                card = analysis.compute(
+                (card,) = analysis.compute(
                     experiment=experiment, generation_strategy=generation_strategy
                 )
             # THEN it marks that constraints are violated for the non-SQ arms
@@ -416,7 +416,7 @@ class TestInsampleEffectsPlot(TestCase):
                 f"{compute_log_prob_feas_from_bounds.__module__}.log_ndtr",
                 side_effect=lambda t: torch.as_tensor([[1]] * t.size()[0]).log(),
             ):
-                card = analysis.compute(
+                (card,) = analysis.compute(
                     experiment=experiment, generation_strategy=generation_strategy
                 )
             # THEN it marks that constraints are not violated
@@ -461,6 +461,6 @@ class TestInsampleEffectsPlot(TestCase):
                     trial_index=0,
                     use_modeled_effects=False,
                 )
-                card = analysis.compute(experiment=experiment)
+                (card,) = analysis.compute(experiment=experiment)
                 # THEN the card has the correct level
                 self.assertEqual(card.level, level)

--- a/ax/analysis/plotly/tests/test_interaction.py
+++ b/ax/analysis/plotly/tests/test_interaction.py
@@ -56,7 +56,7 @@ class TestInteractionPlot(TestCase):
         with self.assertRaisesRegex(UserInputError, "requires an Experiment"):
             analysis.compute()
 
-        card = analysis.compute(
+        (card,) = analysis.compute(
             experiment=self.client.experiment,
             generation_strategy=self.client.generation_strategy,
         )

--- a/ax/analysis/plotly/tests/test_parallel_coordinates.py
+++ b/ax/analysis/plotly/tests/test_parallel_coordinates.py
@@ -29,7 +29,7 @@ class TestParallelCoordinatesPlot(TestCase):
         with self.assertRaisesRegex(UserInputError, "requires an Experiment"):
             analysis.compute()
 
-        card = analysis.compute(experiment=experiment)
+        (card,) = analysis.compute(experiment=experiment)
         self.assertEqual(card.name, "ParallelCoordinatesPlot")
         self.assertEqual(card.title, "Parallel Coordinates for branin")
         self.assertEqual(

--- a/ax/analysis/plotly/tests/test_predicted_effects.py
+++ b/ax/analysis/plotly/tests/test_predicted_effects.py
@@ -102,7 +102,7 @@ class TestPredictedEffectsPlot(TestCase):
             with self.subTest(metric=metric):
                 # WHEN we compute the analysis for a metric
                 analysis = PredictedEffectsPlot(metric_name=metric)
-                card = analysis.compute(
+                (card,) = analysis.compute(
                     experiment=experiment, generation_strategy=generation_strategy
                 )
                 # THEN it makes a card with the right name, title, and subtitle
@@ -185,7 +185,7 @@ class TestPredictedEffectsPlot(TestCase):
                 experiment.optimization_config
             ).objective.metric.name
         )
-        card = analysis.compute(
+        (card,) = analysis.compute(
             experiment=experiment, generation_strategy=generation_strategy
         )
         # THEN it has the right arms
@@ -240,7 +240,7 @@ class TestPredictedEffectsPlot(TestCase):
             f"{get_predictions_by_arm.__module__}.predict_at_point",
             wraps=predict_at_point,
         ) as predict_at_point_spy:
-            card = analysis.compute(
+            (card,) = analysis.compute(
                 experiment=experiment, generation_strategy=generation_strategy
             )
         # THEN it has the right rows for arms with data, as well as the latest trial
@@ -297,7 +297,7 @@ class TestPredictedEffectsPlot(TestCase):
         arms_with_data = set(experiment.lookup_data().df["arm_name"].unique())
         # WHEN we compute the analysis
         analysis = PredictedEffectsPlot(metric_name="branin")
-        card = analysis.compute(
+        (card,) = analysis.compute(
             experiment=experiment, generation_strategy=generation_strategy
         )
         # THEN it has the right rows for arms with data, as well as the latest
@@ -341,7 +341,7 @@ class TestPredictedEffectsPlot(TestCase):
 
         # WHEN we compute the analysis
         analysis = PredictedEffectsPlot(metric_name="branin")
-        card = analysis.compute(
+        (card,) = analysis.compute(
             experiment=experiment,
             generation_strategy=generation_strategy,
         )
@@ -382,7 +382,7 @@ class TestPredictedEffectsPlot(TestCase):
                 f"{compute_log_prob_feas_from_bounds.__module__}.log_ndtr",
                 side_effect=lambda t: torch.as_tensor([[0.25]] * t.size()[0]).log(),
             ):
-                card = analysis.compute(
+                (card,) = analysis.compute(
                     experiment=experiment, generation_strategy=generation_strategy
                 )
             # THEN it marks that constraints are violated for the non-SQ arms
@@ -416,7 +416,7 @@ class TestPredictedEffectsPlot(TestCase):
                 f"{compute_log_prob_feas_from_bounds.__module__}.log_ndtr",
                 side_effect=lambda t: torch.as_tensor([[1]] * t.size()[0]).log(),
             ):
-                card = analysis.compute(
+                (card,) = analysis.compute(
                     experiment=experiment, generation_strategy=generation_strategy
                 )
             # THEN it marks that constraints are not violated

--- a/ax/analysis/plotly/tests/test_progression.py
+++ b/ax/analysis/plotly/tests/test_progression.py
@@ -27,7 +27,7 @@ class TestProgression(TestCase):
             num_trials=2, num_fetches=5, num_complete=2
         )
 
-        card = analysis.compute(experiment=experiment)
+        (card,) = analysis.compute(experiment=experiment)
 
         self.assertEqual(card.name, "ProgressionPlot")
         self.assertEqual(card.title, "branin_map by progression")

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -36,7 +36,7 @@ class TestScatterPlot(TestCase):
         with self.assertRaisesRegex(UserInputError, "requires an Experiment"):
             analysis.compute()
 
-        card = analysis.compute(experiment=self.exp_w_trial_complete)
+        (card,) = analysis.compute(experiment=self.exp_w_trial_complete)
         self.assertEqual(card.name, "ScatterPlot")
         self.assertEqual(
             card.title, f"Observed {self.x_metric_name} vs. {self.y_metric_name}"
@@ -217,7 +217,7 @@ class TestScatterPlot(TestCase):
             y_metric_name=self.y_metric_name,
             show_pareto_frontier=True,
         )
-        card = analysis.compute(experiment=self.experiment)
+        (card,) = analysis.compute(experiment=self.experiment)
 
         # THEN it only has observations with data for both metrics
         self.assertEqual(

--- a/ax/analysis/search_space_summary.py
+++ b/ax/analysis/search_space_summary.py
@@ -5,6 +5,8 @@
 
 # pyre-strict
 
+from typing import Sequence
+
 from ax.analysis.analysis import (
     Analysis,
     AnalysisCard,
@@ -15,6 +17,7 @@ from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
+from pyre_extensions import override
 
 
 class SearchSpaceSummary(Analysis):
@@ -33,27 +36,31 @@ class SearchSpaceSummary(Analysis):
         mapping from parameter value -> list of dependent parameter names.
     """
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> AnalysisCard:
+    ) -> Sequence[AnalysisCard]:
         if experiment is None:
             raise UserInputError(
                 "`SearchSpaceSummary` analysis requires an `Experiment` input"
             )
-        return self._create_analysis_card(
-            title=f"SearchSpaceSummary for `{experiment.name}`",
-            subtitle=(
-                "The search space summary provides an overview of all "
-                "parameters, including their names, types, and ranges or "
-                "categories. This holistic view provides quick understanding "
-                "on the parameters being optimized, allowing one to verify "
-                "and adjust the search space configuration for effective "
-                "exploration."
-            ),
-            level=AnalysisCardLevel.MID,
-            df=experiment.search_space.summary_df,
-            category=AnalysisCardCategory.INFO,
-        )
+
+        return [
+            self._create_analysis_card(
+                title=f"SearchSpaceSummary for `{experiment.name}`",
+                subtitle=(
+                    "The search space summary provides an overview of all "
+                    "parameters, including their names, types, and ranges or "
+                    "categories. This holistic view provides quick understanding "
+                    "on the parameters being optimized, allowing one to verify "
+                    "and adjust the search space configuration for effective "
+                    "exploration."
+                ),
+                level=AnalysisCardLevel.MID,
+                df=experiment.search_space.summary_df,
+                category=AnalysisCardCategory.INFO,
+            )
+        ]

--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -5,6 +5,8 @@
 
 # pyre-strict
 
+from typing import Sequence
+
 from ax.analysis.analysis import (
     Analysis,
     AnalysisCard,
@@ -15,6 +17,7 @@ from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
+from pyre_extensions import override
 
 
 class Summary(Analysis):
@@ -38,18 +41,22 @@ class Summary(Analysis):
     def __init__(self, omit_empty_columns: bool = True) -> None:
         self.omit_empty_columns = omit_empty_columns
 
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> AnalysisCard:
+    ) -> Sequence[AnalysisCard]:
         if experiment is None:
             raise UserInputError("`Summary` analysis requires an `Experiment` input")
-        return self._create_analysis_card(
-            title=f"Summary for {experiment.name}",
-            subtitle="High-level summary of the `Trial`-s in this `Experiment`",
-            level=AnalysisCardLevel.MID,
-            df=experiment.to_df(omit_empty_columns=self.omit_empty_columns),
-            category=AnalysisCardCategory.INFO,
-        )
+
+        return [
+            self._create_analysis_card(
+                title=f"Summary for {experiment.name}",
+                subtitle="High-level summary of the `Trial`-s in this `Experiment`",
+                level=AnalysisCardLevel.MID,
+                df=experiment.to_df(omit_empty_columns=self.omit_empty_columns),
+                category=AnalysisCardCategory.INFO,
+            )
+        ]

--- a/ax/analysis/tests/test_metric_summary.py
+++ b/ax/analysis/tests/test_metric_summary.py
@@ -38,7 +38,7 @@ class TestMetricSummary(TestCase):
             analysis.compute()
 
         experiment = client._experiment
-        card = analysis.compute(experiment=experiment)
+        (card,) = analysis.compute(experiment=experiment)
 
         # Test metadata
         self.assertEqual(card.name, "MetricSummary")

--- a/ax/analysis/tests/test_search_space_summary.py
+++ b/ax/analysis/tests/test_search_space_summary.py
@@ -48,7 +48,7 @@ class TestSearchSpaceSummary(TestCase):
             analysis.compute()
 
         experiment = client._experiment
-        card = analysis.compute(experiment=experiment)
+        (card,) = analysis.compute(experiment=experiment)
 
         # Test metadata
         self.assertEqual(card.name, "SearchSpaceSummary")

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -50,7 +50,7 @@ class TestSummary(TestCase):
             analysis.compute()
 
         experiment = client._experiment
-        card = analysis.compute(experiment=experiment)
+        (card,) = analysis.compute(experiment=experiment)
 
         # Test metadata
         self.assertEqual(card.name, "Summary")
@@ -107,7 +107,7 @@ class TestSummary(TestCase):
 
         # Test without omitting empty columns
         analysis_no_omit = Summary(omit_empty_columns=False)
-        card_no_omit = analysis_no_omit.compute(experiment=experiment)
+        (card_no_omit,) = analysis_no_omit.compute(experiment=experiment)
         self.assertEqual(
             {*card_no_omit.df.columns},
             {

--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -647,8 +647,9 @@ class Client(WithDBSettingsBase):
 
         # Turn Exceptions into MarkdownAnalysisCards with the traceback as the message
         cards = [
-            result.unwrap_or_else(markdown_analysis_card_from_analysis_e)
+            card
             for result in results
+            for card in result.unwrap_or_else(markdown_analysis_card_from_analysis_e)
         ]
 
         # Display the AnalysisCards if requested and if the user is in a notebook
@@ -683,14 +684,12 @@ class Client(WithDBSettingsBase):
             - **PARAMETER_NAME: The parameter value for the arm, for each parameter
         """
 
-        return (
-            Summary(omit_empty_columns=True)
-            .compute(
-                experiment=self._experiment,
-                generation_strategy=self._generation_strategy,
-            )
-            .df
+        (card,) = Summary(omit_empty_columns=True).compute(
+            experiment=self._experiment,
+            generation_strategy=self._generation_strategy,
         )
+
+        return card.df
 
     def get_best_parameterization(
         self, use_model_predictions: bool = True

--- a/ax/service/utils/analysis_base.py
+++ b/ax/service/utils/analysis_base.py
@@ -85,8 +85,9 @@ class AnalysisBase(WithDBSettingsBase):
 
         # Turn Exceptions into MarkdownAnalysisCards with the traceback as the message
         cards = [
-            result.unwrap_or_else(markdown_analysis_card_from_analysis_e)
+            card
             for result in results
+            for card in result.unwrap_or_else(markdown_analysis_card_from_analysis_e)
         ]
 
         # Display the AnalysisCards if requested and if the user is in a notebook


### PR DESCRIPTION
Summary:
New signature: `compute(self, experiment, gs, adapter) -> Sequence[Card]`

This allows for a compositional structure we a single Analysis calls into sub-analysis and returns a group of cards, potentially dynamically based on the result of sequential sub-analyses. For example:
* A ConfigurationSummary which returns both SearchSpaceSummary and MetricSummary cards
* A ResponseSurfaceAnalysis which computes a sensitivity analysis, picks the top 4 surfaces (1D or 2D), generates slice or contour plots, then returns all 5 plots

Differential Revision: D71559084
