### PR TITLE
Reduce scope of mocks

### DIFF
--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -213,6 +213,8 @@ class MultiTypeExperimentTest(TestCase):
         runner1 = self.experiment.runner_for_trial_type(trial_type="type1")
         runner2 = self.experiment.runner_for_trial_type(trial_type="type2")
 
+        # Mock is needed because SyntheticRunner does not implement a 'stop'
+        # method
         with patch.object(
             runner1, "stop", return_value=None
         ) as mock_runner_stop1, patch.object(
@@ -223,9 +225,9 @@ class MultiTypeExperimentTest(TestCase):
             self.experiment.stop_trial_runs(
                 trials=[self.experiment.trials[0], self.experiment.trials[1]]
             )
-            mock_runner_stop1.assert_called_once()
-            mock_runner_stop2.assert_called()
-            mock_mark_stopped.assert_called()
+        mock_runner_stop1.assert_called_once()
+        mock_runner_stop2.assert_called()
+        mock_mark_stopped.assert_called()
 
 
 class MultiTypeExperimentUtilsTest(TestCase):

--- a/ax/core/tests/test_outcome_constraint.py
+++ b/ax/core/tests/test_outcome_constraint.py
@@ -61,16 +61,16 @@ class OutcomeConstraintTest(TestCase):
             OutcomeConstraint(
                 metric=self.minimize_metric, op=ComparisonOp.GEQ, bound=self.bound
             )
-            mock_warning.debug.assert_called_once_with(
-                CONSTRAINT_WARNING_MESSAGE.format(**LOWER_BOUND_MISMATCH)
-            )
+        mock_warning.debug.assert_called_once_with(
+            CONSTRAINT_WARNING_MESSAGE.format(**LOWER_BOUND_MISMATCH)
+        )
         with mock.patch(logger_name) as mock_warning:
             OutcomeConstraint(
                 metric=self.maximize_metric, op=ComparisonOp.LEQ, bound=self.bound
             )
-            mock_warning.debug.assert_called_once_with(
-                CONSTRAINT_WARNING_MESSAGE.format(**UPPER_BOUND_MISMATCH)
-            )
+        mock_warning.debug.assert_called_once_with(
+            CONSTRAINT_WARNING_MESSAGE.format(**UPPER_BOUND_MISMATCH)
+        )
 
     def test_Sortable(self) -> None:
         constraint1 = OutcomeConstraint(
@@ -141,16 +141,16 @@ class ObjectiveThresholdTest(TestCase):
             ObjectiveThreshold(
                 metric=self.minimize_metric, op=ComparisonOp.GEQ, bound=self.bound
             )
-            mock_warning.debug.assert_called_once_with(
-                CONSTRAINT_WARNING_MESSAGE.format(**LOWER_BOUND_MISMATCH)
-            )
+        mock_warning.debug.assert_called_once_with(
+            CONSTRAINT_WARNING_MESSAGE.format(**LOWER_BOUND_MISMATCH)
+        )
         with mock.patch(logger_name) as mock_warning:
             ObjectiveThreshold(
                 metric=self.maximize_metric, op=ComparisonOp.LEQ, bound=self.bound
             )
-            mock_warning.debug.assert_called_once_with(
-                CONSTRAINT_WARNING_MESSAGE.format(**UPPER_BOUND_MISMATCH)
-            )
+        mock_warning.debug.assert_called_once_with(
+            CONSTRAINT_WARNING_MESSAGE.format(**UPPER_BOUND_MISMATCH)
+        )
 
     def test_Relativize(self) -> None:
         self.assertTrue(

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -436,22 +436,19 @@ class UtilsTest(TestCase):
             ),
         ):
             pending = get_pending_observation_features(hss_exp)
-            self.assertEqual(
-                pending,
-                {
-                    "m1": [self.hss_obs_feat],
-                    "m2": [self.hss_obs_feat],
-                },
-            )
-            # Check that candidate metadata is property propagated for abandoned arm.
-            for p in none_throws(pending).values():
-                for pf in p:
-                    self.assertEqual(
-                        none_throws(pf.metadata),
-                        none_throws(self.hss_gr.candidate_metadata_by_arm_signature)[
-                            self.hss_arm.signature
-                        ],
-                    )
+        self.assertEqual(
+            pending,
+            {"m1": [self.hss_obs_feat], "m2": [self.hss_obs_feat]},
+        )
+        # Check that candidate metadata is property propagated for abandoned arm.
+        for p in none_throws(pending).values():
+            for pf in p:
+                self.assertEqual(
+                    none_throws(pf.metadata),
+                    none_throws(self.hss_gr.candidate_metadata_by_arm_signature)[
+                        self.hss_arm.signature
+                    ],
+                )
 
         # Checking with data for all metrics.
         with patch.object(

--- a/ax/generation_strategy/tests/test_aepsych_criterion.py
+++ b/ax/generation_strategy/tests/test_aepsych_criterion.py
@@ -77,17 +77,16 @@ class TestAEPsychCriterion(TestCase):
             )
         )
         with patch.object(experiment, "fetch_data", return_value=data):
