### PR TITLE
Extract generated points from experiment in RandomAdapter rather than tracking them on RandomGenerator

### DIFF
--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1367,7 +1367,7 @@ class ExperimentWithMapDataTest(TestCase):
         super().setUp()
         self.experiment = get_experiment_with_map_data_type()
 
-    def _setupBraninExperiment(self, n: int, incremental: bool = False) -> Experiment:
+    def _setupBraninExperiment(self, n: int) -> Experiment:
         exp = get_branin_experiment_with_timestamp_map_metric()
         batch = exp.new_batch_trial()
         batch.add_arms_and_weights(arms=get_branin_arms(n=n, seed=0))

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -16,7 +16,12 @@ from ax.core.parameter import (
     ParameterType,
     RangeParameter,
 )
-from ax.exceptions.core import AxParameterWarning, AxWarning, UserInputError
+from ax.exceptions.core import (
+    AxParameterWarning,
+    AxWarning,
+    UnsupportedError,
+    UserInputError,
+)
 from ax.utils.common.testutils import TestCase
 from pyre_extensions import none_throws
 
@@ -147,7 +152,8 @@ class RangeParameterTest(TestCase):
     def test_Cast(self) -> None:
         self.assertEqual(self.param2.cast(2.5), 2)
         self.assertEqual(self.param2.cast(3), 3)
-        self.assertEqual(self.param2.cast(None), None)
+        with self.assertRaisesRegex(UnsupportedError, "None values"):
+            self.param2.cast(None)
 
     def test_Clone(self) -> None:
         param_clone = self.param1.clone()
@@ -610,7 +616,8 @@ class FixedParameterTest(TestCase):
     def test_Cast(self) -> None:
         self.assertEqual(self.param1.cast(1), True)
         self.assertEqual(self.param1.cast(False), False)
-        self.assertEqual(self.param1.cast(None), None)
+        with self.assertRaisesRegex(UnsupportedError, "None values"):
+            self.param1.cast(None)
 
     def test_HierarchicalValidation(self) -> None:
         self.assertFalse(self.param1.is_hierarchical)

--- a/ax/modelbridge/random.py
+++ b/ax/modelbridge/random.py
@@ -9,6 +9,7 @@
 
 from collections.abc import Mapping, Sequence
 
+import numpy as np
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
@@ -95,6 +96,35 @@ class RandomAdapter(Adapter):
         linear_constraints = extract_parameter_constraints(
             search_space.parameter_constraints, self.parameters
         )
