### PR TITLE
Reduce mocking in DiscreteAdapter tests

### DIFF
--- a/ax/modelbridge/discrete.py
+++ b/ax/modelbridge/discrete.py
@@ -97,7 +97,7 @@ class DiscreteAdapter(Adapter):
         observation_features, observation_data = separate_observations(observations)
         for od in observation_data:
             all_metric_names.update(od.metric_names)
-        self.outcomes = list(all_metric_names)
+        self.outcomes = sorted(all_metric_names)  # Make it deterministic.
         # Convert observations to arrays
         Xs_array, Ys_array, Yvars_array = self._convert_observations(
             observation_data=observation_data,


### PR DESCRIPTION
Summary:
Uses an actual `DiscreteAdapter` object, initialized using an actual `experiment`, and only mocks the necessary methods of the underlying `DiscreteGenerator` object.

Also renamed the file `test_discrete_modelbridge -> test_discrete_adapter`.

Reviewed By: Balandat

Differential Revision: D74428229
