### PR TITLE
Produce a FAILED HealtheckAnalysisCard an exception occurs computing a healthcheck

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable
-from enum import IntEnum
+from enum import Enum, IntEnum
 from logging import Logger
 from typing import Any, Protocol, Sequence
 
@@ -81,6 +81,14 @@ class AnalysisCardCategory(IntEnum):
     INFO = 4
 
 
+class AnalysisBlobAnnotation(Enum):
+    DATAFRAME = "dataframe"
+    PLOTLY = "plotly"
+    MARKDOWN = "markdown"
+    HEALTHCHECK = "healthcheck"
+    ERROR = "error"
+
+
 class AnalysisCard(Base):
     # Name of the analysis computed, usually the class name of the Analysis which
     # produced the card. Useful for grouping by when querying a large collection of
@@ -108,7 +116,7 @@ class AnalysisCard(Base):
     # grouping the cards to display only one category in notebook environments.
     category: int
     # How to interpret the blob (ex. "dataframe", "plotly", "markdown")
-    blob_annotation = "dataframe"
+    blob_annotation: AnalysisBlobAnnotation = AnalysisBlobAnnotation.DATAFRAME
 
     # Singleton for tracking whether this is the first time the AnalysisCard is being
     # initialized. This is used to control whether the custom IPython Formatter

--- a/ax/analysis/healthcheck/healthcheck_analysis.py
+++ b/ax/analysis/healthcheck/healthcheck_analysis.py
@@ -5,10 +5,20 @@
 
 # pyre-strict
 import json
+import traceback
 from enum import IntEnum
 from typing import Sequence
 
-from ax.analysis.analysis import Analysis, AnalysisBlobAnnotation, AnalysisCard
+import pandas as pd
+
+from ax.analysis.analysis import (
+    Analysis,
+    AnalysisBlobAnnotation,
+    AnalysisCard,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+    AnalysisE,
+)
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
@@ -28,10 +38,41 @@ class HealthcheckAnalysisCard(AnalysisCard):
         return HealthcheckStatus(json.loads(self.blob)["status"])
 
 
+class HealthcheckAnalysisE(AnalysisE):
+    def error_card(self) -> list[AnalysisCard]:
+        exception_stack_trace = "".join(
+            traceback.format_exception(
+                type(self.exception),
+                self.exception,
+                self.exception.__traceback__,
+            )
+        )
+        return [
+            HealthcheckAnalysisCard(
+                name=self.analysis.name,
+                title=f"{self.analysis.name} Error",
+                subtitle=(
+                    f"An error occurred while computing {self.analysis}:\n"
+                    f"{exception_stack_trace}"
+                ),
+                attributes=self.analysis.attributes,
+                blob=json.dumps({"status": HealthcheckStatus.FAIL}),
+                df=pd.DataFrame(),
+                level=AnalysisCardLevel.DEBUG,
+                category=AnalysisCardCategory.ERROR,
+            )
+        ]
+
+
 class HealthcheckAnalysis(Analysis):
     """
     An analysis that performs a health check.
     """
