### PR TITLE
Remove Adapter._prepare_training_data

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -24,7 +24,6 @@ from ax.core.observation import (
     ObservationFeatures,
     observations_from_data,
     recombine_observations,
-    separate_observations,
 )
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ParameterType, RangeParameter
@@ -369,17 +368,6 @@ class Adapter:
 
         return observations, search_space
 
-    def _prepare_training_data(
-        self, observations: list[Observation]
-    ) -> list[Observation]:
-        observation_features, observation_data = separate_observations(observations)
-        if len(observation_features) != len(set(observation_features)):
-            raise ValueError(
-                "Observation features are not unique. "
-                "Something went wrong constructing training data..."
-            )
-        return observations
-
     def _set_training_data(
         self, observations: list[Observation], search_space: SearchSpace
     ) -> list[Observation]:
@@ -388,7 +376,6 @@ class Adapter:
         If the modelbridge specifies _fit_out_of_design, all training data is
         returned. Otherwise, only in design points are returned.
         """
-        observations = self._prepare_training_data(observations=observations)
         self._training_data = deepcopy(observations)
         self._metric_names: set[str] = set()
         for obs in observations:

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -569,17 +569,6 @@ class BaseAdapterTest(TestCase):
         with self.assertRaises(NotImplementedError):
             adapter.transform_observations([])
 
-    @mock.patch(
-        "ax.modelbridge.base.observations_from_data",
-        autospec=True,
-        return_value=([get_observation1(), get_observation1()]),
-    )
-    @mock.patch("ax.modelbridge.base.Adapter._fit", autospec=True)
-    def test_SetTrainingDataDupFeatures(self, _: Mock, __: Mock) -> None:
-        # Throws an error if repeated features in observations.
-        with self.assertRaises(ValueError):
-            Adapter(experiment=get_experiment_for_value(), model=Generator())
-
     def test_UnwrapObservationData(self) -> None:
         observation_data = [get_observation1().data, get_observation2().data]
         f, cov = unwrap_observation_data(observation_data)


### PR DESCRIPTION
Summary:
This method checks that the features of `Observation` objects that are constructed by `observations_from_data` are unique. However, due to the reliance on (approximate) Ax equality checks in `set(observation_features)`, this can be extremely slow and inaccurate. It leads to errors by flagging distinct observation features as duplicates.

Removing it will avoid the faulty errors and should improve runtime, particularly when MapData is utilized.

Differential Revision: D71984539


