### PR TITLE
Flip the default for relativize in adhoc scatter call to true

### DIFF
--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -194,7 +194,7 @@ def compute_scatter_adhoc(
     generation_strategy: GenerationStrategy | None = None,
     adapter: Adapter | None = None,
     use_model_predictions: bool = True,
-    relativize: bool = False,
+    relativize: bool = True,
     trial_index: int | None = None,
     trial_statuses: Sequence[TrialStatus] | None = None,
     additional_arms: Sequence[Arm] | None = None,


### PR DESCRIPTION
Summary: I think this is primarily used by experts where relativization is the classic case.

Differential Revision: D73584035


