### PR TITLE
Speed up Data/MapData operations

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from abc import abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from hashlib import md5
 from io import StringIO
@@ -50,11 +50,14 @@ class BaseData(Base, SerializationMixin):
 
     REQUIRED_COLUMNS = {"arm_name"}
 
+    # Note on text data: https://pandas.pydata.org/docs/user_guide/text.html
+    # Its type can either be `numpy.dtypes.ObjectDType` or StringDtype extension
+    # type; the later is still experimental. So we are using object.
     COLUMN_DATA_TYPES: dict[str, Any] = {
         # Ubiquitous columns.
-        "arm_name": str,
+        "arm_name": np.dtype("O"),
         # Metric data-related columns.
-        "metric_name": str,
+        "metric_name": np.dtype("O"),
         "mean": np.float64,
         "sem": np.float64,
         # Metadata columns available for all subclasses.
@@ -65,7 +68,7 @@ class BaseData(Base, SerializationMixin):
         # Metadata columns available for only some subclasses.
         "frac_nonnull": np.float64,
         "random_split": int,
-        "fidelities": str,  # Dictionary stored as json
+        "fidelities": np.dtype("O"),  # Dictionary stored as json
     }
 
     _df: pd.DataFrame
@@ -101,12 +104,12 @@ class BaseData(Base, SerializationMixin):
             extra_columns = columns - self.supported_columns()
             if extra_columns:
                 raise ValueError(f"Columns {list(extra_columns)} are not supported.")
-            df = df.dropna(axis=0, how="all").reset_index(drop=True)
+            df = df.dropna(axis=0, how="all", ignore_index=True)
             df = self._safecast_df(df=df)
 
             # Reorder the columns for easier viewing
             col_order = [c for c in self.column_data_types() if c in df.columns]
-            self._df = df[col_order]
+            self._df = df.reindex(columns=col_order, copy=False)
 
         self.description = description
 
@@ -116,7 +119,7 @@ class BaseData(Base, SerializationMixin):
         df: pd.DataFrame,
         # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
         #  `typing.Type` to avoid runtime subscripting errors.
-        extra_column_types: dict[str, type] | None = None,
+        extra_column_types: Mapping[str, type] | None = None,
     ) -> pd.DataFrame:
         """Function for safely casting df to standard data types.
 
@@ -132,22 +135,18 @@ class BaseData(Base, SerializationMixin):
             safe_df: DataFrame cast to standard dtypes.
 
         """
-        extra_column_types = extra_column_types or {}
-        dtype = {
-            # Pandas timestamp handlng is weird
-            col: "datetime64[ns]" if coltype is pd.Timestamp else coltype
-            for col, coltype in cls.column_data_types(
-                extra_column_types=extra_column_types
-            ).items()
-            if col in df.columns.values
-            and not (
-                cls.column_data_types(extra_column_types)[col] is int
-                and df.loc[:, col].isnull().any()
-            )
-            and coltype is not Any
-        }
-
-        return assert_is_instance(df.astype(dtype=dtype), pd.DataFrame)
+        dtypes = df.dtypes
+        for col, coltype in cls.column_data_types(
+            extra_column_types=extra_column_types
+        ).items():
+            if col in df.columns.values and coltype is not Any:
+                # Pandas timestamp handlng is weird
+                dtype = "datetime64[ns]" if coltype is pd.Timestamp else coltype
+                if (dtype != dtypes[col]) and not (
+                    coltype is int and df.loc[:, col].isnull().any()
+                ):
+                    df[col] = df[col].astype(dtype)
+        return df
 
     @classmethod
     def required_columns(cls) -> set[str]:
@@ -170,7 +169,7 @@ class BaseData(Base, SerializationMixin):
         cls,
         # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
         #  `typing.Type` to avoid runtime subscripting errors.
-        extra_column_types: dict[str, type] | None = None,
+        extra_column_types: Mapping[str, type] | None = None,
         excluded_columns: Iterable[str] | None = None,
         # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
         #  `typing.Type` to avoid runtime subscripting errors.
@@ -297,9 +296,9 @@ class BaseData(Base, SerializationMixin):
     @classmethod
     def from_evaluations(
         cls: type[TBaseData],
-        evaluations: dict[str, TTrialEvaluation],
+        evaluations: Mapping[str, TTrialEvaluation],
         trial_index: int,
-        sample_sizes: dict[str, int] | None = None,
+        sample_sizes: Mapping[str, int] | None = None,
         start_time: int | str | None = None,
         end_time: int | str | None = None,
     ) -> TBaseData:
@@ -336,16 +335,16 @@ class BaseData(Base, SerializationMixin):
     @staticmethod
     @abstractmethod
     def _get_records(
-        evaluations: dict[str, TTrialEvaluation], trial_index: int
+        evaluations: Mapping[str, TTrialEvaluation], trial_index: int
     ) -> list[dict[str, Any]]:
         pass
 
     @classmethod
     def from_fidelity_evaluations(
         cls: type[TBaseData],
-        evaluations: dict[str, TFidelityTrialEvaluation],
+        evaluations: Mapping[str, TFidelityTrialEvaluation],
         trial_index: int,
-        sample_sizes: dict[str, int] | None = None,
+        sample_sizes: Mapping[str, int] | None = None,
         start_time: int | None = None,
         end_time: int | None = None,
     ) -> TBaseData:
