### PR TITLE
Move legend below for arm effects, scatter + add to utils

### DIFF
--- a/ax/analysis/plotly/arm_effects.py
+++ b/ax/analysis/plotly/arm_effects.py
@@ -18,6 +18,8 @@ from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCar
 from ax.analysis.plotly.utils import (
     BEST_LINE_SETTINGS,
     get_arm_tooltip,
+    LEGEND_POSITION,
+    MARGIN_REDUCUTION,
     trial_status_to_plotly_color,
     truncate_label,
 )
@@ -316,6 +318,8 @@ def _prepare_figure(
         xaxis_title="Arm Name",
         yaxis_title=metric_label,
         yaxis_tickformat=".2%" if is_relative else None,
+        legend=LEGEND_POSITION,
+        margin=MARGIN_REDUCUTION,
     )
 
     # Order arms by trial index, then by arm name. Always put additional arms last.

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -18,6 +18,8 @@ from ax.analysis.plotly.utils import (
     BEST_LINE_SETTINGS,
     get_arm_tooltip,
     is_predictive,
+    LEGEND_POSITION,
+    MARGIN_REDUCUTION,
     trial_status_to_plotly_color,
     truncate_label,
 )
@@ -341,6 +343,8 @@ def _prepare_figure(
         yaxis_title=y_metric_label,
         xaxis_tickformat=".2%" if is_relative else None,
         yaxis_tickformat=".2%" if is_relative else None,
+        legend=LEGEND_POSITION,
+        margin=MARGIN_REDUCUTION,
     )
 
     # Add a red circle with no fill if any arms are marked as possibly infeasible.

--- a/ax/analysis/plotly/sensitivity.py
+++ b/ax/analysis/plotly/sensitivity.py
@@ -12,7 +12,7 @@ from ax.adapter.torch import TorchAdapter
 from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
 
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
-from ax.analysis.plotly.utils import truncate_label
+from ax.analysis.plotly.utils import LEGEND_POSITION, MARGIN_REDUCUTION, truncate_label
 from ax.analysis.utils import extract_relevant_adapter
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
@@ -219,18 +219,12 @@ def _prepare_card_components(
         hover_data=["parameter_name"],
     )
 
-    # Display most important parameters first
     figure.update_layout(
+        # Display most important parameters first
         yaxis={"categoryorder": "total ascending"},
         # move legend to bottom of plot
-        legend={
-            "orientation": "h",
-            "yanchor": "top",
-            "y": -0.2,
-            "xanchor": "center",
-            "x": 0.5,
-            "title_text": "",  # remove title
-        },
+        legend=LEGEND_POSITION,
+        margin=MARGIN_REDUCUTION,
     )
 
     return (

--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -267,7 +267,8 @@ def _prepare_plot(
             x=z_grid.columns.values,
             y=z_grid.index.values,
             colorscale=METRIC_CONTINUOUS_COLOR_SCALE,
-            showscale=False,
+            showscale=True,
+            hoverinfo="skip",
         ),
         layout=go.Layout(
             xaxis_title=truncate_label(label=x_parameter_name),
@@ -278,7 +279,6 @@ def _prepare_plot(
     if display_sampled:
         x_sampled = df[df["sampled"]][x_parameter_name].tolist()
         y_sampled = df[df["sampled"]][y_parameter_name].tolist()
-
         samples = go.Scatter(
             x=x_sampled,
             y=y_sampled,

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -7,7 +7,7 @@
 
 import math
 import re
-from typing import Any, Sequence
+from typing import Any, Sequence, Union
 
 import numpy as np
 
@@ -59,6 +59,18 @@ BEST_LINE_SETTINGS: dict[str, str | dict[str, str] | bool] = {
 # Use the same continuous sequential color scale for all plots. Plasma uses purples for
 # low values and transitions to yellows for high values.
 METRIC_CONTINUOUS_COLOR_SCALE: list[str] = px.colors.sequential.Plasma
+
+# Move the legened to the bottom, and make horizontal
+LEGEND_POSITION: dict[str, Union[float, str]] = {
+    "orientation": "h",
+    "yanchor": "top",
+    "y": -0.2,
+    "xanchor": "center",
+    "x": 0.5,
+    "title_text": "",  # remove title
+}
+
+MARGIN_REDUCUTION: dict[str, int] = {"t": 50}
 
 
 # Use a consistent color for each TrialStatus name, sourced from


### PR DESCRIPTION
Summary:
This diff moves the legend below for all plots where i think it makes sense to have -- we'll keep vertical legend for contour, progression, and parallel coordinates

We also reduce the top margin, i think it was a bit big and this will help with tile view being a bit more dense

We also use the utils file to store common things

Differential Revision: D74920985


