### PR TITLE
New ExperimentData container (for modeling layer)

### DIFF
--- a/ax/adapter/data_utils.py
+++ b/ax/adapter/data_utils.py
@@ -7,11 +7,26 @@
 # pyre-strict
 
 
+"""
+Utilities for working with data for an Ax experiment.
+Unlike the Ax Data object, "data" here refers to both the arm
+parameterizations and the metric observations (from a Data object).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from copy import deepcopy
 from dataclasses import dataclass
 
-from ax.core.base_trial import TrialStatus
-from ax.core.trial_status import NON_ABANDONED_STATUSES
+from ax.core.data import Data
+from ax.core.experiment import Experiment
+from ax.core.map_data import MapData
+from ax.core.map_metric import MapMetric
+from ax.core.trial_status import NON_ABANDONED_STATUSES, TrialStatus
+from ax.core.types import TParameterization
 from ax.exceptions.core import UnsupportedError
+from pandas import DataFrame, MultiIndex, Series
 
 
 @dataclass(frozen=True)
@@ -74,3 +89,261 @@ class DataLoaderConfig:
         if self.fit_only_completed_map_metrics:
             return {TrialStatus.COMPLETED}
         return self.statuses_to_fit
+
+
+@dataclass
+class ExperimentData:
+    """A container for the data from arms and observations of an experiment.
+
+    This is intended as a lightweight container for the data that gets processed
+    within the ``Adapter`` / ``Transform`` layer. This will be passed through
+    transforms, allowing for column-wise, vectorized transforming of the values.
+    This can then be used to construct any necessary data structures for the
+    ``Generator``, such as the ``SupervisedDataset`` objects constructed
+    in ``TorchAdapter``.
+
+    NOTE: This should only be constructed using the ``extract_experiment_data`` helper.
+    Construction of the underlying dataframes manually from scratch can be quite
+    complicated and error prone due to the multi-index involved in both the
+    index and columns of the dataframes.
+
+    Attributes:
+        arm_data: A dataframe, indexed by (trial_index, arm_name), containing the
+            the parameterization of each arm, with one column per parameter.
+            Each row corresponds to the parameterization for the given
+            (trial_index, arm_name) pair.
+        observation_data: A dataframe, indexed by (trial_index, arm_name[, *map_keys])
+            map_keys being optional, containing the mean and sem observations for each
+            metric. The columns of the dataframe are multi-indexed, with the first level
+            being "mean" or "sem" and the second level being the metric name.
+            This is typically constructed by pivoting `(Map)Data.true_df`.
+
+    Example with non-map data:
+        >>> experiment = Experiment(...)  # An experiment with non-map Data.
+        >>> experiment_data = extract_experiment_data(
+        ...     experiment=experiment,
+        ...     data_loader_config=DataLoaderConfig(),
+        ... )
+        >>> print(experiment_data.arm_data)
+                                     x         y
+        trial_index arm_name
+        0           0_0       0.539644  0.878898
+        1           1_0       0.341846  0.213774
+        3           3_0       0.837545  0.732969
+        >>> print(experiment_data.observation_data)
+                             mean      sem
+        metric_name            m1   m2  m1  m2
+        trial_index arm_name
+        0           0_0       0.1  1.0 NaN NaN
+        1           1_0       0.2  2.0 NaN NaN
+
+    Example with map data:
+        >>> experiment = Experiment(...)  # An experiment with MapData.
+        >>> experiment_data = extract_experiment_data(
+        ...     experiment=experiment,
+        ...     data_loader_config=DataLoaderConfig(
+        ...         fit_only_completed_map_metrics=False,
+        ...         latest_rows_per_group=None,
+        ...     ),
+        ... )
+        >>> print(experiment_data.arm_data)
+                               x1   x2
+        trial_index arm_name
+        0           0_0       0.0  0.0
+        1           1_0       1.0  1.0
+        >>> print(experiment_data.observation_data)
+                                            mean               sem
+        metric_name                        branin branin_map branin branin_map
+        trial_index arm_name timestamp
+        0           0_0      0.0        55.602113  55.602113    0.0        0.0
+                             1.0              NaN  55.602113    NaN        0.0
+                             2.0              NaN  55.602113    NaN        0.0
+                             3.0              NaN  55.602113    NaN        0.0
+        1           1_0      0.0        27.702906  27.702906    0.0        0.0
+                             1.0              NaN  27.702906    NaN        0.0
+    """
+
+    arm_data: DataFrame
+    observation_data: DataFrame
+
+    def filter_by_arm_names(self, arm_names: Iterable[str]) -> ExperimentData:
+        """
+        Returns a new ``ExperimentData`` object that is filtered to only include
+        the rows corresponding to arms in ``arm_names``.
+        """
+        return ExperimentData(
+            arm_data=self.arm_data[
+                self.arm_data.index.get_level_values("arm_name").isin(arm_names)
+            ],
+            observation_data=self.observation_data[
+                self.observation_data.index.get_level_values("arm_name").isin(arm_names)
+            ],
+        )
+
+    def filter_latest_observations(self) -> ExperimentData:
+        """
+        Returns a new ``ExperimentData`` object, where the ``observation_data`` is
+        filtered to only include the latest (according to map key index) value
+        for each ``(trial_index, arm_name)`` pair. The resulting ``observation_data``
+        will not have the map keys in its index.
+
+        NOTE: This is an expensive operation. Use sparingly!
+        """
+        if len(self.observation_data.index.names) == 2:
+            # No map key in the observation data. Nothing to filter.
+            return deepcopy(self)
+        if len(self.observation_data.index.names) != 3:
+            raise UnsupportedError(
+                "Filtering latest observations is not supported when the index "
+                f"includes multiple map keys. Got {self.observation_data.index=}"
+            )
+        # This sorts each (trial_index, arm_name) group by the map key value,
+        # fills NaNs (missing observation for a given progression) in each column
+        # with the latest non-null value, and gets the last
+        # row, which is now filled with all the latest observations.
+        # The resulting dataframe has the highest progression observation for each
+        # (trial_index, arm_name) pair for each metric.
+        # TODO: See if we can do this more efficiently, maybe by avoiding groupby.apply.
+        observation_data = (
+            self.observation_data.groupby(
+                level=["trial_index", "arm_name"], group_keys=False
+            )
+            # With map keys, we expect this to be pre-sorted but we can't guarantee.
+            .apply(lambda df: df.sort_index(level=2).ffill().tail(1))
+            .droplevel(2)  # Remove map key from the index.
+        )
+        return ExperimentData(
+            arm_data=self.arm_data.copy(),
+            observation_data=observation_data,
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ExperimentData):
+            return False
+        return self.arm_data.equals(other.arm_data) and self.observation_data.equals(
+            other.observation_data
+        )
+
+
+def extract_experiment_data(
+    experiment: Experiment,
+    data_loader_config: DataLoaderConfig,
+    data: Data | None = None,
+) -> ExperimentData:
+    """Extract ``ExperimentData`` from the trials & ``Data`` of an experiment.
+
+    Args:
+        experiment: The experiment to extract data from.
+        data_loader_config: A DataLoaderConfig of options for loading data. See the
+            docstring of DataLoaderConfig for more details.
+        data: The observation data for the metrics of the experiment.
+            Optional, defaults to `experiment.lookup_data()`.
+    """
+    data = data or experiment.lookup_data()
+    arm_data = _extract_arm_data(experiment=experiment)
+    # Filter arm_data to only include arms with data.
+    arm_data = arm_data.loc[
+        arm_data.index.isin(
+            data.true_df[["trial_index", "arm_name"]].apply(tuple, axis=1)
+        )
+    ]
+    observation_data = _extract_observation_data(
+        experiment=experiment, data_loader_config=data_loader_config, data=data
+    )
+    return ExperimentData(arm_data=arm_data, observation_data=observation_data)
+
+
+def _extract_arm_data(experiment: Experiment) -> DataFrame:
+    """Extract a dataframe containing the trial index, arm name, and
+    the parameterizations from the given experiment.
+
+    The dataframe will include a row for each (trial_index, arm_name) pair,
+    as long as the corresponding trial has some data attached to the experiment.
+
+    Args:
+        experiment: The experiment to extract arms from.
+    """
+    records: dict[tuple[int, str], TParameterization] = {}
+    for trial_index, trial in experiment.trials.items():
+        for arm in trial.arms:
+            records[(trial_index, arm.name)] = arm.parameters
+    if records:
+        df = DataFrame.from_dict(records, orient="index")
+        df.index.names = ["trial_index", "arm_name"]
+    else:
+        # No data, return an empty dataframe with the correct index & columns.
+        index = MultiIndex.from_tuples([], names=["trial_index", "arm_name"])
+        df = DataFrame(index=index, columns=list(experiment.parameters))
+    return df
+
+
+def _extract_observation_data(
+    experiment: Experiment,
+    data_loader_config: DataLoaderConfig,
+    data: Data | None = None,
+) -> DataFrame:
+    """Extracts a dataframe containing filtered observations for the metrics
+    on the experiment.
+
+    See `extract_experiment_data` for a description of the arguments.
+
+    Returns:
+        A dataframe filtered to only include observations from the given statuses
+        to include, and pivoted to be indexed by (trial_index, arm_name, *map_keys)
+        and to have columns "mean" & "sem" for each metric.
+    """
+    data = data if data is not None else experiment.lookup_data()
+    if isinstance(data, MapData):
+        map_keys = data.map_keys
+        if len(map_keys) > 1:
+            raise UnsupportedError(
+                f"Multiple map keys are not supported. The data has {map_keys=}."
+            )
+        if data_loader_config.latest_rows_per_group is not None:
+            data = data.latest(
+                map_keys=map_keys,
+                rows_per_group=data_loader_config.latest_rows_per_group,
+            )
+        elif (
+            data_loader_config.limit_rows_per_metric is not None
+            or data_loader_config.limit_rows_per_group is not None
+        ):
+            data = data.subsample(
+                map_key=data.map_keys[0],
+                limit_rows_per_metric=data_loader_config.limit_rows_per_metric,
+                limit_rows_per_group=data_loader_config.limit_rows_per_group,
+                include_first_last=True,
+            )
+    else:
+        map_keys = []
+    df = data.true_df
+    # Filter out rows for invalid statuses.
+    to_keep = Series(index=df.index, data=False)
+    trial_statuses = df["trial_index"].map(
+        {trial_index: trial.status for trial_index, trial in experiment.trials.items()}
+    )
+    for metric in experiment.metrics.values():
+        valid_statuses = (
+            data_loader_config.statuses_to_fit_map_metric
+            if isinstance(metric, MapMetric)
+            else data_loader_config.statuses_to_fit
+        )
+        to_keep |= (df["metric_name"] == metric.name) & trial_statuses.isin(
+            valid_statuses
+        )
+    df = df.loc[to_keep]
+    # If df is empty, add mean & sem columns to facilitate pivoting.
+    if df.empty:
+        df = df.assign(mean=None, sem=None)
+    # Pivot the df to be indexed by (trial_index, arm_name, *map_keys)
+    # and to have columns "mean" & "sem" for each metric.
+    observation_data = df.pivot(
+        columns="metric_name",
+        index=[
+            "trial_index",
+            "arm_name",
+            *map_keys,
+        ],
+        values=["mean", "sem"],
+    )
+    return observation_data

--- a/ax/adapter/tests/test_data_utils.py
+++ b/ax/adapter/tests/test_data_utils.py
@@ -6,10 +6,20 @@
 
 # pyre-strict
 
-from ax.adapter.data_utils import DataLoaderConfig
+import numpy as np
+from ax.adapter.data_utils import DataLoaderConfig, extract_experiment_data
+from ax.adapter.registry import Generators
+from ax.core.data import Data
 from ax.core.trial_status import NON_ABANDONED_STATUSES, TrialStatus
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import (
+    get_branin_experiment,
+    get_branin_experiment_with_timestamp_map_metric,
+    get_experiment_with_observations,
+)
+from pandas import DataFrame, MultiIndex
+from pandas.testing import assert_frame_equal
 
 
 class TestDataUtils(TestCase):
@@ -44,3 +54,270 @@ class TestDataUtils(TestCase):
         self.assertEqual(config.limit_rows_per_group, 20)
         self.assertEqual(config.statuses_to_fit, set(TrialStatus))
         self.assertEqual(config.statuses_to_fit_map_metric, set(TrialStatus))
+
+    def test_extract_experiment_data_empty(self) -> None:
+        # Tests extraction of experiment data from experiments with no data.
+        empty_exp = get_branin_experiment()
+        for empty_exp in [
+            get_branin_experiment(),
+            get_branin_experiment_with_timestamp_map_metric(),
+        ]:
+            experiment_data = extract_experiment_data(
+                experiment=empty_exp, data_loader_config=DataLoaderConfig()
+            )
+            for df in (experiment_data.arm_data, experiment_data.observation_data):
+                self.assertEqual(len(df), 0)
+                self.assertEqual(df.index.names, ["trial_index", "arm_name"])
+            self.assertEqual(
+                experiment_data.arm_data.columns.to_list(), list(empty_exp.parameters)
+            )
+            self.assertEqual(experiment_data, experiment_data)
+
+    def test_extract_experiment_data_non_map(self) -> None:
+        # This is a 2 objective experiment with 2 trials, 1 arm each.
+        observations = [[0.1, 1.0], [0.2, 2.0]]
+        exp = get_experiment_with_observations(observations=observations)
+        # Add another trial but fail it.
+        sobol = Generators.SOBOL(experiment=exp)
+        exp.new_trial(generator_run=sobol.gen(1)).run().mark_failed()
+        # Add an abandoned trial but include data for one metric.
+        t = exp.new_trial(generator_run=sobol.gen(1)).mark_abandoned()
+        data = Data(
+            df=DataFrame.from_records(
+                [
+                    {
+                        "arm_name": t.arms[0].name,
+                        "metric_name": "m1",
+                        "mean": 0.4,
+                        "sem": 0.2,
+                        "trial_index": t.index,
+                    }
+                ]
+            )
+        )
+        exp.attach_data(data)
+
+        # Test with default config.
+        experiment_data = extract_experiment_data(
+            experiment=exp, data_loader_config=DataLoaderConfig()
+        )
+        # Arm data: All trials with data should be included.
+        # Filtering happens when constructing datasets.
+        arms_with_data = ["0_0", "1_0", "3_0"]
+        expected_arm_df = DataFrame(
+            [exp.arms_by_name[arm_name].parameters for arm_name in arms_with_data],
+            index=MultiIndex.from_tuples(
+                [(0, "0_0"), (1, "1_0"), (3, "3_0")],
+                names=["trial_index", "arm_name"],
+            ),
+        )
+        assert_frame_equal(experiment_data.arm_data, expected_arm_df)
+        # Observation data: Only completed trials should be included.
+        # First 4 rows correspond to 2 metrics from the 2 completed trials.
+        data_df = exp.lookup_data().df[:4]
+        expected_obs_df = data_df.pivot(
+            columns="metric_name",
+            index=["trial_index", "arm_name"],
+            values=["mean", "sem"],
+        )
+        assert_frame_equal(experiment_data.observation_data, expected_obs_df)
+        self.assertTrue(
+            experiment_data.observation_data.index.equals(
+                MultiIndex.from_tuples(
+                    [(0, "0_0"), (1, "1_0")],
+                    names=["trial_index", "arm_name"],
+                )
+            )
+        )
+        self.assertTrue(
+            experiment_data.observation_data.columns.equals(
+                MultiIndex.from_tuples(
+                    [("mean", "m1"), ("mean", "m2"), ("sem", "m1"), ("sem", "m2")],
+                    names=[None, "metric_name"],
+                )
+            )
+        )
+        # The successful trials don't have SEMs.
+        self.assertTrue(experiment_data.observation_data["sem"].isnull().all().all())
+        # Check the metric values.
+        self.assertEqual(
+            experiment_data.observation_data["mean"].to_numpy().tolist(), observations
+        )
+        # Check equality with self.
+        self.assertEqual(experiment_data, experiment_data)
+
+        # Test with config that includes abandoned trials.
+        experiment_data = extract_experiment_data(
+            experiment=exp, data_loader_config=DataLoaderConfig(fit_abandoned=True)
+        )
+        assert_frame_equal(experiment_data.arm_data, expected_arm_df)
+        # All data should be included.
+        data_df = exp.lookup_data().df
+        expected_obs_df = data_df.pivot(
+            columns="metric_name",
+            index=["trial_index", "arm_name"],
+            values=["mean", "sem"],
+        )
+        assert_frame_equal(experiment_data.observation_data, expected_obs_df)
+        self.assertEqual(len(experiment_data.observation_data), 3)
+        # Check the metric & sem values.
+        NAN = float("nan")
+        self.assertTrue(
+            np.array_equal(
+                experiment_data.observation_data["mean"].to_numpy(),
+                np.asarray(observations + [[0.4, NAN]]),
+                equal_nan=True,
+            )
+        )
+        self.assertTrue(
+            np.array_equal(
+                experiment_data.observation_data["sem"].to_numpy(),
+                np.asarray([[NAN, NAN], [NAN, NAN], [0.2, NAN]]),
+                equal_nan=True,
+            )
+        )
+
+    def test_extract_experiment_data_map(self) -> None:
+        exp = get_branin_experiment_with_timestamp_map_metric(with_trials_and_data=True)
+        t_0_metric = 55.602112642270264
+        t_1_metric = 27.702905548512433
+        # Test with default config.
+        experiment_data = extract_experiment_data(
+            experiment=exp, data_loader_config=DataLoaderConfig()
+        )
+        # Arm data: First two trials should be included, since they have data.
+        expected_arm_df = DataFrame(
+            [{"x1": 0.0, "x2": 0.0}, {"x1": 1.0, "x2": 1.0}],
+            index=MultiIndex.from_tuples(
+                [(0, "0_0"), (1, "1_0")], names=["trial_index", "arm_name"]
+            ),
+        )
+        assert_frame_equal(experiment_data.arm_data, expected_arm_df)
+        # Observation data: By default only includes completed map metrics.
+        # There is none, so map metrics are not included.
+        metrics = set(experiment_data.observation_data["mean"])
+        self.assertEqual(metrics, {"branin"})
+        self.assertEqual(len(experiment_data.observation_data), 2)
+        # Complete a trial to include map metrics.
+        exp.trials[0].complete()
+        experiment_data = extract_experiment_data(
+            experiment=exp, data_loader_config=DataLoaderConfig()
+        )
+        # Arm data is not changed.
+        assert_frame_equal(experiment_data.arm_data, expected_arm_df)
+        # Observation data: Map metrics should be included but only with latest
+        # timestamp for trial 0.
+        metrics = set(experiment_data.observation_data["mean"])
+        self.assertEqual(metrics, {"branin", "branin_map"})
+        index = MultiIndex.from_tuples(
+            [(0, "0_0", 0.0), (0, "0_0", 3.0), (1, "1_0", 0.0)],
+            names=["trial_index", "arm_name", "timestamp"],
+        )
+        expected_mean_df = DataFrame(
+            [
+                {"branin": t_0_metric, "branin_map": None},
+                {"branin": None, "branin_map": t_0_metric},
+                {"branin": t_1_metric, "branin_map": None},
+            ],
+            index=index,
+        )
+        self.assertTrue(
+            experiment_data.observation_data["mean"].equals(expected_mean_df)
+        )
+        expected_sem_df = DataFrame(
+            [
+                {"branin": 0.0, "branin_map": None},
+                {"branin": None, "branin_map": 0.0},
+                {"branin": 0.0, "branin_map": None},
+            ],
+            index=index,
+        )
+        self.assertTrue(experiment_data.observation_data["sem"].equals(expected_sem_df))
+
+        # Test with config that includes all map data.
+        experiment_data = extract_experiment_data(
+            experiment=exp,
+            data_loader_config=DataLoaderConfig(
+                fit_only_completed_map_metrics=False,
+                latest_rows_per_group=None,
+            ),
+        )
+        # Arm data is not changed.
+        assert_frame_equal(experiment_data.arm_data, expected_arm_df)
+        # Observation data: Map metrics should be included for all timestamps.
+        metrics = set(experiment_data.observation_data["mean"])
+        self.assertEqual(metrics, {"branin", "branin_map"})
+        index = MultiIndex.from_tuples(
+            [
+                (0, "0_0", 0.0),
+                (0, "0_0", 1.0),
+                (0, "0_0", 2.0),
+                (0, "0_0", 3.0),
+                (1, "1_0", 0.0),
+                (1, "1_0", 1.0),
+            ],
+            names=["trial_index", "arm_name", "timestamp"],
+        )
+        expected_mean_df = DataFrame(
+            [
+                {"branin": t_0_metric, "branin_map": t_0_metric},
+                {"branin": None, "branin_map": t_0_metric},
+                {"branin": None, "branin_map": t_0_metric},
+                {"branin": None, "branin_map": t_0_metric},
+                {"branin": t_1_metric, "branin_map": t_1_metric},
+                {"branin": None, "branin_map": t_1_metric},
+            ],
+            index=index,
+        )
+        self.assertTrue(
+            experiment_data.observation_data["mean"].equals(expected_mean_df)
+        )
+        # Check equality with self.
+        self.assertEqual(experiment_data, experiment_data)
+
+    def test_filter_by_arm_name(self) -> None:
+        # This is a 2 objective experiment with 5 trials, 1 arm each.
+        observations = [[0.1, 1.0], [0.2, 2.0], [0.3, 3.0], [0.4, 4.0], [0.5, 5.0]]
+        exp = get_experiment_with_observations(observations=observations)
+        experiment_data = extract_experiment_data(
+            experiment=exp, data_loader_config=DataLoaderConfig()
+        )
+        self.assertEqual(len(experiment_data.arm_data), 5)
+        self.assertEqual(len(experiment_data.observation_data), 5)
+        # Filter to only include arms 1 & 3.
+        arm_names = ["1_0", "3_0"]
+        filtered = experiment_data.filter_by_arm_names(arm_names=arm_names)
+        self.assertEqual(
+            list(filtered.arm_data.index.get_level_values("arm_name")), arm_names
+        )
+        self.assertEqual(
+            list(filtered.observation_data.index.get_level_values("arm_name")),
+            arm_names,
+        )
+        # Check that filtering was applied correctly.
+        mask = [False, True, False, True, False]
+        assert_frame_equal(filtered.arm_data, experiment_data.arm_data.loc[mask])
+        assert_frame_equal(
+            filtered.observation_data, experiment_data.observation_data.loc[mask]
+        )
+
+    def test_filter_latest_observations(self) -> None:
+        exp = get_branin_experiment_with_timestamp_map_metric(with_trials_and_data=True)
+        experiment_data = extract_experiment_data(
+            experiment=exp,
+            data_loader_config=DataLoaderConfig(
+                fit_only_completed_map_metrics=False,
+                latest_rows_per_group=None,
+            ),
+        )
+        filtered_data = experiment_data.filter_latest_observations()
+        self.assertNotEqual(filtered_data, experiment_data)
+        # Arm data is the same.
+        assert_frame_equal(experiment_data.arm_data, filtered_data.arm_data)
+        # Observation data is filtered to only include one row for each arm
+        # and no timestamp on the index.
+        # In this case, the data is identical to timeframe 0 for both arms.
+        expected_obs_data = experiment_data.observation_data.loc[
+            [(0, "0_0", 0.0), (1, "1_0", 0.0)]
+        ].droplevel(2)
+        assert_frame_equal(filtered_data.observation_data, expected_obs_data)

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -434,6 +434,7 @@ def get_branin_experiment_with_timestamp_map_metric(
     rate: float | None = None,
     map_tracking_metric: bool = False,
     decay_function_name: str = "exp_decay",
+    with_trials_and_data: bool = False,
 ) -> Experiment:
     tracking_metric = (
         get_map_metric(
@@ -466,6 +467,19 @@ def get_branin_experiment_with_timestamp_map_metric(
 
     if with_status_quo:
         exp.status_quo = Arm(parameters={"x1": 0.0, "x2": 0.0})
+
+    if with_trials_and_data:
+        # Add a couple trials with different number of timestamps.
+        # Each fetch attaches data with a new timestamp / progression.
+        # We end up with 4 rows of data for trial 0 and 2 for trial 1.
+        exp.new_trial().add_arm(Arm(parameters={"x1": 0.0, "x2": 0.0})).run()
+        for _ in range(2):
+            exp.fetch_data()
+        exp.new_trial().add_arm(Arm(parameters={"x1": 1.0, "x2": 1.0})).run()
+        for _ in range(2):
+            exp.fetch_data()
+        # Add a trial with no data.
+        exp.new_trial().add_arm(Arm(parameters={"x1": 2.0, "x2": 2.0})).run()
 
     return exp
 


### PR DESCRIPTION
Summary:
Introduces `ExperimentData`, a container of two dataframes that is intended to replace the use of lists of `Observation` objects within the `Adapter` and `Transform` layers. By replacing lists of objects with dataframes, we enable vectorized operations (replacing many nested for loops), which results in 4-5x speed up in data processing within Adapter.

        arm_data: A dataframe containing columns for trial index, arm name, and
            the parameterization of each arm. Each row corresponds to
            a (trial_index, arm_name) pair.
        observation_data: A dataframe containing columns for trial index, arm name,
            any map keys (e.g., progression / step), and the mean and sem observations
            for the metrics. Each row corresponds to an observation for the given
            trial index, arm name, and map key values / progression.
            This is typically constructed by pivoting `(Map)Data.true_df`.

Differential Revision: D69943574


