### PR TITLE
Remove a redundant error for MOO in `BenchmarkMethod.get_best_parameters`

### DIFF
--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -8,10 +8,7 @@
 from dataclasses import dataclass
 
 from ax.core.experiment import Experiment
-from ax.core.optimization_config import (
-    MultiObjectiveOptimizationConfig,
-    OptimizationConfig,
-)
+from ax.core.optimization_config import OptimizationConfig
 from ax.core.types import TParameterization
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 
@@ -73,12 +70,6 @@ class BenchmarkMethod(Base):
             optimization_config: The ``optimization_config`` for the corresponding
                 ``BenchmarkProblem``.
         """
-        if isinstance(optimization_config, MultiObjectiveOptimizationConfig):
-            raise NotImplementedError(
-                "BenchmarkMethod.get_pareto_optimal_parameters is not currently "
-                "supported for multi-objective problems."
-            )
-
         result = BestPointMixin._get_best_trial(
             experiment=experiment,
             generation_strategy=self.generation_strategy,

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -59,7 +59,7 @@ class TestBenchmarkMethod(TestCase):
         method = BenchmarkMethod(generation_strategy=self.gs)
 
         with self.subTest("MOO not supported"), self.assertRaisesRegex(
-            NotImplementedError, "not currently supported for multi-objective"
+            NotImplementedError, "Please use `get_pareto_optimal_parameters`"
         ):
             method.get_best_parameters(
                 experiment=experiment, optimization_config=moo_config


### PR DESCRIPTION
Summary: `BenchmarkMethod.get_best_parameters` errors when given a MOO opt config, but without that error a very similar one would appear one level deeper in the stack, so there's no need to have one in `get_best_parameters`.

Differential Revision: D76618771
