### PR TITLE
Reduce number of experiments tested by top surfaces and sensitivity for speedup

### DIFF
--- a/ax/analysis/plotly/tests/test_sensitivity.py
+++ b/ax/analysis/plotly/tests/test_sensitivity.py
@@ -20,7 +20,10 @@ from ax.api.configs import RangeParameterConfig
 from ax.exceptions.core import UserInputError
 from ax.service.ax_client import AxClient, ObjectiveProperties
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
+from ax.utils.testing.core_stubs import (
+    get_offline_experiments_subset,
+    get_online_experiments_subset,
+)
 from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.modeling_stubs import get_default_generation_strategy_at_MBM_node
 from pyre_extensions import assert_is_instance, none_throws
@@ -131,52 +134,56 @@ class TestSensitivityAnalysisPlot(TestCase):
     @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
     def test_online(self) -> None:
         # Test SensitivityAnalysisPlot can be computed for a variety of experiments
-        # which resemble those we see in an online setting.
+        # which resemble those we see in an online setting, in analogous tests we
+        # run all experiments with modifications to settings, however, this test
+        # is slow and so we limit the number of permutations we validate.
+        order = "total"  # most common
 
-        for experiment in get_online_experiments():
-            for order in ["first", "second", "total"]:
-                for top_k in [None, 1]:
-                    generation_strategy = get_default_generation_strategy_at_MBM_node(
-                        experiment=experiment
-                    )
-                    analysis = SensitivityAnalysisPlot(
-                        # Select and arbitrary metric from the optimization config
-                        metric_names=[
-                            none_throws(
-                                experiment.optimization_config
-                            ).objective.metric_names[0]
-                        ],
-                        order=order,  # pyre-ignore[6] Valid Literal
-                        top_k=top_k,
-                    )
+        for experiment in get_online_experiments_subset():
+            for top_k in [None, 1]:
+                generation_strategy = get_default_generation_strategy_at_MBM_node(
+                    experiment=experiment
+                )
+                analysis = SensitivityAnalysisPlot(
+                    # Select and arbitrary metric from the optimization config
+                    metric_names=[
+                        none_throws(
+                            experiment.optimization_config
+                        ).objective.metric_names[0]
+                    ],
+                    order=order,
+                    top_k=top_k,
+                )
 
-                    _ = analysis.compute(
-                        experiment=experiment, generation_strategy=generation_strategy
-                    )
+                _ = analysis.compute(
+                    experiment=experiment, generation_strategy=generation_strategy
+                )
 
     @mock_botorch_optimize
     @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
     def test_offline(self) -> None:
         # Test SensitivityAnalysisPlot can be computed for a variety of experiments
-        # which resemble those we see in an offline setting.
+        # which resemble those we see in an offline setting, in analogous tests we
+        # run all experiments with modifications to settings, however, this test
+        # is slow and so we limit the number of permutations we validate.
+        order = "total"  # most common
 
-        for experiment in get_offline_experiments():
-            for order in ["first", "second", "total"]:
-                for top_k in [None, 1]:
-                    generation_strategy = get_default_generation_strategy_at_MBM_node(
-                        experiment=experiment
-                    )
-                    analysis = SensitivityAnalysisPlot(
-                        # Select and arbitrary metric from the optimization config
-                        metric_names=[
-                            none_throws(
-                                experiment.optimization_config
-                            ).objective.metric_names[0]
-                        ],
-                        order=order,  # pyre-ignore[6] Valid Literal
-                        top_k=top_k,
-                    )
+        for experiment in get_offline_experiments_subset():
+            for top_k in [None, 1]:
+                generation_strategy = get_default_generation_strategy_at_MBM_node(
+                    experiment=experiment
+                )
+                analysis = SensitivityAnalysisPlot(
+                    # Select and arbitrary metric from the optimization config
+                    metric_names=[
+                        none_throws(
+                            experiment.optimization_config
+                        ).objective.metric_names[0]
+                    ],
+                    order=order,
+                    top_k=top_k,
+                )
 
-                    _ = analysis.compute(
-                        experiment=experiment, generation_strategy=generation_strategy
-                    )
+                _ = analysis.compute(
+                    experiment=experiment, generation_strategy=generation_strategy
+                )

--- a/ax/analysis/plotly/tests/test_top_surfaces.py
+++ b/ax/analysis/plotly/tests/test_top_surfaces.py
@@ -9,7 +9,10 @@ from ax.api.client import Client
 from ax.api.configs import ChoiceParameterConfig, RangeParameterConfig
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_offline_experiments, get_online_experiments
+from ax.utils.testing.core_stubs import (
+    get_offline_experiments_subset,
+    get_online_experiments_subset,
+)
 from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.modeling_stubs import get_default_generation_strategy_at_MBM_node
 from pyre_extensions import assert_is_instance, none_throws
@@ -150,47 +153,81 @@ class TestTopSurfacesAnalysis(TestCase):
     def test_online(self) -> None:
         # Test TopSurfacesAnalysis can be computed for a variety of experiments
         # which resemble those we see in an online setting.
