### PR TITLE
Add `HealthcheckAnalysis._create_healthcheck_analysis_card` method

### DIFF
--- a/ax/analysis/healthcheck/can_generate_candidates.py
+++ b/ax/analysis/healthcheck/can_generate_candidates.py
@@ -5,7 +5,6 @@
 
 # pyre-safe
 
-import json
 from datetime import datetime
 from typing import Sequence
 
@@ -88,22 +87,13 @@ class CanGenerateCandidatesAnalysis(HealthcheckAnalysis):
             subtitle += f"{self.reason}"
 
         return [
-            HealthcheckAnalysisCard(
-                name="CanGenerateCandidates",
+            self._create_healthcheck_analysis_card(
                 title=f"Ax Candidate Generation {title_status}",
-                blob=json.dumps(
-                    {
-                        "status": status,
-                    }
-                ),
                 subtitle=subtitle,
-                df=pd.DataFrame(
-                    {
-                        "status": [status],
-                        "reason": [self.reason],
-                    }
-                ),
+                df=pd.DataFrame(),
                 level=level,
+                status=status,
                 category=AnalysisCardCategory.DIAGNOSTIC,
+                reason=self.reason,
             )
         ]

--- a/ax/analysis/healthcheck/constraints_feasibility.py
+++ b/ax/analysis/healthcheck/constraints_feasibility.py
@@ -5,7 +5,6 @@
 
 # pyre-strict
 
-import json
 from typing import Sequence
 
 import pandas as pd
@@ -68,7 +67,7 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
         subtitle = "All constraints are feasible."
         title_status = "Success"
         level = AnalysisCardLevel.LOW
-        df = pd.DataFrame({"status": [status]})
+        df = pd.DataFrame()
         category = AnalysisCardCategory.DIAGNOSTIC
 
         if experiment is None:
@@ -79,15 +78,14 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
         if experiment.optimization_config is None:
             subtitle = "No optimization config is specified."
             return [
-                HealthcheckAnalysisCard(
-                    name="ConstraintsFeasibility",
+                self._create_healthcheck_analysis_card(
                     title=f"Ax Constraints Feasibility {title_status}",
-                    blob=json.dumps({"status": status}),
                     subtitle=subtitle,
                     df=df,
                     level=level,
+                    status=status,
                     category=category,
-                )
+                ),
             ]
 
         if (
@@ -96,13 +94,12 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
         ):
             subtitle = "No constraints are specified."
             return [
-                HealthcheckAnalysisCard(
-                    name="ConstraintsFeasibility",
+                self._create_healthcheck_analysis_card(
                     title=f"Ax Constraints Feasibility {title_status}",
-                    blob=json.dumps({"status": status}),
                     subtitle=subtitle,
                     df=df,
                     level=level,
+                    status=status,
                     category=category,
                 )
             ]
@@ -126,7 +123,6 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
             model=relevant_adapter,
             prob_threshold=self.prob_threshold,
         )
-        df["status"] = status
 
         if not constraints_feasible:
             status = HealthcheckStatus.WARNING
@@ -140,21 +136,16 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
                 "on this Experiment."
             )
             title_status = "Warning"
-            df.loc[
-                df["overall_probability_constraints_violated"] > self.prob_threshold,
-                "status",
-            ] = status
 
         return [
-            HealthcheckAnalysisCard(
-                name="ConstraintsFeasibility",
+            self._create_healthcheck_analysis_card(
                 title=f"Ax Constraints Feasibility {title_status}",
-                blob=json.dumps({"status": status}),
                 subtitle=subtitle,
                 df=df,
                 level=level,
+                status=status,
                 category=category,
-            )
+            ),
         ]
 
 

--- a/ax/analysis/healthcheck/healthcheck_analysis.py
+++ b/ax/analysis/healthcheck/healthcheck_analysis.py
@@ -37,6 +37,9 @@ class HealthcheckAnalysisCard(AnalysisCard):
     def get_status(self) -> HealthcheckStatus:
         return HealthcheckStatus(json.loads(self.blob)["status"])
 
+    def get_aditional_attrs(self) -> dict[str, str | int | float | bool]:
+        return json.loads(self.blob)
+
 
 class HealthcheckAnalysisE(AnalysisE):
     def error_card(self) -> list[AnalysisCard]:
@@ -81,3 +84,29 @@ class HealthcheckAnalysis(Analysis):
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
     ) -> Sequence[HealthcheckAnalysisCard]: ...
