### PR TITLE
Remove `optimization_config` as argument from `BenchmarkMethod.get_best_parameters`

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -386,10 +386,7 @@ def _update_benchmark_tracking_vars_in_place(
         if problem.is_moo or is_mf_or_mt:
             best_params = None
         else:
-            best_params = method.get_best_parameters(
-                experiment=experiment,
-                optimization_config=problem.optimization_config,
-            )
+            best_params = method.get_best_parameters(experiment=experiment)
         best_params_list.append(best_params)
 
 

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -8,7 +8,6 @@
 from dataclasses import dataclass
 
 from ax.core.experiment import Experiment
-from ax.core.optimization_config import OptimizationConfig
 from ax.core.types import TParameterization
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 
@@ -53,11 +52,7 @@ class BenchmarkMethod(Base):
         if self.name == "DEFAULT":
             self.name = self.generation_strategy.name
 
-    def get_best_parameters(
-        self,
-        experiment: Experiment,
-        optimization_config: OptimizationConfig,
-    ) -> TParameterization | None:
+    def get_best_parameters(self, experiment: Experiment) -> TParameterization | None:
         """
         Get the most promising point.
 
@@ -67,13 +62,10 @@ class BenchmarkMethod(Base):
             experiment: The experiment to get the data from. This should contain
                 values that would be observed in a realistic setting and not
                 contain oracle values.
-            optimization_config: The ``optimization_config`` for the corresponding
-                ``BenchmarkProblem``.
         """
         result = BestPointMixin._get_best_trial(
             experiment=experiment,
             generation_strategy=self.generation_strategy,
-            optimization_config=optimization_config,
         )
         if result is None:
             # This can happen if no points are predicted to satisfy all outcome

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -8,10 +8,7 @@
 from dataclasses import dataclass
 
 from ax.core.experiment import Experiment
-from ax.core.optimization_config import (
-    MultiObjectiveOptimizationConfig,
-    OptimizationConfig,
-)
+from ax.core.optimization_config import OptimizationConfig
 from ax.core.types import TParameterization
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 
@@ -73,12 +70,6 @@ class BenchmarkMethod(Base):
             optimization_config: The ``optimization_config`` for the corresponding
                 ``BenchmarkProblem``.
         """
-        if isinstance(optimization_config, MultiObjectiveOptimizationConfig):
-            raise NotImplementedError(
-                "BenchmarkMethod.get_pareto_optimal_parameters is not currently "
-                "supported for multi-objective problems."
-            )
-
         result = BestPointMixin._get_best_trial(
             experiment=experiment,
             generation_strategy=self.generation_strategy,

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -155,8 +155,5 @@ class TestMethods(TestCase):
             + "get_best_parameters_from_model_predictions_with_trial_index",
             wraps=get_best_parameters_from_model_predictions_with_trial_index,
         ) as mock_get_best_parameters_from_predictions:
-            method.get_best_parameters(
-                experiment=experiment,
-                optimization_config=problem.optimization_config,
-            )
+            method.get_best_parameters(experiment=experiment)
         mock_get_best_parameters_from_predictions.assert_called_once()

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -59,7 +59,7 @@ class TestBenchmarkMethod(TestCase):
         method = BenchmarkMethod(generation_strategy=self.gs)
 
         with self.subTest("MOO not supported"), self.assertRaisesRegex(
-            NotImplementedError, "not currently supported for multi-objective"
+            NotImplementedError, "Please use `get_pareto_optimal_parameters`"
         ):
             method.get_best_parameters(
                 experiment=experiment, optimization_config=moo_config


### PR DESCRIPTION
Summary: Context: Passing the optimization config only has an effect if it is different from the optimization config on the experiment. That functionality is only used in one unit test, which I changed to use `clone_with`; in all other cases that the argument was passed, it did nothing.

Differential Revision: D76618781
