### PR TITLE
Remove n_points > 1 option from best-point selector

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -396,10 +396,9 @@ def _update_benchmark_tracking_vars_in_place(
         # problems, because Ax's best-point functionality doesn't know
         # to predict at the target task or fidelity.
         if compute_best_params:
-            (best_params,) = method.get_best_parameters(
+            best_params = method.get_best_parameters(
                 experiment=experiment,
                 optimization_config=problem.optimization_config,
-                n_points=problem.n_best_points,
             )
             best_params_list.append(best_params)
 

--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -91,8 +91,6 @@ class BenchmarkProblem(Base):
             default) or the ``inference_trace``. See ``BenchmarkResult`` for
             more information. Currently, this is only supported for
             single-objective problems.
-        n_best_points: Number of points for a best-point selector to recommend.
-            Currently, only ``n_best_points=1`` is supported.
         step_runtime_function: Optionally, a function that takes in ``params``
             (typically dictionaries mapping strings to ``TParamValue``s) and
             returns the runtime of an step. If ``step_runtime_function`` is
@@ -111,7 +109,6 @@ class BenchmarkProblem(Base):
     baseline_value: float
     search_space: SearchSpace = field(repr=False)
     report_inference_value_as_trace: bool = False
-    n_best_points: int = 1
     step_runtime_function: TBenchmarkStepRuntimeFunction | None = None
     target_fidelity_and_task: Mapping[str, TParamValue] = field(default_factory=dict)
     status_quo_params: Mapping[str, TParamValue] | None = None
@@ -121,8 +118,6 @@ class BenchmarkProblem(Base):
 
     def __post_init__(self) -> None:
         # Validate inputs
-        if self.n_best_points != 1:
-            raise NotImplementedError("Only `n_best_points=1` is currently supported.")
         if self.report_inference_value_as_trace and self.is_moo:
             raise NotImplementedError(
                 "Inference trace is not supported for MOO. Please set "

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -155,10 +155,8 @@ class TestMethods(TestCase):
             + "get_best_parameters_from_model_predictions_with_trial_index",
             wraps=get_best_parameters_from_model_predictions_with_trial_index,
         ) as mock_get_best_parameters_from_predictions:
-            best_params = method.get_best_parameters(
+            method.get_best_parameters(
                 experiment=experiment,
                 optimization_config=problem.optimization_config,
-                n_points=1,
             )
         mock_get_best_parameters_from_predictions.assert_called_once()
-        self.assertEqual(len(best_params), 1)

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -62,22 +62,15 @@ class TestBenchmarkMethod(TestCase):
             NotImplementedError, "not currently supported for multi-objective"
         ):
             method.get_best_parameters(
-                experiment=experiment, optimization_config=moo_config, n_points=1
+                experiment=experiment, optimization_config=moo_config
             )
 
         soo_config = get_soo_opt_config(outcome_names=["a"])
-        with self.subTest("Multiple points not supported"), self.assertRaisesRegex(
-            NotImplementedError, "only n_points=1"
-        ):
-            method.get_best_parameters(
-                experiment=experiment, optimization_config=soo_config, n_points=2
-            )
-
         with self.subTest("Empty experiment"), self.assertRaisesRegex(
             ValueError, "Cannot identify a best point if experiment has no trials"
         ):
             method.get_best_parameters(
-                experiment=experiment, optimization_config=soo_config, n_points=1
+                experiment=experiment, optimization_config=soo_config
             )
 
         with self.subTest("All constraints violated"):
@@ -86,12 +79,10 @@ class TestBenchmarkMethod(TestCase):
                 constrained=True,
             )
             best_point = method.get_best_parameters(
-                n_points=1,
                 experiment=experiment,
                 optimization_config=none_throws(experiment.optimization_config),
             )
-            self.assertEqual(len(best_point), 1)
-            self.assertEqual(best_point[0], experiment.trials[1].arms[0].parameters)
+            self.assertEqual(best_point, experiment.trials[1].arms[0].parameters)
 
         with self.subTest("No completed trials"):
             experiment = get_experiment_with_observations(observations=[])
@@ -100,9 +91,7 @@ class TestBenchmarkMethod(TestCase):
                 trial = experiment.new_trial(generator_run=sobol_generator.gen(n=1))
                 trial.run()
             best_point = method.get_best_parameters(
-                n_points=1,
                 experiment=experiment,
                 optimization_config=none_throws(experiment.optimization_config),
             )
-            self.assertEqual(len(best_point), 1)
-            self.assertEqual(best_point[0], experiment.trials[2].arms[0].parameters)
+            self.assertEqual(best_point, experiment.trials[2].arms[0].parameters)

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -46,44 +46,6 @@ class TestBenchmarkProblem(TestCase):
         self.maxDiff = None
         super().setUp()
 
-    def test_inference_value_not_implemented(self) -> None:
-        objectives = [
-            Objective(metric=BenchmarkMetric(name, lower_is_better=True))
-            for name in ["Branin", "Currin"]
-        ]
-        optimization_config = OptimizationConfig(objective=objectives[0])
-        test_function = BoTorchTestFunction(
-            botorch_problem=Branin(), outcome_names=["Branin"]
-        )
-        with self.assertRaisesRegex(NotImplementedError, "Only `n_best_points=1`"):
-            BenchmarkProblem(
-                name="foo",
-                optimization_config=optimization_config,
-                num_trials=1,
-                optimal_value=0.0,
-                baseline_value=1.0,
-                search_space=SearchSpace(parameters=[]),
-                test_function=test_function,
-                n_best_points=2,
-            )
-
-        with self.assertRaisesRegex(
-            NotImplementedError, "Inference trace is not supported for MOO"
-        ):
-            BenchmarkProblem(
-                name="foo",
-                optimization_config=MultiObjectiveOptimizationConfig(
-                    objective=MultiObjective(objectives)
-                ),
-                num_trials=1,
-                optimal_value=0.0,
-                search_space=SearchSpace(parameters=[]),
-                baseline_value=1.0,
-                test_function=test_function,
-                n_best_points=1,
-                report_inference_value_as_trace=True,
-            )
-
     def test_mismatch_of_names_on_test_function_and_opt_config_raises(self) -> None:
         objectives = [
             Objective(metric=BenchmarkMetric(name, lower_is_better=True))


### PR DESCRIPTION
Summary:
*Context:*

TLDR: I am cleaning up and refactoring best-point functionality. `n_points > 1` is not supported, so it doesn't make sense to refactor it.

* Current state: Currently, the way we get a best point in benchmarking, is opaque because a recommendation is initially written to `GeneratorRun`, then parsed by `BestPointMixin._get_best_trial`, and then some more processing is done to ensure that the point is not None. This is OK for comparing different generation strategies, because it ensures that a best point will always be present. However, it not very helpful for comparing best-point selection itself. The right way to change a best-point recommendation is via `GeneratorRun.best_arm_predictions`, but all the post-processing will make it hard to see the effect of that. We initially wrote `BenchmarkMethod.get_best_parameters` with the expectation that users could subclass `BenchmarkMethod` and override `get_best_parameters` in order to control best-point selection more directly. But subclassing `BenchmarkMethod` is a bad idea that would cause serialization issues, and developing a best-point selector in that way would then require the work be redone to integrate it into Ax.
* Intermediate goal state: Benchmarks simply use best-point predictions from `GeneratorRun.best_arm_predictions`. If this is None, the inference trace will be NaN at that point.
* Ideal end state: Best-point selectors are eventually introduced as an Ax modeling abstraction that can be changed and run independently of candidate generation.

Differential Revision: D76159679
