### PR TITLE
Implement UnitX.transform_experiment_data

### DIFF
--- a/ax/adapter/transforms/tests/test_bilog_y.py
+++ b/ax/adapter/transforms/tests/test_bilog_y.py
@@ -9,15 +9,18 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from functools import partial
+from itertools import product
 
-from ax.adapter.base import Adapter
+from ax.adapter.base import Adapter, DataLoaderConfig
+from ax.adapter.data_utils import extract_experiment_data
 from ax.adapter.transforms.bilog_y import bilog_transform, BilogY, inv_bilog_transform
-
+from ax.adapter.transforms.log_y import match_ci_width
 from ax.core.observation import observations_from_data
-from ax.exceptions.core import DataRequiredError
 from ax.generators.base import Generator
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 
 class BilogYTest(TestCase):
@@ -29,8 +32,9 @@ class BilogYTest(TestCase):
             with_relative_constraint=True,
         )
         self.data = self.exp.fetch_data()
+        self.bound = self.exp.optimization_config.outcome_constraints[1].bound
 
-    def get_mb(self) -> Adapter:
+    def get_adapter(self) -> Adapter:
         return Adapter(
             search_space=self.exp.search_space,
             generator=Generator(),
@@ -39,15 +43,19 @@ class BilogYTest(TestCase):
         )
 
     def test_Init(self) -> None:
-        observations = observations_from_data(
-            experiment=self.exp, data=self.exp.lookup_data()
-        )
+        # With adapter.
         t = BilogY(
             search_space=self.exp.search_space,
-            observations=observations,
-            adapter=self.get_mb(),
+            adapter=self.get_adapter(),
         )
-        self.assertEqual(t.metric_to_bound, {"branin_e": -0.25})
+        self.assertEqual(t.metric_to_bound, {"branin_e": self.bound})
+
+        with self.subTest("With no adapter"):
+            t = BilogY(
+                search_space=self.exp.search_space,
+                adapter=None,
+            )
+            self.assertEqual(t.metric_to_bound, {})
 
     def test_Bilog(self) -> None:
         self.assertAlmostEqual(
@@ -78,8 +86,7 @@ class BilogYTest(TestCase):
         )
         t = BilogY(
             search_space=self.exp.search_space,
-            observations=observations,
-            adapter=self.get_mb(),
+            adapter=self.get_adapter(),
         )
 
         # Transform
@@ -138,10 +145,7 @@ class BilogYTest(TestCase):
     def test_TransformOptimizationConfig(self) -> None:
         t = BilogY(
             search_space=self.exp.search_space,
-            observations=observations_from_data(
-                experiment=self.exp, data=self.exp.lookup_data()
-            ),
-            adapter=self.get_mb(),
+            adapter=self.get_adapter(),
         )
         oc = self.exp.optimization_config
         # This should be a no-op
@@ -149,40 +153,54 @@ class BilogYTest(TestCase):
         self.assertEqual(new_oc, oc)
 
     def test_TransformSearchSpace(self) -> None:
-        t = BilogY(
-            search_space=self.exp.search_space,
-            observations=observations_from_data(
-                experiment=self.exp, data=self.exp.lookup_data()
-            ),
-            adapter=self.get_mb(),
-        )
+        t = BilogY(search_space=self.exp.search_space, adapter=self.get_adapter())
         # This should be a no-op
         new_ss = t.transform_search_space(self.exp.search_space)
         self.assertEqual(new_ss, self.exp.search_space)
 
