### PR TITLE
Disallow attaching data with NaN or Inf values

### DIFF
--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -35,7 +35,7 @@ from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
 from ax.core.trial_status import TrialStatus
 from ax.early_stopping.strategies import PercentileEarlyStoppingStrategy
-from ax.exceptions.core import UnsupportedError
+from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.storage.sqa_store.db import init_test_engine_and_session_factory
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -487,6 +487,14 @@ class TestClient(TestCase):
                 )
             ),
         )
+
+        # With NaN / Inf values.
+        for value in [float("nan"), float("inf"), float("-inf")]:
+            with self.assertRaisesRegex(UserInputError, "null or inf values"):
+                client.attach_data(
+                    trial_index=trial_index,
+                    raw_data={"foo": (value, 0.0), "bar": (0.5, 0.0)},
+                )
 
     def test_complete_trial(self) -> None:
         client = Client()

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -18,6 +18,7 @@ from functools import partial, reduce
 from typing import Any, cast, Union
 
 import ax.core.observation as observation
+import numpy as np
 import pandas as pd
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
@@ -790,6 +791,9 @@ class Experiment(Base):
         data_init_args = data.deserialize_init_args(data.serialize_init_args(data))
         if data.true_df.empty:
             raise ValueError("Data to attach is empty.")
+        if not np.isfinite(data.true_df["mean"]).all():
+            # Error out if there are any NaNs or infs in the data.
+            raise UserInputError("Data to attach contains null or inf values.")
         metrics_not_on_exp = set(data.true_df["metric_name"].values) - set(
             self.metrics.keys()
         )


### PR DESCRIPTION
Summary: NaN or Inf values in the training data will lead to errors within the modeling layer. By checking for this in `Experiment.attach_data`, we bring the error closer to the source and let the user correct it before the faulty data makes it deeper into the stack.

Differential Revision: D77892970


