### PR TITLE
Make it possible to disable the use of qLogProbabilityOfFeasibility

### DIFF
--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -37,6 +37,7 @@ from ax.utils.common.constants import Keys
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.input_constructors import get_acqf_input_constructor
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
+from botorch.acquisition.logei import qLogProbabilityOfFeasibility
 from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
 from botorch.acquisition.risk_measures import RiskMeasureMCObjective
 from botorch.exceptions.errors import InputDataError
@@ -279,6 +280,8 @@ class Acquisition(Base):
         else:
             training_data = dict(zip(none_throws(surrogate._outcomes), training_data))
 
+        if botorch_acqf_class == qLogProbabilityOfFeasibility:
+            input_constructor_kwargs.pop("objective")
         acqf_inputs = input_constructor(
             training_data=training_data,
             bounds=search_space_digest.bounds,

--- a/ax/generators/torch/botorch_modular/generator.py
+++ b/ax/generators/torch/botorch_modular/generator.py
@@ -74,6 +74,8 @@ class BoTorchGenerator(TorchGenerator, Base):
             scratch on refit. NOTE: This setting is ignored during
             ``cross_validate`` if ``refit_on_cv`` is False. This is also used in
             Surrogate.model_selection.
+        use_p_feasible: Whether we consider dispatching to
+            ``qLogProbabilityOfFeasibility`` in ``choose_botorch_acqf_class``.
     """
 
     acquisition_class: type[Acquisition]
@@ -96,6 +98,7 @@ class BoTorchGenerator(TorchGenerator, Base):
         botorch_acqf_class: type[AcquisitionFunction] | None = None,
         refit_on_cv: bool = False,
         warm_start_refit: bool = True,
+        use_p_feasible: bool = True,
     ) -> None:
         # Check that only one surrogate related option is provided.
         if bool(surrogate_spec) + bool(surrogate_specs) + bool(surrogate) > 1:
@@ -128,6 +131,7 @@ class BoTorchGenerator(TorchGenerator, Base):
 
         self.refit_on_cv = refit_on_cv
         self.warm_start_refit = warm_start_refit
+        self.use_p_feasible = use_p_feasible
 
     @property
     def surrogate(self) -> Surrogate:
@@ -411,7 +415,9 @@ class BoTorchGenerator(TorchGenerator, Base):
                     "`botorch_acqf_class` as part of `model_kwargs`."
                 )
             self._botorch_acqf_class = choose_botorch_acqf_class(
-                torch_opt_config=torch_opt_config, datasets=self.surrogate.training_data
+                torch_opt_config=torch_opt_config,
+                datasets=self.surrogate.training_data,
+                use_p_feasible=self.use_p_feasible,
             )
 
         return self.acquisition_class(

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -285,12 +285,15 @@ def choose_model_class(
 def choose_botorch_acqf_class(
     torch_opt_config: TorchOptConfig,
     datasets: Sequence[SupervisedDataset] | None,
+    use_p_feasible: bool = True,
 ) -> type[AcquisitionFunction]:
     """Chooses the most suitable BoTorch `AcquisitionFunction` class.
 
     Args:
         torch_opt_config: The torch optimization config.
         datasets: The datasets that were used to fit the model.
+        use_p_feasible: Whether we dispatch to `qLogProbabilityOfFeasibility` when
+            there are no feasible points in the training data.
 
     Returns:
         A BoTorch `AcquisitionFunction` class. The current logic chooses between:
@@ -300,8 +303,13 @@ def choose_botorch_acqf_class(
             - `qLogNoisyExpectedHypervolumeImprovement`` for multi-objective
                 optimization.
     """
+
     # Check if the training data is feasible.
-    if torch_opt_config.outcome_constraints is not None and datasets is not None:
+    if (
+        use_p_feasible
+        and torch_opt_config.outcome_constraints is not None
+        and datasets is not None
+    ):
         con_tfs = (
             get_outcome_constraint_transforms(torch_opt_config.outcome_constraints)
             or []

--- a/ax/generators/torch/tests/test_model.py
+++ b/ax/generators/torch/tests/test_model.py
@@ -840,6 +840,28 @@ class BoTorchGeneratorTest(TestCase):
             mock_choose_botorch_acqf_class.assert_called()
             mock_choose_botorch_acqf_class.reset_mock()
             self.assertEqual(points.shape, torch.Size([1]))
+            # Setting use_p_feasible to False should turn off pFeas
+            model = BoTorchGenerator(
+                surrogate=self.surrogate,
+                acquisition_class=Acquisition,
+                acquisition_options=self.acquisition_options,
+                use_p_feasible=False,
+            )
+            model.surrogate.fit(
+                datasets=datasets,
+                search_space_digest=self.search_space_digest,
+            )
+            gen_results = model.gen(
+                n=1,
+                search_space_digest=self.search_space_digest,
+                torch_opt_config=torch_opt_config,
+            )
+            self.assertEqual(
+                model._botorch_acqf_class,
+                qLogNoisyExpectedHypervolumeImprovement
+                if torch_opt_config.is_moo
+                else qLogNoisyExpectedImprovement,
+            )
 
     @mock_botorch_optimize
     def test_surrogate_model_options_propagation(self) -> None:

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -173,7 +173,8 @@ class BoTorchGeneratorUtilsTest(TestCase):
                 torch_opt_config=TorchOptConfig(
                     objective_weights=torch.tensor([1.0, 0.0]),
                     is_moo=False,
-                )
+                ),
+                datasets=self.supervised_dataset,
             ),
         )
         self.assertEqual(
@@ -182,7 +183,8 @@ class BoTorchGeneratorUtilsTest(TestCase):
                 torch_opt_config=TorchOptConfig(
                     objective_weights=torch.tensor([1.0, -1.0]),
                     is_moo=True,
-                )
+                ),
+                datasets=self.supervised_dataset,
             ),
         )
 


### PR DESCRIPTION
Summary: This diff makes it possible to turn off dispatching to `qLogProbabilityOfFeasibility`.

Differential Revision: D75167341


