### PR TITLE
Implement OneHot.transform_experiment_data

### DIFF
--- a/ax/adapter/transforms/logit.py
+++ b/ax/adapter/transforms/logit.py
@@ -81,3 +81,13 @@ class Logit(Transform):
                     param: float = obsf.parameters[p_name]  # pyre-ignore [9]
                     obsf.parameters[p_name] = expit(param).item()
         return observation_features
+
+    def transform_experiment_data(
+        self, experiment_data: ExperimentData
+    ) -> ExperimentData:
+        arm_data = experiment_data.arm_data
+        for p_name in self.transform_parameters:
+            arm_data[p_name] = logit(arm_data[p_name])
+        return ExperimentData(
+            arm_data=arm_data, observation_data=experiment_data.observation_data
+        )

--- a/ax/adapter/transforms/one_hot.py
+++ b/ax/adapter/transforms/one_hot.py
@@ -9,6 +9,7 @@
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
+import pandas as pd
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.rounding import randomized_onehot_round, strict_onehot_round
@@ -207,3 +208,35 @@ class OneHot(Transform):
                 )
                 obsf.parameters[p_name] = val
         return observation_features
+
+    def transform_experiment_data(
+        self, experiment_data: ExperimentData
+    ) -> ExperimentData:
+        arm_data = experiment_data.arm_data
+        for p_name, values in self.encoded_values.items():
+            # First, replace values with 0, 1, 2, so that column names are as expected.
+            arm_data = arm_data.replace(
+                to_replace={p_name: {v: i for i, v in enumerate(values)}}
+            ).astype({p_name: int})
+
+            if len(values) == 2:
+                # Handle the special case. Only need to rename the column.
+                arm_data = arm_data.rename(columns={p_name: p_name + OH_PARAM_INFIX})
+            else:
+                # Use get_dummies to one-hot encode the column.
+                arm_data = pd.get_dummies(
+                    arm_data,
+                    columns=[p_name],
+                    prefix=p_name + OH_PARAM_INFIX,
+                    # Could be int, but using float to match the parameter type.
+                    dtype=float,
+                )
+                # Make sure all expected columns are present, even if there is no
+                # corresponding value in the data.
+                for i in range(len(values)):
+                    if f"{p_name}{OH_PARAM_INFIX}_{i}" not in arm_data:
+                        arm_data[f"{p_name}{OH_PARAM_INFIX}_{i}"] = 0.0
+
+        return ExperimentData(
+            arm_data=arm_data, observation_data=experiment_data.observation_data
+        )


### PR DESCRIPTION
Summary:
As titled. Supports transforming `ExperimentData` with `OneHot` transform.

Background: As part of the larger refactor, we will be using `ExperimentData` in place of `list[Observation]` within the `Adapter`.
- The transforms will be initialized using `ExperimentData`. The `observations` input to the constructors may be deprecated once the use cases are updated.
- The training data for `Adapter` will be represented with `ExperimentData` and will be transformed using `transform_experiment_data`.
- For misc input / output to various `Adapter` and other methods, the `Observation / ObservationFeatures / ObservationData` objects will remain. To support these, we will retain the existing transform methods that service these objects.
- Since `ExperimentData` is not planned to be used as an output of user facing methods, we do not need to untransform it. We are not planning to implement`untransform_experiment_data`.

Differential Revision: D76074577


