### PR TITLE
Update heterogeneous noise test

### DIFF
--- a/ax/benchmark/tests/test_benchmark_runner.py
+++ b/ax/benchmark/tests/test_benchmark_runner.py
@@ -374,8 +374,8 @@ class TestBenchmarkRunner(TestCase):
             self.assertEqual(res["constraint"]["sem"].item(), 0.05)
 
             with self.subTest("heterogeneous arm weights"):
-                arm_0 = Arm(name="0_0", parameters={"x0": 0.0})
-                arm_1 = Arm(name="0_1", parameters={"x0": 2.0})
+                arm_0 = Arm(name="0_0", parameters={f"x{i}": 0.0 for i in range(6)})
+                arm_1 = Arm(name="0_1", parameters={f"x{i}": 0.5 for i in range(6)})
                 trial = Mock(spec=BatchTrial)
                 trial.arms = [arm_0, arm_1]
                 trial.index = 0


### PR DESCRIPTION
Summary: Separating the Ax and BoTorch changes from D72406752. That this test actually worked is a good example for why we need more validation in the BoTorch test functions. We are basically passing in a 1D input to Hartmann6 that is also outside the `bounds`, but things still run because of broadcasting and lack of validation on the BoTorch side.

Differential Revision: D72513532


