### PR TITLE
Rename model input and attribute of Adapter to generator

### DIFF
--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -69,23 +69,23 @@ class GenResults:
 
 
 class Adapter:
-    """The main object for using models in Ax.
+    """The main object for using generators in Ax.
 
-    Adapter specifies 3 methods for using models:
+    Adapter specifies 3 methods for using generators:
 
-    - predict: Make model predictions. This method is not optimized for
+    - predict: Make predictions with the generator. This method is not optimized for
       speed and so should be used primarily for plotting or similar tasks
       and not inside an optimization loop.
-    - gen: Use the model to generate new candidates.
-    - cross_validate: Do cross validation to assess model predictions.
+    - gen: Use the generator to generate new candidates.
+    - cross_validate: Do cross validation to assess generator predictions.
 
     Adapter converts Ax types like Data and Arm to types that are
-    meant to be consumed by the models. The data sent to the model will depend
+    meant to be consumed by the generators. The data sent to the generator will depend
     on the implementation of the subclass, which will specify the actual API
-    for external model.
+    for external generator.
 
     This class also applies a sequence of transforms to the input data and
-    problem specification which can be used to ensure that the external model
+    problem specification which can be used to ensure that the external generator
     receives appropriate inputs.
 
     Subclasses will implement what is here referred to as the "terminal
@@ -97,7 +97,7 @@ class Adapter:
         self,
         *,
         experiment: Experiment,
-        model: Generator,
+        generator: Generator,
         search_space: SearchSpace | None = None,
         data: Data | None = None,
         transforms: Sequence[type[Transform]] | None = None,
@@ -112,17 +112,17 @@ class Adapter:
         fit_only_completed_map_metrics: bool | None = None,
     ) -> None:
         """
-        Applies transforms and fits model.
+        Applies transforms and fits the generator.
 
         Args:
             experiment: An ``Experiment`` object representing the setup and the
                 current state of the experiment, including the search space,
                 trials and observation data. It is used to extract various
                 attributes, and is not mutated.
-            model: A ``Generator`` that is used for generating candidates.
-                Its interface will be specified in subclasses. If model requires
+            generator: A ``Generator`` that is used for generating candidates.
+                Its interface will be specified in subclasses. If generator requires
                 initialization, that should be done prior to its use here.
-            search_space: An optional ``SearchSpace`` for fitting  the model.
+            search_space: An optional ``SearchSpace`` for fitting the generator.
                 If not provided, `experiment.search_space` is used.
                 The search space may be modified during ``Adapter.gen``, e.g.,
                 to try out a different set of parameter bounds or constraints.
@@ -137,20 +137,20 @@ class Adapter:
             transform_configs: A dictionary from transform name to the
                 transform config dictionary.
             optimization_config: An optional ``OptimizationConfig`` defining how to
-                optimize the model. Defaults to `experiment.optimization_config`.
+                optimize the generator. Defaults to `experiment.optimization_config`.
             expand_model_space: If True, expand range parameter bounds in model
                 space to cover given training data. This will make the modeling
                 space larger than the search space if training data fall outside
                 the search space. Will also include training points that violate
                 parameter constraints in the modeling.
-            fit_tracking_metrics: Whether to fit a model for tracking metrics.
+            fit_tracking_metrics: Whether to fit a surrogate model for tracking metrics.
                 Setting this to False will improve runtime at the expense of
                 models not being available for predicting tracking metrics.
                 NOTE: This can only be set to False when the optimization config
                 is provided.
-            fit_on_init: Whether to fit the model on initialization. This can
-                be used to skip model fitting when a fitted model is not needed.
-                To fit the model afterwards, use `_process_and_transform_data`
+            fit_on_init: Whether to fit the generator on initialization. This can
+                be used to skip generator fitting when a fitted generator is not needed.
+                To fit the generator afterwards, use `_process_and_transform_data`
                 to get the transformed inputs and call `_fit_if_implemented` with
                 the transformed inputs.
             data_loader_config: A DataLoaderConfig of options for loading data. See the
@@ -236,8 +236,8 @@ class Adapter:
         # NOTE: training data must be set before setting the status quo.
         self._set_status_quo(experiment=experiment)
 
-        # Save model, apply terminal transform, and fit.
-        self.model = model
+        # Save generator, apply terminal transform, and fit.
+        self.generator = generator
         if fit_on_init:
             observations, search_space = self._transform_data(
                 observations=observations_raw,
@@ -257,13 +257,13 @@ class Adapter:
         observations: list[Observation],
         time_so_far: float,
     ) -> None:
-        r"""Fits the model if `_fit` is implemented and stores fit time.
+        r"""Fits the generator if `_fit` is implemented and stores fit time.
 
         Args:
-            search_space: A transformed search space for fitting the model.
-            observations: The observations to fit the model with. These should
+            search_space: A transformed search space for fitting the generator.
+            observations: The observations to fit the generator with. These should
                 also be transformed.
-            time_so_far: Time spent in initializing the model up to
+            time_so_far: Time spent in initializing the generator up to
                 `_fit_if_implemented` call.
         """
         try:
@@ -532,13 +532,13 @@ class Adapter:
         return self._model_space
 
     def get_training_data(self) -> list[Observation]:
-        """A copy of the (untransformed) data with which the model was fit."""
+        """A copy of the (untransformed) data with which the generator was fit."""
         return deepcopy(self._training_data)
 
     @property
     def training_in_design(self) -> list[bool]:
         """For each observation in the training data, a bool indicating if it
-        is in-design for the model.
+        is in-design for the generator.
         """
         return self._training_in_design
 
@@ -566,7 +566,7 @@ class Adapter:
         search_space: SearchSpace,
         observations: list[Observation],
     ) -> None:
-        """Apply terminal transform and fit model."""
+        """Apply terminal transform and fit the generator."""
         raise AdapterMethodNotImplementedError(
             f"{self.__class__.__name__} does not implement `_fit`."
         )
