### PR TITLE
Add online/offline tests to SensitivityAnalysisPlot

### DIFF
--- a/ax/analysis/plotly/sensitivity.py
+++ b/ax/analysis/plotly/sensitivity.py
@@ -50,6 +50,10 @@ class SensitivityAnalysisPlot(PlotlyAnalysis):
                 raise UserInputError(NO_ADAPTER_ERROR_MSG)
 
         elif generation_strategy is not None:
+            # Fit the current GenerationNode's Adapter if necessary
+            if generation_strategy.model is None and experiment is not None:
+                generation_strategy.current_node._fit(experiment=experiment)
+
             relevant_adapter = generation_strategy.model
 
             if not isinstance(relevant_adapter, TorchAdapter):

--- a/ax/analysis/plotly/tests/test_cross_validation.py
+++ b/ax/analysis/plotly/tests/test_cross_validation.py
@@ -15,7 +15,9 @@ from ax.exceptions.core import UserInputError
 from ax.modelbridge.registry import Generators
 from ax.service.ax_client import AxClient, ObjectiveProperties
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
 from ax.utils.testing.mock import mock_botorch_optimize
+from ax.utils.testing.modeling_stubs import get_default_generation_strategy_at_MBM_node
 from pyre_extensions import assert_is_instance, none_throws
 
 
@@ -139,3 +141,57 @@ class TestCrossValidationPlot(TestCase):
         self.assertEqual(card.name, "CrossValidationPlot")
         # validate that the metric name replacement occured
         self.assertEqual(card.title, "Cross Validation for spunky")
+
+    @mock_botorch_optimize
+    def test_online(self) -> None:
+        # Test CrossValidationPlot can be computed for a variety of experiments which
+        # resemble those we see in an online setting.
+
+        for experiment in get_online_experiments():
+            for untransform in [True, False]:
+                for refined_metric_name in [None, "foo"]:
+                    generation_strategy = get_default_generation_strategy_at_MBM_node(
+                        experiment=experiment
+                    )
+
+                    # Pick an arbitrary metric from the experiment's optimization config
+                    metric_name = none_throws(
+                        experiment.optimization_config
+                    ).objective.metric_names[0]
+
+                    analysis = CrossValidationPlot(
+                        metric_name=metric_name,
+                        untransform=untransform,
+                        refined_metric_name=refined_metric_name,
+                    )
+
+                    _ = analysis.compute(
+                        experiment=experiment, generation_strategy=generation_strategy
+                    )
+
+    @mock_botorch_optimize
+    def test_offline(self) -> None:
+        # Test CrossValidationPlot can be computed for a variety of experiments which
+        # resemble those we see in an online setting.
+
+        for experiment in get_offline_experiments():
+            for untransform in [True, False]:
+                for refined_metric_name in [None, "foo"]:
+                    generation_strategy = get_default_generation_strategy_at_MBM_node(
+                        experiment=experiment
+                    )
+
+                    # Pick an arbitrary metric from the experiment's optimization config
+                    metric_name = none_throws(
+                        experiment.optimization_config
+                    ).objective.metric_names[0]
+
+                    analysis = CrossValidationPlot(
+                        metric_name=metric_name,
+                        untransform=untransform,
+                        refined_metric_name=refined_metric_name,
+                    )
+
+                    _ = analysis.compute(
+                        experiment=experiment, generation_strategy=generation_strategy
+                    )

--- a/ax/analysis/plotly/tests/test_parallel_coordinates.py
+++ b/ax/analysis/plotly/tests/test_parallel_coordinates.py
@@ -18,7 +18,10 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_experiment_with_multi_objective,
     get_experiment_with_scalarized_objective_and_outcome_constraint,
+    get_offline_experiments,
+    get_online_experiments,
 )
+from pyre_extensions import none_throws
 
 
 class TestParallelCoordinatesPlot(TestCase):
@@ -48,7 +51,9 @@ class TestParallelCoordinatesPlot(TestCase):
         )
         self.assertEqual(card.level, AnalysisCardLevel.HIGH)
         self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
