### PR TITLE
Re-Save experiment to DB after constructing the GenerationStrategy

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -369,6 +369,9 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         self._set_generation_strategy(
             choose_generation_strategy_kwargs=choose_generation_strategy_kwargs
         )
+        self._save_experiment_to_db_if_possible(
+            experiment=self.experiment,
+        )
         self._save_generation_strategy_to_db_if_possible()
 
     @property
@@ -1157,6 +1160,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             self._set_generation_strategy(
                 choose_generation_strategy_kwargs=choose_generation_strategy_kwargs
             )
+            self._save_experiment_to_db_if_possible(experiment=self.experiment)
             self._save_generation_strategy_to_db_if_possible()
         else:
             self._generation_strategy = generation_strategy


### PR DESCRIPTION
Summary: In some instances, the experiment may be modified during generation strategy construction, for purposes like attaching auxiliary experiments. To ensure experiment remains compatible with the generation strategy (after storage), we need to save the experiment after constructing the generation strategy.

Differential Revision: D71976712