+
+    def _create_healthcheck_analysis_card(
+        self,
+        title: str,
+        subtitle: str,
+        level: int,
+        df: pd.DataFrame,
+        category: int,
+        status: HealthcheckStatus,
+        **additional_attrs: str | int | float | bool,
+    ) -> HealthcheckAnalysisCard:
+        return HealthcheckAnalysisCard(
+            name=self.name,
+            attributes=self.attributes,
+            title=title,
+            subtitle=subtitle,
+            level=level,
+            df=df,
+            category=category,
+            blob=json.dumps(
+                {
+                    "status": status,
+                    **additional_attrs,
+                }
+            ),
+        )

--- a/ax/analysis/healthcheck/regression_analysis.py
+++ b/ax/analysis/healthcheck/regression_analysis.py
@@ -5,7 +5,6 @@
 
 # pyre-strict
 
-import json
 from typing import Sequence
 
 import pandas as pd
@@ -96,9 +95,7 @@ class RegressionAnalysis(HealthcheckAnalysis):
         )
 
         if regressions_by_trial_df.shape[0] > 0:
-            df = regressions_by_trial_df
             status = HealthcheckStatus.WARNING
-            df["status"] = status
             subtitle = subtitle_base + (
                 "The following arms are regressing the "
                 "following metrics for the respective trials: \n"
@@ -108,20 +105,18 @@ class RegressionAnalysis(HealthcheckAnalysis):
             title_status = "Warning"
         else:
             status = HealthcheckStatus.PASS
-            df = pd.DataFrame({"status": [status]})
             subtitle = subtitle_base + "No metric regessions detected."
             title_status = "Success"
 
         return [
-            HealthcheckAnalysisCard(
-                name="RegressionAnalysis",
+            self._create_healthcheck_analysis_card(
                 title=f"Ax Regression Analysis {title_status}",
-                blob=json.dumps({"status": status}),
                 subtitle=subtitle,
-                df=df,
+                df=regressions_by_trial_df,
                 level=AnalysisCardLevel.LOW,
+                status=status,
                 category=AnalysisCardCategory.DIAGNOSTIC,
-            )
+            ),
         ]
 
 

--- a/ax/analysis/healthcheck/search_space_analysis.py
+++ b/ax/analysis/healthcheck/search_space_analysis.py
@@ -5,7 +5,6 @@
 
 # pyre-strict
 
-import json
 from typing import Sequence, Union
 
 import numpy as np
@@ -70,7 +69,6 @@ class SearchSpaceAnalysis(HealthcheckAnalysis):
         )
         title_status = "Success"
         level = AnalysisCardLevel.LOW
-        df = pd.DataFrame({"status": [status]})
 
         trial = experiment.trials[self.trial_index]
         arms = trial.arms
@@ -90,22 +88,18 @@ class SearchSpaceAnalysis(HealthcheckAnalysis):
             additional_subtitle = msg
             title_status = "Warning"
             level = AnalysisCardLevel.LOW
-            df = boundary_proportions_df[["boundary", "proportion", "bound"]]
-            df["status"] = status
         else:
             additional_subtitle = "Search space does not need to be updated."
 
         return [
-            HealthcheckAnalysisCard(
-                name="SearchSpaceAnalysis",
+            self._create_healthcheck_analysis_card(
                 title=f"Ax Search Space Analysis {title_status}",
-                blob=json.dumps({"status": status}),
                 subtitle=subtitle_base + additional_subtitle,
-                df=df,
+                df=boundary_proportions_df[["boundary", "proportion", "bound"]],
                 level=level,
-                attributes={"trial_index": self.trial_index},
+                status=status,
                 category=AnalysisCardCategory.DIAGNOSTIC,
-            )
+            ),
         ]
 
 

--- a/ax/analysis/healthcheck/should_generate_candidates.py
+++ b/ax/analysis/healthcheck/should_generate_candidates.py
@@ -5,7 +5,6 @@
 
 # pyre-safe
 
-import json
 from typing import Sequence
 
 import pandas as pd
@@ -46,23 +45,12 @@ class ShouldGenerateCandidates(HealthcheckAnalysis):
             else HealthcheckStatus.WARNING
         )
         return [
-            HealthcheckAnalysisCard(
-                name=self.name,
+            self._create_healthcheck_analysis_card(
                 title=f"Ready to Generate Candidates for Trial {self.trial_index}",
-                blob=json.dumps(
-                    {
-                        "status": status,
-                    }
-                ),
                 subtitle=self.reason,
-                df=pd.DataFrame(
-                    {
-                        "status": [status],
-                        "reason": [self.reason],
-                    }
-                ),
+                df=pd.DataFrame(),
                 level=AnalysisCardLevel.CRITICAL,
-                attributes=self.attributes,
+                status=status,
                 category=AnalysisCardCategory.DIAGNOSTIC,
-            )
+            ),
         ]

