### PR TITLE
Misc fixes in cv plot

### DIFF
--- a/ax/analysis/dispatch.py
+++ b/ax/analysis/dispatch.py
@@ -89,15 +89,13 @@ def choose_analyses(experiment: Experiment) -> list[Analysis]:
     ]
 
     # Leave-one-out cross validation for each objective and outcome constraint
-    cv_plots = [
-        CrossValidationPlot(metric_name=name) for name in optimization_config.metrics
-    ]
+    cv_plots = CrossValidationPlot(metric_names=[*optimization_config.metrics.keys()])
 
     return [
         *objective_plots,
         *other_scatters,
         *progressions,
         *interactions,
-        *cv_plots,
+        cv_plots,
         Summary(),
     ]

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -352,6 +352,31 @@ def _prepare_figure(
 
         figure.add_trace(legend_trace)
 
+    # Add horizontal and vertical lines for the status quo.
+    if "status_quo" in df["arm_name"].values:
+        x = df[df["arm_name"] == "status_quo"][f"{x_metric_name}_mean"].iloc[0]
+        y = df[df["arm_name"] == "status_quo"][f"{y_metric_name}_mean"].iloc[0]
+
+        figure.add_shape(
+            type="line",
+            yref="paper",
+            x0=x,
+            y0=0,
+            x1=x,
+            y1=1,
+            line={"color": "gray", "dash": "dot"},
+        )
+
+        figure.add_shape(
+            type="line",
+            xref="paper",
+            x0=0,
+            y0=y,
+            x1=1,
+            y1=y,
+            line={"color": "gray", "dash": "dot"},
+        )
+
     if show_pareto_frontier:
         # Infeasible arms are not included in the Pareto frontier
         eligable_arms = df[df["p_feasible"] >= POSSIBLE_CONSTRAINT_VIOLATION_THRESHOLD]

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -196,42 +196,44 @@ class TestScatterPlot(TestCase):
             for use_model_predictions in [True, False]:
                 for trial_index in [None, 0]:
                     for with_additional_arms in [True, False]:
-                        if use_model_predictions and with_additional_arms:
-                            additional_arms = [
-                                Arm(
-                                    parameters={
-                                        parameter_name: 0
-                                        for parameter_name in (
-                                            experiment.search_space.parameters.keys()
-                                        )
-                                    }
+                        for show_pareto_frontier in [True, False]:
+                            if use_model_predictions and with_additional_arms:
+                                additional_arms = [
+                                    Arm(
+                                        parameters={
+                                            parameter_name: 0
+                                            for parameter_name in (
+                                                experiment.search_space.parameters.keys()  # noqa E501
+                                            )
+                                        }
+                                    )
+                                ]
+                            else:
+                                additional_arms = None
+
+                            generation_strategy = (
+                                get_default_generation_strategy_at_MBM_node(
+                                    experiment=experiment
                                 )
-                            ]
-                        else:
-                            additional_arms = None
-
-                        generation_strategy = (
-                            get_default_generation_strategy_at_MBM_node(
-                                experiment=experiment
                             )
-                        )
-                        generation_strategy.current_node._fit(experiment=experiment)
-                        adapter = none_throws(generation_strategy.model)
+                            generation_strategy.current_node._fit(experiment=experiment)
+                            adapter = none_throws(generation_strategy.model)
 
-                        x_metric_name, y_metric_name = [*adapter.metric_names][:2]
+                            x_metric_name, y_metric_name = [*adapter.metric_names][:2]
 
-                        analysis = ScatterPlot(
-                            x_metric_name=x_metric_name,
-                            y_metric_name=y_metric_name,
-                            use_model_predictions=use_model_predictions,
-                            trial_index=trial_index,
-                            additional_arms=additional_arms,
-                        )
+                            analysis = ScatterPlot(
+                                x_metric_name=x_metric_name,
+                                y_metric_name=y_metric_name,
+                                use_model_predictions=use_model_predictions,
+                                trial_index=trial_index,
+                                additional_arms=additional_arms,
+                                show_pareto_frontier=show_pareto_frontier,
+                            )
 
-                        _ = analysis.compute(
-                            experiment=experiment,
-                            adapter=adapter,
-                        )
+                            _ = analysis.compute(
+                                experiment=experiment,
+                                adapter=adapter,
+                            )
 
     @mock_botorch_optimize
     def test_offline(self) -> None:
@@ -246,39 +248,41 @@ class TestScatterPlot(TestCase):
             for use_model_predictions in [True, False]:
                 for trial_index in [None, 0]:
                     for with_additional_arms in [True, False]:
-                        if use_model_predictions and with_additional_arms:
-                            additional_arms = [
-                                Arm(
-                                    parameters={
-                                        parameter_name: 0
-                                        for parameter_name in (
-                                            experiment.search_space.parameters.keys()
-                                        )
-                                    }
+                        for show_pareto_frontier in [True, False]:
+                            if use_model_predictions and with_additional_arms:
+                                additional_arms = [
+                                    Arm(
+                                        parameters={
+                                            parameter_name: 0
+                                            for parameter_name in (
+                                                experiment.search_space.parameters.keys()  # noqa E501
+                                            )
+                                        }
+                                    )
+                                ]
+                            else:
+                                additional_arms = None
+
+                            generation_strategy = (
+                                get_default_generation_strategy_at_MBM_node(
+                                    experiment=experiment
                                 )
-                            ]
-                        else:
-                            additional_arms = None
-
-                        generation_strategy = (
-                            get_default_generation_strategy_at_MBM_node(
-                                experiment=experiment
                             )
-                        )
-                        generation_strategy.current_node._fit(experiment=experiment)
-                        adapter = none_throws(generation_strategy.model)
+                            generation_strategy.current_node._fit(experiment=experiment)
+                            adapter = none_throws(generation_strategy.model)
 
-                        x_metric_name, y_metric_name = [*adapter.metric_names][:2]
+                            x_metric_name, y_metric_name = [*adapter.metric_names][:2]
 
-                        analysis = ScatterPlot(
-                            x_metric_name=x_metric_name,
-                            y_metric_name=y_metric_name,
-                            use_model_predictions=use_model_predictions,
-                            trial_index=trial_index,
-                            additional_arms=additional_arms,
-                        )
+                            analysis = ScatterPlot(
+                                x_metric_name=x_metric_name,
+                                y_metric_name=y_metric_name,
+                                use_model_predictions=use_model_predictions,
+                                trial_index=trial_index,
+                                additional_arms=additional_arms,
+                                show_pareto_frontier=show_pareto_frontier,
+                            )
 
-                        _ = analysis.compute(
-                            experiment=experiment,
-                            adapter=adapter,
-                        )
+                            _ = analysis.compute(
+                                experiment=experiment,
+                                adapter=adapter,
+                            )

--- a/ax/analysis/plotly/tests/test_unified.py
+++ b/ax/analysis/plotly/tests/test_unified.py
@@ -219,39 +219,41 @@ class TestArmEffectsPlot(TestCase):
             for use_model_predictions in [True, False]:
                 for trial_index in [None, 0]:
                     for with_additional_arms in [True, False]:
-                        if use_model_predictions and with_additional_arms:
-                            additional_arms = [
-                                Arm(
-                                    parameters={
-                                        parameter_name: 0
-                                        for parameter_name in (
-                                            experiment.search_space.parameters.keys()
-                                        )
-                                    }
+                        for show_cumulative_best in [True, False]:
+                            if use_model_predictions and with_additional_arms:
+                                additional_arms = [
+                                    Arm(
+                                        parameters={
+                                            parameter_name: 0
+                                            for parameter_name in (
+                                                experiment.search_space.parameters.keys()  # noqa E501
+                                            )
+                                        }
+                                    )
+                                ]
+                            else:
+                                additional_arms = None
+
+                            generation_strategy = (
+                                get_default_generation_strategy_at_MBM_node(
+                                    experiment=experiment
                                 )
-                            ]
-                        else:
-                            additional_arms = None
-
-                        generation_strategy = (
-                            get_default_generation_strategy_at_MBM_node(
-                                experiment=experiment
                             )
-                        )
-                        generation_strategy.current_node._fit(experiment=experiment)
-                        adapter = none_throws(generation_strategy.model)
+                            generation_strategy.current_node._fit(experiment=experiment)
+                            adapter = none_throws(generation_strategy.model)
 
-                        analysis = ArmEffectsPlot(
-                            metric_names=[*adapter.metric_names],
-                            use_model_predictions=use_model_predictions,
-                            trial_index=trial_index,
-                            additional_arms=additional_arms,
-                        )
+                            analysis = ArmEffectsPlot(
+                                metric_names=[*adapter.metric_names],
+                                use_model_predictions=use_model_predictions,
+                                trial_index=trial_index,
+                                additional_arms=additional_arms,
+                                show_cumulative_best=show_cumulative_best,
+                            )
 
-                        _ = analysis.compute(
-                            experiment=experiment,
-                            adapter=adapter,
-                        )
+                            _ = analysis.compute(
+                                experiment=experiment,
+                                adapter=adapter,
+                            )
 
     @mock_botorch_optimize
     def test_offline(self) -> None:
@@ -262,39 +264,41 @@ class TestArmEffectsPlot(TestCase):
             for use_model_predictions in [True, False]:
                 for trial_index in [None, 0]:
                     for with_additional_arms in [True, False]:
-                        if use_model_predictions and with_additional_arms:
-                            additional_arms = [
-                                Arm(
-                                    parameters={
-                                        parameter_name: 0
-                                        for parameter_name in (
-                                            experiment.search_space.parameters.keys()
-                                        )
-                                    }
+                        for show_cumulative_best in [True, False]:
+                            if use_model_predictions and with_additional_arms:
+                                additional_arms = [
+                                    Arm(
+                                        parameters={
+                                            parameter_name: 0
+                                            for parameter_name in (
+                                                experiment.search_space.parameters.keys()  # noqa E501
+                                            )
+                                        }
+                                    )
+                                ]
+                            else:
+                                additional_arms = None
+
+                            generation_strategy = (
+                                get_default_generation_strategy_at_MBM_node(
+                                    experiment=experiment
                                 )
-                            ]
-                        else:
-                            additional_arms = None
-
-                        generation_strategy = (
-                            get_default_generation_strategy_at_MBM_node(
-                                experiment=experiment
                             )
-                        )
-                        generation_strategy.current_node._fit(experiment=experiment)
-                        adapter = none_throws(generation_strategy.model)
+                            generation_strategy.current_node._fit(experiment=experiment)
+                            adapter = none_throws(generation_strategy.model)
 
-                        analysis = ArmEffectsPlot(
-                            metric_names=[*adapter.metric_names],
-                            use_model_predictions=use_model_predictions,
-                            trial_index=trial_index,
-                            additional_arms=additional_arms,
-                        )
+                            analysis = ArmEffectsPlot(
+                                metric_names=[*adapter.metric_names],
+                                use_model_predictions=use_model_predictions,
+                                trial_index=trial_index,
+                                additional_arms=additional_arms,
+                                show_cumulative_best=show_cumulative_best,
+                            )
 
-                        _ = analysis.compute(
-                            experiment=experiment,
-                            adapter=adapter,
-                        )
+                            _ = analysis.compute(
+                                experiment=experiment,
+                                adapter=adapter,
+                            )
 
 
 class TestArmEffectsPlotRel(TestCase):

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -33,6 +33,20 @@ MARKER_BLUE = "rgba(0, 0, 255, 0.3)"  # slightly more opaque than the CI blue
 CANDIDATE_RED = "rgba(220, 20, 60, 0.3)"
 CANDIDATE_CI_RED = "rgba(220, 20, 60, 0.2)"
 
+# Splat this into a go.Scatter initializer when drawing a line that represents the
+# cummulative best, Pareto frontier, etc. for a unified look and feel.
+BEST_LINE_SETTINGS: dict[str, str | dict[str, str] | bool] = {
+    "mode": "lines",
+    "line": {
+        "color": px.colors.qualitative.Plotly[9],  # Gold
+        "dash": "dash",
+        # This gives us the "stepped" line effect we want
+        "shape": "hv",
+    },
+    # Do not show this line in the legend or in hover tooltips.
+    "showlegend": False,
+    "hoverinfo": "skip",
+}
 
 # Use a consistent color for each TrialStatus name, sourced from
 # the default Plotly color palette. See https://plotly.com/python/discrete-color/

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -66,6 +66,21 @@ TRIAL_STATUS_TO_PLOTLY_COLOR: dict[str, str] = {
 CI_ALPHA: float = 0.5
 
 
+def get_scatter_point_color(
+    hex_color: str,
+    ci_transparency: bool = False,
+) -> str:
+    """
+    Convert a hex color (like those in px.colors.qualitative) to an rgba string.
+
+    Always use transparency for CI colors to improve legibility.
+    """
+    red, green, blue = px.colors.hex_to_rgb(hex_color)
+    alpha = CI_ALPHA if ci_transparency else 1
+
+    return f"rgba({red}, {green}, {blue}, {alpha})"
+
+
 def trial_status_to_plotly_color(
     trial_status: str,
     ci_transparency: bool = False,
@@ -82,10 +97,7 @@ def trial_status_to_plotly_color(
         px.colors.qualitative.Plotly[8],
     )
 
-    red, green, blue = px.colors.hex_to_rgb(hex_color)
-    alpha = CI_ALPHA if ci_transparency else 1
-
-    return f"rgba({red}, {green}, {blue}, {alpha})"
+    return get_scatter_point_color(hex_color=hex_color, ci_transparency=ci_transparency)
 
 
 def get_arm_tooltip(


### PR DESCRIPTION
Summary:
Various misc changes.
## Compute for all metrics if None is provided

This is in line with other plots. Also change refined_metric_name to labels dict so that labels can be applied to all cv plots generated correctly.

## Fix compute_cross_validation_adhoc ignoring passed in Data

Previously this was used just to extract metric names -- presumably we want to actually fit the model with this data

## Make args to compute_cross_validation_adhoc match CrossValidationPlot

As titled. These should not be out of sync

## Make colors match other PlotlyAnalysis
Change the blue here to be the same blue as the other plots, and use the same alpha for the CI

Differential Revision: D72802304