@@ -767,7 +767,7 @@ class Adapter:
         model_gen_options: TConfig | None = None,
     ) -> GeneratorRun:
         """
-        Generate new points from the underlying model according to
+        Generate new points from the underlying generator according to
         search_space, optimization_config and other parameters.
 
         Args:
@@ -780,7 +780,7 @@ class Adapter:
                 features that should be fixed at specified values during
                 generation.
             model_gen_options: A config dictionary that is passed along to the
-                model. See `TorchOptConfig` for details.
+                generator. See `TorchOptConfig` for details.
 
         Returns:
             A GeneratorRun object that contains the generated points and other metadata.
@@ -843,7 +843,7 @@ class Adapter:
                     model_predictions=self.predict([best_obsf]), arm_idx=0
                 )
         except Exception as e:
-            logger.debug(f"Model predictions failed with error {e}.")
+            logger.debug(f"Generator predictions failed with error {e}.")
             model_predictions = None
 
         if best_obsf is None:
@@ -1013,27 +1013,27 @@ class Adapter:
         self._bridge_kwargs = bridge_kwargs
 
     def _get_serialized_model_state(self) -> dict[str, Any]:
-        """Obtains the state of the underlying model (if using a stateful one)
+        """Obtains the state of the underlying generator (if using a stateful one)
         in a readily JSON-serializable form.
         """
-        return self.model.serialize_state(raw_state=self.model._get_state())
+        return self.generator.serialize_state(raw_state=self.generator._get_state())
 
     def _deserialize_model_state(
         self, serialized_state: dict[str, Any]
     ) -> dict[str, Any]:
-        return self.model.deserialize_state(serialized_state=serialized_state)
+        return self.generator.deserialize_state(serialized_state=serialized_state)
 
     def feature_importances(self, metric_name: str) -> dict[str, float]:
         """Computes feature importances for a single metric.
 
-        Depending on the type of the model, this method will approach sensitivity
+        Depending on the type of the generator, this method will approach sensitivity
         analysis (calculating the sensitivity of the metric to changes in the search
         space's parameters, a.k.a. features) differently.
 
-        For Bayesian optimization models (BoTorch models), this method uses parameter
-        inverse lengthscales to compute normalized feature importances.
+        For Bayesian optimization generators (BoTorch generators), this method uses
+        parameter inverse lengthscales to compute normalized feature importances.
 
-        NOTE: Currently, this is only implemented for GP models.
+        NOTE: Currently, this is only implemented for GP-based generators.
 
         Args:
             metric_name: Name of metric to compute feature importances for.
@@ -1103,7 +1103,7 @@ class Adapter:
         )
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(model={self.model})"
+        return f"{self.__class__.__name__}(generator={self.generator})"
 
 
 def unwrap_observation_data(observation_data: list[ObservationData]) -> TModelPredict:

--- a/ax/adapter/discrete.py
+++ b/ax/adapter/discrete.py
@@ -34,11 +34,11 @@ from ax.generators.discrete_base import DiscreteGenerator
 from ax.generators.types import TConfig
 
 
-FIT_MODEL_ERROR = "Model must be fit before {action}."
+FIT_MODEL_ERROR = "Generator must be fit before {action}."
 
 
 class DiscreteAdapter(Adapter):
-    """An adapter for using models based on discrete parameters.
+    """An adapter for using generators based on discrete parameters.
 
     Requires that all parameters to have been transformed to ChoiceParameters.
     """
@@ -47,7 +47,7 @@ class DiscreteAdapter(Adapter):
         self,
         *,
         experiment: Experiment,
-        model: DiscreteGenerator,
+        generator: DiscreteGenerator,
         search_space: SearchSpace | None = None,
         data: Data | None = None,
         transforms: Sequence[type[Transform]] | None = None,
@@ -66,7 +66,7 @@ class DiscreteAdapter(Adapter):
         self.outcomes: list[str] = []
         super().__init__(
             experiment=experiment,
-            model=model,
+            generator=generator,
             search_space=search_space,
             data=data,
             transforms=transforms,
@@ -80,8 +80,8 @@ class DiscreteAdapter(Adapter):
             fit_on_init=fit_on_init,
             fit_only_completed_map_metrics=fit_only_completed_map_metrics,
         )
-        # Re-assing for more precise typing.
-        self.model: DiscreteGenerator = model
+        # Re-assign for more precise typing.
+        self.generator: DiscreteGenerator = generator
 
     def _fit(
         self,
@@ -104,7 +104,7 @@ class DiscreteAdapter(Adapter):
         )
         # Extract parameter values
         parameter_values = _get_parameter_values(search_space, self.parameters)
