### PR TITLE
Update MapKeyToFloat Transform to handle case of constant progressions

### DIFF
--- a/ax/adapter/transforms/metadata_to_float.py
+++ b/ax/adapter/transforms/metadata_to_float.py
@@ -120,7 +120,7 @@ class MetadataToFloat(Transform):
             _transfer(
                 src=obsf.parameters,
                 dst=obsf.metadata,
-                keys=self.parameters.keys(),
+                keys=[p.name for p in self._parameter_list],
             )
         return observation_features
 
@@ -128,7 +128,7 @@ class MetadataToFloat(Transform):
         _transfer(
             src=none_throws(obsf.metadata),
             dst=obsf.parameters,
-            keys=self.parameters.keys(),
+            keys=[p.name for p in self._parameter_list],
         )
 
 


### PR DESCRIPTION
Summary:
## Context: 

This diff addresses scenarios where progression values are constant and uniform across all observations. More formally, for every `obs_feature` in `observations`, the user-specified map key `key` is present in obs_feature.metadata. However, for any two distinct observations `obs_feature1` and `obs_feature2` the condition `obs_feature1.metadata[key] ==  obs_feature2.metadata[key]` holds true.

In such cases, adding the progression as an additional context variable for modeling purposes is redundant. Consequently, the parameter corresponding to `key` is excluded from the `MapKeyToFloat._parameter_list` attribute, rendering the operations `MapKeyToFloat.(un)transform_observation_features` as no-ops or identity functions with respect to this key.


## Changes

- Updates the data structure to store observed map key values in a set, which is not only more efficient but simplifies the tracking of unique values.
- If only a single unique value is encountered for a given map key, it is not added to the transform's `_parameter_list` and a debug-level log message is generated.
- Added a new test case specifically for this scenario.

Differential Revision: D74760362


