### PR TITLE
Consolidate best-point methods

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -9,7 +9,7 @@
 import json
 import logging
 import warnings
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Sequence
 from functools import partial
 
 from logging import Logger
@@ -29,18 +29,9 @@ from ax.core.map_metric import MapMetric
 from ax.core.multi_type_experiment import MultiTypeExperiment
 from ax.core.objective import MultiObjective, Objective
 from ax.core.observation import ObservationFeatures
-from ax.core.optimization_config import (
-    MultiObjectiveOptimizationConfig,
-    OptimizationConfig,
-)
 from ax.core.runner import Runner
 from ax.core.trial import Trial
-from ax.core.types import (
-    TEvaluationOutcome,
-    TModelPredictArm,
-    TParameterization,
-    TParamValue,
-)
+from ax.core.types import TEvaluationOutcome, TParameterization, TParamValue
 
 from ax.core.utils import get_pending_observation_features_based_on_trial_status
 from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
@@ -1563,73 +1554,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
     def global_stopping_strategy(self, gss: BaseGlobalStoppingStrategy) -> None:
         """Update the global stopping strategy."""
         self._global_stopping_strategy = gss
-
-    @copy_doc(BestPointMixin.get_best_trial)
-    def get_best_trial(
-        self,
-        optimization_config: OptimizationConfig | None = None,
-        trial_indices: Iterable[int] | None = None,
-        use_model_predictions: bool = True,
-    ) -> tuple[int, TParameterization, TModelPredictArm | None] | None:
-        return self._get_best_trial(
-            experiment=self.experiment,
-            generation_strategy=self.generation_strategy,
-            trial_indices=trial_indices,
-            use_model_predictions=use_model_predictions,
-        )
-
-    @copy_doc(BestPointMixin.get_pareto_optimal_parameters)
-    def get_pareto_optimal_parameters(
-        self,
-        optimization_config: OptimizationConfig | None = None,
-        trial_indices: Iterable[int] | None = None,
-        use_model_predictions: bool = True,
-    ) -> dict[int, tuple[TParameterization, TModelPredictArm]]:
-        return self._get_pareto_optimal_parameters(
-            experiment=self.experiment,
-            generation_strategy=self.generation_strategy,
-            trial_indices=trial_indices,
-            use_model_predictions=use_model_predictions,
-        )
-
-    @copy_doc(BestPointMixin.get_hypervolume)
-    def get_hypervolume(
-        self,
-        optimization_config: MultiObjectiveOptimizationConfig | None = None,
-        trial_indices: Iterable[int] | None = None,
-        use_model_predictions: bool = True,
-    ) -> float:
-        return BestPointMixin._get_hypervolume(
-            experiment=self.experiment,
-            generation_strategy=self.generation_strategy,
-            optimization_config=optimization_config,
-            trial_indices=trial_indices,
-            use_model_predictions=use_model_predictions,
-        )
-
-    @copy_doc(BestPointMixin.get_trace)
-    def get_trace(
-        self,
-        optimization_config: MultiObjectiveOptimizationConfig | None = None,
-    ) -> list[float]:
-        return BestPointMixin._get_trace(
-            experiment=self.experiment,
-            optimization_config=optimization_config,
-        )
-
-    @copy_doc(BestPointMixin.get_trace_by_progression)
-    def get_trace_by_progression(
-        self,
-        optimization_config: OptimizationConfig | None = None,
-        bins: list[float] | None = None,
-        final_progression_only: bool = False,
-    ) -> tuple[list[float], list[float]]:
-        return BestPointMixin._get_trace_by_progression(
-            experiment=self.experiment,
-            optimization_config=optimization_config,
-            bins=bins,
-            final_progression_only=final_progression_only,
-        )
 
     def _update_trial_with_raw_data(
         self,

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -27,12 +27,7 @@ from ax.core.multi_type_experiment import (
     get_trial_indices_for_statuses,
     MultiTypeExperiment,
 )
-from ax.core.optimization_config import (
-    MultiObjectiveOptimizationConfig,
-    OptimizationConfig,
-)
 from ax.core.runner import Runner
-from ax.core.types import TModelPredictArm, TParameterization
 from ax.core.utils import get_pending_observation_features_based_on_trial_status
 
 from ax.exceptions.core import (
@@ -55,7 +50,6 @@ from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.service.utils.with_db_settings_base import DBSettings, WithDBSettingsBase
 from ax.utils.common.constants import Keys
-from ax.utils.common.docutils import copy_doc
 from ax.utils.common.executils import retry_on_exception
 from ax.utils.common.logger import (
     build_file_handler,
@@ -1241,75 +1235,6 @@ class Scheduler(AnalysisBase, BestPointMixin):
             )
 
         return updated_any_trial_status
-
-    @copy_doc(BestPointMixin.get_best_trial)
-    def get_best_trial(
-        self,
-        optimization_config: OptimizationConfig | None = None,
-        trial_indices: Iterable[int] | None = None,
-        use_model_predictions: bool = True,
-    ) -> tuple[int, TParameterization, TModelPredictArm | None] | None:
-        return self._get_best_trial(
-            experiment=self.experiment,
-            generation_strategy=self.generation_strategy,
-            optimization_config=optimization_config,
-            trial_indices=trial_indices,
-            use_model_predictions=use_model_predictions,
-        )
-
-    @copy_doc(BestPointMixin.get_pareto_optimal_parameters)
-    def get_pareto_optimal_parameters(
-        self,
-        optimization_config: OptimizationConfig | None = None,
-        trial_indices: Iterable[int] | None = None,
-        use_model_predictions: bool = True,
-    ) -> dict[int, tuple[TParameterization, TModelPredictArm]]:
-        return self._get_pareto_optimal_parameters(
-            experiment=self.experiment,
-            generation_strategy=self.generation_strategy,
-            optimization_config=optimization_config,
-            trial_indices=trial_indices,
-            use_model_predictions=use_model_predictions,
-        )
-
-    @copy_doc(BestPointMixin.get_hypervolume)
-    def get_hypervolume(
-        self,
-        optimization_config: MultiObjectiveOptimizationConfig | None = None,
-        trial_indices: Iterable[int] | None = None,
-        use_model_predictions: bool = True,
-    ) -> float:
-        return BestPointMixin._get_hypervolume(
-            experiment=self.experiment,
-            generation_strategy=self.generation_strategy,
-            optimization_config=optimization_config,
-            trial_indices=trial_indices,
-            use_model_predictions=use_model_predictions,
-        )
-
-    @copy_doc(BestPointMixin.get_trace)
-    def get_trace(
-        self,
-        optimization_config: OptimizationConfig | None = None,
-    ) -> list[float]:
-        return BestPointMixin._get_trace(
-            experiment=self.experiment,
-            optimization_config=optimization_config,
-        )
-
-    @copy_doc(BestPointMixin.get_trace_by_progression)
-    def get_trace_by_progression(
-        self,
-        optimization_config: OptimizationConfig | None = None,
-        bins: list[float] | None = None,
-        final_progression_only: bool = False,
-    ) -> tuple[list[float], list[float]]:
-        return BestPointMixin._get_trace_by_progression(
-            experiment=self.experiment,
-            optimization_config=optimization_config,
-            bins=bins,
-            final_progression_only=final_progression_only,
-        )
 
     # ------------------------- III. Protected helpers. -----------------------
 

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC
 from collections.abc import Iterable
 from functools import partial
 
@@ -51,8 +51,10 @@ from pyre_extensions import assert_is_instance, none_throws
 NUM_BINS_PER_TRIAL = 3
 
 
-class BestPointMixin(metaclass=ABCMeta):
-    @abstractmethod
+class BestPointMixin(ABC):
+    experiment: Experiment
+    generation_strategy: GenerationStrategy
+
     def get_best_trial(
         self,
         optimization_config: OptimizationConfig | None = None,
@@ -82,7 +84,13 @@ class BestPointMixin(metaclass=ABCMeta):
         Returns:
             Tuple of trial index, parameterization and model predictions for it.
         """
-        pass
+        return self._get_best_trial(
+            experiment=self.experiment,
+            generation_strategy=self.generation_strategy,
+            optimization_config=optimization_config,
+            trial_indices=trial_indices,
+            use_model_predictions=use_model_predictions,
+        )
 
     def get_best_parameters(
         self,
@@ -125,7 +133,6 @@ class BestPointMixin(metaclass=ABCMeta):
         _, parameterization, vals = res
         return parameterization, vals
 
-    @abstractmethod
     def get_pareto_optimal_parameters(
         self,
         optimization_config: OptimizationConfig | None = None,
@@ -163,9 +170,14 @@ class BestPointMixin(metaclass=ABCMeta):
             Raises a `NotImplementedError` if extracting the Pareto frontier is
             not possible. Note that the returned dict may be empty.
         """
-        pass
+        return self._get_pareto_optimal_parameters(
+            experiment=self.experiment,
+            generation_strategy=self.generation_strategy,
+            optimization_config=optimization_config,
+            trial_indices=trial_indices,
+            use_model_predictions=use_model_predictions,
+        )
 
-    @abstractmethod
     def get_hypervolume(
         self,
         optimization_config: MultiObjectiveOptimizationConfig | None = None,
@@ -186,10 +198,16 @@ class BestPointMixin(metaclass=ABCMeta):
                 also be based on model predictions and may differ from the
                 observed values.
         """
-        pass
+        return self._get_hypervolume(
+            experiment=self.experiment,
+            generation_strategy=self.generation_strategy,
+            optimization_config=optimization_config,
+            trial_indices=trial_indices,
+            use_model_predictions=use_model_predictions,
+        )
 
-    @abstractmethod
     def get_trace(
+        self,
         optimization_config: OptimizationConfig | None = None,
     ) -> list[float]:
         """Get the optimization trace of the given experiment.
@@ -199,7 +217,6 @@ class BestPointMixin(metaclass=ABCMeta):
         `use_model_predictions = False`, though this does it more efficiently.
 
         Args:
-            experiment: The experiment to get the trace for.
             optimization_config: An optional optimization config to use for computing
                 the trace. This allows computing the traces under different objectives
                 or constraints without having to modify the experiment.
@@ -207,10 +224,12 @@ class BestPointMixin(metaclass=ABCMeta):
         Returns:
             A list of observed hypervolumes or best values.
         """
-        pass
+        return self._get_trace(
+            experiment=self.experiment, optimization_config=optimization_config
+        )
 
-    @abstractmethod
     def get_trace_by_progression(
+        self,
         optimization_config: OptimizationConfig | None = None,
         bins: list[float] | None = None,
         final_progression_only: bool = False,
@@ -246,7 +265,12 @@ class BestPointMixin(metaclass=ABCMeta):
             A tuple containing (1) the list of observed hypervolumes or best values and
             (2) a list of associated x-values (i.e., progressions) useful for plotting.
         """
-        pass
+        return self._get_trace_by_progression(
+            experiment=self.experiment,
+            optimization_config=optimization_config,
+            bins=bins,
+            final_progression_only=final_progression_only,
+        )
 
     @staticmethod
     def _get_best_trial(


### PR DESCRIPTION
Summary:
Context:

Currently, code is like this:
```
class BestPointMixin(ABC):
     abstractmethod
    def f(self, args):
        pass

    staticmethod
    def _f(
        experiment: Experiment,
        generation_strategy: GenerationStrategy,
        args
    ):
         [concrete implementation]

class Scheduler(BestPointMixin):
    copy_doc(f)
    def f(self, args):
        return self._f(
            experiment=self.experiment,
            generation_strategy=self.generation_strategy,
            args=args
        )

class AxClient(BestPointMixin):
    copy_doc(f)
    def f(self, args):
        return self._f(
            experiment=self.experiment,
            generation_strategy=self.generation_strategy,
            args=args
        )
```

I believe this was written this way (with four methods where just one might do) because ABCs were more primitive at the this was written -- I'm not sure it was possible to do this:

```
class BestPointMixin(ABC):
    # OK because all subclasses instantiate these
    experiment: Experiment
    generation_strategy: GenerationStrategy

    # Concrete, so no need for subclasses to override
    def f(self, args):
        return self._f(
            experiment=self.experiment,
            generation_strategy=generation_strategy,
            args=args
        )

    staticmethod
    def _f(
        experiment: Experiment,
        generation_strategy: GenerationStrategy,
        args
    ):
         [concrete implementation]
```

# This PR:

Refactors several methods according to the above pattern.

Reviewed By: saitcakmak

Differential Revision: D73282698


