### PR TITLE
No enums in Ax API

### DIFF
--- a/ax/__init__.py
+++ b/ax/__init__.py
@@ -12,8 +12,6 @@ from ax.api.configs import (
     ExperimentConfig,
     GenerationStrategyConfig,
     OrchestrationConfig,
-    ParameterScaling,
-    ParameterType,
     RangeParameterConfig,
     StorageConfig,
 )
@@ -25,8 +23,6 @@ __all__ = [
     "ExperimentConfig",
     "GenerationStrategyConfig",
     "OrchestrationConfig",
-    "ParameterScaling",
-    "ParameterType",
     "RangeParameterConfig",
     "StorageConfig",
     "TOutcome",

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -8,7 +8,7 @@
 from ax.analysis.analysis import AnalysisBlobAnnotation
 from ax.analysis.plotly.scatter import compute_scatter_adhoc, ScatterPlot
 from ax.api.client import Client
-from ax.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
+from ax.api.configs import ExperimentConfig, RangeParameterConfig
 from ax.core.arm import Arm
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
@@ -30,12 +30,12 @@ class TestScatterPlot(TestCase):
                 parameters=[
                     RangeParameterConfig(
                         name="x1",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                     RangeParameterConfig(
                         name="x2",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                 ],

--- a/ax/analysis/plotly/tests/test_sensitivity.py
+++ b/ax/analysis/plotly/tests/test_sensitivity.py
@@ -15,7 +15,7 @@ from ax.analysis.plotly.sensitivity import (
     SensitivityAnalysisPlot,
 )
 from ax.api.client import Client
-from ax.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
+from ax.api.configs import ExperimentConfig, RangeParameterConfig
 from ax.exceptions.core import UserInputError
 from ax.modelbridge.registry import Generators
 from ax.service.ax_client import AxClient, ObjectiveProperties
@@ -59,12 +59,12 @@ class TestSensitivityAnalysisPlot(TestCase):
                 parameters=[
                     RangeParameterConfig(
                         name="x1",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                     RangeParameterConfig(
                         name="x2",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                 ],

--- a/ax/analysis/plotly/tests/test_top_surfaces.py
+++ b/ax/analysis/plotly/tests/test_top_surfaces.py
@@ -6,12 +6,7 @@
 # pyre-strict
 from ax.analysis.plotly.top_surfaces import TopSurfacesAnalysis
 from ax.api.client import Client
-from ax.api.configs import (
-    ChoiceParameterConfig,
-    ExperimentConfig,
-    ParameterType,
-    RangeParameterConfig,
-)
+from ax.api.configs import ChoiceParameterConfig, ExperimentConfig, RangeParameterConfig
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
@@ -30,12 +25,12 @@ class TestTopSurfacesAnalysis(TestCase):
                 parameters=[
                     RangeParameterConfig(
                         name="x1",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                     RangeParameterConfig(
                         name="x2",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                 ],
@@ -114,12 +109,12 @@ class TestTopSurfacesAnalysis(TestCase):
                 parameters=[
                     RangeParameterConfig(
                         name="x1",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                     ChoiceParameterConfig(
                         name="x2",
-                        parameter_type=ParameterType.INT,
+                        parameter_type="int",
                         values=[*range(10)],
                         is_ordered=False,
                     ),

--- a/ax/analysis/plotly/tests/test_unified.py
+++ b/ax/analysis/plotly/tests/test_unified.py
@@ -10,7 +10,7 @@ from ax.analysis.plotly.arm_effects.unified import (
     compute_arm_effects_adhoc,
 )
 from ax.api.client import Client
-from ax.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
+from ax.api.configs import ExperimentConfig, RangeParameterConfig
 from ax.core.arm import Arm
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
@@ -39,12 +39,12 @@ class TestArmEffectsPlot(TestCase):
                 parameters=[
                     RangeParameterConfig(
                         name="x1",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                     RangeParameterConfig(
                         name="x2",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                 ],

--- a/ax/analysis/tests/test_search_space_summary.py
+++ b/ax/analysis/tests/test_search_space_summary.py
@@ -13,13 +13,7 @@ from ax.analysis.analysis import (
 )
 from ax.analysis.search_space_summary import SearchSpaceSummary
 from ax.api.client import Client
-from ax.api.configs import (
-    ChoiceParameterConfig,
-    ExperimentConfig,
-    ParameterScaling,
-    ParameterType,
-    RangeParameterConfig,
-)
+from ax.api.configs import ChoiceParameterConfig, ExperimentConfig, RangeParameterConfig
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
@@ -34,13 +28,13 @@ class TestSearchSpaceSummary(TestCase):
                 parameters=[
                     RangeParameterConfig(
                         name="x1",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0.1, 1),
-                        scaling=ParameterScaling.LOG,
+                        scaling="log",
                     ),
                     ChoiceParameterConfig(
                         name="x2",
-                        parameter_type=ParameterType.INT,
+                        parameter_type="int",
                         values=[0, 1],
                     ),
                 ],

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -14,7 +14,7 @@ from ax.analysis.analysis import (
 )
 from ax.analysis.summary import Summary
 from ax.api.client import Client
-from ax.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
+from ax.api.configs import ExperimentConfig, RangeParameterConfig
 from ax.core.trial import Trial
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
@@ -31,12 +31,12 @@ class TestSummary(TestCase):
                 parameters=[
                     RangeParameterConfig(
                         name="x1",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                     RangeParameterConfig(
                         name="x2",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                 ],

--- a/ax/analysis/tests/test_utils.py
+++ b/ax/analysis/tests/test_utils.py
@@ -10,7 +10,7 @@ import pandas as pd
 from ax.analysis.plotly.utils import truncate_label
 from ax.analysis.utils import _relativize_data, prepare_arm_data
 from ax.api.client import Client
-from ax.api.configs import ExperimentConfig, ParameterType, RangeParameterConfig
+from ax.api.configs import ExperimentConfig, RangeParameterConfig
 from ax.core.arm import Arm
 from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UserInputError
@@ -33,12 +33,12 @@ class TestUtils(TestCase):
                 parameters=[
                     RangeParameterConfig(
                         name="x1",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                     RangeParameterConfig(
                         name="x2",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                 ],

--- a/ax/api/__init__.py
+++ b/ax/api/__init__.py
@@ -12,8 +12,6 @@ from ax.api.configs import (
     ExperimentConfig,
     GenerationStrategyConfig,
     OrchestrationConfig,
-    ParameterScaling,
-    ParameterType,
     RangeParameterConfig,
     StorageConfig,
 )
@@ -25,8 +23,6 @@ __all__ = [
     "ExperimentConfig",
     "GenerationStrategyConfig",
     "OrchestrationConfig",
-    "ParameterScaling",
-    "ParameterType",
     "RangeParameterConfig",
     "StorageConfig",
     "TOutcome",

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -18,7 +18,6 @@ from ax.api.configs import (
     ExperimentConfig,
     GenerationStrategyConfig,
     OrchestrationConfig,
-    ParameterType,
     RangeParameterConfig,
     StorageConfig,
 )
@@ -62,17 +61,17 @@ class TestClient(TestCase):
 
         float_parameter = RangeParameterConfig(
             name="float_param",
-            parameter_type=ParameterType.FLOAT,
+            parameter_type="float",
             bounds=(0, 1),
         )
         int_parameter = RangeParameterConfig(
             name="int_param",
-            parameter_type=ParameterType.INT,
+            parameter_type="int",
             bounds=(0, 1),
         )
         choice_parameter = ChoiceParameterConfig(
             name="choice_param",
-            parameter_type=ParameterType.STRING,
+            parameter_type="str",
             values=["a", "b", "c"],
         )
 
@@ -131,17 +130,17 @@ class TestClient(TestCase):
 
         float_parameter = RangeParameterConfig(
             name="float_param",
-            parameter_type=ParameterType.FLOAT,
+            parameter_type="float",
             bounds=(0, 1),
         )
         int_parameter = RangeParameterConfig(
             name="int_param",
-            parameter_type=ParameterType.INT,
+            parameter_type="int",
             bounds=(0, 1),
         )
         choice_parameter = ChoiceParameterConfig(
             name="choice_param",
-            parameter_type=ParameterType.STRING,
+            parameter_type="str",
             values=["a", "b", "c"],
         )
 
@@ -208,7 +207,7 @@ class TestClient(TestCase):
             experiment_config=ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(0, 1)
+                        name="x1", parameter_type="float", bounds=(0, 1)
                     )
                 ],
                 name="foo",
@@ -278,7 +277,7 @@ class TestClient(TestCase):
             experiment_config=ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(0, 1)
+                        name="x1", parameter_type="float", bounds=(0, 1)
                     )
                 ],
                 name="foo",
@@ -341,10 +340,10 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                     RangeParameterConfig(
-                        name="x2", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x2", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -388,10 +387,10 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                     RangeParameterConfig(
-                        name="x2", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x2", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -436,7 +435,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -532,7 +531,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -633,7 +632,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -657,7 +656,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -680,7 +679,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -702,7 +701,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -724,7 +723,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -772,7 +771,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -796,7 +795,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -842,7 +841,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -889,12 +888,12 @@ class TestClient(TestCase):
                 parameters=[
                     RangeParameterConfig(
                         name="x1",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                     RangeParameterConfig(
                         name="x2",
-                        parameter_type=ParameterType.FLOAT,
+                        parameter_type="float",
                         bounds=(0, 1),
                     ),
                 ],
@@ -956,7 +955,7 @@ class TestClient(TestCase):
             ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -1005,7 +1004,7 @@ class TestClient(TestCase):
             experiment_config=ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -1089,7 +1088,7 @@ class TestClient(TestCase):
             experiment_config=ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -1189,7 +1188,7 @@ class TestClient(TestCase):
             experiment_config=ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                 ],
                 name="foo",
@@ -1232,25 +1231,23 @@ class TestClient(TestCase):
             experiment_config=ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                     RangeParameterConfig(
-                        name="x2", parameter_type=ParameterType.INT, bounds=(-1, 1)
+                        name="x2", parameter_type="int", bounds=(-1, 1)
                     ),
                     ChoiceParameterConfig(
                         name="x3",
-                        parameter_type=ParameterType.STRING,
+                        parameter_type="str",
                         values=["a", "b"],
                     ),
                     ChoiceParameterConfig(
                         name="x4",
-                        parameter_type=ParameterType.INT,
+                        parameter_type="int",
                         values=[1, 2, 3],
                         is_ordered=True,
                     ),
-                    ChoiceParameterConfig(
-                        name="x5", parameter_type=ParameterType.INT, values=[1]
-                    ),
+                    ChoiceParameterConfig(name="x5", parameter_type="int", values=[1]),
                 ],
                 name="foo",
             )
@@ -1290,25 +1287,23 @@ class TestClient(TestCase):
             experiment_config=ExperimentConfig(
                 parameters=[
                     RangeParameterConfig(
-                        name="x1", parameter_type=ParameterType.FLOAT, bounds=(-1, 1)
+                        name="x1", parameter_type="float", bounds=(-1, 1)
                     ),
                     RangeParameterConfig(
-                        name="x2", parameter_type=ParameterType.INT, bounds=(-1, 1)
+                        name="x2", parameter_type="int", bounds=(-1, 1)
                     ),
                     ChoiceParameterConfig(
                         name="x3",
-                        parameter_type=ParameterType.STRING,
+                        parameter_type="str",
                         values=["a", "b"],
                     ),
                     ChoiceParameterConfig(
                         name="x4",
-                        parameter_type=ParameterType.INT,
+                        parameter_type="int",
                         values=[1, 2, 3],
                         is_ordered=True,
                     ),
-                    ChoiceParameterConfig(
-                        name="x5", parameter_type=ParameterType.INT, values=[1]
-                    ),
+                    ChoiceParameterConfig(name="x5", parameter_type="int", values=[1]),
                 ],
                 name="unique_test_experiment",
             )

--- a/ax/api/utils/generation_strategy_dispatch.py
+++ b/ax/api/utils/generation_strategy_dispatch.py
@@ -8,7 +8,7 @@
 
 
 import torch
-from ax.api.configs import GenerationMethod, GenerationStrategyConfig
+from ax.api.configs import GenerationStrategyConfig
 from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UnsupportedError
 from ax.generation_strategy.center_generation_node import CenterGenerationNode
@@ -101,9 +101,9 @@ def _get_mbm_node(
     - FAST: An empty model config that utilizes MBM defaults.
     """
     # Construct the surrogate spec.
-    if gs_config.method == GenerationMethod.FAST:
+    if gs_config.method == "fast":
         model_configs = [ModelConfig(name="MBM defaults")]
-    elif gs_config.method == GenerationMethod.BALANCED:
+    elif gs_config.method == "balanced":
         model_configs = [
             ModelConfig(name="MBM defaults"),
             ModelConfig(
@@ -151,7 +151,7 @@ def choose_generation_strategy(
         A generation strategy.
     """
     # Handle the random search case.
-    if gs_config.method == GenerationMethod.RANDOM_SEARCH:
+    if gs_config.method == "random_search":
         nodes = [
             GenerationNode(
                 node_name="Sobol",
@@ -169,7 +169,7 @@ def choose_generation_strategy(
             _get_sobol_node(gs_config=gs_config),
             _get_mbm_node(gs_config=gs_config),
         ]
-        gs_name = f"Sobol+MBM:{gs_config.method.value}"
+        gs_name = f"Sobol+MBM:{gs_config.method}"
     if gs_config.initialize_with_center:
         center_node = CenterGenerationNode(next_node_name=nodes[0].node_name)
         nodes.insert(0, center_node)

--- a/ax/api/utils/instantiation/from_config.py
+++ b/ax/api/utils/instantiation/from_config.py
@@ -7,13 +7,7 @@
 
 
 import numpy as np
-from ax.api.configs import (
-    ChoiceParameterConfig,
-    ExperimentConfig,
-    ParameterScaling,
-    ParameterType,
-    RangeParameterConfig,
-)
+from ax.api.configs import ChoiceParameterConfig, ExperimentConfig, RangeParameterConfig
 from ax.api.utils.instantiation.from_string import parse_parameter_constraint
 
 from ax.core.experiment import Experiment
@@ -44,9 +38,7 @@ def parameter_from_config(
         # TODO[mpolson64] Add support for RangeParameterConfig.step_size native to
         # RangeParameter instead of converting to ChoiceParameter
         if (step_size := config.step_size) is not None:
-            if not (
-                config.scaling == ParameterScaling.LINEAR or config.scaling is None
-            ):
+            if not (config.scaling == "linear" or config.scaling is None):
                 raise UserInputError(
                     "Non-linear parameter scaling is not supported when using "
                     "step_size."
@@ -70,7 +62,7 @@ def parameter_from_config(
             parameter_type=_parameter_type_converter(config.parameter_type),
             lower=lower,
             upper=upper,
-            log_scale=config.scaling == ParameterScaling.LOG,
+            log_scale=config.scaling == "log",
         )
 
     else:
@@ -140,18 +132,18 @@ def experiment_from_config(config: ExperimentConfig) -> Experiment:
     )
 
 
-def _parameter_type_converter(parameter_type: ParameterType) -> CoreParameterType:
+def _parameter_type_converter(parameter_type: str) -> CoreParameterType:
     """
     Convert from an API ParameterType to a core Ax ParameterType.
     """
 
-    if parameter_type == ParameterType.BOOL:
+    if parameter_type == "bool":
         return CoreParameterType.BOOL
-    elif parameter_type == ParameterType.FLOAT:
+    elif parameter_type == "float":
         return CoreParameterType.FLOAT
-    elif parameter_type == ParameterType.INT:
+    elif parameter_type == "int":
         return CoreParameterType.INT
-    elif parameter_type == ParameterType.STRING:
+    elif parameter_type == "str":
         return CoreParameterType.STRING
     else:
         raise UserInputError(f"Unsupported parameter type {parameter_type}.")

--- a/ax/api/utils/instantiation/tests/test_from_config.py
+++ b/ax/api/utils/instantiation/tests/test_from_config.py
@@ -5,13 +5,7 @@
 
 # pyre-strict
 
-from ax.api.configs import (
-    ChoiceParameterConfig,
-    ExperimentConfig,
-    ParameterScaling,
-    ParameterType,
-    RangeParameterConfig,
-)
+from ax.api.configs import ChoiceParameterConfig, ExperimentConfig, RangeParameterConfig
 from ax.api.utils.instantiation.from_config import (
     _parameter_type_converter,
     experiment_from_config,
@@ -35,7 +29,7 @@ class TestFromConfig(TestCase):
     def test_create_range_parameter(self) -> None:
         float_config = RangeParameterConfig(
             name="float_param",
-            parameter_type=ParameterType.FLOAT,
+            parameter_type="float",
             bounds=(0, 1),
         )
 
@@ -51,9 +45,9 @@ class TestFromConfig(TestCase):
 
         float_config_with_log_scaling = RangeParameterConfig(
             name="float_param_with_log_scaling",
-            parameter_type=ParameterType.FLOAT,
+            parameter_type="float",
             bounds=(1e-10, 1),
-            scaling=ParameterScaling.LOG,
+            scaling="log",
         )
 
         self.assertEqual(
@@ -69,7 +63,7 @@ class TestFromConfig(TestCase):
 
         int_config = RangeParameterConfig(
             name="int_param",
-            parameter_type=ParameterType.INT,
+            parameter_type="int",
             bounds=(0, 1),
         )
 
@@ -85,7 +79,7 @@ class TestFromConfig(TestCase):
 
         step_size_config = RangeParameterConfig(
             name="step_size_param",
-            parameter_type=ParameterType.FLOAT,
+            parameter_type="float",
             bounds=(0, 100),
             step_size=10,
         )
@@ -119,17 +113,17 @@ class TestFromConfig(TestCase):
             parameter_from_config(
                 config=RangeParameterConfig(
                     name="step_size_param_with_scaling",
-                    parameter_type=ParameterType.FLOAT,
+                    parameter_type="float",
                     bounds=(0, 100),
                     step_size=10,
-                    scaling=ParameterScaling.LOG,
+                    scaling="log",
                 )
             )
 
     def test_create_choice_parameter(self) -> None:
         choice_config = ChoiceParameterConfig(
             name="choice_param",
-            parameter_type=ParameterType.STRING,
+            parameter_type="str",
             values=["a", "b", "c"],
         )
 
@@ -144,7 +138,7 @@ class TestFromConfig(TestCase):
 
         choice_config_with_order = ChoiceParameterConfig(
             name="choice_param_with_order",
-            parameter_type=ParameterType.STRING,
+            parameter_type="str",
             values=["a", "b", "c"],
             is_ordered=True,
         )
@@ -160,7 +154,7 @@ class TestFromConfig(TestCase):
 
         choice_config_with_dependents = ChoiceParameterConfig(
             name="choice_param_with_dependents",
-            parameter_type=ParameterType.STRING,
+            parameter_type="str",
             values=["a", "b", "c"],
             dependent_parameters={
                 "a": ["a1", "a2"],
@@ -182,7 +176,7 @@ class TestFromConfig(TestCase):
 
         single_element_choice_config = ChoiceParameterConfig(
             name="single_element_choice_param",
-            parameter_type=ParameterType.STRING,
+            parameter_type="str",
             values=["a"],
         )
         self.assertEqual(
@@ -197,17 +191,17 @@ class TestFromConfig(TestCase):
     def test_experiment_from_config(self) -> None:
         float_parameter = RangeParameterConfig(
             name="float_param",
-            parameter_type=ParameterType.FLOAT,
+            parameter_type="float",
             bounds=(0, 1),
         )
         int_parameter = RangeParameterConfig(
             name="int_param",
-            parameter_type=ParameterType.INT,
+            parameter_type="int",
             bounds=(0, 1),
         )
         choice_parameter = ChoiceParameterConfig(
             name="choice_param",
-            parameter_type=ParameterType.STRING,
+            parameter_type="str",
             values=["a", "b", "c"],
         )
 
@@ -261,7 +255,7 @@ class TestFromConfig(TestCase):
 
         root_parameter = ChoiceParameterConfig(
             name="root_param",
-            parameter_type=ParameterType.STRING,
+            parameter_type="str",
             values=["left", "right"],
             dependent_parameters={
                 "left": ["float_param"],
@@ -321,19 +315,19 @@ class TestFromConfig(TestCase):
 
     def test_parameter_type_converter(self) -> None:
         self.assertEqual(
-            _parameter_type_converter(parameter_type=ParameterType.BOOL),
+            _parameter_type_converter(parameter_type="bool"),
             CoreParameterType.BOOL,
         )
         self.assertEqual(
-            _parameter_type_converter(parameter_type=ParameterType.INT),
+            _parameter_type_converter(parameter_type="int"),
             CoreParameterType.INT,
         )
         self.assertEqual(
-            _parameter_type_converter(parameter_type=ParameterType.FLOAT),
+            _parameter_type_converter(parameter_type="float"),
             CoreParameterType.FLOAT,
         )
         self.assertEqual(
-            _parameter_type_converter(parameter_type=ParameterType.STRING),
+            _parameter_type_converter(parameter_type="str"),
             CoreParameterType.STRING,
         )
         with self.assertRaisesRegex(UserInputError, "Unsupported parameter type"):

--- a/ax/api/utils/tests/test_generation_strategy_dispatch.py
+++ b/ax/api/utils/tests/test_generation_strategy_dispatch.py
@@ -10,7 +10,7 @@
 from typing import Any
 
 import torch
-from ax.api.configs import GenerationMethod, GenerationStrategyConfig
+from ax.api.configs import GenerationStrategyConfig
 from ax.api.utils.generation_strategy_dispatch import choose_generation_strategy
 from ax.core.trial import Trial
 from ax.core.trial_status import TrialStatus
@@ -45,7 +45,7 @@ class TestDispatchUtils(TestCase):
         for case, config_kws in config_kws_cases.items():
             with self.subTest(case=case):
                 gs_config = GenerationStrategyConfig(
-                    method=GenerationMethod.RANDOM_SEARCH, **config_kws
+                    method="random_search", **config_kws
                 )
                 use_center = use_center_cases[case]
                 gs = choose_generation_strategy(gs_config=gs_config)
@@ -69,7 +69,7 @@ class TestDispatchUtils(TestCase):
     @mock_botorch_optimize
     def test_choose_gs_fast_with_options(self) -> None:
         gs_config = GenerationStrategyConfig(
-            method=GenerationMethod.FAST,
+            method="fast",
             initialization_budget=3,
             initialization_random_seed=0,
             use_existing_trials_for_initialization=False,
@@ -149,7 +149,7 @@ class TestDispatchUtils(TestCase):
     def test_choose_gs_balanced(self) -> None:
         gs = choose_generation_strategy(
             gs_config=GenerationStrategyConfig(
-                method=GenerationMethod.BALANCED, initialize_with_center=False
+                method="balanced", initialize_with_center=False
             ),
         )
         self.assertEqual(len(gs._nodes), 2)


### PR DESCRIPTION
Summary:
Remove Enums (ParameterType, ParameterScaling) in the API in favor of string literals. Now there is no need to import an extra class and the method signatures look less scary overall.

What we gain here in terms of ease of use we lose in runtime safety (literals are checked at typecheck time but relax into str at runtime) but overall this seems like a good tradeoff.

Will update docs and tutorials at the top of this stack, so expect tutorial tests to be broken.

Reviewed By: lena-kashtelyan

Differential Revision: D74266083


