### PR TITLE
Clean up ax service logging loose end

### DIFF
--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -539,7 +539,7 @@ def _transform_progression_to_walltime(
         )
         return transformed_times
     except Exception as e:
-        logger.debug(f"Failed to transform progression to walltime: {e}")
+        logger.error(f"Failed to transform progression to walltime: {e}")
         return None
 
 
@@ -648,7 +648,6 @@ def _get_curve_plot_dropdown(
 
 def _merge_trials_dict_with_df(
     df: pd.DataFrame,
-    # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
     trials_dict: dict[int, Any],
     column_name: str,
     always_include_field_column: bool = False,


### PR DESCRIPTION
Summary:
Cleans up a loose end from Ax service logging to warn on failure to
parse completion times.

https://www.internalfb.com/diff/D72667328?dst_version_fbid=1119157499966710&transaction_fbid=969649671821909

Reviewed By: bernardbeckerman

Differential Revision: D77737144


