### PR TITLE
Implement SearchSpaceToChoice.transform_experiment_data

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -756,13 +756,9 @@ def get_pareto_frontier_and_configs(
     # Transform optimization config.
 
     # de-relativize outcome constraints and objective thresholds
-    observations = adapter.get_training_data()
-
     optimization_config = assert_is_instance(
         derelativize_optimization_config_with_raw_status_quo(
-            optimization_config=optimization_config,
-            adapter=adapter,
-            observations=observations,
+            optimization_config=optimization_config, adapter=adapter
         ),
         MultiObjectiveOptimizationConfig,
     )

--- a/ax/adapter/tests/test_transform_utils.py
+++ b/ax/adapter/tests/test_transform_utils.py
@@ -77,9 +77,7 @@ class TransformUtilsTest(TestCase):
             optimization_config=optimization_config,
         )
         new_opt_config = derelativize_optimization_config_with_raw_status_quo(
-            optimization_config=optimization_config,
-            adapter=adapter,
-            observations=OBSERVATION_DATA,
+            optimization_config=optimization_config, adapter=adapter
         )
         expected_bound_values = {"m1": 0.9975, "m2": 1.995, "m3": 5.985}
         for oc in new_opt_config.all_constraints:

--- a/ax/adapter/transforms/utils.py
+++ b/ax/adapter/transforms/utils.py
@@ -16,7 +16,7 @@ from typing import Any, TYPE_CHECKING
 
 import numpy as np
 from ax.adapter.transforms.derelativize import Derelativize
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.observation import ObservationData
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import Parameter
 from ax.core.parameter_constraint import ParameterConstraint
@@ -161,18 +161,13 @@ def construct_new_search_space(
 
 
 def derelativize_optimization_config_with_raw_status_quo(
-    optimization_config: OptimizationConfig,
-    adapter: adapter_module.base.Adapter,
-    observations: list[Observation] | None,
+    optimization_config: OptimizationConfig, adapter: adapter_module.base.Adapter
 ) -> OptimizationConfig:
     """Derelativize optimization_config using raw status-quo values"""
     tf = Derelativize(
         search_space=adapter.model_space.clone(),
-        observations=observations,
         config={"use_raw_status_quo": True},
     )
     return tf.transform_optimization_config(
-        optimization_config=optimization_config.clone(),
-        adapter=adapter,
-        fixed_features=ObservationFeatures(parameters={}),
+        optimization_config=optimization_config.clone(), adapter=adapter
     )


### PR DESCRIPTION
Summary:
As titled. Supports transforming `ExperimentData` with `SearchSpaceToChoice` transform. The transform constructor is also updated to extract the data used to get the signatures from `ExperimentData`.

Background: As part of the larger refactor, we will be using `ExperimentData` in place of `list[Observation]` within the `Adapter`.
- The transforms will be initialized using `ExperimentData`. The `observations` input to the constructors may be deprecated once the use cases are updated.
- The training data for `Adapter` will be represented with `ExperimentData` and will be transformed using `transform_experiment_data`.
- For misc input / output to various `Adapter` and other methods, the `Observation / ObservationFeatures / ObservationData` objects will remain. To support these, we will retain the existing transform methods that service these objects.
- Since `ExperimentData` is not planned to be used as an output of user facing methods, we do not need to untransform it. We are not planning to implement`untransform_experiment_data`.

Differential Revision: D76273590