+
+    """
+    For HealthcheckAnalysis, generate a HealthcheckAnalysisCard with FAIL status.
+    """
+    exception_class: type[AnalysisE] = HealthcheckAnalysisE
 
     @override
     def compute(

--- a/ax/analysis/healthcheck/healthcheck_analysis.py
+++ b/ax/analysis/healthcheck/healthcheck_analysis.py
@@ -8,7 +8,7 @@ import json
 from enum import IntEnum
 from typing import Sequence
 
-from ax.analysis.analysis import Analysis, AnalysisCard
+from ax.analysis.analysis import Analysis, AnalysisBlobAnnotation, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
@@ -22,7 +22,7 @@ class HealthcheckStatus(IntEnum):
 
 
 class HealthcheckAnalysisCard(AnalysisCard):
-    blob_annotation = "healthcheck"
+    blob_annotation: AnalysisBlobAnnotation = AnalysisBlobAnnotation.HEALTHCHECK
 
     def get_status(self) -> HealthcheckStatus:
         return HealthcheckStatus(json.loads(self.blob)["status"])

--- a/ax/analysis/healthcheck/tests/test_healtheck_exception.py
+++ b/ax/analysis/healthcheck/tests/test_healtheck_exception.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import cast, Sequence
+
+from ax.analysis.analysis import AnalysisBlobAnnotation
+from ax.analysis.healthcheck.healthcheck_analysis import (
+    HealthcheckAnalysis,
+    HealthcheckAnalysisCard,
+    HealthcheckStatus,
+)
+from ax.core.experiment import Experiment
+from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
+from ax.utils.common.testutils import TestCase
+
+ERROR_MESSAGE = "Dummy analysis failed!"
+
+
+class TestHealtheckException(TestCase):
+    class DummyAnalysis(HealthcheckAnalysis):
+        def compute(
+            self,
+            experiment: Experiment | None = None,
+            generation_strategy: GenerationStrategy | None = None,
+            adapter: Adapter | None = None,
+        ) -> Sequence[HealthcheckAnalysisCard]:
+            raise ValueError(ERROR_MESSAGE)
+
+    def test_error_analysis_card_on_exception(self) -> None:
+        analysis = self.DummyAnalysis()
+        with self.assertLogs("ax.analysis.analysis", "ERROR") as logs:
+            analysis_cards = analysis.compute_result().unwrap_or_else(
+                lambda e: e.error_card()
+            )
+        # Check that the error message is logged
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn(ERROR_MESSAGE, logs.output[0])
+
+        # Check that a failed healtheck analysis card is produced
+        self.assertEqual(len(analysis_cards), 1)
+        analysis_card = analysis_cards[0]
+        self.assertEqual(
+            analysis_card.blob_annotation, AnalysisBlobAnnotation.HEALTHCHECK
+        )
+        self.assertEqual(type(analysis_card), HealthcheckAnalysisCard)
+        self.assertEqual(
+            (cast(HealthcheckAnalysisCard, analysis_card)).get_status(),
+            HealthcheckStatus.FAIL,
+        )
+
+        # Check that error message is in the analysis card
+        self.assertEqual(analysis_card.name, "DummyAnalysis")
+        self.assertEqual(analysis_card.title, "DummyAnalysis Error")
+        self.assertIn(ERROR_MESSAGE, analysis_card.subtitle)

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -14,6 +14,7 @@ import markdown
 import pandas as pd
 from ax.analysis.analysis import (
     Analysis,
+    AnalysisBlobAnnotation,
     AnalysisCard,
     AnalysisCardCategory,
     AnalysisCardLevel,
@@ -27,7 +28,7 @@ from pyre_extensions import override
 
 
 class MarkdownAnalysisCard(AnalysisCard):
-    blob_annotation = "markdown"
+    blob_annotation: AnalysisBlobAnnotation = AnalysisBlobAnnotation.MARKDOWN
 
     def get_markdown(self) -> str:
         return self.blob

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -6,20 +6,12 @@
 # pyre-strict
 
 
-import traceback
 from typing import Sequence
 
 import markdown
 
 import pandas as pd
-from ax.analysis.analysis import (
-    Analysis,
-    AnalysisBlobAnnotation,
-    AnalysisCard,
-    AnalysisCardCategory,
-    AnalysisCardLevel,
-    AnalysisE,
-)
+from ax.analysis.analysis import Analysis, AnalysisBlobAnnotation, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
@@ -76,26 +68,3 @@ class MarkdownAnalysis(Analysis):
             blob=message,
             category=category,
         )
-
-
-def markdown_analysis_card_from_analysis_e(
-    analysis_e: AnalysisE,
-) -> list[MarkdownAnalysisCard]:
-    return [
-        MarkdownAnalysisCard(
-            name=analysis_e.analysis.name,
-            title=f"{analysis_e.analysis.name} Error",
-            subtitle=f"An error occurred while computing {analysis_e.analysis}",
-            attributes=analysis_e.analysis.attributes,
-            blob="".join(
-                traceback.format_exception(
-                    type(analysis_e.exception),
-                    analysis_e.exception,
-                    analysis_e.exception.__traceback__,
-                )
-            ),
-            df=pd.DataFrame(),
-            level=AnalysisCardLevel.DEBUG,
-            category=AnalysisCardCategory.ERROR,
-        )
-    ]

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -9,7 +9,7 @@
 from typing import Sequence
 
 import pandas as pd
-from ax.analysis.analysis import Analysis, AnalysisCard
+from ax.analysis.analysis import Analysis, AnalysisBlobAnnotation, AnalysisCard
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge.base import Adapter
@@ -40,7 +40,7 @@ body_html_template = """
 
 
 class PlotlyAnalysisCard(AnalysisCard):
-    blob_annotation = "plotly"
+    blob_annotation: AnalysisBlobAnnotation = AnalysisBlobAnnotation.PLOTLY
 
     def get_figure(self) -> go.Figure:
         return pio.from_json(self.blob)

--- a/ax/analysis/plotly/surface/tests/test_contour.py
+++ b/ax/analysis/plotly/surface/tests/test_contour.py
@@ -5,7 +5,11 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.plotly.surface.contour import ContourPlot
 from ax.core.trial import Trial
 from ax.exceptions.core import UserInputError
@@ -97,7 +101,7 @@ class TestContourPlot(TestCase):
             },
         )
         self.assertIsNotNone(card.blob)
-        self.assertEqual(card.blob_annotation, "plotly")
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
 
         # Assert that any row where sampled is True has a value of x that is
         # sampled in at least one trial.

--- a/ax/analysis/plotly/surface/tests/test_slice.py
+++ b/ax/analysis/plotly/surface/tests/test_slice.py
@@ -5,7 +5,11 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.plotly.surface.slice import SlicePlot
 from ax.core.trial import Trial
 from ax.exceptions.core import UserInputError
@@ -80,7 +84,7 @@ class TestSlicePlot(TestCase):
             {"x", "bar_mean", "bar_sem", "sampled"},
         )
         self.assertIsNotNone(card.blob)
-        self.assertEqual(card.blob_annotation, "plotly")
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
 
         # Assert that any row where sampled is True has a value of x that is
         # sampled in at least one trial.

--- a/ax/analysis/plotly/tests/test_cross_validation.py
+++ b/ax/analysis/plotly/tests/test_cross_validation.py
@@ -5,7 +5,11 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.plotly.cross_validation import (
     cross_validation_adhoc_compute,
     CrossValidationPlot,
@@ -85,7 +89,7 @@ class TestCrossValidationPlot(TestCase):
             {"arm_name", "observed", "observed_95_ci", "predicted", "predicted_95_ci"},
         )
         self.assertIsNotNone(card.blob)
-        self.assertEqual(card.blob_annotation, "plotly")
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
         # Assert that all arms are in the cross validation df
         # because trial index is not specified
         for t in self.client.experiment.trials.values():

--- a/ax/analysis/plotly/tests/test_parallel_coordinates.py
+++ b/ax/analysis/plotly/tests/test_parallel_coordinates.py
@@ -6,7 +6,11 @@
 # pyre-strict
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.plotly.parallel_coordinates import (
     _get_parameter_dimension,
     ParallelCoordinatesPlot,
@@ -55,7 +59,7 @@ class TestParallelCoordinatesPlot(TestCase):
             {*card.df.columns}, {"trial_index", "arm_name", "branin", "x1", "x2"}
         )
         self.assertIsNotNone(card.blob)
-        self.assertEqual(card.blob_annotation, "plotly")
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
 
         analysis_no_metric = ParallelCoordinatesPlot()
         _ = analysis_no_metric.compute(experiment=experiment)

--- a/ax/analysis/plotly/tests/test_predicted_effects.py
+++ b/ax/analysis/plotly/tests/test_predicted_effects.py
@@ -9,7 +9,11 @@ from unittest.mock import patch
 
 import torch
 
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.plotly.arm_effects.predicted_effects import PredictedEffectsPlot
 from ax.analysis.plotly.arm_effects.utils import get_predictions_by_arm
 from ax.core.observation import ObservationFeatures
@@ -150,7 +154,7 @@ class TestPredictedEffectsPlot(TestCase):
                     },
                 )
                 self.assertIsNotNone(card.blob)
-                self.assertEqual(card.blob_annotation, "plotly")
+                self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
                 for trial in experiment.trials.values():
                     for arm in trial.arms:
                         self.assertIn(arm.name, card.df["arm_name"].unique())

--- a/ax/analysis/plotly/tests/test_progression.py
+++ b/ax/analysis/plotly/tests/test_progression.py
@@ -6,7 +6,11 @@
 # pyre-strict
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.plotly.progression import (
     _calculate_wallclock_timeseries,
     ProgressionPlot,
@@ -49,7 +53,7 @@ class TestProgression(TestCase):
         )
 
         self.assertIsNotNone(card.blob)
-        self.assertEqual(card.blob_annotation, "plotly")
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
 
     def test_calculate_wallclock_timeseries(self) -> None:
         experiment = get_test_map_data_experiment(

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -5,7 +5,11 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.plotly.scatter import _prepare_data, scatter_plot, ScatterPlot
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.modelbridge.registry import Generators
@@ -67,7 +71,7 @@ class TestScatterPlot(TestCase):
             },
         )
         self.assertIsNotNone(card.blob)
-        self.assertEqual(card.blob_annotation, "plotly")
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
 
     @mock_botorch_optimize
     def test_adhoc_scatter(self) -> None:
@@ -86,7 +90,7 @@ class TestScatterPlot(TestCase):
                 f"Observed {self.x_metric_name} vs. {self.y_metric_name}",
             )
             self.assertIsNotNone(adhoc_card.blob)
-            self.assertEqual(adhoc_card.blob_annotation, "plotly")
+            self.assertEqual(adhoc_card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
         with self.subTest("Custom points provided"):
             gr = adapter.gen(n=3)
             adhoc_cards = scatter_plot(

--- a/ax/analysis/plotly/tests/test_sensitivity.py
+++ b/ax/analysis/plotly/tests/test_sensitivity.py
@@ -5,7 +5,11 @@
 
 # pyre-strict
 
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.plotly.sensitivity import SensitivityAnalysisPlot
 from ax.api.client import Client
 from ax.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
@@ -76,7 +80,7 @@ class TestSensitivityAnalysisPlot(TestCase):
         )
         self.assertEqual(len(card.df), 2)
         self.assertIsNotNone(card.blob)
-        self.assertEqual(card.blob_annotation, "plotly")
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
 
         second_order = SensitivityAnalysisPlot(metric_names=["bar"], order="second")
         (card,) = second_order.compute(generation_strategy=client._generation_strategy)

--- a/ax/analysis/tests/test_analysis_exception.py
+++ b/ax/analysis/tests/test_analysis_exception.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Sequence
+
+from ax.analysis.analysis import (
+    Analysis,
+    AnalysisBlobAnnotation,
+    AnalysisCard,
+    ErrorAnalysisCard,
+)
+from ax.core.experiment import Experiment
+from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.modelbridge.base import Adapter
+from ax.utils.common.testutils import TestCase
+
+ERROR_MESSAGE = "Dummy analysis failed!"
+
+
+class TestAnalysisException(TestCase):
+    class DummyAnalysis(Analysis):
+        def compute(
+            self,
+            experiment: Experiment | None = None,
+            generation_strategy: GenerationStrategy | None = None,
+            adapter: Adapter | None = None,
+        ) -> Sequence[AnalysisCard]:
+            raise ValueError(ERROR_MESSAGE)
+
+    def test_error_analysis_card_on_exception(self) -> None:
+        analysis = self.DummyAnalysis()
+        with self.assertLogs("ax.analysis.analysis", "ERROR") as logs:
+            analysis_cards = analysis.compute_result().unwrap_or_else(
+                lambda e: e.error_card()
+            )
+        # Check that the error message is logged
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn(ERROR_MESSAGE, logs.output[0])
+
+        # Check that an error analysis card is produced
+        self.assertEqual(len(analysis_cards), 1)
+        analysis_card = analysis_cards[0]
+        self.assertEqual(analysis_card.blob_annotation, AnalysisBlobAnnotation.ERROR)
+        self.assertEqual(type(analysis_card), ErrorAnalysisCard)
+
+        # Check that error message is in the analysis card
+        self.assertEqual(analysis_card.name, "DummyAnalysis")
+        self.assertEqual(analysis_card.title, "DummyAnalysis Error")
+        self.assertIn(ERROR_MESSAGE, analysis_card.blob)

--- a/ax/analysis/tests/test_metric_summary.py
+++ b/ax/analysis/tests/test_metric_summary.py
@@ -6,7 +6,11 @@
 # pyre-strict
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.metric_summary import MetricSummary
 from ax.api.client import Client
 from ax.api.configs import ExperimentConfig
@@ -51,7 +55,7 @@ class TestMetricSummary(TestCase):
         self.assertEqual(card.level, AnalysisCardLevel.MID)
         self.assertEqual(card.category, AnalysisCardCategory.INFO)
         self.assertIsNotNone(card.blob)
-        self.assertEqual(card.blob_annotation, "dataframe")
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.DATAFRAME)
 
         # Test dataframe for accuracy
         self.assertEqual(

--- a/ax/analysis/tests/test_search_space_summary.py
+++ b/ax/analysis/tests/test_search_space_summary.py
@@ -6,7 +6,11 @@
 # pyre-strict
 
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.search_space_summary import SearchSpaceSummary
 from ax.api.client import Client
 from ax.api.configs import (
@@ -68,7 +72,7 @@ class TestSearchSpaceSummary(TestCase):
         self.assertEqual(card.level, AnalysisCardLevel.MID)
         self.assertEqual(card.category, AnalysisCardCategory.INFO)
         self.assertIsNotNone(card.blob)
-        self.assertEqual(card.blob_annotation, "dataframe")
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.DATAFRAME)
 
         # Test dataframe for accuracy
         self.assertEqual(

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -7,7 +7,11 @@
 
 import numpy as np
 import pandas as pd
-from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
 from ax.analysis.summary import Summary
 from ax.api.client import Client
 from ax.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
@@ -63,7 +67,7 @@ class TestSummary(TestCase):
         self.assertEqual(card.level, AnalysisCardLevel.MID)
         self.assertEqual(card.category, AnalysisCardCategory.INFO)
         self.assertIsNotNone(card.blob)
-        self.assertEqual(card.blob_annotation, "dataframe")
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.DATAFRAME)
 
         # Test dataframe for accuracy
         self.assertEqual(

--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -19,9 +19,6 @@ from ax.analysis.analysis import (  # Used as a return type
     display_cards,
 )
 from ax.analysis.dispatch import choose_analyses
-from ax.analysis.markdown.markdown_analysis import (
-    markdown_analysis_card_from_analysis_e,
-)
 from ax.analysis.summary import Summary
 from ax.api.configs import (
     ExperimentConfig,
@@ -649,7 +646,7 @@ class Client(WithDBSettingsBase):
         cards = [
             card
             for result in results
-            for card in result.unwrap_or_else(markdown_analysis_card_from_analysis_e)
+            for card in result.unwrap_or_else(lambda e: e.error_card())
         ]
 
         # Display the AnalysisCards if requested and if the user is in a notebook

--- a/ax/service/utils/analysis_base.py
+++ b/ax/service/utils/analysis_base.py
@@ -12,9 +12,6 @@ from ax.analysis.analysis import (
     AnalysisCardCategory,
     display_cards,
 )
-from ax.analysis.markdown.markdown_analysis import (
-    markdown_analysis_card_from_analysis_e,
-)
 from ax.analysis.plotly.parallel_coordinates import ParallelCoordinatesPlot
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
@@ -87,7 +84,7 @@ class AnalysisBase(WithDBSettingsBase):
         cards = [
             card
             for result in results
-            for card in result.unwrap_or_else(markdown_analysis_card_from_analysis_e)
+            for card in result.unwrap_or_else(lambda e: e.error_card())
         ]
 
         # Display the AnalysisCards if requested and if the user is in a notebook

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -1108,7 +1108,10 @@ class Encoder:
             level=int(analysis_card.level),
             dataframe_json=analysis_card.df.to_json(),
             blob=analysis_card.blob,
-            blob_annotation=analysis_card.blob_annotation,
+            # AnalysisCard.blob_annotation is a string, but is also set as an
+            # AnalysisBlobAnnotation enum. Directly saving the enum leads to MySQL
+            # warnings.
+            blob_annotation=str(analysis_card.blob_annotation),
             time_created=timestamp,
             experiment_id=experiment_id,
             attributes=json.dumps(analysis_card.attributes),


### PR DESCRIPTION
Summary:
1. Let analyses define their own exception_class (base is still `AnalysisE`).
2. Add new `AnalysisCard` subclass `ErrorAnalysisCard`.
3. Move `markdown_analysis_card_from_analysis_e` into `AnalysisE.error_card`. Produces an `ErrorAnalysisCard` instead of a `MarkdownAnalysisCard`.
4. Implement `HealtheckAnalysisE` for healthecks to produce a `FAILED` healthcheck card instead of an `ErrorAnalysisCard`.

Differential Revision: D72830895


