### PR TITLE
Make `get_best_raw_objective_point_with_trial_index` return a TModelPredictArm

### DIFF
--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -39,7 +39,7 @@ class ObjectiveTest(TestCase):
 
     def test_Init(self) -> None:
         with self.assertRaisesRegex(UserInputError, "does not specify"):
-            (Objective(metric=self.metrics["m1"]),)
+            Objective(metric=self.metrics["m1"])
         with self.assertRaisesRegex(
             UserInputError, "doesn't match the specified optimization direction"
         ):

--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -260,17 +260,10 @@ class OptimizationLoop:
             return parameterizations, predictions
 
         # Could not find through model, default to using raw objective.
-        _, parameterization, values = get_best_raw_objective_point_with_trial_index(
-            experiment=self.experiment
+        _, parameterization, predict_arm = (
+            get_best_raw_objective_point_with_trial_index(experiment=self.experiment)
         )
-        # For values, grab just the means to conform to TModelPredictArm format.
-        return (
-            parameterization,
-            (
-                {k: v[0] for k, v in values.items()},  # v[0] is mean
-                {k: {k: v[1] * v[1]} for k, v in values.items()},  # v[1] is sem
-            ),
-        )
+        return parameterization, predict_arm
 
     def get_current_model(self) -> Adapter | None:
         """Obtain the most recently used model in optimization."""


### PR DESCRIPTION
Summary:
In every usage of `get_best_raw_objective_point_with_trial_index`, its third return value is either ignored or changed into a TModelPredictArm.

This PR
* makes it return a TModelPredictArm, which makes some downstream functions more unitary.
* Fixes some type annotations that were too broad (the TModelPredictArm won't be None)
* Updates docstrings

Differential Revision: D74401853


