### PR TITLE
Remove BALANCED generation method

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -175,7 +175,7 @@ class Client(WithDBSettingsBase):
 
     def configure_generation_strategy(
         self,
-        method: Literal["balanced", "fast", "random_search"] = "fast",
+        method: Literal["fast", "random_search"] = "fast",
         # Initialization options
         initialization_budget: int | None = None,
         initialization_random_seed: int | None = None,

--- a/ax/api/utils/generation_strategy_dispatch.py
+++ b/ax/api/utils/generation_strategy_dispatch.py
@@ -20,8 +20,6 @@ from ax.generation_strategy.generation_strategy import (
 from ax.generation_strategy.generator_spec import GeneratorSpec
 from ax.generation_strategy.transition_criterion import MinTrials
 from ax.generators.torch.botorch_modular.surrogate import ModelConfig, SurrogateSpec
-from botorch.models.transforms.input import Normalize, Warp
-from gpytorch.kernels.linear_kernel import LinearKernel
 
 
 def _get_sobol_node(
@@ -108,16 +106,6 @@ def _get_mbm_node(
     # Construct the surrogate spec.
     if method == "fast":
         model_configs = [ModelConfig(name="MBM defaults")]
-    elif method == "balanced":
-        model_configs = [
-            ModelConfig(name="MBM defaults"),
-            ModelConfig(
-                covar_module_class=LinearKernel,
-                input_transform_classes=[Warp, Normalize],
-                input_transform_options={"Normalize": {"center": 0.0}},
-                name="LinearKernel with Warp",
-            ),
-        ]
     else:
         raise UnsupportedError(f"Unsupported generation method: {method}.")
 

--- a/ax/api/utils/structs.py
+++ b/ax/api/utils/structs.py
@@ -38,8 +38,6 @@ class GenerationStrategyDispatchStruct:
         method: The generation method to use. Provides high level guidance to the
             underlying generation strategy dispatch logic, which is responsible for
             determinining the exact details. Available options are:
-                - ``"balanced"``, a balanced generation method that may utilize
-                    (per-metric) model selection to achieve a good model accuracy.
                 - ``"fast"``, a faster generation method that uses the built-in
                     defaults from the Modular BoTorch Model without any model
                     selection.
@@ -77,7 +75,7 @@ class GenerationStrategyDispatchStruct:
             input corresponds to a valid device.
     """
 
-    method: Literal["balanced", "fast", "random_search"] = "fast"
+    method: Literal["fast", "random_search"] = "fast"
     # Initialization options
     initialization_budget: int | None = None
     initialization_random_seed: int | None = None

--- a/ax/api/utils/tests/test_generation_strategy_dispatch.py
+++ b/ax/api/utils/tests/test_generation_strategy_dispatch.py
@@ -25,8 +25,6 @@ from ax.utils.testing.core_stubs import (
 )
 from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.utils import run_trials_with_gs
-from botorch.models.transforms.input import Normalize, Warp
-from gpytorch.kernels.linear_kernel import LinearKernel
 from pyre_extensions import assert_is_instance, none_throws
 
 
@@ -140,83 +138,6 @@ class TestDispatchUtils(TestCase):
                 self.assertEqual(model_key, "Manual")
             elif trial.index == 2:
                 self.assertEqual(model_key, "CenterOfSearchSpace")
-            elif trial.index < 5:
-                self.assertEqual(model_key, "Sobol")
-            else:
-                self.assertEqual(model_key, "BoTorch")
-
-    @mock_botorch_optimize
-    def test_choose_gs_balanced(self) -> None:
-        gs = choose_generation_strategy(
-            struct=GenerationStrategyDispatchStruct(
-                method="balanced", initialize_with_center=False
-            ),
-        )
-        self.assertEqual(len(gs._nodes), 2)
-        # Check the Sobol node & TC.
-        sobol_node = gs._nodes[0]
-        self.assertTrue(sobol_node.should_deduplicate)
-        self.assertEqual(len(sobol_node.generator_specs), 1)
-        sobol_spec = sobol_node.generator_specs[0]
-        self.assertEqual(sobol_spec.generator_enum, Generators.SOBOL)
-        self.assertEqual(sobol_spec.model_kwargs, {"seed": None})
-        expected_tc = [
-            MinTrials(
-                threshold=5,
-                transition_to="MBM",
-                block_gen_if_met=True,
-                block_transition_if_unmet=True,
-                use_all_trials_in_exp=True,
-            ),
-            MinTrials(
-                threshold=2,
-                transition_to="MBM",
-                block_gen_if_met=False,
-                block_transition_if_unmet=True,
-                use_all_trials_in_exp=True,
-                only_in_statuses=[TrialStatus.COMPLETED],
-                count_only_trials_with_data=True,
-            ),
-        ]
-        self.assertEqual(sobol_node._transition_criteria, expected_tc)
-        # Check the MBM node.
-        mbm_node = gs._nodes[1]
-        self.assertTrue(mbm_node.should_deduplicate)
-        self.assertEqual(len(mbm_node.generator_specs), 1)
-        mbm_spec = mbm_node.generator_specs[0]
-        self.assertEqual(mbm_spec.generator_enum, Generators.BOTORCH_MODULAR)
-        expected_ss = SurrogateSpec(
-            model_configs=[
-                ModelConfig(name="MBM defaults"),
-                ModelConfig(
-                    covar_module_class=LinearKernel,
-                    input_transform_classes=[Warp, Normalize],
-                    input_transform_options={"Normalize": {"center": 0.0}},
-                    name="LinearKernel with Warp",
-                ),
-            ]
-        )
-        self.assertEqual(
-            mbm_spec.model_kwargs, {"surrogate_spec": expected_ss, "torch_device": None}
-        )
-        self.assertEqual(mbm_node._transition_criteria, [])
-        # Experiment with 2 observations. We should generate 3 more Sobol trials.
-        experiment = get_experiment_with_observations([[1.0], [2.0]])
-        # Mark the existing trials as manual to prevent them from counting for Sobol.
-        # They'll still count for TC, since we use all trials in the experiment.
-        for trial in experiment.trials.values():
-            none_throws(
-                assert_is_instance(trial, Trial).generator_run
-            )._model_key = "Manual"
-        # Generate 5 trials and make sure they're from the correct nodes.
-        run_trials_with_gs(experiment=experiment, gs=gs, num_trials=5)
-        self.assertEqual(len(experiment.trials), 7)
-        for trial in experiment.trials.values():
-            model_key = none_throws(
-                assert_is_instance(trial, Trial).generator_run
-            )._model_key
-            if trial.index < 2:
-                self.assertEqual(model_key, "Manual")
             elif trial.index < 5:
                 self.assertEqual(model_key, "Sobol")
             else:


### PR DESCRIPTION
Summary: The current implementation doesn't work great and was meant to be removed. This diff removes it until we implement a better performing version.

Differential Revision: D75886823


