### PR TITLE
Move `get_best_parameters` off of `BenchmarkMethod`

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -386,10 +386,7 @@ def _update_benchmark_tracking_vars_in_place(
         if problem.is_moo or is_mf_or_mt:
             best_params = None
         else:
-            best_params = method.get_best_parameters(
-                experiment=experiment,
-                optimization_config=problem.optimization_config,
-            )
+            best_params = method.get_best_parameters(experiment=experiment)
         best_params_list.append(best_params)
 
 

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -8,7 +8,6 @@
 from dataclasses import dataclass
 
 from ax.core.experiment import Experiment
-from ax.core.optimization_config import OptimizationConfig
 from ax.core.types import TParameterization
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 
@@ -53,11 +52,7 @@ class BenchmarkMethod(Base):
         if self.name == "DEFAULT":
             self.name = self.generation_strategy.name
 
-    def get_best_parameters(
-        self,
-        experiment: Experiment,
-        optimization_config: OptimizationConfig,
-    ) -> TParameterization | None:
+    def get_best_parameters(self, experiment: Experiment) -> TParameterization | None:
         """
         Get the most promising point.
 
@@ -67,13 +62,10 @@ class BenchmarkMethod(Base):
             experiment: The experiment to get the data from. This should contain
                 values that would be observed in a realistic setting and not
                 contain oracle values.
-            optimization_config: The ``optimization_config`` for the corresponding
-                ``BenchmarkProblem``.
         """
         result = BestPointMixin._get_best_trial(
             experiment=experiment,
             generation_strategy=self.generation_strategy,
-            optimization_config=optimization_config,
         )
         if result is None:
             # This can happen if no points are predicted to satisfy all outcome

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -7,14 +7,10 @@
 
 from dataclasses import dataclass
 
-from ax.core.experiment import Experiment
-from ax.core.types import TParameterization
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.utils.common.base import Base
-from pyre_extensions import none_throws
 
 
 @dataclass(kw_only=True)
@@ -51,25 +47,3 @@ class BenchmarkMethod(Base):
     def __post_init__(self) -> None:
         if self.name == "DEFAULT":
             self.name = self.generation_strategy.name
-
-    def get_best_parameters(self, experiment: Experiment) -> TParameterization | None:
-        """
-        Get the most promising point.
-
-        Only SOO is supported. It will return None if no best point can be found.
-
-        Args:
-            experiment: The experiment to get the data from. This should contain
-                values that would be observed in a realistic setting and not
-                contain oracle values.
-        """
-        result = BestPointMixin._get_best_trial(
-            experiment=experiment,
-            generation_strategy=self.generation_strategy,
-        )
-        if result is None:
-            # This can happen if no points are predicted to satisfy all outcome
-            # constraints.
-            return None
-        _, params, _ = none_throws(result)
-        return params

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -8,10 +8,7 @@
 from dataclasses import dataclass
 
 from ax.core.experiment import Experiment
-from ax.core.optimization_config import (
-    MultiObjectiveOptimizationConfig,
-    OptimizationConfig,
-)
+from ax.core.optimization_config import OptimizationConfig
 from ax.core.types import TParameterization
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 
@@ -73,12 +70,6 @@ class BenchmarkMethod(Base):
             optimization_config: The ``optimization_config`` for the corresponding
                 ``BenchmarkProblem``.
         """
-        if isinstance(optimization_config, MultiObjectiveOptimizationConfig):
-            raise NotImplementedError(
-                "BenchmarkMethod.get_pareto_optimal_parameters is not currently "
-                "supported for multi-objective problems."
-            )
-
         result = BestPointMixin._get_best_trial(
             experiment=experiment,
             generation_strategy=self.generation_strategy,

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -155,8 +155,5 @@ class TestMethods(TestCase):
             + "get_best_parameters_from_model_predictions_with_trial_index",
             wraps=get_best_parameters_from_model_predictions_with_trial_index,
         ) as mock_get_best_parameters_from_predictions:
-            method.get_best_parameters(
-                experiment=experiment,
-                optimization_config=problem.optimization_config,
-            )
+            method.get_best_parameters(experiment=experiment)
         mock_get_best_parameters_from_predictions.assert_called_once()

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -5,27 +5,16 @@
 
 # pyre-strict
 
-from ax.adapter.factory import get_sobol
 from ax.benchmark.benchmark_method import BenchmarkMethod
-from ax.benchmark.benchmark_problem import (
-    get_continuous_search_space,
-    get_moo_opt_config,
-    get_soo_opt_config,
-)
 from ax.benchmark.methods.sobol import get_sobol_generation_strategy
-from ax.core.experiment import Experiment
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_experiment_with_observations
 from pyre_extensions import none_throws
 
 
 class TestBenchmarkMethod(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.gs = get_sobol_generation_strategy()
-
     def test_benchmark_method(self) -> None:
-        method = BenchmarkMethod(name="Sobol10", generation_strategy=self.gs)
+        gs = get_sobol_generation_strategy()
+        method = BenchmarkMethod(name="Sobol10", generation_strategy=gs)
         self.assertEqual(method.name, "Sobol10")
 
         # test that `fit_tracking_metrics` has been correctly set to False
@@ -33,61 +22,15 @@ class TestBenchmarkMethod(TestCase):
             self.assertFalse(none_throws(step.model_kwargs).get("fit_tracking_metrics"))
         self.assertEqual(method.timeout_hours, 4)
 
-        method = BenchmarkMethod(generation_strategy=self.gs, timeout_hours=10)
+        method = BenchmarkMethod(generation_strategy=gs, timeout_hours=10)
         self.assertEqual(method.name, method.generation_strategy.name)
         self.assertEqual(method.timeout_hours, 10)
 
         # test that instantiation works with node-based strategies
-        method = BenchmarkMethod(name="Sobol10", generation_strategy=self.gs)
+        method = BenchmarkMethod(name="Sobol10", generation_strategy=gs)
         for node in method.generation_strategy._nodes:
             self.assertFalse(
                 none_throws(node.generator_spec_to_gen_from.model_kwargs).get(
                     "fit_tracking_metrics"
                 )
             )
-
-    def test_get_best_parameters(self) -> None:
-        """
-        This is tested more thoroughly in `test_benchmark` -- setting up an
-        experiment with data and trials without just running a benchmark is a
-        pain, so in that file, we just run a benchmark.
-        """
-        search_space = get_continuous_search_space(bounds=[(0, 1)])
-        moo_config = get_moo_opt_config(outcome_names=["a", "b"], ref_point=[0, 0])
-        experiment = Experiment(
-            name="test",
-            is_test=True,
-            search_space=search_space,
-            optimization_config=moo_config,
-        )
-
-        method = BenchmarkMethod(generation_strategy=self.gs)
-
-        with self.subTest("MOO not supported"), self.assertRaisesRegex(
-            NotImplementedError, "Please use `get_pareto_optimal_parameters`"
-        ):
-            method.get_best_parameters(experiment=experiment)
-
-        soo_config = get_soo_opt_config(outcome_names=["a"])
-        with self.subTest("Empty experiment"):
-            result = method.get_best_parameters(
-                experiment=experiment.clone_with(optimization_config=soo_config),
-            )
-            self.assertIsNone(result)
-
-        with self.subTest("All constraints violated"):
-            experiment = get_experiment_with_observations(
-                observations=[[1, -1], [2, -1]],
-                constrained=True,
-            )
-            best_point = method.get_best_parameters(experiment=experiment)
-            self.assertIsNone(best_point)
-
-        with self.subTest("No completed trials"):
-            experiment = get_experiment_with_observations(observations=[])
-            sobol_generator = get_sobol(search_space=experiment.search_space)
-            for _ in range(3):
-                trial = experiment.new_trial(generator_run=sobol_generator.gen(n=1))
-                trial.run()
-            best_point = method.get_best_parameters(experiment=experiment)
-            self.assertIsNone(best_point)

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -59,7 +59,7 @@ class TestBenchmarkMethod(TestCase):
         method = BenchmarkMethod(generation_strategy=self.gs)
 
         with self.subTest("MOO not supported"), self.assertRaisesRegex(
-            NotImplementedError, "not currently supported for multi-objective"
+            NotImplementedError, "Please use `get_pareto_optimal_parameters`"
         ):
             method.get_best_parameters(
                 experiment=experiment, optimization_config=moo_config


### PR DESCRIPTION
Summary:
* Move `get_best_parameters` from `BenchmarkMethod` to `benchmark.py`. No changes made to the content of the function.
* Removed `TestMethods.test_get_best_parameters` -- that just runs a mini-benchmark and then checks that a function has been called; we have other units that check those things. (This test was more substantive in the past, but has already shrunk when previous functionality was removed.)
* Moved a test from `test_benchmark_method.py` to `test_benchmark.py`

Differential Revision: D76620213
