### PR TITLE
rename gen_for_multiple_trials_with_mulitple_nodes to gen

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -370,7 +370,7 @@ class Client(WithDBSettingsBase):
             gs = self._generation_strategy_or_choose()
 
             # This will be changed to use gen directly post gen-unfication cc @mgarrard
-            generator_runs = gs.gen_for_multiple_trials_with_multiple_models(
+            generator_runs = gs.gen(
                 experiment=self._experiment,
                 pending_observations=(
                     get_pending_observation_features_based_on_trial_status(

--- a/ax/generation_strategy/generation_strategy.py
+++ b/ax/generation_strategy/generation_strategy.py
@@ -272,7 +272,7 @@ class GenerationStrategy(Base):
         """List of generation steps."""
         return self._nodes  # pyre-ignore[7]
 
-    def gen(
+    def gen_single_trial(
         self,
         experiment: Experiment,
         data: Data | None = None,

--- a/ax/generation_strategy/generation_strategy.py
+++ b/ax/generation_strategy/generation_strategy.py
@@ -325,7 +325,7 @@ class GenerationStrategy(Base):
             )
         return gr[0]
 
-    def gen_for_multiple_trials_with_multiple_models(
+    def gen(
         self,
         experiment: Experiment,
         data: Data | None = None,

--- a/ax/generation_strategy/tests/test_aepsych_criterion.py
+++ b/ax/generation_strategy/tests/test_aepsych_criterion.py
@@ -140,7 +140,9 @@ class TestAEPsychCriterion(TestCase):
         self.assertFalse(move_to_next_node)
 
         for _i in range(6):
-            experiment.new_trial(generation_strategy.gen(experiment=experiment))
+            experiment.new_trial(
+                generation_strategy.gen_single_trial(experiment=experiment)
+            )
         for trial in experiment.trials.values():
             trial._status = TrialStatus.COMPLETED
 

--- a/ax/generation_strategy/tests/test_dispatch_utils.py
+++ b/ax/generation_strategy/tests/test_dispatch_utils.py
@@ -412,7 +412,7 @@ class TestDispatchUtils(TestCase):
         sobol = choose_generation_strategy_legacy(
             search_space=get_factorial_search_space(), random_seed=9
         )
-        sobol.gen(experiment=get_experiment(), n=1)
+        sobol.gen_single_trial(experiment=get_experiment(), n=1)
         # First model is actually an adapter, second is the Sobol engine.
         self.assertEqual(
             assert_is_instance(

--- a/ax/generation_strategy/tests/test_external_generation_node.py
+++ b/ax/generation_strategy/tests/test_external_generation_node.py
@@ -72,7 +72,9 @@ class TestExternalGenerationNode(TestCase):
 
         # Sequential generation.
         for _ in range(3):
-            gr = gs.gen(n=1, experiment=experiment, data=experiment.lookup_data())
+            gr = gs.gen_single_trial(
+                n=1, experiment=experiment, data=experiment.lookup_data()
+            )
             trial = experiment.new_trial(generator_run=gr)
             trial.mark_running(no_runner_required=True)
             experiment.attach_data(get_branin_data(trials=[trial]))
@@ -85,7 +87,7 @@ class TestExternalGenerationNode(TestCase):
         pending_observations = {
             "some_metric": [ObservationFeatures(parameters={"x1": 0.123, "x2": 0.456})]
         }
-        gr = gs.gen(
+        gr = gs.gen_single_trial(
             n=1,
             experiment=experiment,
             data=experiment.lookup_data(),
@@ -100,7 +102,9 @@ class TestExternalGenerationNode(TestCase):
         self.assertEqual(node.last_pending, [{"x1": 0.123, "x2": 0.456}])
 
         # Batch generation.
-        gr = gs.gen(n=5, experiment=experiment, data=experiment.lookup_data())
+        gr = gs.gen_single_trial(
+            n=5, experiment=experiment, data=experiment.lookup_data()
+        )
         self.assertEqual(node.gen_count, 9)
         self.assertEqual(node.update_count, 5)
         self.assertEqual(len(gr.arms), 5)
@@ -118,8 +122,12 @@ class TestExternalGenerationNode(TestCase):
             "ax.adapter.random.RandomAdapter.gen",
             return_value=GeneratorRun(arms=[Arm(parameters=params)], model_key="Sobol"),
         ) as mock_gen:
-            experiment.new_trial(generator_run=gs.gen(n=1, experiment=experiment)).run()
-            experiment.new_trial(generator_run=gs.gen(n=1, experiment=experiment)).run()
+            experiment.new_trial(
+                generator_run=gs.gen_single_trial(n=1, experiment=experiment)
+            ).run()
+            experiment.new_trial(
+                generator_run=gs.gen_single_trial(n=1, experiment=experiment)
+            ).run()
         self.assertEqual(node.gen_count, 6)  # first trial + 5 deduplication attempts
         self.assertEqual(mock_gen.call_count, 7)  # also called for the fallback
         self.assertEqual(node.update_count, 2)

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -941,9 +941,9 @@ class TestGenerationStrategy(TestCase):
                 )
             )
 
-    def test_gen_for_multiple_trials_with_multiple_models_bw_comp(self) -> None:
+    def test_gen_bw_comp(self) -> None:
         # This test initially tested _gen_multiple, however, this has
-        # been replaced with gen_for_multiple_trials_with_multiple_models
+        # been replaced with gen
         # ensure the original gen_multiple behavior is preserved.
         exp = get_experiment_with_multi_objective()
         sobol_MBM_gs = self.sobol_MBM_step_GS
@@ -957,9 +957,7 @@ class TestGenerationStrategy(TestCase):
         ) as gen_spec_fit_mock:
             # Generate first four Sobol GRs (one more to gen after that if
             # first four become trials.
-            grs = sobol_MBM_gs.gen_for_multiple_trials_with_multiple_models(
-                experiment=exp, num_trials=3
-            )
+            grs = sobol_MBM_gs.gen(experiment=exp, num_trials=3)
             self.assertEqual(len(grs), 3)
             # We should only fit once; refitting for each `gen` would be
             # wasteful as there is no new data.
@@ -996,7 +994,7 @@ class TestGenerationStrategy(TestCase):
                     same_elements(original_pending[m], first_3_trials_obs_feats)
                 )
 
-            grs_for_trials = sobol_MBM_gs.gen_for_multiple_trials_with_multiple_models(
+            grs_for_trials = sobol_MBM_gs.gen(
                 experiment=exp,
                 num_trials=3,
                 pending_observations=get_pending(experiment=exp),
@@ -1041,13 +1039,13 @@ class TestGenerationStrategy(TestCase):
         gs = GenerationStrategy(nodes=[self.sobol_node], name="test")
         gs.experiment = exp
         exp._properties[Keys.EXPERIMENT_TOTAL_CONCURRENT_ARMS.value] = 3
-        grs = gs.gen_for_multiple_trials_with_multiple_models(exp, num_trials=2)
+        grs = gs.gen(exp, num_trials=2)
         self.assertEqual(len(grs), 2)
         for gr_list in grs:
             self.assertEqual(len(gr_list), 1)
             self.assertEqual(len(gr_list[0].arms), 3)
 
-    def test_gen_for_multiple_trials_with_multiple_models(self) -> None:
+    def test_gen(self) -> None:
         exp = get_experiment_with_multi_objective()
         sobol_MBM_gs = self.sobol_MBM_step_GS
         sobol_MBM_gs.experiment = exp
@@ -1057,9 +1055,7 @@ class TestGenerationStrategy(TestCase):
         ) as generator_spec_gen_mock:
             # Generate first four Sobol GRs (one more to gen after that if
             # first four become trials.
-            grs = sobol_MBM_gs.gen_for_multiple_trials_with_multiple_models(
-                experiment=exp, num_trials=3
-            )
+            grs = sobol_MBM_gs.gen(experiment=exp, num_trials=3)
         self.assertEqual(len(grs), 3)
         for gr in grs:
             self.assertEqual(len(gr), 1)
@@ -1095,7 +1091,7 @@ class TestGenerationStrategy(TestCase):
                 same_elements(original_pending[m], first_3_trials_obs_feats)
             )
 
-        grs = sobol_MBM_gs.gen_for_multiple_trials_with_multiple_models(
+        grs = sobol_MBM_gs.gen(
             experiment=exp,
             num_trials=3,
         )
@@ -1121,7 +1117,7 @@ class TestGenerationStrategy(TestCase):
                             self.assertIn(p, pending[m])
 
     @mock_botorch_optimize
-    def test_gen_for_multiple_trials_with_multiple_models_with_fixed_features(
+    def test_gen_with_fixed_features(
         self,
     ) -> None:
         exp = get_branin_experiment()
@@ -1151,7 +1147,7 @@ class TestGenerationStrategy(TestCase):
         )
         gs.experiment = exp
         for _ in range(3):
-            grs = gs.gen_for_multiple_trials_with_multiple_models(
+            grs = gs.gen(
                 experiment=exp,
                 num_trials=1,
                 n=2,
@@ -1940,11 +1936,7 @@ class TestGenerationStrategy(TestCase):
                 mock_path=f"{GeneratorSpec.__module__}.GeneratorSpec.gen",
                 original_method=GeneratorSpec.gen,
             ) as generator_spec_gen_mock:
-                exp.new_batch_trial(
-                    generator_runs=gs.gen_for_multiple_trials_with_multiple_models(
-                        exp, n=9
-                    )[0]
-                )
+                exp.new_batch_trial(generator_runs=gs.gen(exp, n=9)[0])
                 fixed_features_in_gen = generator_spec_gen_mock.call_args_list[
                     0
                 ].kwargs.get("fixed_features")
@@ -1965,7 +1957,7 @@ class TestGenerationStrategy(TestCase):
                     parameters={}, trial_index=4
                 )
                 exp.new_batch_trial(
-                    generator_runs=gs.gen_for_multiple_trials_with_multiple_models(
+                    generator_runs=gs.gen(
                         exp, n=9, fixed_features=passed_fixed_features
                     )[0]
                 )

--- a/ax/generation_strategy/tests/test_transition_criterion.py
+++ b/ax/generation_strategy/tests/test_transition_criterion.py
@@ -53,7 +53,6 @@ class TestTransitionCriterion(TestCase):
         self.branin_experiment = get_branin_experiment()
 
     def test_minimum_preference_criterion(self) -> None:
-        """Tests the minimum preference criterion subclass of TransitionCriterion."""
         criterion = MinimumPreferenceOccurances(metric_name="m1", threshold=3)
         experiment = get_experiment()
         generation_strategy = GenerationStrategy(
@@ -104,7 +103,6 @@ class TestTransitionCriterion(TestCase):
             )
 
     def test_aux_experiment_check(self) -> None:
-        """Tests that the aux experiment check transition."""
         # Test incorrect instantiation
         with self.assertRaisesRegex(UserInputError, r"cannot have both .* None"):
             AuxiliaryExperimentCheck(
@@ -114,7 +112,6 @@ class TestTransitionCriterion(TestCase):
             )
 
     def test_aux_experiment_check_in_gs(self) -> None:
-        """Tests that the aux experiment check transition works as expected in a GS."""
         experiment = self.branin_experiment
         gs = GenerationStrategy(
             name="test",
@@ -264,7 +261,6 @@ class TestTransitionCriterion(TestCase):
         )
 
     def test_min_trials_is_met(self) -> None:
-        """Test that the is_met method in  MinTrials works"""
         experiment = self.branin_experiment
         gs = GenerationStrategy(
             name="SOBOL::default",
@@ -286,7 +282,9 @@ class TestTransitionCriterion(TestCase):
 
         # Need to add trials to test the transition criteria `is_met` method
         for _i in range(4):
-            experiment.new_trial(gs.gen(experiment=experiment))
+            experiment.new_trial(
+                generator_run=gs.gen_single_trial(experiment=experiment)
+            )
         node_0_trials = gs._steps[0].trials_from_node
         node_1_trials = gs._steps[1].trials_from_node
 
@@ -393,8 +391,8 @@ class TestTransitionCriterion(TestCase):
         )
         self.assertEqual(gs.current_node_name, "sobol_1")
         # Should not transition because this is a MOO experiment
-        gr = gs.gen(experiment=exp)
-        gr2 = gs.gen(experiment=exp)
+        gr = gs.gen_single_trial(experiment=exp)
+        gr2 = gs.gen_single_trial(experiment=exp)
         self.assertEqual(gr._generation_node_name, "sobol_1")
         self.assertEqual(gr2._generation_node_name, "sobol_1")
         self.assertEqual(gs.current_node_name, "sobol_1")
@@ -420,15 +418,14 @@ class TestTransitionCriterion(TestCase):
             ],
         )
         self.assertEqual(gs.current_node_name, "sobol_1")
-        gr = gs.gen(experiment=exp)
-        gr2 = gs.gen(experiment=exp)
+        gr = gs.gen_single_trial(experiment=exp)
+        gr2 = gs.gen_single_trial(experiment=exp)
         # First generation should use sobol_1, then transition to sobol_2
         self.assertEqual(gr._generation_node_name, "sobol_1")
         self.assertEqual(gr2._generation_node_name, "sobol_2")
         self.assertEqual(gs.current_node_name, "sobol_2")
 
     def test_max_trials_is_met(self) -> None:
-        """Test that the is_met method in MaxTrials works"""
         experiment = self.branin_experiment
         gs = GenerationStrategy(
             name="SOBOL::default",
@@ -465,7 +462,9 @@ class TestTransitionCriterion(TestCase):
         )
         # After adding trials, should pass
         for _i in range(4):
-            experiment.new_trial(gs.gen(experiment=experiment))
+            experiment.new_trial(
+                generator_run=gs.gen_single_trial(experiment=experiment)
+            )
         self.assertTrue(
             gs._steps[0]
             .transition_criteria[0]
@@ -540,7 +539,7 @@ class TestTransitionCriterion(TestCase):
         )
 
         for _i in range(3):
-            experiment.new_trial(gs.gen(experiment=experiment))
+            experiment.new_trial(gs.gen_single_trial(experiment=experiment))
         self.assertTrue(
             max_criterion.is_met(experiment=experiment, curr_node=gs._steps[0])
         )
@@ -562,9 +561,6 @@ class TestTransitionCriterion(TestCase):
         )
 
     def test_repr(self) -> None:
-        """Tests that the repr string is correctly formatted for all
-        TransitionCriterion child classes.
-        """
         self.maxDiff = None
         max_trials_criterion = MaxTrials(
             threshold=5,

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1729,7 +1729,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             else None
         )
         with with_rng_seed(seed=self._random_seed):
-            return none_throws(self.generation_strategy).gen(
+            return none_throws(self.generation_strategy).gen_single_trial(
                 experiment=self.experiment,
                 n=n,
                 pending_observations=self._get_pending_observation_features(

--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -167,7 +167,7 @@ class OptimizationLoop:
     def _get_new_trial(self) -> BaseTrial:
         if self.arms_per_trial == 1:
             return self.experiment.new_trial(
-                generator_run=self.generation_strategy.gen(
+                generator_run=self.generation_strategy.gen_single_trial(
                     experiment=self.experiment,
                     pending_observations=get_pending_observation_features(
                         experiment=self.experiment
@@ -176,7 +176,7 @@ class OptimizationLoop:
             )
         elif self.arms_per_trial > 1:
             return self.experiment.new_batch_trial(
-                generator_run=self.generation_strategy.gen(
+                generator_run=self.generation_strategy.gen_single_trial(
                     experiment=self.experiment, n=self.arms_per_trial
                 )
             )

--- a/ax/service/orchestrator.py
+++ b/ax/service/orchestrator.py
@@ -1680,7 +1680,7 @@ class Orchestrator(AnalysisBase, BestPointMixin):
         # want to enable that functionality for single-arm use cases of the
         # ``Orchestrator``, as it's still in development.
         if self.options.trial_type == TrialType.BATCH_TRIAL:
-            grs = self.generation_strategy.gen_for_multiple_trials_with_multiple_models(
+            grs = self.generation_strategy.gen(
                 experiment=self.experiment,
                 num_trials=num_trials,
                 n=n,
@@ -1691,7 +1691,7 @@ class Orchestrator(AnalysisBase, BestPointMixin):
             pending = get_pending_observation_features_based_on_trial_status(
                 experiment=self.experiment
             )
-            grs = self.generation_strategy.gen_for_multiple_trials_with_multiple_models(
+            grs = self.generation_strategy.gen(
                 experiment=self.experiment,
                 num_trials=num_trials,
                 n=1,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -3041,8 +3041,8 @@ class TestAxClient(TestCase):
         )
         with mock.patch.object(
             GenerationStrategy,
-            "gen",
-            wraps=ax_client.generation_strategy.gen,
+            "gen_single_trial",
+            wraps=ax_client.generation_strategy.gen_single_trial,
         ) as mock_gen:
             with self.subTest("fixed_features is None"):
                 ax_client.get_next_trial()

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -310,12 +310,12 @@ class TestBestPointUtils(TestCase):
         )
 
         for _ in range(3):
-            generator_run = gs.gen(experiment=exp, n=1)
+            generator_run = gs.gen_single_trial(experiment=exp, n=1)
             trial = exp.new_trial(generator_run=generator_run)
             trial.run().mark_completed()
             exp.attach_data(exp.fetch_data())
 
-        generator_run = gs.gen(experiment=exp, n=1)
+        generator_run = gs.gen_single_trial(experiment=exp, n=1)
         trial = exp.new_trial(generator_run=generator_run)
         trial.run().mark_completed()
 

--- a/ax/service/tests/test_with_db_settings_base.py
+++ b/ax/service/tests/test_with_db_settings_base.py
@@ -298,7 +298,7 @@ class TestWithDBSettingsBase(TestCase):
         trials = [experiment.new_trial() for _ in range(5)]
         grs = []
         for t in trials:
-            gr = generation_strategy.gen(experiment)
+            gr = generation_strategy.gen_single_trial(experiment)
             grs.append(gr)
             t.add_generator_run(gr)
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -545,7 +545,7 @@ class JSONStoreTest(TestCase):
         # we remove the fake callable kwarg we added, since model does not
         # expect it.
         generation_strategy = get_generation_strategy(with_callable_model_kwarg=False)
-        gr = generation_strategy.gen(experiment)
+        gr = generation_strategy.gen_single_trial(experiment)
         gs_json = object_to_json(
             generation_strategy,
             encoder_registry=CORE_ENCODER_REGISTRY,
@@ -568,7 +568,7 @@ class JSONStoreTest(TestCase):
         generation_strategy = new_generation_strategy
         experiment.new_trial(gr)  # Add previously generated GR as trial.
         # Make generation strategy aware of the trial's data via `gen`.
-        generation_strategy.gen(experiment, data=get_branin_data())
+        generation_strategy.gen_single_trial(experiment, data=get_branin_data())
         gs_json = object_to_json(
             generation_strategy,
             encoder_registry=CORE_ENCODER_REGISTRY,

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -360,7 +360,7 @@ class SQAStoreTest(TestCase):
             is_test=True,
         )
         aux_exp_gs = get_generation_strategy(with_callable_model_kwarg=False)
-        aux_exp.new_trial(aux_exp_gs.gen(experiment=aux_exp))
+        aux_exp.new_trial(aux_exp_gs.gen_single_trial(experiment=aux_exp))
         save_experiment(aux_exp, config=self.config)
         # pyre-ignore[16]: `AuxiliaryExperimentPurpose` has no attribute
         purpose = self.config.auxiliary_experiment_purpose_enum.PE_EXPERIMENT
@@ -377,7 +377,7 @@ class SQAStoreTest(TestCase):
             },
         )
         target_exp_gs = get_generation_strategy(with_callable_model_kwarg=False)
-        target_exp.new_trial(target_exp_gs.gen(experiment=target_exp))
+        target_exp.new_trial(target_exp_gs.gen_single_trial(experiment=target_exp))
         self.assertIsNone(target_exp.db_id)
         save_experiment(target_exp, config=self.config)
         self.assertIsNotNone(target_exp.db_id)
@@ -744,8 +744,8 @@ class SQAStoreTest(TestCase):
         gs = get_generation_strategy(
             with_experiment=True, with_callable_model_kwarg=False
         )
-        gs.gen(experiment=gs.experiment)
-        gs.gen(experiment=gs.experiment)
+        gs.gen_single_trial(experiment=gs.experiment)
+        gs.gen_single_trial(experiment=gs.experiment)
 
         save_experiment(gs.experiment)
         save_generation_strategy(gs)
@@ -965,7 +965,7 @@ class SQAStoreTest(TestCase):
     def test_EncodeGeneratorRunReducedState(self) -> None:
         exp = get_branin_experiment()
         gs = get_generation_strategy(with_callable_model_kwarg=False)
-        gr = gs.gen(experiment=exp)
+        gr = gs.gen_single_trial(experiment=exp)
 
         for key in [attr.key for attr in GR_LARGE_MODEL_ATTRS]:
             self.assertIsNotNone(getattr(gr, f"_{key}"))
@@ -988,7 +988,7 @@ class SQAStoreTest(TestCase):
     def test_load_and_save_generator_run_reduced_state(self) -> None:
         exp = get_branin_experiment()
         gs = get_generation_strategy(with_callable_model_kwarg=False)
-        gr = gs.gen(experiment=exp)
+        gr = gs.gen_single_trial(experiment=exp)
         original_gen_metadata = {"foo": "bar"}
         gr._gen_metadata = original_gen_metadata
         exp.new_trial(generator_run=gr)
@@ -1715,8 +1715,10 @@ class SQAStoreTest(TestCase):
         # Since we now need to `gen`, we remove the fake callable kwarg we added,
         # since model does not expect it.
         generation_strategy = get_generation_strategy(with_callable_model_kwarg=False)
-        experiment.new_trial(generation_strategy.gen(experiment=experiment))
-        generation_strategy.gen(experiment, data=get_branin_data())
+        experiment.new_trial(
+            generation_strategy.gen_single_trial(experiment=experiment)
+        )
+        generation_strategy.gen_single_trial(experiment, data=get_branin_data())
         save_experiment(experiment)
         save_generation_strategy(generation_strategy=generation_strategy)
         # Try restoring the generation strategy using the experiment its
@@ -1828,8 +1830,10 @@ class SQAStoreTest(TestCase):
         generation_strategy = get_generation_strategy(
             with_generation_nodes=True, with_callable_model_kwarg=False
         )
-        experiment.new_trial(generation_strategy.gen(experiment=experiment))
-        generation_strategy.gen(experiment, data=get_branin_data())
+        experiment.new_trial(
+            generation_strategy.gen_single_trial(experiment=experiment)
+        )
+        generation_strategy.gen_single_trial(experiment, data=get_branin_data())
         save_experiment(experiment)
 
         save_generation_strategy(generation_strategy=generation_strategy)
@@ -1858,8 +1862,10 @@ class SQAStoreTest(TestCase):
         """
         generation_strategy = get_generation_strategy(with_callable_model_kwarg=False)
         experiment = get_branin_experiment()
-        experiment.new_trial(generation_strategy.gen(experiment=experiment))
-        generation_strategy.gen(experiment, data=get_branin_data())
+        experiment.new_trial(
+            generation_strategy.gen_single_trial(experiment=experiment)
+        )
+        generation_strategy.gen_single_trial(experiment, data=get_branin_data())
         self.assertEqual(len(generation_strategy._generator_runs), 2)
         save_experiment(experiment)
         save_generation_strategy(generation_strategy=generation_strategy)
@@ -1894,7 +1900,9 @@ class SQAStoreTest(TestCase):
         self.assertEqual(
             none_throws(new_generation_strategy._experiment)._name, experiment._name
         )
-        experiment.new_trial(new_generation_strategy.gen(experiment=experiment))
+        experiment.new_trial(
+            new_generation_strategy.gen_single_trial(experiment=experiment)
+        )
 
     def test_EncodeDecodeGenerationStrategyReducedStateLoadExperiment(self) -> None:
         """Try restoring the generation strategy using the experiment its
@@ -1903,8 +1911,10 @@ class SQAStoreTest(TestCase):
         """
         generation_strategy = get_generation_strategy(with_callable_model_kwarg=False)
         experiment = get_branin_experiment()
-        experiment.new_trial(generation_strategy.gen(experiment=experiment))
-        generation_strategy.gen(experiment, data=get_branin_data())
+        experiment.new_trial(
+            generation_strategy.gen_single_trial(experiment=experiment)
+        )
+        generation_strategy.gen_single_trial(experiment, data=get_branin_data())
         self.assertEqual(len(generation_strategy._generator_runs), 2)
         save_experiment(experiment)
         save_generation_strategy(generation_strategy=generation_strategy)
@@ -1954,7 +1964,9 @@ class SQAStoreTest(TestCase):
         self.assertEqual(
             none_throws(new_generation_strategy._experiment)._name, experiment._name
         )
-        experiment.new_trial(new_generation_strategy.gen(experiment=experiment))
+        experiment.new_trial(
+            new_generation_strategy.gen_single_trial(experiment=experiment)
+        )
 
     def test_UpdateGenerationStrategy(self) -> None:
         generation_strategy = get_generation_strategy(with_callable_model_kwarg=False)
@@ -1964,7 +1976,9 @@ class SQAStoreTest(TestCase):
         save_experiment(experiment)
 
         # add generator run, save, reload
-        experiment.new_trial(generator_run=generation_strategy.gen(experiment))
+        experiment.new_trial(
+            generator_run=generation_strategy.gen_single_trial(experiment)
+        )
         save_generation_strategy(generation_strategy=generation_strategy)
         loaded_generation_strategy = load_generation_strategy_by_experiment_name(
             experiment_name=experiment.name
@@ -1977,7 +1991,9 @@ class SQAStoreTest(TestCase):
 
         # add another generator run, save, reload
         experiment.new_trial(
-            generator_run=generation_strategy.gen(experiment, data=get_branin_data())
+            generator_run=generation_strategy.gen_single_trial(
+                experiment, data=get_branin_data()
+            )
         )
         save_generation_strategy(generation_strategy=generation_strategy)
         save_experiment(experiment)
@@ -2026,7 +2042,7 @@ class SQAStoreTest(TestCase):
         generator_runs = []
         for i in range(7):
             data = get_branin_data() if i > 0 else None
-            gr = generation_strategy.gen(experiment, data=data)
+            gr = generation_strategy.gen_single_trial(experiment, data=data)
             generator_runs.append(gr)
             trial = experiment.new_trial(generator_run=gr).mark_running(
                 no_runner_required=True
@@ -2052,7 +2068,7 @@ class SQAStoreTest(TestCase):
         generator_runs = []
         for i in range(7):
             data = get_branin_data() if i > 0 else None
-            gr = generation_strategy.gen(experiment, data=data)
+            gr = generation_strategy.gen_single_trial(experiment, data=data)
             generator_runs.append(gr)
             trial = experiment.new_trial(generator_run=gr).mark_running(
                 no_runner_required=True
@@ -2211,7 +2227,9 @@ class SQAStoreTest(TestCase):
         _mock_gr_from_sqa.reset_mock()
 
         generation_strategy = get_generation_strategy(with_callable_model_kwarg=False)
-        experiment.new_trial(generation_strategy.gen(experiment=experiment))
+        experiment.new_trial(
+            generation_strategy.gen_single_trial(experiment=experiment)
+        )
 
         save_generation_strategy(generation_strategy=generation_strategy)
         load_generation_strategy_by_experiment_name(experiment_name=experiment.name)
@@ -2302,7 +2320,7 @@ class SQAStoreTest(TestCase):
         # experiment loading.
         exp = get_branin_experiment()
         gs = get_generation_strategy(with_callable_model_kwarg=False)
-        trial = exp.new_trial(gs.gen(experiment=exp))
+        trial = exp.new_trial(gs.gen_single_trial(experiment=exp))
         for instrumented_attr in GR_LARGE_MODEL_ATTRS:
             self.assertIsNotNone(
                 getattr(trial.generator_run, f"_{instrumented_attr.key}")

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -494,7 +494,7 @@ def run_branin_experiment_with_generation_strategy(
     kwargs_for_get_branin_experiment = kwargs_for_get_branin_experiment or {}
     exp = get_branin_experiment(**kwargs_for_get_branin_experiment)
     for _ in range(num_trials):
-        gr = generation_strategy.gen(n=1, experiment=exp)
+        gr = generation_strategy.gen_single_trial(n=1, experiment=exp)
         trial = exp.new_trial(generator_run=gr)
         trial.mark_running(no_runner_required=True)
         exp.attach_data(get_branin_data(trials=[trial]))

--- a/ax/utils/testing/utils.py
+++ b/ax/utils/testing/utils.py
@@ -59,7 +59,9 @@ def run_trials_with_gs(
         )
     existing_trials = len(experiment.trials)
     for i in range(existing_trials, existing_trials + num_trials):
-        trial = experiment.new_trial(generator_run=gs.gen(experiment=experiment))
+        trial = experiment.new_trial(
+            generator_run=gs.gen_single_trial(experiment=experiment)
+        )
         data = Data(
             df=pd.DataFrame.from_records(
                 [


### PR DESCRIPTION
Summary: We want the most powerful gen to be our default gen, and that's gen_for_multi_with_multi, in the previous diff we free'd up the name gen

Differential Revision: D75718755


