### PR TITLE
Add adhoc contour plot

### DIFF
--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -130,6 +130,45 @@ class ContourPlot(PlotlyAnalysis):
         ]
 
 
+def compute_contour_adhoc(
+    x_parameter_name: str,
+    y_parameter_name: str,
+    experiment: Experiment,
+    generation_strategy: GenerationStrategy | None = None,
+    adapter: Adapter | None = None,
+    metric_name: str | None = None,
+    display_sampled: bool = True,
+) -> list[PlotlyAnalysisCard]:
+    """
+    Helper method to expose adhoc contour plotting. Only for advanced users in
+    a notebook setting.
+
+    Args:
+        parameter_name: The name of the parameter to plot on the x-axis.
+        experiment: The experiment to source data from.
+        generation_strategy: Optional. The generation strategy to extract the adapter
+            from.
+        adapter: Optional. The adapter to use for predictions.
+        metric_name: The name of the metric to plot on the y-axis. If not specified
+            the objective will be used.
+        display_sampled: If True, plot "x"s at x coordinates which have been sampled
+            in at least one trial.
+    """
+    analysis = ContourPlot(
+        x_parameter_name=x_parameter_name,
+        y_parameter_name=y_parameter_name,
+        metric_name=metric_name,
+        display_sampled=display_sampled,
+    )
+    return [
+        *analysis.compute(
+            experiment=experiment,
+            generation_strategy=generation_strategy,
+            adapter=adapter,
+        )
+    ]
+
+
 def _prepare_data(
     experiment: Experiment,
     model: Adapter,

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -127,7 +127,7 @@ def compute_slice_adhoc(
     display_sampled: bool = True,
 ) -> list[PlotlyAnalysisCard]:
     """
-    Helper method to expose adhoc cross validation plotting. Only for advanced users in
+    Helper method to expose adhoc slice plotting. Only for advanced users in
     a notebook setting.
 
     Args:
@@ -140,7 +140,6 @@ def compute_slice_adhoc(
             the objective will be used.
         display_sampled: If True, plot "x"s at x coordinates which have been sampled
             in at least one trial.
-
     """
 
     analysis = SlicePlot(

--- a/ax/analysis/plotly/surface/tests/test_contour.py
+++ b/ax/analysis/plotly/surface/tests/test_contour.py
@@ -10,7 +10,7 @@ from ax.analysis.analysis import (
     AnalysisCardCategory,
     AnalysisCardLevel,
 )
-from ax.analysis.plotly.surface.contour import ContourPlot
+from ax.analysis.plotly.surface.contour import compute_contour_adhoc, ContourPlot
 from ax.core.trial import Trial
 from ax.exceptions.core import UserInputError
 from ax.service.ax_client import AxClient, ObjectiveProperties
@@ -51,6 +51,25 @@ class TestContourPlot(TestCase):
                     "bar": parameterization["x"] ** 2 + parameterization["y"] ** 2
                 },
             )
+        self.expected_subtitle = (
+            "The contour plot visualizes the predicted outcomes "
+            "for bar across a two-dimensional parameter space, "
+            "with other parameters held fixed at their status_quo value "
+            "(or mean value if status_quo is unavailable). This plot helps "
+            "in identifying regions of optimal performance and understanding "
+            "how changes in the selected parameters influence the predicted "
+            "outcomes. Contour lines represent levels of constant predicted "
+            "values, providing insights into the gradient and potential optima "
+            "within the parameter space."
+        )
+        self.expected_title = "x, y vs. bar"
+        self.expected_name = "ContourPlot"
+        self.expected_cols = {
+            "x",
+            "y",
+            "bar_mean",
+            "sampled",
+        }
 
     def test_compute(self) -> None:
         analysis = ContourPlot(
@@ -72,34 +91,59 @@ class TestContourPlot(TestCase):
         )
         self.assertEqual(
             card.name,
-            "ContourPlot",
+            self.expected_name,
         )
-        self.assertEqual(card.title, "x, y vs. bar")
-        self.assertEqual(
-            card.subtitle,
-            (
-                "The contour plot visualizes the predicted outcomes "
-                "for bar across a two-dimensional parameter space, "
-                "with other parameters held fixed at their status_quo value "
-                "(or mean value if status_quo is unavailable). This plot helps "
-                "in identifying regions of optimal performance and understanding "
-                "how changes in the selected parameters influence the predicted "
-                "outcomes. Contour lines represent levels of constant predicted "
-                "values, providing insights into the gradient and potential optima "
-                "within the parameter space."
-            ),
-        )
+        self.assertEqual(card.title, self.expected_title)
+        self.assertEqual(card.subtitle, self.expected_subtitle)
         self.assertEqual(card.level, AnalysisCardLevel.LOW)
         self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
         self.assertEqual(
             {*card.df.columns},
-            {
-                "x",
-                "y",
-                "bar_mean",
-                "sampled",
-            },
+            self.expected_cols,
         )
+        self.assertIsNotNone(card.blob)
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
+
+        # Assert that any row where sampled is True has a value of x that is
+        # sampled in at least one trial.
+        x_values_sampled = {
+            none_throws(assert_is_instance(trial, Trial).arm).parameters["x"]
+            for trial in self.client.experiment.trials.values()
+        }
+        y_values_sampled = {
+            none_throws(assert_is_instance(trial, Trial).arm).parameters["y"]
+            for trial in self.client.experiment.trials.values()
+        }
+        self.assertTrue(
+            card.df.apply(
+                lambda row: row["x"] in x_values_sampled
+                and row["y"] in y_values_sampled
+                if row["sampled"]
+                else True,
+                axis=1,
+            ).all()
+        )
+
+        # Less-than-or-equal to because we may have removed some duplicates
+        self.assertTrue(card.df["sampled"].sum() <= len(self.client.experiment.trials))
+
+    def test_compute_adhoc(self) -> None:
+        (card,) = compute_contour_adhoc(
+            x_parameter_name="x",
+            y_parameter_name="y",
+            metric_name="bar",
+            experiment=self.client.experiment,
+            generation_strategy=self.client.generation_strategy,
+        )
+        self.assertEqual(
+            card.name,
+            self.expected_name,
+        )
+        self.assertEqual(card.title, self.expected_title)
+        self.assertEqual(card.subtitle, self.expected_subtitle)
+        self.assertEqual(card.level, AnalysisCardLevel.LOW)
+        self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
+        self.assertEqual({*card.df.columns}, self.expected_cols)
         self.assertIsNotNone(card.blob)
         self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
 


### PR DESCRIPTION
Summary: While working on updating Ben's tutorials to use the new plots and check them into source control i realized we didn't expose contour as an adhoc method. This diff adds that adhoc method here

Differential Revision: D74782093


