### PR TITLE
Removing dead code in failure rate checking

### DIFF
--- a/ax/service/orchestrator.py
+++ b/ax/service/orchestrator.py
@@ -1039,19 +1039,6 @@ class Orchestrator(AnalysisBase, BestPointMixin):
             self._failure_rate_has_been_exceeded = True
             return True
 
-        if failure_rate_exceeded:
-            if self._num_trials_bad_due_to_err > num_bad_in_orchestrator / 2:
-                self.logger.warning(
-                    "MetricFetchE INFO: Sweep aborted due to an exceeded error rate, "
-                    "which was primarily caused by failure to fetch metrics. Please "
-                    "check if anything could cause your metrics to be flaky or "
-                    "broken."
-                )
-
-            raise self._get_failure_rate_exceeded_error(
-                num_bad_in_orchestrator=num_bad_in_orchestrator,
-                num_ran_in_orchestrator=num_ran_in_orchestrator,
-            )
         return False
 
     def error_if_failure_rate_exceeded(self, force_check: bool = False) -> None:


### PR DESCRIPTION
Summary:
This diff removes dead code that historically threw the failure rate exceeded error, which was moved into a dedicated helper function [`error_if_failure_rate_exceeded`](https://www.internalfb.com/code/fbsource/[42e63b3dff61]/fbcode/ax/service/orchestrator.py?lines=1044). 

This in turn is called in `run` through [`should_abort_optimization`](https://www.internalfb.com/code/fbsource/[42e63b3dff61]/fbcode/ax/service/orchestrator.py?lines=1100), and in [`_complete_optimization`](https://www.internalfb.com/code/fbsource/[42e63b3dff61]/fbcode/ax/service/orchestrator.py?lines=1453).

Reviewed By: bernardbeckerman

Differential Revision: D77885034


