### PR TITLE
Add CenterGenerationNode to choose_generation_strategy

### DIFF
--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -95,7 +95,7 @@ class TestSummary(TestCase):
                 "trial_index": {0: 0, 1: 1},
                 "arm_name": {0: "0_0", 1: "1_0"},
                 "trial_status": {0: "COMPLETED", 1: "FAILED"},
-                "generation_node": {0: "Sobol", 1: "Sobol"},
+                "generation_node": {0: "CenterOfSearchSpace", 1: "Sobol"},
                 "foo": {0: 1.0, 1: np.nan},  # NaN because trial 1 failed
                 "bar": {0: 2.0, 1: np.nan},
                 "x1": {

--- a/ax/api/configs.py
+++ b/ax/api/configs.py
@@ -120,6 +120,10 @@ class GenerationStrategyConfig:
             If ``None``, a default budget of 5 trials is used.
         initialization_random_seed: The random seed to use with the Sobol generator
             that generates the initialization trials.
+        initialize_with_center: If True, the center of the search space is used as the
+            first point. The definition of center respects the scaling of the
+            parameters. For discrete parameters, the median value is considered the
+            center, with the later points being used to break ties.
         use_existing_trials_for_initialization: Whether to count all trials attached
             to the experiment as part of the initialization budget. For example,
             if 2 trials were manually attached to the experiment and this option
@@ -147,6 +151,7 @@ class GenerationStrategyConfig:
     # Initialization options
     initialization_budget: int | None = None
     initialization_random_seed: int | None = None
+    initialize_with_center: bool = True
     use_existing_trials_for_initialization: bool = True
     min_observed_initialization_trials: int | None = None
     allow_exceeding_initialization_budget: bool = False

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -401,8 +401,7 @@ class TestClient(TestCase):
         client.configure_optimization(objective="foo")
         client.configure_generation_strategy(
             generation_strategy_config=GenerationStrategyConfig(
-                # Set this to a large number so test runs fast
-                initialization_budget=1,
+                initialization_budget=1, initialize_with_center=False
             )
         )
 
@@ -935,7 +934,7 @@ class TestClient(TestCase):
                 "trial_index": {0: 0, 1: 1},
                 "arm_name": {0: "0_0", 1: "1_0"},
                 "trial_status": {0: "COMPLETED", 1: "FAILED"},
-                "generation_node": {0: "Sobol", 1: "Sobol"},
+                "generation_node": {0: "CenterOfSearchSpace", 1: "Sobol"},
                 "foo": {0: 1.0, 1: np.nan},  # NaN because trial 1 failed
                 "bar": {0: 2.0, 1: np.nan},
                 "x1": {


### PR DESCRIPTION
Summary:
We have used center point in all benchmarks in the paper and decided to include it in Ax going forward. This diff adds it to the `choose_generation_strategy` that is used by Ax API. Center point is added by default, but the user has the option to opt out using `GenerationStrategyConfig`.

The transition criteria was updated to ensure the `initialization_budget` respects the user input (or the previous default) even when the center point is added. The transition criteria for `min_observed_initialization_trials` was updated to always count all trials on the experiment. There isn't a good way to include only trials from Sobol & Center and it seems sensible to transition when enough training data is collected, regardless of where it originates from.

Reviewed By: esantorella

Differential Revision: D73063657


