### PR TITLE
Add FillMissingParameters by default if its config exists

### DIFF
--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -36,7 +36,6 @@ from ax.modelbridge.transforms.choice_encode import (
     OrderedChoiceToIntegerRange,
 )
 from ax.modelbridge.transforms.derelativize import Derelativize
-from ax.modelbridge.transforms.fill_missing_parameters import FillMissingParameters
 from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
 from ax.modelbridge.transforms.int_to_float import IntToFloat, LogIntToFloat
 from ax.modelbridge.transforms.ivw import IVW
@@ -86,7 +85,6 @@ logger: Logger = get_logger(__name__)
 # candidates are rounded to fit the original search space. This is can be
 # suboptimal when there are discrete parameters with a small number of options.
 Cont_X_trans: list[type[Transform]] = [
-    FillMissingParameters,
     RemoveFixed,
     OrderedChoiceToIntegerRange,
     OneHot,
@@ -104,7 +102,6 @@ Cont_X_trans: list[type[Transform]] = [
 # optimize_acqf_mixed_alternating, which is a more efficient acquisition function
 # optimizer for mixed discrete/continuous problems.
 MBM_X_trans: list[type[Transform]] = [
-    FillMissingParameters,
     RemoveFixed,
     OrderedChoiceToIntegerRange,
     OneHot,
@@ -139,7 +136,6 @@ rel_EB_ashr_trans: list[type[Transform]] = [
 # all choice parameters as discrete, while using continuous relaxation for integer
 # valued RangeParameters.
 Mixed_transforms: list[type[Transform]] = [
-    FillMissingParameters,
     RemoveFixed,
     ChoiceToNumericChoice,
     IntToFloat,

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -826,11 +826,11 @@ class BaseAdapterTest(TestCase):
             experiment=experiment,
             model=Generator(),
             search_space=ss2,
-            transforms=[FillMissingParameters],
+            transforms=[],  # FillMissingParameters added by default.
             transform_configs={"FillMissingParameters": {"fill_values": sq_vals}},
         )
         self.assertEqual(
-            [t.__name__ for t in m._raw_transforms], ["Cast", "FillMissingParameters"]
+            [t.__name__ for t in m._raw_transforms], ["FillMissingParameters", "Cast"]
         )
         # All arms are in design now
         self.assertEqual(sum(m.training_in_design), 12)


### PR DESCRIPTION
Summary:
Various parts of the Adapter already construct the `FillMissingParameters` transform if a config for it exists in the `transform_configs`. This diff takes it one step further and adds it as the first transform (before `Cast`) if its config exists.

Motivation: `None`s in parameters are often used to represent unknown or default values of the status quo parameters. Besides this use case, `None` is not an acceptable value for any of the Ax `ParameterTypes`. If `None`s sneak into the `ObservationFeatures` lower in the stack, they lead to errors.

`Adapter` currently relies on the in-desing point filtering / search space membership checks to remove observations with `None`s.  In D72400250, we're changing things slightly, to allow for `Cast` to remove `None` observations as well. This will allow us to simply transform the observation features and ensure that they are `None`-free.

The only issue this caused was with `FillMissingParameters` transform, which may replace these `None`s with the known default values. To allow this to work, we need `FillMissingParameters` to come before `Cast` in transform order, which can be supported by adding it by default when a corresponding config is provided.

Reviewed By: bletham

Differential Revision: D72460013