-            # We have seen three "yes" and three "no"
-            self.assertTrue(
-                generation_strategy._maybe_transition_to_next_node(
-                    raise_data_required_error=False
-                )
+            move_to_next_node = generation_strategy._maybe_transition_to_next_node(
+                raise_data_required_error=False
             )
+        # We have seen three "yes" and three "no"
+        self.assertTrue(move_to_next_node)
 
-            self.assertEqual(
-                generation_strategy._curr.model_spec_to_gen_from.model_enum,
-                Generators.BOTORCH_MODULAR,
-            )
+        self.assertEqual(
+            generation_strategy._curr.model_spec_to_gen_from.model_enum,
+            Generators.BOTORCH_MODULAR,
+        )
 
     def test_many_criteria(self) -> None:
         criteria = [
@@ -131,13 +130,12 @@ class TestAEPsychCriterion(TestCase):
             )
         )
         with patch.object(experiment, "fetch_data", return_value=data):
-            # We have seen three "yes" and three "no", but not enough trials
-            # are completed
-            self.assertFalse(
-                generation_strategy._maybe_transition_to_next_node(
-                    raise_data_required_error=False
-                )
+            move_to_next_node = generation_strategy._maybe_transition_to_next_node(
+                raise_data_required_error=False
             )
+        # We have seen three "yes" and three "no", but not enough trials are
+        # completed
+        self.assertFalse(move_to_next_node)
 
         for _i in range(6):
             experiment.new_trial(generation_strategy.gen(experiment=experiment))
@@ -153,15 +151,14 @@ class TestAEPsychCriterion(TestCase):
         )
 
         with patch.object(experiment, "fetch_data", return_value=data):
-            # Enough trials are completed but we have not seen three "yes" and three
-            # "no"
-            self.assertTrue(
-                generation_strategy._maybe_transition_to_next_node(
-                    raise_data_required_error=False
-                )
+            move_to_next_node = generation_strategy._maybe_transition_to_next_node(
+                raise_data_required_error=False
             )
+        # Enough trials are completed but we have not seen three "yes" and three
+        # "no"
+        self.assertTrue(move_to_next_node)
 
-            self.assertEqual(
-                generation_strategy._curr.model_spec_to_gen_from.model_enum,
-                Generators.BOTORCH_MODULAR,
-            )
+        self.assertEqual(
+            generation_strategy._curr.model_spec_to_gen_from.model_enum,
+            Generators.BOTORCH_MODULAR,
+        )

--- a/ax/metrics/tests/test_sklearn.py
+++ b/ax/metrics/tests/test_sklearn.py
@@ -49,6 +49,7 @@ class SklearnMetricTest(TestCase):
             "target": np.random.randint(0, 3, (5,)),
         }
         with ExitStack() as es:
+            # mocks sklearn.datasets.load_digits, which loads a datast from disk
             mock_load_digits = es.enter_context(
                 mock.patch(
                     "ax.metrics.sklearn.datasets.load_digits",
@@ -56,6 +57,8 @@ class SklearnMetricTest(TestCase):
                 )
             )
             cv_scores = np.random.random(5)
+            # mocks sklearn.cross_val_score so that the RandomForestClassifier
+            # won't be cross-validated
             mock_cv = es.enter_context(
                 mock.patch(
                     "ax.metrics.sklearn.cross_val_score",
@@ -68,9 +71,7 @@ class SklearnMetricTest(TestCase):
                     wraps=RandomForestClassifier,
                 )
             )
