### PR TITLE
Use AutoTC instead of MinTrials in CenterGN

### DIFF
--- a/ax/generation_strategy/center_generation_node.py
+++ b/ax/generation_strategy/center_generation_node.py
@@ -15,7 +15,7 @@ from ax.core.parameter import ChoiceParameter, FixedParameter, RangeParameter
 from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
 from ax.core.types import TParameterization
 from ax.generation_strategy.external_generation_node import ExternalGenerationNode
-from ax.generation_strategy.transition_criterion import MinTrials
+from ax.generation_strategy.transition_criterion import AutoTransitionAfterGen
 from pyre_extensions import none_throws
 
 
@@ -32,17 +32,14 @@ class CenterGenerationNode(ExternalGenerationNode):
         experiment, this will fallback to Sobol through the use of ``GenerationNode``
         deduplication logic.
         """
-        transition_criteria = [
-            MinTrials(
-                threshold=1,
-                block_gen_if_met=False,
-                block_transition_if_unmet=True,
-                transition_to=next_node_name,
-            ),
-        ]
         super().__init__(
             node_name="CenterOfSearchSpace",
-            transition_criteria=transition_criteria,
+            transition_criteria=[
+                AutoTransitionAfterGen(
+                    transition_to=next_node_name,
+                    continue_trial_generation=False,
+                )
+            ],
             should_deduplicate=True,
         )
         self.search_space: SearchSpace | None = None

--- a/ax/generation_strategy/tests/test_center_generation_node.py
+++ b/ax/generation_strategy/tests/test_center_generation_node.py
@@ -17,7 +17,7 @@ from ax.core.parameter import (
 )
 from ax.core.search_space import SearchSpace
 from ax.generation_strategy.center_generation_node import CenterGenerationNode
-from ax.generation_strategy.transition_criterion import MinTrials
+from ax.generation_strategy.transition_criterion import AutoTransitionAfterGen
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
 from pyre_extensions import none_throws
@@ -58,11 +58,8 @@ class TestCenterGenerationNode(TestCase):
         self.assertEqual(
             node.transition_criteria,
             [
-                MinTrials(
-                    threshold=1,
-                    block_gen_if_met=False,
-                    block_transition_if_unmet=True,
-                    transition_to="test",
+                AutoTransitionAfterGen(
+                    transition_to="test", continue_trial_generation=False
                 )
             ],
         )


### PR DESCRIPTION
Summary: The `AutoTC` always transitions after generating one GR, whereas `MinTrials` requires the trials to be attached to the experiment before it can transition, which causes issues if we try to generate multiple trials at once before attaching them to the experiment (we either get only one trial or generate multiple center points). `AutoTC` seems like the better option in this case, though it is not perfect either. If we generate and forget to attach that trial to the experiment, we will not generate from Center again. I think this is a fair compromise to unblock the use of CenterGN with Ax API, which supports requesting multiple trials at once.

Reviewed By: lena-kashtelyan

Differential Revision: D73276555


