### PR TITLE
Remove `_get_best_row_for_scalarized_objective` and `_get_best_row_for_single_objective`

### DIFF
--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -39,7 +39,7 @@ class ObjectiveTest(TestCase):
 
     def test_Init(self) -> None:
         with self.assertRaisesRegex(UserInputError, "does not specify"):
-            (Objective(metric=self.metrics["m1"]),)
+            Objective(metric=self.metrics["m1"])
         with self.assertRaisesRegex(
             UserInputError, "doesn't match the specified optimization direction"
         ):


### PR DESCRIPTION
Summary:
* Remove `_get_best_row_for_scalarized_objective` and `_get_best_row_for_single_objective`, enabled by cutting `get_best_raw_objective_point_with_trial_index` over to use `get_trace_by_arm_pull_from_data`
* Add more careful no-data handling for `get_trace_by_arm_pull_from_data`, including for empty data and observations with only some metrics observed

Note: `get_best_raw_objective_point_with_trial_index` and `get_trace` are now more similar because they both use `get_trace_by_arm_pull_from_data`. However, they differ in a few aspects such as how they treat multi-objective configs and out-of-design points. I think it would be good if these were closer together, but probably not low-ROI at the moment.

Differential Revision: D74282536


