### PR TITLE
Enable Default Use of Early-Stopped Trial Data with Contextual Progressive Values

### DIFF
--- a/ax/adapter/registry.py
+++ b/ax/adapter/registry.py
@@ -35,6 +35,7 @@ from ax.adapter.transforms.int_range_to_choice import IntRangeToChoice
 from ax.adapter.transforms.int_to_float import IntToFloat, LogIntToFloat
 from ax.adapter.transforms.log import Log
 from ax.adapter.transforms.logit import Logit
+from ax.adapter.transforms.map_key_to_float import MapKeyToFloat
 from ax.adapter.transforms.merge_repeated_measurements import MergeRepeatedMeasurements
 from ax.adapter.transforms.one_hot import OneHot
 from ax.adapter.transforms.relativize import Relativize
@@ -98,7 +99,7 @@ Cont_X_trans: list[type[Transform]] = [
 # will be added to replace the UnitX transform. This setup facilitates the use of
 # optimize_acqf_mixed_alternating, which is a more efficient acquisition function
 # optimizer for mixed discrete/continuous problems.
-MBM_X_trans: list[type[Transform]] = [
+MBM_X_trans_base: list[type[Transform]] = [
     RemoveFixed,
     OrderedChoiceToIntegerRange,
     OneHot,
@@ -106,6 +107,7 @@ MBM_X_trans: list[type[Transform]] = [
     Log,
     Logit,
 ]
+MBM_X_trans: list[type[Transform]] = [MapKeyToFloat, *MBM_X_trans_base]
 
 
 Discrete_X_trans: list[type[Transform]] = [IntRangeToChoice]

--- a/ax/adapter/transforms/map_key_to_float.py
+++ b/ax/adapter/transforms/map_key_to_float.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import warnings
 from math import isnan
 from typing import Any, Optional, TYPE_CHECKING
 
@@ -14,7 +15,6 @@ from ax.adapter.transforms.metadata_to_float import MetadataToFloat
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.search_space import SearchSpace
 from ax.core.utils import extract_map_keys_from_opt_config
-from ax.exceptions.core import UserInputError
 from ax.generators.types import TConfig
 from pyre_extensions import none_throws
 
@@ -63,10 +63,15 @@ class MapKeyToFloat(MetadataToFloat):
                     )
                 }
             else:
-                raise UserInputError(
-                    f"{self.__class__.__name__} requires either `parameters` to be "
-                    "specified in the transform config or an adapter with an "
-                    "optimization config, from which the map keys can be extracted."
+                warnings.warn(
+                    (
+                        f"{self.__class__.__name__} is unable to identify `parameters` "
+                        "in the transform config or an adapter with an "
+                        "optimization config from which the map keys can be inferred; "
+                        "this transform will not perform any operations and behave as "
+                        "a no-op."
+                    ),
+                    stacklevel=2,
                 )
         super().__init__(
             search_space=search_space,

--- a/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
@@ -29,7 +29,6 @@ from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.trial import Trial
 from ax.core.trial_status import TrialStatus
 from ax.early_stopping.strategies import PercentileEarlyStoppingStrategy
-from ax.exceptions.core import UserInputError
 from ax.generation_strategy.center_generation_node import CenterGenerationNode
 from ax.generation_strategy.generation_node import GenerationNode
 from ax.generation_strategy.generation_strategy import GenerationStrategy
@@ -69,7 +68,7 @@ class ClientTest(TestCase):
             model_kwargs={
                 "surrogate_spec": surrogate_spec,
                 "botorch_acqf_class": qLogExpectedImprovement,
-                "transforms": [MapKeyToFloat] + MBM_X_trans + Y_trans,
+                "transforms": MBM_X_trans + Y_trans,
                 "data_loader_config": DataLoaderConfig(
                     fit_only_completed_map_metrics=False,
                     latest_rows_per_group=1,
@@ -270,7 +269,7 @@ class MapKeyToFloatTransformTest(TestCase):
 
     def test_Init(self) -> None:
         # Check for error if adapter & parameters are not provided.
-        with self.assertRaisesRegex(UserInputError, "optimization config"):
+        with self.assertWarnsRegex(Warning, "optimization config"):
             MapKeyToFloat(observations=self.observations)
 
         experiment_data = extract_experiment_data(


### PR DESCRIPTION
Summary:
## Context:

Modifies the default list of MBM input transforms to improve the handling of map keys representing contextual progressive values. By default, when map keys are present and expected (according to the adapter's optimization config), they will be added as a float parameter to the search space.

## Changes:
- Prepends `MapKeyToFloat` to the list of MBM input transforms (`MBM_X_trans`) to automatically augment the input space with map keys as float parameters.
- Introduces a basic/standard list of MBM input transforms `MBM_X_trans_base` excluding `MapKeyToFloat`, to simplify specification of input transforms in cases requiring additional transforms (e.g., `ELC_trans` where additional transforms are required after `MapKeyToFloat` but before the standard list of `MBM_X_trans_base` transforms.
- Makes explicitly specifying map keys through the transform config or implicitly through specifying an adapter with an optimization config optional, providing more flexibility in configuration.

Differential Revision: D76732025


