### PR TITLE
Introduce optional `signature` and `label` attributes to Metric, make `name` argument optional

### DIFF
--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -99,20 +99,48 @@ class Metric(SortableBase, SerializationMixin):
 
     def __init__(
         self,
-        name: str,
+        name: str | None = None,
         lower_is_better: bool | None = None,
         properties: dict[str, Any] | None = None,
+        signature: str | None = None,
+        label: str | None = None,
     ) -> None:
         """Inits Metric.
 
         Args:
-            name: Name of metric.
+            name: Name of metric (on deprecation path).
             lower_is_better: Flag for metrics which should be minimized.
             properties: Dictionary of this metric's properties
+            signature: The name/unique identifier of the metric.
+            label: Label of metric (a.k.a display name).
         """
-        self._name = name
+
+        if (signature and name and signature != name) or (
+            signature is None and name is None
+        ):
+            raise ValueError(
+                "Specify either `signature` or `name`, but not both. "
+                "`signature` should be used as a unique identifier for the metric. "
+                "The `name` argument is on a deprecation path."
+            )
+
+        if signature is not None:
+            self._name: str = signature
+            self._signature: str = signature
+
+        if name is not None:
+            warnings.warn(
+                "The `name` attribute is on a deprecation path and will be "
+                "replaced by `signature`.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self._name: str = name
+            self._signature: str = name
+
         self.lower_is_better = lower_is_better
         self.properties: dict[str, Any] = properties or {}
+        self._label: str = label if label is not None else self._signature
 
     # ---------- Properties and methods that subclasses often override. ----------
 
@@ -283,7 +311,23 @@ class Metric(SortableBase, SerializationMixin):
     @property
     def name(self) -> str:
         """Get name of metric."""
+        warnings.warn(
+            "The `name` attribute is on a deprecation path and will be "
+            "replaced by `signature`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._name
+
+    @property
+    def signature(self) -> str:
+        """Get signature of metric."""
+        return self._signature
+
+    @property
+    def label(self) -> str:
+        """Get label of metric."""
+        return self._label
 
     def clone(self) -> Metric:
         """Create a copy of this Metric."""

--- a/ax/core/tests/test_metric.py
+++ b/ax/core/tests/test_metric.py
@@ -31,8 +31,51 @@ class MetricTest(TestCase):
         pass
 
     def test_init(self) -> None:
-        metric = Metric(name="m1", lower_is_better=False)
-        self.assertEqual(str(metric), METRIC_STRING)
+        with self.subTest("init with different name and signature"):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Specify either `signature` or `name`, but not both. "
+                "`signature` should be used as a unique identifier for the metric. "
+                "The `name` argument is on a deprecation path.",
+            ):
+                metric = Metric(name="m1", signature="m2", lower_is_better=False)
+
+        with self.subTest("init with no name and no signature"):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Specify either `signature` or `name`, but not both. "
+                "`signature` should be used as a unique identifier for the metric. "
+                "The `name` argument is on a deprecation path.",
+            ):
+                metric = Metric(lower_is_better=False)
+
+        with self.subTest("init with name only"):
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                "The `name` attribute is on a deprecation path and will be "
+                "replaced by `signature`.",
+            ):
+                metric = Metric(name="m1", lower_is_better=False)
+                self.assertEqual(str(metric), METRIC_STRING)
+                self.assertEqual(metric.name, metric.signature)
+                self.assertEqual(metric.name, metric.label)
+
+        with self.subTest("init with signature only"):
+            metric = Metric(signature="m1", lower_is_better=False)
+            self.assertEqual(str(metric), METRIC_STRING)
+            self.assertEqual(metric.name, metric.signature)
+            self.assertEqual(metric.name, metric.label)
+
+        with self.subTest("init with same name and signature"):
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                "The `name` attribute is on a deprecation path and will be "
+                "replaced by `signature`.",
+            ):
+                metric = Metric(name="m1", signature="m1", lower_is_better=False)
+                self.assertEqual(str(metric), METRIC_STRING)
+                self.assertEqual(metric.name, metric.signature)
+                self.assertEqual(metric.name, metric.label)
 
     def test_eq(self) -> None:
         metric1 = Metric(name="m1", lower_is_better=False)

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -1609,7 +1609,14 @@ class SQAStoreTest(TestCase):
         # Extract default value.
         properties = serialize_init_args(obj=Metric(name="foo"))
         self.assertEqual(
-            properties, {"name": "foo", "lower_is_better": None, "properties": {}}
+            properties,
+            {
+                "name": "foo",
+                "lower_is_better": None,
+                "properties": {},
+                "signature": "foo",
+                "label": "foo",
+            },
         )
 
         # Extract passed value.
@@ -1618,7 +1625,13 @@ class SQAStoreTest(TestCase):
         )
         self.assertEqual(
             properties,
-            {"name": "foo", "lower_is_better": True, "properties": {"foo": "bar"}},
+            {
+                "name": "foo",
+                "lower_is_better": True,
+                "properties": {"foo": "bar"},
+                "signature": "foo",
+                "label": "foo",
+            },
         )
 
     def test_RegistryAdditions(self) -> None:


### PR DESCRIPTION
Summary:
As titled - throughout our code and data models, we utilize metric names for storage and referencing purposes. However, dealing with metric names can be challenging, particularly when dealing with lengthy names that are difficult to repeatedly reference. 

This change is to introduce the canonical name (signature) and display name (label) for the `Metric` class.


The end goal is to replace the `name` attribute with `signature`. In the envisioned end state, `Metric.signature` will be used under the hood, just as `Metric.name` is currently being used. `Metric.label` will be used for user facing experiences, such as figures, printed outputs, etc.

This change introduces two new optional arguments, `signature` and `label`, to the Metric class. Notably, if `label` is not provided, it will default to the value of `signature`. 

We retain the `name` argument, but raise a DeprecationWarning when used. If both `name` and `signature` are provided, we raise an error if the values differ.

This change represents an intermediate step, as we plan to eventually deprecate and remove the existing `name` argument in favor of these new parameters.

Differential Revision: D75476155


