### PR TITLE
Use mini batches in Sobol sensitivity analysis

### DIFF
--- a/ax/utils/sensitivity/sobol_measures.py
+++ b/ax/utils/sensitivity/sobol_measures.py
@@ -487,9 +487,13 @@ class SobolSensitivityGPMean:
                 # We only need variances, not covariances, so we use the batch
                 # dimension, turning x from (*batch_dim, n, d) to
                 # (*batch_dim, n, 1, d)
-                p = self.model.posterior(x.unsqueeze(-2))
-                mean = p.mean.squeeze(-2)
-                variance = p.variance.squeeze(-2)
+                means, variances = [], []
+                for x_ in x.unsqueeze(-2).split(4096):
+                    p = self.model.posterior(x_)
+                    means.append(p.mean.squeeze(-2))
+                    variances.append(p.variance.squeeze(-2))
+                mean = torch.cat(means, dim=0)
+                variance = torch.cat(variances, dim=0)
             if is_ensemble(self.model):
                 # If x has shape [n, d],
                 # the mean will have shape [n, s, m], where 's' is the ensemble


### PR DESCRIPTION
Summary: Very large tensors are used in this function call, which can lead to high peak memory usage. A recent example had `x.shape = 160_000 x 14`, leading to >20gb of memory usage. Using mini-batches here to reduce the peak memory  usage. With 4096, we see peak memory usage of ~0.6gb.

Reviewed By: esantorella

Differential Revision: D76369180


