### PR TITLE
Explicitly list markdown as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIRES = [
     "plotly>=5.12.0",
     "pyre-extensions",
     "sympy",
+    "markdown",
 ]
 
 # pytest-cov requires pytest >= 3.6


### PR DESCRIPTION
Summary: Liz ran into an issue where it looked like markdown was not installed on her env even though we use it for analyses. We must have been just getting lucky (ie other packages include this dependency and allow us to piggyback) such that this hasnt been a problem until now.

Differential Revision: D71982978


