### PR TITLE
Fix compute_baseline_value_from_sobol to not throw a lot of warnings

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -593,15 +593,18 @@ def compute_baseline_value_from_sobol(
     higher_is_better = isinstance(optimization_config.objective, MultiObjective) or (
         not optimization_config.objective.minimize
     )
-    dummy_optimal_value = float("inf") if higher_is_better else float("-inf")
     dummy_problem = BenchmarkProblem(
         name="dummy",
         optimization_config=optimization_config,
         search_space=search_space,
         num_trials=5,
         test_function=test_function,
-        optimal_value=dummy_optimal_value,
-        baseline_value=-dummy_optimal_value,
+        # Optimal value and baseline value are only used
+        # to compute the score_trace, which we don't use here.
+        # The order of baseline and optimal value needs to be correct,
+        # though, as a ValueError is raised otherwise.
+        optimal_value=1.0 if higher_is_better else -1.0,
+        baseline_value=0.0,
         target_fidelity_and_task=target_fidelity_and_task,
     )
 


### PR DESCRIPTION
Summary:
If you run compute_baseline_value_from_sobol it throws a lot of warnings like this right now:

```
[W 250501 06:22:52 benchmark:108] invalid value encountered in divide
```

This is due to a `inf/inf` when calculating the score trace, as the best_value and the baseline_value are set to inf (-inf).

Reviewed By: esantorella

Differential Revision: D73998629


