### PR TITLE
Add cumulative best line to armeffects so it can be used as an "optimization trace"

### DIFF
--- a/ax/analysis/plotly/tests/test_unified.py
+++ b/ax/analysis/plotly/tests/test_unified.py
@@ -219,39 +219,41 @@ class TestArmEffectsPlot(TestCase):
             for use_model_predictions in [True, False]:
                 for trial_index in [None, 0]:
                     for with_additional_arms in [True, False]:
-                        if use_model_predictions and with_additional_arms:
-                            additional_arms = [
-                                Arm(
-                                    parameters={
-                                        parameter_name: 0
-                                        for parameter_name in (
-                                            experiment.search_space.parameters.keys()
-                                        )
-                                    }
+                        for show_cumulative_best in [True, False]:
+                            if use_model_predictions and with_additional_arms:
+                                additional_arms = [
+                                    Arm(
+                                        parameters={
+                                            parameter_name: 0
+                                            for parameter_name in (
+                                                experiment.search_space.parameters.keys()  # noqa E501
+                                            )
+                                        }
+                                    )
+                                ]
+                            else:
+                                additional_arms = None
+
+                            generation_strategy = (
+                                get_default_generation_strategy_at_MBM_node(
+                                    experiment=experiment
                                 )
-                            ]
-                        else:
-                            additional_arms = None
-
-                        generation_strategy = (
-                            get_default_generation_strategy_at_MBM_node(
-                                experiment=experiment
                             )
-                        )
-                        generation_strategy.current_node._fit(experiment=experiment)
-                        adapter = none_throws(generation_strategy.model)
+                            generation_strategy.current_node._fit(experiment=experiment)
+                            adapter = none_throws(generation_strategy.model)
 
-                        analysis = ArmEffectsPlot(
-                            metric_names=[*adapter.metric_names],
-                            use_model_predictions=use_model_predictions,
-                            trial_index=trial_index,
-                            additional_arms=additional_arms,
-                        )
+                            analysis = ArmEffectsPlot(
+                                metric_names=[*adapter.metric_names],
+                                use_model_predictions=use_model_predictions,
+                                trial_index=trial_index,
+                                additional_arms=additional_arms,
+                                show_cumulative_best=show_cumulative_best,
+                            )
 
-                        _ = analysis.compute(
-                            experiment=experiment,
-                            adapter=adapter,
-                        )
+                            _ = analysis.compute(
+                                experiment=experiment,
+                                adapter=adapter,
+                            )
 
     @mock_botorch_optimize
     def test_offline(self) -> None:
@@ -262,39 +264,41 @@ class TestArmEffectsPlot(TestCase):
             for use_model_predictions in [True, False]:
                 for trial_index in [None, 0]:
                     for with_additional_arms in [True, False]:
-                        if use_model_predictions and with_additional_arms:
-                            additional_arms = [
-                                Arm(
-                                    parameters={
-                                        parameter_name: 0
-                                        for parameter_name in (
-                                            experiment.search_space.parameters.keys()
-                                        )
-                                    }
+                        for show_cumulative_best in [True, False]:
+                            if use_model_predictions and with_additional_arms:
+                                additional_arms = [
+                                    Arm(
+                                        parameters={
+                                            parameter_name: 0
+                                            for parameter_name in (
+                                                experiment.search_space.parameters.keys()  # noqa E501
+                                            )
+                                        }
+                                    )
+                                ]
+                            else:
+                                additional_arms = None
+
+                            generation_strategy = (
+                                get_default_generation_strategy_at_MBM_node(
+                                    experiment=experiment
                                 )
-                            ]
-                        else:
-                            additional_arms = None
-
-                        generation_strategy = (
-                            get_default_generation_strategy_at_MBM_node(
-                                experiment=experiment
                             )
-                        )
-                        generation_strategy.current_node._fit(experiment=experiment)
-                        adapter = none_throws(generation_strategy.model)
+                            generation_strategy.current_node._fit(experiment=experiment)
+                            adapter = none_throws(generation_strategy.model)
 
-                        analysis = ArmEffectsPlot(
-                            metric_names=[*adapter.metric_names],
-                            use_model_predictions=use_model_predictions,
-                            trial_index=trial_index,
-                            additional_arms=additional_arms,
-                        )
+                            analysis = ArmEffectsPlot(
+                                metric_names=[*adapter.metric_names],
+                                use_model_predictions=use_model_predictions,
+                                trial_index=trial_index,
+                                additional_arms=additional_arms,
+                                show_cumulative_best=show_cumulative_best,
+                            )
 
-                        _ = analysis.compute(
-                            experiment=experiment,
-                            adapter=adapter,
-                        )
+                            _ = analysis.compute(
+                                experiment=experiment,
+                                adapter=adapter,
+                            )
 
 
 class TestArmEffectsPlotRel(TestCase):

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -33,6 +33,20 @@ MARKER_BLUE = "rgba(0, 0, 255, 0.3)"  # slightly more opaque than the CI blue
 CANDIDATE_RED = "rgba(220, 20, 60, 0.3)"
 CANDIDATE_CI_RED = "rgba(220, 20, 60, 0.2)"
 
+# Splat this into a go.Scatter initializer when drawing a line that represents the
+# cummulative best, Pareto frontier, etc. for a unified look and feel.
+BEST_LINE_SETTINGS: dict[str, str | dict[str, str] | bool] = {
+    "mode": "lines",
+    "line": {
+        "color": px.colors.qualitative.Plotly[9],  # Gold
+        "dash": "dash",
+        # This gives us the "stepped" line effect we want
+        "shape": "hv",
+    },
+    # Do not show this line in the legend or in hover tooltips.
+    "showlegend": False,
+    "hoverinfo": "skip",
+}
 
 # Use a consistent color for each TrialStatus name, sourced from
 # the default Plotly color palette. See https://plotly.com/python/discrete-color/


### PR DESCRIPTION
Summary: Controlled by new flag show_cummulative_best which defaults to False. Also added a BEST_LINE_SETTINGS constant so we can share the same styling for Pareto frontier in scatter plot

Reviewed By: mgarrard

Differential Revision: D72808446


