### PR TITLE
Update black version in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
     -   id: ufmt
         additional_dependencies:
-        - black==24.4.2
+        - black==24.10.0
         - usort==1.0.8.post1
         - ruff-api==0.1.0
         - stdlibs==2024.1.28


### PR DESCRIPTION
https://github.com/facebook/Ax/commit/33a24387aa7c96c452df829ecae91f6d881b7391  updated the black version, which caused a divergence with what was specified in the pre-commit config. This brings things back into sync.

Clone of https://github.com/pytorch/botorch/pull/2789