### PR TITLE
Sort experiment data by trial_index, arm_name, and metrics

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -14,6 +14,8 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from typing import Any, TYPE_CHECKING
 
+import pandas as pd
+
 from ax.core.arm import Arm
 from ax.core.data import Data
 from ax.core.formatting_utils import data_and_evaluations_from_raw_data
@@ -386,9 +388,13 @@ class BaseTrial(ABC, SortableBase):
             MapMetric if self.experiment.default_data_constructor == MapData else Metric
         )
 
-        return base_metric_cls._unwrap_trial_data_multi(
+        data = base_metric_cls._unwrap_trial_data_multi(
             results=self.fetch_data_results(metrics=metrics, **kwargs)
         )
+        if not isinstance(data, MapData):
+            data._df = sort_by_trial_index_and_arm_name(data._df)
+
+        return data
 
     def lookup_data(self) -> Data:
         """Lookup cached data on experiment for this trial.
@@ -831,3 +837,58 @@ class BaseTrial(ABC, SortableBase):
             new_trial.mark_failed(reason=self.failed_reason)
             return
         new_trial.mark_as(self.status, unsafe=True)
+
+
+def sort_by_trial_index_and_arm_name(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Sorts the dataframe by trial index and arm name. The arm names with default patterns
+    (e.g. `0_1`, `3_11`) are sorted by trial index part (before underscore) and arm
+    number part (after underscore) within trial index. The arm names with non-default
+    patterns (e.g. `status_quo`, `control`, `capped_param_1`) are sorted alphabetically
+    and will be on the top of the sorted dataframe.
+
+    Args:
+        df: The DataFrame to sort.
+
+    Returns:
+        The sorted DataFrame.
+    """
+
+    # Create new columns for sorting the default arm names
+    df["is_default"] = pd.notna(df["arm_name"]) & df["arm_name"].str.count(
+        pat=r"^\d+_\d+$"
+    )
+
+    df["trial_index_part"] = float("NaN")
+    df["arm_name_part"] = float("NaN")
+
+    split_arm_name = df.loc[df["is_default"], "arm_name"].str.split("_")
+    df.loc[df["is_default"], "trial_index_part"] = split_arm_name.str.get(0).astype(int)
+    df.loc[df["is_default"], "arm_name_part"] = split_arm_name.str.get(1).astype(int)
+
+    # Sort the DataFrame by the new columns (trial_index_part and arm_number_part)
+    # for default arm names
+    df = (
+        df.sort_values(
+            by=[
+                "trial_index",
+                "is_default",
+                "trial_index_part",
+                "arm_name_part",
+                "arm_name",
+            ],
+            inplace=False,
+        ).reset_index(drop=True)
+        if not df.empty
+        else df
+    )
+
+    # Drop the temporary 'trial_index_part' and 'arm_number_part' columns
+    df.drop(
+        columns=["trial_index_part", "arm_name_part", "is_default"],
+        # Ignore errors that occur when dropping columns that do not exist in the
+        # dataframe.
+        errors="ignore",
+        inplace=True,
+    )
+    return df

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -21,7 +21,7 @@ import ax.core.observation as observation
 import pandas as pd
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
-from ax.core.base_trial import BaseTrial
+from ax.core.base_trial import BaseTrial, sort_by_trial_index_and_arm_name
 from ax.core.batch_trial import BatchTrial, LifecycleStage
 from ax.core.data import Data
 from ax.core.formatting_utils import DATA_TYPE_LOOKUP, DataType
@@ -713,6 +713,7 @@ class Experiment(Base):
                 trials=trials,
                 **kwargs,
             )
+
             contains_new_data = contains_new_data or new_results_contains_new_data
 
             # Merge in results
@@ -820,6 +821,8 @@ class Experiment(Base):
             )
         cur_time_millis = current_timestamp_in_millis()
         for trial_index, trial_df in data.true_df.groupby(data.true_df["trial_index"]):
+            if not isinstance(data, MapData):
+                trial_df = sort_by_trial_index_and_arm_name(df=trial_df)
             # Overwrite `df` so that `data` only has current trial data.
             data_init_args["df"] = trial_df
             current_trial_data = (


### PR DESCRIPTION
Summary:
Arm order in metric results were displayed per the data order. This led to a random ordering of arms when data is displayed.

To fix this, we want to sort the arm ordering in data.
Data will be sorted by trail_index, then arm_name. Arm name will be sorted as 'custom_name' < '0_1' < '0_2' < '0_11' < '0_100'

Reviewed By: saitcakmak

Differential Revision: D74409276


