### PR TITLE
Fix bug saving trial via sqalchemy

### DIFF
--- a/ax/storage/sqa_store/save.py
+++ b/ax/storage/sqa_store/save.py
@@ -308,7 +308,9 @@ def save_or_update_data_for_trials(
                 experiment_id=experiment.db_id
             ).filter(data_sqa_class.trial_index.isnot(None)).filter(
                 data_sqa_class.trial_index.in_(trial_idcs)
-            ).filter(data_sqa_class.id not in datas_to_keep).delete()
+                # pyre-fixme [16]: sqlalchemy.sql.schema.Column` has no attribute
+                # `not_in`.
+            ).filter(data_sqa_class.id.not_in(datas_to_keep)).delete()
 
     _bulk_merge_into_session(
         objs=datas,

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -830,9 +830,15 @@ class SQAStoreTest(TestCase):
         self.assertEqual(self.experiment, loaded_experiment)
 
         # Update a trial by attaching data
-        self.experiment.attach_data(get_data(trial_index=trial.index))
+        data = get_data(trial_index=trial.index)
+        self.experiment.attach_data(data)
         save_or_update_trial(experiment=self.experiment, trial=trial)
-
+        # make sure loaded experiment has data
+        loaded_experiment = load_experiment(self.experiment.name)
+        self.assertEqual(self.experiment, loaded_experiment)
+        # verify that saving is idempotent, by saving the original experiment again
+        # and reloading
+        save_or_update_trial(experiment=self.experiment, trial=trial)
         loaded_experiment = load_experiment(self.experiment.name)
         self.assertEqual(self.experiment, loaded_experiment)
 


### PR DESCRIPTION
Summary:
The issue here is that saving a trial was not idempotent. If you saved a trial with data and then saved the trial again, then the data would be deleted.

This seems really bad, but I'm honestly not sure of the scope of this bug. I discovered this while working on a test in the next diff in the stack, where a trial is saved with data and then the trial is saved again after being marked completed. The second save deleted the data from the first, and there was no Data on the experiment. 

Using the ColumnOperator rather than python native `not in` resolves this. This was introduced in D54879641.

Reviewed By: Balandat

Differential Revision: D73810845


