### PR TITLE
Update cross validation tests to reduce mocking

### DIFF
--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -255,6 +255,15 @@ class Observation(Base):
         self.data = data
         self.arm_name = arm_name
 
+    def __repr__(self) -> str:
+        return (
+            "Observation(\n"
+            f"    features={self.features},\n"
+            f"    data={self.data},\n"
+            f"    arm_name='{self.arm_name}',\n"
+            ")"
+        )
+
 
 def _observations_from_dataframe(
     experiment: experiment.Experiment,

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -977,3 +977,21 @@ class ObservationsTest(TestCase):
                 observation.features.metadata.get(SOME_METADATA_KEY),
                 f"value_{observation.features.trial_index}",
             )
+
+    def test_observation_repr(self) -> None:
+        obs = Observation(
+            features=ObservationFeatures(parameters={"x": 20}),
+            data=ObservationData(
+                means=np.array([1]), covariance=np.array([[2]]), metric_names=["a"]
+            ),
+            arm_name="0_0",
+        )
+        expected = (
+            "Observation(\n"
+            "    features=ObservationFeatures(parameters={'x': 20}),\n"
+            "    data=ObservationData(metric_names=['a'], "
+            "means=[1], covariance=[[2]]),\n"
+            "    arm_name='0_0',\n"
+            ")"
+        )
+        self.assertEqual(repr(obs), expected)

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -9,9 +9,7 @@
 from __future__ import annotations
 
 from functools import partial
-
 from logging import Logger
-
 from typing import Any, TYPE_CHECKING
 
 from ax.core.arm import Arm

