### PR TITLE
Validate that auxiliary experiments are available in the db

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -369,6 +369,9 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         self._set_generation_strategy(
             choose_generation_strategy_kwargs=choose_generation_strategy_kwargs
         )
+        self._save_experiment_to_db_if_possible(
+            experiment=self.experiment,
+        )
         self._save_generation_strategy_to_db_if_possible()
 
     @property
@@ -1157,6 +1160,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             self._set_generation_strategy(
                 choose_generation_strategy_kwargs=choose_generation_strategy_kwargs
             )
+            self._save_experiment_to_db_if_possible(experiment=self.experiment)
             self._save_generation_strategy_to_db_if_possible()
         else:
             self._generation_strategy = generation_strategy

--- a/ax/storage/sqa_store/load.py
+++ b/ax/storage/sqa_store/load.py
@@ -10,7 +10,6 @@ from math import ceil
 from typing import Any, cast
 
 from ax.analysis.analysis import AnalysisCard
-
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
@@ -32,7 +31,6 @@ from ax.storage.sqa_store.sqa_classes import (
     SQATrial,
 )
 from ax.storage.sqa_store.sqa_config import SQAConfig
-
 from ax.storage.utils import MetricIntent
 from ax.utils.common.constants import Keys
 from pyre_extensions import assert_is_instance, none_throws

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -299,6 +299,24 @@ class SQAStoreTest(TestCase):
         self.assertEqual(experiment_w_aux_exp, loaded_experiment)
         self.assertEqual(len(loaded_experiment.auxiliary_experiments_by_purpose), 1)
 
+    def test_saving_with_aux_exp_not_in_db(self) -> None:
+        aux_experiment = Experiment(
+            name="aux_experiment_not_in_db", search_space=get_search_space()
+        )
+        experiment_w_aux_exp = Experiment(
+            name="test_experiment_w_aux_exp",
+            search_space=get_search_space(),
+            is_test=True,
+            auxiliary_experiments_by_purpose={
+                # pyre-ignore[16]: `AuxiliaryExperimentPurpose` has no attribute
+                self.config.auxiliary_experiment_purpose_enum.MyAuxExpPurpose: [
+                    AuxiliaryExperiment(experiment=aux_experiment)
+                ]
+            },
+        )
+        with self.assertRaisesRegex(SQAEncodeError, "that does not exist in"):
+            save_experiment(experiment_w_aux_exp, config=self.config)
+
     def test_saving_and_loading_experiment_with_cross_referencing_aux_exp(
         self,
     ) -> None:


### PR DESCRIPTION
Summary: Updates auxiliary experiment SQA storage to verify that the auxiliary experiment exists in the DB. If the auxiliary experiment does not exist, we would previously save its name but fail to load the experiment.

Differential Revision: D71980437


