### PR TITLE
Simplify return type of get_torch_test_data

### DIFF
--- a/ax/generators/tests/test_botorch_model.py
+++ b/ax/generators/tests/test_botorch_model.py
@@ -32,7 +32,7 @@ from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition.utils import get_infeasible_cost
 from botorch.fit import fit_gpytorch_mll
 from botorch.models import ModelListGP, SingleTaskGP
-from botorch.models.transforms.input import Warp
+from botorch.models.transforms.input import InputTransform, Warp
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.objective import get_objective_weights_transform
 from gpytorch.kernels.constant_kernel import ConstantKernel
@@ -41,7 +41,7 @@ from gpytorch.likelihoods.gaussian_likelihood import FixedNoiseGaussianLikelihoo
 from gpytorch.mlls import ExactMarginalLogLikelihood, LeaveOneOutPseudoLikelihood
 from gpytorch.priors import GammaPrior
 from gpytorch.priors.lkj_prior import LKJCovariancePrior
-from pyre_extensions import none_throws
+from pyre_extensions import assert_is_instance, none_throws
 
 
 FIT_MODEL_MO_PATH = f"{get_and_fit_model.__module__}.fit_gpytorch_mll"
@@ -70,16 +70,16 @@ class LegacyBoTorchGeneratorTest(TestCase):
         model = LegacyBoTorchGenerator(multitask_gp_ranks={"y": 2, "w": 1})
         datasets = [
             SupervisedDataset(
-                X=Xs1[0],
-                Y=Ys1[0],
-                Yvar=Yvars1[0],
+                X=Xs1,
+                Y=Ys1,
+                Yvar=Yvars1,
                 feature_names=feature_names,
                 outcome_names=["y"],
             ),
             SupervisedDataset(
-                X=Xs2[0],
-                Y=Ys2[0],
-                Yvar=Yvars2[0],
+                X=Xs2,
+                Y=Ys2,
+                Yvar=Yvars2,
                 feature_names=feature_names,
                 outcome_names=["w"],
             ),
@@ -137,16 +137,16 @@ class LegacyBoTorchGeneratorTest(TestCase):
         model = LegacyBoTorchGenerator(**kwargs)
         datasets = [
             SupervisedDataset(
-                X=Xs1[0],
-                Y=Ys1[0],
-                Yvar=Yvars1[0],
+                X=Xs1,
+                Y=Ys1,
+                Yvar=Yvars1,
                 feature_names=feature_names,
                 outcome_names=metric_names,
             ),
             SupervisedDataset(
-                X=Xs2[0],
-                Y=Ys2[0],
-                Yvar=Yvars2[0],
+                X=Xs2,
+                Y=Ys2,
+                Yvar=Yvars2,
                 feature_names=feature_names,
                 outcome_names=metric_names,
             ),
@@ -219,19 +219,19 @@ class LegacyBoTorchGeneratorTest(TestCase):
                 # Test ModelListGP
 
                 # make training data different for each output
-                Xs2_diff = [Xs2[0] + 0.1]
+                Xs2_diff = [Xs2 + 0.1]
                 datasets = [
                     SupervisedDataset(
-                        X=Xs1[0],
-                        Y=Ys1[0],
-                        Yvar=Yvars1[0],
+                        X=Xs1,
+                        Y=Ys1,
+                        Yvar=Yvars1,
                         feature_names=feature_names,
                         outcome_names=metric_names,
                     ),
                     SupervisedDataset(
                         X=Xs2_diff[0],
-                        Y=Ys2[0],
-                        Yvar=Yvars2[0],
+                        Y=Ys2,
+                        Yvar=Yvars2,
                         feature_names=feature_names,
                         outcome_names=metric_names,
                     ),
@@ -257,20 +257,21 @@ class LegacyBoTorchGeneratorTest(TestCase):
                     self.assertIsInstance(mll, mll_cls)
 
                 # Check attributes
-                self.assertTrue(torch.equal(model.Xs[0], Xs1[0]))
+                self.assertTrue(torch.equal(model.Xs[0], Xs1))
                 self.assertTrue(torch.equal(model.Xs[1], Xs2_diff[0]))
-                self.assertEqual(model.dtype, Xs1[0].dtype)
-                self.assertEqual(model.device, Xs1[0].device)
+                self.assertEqual(model.dtype, Xs1.dtype)
+                self.assertEqual(model.device, Xs1.device)
                 self.assertIsInstance(model.model, ModelListGP)
 
                 # Check fitting
                 model_list = cast(ModelListGP, model.model).models
-                untransformed_inputs = [Xs1[0], Xs2_diff[0]]
+                untransformed_inputs = [Xs1, Xs2_diff[0]]
 
                 if use_input_warping:
                     transformed_inputs = [
-                        # pyre-fixme[16]: Undefined attribute: Item `torch._tensor.Te...
-                        model.input_transform.preprocess_transform(x)
+                        assert_is_instance(
+                            model.input_transform, InputTransform
+                        ).preprocess_transform(x)
                         for model, x in zip(model_list, untransformed_inputs)
                     ]
                 else:
@@ -287,12 +288,8 @@ class LegacyBoTorchGeneratorTest(TestCase):
                         model_list[i].likelihood, _GaussianLikelihoodBase
                     )
 
-                self.assertTrue(
-                    torch.equal(model_list[0].train_targets, Ys1[0].view(-1))
-                )
-                self.assertTrue(
-                    torch.equal(model_list[1].train_targets, Ys2[0].view(-1))
-                )
+                self.assertTrue(torch.equal(model_list[0].train_targets, Ys1.view(-1)))
+                self.assertTrue(torch.equal(model_list[1].train_targets, Ys2.view(-1)))
                 if use_input_warping:
                     self.assertTrue(model.use_input_warping)
                 for m in model_list:
@@ -305,16 +302,16 @@ class LegacyBoTorchGeneratorTest(TestCase):
             # Test batched multi-output SingleTaskGP
             datasets_block = [
                 SupervisedDataset(
-                    X=Xs1[0],
-                    Y=Ys1[0],
-                    Yvar=Yvars1[0],
+                    X=Xs1,
+                    Y=Ys1,
+                    Yvar=Yvars1,
                     feature_names=feature_names,
                     outcome_names=metric_names,
                 ),
                 SupervisedDataset(
-                    X=Xs2[0],
-                    Y=Ys2[0],
-                    Yvar=Yvars2[0],
+                    X=Xs2,
+                    Y=Ys2,
+                    Yvar=Yvars2,
                     feature_names=feature_names,
                     outcome_names=metric_names,
                 ),
@@ -333,27 +330,25 @@ class LegacyBoTorchGeneratorTest(TestCase):
             _mock_fit_model.assert_called_once()
 
             # Check attributes
-            self.assertTrue(torch.equal(model.Xs[0], Xs1[0]))
-            self.assertTrue(torch.equal(model.Xs[1], Xs2[0]))
-            self.assertEqual(model.dtype, Xs1[0].dtype)
-            self.assertEqual(model.device, Xs1[0].device)
+            self.assertTrue(torch.equal(model.Xs[0], Xs1))
+            self.assertTrue(torch.equal(model.Xs[1], Xs2))
+            self.assertEqual(model.dtype, Xs1.dtype)
+            self.assertEqual(model.device, Xs1.device)
             if use_input_warping:
                 self.assertIsInstance(model.model, ModelListGP)
                 models = model.model.models
             else:
                 models = [model.model]
-            Ys = [Ys1[0], Ys2[0]]
+            Ys = [Ys1, Ys2]
             for i, m in enumerate(models):
                 self.assertIsInstance(m, SingleTaskGP)
                 self.assertIsInstance(m.likelihood, FixedNoiseGaussianLikelihood)
 
                 if not use_input_warping:
-                    expected_train_inputs = Xs1[0].unsqueeze(0).expand(2, *Xs1[0].shape)
-                    expected_train_targets = torch.cat(Ys1 + Ys2, dim=-1).permute(1, 0)
+                    expected_train_inputs = Xs1.unsqueeze(0).expand(2, *Xs1.shape)
+                    expected_train_targets = torch.cat([Ys1, Ys2], dim=-1).permute(1, 0)
                 else:
-                    expected_train_inputs = m.input_transform.preprocess_transform(
-                        Xs1[0]
-                    )
+                    expected_train_inputs = m.input_transform.preprocess_transform(Xs1)
                     expected_train_targets = Ys[i].squeeze(-1)
                 # Check fitting
                 # train inputs should be `o x n x 1`
@@ -371,7 +366,7 @@ class LegacyBoTorchGeneratorTest(TestCase):
             objective_transform = get_objective_weights_transform(objective_weights)
             infeasible_cost = (
                 get_infeasible_cost(
-                    X=Xs1[0], model=model.model, objective=objective_transform
+                    X=Xs1, model=model.model, objective=objective_transform
                 )
                 .detach()
                 .clone()
@@ -379,8 +374,8 @@ class LegacyBoTorchGeneratorTest(TestCase):
             expected_infeasible_cost = -1 * torch.min(
                 # pyre-fixme[20]: Argument `1` expected.
                 objective_transform(
-                    model.model.posterior(Xs1[0]).mean
-                    - 6 * model.model.posterior(Xs1[0]).variance.sqrt()
+                    model.model.posterior(Xs1).mean
+                    - 6 * model.model.posterior(Xs1).variance.sqrt()
                 ).min(),
                 torch.tensor(0.0, **tkwargs),
             )
@@ -542,16 +537,16 @@ class LegacyBoTorchGeneratorTest(TestCase):
             # Test cross-validation
             combined_datasets = [
                 SupervisedDataset(
-                    Xs1[0],
-                    Y=Ys1[0],
-                    Yvar=Yvars1[0],
+                    Xs1,
+                    Y=Ys1,
+                    Yvar=Yvars1,
                     feature_names=feature_names,
                     outcome_names=metric_names,
                 ),
                 SupervisedDataset(
-                    Xs2[0],
-                    Y=Ys2[0],
-                    Yvar=Yvars2[0],
+                    Xs2,
+                    Y=Ys2,
+                    Yvar=Yvars2,
                     feature_names=feature_names,
                     outcome_names=metric_names,
                 ),
@@ -586,7 +581,7 @@ class LegacyBoTorchGeneratorTest(TestCase):
                 unfit_model.cross_validate(
                     datasets=combined_datasets,
                     search_space_digest=search_space_digest,
-                    X_test=Xs1[0],
+                    X_test=Xs1,
                 )
             with self.assertRaisesRegex(
                 RuntimeError,
@@ -608,9 +603,9 @@ class LegacyBoTorchGeneratorTest(TestCase):
                 for key, val in true_state_dict.items()
             }
             model = get_and_fit_model(
-                Xs=Xs1,
-                Ys=Ys1,
-                Yvars=Yvars1,
+                Xs=[Xs1],
+                Ys=[Ys1],
+                Yvars=[Yvars1],
                 task_features=[],
                 fidelity_features=[],
                 metric_names=[metric_names[0]],
@@ -624,9 +619,9 @@ class LegacyBoTorchGeneratorTest(TestCase):
             true_state_dict["mean_module.raw_constant"] += 0.1
             true_state_dict["covar_module.raw_lengthscale"] += 0.1
             model = get_and_fit_model(
-                Xs=Xs1,
-                Ys=Ys1,
-                Yvars=Yvars1,
+                Xs=[Xs1],
+                Ys=[Ys1],
+                Yvars=[Yvars1],
                 task_features=[],
                 fidelity_features=[],
                 metric_names=[metric_names[0]],
@@ -672,9 +667,9 @@ class LegacyBoTorchGeneratorTest(TestCase):
                 model.fit(
                     datasets=[
                         SupervisedDataset(
-                            X=Xs1[0],
-                            Y=Ys1[0],
-                            Yvar=Yvars1[0],
+                            X=Xs1,
+                            Y=Ys1,
+                            Yvar=Yvars1,
                             feature_names=feature_names,
                             outcome_names=metric_names,
                         )
@@ -718,7 +713,7 @@ class LegacyBoTorchGeneratorTest(TestCase):
             dtype=torch.float, cuda=False, constant_noise=True
         )
         # make infeasible
-        Xs2[0] = -1 * Xs2[0]
+        Xs2 = -1 * Xs2
         objective_weights = torch.tensor(
             [-1.0, 1.0], dtype=torch.float, device=torch.device("cpu")
         )
@@ -733,16 +728,16 @@ class LegacyBoTorchGeneratorTest(TestCase):
             model.fit(
                 datasets=[
                     SupervisedDataset(
-                        X=Xs1[0],
-                        Y=Ys1[0],
-                        Yvar=Yvars1[0],
+                        X=Xs1,
+                        Y=Ys1,
+                        Yvar=Yvars1,
                         feature_names=feature_names,
                         outcome_names=metric_names,
                     ),
                     SupervisedDataset(
-                        X=Xs2[0],
-                        Y=Ys2[0],
-                        Yvar=Yvars2[0],
+                        X=Xs2,
+                        Y=Ys2,
+                        Yvar=Yvars2,
                         feature_names=feature_names,
                         outcome_names=metric_names,
                     ),

--- a/ax/generators/tests/test_botorch_moo_model.py
+++ b/ax/generators/tests/test_botorch_moo_model.py
@@ -30,6 +30,7 @@ from ax.generators.torch.utils import HYPERSPHERE
 from ax.generators.torch_base import TorchOptConfig
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import mock_botorch_optimize
+from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition.multi_objective import (
     logei as moo_logei,
     monte_carlo as moo_monte_carlo,
@@ -71,27 +72,6 @@ PARTITIONING_PATH = "botorch.acquisition.factory.FastNondominatedPartitioning"
 
 def dummy_func(X: torch.Tensor) -> torch.Tensor:
     return X
-
-
-# pyre-fixme[3]: Return type must be annotated.
-def _get_torch_test_data(
-    dtype: torch.dtype = torch.float,
-    cuda: bool = False,
-    constant_noise: bool = True,
-    # pyre-fixme[2]: Parameter must be annotated.
-    task_features=None,
-):
-    device = torch.device("cuda") if cuda else torch.device("cpu")
-    Xs = [torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], dtype=dtype, device=device)]
-    Ys = [torch.tensor([[3.0], [4.0]], dtype=dtype, device=device)]
-    Yvars = [torch.tensor([[0.0], [2.0]], dtype=dtype, device=device)]
-    if constant_noise:
-        Yvars[0].fill_(1.0)
-    bounds = [(0.0, 1.0), (1.0, 4.0), (2.0, 5.0)]
-    feature_names = ["x1", "x2", "x3"]
-    task_features = [] if task_features is None else task_features
-    metric_names = ["y"]
-    return Xs, Ys, Yvars, bounds, task_features, feature_names, metric_names
 
 
 class BotorchMOOModelTest(TestCase):
@@ -143,32 +123,23 @@ class BotorchMOOModelTest(TestCase):
             "dtype": dtype,
         }
         (
-            Xs1,
-            Ys1,
-            Yvars1,
+            Xs,
+            Ys,
+            Yvars,
             bounds,
             tfs,
             feature_names,
-            metric_names,
-        ) = _get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
-        Xs2, Ys2, Yvars2, _, _, _, _ = _get_torch_test_data(
-            dtype=dtype, cuda=cuda, constant_noise=True
-        )
+            _,
+        ) = get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
         training_data = [
             SupervisedDataset(
-                X=Xs1[0],
-                Y=Ys1[0],
-                Yvar=Yvars1[0],
+                X=Xs,
+                Y=Ys,
+                Yvar=Yvars,
                 feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
-            SupervisedDataset(
-                X=Xs2[0],
-                Y=Ys2[0],
-                Yvar=Yvars2[0],
-                feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
+                outcome_names=[name],
+            )
+            for name in ["m1", "m2"]
         ]
 
         n = 3
@@ -273,32 +244,23 @@ class BotorchMOOModelTest(TestCase):
             "dtype": dtype,
         }
         (
-            Xs1,
-            Ys1,
-            Yvars1,
+            Xs,
+            Ys,
+            Yvars,
             bounds,
             tfs,
             feature_names,
-            metric_names,
-        ) = _get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
-        Xs2, Ys2, Yvars2, _, _, _, _ = _get_torch_test_data(
-            dtype=dtype, cuda=cuda, constant_noise=True
-        )
+            _,
+        ) = get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
         training_data = [
             SupervisedDataset(
-                X=Xs1[0],
-                Y=Ys1[0],
-                Yvar=Yvars1[0],
+                X=Xs,
+                Y=Ys,
+                Yvar=Yvars,
                 feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
-            SupervisedDataset(
-                X=Xs2[0],
-                Y=Ys2[0],
-                Yvar=Yvars2[0],
-                feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
+                outcome_names=[name],
+            )
+            for name in ["m1", "m2"]
         ]
 
         n = 3
@@ -379,42 +341,23 @@ class BotorchMOOModelTest(TestCase):
             "dtype": dtype,
         }
         (
-            Xs1,
-            Ys1,
-            Yvars1,
+            Xs,
+            Ys,
+            Yvars,
             bounds,
             tfs,
             feature_names,
-            metric_names,
-        ) = _get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
-        Xs2, Ys2, Yvars2, _, _, _, _ = _get_torch_test_data(
-            dtype=dtype, cuda=cuda, constant_noise=True
-        )
-        Xs3, Ys3, Yvars3, _, _, _, _ = _get_torch_test_data(
-            dtype=dtype, cuda=cuda, constant_noise=True
-        )
+            _,
+        ) = get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
         training_data = [
             SupervisedDataset(
-                X=Xs1[0],
-                Y=Ys1[0],
-                Yvar=Yvars1[0],
+                X=Xs,
+                Y=Ys,
+                Yvar=Yvars,
                 feature_names=feature_names,
-                outcome_names=["m1"],
-            ),
-            SupervisedDataset(
-                X=Xs2[0],
-                Y=Ys2[0],
-                Yvar=Yvars2[0],
-                feature_names=feature_names,
-                outcome_names=["m2"],
-            ),
-            SupervisedDataset(
-                X=Xs3[0],
-                Y=Ys3[0],
-                Yvar=Yvars3[0],
-                feature_names=feature_names,
-                outcome_names=["m3"],
-            ),
+                outcome_names=[name],
+            )
+            for name in ["m1", "m2", "m3"]
         ]
 
         n = 3
@@ -519,35 +462,24 @@ class BotorchMOOModelTest(TestCase):
 
             # test inferred objective thresholds in gen()
             # create several data points
-            Xs1 = [torch.cat([Xs1[0], Xs1[0] - 0.1], dim=0)]
-            Ys1 = [torch.cat([Ys1[0], Ys1[0] - 0.5], dim=0)]
-            Ys2 = [torch.cat([Ys2[0], Ys2[0] + 0.5], dim=0)]
-            Ys3 = [torch.cat([Ys3[0], Ys3[0] - 1.0], dim=0)]
-            Yvars1 = [torch.cat([Yvars1[0], Yvars1[0] + 0.2], dim=0)]
-            Yvars2 = [torch.cat([Yvars2[0], Yvars2[0] + 0.1], dim=0)]
-            Yvars3 = [torch.cat([Yvars3[0], Yvars3[0] + 0.4], dim=0)]
+            Xs = torch.cat([Xs, Xs - 0.1], dim=0)
+            Ys1 = torch.cat([Ys, Ys - 0.5], dim=0)
+            Ys2 = torch.cat([Ys, Ys + 0.5], dim=0)
+            Ys3 = torch.cat([Ys, Ys - 1.0], dim=0)
+            Yvars1 = torch.cat([Yvars, Yvars + 0.2], dim=0)
+            Yvars2 = torch.cat([Yvars, Yvars + 0.1], dim=0)
+            Yvars3 = torch.cat([Yvars, Yvars + 0.4], dim=0)
             training_data_multiple = [
                 SupervisedDataset(
-                    X=Xs1[0],
-                    Y=Ys1[0],
-                    Yvar=Yvars1[0],
+                    X=Xs,
+                    Y=Y,
+                    Yvar=Yvar,
                     feature_names=feature_names,
-                    outcome_names=["m1"],
-                ),
-                SupervisedDataset(
-                    X=Xs1[0],
-                    Y=Ys2[0],
-                    Yvar=Yvars2[0],
-                    feature_names=feature_names,
-                    outcome_names=["m2"],
-                ),
-                SupervisedDataset(
-                    X=Xs1[0],
-                    Y=Ys3[0],
-                    Yvar=Yvars3[0],
-                    feature_names=feature_names,
-                    outcome_names=["m3"],
-                ),
+                    outcome_names=[name],
+                )
+                for Y, Yvar, name in zip(
+                    [Ys1, Ys2, Ys3], [Yvars1, Yvars2, Yvars3], ["m1", "m2", "m3"]
+                )
             ]
             model.fit(
                 datasets=training_data_multiple,
@@ -692,32 +624,23 @@ class BotorchMOOModelTest(TestCase):
             "dtype": dtype,
         }
         (
-            Xs1,
-            Ys1,
-            Yvars1,
+            Xs,
+            Ys,
+            Yvars,
             bounds,
             tfs,
             feature_names,
-            metric_names,
-        ) = _get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
-        Xs2, Ys2, Yvars2, _, _, _, _ = _get_torch_test_data(
-            dtype=dtype, cuda=cuda, constant_noise=True
-        )
+            _,
+        ) = get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
         training_data = [
             SupervisedDataset(
-                X=Xs1[0],
-                Y=Ys1[0],
-                Yvar=Yvars1[0],
+                X=Xs,
+                Y=Ys,
+                Yvar=Yvars,
                 feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
-            SupervisedDataset(
-                X=Xs2[0],
-                Y=Ys2[0],
-                Yvar=Yvars2[0],
-                feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
+                outcome_names=[name],
+            )
+            for name in ["m1", "m2"]
         ]
 
         n = 2
@@ -770,32 +693,23 @@ class BotorchMOOModelTest(TestCase):
             "dtype": torch.float,
         }
         (
-            Xs1,
-            Ys1,
-            Yvars1,
+            Xs,
+            Ys,
+            Yvars,
             bounds,
             tfs,
             feature_names,
-            metric_names,
-        ) = _get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
-        Xs2, Ys2, Yvars2, _, _, _, _ = _get_torch_test_data(
-            dtype=dtype, cuda=cuda, constant_noise=True
-        )
+            _,
+        ) = get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
         training_data = [
             SupervisedDataset(
-                X=Xs1[0],
-                Y=Ys1[0],
-                Yvar=Yvars1[0],
+                X=Xs,
+                Y=Ys,
+                Yvar=Yvars,
                 feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
-            SupervisedDataset(
-                X=Xs2[0],
-                Y=Ys2[0],
-                Yvar=Yvars2[0],
-                feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
+                outcome_names=[name],
+            )
+            for name in ["m1", "m2"]
         ]
 
         n = 2
@@ -863,42 +777,23 @@ class BotorchMOOModelTest(TestCase):
             "dtype": dtype,
         }
         (
-            Xs1,
-            Ys1,
-            Yvars1,
+            Xs,
+            Ys,
+            Yvars,
             bounds,
             tfs,
             feature_names,
-            metric_names,
-        ) = _get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
-        Xs2, Ys2, Yvars2, _, _, _, _ = _get_torch_test_data(
-            dtype=dtype, cuda=cuda, constant_noise=True
-        )
-        Xs3, Ys3, Yvars3, _, _, _, _ = _get_torch_test_data(
-            dtype=dtype, cuda=cuda, constant_noise=True
-        )
+            _,
+        ) = get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
         training_data = [
             SupervisedDataset(
-                X=Xs1[0],
-                Y=Ys1[0],
-                Yvar=Yvars1[0],
+                X=Xs,
+                Y=Ys,
+                Yvar=Yvars,
                 feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
-            SupervisedDataset(
-                X=Xs2[0],
-                Y=Ys2[0],
-                Yvar=Yvars2[0],
-                feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
-            SupervisedDataset(
-                X=Xs3[0],
-                Y=Ys3[0],
-                Yvar=Yvars3[0],
-                feature_names=feature_names,
-                outcome_names=metric_names,
-            ),
+                outcome_names=[name],
+            )
+            for name in ["m1", "m2", "m3"]
         ]
 
         n = 3
@@ -955,7 +850,7 @@ class BotorchMOOModelTest(TestCase):
         self.assertTrue(torch.equal(ckwargs["objective_thresholds"], obj_t[:-1]))
         self.assertIsNone(ckwargs["outcome_constraints"])
         # the second datapoint is out of bounds
-        self.assertTrue(torch.equal(ckwargs["X_observed"], Xs1[0][:1]))
+        self.assertTrue(torch.equal(ckwargs["X_observed"], Xs[:1]))
         self.assertIsNone(ckwargs["X_pending"])
 
         # test that outcome constraints are passed properly
@@ -985,5 +880,5 @@ class BotorchMOOModelTest(TestCase):
         self.assertTrue(torch.equal(ckwargs["outcome_constraints"][0], oc[0]))
         self.assertTrue(torch.equal(ckwargs["outcome_constraints"][1], oc[1]))
         # the second datapoint is out of bounds
-        self.assertTrue(torch.equal(ckwargs["X_observed"], Xs1[0][:1]))
+        self.assertTrue(torch.equal(ckwargs["X_observed"], Xs[:1]))
         self.assertIsNone(ckwargs["X_pending"])

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -320,7 +320,9 @@ def choose_botorch_acqf_class(
         # NOTE: `convert_to_block_design` will drop points that are only observed by
         # some of the metrics which is natural as we are using observed values to
         # determine feasibility.
-        dataset = convert_to_block_design(datasets=datasets, force=True)[0]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=AxWarning)
+            dataset = convert_to_block_design(datasets=datasets, force=True)[0]
         con_observed = torch.stack([con(dataset.Y) for con in con_tfs], dim=-1)
         feas_point_found = (con_observed <= 0).all(dim=-1).any().item()
 

--- a/ax/generators/torch/tests/test_model.py
+++ b/ax/generators/torch/tests/test_model.py
@@ -99,21 +99,21 @@ class BoTorchGeneratorTest(TestCase):
             self.metric_names,  # This is just ["y"].
         ) = get_torch_test_data(dtype=self.dtype)
         Xs2, Ys2, Yvars2, _, _, _, _ = get_torch_test_data(dtype=self.dtype, offset=1.0)
