### PR TITLE
Allow Client.summarize without GS

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -738,7 +738,7 @@ class Client(WithDBSettingsBase):
 
         (card,) = Summary(omit_empty_columns=True).compute(
             experiment=self._experiment,
-            generation_strategy=self._generation_strategy,
+            generation_strategy=self._maybe_generation_strategy,
         )
 
         return card.df


### PR DESCRIPTION
Summary: `Summary` analysis does not utilize the GS. We can let it compute even if GS is not set.

Reviewed By: esantorella

Differential Revision: D75026266


