### PR TITLE
Replace usage of deprecated inputs with ModelConfig

### DIFF
--- a/ax/adapter/registry.py
+++ b/ax/adapter/registry.py
@@ -47,7 +47,6 @@ from ax.adapter.transforms.task_encode import TaskChoiceToIntTaskChoice
 from ax.adapter.transforms.transform_to_new_sq import TransformToNewSQ
 from ax.adapter.transforms.trial_as_task import TrialAsTask
 from ax.adapter.transforms.unit_x import UnitX
-
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
@@ -64,7 +63,7 @@ from ax.generators.torch.botorch import LegacyBoTorchGenerator
 from ax.generators.torch.botorch_modular.generator import (
     BoTorchGenerator as ModularBoTorchGenerator,
 )
-from ax.generators.torch.botorch_modular.surrogate import SurrogateSpec
+from ax.generators.torch.botorch_modular.surrogate import ModelConfig, SurrogateSpec
 from ax.generators.torch.cbo_sac import SACBO
 from ax.utils.common.kwargs import (
     consolidate_kwargs,
@@ -238,7 +237,9 @@ MODEL_KEY_TO_MODEL_SETUP: dict[str, ModelSetup] = {
         transforms=MBM_X_trans + Y_trans,
         default_model_kwargs={
             "surrogate_spec": SurrogateSpec(
-                botorch_model_class=SaasFullyBayesianSingleTaskGP
+                model_configs=[
+                    ModelConfig(botorch_model_class=SaasFullyBayesianSingleTaskGP)
+                ]
             )
         },
     ),
@@ -248,7 +249,9 @@ MODEL_KEY_TO_MODEL_SETUP: dict[str, ModelSetup] = {
         transforms=MBM_MTGP_trans,
         default_model_kwargs={
             "surrogate_spec": SurrogateSpec(
-                botorch_model_class=SaasFullyBayesianMultiTaskGP
+                model_configs=[
+                    ModelConfig(botorch_model_class=SaasFullyBayesianMultiTaskGP)
+                ]
             )
         },
     ),

--- a/ax/adapter/tests/test_pairwise_adapter.py
+++ b/ax/adapter/tests/test_pairwise_adapter.py
@@ -13,7 +13,11 @@ from ax.adapter.pairwise import PairwiseAdapter
 from ax.core import Metric, Objective, OptimizationConfig
 from ax.core.observation import ObservationData, ObservationFeatures
 from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
-from ax.generators.torch.botorch_modular.surrogate import Surrogate
+from ax.generators.torch.botorch_modular.surrogate import (
+    ModelConfig,
+    Surrogate,
+    SurrogateSpec,
+)
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.preference_stubs import get_pbo_experiment
@@ -40,12 +44,18 @@ class PairwiseAdapterTest(TestCase):
     )
     def test_PairwiseAdapter(self) -> None:
         surrogate = Surrogate(
-            botorch_model_class=PairwiseGP,
-            mll_class=PairwiseLaplaceMarginalLogLikelihood,
-            input_transform_classes=[Normalize],
-            input_transform_options={
-                "Normalize": {"d": len(self.experiment.parameters)}
-            },
+            surrogate_spec=SurrogateSpec(
+                model_configs=[
+                    ModelConfig(
+                        botorch_model_class=PairwiseGP,
+                        mll_class=PairwiseLaplaceMarginalLogLikelihood,
+                        input_transform_classes=[Normalize],
+                        input_transform_options={
+                            "Normalize": {"d": len(self.experiment.parameters)}
+                        },
+                    )
+                ]
+            )
         )
 
         cases = [

--- a/ax/adapter/tests/test_registry.py
+++ b/ax/adapter/tests/test_registry.py
@@ -28,7 +28,11 @@ from ax.generators.random.sobol import SobolGenerator
 from ax.generators.torch.botorch_modular.acquisition import Acquisition
 from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
 from ax.generators.torch.botorch_modular.kernels import ScaleMaternKernel
-from ax.generators.torch.botorch_modular.surrogate import Surrogate, SurrogateSpec
+from ax.generators.torch.botorch_modular.surrogate import (
+    ModelConfig,
+    Surrogate,
+    SurrogateSpec,
+)
 from ax.utils.common.kwargs import get_function_argument_names
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -100,7 +104,11 @@ class ModelRegistryTest(TestCase):
         surrogate_spec = generator.surrogate_spec
         self.assertEqual(
             surrogate_spec,
-            SurrogateSpec(botorch_model_class=SaasFullyBayesianSingleTaskGP),
+            SurrogateSpec(
+                model_configs=[
+                    ModelConfig(botorch_model_class=SaasFullyBayesianSingleTaskGP)
+                ]
+            ),
         )
         self.assertEqual(
             generator.surrogate.surrogate_spec.model_configs[0].botorch_model_class,
@@ -323,17 +331,23 @@ class ModelRegistryTest(TestCase):
                 if use_saas
                 else [
                     Surrogate(
-                        botorch_model_class=MultiTaskGP,
-                        mll_class=ExactMarginalLogLikelihood,
-                        covar_module_class=ScaleMaternKernel,
-                        covar_module_options={
-                            "ard_num_dims": DEFAULT,
-                            "lengthscale_prior": GammaPrior(6.0, 3.0),
-                            "outputscale_prior": GammaPrior(2.0, 0.15),
-                            "batch_shape": DEFAULT,
-                        },
-                        allow_batched_models=False,
-                        model_options={},
+                        surrogate_spec=SurrogateSpec(
+                            model_configs=[
+                                ModelConfig(
+                                    botorch_model_class=MultiTaskGP,
+                                    mll_class=ExactMarginalLogLikelihood,
+                                    covar_module_class=ScaleMaternKernel,
+                                    covar_module_options={
+                                        "ard_num_dims": DEFAULT,
+                                        "lengthscale_prior": GammaPrior(6.0, 3.0),
+                                        "outputscale_prior": GammaPrior(2.0, 0.15),
+                                        "batch_shape": DEFAULT,
+                                    },
+                                    model_options={},
+                                )
+                            ],
+                            allow_batched_models=False,
+                        )
                     ),
                     None,
                 ]

--- a/ax/adapter/tests/test_robust_adapter.py
+++ b/ax/adapter/tests/test_robust_adapter.py
@@ -27,7 +27,6 @@ from botorch.acquisition.monte_carlo import qNoisyExpectedImprovement
 from botorch.acquisition.multi_objective.monte_carlo import (
     qNoisyExpectedHypervolumeImprovement,
 )
-from botorch.models.gp_regression import SingleTaskGP
 
 
 class TestRobust(TestCase):
@@ -47,7 +46,7 @@ class TestRobust(TestCase):
             adapter = Generators.BOTORCH_MODULAR(
                 experiment=exp,
                 data=exp.fetch_data(),
-                surrogate=Surrogate(botorch_model_class=SingleTaskGP),
+                surrogate=Surrogate(),
                 botorch_acqf_class=acqf_class or qNoisyExpectedImprovement,
             )
             trial = exp.new_trial(generator_run=adapter.gen(1)).run().mark_completed()

--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -8,11 +8,10 @@
 from typing import Any
 
 from ax.adapter.registry import Generators
-
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.generation_strategy.generation_node import GenerationStep
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from ax.generators.torch.botorch_modular.surrogate import SurrogateSpec
+from ax.generators.torch.botorch_modular.surrogate import ModelConfig, SurrogateSpec
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.analytic import LogExpectedImprovement
 from botorch.acquisition.logei import qLogNoisyExpectedImprovement
@@ -70,7 +69,9 @@ def get_sobol_mbm_generation_strategy(
     """
     model_kwargs: dict[str, type[AcquisitionFunction] | SurrogateSpec | bool] = {
         "botorch_acqf_class": acquisition_cls,
-        "surrogate_spec": SurrogateSpec(botorch_model_class=model_cls),
+        "surrogate_spec": SurrogateSpec(
+            model_configs=[ModelConfig(botorch_model_class=model_cls)]
+        ),
     }
 
     model_name = model_names_abbrevations.get(model_cls.__name__, model_cls.__name__)

--- a/ax/benchmark/problems/surrogate/lcbench/transfer_learning.py
+++ b/ax/benchmark/problems/surrogate/lcbench/transfer_learning.py
@@ -23,7 +23,11 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.exceptions.core import UserInputError
 from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
 from ax.generators.torch.botorch_modular.kernels import ScaleMaternKernel
-from ax.generators.torch.botorch_modular.surrogate import Surrogate
+from ax.generators.torch.botorch_modular.surrogate import (
+    ModelConfig,
+    Surrogate,
+    SurrogateSpec,
+)
 from ax.utils.testing.mock import skip_fit_gpytorch_mll_context_manager
 from botorch.models import SingleTaskGP
 from gpytorch.priors import LogNormalPrior
@@ -67,14 +71,20 @@ def get_lcbench_surrogate() -> Surrogate:
         A Surrogate with the specification used to fit the LCBench data.
     """
     return Surrogate(
-        botorch_model_class=SingleTaskGP,
-        covar_module_class=ScaleMaternKernel,
-        covar_module_options={
-            "nu": 1.5,
-            "ard_num_dims": 7,
-            "outputscale_prior": LogNormalPrior(-3, 0.0025),
-        },
-        input_transform_classes=None,
+        surrogate_spec=SurrogateSpec(
+            model_configs=[
+                ModelConfig(
+                    botorch_model_class=SingleTaskGP,
+                    covar_module_class=ScaleMaternKernel,
+                    covar_module_options={
+                        "nu": 1.5,
+                        "ard_num_dims": 7,
+                        "outputscale_prior": LogNormalPrior(-3, 0.0025),
+                    },
+                    input_transform_classes=None,
+                )
+            ]
+        )
     )
 
 

--- a/ax/generators/torch/tests/test_acquisition.py
+++ b/ax/generators/torch/tests/test_acquisition.py
@@ -49,7 +49,6 @@ from botorch.acquisition.multi_objective.monte_carlo import (
 )
 from botorch.acquisition.objective import LinearMCObjective
 from botorch.exceptions.warnings import OptimizationWarning
-from botorch.models.gp_regression import SingleTaskGP
 from botorch.optim.optimize import (
     optimize_acqf,
     optimize_acqf_discrete,
@@ -111,8 +110,7 @@ class AcquisitionTest(TestCase):
             input_constructor=self.mock_input_constructor,
         )
         self.tkwargs: dict[str, Any] = {"dtype": torch.double}
-        self.botorch_model_class = SingleTaskGP
-        self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
+        self.surrogate = Surrogate()
         self.X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **self.tkwargs)
         self.Y = torch.tensor([[3.0], [4.0]], **self.tkwargs)
         self.Yvar = torch.tensor([[0.0], [2.0]], **self.tkwargs)

--- a/ax/generators/torch/tests/test_model.py
+++ b/ax/generators/torch/tests/test_model.py
@@ -73,8 +73,7 @@ ACQ_OPTIONS: dict[str, SobolQMCNormalSampler] = {
 class BoTorchGeneratorTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.botorch_model_class = SingleTaskGP
-        self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
+        self.surrogate = Surrogate()
         self.acquisition_class = Acquisition
         self.botorch_acqf_class = qExpectedImprovement
         self.acquisition_options = ACQ_OPTIONS
@@ -516,7 +515,11 @@ class BoTorchGeneratorTest(TestCase):
             torch.tensor([2.0]),
             torch.tensor([1.0]),
         )
-        surrogate = Surrogate(botorch_model_class=botorch_model_class)
+        surrogate = Surrogate(
+            surrogate_spec=SurrogateSpec(
+                model_configs=[ModelConfig(botorch_model_class=botorch_model_class)]
+            )
+        )
         model = BoTorchGenerator(
             surrogate=surrogate,
             acquisition_class=Acquisition,
@@ -553,10 +556,6 @@ class BoTorchGeneratorTest(TestCase):
                 search_space_digest=search_space_digest,
                 torch_opt_config=self.torch_opt_config,
             )
-        self.assertEqual(
-            gen_results.gen_metadata["metric_to_model_config_name"],
-            {"y": "from deprecated args"},
-        )
         # Assert acquisition initialized with expected arguments
         mock_init_acqf.assert_called_once_with(
             search_space_digest=search_space_digest,
@@ -655,7 +654,11 @@ class BoTorchGeneratorTest(TestCase):
     @mock_botorch_optimize
     def test_feature_importances(self) -> None:
         for botorch_model_class in [SingleTaskGP, SaasFullyBayesianSingleTaskGP]:
-            surrogate = Surrogate(botorch_model_class=botorch_model_class)
+            surrogate = Surrogate(
+                surrogate_spec=SurrogateSpec(
+                    model_configs=[ModelConfig(botorch_model_class=botorch_model_class)]
+                )
+            )
             model = BoTorchGenerator(
                 surrogate=surrogate,
                 acquisition_class=Acquisition,

--- a/ax/generators/torch/tests/test_sebo.py
+++ b/ax/generators/torch/tests/test_sebo.py
@@ -51,8 +51,7 @@ class TestSebo(TestCase):
     def setUp(self) -> None:
         super().setUp()
         tkwargs: dict[str, Any] = {"dtype": torch.double}
-        self.botorch_model_class = SingleTaskGP
-        self.surrogate = Surrogate(botorch_model_class=self.botorch_model_class)
+        self.surrogate = Surrogate()
         # Function is f(x) = x_1 on [0, 1]^3, target point of [0.5, 0.5, 0.5].
         # Optimal soln is [1.0, 0.5, 0.5]
         self.X = torch.tensor(

--- a/ax/utils/testing/benchmark_stubs.py
+++ b/ax/utils/testing/benchmark_stubs.py
@@ -46,12 +46,10 @@ from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.generation_strategy.external_generation_node import ExternalGenerationNode
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
-from ax.generators.torch.botorch_modular.surrogate import Surrogate
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_branin_experiment_with_multi_objective,
 )
-from botorch.models.gp_regression import SingleTaskGP
 from botorch.test_functions.multi_objective import BraninCurrin
 from botorch.test_functions.synthetic import Branin
 from pyre_extensions import assert_is_instance
@@ -99,9 +97,7 @@ def get_soo_surrogate_test_function(lazy: bool = True) -> SurrogateTestFunction:
     surrogate = TorchAdapter(
         experiment=experiment,
         search_space=experiment.search_space,
-        generator=BoTorchGenerator(
-            surrogate=Surrogate(botorch_model_class=SingleTaskGP)
-        ),
+        generator=BoTorchGenerator(),
         data=experiment.lookup_data(),
         transforms=[],
     )
@@ -143,9 +139,7 @@ def get_moo_surrogate() -> BenchmarkProblem:
     surrogate = TorchAdapter(
         experiment=experiment,
         search_space=experiment.search_space,
-        generator=BoTorchGenerator(
-            surrogate=Surrogate(botorch_model_class=SingleTaskGP)
-        ),
+        generator=BoTorchGenerator(),
         data=experiment.lookup_data(),
         transforms=[],
     )

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2753,33 +2753,47 @@ def get_botorch_model_with_surrogate_spec(
 
 def get_surrogate() -> Surrogate:
     return Surrogate(
-        botorch_model_class=get_model_type(),
-        mll_class=get_mll_type(),
+        surrogate_spec=SurrogateSpec(
+            model_configs=[
+                ModelConfig(
+                    botorch_model_class=get_model_type(),
+                    mll_class=get_mll_type(),
+                )
+            ]
+        )
     )
 
 
 def get_surrogate_spec_with_default() -> SurrogateSpec:
     return SurrogateSpec(
-        botorch_model_class=SingleTaskGP,
-        covar_module_class=ScaleMaternKernel,
-        covar_module_kwargs={
-            "ard_num_dims": DEFAULT,
-            "lengthscale_prior": GammaPrior(6.0, 3.0),
-            "outputscale_prior": GammaPrior(2.0, 0.15),
-            "batch_shape": DEFAULT,
-        },
+        model_configs=[
+            ModelConfig(
+                botorch_model_class=SingleTaskGP,
+                covar_module_class=ScaleMaternKernel,
+                covar_module_options={
+                    "ard_num_dims": DEFAULT,
+                    "lengthscale_prior": GammaPrior(6.0, 3.0),
+                    "outputscale_prior": GammaPrior(2.0, 0.15),
+                    "batch_shape": DEFAULT,
+                },
+            )
+        ]
     )
 
 
 def get_surrogate_spec_with_lognormal() -> SurrogateSpec:
     return SurrogateSpec(
-        botorch_model_class=SingleTaskGP,
-        covar_module_class=RBFKernel,
-        covar_module_kwargs={
-            "ard_num_dims": DEFAULT,
-            "lengthscale_prior": LogNormalPrior(-4.0, 1.0),
-            "batch_shape": DEFAULT,
-        },
+        model_configs=[
+            ModelConfig(
+                botorch_model_class=SingleTaskGP,
+                covar_module_class=RBFKernel,
+                covar_module_options={
+                    "ard_num_dims": DEFAULT,
+                    "lengthscale_prior": LogNormalPrior(-4.0, 1.0),
+                    "batch_shape": DEFAULT,
+                },
+            )
+        ]
     )
 
 


### PR DESCRIPTION
Summary: Replaces the use of deprecated top level inputs to `Surrogate` & `SurrogateSpec` with `ModelConfig`. The top level inputs will be removed in the next diff.

Differential Revision: D75549584