-        self.X_test = Xs2[0]
+        self.X_test = Xs2
         self.block_design_training_data = [
             SupervisedDataset(
-                X=self.Xs[0],
-                Y=self.Ys[0],
-                Yvar=self.Yvars[0],
+                X=self.Xs,
+                Y=self.Ys,
+                Yvar=self.Yvars,
                 feature_names=self.feature_names,
                 outcome_names=self.metric_names,
             )
         ]
         self.non_block_design_training_data = self.block_design_training_data + [
             SupervisedDataset(
-                X=Xs2[0],
-                Y=Ys2[0],
-                Yvar=Yvars2[0],
+                X=Xs2,
+                Y=Ys2,
+                Yvar=Yvars2,
                 feature_names=self.feature_names,
                 outcome_names=["y2"],
             )
@@ -157,9 +157,9 @@ class BoTorchGeneratorTest(TestCase):
                 outcome_names=[mn],
             )
             for X, Y, Yvar, mn in zip(
-                assert_is_instance(self.Xs, list) * 3,
-                self.Ys + Ys2 + self.Ys,
-                assert_is_instance(self.Yvars, list) * 3,
+                [self.Xs for _ in range(3)],
+                [self.Ys, Ys2, self.Ys],
+                [self.Yvars for _ in range(3)],
                 self.moo_metric_names,
             )
         ]
