### PR TITLE
Do not let different transforms in Adapter._transform_data share a SearchSpace instance

### DIFF
--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -329,7 +329,7 @@ class Adapter:
         if transforms is not None:
             for t in transforms:
                 t_instance = t(
-                    search_space=search_space,
+                    search_space=search_space.clone(),
                     observations=observations,
                     adapter=self,
                     config=transform_configs.get(t.__name__, None),

--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -642,7 +642,7 @@ class TorchAdapterTest(TestCase):
             else:
                 expected_X = raw_X
                 expected_Y = raw_Y.unsqueeze(-1)
-            self.assertTrue(torch.equal(dataset.X, expected_X))
+            self.assertTrue(torch.equal(dataset.X, expected_X.to(torch.double)))
             self.assertTrue(torch.equal(dataset.Y, expected_Y))
             self.assertIsNone(dataset.Yvar)
             self.assertEqual(dataset.feature_names, feature_names)


### PR DESCRIPTION
Summary:
**Context**: In D74846187, we saw that some tests were taking a very long time.

This is in large part due to a nasty mutability bug. The`IntToFloat` transform uses the wrong search space, causing it to try a new randomized rounding that doesn't work 10,000 times. The tests were printing many warnings about this. The search space is wrong because different transforms in `Adapter._transform_data` sometimes (not always) share a search space, as in they use the same Python object, so mutating one can change the search space on another transform. There is also a potential issue where they share `Parameter`s but not a search space. In this case, the culprit was `UnitX` and `IntToFloat` sharing a `RangeParameter` which `UnitX` mutated, leaving `IntToFloat` with a parameter in the transformed space and its constraint in the untransformed space.

**This PR**: Clones the search space between transforms so that it is not mutated in place.

Differential Revision: D75569748


