### PR TITLE
Consolidate DataRequiredError handling in transforms

### DIFF
--- a/ax/adapter/transforms/metadata_to_float.py
+++ b/ax/adapter/transforms/metadata_to_float.py
@@ -19,7 +19,6 @@ from ax.core import ParameterType
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import RangeParameter
 from ax.core.search_space import SearchSpace
-from ax.exceptions.core import DataRequiredError
 from ax.generators.types import TConfig
 from ax.utils.common.logger import get_logger
 from pyre_extensions import assert_is_instance, none_throws
@@ -47,6 +46,8 @@ class MetadataToFloat(Transform):
     Transform is done in-place.
     """
 
+    requires_data_for_initialization: bool = True
+
     DEFAULT_LOG_SCALE: bool = False
     DEFAULT_LOGIT_SCALE: bool = False
     DEFAULT_IS_FIDELITY: bool = False
@@ -60,10 +61,6 @@ class MetadataToFloat(Transform):
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
-        if (observations is None or not observations) and experiment_data is None:
-            raise DataRequiredError(
-                f"`{self.__class__.__name__}` transform requires non-empty data."
-            )
         super().__init__(
             search_space=search_space,
             observations=observations,

--- a/ax/adapter/transforms/standardize_y.py
+++ b/ax/adapter/transforms/standardize_y.py
@@ -39,6 +39,8 @@ class StandardizeY(Transform):
     Transform is done in-place.
     """
 
+    requires_data_for_initialization: bool = True
+
     def __init__(
         self,
         search_space: SearchSpace | None = None,
@@ -47,8 +49,6 @@ class StandardizeY(Transform):
         adapter: Optional["base_adapter.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
-        if (observations is None or len(observations) == 0) and experiment_data is None:
-            raise DataRequiredError("`StandardizeY` transform requires non-empty data.")
         super().__init__(
             search_space=search_space,
             observations=observations,

--- a/ax/adapter/transforms/stratified_standardize_y.py
+++ b/ax/adapter/transforms/stratified_standardize_y.py
@@ -19,7 +19,6 @@ from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.parameter import ChoiceParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
-from ax.exceptions.core import DataRequiredError
 from ax.generators.types import TConfig
 from pyre_extensions import assert_is_instance, none_throws
 
@@ -44,6 +43,8 @@ class StratifiedStandardizeY(Transform):
 
     Transform is done in-place.
     """
+
+    requires_data_for_initialization: bool = True
 
     def __init__(
         self,
@@ -70,10 +71,6 @@ class StratifiedStandardizeY(Transform):
 
         """
         assert search_space is not None, "StratifiedStandardizeY requires search space"
-        if observations is None and experiment_data is None:
-            raise DataRequiredError(
-                "StratifiedStandardizeY requires observations or experiment_data."
-            )
         super().__init__(
             search_space=search_space,
             observations=observations,

--- a/ax/adapter/transforms/tests/test_search_space_to_choice_transform.py
+++ b/ax/adapter/transforms/tests/test_search_space_to_choice_transform.py
@@ -100,7 +100,7 @@ class SearchSpaceToChoiceTest(TestCase):
                 observations=[],
             )
         # Test with empty experiment data.
-        with self.assertRaisesRegex(DataRequiredError, "non-empty experiment data"):
+        with self.assertRaisesRegex(DataRequiredError, "non-empty data"):
             SearchSpaceToChoice(
                 search_space=self.search_space,
                 experiment_data=extract_experiment_data(

--- a/ax/adapter/transforms/tests/test_stratified_standardize_y_transform.py
+++ b/ax/adapter/transforms/tests/test_stratified_standardize_y_transform.py
@@ -142,9 +142,7 @@ class StratifiedStandardizeYTransformTest(TestCase):
         self.assertEqual(set(self.t.Ystd), set(Ystd_expected))
         for k, v in self.t.Ystd.items():
             self.assertAlmostEqual(v, Ystd_expected[k])
-        with self.assertRaisesRegex(
-            DataRequiredError, "requires observations or experiment_data"
-        ):
+        with self.assertRaisesRegex(DataRequiredError, "requires non-empty data"):
             StratifiedStandardizeY(search_space=self.search_space)
         with self.assertRaises(ValueError):
             # No parameter specified

--- a/ax/adapter/transforms/tests/test_trial_as_task_transform.py
+++ b/ax/adapter/transforms/tests/test_trial_as_task_transform.py
@@ -250,7 +250,7 @@ class TrialAsTaskTransformTest(TestCase):
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             TrialAsTask(
                 search_space=rss,
-                observations=[],
+                observations=self.training_obs,
                 adapter=self.adapter,
             )
 

--- a/ax/adapter/transforms/trial_as_task.py
+++ b/ax/adapter/transforms/trial_as_task.py
@@ -15,7 +15,7 @@ from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.core.utils import get_target_trial_index
-from ax.exceptions.core import DataRequiredError, UnsupportedError
+from ax.exceptions.core import UnsupportedError
 from ax.generators.types import TConfig
 from ax.utils.common.logger import get_logger
 from pyre_extensions import none_throws
@@ -57,6 +57,8 @@ class TrialAsTask(Transform):
     Transform is done in-place.
     """
 
+    requires_data_for_initialization: bool = True
+
     def __init__(
         self,
         search_space: SearchSpace | None = None,
@@ -76,10 +78,6 @@ class TrialAsTask(Transform):
         if isinstance(search_space, RobustSearchSpace):
             raise UnsupportedError(
                 "TrialAsTask transform is not supported for RobustSearchSpace."
-            )
-        if (observations is None or len(observations) == 0) and experiment_data is None:
-            raise DataRequiredError(
-                "`TrialAsTask` transform requires observations or experiment_data."
             )
         # Identify values of trial.
         if experiment_data is not None:

--- a/ax/adapter/transforms/winsorize.py
+++ b/ax/adapter/transforms/winsorize.py
@@ -30,12 +30,7 @@ from ax.core.outcome_constraint import (
     ScalarizedOutcomeConstraint,
 )
 from ax.core.search_space import SearchSpace
-from ax.exceptions.core import (
-    AxWarning,
-    DataRequiredError,
-    UnsupportedError,
-    UserInputError,
-)
+from ax.exceptions.core import AxWarning, UnsupportedError, UserInputError
 from ax.generators.types import TConfig, WinsorizationConfig
 from pyre_extensions import assert_is_instance, none_throws
 
@@ -90,6 +85,8 @@ class Winsorize(Transform):
     the optimization config.
     """
 
+    requires_data_for_initialization: bool = True
+
     cutoffs: dict[str, tuple[float, float]]
 
     def __init__(
@@ -100,8 +97,6 @@ class Winsorize(Transform):
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
-        if (observations is None or len(observations) == 0) and experiment_data is None:
-            raise DataRequiredError("`Winsorize` transform requires non-empty data.")
         super().__init__(
             search_space=search_space,
             observations=observations,


### PR DESCRIPTION
Summary: A number of transforms independently checked for non-empty `observation` or `experiment_data` in their constructors. This diff consolidates that logic on the base `Transform` class and adds a check that `experiment_data` is not empty.

Differential Revision: D77052502


