### PR TITLE
Fixing incompatible device in client.compute_analyses (no ruff)

### DIFF
--- a/ax/utils/sensitivity/derivative_measures.py
+++ b/ax/utils/sensitivity/derivative_measures.py
@@ -100,6 +100,7 @@ class GpDGSMGpMean:
         self.num_bootstrap_samples = (
             num_bootstrap_samples - 1
         )  # deduct 1 because the first is meant to be the full grid
+        self.torch_device: torch.device = bounds.device
         if self.derivative_gp and (self.kernel_type is None):
             raise ValueError("Kernel type has to be specified to use derivative GP")
         self.num_mc_samples = num_mc_samples
@@ -108,11 +109,13 @@ class GpDGSMGpMean:
             self.input_mc_samples = (
                 draw_sobol_samples(bounds=bounds, n=num_mc_samples, q=1, seed=1234)
                 .squeeze(1)
-                .to(dtype)
+                .to(dtype=dtype, device=self.torch_device)
             )
         else:
             self.input_mc_samples = unnormalize(
-                torch.rand(num_mc_samples, self.dim, dtype=dtype),
+                torch.rand(
+                    num_mc_samples, self.dim, dtype=dtype, device=self.torch_device
+                ),
                 bounds=bounds,
             )
 

--- a/ax/utils/sensitivity/derivative_measures.py
+++ b/ax/utils/sensitivity/derivative_measures.py
@@ -109,7 +109,7 @@ class GpDGSMGpMean:
             self.input_mc_samples = (
                 draw_sobol_samples(bounds=bounds, n=num_mc_samples, q=1, seed=1234)
                 .squeeze(1)
-                .to(dtype=dtype, device=self.torch_device)
+                .to(dtype)
             )
         else:
             self.input_mc_samples = unnormalize(

--- a/ax/utils/sensitivity/sobol_measures.py
+++ b/ax/utils/sensitivity/sobol_measures.py
@@ -73,16 +73,31 @@ class SobolSensitivity:
             num_bootstrap_samples - 1
         )  # deduct 1 because the first is meant to be the full grid
         self.bootstrap_array = bootstrap_array
+        self.torch_device: torch.device = bounds.device
         if input_qmc:
             sobol_kwargs = {"bounds": bounds, "n": num_mc_samples, "q": 1}
             seed_A, seed_B = 1234, 5678  # to make it reproducible
             # pyre-ignore
-            self.A = draw_sobol_samples(**sobol_kwargs, seed=seed_A).squeeze(1)
+            self.A = (
+                draw_sobol_samples(**sobol_kwargs, seed=seed_A)
+                .squeeze(1)
+                .to(self.torch_device)
+            )
             # pyre-ignore
-            self.B = draw_sobol_samples(**sobol_kwargs, seed=seed_B).squeeze(1)
+            self.B = (
+                draw_sobol_samples(**sobol_kwargs, seed=seed_B)
+                .squeeze(1)
+                .to(self.torch_device)
+            )
         else:
-            self.A = unnormalize(torch.rand(num_mc_samples, self.dim), bounds=bounds)
-            self.B = unnormalize(torch.rand(num_mc_samples, self.dim), bounds=bounds)
+            self.A = unnormalize(
+                torch.rand(num_mc_samples, self.dim).to(self.torch_device),
+                bounds=bounds,
+            )
+            self.B = unnormalize(
+                torch.rand(num_mc_samples, self.dim).to(self.torch_device),
+                bounds=bounds,
+            )
 
         # uniform integral distribution for discrete features
         self.A = sample_discrete_parameters(
@@ -879,7 +894,10 @@ def ax_parameter_sens(
         metrics = adapter.outcomes
     generator, digest = _get_generator_and_digest(adapter=adapter)
     model_list = _get_model_per_metric(generator=generator, metrics=metrics)
+
+    device = next(model_list[0].parameters()).device  # get device of the first model
     bounds = torch.tensor(digest.bounds).T  # transposing to make it 2 x d
+    bounds = bounds.to(device)  # makes sure bounds are on the same device as the models
 
     # for second order indices, we need to compute first order indices first
     # which is what is done here. With the first order indices, we can then subtract
@@ -893,7 +911,7 @@ def ax_parameter_sens(
     )
     feature_names = digest.feature_names
     indices_unsigned = array_with_string_indices_to_dict(
-        rows=metrics, cols=feature_names, A=ind.numpy()
+        rows=metrics, cols=feature_names, A=ind.cpu().numpy()
     )
     if signed:
         ind_deriv = compute_derivatives_from_model_list(
@@ -910,10 +928,10 @@ def ax_parameter_sens(
         # them differently here.
         for i in digest.categorical_features:
             ind_deriv[:, i] = 1.0
-        ind *= torch.sign(ind_deriv)
+        ind *= torch.sign(ind_deriv).to(device)
 
     indices = array_with_string_indices_to_dict(
-        rows=metrics, cols=feature_names, A=ind.numpy()
+        rows=metrics, cols=feature_names, A=ind.cpu().numpy()
     )
     if order == "second":
         second_order_values = compute_sobol_indices_from_model_list(
@@ -931,7 +949,7 @@ def ax_parameter_sens(
         second_order_dict = array_with_string_indices_to_dict(
             rows=metrics,
             cols=second_order_feature_names,
-            A=second_order_values.numpy(),
+            A=second_order_values.cpu().numpy(),
         )
         for metric in metrics:
             indices[metric].update(second_order_dict[metric])

--- a/ax/utils/sensitivity/sobol_measures.py
+++ b/ax/utils/sensitivity/sobol_measures.py
@@ -889,9 +889,10 @@ def ax_parameter_sens(
 
     # get device and dtype of the first model
     first_model = next(model_list[0].parameters())
-    device, dtype = first_model.device, first_model.dtype
+    device = first_model.device
     bounds = torch.tensor(
-        digest.bounds, device=device, dtype=dtype
+        digest.bounds,
+        device=device,
     ).T  # transposing to make it 2 x d
 
     # for second order indices, we need to compute first order indices first


### PR DESCRIPTION
Making sure that the torch_device is set to the same as the model in the client.compute_analyses in case CUDA is used in the Modular BoTorch Interface.

Related to the issue [#3813](https://github.com/facebook/Ax/issues/3813)
and without the messed-up formatting from #3833, following @Balandat's advice. 