### PR TITLE
Reduce mocking in tile_fitted tests

### DIFF
--- a/ax/plot/tests/test_tile_fitted.py
+++ b/ax/plot/tests/test_tile_fitted.py
@@ -8,75 +8,58 @@
 
 from unittest import mock
 
+import numpy as np
 from ax.adapter.base import Adapter
 from ax.adapter.registry import Generators
-
 from ax.core import Experiment
-
 from ax.core.arm import Arm
 from ax.core.metric import Metric
-from ax.core.observation import Observation
+from ax.core.observation import Observation, ObservationData
 from ax.core.search_space import SearchSpace
-from ax.generators.discrete.full_factorial import FullFactorialGenerator
+from ax.generators.base import Generator
 from ax.metrics.branin import BraninMetric
 from ax.plot.scatter import tile_fitted, tile_observations
 from ax.runners.synthetic import SyntheticRunner
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_branin_arms,
+    get_branin_experiment,
     get_branin_search_space,
     get_data,
     get_experiment_with_data,
-    get_search_space,
 )
-from ax.utils.testing.modeling_stubs import get_observation
 
 
-@mock.patch(
-    "ax.adapter.base.observations_from_data",
-    autospec=True,
-    return_value=([get_observation()]),
-)
-@mock.patch(
-    "ax.adapter.base.gen_arms", autospec=True, return_value=[Arm(parameters={})]
-)
-def get_adapter(
-    _, __, status_quo_name: str | None = None, sq_arm: Arm | None = None
-) -> Adapter:
-    if sq_arm is None:
-        sq_arm = Arm(
-            parameters={"w": 1.0, "x": 1.0, "y": "foo", "z": True}, name=status_quo_name
-        )
-    exp = Experiment(
-        search_space=get_search_space(),
-        status_quo=Arm(
-            parameters={"w": 1.0, "x": 1.0, "y": "foo", "z": True}, name=status_quo_name
-        )
-        if status_quo_name is not None
-        else None,
+def get_adapter(with_status_quo: bool) -> Adapter:
+    experiment = get_branin_experiment(
+        with_completed_batch=True, with_status_quo=with_status_quo
     )
-    adapter = Adapter(
-        experiment=exp, generator=FullFactorialGenerator(), data=get_data()
-    )
+    adapter = Adapter(experiment=experiment, generator=Generator())
     adapter._predict = mock.MagicMock(
         "ax.adapter.base.Adapter._predict",
         autospec=True,
-        return_value=[get_observation().data],
+        return_value=[
+            ObservationData(
+                metric_names=["branin"],
+                means=np.array([1.0]),
+                covariance=np.array([[1.0]]),
+            )
+        ],
     )
     return adapter
 
 
 class TileFittedTest(TestCase):
     def test_TileFitted(self) -> None:
-        model = get_adapter(status_quo_name=None)
+        adapter = get_adapter(with_status_quo=False)
 
         # Should throw if `status_quo_arm` is None and rel=True
         with self.assertRaises(ValueError):
-            tile_fitted(model, rel=True)
-        tile_fitted(model, rel=False)
+            tile_fitted(adapter, rel=True)
+        tile_fitted(adapter, rel=False)
 
-        model = get_adapter(status_quo_name="1_1")
-        config = tile_fitted(model, rel=True)
+        adapter = get_adapter(with_status_quo=True)
+        config = tile_fitted(adapter, rel=True)
         self.assertIsNotNone(config)
 
         for key in ["layout", "data"]:
@@ -96,31 +79,35 @@ class TileFittedTest(TestCase):
             self.assertIn(key, config.data["layout"])
 
         # Data
-        for i in range(2):
-            self.assertEqual(config.data["data"][i]["x"], ["1_1"])
-            self.assertEqual(config.data["data"][i]["y"], [0.0])
-            self.assertEqual(config.data["data"][i]["type"], "scatter")
-            self.assertIn("Arm 1_1", config.data["data"][i]["text"][0])
-            self.assertIn("[-138.593%, 138.593%]", config.data["data"][i]["text"][0])
-            self.assertIn("0.0%", config.data["data"][i]["text"][0])
+        data = config.data["data"][0]
+        arm_names = [arm.name for arm in adapter._experiment.trials[0].arms]
+        # Bring SQ to the front.
+        arm_names.insert(0, arm_names.pop(arm_names.index("status_quo")))
+        self.assertEqual(data["x"], arm_names)
+        self.assertEqual(data["y"], [0.0] * len(arm_names))
+        self.assertEqual(data["type"], "scatter")
+        for text, arm in zip(data["text"], arm_names):
+            self.assertIn(f"Arm {arm}", text)
+            self.assertIn("[-277.186%, 277.186%]", text)
+            self.assertIn("0.0%", text)
 
-            for key in [
-                "type",
-                "x",
-                "y",
-                "marker",
-                "mode",
-                "name",
-                "text",
-                "hoverinfo",
-                "error_y",
-                "visible",
-                "legendgroup",
-                "showlegend",
-                "xaxis",
-                "yaxis",
-            ]:
-                self.assertIn(key, config.data["data"][i])
+        for key in [
+            "type",
+            "x",
+            "y",
+            "marker",
+            "mode",
+            "name",
+            "text",
+            "hoverinfo",
+            "error_y",
+            "visible",
+            "legendgroup",
+            "showlegend",
+            "xaxis",
+            "yaxis",
+        ]:
+            self.assertIn(key, data)
 
     def test_TileFittedOutOfDesignDataSelector(self) -> None:
         exp = Experiment(
@@ -155,14 +142,14 @@ class TileFittedTest(TestCase):
         exp.attach_data(data0)
         exp.attach_data(data1)
 
-        model = Generators.THOMPSON(experiment=exp, data=exp.lookup_data())
+        adapter = Generators.THOMPSON(experiment=exp, data=exp.lookup_data())
 
         def data_selector(obs: Observation) -> bool:
             return obs.features.trial_index != 0 or obs.arm_name == "status_quo"
 
-        tile_fitted(model, rel=False)
+        tile_fitted(adapter, rel=False)
         tile_fitted(
-            model,
+            adapter,
             rel=False,
             data_selector=data_selector,
         )


### PR DESCRIPTION
Summary: As titled. The adapter was constructed with no trials but data (totally makes sense), which also required changing the underlying experiment.

Differential Revision: D77257517


