### PR TITLE
Include auxiliary experiment datasets in surrogate model fitting

### DIFF
--- a/ax/adapter/pairwise.py
+++ b/ax/adapter/pairwise.py
@@ -10,15 +10,15 @@ from __future__ import annotations
 
 import numpy as np
 import torch
+from ax.adapter.adapter_utils import prep_pairwise_data
 from ax.adapter.torch import TorchAdapter
 from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
 from ax.utils.common.constants import Keys
-from botorch.models.utils.assorted import consolidate_duplicates
-from botorch.utils.containers import DenseContainer, SliceContainer
-from botorch.utils.datasets import RankingDataset, SupervisedDataset
-from torch import Tensor
+from botorch.utils.containers import DenseContainer
+from botorch.utils.datasets import SupervisedDataset
+from pyre_extensions import none_throws
 
 
 class PairwiseAdapter(TorchAdapter):
@@ -59,8 +59,12 @@ class PairwiseAdapter(TorchAdapter):
             X = torch.stack(Xs[outcome], dim=0)
             Y = torch.tensor(Ys[outcome], dtype=torch.long).unsqueeze(-1)
             if outcome == Keys.PAIRWISE_PREFERENCE_QUERY.value:
-                dataset = _prep_pairwise_data(
-                    X=X, Y=Y, outcome=outcome, parameters=parameters
+                dataset = prep_pairwise_data(
+                    X=X,
+                    Y=Y,
+                    group_indices=torch.tensor(none_throws(trial_indices)[outcome]),
+                    outcome=outcome,
+                    parameters=parameters,
                 )
             else:  # pragma: no cover
                 event_shape = torch.Size([X.shape[-1]])
@@ -90,72 +94,3 @@ class PairwiseAdapter(TorchAdapter):
     ) -> list[ObservationData]:
         # TODO: Implement `_predict` to enable examining predicted effects
         raise NotImplementedError
-
-
-def _prep_pairwise_data(
-    X: Tensor,
-    Y: Tensor,
-    outcome: str,
-    parameters: list[str],
-) -> SupervisedDataset:
-    """Prep data for pairwise modeling."""
-    # Update Xs and Ys shapes for PairwiseGP
-    Y = _binary_pref_to_comp_pair(Y=Y)
-    X, Y = _consolidate_comparisons(X=X, Y=Y)
-
-    datapoints, comparisons = X, Y.long()
-    event_shape = torch.Size([2 * datapoints.shape[-1]])
-    # pyre-fixme[6]: For 2nd param expected `LongTensor` but
-    dataset_X = SliceContainer(datapoints, comparisons, event_shape=event_shape)
-    dataset_Y = torch.tensor([[0, 1]]).expand(comparisons.shape)
-    dataset = RankingDataset(
-        X=dataset_X,
-        Y=dataset_Y,
-        feature_names=parameters,
-        outcome_names=[outcome],
-    )
-    return dataset
-
-
-def _binary_pref_to_comp_pair(Y: Tensor) -> Tensor:
-    """Convert Y from binary indicator pair to index pair comparisons
-
-    Convert Y from binary indicator pair such as [[0, 1], [1, 0], ...]
-    to index comparisons like [[1, 0], [2, 3], ...]
-    """
-    Y_shape = Y.shape[:-2] + (-1, 2)
-    Y = Y.reshape(Y_shape)
-
-    _validate_Y_values(Y)
-
-    idx_shift = (torch.arange(0, Y.shape[-2]) * 2).unsqueeze(-1).expand_as(Y)
-    comparison_pairs = idx_shift + (1 - Y)
-    return comparison_pairs
-
-
-def _consolidate_comparisons(X: Tensor, Y: Tensor) -> tuple[Tensor, Tensor]:
-    """Drop duplicated Xs and update the indices in Ys accordingly"""
-    if Y.shape[-1] != 2:
-        raise ValueError(
-            "The last dimension of Y must contain 2 elements "
-            "representing the pairwise comparison."
-        )
-
-    if len(Y.shape) != 2:
-        raise ValueError("Y must have 2 dimensions.")
-
-    X, Y, _ = consolidate_duplicates(X, Y)
-    return X, Y
-
-
-def _validate_Y_values(Y: Tensor) -> None:
-    """Check if Ys have valid values"""
-    # Y must have even number of elements
-    if Y.shape[-1] != 2:
-        raise ValueError(
-            f"Trailing dimension of `Y` should be size 2 but is {Y.shape[-1]}"
-        )
-
-    # all adjacent pairs must have exactly a 0 and a 1
-    if not (Y.min(dim=-1).values.eq(0).all() and Y.max(dim=-1).values.eq(1).all()):
-        raise ValueError("`Y` values must be `{0, 1}.`")

--- a/ax/adapter/tests/test_pairwise_adapter.py
+++ b/ax/adapter/tests/test_pairwise_adapter.py
@@ -8,11 +8,8 @@
 
 import numpy as np
 import torch
-from ax.adapter.pairwise import (
-    _binary_pref_to_comp_pair,
-    _consolidate_comparisons,
-    PairwiseAdapter,
-)
+from ax.adapter.adapter_utils import _binary_pref_to_comp_pair, _consolidate_comparisons
+from ax.adapter.pairwise import PairwiseAdapter
 from ax.core import Metric, Objective, OptimizationConfig
 from ax.core.observation import ObservationData, ObservationFeatures
 from ax.models.torch.botorch_modular.model import BoTorchGenerator

