### PR TITLE
Mock out ax_parameter_sens in online/offline tests

### DIFF
--- a/ax/analysis/plotly/tests/test_sensitivity.py
+++ b/ax/analysis/plotly/tests/test_sensitivity.py
@@ -5,6 +5,8 @@
 
 # pyre-strict
 
+from unittest.mock import Mock, patch
+
 from ax.analysis.analysis import (
     AnalysisBlobAnnotation,
     AnalysisCardCategory,
@@ -87,8 +89,17 @@ class TestSensitivityAnalysisPlot(TestCase):
         self.assertEqual(len(card.df), 3)  # 2 first order + 1 second order
 
     @mock_botorch_optimize
-    @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
-    def test_online(self) -> None:
+    @patch(  # pyre-fixme[56]: Pyre was not able to infer the type of argument lambda
+        f"{SensitivityAnalysisPlot.__module__}.ax_parameter_sens",
+        wraps=lambda model_bridge, metrics, **kwargs: {
+            outcome: {parameter: 0 for parameter in model_bridge.parameters}
+            for outcome in (metrics if metrics is not None else model_bridge.outcomes)
+        },
+    )
+    def test_online(
+        self,
+        _sensitivity_mock: Mock,
+    ) -> None:
         # Test SensitivityAnalysisPlot can be computed for a variety of experiments
         # which resemble those we see in an online setting.
 
@@ -114,8 +125,14 @@ class TestSensitivityAnalysisPlot(TestCase):
                     )
 
     @mock_botorch_optimize
-    @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
-    def test_offline(self) -> None:
+    @patch(  # pyre-fixme[56]: Pyre was not able to infer the type of argument lambda
+        f"{SensitivityAnalysisPlot.__module__}.ax_parameter_sens",
+        wraps=lambda model_bridge, metrics, **kwargs: {
+            outcome: {parameter: 0 for parameter in model_bridge.parameters}
+            for outcome in (metrics if metrics is not None else model_bridge.outcomes)
+        },
+    )
+    def test_offline(self, _sensitivity_mock: Mock) -> None:
         # Test SensitivityAnalysisPlot can be computed for a variety of experiments
         # which resemble those we see in an offline setting.
 

--- a/ax/analysis/plotly/tests/test_top_surfaces.py
+++ b/ax/analysis/plotly/tests/test_top_surfaces.py
@@ -4,6 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+
+from unittest.mock import Mock, patch
+
+from ax.analysis.plotly.sensitivity import SensitivityAnalysisPlot
+
 from ax.analysis.plotly.top_surfaces import TopSurfacesAnalysis
 from ax.api.client import Client
 from ax.api.configs import (
@@ -149,8 +154,17 @@ class TestTopSurfacesAnalysis(TestCase):
         self.assertEqual(cards[1].title, "x1 vs. bar")
 
     @mock_botorch_optimize
-    @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
-    def test_online(self) -> None:
+    @patch(  # pyre-fixme[56]: Pyre was not able to infer the type of argument lambda
+        f"{SensitivityAnalysisPlot.__module__}.ax_parameter_sens",
+        wraps=lambda model_bridge, metrics, **kwargs: {
+            outcome: {parameter: 0 for parameter in model_bridge.parameters}
+            for outcome in (metrics if metrics is not None else model_bridge.outcomes)
+        },
+    )
+    def test_online(
+        self,
+        _sensitivity_mock: Mock,
+    ) -> None:
         # Test TopSurfacesAnalysis can be computed for a variety of experiments
         # which resemble those we see in an online setting.
 
@@ -174,8 +188,17 @@ class TestTopSurfacesAnalysis(TestCase):
                     )
 
     @mock_botorch_optimize
-    @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
-    def test_offline(self) -> None:
+    @patch(  # pyre-fixme[56]: Pyre was not able to infer the type of argument lambda
+        f"{SensitivityAnalysisPlot.__module__}.ax_parameter_sens",
+        wraps=lambda model_bridge, metrics, **kwargs: {
+            outcome: {parameter: 0 for parameter in model_bridge.parameters}
+            for outcome in (metrics if metrics is not None else model_bridge.outcomes)
+        },
+    )
+    def test_offline(
+        self,
+        _sensitivity_mock: Mock,
+    ) -> None:
         # Test TopSurfacesAnalysis can be computed for a variety of experiments
         # which resemble those we see in an offline setting.
 


### PR DESCRIPTION
Summary:
Should be safe since ax_parameter_sens is tested elsewhere.

These tests try and call compute() using over 100 different experiments, making each test very expensive -- this doubled our OSS unit testing time. With these changes the tests go from taking ~300s to ~50s on my machine in dev mode.

Differential Revision: D73066856


