### PR TITLE
Implement DefaultRBFKernel for easy customizability

### DIFF
--- a/ax/models/torch/tests/test_covar_modules_argparse.py
+++ b/ax/models/torch/tests/test_covar_modules_argparse.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import torch
+from ax.exceptions.core import UserInputError
 from ax.models.torch.botorch_modular.input_constructors.covar_modules import (
     covar_module_argparse,
 )
-from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
+from ax.models.torch.botorch_modular.kernels import DefaultRBFKernel, ScaleMaternKernel
 from ax.utils.common.testutils import TestCase
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.multitask import MultiTaskGP
@@ -152,3 +153,41 @@ class CovarModuleArgparseTest(TestCase):
         )
 
         self.assertEqual(covar_module_kwargs["batch_shape"], torch.Size([]))
+
+    def test_argparse_default_rbf(self) -> None:
+        with self.assertRaisesRegex(UserInputError, "Only one of"):
+            covar_module_argparse(
+                DefaultRBFKernel,
+                botorch_model_class=SingleTaskGP,
+                dataset=self.dataset,
+                inactive_features=["x1"],
+                active_dims=[0],
+            )
+        # Test with inactive features.
+        covar_module_kwargs = covar_module_argparse(
+            DefaultRBFKernel,
+            botorch_model_class=SingleTaskGP,
+            dataset=self.dataset,
+            inactive_features=["x9"],
+        )
+        expected = {
+            "active_dims": list(range(9)),
+            "batch_shape": torch.Size([2]),  # For 2 outputs.
+            "ard_num_dims": 9,
+        }
+        self.assertEqual(covar_module_kwargs, expected)
+        # Test other inputs.
+        covar_module_kwargs = covar_module_argparse(
+            DefaultRBFKernel,
+            botorch_model_class=SingleTaskGP,
+            dataset=self.dataset,
+            active_dims=[-3, -2],
+            ard_num_dims=1,
+            batch_shape=torch.Size([]),
+        )
+        expected = {
+            "active_dims": [7, 8],
+            "batch_shape": torch.Size([]),
+            "ard_num_dims": 1,
+        }
+        self.assertEqual(covar_module_kwargs, expected)

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -12,7 +12,7 @@ import torch
 
 # Ax `Acquisition` & other MBM imports
 from ax.models.torch.botorch_modular.acquisition import Acquisition
-from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
+from ax.models.torch.botorch_modular.kernels import DefaultRBFKernel, ScaleMaternKernel
 from ax.models.torch.botorch_modular.sebo import SEBOAcquisition
 
 # BoTorch `AcquisitionFunction` imports
@@ -165,6 +165,7 @@ KERNEL_REGISTRY: dict[type[Kernel], str] = {
     LinearKernel: "LinearKernel",
     ScaleMaternKernel: "ScaleMaternKernel",
     RBFKernel: "RBFKernel",
+    DefaultRBFKernel: "DefaultRBFKernel",
 }
 
 LIKELIHOOD_REGISTRY: dict[type[GaussianLikelihood], str] = {

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -100,10 +100,14 @@ from ax.metrics.factorial import FactorialMetric
 from ax.metrics.hartmann6 import Hartmann6Metric
 from ax.modelbridge.factory import Cont_X_trans, Generators, get_factorial, get_sobol
 from ax.models.torch.botorch_modular.acquisition import Acquisition
-from ax.models.torch.botorch_modular.kernels import ScaleMaternKernel
+from ax.models.torch.botorch_modular.kernels import DefaultRBFKernel, ScaleMaternKernel
 from ax.models.torch.botorch_modular.model import BoTorchGenerator
 from ax.models.torch.botorch_modular.sebo import SEBOAcquisition
-from ax.models.torch.botorch_modular.surrogate import Surrogate, SurrogateSpec
+from ax.models.torch.botorch_modular.surrogate import (
+    ModelConfig,
+    Surrogate,
+    SurrogateSpec,
+)
 from ax.models.winsorization_config import WinsorizationConfig
 from ax.runners.synthetic import SyntheticRunner
 from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
@@ -2369,7 +2373,15 @@ def get_botorch_model_with_default_acquisition_class() -> BoTorchGenerator:
 def get_botorch_model_with_surrogate_specs() -> BoTorchGenerator:
     return BoTorchGenerator(
         surrogate_specs={
-            "name": SurrogateSpec(botorch_model_kwargs={"some_option": "some_value"})
+            "name": SurrogateSpec(
+                model_configs=[
+                    ModelConfig(
+                        model_options={"some_option": "some_value"},
+                        covar_module_class=DefaultRBFKernel,
+                        covar_module_options={"inactive_features": []},
+                    )
+                ]
+            )
         }
     )
 


### PR DESCRIPTION
Summary: Implements `DefaultRBFKernel`, a simple subclass of `RBFKernel` that allows easy customization of arguments like `active_dims` while using the default BoTorch priors (which are kinda messy to specify).

Differential Revision: D72053896


