### PR TITLE
fetch_data implementation

### DIFF
--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 from ax.core.arm import Arm
@@ -249,6 +249,7 @@ class MultiTypeExperiment(Experiment):
     @copy_doc(Experiment.fetch_data)
     def fetch_data(
         self,
+        trial_indices: Iterable[int] | None = None,
         metrics: list[Metric] | None = None,
         combine_with_last_data: bool = False,
         overwrite_existing_data: bool = False,

--- a/ax/generation_strategy/tests/test_generation_node_input_constructors.py
+++ b/ax/generation_strategy/tests/test_generation_node_input_constructors.py
@@ -513,7 +513,7 @@ class TestGenerationNodeInputConstructors(TestCase):
                 complete=True,
                 num_arms=1,
             )
-        self.experiment.fetch_trials_data(trial_indices=[0])
+        self.experiment.fetch_data(trial_indices=[0])
         target_trial = NodeInputConstructors.TARGET_TRIAL_FIXED_FEATURES(
             previous_node=None,
             next_node=self.sobol_generation_node,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -2627,9 +2627,7 @@ class TestAxClient(TestCase):
         # Check that the data in the frontier matches the observed data
         # (it should be in the original, un-transformed space)
         input_data = (
-            ax_client.experiment.fetch_trials_data([idx_of_frontier_point])
-            .df["mean"]
-            .values
+            ax_client.experiment.fetch_data([idx_of_frontier_point]).df["mean"].values
         )
         pareto_y = observed_pareto[idx_of_frontier_point][1][0]
         pareto_y_list = [pareto_y["branin"], pareto_y["currin"]]


### PR DESCRIPTION
Summary: This commit inlcudes an implementation for fetch_data and unittest associated with it.  fetch_data retrieves data for specified trials and metrics using the experiment's fetch_trials_data_results method. It's particularly useful for getting the latest data when using asynchronous runners. The method converts metric names to actual Metric objects and handles the case when trial_indices is None by fetching data for all trials.

Reviewed By: lena-kashtelyan

Differential Revision: D77246901