-            metric = SklearnMetric(
-                name="test_metric",
-            )
+            metric = SklearnMetric(name="test_metric")
             self.assertIs(metric.dataset, SklearnDataset.DIGITS)
             self.assertIs(metric.model_type, SklearnModelType.RF)
             self.assertFalse(metric.lower_is_better)

--- a/ax/metrics/tests/test_tensorboard.py
+++ b/ax/metrics/tests/test_tensorboard.py
@@ -54,91 +54,70 @@ class TensorboardMetricTest(TestCase):
     def test_fetch_trial_data(self) -> None:
         fake_data = [8.0, 9.0, 2.0, 1.0]
         fake_multiplexer = _get_fake_multiplexer(fake_data=fake_data)
+        metric = TensorboardMetric(
+            name="loss", tag="loss", lower_is_better=True, smoothing=0
+        )
+        trial = get_trial()
 
+        # This is mocked to avoid an xdb call
         with mock.patch.object(
             TensorboardMetric,
             "_get_event_multiplexer_for_trial",
             return_value=fake_multiplexer,
         ):
-            metric = TensorboardMetric(
-                name="loss", tag="loss", lower_is_better=True, smoothing=0
-            )
-            trial = get_trial()
-
             result = metric.fetch_trial_data(trial=trial)
 
-            df = assert_is_instance(result.unwrap(), MapData).map_df
+        df = assert_is_instance(result.unwrap(), MapData).map_df
 
-            expected_df = pd.DataFrame(
-                [
-                    {
-                        "arm_name": "0_0",
-                        "metric_name": "loss",
-                        "mean": fake_data[i],
-                        "sem": float("nan"),
-                        "trial_index": 0,
-                        "step": float(i),
-                    }
-                    for i in range(len(fake_data))
-                ]
-            )
+        expected_df = pd.DataFrame(
+            [
+                {
+                    "arm_name": "0_0",
+                    "metric_name": "loss",
+                    "mean": fake_data[i],
+                    "sem": float("nan"),
+                    "trial_index": 0,
+                    "step": float(i),
+                }
+                for i in range(len(fake_data))
+            ]
+        )
 
-            self.assertTrue(df.equals(expected_df))
+        self.assertTrue(df.equals(expected_df))
 
     def test_fetch_trial_data_with_bad_data(self) -> None:
         nan_data = [1, 2, np.nan, 4]
         nan_multiplexer = _get_fake_multiplexer(fake_data=nan_data)
+        metric = TensorboardMetric(name="loss", tag="loss")
 
+        trial = get_trial()
         with mock.patch.object(
             TensorboardMetric,
             "_get_event_multiplexer_for_trial",
             return_value=nan_multiplexer,
         ):
-            metric = TensorboardMetric(
-                name="loss",
-                tag="loss",
-            )
-
-            trial = get_trial()
-
             result = metric.fetch_trial_data(trial=trial)
 
-            err = assert_is_instance(result.unwrap_err(), MetricFetchE)
-            self.assertEqual(
-                err.message,
-                "Failed to fetch data for loss",
-            )
-            self.assertEqual(
-                str(err.exception),
-                "Found NaNs or Infs in data",
-            )
+        err = assert_is_instance(result.unwrap_err(), MetricFetchE)
+        self.assertEqual(err.message, "Failed to fetch data for loss")
+        self.assertEqual(str(err.exception), "Found NaNs or Infs in data")
 
         inf_data = [1, 2, np.inf, 4]
         inf_multiplexer = _get_fake_multiplexer(fake_data=inf_data)
 
+        metric = TensorboardMetric(name="loss", tag="loss")
+
+        trial = get_trial()
         with mock.patch.object(
             TensorboardMetric,
             "_get_event_multiplexer_for_trial",
             return_value=inf_multiplexer,
         ):
-            metric = TensorboardMetric(
-                name="loss",
-                tag="loss",
-            )
-
-            trial = get_trial()
-
             result = metric.fetch_trial_data(trial=trial)
 
-            err = assert_is_instance(result.unwrap_err(), MetricFetchE)
-            self.assertEqual(
-                err.message,
-                "Failed to fetch data for loss",
-            )
-            self.assertEqual(
-                str(err.exception),
-                "Found NaNs or Infs in data",
-            )
+        err = assert_is_instance(result.unwrap_err(), MetricFetchE)
+        self.assertEqual(err.message, "Failed to fetch data for loss")
+        self.assertEqual(str(err.exception), "Found NaNs or Infs in data")
 
     def test_smoothing(self) -> None:
         fake_data = [8.0, 4.0, 2.0, 1.0]
