### PR TITLE
remove SQLAlchemy from critical import path

### DIFF
--- a/ax/storage/registry_bundle.py
+++ b/ax/storage/registry_bundle.py
@@ -23,9 +23,16 @@ from ax.storage.json_store.registry import (
 )
 from ax.storage.metric_registry import register_metrics
 from ax.storage.runner_registry import register_runners
-from ax.storage.sqa_store.decoder import Decoder
-from ax.storage.sqa_store.encoder import Encoder
-from ax.storage.sqa_store.sqa_config import SQAConfig
+
+# Allow Ax to be used without SQLAlchemy.
+try:
+    from ax.storage.sqa_store.decoder import Decoder
+    from ax.storage.sqa_store.encoder import Encoder
+    from ax.storage.sqa_store.sqa_config import SQAConfig
+except (ModuleNotFoundError, TypeError):
+    Decoder = None
+    Encoder = None
+    SQAConfig = None
 
 
 class RegistryBundleBase(ABC):


### PR DESCRIPTION
Summary:
Changes to `__init__.py` in FOO caused SQLAlchemy to make its way onto the critical path for `import ax`. Because we want to maintain SQLAlchemy as an optional dependency (for now, this may be rethought in the future) we need to make sure this path can gracefully fail.

See breakage here: https://github.com/facebook/Ax/actions/runs/14099230949/job/39492253946

Differential Revision: D71978009


