### PR TITLE
add longtest to top surfaces compute categorical test

### DIFF
--- a/ax/analysis/plotly/tests/test_top_surfaces.py
+++ b/ax/analysis/plotly/tests/test_top_surfaces.py
@@ -99,6 +99,8 @@ class TestTopSurfacesAnalysis(TestCase):
         self.assertIn("vs. bar", with_contours[2].title)
         self.assertIn("vs. bar", with_contours[3].title)
 
+    @mock_botorch_optimize
+    @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
     def test_compute_categorical_parameters(self) -> None:
         client = Client()
         client.configure_experiment(


### PR DESCRIPTION
Summary: Computing the sobol indicies is time consuming and we don't currently have a good mock for that afaik, add mock botorch and long test

Differential Revision: D74675188


