### PR TITLE
Rename model_bridge inputs to adapter in model fit quality helpers

### DIFF
--- a/ax/generation_strategy/model_spec.py
+++ b/ax/generation_strategy/model_spec.py
@@ -238,7 +238,7 @@ class GeneratorSpec(SortableBase, SerializationMixin):
         generator_run = fitted_model.gen(**model_gen_kwargs)
         fit_and_std_quality_and_generalization_dict = (
             get_fit_and_std_quality_and_generalization_dict(
-                fitted_model_bridge=self.fitted_model,
+                fitted_adapter=self.fitted_model,
             )
         )
         generator_run._gen_metadata = (

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -2051,7 +2051,7 @@ class Scheduler(AnalysisBase, BestPointMixin):
         )
 
 
-def get_fitted_model_bridge(scheduler: Scheduler, force_refit: bool = False) -> Adapter:
+def get_fitted_adapter(scheduler: Scheduler, force_refit: bool = False) -> Adapter:
     """Returns a fitted Adapter object. If the model is fit already, directly
     returns the already fitted model. Otherwise, fits and returns a new one.
 
@@ -2063,8 +2063,8 @@ def get_fitted_model_bridge(scheduler: Scheduler, force_refit: bool = False) -> 
         A Adapter object fitted to the observations of the scheduler's experiment.
     """
     gs = scheduler.generation_strategy
-    model_bridge = gs.model  # Optional[Adapter]
-    if model_bridge is None or force_refit:  # Need to re-fit the model.
+    adapter = gs.model  # Optional[Adapter]
+    if adapter is None or force_refit:  # Need to re-fit the model.
         gs._curr._fit(experiment=scheduler.experiment)
-        model_bridge = cast(Adapter, gs.model)
-    return model_bridge
+        adapter = cast(Adapter, gs.model)
+    return adapter

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -49,11 +49,11 @@ from ax.generation_strategy.generation_strategy import (
 )
 from ax.metrics.branin import BraninMetric
 from ax.metrics.branin_map import BraninTimestampMapMetric
-from ax.modelbridge.cross_validation import compute_model_fit_metrics_from_modelbridge
+from ax.modelbridge.cross_validation import compute_model_fit_metrics_from_adapter
 from ax.modelbridge.registry import Generators, MBM_MTGP_trans
 from ax.service.scheduler import (
     FailureRateExceededError,
-    get_fitted_model_bridge,
+    get_fitted_adapter,
     MessageOutput,
     OptimizationResult,
     Scheduler,
@@ -1828,7 +1828,7 @@ class TestAxScheduler(TestCase):
         self.assertEqual(message, "Exceeding the total number of trials.")
 
     @mock_botorch_optimize
-    def test_get_fitted_model_bridge(self) -> None:
+    def test_get_fitted_adapter(self) -> None:
         self.branin_experiment._properties[Keys.IMMUTABLE_SEARCH_SPACE_AND_OPT_CONF] = (
             True
         )
@@ -1862,12 +1862,12 @@ class TestAxScheduler(TestCase):
         self,
         scheduler: Scheduler,
     ) -> None:
-        # testing get_fitted_model_bridge
-        model_bridge = get_fitted_model_bridge(scheduler)
+        # testing get_fitted_adapter
+        adapter = get_fitted_adapter(scheduler)
 
-        # testing compatibility with compute_model_fit_metrics_from_modelbridge
-        fit_metrics = compute_model_fit_metrics_from_modelbridge(
-            model_bridge=model_bridge,
+        # testing compatibility with compute_model_fit_metrics_from_adapter
+        fit_metrics = compute_model_fit_metrics_from_adapter(
+            adapter=adapter,
             untransform=False,
         )
         r2 = fit_metrics.get("coefficient_of_determination")
@@ -1885,8 +1885,8 @@ class TestAxScheduler(TestCase):
         self.assertIsInstance(std_branin, float)
 
         # testing with empty metrics dict
-        empty_metrics = compute_model_fit_metrics_from_modelbridge(
-            model_bridge=model_bridge,
+        empty_metrics = compute_model_fit_metrics_from_adapter(
+            adapter=adapter,
             fit_metrics_dict={},
             untransform=False,
         )

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -38,7 +38,7 @@ from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.modelbridge import Adapter
 from ax.modelbridge.cross_validation import (
-    compute_model_fit_metrics_from_modelbridge,
+    compute_model_fit_metrics_from_adapter,
     cross_validate,
 )
 from ax.modelbridge.random import RandomAdapter
@@ -1532,18 +1532,18 @@ def warn_if_unpredictable_metrics(
         A string warning the user about unpredictable metrics, if applicable.
     """
     # Get fit quality dict.
-    model_bridge = generation_strategy.model  # Optional[Adapter]
-    if model_bridge is None:  # Need to re-fit the model.
+    adapter = generation_strategy.model  # Optional[Adapter]
+    if adapter is None:  # Need to re-fit the model.
         generation_strategy._curr._fit(experiment=experiment)
-        model_bridge = cast(Adapter, generation_strategy.model)
-    if isinstance(model_bridge, RandomAdapter):
+        adapter = cast(Adapter, generation_strategy.model)
+    if isinstance(adapter, RandomAdapter):
         logger.debug(
-            "Current modelbridge on GenerationStrategy is RandomAdapter. "
+            "Current adapter on GenerationStrategy is RandomAdapter. "
             "Not checking metric predictability."
         )
         return None
-    model_fit_dict = compute_model_fit_metrics_from_modelbridge(
-        model_bridge=model_bridge,
+    model_fit_dict = compute_model_fit_metrics_from_adapter(
+        adapter=adapter,
         generalization=True,  # use generalization metrics for user warning
         untransform=False,
     )


### PR DESCRIPTION
Summary:
Just a tiny slice of the argument & file renaming that we need to do to see adapter / generator refactor to completion.

NOTE: This diff renames arguments in a BC-breaking fashion. I think this is ok since these are relatively low level helpers and shouldn't be directly used in user workflows.

Differential Revision: D74073117


