### PR TITLE
Update MapKeyToFloat Transform to handle case of non-existent map keys

### DIFF
--- a/ax/adapter/transforms/metadata_to_float.py
+++ b/ax/adapter/transforms/metadata_to_float.py
@@ -120,7 +120,7 @@ class MetadataToFloat(Transform):
             _transfer(
                 src=obsf.parameters,
                 dst=obsf.metadata,
-                keys=self.parameters.keys(),
+                keys=[p.name for p in self._parameter_list],
             )
         return observation_features
 
@@ -128,7 +128,7 @@ class MetadataToFloat(Transform):
         _transfer(
             src=none_throws(obsf.metadata),
             dst=obsf.parameters,
-            keys=self.parameters.keys(),
+            keys=[p.name for p in self._parameter_list],
         )
 
 


### PR DESCRIPTION
Summary:
## Context:

This update addresses cases where there exists an `obs_feature` in `observations` such that the user-specified map key(s) is not in the `obs_feature.metadata` dict.

## Changes

Instead of transferring key-values between `obs_feature.metadata/parameters` based on user-specified keys in `config["parameters"]`, this update uses parameters that have been successfully added to `MapKeyToFloat._parameter_list` during initialization.

Additional test cases ensure that the appropriate exception is raised when:
1. Initializing `MapKeyToFloat` with a map key not present in one or more observation features' metadata.
2. Calling `transform_observation_features` with an `MapKeyToFloat` instance containing a map key (in its `_parameter_list` attribute) not present in one or more observation features' metadata.

Differential Revision: D74776969


