### PR TITLE
Move legend of sensitivity plot to bottom of plot

### DIFF
--- a/ax/analysis/plotly/sensitivity.py
+++ b/ax/analysis/plotly/sensitivity.py
@@ -220,7 +220,18 @@ def _prepare_card_components(
     )
 
     # Display most important parameters first
-    figure.update_layout(yaxis={"categoryorder": "total ascending"})
+    figure.update_layout(
+        yaxis={"categoryorder": "total ascending"},
+        # move legend to bottom of plot
+        legend={
+            "orientation": "h",
+            "yanchor": "top",
+            "y": -0.2,
+            "xanchor": "center",
+            "x": 0.5,
+            "title_text": "",  # remove title
+        },
+    )
 
     return (
         plotting_df[["parameter_name", "sensitivity"]],


### PR DESCRIPTION
Summary: This legend tends to take up a lot of space, and since we've landed on tiled view, let's move it below to save in horizontal space

Differential Revision: D74852684