-        self.assertEqual({*card.df.columns}, {"arm_name", "branin", "x1", "x2"})
+        self.assertEqual(
+            {*card.df.columns}, {"trial_index", "arm_name", "branin", "x1", "x2"}
+        )
         self.assertIsNotNone(card.blob)
         self.assertEqual(card.blob_annotation, "plotly")
 
@@ -100,3 +105,31 @@ class TestParallelCoordinatesPlot(TestCase):
                 "values": [2, 0, 1],
             },
         )
+
+    def test_online(self) -> None:
+        # Test ParallelCoordinatesPlot can be computed for a variety of experiments
+        # which resemble those we see in an online setting.
+
+        for experiment in get_online_experiments():
+            analysis = ParallelCoordinatesPlot(
+                # Select and arbitrary metric from the optimization config
+                metric_name=none_throws(
+                    experiment.optimization_config
+                ).objective.metric_names[0]
+            )
+
+            _ = analysis.compute(experiment=experiment)
+
+    def test_offline(self) -> None:
+        # Test ParallelCoordinatesPlot can be computed for a variety of experiments
+        # which resemble those we see in an offline setting.
+
+        for experiment in get_offline_experiments():
+            analysis = ParallelCoordinatesPlot(
+                # Select and arbitrary metric from the optimization config
+                metric_name=none_throws(
+                    experiment.optimization_config
+                ).objective.metric_names[0]
+            )
+
+            _ = analysis.compute(experiment=experiment)

--- a/ax/analysis/plotly/tests/test_sensitivity.py
+++ b/ax/analysis/plotly/tests/test_sensitivity.py
@@ -11,8 +11,10 @@ from ax.api.client import Client
 from ax.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
 from ax.utils.testing.mock import mock_botorch_optimize
-from pyre_extensions import assert_is_instance
+from ax.utils.testing.modeling_stubs import get_default_generation_strategy_at_MBM_node
+from pyre_extensions import assert_is_instance, none_throws
 
 
 class TestSensitivityAnalysisPlot(TestCase):
@@ -79,3 +81,57 @@ class TestSensitivityAnalysisPlot(TestCase):
         second_order = SensitivityAnalysisPlot(metric_names=["bar"], order="second")
         (card,) = second_order.compute(generation_strategy=client._generation_strategy)
         self.assertEqual(len(card.df), 3)  # 2 first order + 1 second order
+
+    @mock_botorch_optimize
+    @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
+    def test_online(self) -> None:
+        # Test SensitivityAnalysisPlot can be computed for a variety of experiments
+        # which resemble those we see in an online setting.
+
+        for experiment in get_online_experiments():
+            for order in ["first", "second", "total"]:
+                for top_k in [None, 1]:
+                    generation_strategy = get_default_generation_strategy_at_MBM_node(
+                        experiment=experiment
+                    )
+                    analysis = SensitivityAnalysisPlot(
+                        # Select and arbitrary metric from the optimization config
+                        metric_names=[
+                            none_throws(
+                                experiment.optimization_config
+                            ).objective.metric_names[0]
+                        ],
+                        order=order,  # pyre-ignore[6] Valid Literal
+                        top_k=top_k,
+                    )
+
+                    _ = analysis.compute(
+                        experiment=experiment, generation_strategy=generation_strategy
+                    )
+
+    @mock_botorch_optimize
+    @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
+    def test_offline(self) -> None:
+        # Test SensitivityAnalysisPlot can be computed for a variety of experiments
+        # which resemble those we see in an offline setting.
+
+        for experiment in get_offline_experiments():
+            for order in ["first", "second", "total"]:
+                for top_k in [None, 1]:
+                    generation_strategy = get_default_generation_strategy_at_MBM_node(
+                        experiment=experiment
+                    )
+                    analysis = SensitivityAnalysisPlot(
+                        # Select and arbitrary metric from the optimization config
+                        metric_names=[
+                            none_throws(
+                                experiment.optimization_config
+                            ).objective.metric_names[0]
+                        ],
+                        order=order,  # pyre-ignore[6] Valid Literal
+                        top_k=top_k,
+                    )
+
+                    _ = analysis.compute(
+                        experiment=experiment, generation_strategy=generation_strategy
+                    )