--- a/ax/analysis/healthcheck/tests/test_can_generate_candidates.py
+++ b/ax/analysis/healthcheck/tests/test_can_generate_candidates.py
@@ -7,7 +7,6 @@
 
 from datetime import datetime, timedelta
 
-import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 from ax.analysis.healthcheck.can_generate_candidates import (
     CanGenerateCandidatesAnalysis,
@@ -16,7 +15,6 @@ from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckStatus
 from ax.core.trial_status import TrialStatus
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
-from pandas import testing as pdt
 
 
 class TestCanGenerateCandidates(TestCase):
@@ -30,7 +28,7 @@ class TestCanGenerateCandidates(TestCase):
         ).compute(experiment=None, generation_strategy=None)
         # THEN it is PASSES
         self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
-        self.assertEqual(card.name, "CanGenerateCandidates")
+        self.assertEqual(card.name, "CanGenerateCandidatesAnalysis")
         self.assertEqual(card.title, "Ax Candidate Generation Success")
         self.assertEqual(
             card.subtitle,
@@ -41,14 +39,13 @@ class TestCanGenerateCandidates(TestCase):
         )
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
         self.assertEqual(card.category, AnalysisCardCategory.DIAGNOSTIC)
-        pdt.assert_frame_equal(
-            card.df,
-            pd.DataFrame(
-                {
-                    "status": [HealthcheckStatus.PASS.value],
-                    "reason": ["No problems found."],
-                }
-            ),
+        self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
+        self.assertDictEqual(
+            card.get_aditional_attrs(),
+            {
+                "status": HealthcheckStatus.PASS,
+                "reason": "No problems found.",
+            },
         )
 
     def test_warns_if_a_trial_was_recently_run(self) -> None:
@@ -65,7 +62,7 @@ class TestCanGenerateCandidates(TestCase):
         ).compute(experiment=experiment, generation_strategy=None)
         # THEN it is a WARNING
         self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
-        self.assertEqual(card.name, "CanGenerateCandidates")
+        self.assertEqual(card.name, "CanGenerateCandidatesAnalysis")
         self.assertEqual(card.title, "Ax Candidate Generation Warning")
         self.assertEqual(
             card.subtitle,
@@ -78,14 +75,13 @@ class TestCanGenerateCandidates(TestCase):
             ),
         )
         self.assertEqual(card.level, AnalysisCardLevel.MID)
-        pdt.assert_frame_equal(
-            card.df,
-            pd.DataFrame(
-                {
-                    "status": [HealthcheckStatus.WARNING.value],
-                    "reason": ["The data is borked."],
-                }
-            ),
+        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+        self.assertDictEqual(
+            card.get_aditional_attrs(),
+            {
+                "status": HealthcheckStatus.WARNING,
+                "reason": "The data is borked.",
+            },
         )
 
     def test_is_fail_no_trials_have_been_run(self) -> None:
@@ -101,7 +97,7 @@ class TestCanGenerateCandidates(TestCase):
         ).compute(experiment=experiment, generation_strategy=None)
         # THEN it is an ERROR
         self.assertEqual(card.get_status(), HealthcheckStatus.FAIL)
-        self.assertEqual(card.name, "CanGenerateCandidates")
+        self.assertEqual(card.name, "CanGenerateCandidatesAnalysis")
         self.assertEqual(card.title, "Ax Candidate Generation Failure")
         self.assertEqual(
             card.subtitle,
@@ -112,14 +108,13 @@ class TestCanGenerateCandidates(TestCase):
             ),
         )
         self.assertEqual(card.level, AnalysisCardLevel.HIGH)
-        pdt.assert_frame_equal(
-            card.df,
-            pd.DataFrame(
-                {
-                    "status": [HealthcheckStatus.FAIL.value],
-                    "reason": ["The data is gone."],
-                }
-            ),
+        self.assertEqual(card.get_status(), HealthcheckStatus.FAIL)
+        self.assertDictEqual(
+            card.get_aditional_attrs(),
+            {
+                "status": HealthcheckStatus.FAIL,
+                "reason": "The data is gone.",
+            },
         )
 
     def test_is_fail_if_no_trial_was_recently_run(self) -> None:
@@ -137,7 +132,7 @@ class TestCanGenerateCandidates(TestCase):
         ).compute(experiment=experiment, generation_strategy=None)
         # THEN it is an ERROR
         self.assertEqual(card.get_status(), HealthcheckStatus.FAIL)
