### PR TITLE
Update transform storage to utilize strings rather than integers

### DIFF
--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -61,7 +61,6 @@ from ax.models.torch.botorch_modular.model import BoTorchGenerator
 from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.models.winsorization_config import WinsorizationConfig
 from ax.storage.botorch_modular_registry import CLASS_TO_REGISTRY
-from ax.storage.transform_registry import TRANSFORM_REGISTRY
 from ax.utils.common.serialization import serialize_init_args
 from ax.utils.common.typeutils_torch import torch_type_to_str
 from ax.utils.testing.backend_simulator import (
@@ -415,8 +414,7 @@ def transform_type_to_dict(transform_type: type[Transform]) -> dict[str, Any]:
     """Convert a transform class to a dictionary."""
     return {
         "__type": "Type[Transform]",
-        "index_in_registry": TRANSFORM_REGISTRY[transform_type],
-        "transform_type": f"{transform_type}",
+        "transform_type": transform_type.__name__,
     }
 
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -24,6 +24,8 @@ from ax.generation_strategy.generation_node import GenerationNode, GenerationSte
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import DataLoaderConfig
 from ax.modelbridge.registry import Generators
+from ax.modelbridge.transforms.log import Log
+from ax.modelbridge.transforms.one_hot import OneHot
 from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
 from ax.models.torch.botorch_modular.surrogate import SurrogateSpec
 from ax.models.torch.botorch_modular.utils import ModelConfig
@@ -895,7 +897,25 @@ class JSONStoreTest(TestCase):
                 {
                     "__type": "GeneratorSpec",
                     "model_enum": {"__type": "Generators", "name": "BOTORCH_MODULAR"},
-                    "model_kwargs": {},
+                    "model_kwargs": {
+                        "transforms": [
+                            {
+                                "__type": "Type[Transform]",
+                                "index_in_registry": 6,
+                                "transform_type": (
+                                    "<class 'ax.modelbridge.transforms"
+                                    ".one_hot.OneHot'>"
+                                ),
+                            },
+                            {
+                                "__type": "Type[Transform]",
+                                "index_in_registry": 5,
+                                "transform_type": (
+                                    "<class 'ax.modelbridge.transforms.log.Log'>"
+                                ),
+                            },
+                        ]
+                    },
                     "model_gen_kwargs": {
                         "model_gen_options": {
                             "optimizer_kwargs": {"num_restarts": 10},
@@ -938,6 +958,11 @@ class JSONStoreTest(TestCase):
         self.assertEqual(len(node.transition_criteria), 1)
         # Status quo is discarded, so we have 2 input constructors left.
         self.assertEqual(len(node.input_constructors), 2)
+        # Check that transforms got correctly deserialized.
+        self.assertEqual(
+            node.model_specs[0].model_kwargs["transforms"],
+            [OneHot, Log],
+        )
 
     def test_SobolQMCNormalSampler(self) -> None:
         # This fails default equality checks, so testing it separately.

--- a/ax/storage/json_store/tests/test_transform_encode.py
+++ b/ax/storage/json_store/tests/test_transform_encode.py
@@ -30,39 +30,32 @@ class TestTransformEncode(unittest.TestCase):
         super().setUp()
 
         self.deprecatedTestCases = [
-            (OrderedChoiceEncode, OrderedChoiceToIntegerRange, 7),
-            (ChoiceEncode, ChoiceToNumericChoice, 19),
-            (TaskEncode, TaskChoiceToIntTaskChoice, 13),
+            (OrderedChoiceEncode, OrderedChoiceToIntegerRange),
+            (ChoiceEncode, ChoiceToNumericChoice),
+            (TaskEncode, TaskChoiceToIntTaskChoice),
         ]
 
     def test_encode_and_decode_transform(self) -> None:
         with self.subTest("IntRangeToChoice"):
-            registry_index = 2
-
             transform_dict = transform_type_to_dict(IntRangeToChoice)
             self.assertEqual(transform_dict["__type"], "Type[Transform]")
-            self.assertEqual(transform_dict["index_in_registry"], registry_index)
             self.assertIn("IntRangeToChoice", transform_dict["transform_type"])
 
             decoded_transform_type = transform_type_from_json(transform_dict)
             self.assertEqual(decoded_transform_type, IntRangeToChoice)
 
         with self.subTest("MapKeyToFloat"):
-            registry_index = 31
-
             transform_dict = transform_type_to_dict(MapKeyToFloat)
             self.assertEqual(transform_dict["__type"], "Type[Transform]")
-            self.assertEqual(transform_dict["index_in_registry"], registry_index)
             self.assertIn("MapKeyToFloat", transform_dict["transform_type"])
 
             decoded_transform_type = transform_type_from_json(transform_dict)
             self.assertEqual(decoded_transform_type, MapKeyToFloat)
 
     def test_encode_and_decode_deprecated_transforms(self) -> None:
-        for deprecated_type, current_type, registry_index in self.deprecatedTestCases:
+        for deprecated_type, current_type in self.deprecatedTestCases:
             transform_dict = transform_type_to_dict(deprecated_type)
             self.assertEqual(transform_dict["__type"], "Type[Transform]")
-            self.assertEqual(transform_dict["index_in_registry"], registry_index)
             self.assertIn(deprecated_type.__name__, transform_dict["transform_type"])
 
             decoded_transform_type = transform_type_from_json(transform_dict)

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -47,72 +47,87 @@ from ax.modelbridge.transforms.unit_x import UnitX
 from ax.modelbridge.transforms.winsorize import Winsorize
 
 
-# TODO: Annotate and add `register_transform`
-
 """
-Mapping of Transform classes to ints.
+A registry of transform classes for storage.
 
-All transforms will be stored in the same table in the database. When
-saving, we look up the transform subclass in TRANSFORM_REGISTRY, and store
-the corresponding type field in the database. When loading, we look
-up the type field in REVERSE_TRANSFORM_REGISTRY, and initialize the
-corresponding transform subclass.
+Transforms are stored in the DB as part of the JSON-encoded
+GenerationNode (or Step) objects. When loading the GenerationStrategy,
+we will look up the transform class that matches the stringified
+transform type in JSON object, and return the matching transform class.
+
+NOTE: If removing a transform, please add it to REMOVED_TRANSFORMS.
+These will be discarded while loading experiments from the DB.
+If deprecating a transform in favor of a new one (i.e. renaming),
+please add it to DEPRECATED_TRANSFORMS. When loading from the DB,
+we will return the replacement class.
 """
-TRANSFORM_REGISTRY: dict[type[Transform], int] = {
-    ConvertMetricNames: 0,
-    Derelativize: 1,
-    IntRangeToChoice: 2,
-    IntToFloat: 3,
-    IVW: 4,
-    Log: 5,
-    OneHot: 6,
-    OrderedChoiceEncode: 7,  # TO BE DEPRECATED
-    OrderedChoiceToIntegerRange: 7,
+TRANSFORM_REGISTRY: set[type[Transform]] = {
+    ConvertMetricNames,
+    Derelativize,
+    IntRangeToChoice,
+    IntToFloat,
+    IVW,
+    Log,
+    OneHot,
+    OrderedChoiceEncode,  # TO BE DEPRECATED
+    OrderedChoiceToIntegerRange,
     # This transform was upstreamed into the base modelbridge.
-    # Old transforms serialized with this will have the OutOfDesign transform
-    # replaced with a no-op, the base transform.
-    # DEPRECATED: OutOfDesign: 8
-    Transform: 8,
-    RemoveFixed: 9,
-    SearchSpaceToChoice: 10,
-    StandardizeY: 11,
-    StratifiedStandardizeY: 12,
-    TaskEncode: 13,  # TO BE DEPRECATED
-    TaskChoiceToIntTaskChoice: 13,
-    TrialAsTask: 14,
-    UnitX: 15,
-    Winsorize: 16,
-    # CapParameter: 17,  DEPRECATED
-    PowerTransformY: 18,
-    ChoiceEncode: 19,  # TO BE DEPRECATED
-    ChoiceToNumericChoice: 19,
-    Logit: 20,
-    # MapUnitX: 21, DEPRECATED
-    MetricsAsTask: 22,
-    LogY: 23,
-    Relativize: 24,
-    RelativizeWithConstantControl: 25,
-    MergeRepeatedMeasurements: 26,
-    TimeAsFeature: 27,
-    TransformToNewSQ: 28,
-    FillMissingParameters: 29,
-    LogIntToFloat: 30,
-    MapKeyToFloat: 31,
-    BilogY: 32,
+    # DEPRECATED: OutOfDesign
+    RemoveFixed,
+    SearchSpaceToChoice,
+    StandardizeY,
+    StratifiedStandardizeY,
+    TaskEncode,  # TO BE DEPRECATED
+    TaskChoiceToIntTaskChoice,
+    TrialAsTask,
+    UnitX,
+    Winsorize,
+    # CapParameter,  DEPRECATED
+    PowerTransformY,
+    ChoiceEncode,  # TO BE DEPRECATED
+    ChoiceToNumericChoice,
+    Logit,
+    # MapUnitX, DEPRECATED
+    MetricsAsTask,
+    LogY,
+    Relativize,
+    RelativizeWithConstantControl,
+    MergeRepeatedMeasurements,
+    TimeAsFeature,
+    TransformToNewSQ,
+    FillMissingParameters,
+    LogIntToFloat,
+    MapKeyToFloat,
+    BilogY,
+}
+
+REMOVED_TRANSFORMS: set[str] = {
+    "OutOfDesign",
+    "CapParameter",
+    "MapUnitX",
 }
 
 """
-List transforms which are be deprecated.
+Dict mapping transforms which are being deprecated to the transforms replacing them.
 These will be present in TRANSFORM_REGISTRY so that old call sites
-can still store properly, but when loading back the new class will
-be used.
+can still store properly, but when loading back the new class will be used.
 """
-DEPRECATED_TRANSFORMS: list[type[Transform]] = [
-    OrderedChoiceEncode,  # replaced by OrderedChoiceToIntegerRange
-    ChoiceEncode,  # replaced by ChoiceToNumericChoice
-    TaskEncode,  # replaced by TaskChoiceToIntTaskChoice
-]
-
-REVERSE_TRANSFORM_REGISTRY: dict[int, type[Transform]] = {
-    v: k for k, v in TRANSFORM_REGISTRY.items() if k not in DEPRECATED_TRANSFORMS
+DEPRECATED_TRANSFORMS: dict[str, type[Transform]] = {
+    "OrderedChoiceEncode": OrderedChoiceToIntegerRange,
+    "ChoiceEncode": ChoiceToNumericChoice,
+    "TaskEncode": TaskChoiceToIntTaskChoice,
 }
+
+REVERSE_TRANSFORM_REGISTRY: dict[str, type[Transform]] = {
+    k.__name__: k for k in TRANSFORM_REGISTRY if k not in DEPRECATED_TRANSFORMS
+}
+
+
+def register_transform(transform: type[Transform]) -> None:
+    """Register a transform class for storage.
+
+    This is intended for external additions. Transforms that are available in
+    the core library should be added to the TRANSFORM_REGISTRY directly.
+    """
+    TRANSFORM_REGISTRY.add(transform)
+    REVERSE_TRANSFORM_REGISTRY[transform.__class__.__name__] = transform


### PR DESCRIPTION
Summary:
The existing storage for transforms relies on an integer valued registry. The transforms are mapped to the integer values found in the registry, which is JSON encoded along with the transform name, and the decoder looks up the transform class from the reverse registry using the integer.

This comes with a challange when prototyping new transforms. To support them, we may need to add them to the registry with some integer, which may get assigned to some other transform before the transform lands (this is a race condition that shouldn't happen often but it did happen recently). Besides this, if the transform lives in the internal codebase, we need to assign it an integer that doesn't conflict with the OSS registry, then deal with this inconsistency when moving the transform to OSS (since we now want it to have a value that is future & backwards compatible).

But why do we need integers in the first place? This is JSON encoding and the transform name is already being encoded along with the integer. If we updated the reverse registry to map the transform name to the classes, we can just look up the class from the transform name. If we're then moving some transform from internal codebase to OSS, the name is unchanged so we just need to add it to the OSS registry for everything to continue working. No need to deal with integers or race conditions.

Also updated the logic for deprecated & removed transforms to work with the updated logic.

Backwards compatibility: I don't think there are any concerns here. I was happily surprised when I saw that the transform name was already being stored along with the integer value. We will just make use of it when loading old experiments.
Update: Actually, there was a minor backwards compatibility issue, since the previously stored string was `str(transform_type)`, which produces `"<class 'ax.modelbridge.transforms.transform_type'>"` rather than `"transform_type"`. Added a logic to extract `"transform_type"` from there.

Differential Revision: D71590471


