### PR TITLE
Remove redundant _array_to_tensor utility, reduce mocking, rename modelbridge->adapter

### DIFF
--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -595,11 +595,11 @@ def infer_reference_point_from_experiment(
         )
 
     # Reading experiment data.
-    mb_reference = get_tensor_converter_model(
+    adapter = get_tensor_converter_model(
         experiment=experiment,
         data=data,
     )
-    obs_feats, obs_data, _ = _get_modelbridge_training_data(modelbridge=mb_reference)
+    obs_feats, obs_data, _ = _get_modelbridge_training_data(adapter=adapter)
 
     # Since objectives could have arbitrary orders in objective_thresholds and
     # further down the road `get_pareto_frontier_and_configs` arbitrarily changes the
@@ -648,7 +648,7 @@ def infer_reference_point_from_experiment(
 
     # Finding the pareto frontier
     frontier_observations, f, obj_w, _ = get_pareto_frontier_and_configs(
-        modelbridge=mb_reference,
+        modelbridge=adapter,
         observation_features=obs_feats,
         observation_data=obs_data,
         objective_thresholds=inferred_rp,
@@ -671,7 +671,7 @@ def infer_reference_point_from_experiment(
         opt_config._outcome_constraints = []  # removing the constraints
         # getting the unconstrained pareto frontier
         frontier_observations, f, obj_w, _ = get_pareto_frontier_and_configs(
-            modelbridge=mb_reference,
+            modelbridge=adapter,
             observation_features=obs_feats,
             observation_data=obs_data,
             objective_thresholds=inferred_rp,


### PR DESCRIPTION
Summary:
`_array_to_tensor`: If you have a `TorchAdapter`, just call `adapter._array_to_tensor`. If not, call `torch.as_tensor`. No need for an extra private utility here.

`_get_modelbridge_training_data`: `modelbridge` input is renamed to `adapter`. This is a private utility that's only used in a few other utils, so easy change.

Removed `MockAdapter` in `test_modelbridge_utils` and replacedc with `TorchAdapter`.

Differential Revision: D74415281


