### PR TITLE
Remove deprecated surrogate_specs input

### DIFF
--- a/ax/generators/torch/botorch_modular/generator.py
+++ b/ax/generators/torch/botorch_modular/generator.py
@@ -7,9 +7,8 @@
 # pyre-strict
 
 import dataclasses
-import warnings
 from collections import OrderedDict
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Any
 
 import numpy.typing as npt
@@ -91,7 +90,6 @@ class BoTorchGenerator(TorchGenerator, Base):
     def __init__(
         self,
         surrogate_spec: SurrogateSpec | None = None,
-        surrogate_specs: Mapping[str, SurrogateSpec] | None = None,
         surrogate: Surrogate | None = None,
         acquisition_class: type[Acquisition] | None = None,
         acquisition_options: dict[str, Any] | None = None,
@@ -101,26 +99,11 @@ class BoTorchGenerator(TorchGenerator, Base):
         use_p_feasible: bool = True,
     ) -> None:
         # Check that only one surrogate related option is provided.
-        if bool(surrogate_spec) + bool(surrogate_specs) + bool(surrogate) > 1:
+        if surrogate_spec is not None and surrogate is not None:
             raise UserInputError(
-                "Only one of `surrogate_spec`, `surrogate_specs`, and `surrogate` "
+                "Only one of `surrogate_spec` or `surrogate` "
                 "can be specified. Please use `surrogate_spec`."
             )
-        if surrogate_specs is not None:
-            if len(surrogate_specs) > 1:
-                raise DeprecationWarning(
-                    "Support for multiple `Surrogate`s has been deprecated. "
-                    "Please use the `surrogate_spec` input in the future to "
-                    "specify a single `Surrogate`."
-                )
-            warnings.warn(
-                "The `surrogate_specs` argument is deprecated in favor of "
-                "`surrogate_spec`, which accepts a single `SurrogateSpec` object. "
-                "Please use `surrogate_spec` in the future.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            surrogate_spec = next(iter(surrogate_specs.values()))
         self.surrogate_spec = surrogate_spec
         self._surrogate = surrogate
 

--- a/ax/generators/torch/tests/test_model.py
+++ b/ax/generators/torch/tests/test_model.py
@@ -373,25 +373,6 @@ class BoTorchGeneratorTest(TestCase):
             self.model.predict(X=self.X_test, use_posterior_predictive=True)
         mock_predict.assert_called_with(X=self.X_test, use_posterior_predictive=True)
 
-    def test_with_surrogate_specs_input(self) -> None:
-        spec1 = SurrogateSpec(
-            botorch_model_class=SingleTaskGP,
-            outcomes=["y1", "y3"],
-        )
-        surrogate_specs = {
-            "Vanilla": spec1,
-            "Bayesian": SurrogateSpec(
-                botorch_model_class=SaasFullyBayesianSingleTaskGP,
-                outcomes=["y2"],
-            ),
-        }
-        with self.assertRaisesRegex(DeprecationWarning, "Support for multiple"):
-            BoTorchGenerator(surrogate_specs=surrogate_specs)
-
-        with self.assertWarnsRegex(DeprecationWarning, "surrogate_specs"):
-            model = BoTorchGenerator(surrogate_specs={"s": spec1})
-        self.assertIs(model.surrogate_spec, spec1)
-
     @mock_botorch_optimize
     def test_cross_validate(self) -> None:
         self.model.fit(

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -74,7 +74,6 @@ from ax.utils.testing.core_stubs import (
     get_botorch_model,
     get_botorch_model_with_default_acquisition_class,
     get_botorch_model_with_surrogate_spec,
-    get_botorch_model_with_surrogate_specs,
     get_branin_data,
     get_branin_experiment,
     get_branin_experiment_with_timestamp_map_metric,
@@ -176,7 +175,6 @@ TEST_CASES = [
     ("BoTorchGenerator", get_botorch_model),
     ("BoTorchGenerator", get_botorch_model_with_default_acquisition_class),
     ("BoTorchGenerator", get_botorch_model_with_surrogate_spec),
-    ("BoTorchGenerator", get_botorch_model_with_surrogate_specs),
     ("BraninMetric", get_branin_metric),
     ("CenterGenerationNode", partial(CenterGenerationNode, next_node_name="SOBOL")),
     ("ChainedInputTransform", get_chained_input_transform),
@@ -1029,8 +1027,9 @@ class JSONStoreTest(TestCase):
             "refit_on_cv": False,
             "warm_start_refit": True,
         }
-        expected_object = get_botorch_model_with_surrogate_spec()
+        expected_object = get_botorch_model_with_surrogate_spec(with_covar_module=False)
         expected_object.surrogate_spec.model_configs[0].input_transform_classes = None
+        expected_object.surrogate_spec.model_configs[0].name = "from deprecated args"
         # The new default value is None; we need to manually set it to the old value
         self.assertIsNone(
             none_throws(expected_object.surrogate_spec).model_configs[0].mll_class

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -10,7 +10,6 @@
 from __future__ import annotations
 
 import itertools
-
 from collections import OrderedDict
 from collections.abc import Iterable, MutableMapping
 from datetime import datetime, timedelta
@@ -2736,26 +2735,20 @@ def get_botorch_model_with_default_acquisition_class() -> BoTorchGenerator:
     )
 
 
-def get_botorch_model_with_surrogate_specs() -> BoTorchGenerator:
-    return BoTorchGenerator(
-        surrogate_specs={
-            "name": SurrogateSpec(
-                model_configs=[
-                    ModelConfig(
-                        model_options={"some_option": "some_value"},
-                        covar_module_class=DefaultRBFKernel,
-                        covar_module_options={"inactive_features": []},
-                    )
-                ]
-            )
-        }
-    )
-
-
-def get_botorch_model_with_surrogate_spec() -> BoTorchGenerator:
-    return BoTorchGenerator(
-        surrogate_spec=SurrogateSpec(botorch_model_kwargs={"some_option": "some_value"})
-    )
+def get_botorch_model_with_surrogate_spec(
+    with_covar_module: bool = True,
+) -> BoTorchGenerator:
+    if with_covar_module:
+        config = ModelConfig(
+            model_options={"some_option": "some_value"},
+            covar_module_class=DefaultRBFKernel,
+            covar_module_options={"inactive_features": []},
+        )
+    else:
+        config = ModelConfig(
+            model_options={"some_option": "some_value"},
+        )
+    return BoTorchGenerator(surrogate_spec=SurrogateSpec(model_configs=[config]))
 
 
 def get_surrogate() -> Surrogate:


### PR DESCRIPTION
Summary:
This has been deprecated ~9 months ago, time to clean it up.

Updated the decoder to discard `surrogate_specs` input with multiple entries, after logging an exception. Previously, it would be loaded for it to error out during runtime if used.

Reviewed By: Balandat

Differential Revision: D75530170


