### PR TITLE
Make images in docs smaller

### DIFF
--- a/docs/intro-to-ae.mdx
+++ b/docs/intro-to-ae.mdx
@@ -3,6 +3,11 @@ id: intro-to-ae
 title: Introduction to Adaptive Experimentation
 ---
 
+import Traditional_vs_Adaptive from './assets/traditional_vs_adaptive.svg';
+import doe from './assets/doe.png';
+import line_square_cube from './assets/line_square_cube.png';
+import discrepancy_dims from './assets/discrepancy_dims.png';
+
 # Introduction to Adaptive Experimentation
 
 In engineering tasks we often encounter so-called "black box" optimization
@@ -25,7 +30,7 @@ Adaptive experimentation is an approach to solving these problems efficiently by
 leveraging data from prior iterations to inform future decisions on which trials
 to run next.
 
-![Traditional vs. Adaptive design](assets/traditional_vs_adaptive.svg)
+<center><Traditional_vs_Adaptive alt="Traditional vs. Adaptive design" width="60%" height="auto"/></center>
 
 ## Traditional methods are inefficient, especially in high dimensions
 
@@ -50,14 +55,14 @@ points that are more uniformly dispersed. Examples include:
 - Latin Hypercube Sampling. Both rely on some form of subdividing a search space
   and assigning points in relation to these subdivisions.
 
-![DoE sampling methods](assets/doe.png)
+<center><img src={doe} alt="DoE sampling methods" width="60%"/></center>
 
 Unfortunately getting broad coverage of the domain requires many samples, which
 can be expensive. Worse, as more dimensions are added more points are required
 to achieve the same coverage. To illustrate, imagine points distributed on a
 line (1D), a square (2D), and a cube (3D).
 
-![Sampling from a line, a square, and a cube](assets/line_square_cube.png)
+<center><img src={line_square_cube} alt="Sampling from a line, a square, and a cube" width="60%"/></center>
 
 Notice how even though there are 9x more points in the cube than on the line,
 the
@@ -79,7 +84,7 @@ below. In the case of grid search, to have even just two subdivisions in each of
 20 dimensions would require $$20^2 = 400$$ points, well over our 100 point
 budget!
 
-![Discrepancy vs. input dimensionality](assets/discrepancy_dims.png)
+<center><img src={discrepancy_dims} alt="Discrepancy vs. input dimensionality" width="60%"/></center>
 
 ## Adaptive experimentation outperforms traditional methods
 

--- a/docs/intro-to-bo.mdx
+++ b/docs/intro-to-bo.mdx
@@ -3,6 +3,10 @@ id: intro-to-bo
 title: Introduction to Bayesian Optimization
 ---
 
+import surrogate from './assets/surrogate.png';
+import ei from './assets/ei.png';
+import gpei from './assets/gpei.gif';
+
 # Introduction to Bayesian Optimization
 
 Bayesian optimization (BO) is a highly effective adaptive experimentation method
@@ -71,7 +75,7 @@ outcome and quantify the uncertainty of configurations that have not yet been
 tested. Intuitively, the uncertainty bands are tight in regions that are
 well-explored and become wider as we move away from them.
 
-![GP surrogate model](assets/surrogate.png)
+<center><img src={surrogate} alt="GP surrogate model" width="60%"/></center>
 
 ## Acquisition Functions
 
@@ -106,13 +110,13 @@ A visualization of the expected improvement based on the surrogate model
 predictions is shown below, where the next suggestion is where the expected
 improvement is at its maximum.
 
-![Expected Improvement (EI) acquisition function](assets/ei.png)
+<center><img src={ei} alt="Expected Improvement (EI) acquisition function" width="60%"/></center>
 
 Once a new highest EI is selected and evaluated, the surrogate model is
 retrained and a new suggestion is made. As described above, this process
 continues iteratively until a stopping condition, set by the user, is reached.
 
-![Full Bayesian optimization loop](assets/gpei.gif)
+<center><img src={gpei} alt="Full Bayesian optimization loop" width="60%"/></center>
 
 Using an acquisition function like EI to sample new points initially promotes
 quick exploration because the expected values, informed by the uncertainty


### PR DESCRIPTION
Summary:
These were defaulting to filling up the full width of the page, which in some cases made them tall enough to basically be in the only thing visible on the page. Let's make them a bit smaller.

It's a bit annoying that this isn't possible just in markdown, so we change these docs to mdx and use html for sizing.

Differential Revision: D73619790
