### PR TITLE
Avoid concatenating empty DataFrames to stop using deprecated Pandas functionality

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -279,13 +279,15 @@ class BaseData(Base, SerializationMixin):
             data: Iterable of Ax objects of this class to combine.
         """
         dfs = []
+
         for datum in data:
-            if not isinstance(datum, cls):
+            if type(datum) is not cls:
                 raise TypeError(
                     f"All data objects must be instances of class {cls}. Got "
                     f"{type(datum)}."
                 )
-            dfs.append(datum.df)
+            if len(datum.df) > 0:
+                dfs.append(datum.df)
 
         if len(dfs) == 0:
             return cls()


### PR DESCRIPTION
Context: Unit tests are producing many of this warning:

```
[...]/ax/Ax/ax/core/data.py:293: FutureWarning:

The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
```

This stems from trying to concatenate empty DataFrames.

This PR: Only concatenates non-empty DataFrames in `BaseData.from_multiple`. If there are none, it will fall back to the behavior used for an empty list, which is to create a `BaseData` with no `df` input.

Test plan: Warnings from ax/analysis/plotly/tests/test_sensitivity.py are no longer there.