### PR TITLE
Speed up sensitivity analyses by using batch dimension

### DIFF
--- a/ax/utils/sensitivity/derivative_measures.py
+++ b/ax/utils/sensitivity/derivative_measures.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import partial
 from typing import Any
@@ -90,16 +90,12 @@ class GpDGSMGpMean:
                 this list are generated using an integer-valued uniform distribution,
                 rather than the default (pseudo-)random continuous uniform distribution.
         """
-        # pyre-fixme[4]: Attribute must be annotated.
-        self.dim = assert_is_instance(model.train_inputs, tuple)[0].shape[-1]
+        self.dim: int = assert_is_instance(model.train_inputs, tuple)[0].shape[-1]
         self.derivative_gp = derivative_gp
         self.kernel_type = kernel_type
-        # pyre-fixme[4]: Attribute must be annotated.
-        self.bootstrap = num_bootstrap_samples > 1
-        # pyre-fixme[4]: Attribute must be annotated.
-        self.num_bootstrap_samples = (
-            num_bootstrap_samples - 1
-        )  # deduct 1 because the first is meant to be the full grid
+        self.bootstrap: bool = num_bootstrap_samples > 1
+        # deduct 1 because the first is meant to be the full grid
+        self.num_bootstrap_samples: int = num_bootstrap_samples - 1
         self.torch_device: torch.device = bounds.device
         if self.derivative_gp and (self.kernel_type is None):
             raise ValueError("Kernel type has to be specified to use derivative GP")
@@ -417,7 +413,7 @@ class GpDGSMGpSampling(GpDGSMGpMean):
 
 
 def compute_derivatives_from_model_list(
-    model_list: list[Model],
+    model_list: Sequence[Model],
     bounds: torch.Tensor,
     discrete_features: list[int] | None = None,
     **kwargs: Any,


### PR DESCRIPTION
Summary:
* Speed up sensitivity computations by using batch dimension -- use an x of shape [n, 1, d] instead of [n, d]. This avoids the costly creation of an (n, n) covariance matrix when we only need its diagonal elements.
* Stop doing those computations in minibatches, which was done to avoid the superlinear memory usage from large batch sizes (Use mini batches in SobolSensitivityGPMean #1848 ), which came from the (n,n) covariance matrix we no longer compute.

Reviewed By: Balandat

Differential Revision: D75712208


