### PR TITLE
[Ax][Tutorials] Fix broken links

### DIFF
--- a/tutorials/automating/automating.ipynb
+++ b/tutorials/automating/automating.ipynb
@@ -12,7 +12,7 @@
       },
       "source": [
         "# Automating Orchestration\n",
-        "Previously, we've demonstrated [using Ax for ask-tell optimization](../ask_tell), a paradigm in which we \"ask\" Ax for candidate configurations and \"tell\" Ax our observations.\n",
+        "Previously, we've demonstrated [using Ax for ask-tell optimization](../getting_started), a paradigm in which we \"ask\" Ax for candidate configurations and \"tell\" Ax our observations.\n",
         "This can be effective in many scenerios, and it can be automated through use of flow control statements like `for` and `while` loops.\n",
         "However there are some situations where it would be beneficial to allow Ax to orchestrate the entire optimization: deploying trials to external systems, polling their status, and reading reading their results.\n",
         "This can be common in a number of real world engineering tasks, including:\n",
@@ -36,7 +36,7 @@
         "\n",
         "### Prerequisites\n",
         "* Understanding of [adaptive experimentation](../../intro-to-ae) and [Bayesian optimization](../../intro-to-bo)\n",
-        "* Familiarity with [configuring and conducting experiments in Ax](../ask_tell)"
+        "* Familiarity with [configuring and conducting experiments in Ax](../getting_started)"
       ]
     },
     {
@@ -375,7 +375,7 @@
         "## Step 3: Initialize the Client and Configure the Experiment\n",
         "\n",
         "Finally, we can initialize the `Client` and configure the experiment as before.\n",
-        "This will be familiar to readers of the [Ask-tell optimization with Ax tutorial](../ask_tell) -- the only difference is we will attach the previously defined Runner and Metric by calling `configure_runner` and `configure_metrics` respectively.\n",
+        "This will be familiar to readers of the [Ask-tell optimization with Ax tutorial](../getting_started) -- the only difference is we will attach the previously defined Runner and Metric by calling `configure_runner` and `configure_metrics` respectively.\n",
         "\n",
         "Note that when initializing `hartmann6_metric` we set `name=hartmann6`, matching the objective we now set in `configure_optimization`. The `configure_metrics` method uses this name to ensure that data fetched by this Metric is used correctly during the experiment.\n",
         "Be careful to correctly set the name of the Metric to reflect its use as an objective or outcome constraint."

--- a/tutorials/early_stopping/early_stopping.ipynb
+++ b/tutorials/early_stopping/early_stopping.ipynb
@@ -33,7 +33,7 @@
         "## Prerequisites\n",
         "- Familiarity with Python and basic programming concepts\n",
         "- Understanding of [adaptive experimentation](../../intro-to-ae) and [Bayesian optimization](../../intro-to-bo)\n",
-        "- [Ask-tell Optimization of Python Functions](../ask_tell)"
+        "- [Ask-tell Optimization of Python Functions](../getting_started)"
       ]
     },
     {

--- a/tutorials/materials_science/materials_science.ipynb
+++ b/tutorials/materials_science/materials_science.ipynb
@@ -12,7 +12,7 @@
       "source": [
         "# Ax for Materials Science\n",
         "\n",
-        "Some optimization experiments, like the one described in this [tutorial](../ask_tell), can be conducted in a completely automated manner.\n",
+        "Some optimization experiments, like the one described in this [tutorial](../getting_started), can be conducted in a completely automated manner.\n",
         "Other experiments may require a human in the loop, for instance a scientist manually conducting and evaluating each trial in a lab.\n",
         "In this tutorial we demonstrate this ask-tell optimization in a human-in-the-loop setting by imagining the task of maximizing the strength of a 3D printed part using compression testing (i.e., crushing the part) where different print settings will have to be manually tried and evaluated.\n",
         "\n",


### PR DESCRIPTION
rename broke some links in docusaurus (https://github.com/facebook/Ax/actions/runs/14735852864/job/41361624475) and is failing the latest website build in GHA

```
  Exhaustive list of all broken links found:
  - Broken link on source page path = /docs/next/tutorials/automating/:
     -> linking to ../ask_tell (resolved as: /docs/next/tutorials/ask_tell)
  - Broken link on source page path = /docs/next/tutorials/early_stopping/:
     -> linking to ../ask_tell (resolved as: /docs/next/tutorials/ask_tell)
  - Broken link on source page path = /docs/next/tutorials/materials_science/:
     -> linking to ../ask_tell (resolved as: /docs/next/tutorials/ask_tell)
```