+        order = "total"  # most common
 
-        for experiment in get_online_experiments():
-            for order in ["first", "second", "total"]:
-                for top_k in range(3):
-                    generation_strategy = get_default_generation_strategy_at_MBM_node(
-                        experiment=experiment
-                    )
-                    analysis = TopSurfacesAnalysis(
-                        # Select and arbitrary metric from the optimization config
-                        metric_name=none_throws(
-                            experiment.optimization_config
-                        ).objective.metric_names[0],
-                        order=order,  # pyre-ignore[6] Valid Literal
-                        top_k=top_k,
-                    )
+        for experiment in get_online_experiments_subset():
+            generation_strategy = get_default_generation_strategy_at_MBM_node(
+                experiment=experiment
+            )
+            analysis = TopSurfacesAnalysis(
+                # Select and arbitrary metric from the optimization config
+                metric_name=none_throws(
+                    experiment.optimization_config
+                ).objective.metric_names[0],
+                order=order,
+                top_k=2,
+            )
 
-                    _ = analysis.compute(
-                        experiment=experiment, generation_strategy=generation_strategy
-                    )
+            _ = analysis.compute(
+                experiment=experiment, generation_strategy=generation_strategy
+            )
+
+        # test with default top k
+        for experiment in get_online_experiments_subset():
+            generation_strategy = get_default_generation_strategy_at_MBM_node(
+                experiment=experiment
+            )
+            analysis = TopSurfacesAnalysis(
+                # Select and arbitrary metric from the optimization config
+                metric_name=none_throws(
+                    experiment.optimization_config
+                ).objective.metric_names[0],
+                order=order,
+            )
+
+            _ = analysis.compute(
+                experiment=experiment, generation_strategy=generation_strategy
+            )
 
     @mock_botorch_optimize
     @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
     def test_offline(self) -> None:
         # Test TopSurfacesAnalysis can be computed for a variety of experiments
-        # which resemble those we see in an offline setting.
+        # which resemble those we see in an offline setting, in analogous tests we
+        # run all experiments with modifications to settings, however, this test
+        # is slow and so we limit the number of permutations we validate.
+        order = "total"  # most common
 
-        for experiment in get_offline_experiments():
-            for order in ["first", "second", "total"]:
-                for top_k in range(3):
-                    generation_strategy = get_default_generation_strategy_at_MBM_node(
-                        experiment=experiment
-                    )
-                    analysis = TopSurfacesAnalysis(
-                        # Select and arbitrary metric from the optimization config
-                        metric_name=none_throws(
-                            experiment.optimization_config
-                        ).objective.metric_names[0],
-                        order=order,  # pyre-ignore[6] Valid Literal
-                        top_k=top_k,
-                    )
+        for experiment in get_offline_experiments_subset():
+            generation_strategy = get_default_generation_strategy_at_MBM_node(
+                experiment=experiment
+            )
+            analysis = TopSurfacesAnalysis(
+                # Select and arbitrary metric from the optimization config
+                metric_name=none_throws(
+                    experiment.optimization_config
+                ).objective.metric_names[0],
+                order=order,
+                top_k=2,
+            )
 
-                    _ = analysis.compute(
-                        experiment=experiment, generation_strategy=generation_strategy
-                    )
+            _ = analysis.compute(
+                experiment=experiment, generation_strategy=generation_strategy
+            )
+
+        # run the test with the default top k
+        for experiment in get_offline_experiments_subset():
+            generation_strategy = get_default_generation_strategy_at_MBM_node(
+                experiment=experiment
+            )
+            analysis = TopSurfacesAnalysis(
+                # Select and arbitrary metric from the optimization config
+                metric_name=none_throws(
+                    experiment.optimization_config
+                ).objective.metric_names[0],
+                order=order,
+            )
+
+            _ = analysis.compute(
+                experiment=experiment, generation_strategy=generation_strategy
+            )

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1106,7 +1106,77 @@ def get_online_experiments() -> list[Experiment]:
     ]
 
     experiments = [*single_objective, *multi_objective]
+    _configure_online_experiments(experiments=experiments)
 
