### PR TITLE
Use GeneratorRun.best_arm_predictions for best points used for inference value

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -275,85 +275,47 @@ def _get_cumulative_cost(
     return previous_cost + sum(per_trial_times)
 
 
-def _get_oracle_value_of_params(
-    params: Mapping[str, TParamValue], problem: BenchmarkProblem
-) -> float:
-    """
-    A roundabout way of getting the value of a parameterization:
-    1. Construct an experiment with the parameterization as its only trial,
-        using the BenchmarkProblem to get the oracle value of that
-        parameterization.
-    2. Get the optimization trace of that experiment.
-    """
-    dummy_experiment = get_oracle_experiment_from_params(
-        problem=problem, dict_of_dict_of_params={0: {"0_0": params}}
-    )
-    (inference_value,) = get_trace(
-        experiment=dummy_experiment, optimization_config=problem.optimization_config
-    )
-    return inference_value
-
-
-def _get_oracle_trace_from_arms(
-    evaluated_arms_list: Iterable[set[Arm]], problem: BenchmarkProblem
+def _get_trace_from_arms(
+    arms_list: Iterable[set[Arm]], problem: BenchmarkProblem, cumulative_best: bool
 ) -> npt.NDArray:
     """
-    Get the oracle trace from a list of arms.
+    Get a trace from a list of sets of arms.
 
-    1. Construct a dummy experiment where trial ``i`` contains the arms in
-        ``evaluated_arms_list[i]``; if there are multiple arms, it will be a
-        ``BatchTrial``. Its data will be at oracle values.
-    2. Get the optimization trace of that experiment.
+    If 'cumulative_best' is True:
+        1. Construct a dummy experiment where trial ``i`` contains the arms in
+            ``arms_list[i]``; if there are multiple arms, it will be a
+            ``BatchTrial``. Its data will be at oracle values.
+        2. Get the optimization trace of that experiment. It will be increasing
+            (if higher is better) or lower (otherwise).
+
+    If `cumulative_best` is False:
+        1. For each set of arms in `arms_list`, construct a one-trial dummy
+            experiment in which trial ``i`` contains the arms in
+            ``arms_list[i]``; if there are multiple arms, it will be a
+            ``BatchTrial``. Its data will be at oracle values.
+        2. Get the value of each trial.
     """
+    # TODO: make sure this works reasonably with empty arms_list
     dummy_experiment = get_oracle_experiment_from_params(
         problem=problem,
         dict_of_dict_of_params={
             i: {arm.name: arm.parameters for arm in arms}
-            for i, arms in enumerate(evaluated_arms_list)
+            for i, arms in enumerate(arms_list)
         },
     )
-    oracle_trace = get_trace(
+    trace = get_trace(
         experiment=dummy_experiment,
         optimization_config=problem.optimization_config,
+        cumulative_best=cumulative_best,
     )
-    return np.array(oracle_trace)
-
-
-def _get_inference_trace_from_params(
-    best_params_list: Sequence[Mapping[str, TParamValue]],
-    problem: BenchmarkProblem,
-    n_elements: int,
-) -> npt.NDArray:
-    """
-    Get the inference value of each parameterization in ``best_params_list``.
-
-    ``best_params_list`` can be empty, indicating that inference value is not
-    supported for this benchmark, in which case the returned array will be all
-    NaNs with length ``n_elements``. If it is not empty, it must have length
-    ``n_elements``.
-    """
-    if len(best_params_list) == 0:
-        return np.full(n_elements, np.nan)
-    if len(best_params_list) != n_elements:
-        raise RuntimeError(
-            f"Expected {n_elements} elements in `best_params_list`, got "
-            f"{len(best_params_list)}."
-        )
-    return np.array(
-        [
-            _get_oracle_value_of_params(params=params, problem=problem)
-            for params in best_params_list
-        ]
-    )
+    return np.array(trace)
 
 
 def _update_benchmark_tracking_vars_in_place(
     experiment: Experiment,
-    method: BenchmarkMethod,
-    problem: BenchmarkProblem,
     cost_trace: list[float],
     evaluated_arms_list: list[set[Arm]],
-    best_params_list: list[Mapping[str, TParamValue]],
+    best_arms_list: list[set[Arm]],
     completed_trial_idcs: set[int],
 ) -> None:
     """
@@ -372,9 +334,6 @@ def _update_benchmark_tracking_vars_in_place(
     newly_completed_trials = currently_completed_trial_idcs - completed_trial_idcs
     completed_trial_idcs |= newly_completed_trials
 
-    is_mf_or_mt = len(problem.target_fidelity_and_task) > 0
-    compute_best_params = not (problem.is_moo or is_mf_or_mt)
-
     if len(newly_completed_trials) > 0:
         previous_cost = cost_trace[-1] if len(cost_trace) > 0 else 0.0
         cost = _get_cumulative_cost(
@@ -391,17 +350,16 @@ def _update_benchmark_tracking_vars_in_place(
         }
         evaluated_arms_list.append(params)
 
-        # Inference trace: Not supported for MOO.
-        # It's also not supported for multi-fidelity or multi-task
-        # problems, because Ax's best-point functionality doesn't know
-        # to predict at the target task or fidelity.
-        if compute_best_params:
-            (best_params,) = method.get_best_parameters(
-                experiment=experiment,
-                optimization_config=problem.optimization_config,
-                n_points=problem.n_best_points,
-            )
-            best_params_list.append(best_params)
+        best_arm_predictions = (
+            experiment.trials[i].generator_runs[0].best_arm_predictions
+            for i in newly_completed_trials
+        )
+        best_arms = {
+            best_arm_pred[0]
+            for best_arm_pred in best_arm_predictions
+            if best_arm_pred is not None
+        }
+        best_arms_list.append(best_arms)
 
 
 def benchmark_replication(
@@ -469,7 +427,7 @@ def benchmark_replication(
     # Since multiple trials can complete at once, there may be fewer elements in
     # these traces than the number of trials run.
     cost_trace: list[float] = []
-    best_params_list: list[Mapping[str, TParamValue]] = []  # For inference trace
+    best_arms_list: list[set[Arm]] = []  # For inference trace
     evaluated_arms_list: list[set[Arm]] = []  # For oracle trace
     completed_trial_idcs: set[int] = set()
 
@@ -496,11 +454,9 @@ def benchmark_replication(
         ):
             _update_benchmark_tracking_vars_in_place(
                 experiment=experiment,
-                method=method,
-                problem=problem,
                 cost_trace=cost_trace,
                 evaluated_arms_list=evaluated_arms_list,
-                best_params_list=best_params_list,
+                best_arms_list=best_arms_list,
                 completed_trial_idcs=completed_trial_idcs,
             )
 
@@ -520,13 +476,11 @@ def benchmark_replication(
             trials=experiment.trials, simulator=simulator
         )
 
-    inference_trace = _get_inference_trace_from_params(
-        best_params_list=best_params_list,
-        problem=problem,
-        n_elements=len(cost_trace),
+    inference_trace = _get_trace_from_arms(
+        arms_list=best_arms_list, problem=problem, cumulative_best=False
     )
-    oracle_trace = _get_oracle_trace_from_arms(
-        evaluated_arms_list=evaluated_arms_list, problem=problem
+    oracle_trace = _get_trace_from_arms(
+        arms_list=evaluated_arms_list, problem=problem, cumulative_best=True
     )
 
     optimization_trace = (

--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -47,7 +47,7 @@ from ax.core.trial_status import TrialStatus
 from ax.core.types import TParamValue
 from ax.core.utils import get_model_times
 from ax.service.scheduler import Scheduler
-from ax.service.utils.best_point_mixin import BestPointMixin
+from ax.service.utils.best_point import get_trace
 from ax.service.utils.scheduler_options import SchedulerOptions, TrialType
 from ax.utils.common.logger import DEFAULT_LOG_LEVEL, get_logger
 from ax.utils.common.random import with_rng_seed
@@ -288,7 +288,7 @@ def _get_oracle_value_of_params(
     dummy_experiment = get_oracle_experiment_from_params(
         problem=problem, dict_of_dict_of_params={0: {"0_0": params}}
     )
-    (inference_value,) = BestPointMixin._get_trace(
+    (inference_value,) = get_trace(
         experiment=dummy_experiment, optimization_config=problem.optimization_config
     )
     return inference_value
@@ -312,7 +312,7 @@ def _get_oracle_trace_from_arms(
             for i, arms in enumerate(evaluated_arms_list)
         },
     )
-    oracle_trace = BestPointMixin._get_trace(
+    oracle_trace = get_trace(
         experiment=dummy_experiment,
         optimization_config=problem.optimization_config,
     )

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -7,19 +7,10 @@
 
 from dataclasses import dataclass
 
-from ax.core.experiment import Experiment
-from ax.core.optimization_config import (
-    MultiObjectiveOptimizationConfig,
-    OptimizationConfig,
-)
-from ax.core.trial_status import TrialStatus
-from ax.core.types import TParameterization
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.utils.common.base import Base
-from pyre_extensions import none_throws
 
 
 @dataclass(kw_only=True)
@@ -64,67 +55,3 @@ class BenchmarkMethod(Base):
     def __post_init__(self) -> None:
         if self.name == "DEFAULT":
             self.name = self.generation_strategy.name
-
-    def get_best_parameters(
-        self,
-        experiment: Experiment,
-        optimization_config: OptimizationConfig,
-        n_points: int,
-    ) -> list[TParameterization]:
-        """
-        Get ``n_points`` promising points. NOTE: Only SOO with n_points = 1 is
-        supported.
-
-        The expected use case is that these points will be evaluated against an
-        oracle for hypervolume (if multi-objective) or for the value of the best
-        parameter (if single-objective).
-
-        For multi-objective cases, ``n_points > 1`` is needed. For SOO, ``n_points > 1``
-        reflects setups where we can choose some points which will then be
-        evaluated noiselessly or at high fidelity and then use the best one.
-
-
-        Args:
-            experiment: The experiment to get the data from. This should contain
-                values that would be observed in a realistic setting and not
-                contain oracle values.
-            optimization_config: The ``optimization_config`` for the corresponding
-                ``BenchmarkProblem``.
-            n_points: The number of points to return.
-        """
-        if isinstance(optimization_config, MultiObjectiveOptimizationConfig):
-            raise NotImplementedError(
-                "BenchmarkMethod.get_pareto_optimal_parameters is not currently "
-                "supported for multi-objective problems."
-            )
-
-        if n_points != 1:
-            raise NotImplementedError(
-                f"Currently only n_points=1 is supported. Got {n_points=}."
-            )
-        if len(experiment.trials) == 0:
-            raise ValueError(
-                "Cannot identify a best point if experiment has no trials."
-            )
-
-        def _get_first_parameterization_from_last_trial() -> TParameterization:
-            return experiment.trials[max(experiment.trials)].arms[0].parameters
-
-        # SOO, n=1 case.
-        # Note: This has the same effect as Scheduler.get_best_parameters
-        if len(experiment.trials_by_status[TrialStatus.COMPLETED]) == 0:
-            return [_get_first_parameterization_from_last_trial()]
-
-        result = BestPointMixin._get_best_trial(
-            experiment=experiment,
-            generation_strategy=self.generation_strategy,
-            optimization_config=optimization_config,
-            use_model_predictions=self.use_model_predictions_for_best_point,
-        )
-        if result is None:
-            # This can happen if no points are predicted to satisfy all outcome
-            # constraints.
-            params = _get_first_parameterization_from_last_trial()
-        else:
-            i, params, prediction = none_throws(result)
-        return [params]

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -7,25 +7,13 @@
 
 
 from logging import WARNING
-from unittest.mock import patch
 
 import numpy as np
-from ax.benchmark.benchmark import (
-    benchmark_replication,
-    get_benchmark_runner,
-    get_benchmark_scheduler_options,
-)
+from ax.benchmark.benchmark import benchmark_replication
 from ax.benchmark.methods.modular_botorch import get_sobol_botorch_modular_acquisition
 from ax.benchmark.methods.sobol import get_sobol_benchmark_method
 from ax.benchmark.problems.registry import get_problem
-from ax.core.experiment import Experiment
 from ax.modelbridge.registry import Generators
-from ax.service.scheduler import Scheduler
-from ax.service.utils.best_point import (
-    get_best_by_raw_objective_with_trial_index,
-    get_best_parameters_from_model_predictions_with_trial_index,
-)
-from ax.utils.common.random import with_rng_seed
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import mock_botorch_optimize
 from botorch.acquisition.acquisition import AcquisitionFunction
@@ -118,63 +106,3 @@ class TestMethods(TestCase):
         gs = method.generation_strategy
         self.assertEqual(len(gs._steps), 1)
         self.assertEqual(gs._steps[0].model, Generators.SOBOL)
-
-    def _test_get_best_parameters(self, use_model_predictions: bool) -> None:
-        problem = get_problem(problem_key="ackley4", num_trials=2, noise_std=1.0)
-
-        method = get_sobol_botorch_modular_acquisition(
-            model_cls=SingleTaskGP,
-            acquisition_cls=qLogExpectedImprovement,
-            distribute_replications=False,
-            use_model_predictions_for_best_point=use_model_predictions,
-            num_sobol_trials=1,
-        )
-
-        experiment = Experiment(
-            name="test",
-            search_space=problem.search_space,
-            optimization_config=problem.optimization_config,
-            runner=get_benchmark_runner(problem=problem),
-        )
-
-        scheduler = Scheduler(
-            experiment=experiment,
-            generation_strategy=method.generation_strategy.clone_reset(),
-            options=get_benchmark_scheduler_options(
-                method=method, logging_level=WARNING
-            ),
-        )
-
-        with with_rng_seed(seed=0):
-            scheduler.run_n_trials(max_trials=problem.num_trials)
-
-        # because the second trial is a BoTorch trial, the model should be used
-        best_point_mixin_path = "ax.service.utils.best_point_mixin.best_point_utils."
-        with patch(
-            best_point_mixin_path
-            + "get_best_parameters_from_model_predictions_with_trial_index",
-            wraps=get_best_parameters_from_model_predictions_with_trial_index,
-        ) as mock_get_best_parameters_from_predictions, patch(
-            best_point_mixin_path + "get_best_by_raw_objective_with_trial_index",
-            wraps=get_best_by_raw_objective_with_trial_index,
-        ) as mock_get_best_by_raw_objective_with_trial_index:
-            best_params = method.get_best_parameters(
-                experiment=experiment,
-                optimization_config=problem.optimization_config,
-                n_points=1,
-            )
-        if use_model_predictions:
-            mock_get_best_parameters_from_predictions.assert_called_once()
-            # get_best_by_raw_objective_with_trial_index might be used as
-            # fallback
-        else:
-            mock_get_best_parameters_from_predictions.assert_not_called()
-            mock_get_best_by_raw_objective_with_trial_index.assert_called_once()
-        self.assertEqual(len(best_params), 1)
-
-    def test_get_best_parameters(self) -> None:
-        for use_model_predictions in [False, True]:
-            with self.subTest(f"{use_model_predictions=}"):
-                self._test_get_best_parameters(
-                    use_model_predictions=use_model_predictions
-                )

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -6,16 +6,8 @@
 # pyre-strict
 
 from ax.benchmark.benchmark_method import BenchmarkMethod
-from ax.benchmark.benchmark_problem import (
-    get_continuous_search_space,
-    get_moo_opt_config,
-    get_soo_opt_config,
-)
 from ax.benchmark.methods.sobol import get_sobol_generation_strategy
-from ax.core.experiment import Experiment
-from ax.modelbridge.factory import get_sobol
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_experiment_with_observations
 from pyre_extensions import none_throws
 
 
@@ -45,64 +37,3 @@ class TestBenchmarkMethod(TestCase):
                     "fit_tracking_metrics"
                 )
             )
-
-    def test_get_best_parameters(self) -> None:
-        """
-        This is tested more thoroughly in `test_benchmark` -- setting up an
-        experiment with data and trials without just running a benchmark is a
-        pain, so in that file, we just run a benchmark.
-        """
-        search_space = get_continuous_search_space(bounds=[(0, 1)])
-        experiment = Experiment(name="test", is_test=True, search_space=search_space)
-        moo_config = get_moo_opt_config(outcome_names=["a", "b"], ref_point=[0, 0])
-
-        method = BenchmarkMethod(generation_strategy=self.gs)
-
-        with self.subTest("MOO not supported"), self.assertRaisesRegex(
-            NotImplementedError, "not currently supported for multi-objective"
-        ):
-            method.get_best_parameters(
-                experiment=experiment, optimization_config=moo_config, n_points=1
-            )
-
-        soo_config = get_soo_opt_config(outcome_names=["a"])
-        with self.subTest("Multiple points not supported"), self.assertRaisesRegex(
-            NotImplementedError, "only n_points=1"
-        ):
-            method.get_best_parameters(
-                experiment=experiment, optimization_config=soo_config, n_points=2
-            )
-
-        with self.subTest("Empty experiment"), self.assertRaisesRegex(
-            ValueError, "Cannot identify a best point if experiment has no trials"
-        ):
-            method.get_best_parameters(
-                experiment=experiment, optimization_config=soo_config, n_points=1
-            )
-
-        with self.subTest("All constraints violated"):
-            experiment = get_experiment_with_observations(
-                observations=[[1, -1], [2, -1]],
-                constrained=True,
-            )
-            best_point = method.get_best_parameters(
-                n_points=1,
-                experiment=experiment,
-                optimization_config=none_throws(experiment.optimization_config),
-            )
-            self.assertEqual(len(best_point), 1)
-            self.assertEqual(best_point[0], experiment.trials[1].arms[0].parameters)
-
-        with self.subTest("No completed trials"):
-            experiment = get_experiment_with_observations(observations=[])
-            sobol_generator = get_sobol(search_space=experiment.search_space)
-            for _ in range(3):
-                trial = experiment.new_trial(generator_run=sobol_generator.gen(n=1))
-                trial.run()
-            best_point = method.get_best_parameters(
-                n_points=1,
-                experiment=experiment,
-                optimization_config=none_throws(experiment.optimization_config),
-            )
-            self.assertEqual(len(best_point), 1)
-            self.assertEqual(best_point[0], experiment.trials[2].arms[0].parameters)

--- a/ax/plot/pareto_frontier.py
+++ b/ax/plot/pareto_frontier.py
@@ -25,7 +25,7 @@ from ax.plot.base import AxPlotConfig, AxPlotTypes, CI_OPACITY, DECIMALS
 from ax.plot.color import COLORS, DISCRETE_COLOR_SCALE, rgba
 from ax.plot.helper import _format_CI, _format_dict, extend_range
 from ax.plot.pareto_utils import ParetoFrontierResults
-from ax.service.utils.best_point_mixin import BestPointMixin
+from ax.service.utils.best_point import get_trace
 from plotly import express as px
 from pyre_extensions import assert_is_instance, none_throws
 from scipy.stats import norm
@@ -62,7 +62,7 @@ def scatter_plot_with_hypervolume_trace_plotly(experiment: Experiment) -> go.Fig
     Arguments:
         experiment: MOO experiment to calculate the hypervolume trace from
     """
-    hypervolume_trace = BestPointMixin._get_trace(experiment=experiment)
+    hypervolume_trace = get_trace(experiment=experiment)
 
     df = pd.DataFrame(
         {

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -16,7 +16,7 @@ from ax.core.generator_run import GeneratorRun
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.trial import Trial
 from ax.exceptions.core import DataRequiredError
-from ax.service.utils.best_point import extract_Y_from_data
+from ax.service.utils.best_point import extract_Y_from_data, get_trace
 from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -31,9 +31,6 @@ from pyre_extensions import assert_is_instance, none_throws
 
 class TestBestPointMixin(TestCase):
     def test_get_trace(self) -> None:
-        # Alias for easier access.
-        get_trace = BestPointMixin._get_trace
-
         # Single objective, minimize.
         exp = get_experiment_with_observations(
             observations=[[11], [10], [9], [15], [5]], minimize=True

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -16,7 +16,7 @@ from ax.core.generator_run import GeneratorRun
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.trial import Trial
 from ax.exceptions.core import DataRequiredError
-from ax.service.utils.best_point import extract_Y_from_data, get_trace
+from ax.service.utils.best_point import get_trace
 from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -200,18 +200,3 @@ class TestBestPointMixin(TestCase):
             minimize=True,
         )
         self.assertEqual(get_best(exp), 10)  # 5 and 9 are out of design
-
-    def test_extract_Y_from_data(self) -> None:
-        # Single objective, minimize.
-        exp = get_experiment_with_observations(
-            observations=[[11], [10], [9], [15], [5]], minimize=True
-        )
-        self.assertNotEqual(len(exp.lookup_data().df), 0)
-
-        if not exp.optimization_config:
-            raise TypeError("No objective")
-
-        metric_names = exp.optimization_config.objective.metric_names
-
-        output, _ = extract_Y_from_data(experiment=exp, metric_names=metric_names)
-        self.assertNotEqual(len(output), 0)

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -8,10 +8,8 @@
 
 from abc import ABC
 from collections.abc import Iterable
-from functools import partial
 
 import numpy as np
-import torch
 from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
 from ax.core.objective import ScalarizedObjective
@@ -23,28 +21,11 @@ from ax.core.trial import Trial
 from ax.core.types import TModelPredictArm, TParameterization
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from ax.modelbridge.modelbridge_utils import (
-    extract_objective_thresholds,
-    extract_objective_weights,
-    extract_outcome_constraints,
-    observed_hypervolume,
-    predicted_hypervolume,
-    validate_and_apply_final_transform,
-)
+from ax.modelbridge.modelbridge_utils import observed_hypervolume, predicted_hypervolume
 from ax.modelbridge.torch import TorchAdapter
-from ax.modelbridge.transforms.derelativize import Derelativize
-from ax.models.torch.botorch_moo_defaults import (
-    get_outcome_constraint_transforms,
-    get_weighted_mc_objective_and_objective_thresholds,
-)
 from ax.plot.pareto_utils import get_tensor_converter_model
 from ax.service.utils import best_point as best_point_utils
-from ax.service.utils.best_point import (
-    extract_Y_from_data,
-    fill_missing_thresholds_from_nadir,
-)
 from ax.service.utils.best_point_utils import select_baseline_name_default_first_trial
-from botorch.utils.multi_objective.box_decompositions import DominatedPartitioning
 from pyre_extensions import assert_is_instance, none_throws
 
 
@@ -204,28 +185,6 @@ class BestPointMixin(ABC):
             optimization_config=optimization_config,
             trial_indices=trial_indices,
             use_model_predictions=use_model_predictions,
-        )
-
-    def get_trace(
-        self,
-        optimization_config: OptimizationConfig | None = None,
-    ) -> list[float]:
-        """Get the optimization trace of the given experiment.
-
-        The output is equivalent to calling `_get_hypervolume` or `_get_best_trial`
-        repeatedly, with an increasing sequence of `trial_indices` and with
-        `use_model_predictions = False`, though this does it more efficiently.
-
-        Args:
-            optimization_config: An optional optimization config to use for computing
-                the trace. This allows computing the traces under different objectives
-                or constraints without having to modify the experiment.
-
-        Returns:
-            A list of observed hypervolumes or best values.
-        """
-        return self._get_trace(
-            experiment=self.experiment, optimization_config=optimization_config
         )
 
     def get_trace_by_progression(
@@ -414,152 +373,6 @@ class BestPointMixin(ABC):
         return observed_hypervolume(
             modelbridge=minimal_model, optimization_config=moo_optimization_config
         )
-
-    @staticmethod
-    def _get_trace(
-        experiment: Experiment,
-        optimization_config: OptimizationConfig | None = None,
-    ) -> list[float]:
-        """Compute the optimization trace at each iteration.
-
-        Given an experiment and an optimization config, compute the performance
-        at each iteration. For multi-objective, the performance is computed as
-        the hypervolume. For single objective, the performance is computed as
-        the best observed objective value.
-
-        Infeasible points (that violate constraints) do not contribute to
-        improvements in the optimization trace. If the first trial(s) are infeasible,
-        the trace can start at inf or -inf.
-
-        An iteration here refers to a completed or early-stopped (batch) trial.
-        There will be one performance metric in the trace for each iteration.
-
-        Args:
-            experiment: The experiment to get the trace for.
-            optimization_config: Optimization config to use in place of the one
-                stored on the experiment.
-
-        Returns:
-            A list of performance values at each iteration.
-        """
-        optimization_config = optimization_config or none_throws(
-            experiment.optimization_config
-        )
-        # Get the names of the metrics in optimization config.
-        metric_names = set(optimization_config.objective.metric_names)
-        for cons in optimization_config.outcome_constraints:
-            metric_names.update({cons.metric.name})
-        metric_names = list(metric_names)
-        # Convert data into a tensor.
-        Y, trial_indices = extract_Y_from_data(
-            experiment=experiment, metric_names=metric_names
-        )
-        if Y.numel() == 0:
-            return []
-
-        # Derelativize the optimization config.
-        tf = Derelativize(
-            search_space=None, observations=None, config={"use_raw_status_quo": True}
-        )
-        optimization_config = tf.transform_optimization_config(
-            optimization_config=optimization_config.clone(),
-            modelbridge=get_tensor_converter_model(
-                experiment=experiment, data=experiment.lookup_data()
-            ),
-            fixed_features=None,
-        )
-
-        # Extract weights, constraints, and objective_thresholds.
-        objective_weights = extract_objective_weights(
-            objective=optimization_config.objective, outcomes=metric_names
-        )
-        outcome_constraints = extract_outcome_constraints(
-            outcome_constraints=optimization_config.outcome_constraints,
-            outcomes=metric_names,
-        )
-        to_tensor = partial(
-            torch.as_tensor, dtype=torch.double, device=torch.device("cpu")
-        )
-        if optimization_config.is_moo_problem:
-            objective_thresholds = extract_objective_thresholds(
-                objective_thresholds=fill_missing_thresholds_from_nadir(
-                    experiment=experiment, optimization_config=optimization_config
-                ),
-                objective=optimization_config.objective,
-                outcomes=metric_names,
-            )
-            objective_thresholds = to_tensor(none_throws(objective_thresholds))
-        else:
-            objective_thresholds = None
-        (
-            objective_weights,
-            outcome_constraints,
-            _,
-            _,
-            _,
-        ) = validate_and_apply_final_transform(
-            objective_weights=objective_weights,
-            outcome_constraints=outcome_constraints,
-            linear_constraints=None,
-            pending_observations=None,
-            final_transform=to_tensor,
-        )
-        # Get weighted tensor objectives.
-        if optimization_config.is_moo_problem:
-            (
-                obj,
-                weighted_objective_thresholds,
-            ) = get_weighted_mc_objective_and_objective_thresholds(
-                objective_weights=objective_weights,
-                objective_thresholds=none_throws(objective_thresholds),
-            )
-            Y_obj = obj(Y)
-            infeas_value = weighted_objective_thresholds
-        else:
-            Y_obj = Y @ objective_weights
-            infeas_value = float("-inf")
-        # Account for feasibility.
-        if outcome_constraints is not None:
-            cons_tfs = none_throws(
-                get_outcome_constraint_transforms(outcome_constraints)
-            )
-            feas = torch.all(torch.stack([c(Y) <= 0 for c in cons_tfs], dim=-1), dim=-1)
-            # Set the infeasible points to reference point or to NaN
-            Y_obj[~feas] = infeas_value
-        # Get unique trial indices. Note: only completed/early-stopped
-        # trials are present.
-        unique_trial_indices = trial_indices.unique().sort().values.tolist()
-        # compute the performance at each iteration (completed/early-stopped
-        # trial).
-        # For `BatchTrial`s, there is one performance value per iteration, even
-        # if the iteration (`BatchTrial`) has multiple arms.
-        if optimization_config.is_moo_problem:
-            # Compute the hypervolume trace.
-            partitioning = DominatedPartitioning(
-                ref_point=weighted_objective_thresholds.double()
-            )
-            # compute hv for each iteration (trial_index)
-            hvs = []
-            for trial_index in unique_trial_indices:
-                new_Y = Y_obj[trial_indices == trial_index]
-                # update with new point
-                partitioning.update(Y=new_Y)
-                hv = partitioning.compute_hypervolume().item()
-                hvs.append(hv)
-            return hvs
-        running_max = float("-inf")
-        raw_maximum = np.zeros(len(unique_trial_indices))
-        # Find the best observed value for each iterations.
-        # Enumerate the unique trial indices because only indices
-        # of completed/early-stopped trials are present.
-        for i, trial_index in enumerate(unique_trial_indices):
-            new_Y = Y_obj[trial_indices == trial_index]
-            running_max = max(running_max, new_Y.max().item())
-            raw_maximum[i] = running_max
-        if optimization_config.objective.minimize:
-            # Negate the result if it is a minimization problem.
-            raw_maximum = -raw_maximum
-        return raw_maximum.tolist()
 
     @staticmethod
     def _get_trace_by_progression(


### PR DESCRIPTION
Summary:
Context:

* Benchmarking has its own best-point logic that is different from Ax's best-point logic, which is essentially writing `best_arm_predictions` to a GeneratorRun
* This discrepancy makes developing and debugging best-point functionality hard.
* Also, current best-point logic is intertwined with Scheduler, which makes it hard to move off of Scheduler

With this change, benchmarking will not have its own best-point logic, but will instead use the values on `GeneratorRun.best_arm_predictions`, for better or for worse. This may mostly make the best-point recommendations worse. That is bad for using the inference trace to benchmark noisy problems, but it is good for developing better best-point functionality.

This PR:

Uses GeneratorRun.best_arm_predictions for best points used for inference value.
* Deletes `BenchmarkMethod.get_best_parameters`
* Consolidates `_get_inference_trace_from_params` and `_get_oracle_trace_from_arms` into one function

Differential Revision: D73148478


