### PR TITLE
Support ExperimentData in MergeRepeatedMeasurements transform

### DIFF
--- a/ax/adapter/transforms/tests/test_merge_repeated_measurements_transform.py
+++ b/ax/adapter/transforms/tests/test_merge_repeated_measurements_transform.py
@@ -7,11 +7,18 @@
 # pyre-strict
 
 from copy import deepcopy
+from math import sqrt
 
 import numpy as np
+from ax.adapter.base import DataLoaderConfig
+from ax.adapter.data_utils import extract_experiment_data
 from ax.adapter.transforms.merge_repeated_measurements import MergeRepeatedMeasurements
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.exceptions.core import DataRequiredError
 from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import get_experiment_with_observations
+from pandas import DataFrame
+from pandas.testing import assert_frame_equal
 
 
 def compare_obs(
@@ -28,7 +35,8 @@ class MergeRepeatedMeasurementsTransformTest(TestCase):
     def test_Transform(self) -> None:
         obs_feats1 = ObservationFeatures(parameters={"a": 0.0})
         with self.assertRaisesRegex(
-            RuntimeError, "MergeRepeatedMeasurements requires observations"
+            DataRequiredError,
+            "`MergeRepeatedMeasurements` transform requires non-empty data",
         ):
             # test that observations are required
             MergeRepeatedMeasurements()
@@ -214,3 +222,44 @@ class MergeRepeatedMeasurementsTransformTest(TestCase):
         arm_names = {obs.arm_name for obs in observations}
         arm_names2 = {obs.arm_name for obs in observations2}
         self.assertEqual(arm_names, arm_names2)
+
+    def test_with_experiment_data(self) -> None:
+        # Experiment with similar data as the above test.
+        experiment = get_experiment_with_observations(
+            observations=[[1.0, 1.0], [1.0, 2.0]],
+            sems=[[1.0, sqrt(2.0)], [1.0, sqrt(3.0)]],
+            parameterizations=[{"x": 0.0, "y": 1.0}, {"x": 0.0, "y": 1.0}],
+        )
+        experiment_data = extract_experiment_data(
+            experiment=experiment, data_loader_config=DataLoaderConfig()
+        )
+        t = MergeRepeatedMeasurements(experiment_data=experiment_data)
+        # Check for correct transform setup.
+        w1, w2 = 3 / 5.0, 2 / 5.0
+        expected = {
+            "m1": {"mean": 1.0, "var": 0.5},
+            "m2": {"mean": w1 + 2 * w2, "var": 6 / 5.0},
+        }
+        actual = t.arm_to_merged["0_0"]
+        # m1 is exact, m2 is approximate due to float precision.
+        self.assertEqual(actual["m1"], expected["m1"])
+        self.assertAlmostEqual(actual["m2"]["mean"], expected["m2"]["mean"], places=5)
+        self.assertAlmostEqual(actual["m2"]["var"], expected["m2"]["var"], places=5)
+        # Transform the data.
+        transformed_data = t.transform_experiment_data(
+            experiment_data=deepcopy(experiment_data),
+        )
+        # Check that the data is transformed correctly.
+        # Arm data only retains the first row.
+        assert_frame_equal(
+            transformed_data.arm_data, experiment_data.arm_data.iloc[[0]]
+        )
+        # Observation data is overwritten with the merged data.
+        expected_obs_data = DataFrame(
+            index=transformed_data.arm_data.index,
+            columns=transformed_data.observation_data.columns,
+            data=[
+                [1.0, w1 + 2 * w2, 0.5**0.5, (6 / 5.0) ** 0.5],
+            ],
+        )
+        assert_frame_equal(transformed_data.observation_data, expected_obs_data)

--- a/ax/adapter/transforms/tests/test_merge_repeated_measurements_transform.py
+++ b/ax/adapter/transforms/tests/test_merge_repeated_measurements_transform.py
@@ -42,6 +42,11 @@ class MergeRepeatedMeasurementsTransformTest(TestCase):
             features=obs_feats1,
         )
         with self.assertRaisesRegex(
+            NotImplementedError, "All observations must have arm names."
+        ):
+            MergeRepeatedMeasurements(observations=[observation])
+        observation.arm_name = "0_0"
+        with self.assertRaisesRegex(
             NotImplementedError, "All metrics must have noise observations."
         ):
             MergeRepeatedMeasurements(observations=[observation])
@@ -53,6 +58,7 @@ class MergeRepeatedMeasurementsTransformTest(TestCase):
                 covariance=np.ones((2, 2)),
             ),
             features=obs_feats1,
+            arm_name="0_0",
         )
         with self.assertRaisesRegex(
             NotImplementedError, "Only independent metrics are currently supported."
@@ -69,6 +75,7 @@ class MergeRepeatedMeasurementsTransformTest(TestCase):
                     covariance=zero_covar,
                 ),
                 features=obs_feats1,
+                arm_name="0_0",
             ),
             Observation(
                 data=ObservationData(
@@ -77,6 +84,7 @@ class MergeRepeatedMeasurementsTransformTest(TestCase):
                     covariance=zero_covar,
                 ),
                 features=obs_feats1,
+                arm_name="0_0",
             ),
         ]
         with self.assertRaisesRegex(
@@ -94,6 +102,7 @@ class MergeRepeatedMeasurementsTransformTest(TestCase):
                     covariance=zero_covar,
                 ),
                 features=obs_feats1,
+                arm_name="0_0",
             ),
             Observation(
                 data=ObservationData(
@@ -102,6 +111,7 @@ class MergeRepeatedMeasurementsTransformTest(TestCase):
                     covariance=zero_covar,
                 ),
                 features=obs_feats1,
+                arm_name="0_0",
             ),
             Observation(
                 data=ObservationData(
@@ -110,6 +120,7 @@ class MergeRepeatedMeasurementsTransformTest(TestCase):
                     covariance=zero_covar,
                 ),
                 features=ObservationFeatures(parameters={"a": 2.0}),
+                arm_name="0_1",
             ),
         ]
         t = MergeRepeatedMeasurements(observations=observations)


### PR DESCRIPTION
Summary:
Supports transforming `ExperimentData` with `MergeRepeatedMeasurements` transform. The transform constructor is also updated to extract the necessary data from `ExperimentData`.

Background: As part of the larger refactor, we will be using `ExperimentData` in place of `list[Observation]` within the `Adapter`.
- The transforms will be initialized using `ExperimentData`. The `observations` input to the constructors may be deprecated once the use cases are updated.
- The training data for `Adapter` will be represented with `ExperimentData` and will be transformed using `transform_experiment_data`.
- For misc input / output to various `Adapter` and other methods, the `Observation / ObservationFeatures / ObservationData` objects will remain. To support these, we will retain the existing transform methods that service these objects.
- Since `ExperimentData` is not planned to be used as an output of user facing methods, we do not need to untransform it. We are not planning to implement`untransform_experiment_data`.

Differential Revision: D77667731


