### PR TITLE
Improve sanitization of metric names in API

### DIFF
--- a/ax/api/utils/instantiation/tests/test_from_string.py
+++ b/ax/api/utils/instantiation/tests/test_from_string.py
@@ -240,6 +240,10 @@ class TestFromString(TestCase):
 
     def test_sanitize_name(self) -> None:
         self.assertEqual(_sanitize_name("foo.bar.baz"), "foo__dot__bar__dot__baz")
+        self.assertEqual(_sanitize_name("foo.bar/1"), "foo__dot__bar__slash__1")
+        self.assertEqual(
+            _sanitize_name("foo.bar + 0.1 * baz"), "foo__dot__bar + 0.1 * baz"
+        )
 
         constraint = parse_parameter_constraint(constraint_str="foo.bar + foo.baz <= 1")
         self.assertEqual(


### PR DESCRIPTION
Summary:
Become more lenient with where sanitization can happen, specifically by replacing occurances of "." and "/" when they appear after a valid Python variable name and before any alphanumeric character.

Note that we have to be careful not to oversanitize as some dots and slashes should mean something to the parser! Ideally we can get into a world in which Ax does not accept parameter or metric names which do not obey the same rules as Python variable names, which tend to cause trouble in unpredictable parts of our stack.

Differential Revision: D77699011


