### PR TITLE
PreferenceOptimizationConfig

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -2022,6 +2022,7 @@ class Experiment(Base):
         self,
         purpose: AuxiliaryExperimentPurpose,
         auxiliary_experiment_name: str,
+        raise_if_not_found: bool = False,
     ) -> AuxiliaryExperiment | None:
         """Find the aux experiment with the given name and purpose in the experiment.
 
@@ -2031,13 +2032,22 @@ class Experiment(Base):
 
         Returns:
             The aux experiment with the given name and purpose, or None if not found.
+            if raise_if_not_found is True, raises a ValueError if not found.
         """
-        if purpose not in self.auxiliary_experiments_by_purpose:
-            return None
-        for auxiliary_experiment in self.auxiliary_experiments_by_purpose[purpose]:
-            if auxiliary_experiment.experiment.name == auxiliary_experiment_name:
-                return auxiliary_experiment
-        return None
+        found_aux_exp = None
+        if purpose in self.auxiliary_experiments_by_purpose:
+            for auxiliary_experiment in self.auxiliary_experiments_by_purpose[purpose]:
+                if auxiliary_experiment.experiment.name == auxiliary_experiment_name:
+                    found_aux_exp = auxiliary_experiment
+                    break
+
+        if raise_if_not_found:
+            if found_aux_exp is None:
+                raise UserInputError(
+                    f"Auxiliary experiment {auxiliary_experiment_name} is not "
+                    f"found for purpose {purpose}."
+                )
+        return found_aux_exp
 
     @property
     def auxiliary_experiments_by_purpose_for_storage(

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -331,7 +331,7 @@ def choose_botorch_acqf_class(
             logger.debug(f"Chose BoTorch acquisition function class: {acqf_class}.")
             return acqf_class
 
-    if torch_opt_config.is_moo:
+    if torch_opt_config.is_moo and not torch_opt_config.use_learned_objective:
         acqf_class = qLogNoisyExpectedHypervolumeImprovement
     else:
         acqf_class = qLogNoisyExpectedImprovement

--- a/ax/generators/torch/utils.py
+++ b/ax/generators/torch/utils.py
@@ -43,6 +43,7 @@ from botorch.acquisition.objective import (
     ConstrainedMCObjective,
     GenericMCObjective,
     IdentityMCObjective,
+    LearnedObjective,
     LinearMCObjective,
     MCAcquisitionObjective,
     PosteriorTransform,
@@ -400,6 +401,7 @@ def get_botorch_objective_and_transform(
     outcome_constraints: tuple[Tensor, Tensor] | None = None,
     X_observed: Tensor | None = None,
     risk_measure: RiskMeasureMCObjective | None = None,
+    learned_objective_preference_model: Model | None = None,
 ) -> tuple[MCAcquisitionObjective | None, PosteriorTransform | None]:
     """Constructs a BoTorch `AcquisitionObjective` object.
 
@@ -422,6 +424,15 @@ def get_botorch_objective_and_transform(
         A two-tuple containing (optionally) an `MCAcquisitionObjective` and
         (optionally) a `PosteriorTransform`.
     """
+
+    if learned_objective_preference_model is not None:
+        if risk_measure is not None:
+            raise UnsupportedError(
+                "Risk measures are not supported in with a preference objective."
+            )
+        objective = LearnedObjective(pref_model=learned_objective_preference_model)
+        return objective, None
+
     if risk_measure is not None:
         risk_measure = _get_risk_measure(
             model=model,

--- a/ax/generators/torch_base.py
+++ b/ax/generators/torch_base.py
@@ -90,6 +90,7 @@ class TorchOptConfig:
     is_moo: bool = False
     risk_measure: RiskMeasureMCObjective | None = None
     fit_out_of_design: bool = False
+    use_learned_objective: bool = False
 
 
 @dataclass(frozen=True)

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -26,6 +26,7 @@ from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
+    PreferenceOptimizationConfig,
 )
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.parameter import ChoiceParameter, FixedParameter, RangeParameter
@@ -333,6 +334,19 @@ def optimization_config_to_dict(
         "objective": optimization_config.objective,
         "outcome_constraints": optimization_config.outcome_constraints,
         "risk_measure": optimization_config.risk_measure,
+    }
+
+
+def preference_optimization_config_to_dict(
+    preference_optimization_config: PreferenceOptimizationConfig,
+) -> dict[str, Any]:
+    """Convert Ax optimization config to a dictionary."""
+    pref_profile_name = preference_optimization_config.preference_profile_name
+    return {
+        "__type": preference_optimization_config.__class__.__name__,
+        "objective": preference_optimization_config.objective,
+        "outcome_constraints": preference_optimization_config.outcome_constraints,
+        "preference_profile_name": pref_profile_name,
     }
 
 

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -44,6 +44,7 @@ from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
+    PreferenceOptimizationConfig,
 )
 from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.parameter import (
@@ -154,6 +155,7 @@ from ax.storage.json_store.encoders import (
     parameter_distribution_to_dict,
     pathlib_to_dict,
     percentile_early_stopping_strategy_to_dict,
+    preference_optimization_config_to_dict,
     range_parameter_to_dict,
     risk_measure_to_dict,
     robust_search_space_to_dict,
@@ -255,6 +257,7 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     pathlib.WindowsPath: pathlib_to_dict,
     pathlib.PurePosixPath: pathlib_to_dict,
     pathlib.PureWindowsPath: pathlib_to_dict,
+    PreferenceOptimizationConfig: preference_optimization_config_to_dict,
     RangeParameter: range_parameter_to_dict,
     RiskMeasure: risk_measure_to_dict,
     RobustSearchSpace: robust_search_space_to_dict,
@@ -389,6 +392,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "PurePath": pathlib_from_json,
     "PosixPath": pathlib_from_json,
     "WindowsPath": pathlib_from_json,
+    "PreferenceOptimizationConfig": PreferenceOptimizationConfig,
     "PurePosixPath": pathlib_from_json,
     "PureWindowsPath": pathlib_from_json,
     "PercentileEarlyStoppingStrategy": PercentileEarlyStoppingStrategy,


### PR DESCRIPTION
Summary:
Enable more PLBO (BO candidate generation part of BOPE) to work with regular MBM and TorchAdapter by supplying pref opt config and set the correct aux PE experiment.

to-do items:
- docstrings
- update sqa storage

Meta: see https://docs.google.com/document/d/1KENayOLCe7-kT85qlOk09AXUHhJXLpqKhsgyVVTwa2Q/edit?tab=t.0#heading=h.6olhm9qnegf3 for more design details and discussions

Differential Revision: D71692019
