### PR TITLE
only warn on MetricFetchE if trial is complete

### DIFF
--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -1920,10 +1920,6 @@ class Scheduler(AnalysisBase, BestPointMixin):
                 # Log the Err so the user is aware that something has failed, even if
                 # we do not do anything
                 metric_fetch_e = result.unwrap_err()
-                self.logger.warning(
-                    f"Failed to fetch {metric_name} for trial {trial_index}, found "
-                    f"{metric_fetch_e}."
-                )
 
                 # If the metric is available while running just continue (we can try
                 # again later).
@@ -1942,6 +1938,10 @@ class Scheduler(AnalysisBase, BestPointMixin):
                     )
                     continue
 
+                self.logger.error(
+                    f"Failed to fetch {metric_name} for trial {trial_index} with "
+                    f"status {status}, found {metric_fetch_e}."
+                )
                 self._num_metric_fetch_e_encountered += 1
                 self._report_metric_fetch_e(
                     trial=self.experiment.trials[trial_index],

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -1626,11 +1626,6 @@ class TestAxScheduler(TestCase):
             )
             scheduler.run_n_trials(max_trials=1)
             self.assertTrue(
-                any(
-                    "Failed to fetch branin_map for trial 0" in msg for msg in lg.output
-                )
-            )
-            self.assertTrue(
                 any("Waiting for completed trials" in msg for msg in lg.output)
             )
         self.assertEqual(scheduler.experiment.trials[0].status, TrialStatus.COMPLETED)


### PR DESCRIPTION
Summary: It is expected that a metric may not be fetchable while a given trial is running, especially early on in that trial's run. This diff moves the associated warning to only fire when a metric is still not fetchable after the trial has completed, and raises the loglevel to an error.

Reviewed By: mpolson64

Differential Revision: D74897258