-        self.model.fit(
+        self.generator.fit(
             Xs=Xs_array,
             Ys=Ys_array,
             Yvars=Yvars_array,
@@ -122,7 +122,7 @@ class DiscreteAdapter(Adapter):
             [of.parameters[param] for param in self.parameters]
             for of in observation_features
         ]
-        f, cov = self.model.predict(
+        f, cov = self.generator.predict(
             X=X, use_posterior_predictive=use_posterior_predictive
         )
         # Convert arrays to observations
@@ -198,7 +198,7 @@ class DiscreteAdapter(Adapter):
                 ]
 
         # Generate the candidates
-        X, w, gen_metadata = self.model.gen(
+        X, w, gen_metadata = self.generator.gen(
             n=n,
             parameter_values=parameter_values,
             objective_weights=objective_weights,
@@ -246,8 +246,8 @@ class DiscreteAdapter(Adapter):
             [obsf.parameters[param] for param in self.parameters]
             for obsf in cv_test_points
         ]
-        # Use the model to do the cross validation
-        f_test, cov_test = self.model.cross_validate(
+        # Use the generator to do the cross validation
+        f_test, cov_test = self.generator.cross_validate(
             Xs_train=Xs_train,
             Ys_train=Ys_train,
             Yvars_train=Yvars_train,

--- a/ax/adapter/random.py
+++ b/ax/adapter/random.py
@@ -39,7 +39,7 @@ class RandomAdapter(Adapter):
         self,
         *,
         experiment: Experiment,
-        model: RandomGenerator,
+        generator: RandomGenerator,
         search_space: SearchSpace | None = None,
         data: Data | None = None,
         transforms: Sequence[type[Transform]] | None = None,
@@ -54,7 +54,7 @@ class RandomAdapter(Adapter):
         self.parameters: list[str] = []
         super().__init__(
             search_space=search_space,
-            model=model,
+            generator=generator,
             transforms=transforms,
             experiment=experiment,
             data=data,
@@ -68,7 +68,7 @@ class RandomAdapter(Adapter):
             fit_on_init=fit_on_init,
         )
         # Re-assign for more precise typing.
-        self.model: RandomGenerator = model
+        self.generator: RandomGenerator = generator
 
     def _fit(
         self,
@@ -98,7 +98,7 @@ class RandomAdapter(Adapter):
         )
         # Extract generated points to deduplicate against.
         generated_points = None
-        if self.model.deduplicate:
+        if self.generator.deduplicate:
             arms_to_deduplicate = self._experiment.arms_by_signature_for_deduplication
             generated_obs = [
                 ObservationFeatures.from_arm(arm=arm)
@@ -124,7 +124,7 @@ class RandomAdapter(Adapter):
                 generated_points = np.unique(generated_points, axis=0)
 
         # Generate the candidates
-        X, w = self.model.gen(
+        X, w = self.generator.gen(
             n=n,
             bounds=search_space_digest.bounds,
             linear_constraints=linear_constraints,

--- a/ax/adapter/registry.py
+++ b/ax/adapter/registry.py
@@ -349,7 +349,7 @@ class ModelRegistryBase(Enum):
             ],
             keywords=get_function_argument_names(model_class),
         )
-        model = model_class(**model_kwargs)
+        generator = model_class(**model_kwargs)
 
         # Create `Adapter`: defaults + standard kwargs + passed in kwargs.
         bridge_kwargs = consolidate_kwargs(
@@ -369,7 +369,7 @@ class ModelRegistryBase(Enum):
             search_space=search_space or none_throws(experiment).search_space,
             experiment=experiment,
             data=data,
-            model=model,
+            generator=generator,
             **bridge_kwargs,
         )
 

--- a/ax/adapter/tests/test_adapter_utils.py
+++ b/ax/adapter/tests/test_adapter_utils.py
@@ -359,7 +359,7 @@ class TestAdapterUtils(TestCase):
     def test_get_in_desing_adapter_training_data(self) -> None:
         def get_adapter(min: float, max: float) -> TorchAdapter:
             return TorchAdapter(
-                model=BoTorchGenerator(),
+                generator=BoTorchGenerator(),
                 experiment=get_experiment_with_observations(
                     observations=[[0.5, 1.0], [1.5, 2.0]],
                     parameterizations=[

--- a/ax/adapter/tests/test_cross_validation.py
+++ b/ax/adapter/tests/test_cross_validation.py
@@ -55,7 +55,9 @@ class CrossValidationTest(TestCase):
         )
         with mock_botorch_optimize_context_manager():
             self.adapter = TorchAdapter(
-                experiment=self.experiment, model=BoTorchGenerator(), transforms=[UnitX]
+                experiment=self.experiment,
+                generator=BoTorchGenerator(),
+                transforms=[UnitX],
             )
         self.training_data = self.adapter.get_training_data()
         self.observation_data = ObservationData(

--- a/ax/adapter/tests/test_discrete_adapter.py
+++ b/ax/adapter/tests/test_discrete_adapter.py
@@ -79,7 +79,7 @@ class DiscreteAdapterTest(TestCase):
         adapter = DiscreteAdapter()
         adapter._training_data = self.observations
         model = mock.create_autospec(DiscreteGenerator, instance=True)
-        adapter.model = model
+        adapter.generator = model
         adapter._fit(self.search_space, self.observations)
         self.assertEqual(adapter.parameters, ["x", "y", "z"])
         self.assertEqual(sorted(adapter.outcomes), ["a", "b"])
@@ -116,7 +116,7 @@ class DiscreteAdapterTest(TestCase):
                 (np.array([[1.0, 4.0], [4.0, 6]]), np.array([[2.0, 5.0], [5.0, 7]]))
             ),
         )
-        adapter.model = model
+        adapter.generator = model
         adapter.parameters = ["x", "y", "z"]
         adapter.outcomes = ["a", "b"]
         observation_data = adapter._predict(self.observation_features)
@@ -148,7 +148,7 @@ class DiscreteAdapterTest(TestCase):
             [1.0, 2.0],
             {"best_x": best_x},
         )
-        adapter.model = model
+        adapter.generator = model
         adapter.parameters = ["x", "y", "z"]
         adapter.outcomes = ["a", "b"]
         gen_results = adapter._gen(
@@ -238,7 +238,7 @@ class DiscreteAdapterTest(TestCase):
                 (np.array([[1.0, 4.0], [4.0, 6]]), np.array([[2.0, 5.0], [5.0, 7]]))
             ),
         )
-        adapter.model = model
+        adapter.generator = model
         adapter.parameters = ["x", "y", "z"]
         adapter.outcomes = ["a", "b"]
         observation_data = adapter._cross_validate(

--- a/ax/adapter/tests/test_factory.py
+++ b/ax/adapter/tests/test_factory.py
@@ -84,7 +84,7 @@ class TestAdapterFactorySingleObjective(TestCase):
             experiment=exp, data=data, min_weight=0.0
         )
         self.assertIsInstance(eb_thompson, DiscreteAdapter)
-        self.assertIsInstance(eb_thompson.model, EmpiricalBayesThompsonSampler)
+        self.assertIsInstance(eb_thompson.generator, EmpiricalBayesThompsonSampler)
         thompson_run = eb_thompson.gen(n=5)
         self.assertEqual(len(thompson_run.arms), 5)
 
@@ -97,7 +97,7 @@ class TestAdapterFactorySingleObjective(TestCase):
         exp.new_batch_trial().add_generator_run(factorial_run).run().mark_completed()
         data = exp.fetch_data()
         thompson = get_thompson(experiment=exp, data=data)
-        self.assertIsInstance(thompson.model, ThompsonSampler)
+        self.assertIsInstance(thompson.generator, ThompsonSampler)
 
     def test_uniform(self) -> None:
         exp = get_branin_experiment()

--- a/ax/adapter/tests/test_pairwise_adapter.py
+++ b/ax/adapter/tests/test_pairwise_adapter.py
@@ -63,7 +63,7 @@ class PairwiseAdapterTest(TestCase):
                 experiment=self.experiment,
                 search_space=self.experiment.search_space,
                 data=self.data,
-                model=BoTorchGenerator(
+                generator=BoTorchGenerator(
                     botorch_acqf_class=botorch_acqf_class,
                     surrogate=surrogate,
                 ),

--- a/ax/adapter/tests/test_random_adapter.py
+++ b/ax/adapter/tests/test_random_adapter.py
@@ -49,24 +49,24 @@ class RandomAdapterTest(TestCase):
         self.model_gen_options = {"option": "yes"}
 
     def test_fit(self) -> None:
-        adapter = RandomAdapter(experiment=self.experiment, model=RandomGenerator())
+        adapter = RandomAdapter(experiment=self.experiment, generator=RandomGenerator())
         self.assertEqual(adapter.parameters, ["x", "y", "z"])
-        self.assertTrue(isinstance(adapter.model, RandomGenerator))
+        self.assertTrue(isinstance(adapter.generator, RandomGenerator))
 
     def test_predict(self) -> None:
-        adapter = RandomAdapter(experiment=self.experiment, model=RandomGenerator())
+        adapter = RandomAdapter(experiment=self.experiment, generator=RandomGenerator())
         with self.assertRaises(NotImplementedError):
             adapter._predict([])
 
     def test_cross_validate(self) -> None:
-        adapter = RandomAdapter(experiment=self.experiment, model=RandomGenerator())
+        adapter = RandomAdapter(experiment=self.experiment, generator=RandomGenerator())
         with self.assertRaises(NotImplementedError):
             adapter._cross_validate(self.search_space, [], [])
 
     def test_gen_w_constraints(self) -> None:
-        adapter = RandomAdapter(experiment=self.experiment, model=RandomGenerator())
+        adapter = RandomAdapter(experiment=self.experiment, generator=RandomGenerator())
         with mock.patch.object(
-            adapter.model,
+            adapter.generator,
             "gen",
             return_value=(
                 np.array([[1.0, 2.0, 3.0], [3.0, 4.0, 3.0]]),
@@ -108,10 +108,11 @@ class RandomAdapterTest(TestCase):
         # Test with no constraints, no fixed feature, no pending observations
         search_space = SearchSpace(self.parameters[:2])
         adapter = RandomAdapter(
-            experiment=Experiment(search_space=search_space), model=RandomGenerator()
+            experiment=Experiment(search_space=search_space),
+            generator=RandomGenerator(),
         )
         with mock.patch.object(
-            adapter.model,
+            adapter.generator,
             "gen",
             return_value=(np.array([[1.0, 2.0], [3.0, 4.0]]), np.array([1.0, 2.0])),
         ) as mock_gen:
@@ -136,7 +137,7 @@ class RandomAdapterTest(TestCase):
         exp = Experiment(search_space=get_small_discrete_search_space())
         sobol = RandomAdapter(
             experiment=exp,
-            model=SobolGenerator(deduplicate=True),
+            generator=SobolGenerator(deduplicate=True),
             transforms=Cont_X_trans,
         )
         for _ in range(4):  # Search space is {[0, 1], {"red", "panda"}}
@@ -162,7 +163,7 @@ class RandomAdapterTest(TestCase):
         experiment.add_tracking_metric(metric=Metric("ax_test_metric"))
         sobol = RandomAdapter(
             search_space=self.search_space,
-            model=SobolGenerator(),
+            generator=SobolGenerator(),
             experiment=experiment,
             data=data,
             transforms=Cont_X_trans,
@@ -183,7 +184,7 @@ class RandomAdapterTest(TestCase):
         )
         # Using Cont_X_trans, particularly UnitX here to test transform application.
         adapter = RandomAdapter(
-            experiment=exp, model=generator, transforms=Cont_X_trans
+            experiment=exp, generator=generator, transforms=Cont_X_trans
         )
 
         # No pending points or previous trials on the experiment.

--- a/ax/adapter/tests/test_registry.py
+++ b/ax/adapter/tests/test_registry.py
@@ -73,7 +73,7 @@ class ModelRegistryTest(TestCase):
             data=exp.fetch_data(),
         )
         self.assertIsInstance(gpei, TorchAdapter)
-        generator = assert_is_instance(gpei.model, BoTorchGenerator)
+        generator = assert_is_instance(gpei.generator, BoTorchGenerator)
         self.assertEqual(generator.botorch_acqf_class, qExpectedImprovement)
         self.assertEqual(generator.acquisition_class, Acquisition)
         self.assertEqual(generator.acquisition_options, {"best_f": 0.0})
@@ -96,7 +96,7 @@ class ModelRegistryTest(TestCase):
         saasbo = Generators.SAASBO(experiment=exp, data=exp.fetch_data())
         self.assertIsInstance(saasbo, TorchAdapter)
         self.assertEqual(saasbo._model_key, "SAASBO")
-        generator = assert_is_instance(saasbo.model, BoTorchGenerator)
+        generator = assert_is_instance(saasbo.generator, BoTorchGenerator)
         surrogate_spec = generator.surrogate_spec
         self.assertEqual(
             surrogate_spec,
@@ -223,7 +223,7 @@ class ModelRegistryTest(TestCase):
             experiment=exp, data=data, min_weight=0.0
         )
         self.assertIsInstance(eb_thompson, DiscreteAdapter)
-        self.assertIsInstance(eb_thompson.model, EmpiricalBayesThompsonSampler)
+        self.assertIsInstance(eb_thompson.generator, EmpiricalBayesThompsonSampler)
         thompson_run = eb_thompson.gen(n=5)
         self.assertEqual(len(thompson_run.arms), 5)
 
@@ -236,7 +236,7 @@ class ModelRegistryTest(TestCase):
         exp.new_batch_trial().add_generator_run(factorial_run).run().mark_completed()
         data = exp.fetch_data()
         thompson = Generators.THOMPSON(experiment=exp, data=data)
-        self.assertIsInstance(thompson.model, ThompsonSampler)
+        self.assertIsInstance(thompson.generator, ThompsonSampler)
 
     def test_enum_uniform(self) -> None:
         """Tests uniform random instantiation through the Generators enum."""
@@ -347,7 +347,7 @@ class ModelRegistryTest(TestCase):
                     surrogate=surrogate,
                 )
                 self.assertIsInstance(mtgp, TorchAdapter)
-                generator = assert_is_instance(mtgp.model, BoTorchGenerator)
+                generator = assert_is_instance(mtgp.generator, BoTorchGenerator)
                 self.assertEqual(generator.acquisition_class, Acquisition)
                 is_moo = isinstance(
                     exp.optimization_config, MultiObjectiveOptimizationConfig
@@ -391,7 +391,7 @@ class ModelRegistryTest(TestCase):
         exp = get_branin_experiment()
         sobol = Generators.SOBOL(experiment=exp)
         gr = sobol.gen(n=1)
-        expected_state = sobol.model._get_state()
+        expected_state = sobol.generator._get_state()
         self.assertEqual(gr._model_state_after_gen, expected_state)
         extracted = _extract_model_state_after_gen(
             generator_run=gr, model_class=SobolGenerator

--- a/ax/adapter/tests/test_torch_moo_adapter.py
+++ b/ax/adapter/tests/test_torch_moo_adapter.py
@@ -105,7 +105,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
         )
         adapter = TorchAdapter(
             search_space=exp.search_space,
-            model=MultiObjectiveLegacyBoTorchGenerator(),
+            generator=MultiObjectiveLegacyBoTorchGenerator(),
             optimization_config=exp.optimization_config,
             transforms=[transform_1, transform_2],
             experiment=exp,
@@ -279,7 +279,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
             experiment=exp,
             search_space=exp.search_space,
             data=exp.fetch_data(),
-            model=MultiObjectiveLegacyBoTorchGenerator(),
+            generator=MultiObjectiveLegacyBoTorchGenerator(),
             transforms=[],
         )
         observation_features = [
@@ -358,7 +358,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
             )
             adapter = TorchAdapter(
                 search_space=exp.search_space,
-                model=MultiObjectiveLegacyBoTorchGenerator(),
+                generator=MultiObjectiveLegacyBoTorchGenerator(),
                 optimization_config=optimization_config,
                 transforms=[],
                 experiment=exp,
@@ -444,7 +444,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
         data = exp.fetch_data()
         adapter = TorchAdapter(
             search_space=exp.search_space,
-            model=MultiObjectiveLegacyBoTorchGenerator(),
+            generator=MultiObjectiveLegacyBoTorchGenerator(),
             optimization_config=exp.optimization_config,
             transforms=Cont_X_trans + Y_trans,
             torch_device=torch.device("cuda" if cuda else "cpu"),
@@ -574,7 +574,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
         set_rng_seed(0)  # make model fitting deterministic
         adapter = TorchAdapter(
             search_space=exp.search_space,
-            model=MultiObjectiveLegacyBoTorchGenerator(),
+            generator=MultiObjectiveLegacyBoTorchGenerator(),
             optimization_config=exp.optimization_config,
             transforms=ST_MTGP_trans,
             experiment=exp,
@@ -636,7 +636,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
         exp._trials = get_hss_trials_with_fixed_parameter(exp=exp)
         adapter = TorchAdapter(
             search_space=hss,
-            model=MultiObjectiveLegacyBoTorchGenerator(),
+            generator=MultiObjectiveLegacyBoTorchGenerator(),
             optimization_config=exp.optimization_config,
             transforms=Cont_X_trans + Y_trans,
             torch_device=torch.device("cuda" if cuda else "cpu"),
@@ -683,7 +683,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
         data = exp.fetch_data()
         adapter = TorchAdapter(
             search_space=exp.search_space,
-            model=BoTorchGenerator(),
+            generator=BoTorchGenerator(),
             optimization_config=exp.optimization_config,
             transforms=Cont_X_trans + Y_trans,
             torch_device=torch.device("cuda" if cuda else "cpu"),
@@ -715,7 +715,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
         )
         adapter = TorchAdapter(
             search_space=exp.search_space,
-            model=MultiObjectiveLegacyBoTorchGenerator(),
+            generator=MultiObjectiveLegacyBoTorchGenerator(),
             optimization_config=exp.optimization_config,
             transforms=[],
             experiment=exp,

--- a/ax/adapter/tests/test_transform_utils.py
+++ b/ax/adapter/tests/test_transform_utils.py
@@ -73,7 +73,7 @@ class TransformUtilsTest(TestCase):
                 search_space=dummy_search_space,
                 status_quo=Arm(parameters={"x": 2.0, "y": 10.0}, name="1_1"),
             ),
-            model=Generator(),
+            generator=Generator(),
             optimization_config=optimization_config,
         )
         new_opt_config = derelativize_optimization_config_with_raw_status_quo(

--- a/ax/adapter/transforms/tests/test_bilog_y.py
+++ b/ax/adapter/transforms/tests/test_bilog_y.py
@@ -33,7 +33,7 @@ class BilogYTest(TestCase):
     def get_mb(self) -> Adapter:
         return Adapter(
             search_space=self.exp.search_space,
-            model=Generator(),
+            generator=Generator(),
             experiment=self.exp,
             data=self.exp.lookup_data(),
         )

--- a/ax/adapter/transforms/tests/test_derelativize_transform.py
+++ b/ax/adapter/transforms/tests/test_derelativize_transform.py
@@ -129,7 +129,7 @@ class DerelativizeTransformTest(TestCase):
                 search_space=search_space,
                 status_quo=Arm(parameters={"x": 2.0, "y": 10.0}, name="1_1"),
             ),
-            model=Generator(),
+            generator=Generator(),
         )
 
         # Test with no relative constraints
@@ -211,7 +211,7 @@ class DerelativizeTransformTest(TestCase):
                 search_space=search_space,
                 status_quo=Arm(parameters={"x": None, "y": None}, name="1_2"),
             ),
-            model=Generator(),
+            generator=Generator(),
         )
         oc = OptimizationConfig(
             objective=objective,
@@ -260,7 +260,7 @@ class DerelativizeTransformTest(TestCase):
                 search_space=search_space,
                 status_quo=Arm(parameters={"x": 2.0, "y": 10.0}, name="1_1"),
             ),
-            model=Generator(),
+            generator=Generator(),
         )
         oc = OptimizationConfig(
             objective=objective,
@@ -314,7 +314,9 @@ class DerelativizeTransformTest(TestCase):
             t2.transform_optimization_config(deepcopy(oc_scalarized_only), g, None)
 
         # Raises error with relative constraint, no status quo.
-        g = Adapter(experiment=Experiment(search_space=search_space), model=Generator())
+        g = Adapter(
+            experiment=Experiment(search_space=search_space), generator=Generator()
+        )
         with self.assertRaises(DataRequiredError):
             t.transform_optimization_config(deepcopy(oc), g, None)
 
@@ -337,7 +339,7 @@ class DerelativizeTransformTest(TestCase):
             parameters=[RangeParameter("x", ParameterType.FLOAT, 0, 20)]
         )
         adapter = Adapter(
-            experiment=Experiment(search_space=search_space), model=Generator()
+            experiment=Experiment(search_space=search_space), generator=Generator()
         )
         with self.assertRaises(ValueError):
             t.transform_optimization_config(
@@ -380,7 +382,7 @@ class DerelativizeTransformTest(TestCase):
             for with_raw_sq in [False, True]:
                 adapter = TorchAdapter(
                     experiment=exp,
-                    model=BoTorchGenerator(),
+                    generator=BoTorchGenerator(),
                     transforms=[Derelativize],
                     transform_configs={
                         "Derelativize": {"use_raw_status_quo": with_raw_sq}
@@ -422,7 +424,7 @@ class DerelativizeTransformTest(TestCase):
         exp.attach_data(get_branin_data(trials=[trial], metrics=exp.metrics))
 
         adapter = TorchAdapter(
-            experiment=exp, model=BoTorchGenerator(), transforms=[Derelativize]
+            experiment=exp, generator=BoTorchGenerator(), transforms=[Derelativize]
         )
         # Shouldn't log in regular usage here.
         with self.assertNoLogs(logger=logger):

--- a/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
@@ -69,7 +69,7 @@ class MapKeyToFloatTransformTest(TestCase):
             experiment=Experiment(
                 search_space=self.search_space, optimization_config=optimization_config
             ),
-            model=Generator(),
+            generator=Generator(),
         )
 
         self.observations = []

--- a/ax/adapter/transforms/tests/test_relativize_transform.py
+++ b/ax/adapter/transforms/tests/test_relativize_transform.py
@@ -131,7 +131,7 @@ class RelativizeDataTest(TestCase):
             data = exp.fetch_data()
             adapter = Adapter(
                 search_space=exp.search_space,
-                model=Generator(),
+                generator=Generator(),
                 transforms=[relativize_cls],
                 experiment=exp,
                 data=data,
@@ -148,7 +148,7 @@ class RelativizeDataTest(TestCase):
             none_throws(exp._status_quo)._parameters["x1"] = 0.0
             adapter = Adapter(
                 search_space=exp.search_space,
-                model=Generator(),
+                generator=Generator(),
                 transforms=[relativize_cls],
                 experiment=exp,
                 data=data,

--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -75,7 +75,7 @@ class TransformToNewSQSpecificTest(TestCase):
     def _refresh_adapter(self) -> None:
         self.adapter = Adapter(
             search_space=self.exp.search_space,
-            model=Generator(),
+            generator=Generator(),
             experiment=self.exp,
             data=self.exp.lookup_data(),
         )

--- a/ax/adapter/transforms/tests/test_trial_as_task_transform.py
+++ b/ax/adapter/transforms/tests/test_trial_as_task_transform.py
@@ -26,7 +26,7 @@ class TrialAsTaskTransformTest(TestCase):
         self.exp = get_branin_experiment(with_status_quo=True, with_batch=True)
         self.adapter = Adapter(
             search_space=self.exp.search_space,
-            model=Generator(),
+            generator=Generator(),
             experiment=self.exp,
         )
         self.exp.new_batch_trial().add_arm(
@@ -257,7 +257,7 @@ class TrialAsTaskTransformTest(TestCase):
         exp.new_trial().add_arm(Arm(parameters={"x": 1}))
         adapter = Adapter(
             search_space=exp.search_space,
-            model=Generator(),
+            generator=Generator(),
             experiment=exp,
         )
         training_obs = self.training_obs[:1]
@@ -285,7 +285,7 @@ class TrialAsTaskTransformTest(TestCase):
         exp.new_trial().add_arm(Arm(parameters={"x": 2}))
         adapter = Adapter(
             search_space=exp.search_space,
-            model=Generator(),
+            generator=Generator(),
             experiment=exp,
         )
         training_obs = self.training_obs[:1]

--- a/ax/adapter/transforms/tests/test_winsorize_transform.py
+++ b/ax/adapter/transforms/tests/test_winsorize_transform.py
@@ -588,7 +588,7 @@ class WinsorizeTransformTest(TestCase):
         )
         adapter = Adapter(
             experiment=Experiment(search_space=search_space),
-            model=Generator(),
+            generator=Generator(),
             transforms=[],
             data=Data(),
             optimization_config=oc,
@@ -608,7 +608,7 @@ class WinsorizeTransformTest(TestCase):
                 search_space=search_space,
                 status_quo=Arm(parameters={"x": 2.0, "y": 10.0}, name="1_1"),
             ),
-            model=Generator(),
+            generator=Generator(),
             transforms=[],
             data=Data(),
             optimization_config=oc,
@@ -700,6 +700,6 @@ def _wrap_optimization_config_in_adapter(
 ) -> Adapter:
     return Adapter(
         experiment=Experiment(search_space=SearchSpace(parameters=[])),
-        model=Generator(),
+        generator=Generator(),
         optimization_config=optimization_config,
     )

--- a/ax/analysis/healthcheck/regression_detection_utils.py
+++ b/ax/analysis/healthcheck/regression_detection_utils.py
@@ -105,7 +105,7 @@ def compute_regression_probabilities_single_trial(
         experiment=experiment,
         search_space=experiment.search_space,
         data=target_data,
-        model=EBAshr(),
+        generator=EBAshr(),
         transforms=rel_EB_ashr_trans,
         optimization_config=experiment.optimization_config,
     )
@@ -122,7 +122,7 @@ def compute_regression_probabilities_single_trial(
     b = np.array([abs(size_thresholds[metric]) for metric in metric_names])
 
     _, regression_probabilities = assert_is_instance(
-        adapter.model, EBAshr
+        adapter.generator, EBAshr
     )._get_regression_indicator(
         objective_weights=np.zeros(len(metric_names)), outcome_constraints=(A, b)
     )

--- a/ax/benchmark/problems/surrogate/lcbench/transfer_learning.py
+++ b/ax/benchmark/problems/surrogate/lcbench/transfer_learning.py
@@ -126,17 +126,17 @@ def get_lcbench_benchmark_problem(
         """
         # We load the model hyperparameters from the saved state dict.
         with skip_fit_gpytorch_mll_context_manager():
-            mb = Generators.BOTORCH_MODULAR(
+            adapter = Generators.BOTORCH_MODULAR(
                 surrogate=get_lcbench_surrogate(),
                 experiment=obj["experiment"],
                 search_space=obj["experiment"].search_space,
                 data=obj["data"],
                 transforms=Cont_X_trans + Y_trans,
             )
-        assert_is_instance(mb.model, BoTorchGenerator).surrogate.model.load_state_dict(
-            obj["state_dict"]
-        )
-        return assert_is_instance(mb, TorchAdapter)
+        assert_is_instance(
+            adapter.generator, BoTorchGenerator
+        ).surrogate.model.load_state_dict(obj["state_dict"])
+        return assert_is_instance(adapter, TorchAdapter)
 
     name = f"LCBench_Surrogate_{dataset_name}:v1"
 

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -528,7 +528,7 @@ def get_transform_helper_model(
         experiment=experiment,
         search_space=experiment.search_space,
         data=data,
-        model=TorchGenerator(),
+        generator=TorchGenerator(),
         transforms=transforms,
         transform_configs={"MapKeyToFloat": {"default_log_scale": False}},
         data_loader_config=DataLoaderConfig(

--- a/ax/generation_strategy/tests/test_dispatch_utils.py
+++ b/ax/generation_strategy/tests/test_dispatch_utils.py
@@ -411,7 +411,8 @@ class TestDispatchUtils(TestCase):
         sobol.gen(experiment=get_experiment(), n=1)
         # First model is actually an adapter, second is the Sobol engine.
         self.assertEqual(
-            assert_is_instance(none_throws(sobol.model).model, SobolGenerator).seed, 9
+            assert_is_instance(none_throws(sobol.model).generator, SobolGenerator).seed,
+            9,
         )
 
         with self.subTest("warns if use_saasbo is true"):

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -581,7 +581,7 @@ class TestGenerationStrategy(TestCase):
                 ms = none_throws(g._model_state_after_gen).copy()
                 # Compare the model state to Sobol state.
                 sobol_model = assert_is_instance(
-                    none_throws(gs.model).model, SobolGenerator
+                    none_throws(gs.model).generator, SobolGenerator
                 )
                 # Replace expected seed with the one generated in __init__.
                 expected_seed = sobol_model.seed
@@ -678,8 +678,11 @@ class TestGenerationStrategy(TestCase):
         )
         exp = get_branin_experiment()
         gs.gen(exp)
-        # pyre-fixme[16]: Optional type has no attribute `model`.
-        self.assertFalse(gs._model.model.scramble)
+        self.assertFalse(
+            assert_is_instance(
+                none_throws(gs._model).generator, SobolGenerator
+            ).scramble
+        )
 
     def test_sobol_MBM_strategy_batches(self) -> None:
         mock_MBM_gen = self.mock_torch_adapter.return_value.gen
@@ -714,7 +717,7 @@ class TestGenerationStrategy(TestCase):
         def get_sobol(experiment: Experiment) -> RandomAdapter:
             return RandomAdapter(
                 experiment=experiment,
-                model=SobolGenerator(),
+                generator=SobolGenerator(),
                 transforms=Cont_X_trans,
             )
 
@@ -1569,7 +1572,7 @@ class TestGenerationStrategy(TestCase):
                 ms = none_throws(g._model_state_after_gen).copy()
                 # Compare the model state to Sobol state.
                 sobol_model = assert_is_instance(
-                    none_throws(self.sobol_MBM_GS_nodes.model).model, SobolGenerator
+                    none_throws(self.sobol_MBM_GS_nodes.model).generator, SobolGenerator
                 )
                 # Replace expected seed with the one generated in __init__.
                 expected_seed = sobol_model.seed

--- a/ax/generation_strategy/tests/test_model_spec.py
+++ b/ax/generation_strategy/tests/test_model_spec.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock, Mock, patch
 from ax.adapter.adapter_utils import extract_search_space_digest
 from ax.adapter.factory import get_sobol
 from ax.adapter.registry import Generators
-
 from ax.core.observation import ObservationFeatures
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.model_spec import (
@@ -66,7 +65,7 @@ class GeneratorSpecTest(BaseGeneratorSpecTest):
             ms.fit(experiment=self.experiment, data=self.data)
         mock_logger.debug.assert_called_with(
             "The observations are identical to the last set of observations "
-            "used to fit the model. Skipping model fitting."
+            "used to fit the generator. Skipping generator fitting."
         )
         wrapped_extract_ssd.assert_called_once()
 

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -337,7 +337,7 @@ def get_tensor_converter_model(experiment: Experiment, data: Data) -> TorchAdapt
         experiment=experiment,
         search_space=to_nonrobust_search_space(experiment.search_space),
         data=data,
-        model=TorchGenerator(),
+        generator=TorchGenerator(),
         transforms=[SearchSpaceToFloat],
         data_loader_config=DataLoaderConfig(
             fit_out_of_design=True,

--- a/ax/plot/tests/test_feature_importances.py
+++ b/ax/plot/tests/test_feature_importances.py
@@ -48,7 +48,7 @@ def get_sensitivity_values(ax_model: Adapter) -> dict:
 
     Returns map {'metric_name': {'parameter_name': sensitivity_value}}
     """
-    generator = assert_is_instance(ax_model.model, LegacyBoTorchGenerator)
+    generator = assert_is_instance(ax_model.generator, LegacyBoTorchGenerator)
     if hasattr(generator.model.covar_module, "outputscale"):
         # pyre-ignore [16]: Covar modules are difficult to type.
         ls = generator.model.covar_module.base_kernel.lengthscale.squeeze()

--- a/ax/plot/tests/test_tile_fitted.py
+++ b/ax/plot/tests/test_tile_fitted.py
@@ -55,7 +55,9 @@ def get_adapter(
         if status_quo_name is not None
         else None,
     )
-    adapter = Adapter(experiment=exp, model=FullFactorialGenerator(), data=get_data())
+    adapter = Adapter(
+        experiment=exp, generator=FullFactorialGenerator(), data=get_data()
+    )
     adapter._predict = mock.MagicMock(
         "ax.adapter.base.Adapter._predict",
         autospec=True,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -2527,7 +2527,7 @@ class TestAxClient(TestCase):
         # This overwrites the `predict` call to return the original observations,
         # while testing the rest of the code as if we're using predictions.
         # pyre-fixme[16]: `Optional` has no attribute `model`.
-        model = ax_client.generation_strategy.model.model
+        model = ax_client.generation_strategy.model.generator
         ys = model.surrogate.training_data[0].Y
         with patch.object(
             model, "predict", return_value=(ys, torch.zeros(*ys.shape, ys.shape[-1]))

--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -345,7 +345,7 @@ class TestManagedLoop(TestCase):
             random_seed=12345,
         )
         # pyre-fixme[16]: Optional type has no attribute `model`.
-        self.assertEqual(12345, model.model.seed)
+        self.assertEqual(12345, model.generator.seed)
 
     def test_optimize_search_space_exhausted(self) -> None:
         """Tests optimization as a single call."""

--- a/ax/utils/sensitivity/sobol_measures.py
+++ b/ax/utils/sensitivity/sobol_measures.py
@@ -949,7 +949,7 @@ def _get_generator_and_digest(
         raise NotImplementedError(
             f"{type(adapter)=}, but only TorchAdapter is supported."
         )
-    generator = adapter.model
+    generator = adapter.generator
     if not isinstance(generator, (LegacyBoTorchGenerator, ModularBoTorchGenerator)):
         raise NotImplementedError(
             f"{type(generator)=}, but only LegacyBoTorchGenerator and "
@@ -972,7 +972,7 @@ def _get_model_per_metric(
             if gp_model.num_outputs == 1:  # can accept single output models
                 return [gp_model for _ in model_idx]
             raise NotImplementedError(
-                f"type(adapter.model.model) = {type(gp_model)}, "
+                f"type(adapter.generator.model) = {type(gp_model)}, "
                 "but only ModelList is supported."
             )
         return [gp_model.models[i] for i in model_idx]

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -99,7 +99,9 @@ def get_soo_surrogate_test_function(lazy: bool = True) -> SurrogateTestFunction:
     surrogate = TorchAdapter(
         experiment=experiment,
         search_space=experiment.search_space,
-        model=BoTorchGenerator(surrogate=Surrogate(botorch_model_class=SingleTaskGP)),
+        generator=BoTorchGenerator(
+            surrogate=Surrogate(botorch_model_class=SingleTaskGP)
+        ),
         data=experiment.lookup_data(),
         transforms=[],
     )
@@ -141,7 +143,9 @@ def get_moo_surrogate() -> BenchmarkProblem:
     surrogate = TorchAdapter(
         experiment=experiment,
         search_space=experiment.search_space,
-        model=BoTorchGenerator(surrogate=Surrogate(botorch_model_class=SingleTaskGP)),
+        generator=BoTorchGenerator(
+            surrogate=Surrogate(botorch_model_class=SingleTaskGP)
+        ),
         data=experiment.lookup_data(),
         transforms=[],
     )


### PR DESCRIPTION
Summary:
Renames the input & the attribute and updates the docstrings where "generator" term seemed more appropriate.

There are many other methods and attributes with `model` in their name. I'll tackle them in separate diffs to keep both diff authoring and review manageable. The term "model" was very overloaded, so renaming it to "generator" requires quite a bit of care.

Differential Revision: D75173850
