### PR TITLE
Refactor of MultiTask / FullyBayesianMultiTaskGP to use ProcuctKernel & IndexKernel

### DIFF
--- a/ax/adapter/tests/test_registry.py
+++ b/ax/adapter/tests/test_registry.py
@@ -381,18 +381,19 @@ class ModelRegistryTest(TestCase):
                         model,
                         SaasFullyBayesianMultiTaskGP if use_saas else MultiTaskGP,
                     )
+                    data_covar_module, task_covar_module = model.covar_module.kernels
                     if use_saas is False and default_model is False:
-                        self.assertIsInstance(model.covar_module, ScaleKernel)
-                        base_kernel = model.covar_module.base_kernel
+                        self.assertIsInstance(data_covar_module, ScaleKernel)
+                        base_kernel = data_covar_module.base_kernel
                         self.assertIsInstance(base_kernel, MaternKernel)
                         self.assertEqual(
                             base_kernel.lengthscale_prior.concentration, 6.0
                         )
                         self.assertEqual(base_kernel.lengthscale_prior.rate, 3.0)
                     elif use_saas is False:
-                        self.assertIsInstance(model.covar_module, RBFKernel)
+                        self.assertIsInstance(data_covar_module, RBFKernel)
                         self.assertIsInstance(
-                            model.covar_module.lengthscale_prior, LogNormalPrior
+                            data_covar_module.lengthscale_prior, LogNormalPrior
                         )
 
                 gr = mtgp.gen(

--- a/ax/generators/tests/test_botorch_defaults.py
+++ b/ax/generators/tests/test_botorch_defaults.py
@@ -100,25 +100,20 @@ class BotorchDefaultsTest(TestCase):
         model = _get_model(
             X=x, Y=y, Yvar=partial_var.clone(), task_feature=1, prior=prior
         )
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `kernels`.
+        task_covar_module = model.covar_module.kernels[1]
         self.assertIsInstance(
-            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-            #  `IndexKernelPrior`.
-            model.task_covar_module.IndexKernelPrior,
+            task_covar_module.IndexKernelPrior,
             LKJCovariancePrior,
         )
         self.assertEqual(
-            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-            #  `IndexKernelPrior`.
-            model.task_covar_module.IndexKernelPrior.sd_prior.concentration,
+            task_covar_module.IndexKernelPrior.sd_prior.concentration,
             2.0,
         )
-        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-        #  `IndexKernelPrior`.
-        self.assertEqual(model.task_covar_module.IndexKernelPrior.sd_prior.rate, 0.44)
+        self.assertEqual(task_covar_module.IndexKernelPrior.sd_prior.rate, 0.44)
         self.assertEqual(
-            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-            #  `IndexKernelPrior`.
-            model.task_covar_module.IndexKernelPrior.correlation_prior.eta,
+            task_covar_module.IndexKernelPrior.correlation_prior.eta,
             0.6,
         )
 
@@ -129,25 +124,20 @@ class BotorchDefaultsTest(TestCase):
             task_feature=1,
             prior={"type": LKJCovariancePrior},
         )
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `kernels`.
+        task_covar_module = model.covar_module.kernels[1]
         self.assertIsInstance(
-            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-            #  `IndexKernelPrior`.
-            model.task_covar_module.IndexKernelPrior,
+            task_covar_module.IndexKernelPrior,
             LKJCovariancePrior,
         )
         self.assertEqual(
-            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-            #  `IndexKernelPrior`.
-            model.task_covar_module.IndexKernelPrior.sd_prior.concentration,
+            task_covar_module.IndexKernelPrior.sd_prior.concentration,
             1.0,
         )
-        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-        #  `IndexKernelPrior`.
-        self.assertEqual(model.task_covar_module.IndexKernelPrior.sd_prior.rate, 0.15)
+        self.assertEqual(task_covar_module.IndexKernelPrior.sd_prior.rate, 0.15)
         self.assertEqual(
-            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-            #  `IndexKernelPrior`.
-            model.task_covar_module.IndexKernelPrior.correlation_prior.eta,
+            task_covar_module.IndexKernelPrior.correlation_prior.eta,
             0.5,
         )
         prior = {
@@ -186,19 +176,16 @@ class BotorchDefaultsTest(TestCase):
         )
         self.assertIs(type(model), MultiTaskGP)
         self.assertIsInstance(model.likelihood, GaussianLikelihood)
+        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
+        #  `kernels`.
+        data_covar_module, task_covar_module = model.covar_module.kernels
         self.assertEqual(
-            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-            #  `base_kernel`.
-            model.covar_module.base_kernel.lengthscale_prior.concentration,
+            data_covar_module.base_kernel.lengthscale_prior.concentration,
             12.0,
         )
