### PR TITLE
log model config to eval metric on Surrogate

### DIFF
--- a/ax/models/torch/botorch_modular/input_constructors/covar_modules.py
+++ b/ax/models/torch/botorch_modular/input_constructors/covar_modules.py
@@ -14,7 +14,11 @@ from typing import Any
 
 import torch
 from ax.exceptions.core import UserInputError
-from ax.models.torch.botorch_modular.kernels import DefaultRBFKernel, ScaleMaternKernel
+from ax.models.torch.botorch_modular.kernels import (
+    DefaultMaternKernel,
+    DefaultRBFKernel,
+    ScaleMaternKernel,
+)
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import _argparse_type_encoder
 from botorch.models import MultiTaskGP
@@ -160,9 +164,9 @@ def _covar_module_argparse_linear(
     )
 
 
-@covar_module_argparse.register(DefaultRBFKernel)
+@covar_module_argparse.register((DefaultRBFKernel, DefaultMaternKernel))
 def _covar_module_argparse_default_rbf(
-    covar_module_class: type[DefaultRBFKernel],
+    covar_module_class: type[DefaultRBFKernel] | type[DefaultMaternKernel],
     botorch_model_class: type[Model],
     dataset: SupervisedDataset,
     ard_num_dims: int | _DefaultType = DEFAULT,

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -12,7 +12,11 @@ import torch
 
 # Ax `Acquisition` & other MBM imports
 from ax.models.torch.botorch_modular.acquisition import Acquisition
-from ax.models.torch.botorch_modular.kernels import DefaultRBFKernel, ScaleMaternKernel
+from ax.models.torch.botorch_modular.kernels import (
+    DefaultMaternKernel,
+    DefaultRBFKernel,
+    ScaleMaternKernel,
+)
 from ax.models.torch.botorch_modular.sebo import SEBOAcquisition
 
 # BoTorch `AcquisitionFunction` imports
@@ -166,6 +170,7 @@ KERNEL_REGISTRY: dict[type[Kernel], str] = {
     ScaleMaternKernel: "ScaleMaternKernel",
     RBFKernel: "RBFKernel",
     DefaultRBFKernel: "DefaultRBFKernel",
+    DefaultMaternKernel: "DefaultMaternKernel",
 }
 
 LIKELIHOOD_REGISTRY: dict[type[GaussianLikelihood], str] = {


### PR DESCRIPTION
Summary: This is nice for tracking what the model evaluation was for different model configs. These aren't saved at the moment, but I'm not sure we need to save them.

Reviewed By: mgarrard

Differential Revision: D73953099


