### PR TITLE
Add mock_botorch_optimize to test_get_pareto_optimal_parameters_simple_with_minimize

### DIFF
--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -2710,6 +2710,7 @@ class TestAxClient(TestCase):
         self.assertGreater(len(observed_pareto), 0)
 
     # Part 1/2 of tests run by helper_test_get_pareto_optimal_parameters_simple
+    @mock_botorch_optimize
     def test_get_pareto_optimal_parameters_simple_with_minimize_false(self) -> None:
         minimize = False
         for use_y0_threshold, use_y2_constraint in product(
@@ -2722,6 +2723,7 @@ class TestAxClient(TestCase):
             )
 
     # Part 2/2 of tests run by helper_test_get_pareto_optimal_parameters_simple
+    @mock_botorch_optimize
     def test_get_pareto_optimal_parameters_simple_with_minimize_true(self) -> None:
         minimize = True
         for use_y0_threshold, use_y2_constraint in product(


### PR DESCRIPTION
Summary: Test is currently flaky due to timeout. This test is generating new candidates via qnehvi, so adding mock_botorch_optimize should speed things up

Differential Revision: D73444839