--- a/ax/analysis/tests/test_metric_summary.py
+++ b/ax/analysis/tests/test_metric_summary.py
@@ -13,6 +13,7 @@ from ax.api.configs import ExperimentConfig
 from ax.core.metric import Metric
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
 
 
 class TestMetricSummary(TestCase):
@@ -85,3 +86,19 @@ class TestMetricSummary(TestCase):
             }
         )
         pd.testing.assert_frame_equal(card.df, expected)
+
+    def test_online(self) -> None:
+        # Test MetricSummary can be computed for a variety of experiments which
+        # resemble those we see in an online setting.
+
+        analysis = MetricSummary()
+        for experiment in get_online_experiments():
+            _ = analysis.compute(experiment=experiment)
+
+    def test_offline(self) -> None:
+        # Test MetricSummary can be computed for a variety of experiments which
+        # resemble those we see in an offline setting.
+
+        analysis = MetricSummary()
+        for experiment in get_offline_experiments():
+            _ = analysis.compute(experiment=experiment)

--- a/ax/analysis/tests/test_search_space_summary.py
+++ b/ax/analysis/tests/test_search_space_summary.py
@@ -18,6 +18,7 @@ from ax.api.configs import (
 )
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
 
 
 class TestSearchSpaceSummary(TestCase):
@@ -84,3 +85,19 @@ class TestSearchSpaceSummary(TestCase):
             }
         )
         pd.testing.assert_frame_equal(card.df, expected)
+
+    def test_online(self) -> None:
+        # Test SearchSpaceSummary can be computed for a variety of experiments which
+        # resemble those we see in an online setting.
+
+        analysis = SearchSpaceSummary()
+        for experiment in get_online_experiments():
+            _ = analysis.compute(experiment=experiment)
+
+    def test_offline(self) -> None:
+        # Test SearchSpaceSummary can be computed for a variety of experiments which
+        # resemble those we see in an offline setting.
+
+        analysis = SearchSpaceSummary()
+        for experiment in get_offline_experiments():
+            _ = analysis.compute(experiment=experiment)

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -14,6 +14,7 @@ from ax.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
 from ax.core.trial import Trial
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
 from pyre_extensions import assert_is_instance, none_throws
 
 
@@ -123,3 +124,23 @@ class TestSummary(TestCase):
             },
         )
         self.assertEqual(len(card_no_omit.df), len(experiment.arms_by_name))
+
+    def test_online(self) -> None:
+        # Test MetricSummary can be computed for a variety of experiments which
+        # resemble those we see in an online setting.
+
+        for omit_empty_columns in [True, False]:
+            analysis = Summary(omit_empty_columns=omit_empty_columns)
+
+            for experiment in get_online_experiments():
+                _ = analysis.compute(experiment=experiment)
+
+    def test_offline(self) -> None:
+        # Test MetricSummary can be computed for a variety of experiments which
+        # resemble those we see in an offline setting.
+
+        for omit_empty_columns in [True, False]:
+            analysis = Summary(omit_empty_columns=omit_empty_columns)
+
+            for experiment in get_offline_experiments():
+                _ = analysis.compute(experiment=experiment)

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -10,6 +10,8 @@ from logging import Logger
 from typing import Any
 
 import numpy as np
+from ax.api.configs import GenerationStrategyConfig
+from ax.api.utils.generation_strategy_dispatch import choose_generation_strategy
 from ax.core.experiment import Experiment
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
@@ -194,6 +196,19 @@ def get_generation_strategy(
         gs._steps[0].completion_criteria = [
             MinimumPreferenceOccurances(metric_name="m1", threshold=3)
         ] * with_completion_criteria
+    return gs
+
+
+def get_default_generation_strategy_at_MBM_node(
+    experiment: Experiment,
+) -> GenerationStrategy:
+    gs = choose_generation_strategy(gs_config=GenerationStrategyConfig())
+
+    gs._experiment = experiment
+
+    mbm_node = next(node for name, node in gs.nodes_dict.items() if "MBM" in name)
+    gs._curr = mbm_node
+
     return gs
 
 


### PR DESCRIPTION
Summary:
Also add logic to fix error if no adapter provided and current GeneratioNode's adapter is not fit.

Note: We should centralize the logic for picking which adapter to use.

Differential Revision: D72329492


