### PR TITLE
Add ax_long_test to test_get_standard_plots

### DIFF
--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -366,6 +366,12 @@ class ReportUtilsTest(TestCase):
         )
         self.assertDictEqual(expected_output, actual_output)
 
+    @TestCase.ax_long_test(
+        reason=(
+            "get_standard_plots still too slow under @mock_botorch_optimize for this "
+            "test. Will be deprecated soon."
+        )
+    )
     @mock_botorch_optimize
     def test_get_standard_plots(self) -> None:
         exp = get_branin_experiment()


### PR DESCRIPTION
Summary: As titled. get_standard_plots will be removed soon, so no need to work on speedind this test case up

Differential Revision: D73449935


