### PR TITLE
Bug fix: Use simulated backend even when max_parallelism=1 when there is an ESS or variable runtimes

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -110,7 +110,9 @@ def compute_score_trace(
 
 
 def get_benchmark_runner(
-    problem: BenchmarkProblem, max_concurrency: int = 1
+    problem: BenchmarkProblem,
+    max_concurrency: int = 1,
+    force_use_simulated_backend: bool = False,
 ) -> BenchmarkRunner:
     """
     Construct a ``BenchmarkRunner`` for the given problem and concurrency.
@@ -126,6 +128,10 @@ def get_benchmark_runner(
         max_concurrency: The maximum number of trials that can be run concurrently.
             Typically, ``max_pending_trials`` from ``SchedulerOptions``, which are
             stored on the ``BenchmarkMethod``.
+        force_use_simulated_backend: Whether to use a simulated backend even if
+            ``max_concurrency`` is 1 and ``problem.step_runtime_function`` is
+            None. Recommended for use with a ``BenchmarkMethod`` that uses early
+            stopping.
     """
 
     return BenchmarkRunner(
@@ -133,6 +139,7 @@ def get_benchmark_runner(
         noise_std=problem.noise_std,
         step_runtime_function=problem.step_runtime_function,
         max_concurrency=max_concurrency,
+        force_use_simulated_backend=force_use_simulated_backend,
     )
 
 
@@ -439,7 +446,9 @@ def benchmark_replication(
         logging_level=scheduler_logging_level,
     )
     runner = get_benchmark_runner(
-        problem=problem, max_concurrency=scheduler_options.max_pending_trials
+        problem=problem,
+        max_concurrency=scheduler_options.max_pending_trials,
+        force_use_simulated_backend=method.early_stopping_strategy is not None,
     )
     experiment = Experiment(
         name=f"{problem.name}|{method.name}_{int(time())}",

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -320,6 +320,7 @@ def get_discrete_search_space(n_values: int = 20) -> SearchSpace:
 
 def get_async_benchmark_method(
     early_stopping_strategy: BaseEarlyStoppingStrategy | None = None,
+    max_pending_trials: int = 2,
 ) -> BenchmarkMethod:
     gs = GenerationStrategy(
         nodes=[DeterministicGenerationNode(search_space=get_discrete_search_space())]
@@ -327,7 +328,7 @@ def get_async_benchmark_method(
     return BenchmarkMethod(
         generation_strategy=gs,
         distribute_replications=False,
-        max_pending_trials=2,
+        max_pending_trials=max_pending_trials,
         batch_size=1,
         early_stopping_strategy=early_stopping_strategy,
     )


### PR DESCRIPTION
Summary:
Context: Currently, at odds with a docsting, we use a simulated backend only when max_parallelism > 1, since that is the only time when we need a simulated backend to ensure that events happen in the correct order. However, I don't think early stopping would work without a simulated backend, regardless of parallelism, since `BenchmarkMapMetric` relies on the backend simulator to know what data from not-run steps to discard. Lack of a simulated backend also inhibits proper tracing of cost.

This PR:
* Adds an argument `force_use_simulated_backend` to `BenchmarkRunner`
* Makes it True when constructing a runner and there is an early stopping strategy

Reviewed By: Balandat

Differential Revision: D72391347


