### PR TITLE
Docusaurus: Fix broken links

### DIFF
--- a/docs/why-ax.md
+++ b/docs/why-ax.md
@@ -22,7 +22,7 @@ costly simulations are contexts in which adaptive experimentation techniques are
 especially useful. Ax can optimize continuous (e.g., integer or floating
 point)-valued configurations, discrete configurations (e.g., variants of an A/B
 test), or mixed spaces using techniques like
-[Bayesian optimization](../intro-to-bo). This makes it suitable for a wide range
+[Bayesian optimization](./intro-to-bo). This makes it suitable for a wide range
 of applications.
 
 # Unique capabilities
@@ -37,7 +37,7 @@ of applications.
   providing sensible defaults and enabling practitioners to leverage advanced
   techniques otherwise only accessible to optimization experts.
 
-- Ax leverages state-of-the-art [Bayesian optimization](../intro-to-bo)
+- Ax leverages state-of-the-art [Bayesian optimization](./intro-to-bo)
   algorithms implemented in [BoTorch](https://botorch.org/), to deliver strong
   performance across a variety of problem classes.
 


### PR DESCRIPTION
Fixes

https://github.com/facebook/Ax/actions/runs/14807699828/job/41578447875
```
Error:  Error: Unable to build website for locale en.
    at tryToBuildLocale (/home/runner/work/Ax/Ax/website/node_modules/@docusaurus/core/lib/commands/build/build.js:78:15)
    at async /home/runner/work/Ax/Ax/website/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9
    ... 4 lines matching cause stack trace ...
    at async file:///home/runner/work/Ax/Ax/website/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3 {
  [cause]: Error: Docusaurus found broken links!

  Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
  Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

  Exhaustive list of all broken links found:
  - Broken link on source page path = /docs/next/why-ax:
     -> linking to ../intro-to-bo (resolved as: /docs/intro-to-bo)
```

I think the source of confusion dev-side is that tutorials are nested in subfolders (since they sometimes contain additional data i.e. plots) while docs are all in the same folder.