### PR TITLE
Remove landing page link to quickstart tutorial

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -165,7 +165,7 @@ const MyPage = () => {
               Get started
             </Link>
             <Link
-              to="/docs/tutorials/quickstart/"
+              to="/docs/tutorials/"
               className="button button--lg button--outline button--secondary margin--sm">
               Tutorials
             </Link>


### PR DESCRIPTION
Summary:
The landing page is unversioned, so the `"/docs/tutorials/quickstart/"` link was actually pointing to stable but that tutorial is not yet in stable. This is breaking docusaurus's link checker blocking website builds.

The error is correct, we shouldn't be using links to "unreleased" pages from the landing page. Here we revert that link back to what's correct in stable.

I'll open a followup diff to change it back to the quickstart tutorial, that diff should be landed alongside the version release.

Differential Revision: D73937615


