### PR TITLE
Change default behavior of CrossValidationPlot to not untransform

### DIFF
--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -48,7 +48,7 @@ class CrossValidationPlot(PlotlyAnalysis):
         self,
         metric_names: Sequence[str] | None = None,
         folds: int = -1,
-        untransform: bool = True,
+        untransform: bool = False,
         trial_index: int | None = None,
         labels: Mapping[str, str] | None = None,
     ) -> None:


### PR DESCRIPTION
Summary: Plot the CV in transformed space by default.

Differential Revision: D74765147


