### PR TITLE
Allow for best-point predictions in MF/MT settings

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -389,8 +389,6 @@ def _update_benchmark_tracking_vars_in_place(
     newly_completed_trials = currently_completed_trial_idcs - completed_trial_idcs
     completed_trial_idcs |= newly_completed_trials
 
-    is_mf_or_mt = len(problem.target_fidelity_and_task) > 0
-
     if len(newly_completed_trials) > 0:
         previous_cost = cost_trace[-1] if len(cost_trace) > 0 else 0.0
         cost = _get_cumulative_cost(
@@ -408,10 +406,10 @@ def _update_benchmark_tracking_vars_in_place(
         evaluated_arms_list.append(params)
 
         # Inference trace: Not supported for MOO.
-        # It's also not supported for multi-fidelity or multi-task
-        # problems, because Ax's best-point functionality doesn't know
-        # to predict at the target task or fidelity.
-        if problem.is_moo or is_mf_or_mt:
+        # Note: Ax's best-point functionality doesn't know to predict at the
+        # target task or fidelity, so this won't produce good recommendations in
+        # MF/MT settings.
+        if problem.is_moo:
             best_params = None
         else:
             best_params = get_best_parameters(

--- a/ax/benchmark/problems/synthetic/from_botorch.py
+++ b/ax/benchmark/problems/synthetic/from_botorch.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Functions that create ``BenchmarkProblem``s based on BoTorch test functions.
+"""
+
+from typing import Literal
+
+from ax.benchmark.benchmark_problem import BenchmarkProblem, create_problem_from_botorch
+from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
+from ax.core.search_space import SearchSpace
+from botorch.test_functions.multi_fidelity import AugmentedBranin
+
+
+def get_augmented_branin_search_space(
+    fidelity_or_task: Literal["fidelity", "task"],
+) -> SearchSpace:
+    """
+    Get the ``SearchSpace`` that matches the ``AugmentedBranin`` test problem.
+
+    ``AugmentedBranin`` has an extra parameter beyond the normal two which has
+    been treated as a fidelity parameter.
+
+    Args:
+        fidelity_or_task: If "fidelity", the extra parameter is a fidelity
+            parameter and will be continuous, because fidelity ChoiceParameters
+            can't be used with the ``OrderedChoiceToIntegerRange`` transform. If
+            "task", the extra parameter is a task parameter and is discrete,
+            because a ``RangeParameter`` cannot be a task.
+    """
+    if fidelity_or_task == "fidelity":
+        extra_parameter = RangeParameter(
+            name="x2",
+            parameter_type=ParameterType.FLOAT,
+            lower=0.0,
+            upper=1.0,
+            is_fidelity=True,
+            target_value=1,
+        )
+    else:
+        extra_parameter = ChoiceParameter(
+            name="x2",
+            parameter_type=ParameterType.FLOAT,
+            values=[0, 1],
+            is_fidelity=False,
+            is_task=True,
+            target_value=1,
+        )
+    parameters = [
+        RangeParameter(
+            name=f"x{i}",
+            parameter_type=ParameterType.FLOAT,
+            lower=0.0,
+            upper=1.0,
+        )
+        for i in range(2)
+    ] + [extra_parameter]
+    return SearchSpace(parameters=parameters)
+
+
+def get_augmented_branin_problem(
+    fidelity_or_task: Literal["fidelity", "task"],
+    report_inference_value_as_trace: bool = True,
+) -> BenchmarkProblem:
+    """
+    Get a Branin problem with a fidelity or task parameter.
+
+    Args:
+        fidelity_or_task: If "fidelity", the extra parameter is a fidelity
+            parameter. If "task", the extra parameter is a task parameter.
+        report_inference_value_as_trace: Passed to
+            ``create_problem_from_botorch`` then to ``BenchmarkProblem``.
+    """
+
+    return create_problem_from_botorch(
+        test_problem_class=AugmentedBranin,
+        test_problem_kwargs={},
+        search_space=get_augmented_branin_search_space(
+            fidelity_or_task=fidelity_or_task
+        ),
+        num_trials=3,
+        baseline_value=3.0,
+        report_inference_value_as_trace=report_inference_value_as_trace,
+    )

--- a/ax/benchmark/tests/problems/synthetic/test_from_botorch.py
+++ b/ax/benchmark/tests/problems/synthetic/test_from_botorch.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.benchmark.problems.synthetic.from_botorch import (
+    get_augmented_branin_problem,
+    get_augmented_branin_search_space,
+)
+from ax.core.parameter import ChoiceParameter, RangeParameter
+from ax.utils.common.testutils import TestCase
+from pyre_extensions import assert_is_instance
+
+
+class TestBoTorchProblems(TestCase):
+    def test_get_augmented_branin_search_space(self) -> None:
+        with self.subTest("fidelity"):
+            search_space = get_augmented_branin_search_space(
+                fidelity_or_task="fidelity"
+            )
+            param = assert_is_instance(search_space.parameters["x2"], RangeParameter)
+            self.assertEqual(param.target_value, 1.0)
+            self.assertTrue(param.is_fidelity)
+
+        with self.subTest("task"):
+            problem = get_augmented_branin_problem(fidelity_or_task="task")
+            param = assert_is_instance(
+                problem.search_space.parameters["x2"], ChoiceParameter
+            )
+            self.assertEqual(param.target_value, 1.0)
+            self.assertTrue(param.is_task)
+            self.assertFalse(param.is_fidelity)
+
+    def test_get_augmented_branin_problem(self) -> None:
+        with self.subTest("inference value as trace"):
+            problem = get_augmented_branin_problem(
+                fidelity_or_task="fidelity", report_inference_value_as_trace=True
+            )
+            self.assertTrue(problem.report_inference_value_as_trace)
+            self.assertEqual(problem.name, "AugmentedBranin")
+
+        with self.subTest("Do not report inference value as trace"):
+            problem = get_augmented_branin_problem(
+                fidelity_or_task="fidelity", report_inference_value_as_trace=False
+            )
+            self.assertFalse(problem.report_inference_value_as_trace)

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -816,6 +816,15 @@ class TestBenchmark(TestCase):
                 ),
                 "MBM::SingleTaskGP_qKnowledgeGradient",
             ),
+            (
+                get_sobol_botorch_modular_acquisition(
+                    model_cls=SingleTaskGP,
+                    acquisition_cls=qLogNoisyExpectedImprovement,
+                    distribute_replications=False,
+                ),
+                get_augmented_branin_problem(fidelity_or_task="fidelity"),
+                "MBM::SingleTaskGP_qLogNEI",
+            ),
         ]:
             with self.subTest(method=method, problem=problem):
                 res = self.benchmark_replication(problem=problem, method=method, seed=0)


### PR DESCRIPTION
Summary: Context: Ax recommends a best point in multi-task and multi-fidelity scenarios, even though we should not expect the recommendations to be very good. Let's surface those recommendations in benchmarking rather than putting in NaNs so that we can measure any improvements we make to best- point functionality in such settings.

Differential Revision: D76634560


