### PR TITLE
Suppress Scheduler INFO logs in unit tests

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -110,7 +110,9 @@ def compute_score_trace(
 
 
 def get_benchmark_runner(
-    problem: BenchmarkProblem, max_concurrency: int = 1
+    problem: BenchmarkProblem,
+    max_concurrency: int = 1,
+    force_use_simulated_backend: bool = False,
 ) -> BenchmarkRunner:
     """
     Construct a ``BenchmarkRunner`` for the given problem and concurrency.
@@ -126,6 +128,10 @@ def get_benchmark_runner(
         max_concurrency: The maximum number of trials that can be run concurrently.
             Typically, ``max_pending_trials`` from ``SchedulerOptions``, which are
             stored on the ``BenchmarkMethod``.
+        force_use_simulated_backend: Whether to use a simulated backend even if
+            ``max_concurrency`` is 1 and ``problem.step_runtime_function`` is
+            None. Recommended for use with a ``BenchmarkMethod`` that uses early
+            stopping.
     """
 
     return BenchmarkRunner(
@@ -133,6 +139,7 @@ def get_benchmark_runner(
         noise_std=problem.noise_std,
         step_runtime_function=problem.step_runtime_function,
         max_concurrency=max_concurrency,
+        force_use_simulated_backend=force_use_simulated_backend,
     )
 
 
@@ -439,7 +446,9 @@ def benchmark_replication(
         logging_level=scheduler_logging_level,
     )
     runner = get_benchmark_runner(
-        problem=problem, max_concurrency=scheduler_options.max_pending_trials
+        problem=problem,
+        max_concurrency=scheduler_options.max_pending_trials,
+        force_use_simulated_backend=method.early_stopping_strategy is not None,
     )
     experiment = Experiment(
         name=f"{problem.name}|{method.name}_{int(time())}",

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 
+from logging import WARNING
 from unittest.mock import patch
 
 import numpy as np
@@ -83,7 +84,9 @@ class TestMethods(TestCase):
         # Only run one non-Sobol trial
         n_total_trials = n_sobol_trials + 1
         problem = get_problem(problem_key="ackley4", num_trials=n_total_trials)
-        result = benchmark_replication(problem=problem, method=method, seed=0)
+        result = benchmark_replication(
+            problem=problem, method=method, seed=0, scheduler_logging_level=WARNING
+        )
         self.assertTrue(np.isfinite(result.score_trace).all())
         self.assertEqual(result.optimization_trace.shape, (n_total_trials,))
 
@@ -115,9 +118,6 @@ class TestMethods(TestCase):
         gs = method.generation_strategy
         self.assertEqual(len(gs._steps), 1)
         self.assertEqual(gs._steps[0].model, Generators.SOBOL)
-        problem = get_problem(problem_key="ackley4", num_trials=3)
-        result = benchmark_replication(problem=problem, method=method, seed=0)
-        self.assertTrue(np.isfinite(result.score_trace).all())
 
     def _test_get_best_parameters(self, use_model_predictions: bool) -> None:
         problem = get_problem(problem_key="ackley4", num_trials=2, noise_std=1.0)
@@ -140,7 +140,9 @@ class TestMethods(TestCase):
         scheduler = Scheduler(
             experiment=experiment,
             generation_strategy=method.generation_strategy.clone_reset(),
-            options=get_benchmark_scheduler_options(method=method),
+            options=get_benchmark_scheduler_options(
+                method=method, logging_level=WARNING
+            ),
         )
 
         with with_rng_seed(seed=0):

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -320,6 +320,7 @@ def get_discrete_search_space(n_values: int = 20) -> SearchSpace:
 
 def get_async_benchmark_method(
     early_stopping_strategy: BaseEarlyStoppingStrategy | None = None,
+    max_pending_trials: int = 2,
 ) -> BenchmarkMethod:
     gs = GenerationStrategy(
         nodes=[DeterministicGenerationNode(search_space=get_discrete_search_space())]
@@ -327,7 +328,7 @@ def get_async_benchmark_method(
     return BenchmarkMethod(
         generation_strategy=gs,
         distribute_replications=False,
-        max_pending_trials=2,
+        max_pending_trials=max_pending_trials,
         batch_size=1,
         early_stopping_strategy=early_stopping_strategy,
     )


### PR DESCRIPTION
Summary:
Context: I was looking to see if a specific log was happening and couldn't easily find it.

This diff: As titled

Reviewed By: Balandat

Differential Revision: D72392488


