### PR TITLE
Add bandit rollout plot to analyses

### DIFF
--- a/ax/analysis/plotly/bandit_rollout.py
+++ b/ax/analysis/plotly/bandit_rollout.py
@@ -1,0 +1,168 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import List, Sequence
+
+import pandas as pd
+import plotly.express as px
+from ax.adapter.base import Adapter
+from ax.analysis.analysis import AnalysisCardCategory, AnalysisCardLevel
+from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
+from ax.core.batch_trial import BatchTrial
+from ax.core.experiment import Experiment
+from ax.core.trial_status import TrialStatus
+from ax.exceptions.core import UserInputError
+from ax.generation_strategy.generation_strategy import GenerationStrategy
+from plotly import graph_objects as go
+from pyre_extensions import override
+
+
+class BanditRollout(PlotlyAnalysis):
+    """
+    BanditRollout visualizes the distribution of weights across different trials
+    and arms in an experiment using a bar plot.
+    This class is useful for understanding how weights are allocated to different
+    arms over the course of an experiment,
+    providing insights into the exploration and exploitation dynamics of a bandit
+    algorithm.
+
+    The DataFrame computed will contain one row per arm and the following columns:
+        - trial_index: The trial index during which the arm was run
+        - arm_name: The name of the arm
+        - weight: The weight assigned to the arm in the trial
+        - normalized_weight: The weight normalized within each trial
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the BanditRollout analysis class.
+
+        This class visualizes the distribution of weights across different trials
+        and arms in an experiment using a bar plot, helping to understand the
+        exploration and exploitation dynamics of bandit algorithms.
+        """
+        super().__init__()
+
+    def _prepare_data(self, experiment: Experiment) -> pd.DataFrame:
+        """
+        Prepare the data for plotting.
+
+        This function takes an experiment as input, extracts the arm weights from each
+        trial, and returns a DataFrame with the trial index, arm name, weight, and
+        normalized weight. The normalized weight is calculated by dividing the weight
+        of each arm by the total weight of all arms in the same trial.
+
+        Args:
+            experiment (Experiment): The experiment to extract data from.
+
+        Returns:
+            pd.DataFrame: A DataFrame containing the trial index, arm name, weight, and
+                normalized weight for each arm in the experiment.
+        """
+
+        data_df: pd.DataFrame = pd.DataFrame()
+        trial_index: List[int] = []
+        arm_name: List[str] = []
+        arm_weight: List[float] = []
+
+        for trial in experiment.trials.values():
+            if not isinstance(trial, BatchTrial):
+                raise NotImplementedError(
+                    "Only experiments with multi-arm trials are currently supported."
+                )
+            if trial.status in {TrialStatus.FAILED, TrialStatus.ABANDONED}:
+                continue
+            for arm, weight in trial.arm_weights.items():
+                trial_index.append(trial.index)
+                arm_name.append(arm.name)
+                arm_weight.append(weight)
+
+        data_df["trial_index"] = trial_index
+        data_df["arm_name"] = arm_name
+        data_df["arm_weight"] = arm_weight
+
+        # Normalize weights
+        total_weight = data_df["arm_weight"].sum()
+        if total_weight == 0:
+            raise UserInputError(
+                "All weights are zero. Please check your experiment and try again."
+            )
+
+        data_df["normalized_weight"] = data_df.groupby("trial_index")[
+            "arm_weight"
+        ].transform(lambda x: x / x.sum())
+
+        return data_df
+
+    def _prepare_plot(self, df: pd.DataFrame, experiment_name: str) -> go.Figure:
+        """
+        Prepare the plot for rendering.
+
+        This function takes a DataFrame as input, groups the data by trial index
+        and arm name, sums the normalized weight, and returns a bar plot using
+        Plotly Express. The x-axis represents the trial index, the color
+        represents the arm name, and the y-axis represents the normalized weight.
+
+        Args:
+            df (pd.DataFrame): The DataFrame containing the trial index, arm name,
+                weight, and normalized weight for each arm in the experiment.
+
+        Returns:
+            go.Figure: A bar plot representing the distribution of weights across
+                different trials and arms in the experiment.
+        """
+        fig = px.bar(
+            df,
+            x=df["trial_index"].astype("str"),
+            color="arm_name",
+            y="normalized_weight",
+            title=f"Bandit Rollout Weights by Trial for {experiment_name}",
+            labels={
+                "x": "Trial Index",
+                "normalized_weight": "Normalized Weight",
+                "arm_name": "Arm Name",
+            },
+            color_discrete_sequence=px.colors.qualitative.Alphabet,
+        )
+        return fig
+
+    @override
+    def compute(
+        self,
+        experiment: Experiment | None = None,
+        generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
+    ) -> Sequence[PlotlyAnalysisCard]:
+        if experiment is None:
+            raise UserInputError("BanditRollout requires an Experiment")
+
+        df = self._prepare_data(
+            experiment=experiment,
+        )
+        fig = self._prepare_plot(df=df, experiment_name=experiment.name)
+
+        return [
+            self._create_plotly_analysis_card(
+                title=f"Bandit Rollout Weights by Trial for {experiment.name}",
+                subtitle=(
+                    "The Bandit Rollout visualization provides a comprehensive "
+                    "overview of the allocation of weights across different trials "
+                    "and arms. By representing each trial as a distinct axis, this "
+                    "plot allows for the examination of exploration and exploitation "
+                    "dynamics over time. It aids in identifying trends and patterns in "
+                    "arm performance, offering insights into the effectiveness of the "
+                    "bandit algorithm. Observing the distribution of weights can "
+                    "reveal correlations and interactions that contribute to the "
+                    "success or failure of various strategies, enhancing the "
+                    "understanding of experimental results."
+                ),
+                level=AnalysisCardLevel.LOW,
+                category=AnalysisCardCategory.INSIGHT,
+                df=df,
+                fig=fig,
+            )
+        ]