+        # Extract generated points to deduplicate against.
+        if self.model.deduplicate:
+            arms_to_deduplicate = self._experiment.arms_by_signature_for_deduplication
+            generated_obs = [
+                ObservationFeatures.from_arm(arm=arm)
+                for arm in arms_to_deduplicate.values()
+            ]
+            # Transform
+            for t in self.transforms.values():
+                generated_obs = t.transform_observation_features(generated_obs)
+            # Add pending observations -- already transformed.
+            generated_obs.extend(
+                [obs for obs_list in pending_observations.values() for obs in obs_list]
+            )
+            if len(generated_obs) == 0:
+                generated_points = None
+            else:
+                # Extract generated points array (n x d).
+                generated_points = np.array(
+                    [
+                        [obs.parameters[p] for p in self.parameters]
+                        for obs in generated_obs
+                    ]
+                )
+                # Take unique points only, since there may be duplicates coming
+                # from pending observations for different metrics.
+                generated_points = np.unique(generated_points, axis=0)
+        else:
+            generated_points = None
         # Generate the candidates
         X, w = self.model.gen(
             n=n,
@@ -103,6 +133,7 @@ class RandomAdapter(Adapter):
             fixed_features=fixed_features_dict,
             model_gen_options=model_gen_options,
             rounding_func=transform_callback(self.parameters, self.transforms),
+            generated_points=generated_points,
         )
         observation_features = parse_observation_features(X, self.parameters)
         return GenResults(

--- a/ax/modelbridge/registry.py
+++ b/ax/modelbridge/registry.py
@@ -36,7 +36,6 @@ from ax.modelbridge.transforms.choice_encode import (
     OrderedChoiceToIntegerRange,
 )
 from ax.modelbridge.transforms.derelativize import Derelativize
-from ax.modelbridge.transforms.fill_missing_parameters import FillMissingParameters
 from ax.modelbridge.transforms.int_range_to_choice import IntRangeToChoice
 from ax.modelbridge.transforms.int_to_float import IntToFloat, LogIntToFloat
 from ax.modelbridge.transforms.ivw import IVW
@@ -86,7 +85,6 @@ logger: Logger = get_logger(__name__)
 # candidates are rounded to fit the original search space. This is can be
 # suboptimal when there are discrete parameters with a small number of options.
 Cont_X_trans: list[type[Transform]] = [
-    FillMissingParameters,
     RemoveFixed,
     OrderedChoiceToIntegerRange,
     OneHot,
@@ -104,7 +102,6 @@ Cont_X_trans: list[type[Transform]] = [
 # optimize_acqf_mixed_alternating, which is a more efficient acquisition function
 # optimizer for mixed discrete/continuous problems.
 MBM_X_trans: list[type[Transform]] = [
-    FillMissingParameters,
     RemoveFixed,
     OrderedChoiceToIntegerRange,
     OneHot,
@@ -139,7 +136,6 @@ rel_EB_ashr_trans: list[type[Transform]] = [
 # all choice parameters as discrete, while using continuous relaxation for integer
 # valued RangeParameters.
 Mixed_transforms: list[type[Transform]] = [
-    FillMissingParameters,
     RemoveFixed,
     ChoiceToNumericChoice,
     IntToFloat,

--- a/ax/modelbridge/tests/test_base_modelbridge.py
+++ b/ax/modelbridge/tests/test_base_modelbridge.py
@@ -826,11 +826,11 @@ class BaseAdapterTest(TestCase):
             experiment=experiment,
             model=Generator(),
             search_space=ss2,
-            transforms=[FillMissingParameters],
+            transforms=[],  # FillMissingParameters added by default.
             transform_configs={"FillMissingParameters": {"fill_values": sq_vals}},
         )
         self.assertEqual(
-            [t.__name__ for t in m._raw_transforms], ["Cast", "FillMissingParameters"]
+            [t.__name__ for t in m._raw_transforms], ["FillMissingParameters", "Cast"]
         )
         # All arms are in design now
         self.assertEqual(sum(m.training_in_design), 12)

--- a/ax/modelbridge/transforms/tests/test_cast_transform.py
+++ b/ax/modelbridge/transforms/tests/test_cast_transform.py
@@ -247,3 +247,39 @@ class CastTransformTest(TestCase):
             obsf.metadata.get(Keys.FULL_PARAMETERIZATION),
             self.obs_feats_hss_2.parameters,
         )
+
+    def test_cast_parameter_type_and_none(self) -> None:
+        # This test covers removal of observations with Nones, casting
+        # to correct parameter type and rounding to digits for RangeParameters.
+        search_space = SearchSpace(
+            parameters=[
+                ChoiceParameter(
+                    name="choice",
+                    parameter_type=ParameterType.STRING,
+                    values=["1", "2", "3"],
+                ),
+                RangeParameter(
+                    name="range",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=5.0,
+                    digits=1,
+                ),
+            ]
+        )
+        t = Cast(search_space=search_space)
+        obs_features = [
+            ObservationFeatures(parameters={"choice": None, "range": 5.0}),
+            ObservationFeatures(parameters={"choice": 1, "range": 3}),
+            ObservationFeatures(parameters={"choice": "2", "range": 3.567}),
+        ]
+        tf_obs_features = t.transform_observation_features(
+            observation_features=obs_features
+        )
+        self.assertEqual(
+            tf_obs_features,
+            [
+                ObservationFeatures(parameters={"choice": "1", "range": 3.0}),
+                ObservationFeatures(parameters={"choice": "2", "range": 3.6}),
+            ],
+        )

--- a/ax/models/random/sobol.py
+++ b/ax/models/random/sobol.py
@@ -80,6 +80,7 @@ class SobolGenerator(RandomGenerator):
         fixed_features: dict[int, float] | None = None,
         model_gen_options: TConfig | None = None,
         rounding_func: Callable[[npt.NDArray], npt.NDArray] | None = None,
+        generated_points: npt.NDArray | None = None,
     ) -> tuple[npt.NDArray, npt.NDArray]:
         """Generate new candidates.
 
@@ -93,7 +94,8 @@ class SobolGenerator(RandomGenerator):
                 should be fixed to a particular value during generation.
             rounding_func: A function that rounds an optimization result
                 appropriately (e.g., according to `round-trip` transformations).
-
+            generated_points: A numpy array of shape `n x d` containing the
+                previously generated points to deduplicate against.
         Returns:
             2-element tuple containing
 
@@ -113,6 +115,7 @@ class SobolGenerator(RandomGenerator):
             fixed_features=fixed_features,
             model_gen_options=model_gen_options,
             rounding_func=rounding_func,
+            generated_points=generated_points,
         )
         if self.engine:
             self.init_position = none_throws(self.engine).num_generated

--- a/ax/models/tests/test_random.py
+++ b/ax/models/tests/test_random.py
@@ -29,7 +29,7 @@ class RandomGeneratorTest(TestCase):
         for model in (self.random_model, RandomGenerator(seed=5)):
             state = model._get_state()
             self.assertEqual(state["seed"], model.seed)
-            self.assertEqual(state["generated_points"], model.generated_points)
+            self.assertEqual(state["init_position"], model.init_position)
 
     def test_RandomGeneratorGenSamples(self) -> None:
         with self.assertRaises(NotImplementedError):
@@ -79,12 +79,3 @@ class RandomGeneratorTest(TestCase):
         # pyre-fixme[6]: For 1st param expected `List[Tuple[float, float]]` but got
         #  `None`.
         self.assertEqual(self.random_model._convert_bounds(None), None)
-
-    def test_GetLastPoint(self) -> None:
-        generated_points = np.array([[1, 2, 3], [4, 5, 6]])
-        RandomGeneratorWithPoints = RandomGenerator(generated_points=generated_points)
-        result = RandomGeneratorWithPoints._get_last_point()
-        expected = torch.tensor([[4], [5], [6]])
-        comparison = result == expected
-        # pyre-fixme[16]: `bool` has no attribute `any`.
-        self.assertEqual(comparison.any(), True)

--- a/ax/models/tests/test_sobol.py
+++ b/ax/models/tests/test_sobol.py
@@ -40,12 +40,11 @@ class SobolGeneratorTest(TestCase):
         state = generator._get_state()
         self.assertEqual(state.get("init_position"), 3)
         self.assertEqual(state.get("seed"), generator.seed)
-        self.assertTrue(
-            np.array_equal(
-                state.get("generated_points"),
-                # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtyp...
-                generator.generated_points,
-            )
+        generator.gen(
+            n=3,
+            bounds=bounds,
+            rounding_func=lambda x: x,
+            generated_points=generated_points,
         )
 
     def test_SobolGeneratorFixedSpace(self) -> None:
@@ -78,12 +77,21 @@ class SobolGeneratorTest(TestCase):
             rounding_func=lambda x: x,
         )
         self.assertEqual(np.shape(generated_points), (1, 2))
+        # Errors out if we have already generated the only point.
+        with self.assertRaisesRegex(SearchSpaceExhausted, "Rejection sampling"):
+            generator.gen(
+                n=1,
+                bounds=bounds,
+                fixed_features={0: 1, 1: 2},
+                rounding_func=lambda x: x,
+                generated_points=generated_points,
+            )
 
     def test_SobolGeneratorNoScramble(self) -> None:
         generator = SobolGenerator(scramble=False)
         n_tunable = fixed_param_index = 3
         bounds = self._create_bounds(n_tunable=n_tunable, n_fixed=1)
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=3,
             bounds=bounds,
             fixed_features={fixed_param_index: 1},
@@ -101,20 +109,23 @@ class SobolGeneratorTest(TestCase):
         generator = SobolGenerator(seed=0)
         n_tunable = fixed_param_index = 3
         bounds = self._create_bounds(n_tunable=n_tunable, n_fixed=1)
-        bulk_generated_points, bulk_weights = bulk_generator.gen(
+        bulk_generated_points, _ = bulk_generator.gen(
             n=3,
             bounds=bounds,
             fixed_features={fixed_param_index: 1},
             rounding_func=lambda x: x,
         )
         np_bounds = np.array(bounds)
+        all_generated = np.zeros((0, len(bounds)))
         for expected_points in bulk_generated_points:
             generated_points, weights = generator.gen(
                 n=1,
                 bounds=bounds,
                 fixed_features={fixed_param_index: 1},
                 rounding_func=lambda x: x,
+                generated_points=all_generated,
             )
+            all_generated = np.vstack((all_generated, generated_points))
             self.assertEqual(weights, [1])
             self.assertTrue(np.all(generated_points >= np_bounds[:, 0]))
             self.assertTrue(np.all(generated_points <= np_bounds[:, 1]))
@@ -129,7 +140,7 @@ class SobolGeneratorTest(TestCase):
         bounds = self._create_bounds(n_tunable=n_tunable, n_fixed=1)
         A = np.array([[1, -1, 0, 0], [0, 1, -1, 0], [0, 0, 1, -1]])
         b = np.array([0, 0, 0])
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=3,
             bounds=bounds,
             linear_constraints=(A, b),
@@ -154,7 +165,7 @@ class SobolGeneratorTest(TestCase):
         A = np.array([[1, 1, 0, 0], [0, 1, 1, 0]])
         b = np.array([1, 1])
 
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=3,
             bounds=bounds,
             linear_constraints=(A, b),
@@ -177,14 +188,14 @@ class SobolGeneratorTest(TestCase):
             "botorch.utils.sampling.sample_polytope",
             wraps=sample_polytope,
         ) as wrapped_sampler:
-            generated_points, weights = generator.gen(
+            generated_points, _ = generator.gen(
                 n=3,
                 bounds=bounds,
                 linear_constraints=(A, b),
                 rounding_func=lambda x: x,
             )
         # First call uses the original seed since no candidates are generated.
-        self.assertEqual(wrapped_sampler.call_args[-1]["seed"], 0)
+        self.assertEqual(wrapped_sampler.call_args.kwargs["seed"], 0)
         self.assertTrue(
             "exceeded specified maximum draws" in mock_logger.call_args[0][0]
         )
@@ -200,9 +211,10 @@ class SobolGeneratorTest(TestCase):
                 bounds=bounds,
                 linear_constraints=(A, b),
                 rounding_func=lambda x: x,
+                generated_points=generated_points,
             )
         # Second call uses seed 3 since 3 candidates are already generated.
-        self.assertEqual(wrapped_sampler.call_args[-1]["seed"], 3)
+        self.assertEqual(wrapped_sampler.call_args.kwargs["seed"], 3)
 
     def test_SobolGeneratorFallbackToPolytopeSamplerWithFixedParam(self) -> None:
         # Ten parameters with sum less than 1. In this example, the rejection
@@ -212,7 +224,7 @@ class SobolGeneratorTest(TestCase):
         bounds = self._create_bounds(n_tunable=10, n_fixed=1)
         A = np.insert(np.ones((1, 10)), 10, 0, axis=1)
         b = np.array([1]).reshape((1, 1))
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=3,
             bounds=bounds,
             linear_constraints=(A, b),
@@ -252,6 +264,7 @@ class SobolGeneratorTest(TestCase):
             bounds=bounds,
             fixed_features={fixed_param_index: 1},
             rounding_func=lambda x: x,
+            generated_points=generated_points_first_batch,
         )
 
         generated_points_two_trials = np.vstack(
@@ -268,7 +281,7 @@ class SobolGeneratorTest(TestCase):
     def test_SobolGeneratorBadBounds(self) -> None:
         generator = SobolGenerator()
         with self.assertRaisesRegex(ValueError, "This generator operates on"):
-            generated_points, weights = generator.gen(
+            generator.gen(
                 n=1,
                 bounds=[(-1, 1)],
                 rounding_func=lambda x: x,
@@ -279,7 +292,7 @@ class SobolGeneratorTest(TestCase):
         n_tunable = fixed_param_index = 3
         bounds = self._create_bounds(n_tunable=n_tunable, n_fixed=1)
         with self.assertRaises(SearchSpaceExhausted):
-            generated_points, weights = generator.gen(
+            generator.gen(
                 n=3,
                 bounds=bounds,
                 linear_constraints=(
@@ -295,7 +308,7 @@ class SobolGeneratorTest(TestCase):
         generator = SobolGenerator(seed=0, deduplicate=True)
         n_tunable = fixed_param_index = 3
         bounds = self._create_bounds(n_tunable=n_tunable, n_fixed=1)
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=2,
             bounds=bounds,
             linear_constraints=(
@@ -306,7 +319,7 @@ class SobolGeneratorTest(TestCase):
             rounding_func=lambda x: x,
         )
         self.assertEqual(len(generated_points), 2)
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=1,
             bounds=bounds,
             linear_constraints=(
@@ -317,10 +330,3 @@ class SobolGeneratorTest(TestCase):
             rounding_func=lambda x: x,
         )
         self.assertEqual(len(generated_points), 1)
-        self.assertTrue(
-            np.array_equal(
-                generator._get_state().get("generated_points"),
-                # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtyp...
-                generator.generated_points,
-            )
-        )

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -616,10 +616,10 @@ class SQAStoreTest(TestCase):
             bkw = gr._bridge_kwargs
             self.assertIsNotNone(bkw)
             self.assertEqual(len(bkw), 8)
-            # This has seed, generated points and init position.
+            # This has seed and init position.
             ms = gr._model_state_after_gen
             self.assertIsNotNone(ms)
-            self.assertEqual(len(ms), 3)
+            self.assertEqual(len(ms), 2)
             gm = gr._gen_metadata
             self.assertIsNotNone(gm)
             self.assertEqual(len(gm), 0)


### PR DESCRIPTION
Summary:
`RandomGenerator` was keeping track of generated points, and using them for deduplication regardless of the status of the trials generated using these points. In experiments with discrete spaces and many FAILED trials, this eventually leads to all of the search space being included in `generated_points` and the random node not being able to generate any new candidates.

This diff replaces the logic to instead extract the points to deduplicate against in `RandomAdapter`, using the same utility that controls deduplication in `GeneratioNode` level. The reason for handling deduplication within `RandomGenerator` rather than deferring to `GenerationNode` is that the generators operate on the continuous space and they may generate many duplicates (quite cheaply) before finding a point that is not a duplicate after transforming back to the original space. If we were to rely on `GenerationNode`, we would only be allowed 5 attempts to generate a non-duplicate trial, which may result in quickly falling back to Sobol node to generate another possibly duplicate arm.

Differential Revision: D72331178


