### PR TITLE
Improve generation method string

### DIFF
--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -72,6 +72,7 @@ class TestSummary(TestCase):
                 "arm_name",
                 "trial_status",
                 "generation_node",
+                "generation_method",
                 "foo",
                 "bar",
                 "x1",
@@ -91,6 +92,7 @@ class TestSummary(TestCase):
                 "arm_name": {0: "0_0", 1: "1_0"},
                 "trial_status": {0: "COMPLETED", 1: "FAILED"},
                 "generation_node": {0: "Sobol", 1: "Sobol"},
+                "generation_method": {0: "Sobol", 1: "Sobol"},
                 "foo": {0: 1.0, 1: np.nan},  # NaN because trial 1 failed
                 "bar": {0: 2.0, 1: np.nan},
                 "x1": {
@@ -116,6 +118,7 @@ class TestSummary(TestCase):
                 "trial_status",
                 "fail_reason",
                 "generation_node",
+                "generation_method",
                 "foo",
                 "bar",
                 "x1",

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -870,6 +870,7 @@ class TestClient(TestCase):
                 "arm_name",
                 "trial_status",
                 "generation_node",
+                "generation_method",
                 "foo",
                 "bar",
                 "x1",
@@ -889,6 +890,7 @@ class TestClient(TestCase):
                 "arm_name": {0: "0_0", 1: "1_0"},
                 "trial_status": {0: "COMPLETED", 1: "FAILED"},
                 "generation_node": {0: "Sobol", 1: "Sobol"},
+                "generation_method": {0: "Sobol", 1: "Sobol"},
                 "foo": {0: 1.0, 1: np.nan},  # NaN because trial 1 failed
                 "bar": {0: 2.0, 1: np.nan},
                 "x1": {

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1879,6 +1879,7 @@ class Experiment(Base):
 
                 # Find the arm's associated generation method from the trial via the
                 # GeneratorRuns if possible
+                generation_method = trial.generation_method_str
                 grs = [gr for gr in trial.generator_runs if arm in gr.arms]
                 generation_node = grs[0]._generation_node_name if len(grs) > 0 else None
 
@@ -1901,6 +1902,7 @@ class Experiment(Base):
                     "trial_status": trial.status.name,
                     "fail_reason": trial.run_metadata.get("fail_reason", None),
                     "generation_node": generation_node,
+                    "generation_method": generation_method,
                     **metadata,
                     **observed_means,
                     **arm.parameters,

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1335,6 +1335,7 @@ class ExperimentTest(TestCase):
                 "trial_index": [0, 1, 2],
                 "arm_name": ["0_0", "1_0", "0_0"],
                 "trial_status": ["COMPLETED", "COMPLETED", "CANDIDATE"],
+                "generation_method": ["Sobol", "Sobol", "Sobol"],
                 "name": ["0", "1", None],  # the metadata
                 "m1": [1.0, 3.0, None],
                 "m2": [2.0, 4.0, None],
@@ -1342,7 +1343,7 @@ class ExperimentTest(TestCase):
                 "y": ys,
             }
         )
-        self.assertTrue(df.equals(expected_df))
+        pd.testing.assert_frame_equal(df, expected_df)
         # Check that empty columns are included when omit=False.
         df = experiment.to_df(omit_empty_columns=False)
         self.assertEqual(
@@ -1353,6 +1354,7 @@ class ExperimentTest(TestCase):
                 "trial_status",
                 "fail_reason",
                 "generation_node",
+                "generation_method",
                 "name",
                 "m1",
                 "m2",


### PR DESCRIPTION
Summary: Uses trial.generation_method_str for generation method column in `Experiment.to_df()`. This adds a more descriptive method-based column to the dataframe (e.g., Sobol, SAASBO instead of GenerationStep_0, GenerationStep_1, etc.).

Reviewed By: saitcakmak

Differential Revision: D69212624


