### PR TITLE
Always use model predictions, not empirical best, for best-point

### DIFF
--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -35,13 +35,6 @@ class BenchmarkMethod(Base):
             replication.
         distribute_replications: Indicates whether the replications should be
             run in a distributed manner. Ax itself does not use this attribute.
-        use_model_predictions_for_best_point: Whether to use model
-            predictions with ``get_pareto_optimal_parameters`` (if
-            multi-objective) or `BestPointMixin._get_best_trial` (if
-            single-objective). However, note that if multi-objective,
-            best-point selection is not currently supported and
-            ``get_pareto_optimal_parameters`` will raise a
-            ``NotImplementedError``.
         batch_size: Number of arms per trial. If greater than 1, trials are
             ``BatchTrial``s; otherwise, they are ``Trial``s. Defaults to 1. This
             and the following arguments are passed to ``OrchestratorOptions``.
@@ -54,7 +47,6 @@ class BenchmarkMethod(Base):
 
     timeout_hours: float = 4.0
     distribute_replications: bool = False
-    use_model_predictions_for_best_point: bool = False
 
     batch_size: int | None = 1
     run_trials_in_batches: bool = False
@@ -119,7 +111,6 @@ class BenchmarkMethod(Base):
             experiment=experiment,
             generation_strategy=self.generation_strategy,
             optimization_config=optimization_config,
-            use_model_predictions=self.use_model_predictions_for_best_point,
         )
         if result is None:
             # This can happen if no points are predicted to satisfy all outcome

--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -110,7 +110,6 @@ def get_sobol_botorch_modular_acquisition(
     name: str | None = None,
     num_sobol_trials: int = 5,
     model_gen_kwargs: dict[str, Any] | None = None,
-    use_model_predictions_for_best_point: bool = False,
     batch_size: int = 1,
 ) -> BenchmarkMethod:
     """Get a `BenchmarkMethod` that uses Sobol followed by MBM.
@@ -126,7 +125,6 @@ def get_sobol_botorch_modular_acquisition(
             `BatchTrial`s.
         model_gen_kwargs: Passed to the BoTorch `GenerationStep` and ultimately
             to the BoTorch `Model`.
-        use_model_predictions_for_best_point: Passed to the created `BenchmarkMethod`.
         batch_size: Passed to the created ``BenchmarkMethod``.
 
     Example:
@@ -166,6 +164,5 @@ def get_sobol_botorch_modular_acquisition(
     return BenchmarkMethod(
         generation_strategy=generation_strategy,
         distribute_replications=distribute_replications,
-        use_model_predictions_for_best_point=use_model_predictions_for_best_point,
         batch_size=batch_size,
     )

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -678,7 +678,6 @@ class TestBenchmark(TestCase):
     def _test_replication_with_inference_value(
         self,
         batch_size: int,
-        use_model_predictions: bool,
         report_inference_value_as_trace: bool,
     ) -> None:
         seed = 1
@@ -686,7 +685,6 @@ class TestBenchmark(TestCase):
             model_cls=SingleTaskGP,
             acquisition_cls=qLogNoisyExpectedImprovement,
             distribute_replications=False,
-            use_model_predictions_for_best_point=use_model_predictions,
             num_sobol_trials=3,
             batch_size=batch_size,
         )
@@ -713,23 +711,15 @@ class TestBenchmark(TestCase):
         self.assertTrue((res.inference_trace >= res.oracle_trace).all())
 
     def test_replication_with_inference_value(self) -> None:
-        for (
-            use_model_predictions,
-            batch_size,
-            report_inference_value_as_trace,
-        ) in product(
-            [False, True],
-            [1, 2],
-            [False, True],
+        for batch_size, report_inference_value_as_trace in product(
+            [1, 2], [False, True]
         ):
             with self.subTest(
                 batch_size=batch_size,
-                use_model_predictions=use_model_predictions,
                 report_inference_value_as_trace=report_inference_value_as_trace,
             ):
                 self._test_replication_with_inference_value(
                     batch_size=batch_size,
-                    use_model_predictions=use_model_predictions,
                     report_inference_value_as_trace=report_inference_value_as_trace,
                 )
 


### PR DESCRIPTION
Summary:
In the short time that Ax benchmarking has supported an inference trace, it has been a perennial source of confusion that there are two different ways to get the "best point" used for the inference trace: the model-recommended best point and the empirical best point. Combined with the "oracle trace," there are three different traces that might be used to evaluate a noisy problem. "Empirical best" -- that is `use_model_predictions_for_best_point=False` -- rarely makes sense to do. It is essentially choosing a point on the basis of noise even if the model is much smarter than that.

This diff:
* Removes the option `use_model_predictions_for_best_point` from `BenchmarkMethod`

Differential Revision: D76156686


