### PR TITLE
Disallow setting some Botorch optimizer_kwargs through GeneratorStep

### DIFF
--- a/ax/models/torch/botorch_modular/acquisition.py
+++ b/ax/models/torch/botorch_modular/acquisition.py
@@ -363,6 +363,28 @@ class Acquisition(Base):
             candidates, a tensor with the associated acquisition values, and a tensor
             with the weight for each candidate.
         """
+        # Options that would need to be passed in the transformed space are
+        # disallowed, since this would be very difficult for an end user to do
+        # directly, and someone who uses BoTorch at this level of detail would
+        # probably be better off using BoTorch directly.
+        # `return_best_only` and `return_full_tree` are disallowed because
+        # Ax expects `optimize_acqf` to return tensors of a certain shape.
+        if optimizer_options is not None:
+            forbidden_optimizer_options = [
+                "equality_constraints",
+                "inequality_constraints",
+                "nonlinear_inequality_constraints",
+                "batch_initial_conditions",
+                "return_best_only",
+                "return_full_tree",
+            ]
+
+            for kw in optimizer_options:
+                if kw in forbidden_optimizer_options:
+                    raise ValueError(
+                        f"Argument {kw} is not allowed in `optimizer_options`."
+                    )
+
         _tensorize = partial(torch.tensor, dtype=self.dtype, device=self.device)
         ssd = search_space_digest
         bounds = _tensorize(ssd.bounds).t()

--- a/ax/models/torch/botorch_modular/utils.py
+++ b/ax/models/torch/botorch_modular/utils.py
@@ -260,12 +260,27 @@ def construct_acquisition_and_optimizer_options(
     opt_options = {}
 
     if model_gen_options:
+        # Define the allowed paths
+
+        if (
+            len(
+                extra_keys_in_model_gen_options := set(model_gen_options.keys())
+                - {Keys.OPTIMIZER_KWARGS.value, Keys.ACQF_KWARGS.value}
+            )
+            > 0
+        ):
+            raise ValueError(
+                "Found forbidden keys in `model_gen_options`: "
+                f"{extra_keys_in_model_gen_options}."
+            )
+
         acq_options.update(
             assert_is_instance(
                 model_gen_options.get(Keys.ACQF_KWARGS, {}),
                 dict,
             )
         )
+
         # TODO: Add this if all acq. functions accept the `subset_model`
         # kwarg or opt for kwarg filtering.
         # acq_options[SUBSET_MODEL] = model_gen_options.get(SUBSET_MODEL)

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -394,6 +394,17 @@ class AcquisitionTest(TestCase):
                     optimizer_options=optimizer_options,
                 )
 
+        optimizer_options = {"batch_initial_conditions": None}
+        with self.subTest(optimizer_options=None), self.assertRaisesRegex(
+            ValueError, "Argument "
+        ):
+            acquisition.optimize(
+                n=n,
+                search_space_digest=ssd1,
+                rounding_func=self.rounding_func,
+                optimizer_options=optimizer_options,
+            )
+
         # check this works without any fixed_feature specified
         # 2 candidates have acqf value 8, but [1, 3, 4] is pending and thus should
         # not be selected. [2, 3, 4] is the best point, but has already been picked

--- a/ax/models/torch/tests/test_model.py
+++ b/ax/models/torch/tests/test_model.py
@@ -615,7 +615,6 @@ class BoTorchGeneratorTest(TestCase):
             torch.equal(ckwargs["X_baseline"], none_throws(expected_X_baseline))
         )
 
-        # Assert `construct_acquisition_and_optimizer_options` called with kwargs
         mock_construct_options.assert_called_with(
             acqf_options=self.acquisition_options,
             model_gen_options=self.model_gen_options,

--- a/ax/models/torch/tests/test_utils.py
+++ b/ax/models/torch/tests/test_utils.py
@@ -10,6 +10,7 @@ import warnings
 from collections import OrderedDict
 
 import numpy as np
+
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import AxWarning, UnsupportedError
@@ -229,6 +230,21 @@ class BoTorchGeneratorUtilsTest(TestCase):
             {Keys.NUM_FANTASIES: 64, Keys.CURRENT_VALUE: torch.tensor([1.0])},
         )
         self.assertEqual(final_opt_options, optimizer_kwargs)
+
+        with self.assertRaisesRegex(
+            ValueError, "Found forbidden keys in `model_gen_options`"
+        ):
+            construct_acquisition_and_optimizer_options(
+                # pyre-fixme[6]: For 1st param expected `Dict[str, Union[None, Dict[str,
+                #  typing.Any], OptimizationConfig, AcquisitionFunction, float, int,
+                #  str]]` but got `Dict[Keys, int]`.
+                # pyre-fixme[6]: For 2nd param expected `Optional[Dict[str, Union[None,
+                #  Dict[str, typing.Any], OptimizationConfig, AcquisitionFunction,
+                #  float, int, str]]]` but got `Dict[Keys, Union[Dict[Keys, int],
+                #  Dict[Keys, Tensor]]]`.
+                acqf_options=acqf_options,
+                model_gen_options={**model_gen_options, "extra": "key"},
+            )
 
     def test_use_model_list(self) -> None:
         self.assertFalse(


### PR DESCRIPTION
Summary: I added a check s.t. we only allow a white listed set of attributes. As there are some attributes that should not be set, as they are working transformed space.

Differential Revision: D71492663