@@ -146,76 +125,74 @@ class TensorboardMetricTest(TestCase):
         smooth_data = pd.Series(fake_data).ewm(alpha=smoothing).mean().tolist()
 
         fake_multiplexer = _get_fake_multiplexer(fake_data=fake_data)
+        metric = TensorboardMetric(
+            name="loss", tag="loss", lower_is_better=True, smoothing=smoothing
+        )
+        trial = get_trial()
 
         with mock.patch.object(
             TensorboardMetric,
             "_get_event_multiplexer_for_trial",
             return_value=fake_multiplexer,
         ):
-            metric = TensorboardMetric(
-                name="loss", tag="loss", lower_is_better=True, smoothing=smoothing
-            )
-            trial = get_trial()
-
             result = metric.fetch_trial_data(trial=trial)
 
-            df = assert_is_instance(result.unwrap(), MapData).map_df
+        df = assert_is_instance(result.unwrap(), MapData).map_df
 
-            expected_df = pd.DataFrame(
-                [
-                    {
-                        "arm_name": "0_0",
-                        "metric_name": "loss",
-                        "mean": smooth_data[i],
-                        "sem": float("nan"),
-                        "trial_index": 0,
-                        "step": float(i),
-                    }
-                    for i in range(len(fake_data))
-                ]
-            )
+        expected_df = pd.DataFrame(
+            [
+                {
+                    "arm_name": "0_0",
+                    "metric_name": "loss",
+                    "mean": smooth_data[i],
+                    "sem": float("nan"),
+                    "trial_index": 0,
+                    "step": float(i),
+                }
+                for i in range(len(fake_data))
+            ]
+        )
 
-            self.assertTrue(df.equals(expected_df))
+        self.assertTrue(df.equals(expected_df))
 
     def test_cumulative_best(self) -> None:
         fake_data = [4.0, 8.0, 2.0, 1.0]
         cummin_data = pd.Series(fake_data).cummin().tolist()
 
         fake_multiplexer = _get_fake_multiplexer(fake_data=fake_data)
+        metric = TensorboardMetric(
+            name="loss",
+            tag="loss",
+            lower_is_better=True,
+            cumulative_best=True,
+            smoothing=0,
+        )
+        trial = get_trial()
 
         with mock.patch.object(
             TensorboardMetric,
             "_get_event_multiplexer_for_trial",
             return_value=fake_multiplexer,
         ):
-            metric = TensorboardMetric(
-                name="loss",
-                tag="loss",
-                lower_is_better=True,
-                cumulative_best=True,
-                smoothing=0,
-            )
-            trial = get_trial()
-
             result = metric.fetch_trial_data(trial=trial)
 
-            df = assert_is_instance(result.unwrap(), MapData).map_df
+        df = assert_is_instance(result.unwrap(), MapData).map_df
 
-            expected_df = pd.DataFrame(
-                [
-                    {
-                        "arm_name": "0_0",
-                        "metric_name": "loss",
-                        "mean": cummin_data[i],
-                        "sem": float("nan"),
-                        "trial_index": 0,
-                        "step": float(i),
-                    }
-                    for i in range(len(fake_data))
-                ]
-            )
+        expected_df = pd.DataFrame(
+            [
+                {
+                    "arm_name": "0_0",
+                    "metric_name": "loss",
+                    "mean": cummin_data[i],
+                    "sem": float("nan"),
+                    "trial_index": 0,
+                    "step": float(i),
+                }
+                for i in range(len(fake_data))
+            ]
+        )
 
-            self.assertTrue(df.equals(expected_df))
+        self.assertTrue(df.equals(expected_df))
 
     def test_percentile(self) -> None:
         fake_data = [8.0, 4.0, 2.0, 1.0]

--- a/ax/modelbridge/transforms/tests/test_cast_transform.py
+++ b/ax/modelbridge/transforms/tests/test_cast_transform.py
@@ -139,11 +139,9 @@ class CastTransformTest(TestCase):
             flattened_search_space = self.t_hss.transform_search_space(
                 search_space=self.hss
             )
