### PR TITLE
Implement Log.transform_experiment_data

### DIFF
--- a/ax/adapter/transforms/bilog_y.py
+++ b/ax/adapter/transforms/bilog_y.py
@@ -12,6 +12,7 @@ from typing import Callable, TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.log_y import match_ci_width
 from ax.core.observation import Observation, ObservationData
@@ -45,16 +46,28 @@ class BilogY(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         """Initialize the ``BilogY`` transform.
 
         Args:
-            search_space: The search space of the experiment. Unused.
+            search_space: The search space of the experiment.
             observations: A list of observations from the experiment.
-            adapter: The `Adapter` within which the transform is used.
+            experiment_data: A container for the parameterizations, metadata and
+                observations for the trials in the experiment.
+                Constructed using ``extract_experiment_data``.
+            adapter: Adapter for referencing experiment, status quo, etc.
+            config: A dictionary of options specific to each transform.
         """
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         if observations is None or len(observations) == 0:
             raise DataRequiredError("BilogY requires observations.")
         if adapter is not None and adapter._optimization_config is not None:

--- a/ax/adapter/transforms/cast.py
+++ b/ax/adapter/transforms/cast.py
@@ -8,8 +8,8 @@
 
 from typing import Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-
 from ax.core.observation import Observation, ObservationFeatures, separate_observations
 from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
 from ax.exceptions.core import UserInputError
@@ -45,10 +45,18 @@ class Cast(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         self.search_space: SearchSpace = none_throws(search_space).clone()
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         config = (config or {}).copy()
         self.flatten_hss: bool = assert_is_instance(
             config.pop(

--- a/ax/adapter/transforms/choice_encode.py
+++ b/ax/adapter/transforms/choice_encode.py
@@ -10,6 +10,7 @@ from typing import Any, Optional, TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.deprecated_transform_mixin import DeprecatedTransformMixin
 from ax.adapter.transforms.utils import ClosestLookupDict, construct_new_search_space
@@ -50,10 +51,18 @@ class ChoiceToNumericChoice(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "ChoiceToNumericChoice requires search space"
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # Identify parameters that should be transformed
         self.encoded_parameters: dict[str, dict[TParamValue, TParamValue]] = {}
         self.encoded_parameters_inverse: dict[str, ClosestLookupDict] = {}
@@ -146,10 +155,18 @@ class OrderedChoiceToIntegerRange(ChoiceToNumericChoice):
     def __init__(
         self,
         search_space: SearchSpace,
-        observations: list[Observation],
+        observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # Identify parameters that should be transformed
         self.encoded_parameters: dict[str, dict[TParamValue, int]] = {}
         for p in search_space.parameters.values():

--- a/ax/adapter/transforms/convert_metric_names.py
+++ b/ax/adapter/transforms/convert_metric_names.py
@@ -8,8 +8,8 @@
 
 from typing import Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-
 from ax.core.multi_type_experiment import MultiTypeExperiment
 from ax.core.observation import Observation, ObservationData
 from ax.core.search_space import SearchSpace
@@ -42,9 +42,17 @@ class ConvertMetricNames(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         assert observations is not None, "ConvertMetricNames requires observations"
         if config is None:
             raise ValueError("Config cannot be none.")

--- a/ax/adapter/transforms/derelativize.py
+++ b/ax/adapter/transforms/derelativize.py
@@ -45,6 +45,8 @@ class Derelativize(Transform):
     Transform is done in-place.
     """
 
+    no_op_for_experiment_data: bool = True
+
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,

--- a/ax/adapter/transforms/fill_missing_parameters.py
+++ b/ax/adapter/transforms/fill_missing_parameters.py
@@ -8,8 +8,8 @@
 
 from typing import Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParameterization
@@ -37,9 +37,17 @@ class FillMissingParameters(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         config = config or {}
         self.fill_values: TParameterization | None = config.get(  # pyre-ignore[8]
             "fill_values", None

--- a/ax/adapter/transforms/int_range_to_choice.py
+++ b/ax/adapter/transforms/int_range_to_choice.py
@@ -9,9 +9,9 @@
 from numbers import Real
 from typing import cast, Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import construct_new_search_space
-
 from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
@@ -28,13 +28,23 @@ class IntRangeToChoice(Transform):
     Transform is done in-place.
     """
 
+    no_op_for_experiment_data: bool = True
+
     def __init__(
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         assert search_space is not None, "IntRangeToChoice requires search space"
         config = config or {}
         self.max_choices: float = float(

--- a/ax/adapter/transforms/int_to_float.py
+++ b/ax/adapter/transforms/int_to_float.py
@@ -197,6 +197,16 @@ class IntToFloat(Transform):
 
         return observation_features
 
+    def transform_experiment_data(
+        self, experiment_data: ExperimentData
+    ) -> ExperimentData:
+        arm_data = experiment_data.arm_data
+        column_to_type = {p: float for p in self.transform_parameters}
+        arm_data = arm_data.astype(dtype=column_to_type)
+        return ExperimentData(
+            arm_data=arm_data, observation_data=experiment_data.observation_data
+        )
+
 
 class LogIntToFloat(IntToFloat):
     """Convert a log-scale RangeParameter of type int to type float.

--- a/ax/adapter/transforms/int_to_float.py
+++ b/ax/adapter/transforms/int_to_float.py
@@ -9,13 +9,13 @@
 from logging import Logger
 from typing import Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.rounding import (
     contains_constrained_integer,
     randomized_round_parameters,
 )
 from ax.adapter.transforms.utils import construct_new_search_space
-
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
@@ -52,11 +52,19 @@ class IntToFloat(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         self.search_space: SearchSpace = none_throws(
             search_space, "IntToFloat requires search space"
+        )
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
         )
         config = config or {}
         self.rounding: str = assert_is_instance(config.get("rounding", "strict"), str)
@@ -201,6 +209,7 @@ class LogIntToFloat(IntToFloat):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
@@ -211,6 +220,7 @@ class LogIntToFloat(IntToFloat):
         super().__init__(
             search_space=search_space,
             observations=observations,
+            experiment_data=experiment_data,
             adapter=adapter,
             config=config,
         )

--- a/ax/adapter/transforms/log.py
+++ b/ax/adapter/transforms/log.py
@@ -9,8 +9,8 @@
 import math
 from typing import Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
@@ -31,10 +31,18 @@ class Log(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "Log requires search space"
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # Identify parameters that should be transformed
         self.transform_parameters: set[str] = {
             p_name

--- a/ax/adapter/transforms/log_y.py
+++ b/ax/adapter/transforms/log_y.py
@@ -9,12 +9,12 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-
 from logging import Logger
 from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
@@ -53,6 +53,7 @@ class LogY(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: base_adapter.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
@@ -67,6 +68,8 @@ class LogY(Transform):
         super().__init__(
             search_space=search_space,
             observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
             config=config,
         )
         # pyre-fixme[4]: Attribute must be annotated.

--- a/ax/adapter/transforms/logit.py
+++ b/ax/adapter/transforms/logit.py
@@ -8,8 +8,8 @@
 
 from typing import Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
@@ -31,10 +31,18 @@ class Logit(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "Logit requires search space"
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # Identify parameters that should be transformed
         self.transform_parameters: set[str] = {
             p_name

--- a/ax/adapter/transforms/map_key_to_float.py
+++ b/ax/adapter/transforms/map_key_to_float.py
@@ -9,6 +9,7 @@
 from math import isnan
 from typing import Any, Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.metadata_to_float import MetadataToFloat
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.search_space import SearchSpace
@@ -46,6 +47,7 @@ class MapKeyToFloat(MetadataToFloat):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
@@ -69,6 +71,7 @@ class MapKeyToFloat(MetadataToFloat):
         super().__init__(
             search_space=search_space,
             observations=observations,
+            experiment_data=experiment_data,
             adapter=adapter,
             config=config,
         )

--- a/ax/adapter/transforms/merge_repeated_measurements.py
+++ b/ax/adapter/transforms/merge_repeated_measurements.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 
 import numpy as np
 from ax.adapter.base import Adapter
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.core.arm import Arm
 from ax.core.observation import Observation, ObservationData, separate_observations
@@ -36,11 +37,19 @@ class MergeRepeatedMeasurements(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         if observations is None:
             raise RuntimeError("MergeRepeatedMeasurements requires observations")
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # create a mapping of arm_key -> {metric_name: {means: [], vars: []}}
         arm_to_multi_obs: defaultdict[
             str, defaultdict[str, defaultdict[str, list[float]]]

--- a/ax/adapter/transforms/metadata_to_float.py
+++ b/ax/adapter/transforms/metadata_to_float.py
@@ -13,6 +13,7 @@ from logging import Logger
 from math import isnan
 from typing import Any, SupportsFloat, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.core import ParameterType
 from ax.core.observation import Observation, ObservationFeatures
@@ -55,6 +56,7 @@ class MetadataToFloat(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
@@ -62,6 +64,13 @@ class MetadataToFloat(Transform):
             raise DataRequiredError(
                 "`MetadataToRange` transform requires non-empty data."
             )
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         config = config or {}
         self.parameters: dict[str, dict[str, Any]] = assert_is_instance(
             config.get("parameters", {}), dict

--- a/ax/adapter/transforms/metrics_as_task.py
+++ b/ax/adapter/transforms/metrics_as_task.py
@@ -9,6 +9,7 @@
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType
@@ -43,9 +44,17 @@ class MetricsAsTask(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # Use config to specify metric task map
         if config is None or "metric_task_map" not in config:
             raise ValueError("config must specify metric_task_map")

--- a/ax/adapter/transforms/one_hot.py
+++ b/ax/adapter/transforms/one_hot.py
@@ -9,6 +9,7 @@
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.rounding import randomized_onehot_round, strict_onehot_round
 from ax.adapter.transforms.utils import construct_new_search_space
@@ -86,10 +87,18 @@ class OneHot(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "OneHot requires search space"
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # Identify parameters that should be transformed
         # pyre-fixme[4]: Attribute must be annotated.
         self.rounding = "strict"

--- a/ax/adapter/transforms/power_transform_y.py
+++ b/ax/adapter/transforms/power_transform_y.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import numpy as np
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import get_data, match_ci_width_truncated
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
@@ -51,15 +52,19 @@ class PowerTransformY(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         """Initialize the ``PowerTransformY`` transform.
 
         Args:
-            search_space: The search space of the experiment. Unused.
+            search_space: The search space of the experiment.
             observations: A list of observations from the experiment.
-            adapter: The `Adapter` within which the transform is used. Unused.
+            experiment_data: A container for the parameterizations, metadata and
+                observations for the trials in the experiment.
+                Constructed using ``extract_experiment_data``.
+            adapter: Adapter for referencing experiment, status quo, etc.
             config: A dictionary of options to control the behavior of the transform.
                 Can contain the following keys:
                 - "metrics": A list of metric names to apply the transform to. If
@@ -67,6 +72,13 @@ class PowerTransformY(Transform):
                 - "clip_mean": Whether to clip the mean to the image of the transform.
                     Defaults to True.
         """
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         if observations is None or len(observations) == 0:
             raise DataRequiredError("PowerTransformY requires observations.")
         # pyre-fixme[9]: Can't annotate config["metrics"] properly.

--- a/ax/adapter/transforms/relativize.py
+++ b/ax/adapter/transforms/relativize.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-
 from math import sqrt
 from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 from ax.adapter import Adapter
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
@@ -53,6 +53,7 @@ class BaseRelativize(Transform, ABC):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
@@ -61,6 +62,7 @@ class BaseRelativize(Transform, ABC):
         super().__init__(
             search_space=search_space,
             observations=observations,
+            experiment_data=experiment_data,
             adapter=adapter,
             config=config,
         )

--- a/ax/adapter/transforms/remove_fixed.py
+++ b/ax/adapter/transforms/remove_fixed.py
@@ -8,9 +8,9 @@
 
 from typing import Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import construct_new_search_space
-
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, FixedParameter, RangeParameter
 from ax.core.search_space import SearchSpace
@@ -34,10 +34,18 @@ class RemoveFixed(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "RemoveFixed requires search space"
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # Identify parameters that should be transformed
         self.fixed_parameters: dict[str, FixedParameter] = {
             p_name: p

--- a/ax/adapter/transforms/search_space_to_choice.py
+++ b/ax/adapter/transforms/search_space_to_choice.py
@@ -8,8 +8,8 @@
 
 from typing import Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-
 from ax.core.arm import Arm
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, FixedParameter, ParameterType
@@ -39,6 +39,7 @@ class SearchSpaceToChoice(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
@@ -47,6 +48,8 @@ class SearchSpaceToChoice(Transform):
         super().__init__(
             search_space=search_space,
             observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
             config=config,
         )
         if any(p.is_fidelity for p in search_space.parameters.values()):

--- a/ax/adapter/transforms/standardize_y.py
+++ b/ax/adapter/transforms/standardize_y.py
@@ -11,6 +11,7 @@ from logging import Logger
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import get_data
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
@@ -41,11 +42,19 @@ class StandardizeY(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["base_adapter.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         if observations is None or len(observations) == 0:
             raise DataRequiredError("`StandardizeY` transform requires non-empty data.")
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         observation_data = [obs.data for obs in observations]
         Ys = get_data(observation_data=observation_data)
         # Compute means and SDs

--- a/ax/adapter/transforms/stratified_standardize_y.py
+++ b/ax/adapter/transforms/stratified_standardize_y.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.standardize_y import compute_standardization_parameters
 from ax.core.observation import Observation, ObservationFeatures, separate_observations
@@ -47,24 +48,35 @@ class StratifiedStandardizeY(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         """Initialize StratifiedStandardizeY.
 
         Args:
-            search_space: The experiment search space.
-            observations: Observations from the experiment for all previous trials.
-            adapter: The adapter.
-            config: A that may containing a "parameter_name" key specifying the name of
-                the parameter to use for stratification and a "strata_mapping" key
-                that corresponds to a dictionary that maps parameter values to strata
-                for standardization. The strata can be of type bool, int, str, or
-                float.
+            search_space: The search space of the experiment.
+            observations: A list of observations from the experiment.
+            experiment_data: A container for the parameterizations, metadata and
+                observations for the trials in the experiment.
+                Constructed using ``extract_experiment_data``.
+            adapter: Adapter for referencing experiment, status quo, etc.
+            config: A dictionary of options that may contain a "parameter_name" key
+                specifying the name of the parameter to use for stratification and a
+                "strata_mapping" key that corresponds to a dictionary that maps
+                parameter values to strata for standardization. The strata can be
+                of type bool, int, str, or float.
 
         """
         assert search_space is not None, "StratifiedStandardizeY requires search space"
         assert observations is not None, "StratifiedStandardizeY requires observations"
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # Get parameter name for standardization.
         self.strata_mapping = None  # pyre-ignore [8]
         if config is not None and "parameter_name" in config:

--- a/ax/adapter/transforms/task_encode.py
+++ b/ax/adapter/transforms/task_encode.py
@@ -8,11 +8,10 @@
 
 from typing import Any, Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.choice_encode import OrderedChoiceToIntegerRange
-
 from ax.adapter.transforms.deprecated_transform_mixin import DeprecatedTransformMixin
 from ax.adapter.transforms.utils import construct_new_search_space
-
 from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType
 from ax.core.search_space import SearchSpace
@@ -38,14 +37,22 @@ class TaskChoiceToIntTaskChoice(OrderedChoiceToIntegerRange):
 
     def __init__(
         self,
-        search_space: SearchSpace | None = None,
+        search_space: SearchSpace,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         assert (
             search_space is not None
         ), "TaskChoiceToIntTaskChoice requires search space"
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # Identify parameters that should be transformed
         self.encoded_parameters: dict[str, dict[TParamValue, int]] = {}
         self.target_values: dict[str, int] = {}

--- a/ax/adapter/transforms/time_as_feature.py
+++ b/ax/adapter/transforms/time_as_feature.py
@@ -12,8 +12,8 @@ from time import time
 from typing import TYPE_CHECKING
 
 import pandas as pd
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import RobustSearchSpace, SearchSpace
@@ -43,9 +43,17 @@ class TimeAsFeature(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         assert observations is not None, "TimeAsFeature requires observations"
         if isinstance(search_space, RobustSearchSpace):
             raise UnsupportedError(

--- a/ax/adapter/transforms/transform_to_new_sq.py
+++ b/ax/adapter/transforms/transform_to_new_sq.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.relativize import BaseRelativize, get_metric_index
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
@@ -48,12 +49,14 @@ class TransformToNewSQ(BaseRelativize):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         super().__init__(
             search_space=search_space,
             observations=observations,
+            experiment_data=experiment_data,
             adapter=adapter,
             config=config,
         )

--- a/ax/adapter/transforms/trial_as_task.py
+++ b/ax/adapter/transforms/trial_as_task.py
@@ -9,8 +9,8 @@
 from logging import Logger
 from typing import Optional, TYPE_CHECKING
 
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import RobustSearchSpace, SearchSpace
@@ -61,9 +61,17 @@ class TrialAsTask(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         assert observations is not None, "TrialAsTask requires observations"
         assert adapter is not None, "TrialAsTask requires adapter"
         # Identify values of trial.

--- a/ax/adapter/transforms/unit_x.py
+++ b/ax/adapter/transforms/unit_x.py
@@ -9,6 +9,7 @@
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
@@ -40,10 +41,18 @@ class UnitX(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "UnitX requires search space"
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         # Identify parameters that should be transformed
         self.bounds: dict[str, tuple[float, float]] = {}
         for p_name, p in search_space.parameters.items():

--- a/ax/adapter/transforms/winsorize.py
+++ b/ax/adapter/transforms/winsorize.py
@@ -11,6 +11,7 @@ from typing import Optional, TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import (
     derelativize_optimization_config_with_raw_status_quo,
@@ -95,11 +96,19 @@ class Winsorize(Transform):
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
+        experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         if observations is None or len(observations) == 0:
             raise DataRequiredError("`Winsorize` transform requires non-empty data.")
+        super().__init__(
+            search_space=search_space,
+            observations=observations,
+            experiment_data=experiment_data,
+            adapter=adapter,
+            config=config,
+        )
         optimization_config = adapter._optimization_config if adapter else None
         if config is None and optimization_config is None:
             raise ValueError(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import itertools
 from collections import OrderedDict
-from collections.abc import Iterable, MutableMapping
+from collections.abc import Iterable, Mapping, MutableMapping
 from datetime import datetime, timedelta
 from logging import Logger
 from math import prod
@@ -911,7 +911,7 @@ def get_experiment_with_observations(
     constrained: bool = False,
     with_tracking_metrics: bool = False,
     search_space: SearchSpace | None = None,
-    parameterizations: Sequence[TParameterization] | None = None,
+    parameterizations: Sequence[Mapping[str, TParamValue]] | None = None,
     sems: list[list[float]] | None = None,
     optimization_config: OptimizationConfig | None = None,
 ) -> Experiment:


### PR DESCRIPTION
Summary:
As titled. Supports transforming `ExperimentData` with `Log` transform.

Background: As part of the larger refactor, we will be using `ExperimentData` in place of `list[Observation]` within the `Adapter`.
- The transforms will be initialized using `ExperimentData`. The `observations` input to the constructors may be deprecated once the use cases are updated.
- The training data for `Adapter` will be represented with `ExperimentData` and will be transformed using `transform_experiment_data`.
- For misc input / output to various `Adapter` and other methods, the `Observation / ObservationFeatures / ObservationData` objects will remain. To support these, we will retain the existing transform methods that service these objects.
- Since `ExperimentData` is not planned to be used as an output of user facing methods, we do not need to untransform it. We are not planning to implement`untransform_experiment_data`.

Reviewed By: SebastianAment

Differential Revision: D75905207