--- a/ax/analysis/plotly/tests/test_bandit_rollout.py
+++ b/ax/analysis/plotly/tests/test_bandit_rollout.py
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+from ax.analysis.analysis import (
+    AnalysisBlobAnnotation,
+    AnalysisCardCategory,
+    AnalysisCardLevel,
+)
+
+from ax.analysis.plotly.bandit_rollout import BanditRollout
+from ax.core.experiment import Experiment
+from ax.exceptions.core import UserInputError
+from ax.storage.sqa_store.db import init_test_engine_and_session_factory
+from ax.utils.testing.core_stubs import (
+    get_discrete_search_space,
+    get_online_experiments,
+    get_sobol,
+)
+from later.unittest import TestCase
+
+
+class TestBanditRollout(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        init_test_engine_and_session_factory(force_init=True)
+
+        self.experiment = Experiment(
+            search_space=get_discrete_search_space(), name="test_experiment"
+        )
+
+        generator = get_sobol(search_space=self.experiment.search_space)
+        for _ in range(2):
+            gr = generator.gen(n=2)
+            self.experiment.new_batch_trial(generator_run=gr)
+            self.experiment.new_batch_trial(generator_run=gr)
+
+    def test_compute(self) -> None:
+        analysis = BanditRollout()
+
+        with self.assertRaisesRegex(UserInputError, "requires an Experiment"):
+            analysis.compute()
+        (card,) = analysis.compute(experiment=self.experiment)
+        self.assertEqual(card.name, "BanditRollout")
+        self.assertEqual(
+            card.title, f"Bandit Rollout Weights by Trial for {self.experiment.name}"
+        )
+        self.assertEqual(
+            card.subtitle,
+            (
+                "The Bandit Rollout visualization provides a comprehensive "
+                "overview of the allocation of weights across different trials "
+                "and arms. By representing each trial as a distinct axis, this "
+                "plot allows for the examination of exploration and exploitation "
+                "dynamics over time. It aids in identifying trends and patterns in "
+                "arm performance, offering insights into the effectiveness of the "
+                "bandit algorithm. Observing the distribution of weights can "
+                "reveal correlations and interactions that contribute to the "
+                "success or failure of various strategies, enhancing the "
+                "understanding of experimental results."
+            ),
+        )
+        self.assertEqual(card.level, AnalysisCardLevel.LOW)
+        self.assertEqual(card.category, AnalysisCardCategory.INSIGHT)
+        self.assertEqual(
+            {*card.df.columns},
+            {"trial_index", "arm_name", "arm_weight", "normalized_weight"},
+        )
+        self.assertIsNotNone(card.blob)
+        self.assertEqual(card.blob_annotation, AnalysisBlobAnnotation.PLOTLY)
+
+    def test_online(self) -> None:
+        # Test ParallelCoordinatesPlot can be computed for a variety of experiments
+        # which resemble those we see in an online setting.
+        for experiment in get_online_experiments():
+            analysis = BanditRollout()
+            _ = analysis.compute(experiment=experiment)


### PR DESCRIPTION
Summary:
Added BanditRollout analysis class to visualize distribution of weights across trials and arms in an experiment. This class provides insights into exploration and exploitation dynamics of bandit algorithms by plotting the allocation of weights across different trials and arms. Includes tests for online and offline experiments, ensuring compatibility with various experimental settings.
Here is a bento nb for the funcitonality: https://fburl.com/anp/r80cyz4x

Reviewed By: mpolson64

Differential Revision: D75628893


