### PR TITLE
do not fill missing values in fixed_features

### DIFF
--- a/ax/modelbridge/base.py
+++ b/ax/modelbridge/base.py
@@ -810,7 +810,8 @@ class Adapter:
                 )
             for metric, po in pending_observations.items():
                 pending_observations[metric] = t.transform_observation_features(po)
-            (fixed_features,) = t.transform_observation_features([fixed_features])
+            if not isinstance(t, FillMissingParameters):
+                (fixed_features,) = t.transform_observation_features([fixed_features])
         return BaseGenArgs(
             search_space=search_space,
             optimization_config=optimization_config,


### PR DESCRIPTION
Summary:
If the FillMissingParameters transform is active on an adapter, it
will fill missing values in fixed_features. But fixed_features is meant to be
partially specified with missing values indicating a feature should not be
fixed, so it is a bug to fill it.

Differential Revision: D72071652


