### PR TITLE
Merge adjacent output blocks

### DIFF
--- a/website/src/components/CellOutput.jsx
+++ b/website/src/components/CellOutput.jsx
@@ -6,32 +6,17 @@
  */
 
 import React from 'react';
-import {v4 as uuidv4} from 'uuid';
+import CodeBlock from '@theme/CodeBlock';
 
 const CellOutput = (props) => {
   return (
-    <div
-      style={{
-        backgroundColor: 'var(--ifm-pre-background)',
-        marginBottom: '10px',
-        borderRadius: 'var(--ifm-global-radius)',
-        overflow: 'hidden',
-        padding: '5px',
-        font: 'var(--ifm-code-font-size) / var(--ifm-pre-line-height) var(--ifm-font-family-monospace)',
-      }}
+    <CodeBlock
+      language="python"
+      title="Output:"
     >
-      <span style={{color: 'red'}}>Out: </span>
-      <pre style={{margin: '0px', backgroundColor: 'inherit', padding: '8px'}}>
-        {props.children.split('\n').map((line) => {
-          return (
-            <p key={uuidv4()} style={{marginBottom: '0px'}}>
-              {line}
-            </p>
-          );
-        })}
-      </pre>
-    </div>
-  );
+      {props.children}
+    </CodeBlock>
+  )
 };
 
 export default CellOutput;


### PR DESCRIPTION
Summary:
## 1. Use the built-in docusaurus code block for cell outputs

We're already using the built-in docusaurus code blocks whenever we use triple backticks "```" in mdx/md, (e.g. in all our docs and tutorials) let's also use them for the outputs. Docusaurus provides a component interface to render these same code blocks.

I included a couple small visual changes to the output blocks enabled by docusaurus's code blocks:
1. add number lines
2. add a title header to the blocks indicating "Output:"
3. Add python syntax highlighting

## 2. Group adjacent cell outputs into a single code block

This happens because the stdout gets periodically flushed to the output during ipy notebook code execution. This is useful since it

regarding (2), this happens during ipy notebook execution because the stdout gets flushed periodically by jupyter. This makes sense since jupyter doesn't know when or how long our code will be writing to stdout, but it achieves this by intermittently writing separate output blocks instead of appending to a single block. We work around this by merging these adjacent blocks during our ipy to mdx conversion script.

Differential Revision: D72162075