-            mock_hss_flatten.assert_called_once()
-            self.assertIsNot(flattened_search_space, self.hss)
-            self.assertFalse(
-                isinstance(flattened_search_space, HierarchicalSearchSpace)
-            )
+        mock_hss_flatten.assert_called_once()
+        self.assertIsNot(flattened_search_space, self.hss)
+        self.assertFalse(isinstance(flattened_search_space, HierarchicalSearchSpace))
 
     def test_transform_observation_features_HSS(self) -> None:
         # Untransform the observation features first to cast them and
@@ -159,7 +157,7 @@ class CastTransformTest(TestCase):
             transformed_obs_feats = self.t_hss.transform_observation_features(
                 observation_features=obs_feats
             )
-            mock_flatten_obsf.assert_called_once()
+        mock_flatten_obsf.assert_called_once()
 
         for obsf in transformed_obs_feats:
             # Check that transformed obs feats have all the parameters
@@ -223,7 +221,7 @@ class CastTransformTest(TestCase):
             obs_feats = self.t_hss.untransform_observation_features(
                 observation_features=[self.obs_feats_hss]
             )
-            mock_cast_obsf.assert_called_once()
+        mock_cast_obsf.assert_called_once()
 
         self.assertEqual(len(obs_feats), 1)
         obsf = obs_feats[0]

--- a/ax/modelbridge/transforms/tests/test_time_as_feature_transform.py
+++ b/ax/modelbridge/transforms/tests/test_time_as_feature_transform.py
@@ -49,8 +49,10 @@ class TimeAsFeatureTransformTest(TestCase):
             )
             for obsf in self.training_feats
         ]
+        self.time_return_value = 5.0
         time_patcher = mock.patch(
-            "ax.modelbridge.transforms.time_as_feature.time", return_value=5.0
+            "ax.modelbridge.transforms.time_as_feature.time",
+            return_value=self.time_return_value,
         )
         self.time_patcher = time_patcher.start()
         self.addCleanup(time_patcher.stop)
@@ -60,7 +62,7 @@ class TimeAsFeatureTransformTest(TestCase):
         )
 
     def test_init(self) -> None:
-        self.assertEqual(self.t.current_time, 5.0)
+        self.assertEqual(self.t.current_time, self.time_return_value)
         self.assertEqual(self.t.min_duration, 1.0)
         self.assertEqual(self.t.max_duration, 4.0)
         self.assertEqual(self.t.duration_range, 3.0)
@@ -103,7 +105,9 @@ class TimeAsFeatureTransformTest(TestCase):
         obsf_trans = self.t.transform_observation_features(obsf)
         self.assertEqual(
             obsf_trans[0],
-            ObservationFeatures({"x": 2.5, "duration": 0.5, "start_time": 5.0}),
+            ObservationFeatures(
+                {"x": 2.5, "duration": 0.5, "start_time": self.time_return_value}
+            ),
         )
         # test untransforming observation features that do not have
         # start/end time (important for fixed features in MOO when un-

--- a/ax/models/tests/test_botorch_moo_model.py
+++ b/ax/models/tests/test_botorch_moo_model.py
@@ -212,8 +212,8 @@ class BotorchMOOModelTest(TestCase):
                 search_space_digest=search_space_digest,
                 torch_opt_config=torch_opt_config,
             )
-            # Sample_simplex should be called once for generated candidate.
-            self.assertEqual(n, _mock_sample_simplex.call_count)
+        # Sample_simplex should be called once for generated candidate.
+        self.assertEqual(n, _mock_sample_simplex.call_count)
 
         torch_opt_config.model_gen_options["acquisition_function_kwargs"] = {
             "random_scalarization": True,
@@ -229,8 +229,8 @@ class BotorchMOOModelTest(TestCase):
                 search_space_digest=search_space_digest,
                 torch_opt_config=torch_opt_config,
             )
-            # Sample_simplex should be called once per generated candidate.
-            self.assertEqual(n, _mock_sample_hypersphere.call_count)
+        # Sample_simplex should be called once per generated candidate.
+        self.assertEqual(n, _mock_sample_hypersphere.call_count)
 
         # test input warping
         self.assertFalse(model.use_input_warping)
@@ -436,7 +436,7 @@ class BotorchMOOModelTest(TestCase):
                 datasets=training_data,
                 search_space_digest=search_space_digest,
             )
