### PR TITLE
Fix error in encoder.py: TypeError: 'NoneType' object is not iterable

### DIFF
--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -791,10 +791,18 @@ class Encoder:
         best_arm_name = None
         best_arm_parameters = None
         best_arm_predictions = None
+
         if generator_run.best_arm_predictions is not None:
-            best_arm = generator_run.best_arm_predictions[0]
-            # pyre-fixme[16]: `Optional` has no attribute `__getitem__`.
-            best_arm_predictions = list(generator_run.best_arm_predictions[1])
+            best_arm, model_predict_arm = generator_run.best_arm_predictions
+
+            if model_predict_arm is not None:
+                best_arm_predictions = list(model_predict_arm)
+            else:
+                logger.warning(
+                    f"No model predictions found with best arm '{best_arm._name}'."
+                    " Setting best_arm_predictions=None in storage"
+                )
+
             best_arm_name = best_arm._name
             best_arm_parameters = best_arm.parameters
         model_predictions = (


### PR DESCRIPTION
Summary:
## Context

Encountered failures `Error:'NoneType' object is not iterable` in encoder.py


This is the result of calling
`best_arm_predictions = list(generator_run.best_arm_predictions[1])`
when `generator_run.best_arm_predictions[1]=None`



## The Fix

- Adds a none check for `generator_run.best_arm_predictions[1]` before converting to list
- If None, `gr_sqa.best_arm_predictions` is set to None, and a warning message is logged
- Unit testing is also added to cover the following cases
  - encoder.generator_run_to_sqa() with BOTH best_arm and model predictions
  - encoder.generator_run_to_sqa() with `generator_run.best_arm_predictions=None`
  - encoder.generator_run_to_sqa() with best_arm, but NO model predctions.

Differential Revision: D73791904


