### PR TITLE
Truncate labels on all PlotlyAnalysis

### DIFF
--- a/ax/analysis/plotly/arm_effects/unified.py
+++ b/ax/analysis/plotly/arm_effects/unified.py
@@ -16,6 +16,7 @@ from ax.analysis.plotly.utils import (
     BEST_LINE_SETTINGS,
     get_arm_tooltip,
     trial_status_to_plotly_color,
+    truncate_label,
 )
 from ax.analysis.utils import (
     extract_relevant_adapter,
@@ -132,9 +133,9 @@ class ArmEffectsPlot(PlotlyAnalysis):
         )
 
         # Retrieve the metric labels from the mapping provided by the user, defaulting
-        # to the metric name if no label is provided.
+        # to the metric name if no label is provided, truncated.
         metric_labels = {
-            metric_name: self.labels.get(metric_name, metric_name)
+            metric_name: self.labels.get(metric_name, truncate_label(label=metric_name))
             for metric_name in metric_names
         }
 

--- a/ax/analysis/plotly/parallel_coordinates.py
+++ b/ax/analysis/plotly/parallel_coordinates.py
@@ -12,7 +12,11 @@ import pandas as pd
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
-from ax.analysis.plotly.utils import METRIC_CONTINUOUS_COLOR_SCALE, select_metric
+from ax.analysis.plotly.utils import (
+    METRIC_CONTINUOUS_COLOR_SCALE,
+    select_metric,
+    truncate_label,
+)
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
@@ -126,7 +130,7 @@ def _prepare_plot(df: pd.DataFrame, metric_name: str) -> go.Figure:
             dimensions=[
                 *parameter_dimensions,
                 {
-                    "label": _truncate_label(label=metric_name),
+                    "label": truncate_label(label=metric_name),
                     "values": df[metric_name].tolist(),
                 },
             ],
@@ -161,7 +165,7 @@ def _get_parameter_dimension(series: pd.Series) -> dict[str, Any]:
         return {
             "tickvals": None,
             "ticktext": None,
-            "label": _truncate_label(label=str(series.name)),
+            "label": truncate_label(label=str(series.name)),
             "values": series.tolist(),
         }
 
@@ -170,14 +174,8 @@ def _get_parameter_dimension(series: pd.Series) -> dict[str, Any]:
     mapping = {v: k for k, v in enumerate(sorted(series.unique()))}
 
     return {
-        "tickvals": [_truncate_label(label=str(val)) for val in mapping.values()],
-        "ticktext": [_truncate_label(label=str(key)) for key in mapping.keys()],
-        "label": _truncate_label(label=str(series.name)),
+        "tickvals": [truncate_label(label=str(val)) for val in mapping.values()],
+        "ticktext": [truncate_label(label=str(key)) for key in mapping.keys()],
+        "label": truncate_label(label=str(series.name)),
         "values": series.map(mapping).tolist(),
     }
-
-
-def _truncate_label(label: str, n: int = 18) -> str:
-    if len(label) > n:
-        return label[:n] + "..."
-    return label

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -17,6 +17,7 @@ from ax.analysis.plotly.utils import (
     get_arm_tooltip,
     is_predictive,
     trial_status_to_plotly_color,
+    truncate_label,
 )
 from ax.analysis.utils import (
     extract_relevant_adapter,
@@ -146,8 +147,14 @@ class ScatterPlot(PlotlyAnalysis):
             relativize=self.relativize,
         )
 
-        x_metric_label = self.labels.get(self.x_metric_name, self.x_metric_name)
-        y_metric_label = self.labels.get(self.y_metric_name, self.y_metric_name)
+        # Retrieve the metric labels from the mapping provided by the user, defaulting
+        # to the metric name if no label is provided, truncated.
+        x_metric_label = self.labels.get(
+            self.x_metric_name, truncate_label(label=self.x_metric_name)
+        )
+        y_metric_label = self.labels.get(
+            self.y_metric_name, truncate_label(label=self.y_metric_name)
+        )
 
         x_lower_is_better = experiment.metrics[self.x_metric_name].lower_is_better
         y_lower_is_better = experiment.metrics[self.y_metric_name].lower_is_better

--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -17,7 +17,11 @@ from ax.analysis.plotly.surface.utils import (
     is_axis_log_scale,
     select_fixed_value,
 )
-from ax.analysis.plotly.utils import METRIC_CONTINUOUS_COLOR_SCALE, select_metric
+from ax.analysis.plotly.utils import (
+    METRIC_CONTINUOUS_COLOR_SCALE,
+    select_metric,
+    truncate_label,
+)
 from ax.analysis.utils import extract_relevant_adapter
 from ax.core.experiment import Experiment
 from ax.core.observation import ObservationFeatures
@@ -227,8 +231,8 @@ def _prepare_plot(
             showscale=False,
         ),
         layout=go.Layout(
-            xaxis_title=x_parameter_name,
-            yaxis_title=y_parameter_name,
+            xaxis_title=truncate_label(label=x_parameter_name),
+            yaxis_title=truncate_label(label=y_parameter_name),
         ),
     )
 

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -17,7 +17,11 @@ from ax.analysis.plotly.surface.utils import (
     is_axis_log_scale,
     select_fixed_value,
 )
-from ax.analysis.plotly.utils import get_scatter_point_color, select_metric
+from ax.analysis.plotly.utils import (
+    get_scatter_point_color,
+    select_metric,
+    truncate_label,
+)
 from ax.analysis.utils import extract_relevant_adapter
 from ax.core.experiment import Experiment
 from ax.core.observation import ObservationFeatures
@@ -250,8 +254,8 @@ def _prepare_plot(
     fig = go.Figure(
         [line, error_band],
         layout=go.Layout(
-            xaxis_title=parameter_name,
-            yaxis_title=metric_name,
+            xaxis_title=truncate_label(label=parameter_name),
+            yaxis_title=truncate_label(label=metric_name),
         ),
     )
 


### PR DESCRIPTION
Summary: This was previously only used in ParallelCoordinatesAnalysis but is useful across all analyses, where long labels can either bleed into the main plot OR cause the main plot to get squished. See Human In the Loop tutorial on the website for a particularly bad example with the feature importance plot:  {F1977191970}

Reviewed By: mgarrard

Differential Revision: D73140606


