### PR TITLE
fix data selector + training_in_design in legacy plotting

### DIFF
--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -185,12 +185,13 @@ def _get_in_sample_arms(
     observations = model.get_training_data()
     training_in_design = model.training_in_design
     if data_selector is not None:
-        observations = [obs for obs in observations if data_selector(obs)]
-        training_in_design = [
-            model.training_in_design[i]
-            for i, obs in enumerate(observations)
-            if data_selector(obs)
-        ]
+        new_observations = []
+        training_in_design = []
+        for i, obs in enumerate(observations):
+            if data_selector(obs):
+                training_in_design.append(model.training_in_design[i])
+                new_observations.append(obs)
+        observations = new_observations
     trial_selector = None
     if fixed_features is not None:
         trial_selector = fixed_features.trial_index


### PR DESCRIPTION
Summary: This was broken before. We would filter the observation which caused misalignment between ordering and training_in_design. This led to failures if some arms where out of design (e.g. SQ).

Reviewed By: mgarrard

Differential Revision: D74088220