@@ -587,7 +587,7 @@ class BoTorchGeneratorTest(TestCase):
         self.assertEqual(m.num_outputs, 1)
         training_data = ckwargs["training_data"]
         self.assertIsInstance(training_data, SupervisedDataset)
-        self.assertTrue(torch.equal(training_data.X, self.Xs[0]))
+        self.assertTrue(torch.equal(training_data.X, self.Xs))
         self.assertTrue(
             torch.equal(
                 training_data.Y,
@@ -797,9 +797,9 @@ class BoTorchGeneratorTest(TestCase):
                 outcome_names=[mn],
             )
             for X, Y, Yvar, mn in zip(
-                [self.Xs[0], self.Xs[0][:1], self.Xs[0][1:]],
-                [self.Ys[0], self.Ys[0][:1] + 1, self.Ys[0][1:]],
-                [self.Yvars[0], self.Yvars[0][:1], self.Yvars[0][1:]],
+                [self.Xs, self.Xs[:1], self.Xs[1:]],
+                [self.Ys, self.Ys[:1] + 1, self.Ys[1:]],
+                [self.Yvars, self.Yvars[:1], self.Yvars[1:]],
                 self.moo_metric_names,
             )
         ]
@@ -986,7 +986,7 @@ class BoTorchGeneratorTest(TestCase):
         self.assertEqual(m.num_outputs, 2)
         training_data = ckwargs["training_data"]
         self.assertIsNotNone(training_data.Yvar)
