### PR TITLE
If we have sq always releativize

### DIFF
--- a/ax/analysis/plotly/arm_effects/unified.py
+++ b/ax/analysis/plotly/arm_effects/unified.py
@@ -62,7 +62,6 @@ class ArmEffectsPlot(PlotlyAnalysis):
         self,
         metric_names: Sequence[str] | None = None,
         use_model_predictions: bool = True,
-        relativize: bool = False,
         trial_index: int | None = None,
         trial_statuses: Sequence[TrialStatus] | None = None,
         additional_arms: Sequence[Arm] | None = None,
@@ -78,9 +77,6 @@ class ArmEffectsPlot(PlotlyAnalysis):
                 on the model. If ``False``, the plot will show the observed effects of
                 each arm. The latter is often less trustworthy than the former,
                 especially when model fit is good and in high-noise settings.
-            relativize: Whether to relativize the effects of each arm against the status
-                quo arm. If multiple status quo arms are present, relativize each arm
-                against the status quo arm from the same trial.
             trial_index: If present, only use arms from the trial with the given index.
             additional_arms: If present, include these arms in the plot in addition to
                 the arms in the experiment. These arms will be marked as belonging to a
@@ -93,7 +89,6 @@ class ArmEffectsPlot(PlotlyAnalysis):
 
         self.metric_names = metric_names
         self.use_model_predictions = use_model_predictions
-        self.relativize = relativize
         self.trial_index = trial_index
         self.trial_statuses = trial_statuses
         self.additional_arms = additional_arms
@@ -121,6 +116,11 @@ class ArmEffectsPlot(PlotlyAnalysis):
         else:
             relevant_adapter = None
 
+        # if status quo is specified, results will be relativized during data prep
+        relativize = (
+            experiment.status_quo is not None and experiment.status_quo.name is not None
+        )
+
         df = prepare_arm_data(
             experiment=experiment,
             metric_names=metric_names,
@@ -129,7 +129,6 @@ class ArmEffectsPlot(PlotlyAnalysis):
             trial_index=self.trial_index,
             trial_statuses=self.trial_statuses,
             additional_arms=self.additional_arms,
-            relativize=self.relativize,
         )
 
         # Retrieve the metric labels from the mapping provided by the user, defaulting