+    return experiments
+
+
+def get_online_experiments_subset() -> list[Experiment]:
+    """
+    Set of 4 experiments includes: 1 single objective exp with choice parameter,
+    parameter constraint, and relative constriant. 3 multi-objective experiments
+    with (a) choice param, fixed param, relative and absolute constraint, (b)
+    fixed param and relative constraint (c) no constraints but both fixed and
+    choice param
+    """
+    experiments = []
+    experiments.append(
+        get_branin_experiment(
+            with_batch=True,
+            num_batch_trial=2,
+            num_arms_per_trial=10,
+            with_completed_batch=True,
+            with_status_quo=True,
+            status_quo_unknown_parameters=True,
+            with_choice_parameter=True,
+            with_parameter_constraint=True,
+            with_relative_constraint=True,
+        )
+    )
+    experiments.append(
+        get_branin_experiment_with_multi_objective(
+            num_objectives=3,
+            with_batch=True,
+            with_status_quo=True,
+            with_completed_batch=True,
+            has_objective_thresholds=True,
+            with_choice_parameter=True,
+            with_fixed_parameter=True,
+            with_relative_constraint=True,
+            with_absolute_constraint=True,
+        )
+    )
+    experiments.append(
+        get_branin_experiment_with_multi_objective(
+            num_objectives=3,
+            with_batch=True,
+            with_status_quo=True,
+            with_completed_batch=True,
+            has_objective_thresholds=True,
+            with_choice_parameter=False,
+            with_fixed_parameter=True,
+            with_relative_constraint=True,
+            with_absolute_constraint=False,
+        )
+    )
+    experiments.append(
+        get_branin_experiment_with_multi_objective(
+            num_objectives=3,
+            with_batch=True,
+            with_status_quo=True,
+            with_completed_batch=True,
+            has_objective_thresholds=True,
+            with_choice_parameter=True,
+            with_fixed_parameter=True,
+            with_relative_constraint=False,
+            with_absolute_constraint=False,
+        )
+    )
+    _configure_online_experiments(experiments=experiments)
+    return experiments
+
+
+def _configure_online_experiments(experiments: list[Experiment]) -> None:
     for experiment in experiments:
         sobol_generator = get_sobol(search_space=experiment.search_space)
 
@@ -1139,8 +1209,6 @@ def get_online_experiments() -> list[Experiment]:
         trial = experiment.new_batch_trial()
         # Detatch the arms from the GeneratorRun so they appear as custom arms
         trial.add_arms_and_weights(arms=sobol_run.arms)
-
-    return experiments
 
 
 def get_offline_experiments() -> list[Experiment]:
@@ -1188,7 +1256,75 @@ def get_offline_experiments() -> list[Experiment]:
     ]
 
     experiments = [*single_objective, *multi_objective]
+    _configure_offline_experiments(experiments=experiments)
 
+    return experiments
+
+
+def get_offline_experiments_subset() -> list[Experiment]:
+    """
+    Set of 4 experiments that include:
+    1. Single objective with choice param and param constraint
+    2. Mulit-objective with objective threshold, absolute constraint, choice param,
+        and fixed param
+    3. Mulit-objective with no thresholds, constraint, or special params
+    4. Mulit-objective with objective threshold and fixed param
+    """
+    experiments = []
+    experiments.append(
+        get_branin_experiment(
+            with_trial=True,
+            num_trial=10,
+            with_completed_trial=True,
+            with_status_quo=False,
+            with_choice_parameter=True,
+            with_parameter_constraint=True,
+        )
+    )
+    experiments.append(
+        get_branin_experiment_with_multi_objective(
+            num_objectives=3,
+            with_trial=True,
+            num_trial=10,
+            with_completed_trial=True,
+            with_status_quo=False,
+            has_objective_thresholds=True,
+            with_absolute_constraint=True,
+            with_choice_parameter=True,
+            with_fixed_parameter=True,
+        )
+    )
+    experiments.append(
+        get_branin_experiment_with_multi_objective(
+            num_objectives=3,
+            with_trial=True,
+            num_trial=10,
+            with_completed_trial=True,
+            with_status_quo=False,
+            has_objective_thresholds=False,
+            with_absolute_constraint=False,
+            with_choice_parameter=False,
+            with_fixed_parameter=False,
+        )
+    )
+    experiments.append(
+        get_branin_experiment_with_multi_objective(
+            num_objectives=3,
+            with_trial=True,
+            num_trial=10,
+            with_completed_trial=True,
+            with_status_quo=False,
+            has_objective_thresholds=True,
+            with_absolute_constraint=False,
+            with_choice_parameter=False,
+            with_fixed_parameter=True,
+        )
+    )
+    _configure_offline_experiments(experiments=experiments)
+    return experiments
+
+
+def _configure_offline_experiments(experiments: list[Experiment]) -> None:
     for experiment in experiments:
         sobol_generator = get_sobol(search_space=experiment.search_space)
 
@@ -1214,8 +1350,6 @@ def get_offline_experiments() -> list[Experiment]:
         trial = experiment.new_trial()
         # Detatch the arms from the GeneratorRun so they appear as custom arms
         trial.add_arm(arm=sobol_run.arms[0])
-
-    return experiments
 
 
 ##############################


### PR DESCRIPTION
Summary:
Currently we have 4 flaky tests due to these four tests being too long even with the long test decorator. I think these are also slowing down the OSS test time significantly, which is annoying.

I manually curated 4 experiments to check for both online and offline trying to create expeirments that i think are reasonable, we're seeing pretty significant speed up

I do think testing the full suite here is nice, and i'll add a task to the backlog to make these tests faster in a more involved way, but in the meantime they aren't doing us any good if they aren't running on diffs so let's get them into a more usable state

Differential Revision: D74846187


