### PR TITLE
Make trial_index a required column in Data

### DIFF
--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -9,7 +9,6 @@ from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
-
 import pandas as pd
 from ax.analysis.plotly.parallel_coordinates import ParallelCoordinatesPlot
 from ax.api.client import Client
@@ -25,7 +24,6 @@ from ax.api.configs import (
 from ax.api.protocols.metric import IMetric
 from ax.api.protocols.runner import IRunner
 from ax.api.types import TParameterization
-
 from ax.core.experiment import Experiment
 from ax.core.formatting_utils import DataType
 from ax.core.map_data import MapData
@@ -413,11 +411,11 @@ class TestClient(TestCase):
             ).map_df.equals(
                 pd.DataFrame(
                     {
+                        "trial_index": {0: 0},
                         "arm_name": {0: "0_0"},
                         "metric_name": {0: "foo"},
                         "mean": {0: 1.0},
                         "sem": {0: np.nan},
-                        "trial_index": {0: 0},
                         "step": {0: np.nan},
                     }
                 )
@@ -438,11 +436,11 @@ class TestClient(TestCase):
             ).map_df.equals(
                 pd.DataFrame(
                     {
+                        "trial_index": {0: 0, 1: 0},
                         "arm_name": {0: "0_0", 1: "0_0"},
                         "metric_name": {0: "foo", 1: "foo"},
                         "mean": {0: 1.0, 1: 2.0},
                         "sem": {0: np.nan, 1: np.nan},
-                        "trial_index": {0: 0, 1: 0},
                         "step": {0: np.nan, 1: 10.0},
                     }
                 )
@@ -465,11 +463,11 @@ class TestClient(TestCase):
             ).map_df.equals(
                 pd.DataFrame(
                     {
+                        "trial_index": {0: 0, 1: 0, 2: 0},
                         "arm_name": {0: "0_0", 1: "0_0", 2: "0_0"},
                         "metric_name": {0: "foo", 1: "foo", 2: "bar"},
                         "mean": {0: 2.0, 1: 1.0, 2: 2.0},
                         "sem": {0: np.nan, 1: np.nan, 2: np.nan},
-                        "trial_index": {0: 0, 1: 0, 2: 0},
                         "step": {0: 10.0, 1: np.nan, 2: np.nan},
                     }
                 )
@@ -511,11 +509,11 @@ class TestClient(TestCase):
             ).map_df.equals(
                 pd.DataFrame(
                     {
+                        "trial_index": {0: 0, 1: 0},
                         "arm_name": {0: "0_0", 1: "0_0"},
                         "metric_name": {0: "foo", 1: "bar"},
                         "mean": {0: 1.0, 1: 2.0},
                         "sem": {0: np.nan, 1: np.nan},
-                        "trial_index": {0: 0, 1: 0},
                         "step": {0: np.nan, 1: np.nan},
                     }
                 )
@@ -540,11 +538,11 @@ class TestClient(TestCase):
             ).map_df.equals(
                 pd.DataFrame(
                     {
+                        "trial_index": {0: 1, 1: 1},
                         "arm_name": {0: "1_0", 1: "1_0"},
                         "metric_name": {0: "foo", 1: "bar"},
                         "mean": {0: 1.0, 1: 2.0},
                         "sem": {0: np.nan, 1: np.nan},
-                        "trial_index": {0: 1, 1: 1},
                         "step": {0: 10.0, 1: 10.0},
                     }
                 )
@@ -566,11 +564,11 @@ class TestClient(TestCase):
             ).map_df.equals(
                 pd.DataFrame(
                     {
+                        "trial_index": {0: 2},
                         "arm_name": {0: "2_0"},
                         "metric_name": {0: "foo"},
                         "mean": {0: 1.0},
                         "sem": {0: np.nan},
-                        "trial_index": {0: 2},
                         "step": {0: np.nan},
                     }
                 )
@@ -708,11 +706,11 @@ class TestClient(TestCase):
             ).map_df.equals(
                 pd.DataFrame(
                     {
+                        "trial_index": {0: 0},
                         "arm_name": {0: "0_0"},
                         "metric_name": {0: "foo"},
                         "mean": {0: 0.0},
                         "sem": {0: np.nan},
-                        "trial_index": {0: 0},
                         "step": {0: 1.0},
                     }
                 )
@@ -778,11 +776,11 @@ class TestClient(TestCase):
             ).map_df.equals(
                 pd.DataFrame(
                     {
+                        "trial_index": {0: 0, 1: 1, 2: 2, 3: 3},
                         "arm_name": {0: "0_0", 1: "1_0", 2: "2_0", 3: "3_0"},
                         "metric_name": {0: "foo", 1: "foo", 2: "foo", 3: "foo"},
                         "mean": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
                         "sem": {0: np.nan, 1: np.nan, 2: np.nan, 3: np.nan},
-                        "trial_index": {0: 0, 1: 1, 2: 2, 3: 3},
                         "progression": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
                     }
                 )

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -48,20 +48,20 @@ class BaseData(Base, SerializationMixin):
 
     """
 
-    REQUIRED_COLUMNS = {"arm_name"}
+    REQUIRED_COLUMNS = {"trial_index", "arm_name"}
 
     # Note on text data: https://pandas.pydata.org/docs/user_guide/text.html
     # Its type can either be `numpy.dtypes.ObjectDType` or StringDtype extension
     # type; the later is still experimental. So we are using object.
     COLUMN_DATA_TYPES: dict[str, Any] = {
         # Ubiquitous columns.
+        "trial_index": int,
         "arm_name": np.dtype("O"),
         # Metric data-related columns.
         "metric_name": np.dtype("O"),
         "mean": np.float64,
         "sem": np.float64,
         # Metadata columns available for all subclasses.
-        "trial_index": int,
         "start_time": pd.Timestamp,
         "end_time": pd.Timestamp,
         "n": int,

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -20,43 +20,41 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.common.timeutils import current_timestamp_in_millis
 
 REPR_1000: str = (
-    "Data(df=\n"
-    + "|    |   arm_name | metric_name   |   mean |   sem |   trial_index "
-    + "| start_time          | end_time            |\n"
-    + "|---:|-----------:|:--------------|-------:|------:|--------------:"
-    + "|:--------------------|:--------------------|\n"
-    + "|  0 |        0_0 | a             |    2   |   0.2 |             1 "
-    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
-    + "|  1 |        0_0 | b             |    1.8 |   0.3 |             1 "
-    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
-    + "|  2 |        0_1 | a             |    4   |   0.6 |             1 "
-    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
-    + "|  3 |        0_1 | b             |    3.7 |   0.5 |             1 "
-    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
-    + "|  4 |        0_2 | a             |    0.5 | nan   |             1 "
-    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
-    + "|  5 |        0_2 | b             |    3   | nan   |             1 "
-    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |)"
+    "Data(df=\n|    |   trial_index |   arm_name | metric_name   |   mean |   sem "
+    "| start_time          | end_time            |\n"
+    "|---:|--------------:|-----------:|:--------------|-------:|------:"
+    "|:--------------------|:--------------------|\n"
+    "|  0 |             1 |        0_0 | a             |    2   |   0.2 "
+    "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    "|  1 |             1 |        0_0 | b             |    1.8 |   0.3 "
+    "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    "|  2 |             1 |        0_1 | a             |    4   |   0.6 "
+    "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    "|  3 |             1 |        0_1 | b             |    3.7 |   0.5 "
+    "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    "|  4 |             1 |        0_2 | a             |    0.5 | nan   "
+    "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    "|  5 |             1 |        0_2 | b             |    3   | nan   "
+    "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |)"
 )
 
 REPR_500: str = (
-    "Data(df=\n"
-    + "|    |   arm_name | metric_name   |   mean |   sem |   trial_index "
-    + "| start_time          | end_time            |\n"
-    + "|---:|-----------:|:--------------|-------:|------:|--------------:"
-    + "|:--------------------|:--------------------|\n"
-    + "|  0 |        0_0 | a             |    2   |   0.2 |             1 "
-    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
-    + "|  1 |        0_0 | b             |    1.8 |   0.3 |             1 "
-    + "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
-    + "|  2 |        0_1 | a             |    4   |   0...)"
+    "Data(df=\n|    |   trial_index |   arm_name | metric_name   |   mean |   sem "
+    "| start_time          | end_time            |\n"
+    "|---:|--------------:|-----------:|:--------------|-------:|------:"
+    "|:--------------------|:--------------------|\n"
+    "|  0 |             1 |        0_0 | a             |    2   |   0.2 "
+    "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    "|  1 |             1 |        0_0 | b             |    1.8 |   0.3 "
+    "| 2018-01-01 00:00:00 | 2018-01-02 00:00:00 |\n"
+    "|  2 |             1 |        0_1 | a           ...)"
 )
 
 
 class DataTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.df_hash = "3dd7ab8c67942d43c78ea4af05bbb1c4"
+        self.df_hash = "be6ca1edb2d83e08c460665476d32caa"
         self.df = pd.DataFrame(
             [
                 {
@@ -171,20 +169,13 @@ class DataTest(TestCase):
         merged_data = set_single_trial(data)
         self.assertTrue((merged_data.df["trial_index"] == 0).all())
 
-        data = Data(
-            df=pd.DataFrame(
-                [{"arm_name": "0_1", "mean": 3.7, "sem": 0.5, "metric_name": "b"}]
-            )
-        )
-        merged_data = set_single_trial(data)
-        self.assertTrue("trial_index" not in merged_data.df)
-
     def test_CustomData(self) -> None:
         CustomData = custom_data_class(
             column_data_types={"metadata": str, "created_time": pd.Timestamp},
             required_columns={"metadata"},
         )
         data_entry = {
+            "trial_index": 0,
             "arm_name": "0_1",
             "mean": 3.7,
             "sem": 0.5,
@@ -197,6 +188,7 @@ class DataTest(TestCase):
         self.assertTrue(isinstance(data.df.iloc[0]["created_time"], pd.Timestamp))
 
         data_entry2 = {
+            "trial_index": 0,
             "arm_name": "0_1",
             "mean": 3.7,
             "sem": 0.5,

--- a/ax/metrics/tests/test_tensorboard.py
+++ b/ax/metrics/tests/test_tensorboard.py
@@ -98,11 +98,11 @@ class TensorboardMetricTest(TestCase):
         expected_df = pd.DataFrame(
             [
                 {
+                    "trial_index": 0,
                     "arm_name": "0_0",
                     "metric_name": "loss",
                     "mean": fake_data[i],
                     "sem": float("nan"),
-                    "trial_index": 0,
                     "step": float(i),
                 }
                 for i in range(len(fake_data))
@@ -168,11 +168,11 @@ class TensorboardMetricTest(TestCase):
         expected_df = pd.DataFrame(
             [
                 {
+                    "trial_index": 0,
                     "arm_name": "0_0",
                     "metric_name": "loss",
                     "mean": smooth_data[i],
                     "sem": float("nan"),
-                    "trial_index": 0,
                     "step": float(i),
                 }
                 for i in range(len(fake_data))
@@ -207,11 +207,11 @@ class TensorboardMetricTest(TestCase):
         expected_df = pd.DataFrame(
             [
                 {
+                    "trial_index": 0,
                     "arm_name": "0_0",
                     "metric_name": "loss",
                     "mean": cummin_data[i],
                     "sem": float("nan"),
-                    "trial_index": 0,
                     "step": float(i),
                 }
                 for i in range(len(fake_data))
@@ -240,11 +240,11 @@ class TensorboardMetricTest(TestCase):
         expected_df = pd.DataFrame(
             [
                 {
+                    "trial_index": 0,
                     "arm_name": "0_0",
                     "metric_name": "loss",
                     "mean": percentile_data[i],
                     "sem": float("nan"),
-                    "trial_index": 0,
                     "step": float(i),
                 }
                 for i in range(len(fake_data))

--- a/ax/utils/stats/tests/test_statstools.py
+++ b/ax/utils/stats/tests/test_statstools.py
@@ -84,19 +84,33 @@ class RelativizeDataTest(TestCase):
             df=pd.DataFrame(
                 [
                     {
+                        "trial_index": 0,
                         "mean": 2,
                         "sem": 0,
                         "metric_name": "foobar",
                         "arm_name": "status_quo",
                     },
                     {
+                        "trial_index": 0,
                         "mean": 5,
                         "sem": 0,
                         "metric_name": "foobaz",
                         "arm_name": "status_quo",
                     },
-                    {"mean": 1, "sem": 0, "metric_name": "foobar", "arm_name": "0_0"},
-                    {"mean": 10, "sem": 0, "metric_name": "foobaz", "arm_name": "0_0"},
+                    {
+                        "trial_index": 0,
+                        "mean": 1,
+                        "sem": 0,
+                        "metric_name": "foobar",
+                        "arm_name": "0_0",
+                    },
+                    {
+                        "trial_index": 0,
+                        "mean": 10,
+                        "sem": 0,
+                        "metric_name": "foobaz",
+                        "arm_name": "0_0",
+                    },
                 ]
             )
         )
@@ -104,12 +118,19 @@ class RelativizeDataTest(TestCase):
             df=pd.DataFrame(
                 [
                     {
+                        "trial_index": 0,
                         "mean": -0.5,
                         "sem": 0,
                         "metric_name": "foobar",
                         "arm_name": "0_0",
                     },
-                    {"mean": 1, "sem": 0, "metric_name": "foobaz", "arm_name": "0_0"},
+                    {
+                        "trial_index": 0,
+                        "mean": 1,
+                        "sem": 0,
+                        "metric_name": "foobaz",
+                        "arm_name": "0_0",
+                    },
                 ]
             )
         )
@@ -117,24 +138,33 @@ class RelativizeDataTest(TestCase):
             df=pd.DataFrame(
                 [
                     {
+                        "trial_index": 0,
                         "mean": 0,
                         "sem": 0,
                         "metric_name": "foobar",
                         "arm_name": "status_quo",
                     },
                     {
+                        "trial_index": 0,
                         "mean": -0.5,
                         "sem": 0,
                         "metric_name": "foobar",
                         "arm_name": "0_0",
                     },
                     {
+                        "trial_index": 0,
                         "mean": 0,
                         "sem": 0,
                         "metric_name": "foobaz",
                         "arm_name": "status_quo",
                     },
-                    {"mean": 1, "sem": 0, "metric_name": "foobaz", "arm_name": "0_0"},
+                    {
+                        "trial_index": 0,
+                        "mean": 1,
+                        "sem": 0,
+                        "metric_name": "foobaz",
+                        "arm_name": "0_0",
+                    },
                 ]
             )
         )


### PR DESCRIPTION
Summary: `trial_index` is an ubiquous column in all `Data` objects. Ax supports attaching the same arm to multiple trials, which necessitates tracking the data by `(trial_index, arm_name)` pair, rather than by `arm_name` alone. This change ensures that `trial_index` column is always available, even if `Data` is empty.

Reviewed By: Balandat

Differential Revision: D73196384