-        self.assertTrue(torch.equal(training_data.X, self.Xs[0]))
+        self.assertTrue(torch.equal(training_data.X, self.Xs))
         self.assertTrue(
             torch.equal(
                 training_data.Y,

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -10,7 +10,6 @@ import warnings
 from collections import OrderedDict
 
 import numpy as np
-
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import AxWarning, UnsupportedError

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -59,22 +59,19 @@ class BoTorchGeneratorUtilsTest(TestCase):
             dtype=self.dtype,
             offset=1.0,  # Making this data different.
         )
-        self.fixed_noise_dataset = [
-            SupervisedDataset(
-                X=X,
-                Y=Y,
-                Yvar=Yvar,
-                feature_names=self.feature_names,
-                outcome_names=[mn],
-            )
-            for X, Y, Yvar, mn in zip(self.Xs, self.Ys, self.Yvars, self.metric_names)
-        ][0]
-        self.supervised_dataset = [
-            SupervisedDataset(
-                X=X, Y=Y, feature_names=self.feature_names, outcome_names=[mn]
-            )
-            for X, Y, mn in zip(self.Xs, self.Ys, self.metric_names)
-        ][0]
+        self.fixed_noise_dataset = SupervisedDataset(
+            X=self.Xs,
+            Y=self.Ys,
+            Yvar=self.Yvars,
+            feature_names=self.feature_names,
+            outcome_names=self.metric_names,
+        )
+        self.supervised_dataset = SupervisedDataset(
+            X=self.Xs,
+            Y=self.Ys,
+            feature_names=self.feature_names,
+            outcome_names=self.metric_names,
+        )
         self.none_Yvars = [torch.tensor([[np.nan], [np.nan]])]
         self.task_features = []
         self.objective_thresholds = torch.tensor([0.5, 1.5])
@@ -173,7 +170,7 @@ class BoTorchGeneratorUtilsTest(TestCase):
                     objective_weights=torch.tensor([1.0, 0.0]),
                     is_moo=False,
                 ),
