### PR TITLE
Implementation of complete_batch_trial and attach_batch_data

### DIFF
--- a/ax/api/utils/instantiation/from_string.py
+++ b/ax/api/utils/instantiation/from_string.py
@@ -23,6 +23,7 @@ from ax.core.outcome_constraint import (
 )
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.exceptions.core import UserInputError
+from pyre_extensions import assert_is_instance, none_throws
 from sympy.core.add import Add
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
@@ -142,7 +143,7 @@ def parse_objective(objective_str: str) -> Objective:
             ]
         )
 
-    return _create_single_objective(expression=expression)
+    return _create_single_objective(expression=assert_is_instance(expression, Expr))
 
 
 def parse_outcome_constraint(constraint_str: str) -> OutcomeConstraint:
@@ -228,7 +229,9 @@ def _create_single_objective(expression: Expr) -> Objective:
 
         # Since the objectives 1 * loss and 2 * loss are equivalent, we can just use
         # the sign from the coefficient rather than its value
-        minimize = bool(expression.as_coefficient(symbol) < 0)
+        minimize = bool(
+            none_throws(expression.as_coefficient(assert_is_instance(symbol, Expr))) < 0
+        )
 
         return Objective(
             metric=MapMetric(

--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -13,6 +13,7 @@ from ax.core.metric import Metric, MetricFetchE
 from ax.utils.common.result import Result
 
 MapMetricFetchResult = Result[MapData, MetricFetchE]
+DEFAULT_MAP_KEY = "step"
 
 
 class MapMetric(Metric):
@@ -30,4 +31,4 @@ class MapMetric(Metric):
     """
 
     data_constructor: type[MapData] = MapData
-    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="step", default_value=0.0)
+    map_key_info: MapKeyInfo[float] = MapKeyInfo(key=DEFAULT_MAP_KEY, default_value=0.0)

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -23,6 +23,7 @@ from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.trial_status import TrialStatus
 from ax.core.types import ComparisonOp
 from ax.core.utils import (
+    _maybe_update_trial_status_to_complete,
     batch_trial_only,
     best_feasible_objective,
     extract_pending_observations,
@@ -35,7 +36,7 @@ from ax.core.utils import (
     get_target_trial_index,
     MissingMetrics,
 )
-from ax.exceptions.core import AxError
+from ax.exceptions.core import AxError, UserInputError
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -297,6 +298,74 @@ class UtilsTest(TestCase):
                     "m1": [self.obs_feat],
                 },
             )
+
+    def test_update_trial_status(self) -> None:
+        """
+        Test that _update_trial_status marks a trial as failed when optimization_config
+        is not None and there are missing metrics.
+        """
+        # Create an experiment with optimization config
+        experiment = get_experiment()
+
+        # Make sure optimization_config is not None
+        self.assertIsNotNone(experiment.optimization_config)
+        trial = experiment.new_trial(GeneratorRun([self.arm]))
+        trial.mark_running(no_runner_required=True)
+
+        # Attach data for only one metric (not all required by optimization config)
+        data = Data(
+            df=pd.DataFrame(
+                [
+                    {
+                        "arm_name": none_throws(trial.arm).name,
+                        "mean": 1.0,
+                        "sem": 0.1,
+                        "trial_index": trial.index,
+                        "metric_name": "m1",  # Only attach data for m1, not m2
+                        "start_time": "2018-01-01",
+                        "end_time": "2018-01-02",
+                    }
+                ]
+            )
+        )
+        experiment.attach_data(data)
+
+        # The trial should be marked as failed since there are missing metrics
+        # and optimization_config is not None
+        _maybe_update_trial_status_to_complete(
+            experiment=experiment, trial_index=trial.index
+        )
+        self.assertEqual(trial.status, TrialStatus.FAILED)
+
+        # Check that the failure reason contains information about missing metrics
+        self.assertIsNotNone(trial.failed_reason)
+
+        self.assertTrue(
+            "missing" in trial.failed_reason,
+            f"Expected 'missing' in failure reason, but got: {trial.failed_reason}",
+        )
+
+        with self.subTest("Test with no opt config"):
+            experiment = get_experiment()
+
+            # Set optimization_config to None
+            experiment._optimization_config = None
+            self.assertIsNone(experiment.optimization_config)
+
+            trial = experiment.new_trial(GeneratorRun([self.arm]))
+            trial.mark_running(no_runner_required=True)
+            original_status = trial.status
+
+            # this should return early without modifying the trial
+            with self.assertRaisesRegex(
+                UserInputError,
+                "Cannot attempt to mark a trial as failed without an optimization"
+                " config on the expeirment",
+            ):
+                _maybe_update_trial_status_to_complete(
+                    experiment=experiment, trial_index=trial.index
+                )
+            self.assertEqual(trial.status, original_status)
 
     def test_get_pending_observation_features_multi_trial(self) -> None:
         # With `fetch_data` on trial returning data for metric "m2", that metric


### PR DESCRIPTION
Summary:
This commit includes implementation for complete_batch_trial and attach_batch_data along with their respective unittests.

The `complete_batch_trial` method completes a batch trial and updates the experiment with the provided data. It takes a trial index, raw data (a dictionary mapping arm names to their corresponding outcomes), and an optional progression parameter. The method attaches the data to the trial, updates the trial status, saves the trial to the database if possible, and returns the updated trial status.

The `attach_batch_data` method attaches raw data to a batch trial without completing it. It takes a trial index, raw data (a dictionary mapping arm names to their corresponding outcomes), and an optional progression parameter. The method converts the raw data into a format with progression information, attaches it to the batch trial, and saves the trial to the database if possible. This method is often used in conjunction with `complete_batch_trial` when you want to attach data first and then complete the trial separately.

Reviewed By: mgarrard

Differential Revision: D76319030


