### PR TITLE
Remove `weights` from `MultiObjective`

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -445,9 +445,9 @@ def extract_objective_weights(objective: Objective, outcomes: list[str]) -> npt.
         for obj_metric, obj_weight in objective.metric_weights:
             objective_weights[outcomes.index(obj_metric.name)] = obj_weight * s
     elif isinstance(objective, MultiObjective):
-        for obj, obj_weight in objective.objective_weights:
+        for obj in objective.objectives:
             s = -1.0 if obj.minimize else 1.0
-            objective_weights[outcomes.index(obj.metric.name)] = obj_weight * s
+            objective_weights[outcomes.index(obj.metric.name)] = s
     else:
         s = -1.0 if objective.minimize else 1.0
         objective_weights[outcomes.index(objective.metric.name)] = s

--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -96,8 +96,6 @@ class MultiObjective(Objective):
         objectives: List of objectives.
     """
 
-    weights: list[float]
-
     def __init__(
         self,
         objectives: list[Objective] | None = None,
@@ -134,11 +132,6 @@ class MultiObjective(Objective):
         # pyre-fixme[4]: Attribute must be annotated.
         self._objectives = none_throws(objectives)
 
-        # For now, assume all objectives are weighted equally.
-        # This might be used in the future to change emphasis on the
-        # relative focus of the exploration during the optimization.
-        self.weights = [1.0 for _ in range(len(objectives))]
-
     @property
     def metric(self) -> Metric:
         """Override base method to error."""
@@ -155,11 +148,6 @@ class MultiObjective(Objective):
     def objectives(self) -> list[Objective]:
         """Get the objectives."""
         return self._objectives
-
-    @property
-    def objective_weights(self) -> Iterable[tuple[Objective, float]]:
-        """Get the objectives and weights."""
-        return zip(self.objectives, self.weights)
 
     def clone(self) -> MultiObjective:
         """Create a copy of the objective."""

--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -70,8 +70,6 @@ class ObjectiveTest(TestCase):
         self.assertEqual(self.multi_objective.metrics, list(self.metrics.values()))
         minimizes = [obj.minimize for obj in self.multi_objective.objectives]
         self.assertEqual(minimizes, [True, True, False])
-        weights = [mw[1] for mw in self.multi_objective.objective_weights]
-        self.assertEqual(weights, [1.0, 1.0, 1.0])
         self.assertEqual(self.multi_objective.clone(), self.multi_objective)
         self.assertEqual(
             str(self.multi_objective),

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -617,8 +617,6 @@ def _compute_hv_trace(
     return hvs
 
 
-# NOTE: we are ignoring `MultiObjective` weights here. these
-# should likely be deprecated or removed
 def get_hypervolume_trace_of_outcomes_multi_objective(
     df_wide: pd.DataFrame,
     optimization_config: MultiObjectiveOptimizationConfig,

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -303,7 +303,6 @@ def multi_objective_to_dict(objective: MultiObjective) -> dict[str, Any]:
     return {
         "__type": objective.__class__.__name__,
         "objectives": objective.objectives,
-        "weights": objective.weights,
     }
 
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -1031,6 +1031,37 @@ class JSONStoreTest(TestCase):
         expected_object.surrogate_spec.model_configs[0].input_transform_classes = None
         self.assertEqual(object_from_json(object_json), expected_object)
 
+    def test_multi_objective_backwards_compatibility(self) -> None:
+        object_json = {
+            "__type": "MultiObjective",
+            "objectives": [
+                {
+                    "__type": "Objective",
+                    "metric": {
+                        "name": "m1",
+                        "lower_is_better": None,
+                        "properties": {},
+                        "__type": "Metric",
+                    },
+                    "minimize": False,
+                },
+                {
+                    "__type": "Objective",
+                    "metric": {
+                        "name": "m3",
+                        "lower_is_better": True,
+                        "properties": {},
+                        "__type": "Metric",
+                    },
+                    "minimize": True,
+                },
+            ],
+            "weights": [1.0, 1.0],
+        }
+        deserialized_object = object_from_json(object_json)
+        expected_object = get_multi_objective()
+        self.assertEqual(deserialized_object, expected_object)
+
     def test_surrogate_spec_backwards_compatibility(self) -> None:
         # This is an invalid example that has both deprecated args
         # and model config specified. Deprecated args will be ignored.


### PR DESCRIPTION
Summary:
Context: `MultiObjective` has a `weights` field that is always all 1's. It can only be set by changing the attribute, not in the init. Downstream utilities such as those that get hypervolumes tend to ignore these weights, so using them might not be correct.

This PR:
* Removes `MultiObjective.weights`
* Removes `MultiObjective.objective_weights`
* Updates one reference to `MultiObjective.weights` (so that the code behaves as if weights are all 1 now)
* Updated JSON encoder

Differential Revision: D74351597


