### PR TITLE
Implement FillMissingParameters.transform_experiment_data

### DIFF
--- a/ax/adapter/transforms/choice_encode.py
+++ b/ax/adapter/transforms/choice_encode.py
@@ -129,6 +129,16 @@ class ChoiceToNumericChoice(Transform):
                         obsf.parameters[p_name] = reverse_transform[pval]
         return observation_features
 
+    def transform_experiment_data(
+        self, experiment_data: ExperimentData
+    ) -> ExperimentData:
+        return ExperimentData(
+            arm_data=experiment_data.arm_data.replace(
+                to_replace=self.encoded_parameters
+            ),
+            observation_data=experiment_data.observation_data,
+        )
+
 
 class ChoiceEncode(DeprecatedTransformMixin, ChoiceToNumericChoice):
     """Deprecated alias for ChoiceToNumericChoice."""

--- a/ax/adapter/transforms/remove_fixed.py
+++ b/ax/adapter/transforms/remove_fixed.py
@@ -87,3 +87,11 @@ class RemoveFixed(Transform):
             for p_name, p in self.fixed_parameters.items():
                 obsf.parameters[p_name] = p.value
         return observation_features
+
+    def transform_experiment_data(
+        self, experiment_data: ExperimentData
+    ) -> ExperimentData:
+        return ExperimentData(
+            arm_data=experiment_data.arm_data.drop(columns=list(self.fixed_parameters)),
+            observation_data=experiment_data.observation_data,
+        )


### PR DESCRIPTION
Summary:
As titled. Supports transforming `ExperimentData` with `FillMissingParameters` transform.


Background: As part of the larger refactor, we will be using `ExperimentData` in place of `list[Observation]` within the `Adapter`.
- The transforms will be initialized using `ExperimentData`. The `observations` input to the constructors may be deprecated once the use cases are updated.
- The training data for `Adapter` will be represented with `ExperimentData` and will be transformed using `transform_experiment_data`.
- For misc input / output to various `Adapter` and other methods, the `Observation / ObservationFeatures / ObservationData` objects will remain. To support these, we will retain the existing transform methods that service these objects.
- Since `ExperimentData` is not planned to be used as an output of user facing methods, we do not need to untransform it. We are not planning to implement`untransform_experiment_data`.

Differential Revision: D75972103


