### PR TITLE
Fix transforms used in get_tensor_converter_adapter

### DIFF
--- a/ax/global_stopping/strategies/improvement.py
+++ b/ax/global_stopping/strategies/improvement.py
@@ -237,11 +237,11 @@ class ImprovementGlobalStoppingStrategy(BaseGlobalStoppingStrategy):
         if reference_trial_index in self.hv_by_trial:
             hv_reference = self.hv_by_trial[reference_trial_index]
         else:
-            mb_reference = get_tensor_converter_adapter(
+            adapter_reference = get_tensor_converter_adapter(
                 experiment=experiment, data=Data(data_df_reference)
             )
             hv_reference = observed_hypervolume(
-                adapter=mb_reference, objective_thresholds=objective_thresholds
+                adapter=adapter_reference, objective_thresholds=objective_thresholds
             )
             self.hv_by_trial[reference_trial_index] = hv_reference
 
@@ -250,8 +250,12 @@ class ImprovementGlobalStoppingStrategy(BaseGlobalStoppingStrategy):
             return False, message
 
         # Computing HV at current trial
-        mb = get_tensor_converter_adapter(experiment=experiment, data=Data(data_df))
-        hv = observed_hypervolume(mb, objective_thresholds=objective_thresholds)
+        adapter = get_tensor_converter_adapter(
+            experiment=experiment, data=Data(data_df)
+        )
+        hv = observed_hypervolume(
+            adapter=adapter, objective_thresholds=objective_thresholds
+        )
         self.hv_by_trial[trial_to_check] = hv
 
         hv_improvement = (hv - hv_reference) / hv_reference

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import numpy as np
 import torch
 from ax.adapter.registry import Generators
+from ax.adapter.torch import TorchAdapter
 from ax.core.data import Data
 from ax.core.objective import MultiObjective, Objective
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
@@ -29,6 +30,7 @@ from ax.plot.pareto_frontier import (
 from ax.plot.pareto_utils import (
     _extract_observed_pareto_2d,
     get_observed_pareto_frontiers,
+    get_tensor_converter_adapter,
     infer_reference_point_from_experiment,
     logger,
     to_nonrobust_search_space,
@@ -391,3 +393,13 @@ class TestInfereReferencePointFromExperiment(TestCase):
             self.assertEqual(inferred_reference_point[1].op, ComparisonOp.GEQ)
             self.assertEqual(inferred_reference_point[1].bound, 0.35)
             self.assertEqual(inferred_reference_point[1].metric.name, "m2")
+
+    def test_get_tensor_converter_adapter(self) -> None:
+        # Test that it can convert experiments with different number of observations.
+        for num_observations in (1, 10, 2000):
+            experiment = get_experiment_with_observations(
+                observations=[[0.0] for _ in range(num_observations)],
+            )
+            self.assertIsInstance(
+                get_tensor_converter_adapter(experiment=experiment), TorchAdapter
+            )

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -8,11 +8,10 @@
 from unittest.mock import Mock
 
 import pandas as pd
-
+from ax.adapter.registry import Generators
 from ax.core.arm import Arm
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
-from ax.core.generator_run import GeneratorRun
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.trial import Trial
 from ax.exceptions.core import DataRequiredError
@@ -20,8 +19,6 @@ from ax.service.utils.best_point import get_trace
 from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
-    get_arm_weights2,
-    get_arms_from_dict,
     get_experiment_with_batch_trial,
     get_experiment_with_observations,
     get_experiment_with_trial,
@@ -142,8 +139,7 @@ class TestBestPointMixin(TestCase):
         # completed/early-stopped trial
         trial1 = assert_is_instance(trial, BatchTrial).clone_to()
         trial1.mark_abandoned(unsafe=True)
-        arms = get_arms_from_dict(get_arm_weights2())
-        trial2 = exp.new_batch_trial(GeneratorRun(arms))
+        trial2 = exp.new_batch_trial(Generators.SOBOL(experiment=exp).gen(n=3))
         trial2.mark_running(no_runner_required=True).mark_completed()
         df_dict2 = []
         for i, arm in enumerate(trial2.arms):


### PR DESCRIPTION
Summary:
In D76275126, this was updated to use `SearchSpaceToChoice` transform, but that doesn't work for all cases since `ChoiceParameter` does not support more than 1000 values.

A simpler solution is to use `MBM_X_trans`, which is part of the default set of transforms Ax uses. If they work as default for any given experiment, they should work well for this utility as well.

Differential Revision: D76431509
