### PR TITLE
Fix Cast.transform_observations

### DIFF
--- a/ax/models/random/sobol.py
+++ b/ax/models/random/sobol.py
@@ -80,6 +80,7 @@ class SobolGenerator(RandomGenerator):
         fixed_features: dict[int, float] | None = None,
         model_gen_options: TConfig | None = None,
         rounding_func: Callable[[npt.NDArray], npt.NDArray] | None = None,
+        generated_points: npt.NDArray | None = None,
     ) -> tuple[npt.NDArray, npt.NDArray]:
         """Generate new candidates.
 
@@ -93,7 +94,8 @@ class SobolGenerator(RandomGenerator):
                 should be fixed to a particular value during generation.
             rounding_func: A function that rounds an optimization result
                 appropriately (e.g., according to `round-trip` transformations).
-
+            generated_points: A numpy array of shape `n x d` containing the
+                previously generated points to deduplicate against.
         Returns:
             2-element tuple containing
 
@@ -113,6 +115,7 @@ class SobolGenerator(RandomGenerator):
             fixed_features=fixed_features,
             model_gen_options=model_gen_options,
             rounding_func=rounding_func,
+            generated_points=generated_points,
         )
         if self.engine:
             self.init_position = none_throws(self.engine).num_generated

--- a/ax/models/tests/test_random.py
+++ b/ax/models/tests/test_random.py
@@ -29,7 +29,7 @@ class RandomGeneratorTest(TestCase):
         for model in (self.random_model, RandomGenerator(seed=5)):
             state = model._get_state()
             self.assertEqual(state["seed"], model.seed)
-            self.assertEqual(state["generated_points"], model.generated_points)
+            self.assertEqual(state["init_position"], model.init_position)
 
     def test_RandomGeneratorGenSamples(self) -> None:
         with self.assertRaises(NotImplementedError):
@@ -79,12 +79,3 @@ class RandomGeneratorTest(TestCase):
         # pyre-fixme[6]: For 1st param expected `List[Tuple[float, float]]` but got
         #  `None`.
         self.assertEqual(self.random_model._convert_bounds(None), None)
-
-    def test_GetLastPoint(self) -> None:
-        generated_points = np.array([[1, 2, 3], [4, 5, 6]])
-        RandomGeneratorWithPoints = RandomGenerator(generated_points=generated_points)
-        result = RandomGeneratorWithPoints._get_last_point()
-        expected = torch.tensor([[4], [5], [6]])
-        comparison = result == expected
-        # pyre-fixme[16]: `bool` has no attribute `any`.
-        self.assertEqual(comparison.any(), True)

--- a/ax/models/tests/test_sobol.py
+++ b/ax/models/tests/test_sobol.py
@@ -40,12 +40,11 @@ class SobolGeneratorTest(TestCase):
         state = generator._get_state()
         self.assertEqual(state.get("init_position"), 3)
         self.assertEqual(state.get("seed"), generator.seed)
-        self.assertTrue(
-            np.array_equal(
-                state.get("generated_points"),
-                # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtyp...
-                generator.generated_points,
-            )
+        generator.gen(
+            n=3,
+            bounds=bounds,
+            rounding_func=lambda x: x,
+            generated_points=generated_points,
         )
 
     def test_SobolGeneratorFixedSpace(self) -> None:
@@ -78,12 +77,21 @@ class SobolGeneratorTest(TestCase):
             rounding_func=lambda x: x,
         )
         self.assertEqual(np.shape(generated_points), (1, 2))
+        # Errors out if we have already generated the only point.
+        with self.assertRaisesRegex(SearchSpaceExhausted, "Rejection sampling"):
+            generator.gen(
+                n=1,
+                bounds=bounds,
+                fixed_features={0: 1, 1: 2},
+                rounding_func=lambda x: x,
+                generated_points=generated_points,
+            )
 
     def test_SobolGeneratorNoScramble(self) -> None:
         generator = SobolGenerator(scramble=False)
         n_tunable = fixed_param_index = 3
         bounds = self._create_bounds(n_tunable=n_tunable, n_fixed=1)
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=3,
             bounds=bounds,
             fixed_features={fixed_param_index: 1},
@@ -101,20 +109,23 @@ class SobolGeneratorTest(TestCase):
         generator = SobolGenerator(seed=0)
         n_tunable = fixed_param_index = 3
         bounds = self._create_bounds(n_tunable=n_tunable, n_fixed=1)
-        bulk_generated_points, bulk_weights = bulk_generator.gen(
+        bulk_generated_points, _ = bulk_generator.gen(
             n=3,
             bounds=bounds,
             fixed_features={fixed_param_index: 1},
             rounding_func=lambda x: x,
         )
         np_bounds = np.array(bounds)
+        all_generated = np.zeros((0, len(bounds)))
         for expected_points in bulk_generated_points:
             generated_points, weights = generator.gen(
                 n=1,
                 bounds=bounds,
                 fixed_features={fixed_param_index: 1},
                 rounding_func=lambda x: x,
+                generated_points=all_generated,
             )
+            all_generated = np.vstack((all_generated, generated_points))
             self.assertEqual(weights, [1])
             self.assertTrue(np.all(generated_points >= np_bounds[:, 0]))
             self.assertTrue(np.all(generated_points <= np_bounds[:, 1]))
@@ -129,7 +140,7 @@ class SobolGeneratorTest(TestCase):
         bounds = self._create_bounds(n_tunable=n_tunable, n_fixed=1)
         A = np.array([[1, -1, 0, 0], [0, 1, -1, 0], [0, 0, 1, -1]])
         b = np.array([0, 0, 0])
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=3,
             bounds=bounds,
             linear_constraints=(A, b),
@@ -154,7 +165,7 @@ class SobolGeneratorTest(TestCase):
         A = np.array([[1, 1, 0, 0], [0, 1, 1, 0]])
         b = np.array([1, 1])
 
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=3,
             bounds=bounds,
             linear_constraints=(A, b),
@@ -177,14 +188,14 @@ class SobolGeneratorTest(TestCase):
             "botorch.utils.sampling.sample_polytope",
             wraps=sample_polytope,
         ) as wrapped_sampler:
-            generated_points, weights = generator.gen(
+            generated_points, _ = generator.gen(
                 n=3,
                 bounds=bounds,
                 linear_constraints=(A, b),
                 rounding_func=lambda x: x,
             )
         # First call uses the original seed since no candidates are generated.
-        self.assertEqual(wrapped_sampler.call_args[-1]["seed"], 0)
+        self.assertEqual(wrapped_sampler.call_args.kwargs["seed"], 0)
         self.assertTrue(
             "exceeded specified maximum draws" in mock_logger.call_args[0][0]
         )
@@ -200,9 +211,10 @@ class SobolGeneratorTest(TestCase):
                 bounds=bounds,
                 linear_constraints=(A, b),
                 rounding_func=lambda x: x,
+                generated_points=generated_points,
             )
         # Second call uses seed 3 since 3 candidates are already generated.
-        self.assertEqual(wrapped_sampler.call_args[-1]["seed"], 3)
+        self.assertEqual(wrapped_sampler.call_args.kwargs["seed"], 3)
 
     def test_SobolGeneratorFallbackToPolytopeSamplerWithFixedParam(self) -> None:
         # Ten parameters with sum less than 1. In this example, the rejection
@@ -212,7 +224,7 @@ class SobolGeneratorTest(TestCase):
         bounds = self._create_bounds(n_tunable=10, n_fixed=1)
         A = np.insert(np.ones((1, 10)), 10, 0, axis=1)
         b = np.array([1]).reshape((1, 1))
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=3,
             bounds=bounds,
             linear_constraints=(A, b),
@@ -252,6 +264,7 @@ class SobolGeneratorTest(TestCase):
             bounds=bounds,
             fixed_features={fixed_param_index: 1},
             rounding_func=lambda x: x,
+            generated_points=generated_points_first_batch,
         )
 
         generated_points_two_trials = np.vstack(
@@ -268,7 +281,7 @@ class SobolGeneratorTest(TestCase):
     def test_SobolGeneratorBadBounds(self) -> None:
         generator = SobolGenerator()
         with self.assertRaisesRegex(ValueError, "This generator operates on"):
-            generated_points, weights = generator.gen(
+            generator.gen(
                 n=1,
                 bounds=[(-1, 1)],
                 rounding_func=lambda x: x,
@@ -279,7 +292,7 @@ class SobolGeneratorTest(TestCase):
         n_tunable = fixed_param_index = 3
         bounds = self._create_bounds(n_tunable=n_tunable, n_fixed=1)
         with self.assertRaises(SearchSpaceExhausted):
-            generated_points, weights = generator.gen(
+            generator.gen(
                 n=3,
                 bounds=bounds,
                 linear_constraints=(
@@ -295,7 +308,7 @@ class SobolGeneratorTest(TestCase):
         generator = SobolGenerator(seed=0, deduplicate=True)
         n_tunable = fixed_param_index = 3
         bounds = self._create_bounds(n_tunable=n_tunable, n_fixed=1)
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=2,
             bounds=bounds,
             linear_constraints=(
@@ -306,7 +319,7 @@ class SobolGeneratorTest(TestCase):
             rounding_func=lambda x: x,
         )
         self.assertEqual(len(generated_points), 2)
-        generated_points, weights = generator.gen(
+        generated_points, _ = generator.gen(
             n=1,
             bounds=bounds,
             linear_constraints=(
@@ -317,10 +330,3 @@ class SobolGeneratorTest(TestCase):
             rounding_func=lambda x: x,
         )
         self.assertEqual(len(generated_points), 1)
-        self.assertTrue(
-            np.array_equal(
-                generator._get_state().get("generated_points"),
-                # pyre-fixme[6]: For 2nd argument expected `Union[_SupportsArray[dtyp...
-                generator.generated_points,
-            )
-        )

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -616,10 +616,10 @@ class SQAStoreTest(TestCase):
             bkw = gr._bridge_kwargs
             self.assertIsNotNone(bkw)
             self.assertEqual(len(bkw), 8)
-            # This has seed, generated points and init position.
+            # This has seed and init position.
             ms = gr._model_state_after_gen
             self.assertIsNotNone(ms)
-            self.assertEqual(len(ms), 3)
+            self.assertEqual(len(ms), 2)
             gm = gr._gen_metadata
             self.assertIsNotNone(gm)
             self.assertEqual(len(gm), 0)


### PR DESCRIPTION
Summary:
In D72400250, we started dropping observation features with `None`s in `Cast.transform_observation_features`. This doesn't play well with base `Transform.transform_observations` implementation, since the observation data is unmodified and re-construction of the `Observation` objects fails due to lists of unequal lengths.
This diff fixes the issue by implementing `Cast.transform_observations` that processes each observation in a loop, dropping it completely if the features are dropped. The looping here is ok (will probably go away with the larger refactor) since the underlying transform logic also loops over the objects to process them.

Reviewed By: Balandat

Differential Revision: D72568516
