### PR TITLE
Rename GStep.model->generator GStep.model_name->generator_name

### DIFF
--- a/ax/adapter/tests/test_model_fit_metrics.py
+++ b/ax/adapter/tests/test_model_fit_metrics.py
@@ -63,11 +63,11 @@ class TestAdapterFitMetrics(TestCase):
         self.generation_strategy = GenerationStrategy(
             steps=[
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=NUM_SOBOL,
                     max_parallelism=NUM_SOBOL,
                 ),
-                GenerationStep(model=Generators.BOTORCH_MODULAR, num_trials=-1),
+                GenerationStep(generator=Generators.BOTORCH_MODULAR, num_trials=-1),
             ]
         )
 

--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -88,12 +88,12 @@ def get_sobol_mbm_generation_strategy(
         name=name,
         steps=[
             GenerationStep(
-                model=Generators.SOBOL,
+                generator=Generators.SOBOL,
                 num_trials=num_sobol_trials,
                 min_trials_observed=num_sobol_trials,
             ),
             GenerationStep(
-                model=Generators.BOTORCH_MODULAR,
+                generator=Generators.BOTORCH_MODULAR,
                 num_trials=-1,
                 model_kwargs=model_kwargs,
                 model_gen_kwargs=model_gen_kwargs or {},

--- a/ax/benchmark/methods/sobol.py
+++ b/ax/benchmark/methods/sobol.py
@@ -18,7 +18,7 @@ def get_sobol_generation_strategy() -> GenerationStrategy:
     return GenerationStrategy(
         name="Sobol",
         steps=[
-            GenerationStep(model=Generators.SOBOL, num_trials=-1),
+            GenerationStep(generator=Generators.SOBOL, num_trials=-1),
         ],
     )
 

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -51,7 +51,7 @@ class TestMethods(TestCase):
         self.assertEqual(method.name, expected_name)
         gs = method.generation_strategy
         sobol, kg = gs._steps
-        self.assertEqual(kg.model, Generators.BOTORCH_MODULAR)
+        self.assertEqual(kg.generator, Generators.BOTORCH_MODULAR)
         model_kwargs = none_throws(kg.model_kwargs)
         self.assertEqual(model_kwargs["botorch_acqf_class"], qKnowledgeGradient)
         surrogate_spec = model_kwargs["surrogate_spec"]
@@ -119,7 +119,7 @@ class TestMethods(TestCase):
         self.assertEqual(method.name, "Sobol")
         gs = method.generation_strategy
         self.assertEqual(len(gs._steps), 1)
-        self.assertEqual(gs._steps[0].model, Generators.SOBOL)
+        self.assertEqual(gs._steps[0].generator, Generators.SOBOL)
 
     def _test_get_best_parameters(self, use_model_predictions: bool) -> None:
         problem = get_benchmark_problem(

--- a/ax/generation_strategy/dispatch_utils.py
+++ b/ax/generation_strategy/dispatch_utils.py
@@ -65,7 +65,7 @@ def _make_sobol_step(
 ) -> GenerationStep:
     """Shortcut for creating a Sobol generation step."""
     return GenerationStep(
-        model=Generators.SOBOL,
+        generator=Generators.SOBOL,
         num_trials=num_trials,
         # NOTE: ceil(-1 / 2) = 0, so this is safe to do when num trials is -1.
         min_trials_observed=min_trials_observed or ceil(num_trials / 2),
@@ -81,7 +81,7 @@ def _make_botorch_step(
     min_trials_observed: int | None = None,
     enforce_num_trials: bool = True,
     max_parallelism: int | None = None,
-    model: GeneratorRegistryBase = Generators.BOTORCH_MODULAR,
+    generator: GeneratorRegistryBase = Generators.BOTORCH_MODULAR,
     model_kwargs: dict[str, Any] | None = None,
     winsorization_config: None
     | (WinsorizationConfig | dict[str, WinsorizationConfig]) = None,
@@ -114,7 +114,7 @@ def _make_botorch_step(
     )
 
     if not no_winsorization:
-        _, default_bridge_kwargs = model.view_defaults()
+        _, default_bridge_kwargs = generator.view_defaults()
         default_transforms = default_bridge_kwargs["transforms"]
         transforms = model_kwargs.get("transforms", default_transforms)
         model_kwargs["transforms"] = [cast(type[Transform], Winsorize)] + transforms
@@ -123,7 +123,7 @@ def _make_botorch_step(
                 winsorization_transform_config
             )
 
-    if MODEL_KEY_TO_MODEL_SETUP[model.value].model_class != ModularBoTorchGenerator:
+    if MODEL_KEY_TO_MODEL_SETUP[generator.value].model_class != ModularBoTorchGenerator:
         if verbose is not None:
             model_kwargs.update({"verbose": verbose})
         if disable_progbar is not None:
@@ -138,7 +138,7 @@ def _make_botorch_step(
             "dropping these arguments."
         )
     return GenerationStep(
-        model=model,
+        generator=generator,
         num_trials=num_trials,
         # NOTE: ceil(-1 / 2) = 0, so this is safe to do when num trials is -1.
         min_trials_observed=min_trials_observed or ceil(num_trials / 2),
@@ -548,7 +548,7 @@ def choose_generation_strategy_legacy(
             )
         steps.append(
             _make_botorch_step(
-                model=suggested_model,
+                generator=suggested_model,
                 winsorization_config=winsorization_config,
                 derelativize_with_raw_status_quo=derelativize_with_raw_status_quo,
                 no_winsorization=no_winsorization,

--- a/ax/generation_strategy/generation_strategy.py
+++ b/ax/generation_strategy/generation_strategy.py
@@ -488,7 +488,7 @@ class GenerationStrategy(Base):
                 raise UserInputError(
                     "Maximum parallelism should be None (if no limit) or "
                     f"a positive number. Got: {step.max_parallelism} for "
-                    f"step {step.model_name}."
+                    f"step {step.generator_name}."
                 )
 
             step._node_name = f"GenerationStep_{str(idx)}"

--- a/ax/generation_strategy/tests/test_aepsych_criterion.py
+++ b/ax/generation_strategy/tests/test_aepsych_criterion.py
@@ -40,12 +40,12 @@ class TestAEPsychCriterion(TestCase):
             name="SOBOL+MBM::default",
             steps=[
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=-1,
                     completion_criteria=[criterion],
                 ),
                 GenerationStep(
-                    model=Generators.BOTORCH_MODULAR,
+                    generator=Generators.BOTORCH_MODULAR,
                     num_trials=-1,
                     max_parallelism=1,
                 ),
@@ -100,10 +100,12 @@ class TestAEPsychCriterion(TestCase):
             name="SOBOL+MBM::default",
             steps=[
                 GenerationStep(
-                    model=Generators.SOBOL, num_trials=-1, completion_criteria=criteria
+                    generator=Generators.SOBOL,
+                    num_trials=-1,
+                    completion_criteria=criteria,
                 ),
                 GenerationStep(
-                    model=Generators.BOTORCH_MODULAR,
+                    generator=Generators.BOTORCH_MODULAR,
                     num_trials=-1,
                     max_parallelism=1,
                 ),

--- a/ax/generation_strategy/tests/test_dispatch_utils.py
+++ b/ax/generation_strategy/tests/test_dispatch_utils.py
@@ -54,9 +54,9 @@ class TestDispatchUtils(TestCase):
             sobol_gpei = choose_generation_strategy_legacy(
                 search_space=get_branin_search_space()
             )
-            self.assertEqual(sobol_gpei._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol_gpei._steps[0].generator, Generators.SOBOL)
             self.assertEqual(sobol_gpei._steps[0].num_trials, 5)
-            self.assertEqual(sobol_gpei._steps[1].model, Generators.BOTORCH_MODULAR)
+            self.assertEqual(sobol_gpei._steps[1].generator, Generators.BOTORCH_MODULAR)
             expected_model_kwargs: dict[str, Any] = {
                 "torch_device": None,
                 "transforms": expected_transforms,
@@ -80,35 +80,35 @@ class TestDispatchUtils(TestCase):
                 search_space=get_branin_search_space(),
                 max_initialization_trials=2,
             )
-            self.assertEqual(sobol_gpei._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol_gpei._steps[0].generator, Generators.SOBOL)
             self.assertEqual(sobol_gpei._steps[0].num_trials, 2)
-            self.assertEqual(sobol_gpei._steps[1].model, Generators.BOTORCH_MODULAR)
+            self.assertEqual(sobol_gpei._steps[1].generator, Generators.BOTORCH_MODULAR)
         with self.subTest("min sobol trials"):
             sobol_gpei = choose_generation_strategy_legacy(
                 search_space=get_branin_search_space(),
                 min_sobol_trials_observed=1,
             )
-            self.assertEqual(sobol_gpei._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol_gpei._steps[0].generator, Generators.SOBOL)
             self.assertEqual(sobol_gpei._steps[0].min_trials_observed, 1)
-            self.assertEqual(sobol_gpei._steps[1].model, Generators.BOTORCH_MODULAR)
+            self.assertEqual(sobol_gpei._steps[1].generator, Generators.BOTORCH_MODULAR)
         with self.subTest("num_initialization_trials > max_initialization_trials"):
             sobol_gpei = choose_generation_strategy_legacy(
                 search_space=get_branin_search_space(),
                 max_initialization_trials=2,
                 num_initialization_trials=3,
             )
-            self.assertEqual(sobol_gpei._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol_gpei._steps[0].generator, Generators.SOBOL)
             self.assertEqual(sobol_gpei._steps[0].num_trials, 3)
-            self.assertEqual(sobol_gpei._steps[1].model, Generators.BOTORCH_MODULAR)
+            self.assertEqual(sobol_gpei._steps[1].generator, Generators.BOTORCH_MODULAR)
         with self.subTest("num_initialization_trials > max_initialization_trials"):
             sobol_gpei = choose_generation_strategy_legacy(
                 search_space=get_branin_search_space(),
                 max_initialization_trials=2,
                 num_initialization_trials=3,
             )
-            self.assertEqual(sobol_gpei._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol_gpei._steps[0].generator, Generators.SOBOL)
             self.assertEqual(sobol_gpei._steps[0].num_trials, 3)
-            self.assertEqual(sobol_gpei._steps[1].model, Generators.BOTORCH_MODULAR)
+            self.assertEqual(sobol_gpei._steps[1].generator, Generators.BOTORCH_MODULAR)
         with self.subTest("MOO"):
             optimization_config = MultiObjectiveOptimizationConfig(
                 objective=MultiObjective(objectives=[])
@@ -117,9 +117,9 @@ class TestDispatchUtils(TestCase):
                 search_space=get_branin_search_space(),
                 optimization_config=optimization_config,
             )
-            self.assertEqual(sobol_gpei._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol_gpei._steps[0].generator, Generators.SOBOL)
             self.assertEqual(sobol_gpei._steps[0].num_trials, 5)
-            self.assertEqual(sobol_gpei._steps[1].model, Generators.BOTORCH_MODULAR)
+            self.assertEqual(sobol_gpei._steps[1].generator, Generators.BOTORCH_MODULAR)
             model_kwargs = none_throws(sobol_gpei._steps[1].model_kwargs)
             self.assertEqual(
                 set(model_kwargs.keys()),
@@ -135,13 +135,13 @@ class TestDispatchUtils(TestCase):
             sobol = choose_generation_strategy_legacy(
                 search_space=get_factorial_search_space(), num_trials=1000
             )
-            self.assertEqual(sobol._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol._steps[0].generator, Generators.SOBOL)
             self.assertEqual(len(sobol._steps), 1)
         with self.subTest("Sobol (because of too many categories)"):
             sobol_large = choose_generation_strategy_legacy(
                 search_space=get_large_factorial_search_space(), verbose=True
             )
-            self.assertEqual(sobol_large._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol_large._steps[0].generator, Generators.SOBOL)
             self.assertEqual(len(sobol_large._steps), 1)
         with self.subTest("Sobol (because of too many categories) with saasbo"):
             with self.assertLogs(
@@ -159,7 +159,7 @@ class TestDispatchUtils(TestCase):
                     ),
                     logger.output,
                 )
-            self.assertEqual(sobol_large._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol_large._steps[0].generator, Generators.SOBOL)
             self.assertEqual(len(sobol_large._steps), 1)
         with self.subTest("SOBOL due to too many unordered choices"):
             # Search space with more unordered choices than ordered parameters.
@@ -169,7 +169,7 @@ class TestDispatchUtils(TestCase):
                     num_unordered_choices=100,
                 )
             )
-            self.assertEqual(sobol._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol._steps[0].generator, Generators.SOBOL)
             self.assertEqual(len(sobol._steps), 1)
         with self.subTest("GPEI with more unordered choices than ordered parameters"):
             # Search space with more unordered choices than ordered parameters.
@@ -179,15 +179,15 @@ class TestDispatchUtils(TestCase):
                     num_unordered_choices=10,
                 )
             )
-            self.assertEqual(sobol_gpei._steps[1].model, Generators.BOTORCH_MODULAR)
+            self.assertEqual(sobol_gpei._steps[1].generator, Generators.BOTORCH_MODULAR)
         with self.subTest("GPEI despite many unordered 2-value parameters"):
             gs = choose_generation_strategy_legacy(
                 search_space=get_large_factorial_search_space(
                     num_levels=2, num_parameters=10
                 ),
             )
-            self.assertEqual(gs._steps[0].model, Generators.SOBOL)
-            self.assertEqual(gs._steps[1].model, Generators.BOTORCH_MODULAR)
+            self.assertEqual(gs._steps[0].generator, Generators.SOBOL)
+            self.assertEqual(gs._steps[1].generator, Generators.BOTORCH_MODULAR)
         with self.subTest("GPEI-Batched"):
             sobol_gpei_batched = choose_generation_strategy_legacy(
                 search_space=get_branin_search_space(),
@@ -198,9 +198,9 @@ class TestDispatchUtils(TestCase):
             bo_mixed = choose_generation_strategy_legacy(
                 search_space=get_factorial_search_space()
             )
-            self.assertEqual(bo_mixed._steps[0].model, Generators.SOBOL)
+            self.assertEqual(bo_mixed._steps[0].generator, Generators.SOBOL)
             self.assertEqual(bo_mixed._steps[0].num_trials, 6)
-            self.assertEqual(bo_mixed._steps[1].model, Generators.BO_MIXED)
+            self.assertEqual(bo_mixed._steps[1].generator, Generators.BO_MIXED)
             expected_model_kwargs = {
                 "torch_device": None,
                 "transforms": [Winsorize] + Mixed_transforms + Y_trans,
@@ -213,9 +213,9 @@ class TestDispatchUtils(TestCase):
             # pyre-fixme[16]: `Parameter` has no attribute `_is_ordered`.
             ss.parameters["x2"]._is_ordered = False
             bo_mixed_2 = choose_generation_strategy_legacy(search_space=ss)
-            self.assertEqual(bo_mixed_2._steps[0].model, Generators.SOBOL)
+            self.assertEqual(bo_mixed_2._steps[0].generator, Generators.SOBOL)
             self.assertEqual(bo_mixed_2._steps[0].num_trials, 5)
-            self.assertEqual(bo_mixed_2._steps[1].model, Generators.BO_MIXED)
+            self.assertEqual(bo_mixed_2._steps[1].generator, Generators.BO_MIXED)
             expected_model_kwargs = {
                 "torch_device": None,
                 "transforms": [Winsorize] + Mixed_transforms + Y_trans,
@@ -232,9 +232,9 @@ class TestDispatchUtils(TestCase):
             moo_mixed = choose_generation_strategy_legacy(
                 search_space=search_space, optimization_config=optimization_config
             )
-            self.assertEqual(moo_mixed._steps[0].model, Generators.SOBOL)
+            self.assertEqual(moo_mixed._steps[0].generator, Generators.SOBOL)
             self.assertEqual(moo_mixed._steps[0].num_trials, 5)
-            self.assertEqual(moo_mixed._steps[1].model, Generators.BO_MIXED)
+            self.assertEqual(moo_mixed._steps[1].generator, Generators.BO_MIXED)
             model_kwargs = none_throws(moo_mixed._steps[1].model_kwargs)
             self.assertEqual(
                 set(model_kwargs.keys()),
@@ -253,9 +253,9 @@ class TestDispatchUtils(TestCase):
                 num_initialization_trials=3,
                 use_saasbo=True,
             )
-            self.assertEqual(sobol_fullybayesian._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol_fullybayesian._steps[0].generator, Generators.SOBOL)
             self.assertEqual(sobol_fullybayesian._steps[0].num_trials, 3)
-            self.assertEqual(sobol_fullybayesian._steps[1].model, Generators.SAASBO)
+            self.assertEqual(sobol_fullybayesian._steps[1].generator, Generators.SAASBO)
         with self.subTest("SAASBO MOO"):
             sobol_fullybayesianmoo = choose_generation_strategy_legacy(
                 search_space=get_branin_search_space(),
@@ -266,10 +266,12 @@ class TestDispatchUtils(TestCase):
                     objective=MultiObjective(objectives=[])
                 ),
             )
-            self.assertEqual(sobol_fullybayesianmoo._steps[0].model, Generators.SOBOL)
+            self.assertEqual(
+                sobol_fullybayesianmoo._steps[0].generator, Generators.SOBOL
+            )
             self.assertEqual(sobol_fullybayesianmoo._steps[0].num_trials, 3)
             self.assertEqual(
-                sobol_fullybayesianmoo._steps[1].model,
+                sobol_fullybayesianmoo._steps[1].generator,
                 Generators.SAASBO,
             )
         with self.subTest("SAASBO"):
@@ -280,11 +282,11 @@ class TestDispatchUtils(TestCase):
                 use_saasbo=True,
             )
             self.assertEqual(
-                sobol_fullybayesian_large._steps[0].model, Generators.SOBOL
+                sobol_fullybayesian_large._steps[0].generator, Generators.SOBOL
             )
             self.assertEqual(sobol_fullybayesian_large._steps[0].num_trials, 30)
             self.assertEqual(
-                sobol_fullybayesian_large._steps[1].model,
+                sobol_fullybayesian_large._steps[1].generator,
                 Generators.SAASBO,
             )
         with self.subTest("num_initialization_trials"):
@@ -295,40 +297,40 @@ class TestDispatchUtils(TestCase):
             gs_12_init_trials = choose_generation_strategy_legacy(
                 search_space=ss, num_trials=100
             )
-            self.assertEqual(gs_12_init_trials._steps[0].model, Generators.SOBOL)
+            self.assertEqual(gs_12_init_trials._steps[0].generator, Generators.SOBOL)
             self.assertEqual(gs_12_init_trials._steps[0].num_trials, 12)
             self.assertEqual(
-                gs_12_init_trials._steps[1].model, Generators.BOTORCH_MODULAR
+                gs_12_init_trials._steps[1].generator, Generators.BOTORCH_MODULAR
             )
             # at least 5 initialization trials are performed
             gs_5_init_trials = choose_generation_strategy_legacy(
                 search_space=ss, num_trials=0
             )
-            self.assertEqual(gs_5_init_trials._steps[0].model, Generators.SOBOL)
+            self.assertEqual(gs_5_init_trials._steps[0].generator, Generators.SOBOL)
             self.assertEqual(gs_5_init_trials._steps[0].num_trials, 5)
             self.assertEqual(
-                gs_5_init_trials._steps[1].model, Generators.BOTORCH_MODULAR
+                gs_5_init_trials._steps[1].generator, Generators.BOTORCH_MODULAR
             )
             # avoid spending >20% of budget on initialization trials if there are
             # more than 5 initialization trials
             gs_6_init_trials = choose_generation_strategy_legacy(
                 search_space=ss, num_trials=30
             )
-            self.assertEqual(gs_6_init_trials._steps[0].model, Generators.SOBOL)
+            self.assertEqual(gs_6_init_trials._steps[0].generator, Generators.SOBOL)
             self.assertEqual(gs_6_init_trials._steps[0].num_trials, 6)
             self.assertEqual(
-                gs_6_init_trials._steps[1].model, Generators.BOTORCH_MODULAR
+                gs_6_init_trials._steps[1].generator, Generators.BOTORCH_MODULAR
             )
         with self.subTest("suggested_model_override"):
             sobol_gpei = choose_generation_strategy_legacy(
                 search_space=get_branin_search_space()
             )
-            self.assertEqual(sobol_gpei._steps[1].model, Generators.BOTORCH_MODULAR)
+            self.assertEqual(sobol_gpei._steps[1].generator, Generators.BOTORCH_MODULAR)
             sobol_saasbo = choose_generation_strategy_legacy(
                 search_space=get_branin_search_space(),
                 suggested_model_override=Generators.SAASBO,
             )
-            self.assertEqual(sobol_saasbo._steps[1].model, Generators.SAASBO)
+            self.assertEqual(sobol_saasbo._steps[1].generator, Generators.SAASBO)
 
     def test_make_botorch_step_extra(self) -> None:
         # Test parts of _make_botorch_step that are not directly exposed in
@@ -359,12 +361,12 @@ class TestDispatchUtils(TestCase):
                     disable_progbar=disable_progbar,
                     use_saasbo=True,
                 )
-                self.assertEqual(sobol_saasbo._steps[0].model, Generators.SOBOL)
+                self.assertEqual(sobol_saasbo._steps[0].generator, Generators.SOBOL)
                 self.assertNotIn(
                     "disable_progbar",
                     none_throws(sobol_saasbo._steps[0].model_kwargs),
                 )
-                self.assertEqual(sobol_saasbo._steps[1].model, Generators.SAASBO)
+                self.assertEqual(sobol_saasbo._steps[1].generator, Generators.SAASBO)
                 self.assertNotIn(
                     "disable_progbar",
                     none_throws(sobol_saasbo._steps[0].model_kwargs),
@@ -390,12 +392,14 @@ class TestDispatchUtils(TestCase):
                     use_saasbo=False,
                 )
                 self.assertEqual(len(gp_saasbo._steps), 2)
-                self.assertEqual(gp_saasbo._steps[0].model, Generators.SOBOL)
+                self.assertEqual(gp_saasbo._steps[0].generator, Generators.SOBOL)
                 self.assertNotIn(
                     "disable_progbar",
                     none_throws(gp_saasbo._steps[0].model_kwargs),
                 )
-                self.assertEqual(gp_saasbo._steps[1].model, Generators.BOTORCH_MODULAR)
+                self.assertEqual(
+                    gp_saasbo._steps[1].generator, Generators.BOTORCH_MODULAR
+                )
                 self.assertNotIn(
                     "disable_progbar",
                     none_throws(gp_saasbo._steps[1].model_kwargs),
@@ -566,11 +570,11 @@ class TestDispatchUtils(TestCase):
             sobol_gpei = choose_generation_strategy_legacy(
                 search_space=ss, num_trials=23
             )
-            self.assertEqual(sobol_gpei._steps[0].model, Generators.SOBOL)
-            self.assertEqual(sobol_gpei._steps[1].model, Generators.BO_MIXED)
+            self.assertEqual(sobol_gpei._steps[0].generator, Generators.SOBOL)
+            self.assertEqual(sobol_gpei._steps[1].generator, Generators.BO_MIXED)
         with self.subTest("with budget that is exhaustive, Sobol is used"):
             sobol = choose_generation_strategy_legacy(search_space=ss, num_trials=36)
-            self.assertEqual(sobol._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol._steps[0].generator, Generators.SOBOL)
             self.assertEqual(len(sobol._steps), 1)
         with self.subTest("with budget that is exhaustive and use_saasbo, it warns"):
             with self.assertLogs(
@@ -588,7 +592,7 @@ class TestDispatchUtils(TestCase):
                     ),
                     logger.output,
                 )
-            self.assertEqual(sobol._steps[0].model, Generators.SOBOL)
+            self.assertEqual(sobol._steps[0].generator, Generators.SOBOL)
             self.assertEqual(len(sobol._steps), 1)
 
     def test_use_batch_trials(self) -> None:
@@ -756,12 +760,12 @@ class TestDispatchUtils(TestCase):
                     jit_compile=jit_compile,
                     use_saasbo=True,
                 )
-                self.assertEqual(sobol_saasbo._steps[0].model, Generators.SOBOL)
+                self.assertEqual(sobol_saasbo._steps[0].generator, Generators.SOBOL)
                 self.assertNotIn(
                     "jit_compile",
                     none_throws(sobol_saasbo._steps[0].model_kwargs),
                 )
-                self.assertEqual(sobol_saasbo._steps[1].model, Generators.SAASBO)
+                self.assertEqual(sobol_saasbo._steps[1].generator, Generators.SAASBO)
                 self.assertNotIn(
                     "jit_compile",
                     none_throws(sobol_saasbo._steps[0].model_kwargs),
@@ -787,12 +791,14 @@ class TestDispatchUtils(TestCase):
                     use_saasbo=False,
                 )
                 self.assertEqual(len(gp_saasbo._steps), 2)
-                self.assertEqual(gp_saasbo._steps[0].model, Generators.SOBOL)
+                self.assertEqual(gp_saasbo._steps[0].generator, Generators.SOBOL)
                 self.assertNotIn(
                     "jit_compile",
                     none_throws(gp_saasbo._steps[0].model_kwargs),
                 )
-                self.assertEqual(gp_saasbo._steps[1].model, Generators.BOTORCH_MODULAR)
+                self.assertEqual(
+                    gp_saasbo._steps[1].generator, Generators.BOTORCH_MODULAR
+                )
                 self.assertNotIn(
                     "jit_compile",
                     none_throws(gp_saasbo._steps[1].model_kwargs),

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -355,14 +355,12 @@ class TestGenerationStep(TestCase):
         super().setUp()
         self.model_kwargs = {"init_position": 5}
         self.sobol_generation_step = GenerationStep(
-            model=Generators.SOBOL,
+            generator=Generators.SOBOL,
             num_trials=5,
             model_kwargs=self.model_kwargs,
         )
         self.generator_spec = GeneratorSpec(
-            # pyre-fixme[6]: For 1st param expected `GeneratorRegistryBase` but got
-            #  `Union[typing.Callable[..., Adapter], GeneratorRegistryBase]`.
-            generator_enum=self.sobol_generation_step.model,
+            generator_enum=self.sobol_generation_step.generator,
             model_kwargs=self.model_kwargs,
         )
 
@@ -371,20 +369,20 @@ class TestGenerationStep(TestCase):
             self.sobol_generation_step.generator_specs,
             [self.generator_spec],
         )
-        self.assertEqual(self.sobol_generation_step.model_name, "Sobol")
+        self.assertEqual(self.sobol_generation_step.generator_name, "Sobol")
 
         named_generation_step = GenerationStep(
-            model=Generators.SOBOL,
+            generator=Generators.SOBOL,
             num_trials=5,
             model_kwargs=self.model_kwargs,
-            model_name="Custom Sobol",
+            generator_name="Custom Sobol",
         )
-        self.assertEqual(named_generation_step.model_name, "Custom Sobol")
+        self.assertEqual(named_generation_step.generator_name, "Custom Sobol")
 
     def test_min_trials_observed(self) -> None:
         with self.assertRaisesRegex(UserInputError, "min_trials_observed > num_trials"):
             GenerationStep(
-                model=Generators.SOBOL,
+                generator=Generators.SOBOL,
                 num_trials=5,
                 min_trials_observed=10,
                 model_kwargs=self.model_kwargs,
@@ -394,7 +392,8 @@ class TestGenerationStep(TestCase):
         with self.assertRaisesRegex(
             UserInputError, "must be a `GeneratorRegistryBase`"
         ):
-            GenerationStep(model=get_sobol, num_trials=-1)
+            # pyre-ignore [6]: Testing deprecated input.
+            GenerationStep(generator=get_sobol, num_trials=-1)
 
     def test_properties(self) -> None:
         step = self.sobol_generation_step

--- a/ax/generation_strategy/tests/test_transition_criterion.py
+++ b/ax/generation_strategy/tests/test_transition_criterion.py
@@ -60,12 +60,12 @@ class TestTransitionCriterion(TestCase):
             name="SOBOL::default",
             steps=[
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=-1,
                     completion_criteria=[criterion],
                 ),
                 GenerationStep(
-                    model=Generators.BOTORCH_MODULAR,
+                    generator=Generators.BOTORCH_MODULAR,
                     num_trials=-1,
                     max_parallelism=1,
                 ),
@@ -205,18 +205,18 @@ class TestTransitionCriterion(TestCase):
             name="SOBOL+MBM::default",
             steps=[
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=3,
                 ),
                 GenerationStep(
-                    model=Generators.BOTORCH_MODULAR,
+                    generator=Generators.BOTORCH_MODULAR,
                     num_trials=4,
                     max_parallelism=1,
                     min_trials_observed=2,
                     enforce_num_trials=False,
                 ),
                 GenerationStep(
-                    model=Generators.BOTORCH_MODULAR,
+                    generator=Generators.BOTORCH_MODULAR,
                     num_trials=-1,
                 ),
             ],
@@ -270,7 +270,7 @@ class TestTransitionCriterion(TestCase):
             name="SOBOL::default",
             steps=[
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=4,
                     min_trials_observed=2,
                     enforce_num_trials=True,
@@ -434,19 +434,19 @@ class TestTransitionCriterion(TestCase):
             name="SOBOL::default",
             steps=[
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=4,
                     min_trials_observed=0,
                     enforce_num_trials=True,
                 ),
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=4,
                     min_trials_observed=0,
                     enforce_num_trials=False,
                 ),
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=-1,
                     max_parallelism=1,
                 ),
@@ -521,7 +521,7 @@ class TestTransitionCriterion(TestCase):
             name="SOBOL::default",
             steps=[
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=4,
                     min_trials_observed=2,
                     enforce_num_trials=True,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -219,9 +219,9 @@ def get_client_with_simple_discrete_moo_problem(
 ) -> AxClient:
     gs = GenerationStrategy(
         steps=[
-            GenerationStep(model=Generators.SOBOL, num_trials=3),
+            GenerationStep(generator=Generators.SOBOL, num_trials=3),
             GenerationStep(
-                model=Generators.BOTORCH_MODULAR,
+                generator=Generators.BOTORCH_MODULAR,
                 num_trials=-1,
                 model_kwargs={
                     # To avoid search space exhausted errors.
@@ -507,7 +507,7 @@ class TestAxClient(TestCase):
         """
         ax_client = get_branin_optimization()
         self.assertEqual(
-            [s.model for s in none_throws(ax_client.generation_strategy)._steps],
+            [s.generator for s in none_throws(ax_client.generation_strategy)._steps],
             [Generators.SOBOL, Generators.BOTORCH_MODULAR],
         )
         with self.assertRaisesRegex(ValueError, ".* no trials"):
@@ -725,7 +725,7 @@ class TestAxClient(TestCase):
             },
         )
         self.assertEqual(
-            [s.model for s in none_throws(ax_client.generation_strategy)._steps],
+            [s.generator for s in none_throws(ax_client.generation_strategy)._steps],
             [Generators.SOBOL, Generators.BOTORCH_MODULAR],
         )
         with self.assertRaisesRegex(ValueError, ".* no trials"):
@@ -791,7 +791,7 @@ class TestAxClient(TestCase):
         """Test basic experiment creation."""
         ax_client = AxClient(
             GenerationStrategy(
-                steps=[GenerationStep(model=Generators.SOBOL, num_trials=30)]
+                steps=[GenerationStep(generator=Generators.SOBOL, num_trials=30)]
             )
         )
         with self.assertRaisesRegex(AssertionError, "Experiment not set on Ax client"):
@@ -931,7 +931,7 @@ class TestAxClient(TestCase):
         """
         ax_client = AxClient(
             GenerationStrategy(
-                steps=[GenerationStep(model=Generators.SOBOL, num_trials=30)]
+                steps=[GenerationStep(generator=Generators.SOBOL, num_trials=30)]
             )
         )
         ax_client.create_experiment(
@@ -1028,7 +1028,7 @@ class TestAxClient(TestCase):
     def test_create_single_objective_experiment_with_objectives_dict(self) -> None:
         ax_client = AxClient(
             GenerationStrategy(
-                steps=[GenerationStep(model=Generators.SOBOL, num_trials=30)]
+                steps=[GenerationStep(generator=Generators.SOBOL, num_trials=30)]
             )
         )
         with self.assertRaisesRegex(AssertionError, "Experiment not set on Ax client"):
@@ -1356,7 +1356,7 @@ class TestAxClient(TestCase):
         """Test basic experiment creation."""
         ax_client = AxClient(
             GenerationStrategy(
-                steps=[GenerationStep(model=Generators.SOBOL, num_trials=30)]
+                steps=[GenerationStep(generator=Generators.SOBOL, num_trials=30)]
             )
         )
         with self.assertRaisesRegex(AssertionError, "Experiment not set on Ax client"):
@@ -1520,7 +1520,7 @@ class TestAxClient(TestCase):
         """Check that we do not allow constraints on the objective metric."""
         ax_client = AxClient(
             GenerationStrategy(
-                steps=[GenerationStep(model=Generators.SOBOL, num_trials=30)]
+                steps=[GenerationStep(generator=Generators.SOBOL, num_trials=30)]
             )
         )
         with self.assertRaises(ValueError):

--- a/ax/service/tests/test_interactive_loop.py
+++ b/ax/service/tests/test_interactive_loop.py
@@ -36,7 +36,9 @@ class TestInteractiveLoop(TestCase):
     def setUp(self) -> None:
         generation_strategy = GenerationStrategy(
             steps=[
-                GenerationStep(model=Generators.SOBOL, max_parallelism=1, num_trials=-1)
+                GenerationStep(
+                    generator=Generators.SOBOL, max_parallelism=1, num_trials=-1
+                )
             ]
         )
         self.ax_client = AxClient(generation_strategy=generation_strategy)

--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -376,7 +376,8 @@ class TestManagedLoop(TestCase):
     def test_custom_gs(self) -> None:
         """Managed loop with custom generation strategy"""
         strategy0 = GenerationStrategy(
-            name="Sobol", steps=[GenerationStep(model=Generators.SOBOL, num_trials=-1)]
+            name="Sobol",
+            steps=[GenerationStep(generator=Generators.SOBOL, num_trials=-1)],
         )
         loop = OptimizationLoop.with_evaluation_function(
             parameters=[
@@ -418,7 +419,7 @@ class TestManagedLoop(TestCase):
             total_trials=6,
             generation_strategy=GenerationStrategy(
                 name="Sobol",
-                steps=[GenerationStep(model=Generators.SOBOL, num_trials=3)],
+                steps=[GenerationStep(generator=Generators.SOBOL, num_trials=3)],
             ),
         )
         self.assertEqual(len(exp.trials), 3)  # Check that we stopped at 3 trials.
@@ -440,7 +441,8 @@ class TestManagedLoop(TestCase):
     # pyre-fixme[3]: Return type must be annotated.
     def test_annotate_exception(self, _):
         strategy0 = GenerationStrategy(
-            name="Sobol", steps=[GenerationStep(model=Generators.SOBOL, num_trials=-1)]
+            name="Sobol",
+            steps=[GenerationStep(generator=Generators.SOBOL, num_trials=-1)],
         )
         loop = OptimizationLoop.with_evaluation_function(
             parameters=[

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -192,20 +192,22 @@ class TestAxOrchestrator(TestCase):
         self.two_sobol_steps_GS = GenerationStrategy(  # Contrived GS to ensure
             steps=[  # that `DataRequiredError` is property handled in orchestrator.
                 GenerationStep(  # This error is raised when not enough trials
-                    model=Generators.SOBOL,  # have been observed to proceed to next
+                    generator=Generators.SOBOL,  # have been observed to proceed to next
                     num_trials=5,  # geneneration step.
                     min_trials_observed=3,
                     max_parallelism=2,
                 ),
                 GenerationStep(
-                    model=Generators.SOBOL, num_trials=-1, max_parallelism=3
+                    generator=Generators.SOBOL, num_trials=-1, max_parallelism=3
                 ),
             ]
         )
         # GS to force the orchestrator to poll completed trials after each ran trial.
         self.sobol_GS_no_parallelism = GenerationStrategy(
             steps=[
-                GenerationStep(model=Generators.SOBOL, num_trials=-1, max_parallelism=1)
+                GenerationStep(
+                    generator=Generators.SOBOL, num_trials=-1, max_parallelism=1
+                )
             ]
         )
         self.orchestrator_options_kwargs = {}
@@ -1858,11 +1860,11 @@ class TestAxOrchestrator(TestCase):
         generation_strategy = GenerationStrategy(
             steps=[
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=NUM_SOBOL,
                     max_parallelism=NUM_SOBOL,
                 ),
-                GenerationStep(model=Generators.BOTORCH_MODULAR, num_trials=-1),
+                GenerationStep(generator=Generators.BOTORCH_MODULAR, num_trials=-1),
             ]
         )
         orchestrator = Orchestrator(
@@ -2122,10 +2124,10 @@ class TestAxOrchestrator(TestCase):
     ) -> None:
         gs = GenerationStrategy(
             steps=[
-                GenerationStep(model=Generators.SOBOL, num_trials=1),
-                GenerationStep(model=Generators.BOTORCH_MODULAR, num_trials=1),
+                GenerationStep(generator=Generators.SOBOL, num_trials=1),
+                GenerationStep(generator=Generators.BOTORCH_MODULAR, num_trials=1),
                 GenerationStep(
-                    model=Generators.BOTORCH_MODULAR,
+                    generator=Generators.BOTORCH_MODULAR,
                     model_kwargs={
                         # this will cause an error if the model
                         # doesn't get fixed features
@@ -2720,20 +2722,22 @@ class TestAxOrchestratorMultiTypeExperiment(TestAxOrchestrator):
         self.two_sobol_steps_GS = GenerationStrategy(  # Contrived GS to ensure
             steps=[  # that `DataRequiredError` is property handled in orchestrator.
                 GenerationStep(  # This error is raised when not enough trials
-                    model=Generators.SOBOL,  # have been observed to proceed to next
+                    generator=Generators.SOBOL,  # have been observed to proceed to next
                     num_trials=5,  # geneneration step.
                     min_trials_observed=3,
                     max_parallelism=2,
                 ),
                 GenerationStep(
-                    model=Generators.SOBOL, num_trials=-1, max_parallelism=3
+                    generator=Generators.SOBOL, num_trials=-1, max_parallelism=3
                 ),
             ]
         )
         # GS to force the Orchestrator to poll completed trials after each ran trial.
         self.sobol_GS_no_parallelism = GenerationStrategy(
             steps=[
-                GenerationStep(model=Generators.SOBOL, num_trials=-1, max_parallelism=1)
+                GenerationStep(
+                    generator=Generators.SOBOL, num_trials=-1, max_parallelism=1
+                )
             ]
         )
         self.orchestrator_options_kwargs: dict[str, str | None] = {

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -1265,13 +1265,15 @@ class ReportUtilsTest(TestCase):
         gs = GenerationStrategy(
             steps=[
                 GenerationStep(
-                    model=Generators.SOBOL,
+                    generator=Generators.SOBOL,
                     num_trials=3,
                     min_trials_observed=3,
                     max_parallelism=3,
                 ),
                 GenerationStep(
-                    model=Generators.BOTORCH_MODULAR, num_trials=-1, max_parallelism=3
+                    generator=Generators.BOTORCH_MODULAR,
+                    num_trials=-1,
+                    max_parallelism=3,
                 ),
             ]
         )

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -869,9 +869,14 @@ def generation_step_from_json(
         if "completion_criteria" in generation_step_json.keys()
         else []
     )
+    if "model" in generation_step_json:
+        # Old arg name for backwards compatibility.
+        generator_json = generation_step_json.pop("model")
+    else:
+        generator_json = generation_step_json.pop("generator")
     generation_step = GenerationStep(
-        model=object_from_json(
-            generation_step_json.pop("model"),
+        generator=object_from_json(
+            object_json=generator_json,
             decoder_registry=decoder_registry,
             class_decoder_registry=class_decoder_registry,
         ),
@@ -906,6 +911,7 @@ def generation_step_from_json(
         ),
         index=generation_step_json.pop("index", -1),
         should_deduplicate=generation_step_json.pop("should_deduplicate", False),
+        generator_name=generation_step_json.pop("generator_name", None),
     )
     return generation_step
 

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -418,7 +418,7 @@ def generation_step_to_dict(generation_step: GenerationStep) -> dict[str, Any]:
     """Converts Ax generation step to a dictionary."""
     return {
         "__type": generation_step.__class__.__name__,
-        "model": generation_step.model,
+        "generator": generation_step.generator,
         "num_trials": generation_step.num_trials,
         "min_trials_observed": generation_step.min_trials_observed,
         "completion_criteria": generation_step.completion_criteria,
@@ -434,6 +434,7 @@ def generation_step_to_dict(generation_step: GenerationStep) -> dict[str, Any]:
         "index": generation_step.index,
         "should_deduplicate": generation_step.should_deduplicate,
         "transition_criteria": generation_step.transition_criteria,
+        "generator_name": generation_step.generator_name,
     }
 
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -535,7 +535,7 @@ class JSONStoreTest(TestCase):
         generation_strategy._unset_non_persistent_state_fields()
         self.assertEqual(generation_strategy, new_generation_strategy)
         self.assertGreater(len(new_generation_strategy._steps), 0)
-        self.assertIsInstance(new_generation_strategy._steps[0].model, Generators)
+        self.assertIsInstance(new_generation_strategy._steps[0].generator, Generators)
         # Model has not yet been initialized on this GS since it hasn't generated
         # anything yet.
         self.assertIsNone(new_generation_strategy.adapter)
@@ -561,7 +561,7 @@ class JSONStoreTest(TestCase):
         # well.
         generation_strategy._unset_non_persistent_state_fields()
         self.assertEqual(generation_strategy, new_generation_strategy)
-        self.assertIsInstance(new_generation_strategy._steps[0].model, Generators)
+        self.assertIsInstance(new_generation_strategy._steps[0].generator, Generators)
 
         # Check that we can encode and decode the generation strategy after
         # it has generated some trials and been updated with some data.
@@ -584,7 +584,7 @@ class JSONStoreTest(TestCase):
         # well.
         generation_strategy._unset_non_persistent_state_fields()
         self.assertEqual(generation_strategy, new_generation_strategy)
-        self.assertIsInstance(new_generation_strategy._steps[0].model, Generators)
+        self.assertIsInstance(new_generation_strategy._steps[0].generator, Generators)
 
     def test_EncodeDecodeNumpy(self) -> None:
         arr = np.array([[1, 2, 3], [4, 5, 6]])
@@ -830,6 +830,7 @@ class JSONStoreTest(TestCase):
         generation_step = object_from_json(json)
         self.assertIsInstance(generation_step, GenerationStep)
         self.assertEqual(generation_step.model_kwargs, {"other_kwarg": 5})
+        self.assertEqual(generation_step.generator, Generators.BOTORCH_MODULAR)
 
     def test_generator_run_backwards_compatibility(self) -> None:
         # Test that we can load a generator run with deprecated kwargs.

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -1729,7 +1729,7 @@ class SQAStoreTest(TestCase):
         # well.
         generation_strategy._unset_non_persistent_state_fields()
         self.assertEqual(generation_strategy, new_generation_strategy)
-        self.assertIsInstance(new_generation_strategy._steps[0].model, Generators)
+        self.assertIsInstance(new_generation_strategy._steps[0].generator, Generators)
         self.assertEqual(len(new_generation_strategy._generator_runs), 2)
         self.assertEqual(
             none_throws(new_generation_strategy._experiment)._name, experiment._name
@@ -1889,7 +1889,7 @@ class SQAStoreTest(TestCase):
         self.assertEqual(new_generation_strategy, generation_strategy)
         # Model should be successfully restored in generation strategy even with
         # the reduced state.
-        self.assertIsInstance(new_generation_strategy._steps[0].model, Generators)
+        self.assertIsInstance(new_generation_strategy._steps[0].generator, Generators)
         self.assertEqual(len(new_generation_strategy._generator_runs), 2)
         self.assertEqual(
             none_throws(new_generation_strategy._experiment)._name, experiment._name
@@ -1949,7 +1949,7 @@ class SQAStoreTest(TestCase):
         self.assertEqual(new_generation_strategy, generation_strategy)
         # Model should be successfully restored in generation strategy even with
         # the reduced state.
-        self.assertIsInstance(new_generation_strategy._steps[0].model, Generators)
+        self.assertIsInstance(new_generation_strategy._steps[0].generator, Generators)
         self.assertEqual(len(new_generation_strategy._generator_runs), 2)
         self.assertEqual(
             none_throws(new_generation_strategy._experiment)._name, experiment._name

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -548,7 +548,7 @@ def get_legacy_list_surrogate_generation_step_as_dict() -> dict[str, Any]:
 
 def get_surrogate_generation_step() -> GenerationStep:
     return GenerationStep(
-        model=Generators.BOTORCH_MODULAR,
+        generator=Generators.BOTORCH_MODULAR,
         num_trials=-1,
         max_parallelism=1,
         model_kwargs={


### PR DESCRIPTION
Summary:
Renames GStep inputs & corresponding attributes.
- `model -> generator` (refers to the enum)
- `model_name -> generator_name` (optional override for the enum key)

**Q:** Should we do the same for `model_kwargs->generator_kwargs` and `model_gen_kwargs->generator_gen_kwargs`? The terminology is a bit confusing since we refer to the enum as `Generators`, which implies that the collective `Adapter(Generator)` object is a "generator". But if we wanted to be precise, `model_kwargs` are split between the constructors of `Adapter` and `Generator` (not the enum) depending on their signatures; and `model_gen_kwargs` is passed to `Adapter.gen` (may be passed down to `Generator.gen` from there. If we're ok with referring to the collective `Adapter(Generator)` as a "generator", I think renaming them is fine.

Differential Revision: D75633383