-    def test_AdapterIsNone(self) -> None:
-        t = BilogY(
-            search_space=self.exp.search_space,
-            observations=observations_from_data(
-                experiment=self.exp, data=self.exp.lookup_data()
-            ),
-            adapter=None,
+    def test_transform_experiment_data(self) -> None:
+        t = BilogY(search_space=self.exp.search_space, adapter=self.get_adapter())
+        experiment_data = extract_experiment_data(
+            experiment=self.exp, data_loader_config=DataLoaderConfig()
         )
-        self.assertEqual(t.metric_to_bound, {})
+        transformed_data = t.transform_experiment_data(
+            experiment_data=deepcopy(experiment_data)
+        )
 
-    def test_Raises(self) -> None:
-        exp = get_branin_experiment(with_status_quo=True, with_batch=True)
-        with self.assertRaisesRegex(DataRequiredError, "BilogY requires observations."):
-            BilogY(
-                search_space=exp.search_space,
-                observations=observations_from_data(
-                    experiment=exp, data=exp.lookup_data()
-                ),
-                adapter=None,
-            )
-        # Relative constraints should raise
-        exp = get_branin_experiment(
-            with_status_quo=True,
-            with_completed_batch=True,
-            with_relative_constraint=True,
+        # Check that arm data is identical.
+        assert_frame_equal(transformed_data.arm_data, experiment_data.arm_data)
+
+        # Check that non-constraint metrics are unchanged.
+        cols = list(product(("mean", "sem"), ("branin", "branin_d")))
+        assert_frame_equal(
+            transformed_data.observation_data[cols],
+            experiment_data.observation_data[cols],
+        )
+
+        # Check that `branin_e` has been transformed correctly.
+        assert_series_equal(
+            transformed_data.observation_data[("mean", "branin_e")],
+            bilog_transform(
+                experiment_data.observation_data[("mean", "branin_e")], bound=self.bound
+            ),
+        )
+        # Sem is smaller than before.
+        self.assertTrue(
+            (
+                transformed_data.observation_data[("sem", "branin_e")]
+                < experiment_data.observation_data[("sem", "branin_e")]
+            ).all()
+        )
+        # Compare against transforming the old way.
+        mean, var = match_ci_width(
+            mean=experiment_data.observation_data[("mean", "branin_e")],
+            variance=experiment_data.observation_data[("sem", "branin_e")] ** 2,
+            transform=partial(bilog_transform, bound=self.bound),
+        )
+        assert_series_equal(
+            transformed_data.observation_data[("mean", "branin_e")], mean
+        )
+        # Can't use assert_series_equal since the metadata is destroyed in var.
+        self.assertTrue(
+            transformed_data.observation_data[("sem", "branin_e")].equals(var**0.5)
         )

--- a/ax/adapter/transforms/tests/test_unit_x_transform.py
+++ b/ax/adapter/transforms/tests/test_unit_x_transform.py
@@ -9,6 +9,8 @@
 from copy import deepcopy
 
 import numpy as np
+from ax.adapter.base import DataLoaderConfig
+from ax.adapter.data_utils import extract_experiment_data
 from ax.adapter.transforms.unit_x import UnitX
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
@@ -16,21 +18,18 @@ from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_robust_search_space
+from ax.utils.testing.core_stubs import (
+    get_experiment_with_observations,
+    get_robust_search_space,
+)
+from pandas import DataFrame
+from pandas.testing import assert_frame_equal
 from pyre_extensions import assert_is_instance
 
 
 class UnitXTransformTest(TestCase):
-    transform_class = UnitX
-    # pyre-fixme[4]: Attribute must be annotated.
-    expected_c_dicts = [{"x": -1.0, "y": 1.0}, {"x": -1.0, "a": 1.0}]
-    expected_c_bounds = [0.0, 1.0]
-
     def setUp(self) -> None:
         super().setUp()
-        self.target_lb = self.transform_class.target_lb
-        self.target_range = self.transform_class.target_range
-        self.target_ub = self.target_lb + self.target_range
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(
@@ -56,10 +55,7 @@ class UnitXTransformTest(TestCase):
                 ParameterConstraint(constraint_dict={"x": -0.5, "a": 1}, bound=0.5),
             ],
         )
-        self.t = self.transform_class(
-            search_space=self.search_space,
-            observations=[],
-        )
+        self.t = UnitX(search_space=self.search_space)
         self.search_space_with_target = SearchSpace(
             parameters=[
                 RangeParameter(
@@ -86,13 +82,7 @@ class UnitXTransformTest(TestCase):
             obs_ft2,
             [
                 ObservationFeatures(
-                    parameters={
-                        "x": self.target_lb + self.target_range / 2.0,
-                        "y": 1.0,
-                        "z": 2,
-                        "a": 2,
-                        "b": "b",
-                    }
+                    parameters={"x": 0.5, "y": 1.0, "z": 2, "a": 2, "b": "b"}
                 )
             ],
         )
@@ -103,7 +93,7 @@ class UnitXTransformTest(TestCase):
         obs_ft3 = self.t.transform_observation_features(obs_ft3)
         self.assertEqual(
             obs_ft3[0],
-            ObservationFeatures(parameters={"x": self.target_ub, "z": 2}),
+            ObservationFeatures(parameters={"x": 1.0, "z": 2}),
         )
         obs_ft5 = self.t.transform_observation_features([ObservationFeatures({})])
         self.assertEqual(obs_ft5[0], ObservationFeatures({}))
@@ -114,31 +104,35 @@ class UnitXTransformTest(TestCase):
 
         # Parameters transformed
         true_bounds = {
-            "x": (self.target_lb, 1.0),
-            "y": (self.target_lb, 1.0),
+            "x": (0.0, 1.0),
+            "y": (0.0, 1.0),
             "z": (1.0, 2.0),
             "a": (1.0, 2.0),
         }
         for p_name, (l, u) in true_bounds.items():
-            self.assertEqual(ss2.parameters[p_name].lower, l)
-            self.assertEqual(ss2.parameters[p_name].upper, u)
-        self.assertEqual(ss2.parameters["b"].values, ["a", "b", "c"])
+            self.assertEqual(
+                assert_is_instance(ss2.parameters[p_name], RangeParameter).lower, l
+            )
+            self.assertEqual(
+                assert_is_instance(ss2.parameters[p_name], RangeParameter).upper, u
+            )
+        self.assertEqual(
+            assert_is_instance(ss2.parameters["b"], ChoiceParameter).values,
+            ["a", "b", "c"],
+        )
         self.assertEqual(len(ss2.parameters), 5)
         # Constraints transformed
         self.assertEqual(
-            ss2.parameter_constraints[0].constraint_dict, self.expected_c_dicts[0]
+            ss2.parameter_constraints[0].constraint_dict, {"x": -1.0, "y": 1.0}
         )
-        self.assertEqual(ss2.parameter_constraints[0].bound, self.expected_c_bounds[0])
+        self.assertEqual(ss2.parameter_constraints[0].bound, 0.0)
         self.assertEqual(
-            ss2.parameter_constraints[1].constraint_dict, self.expected_c_dicts[1]
+            ss2.parameter_constraints[1].constraint_dict, {"x": -1.0, "a": 1.0}
         )
-        self.assertEqual(ss2.parameter_constraints[1].bound, self.expected_c_bounds[1])
+        self.assertEqual(ss2.parameter_constraints[1].bound, 1.0)
 
         # Test transform of target value
-        t = self.transform_class(
-            search_space=self.search_space_with_target,
-            observations=[],
-        )
+        t = UnitX(search_space=self.search_space_with_target)
         t.transform_search_space(self.search_space_with_target)
         self.assertEqual(
             self.search_space_with_target.parameters["x"].target_value, 1.0
@@ -175,14 +169,8 @@ class UnitXTransformTest(TestCase):
         self.t.transform_search_space(new_ss)
         # Parameters transformed
         true_bounds = {
-            "x": [
-                0.25 * self.target_range + self.target_lb,
-                0.5 * self.target_range + self.target_lb,
-            ],
-            "y": [
-                0.25 * self.target_range + self.target_lb,
-                1.0 * self.target_range + self.target_lb,
-            ],
+            "x": [0.25, 0.5],
+            "y": [0.25, 1.0],
             "z": [1.0, 1.5],
             "a": [0, 2],
         }
@@ -197,23 +185,16 @@ class UnitXTransformTest(TestCase):
         self.assertEqual(len(new_ss.parameters), 5)
         # # Constraints transformed
         self.assertEqual(
-            new_ss.parameter_constraints[0].constraint_dict, self.expected_c_dicts[0]
+            new_ss.parameter_constraints[0].constraint_dict, {"x": -1.0, "y": 1.0}
         )
+        self.assertEqual(new_ss.parameter_constraints[0].bound, 0.0)
         self.assertEqual(
-            new_ss.parameter_constraints[0].bound, self.expected_c_bounds[0]
+            new_ss.parameter_constraints[1].constraint_dict, {"x": -1.0, "a": 1.0}
         )
-        self.assertEqual(
-            new_ss.parameter_constraints[1].constraint_dict, self.expected_c_dicts[1]
-        )
-        self.assertEqual(
-            new_ss.parameter_constraints[1].bound, self.expected_c_bounds[1]
-        )
+        self.assertEqual(new_ss.parameter_constraints[1].bound, 1.0)
 
         # Test transform of target value
-        t = self.transform_class(
-            search_space=self.search_space_with_target,
-            observations=[],
-        )
+        t = UnitX(search_space=self.search_space_with_target)
         new_search_space_with_target = SearchSpace(
             parameters=[
                 RangeParameter(
@@ -227,50 +208,30 @@ class UnitXTransformTest(TestCase):
             ]
         )
         t.transform_search_space(new_search_space_with_target)
-        self.assertEqual(
-            new_search_space_with_target.parameters["x"].target_value,
-            0.5 * self.target_range + self.target_lb,
-        )
+        self.assertEqual(new_search_space_with_target.parameters["x"].target_value, 0.5)
 
     def test_w_robust_search_space_univariate(self) -> None:
         # Check that if no transforms are needed, it is untouched.
         for multivariate in (True, False):
-            rss = get_robust_search_space(
-                multivariate=multivariate,
-                lb=self.target_lb,
-                ub=self.target_ub,
-            )
+            rss = get_robust_search_space(multivariate=multivariate, lb=0.0, ub=1.0)
             expected = str(rss)
-            t = self.transform_class(
-                search_space=rss,
-                observations=[],
-            )
+            t = UnitX(search_space=rss)
             self.assertEqual(expected, str(t.transform_search_space(rss)))
         # Error if distribution is multiplicative.
         rss = get_robust_search_space()
         rss.parameter_distributions[0].multiplicative = True
-        t = self.transform_class(
-            search_space=rss,
-            observations=[],
-        )
+        t = UnitX(search_space=rss)
         with self.assertRaisesRegex(NotImplementedError, "multiplicative"):
             t.transform_search_space(rss)
         # Correctly transform univariate additive distributions.
         rss = get_robust_search_space(lb=5.0, ub=10.0)
-        t = self.transform_class(
-            search_space=rss,
-            observations=[],
-        )
+        t = UnitX(search_space=rss)
         t.transform_search_space(rss)
         dists = rss.parameter_distributions
-        self.assertEqual(
-            dists[0].distribution_parameters["loc"], 0.2 * self.target_range
-        )
-        self.assertEqual(dists[0].distribution_parameters["scale"], self.target_range)
+        self.assertEqual(dists[0].distribution_parameters["loc"], 0.2)
+        self.assertEqual(dists[0].distribution_parameters["scale"], 1.0)
         self.assertEqual(dists[1].distribution_parameters["loc"], 0.0)
-        self.assertEqual(
-            dists[1].distribution_parameters["scale"], 0.2 * self.target_range
-        )
+        self.assertEqual(dists[1].distribution_parameters["scale"], 0.2)
         # Correctly transform environmental distributions.
         rss = get_robust_search_space(lb=5.0, ub=10.0)
         all_parameters = list(rss.parameters.values())
@@ -286,14 +247,11 @@ class UnitXTransformTest(TestCase):
             dist.distribution_parameters["loc"],
             t._normalize_value(1.0, (5.0, 10.0)),
         )
-        self.assertEqual(dist.distribution_parameters["scale"], self.target_range)
+        self.assertEqual(dist.distribution_parameters["scale"], 1.0)
         # Error if transform via loc / scale is not supported.
         rss = get_robust_search_space(use_discrete=True)
         rss.parameters["z"]._parameter_type = ParameterType.FLOAT
-        t = self.transform_class(
-            search_space=rss,
-            observations=[],
-        )
+        t = UnitX(search_space=rss)
         with self.assertRaisesRegex(UnsupportedError, "`loc` and `scale`"):
             t.transform_search_space(rss)
 
@@ -301,7 +259,7 @@ class UnitXTransformTest(TestCase):
         # Error if trying to transform non-normal multivariate distributions.
         rss = get_robust_search_space(multivariate=True)
         rss.parameter_distributions[0].distribution_class = "multivariate_t"
-        t = self.transform_class(
+        t = UnitX(
             search_space=rss,
             observations=[],
         )
@@ -310,25 +268,16 @@ class UnitXTransformTest(TestCase):
         # Transform multivariate normal.
         rss = get_robust_search_space(multivariate=True)
         old_params = deepcopy(rss.parameter_distributions[0].distribution_parameters)
-        t = self.transform_class(
-            search_space=rss,
-            observations=[],
-        )
+        t = UnitX(search_space=rss)
         t.transform_search_space(rss)
         new_params = rss.parameter_distributions[0].distribution_parameters
         self.assertIsInstance(new_params["mean"], np.ndarray)
         self.assertIsInstance(new_params["cov"], np.ndarray)
         self.assertTrue(
-            np.allclose(
-                new_params["mean"],
-                np.asarray(old_params["mean"]) / 5.0 * self.target_range,
-            )
+            np.allclose(new_params["mean"], np.asarray(old_params["mean"]) / 5.0)
         )
         self.assertTrue(
-            np.allclose(
-                new_params["cov"],
-                np.asarray(old_params["cov"]) / ((5.0 / self.target_range) ** 2),
-            )
+            np.allclose(new_params["cov"], np.asarray(old_params["cov"]) / 25.0)
         )
         # Transform multivariate normal environmental distribution.
         rss = get_robust_search_space(multivariate=True)
@@ -339,18 +288,11 @@ class UnitXTransformTest(TestCase):
             num_samples=rss.num_samples,
             environmental_variables=rss_params[:2],
         )
-        t = self.transform_class(
-            search_space=rss,
-            observations=[],
-        )
+        t = UnitX(search_space=rss)
         t.transform_search_space(rss)
         new_params = rss.parameter_distributions[0].distribution_parameters
         self.assertTrue(
-            np.allclose(
-                new_params["mean"],
-                np.asarray(old_params["mean"]) / 5.0 * self.target_range
-                + self.target_lb,
-            )
+            np.allclose(new_params["mean"], np.asarray(old_params["mean"]) / 5.0)
         )
         # Errors if mean / cov are of wrong shape.
         rss.parameter_distributions[0].distribution_parameters["mean"] = [1.0]
@@ -360,3 +302,42 @@ class UnitXTransformTest(TestCase):
         rss.parameter_distributions[0].distribution_parameters["cov"] = [1.0]
         with self.assertRaisesRegex(UserInputError, "cov"):
             t.transform_search_space(rss)
+
+    def test_transform_experiment_data(self) -> None:
+        parameterizations = [
+            {"x": 1.0, "y": 1.5, "z": 1.0, "a": 1, "b": "b"},
+            {"x": 2.0, "y": 2.0, "z": 2.0, "a": 2, "b": "b"},
+        ]
+        experiment = get_experiment_with_observations(
+            observations=[[1.0], [2.0]],
+            search_space=self.search_space,
+            parameterizations=parameterizations,
+        )
+        experiment_data = extract_experiment_data(
+            experiment=experiment, data_loader_config=DataLoaderConfig()
+        )
+        transformed_data = self.t.transform_experiment_data(
+            experiment_data=deepcopy(experiment_data)
+        )
+
+        # Check that `x` and `y` have been transformed.
+        expected = DataFrame(
+            index=transformed_data.arm_data.index,
+            data={
+                "x": [0.0, 0.5],
+                "y": [0.5, 1.0],
+            },
+            columns=["x", "y"],
+        )
+        assert_frame_equal(transformed_data.arm_data[["x", "y"]], expected)
+
+        # Remaining columns are unchanged.
+        # "z" is log-scale and "a" is in, so they're not transformed.
+        cols = ["z", "a", "b", "metadata"]
+        assert_frame_equal(
+            transformed_data.arm_data[cols], experiment_data.arm_data[cols]
+        )
+        # Observation data is unchanged.
+        assert_frame_equal(
+            transformed_data.observation_data, experiment_data.observation_data
+        )


### PR DESCRIPTION
Summary:
As titled. Supports transforming `ExperimentData` with `UnitX` transform.

Background: As part of the larger refactor, we will be using `ExperimentData` in place of `list[Observation]` within the `Adapter`.
- The transforms will be initialized using `ExperimentData`. The `observations` input to the constructors may be deprecated once the use cases are updated.
- The training data for `Adapter` will be represented with `ExperimentData` and will be transformed using `transform_experiment_data`.
- For misc input / output to various `Adapter` and other methods, the `Observation / ObservationFeatures / ObservationData` objects will remain. To support these, we will retain the existing transform methods that service these objects.
- Since `ExperimentData` is not planned to be used as an output of user facing methods, we do not need to untransform it. We are not planning to implement`untransform_experiment_data`.

Differential Revision: D76085733


