### PR TITLE
pyre fixes for D75477355, group 10

### DIFF
--- a/ax/generators/tests/test_botorch_model.py
+++ b/ax/generators/tests/test_botorch_model.py
@@ -269,6 +269,7 @@ class LegacyBoTorchGeneratorTest(TestCase):
 
                 if use_input_warping:
                     transformed_inputs = [
+                        # pyre-fixme[16]: Undefined attribute: Item `torch._tensor.Te...
                         model.input_transform.preprocess_transform(x)
                         for model, x in zip(model_list, untransformed_inputs)
                     ]

--- a/ax/generators/torch/botorch.py
+++ b/ax/generators/torch/botorch.py
@@ -577,11 +577,14 @@ def get_feature_importances_from_botorch_model(
             # this can be a ModelList of a SAAS and STGP, so this is a necessary way
             # to get the lengthscale
             if hasattr(m.covar_module, "base_kernel"):
+                # pyre-fixme[16]: Undefined attribute: Item `torch._tensor.Tensor` of...
                 ls = m.covar_module.base_kernel.lengthscale
             else:
+                # pyre-fixme[16]: Undefined attribute: Item `torch._tensor.Tensor` of...
                 ls = m.covar_module.lengthscale
         except AttributeError:
             ls = None
+        # pyre-fixme[29]: Call error: `typing.Union[BoundMethod[typing.Callable(torch...
         if ls is None or ls.shape[-1] != m.train_inputs[0].shape[-1]:
             # TODO: We could potentially set the feature importances to NaN in this
             # case, but this require knowing the batch dimension of this model.
@@ -592,6 +595,7 @@ def get_feature_importances_from_botorch_model(
             )
         if ls.ndim == 2:
             ls = ls.unsqueeze(0)
+        # pyre-fixme[6]: Incompatible parameter type: In call `is_ensemble`, for 1st ...
         if is_ensemble(m):  # Take the median over the model batch dimension
             ls = torch.quantile(ls, q=0.5, dim=0, keepdim=True)
         lengthscales.append(ls)

--- a/ax/generators/torch/tests/test_surrogate.py
+++ b/ax/generators/torch/tests/test_surrogate.py
@@ -236,6 +236,7 @@ class SurrogateInputConstructorsTest(TestCase):
             self.assertEqual(len(tf_values), 2)
             self.assertIsInstance(tf_values[0], Normalize)
             self.assertIsInstance(tf_values[1], Log10)
+            # pyre-fixme[29]: Call error: `typing.Union[BoundMethod[typing.Callable(t...
             self.assertEqual(tf_values[1].indices.tolist(), [0])
 
         bounds = [(1.0, 5.0), (2.0, 10.0)]
@@ -1576,6 +1577,7 @@ class SurrogateTest(TestCase):
         intf_values = list(intf.values())
         self.assertIsInstance(intf_values[0], InputPerturbation)
         self.assertIsInstance(intf_values[1], Normalize)
+        # pyre-fixme[6]: Incompatible parameter type: In call `torch._C._VariableFunc...
         self.assertTrue(torch.equal(intf_values[0].perturbation_set, torch.zeros(2, 2)))
 
     def test_fit_mixed(self) -> None:
@@ -2009,9 +2011,12 @@ class SurrogateWithModelListTest(TestCase):
                 self.assertEqual(type(m.likelihood), GaussianLikelihood)
                 self.assertEqual(type(m.covar_module), MaternKernel)
                 if submodel_covar_module_options:
+                    # pyre-fixme[16]: Undefined attribute: Item `torch._tensor.Tensor...
                     self.assertEqual(m.covar_module.ard_num_dims, 3)
                 else:
+                    # pyre-fixme[16]: Undefined attribute: Item `torch._tensor.Tensor...
                     self.assertEqual(m.covar_module.ard_num_dims, None)
+                # pyre-fixme[16]: Undefined attribute: Item `torch._tensor.Tensor` of...
                 m_noise_constraint = m.likelihood.noise_covar.raw_noise_constraint
                 if submodel_likelihood_options:
                     self.assertEqual(type(m_noise_constraint), Interval)


### PR DESCRIPTION
Summary: Not sure why all typing tests didn't run on D75477355 but a bunch of tests apparently didn't run. All the changes in this file are comment-only pyre ignores.

Differential Revision: D75608556


