### PR TITLE
GenerationNode: use experiment rather than self.experiment when fitting fallback model

### DIFF
--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -560,11 +560,9 @@ class GenerationNode(SerializationMixin, SortableBase):
             f"{fallback_model.model_enum}"
         )
 
-        # fit fallback model using information from `self.experiment`
-        # as ground truth
+        # Fit fallback model using information from the experiment as ground truth.
         fallback_model.fit(
-            experiment=self.experiment,
-            data=self.experiment.lookup_data(),
+            experiment=experiment,
             **self._get_model_state_from_last_generator_run(model_spec=fallback_model),
         )
         # Switch _model_spec_to_gen_from to a fallback spec


### PR DESCRIPTION
Summary:
We're generating candidates for the `experiment`, so we can use it for fitting the model. It seems somewhat odd to be switching between `self.experiment` and `experiment` for `fit` and `gen` calls. In addition, `self.experiment` creates an unnecessary dependency on the generation strategy, which makes it more difficult to test related functionality.


This brings up the question: A lot of the internal logic around transitions in `GenerationNode` relies on `self.experiment`, which looks it up from the `GenerationStrategy`. Since `GenerationNode` itself now receives the `experiment`, should we just set `GenerationNode.experiment` on each call to `GenerationNode.gen/_fit` rather than accessing to it through `GenerationNode.generation_strategy.experiment`?

Reviewed By: lena-kashtelyan

Differential Revision: D71772493


