### PR TITLE
Remove unused _raise_deprecation_warning

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -880,7 +880,7 @@ class Client(WithDBSettingsBase):
     def predict(
         self,
         points: Sequence[TParameterization],
-    ) -> list[TOutcome]:
+    ) -> list[dict[str, tuple[float, float]]]:
         """
         Use the current surrogate model to predict the outcome of the provided
         list of parameterizations.
@@ -915,7 +915,7 @@ class Client(WithDBSettingsBase):
             {
                 metric_name: (
                     mean[metric_name][i],
-                    covariance[metric_name][metric_name][i],
+                    covariance[metric_name][metric_name][i] ** 0.5,
                 )
                 for metric_name in mean.keys()
             }

--- a/ax/api/utils/tests/test_generation_strategy_dispatch.py
+++ b/ax/api/utils/tests/test_generation_strategy_dispatch.py
@@ -142,3 +142,37 @@ class TestDispatchUtils(TestCase):
                 self.assertEqual(model_key, "Sobol")
             else:
                 self.assertEqual(model_key, "BoTorch")
+
+    def test_choose_gs_no_initialization(self) -> None:
+        struct = GenerationStrategyDispatchStruct(
+            method="fast", initialization_budget=0
+        )
+        gs = choose_generation_strategy(struct=struct)
+        self.assertEqual(len(gs._nodes), 1)
+        self.assertEqual(gs.name, "MBM:fast")
+        mbm_node = gs._nodes[0]
+        self.assertEqual(mbm_node.node_name, "MBM")
+
+    def test_choose_gs_center_only_initialization(self) -> None:
+        struct = GenerationStrategyDispatchStruct(
+            method="fast", initialization_budget=1, initialize_with_center=True
+        )
+        gs = choose_generation_strategy(struct=struct)
+        self.assertEqual(len(gs._nodes), 2)
+        self.assertEqual(gs.name, "Center+MBM:fast")
+        center_node = gs._nodes[0]
+        self.assertEqual(center_node.node_name, "CenterOfSearchSpace")
+        mbm_node = gs._nodes[1]
+        self.assertEqual(mbm_node.node_name, "MBM")
+
+    def test_choose_gs_single_sobol_initialization(self) -> None:
+        struct = GenerationStrategyDispatchStruct(
+            method="fast", initialization_budget=1, initialize_with_center=False
+        )
+        gs = choose_generation_strategy(struct=struct)
+        self.assertEqual(len(gs._nodes), 2)
+        self.assertEqual(gs.name, "Sobol+MBM:fast")
+        sobol_node = gs._nodes[0]
+        self.assertEqual(sobol_node.node_name, "Sobol")
+        mbm_node = gs._nodes[1]
+        self.assertEqual(mbm_node.node_name, "MBM")

--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 import inspect
-import warnings
 from collections import OrderedDict
 from collections.abc import Sequence
 from copy import deepcopy
@@ -81,7 +80,7 @@ from botorch.utils.datasets import MultiTaskDataset, RankingDataset, SupervisedD
 from botorch.utils.dispatcher import Dispatcher
 from botorch.utils.evaluation import AIC, BIC, compute_in_sample_model_fit_metric, MLL
 from botorch.utils.transforms import normalize_indices
-from botorch.utils.types import _DefaultType, DEFAULT
+from botorch.utils.types import _DefaultType
 from gpytorch.models.exact_gp import ExactGP
 from pyre_extensions import assert_is_instance, none_throws
 from torch import Tensor
@@ -378,45 +377,6 @@ def _construct_submodules(
         submodules["outcome_transform"] = None
 
     return submodules
-
-
-def _raise_deprecation_warning(
-    is_surrogate: bool = False,
-    **kwargs: Any,
-) -> bool:
-    """Raise deprecation warnings for deprecated arguments.
-
-    Args:
-        is_surrogate: A boolean indicating whether the warning is called from
-            Surrogate.
-
-    Returns:
-        A boolean indicating whether any deprecation warnings were raised.
-    """
-    msg = "{k} is deprecated and will be removed in a future version. "
-    if is_surrogate:
-        msg += "Please specify {k} via `surrogate_spec.model_configs`."
-    else:
-        msg += "Please specify {k} via `model_configs`."
-    warnings_raised = False
-    default_is_dict = {"botorch_model_kwargs", "mll_kwargs"}
-    default_is_default = {"input_transform_classes"}
-    for k, v in kwargs.items():
-        should_raise = False
-        if k in default_is_dict:
-            if v not in [{}, None]:
-                should_raise = True
-        elif k in default_is_default:
-            if v != DEFAULT:
-                should_raise = True
-        if should_raise:
-            warnings.warn(
-                msg.format(k=k),
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            warnings_raised = True
-    return warnings_raised
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Summary: This is leftover from a recent diff that removed deprecated inputs.

Differential Revision: D76838308
