### PR TITLE
Silence dataset conversion warnings in choose_botorch_acqf_class

### DIFF
--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -320,7 +320,9 @@ def choose_botorch_acqf_class(
         # NOTE: `convert_to_block_design` will drop points that are only observed by
         # some of the metrics which is natural as we are using observed values to
         # determine feasibility.
-        dataset = convert_to_block_design(datasets=datasets, force=True)[0]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=AxWarning)
+            dataset = convert_to_block_design(datasets=datasets, force=True)[0]
         con_observed = torch.stack([con(dataset.Y) for con in con_tfs], dim=-1)
         feas_point_found = (con_observed <= 0).all(dim=-1).any().item()
 

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -10,7 +10,6 @@ import warnings
 from collections import OrderedDict
 
 import numpy as np
-
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import AxWarning, UnsupportedError


### PR DESCRIPTION
Summary: I found these warnings about dropping observations confusing. We should raise them while choosing the acqf.

Differential Revision: D75686090