@@ -170,7 +169,7 @@ class ArmEffectsPlot(PlotlyAnalysis):
                 fig=_prepare_figure(
                     df=df,
                     metric_name=metric_name,
-                    is_relative=self.relativize,
+                    is_relative=relativize,
                     status_quo_arm_name=experiment.status_quo.name
                     if experiment.status_quo
                     else None,
@@ -217,9 +216,6 @@ def compute_arm_effects_adhoc(
             on the model. If ``False``, the plot will show the observed effects of
             each arm. The latter is often less trustworthy than the former,
             especially when model fit is good and in high-noise settings.
-        relativize: Whether to relativize the effects of each arm against the status
-            quo arm. If multiple status quo arms are present, relativize each arm
-            against the status quo arm from the same trial.
         trial_index: If present, only use arms from the trial with the given index.
         additional_arms: If present, include these arms in the plot in addition to
             the arms in the experiment. These arms will be marked as belonging to a
@@ -233,7 +229,6 @@ def compute_arm_effects_adhoc(
     analysis = ArmEffectsPlot(
         metric_names=metric_names,
         use_model_predictions=use_model_predictions,
-        relativize=relativize,
         trial_index=trial_index,
         trial_statuses=trial_statuses,
         additional_arms=additional_arms,

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -63,7 +63,6 @@ class ScatterPlot(PlotlyAnalysis):
         x_metric_name: str,
         y_metric_name: str,
         use_model_predictions: bool = True,
-        relativize: bool = False,
         trial_index: int | None = None,
         trial_statuses: Sequence[TrialStatus] | None = None,
         additional_arms: Sequence[Arm] | None = None,
@@ -79,9 +78,6 @@ class ScatterPlot(PlotlyAnalysis):
                 on the model. If ``False``, the plot will show the observed effects of
                 each arm. The latter is often less trustworthy than the former,
                 especially when model fit is good and in high-noise settings.
-            relativize: Whether to relativize the effects of each arm against the status
-                quo arm. If multiple status quo arms are present, relativize each arm
-                against the status quo arm from the same trial.
             trial_index: If present, only use arms from the trial with the given index.
             additional_arms: If present, include these arms in the plot in addition to
                 the arms in the experiment. These arms will be marked as belonging to a
@@ -95,7 +91,6 @@ class ScatterPlot(PlotlyAnalysis):
         self.x_metric_name = x_metric_name
         self.y_metric_name = y_metric_name
         self.use_model_predictions = use_model_predictions
-        self.relativize = relativize
         self.trial_index = trial_index
         self.trial_statuses = trial_statuses
         self.additional_arms = additional_arms
@@ -112,6 +107,10 @@ class ScatterPlot(PlotlyAnalysis):
         if experiment is None:
             raise UserInputError("ScatterPlot requires an Experiment")
 
+        # if status quo is specified, results will be relativized during data prep
+        relativize = (
+            experiment.status_quo is not None and experiment.status_quo.name is not None
+        )
         if self.use_model_predictions:
             relevant_adapter = extract_relevant_adapter(
                 experiment=experiment,
@@ -144,7 +143,6 @@ class ScatterPlot(PlotlyAnalysis):
             trial_index=self.trial_index,
             trial_statuses=self.trial_statuses,
             additional_arms=self.additional_arms,
-            relativize=self.relativize,
         )
 
         # Retrieve the metric labels from the mapping provided by the user, defaulting
@@ -165,7 +163,7 @@ class ScatterPlot(PlotlyAnalysis):
             y_metric_name=self.y_metric_name,
             x_metric_label=x_metric_label,
             y_metric_label=y_metric_label,
-            is_relative=self.relativize,
+            is_relative=relativize,
             show_pareto_frontier=self.show_pareto_frontier,
             x_lower_is_better=x_lower_is_better
             if x_lower_is_better is not None
@@ -201,7 +199,6 @@ def compute_scatter_adhoc(
     generation_strategy: GenerationStrategy | None = None,
     adapter: Adapter | None = None,
     use_model_predictions: bool = True,
-    relativize: bool = False,
     trial_index: int | None = None,
     trial_statuses: Sequence[TrialStatus] | None = None,
     additional_arms: Sequence[Arm] | None = None,
@@ -226,9 +223,6 @@ def compute_scatter_adhoc(
             on the model. If ``False``, the plot will show the observed effects of
             each arm. The latter is often less trustworthy than the former,
             especially when model fit is good and in high-noise settings.
-        relativize: Whether to relativize the effects of each arm against the status
-            quo arm. If multiple status quo arms are present, relativize each arm
-            against the status quo arm from the same trial.
         trial_index: If present, only use arms from the trial with the given index.
         additional_arms: If present, include these arms in the plot in addition to
             the arms in the experiment. These arms will be marked as belonging to a
@@ -240,7 +234,6 @@ def compute_scatter_adhoc(
         x_metric_name=x_metric_name,
         y_metric_name=y_metric_name,
         use_model_predictions=use_model_predictions,
-        relativize=relativize,
         trial_index=trial_index,
         trial_statuses=trial_statuses,
         additional_arms=additional_arms,

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -187,7 +187,6 @@ class TestScatterPlot(TestCase):
     def test_online(self) -> None:
         # Test ScatterPlot can be computed for a variety of experiments which
         # resemble those we see in an online setting.
-
         for experiment in get_online_experiments():
             # Skip experiments with fewer than 2 metrics
             if len(experiment.metrics) < 2:

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1136,7 +1136,7 @@ def get_online_experiments() -> list[Experiment]:
 
         # Add a custom arm to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial()
+        trial = experiment.new_batch_trial(add_status_quo_arm=True)
         # Detatch the arms from the GeneratorRun so they appear as custom arms
         trial.add_arms_and_weights(arms=sobol_run.arms)
 


### PR DESCRIPTION
Summary:
Previously, we supported relativize as an argument to be specified during analysis creation, however, it is likely that if there is a sq present, we should always relativize against it.

Relativized results are significantly more interpretable

Differential Revision: D74447254


