### PR TITLE
Add repr for Observation

### DIFF
--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -255,6 +255,15 @@ class Observation(Base):
         self.data = data
         self.arm_name = arm_name
 
+    def __repr__(self) -> str:
+        return (
+            "Observation(\n"
+            f"    features={self.features},\n"
+            f"    data={self.data},\n"
+            f"    arm_name='{self.arm_name}',\n"
+            ")"
+        )
+
 
 def _observations_from_dataframe(
     experiment: experiment.Experiment,

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -977,3 +977,21 @@ class ObservationsTest(TestCase):
                 observation.features.metadata.get(SOME_METADATA_KEY),
                 f"value_{observation.features.trial_index}",
             )
+
+    def test_observation_repr(self) -> None:
+        obs = Observation(
+            features=ObservationFeatures(parameters={"x": 20}),
+            data=ObservationData(
+                means=np.array([1]), covariance=np.array([[2]]), metric_names=["a"]
+            ),
+            arm_name="0_0",
+        )
+        expected = (
+            "Observation(\n"
+            "    features=ObservationFeatures(parameters={'x': 20}),\n"
+            "    data=ObservationData(metric_names=['a'], "
+            "means=[1], covariance=[[2]]),\n"
+            "    arm_name='0_0',\n"
+            ")"
+        )
+        self.assertEqual(repr(obs), expected)


### PR DESCRIPTION
Summary:
`[<ax.core.observation.Observation object at 0x7fe64d541fd0>, <ax.core.observation.Observation object at 0x7fe64d541e20>, <ax.core.observation.Observation object at 0x7fe64d542210>]` is quite an unhelpful printout when trying to debug an error.

This diff implements `Observation.__repr__`, which will lead to rendering much more useful information, like parameters and mean & sem observations.

I wonder how much time I would've saved debugging if I had done this a year ago...

Differential Revision: D74401248


