### PR TITLE
Add broad online/offline tests to .*Summary tests

### DIFF
--- a/ax/analysis/tests/test_metric_summary.py
+++ b/ax/analysis/tests/test_metric_summary.py
@@ -13,6 +13,7 @@ from ax.api.configs import ExperimentConfig
 from ax.core.metric import Metric
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
 
 
 class TestMetricSummary(TestCase):
@@ -85,3 +86,19 @@ class TestMetricSummary(TestCase):
             }
         )
         pd.testing.assert_frame_equal(card.df, expected)
+
+    def test_online(self) -> None:
+        # Test MetricSummary can be computed for a variety of experiments which
+        # resemble those we see in an online setting.
+
+        analysis = MetricSummary()
+        for experiment in get_online_experiments():
+            _ = analysis.compute(experiment=experiment)
+
+    def test_offline(self) -> None:
+        # Test MetricSummary can be computed for a variety of experiments which
+        # resemble those we see in an offline setting.
+
+        analysis = MetricSummary()
+        for experiment in get_offline_experiments():
+            _ = analysis.compute(experiment=experiment)

--- a/ax/analysis/tests/test_search_space_summary.py
+++ b/ax/analysis/tests/test_search_space_summary.py
@@ -18,6 +18,7 @@ from ax.api.configs import (
 )
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
 
 
 class TestSearchSpaceSummary(TestCase):
@@ -84,3 +85,19 @@ class TestSearchSpaceSummary(TestCase):
             }
         )
         pd.testing.assert_frame_equal(card.df, expected)
+
+    def test_online(self) -> None:
+        # Test SearchSpaceSummary can be computed for a variety of experiments which
+        # resemble those we see in an online setting.
+
+        analysis = SearchSpaceSummary()
+        for experiment in get_online_experiments():
+            _ = analysis.compute(experiment=experiment)
+
+    def test_offline(self) -> None:
+        # Test SearchSpaceSummary can be computed for a variety of experiments which
+        # resemble those we see in an offline setting.
+
+        analysis = SearchSpaceSummary()
+        for experiment in get_offline_experiments():
+            _ = analysis.compute(experiment=experiment)

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -14,6 +14,7 @@ from ax.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
 from ax.core.trial import Trial
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
 from pyre_extensions import assert_is_instance, none_throws
 
 
@@ -123,3 +124,23 @@ class TestSummary(TestCase):
             },
         )
         self.assertEqual(len(card_no_omit.df), len(experiment.arms_by_name))
+
+    def test_online(self) -> None:
+        # Test MetricSummary can be computed for a variety of experiments which
+        # resemble those we see in an online setting.
+
+        for omit_empty_columns in [True, False]:
+            analysis = Summary(omit_empty_columns=omit_empty_columns)
+
+            for experiment in get_online_experiments():
+                _ = analysis.compute(experiment=experiment)
+
+    def test_offline(self) -> None:
+        # Test MetricSummary can be computed for a variety of experiments which
+        # resemble those we see in an offline setting.
+
+        for omit_empty_columns in [True, False]:
+            analysis = Summary(omit_empty_columns=omit_empty_columns)
+
+            for experiment in get_offline_experiments():
+                _ = analysis.compute(experiment=experiment)


### PR DESCRIPTION
Summary: These broad tests ensure that all Summary analyses can compute on a representative set of experiments without raising an error. ** NOTE THAT THESE TEST WILL NOT SUPPLANT TYPICAL UNITTESTS**

Reviewed By: Cesar-Cardoso

Differential Revision: D72316888


