### PR TITLE
Support accessing the current generation node in ESS

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -569,7 +569,9 @@ class Client(WithDBSettingsBase):
         es_response = none_throws(
             self._early_stopping_strategy_or_choose()
         ).should_stop_trials_early(
-            trial_indices={trial_index}, experiment=self._experiment
+            trial_indices={trial_index},
+            experiment=self._experiment,
+            current_node=self._generation_strategy_or_choose()._curr,
         )
 
         # TODO[mpolson64]: log the returned reason for stopping the trial

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -30,6 +30,7 @@ from ax.core.map_metric import MapMetric
 from ax.core.objective import MultiObjective
 from ax.core.trial_status import TrialStatus
 from ax.early_stopping.utils import estimate_early_stopping_savings
+from ax.generation_strategy.generation_node import GenerationNode
 from ax.generators.torch_base import TorchGenerator
 from ax.utils.common.base import Base
 from ax.utils.common.logger import get_logger
@@ -109,6 +110,7 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         self,
         trial_indices: set[int],
         experiment: Experiment,
+        current_node: GenerationNode | None = None,
     ) -> dict[int, str | None]:
         """Decide whether to complete trials before evaluation is fully concluded.
 
@@ -118,6 +120,10 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         Args:
             trial_indices: Indices of candidate trials to stop early.
             experiment: Experiment that contains the trials and other contextual data.
+            current_node: The current ``GenerationNode`` on the ``GenerationStrategy``
+                used to generate trials for the ``Experiment``. Early stopping
+                strategies may utilize components of the current node when making
+                stopping decisions.
 
         Returns:
             A dictionary mapping trial indices that should be early stopped to

--- a/ax/early_stopping/strategies/logical.py
+++ b/ax/early_stopping/strategies/logical.py
@@ -7,11 +7,11 @@
 
 from collections.abc import Sequence
 from functools import reduce
-from typing import Any
 
 from ax.core.experiment import Experiment
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.exceptions.core import UserInputError
+from ax.generation_strategy.generation_node import GenerationNode
 
 
 class LogicalEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
@@ -31,13 +31,17 @@ class AndEarlyStoppingStrategy(LogicalEarlyStoppingStrategy):
         self,
         trial_indices: set[int],
         experiment: Experiment,
-        **kwargs: dict[str, Any],
+        current_node: GenerationNode | None = None,
     ) -> dict[int, str | None]:
         left = self.left.should_stop_trials_early(
-            trial_indices=trial_indices, experiment=experiment, **kwargs
+            trial_indices=trial_indices,
+            experiment=experiment,
+            current_node=current_node,
         )
         right = self.right.should_stop_trials_early(
-            trial_indices=trial_indices, experiment=experiment, **kwargs
+            trial_indices=trial_indices,
+            experiment=experiment,
+            current_node=current_node,
         )
         return {
             trial: f"{left[trial]}, {right[trial]}" for trial in left if trial in right
@@ -63,13 +67,17 @@ class OrEarlyStoppingStrategy(LogicalEarlyStoppingStrategy):
         self,
         trial_indices: set[int],
         experiment: Experiment,
-        **kwargs: dict[str, Any],
+        current_node: GenerationNode | None = None,
     ) -> dict[int, str | None]:
         return {
             **self.left.should_stop_trials_early(
-                trial_indices=trial_indices, experiment=experiment, **kwargs
+                trial_indices=trial_indices,
+                experiment=experiment,
+                current_node=current_node,
             ),
             **self.right.should_stop_trials_early(
-                trial_indices=trial_indices, experiment=experiment, **kwargs
+                trial_indices=trial_indices,
+                experiment=experiment,
+                current_node=current_node,
             ),
         }

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -15,6 +15,7 @@ from ax.core.experiment import Experiment
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.early_stopping.utils import align_partial_results
 from ax.exceptions.core import UnsupportedError
+from ax.generation_strategy.generation_node import GenerationNode
 from ax.utils.common.logger import get_logger
 from pyre_extensions import none_throws
 
@@ -88,6 +89,7 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         self,
         trial_indices: set[int],
         experiment: Experiment,
+        current_node: GenerationNode | None = None,
     ) -> dict[int, str | None]:
         """Stop a trial if its performance is in the bottom `percentile_threshold`
         of the trials at the same step.
@@ -95,6 +97,10 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         Args:
             trial_indices: Indices of candidate trials to consider for early stopping.
             experiment: Experiment that contains the trials and other contextual data.
+            current_node: The current ``GenerationNode`` on the ``GenerationStrategy``
+                used to generate trials for the ``Experiment``. Early stopping
+                strategies may utilize components of the current node when making
+                stopping decisions.
 
         Returns:
             A dictionary mapping trial indices that should be early stopped to

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -13,6 +13,7 @@ import pandas as pd
 from ax.core.experiment import Experiment
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.exceptions.core import UnsupportedError
+from ax.generation_strategy.generation_node import GenerationNode
 from ax.utils.common.logger import get_logger
 
 logger: Logger = get_logger(__name__)
@@ -80,6 +81,7 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         self,
         trial_indices: set[int],
         experiment: Experiment,
