### PR TITLE
Fallback to default ModelConfig when no model for ranking dataset is specified

### DIFF
--- a/ax/adapter/tests/test_pairwise_adapter.py
+++ b/ax/adapter/tests/test_pairwise_adapter.py
@@ -17,7 +17,7 @@ from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.preference_stubs import get_pbo_experiment
-from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
+from botorch.acquisition.logei import qLogNoisyExpectedImprovement
 from botorch.acquisition.preference import (
     AnalyticExpectedUtilityOfBestOption,
     qExpectedUtilityOfBestOption,
@@ -49,7 +49,7 @@ class PairwiseAdapterTest(TestCase):
         )
 
         cases = [
-            (qNoisyExpectedImprovement, None, 3),
+            (qLogNoisyExpectedImprovement, None, 3),
             (qExpectedUtilityOfBestOption, None, 3),
             (
                 AnalyticExpectedUtilityOfBestOption,

--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -947,6 +947,22 @@ class TorchAdapterTest(TestCase):
                 },
                 eval_criterion=MSE,
             ),
+            # We should handle default preference model fallback when unspecified
+            SurrogateSpec(
+                model_configs=[
+                    ModelConfig(
+                        botorch_model_class=SingleTaskGP,
+                        outcome_transform_classes=[Standardize],
+                        name="STGP",
+                    ),
+                    ModelConfig(
+                        botorch_model_class=AdditiveMapSaasSingleTaskGP,
+                        outcome_transform_classes=[Standardize],
+                        name="SAAS",
+                    ),
+                ],
+                eval_criterion=MSE,
+            ),
         ]
 
         for surrogate_spec in surrogate_specs:


### PR DESCRIPTION
Summary:
## Context

We currently included auxiliary PE experiments in the list of datasets during model fitting. This works fine when no model configs are being specified (where we'll fall back to the default `ModelConfig`) or when the model configs are correctly specified for the preference metric (via `metric_to_model_configs`).

However, in cases where the model configs are incorrectly specified for the preference aux dataset, an error will be thrown during model fitting even if the preference model fitted will not be used (for now).

Now, we will run into a `InputDataError: Expected all inputs to share the same dtype. Got torch.float64 for X, torch.int64 for Y, and None for Yvar.` error in this scenario because we are attempting to fit a `SingleTaskGP` on a `RankingDataset` when `PairwiseGP` is not part of the specified model config.

Meta: One such example is for existing PTS GS where we don't have `PairwiseGP` being part of any model config, but after D73286263, we'll try to fit a model on the auxiliary PE experiment if there is one, resulting in a model fitting error, even if the PE experiment is not being used. For PLBO now, we are getting the preference model elsewhere; for regular MBM model, we are not using the preference model at all; but in either case we should expect the model fitting to work normally even with an aux PE experiment.

## This diff

We'll fall back to the default model config when no model for ranking dataset is specified.

Reviewed By: saitcakmak

Differential Revision: D75021638