-                datasets=self.supervised_dataset,
+                datasets=[self.supervised_dataset],
             ),
         )
         self.assertEqual(
@@ -183,7 +180,7 @@ class BoTorchGeneratorUtilsTest(TestCase):
                     objective_weights=torch.tensor([1.0, -1.0]),
                     is_moo=True,
                 ),
-                datasets=self.supervised_dataset,
+                datasets=[self.supervised_dataset],
             ),
         )
 
@@ -249,12 +246,11 @@ class BoTorchGeneratorUtilsTest(TestCase):
             use_model_list(
                 datasets=[
                     SupervisedDataset(
-                        X=self.Xs[0],
-                        Y=Y,
+                        X=self.Xs,
+                        Y=self.Ys,
                         feature_names=self.feature_names,
                         outcome_names=["y"],
                     )
-                    for Y in self.Ys
                 ],
                 model_configs=[ModelConfig(botorch_model_class=SingleTaskGP)],
                 search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
@@ -266,12 +262,11 @@ class BoTorchGeneratorUtilsTest(TestCase):
                 datasets=2
                 * [
                     SupervisedDataset(
-                        X=self.Xs[0],
-                        Y=Y,
+                        X=self.Xs,
+                        Y=self.Ys,
                         feature_names=self.feature_names,
                         outcome_names=["y"],
                     )
-                    for Y in self.Ys
                 ],
                 model_configs=[ModelConfig(botorch_model_class=SingleTaskGP)],
                 search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
@@ -283,12 +278,11 @@ class BoTorchGeneratorUtilsTest(TestCase):
                 datasets=2
                 * [
                     SupervisedDataset(
-                        X=self.Xs[0],
-                        Y=Y,
+                        X=self.Xs,
+                        Y=self.Ys,
                         feature_names=self.feature_names,
                         outcome_names=["y"],
                     )
-                    for Y in self.Ys
                 ],
                 model_configs=[ModelConfig(botorch_model_class=SingleTaskGP)],
                 search_space_digest=SearchSpaceDigest(feature_names=[], bounds=[]),
@@ -299,14 +293,14 @@ class BoTorchGeneratorUtilsTest(TestCase):
             use_model_list(
                 datasets=[
                     SupervisedDataset(
-                        X=self.Xs[0],
-                        Y=self.Ys[0],
+                        X=self.Xs,
+                        Y=self.Ys,
                         feature_names=self.feature_names,
                         outcome_names=["y"],
                     ),
                     SupervisedDataset(
-                        X=self.Xs2[0],
-                        Y=self.Ys2[0],
+                        X=self.Xs2,
+                        Y=self.Ys2,
                         feature_names=self.feature_names,
                         outcome_names=["y"],
                     ),
@@ -339,14 +333,14 @@ class BoTorchGeneratorUtilsTest(TestCase):
             use_model_list(
                 datasets=[
                     SupervisedDataset(
-                        X=self.Xs[0],
-                        Y=self.Ys[0],
+                        X=self.Xs,
+                        Y=self.Ys,
                         feature_names=self.feature_names,
                         outcome_names=["y"],
                     ),
                     SupervisedDataset(
-                        X=self.Xs2[0],
-                        Y=self.Ys2[0],
+                        X=self.Xs2,
+                        Y=self.Ys2,
                         feature_names=self.feature_names,
                         outcome_names=["y"],
                     ),
@@ -361,8 +355,8 @@ class BoTorchGeneratorUtilsTest(TestCase):
             use_model_list(
                 datasets=[
                     SupervisedDataset(
-                        X=self.Xs[0],
-                        Y=self.Ys[0].repeat(1, 2),
+                        X=self.Xs,
+                        Y=self.Ys.repeat(1, 2),
                         feature_names=self.feature_names,
                         outcome_names=["y1", "y2"],
                     ),

--- a/ax/utils/testing/torch_stubs.py
+++ b/ax/utils/testing/torch_stubs.py
@@ -20,9 +20,9 @@ def get_torch_test_data(
     task_features: list[int] | None = None,
     offset: float = 0.0,
 ) -> tuple[
-    list[torch.Tensor],
-    list[torch.Tensor],
-    list[torch.Tensor],
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
     list[tuple[float, float]],
     list[int],
     list[str],
@@ -32,21 +32,18 @@ def get_torch_test_data(
         "device": torch.device("cuda" if cuda else "cpu"),
         "dtype": dtype,
     }
-    Xs = [
-        torch.tensor(
-            [
-                [1.0 + offset, 2.0 + offset, 3.0 + offset],
-                [2.0 + offset, 3.0 + offset, 4.0 + offset],
-            ],
-            **tkwargs,
-        )
-    ]
-    Ys = [torch.tensor([[3.0 + offset], [4.0 + offset]], **tkwargs)]
+    X = torch.tensor(
+        [
+            [1.0 + offset, 2.0 + offset, 3.0 + offset],
+            [2.0 + offset, 3.0 + offset, 4.0 + offset],
+        ],
+        **tkwargs,
+    )
+    Y = torch.tensor([[3.0 + offset], [4.0 + offset]], **tkwargs)
     if constant_noise:
         Yvar = torch.ones(2, 1, **tkwargs)
     else:
         Yvar = torch.tensor([[0.0 + offset], [2.0 + offset]], **tkwargs)
-    Yvars = [Yvar]
 
     bounds = [
         (0.0 + offset, 1.0 + offset),
@@ -56,4 +53,4 @@ def get_torch_test_data(
     feature_names = ["x1", "x2", "x3"]
     task_features = [] if task_features is None else task_features
     metric_names = ["y"]
-    return Xs, Ys, Yvars, bounds, task_features, feature_names, metric_names
+    return X, Y, Yvar, bounds, task_features, feature_names, metric_names


### PR DESCRIPTION
Summary: I didn't enjoy the single element `list[Tensor]` return type when working on tests. IMO, a single element list just leads to confusion, since why would we use a list if there is only one element? This diff simplifies it to `Tensor` and also deletes a couple duplicate definitions of the same utility.

Differential Revision: D75691765


