### PR TITLE
Update Trial Status Filtering in Plots

### DIFF
--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -33,7 +33,7 @@ from ax.analysis.utils import (
 )
 from ax.core.arm import Arm
 from ax.core.experiment import Experiment
-from ax.core.trial_status import TrialStatus
+from ax.core.trial_status import STATUSES_EXPECTING_DATA, TrialStatus
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.utils.common.logger import get_logger
@@ -277,12 +277,13 @@ def _prepare_figure(
     candidate_trial = df[df["trial_status"] == TrialStatus.CANDIDATE.name][
         "trial_index"
     ].max()
-    completed_trials = df[df["trial_status"] == TrialStatus.COMPLETED.name][
+    # Filter out undesired trials like FAILED and ABANDONED trials from plot.
+    trials = df[df["trial_status"].isin([ts.name for ts in STATUSES_EXPECTING_DATA])][
         "trial_index"
     ].unique()
 
-    completed_trials_list = completed_trials.tolist()
-    trial_indices = completed_trials_list.copy()
+    trials_list = trials.tolist()
+    trial_indices = trials_list.copy()
     if not np.isnan(candidate_trial):
         trial_indices.append(candidate_trial)
     scatters = []
@@ -297,7 +298,7 @@ def _prepare_figure(
                 "array": xy_df[f"{x_metric_name}_sem"] * Z_SCORE_95_CI,
                 "color": trial_index_to_color(
                     trial_df=trial_df,
-                    completed_trials_list=completed_trials_list,
+                    trials_list=trials_list,
                     trial_index=trial_index,
                     transparent=True,
                 ),
@@ -308,7 +309,7 @@ def _prepare_figure(
                 "array": xy_df[f"{y_metric_name}_sem"] * Z_SCORE_95_CI,
                 "color": trial_index_to_color(
                     trial_df=trial_df,
-                    completed_trials_list=completed_trials_list,
+                    trials_list=trials_list,
                     trial_index=trial_index,
                     transparent=True,
                 ),
@@ -316,7 +317,7 @@ def _prepare_figure(
         marker = {
             "color": trial_index_to_color(
                 trial_df=trial_df,
-                completed_trials_list=completed_trials_list,
+                trials_list=trials_list,
                 trial_index=trial_index,
                 transparent=False,
             ),

--- a/ax/analysis/plotly/tests/test_utils.py
+++ b/ax/analysis/plotly/tests/test_utils.py
@@ -20,7 +20,7 @@ from ax.utils.common.testutils import TestCase
 
 class TestUtils(TestCase):
     def test_trial_index_to_color(self) -> None:
-        completed_trials_list = [0, 1, 11]
+        trials_list = [0, 1, 11]
         test_df = pd.DataFrame(
             {
                 "trial_index": [0, 1, 11, 15],  # Trial 15 is a candidate trial
@@ -35,7 +35,7 @@ class TestUtils(TestCase):
         # Test last completed trial is Botorch Blue
         botorch_blue_no_transparency = trial_index_to_color(
             trial_df=test_df.iloc[[2]],
-            completed_trials_list=completed_trials_list,
+            trials_list=trials_list,
             trial_index=11,
             transparent=False,
         )
@@ -47,7 +47,7 @@ class TestUtils(TestCase):
         # Test last completed trial is Botorch Blue with transparency
         botorch_blue_with_transparency = trial_index_to_color(
             trial_df=test_df.iloc[[2]],
-            completed_trials_list=completed_trials_list,
+            trials_list=trials_list,
             trial_index=11,
             transparent=True,
         )
@@ -61,7 +61,7 @@ class TestUtils(TestCase):
         # Test candidate trial is LIGHT_AX_BLUE with transparency
         candidate_light_ax_blue_with_transparency = trial_index_to_color(
             trial_df=test_df.iloc[[3]],
-            completed_trials_list=completed_trials_list,
+            trials_list=trials_list,
             trial_index=15,
             transparent=True,
         )

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -126,7 +126,7 @@ def get_scatter_point_color(
 
 def trial_index_to_color(
     trial_df: pd.DataFrame,
-    completed_trials_list: list[int],
+    trials_list: list[int],
     trial_index: int,
     transparent: bool,
 ) -> str:
@@ -137,15 +137,19 @@ def trial_index_to_color(
     it calculates a color from the BOTORCH_COLOR_SCALE based on the trial's
     normalized index (relative to all completed trials).
 
+    Note, we are calculating normalized_index here by using the length of the
+    trials list and the index of each trial_index in that list rather than the
+    trial_index associated with each trial. This is done to ensure trial colors
+    are evenly spaced out, even in cases where there are many FAILED trials.
     """
-    max_trial_index = len(completed_trials_list) - 1
+    max_trial_index = len(trials_list) - 1
 
     if trial_df["trial_status"].iloc[0] == TrialStatus.CANDIDATE.name:
         return get_scatter_point_color(
             hex_color=LIGHT_AX_BLUE, ci_transparency=transparent
         )
 
-    adj_trial_index = completed_trials_list.index(trial_index)
+    adj_trial_index = trials_list.index(trial_index)
     normalized_index = 0 if max_trial_index == 0 else adj_trial_index / max_trial_index
     color_index = int(normalized_index * (len(BOTORCH_COLOR_SCALE) - 1))
     hex_color = BOTORCH_COLOR_SCALE[color_index]


### PR DESCRIPTION
Summary: Update `ArmEffectsPlot` and `ScatterPlot` to accept all `TrialStatus`'s that are expecting data, not just `COMPLETED`.

Differential Revision: D75886336


