### PR TITLE
Implement TrialAsTask.transform_experiment_data

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -756,13 +756,9 @@ def get_pareto_frontier_and_configs(
     # Transform optimization config.
 
     # de-relativize outcome constraints and objective thresholds
-    observations = adapter.get_training_data()
-
     optimization_config = assert_is_instance(
         derelativize_optimization_config_with_raw_status_quo(
-            optimization_config=optimization_config,
-            adapter=adapter,
-            observations=observations,
+            optimization_config=optimization_config, adapter=adapter
         ),
         MultiObjectiveOptimizationConfig,
     )

--- a/ax/adapter/tests/test_transform_utils.py
+++ b/ax/adapter/tests/test_transform_utils.py
@@ -77,9 +77,7 @@ class TransformUtilsTest(TestCase):
             optimization_config=optimization_config,
         )
         new_opt_config = derelativize_optimization_config_with_raw_status_quo(
-            optimization_config=optimization_config,
-            adapter=adapter,
-            observations=OBSERVATION_DATA,
+            optimization_config=optimization_config, adapter=adapter
         )
         expected_bound_values = {"m1": 0.9975, "m2": 1.995, "m3": 5.985}
         for oc in new_opt_config.all_constraints:

--- a/ax/adapter/transforms/search_space_to_choice.py
+++ b/ax/adapter/transforms/search_space_to_choice.py
@@ -14,9 +14,10 @@ from ax.core.arm import Arm
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, FixedParameter, ParameterType
 from ax.core.search_space import RobustSearchSpace, SearchSpace
-from ax.exceptions.core import UnsupportedError
+from ax.core.types import TParameterization, TParamValue
+from ax.exceptions.core import DataRequiredError, UnsupportedError
 from ax.generators.types import TConfig
-from pyre_extensions import assert_is_instance
+from pyre_extensions import assert_is_instance, none_throws
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
@@ -44,7 +45,10 @@ class SearchSpaceToChoice(Transform):
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "SearchSpaceToChoice requires search space"
-        assert observations is not None, "SeachSpaceToChoice requires observations"
+        if (observations is None or len(observations) == 0) and experiment_data is None:
+            raise DataRequiredError(
+                "`SeachSpaceToChoice` transform requires non-empty data."
+            )
         super().__init__(
             search_space=search_space,
             observations=observations,
@@ -62,14 +66,28 @@ class SearchSpaceToChoice(Transform):
                 "SearchSpaceToChoice transform is not supported for RobustSearchSpace."
             )
         self.parameter_name = "arms"
-        # pyre-fixme[4]: Attribute must be annotated.
-        self.signature_to_parameterization = {
-            Arm(parameters=obs.features.parameters).signature: obs.features.parameters
-            for obs in observations
-        }
+        self.parameters: list[str] = list(search_space.parameters)
+        if experiment_data is not None:
+            arm_data = experiment_data.arm_data
+            if arm_data.empty:
+                raise DataRequiredError(
+                    "SearchSpaceToChoice transform requires non-empty experiment data."
+                )
+            arm_data = arm_data[self.parameters]
+            self.signature_to_parameterization: dict[str, TParameterization] = {
+                Arm(parameters=row).signature: row
+                for row in arm_data.to_dict(orient="records")
+            }
+        else:
+            self.signature_to_parameterization: dict[str, TParameterization] = {
+                Arm(
+                    parameters=obs.features.parameters
+                ).signature: obs.features.parameters
+                for obs in none_throws(observations)
+            }
 
     def _transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
-        values = list(self.signature_to_parameterization.keys())
+        values: list[TParamValue] = list(self.signature_to_parameterization.keys())
         if len(values) > 1:
             parameter = ChoiceParameter(
                 name=self.parameter_name,
@@ -106,6 +124,23 @@ class SearchSpaceToChoice(Transform):
         for obsf in observation_features:
             # Do not untransform empty dict as it wasn't transformed in the first place
             if len(obsf.parameters) != 0:
-                signature = obsf.parameters[self.parameter_name]
+                signature = assert_is_instance(
+                    obsf.parameters[self.parameter_name], str
+                )
                 obsf.parameters = self.signature_to_parameterization[signature]
         return observation_features
+
+    def transform_experiment_data(
+        self, experiment_data: ExperimentData
+    ) -> ExperimentData:
+        arm_data = experiment_data.arm_data
+        if arm_data.empty:
+            return experiment_data
+        arm_data[self.parameter_name] = arm_data[self.parameters].apply(
+            lambda row: Arm(parameters=row).signature, axis=1
+        )
+        arm_data = arm_data[[self.parameter_name, "metadata"]]
+        return ExperimentData(
+            arm_data=arm_data,
+            observation_data=experiment_data.observation_data,
+        )

--- a/ax/adapter/transforms/utils.py
+++ b/ax/adapter/transforms/utils.py
@@ -16,7 +16,7 @@ from typing import Any, TYPE_CHECKING
 
 import numpy as np
 from ax.adapter.transforms.derelativize import Derelativize
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.observation import ObservationData
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import Parameter
 from ax.core.parameter_constraint import ParameterConstraint
@@ -161,18 +161,13 @@ def construct_new_search_space(
 
 
 def derelativize_optimization_config_with_raw_status_quo(
-    optimization_config: OptimizationConfig,
-    adapter: adapter_module.base.Adapter,
-    observations: list[Observation] | None,
+    optimization_config: OptimizationConfig, adapter: adapter_module.base.Adapter
 ) -> OptimizationConfig:
     """Derelativize optimization_config using raw status-quo values"""
     tf = Derelativize(
         search_space=adapter.model_space.clone(),
-        observations=observations,
         config={"use_raw_status_quo": True},
     )
     return tf.transform_optimization_config(
-        optimization_config=optimization_config.clone(),
-        adapter=adapter,
-        fixed_features=ObservationFeatures(parameters={}),
+        optimization_config=optimization_config.clone(), adapter=adapter
     )


### PR DESCRIPTION
Summary:
Supports transforming `ExperimentData` with `TrialAsTask` transform. The transform constructor is also updated to extract the data used to get the trial level mapping from `ExperimentData`.

Background: As part of the larger refactor, we will be using `ExperimentData` in place of `list[Observation]` within the `Adapter`.
- The transforms will be initialized using `ExperimentData`. The `observations` input to the constructors may be deprecated once the use cases are updated.
- The training data for `Adapter` will be represented with `ExperimentData` and will be transformed using `transform_experiment_data`.
- For misc input / output to various `Adapter` and other methods, the `Observation / ObservationFeatures / ObservationData` objects will remain. To support these, we will retain the existing transform methods that service these objects.
- Since `ExperimentData` is not planned to be used as an output of user facing methods, we do not need to untransform it. We are not planning to implement`untransform_experiment_data`.

Differential Revision: D76348224