-        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-        #  `base_kernel`.
-        self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
+        self.assertEqual(data_covar_module.base_kernel.lengthscale_prior.rate, 2.0)
         self.assertIsInstance(
-            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-            #  `IndexKernelPrior`.
-            model.task_covar_module.IndexKernelPrior,
+            task_covar_module.IndexKernelPrior,
             LKJCovariancePrior,
         )
         model = _get_model(
@@ -211,18 +198,12 @@ class BotorchDefaultsTest(TestCase):
         self.assertIsInstance(model, MultiTaskGP)
         self.assertIsInstance(model.likelihood, FixedNoiseGaussianLikelihood)
         self.assertEqual(
-            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-            #  `base_kernel`.
-            model.covar_module.base_kernel.lengthscale_prior.concentration,
+            data_covar_module.base_kernel.lengthscale_prior.concentration,
             12.0,
         )
-        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-        #  `base_kernel`.
-        self.assertEqual(model.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
+        self.assertEqual(data_covar_module.base_kernel.lengthscale_prior.rate, 2.0)
         self.assertIsInstance(
-            # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
-            #  `IndexKernelPrior`.
-            model.task_covar_module.IndexKernelPrior,
+            task_covar_module.IndexKernelPrior,
             LKJCovariancePrior,
         )
         # test passing customized prior
@@ -368,14 +349,15 @@ class BotorchDefaultsTest(TestCase):
         #  function.
         for m in model.models:
             self.assertIs(type(m), MultiTaskGP)
+            data_covar_module, task_covar_module = m.covar_module.kernels
             self.assertIsInstance(m.likelihood, FixedNoiseGaussianLikelihood)
             self.assertEqual(
-                m.covar_module.base_kernel.lengthscale_prior.concentration,
+                data_covar_module.base_kernel.lengthscale_prior.concentration,
                 12.0,
             )
-            self.assertEqual(m.covar_module.base_kernel.lengthscale_prior.rate, 2.0)
-            self.assertEqual(m.covar_module.outputscale_prior.concentration, 2.0)
-            self.assertEqual(m.covar_module.outputscale_prior.rate, 12.0)
+            self.assertEqual(data_covar_module.base_kernel.lengthscale_prior.rate, 2.0)
+            self.assertEqual(data_covar_module.outputscale_prior.concentration, 2.0)
+            self.assertEqual(data_covar_module.outputscale_prior.rate, 12.0)
 
     def test_get_acquisition_func(self) -> None:
         d, m = 3, 2

--- a/ax/generators/tests/test_botorch_model.py
+++ b/ax/generators/tests/test_botorch_model.py
@@ -162,34 +162,33 @@ class LegacyBoTorchGeneratorTest(TestCase):
         # Check ranks
         model_list = cast(ModelListGP, model.model).models
         for i in range(1):
+            data_covar_module, task_covar_module = model_list[i].covar_module.kernels
             self.assertEqual(
-                model_list[i].covar_module.base_kernel.lengthscale_prior.concentration,
+                data_covar_module.base_kernel.lengthscale_prior.concentration,
                 6.0,
             )
             self.assertEqual(
-                model_list[i].covar_module.base_kernel.lengthscale_prior.rate,
+                data_covar_module.base_kernel.lengthscale_prior.rate,
                 3.0,
             )
             self.assertEqual(
-                model_list[i].covar_module.outputscale_prior.concentration,
+                data_covar_module.outputscale_prior.concentration,
                 3.0,
             )
             self.assertEqual(
-                model_list[i].covar_module.outputscale_prior.rate,
+                data_covar_module.outputscale_prior.rate,
                 12.0,
             )
             self.assertIsInstance(
-                model_list[i].task_covar_module.IndexKernelPrior, LKJCovariancePrior
+                task_covar_module.IndexKernelPrior, LKJCovariancePrior
             )
             self.assertEqual(
-                model_list[i].task_covar_module.IndexKernelPrior.sd_prior.concentration,
+                task_covar_module.IndexKernelPrior.sd_prior.concentration,
                 2.0,
             )
+            self.assertEqual(task_covar_module.IndexKernelPrior.sd_prior.rate, 0.44)
             self.assertEqual(
-                model_list[i].task_covar_module.IndexKernelPrior.sd_prior.rate, 0.44
-            )
-            self.assertEqual(
-                model_list[i].task_covar_module.IndexKernelPrior.correlation_prior.eta,
+                task_covar_module.IndexKernelPrior.correlation_prior.eta,
                 0.6,
             )
 

--- a/ax/generators/torch/tests/test_surrogate.py
+++ b/ax/generators/torch/tests/test_surrogate.py
@@ -1066,8 +1066,14 @@ class SurrogateTest(TestCase):
                 )
                 # check the selected model
                 model = none_throws(surrogate._model)
+                covar_module = (
+                    model.covar_module
+                    if not isinstance(model, MultiTaskGP)
+                    else model.covar_module.kernels[0]
+                )
+
                 self.assertIsInstance(
-                    model.covar_module,
+                    covar_module,
                     LinearKernel if eval_criterion in ("MSE", "BIC") else RBFKernel,
                 )
                 if eval_criterion == "BIC":


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/botorch_fb/pull/23

X-link: https://github.com/pytorch/botorch/pull/2908

Modifed MultiTask and FullyBayesianMultiTask to use IndexKernel instead of two different covar modules. For large matrices, this constitutes a significant speed-up (2-3x anecdotally) and a seemingly even larger memory decrease.

In addition, this makes MultiTaskFBGP and SingleTaskFBGPs share a lot of code. I'll enable more code sharing between them in a subsequent diff.

With some additional functionality in IndexKernel (i.e. structured learning of the covar_matrix elements), this change would apply to other MTGPs as well.

NOTE: Providing negative indices to an IndexKernel is not supported: https://github.com/pytorch/pytorch/issues/76347

Reviewed By: saitcakmak

Differential Revision: D76317553


