### PR TITLE
Code modularization for BatchTrial instanaces

### DIFF
--- a/ax/api/utils/instantiation/from_string.py
+++ b/ax/api/utils/instantiation/from_string.py
@@ -23,6 +23,7 @@ from ax.core.outcome_constraint import (
 )
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.exceptions.core import UserInputError
+from pyre_extensions import assert_is_instance, none_throws
 from sympy.core.add import Add
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
@@ -142,7 +143,7 @@ def parse_objective(objective_str: str) -> Objective:
             ]
         )
 
-    return _create_single_objective(expression=expression)
+    return _create_single_objective(expression=assert_is_instance(expression, Expr))
 
 
 def parse_outcome_constraint(constraint_str: str) -> OutcomeConstraint:
@@ -228,7 +229,9 @@ def _create_single_objective(expression: Expr) -> Objective:
 
         # Since the objectives 1 * loss and 2 * loss are equivalent, we can just use
         # the sign from the coefficient rather than its value
-        minimize = bool(expression.as_coefficient(symbol) < 0)
+        minimize = bool(
+            none_throws(expression.as_coefficient(assert_is_instance(symbol, Expr))) < 0
+        )
 
         return Objective(
             metric=MapMetric(

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1213,6 +1213,18 @@ class Experiment(Base):
             lifecycle_stage=lifecycle_stage,
         )
 
+    def get_batch_trial(self, trial_index: int) -> BatchTrial:
+        """
+        Return a trial on experiment cast as BatchTrial
+        Args:
+            trial_index: The index of the trial to lookup data for.
+        Returns:
+            The requested trial cast as BatchTrial
+        """
+        return assert_is_instance(
+            self.get_trials_by_indices(trial_indices=[trial_index])[0], BatchTrial
+        )
+
     def get_trials_by_indices(self, trial_indices: Iterable[int]) -> list[BaseTrial]:
         """Grabs trials on this experiment by their indices."""
         trial_indices = list(trial_indices)

--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -13,6 +13,7 @@ from ax.core.metric import Metric, MetricFetchE
 from ax.utils.common.result import Result
 
 MapMetricFetchResult = Result[MapData, MetricFetchE]
+DEFAULT_MAP_KEY = "step"
 
 
 class MapMetric(Metric):
@@ -30,4 +31,4 @@ class MapMetric(Metric):
     """
 
     data_constructor: type[MapData] = MapData
-    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="step", default_value=0.0)
+    map_key_info: MapKeyInfo[float] = MapKeyInfo(key=DEFAULT_MAP_KEY, default_value=0.0)

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -23,6 +23,7 @@ from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.trial_status import TrialStatus
 from ax.core.types import ComparisonOp
 from ax.core.utils import (
+    _maybe_update_trial_status_to_complete,
     batch_trial_only,
     best_feasible_objective,
     extract_pending_observations,
@@ -35,7 +36,7 @@ from ax.core.utils import (
     get_target_trial_index,
     MissingMetrics,
 )
-from ax.exceptions.core import AxError
+from ax.exceptions.core import AxError, UserInputError
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -297,6 +298,74 @@ class UtilsTest(TestCase):
                     "m1": [self.obs_feat],
                 },
             )
+
+    def test_update_trial_status(self) -> None:
+        """
+        Test that _update_trial_status marks a trial as failed when optimization_config
+        is not None and there are missing metrics.
+        """
+        # Create an experiment with optimization config
+        experiment = get_experiment()
+
+        # Make sure optimization_config is not None
+        self.assertIsNotNone(experiment.optimization_config)
+        trial = experiment.new_trial(GeneratorRun([self.arm]))
+        trial.mark_running(no_runner_required=True)
+
+        # Attach data for only one metric (not all required by optimization config)
+        data = Data(
+            df=pd.DataFrame(
+                [
+                    {
+                        "arm_name": none_throws(trial.arm).name,
+                        "mean": 1.0,
+                        "sem": 0.1,
+                        "trial_index": trial.index,
+                        "metric_name": "m1",  # Only attach data for m1, not m2
+                        "start_time": "2018-01-01",
+                        "end_time": "2018-01-02",
+                    }
+                ]
+            )
+        )
+        experiment.attach_data(data)
+
+        # The trial should be marked as failed since there are missing metrics
+        # and optimization_config is not None
+        _maybe_update_trial_status_to_complete(
+            experiment=experiment, trial_index=trial.index
+        )
+        self.assertEqual(trial.status, TrialStatus.FAILED)
+
+        # Check that the failure reason contains information about missing metrics
+        self.assertIsNotNone(trial.failed_reason)
+
+        self.assertTrue(
+            "missing" in trial.failed_reason,
+            f"Expected 'missing' in failure reason, but got: {trial.failed_reason}",
+        )
+
+        with self.subTest("Test with no opt config"):
+            experiment = get_experiment()
+
+            # Set optimization_config to None
+            experiment._optimization_config = None
+            self.assertIsNone(experiment.optimization_config)
+
+            trial = experiment.new_trial(GeneratorRun([self.arm]))
+            trial.mark_running(no_runner_required=True)
+            original_status = trial.status
+
+            # this should return early without modifying the trial
+            with self.assertRaisesRegex(
+                UserInputError,
+                "Cannot attempt to mark a trial as failed without an optimization"
+                " config on the expeirment",
+            ):
+                _maybe_update_trial_status_to_complete(
+                    experiment=experiment, trial_index=trial.index
+                )
+            self.assertEqual(trial.status, original_status)
 
     def test_get_pending_observation_features_multi_trial(self) -> None:
         # With `fetch_data` on trial returning data for metric "m2", that metric


### PR DESCRIPTION
Summary: Add a get batch trial method stub that checks if there is an instance of BatchTrial and if so returns it. This reduces repetitive code and also might come in handy when implementing future methods.

Reviewed By: eonofrey

Differential Revision: D76734401