--- a/ax/models/torch/tests/test_acquisition.py
+++ b/ax/models/torch/tests/test_acquisition.py
@@ -136,7 +136,7 @@ class AcquisitionTest(TestCase):
             self.surrogate.fit(
                 datasets=self.training_data,
                 search_space_digest=SearchSpaceDigest(
-                    feature_names=self.search_space_digest.feature_names[:1],
+                    feature_names=self.search_space_digest.feature_names,
                     bounds=self.search_space_digest.bounds,
                     target_values=self.search_space_digest.target_values,
                 ),

--- a/ax/models/torch/tests/test_input_transform_argparse.py
+++ b/ax/models/torch/tests/test_input_transform_argparse.py
@@ -110,8 +110,10 @@ class InputTransformArgparseTest(TestCase):
                 )
             )
         )
-        self.assertEqual(input_transform_kwargs["d"], 3)
-        self.assertEqual(input_transform_kwargs["indices"], [0, 1])
+        # Use the dimension of the datasets as the ground truth as
+        # that's what will be fed to the model.
+        self.assertEqual(input_transform_kwargs["d"], 4)
+        self.assertEqual(input_transform_kwargs["indices"], [0, 1, 3])
 
         input_transform_kwargs = input_transform_argparse(
             Normalize,
@@ -159,8 +161,8 @@ class InputTransformArgparseTest(TestCase):
             dataset=mtds,
             search_space_digest=self.search_space_digest,
         )
-        self.assertEqual(input_transform_kwargs["d"], 3)
-        self.assertEqual(input_transform_kwargs["indices"], [0, 1])
+        self.assertEqual(input_transform_kwargs["d"], 4)
+        self.assertEqual(input_transform_kwargs["indices"], [0, 1, 3])
 
         input_transform_kwargs = input_transform_argparse(
             Normalize,
@@ -171,8 +173,8 @@ class InputTransformArgparseTest(TestCase):
             },
         )
 
-        self.assertEqual(input_transform_kwargs["d"], 3)
-        self.assertEqual(input_transform_kwargs["indices"], [0, 1])
+        self.assertEqual(input_transform_kwargs["d"], 4)
+        self.assertEqual(input_transform_kwargs["indices"], [0, 1, 3])
         self.assertTrue(input_transform_kwargs["bounds"] is None)
 
     def test_argparse_warp(self) -> None:

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -147,6 +147,8 @@ from ax.utils.testing.utils_testing_stubs import get_backend_simulator_with_tria
 from botorch.models import SingleTaskGP
 from botorch.models.transforms.outcome import Standardize
 from botorch.sampling.normal import SobolQMCNormalSampler
+from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikelihood
+from pyre_extensions import none_throws
 
 
 # pyre-fixme[5]: Global expression must be annotated.
@@ -1029,6 +1031,13 @@ class JSONStoreTest(TestCase):
         }
         expected_object = get_botorch_model_with_surrogate_spec()
         expected_object.surrogate_spec.model_configs[0].input_transform_classes = None
+        # The new default value is None; we need to manually set it to the old value
+        self.assertIsNone(
+            none_throws(expected_object.surrogate_spec).model_configs[0].mll_class
+        )
+        expected_object.surrogate_spec.model_configs[
+            0
+        ].mll_class = ExactMarginalLogLikelihood
         self.assertEqual(object_from_json(object_json), expected_object)
 
     def test_multi_objective_backwards_compatibility(self) -> None:
@@ -1143,6 +1152,7 @@ class JSONStoreTest(TestCase):
                 ModelConfig(
                     botorch_model_class=SingleTaskGP,
                     covar_module_class=ScaleMaternKernel,
+                    mll_class=ExactMarginalLogLikelihood,
                     outcome_transform_classes=[Standardize],
                     input_transform_classes=None,
                 )


### PR DESCRIPTION
Summary:
## What this diff enables

With `PE_EXPERIMENT` in the auxiliary experiment, it now extract the dataset from the aux experiment and fit a submodel on the dataset, which may be used later (e.g., to construct a learned objective in the `Acquisition` class).

In the meanwhile, `self._model` is still modeling the original set of outputs (so that everything else such as cross validation or candidate generation still works as usual), except that there is now an additional preference model fitted and accessible in `self._submodels`.

## Notable Changes
- Support parsing `RaningDataset` in `TorchAdapter` (and as a bonus point, we may deprecate [PairwiseAdapter](https://www.internalfb.com/code/fbsource/fbcode/ax/modelbridge/pairwise.py?lines=24-92) as all the logic there is upstreamed (will do that in a followup diff).
- `choose_model_class` takes in just a single dataset instead of a list of dataset as we may have different default models for different datasets (e.g., `SingleTaskGP` for most datasets but `PairwiseGP` for `RankingDataset`)
- `mll_class` is no longer a required field in `ModelConfig` dataclass. When missing, it'll be inferred altogether with the default botorch_model_class.
- Removed the `default_botorch_model_class`, and instead fill in missing value of `ModelConfig` according to dataset and search_space_digest as we may need different models (e.g., PairwiseGP vs. SingleTaskGP) for different datasets.
- Updated `use_model_list` to not rely on `default_botorch_model_class`, which is something we might have to infer when fitting individual models.

Meta: [original design doc](https://docs.google.com/document/d/1KENayOLCe7-kT85qlOk09AXUHhJXLpqKhsgyVVTwa2Q/edit?usp=sharing)

Differential Revision: D73286263
