### PR TITLE
Silence sort_values warnings in parameter_from_config

### DIFF
--- a/ax/api/configs.py
+++ b/ax/api/configs.py
@@ -50,6 +50,6 @@ class StorageConfig:
     experiment and its data.
     """
 
-    creator: Callable[..., Any] | None = None  # pyre-fixme[4]
+    creator: Callable[..., Any] | None = None
     url: str | None = None
     registry_bundle: RegistryBundleBase | None = None

--- a/ax/api/utils/instantiation/from_config.py
+++ b/ax/api/utils/instantiation/from_config.py
@@ -49,6 +49,7 @@ def parameter_from_config(
                 parameter_type=_parameter_type_converter(config.parameter_type),
                 values=[*np.arange(lower, upper + step_size, step_size)],
                 is_ordered=True,
+                sort_values=False,  # already sorted by np.arange.
             )
 
         return RangeParameter(
@@ -82,6 +83,7 @@ def parameter_from_config(
             # pyre-fixme[6] Variance issue caused by ChoiceParameter.dependents using
             # List instead of immutable container type.
             dependents=config.dependent_parameters,
+            sort_values=config.parameter_type != "str",  # Matches default behavior.
         )
 
 


### PR DESCRIPTION
Summary:
Prevents warnings like this one, which can get quite intrusive when there are many choice parameters.
```
[W 250616 16:08:01 from_config:75] `sort_values` is not specified for `ChoiceParameter` "P4". Defaulting to `True` for parameters of `ParameterType` FLOAT. To override this behavior (or avoid this warning), specify `sort_values` during `ChoiceParameter` construction.
```

Reviewed By: mpolson64

Differential Revision: D77880184