+        current_node: GenerationNode | None = None,
     ) -> dict[int, str | None]:
         """Stop a trial if its performance doesn't reach a pre-specified threshold
         by `min_progression`.
@@ -87,6 +89,10 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         Args:
             trial_indices: Indices of candidate trials to consider for early stopping.
             experiment: Experiment that contains the trials and other contextual data.
+            current_node: The current ``GenerationNode`` on the ``GenerationStrategy``
+                used to generate trials for the ``Experiment``. Early stopping
+                strategies may utilize components of the current node when making
+                stopping decisions.
 
         Returns:
             A dictionary mapping trial indices that should be early stopped to

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1316,6 +1316,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             early_stopping_strategy=self._early_stopping_strategy,
             trial_indices=trial_indices,
             experiment=self.experiment,
+            current_node=self.generation_strategy._curr,
         )
 
     def stop_trial_early(self, trial_index: int) -> None:

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -31,7 +31,6 @@ from ax.core.multi_type_experiment import (
 )
 from ax.core.runner import Runner
 from ax.core.utils import get_pending_observation_features_based_on_trial_status
-
 from ax.exceptions.core import (
     AxError,
     DataRequiredError,
@@ -1209,6 +1208,7 @@ class Scheduler(AnalysisBase, BestPointMixin):
             early_stopping_strategy=self.options.early_stopping_strategy,
             trial_indices=self.running_trial_indices,
             experiment=self.experiment,
+            current_node=self.generation_strategy._curr,
         )
         self.experiment.stop_trial_runs(
             trials=[self.experiment.trials[trial_idx] for trial_idx in stop_trial_info],

--- a/ax/service/tests/test_early_stopping.py
+++ b/ax/service/tests/test_early_stopping.py
@@ -29,8 +29,7 @@ class TestEarlyStoppingUtils(TestCase):
         }
         actual = early_stopping_utils.should_stop_trials_early(
             early_stopping_strategy=DummyEarlyStoppingStrategy(expected),
-            # pyre-fixme[6]: For 2nd param expected `Set[int]` but got `List[int]`.
-            trial_indices=[1, 2, 3],
+            trial_indices={1, 2, 3},
             experiment=self.branin_experiment,
         )
         self.assertEqual(actual, expected)
@@ -38,8 +37,7 @@ class TestEarlyStoppingUtils(TestCase):
     def test_should_stop_trials_early_no_strategy(self) -> None:
         actual = early_stopping_utils.should_stop_trials_early(
             early_stopping_strategy=None,
-            # pyre-fixme[6]: For 2nd param expected `Set[int]` but got `List[int]`.
-            trial_indices=[1, 2, 3],
+            trial_indices={1, 2, 3},
             experiment=self.branin_experiment,
         )
         expected = {}

--- a/ax/service/tests/test_scheduler.py
+++ b/ax/service/tests/test_scheduler.py
@@ -46,6 +46,7 @@ from ax.exceptions.core import (
 from ax.exceptions.generation_strategy import AxGenerationException
 from ax.generation_strategy.dispatch_utils import choose_generation_strategy_legacy
 from ax.generation_strategy.generation_strategy import (
+    GenerationNode,
     GenerationStep,
     GenerationStrategy,
 )
@@ -1180,7 +1181,7 @@ class TestAxScheduler(TestCase):
                 self,
                 trial_indices: set[int],
                 experiment: Experiment,
-                **kwargs: dict[str, Any],
+                current_node: GenerationNode | None = None,
             ) -> dict[int, str | None]:
                 # Make sure that we can lookup data for the trial,
                 # even though we won't use it in this dummy strategy

--- a/ax/service/utils/early_stopping.py
+++ b/ax/service/utils/early_stopping.py
@@ -8,6 +8,7 @@
 
 from ax.core.experiment import Experiment
 from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
+from ax.generation_strategy.generation_node import GenerationNode
 from pyre_extensions import none_throws
 
 
@@ -15,6 +16,7 @@ def should_stop_trials_early(
     early_stopping_strategy: BaseEarlyStoppingStrategy | None,
     trial_indices: set[int],
     experiment: Experiment,
+    current_node: GenerationNode | None = None,
 ) -> dict[int, str | None]:
     """Evaluate whether to early-stop running trials.
 
@@ -23,7 +25,10 @@ def should_stop_trials_early(
             whether a trial should be stopped given the state of an experiment.
         trial_indices: Indices of trials to consider for early stopping.
         experiment: The experiment containing the trials.
-
+        current_node: The current ``GenerationNode`` on the ``GenerationStrategy``
+            used to generate trials for the ``Experiment``. Early stopping
+            strategies may utilize components of the current node when making
+            stopping decisions.
     Returns:
         A dictionary mapping trial indices that should be early stopped to
         (optional) messages with the associated reason.
@@ -33,7 +38,9 @@ def should_stop_trials_early(
 
     early_stopping_strategy = none_throws(early_stopping_strategy)
     return early_stopping_strategy.should_stop_trials_early(
-        trial_indices=trial_indices, experiment=experiment
+        trial_indices=trial_indices,
+        experiment=experiment,
+        current_node=current_node,
     )
 
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2641,7 +2641,7 @@ class DummyEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         self,
         trial_indices: set[int],
         experiment: Experiment,
-        **kwargs: dict[str, Any],
+        current_node: GenerationNode | None = None,
     ) -> dict[int, str | None]:
         return self.early_stop_trials
 


### PR DESCRIPTION
Summary:
This diff allows the early stopping strategies to access the current generation node and the underlying components when making early stopping decisions. This can be useful if we want to utilize the surrogate model for early stopping, as it will allow us to access it directly without having to re-fit.

NOTE: Opted to go for current node here rather than the full `GenerationStrategy`. There has been discussions around merging ESS into GS, and using GNode here avoids the need for a refactor to avoid cyclical dependencies if we decide to go with that refactor.

Differential Revision: D75097822


