### PR TITLE
Fix flaky sensitivity test

### DIFF
--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -314,7 +314,7 @@ class SensitivityAnalysisTest(TestCase):
                     input_qmc=True,
                     num_mc_samples=num_mc_samples,
                     order="second",
-                    signed=True,
+                    signed=False,
                 )
 
                 so_ind_tnsr = compute_sobol_indices_from_model_list(
@@ -337,7 +337,7 @@ class SensitivityAnalysisTest(TestCase):
                     # pyre-fixme[6]: For 2nd argument expected
                     #  `SupportsRSub[Variable[_T], SupportsAbs[SupportsRound[object]]]`
                     #  but got `Union[bool, float, int]`.
-                    -fo_ind_tnsr[0, 0].item(),
+                    fo_ind_tnsr[0, 0].item(),
                 )
                 self.assertAlmostEqual(
                     second_ind_dict["branin"]["x2"],


### PR DESCRIPTION
Summary:
Fixes a sensitivity test that was flaky because it relies on a
gradient estimate that is not deterministic for signing. There is already a
proper test for signing lower that accounts for nondeterminism in the gradient,
so we can have this test focus on what it is testing (second order measures)
and save the signing bit for the later test.

Differential Revision: D73920896