-            _mock_fit_model.assert_called_once()
+        _mock_fit_model.assert_called_once()
         with ExitStack() as es:
             _mock_acqf = es.enter_context(
                 mock.patch(
@@ -735,7 +735,7 @@ class BotorchMOOModelTest(TestCase):
                 datasets=training_data,
                 search_space_digest=search_space_digest,
             )
-            _mock_fit_model.assert_called_once()
+        _mock_fit_model.assert_called_once()
 
         with mock.patch(
             SAMPLE_SIMPLEX_UTIL_PATH,
@@ -813,7 +813,7 @@ class BotorchMOOModelTest(TestCase):
                 datasets=training_data,
                 search_space_digest=search_space_digest,
             )
-            _mock_fit_model.assert_called_once()
+        _mock_fit_model.assert_called_once()
 
         torch_opt_config = TorchOptConfig(
             objective_weights=objective_weights,
@@ -834,8 +834,8 @@ class BotorchMOOModelTest(TestCase):
                 search_space_digest=search_space_digest,
                 torch_opt_config=torch_opt_config,
             )
-            # get_chebyshev_scalarization should be called once for generated candidate.
-            self.assertEqual(n, _mock_chebyshev_scalarization.call_count)
+        # get_chebyshev_scalarization should be called once for generated candidate.
+        self.assertEqual(n, _mock_chebyshev_scalarization.call_count)
 
     @mock_botorch_optimize
     def test_BotorchMOOModel_with_qehvi_and_outcome_constraints(
@@ -917,7 +917,7 @@ class BotorchMOOModelTest(TestCase):
                 datasets=training_data,
                 search_space_digest=search_space_digest,
             )
-            _mock_fit_model.assert_called_once()
+        _mock_fit_model.assert_called_once()
 
         # test wrong number of objective thresholds
         torch_opt_config = TorchOptConfig(
@@ -946,17 +946,18 @@ class BotorchMOOModelTest(TestCase):
                 search_space_digest=search_space_digest,
                 torch_opt_config=torch_opt_config,
             )
-            mock_get_nehvi.assert_called_once()
-            _, ckwargs = mock_get_nehvi.call_args
-            self.assertEqual(ckwargs["model"].num_outputs, 2)
-            self.assertTrue(
-                torch.equal(ckwargs["objective_weights"], objective_weights[:-1])
-            )
-            self.assertTrue(torch.equal(ckwargs["objective_thresholds"], obj_t[:-1]))
-            self.assertIsNone(ckwargs["outcome_constraints"])
-            # the second datapoint is out of bounds
-            self.assertTrue(torch.equal(ckwargs["X_observed"], Xs1[0][:1]))
-            self.assertIsNone(ckwargs["X_pending"])
+        mock_get_nehvi.assert_called_once()
+        _, ckwargs = mock_get_nehvi.call_args
+        self.assertEqual(ckwargs["model"].num_outputs, 2)
+        self.assertTrue(
+            torch.equal(ckwargs["objective_weights"], objective_weights[:-1])
+        )
+        self.assertTrue(torch.equal(ckwargs["objective_thresholds"], obj_t[:-1]))
+        self.assertIsNone(ckwargs["outcome_constraints"])
+        # the second datapoint is out of bounds
+        self.assertTrue(torch.equal(ckwargs["X_observed"], Xs1[0][:1]))
+        self.assertIsNone(ckwargs["X_pending"])
+
         # test that outcome constraints are passed properly
         oc = (
             torch.tensor([[0.0, 0.0, 1.0]], **tkwargs),
@@ -976,15 +977,13 @@ class BotorchMOOModelTest(TestCase):
                 search_space_digest=search_space_digest,
                 torch_opt_config=torch_opt_config,
             )
-            mock_get_nehvi.assert_called_once()
-            _, ckwargs = mock_get_nehvi.call_args
-            self.assertEqual(ckwargs["model"].num_outputs, 3)
-            self.assertTrue(
-                torch.equal(ckwargs["objective_weights"], objective_weights)
-            )
-            self.assertTrue(torch.equal(ckwargs["objective_thresholds"], obj_t))
-            self.assertTrue(torch.equal(ckwargs["outcome_constraints"][0], oc[0]))
-            self.assertTrue(torch.equal(ckwargs["outcome_constraints"][1], oc[1]))
-            # the second datapoint is out of bounds
-            self.assertTrue(torch.equal(ckwargs["X_observed"], Xs1[0][:1]))
-            self.assertIsNone(ckwargs["X_pending"])
+        mock_get_nehvi.assert_called_once()
+        _, ckwargs = mock_get_nehvi.call_args
+        self.assertEqual(ckwargs["model"].num_outputs, 3)
+        self.assertTrue(torch.equal(ckwargs["objective_weights"], objective_weights))
+        self.assertTrue(torch.equal(ckwargs["objective_thresholds"], obj_t))
+        self.assertTrue(torch.equal(ckwargs["outcome_constraints"][0], oc[0]))
+        self.assertTrue(torch.equal(ckwargs["outcome_constraints"][1], oc[1]))
+        # the second datapoint is out of bounds
+        self.assertTrue(torch.equal(ckwargs["X_observed"], Xs1[0][:1]))
+        self.assertIsNone(ckwargs["X_pending"])

--- a/ax/models/tests/test_eb_thompson.py
+++ b/ax/models/tests/test_eb_thompson.py
@@ -75,11 +75,11 @@ class EmpiricalBayesThompsonSamplerTest(TestCase):
                 parameter_values=self.parameter_values,
                 objective_weights=np.array([1, 0]),
             )
