### PR TITLE
Implement TransformToNewSQ.transform_experiment_data (#3916)

### DIFF
--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -16,6 +16,7 @@ from ax.adapter.transforms.tests.test_relativize_transform import RelativizeData
 from ax.adapter.transforms.transform_to_new_sq import TransformToNewSQ
 from ax.core.batch_trial import BatchTrial
 from ax.core.observation import observations_from_data
+from ax.exceptions.core import DataRequiredError
 from ax.generators.base import Generator
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -85,7 +86,7 @@ class TransformToNewSQSpecificTest(TestCase):
         self.adapter._status_quo_name = None
 
         with self.assertRaisesRegex(
-            AssertionError, "TransformToNewSQ requires status quo data."
+            DataRequiredError, "TransformToNewSQ requires status quo data."
         ):
             TransformToNewSQ(
                 search_space=None,

--- a/ax/utils/stats/statstools.py
+++ b/ax/utils/stats/statstools.py
@@ -151,8 +151,8 @@ def positive_part_james_stein(
 def relativize(
     means_t: npt.NDArray | list[float] | float,
     sems_t: npt.NDArray | list[float] | float,
-    mean_c: float,
-    sem_c: float,
+    mean_c: npt.NDArray | float,
+    sem_c: npt.NDArray | float,
     bias_correction: bool = True,
     cov_means: npt.NDArray | list[float] | float = 0.0,
     as_percent: bool = False,


### PR DESCRIPTION
Summary:

Supports transforming `ExperimentData` with `TransformToNewSQ` transform.

Background: As part of the larger refactor, we will be using `ExperimentData` in place of `list[Observation]` within the `Adapter`.
- The transforms will be initialized using `ExperimentData`. The `observations` input to the constructors may be deprecated once the use cases are updated.
- The training data for `Adapter` will be represented with `ExperimentData` and will be transformed using `transform_experiment_data`.
- For misc input / output to various `Adapter` and other methods, the `Observation / ObservationFeatures / ObservationData` objects will remain. To support these, we will retain the existing transform methods that service these objects.
- Since `ExperimentData` is not planned to be used as an output of user facing methods, we do not need to untransform it. We are not planning to implement`untransform_experiment_data`.

Differential Revision: D76565328
