### PR TITLE
Add BilogY to Y_trans

### DIFF
--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -30,6 +30,7 @@ from ax.modelbridge.discrete import DiscreteAdapter
 from ax.modelbridge.random import RandomAdapter
 from ax.modelbridge.torch import TorchAdapter
 from ax.modelbridge.transforms.base import Transform
+from ax.modelbridge.transforms.bilog_y import BilogY
 from ax.modelbridge.transforms.choice_encode import (
     ChoiceToNumericChoice,
     OrderedChoiceToIntegerRange,
@@ -147,7 +148,7 @@ Mixed_transforms: list[type[Transform]] = [
     UnitX,
 ]
 
-Y_trans: list[type[Transform]] = [IVW, Derelativize, StandardizeY]
+Y_trans: list[type[Transform]] = [IVW, Derelativize, BilogY, StandardizeY]
 
 # Expected `List[Type[Transform]]` for 2nd anonymous parameter to
 # call `list.__add__` but got `List[Type[SearchSpaceToChoice]]`.

--- a/ax/modelbridge/transforms/bilog_y.py
+++ b/ax/modelbridge/transforms/bilog_y.py
@@ -14,7 +14,6 @@ from typing import Callable, TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 from ax.core.observation import Observation, ObservationData
-from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import DataRequiredError
 from ax.modelbridge.transforms.base import Transform
@@ -64,17 +63,11 @@ class BilogY(Transform):
         if observations is None or len(observations) == 0:
             raise DataRequiredError("BilogY requires observations.")
         if modelbridge is not None and modelbridge._optimization_config is not None:
-            ocs: list[OutcomeConstraint] = (
-                modelbridge._optimization_config.outcome_constraints
-                if modelbridge
-                else []
-            )
-            if any(oc.relative for oc in ocs):
-                raise ValueError(
-                    "BilogY cannot be used with relative outcome constraints."
-                )
+            # TODO @deriksson: Add support for relative outcome constraints
             self.metric_to_bound: dict[str, float] = {
-                oc.metric.name: oc.bound for oc in ocs
+                oc.metric.name: oc.bound
+                for oc in modelbridge._optimization_config.outcome_constraints
+                if not oc.relative
             }
         else:
             self.metric_to_bound = {}


### PR DESCRIPTION
Summary: This adds `BilogY` to `Y_trans` and modifies `BilogY` to ignore relative constraints. The latter will be addressed (likely to derelativize using the raw status quo) once we align on the next steps for `Derelativize`.

Reviewed By: saitcakmak

Differential Revision: D71518762