-            self.assertEqual(arms, [[4, 4], [3, 3], [2, 2], [1, 1]])
-            for weight, expected_weight in zip(
-                weights, [5 * i for i in [0.66, 0.25, 0.07, 0.02]]
-            ):
-                self.assertAlmostEqual(weight, expected_weight, delta=0.1)
+        self.assertEqual(arms, [[4, 4], [3, 3], [2, 2], [1, 1]])
+        for weight, expected_weight in zip(
+            weights, [5 * i for i in [0.66, 0.25, 0.07, 0.02]]
+        ):
+            self.assertAlmostEqual(weight, expected_weight, delta=0.1)
 
     def test_EmpiricalBayesThompsonSamplerWarning(self) -> None:
         set_rng_seed(0)

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -394,14 +394,14 @@ class TestBestPointUtils(TestCase):
                 modelbridge=test_modelbridge_1,
                 observations=test_observations_1,
             )
-            self.assertTrue(
-                any(
-                    "Adapter and Experiment provided to "
-                    "`_derel_opt_config_wrapper`. Ignoring the latter." in warning
-                    for warning in lg.output
-                ),
-                msg=lg.output,
-            )
+        self.assertTrue(
+            any(
+                "Adapter and Experiment provided to "
+                "`_derel_opt_config_wrapper`. Ignoring the latter." in warning
+                for warning in lg.output
+            ),
+            msg=lg.output,
+        )
         self.assertEqual(returned_value, DUMMY_OPTIMIZATION_CONFIG)
         mock_derelativize.assert_called_with(
             optimization_config=input_optimization_config,

--- a/ax/utils/common/tests/test_kwargutils.py
+++ b/ax/utils/common/tests/test_kwargutils.py
@@ -25,14 +25,14 @@ class TestWarnOnKwargs(TestCase):
                 return
 
             warn_on_kwargs(callable_with_kwargs=callable_arg, foo="")
-            mock_warning.assert_called_once_with(
-                "Found unexpected kwargs: %s while calling %s "
-                "from JSON. These kwargs will be ignored.",
-                {"foo": ""},
-                callable_arg,
-            )
+        mock_warning.assert_called_once_with(
+            "Found unexpected kwargs: %s while calling %s "
+            "from JSON. These kwargs will be ignored.",
+            {"foo": ""},
+            callable_arg,
+        )
 
     def test_it_does_not_warn_if_no_kwargs_are_passed(self) -> None:
         with patch.object(logger, "warning") as mock_warning:
             warn_on_kwargs(callable_with_kwargs=lambda: None)
-            mock_warning.assert_not_called()
+        mock_warning.assert_not_called()


### PR DESCRIPTION
Summary:
Modules where the only change was to reduce scope (e.g. by un-indenting) to make sure the mock is not used more widely than needed and make it clear where it is used:
* test_kwargutils, test_utils, test_best_point_utils, test_outcome_constraint, test_eb_thompson, test_aepsych_criterion, test_botorch_moo_model, test_cast_transform

Other changes:
* In test_time_as_feature_transform, replaced '5' with 'time_return_value' to make it easier to understand where this is coming from and why we have the mock
* test_random_modelbridge: Type annotation fixes
* test_sklearn: Add comments
* test_tensorboard: Reduce scope of mocks and add a comment
* test_multi_type_experiment: Use `wraps`

Differential Revision: D67996143