--- a/ax/modelbridge/cross_validation.py
+++ b/ax/modelbridge/cross_validation.py
@@ -123,7 +123,7 @@ def cross_validate(
     arm_names_rnd = np.array(list(arm_names))
     # Not necessary to shuffle when using LOO, avoids differences in floating point
     # computations making equality tests brittle.
-    if folds != -1:
+    if folds != n:
         np.random.shuffle(arm_names_rnd)
     result = []
     for train_names, test_names in _gen_train_test_split(

--- a/ax/modelbridge/tests/test_cross_validation.py
+++ b/ax/modelbridge/tests/test_cross_validation.py
@@ -7,19 +7,18 @@
 # pyre-strict
 
 import warnings
+from copy import deepcopy
 from unittest import mock
 
 import numpy as np
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.observation import Observation, ObservationData
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
 )
 from ax.core.outcome_constraint import OutcomeConstraint
-from ax.core.parameter import FixedParameter, ParameterType
-from ax.core.search_space import SearchSpace
 from ax.core.types import ComparisonOp
 from ax.modelbridge.cross_validation import (
     assess_model_fit,
@@ -30,109 +29,60 @@ from ax.modelbridge.cross_validation import (
     has_good_opt_config_model_fit,
 )
 from ax.modelbridge.registry import Generators
+from ax.modelbridge.torch import TorchAdapter
+from ax.modelbridge.transforms.unit_x import UnitX
+from ax.models.torch.botorch_modular.model import BoTorchGenerator
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_branin_experiment
-from ax.utils.testing.mock import mock_botorch_optimize
-from ax.utils.testing.modeling_stubs import get_observation1trans, get_observation2trans
+from ax.utils.testing.core_stubs import (
+    get_branin_experiment,
+    get_experiment_with_observations,
+    get_search_space_for_range_value,
+)
+from ax.utils.testing.mock import (
+    mock_botorch_optimize,
+    mock_botorch_optimize_context_manager,
+)
 
 
 class CrossValidationTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.training_data = [
-            Observation(
-                features=ObservationFeatures(parameters={"x": 2.0}, trial_index=0),
-                data=ObservationData(
-                    means=np.array([2.0, 4.0]),
-                    covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
-                    metric_names=["a", "b"],
-                ),
-                arm_name="1_1",
-            ),
-            Observation(
-                features=ObservationFeatures(parameters={"x": 2.0}, trial_index=1),
-                data=ObservationData(
-                    means=np.array([3.0, 5.0, 6.0]),
-                    covariance=np.array(
-                        [[1.0, 2.0, 3.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]
-                    ),
-                    metric_names=["a", "b", "a"],
-                ),
-                arm_name="1_1",
-            ),
-            Observation(
-                features=ObservationFeatures(parameters={"x": 3.0}),
-                data=ObservationData(
-                    means=np.array([7.0, 8.0]),
-                    covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
-                    metric_names=["a", "b"],
-                ),
-                arm_name="1_2",
-            ),
-            Observation(
-                features=ObservationFeatures(parameters={"x": 4.0}, trial_index=2),
-                data=ObservationData(
-                    means=np.array([9.0, 10.0]),
-                    covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
-                    metric_names=["a", "b"],
-                ),
-                arm_name="1_3",
-            ),
-        ]
-        self.observation_data = [
-            ObservationData(
-                means=np.array([2.0, 1.0]),
-                covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
-                metric_names=["a", "b"],
+        self.experiment = get_experiment_with_observations(
+            observations=[[2.0, 4.0], [3.0, 5.0], [7.0, 8.0], [9.0, 10.0]],
+            sems=[[1.0, 2.0], [1.0, 2.0], [1.0, 2.0], [1.0, 2.0]],
+            search_space=get_search_space_for_range_value(min=0.0, max=10.0),
+            parameterizations=[{"x": 2.0}, {"x": 2.0}, {"x": 3.0}, {"x": 4.0}],
+        )
+        with mock_botorch_optimize_context_manager():
+            self.adapter = TorchAdapter(
+                experiment=self.experiment, model=BoTorchGenerator(), transforms=[UnitX]
             )
-        ] * 4
-        self.observation_data_transformed_result = [get_observation1trans().data] * 4
-        self.transformed_cv_input_dict = {
-            "cv_training_data": [get_observation2trans()],
-            "cv_test_points": [get_observation1trans().features],
-            "search_space": SearchSpace(
-                [FixedParameter("x", ParameterType.FLOAT, 8.0)]
-            ),
-        }
+        self.training_data = self.adapter.get_training_data()
+        self.observation_data = ObservationData(
+            means=np.array([2.0, 1.0]),
+            covariance=np.array([[1.0, 2.0], [3.0, 4.0]]),
+            metric_names=["m1", "m2"],
+        )
         self.diagnostics: list[CVDiagnostics] = [
-            {"Fisher exact test p": {"y_a": 0.0, "y_b": 0.4}},
-            {"Fisher exact test p": {"y_a": 0.1, "y_b": 0.1}},
-            {"Fisher exact test p": {"y_a": 0.5, "y_b": 0.6}},
+            {"Fisher exact test p": {"y_m1": 0.0, "y_m2": 0.4}},
+            {"Fisher exact test p": {"y_m1": 0.1, "y_m2": 0.1}},
+            {"Fisher exact test p": {"y_m1": 0.5, "y_m2": 0.6}},
         ]
 
-    def test_CrossValidate(self) -> None:
-        # Prepare input and output data
-        ma = mock.MagicMock()
-        ma.get_training_data = mock.MagicMock(
-            "ax.modelbridge.base.Adapter.get_training_data",
-            autospec=True,
-            return_value=self.training_data,
-        )
-        ma.cross_validate = mock.MagicMock(
-            "ax.modelbridge.base.Adapter.cross_validate",
-            autospec=True,
-            return_value=self.observation_data,
-        )
-        ma._transform_inputs_for_cv = mock.MagicMock(
-            "ax.modelbridge.base.Adapter._transform_inputs_for_cv",
-            autospec=True,
-            return_value=list(self.transformed_cv_input_dict.values()),
-        )
-        ma._cross_validate = mock.MagicMock(
-            "ax.modelbridge.base.Adapter._cross_validate",
-            autospec=True,
-            return_value=self.observation_data_transformed_result,
-        )
+    def test_cross_validate_base(self) -> None:
         # Do cross validation
-        with self.assertRaises(ValueError):
-            cross_validate(model=ma, folds=4)
-        with self.assertRaises(ValueError):
-            cross_validate(model=ma, folds=0)
+        with self.assertRaisesRegex(ValueError, "which is less than folds"):
+            cross_validate(model=self.adapter, folds=4)
+        with self.assertRaisesRegex(ValueError, "Folds must be"):
+            cross_validate(model=self.adapter, folds=0)
         # First 2-fold
-        result = cross_validate(model=ma, folds=2)
+        with mock.patch.object(
+            self.adapter, "cross_validate", wraps=self.adapter.cross_validate
+        ) as mock_cv:
+            result = cross_validate(model=self.adapter, folds=2)
         self.assertEqual(len(result), 4)
         # Check that Adapter.cross_validate was called correctly.
-        z = ma.cross_validate.mock_calls
+        z = mock_cv.mock_calls
         self.assertEqual(len(z), 2)
         train = [
             [obs.features.parameters["x"] for obs in r[2]["cv_training_data"]]
@@ -150,9 +100,12 @@ class CrossValidationTest(TestCase):
         )
 
         # Test LOO
-        result = cross_validate(model=ma, folds=-1)
+        with mock.patch.object(
+            self.adapter, "cross_validate", wraps=self.adapter.cross_validate
+        ) as mock_cv:
+            result = cross_validate(model=self.adapter, folds=-1)
         self.assertEqual(len(result), 4)
-        z = ma.cross_validate.mock_calls[2:]
+        z = mock_cv.mock_calls
         self.assertEqual(len(z), 3)
         train = [
             [obs.features.parameters["x"] for obs in r[2]["cv_training_data"]]
@@ -169,13 +122,21 @@ class CrossValidationTest(TestCase):
             np.array_equal(sorted(all_test), np.array([2.0, 2.0, 3.0, 4.0]))
         )
         # Test LOO in transformed space
-        result = cross_validate(model=ma, folds=-1, untransform=False)
+        with mock.patch.object(
+            self.adapter,
+            "_transform_inputs_for_cv",
+            wraps=self.adapter._transform_inputs_for_cv,
+        ) as mock_transform_cv, mock.patch.object(
+            self.adapter,
+            "_cross_validate",
+            side_effect=lambda **kwargs: [self.observation_data]
+            * len(kwargs["cv_test_points"]),
+        ) as mock_cv:
+            result = cross_validate(model=self.adapter, folds=-1, untransform=False)
         result_predicted_obs_data = [cv_result.predicted for cv_result in result]
-        self.assertEqual(
-            result_predicted_obs_data, self.observation_data_transformed_result
-        )
+        self.assertEqual(result_predicted_obs_data, [self.observation_data] * 4)
         # Check that Adapter._transform_inputs_for_cv was called correctly.
-        z = ma._transform_inputs_for_cv.mock_calls
+        z = mock_transform_cv.mock_calls
         self.assertEqual(len(z), 3)
         train = [
             [obs.features.parameters["x"] for obs in r[2]["cv_training_data"]]
@@ -192,20 +153,36 @@ class CrossValidationTest(TestCase):
             np.array_equal(sorted(all_test), np.array([2.0, 2.0, 3.0, 4.0]))
         )
         # Test Adapter._cross_validate was called correctly.
-        z = ma._cross_validate.mock_calls
-        self.assertEqual(len(z), 3)
-        ma._cross_validate.assert_called_with(
-            **self.transformed_cv_input_dict, use_posterior_predictive=False
+        self.assertEqual(mock_cv.call_count, 3)
+        transform = self.adapter.transforms["UnitX"]
+        # Compare against arbitrary call since the call ordering depends on
+        # the order of arm names, which is not deterministic.
+        expected_call = mock.call(
+            cv_training_data=transform.transform_observations(
+                deepcopy(self.training_data[:-1])
+            ),
+            cv_test_points=transform.transform_observation_features(
+                [self.training_data[-1].features.clone()]
+            ),
+            search_space=transform.transform_search_space(
+                self.adapter._search_space.clone()
+            ),
+            use_posterior_predictive=False,
         )
+        self.assertTrue(expected_call in mock_cv.mock_calls)
 
-        # Test selector
-
+    def test_cross_validate_w_test_selector(self) -> None:
         def test_selector(obs: Observation) -> bool:
             return obs.features.parameters["x"] != 4.0
 
-        result = cross_validate(model=ma, folds=-1, test_selector=test_selector)
+        with mock.patch.object(
+            self.adapter, "cross_validate", wraps=self.adapter.cross_validate
+        ) as mock_cv:
+            result = cross_validate(
+                model=self.adapter, folds=-1, test_selector=test_selector
+            )
         self.assertEqual(len(result), 3)
-        z = ma.cross_validate.mock_calls[5:]
+        z = mock_cv.mock_calls
         self.assertEqual(len(z), 2)
         all_test = np.hstack(
             [[obsf.parameters["x"] for obsf in r[2]["cv_test_points"]] for r in z]
@@ -214,17 +191,16 @@ class CrossValidationTest(TestCase):
 
         # test observation noise
         for untransform in (True, False):
-            result = cross_validate(
-                model=ma,
-                folds=-1,
-                use_posterior_predictive=True,
-                untransform=untransform,
-            )
-            if untransform:
-                mock_cv = ma.cross_validate
-            else:
-                mock_cv = ma._cross_validate
-            call_kwargs = mock_cv.mock_calls[-1].kwargs
+            with mock.patch.object(
+                self.adapter, "_cross_validate", wraps=self.adapter._cross_validate
+            ) as mock_cv:
+                result = cross_validate(
+                    model=self.adapter,
+                    folds=-1,
+                    use_posterior_predictive=True,
+                    untransform=untransform,
+                )
+            call_kwargs = mock_cv.call_args.kwargs
             self.assertTrue(call_kwargs["use_posterior_predictive"])
 
     def test_cross_validate_gives_a_useful_error_for_model_with_no_data(self) -> None:
@@ -255,65 +231,75 @@ class CrossValidationTest(TestCase):
         with self.assertRaises(NotImplementedError):
             cross_validate(model=sobol)
 
-    def test_ComputeDiagnostics(self) -> None:
+    def test_compute_diagnostics(self) -> None:
         # Construct CVResults
-        result = []
-        for i, obs in enumerate(self.training_data):
-            result.append(CVResult(observed=obs, predicted=self.observation_data[i]))
+        result = [
+            CVResult(observed=obs, predicted=self.observation_data)
+            for obs in self.training_data
+        ]
         # Compute diagnostics
         diag = compute_diagnostics(result=result)
         for v in diag.values():
-            self.assertEqual(set(v.keys()), {"a", "b"})
+            self.assertEqual(set(v.keys()), {"m1", "m2"})
         # Check for correct computation, relative to manually computed result
-        self.assertAlmostEqual(diag["MAPE"]["a"], 0.4984126984126984)
-        self.assertAlmostEqual(diag["MAPE"]["b"], 0.8312499999999999)
+        self.assertAlmostEqual(diag["MAPE"]["m1"], 0.4563492063492064)
+        self.assertAlmostEqual(diag["MAPE"]["m2"], 0.8312499999999999)
         self.assertAlmostEqual(
-            diag["wMAPE"]["a"],
-            sum([0.0, 1.0, 4.0, 5.0, 7.0]) / sum([2, 3, 6, 7, 9]),
+            diag["wMAPE"]["m1"],
+            sum([0.0, 1.0, 5.0, 7.0]) / sum([2, 3, 7, 9]),
         )
         self.assertAlmostEqual(
-            diag["wMAPE"]["b"], sum([3.0, 4.0, 7.0, 9.0]) / sum([4, 5, 8, 10])
+            diag["wMAPE"]["m2"], sum([3.0, 4.0, 7.0, 9.0]) / sum([4, 5, 8, 10])
         )
-        self.assertAlmostEqual(diag["Total raw effect"]["a"], 3.5)
-        self.assertAlmostEqual(diag["Total raw effect"]["b"], 1.5)
-        self.assertAlmostEqual(diag["Log likelihood"]["a"], -50.09469266602336)
-        self.assertAlmostEqual(diag["Log likelihood"]["b"], -25.82334285505847)
-        self.assertEqual(diag["MSE"]["a"], 18.2)
-        self.assertEqual(diag["MSE"]["b"], 38.75)
+        self.assertAlmostEqual(diag["Total raw effect"]["m1"], 3.5)
+        self.assertAlmostEqual(diag["Total raw effect"]["m2"], 1.5)
+        self.assertAlmostEqual(diag["Log likelihood"]["m1"], -41.175754132818696)
+        self.assertAlmostEqual(diag["Log likelihood"]["m2"], -25.82334285505847)
+        self.assertEqual(diag["MSE"]["m1"], 18.75)
+        self.assertEqual(diag["MSE"]["m2"], 38.75)
 
-    def test_AssessModelFit(self) -> None:
+    def test_assess_model_fit(self) -> None:
         # Construct diagnostics
-        result = []
-        for i, obs in enumerate(self.training_data):
-            result.append(CVResult(observed=obs, predicted=self.observation_data[i]))
+        result = [
+            CVResult(observed=obs, predicted=self.observation_data)
+            for obs in self.training_data
+        ]
         diag = compute_diagnostics(result=result)
         for v in diag.values():
-            self.assertEqual(set(v.keys()), {"a", "b"})
+            self.assertEqual(set(v.keys()), {"m1", "m2"})
         # Check for correct computation, relative to manually computed result
-        self.assertAlmostEqual(diag["Fisher exact test p"]["a"], 0.10)
-        self.assertAlmostEqual(diag["Fisher exact test p"]["b"], 0.166666666)
+        self.assertAlmostEqual(diag["Fisher exact test p"]["m1"], 0.16666, places=4)
+        self.assertAlmostEqual(diag["Fisher exact test p"]["m2"], 0.16666, places=4)
 
+        diag["Fisher exact test p"]["m1"] = 0.1  # differentiate for testing.
         assess_model_fit_result = assess_model_fit(
             diagnostics=diag, significance_level=0.05
         )
-        self.assertTrue("a" in assess_model_fit_result.bad_fit_metrics_to_fisher_score)
-        self.assertTrue("b" in assess_model_fit_result.bad_fit_metrics_to_fisher_score)
+        self.assertTrue("m1" in assess_model_fit_result.bad_fit_metrics_to_fisher_score)
+        self.assertTrue("m2" in assess_model_fit_result.bad_fit_metrics_to_fisher_score)
         assess_model_fit_result = assess_model_fit(
             diagnostics=diag, significance_level=0.15
         )
-        self.assertTrue("a" in assess_model_fit_result.good_fit_metrics_to_fisher_score)
-        self.assertTrue("b" in assess_model_fit_result.bad_fit_metrics_to_fisher_score)
+        self.assertTrue(
+            "m1" in assess_model_fit_result.good_fit_metrics_to_fisher_score
+        )
+        self.assertTrue("m2" in assess_model_fit_result.bad_fit_metrics_to_fisher_score)
         assess_model_fit_result = assess_model_fit(
             diagnostics=diag, significance_level=0.2
         )
-        self.assertTrue("a" in assess_model_fit_result.good_fit_metrics_to_fisher_score)
-        self.assertTrue("b" in assess_model_fit_result.good_fit_metrics_to_fisher_score)
+        self.assertTrue(
+            "m1" in assess_model_fit_result.good_fit_metrics_to_fisher_score
+        )
+        self.assertTrue(
+            "m2" in assess_model_fit_result.good_fit_metrics_to_fisher_score
+        )
 
-    def test_HasGoodOptConfigModelFit(self) -> None:
+    def test_has_good_opt_config_model_fit(self) -> None:
         # Construct diagnostics
-        result = []
-        for i, obs in enumerate(self.training_data):
-            result.append(CVResult(observed=obs, predicted=self.observation_data[i]))
+        result = [
+            CVResult(observed=obs, predicted=self.observation_data)
+            for obs in self.training_data
+        ]
         diag = compute_diagnostics(result=result)
         assess_model_fit_result = assess_model_fit(
             diagnostics=diag,
@@ -322,7 +308,7 @@ class CrossValidationTest(TestCase):
 
         # Test single objective
         optimization_config = OptimizationConfig(
-            objective=Objective(metric=Metric("a"), minimize=True)
+            objective=Objective(metric=Metric("m1"), minimize=True)
         )
         has_good_fit = has_good_opt_config_model_fit(
             optimization_config=optimization_config,
@@ -334,8 +320,8 @@ class CrossValidationTest(TestCase):
         optimization_config = MultiObjectiveOptimizationConfig(
             objective=MultiObjective(
                 objectives=[
-                    Objective(Metric("a"), minimize=False),
-                    Objective(Metric("b"), minimize=False),
+                    Objective(Metric("m1"), minimize=False),
+                    Objective(Metric("m2"), minimize=False),
                 ]
             )
         )
@@ -347,9 +333,9 @@ class CrossValidationTest(TestCase):
 
         # Test constraints
         optimization_config = OptimizationConfig(
-            objective=Objective(metric=Metric("a"), minimize=False),
+            objective=Objective(metric=Metric("m1"), minimize=False),
             outcome_constraints=[
-                OutcomeConstraint(metric=Metric("b"), op=ComparisonOp.GEQ, bound=0.1)
+                OutcomeConstraint(metric=Metric("m2"), op=ComparisonOp.GEQ, bound=0.1)
             ],
         )
         has_good_fit = has_good_opt_config_model_fit(

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -657,7 +657,7 @@ class TestBestPointUtils(TestCase):
         # Check that index is carried over for interfacing appropriately
         # with related dataframes.
         exp = get_experiment_with_observations(
-            observations=[[-1, 1, 1], [1, 2, 1], [3, 3, -1], [2, 4, 1], [2, 0, 1]],
+            observations=[[-1, 1], [1, 2], [3, 3], [2, 4], [2, 0]],
             constrained=False,
         )
         df = exp.lookup_data().df


### PR DESCRIPTION
Summary: They now use data from an actual experiment and an actual `Adapter` rather than a mock object with all mock methods.

Differential Revision: D74342457