@@ -381,14 +380,14 @@ class BaseData(Base, SerializationMixin):
     @staticmethod
     @abstractmethod
     def _get_fidelity_records(
-        evaluations: dict[str, TFidelityTrialEvaluation], trial_index: int
+        evaluations: Mapping[str, TFidelityTrialEvaluation], trial_index: int
     ) -> list[dict[str, Any]]:
         pass
 
     @staticmethod
     def _add_cols_to_records(
         records: list[dict[str, Any]],
-        sample_sizes: dict[str, int] | None = None,
+        sample_sizes: Mapping[str, int] | None = None,
         start_time: int | str | None = None,
         end_time: int | str | None = None,
     ) -> list[dict[str, Any]]:
@@ -450,7 +449,7 @@ class Data(BaseData):
 
     @staticmethod
     def _get_records(
-        evaluations: dict[str, TTrialEvaluation], trial_index: int
+        evaluations: Mapping[str, TTrialEvaluation], trial_index: int
     ) -> list[dict[str, Any]]:
         return [
             {
@@ -466,7 +465,7 @@ class Data(BaseData):
 
     @staticmethod
     def _get_fidelity_records(
-        evaluations: dict[str, TFidelityTrialEvaluation], trial_index: int
+        evaluations: Mapping[str, TFidelityTrialEvaluation], trial_index: int
     ) -> list[dict[str, Any]]:
         return [
             {
@@ -571,7 +570,7 @@ def _ms_epoch_to_isoformat(epoch: int) -> str:
 def custom_data_class(
     # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
     #  `typing.Type` to avoid runtime subscripting errors.
-    column_data_types: dict[str, type] | None = None,
+    column_data_types: Mapping[str, type] | None = None,
     required_columns: set[str] | None = None,
     time_columns: set[str] | None = None,
 ) -> type[Data]:
@@ -596,7 +595,7 @@ def custom_data_class(
 
         @classmethod
         def column_data_types(
-            cls, extra_column_types: dict[str, type] | None = None
+            cls, extra_column_types: Mapping[str, type] | None = None
         ) -> dict[str, type]:
             return super().column_data_types(
                 {**(extra_column_types or {}), **(column_data_types or {})}

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -783,7 +783,7 @@ class Experiment(Base):
             )
         data_type = type(data)
         data_init_args = data.deserialize_init_args(data.serialize_init_args(data))
-        if data.df.empty:
+        if data.true_df.empty:
             raise ValueError("Data to attach is empty.")
         metrics_not_on_exp = set(data.true_df["metric_name"].values) - set(
             self.metrics.keys()
@@ -820,7 +820,13 @@ class Experiment(Base):
             elif overwrite_existing_data:
                 if len(current_trial_data) > 0:
                     _, last_data = list(current_trial_data.items())[-1]
-                    last_data_metrics = set(last_data.df["metric_name"])
+                    # It may seem odd to use `true_df` here, because with
+                    # MapData, `df` is shorter, and since it is cached, it won't
+                    # be constructed too often. However, constructing MapData's
+                    # `df` is sufficiently expensive due to the groupby-apply
+                    # and sort operations needed that using `true_df` is much
+                    # faster even if repeated many times.
+                    last_data_metrics = set(last_data.true_df["metric_name"])
                     new_data_metrics = set(trial_df["metric_name"])
                     difference = last_data_metrics.difference(new_data_metrics)
                     if len(difference) > 0:

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -431,7 +431,7 @@ def get_feature_cols(data: Data) -> list[str]:
     Returns:
         A list of column names to be used to group observations.
     """
-    feature_cols = OBS_COLS.intersection(data.df.columns)
+    feature_cols = OBS_COLS.intersection(data.true_df.columns)
     if isinstance(data, MapData):
         feature_cols = feature_cols.union(data.map_keys)
 


### PR DESCRIPTION
Summary:
Alltogether, these changes result in a 73% decrease in runtime (from 318s to 85s) on a benchmark where nearly all of the time is spent managing data. These benefits will be larger as data grows due to removing expensive grouping and sorting operations.

Changes:
* [30% speedup] In `BaseData._safecast_df`, only convert columns if they are not already the appropriate type. The previous behavior, using `df.astype(dtype=dtype)`, always made a copy even if the dtypes were already correct
    * Mark the correct type for string types to be "object" -- this is what `astype(str)` results in, and is needed to make checking that columns are already the correct type work. I added a comment on why we shouldn't (IMO) switch to StringDtype, which is has an experimental API that is subject to change.
* [25% speedup] In some data-fetching operations, use `[Data, MapData].true_df` in place of `.df`, because calling `df` is very expensive for MapData
* [13% speedup] In MapData.__init__, only
    * When constructing an empty df, do it with the columns already of the right dtype and in the right order (this is probably minor)
    * Before dropping rows that are all null, `check if trial_index` has any nulls -- this has a large effect in this example where there are no nulls
    * Use `reindex` to reorder columns


Potential follow-ups:
* `BaseData._safecast_df` now mutates the DataFrame in place. It would be best to change its return type to `None`.
* There could be some speedup by using `sort=False` with `MapData.df`, but to do that we might want to separate out an intermediate "_df" that has unsorted columns from
* Reordering columns is expensive. We might want to warn if they are passed in the wrong order (although this is probably only a highly helpful and actionable warning for benchmarking)

Reviewed By: saitcakmak

Differential Revision: D72489384


