### PR TITLE
Eliminate duplicate underscore in OneHot encoded parameter names

### DIFF
--- a/ax/adapter/tests/test_adapter_utils.py
+++ b/ax/adapter/tests/test_adapter_utils.py
@@ -242,19 +242,19 @@ class TestAdapterUtils(TestCase):
                     name="range", parameter_type=ParameterType.FLOAT, lower=0, upper=1
                 ),
                 RangeParameter(
-                    name="choice_OH_PARAM__0",
+                    name="choice_OH_PARAM_0",
                     parameter_type=ParameterType.FLOAT,
                     lower=0,
                     upper=1,
                 ),
                 RangeParameter(
-                    name="choice_OH_PARAM__1",
+                    name="choice_OH_PARAM_1",
                     parameter_type=ParameterType.FLOAT,
                     lower=0,
                     upper=1,
                 ),
                 RangeParameter(
-                    name="choice_OH_PARAM__2",
+                    name="choice_OH_PARAM_2",
                     parameter_type=ParameterType.FLOAT,
                     lower=0,
                     upper=1,

--- a/ax/adapter/transforms/one_hot.py
+++ b/ax/adapter/transforms/one_hot.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from ax import adapter as adapter_module  # noqa F401
 
 
-OH_PARAM_INFIX = "_OH_PARAM_"
+OH_PARAM_INFIX = "_OH_PARAM"
 
 
 class OneHotEncoder:


### PR DESCRIPTION
Summary:
`OneHot` transform had a duplicate `_` in the transformed parameter names. This diff removes that. With this change, the transformed parameter name will be
- For two values only: `parameter_OH_PARAM`, which was `parameter_OH_PARAM_`
- For more values: `parameter_OH_PARAM_i` which was `parameter_OH_PARAM__i`.

Differential Revision: D75892920


