### PR TITLE
Remove subclasses of Analysis

### DIFF
--- a/ax/analysis/healthcheck/__init__.py
+++ b/ax/analysis/healthcheck/__init__.py
@@ -13,7 +13,7 @@ from ax.analysis.healthcheck.constraints_feasibility import (
     ConstraintsFeasibilityAnalysis,
 )
 from ax.analysis.healthcheck.healthcheck_analysis import (
-    HealthcheckAnalysis,
+    create_healthcheck_analysis_card,
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
@@ -23,9 +23,9 @@ from ax.analysis.healthcheck.search_space_analysis import SearchSpaceAnalysis
 from ax.analysis.healthcheck.should_generate_candidates import ShouldGenerateCandidates
 
 __all__ = [
+    "create_healthcheck_analysis_card",
     "ConstraintsFeasibilityAnalysis",
     "CanGenerateCandidatesAnalysis",
-    "HealthcheckAnalysis",
     "HealthcheckAnalysisCard",
     "HealthcheckStatus",
     "ShouldGenerateCandidates",

--- a/ax/analysis/healthcheck/can_generate_candidates.py
+++ b/ax/analysis/healthcheck/can_generate_candidates.py
@@ -9,9 +9,10 @@ from datetime import datetime
 
 import pandas as pd
 from ax.adapter.base import Adapter
+from ax.analysis.analysis import Analysis
 
 from ax.analysis.healthcheck.healthcheck_analysis import (
-    HealthcheckAnalysis,
+    create_healthcheck_analysis_card,
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
@@ -20,7 +21,7 @@ from ax.generation_strategy.generation_strategy import GenerationStrategy
 from pyre_extensions import none_throws, override
 
 
-class CanGenerateCandidatesAnalysis(HealthcheckAnalysis):
+class CanGenerateCandidatesAnalysis(Analysis):
     REASON_PREFIX: str = "This experiment cannot generate candidates.\nREASON: "
     LAST_RUN_TEMPLATE: str = "\n\nLAST TRIAL RUN: {days} day(s) ago"
 
@@ -80,7 +81,8 @@ class CanGenerateCandidatesAnalysis(HealthcheckAnalysis):
         else:
             subtitle += f"{self.reason}"
 
-        return self._create_healthcheck_analysis_card(
+        return create_healthcheck_analysis_card(
+            name=self.__class__.__name__,
             title=f"Ax Candidate Generation {title_status}",
             subtitle=subtitle,
             df=pd.DataFrame(),

--- a/ax/analysis/healthcheck/constraints_feasibility.py
+++ b/ax/analysis/healthcheck/constraints_feasibility.py
@@ -8,9 +8,9 @@
 import pandas as pd
 from ax.adapter.base import Adapter
 from ax.adapter.transforms.derelativize import Derelativize
-
+from ax.analysis.analysis import Analysis
 from ax.analysis.healthcheck.healthcheck_analysis import (
-    HealthcheckAnalysis,
+    create_healthcheck_analysis_card,
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
@@ -23,7 +23,7 @@ from ax.generation_strategy.generation_strategy import GenerationStrategy
 from pyre_extensions import assert_is_instance, override
 
 
-class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
+class ConstraintsFeasibilityAnalysis(Analysis):
     """
     Analysis for checking the feasibility of the constraints for the experiment.
     A constraint is considered feasible if the probability of constraints violation
@@ -70,7 +70,8 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
 
         if experiment.optimization_config is None:
             subtitle = "No optimization config is specified."
-            return self._create_healthcheck_analysis_card(
+            return create_healthcheck_analysis_card(
+                name=self.__class__.__name__,
                 title=f"Ax Constraints Feasibility {title_status}",
                 subtitle=subtitle,
                 df=df,
@@ -82,7 +83,8 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
             or len(experiment.optimization_config.outcome_constraints) == 0
         ):
             subtitle = "No constraints are specified."
-            return self._create_healthcheck_analysis_card(
+            return create_healthcheck_analysis_card(
+                name=self.__class__.__name__,
                 title=f"Ax Constraints Feasibility {title_status}",
                 subtitle=subtitle,
                 df=df,
@@ -125,7 +127,8 @@ class ConstraintsFeasibilityAnalysis(HealthcheckAnalysis):
             )
             title_status = "Warning"
 
-        return self._create_healthcheck_analysis_card(
+        return create_healthcheck_analysis_card(
+            name=self.__class__.__name__,
             title=f"Ax Constraints Feasibility {title_status}",
             subtitle=subtitle,
             df=df,

--- a/ax/analysis/healthcheck/healthcheck_analysis.py
+++ b/ax/analysis/healthcheck/healthcheck_analysis.py
@@ -9,13 +9,7 @@ import json
 from enum import IntEnum
 
 import pandas as pd
-from ax.adapter.base import Adapter
-
-from ax.analysis.analysis import Analysis
-from ax.analysis.analysis_card import AnalysisCard, AnalysisCardBase
-from ax.core.experiment import Experiment
-from ax.generation_strategy.generation_strategy import GenerationStrategy
-from pyre_extensions import override
+from ax.analysis.analysis_card import AnalysisCard
 
 
 class HealthcheckStatus(IntEnum):
@@ -35,36 +29,23 @@ class HealthcheckAnalysisCard(AnalysisCard):
         return json.loads(self.blob)
 
 
-class HealthcheckAnalysis(Analysis):
-    """
-    An analysis that performs a health check.
-    """
-
-    @override
-    def compute(
-        self,
-        experiment: Experiment | None = None,
-        generation_strategy: GenerationStrategy | None = None,
-        adapter: Adapter | None = None,
-    ) -> AnalysisCardBase: ...
-
-    def _create_healthcheck_analysis_card(
-        self,
-        title: str,
-        subtitle: str,
-        df: pd.DataFrame,
-        status: HealthcheckStatus,
-        **additional_attrs: str | int | float | bool,
-    ) -> HealthcheckAnalysisCard:
-        return HealthcheckAnalysisCard(
-            name=self.__class__.__name__,
-            title=title,
-            subtitle=subtitle,
-            df=df,
-            blob=json.dumps(
-                {
-                    "status": status,
-                    **additional_attrs,
-                }
-            ),
-        )
+def create_healthcheck_analysis_card(
+    name: str,
+    title: str,
+    subtitle: str,
+    df: pd.DataFrame,
+    status: HealthcheckStatus,
+    **additional_attrs: str | int | float | bool,
+) -> HealthcheckAnalysisCard:
+    return HealthcheckAnalysisCard(
+        name=name,
+        title=title,
+        subtitle=subtitle,
+        df=df,
+        blob=json.dumps(
+            {
+                "status": status,
+                **additional_attrs,
+            }
+        ),
+    )

--- a/ax/analysis/healthcheck/metric_fetching_errors.py
+++ b/ax/analysis/healthcheck/metric_fetching_errors.py
@@ -11,8 +11,9 @@ from typing import Any, Union
 
 import pandas as pd
 from ax.adapter import Adapter
+from ax.analysis.analysis import Analysis
 from ax.analysis.healthcheck.healthcheck_analysis import (
-    HealthcheckAnalysis,
+    create_healthcheck_analysis_card,
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
@@ -25,7 +26,7 @@ from pyre_extensions import override
 logger: Logger = get_logger(__name__)
 
 
-class MetricFetchingErrorsAnalysis(HealthcheckAnalysis):
+class MetricFetchingErrorsAnalysis(Analysis):
     """
     Analysis to check if any metric fetch errors occurred.
     If any metric fetch errors have occurred, the analysis will display the
@@ -64,7 +65,8 @@ class MetricFetchingErrorsAnalysis(HealthcheckAnalysis):
         metric_fetch_errors = experiment._metric_fetching_errors
 
         if len(metric_fetch_errors) == 0:
-            return self._create_healthcheck_analysis_card(
+            return create_healthcheck_analysis_card(
+                name=self.__class__.__name__,
                 title="Metric Fetch Errors",
                 subtitle="No metric fetch errors found.",
                 df=df,
@@ -118,7 +120,8 @@ class MetricFetchingErrorsAnalysis(HealthcheckAnalysis):
         }
         subtitle = df.rename(columns=subtitle_df_columns)
 
-        return self._create_healthcheck_analysis_card(
+        return create_healthcheck_analysis_card(
+            name=self.__class__.__name__,
             title="Metric Fetch Errors",
             subtitle=subtitle.to_markdown(index=False),
             df=df,

--- a/ax/analysis/healthcheck/no_effects_analysis.py
+++ b/ax/analysis/healthcheck/no_effects_analysis.py
@@ -7,9 +7,10 @@
 
 
 from ax.adapter.base import Adapter
+from ax.analysis.analysis import Analysis
 
 from ax.analysis.healthcheck.healthcheck_analysis import (
-    HealthcheckAnalysis,
+    create_healthcheck_analysis_card,
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
@@ -21,7 +22,7 @@ from ax.utils.stats.no_effects import check_experiment_effects_per_metric
 from pyre_extensions import override
 
 
-class TestOfNoEffectAnalysis(HealthcheckAnalysis):
+class TestOfNoEffectAnalysis(Analysis):
     """
     Analysis for checking whether a randomization test can show that there are any
     effects whatsoever. This test is performed independently on each metric
@@ -116,7 +117,8 @@ class TestOfNoEffectAnalysis(HealthcheckAnalysis):
             )
             title_status = "Warning"
 
-        return self._create_healthcheck_analysis_card(
+        return create_healthcheck_analysis_card(
+            name=self.__class__.__name__,
             title=f"Ax Test of No Effect {title_status}",
             subtitle=subtitle,
             df=df_tone,

--- a/ax/analysis/healthcheck/regression_analysis.py
+++ b/ax/analysis/healthcheck/regression_analysis.py
@@ -5,11 +5,11 @@
 
 # pyre-strict
 
-
 import pandas as pd
 from ax.adapter.base import Adapter
+from ax.analysis.analysis import Analysis
 from ax.analysis.healthcheck.healthcheck_analysis import (
-    HealthcheckAnalysis,
+    create_healthcheck_analysis_card,
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
@@ -22,7 +22,7 @@ from ax.generation_strategy.generation_strategy import GenerationStrategy
 from pyre_extensions import none_throws, override
 
 
-class RegressionAnalysis(HealthcheckAnalysis):
+class RegressionAnalysis(Analysis):
     r"""
     Analysis for detecting the regressing arm, metric pairs across all trials with data.
     For each metric, the regressions are defined as the arms that have a probability of
@@ -106,7 +106,8 @@ class RegressionAnalysis(HealthcheckAnalysis):
             subtitle = subtitle_base + "No metric regessions detected."
             title_status = "Success"
 
-        return self._create_healthcheck_analysis_card(
+        return create_healthcheck_analysis_card(
+            name=self.__class__.__name__,
             title=f"Ax Regression Analysis {title_status}",
             subtitle=subtitle,
             df=regressions_by_trial_df,

--- a/ax/analysis/healthcheck/search_space_analysis.py
+++ b/ax/analysis/healthcheck/search_space_analysis.py
@@ -10,9 +10,10 @@ from typing import Union
 import numpy as np
 import pandas as pd
 from ax.adapter.base import Adapter
+from ax.analysis.analysis import Analysis
 
 from ax.analysis.healthcheck.healthcheck_analysis import (
-    HealthcheckAnalysis,
+    create_healthcheck_analysis_card,
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
@@ -27,7 +28,7 @@ from ax.generation_strategy.generation_strategy import GenerationStrategy
 from pyre_extensions import assert_is_instance, override
 
 
-class SearchSpaceAnalysis(HealthcheckAnalysis):
+class SearchSpaceAnalysis(Analysis):
     r"""
     Analysis for checking wehther the search space of the experiment should be expanded.
     It checks whether the suggested parameters land at the boundary of the search space
@@ -88,7 +89,8 @@ class SearchSpaceAnalysis(HealthcheckAnalysis):
         else:
             additional_subtitle = "Search space does not need to be updated."
 
-        return self._create_healthcheck_analysis_card(
+        return create_healthcheck_analysis_card(
+            name=self.__class__.__name__,
             title=f"Ax Search Space Analysis {title_status}",
             subtitle=subtitle_base + additional_subtitle,
             df=boundary_proportions_df[["boundary", "proportion", "bound"]],

--- a/ax/analysis/healthcheck/should_generate_candidates.py
+++ b/ax/analysis/healthcheck/should_generate_candidates.py
@@ -8,9 +8,9 @@
 
 import pandas as pd
 from ax.adapter.base import Adapter
-
+from ax.analysis.analysis import Analysis
 from ax.analysis.healthcheck.healthcheck_analysis import (
-    HealthcheckAnalysis,
+    create_healthcheck_analysis_card,
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
@@ -19,7 +19,7 @@ from ax.generation_strategy.generation_strategy import GenerationStrategy
 from pyre_extensions import override
 
 
-class ShouldGenerateCandidates(HealthcheckAnalysis):
+class ShouldGenerateCandidates(Analysis):
     def __init__(
         self,
         should_generate: bool,
@@ -42,7 +42,8 @@ class ShouldGenerateCandidates(HealthcheckAnalysis):
             if self.should_generate
             else HealthcheckStatus.WARNING
         )
-        return self._create_healthcheck_analysis_card(
+        return create_healthcheck_analysis_card(
+            name=self.__class__.__name__,
             title=f"Ready to Generate Candidates for Trial {self.trial_index}",
             subtitle=self.reason,
             df=pd.DataFrame(),

--- a/ax/analysis/healthcheck/tests/test_healtheck_exception.py
+++ b/ax/analysis/healthcheck/tests/test_healtheck_exception.py
@@ -8,10 +8,9 @@
 
 from ax.adapter.base import Adapter
 
-from ax.analysis.healthcheck.healthcheck_analysis import (
-    HealthcheckAnalysis,
-    HealthcheckAnalysisCard,
-)
+from ax.analysis.analysis import Analysis
+
+from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckAnalysisCard
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.utils.common.testutils import TestCase
@@ -20,7 +19,7 @@ ERROR_MESSAGE = "Dummy analysis failed!"
 
 
 class TestHealtheckException(TestCase):
-    class DummyAnalysis(HealthcheckAnalysis):
+    class DummyAnalysis(Analysis):
         def compute(
             self,
             experiment: Experiment | None = None,

--- a/ax/analysis/markdown/__init__.py
+++ b/ax/analysis/markdown/__init__.py
@@ -5,9 +5,6 @@
 
 # pyre-strict
 
-from ax.analysis.markdown.markdown_analysis import (
-    MarkdownAnalysis,
-    MarkdownAnalysisCard,
-)
+from ax.analysis.markdown.markdown_analysis import MarkdownAnalysisCard
 
-__all__ = ["MarkdownAnalysis", "MarkdownAnalysisCard"]
+__all__ = ["MarkdownAnalysisCard"]

--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -7,15 +7,10 @@
 
 
 import markdown
-
 import pandas as pd
-from ax.adapter.base import Adapter
-from ax.analysis.analysis import Analysis
-from ax.analysis.analysis_card import AnalysisCard, AnalysisCardBase
-from ax.core.experiment import Experiment
-from ax.generation_strategy.generation_strategy import GenerationStrategy
+
+from ax.analysis.analysis_card import AnalysisCard
 from IPython.display import Markdown
-from pyre_extensions import override
 
 
 class MarkdownAnalysisCard(AnalysisCard):
@@ -29,34 +24,17 @@ class MarkdownAnalysisCard(AnalysisCard):
         return Markdown(self.get_markdown())
 
 
-class MarkdownAnalysis(Analysis):
-    """
-    An Analysis that computes a paragraph of Markdown formatted text.
-    """
-
-    @override
-    def compute(
-        self,
-        experiment: Experiment | None = None,
-        generation_strategy: GenerationStrategy | None = None,
-        adapter: Adapter | None = None,
-    ) -> AnalysisCardBase: ...
-
-    def _create_markdown_analysis_card(
-        self,
-        title: str,
-        subtitle: str,
-        df: pd.DataFrame,
-        message: str,
-    ) -> MarkdownAnalysisCard:
-        """
-        Make a MarkdownAnalysisCard from this Analysis using provided fields and
-        details about the Analysis class.
-        """
-        return MarkdownAnalysisCard(
-            name=self.__class__.__name__,
-            title=title,
-            subtitle=subtitle,
-            df=df,
-            blob=message,
-        )
+def create_markdown_analysis_card(
+    name: str,
+    title: str,
+    subtitle: str,
+    df: pd.DataFrame,
+    message: str,
+) -> MarkdownAnalysisCard:
+    return MarkdownAnalysisCard(
+        name=name,
+        title=title,
+        subtitle=subtitle,
+        df=df,
+        blob=message,
+    )

--- a/ax/analysis/plotly/__init__.py
+++ b/ax/analysis/plotly/__init__.py
@@ -8,7 +8,7 @@
 from ax.analysis.plotly.arm_effects import ArmEffectsPlot
 from ax.analysis.plotly.cross_validation import CrossValidationPlot
 from ax.analysis.plotly.parallel_coordinates import ParallelCoordinatesPlot
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
+from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
 from ax.analysis.plotly.progression import ProgressionPlot
 from ax.analysis.plotly.scatter import ScatterPlot
 from ax.analysis.plotly.sensitivity import SensitivityAnalysisPlot
@@ -21,7 +21,6 @@ __all__ = [
     "ContourPlot",
     "CrossValidationPlot",
     "ParallelCoordinatesPlot",
-    "PlotlyAnalysis",
     "PlotlyAnalysisCard",
     "ProgressionPlot",
     "ScatterPlot",

--- a/ax/analysis/plotly/arm_effects.py
+++ b/ax/analysis/plotly/arm_effects.py
@@ -11,9 +11,11 @@ import numpy as np
 
 import pandas as pd
 from ax.adapter.base import Adapter
+
+from ax.analysis.analysis import Analysis
 from ax.analysis.analysis_card import AnalysisCardBase
 from ax.analysis.plotly.color_constants import CONSTRAINT_VIOLATION_COLOR
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis
+from ax.analysis.plotly.plotly_analysis import create_plotly_analysis_card
 from ax.analysis.plotly.utils import (
     BEST_LINE_SETTINGS,
     get_arm_tooltip,
@@ -40,7 +42,7 @@ from plotly import graph_objects as go
 from pyre_extensions import override
 
 
-class ArmEffectsPlot(PlotlyAnalysis):
+class ArmEffectsPlot(Analysis):
     """
     Plot the effects of each arm in an experiment on a given metric. Effects may be
     either the raw observed effects, or the predicted effects using a model. The
@@ -147,7 +149,8 @@ class ArmEffectsPlot(PlotlyAnalysis):
         }
 
         cards = [
-            self._create_plotly_analysis_card(
+            create_plotly_analysis_card(
+                name=self.__class__.__name__,
                 title=(
                     f"{'Modeled' if self.use_model_predictions else 'Observed'} "
                     f"{'Relativized ' if self.relativize else ''}Arm "

--- a/ax/analysis/plotly/bandit_rollout.py
+++ b/ax/analysis/plotly/bandit_rollout.py
@@ -10,8 +10,12 @@ from typing import List
 import pandas as pd
 import plotly.express as px
 from ax.adapter.base import Adapter
+from ax.analysis.analysis import Analysis
 from ax.analysis.plotly.color_constants import DISCRETE_ARM_SCALE
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
+from ax.analysis.plotly.plotly_analysis import (
+    create_plotly_analysis_card,
+    PlotlyAnalysisCard,
+)
 from ax.core.batch_trial import BatchTrial
 from ax.core.experiment import Experiment
 from ax.core.trial_status import TrialStatus
@@ -21,7 +25,7 @@ from plotly import graph_objects as go
 from pyre_extensions import override
 
 
-class BanditRollout(PlotlyAnalysis):
+class BanditRollout(Analysis):
     """
     BanditRollout visualizes the distribution of weights across different trials
     and arms in an experiment using a bar plot.
@@ -145,7 +149,8 @@ class BanditRollout(PlotlyAnalysis):
         )
         fig = self._prepare_plot(df=df, experiment_name=experiment.name)
 
-        return self._create_plotly_analysis_card(
+        return create_plotly_analysis_card(
+            name=self.__class__.__name__,
             title=f"Bandit Rollout Weights by Trial for {experiment.name}",
             subtitle=(
                 "The Bandit Rollout visualization provides a comprehensive "

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -11,10 +11,12 @@ from typing import Mapping, Sequence
 import pandas as pd
 from ax.adapter.base import Adapter
 from ax.adapter.cross_validation import cross_validate, CVResult
+from ax.analysis.analysis import Analysis
 from ax.analysis.analysis_card import AnalysisCardBase
 from ax.analysis.plotly.color_constants import AX_BLUE
 
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis
+from ax.analysis.plotly.plotly_analysis import create_plotly_analysis_card
+
 from ax.analysis.plotly.utils import get_scatter_point_color, Z_SCORE_95_CI
 
 from ax.analysis.utils import extract_relevant_adapter
@@ -32,7 +34,7 @@ FILLED_AX_BLUE: str = get_scatter_point_color(
 )
 
 
-class CrossValidationPlot(PlotlyAnalysis):
+class CrossValidationPlot(Analysis):
     """
     Plotly Scatter plot for cross validation for model predictions using the current
     model on the GenerationStrategy. This plot is useful for understanding how well
@@ -135,7 +137,8 @@ class CrossValidationPlot(PlotlyAnalysis):
                 )
             )
 
-            card = self._create_plotly_analysis_card(
+            card = create_plotly_analysis_card(
+                name=self.__class__.__name__,
                 title=f"Cross Validation for {metric_title}",
                 subtitle=(
                     "The cross-validation plot displays the model fit for each "

--- a/ax/analysis/plotly/marginal_effects.py
+++ b/ax/analysis/plotly/marginal_effects.py
@@ -7,13 +7,13 @@
 
 import pandas as pd
 from ax.adapter.base import Adapter
+from ax.analysis.analysis import Analysis
 from ax.analysis.analysis_card import AnalysisCardBase
 from ax.analysis.plotly.color_constants import (
     NEGATIVE_CHANGE_COLOR,
     POSITIVE_CHANGE_COLOR,
 )
-
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis
+from ax.analysis.plotly.plotly_analysis import create_plotly_analysis_card
 
 from ax.analysis.utils import extract_relevant_adapter
 from ax.core.experiment import Experiment
@@ -26,7 +26,7 @@ from plotly import graph_objects as go
 from pyre_extensions import none_throws, override
 
 
-class MarginalEffectsPlot(PlotlyAnalysis):
+class MarginalEffectsPlot(Analysis):
     """
     Plotly bar charts showing the marginal effect of each factor level of
     selected `ChoiceParameters` on the given metric. This plot is useful
@@ -104,7 +104,8 @@ class MarginalEffectsPlot(PlotlyAnalysis):
             param_df = df[df["Name"] == param]
             fig = _prepare_plot(param_df, self.metric_name)
             cards.append(
-                self._create_plotly_analysis_card(
+                create_plotly_analysis_card(
+                    name=self.__class__.__name__,
                     title=f"Marginal Effects for {param}",
                     subtitle=(
                         "This plot visualizes the predicted relative changes in "

--- a/ax/analysis/plotly/parallel_coordinates.py
+++ b/ax/analysis/plotly/parallel_coordinates.py
@@ -10,9 +10,12 @@ from typing import Any
 import numpy as np
 import pandas as pd
 from ax.adapter.base import Adapter
+from ax.analysis.analysis import Analysis
 from ax.analysis.plotly.color_constants import METRIC_CONTINUOUS_COLOR_SCALE
-
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
+from ax.analysis.plotly.plotly_analysis import (
+    create_plotly_analysis_card,
+    PlotlyAnalysisCard,
+)
 from ax.analysis.plotly.utils import select_metric, truncate_label
 from ax.core.experiment import Experiment
 from ax.exceptions.core import UserInputError
@@ -21,7 +24,7 @@ from plotly import graph_objects as go
 from pyre_extensions import override
 
 
-class ParallelCoordinatesPlot(PlotlyAnalysis):
+class ParallelCoordinatesPlot(Analysis):
     """
     Plotly Parcoords plot for a single metric, with one line per arm and dimensions for
     each parameter in the search space. This plot is useful for understanding how
@@ -60,7 +63,8 @@ class ParallelCoordinatesPlot(PlotlyAnalysis):
         df = _prepare_data(experiment=experiment, metric=metric_name)
         fig = _prepare_plot(df=df, metric_name=metric_name)
 
-        return self._create_plotly_analysis_card(
+        return create_plotly_analysis_card(
+            name=self.__class__.__name__,
             title=f"Parallel Coordinates for {metric_name}",
             subtitle=(
                 "The parallel coordinates plot displays multi-dimensional "

--- a/ax/analysis/plotly/plotly_analysis.py
+++ b/ax/analysis/plotly/plotly_analysis.py
@@ -5,14 +5,10 @@
 
 # pyre-strict
 
+
 import pandas as pd
-from ax.adapter.base import Adapter
-from ax.analysis.analysis import Analysis
-from ax.analysis.analysis_card import AnalysisCard, AnalysisCardBase
-from ax.core.experiment import Experiment
-from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.analysis.analysis_card import AnalysisCard
 from plotly import graph_objects as go, io as pio
-from pyre_extensions import override
 
 # Body HTML template for Plotly figures with a couple tricks for rendering in Jupyter.
 # 1. It is necessary to use the UTF-8 encoding with plotly graphics to get e.g.
@@ -60,34 +56,17 @@ class PlotlyAnalysisCard(AnalysisCard):
         return self.get_figure()
 
 
-class PlotlyAnalysis(Analysis):
-    """
-    An Analysis that computes a Plotly figure.
-    """
-
-    @override
-    def compute(
-        self,
-        experiment: Experiment | None = None,
-        generation_strategy: GenerationStrategy | None = None,
-        adapter: Adapter | None = None,
-    ) -> AnalysisCardBase: ...
-
-    def _create_plotly_analysis_card(
-        self,
-        title: str,
-        subtitle: str,
-        df: pd.DataFrame,
-        fig: go.Figure,
-    ) -> PlotlyAnalysisCard:
-        """
-        Make a PlotlyAnalysisCard from this Analysis using provided fields and
-        details about the Analysis class.
-        """
-        return PlotlyAnalysisCard(
-            name=self.__class__.__name__,
-            title=title,
-            subtitle=subtitle,
-            df=df,
-            blob=pio.to_json(fig),
-        )
+def create_plotly_analysis_card(
+    name: str,
+    title: str,
+    subtitle: str,
+    df: pd.DataFrame,
+    fig: go.Figure,
+) -> PlotlyAnalysisCard:
+    return PlotlyAnalysisCard(
+        name=name,
+        title=title,
+        subtitle=subtitle,
+        df=df,
+        blob=pio.to_json(fig),
+    )

--- a/ax/analysis/plotly/progression.py
+++ b/ax/analysis/plotly/progression.py
@@ -8,8 +8,11 @@
 import numpy as np
 import plotly.express as px
 from ax.adapter.base import Adapter
-
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
+from ax.analysis.analysis import Analysis
+from ax.analysis.plotly.plotly_analysis import (
+    create_plotly_analysis_card,
+    PlotlyAnalysisCard,
+)
 from ax.analysis.plotly.utils import select_metric
 from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
@@ -21,7 +24,7 @@ from plotly import graph_objects as go
 from pyre_extensions import assert_is_instance, override
 
 
-class ProgressionPlot(PlotlyAnalysis):
+class ProgressionPlot(Analysis):
     """
     Plotly Scatter showing a timerseries-like metric's progression, with one line for
     each arm. The plot also includes a marker on the terminal step of any trial that
@@ -132,7 +135,8 @@ class ProgressionPlot(PlotlyAnalysis):
                 )
             )
 
-        return self._create_plotly_analysis_card(
+        return create_plotly_analysis_card(
+            name=self.__class__.__name__,
             title=f"{metric_name} by {x_axis_name.replace('_', ' ')}",
             subtitle=(
                 "The progression plot tracks the evolution of each metric "

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -13,9 +13,13 @@ import numpy as np
 import pandas as pd
 from ax.adapter.base import Adapter
 from ax.adapter.registry import Generators
+from ax.analysis.analysis import Analysis
 from ax.analysis.plotly.color_constants import CONSTRAINT_VIOLATION_COLOR
 
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
+from ax.analysis.plotly.plotly_analysis import (
+    create_plotly_analysis_card,
+    PlotlyAnalysisCard,
+)
 from ax.analysis.plotly.utils import (
     BEST_LINE_SETTINGS,
     get_arm_tooltip,
@@ -42,7 +46,7 @@ from pyre_extensions import override
 logger: Logger = get_logger(__name__)
 
 
-class ScatterPlot(PlotlyAnalysis):
+class ScatterPlot(Analysis):
     """
     Plotly Scatter plot for any two metrics. Each arm is represented by a single point
     with 95% confidence intervals if the data is available. Effects may be either the
@@ -179,7 +183,8 @@ class ScatterPlot(PlotlyAnalysis):
             else False,
         )
 
-        return self._create_plotly_analysis_card(
+        return create_plotly_analysis_card(
+            name=self.__class__.__name__,
             title=(
                 f"{'Modeled' if self.use_model_predictions else 'Observed'} "
                 f"{'Relativized ' if self.relativize else ''}Effects:"

--- a/ax/analysis/plotly/sensitivity.py
+++ b/ax/analysis/plotly/sensitivity.py
@@ -9,9 +9,11 @@ from typing import Literal, Mapping, Sequence
 import pandas as pd
 from ax.adapter.base import Adapter
 from ax.adapter.torch import TorchAdapter
-from ax.analysis.analysis_card import AnalysisCardBase
 
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis
+from ax.analysis.analysis import Analysis
+from ax.analysis.analysis_card import AnalysisCardBase
+from ax.analysis.plotly.plotly_analysis import create_plotly_analysis_card
+
 from ax.analysis.plotly.utils import (
     COLOR_FOR_DECREASES,
     COLOR_FOR_INCREASES,
@@ -31,7 +33,7 @@ from pyre_extensions import override
 MAX_LABEL_LEN: int = 20
 
 
-class SensitivityAnalysisPlot(PlotlyAnalysis):
+class SensitivityAnalysisPlot(Analysis):
     """
     Compute sensitivity for all metrics on a TorchAdapter.
 
@@ -104,7 +106,8 @@ class SensitivityAnalysisPlot(PlotlyAnalysis):
                 metric_label=metric_label,
             )
 
-            card = self._create_plotly_analysis_card(
+            card = create_plotly_analysis_card(
+                name=self.__class__.__name__,
                 title=f"Sensitivity Analysis for {metric_label}",
                 subtitle=(
                     f"Understand how each parameter affects {metric_label} according "

--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -9,9 +9,14 @@ import math
 
 import pandas as pd
 from ax.adapter.base import Adapter
+
+from ax.analysis.analysis import Analysis
 from ax.analysis.plotly.color_constants import METRIC_CONTINUOUS_COLOR_SCALE
 
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
+from ax.analysis.plotly.plotly_analysis import (
+    create_plotly_analysis_card,
+    PlotlyAnalysisCard,
+)
 from ax.analysis.plotly.surface.utils import (
     get_parameter_values,
     is_axis_log_scale,
@@ -28,7 +33,7 @@ from plotly import graph_objects as go
 from pyre_extensions import none_throws, override
 
 
-class ContourPlot(PlotlyAnalysis):
+class ContourPlot(Analysis):
     """
     Plot a 2D surface of the surrogate model's predicted outcomes for a given pair of
     parameters, where all other parameters are held fixed at their status-quo value or
@@ -106,7 +111,8 @@ class ContourPlot(PlotlyAnalysis):
             is_relative=self.relativize,
         )
 
-        return self._create_plotly_analysis_card(
+        return create_plotly_analysis_card(
+            name=self.__class__.__name__,
             title=(
                 f"{self.x_parameter_name}, {self.y_parameter_name} vs. "
                 f"{metric_name}"

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -9,10 +9,14 @@ import math
 
 import pandas as pd
 from ax.adapter.base import Adapter
+from ax.analysis.analysis import Analysis
 from ax.analysis.analysis_card import AnalysisCardBase
 from ax.analysis.plotly.color_constants import AX_BLUE
 
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
+from ax.analysis.plotly.plotly_analysis import (
+    create_plotly_analysis_card,
+    PlotlyAnalysisCard,
+)
 from ax.analysis.plotly.surface.utils import (
     get_parameter_values,
     is_axis_log_scale,
@@ -34,7 +38,7 @@ from plotly import graph_objects as go
 from pyre_extensions import none_throws, override
 
 
-class SlicePlot(PlotlyAnalysis):
+class SlicePlot(Analysis):
     """
     Plot a 1D "slice" of the surrogate model's predicted outcomes for a given
     parameter, where all other parameters are held fixed at their status-quo value or
@@ -105,7 +109,8 @@ class SlicePlot(PlotlyAnalysis):
             is_relative=self.relativize,
         )
 
-        return self._create_plotly_analysis_card(
+        return create_plotly_analysis_card(
+            name=self.__class__.__name__,
             title=f"{self.parameter_name} vs. {metric_name}",
             subtitle=(
                 "The slice plot provides a one-dimensional view of predicted "

--- a/ax/analysis/plotly/top_surfaces.py
+++ b/ax/analysis/plotly/top_surfaces.py
@@ -8,9 +8,9 @@
 from typing import Literal
 
 from ax.adapter.base import Adapter
+from ax.analysis.analysis import Analysis
 from ax.analysis.analysis_card import AnalysisCardGroup
-
-from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard
+from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
 from ax.analysis.plotly.sensitivity import SensitivityAnalysisPlot
 from ax.analysis.plotly.surface.contour import ContourPlot
 from ax.analysis.plotly.surface.slice import SlicePlot
@@ -21,7 +21,7 @@ from ax.generation_strategy.generation_strategy import GenerationStrategy
 from pyre_extensions import override
 
 
-class TopSurfacesAnalysis(PlotlyAnalysis):
+class TopSurfacesAnalysis(Analysis):
     def __init__(
         self,
         metric_name: str | None = None,

--- a/tutorials/analyses/analyses.ipynb
+++ b/tutorials/analyses/analyses.ipynb
@@ -25,9 +25,7 @@
         "parameters in the search space are most relevent, then produces `SlicePlot`s and\n",
         "`ContourPlot`s for the most important surfaces.\n",
         "\n",
-        "Ax currently provides implementations for 3 base classes: (1)`Analysis` -- for\n",
-        "creating tables, (2) `PlotlyAnalysis` -- for producing plots using the Plotly\n",
-        "library, and (3) `MarkdownAnalysis` -- for producing messages. Importantly Ax is\n",
+        "Importantly Ax is\n",
         "able to save these cards to the database using `save_analysis_cards`, allowing\n",
         "for analyses to be pre-computed and displayed at a later time. This is done\n",
         "automatically when `Client.compute_analyses` is called.\n",
@@ -245,9 +243,9 @@
         "## Plotly Analyses\n",
         "\n",
         "Analyses do not just have to be Pandas dataframes.\n",
-        "Ax also defines a class `PlotlyAnalysis` class, where the `compute` method returns a `PlotlyAnalysisCard` containing both a dataframe and a plotly `Figure`.\n",
+        "Ax also defines a class `PlotlyAnalysisCard` containing both a dataframe and a plotly `Figure`.\n",
         "\n",
-        "Implementing a `PlotlyAnalysis` is not significantly different from creating a base `Analysis`. Let's create a bar chart based on `TrialStatusTable`."
+        "Let's create a bar chart based on `TrialStatusTable`."
       ]
     },
     {
@@ -256,11 +254,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from ax.analysis.plotly.plotly_analysis import PlotlyAnalysis, PlotlyAnalysisCard\n",
+        "from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard, create_plotly_analysis_card\n",
         "from plotly import express as px\n",
         "\n",
         "\n",
-        "class TrialStatusTable(PlotlyAnalysis):\n",
+        "class TrialStatusTable(Analysis):\n",
         "    def __init__(self, as_fraction: bool) -> None:\n",
         "        super().__init__()\n",
         "\n",
@@ -286,7 +284,8 @@
         "        fig = px.bar(df, x=\"status\", y=\"count\")\n",
         "\n",
         "        # Use _create_plotly_analysis_card rather than AnalysisCard to automatically populate relevant metadata\n",
-        "        return self._create_plotly_analysis_card(\n",
+        "        return create_plotly_analysis_card(\n",
+        "            name=self.__class__.__name__,\n",
         "            title=\"Trials by Status\",\n",
         "            subtitle=\"How many trials are in each status?\",\n",
         "            df=df,\n",


### PR DESCRIPTION
Summary:
Post AnalysisCardGroup refactor these classes no longer hold any meaning and can just be replaced by Analysis.

Note that PlotlyAnalysisCard, MarkdownAnalysisCard, etc are still of course necessary and still remain

Differential Revision: D77896085
