### PR TITLE
Default to empty fixed features rather than None in Adapter.gen

### DIFF
--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -206,7 +206,7 @@ class BaseAdapterTest(TestCase):
             search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
             optimization_config=None,
             pending_observations={},
-            fixed_features=None,
+            fixed_features=ObservationFeatures(parameters={}),
             model_gen_options=None,
         )
 
@@ -224,7 +224,7 @@ class BaseAdapterTest(TestCase):
             search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
             optimization_config=oc2,
             pending_observations={},
-            fixed_features=None,
+            fixed_features=ObservationFeatures(parameters={}),
             model_gen_options=None,
         )
 
@@ -646,7 +646,7 @@ class BaseAdapterTest(TestCase):
             adapter,
             n=1,
             search_space=ss,
-            fixed_features=None,
+            fixed_features=ObservationFeatures(parameters={}),
             model_gen_options=None,
             optimization_config=OptimizationConfig(
                 objective=Objective(metric=Metric("test_metric"), minimize=False),


### PR DESCRIPTION
Summary:
We have some transforms that add parameters to the search space. These transforms typically require a fixed features input, which they then modify to fix the added parameters to a certain value during candidate generation. With the current default of `None`, we need the user to pass in `fixed_features` at each `gen` call to ensure that these transforms work as expected. If we simply default to an empty `ObservationFeatures` object for `fixed_features`, we can eliminate the need for this input and simplify the GS setup.

An example is `MapKeyToFloat`, which transforms empty fixed features to target progression. Since gen kwargs cannot be included in the `Generators` registry, we currently need a full `ModelSpec` or `GenerationNode` to be constructed with `default_model_gen_kwargs` or appropriate node input constructor for the transform to work correctly.

Reviewed By: Balandat

Differential Revision: D71648117


