### PR TITLE
Update website documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,33 +77,8 @@ We use [Pyre](https://pyre-check.org/) for static type checking and require code
 
 ## Website
 
-The Ax website was created with [Docusaurus](https://docusaurus.io/), with heavy customization to support tutorials, complete API documentation via Sphinx, and versioning.
+The Ax website was created with [Docusaurus](https://docusaurus.io/), with some customization to support tutorials, and supplemented with Sphinx for API documentation. See the [website/README.md](website/README.md) for more details.
 
-FontAwesome icons were used under the [Creative Commons Attribution 4.0 International](https://fontawesome.com/license).
-
-### Local Building
-
-You will need [Node](https://nodejs.org/en/) >= 8.x and [Yarn](https://yarnpkg.com/en/) >= 1.5
-to build the Sphinx docs and Docusaurus site (which embeds the Sphinx docs inside). The
-following command will both build the docs and serve the (unversioned) site locally:
-```
-./scripts/make_docs.sh
-```
-
-Open http://localhost:3000 (if doesn't automatically open). Anytime you change the contents of the page, the page should auto-update.
-
-To build a static version, add the `-b` flag.
-
-Additional details:
-
-* This is the unversioned site built off of the current repository. Versioning is much more complex, and is generally not necessary for testing the site. Versioning is automatically handled when publishing the site to `gh-pages`.
-* Skipping Sphinx API & tutorials: to build the site without running Sphinx or compiling the tutorials, pass the `-o` flag to the `make_docs.sh` script. This is especially useful when you want to iterate quickly on making changes to the Docusaurus config and you've already run Sphinx and tutorial generation (the outputs are still in `website` subdirectory and will be picked up).
-* Tutorials: we embed tutorials written in Jupyter notebooks into the site. By default, these tutorials are converted to HTML without execution. However, you can execute all tutorials via `./scripts/make_docs.sh -t`. If you do execute the tutorials, please keep in mind that the version of Ax you have installed should match the version of Ax you're trying to build tutorials for.
-
-### Publishing
-The site is hosted as a GitHub page (on the `gh-pages` branch). We build the [latest version](https://ax.dev/versions/latest/index.html) of the site with every commit to the `main` branch via GitHub Actions. The latest version of the site can be manually updated using `./scripts/publish_site.sh` (assuming proper credentials).
-
-When new version of Ax rolls out, we add a new version to the site via `./scripts/publish_site.sh -v [version]`.
 
 ## License
 By contributing to Ax, you agree that your contributions will be licensed

--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = ../website/build
+BUILDDIR      = build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -49,17 +49,19 @@ help:
 	@echo "  coverage   to run coverage check of the documentation (if enabled)"
 
 clean:
-	rm -rf $(BUILDDIR)/api/*
+	rm -rf $(BUILDDIR)
+	@echo
+	@echo "Finished cleaning. $(BUILDDIR) has been deleted."
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/api
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/api."
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 dirhtml:
-	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/api
+	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/api."
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
 singlehtml:
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml

--- a/website/README.md
+++ b/website/README.md
@@ -1,29 +1,28 @@
-The Ax website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
+The Ax website was created with [Docusaurus](https://docusaurus.io/), with some customization to support tutorials, and supplemented with Sphinx for API documentation.
 
-## Building (All-in-one)
+## Dependencies
 
-For convenience we provide a single shell script to convert the tutorials and build the website in one command:
-```bash
-./scripts/make_docs.sh
-```
-
-To also execute the tutorials, run
-```bash
-./scripts/make_docs.sh -t
-```
-
-To generate a static build of the website in the `website/build` directory, run
-```bash
-./scripts/make_docs.sh -b
-```
-
-## Building (manually)
-
-### Notebooks
 Ensure necessary dependencies are installed (ideally to your virtual env):
 ```bash
 pip install -e ".[tutorial]"
 ```
+
+## Building (all-in-one)
+
+For convenience we provide a single shell script to convert the tutorials and build the website in one command. Must be executed from the repository root.
+```bash
+./scripts/make_docs.sh
+```
+
+To also execute the tutorials, add the `-t` flag.
+To generate a static build add the `-b` flag.
+
+`-h` for all options.
+
+
+## Building (manually)
+
+### Notebooks
 
 Tutorials can be executed locally using the following script. This is optional for locally building the website and is slow.
 ```bash
@@ -43,7 +42,7 @@ You need [Node](https://nodejs.org/en/) >= 18.x and
 Switch to the `website` dir from the project root and start the server:
 ```bash
 cd website
-yarn
+yarn install
 yarn start
 ```
 
@@ -51,26 +50,25 @@ Open http://localhost:3000 (if doesn't automatically open).
 
 Anytime you change the contents of the page, the page should auto-update.
 
-Note that you may need to switch to the "Next" version of the website documentation to see your latest changes.
+> [!NOTE]
+> You may need to switch to the "Next" version of the website documentation to see your latest changes.
 
 ### Sphinx
-Sphinx is used to generate an API reference from the source file docstrings. In production we use ReadTheDocs to build and host these docs, but they can also be built locally for testing.
+Sphinx is used to generate an API reference from the source file docstrings. In production we use [ReadTheDocs](https://ax.readthedocs.io/en/stable/index.html) to build and host these docs, but they can also be built locally for testing.
 ```sh
 cd sphinx/
 make html
 ```
 
-The build output is in `sphinx/build/` but Sphinx does not provide a server. There are many ways to view the output, here's an example using python:
+The build output is in `sphinx/build/html/` but Sphinx does not provide a server. Here's a serving example using Python:
 
 ```sh
-cd sphinx/build/
+cd sphinx/build/html/
 python3 -m http.server 8000
 ```
 
 
 ## Publishing
 
-The site is hosted on GitHub pages, via the `gh-pages` branch of the Ax
-[GitHub repo](https://github.com/facebook/Ax/tree/gh-pages).
-The website is automatically built and published from GitHub Actions - see the
+The site is hosted on GitHub pages, automatically deployed using the Github [deploy-pages](https://github.com/actions/deploy-pages) action - see the
 [config file](https://github.com/facebook/Ax/blob/main/.github/workflows/publish_website.yml) for details.


### PR DESCRIPTION
Summary:
1. Fix instructions for building sphinx locally. The makefile was using an old destination from before we migrated to ReadTheDocs. This didn't affect ReadTheDocs or our own workflow tests (neither use the makefile) but correct documentation allows us to debug sphinx locally more easily.
2. Remove old and incorrect Ax website documentation in `CONTRIBUTING.md`. Remove this old documentation and instead point users to the docs in `website/README.md`
3. Add `website/README.md` to the botorch repo. This was mistakenly missing. Remove old botorch documentation from `CONTRIBUTING.md` and point to `website/README.md` same as the Ax repo.

Differential Revision: D77888215


