### PR TITLE
Disallow None in parameter values, drop None observations in Cast

### DIFF
--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1367,7 +1367,7 @@ class ExperimentWithMapDataTest(TestCase):
         super().setUp()
         self.experiment = get_experiment_with_map_data_type()
 
-    def _setupBraninExperiment(self, n: int, incremental: bool = False) -> Experiment:
+    def _setupBraninExperiment(self, n: int) -> Experiment:
         exp = get_branin_experiment_with_timestamp_map_metric()
         batch = exp.new_batch_trial()
         batch.add_arms_and_weights(arms=get_branin_arms(n=n, seed=0))

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -16,7 +16,12 @@ from ax.core.parameter import (
     ParameterType,
     RangeParameter,
 )
-from ax.exceptions.core import AxParameterWarning, AxWarning, UserInputError
+from ax.exceptions.core import (
+    AxParameterWarning,
+    AxWarning,
+    UnsupportedError,
+    UserInputError,
+)
 from ax.utils.common.testutils import TestCase
 from pyre_extensions import none_throws
 
@@ -147,7 +152,8 @@ class RangeParameterTest(TestCase):
     def test_Cast(self) -> None:
         self.assertEqual(self.param2.cast(2.5), 2)
         self.assertEqual(self.param2.cast(3), 3)
-        self.assertEqual(self.param2.cast(None), None)
+        with self.assertRaisesRegex(UnsupportedError, "None values"):
+            self.param2.cast(None)
 
     def test_Clone(self) -> None:
         param_clone = self.param1.clone()
@@ -610,7 +616,8 @@ class FixedParameterTest(TestCase):
     def test_Cast(self) -> None:
         self.assertEqual(self.param1.cast(1), True)
         self.assertEqual(self.param1.cast(False), False)
-        self.assertEqual(self.param1.cast(None), None)
+        with self.assertRaisesRegex(UnsupportedError, "None values"):
+            self.param1.cast(None)
 
     def test_HierarchicalValidation(self) -> None:
         self.assertFalse(self.param1.is_hierarchical)

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -36,7 +36,6 @@ from ax.modelbridge.transforms.choice_encode import (
     OrderedChoiceToIntegerRange,
 )
 from ax.modelbridge.transforms.derelativize import Derelativize
-from ax.modelbridge.transforms.fill_missing_parameters import FillMissingParameters
 from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
 from ax.modelbridge.transforms.int_to_float import IntToFloat, LogIntToFloat
 from ax.modelbridge.transforms.ivw import IVW
@@ -86,7 +85,6 @@ logger: Logger = get_logger(__name__)
 # candidates are rounded to fit the original search space. This is can be
 # suboptimal when there are discrete parameters with a small number of options.
 Cont_X_trans: list[type[Transform]] = [
-    FillMissingParameters,
     RemoveFixed,
     OrderedChoiceToIntegerRange,
     OneHot,
@@ -104,7 +102,6 @@ Cont_X_trans: list[type[Transform]] = [
 # optimize_acqf_mixed_alternating, which is a more efficient acquisition function
 # optimizer for mixed discrete/continuous problems.
 MBM_X_trans: list[type[Transform]] = [
-    FillMissingParameters,
     RemoveFixed,
     OrderedChoiceToIntegerRange,
     OneHot,
@@ -139,7 +136,6 @@ rel_EB_ashr_trans: list[type[Transform]] = [
 # all choice parameters as discrete, while using continuous relaxation for integer
 # valued RangeParameters.
 Mixed_transforms: list[type[Transform]] = [
-    FillMissingParameters,
     RemoveFixed,
     ChoiceToNumericChoice,
     IntToFloat,

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -826,11 +826,11 @@ class BaseAdapterTest(TestCase):
             experiment=experiment,
             model=Generator(),
             search_space=ss2,
-            transforms=[FillMissingParameters],
+            transforms=[],  # FillMissingParameters added by default.
             transform_configs={"FillMissingParameters": {"fill_values": sq_vals}},
         )
         self.assertEqual(
-            [t.__name__ for t in m._raw_transforms], ["Cast", "FillMissingParameters"]
+            [t.__name__ for t in m._raw_transforms], ["FillMissingParameters", "Cast"]
         )
         # All arms are in design now
         self.assertEqual(sum(m.training_in_design), 12)

--- a/ax/modelbridge/transforms/tests/test_cast_transform.py
+++ b/ax/modelbridge/transforms/tests/test_cast_transform.py
@@ -247,3 +247,39 @@ class CastTransformTest(TestCase):
             obsf.metadata.get(Keys.FULL_PARAMETERIZATION),
             self.obs_feats_hss_2.parameters,
         )
+
+    def test_cast_parameter_type_and_none(self) -> None:
+        # This test covers removal of observations with Nones, casting
+        # to correct parameter type and rounding to digits for RangeParameters.
+        search_space = SearchSpace(
+            parameters=[
+                ChoiceParameter(
+                    name="choice",
+                    parameter_type=ParameterType.STRING,
+                    values=["1", "2", "3"],
+                ),
+                RangeParameter(
+                    name="range",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=5.0,
+                    digits=1,
+                ),
+            ]
+        )
+        t = Cast(search_space=search_space)
+        obs_features = [
+            ObservationFeatures(parameters={"choice": None, "range": 5.0}),
+            ObservationFeatures(parameters={"choice": 1, "range": 3}),
+            ObservationFeatures(parameters={"choice": "2", "range": 3.567}),
+        ]
+        tf_obs_features = t.transform_observation_features(
+            observation_features=obs_features
+        )
+        self.assertEqual(
+            tf_obs_features,
+            [
+                ObservationFeatures(parameters={"choice": "1", "range": 3.0}),
+                ObservationFeatures(parameters={"choice": "2", "range": 3.6}),
+            ],
+        )


### PR DESCRIPTION
Summary:
`None`s in parameters are often used to represent unknown or default values of the status quo parameters. Besides this use case, `None` is not an acceptable value for any of the Ax `ParameterTypes`. If `None`s sneak into the `ObservationFeatures` lower in the stack, they lead to errors.

`Adapter` currently relies on the in-desing point filtering / search space membership checks to remove observations with `None`s.  In this diff, we're changing things slightly, to allow for `Cast` to remove `None` observations as well. This will allow us to simply transform the observation features and ensure that they are `None`-free.

In addition, `Parameter.cast` is updated to raise an error rather than returning back `None` values. This will prevent the users from mistakenly constructing parameters with `None`s in the values.

Differential Revision: D72400250