-        self.assertEqual(card.name, "CanGenerateCandidates")
+        self.assertEqual(card.name, "CanGenerateCandidatesAnalysis")
         self.assertEqual(card.title, "Ax Candidate Generation Failure")
         self.assertEqual(
             card.subtitle,
@@ -150,12 +145,11 @@ class TestCanGenerateCandidates(TestCase):
             ),
         )
         self.assertEqual(card.level, AnalysisCardLevel.HIGH)
-        pdt.assert_frame_equal(
-            card.df,
-            pd.DataFrame(
-                {
-                    "status": [HealthcheckStatus.FAIL.value],
-                    "reason": ["The data is old."],
-                }
-            ),
+        self.assertEqual(card.get_status(), HealthcheckStatus.FAIL)
+        self.assertDictEqual(
+            card.get_aditional_attrs(),
+            {
+                "status": HealthcheckStatus.FAIL,
+                "reason": "The data is old.",
+            },
         )

--- a/ax/analysis/healthcheck/tests/test_constraints_feasibility.py
+++ b/ax/analysis/healthcheck/tests/test_constraints_feasibility.py
@@ -5,8 +5,6 @@
 
 # pyre-strict
 
-import json
-
 import numpy as np
 import pandas as pd
 
@@ -166,7 +164,7 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
         (card,) = cfa.compute(
             experiment=self.experiment, generation_strategy=self.generation_strategy
         )
-        self.assertEqual(card.name, "ConstraintsFeasibility")
+        self.assertEqual(card.name, "ConstraintsFeasibilityAnalysis")
         self.assertEqual(card.title, "Ax Constraints Feasibility Success")
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
         self.assertEqual(card.category, AnalysisCardCategory.DIAGNOSTIC)
@@ -194,7 +192,7 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
         (card,) = cfa.compute(
             experiment=experiment, generation_strategy=generation_strategy
         )
-        self.assertEqual(card.name, "ConstraintsFeasibility")
+        self.assertEqual(card.name, "ConstraintsFeasibilityAnalysis")
         self.assertEqual(card.title, "Ax Constraints Feasibility Warning")
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
         subtitle = (
@@ -207,7 +205,7 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
             "on this Experiment."
         )
         self.assertEqual(card.subtitle, subtitle)
-        self.assertEqual(json.loads(card.blob), {"status": HealthcheckStatus.WARNING})
+        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
 
         # experiment with no constraints
         experiment.optimization_config = OptimizationConfig(
@@ -218,18 +216,18 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
         (card,) = cfa.compute(
             experiment=experiment, generation_strategy=generation_strategy
         )
-        self.assertEqual(card.name, "ConstraintsFeasibility")
+        self.assertEqual(card.name, "ConstraintsFeasibilityAnalysis")
         self.assertEqual(card.title, "Ax Constraints Feasibility Success")
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
         self.assertEqual(card.subtitle, "No constraints are specified.")
-        self.assertEqual(json.loads(card.blob), {"status": HealthcheckStatus.PASS})
+        self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
 
     def test_no_optimization_config(self) -> None:
         experiment = get_branin_experiment(has_optimization_config=False)
         cfa = ConstraintsFeasibilityAnalysis()
         (card,) = cfa.compute(experiment=experiment, generation_strategy=None)
-        self.assertEqual(card.name, "ConstraintsFeasibility")
+        self.assertEqual(card.name, "ConstraintsFeasibilityAnalysis")
         self.assertEqual(card.title, "Ax Constraints Feasibility Success")
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
         self.assertEqual(card.subtitle, "No optimization config is specified.")
-        self.assertEqual(json.loads(card.blob), {"status": HealthcheckStatus.PASS})
+        self.assertEqual(card.get_status(), HealthcheckStatus.PASS)


### PR DESCRIPTION
Summary: Similar to `PlotlyAnalysis._create_plotly_analysis_card` and `MarkdownAnalysis._create_markdown_analysis_card`. Enforces that the same healthcheck always has the same name. Currently failed healthchecks use the analysis class name, and successful ones use whatever is defined in its implementation.

Differential Revision: D73071736


