### PR TITLE
Improve log message when < max_trials returned

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -376,7 +376,8 @@ class Client(WithDBSettingsBase):
 
         if len(res) != max_trials:
             logger.warning(
-                f"{max_trials} requested but only {len(res)} could be generated."
+                f"{max_trials} trials requested but only {len(res)} could be "
+                "generated."
             )
 
         # pyre-fixme[7]: Core Ax allows users to specify TParameterization values as


### PR DESCRIPTION
Summary:
As titled. Before it was producing logs like this which were confusing.
`[WARNING 04-30 01:19:04] ax.api.client: 3 requested but only 2 could be generated.`

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: paschai

Differential Revision: D73924689


