### PR TITLE
Remove `TFidelityTrialEvaluation`; typing improvements

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -479,10 +479,7 @@ class Client(WithDBSettingsBase):
 
         trial = assert_is_instance(self._experiment.trials[trial_index], Trial)
         trial.update_trial_data(
-            # pyre-fixme[6]: Type narrowing broken because core Ax TParameterization
-            # is dict not Mapping
-            raw_data=data_with_progression,
-            combine_with_last_data=True,
+            raw_data=data_with_progression, combine_with_last_data=True
         )
 
         self._save_or_update_trial_in_db_if_possible(

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
-from hashlib import md5
 from io import StringIO
 from typing import Any, cast, TypeVar
 
@@ -26,7 +25,7 @@ from ax.utils.common.serialization import (
     TClassDecoderRegistry,
     TDecoderRegistry,
 )
-from pyre_extensions import assert_is_instance, none_throws
+from pyre_extensions import assert_is_instance
 
 TData = TypeVar("TData", bound="Data")
 DF_REPR_MAX_LENGTH = 1000
@@ -226,23 +225,6 @@ class Data(Base, SerializationMixin):
     @property
     def df(self) -> pd.DataFrame:
         return self._df
-
-    @property
-    def df_hash(self) -> str:
-        """Compute hash of pandas DataFrame.
-
-        This first serializes the DataFrame and computes the md5 hash on the
-        resulting string. Note that this may cause performance issue for very large
-        DataFrames.
-
-        Args:
-            df: The DataFrame for which to compute the hash.
-
-        Returns
-            str: The hash of the DataFrame.
-
-        """
-        return md5(none_throws(self.df.to_json()).encode("utf-8")).hexdigest()
 
     def get_filtered_results(self: TData, **filters: dict[str, Any]) -> pd.DataFrame:
         """Return filtered subset of data.

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -416,17 +416,6 @@ class Data(Base, SerializationMixin):
         return Data(df=deepcopy(self.df), description=self.description)
 
 
-def set_single_trial(data: Data) -> Data:
-    """Returns a new Data object where we set all rows to have the same
-    trial index (i.e. 0). This is meant to be used with our IVW transform,
-    which will combine multiple observations of the same outcome.
-    """
-    df = data._df.copy()
-    if "trial_index" in df:
-        df["trial_index"] = 0
-    return Data(df=df)
-
-
 def clone_without_metrics(data: Data, excluded_metric_names: Iterable[str]) -> Data:
     """Returns a new data object where rows containing the outcomes specified by
     `metric_names` are filtered out. Used to sanitize data before using it as

--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -128,7 +128,6 @@ class MapData(Data):
         if map_key_infos is None and df is not None:
             raise ValueError("map_key_infos may be `None` iff `df` is None.")
 
-        # pyre-fixme[4]: Attribute must be annotated.
         self._map_key_infos = list(map_key_infos) if map_key_infos is not None else []
 
         if df is None:  # If df is None create an empty dataframe with appropriate cols
@@ -356,7 +355,6 @@ class MapData(Data):
         )
 
     @classmethod
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     def serialize_init_args(cls, obj: Any) -> dict[str, Any]:
         map_data = assert_is_instance(obj, MapData)
         properties = serialize_init_args(

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -118,7 +118,6 @@ class DataTest(TestCase):
         self.assertEqual(Data(), Data())
         data = Data(df=self.df)
         self.assertEqual(data, data)
-        self.assertEqual(data.df_hash, self.df_hash)
 
         df = data.df
         self.assertEqual(
@@ -136,10 +135,7 @@ class DataTest(TestCase):
             REPR_1000,
         )
         with patch(f"{Data.__module__}.DF_REPR_MAX_LENGTH", 500):
-            self.assertEqual(
-                str(Data(df=self.df)),
-                REPR_500,
-            )
+            self.assertEqual(str(Data(df=self.df)), REPR_500)
 
     def test_clone(self) -> None:
         data = Data(df=self.df, description="test")

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -10,12 +10,7 @@ import random
 from unittest.mock import patch
 
 import pandas as pd
-from ax.core.data import (
-    clone_without_metrics,
-    custom_data_class,
-    Data,
-    set_single_trial,
-)
+from ax.core.data import clone_without_metrics, custom_data_class, Data
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.timeutils import current_timestamp_in_millis
 
@@ -159,11 +154,6 @@ class DataTest(TestCase):
         self.assertTrue(df.empty)
         self.assertTrue(set(df.columns == Data.REQUIRED_COLUMNS))
         self.assertTrue(Data.from_multiple_data([]).df.empty)
-
-    def test_SetSingleBatch(self) -> None:
-        data = Data(df=self.df)
-        merged_data = set_single_trial(data)
-        self.assertTrue((merged_data.df["trial_index"] == 0).all())
 
     def test_CustomData(self) -> None:
         CustomData = custom_data_class(

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -236,27 +236,6 @@ class DataTest(TestCase):
             self.assertEqual(data.df["start_time"][0].day, day)
             self.assertEqual(data.df["end_time"][0].day, day)
 
-    def test_FromFidelityEvaluations(self) -> None:
-        for sem in (0.5, None):
-            eval1 = (3.7, sem) if sem is not None else 3.7
-            eval2 = (3.8, sem) if sem is not None else 3.8
-            data = Data.from_fidelity_evaluations(
-                evaluations={
-                    "0_1": [
-                        ({"f1": 1.0, "f2": 0.5}, {"b": eval1}),
-                        ({"f1": 1.0, "f2": 0.75}, {"b": eval2}),
-                    ]
-                },
-                trial_index=0,
-                sample_sizes={"0_1": 2},
-                start_time=current_timestamp_in_millis(),
-                end_time=current_timestamp_in_millis(),
-            )
-            self.assertEqual(data.df["sem"].isnull().all(), sem is None)
-            self.assertEqual(len(data.df), 2)
-            self.assertIn("start_time", data.df)
-            self.assertIn("end_time", data.df)
-
     def test_CloneWithoutMetrics(self) -> None:
         data = Data(df=self.df)
         expected = Data(

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1388,7 +1388,6 @@ class ExperimentWithMapDataTest(TestCase):
         self.experiment.new_trial()
         self.experiment.trials[0].mark_running(no_runner_required=True)
         first_epoch = MapData.from_map_evaluations(
-            # pyre-fixme[6]: For 1st param expected `Dict[str, List[Tuple[Dict[str, H...
             evaluations={
                 arm_name: partial_results[0:1]
                 for arm_name, partial_results in evaluations.items()
@@ -1397,7 +1396,6 @@ class ExperimentWithMapDataTest(TestCase):
         )
         self.experiment.attach_data(first_epoch)
         remaining_epochs = MapData.from_map_evaluations(
-            # pyre-fixme[6]: For 1st param expected `Dict[str, List[Tuple[Dict[str, H...
             evaluations={
                 arm_name: partial_results[1:4]
                 for arm_name, partial_results in evaluations.items()

--- a/ax/core/tests/test_formatting_utils.py
+++ b/ax/core/tests/test_formatting_utils.py
@@ -60,11 +60,7 @@ class TestRawDataToEvaluation(TestCase):
 
     def test_it_accepts_a_list_for_single_objectives(self) -> None:
         raw_data = [({"arm__0": (0, 1)}, {"objective_a": (1.4, None)})]
-        result = raw_data_to_evaluation(
-            # pyre-fixme[6]: For 1st param expected `Union[Dict[str, Union[Tuple[Unio...
-            raw_data=raw_data,
-            metric_names=["objective_a"],
-        )
+        result = raw_data_to_evaluation(raw_data=raw_data, metric_names=["objective_a"])
         self.assertEqual(raw_data, result)
 
     def test_it_turns_a_tuple_into_a_dict(self) -> None:

--- a/ax/core/tests/test_types.py
+++ b/ax/core/tests/test_types.py
@@ -56,33 +56,42 @@ class TypesTest(TestCase):
     def test_Validate(self) -> None:
         trial_evaluation = {"foo": 0.0}
         trial_evaluation_with_noise = {"foo": (0.0, 0.0)}
-        fidelity_trial_evaluation = [({"a": 0.0}, trial_evaluation)]
         map_trial_evaluation = [({"a": 0.0}, trial_evaluation)]
 
-        validate_evaluation_outcome(outcome=trial_evaluation)  # pyre-ignore[6]
-        validate_evaluation_outcome(
-            outcome=trial_evaluation_with_noise  # pyre-ignore[6]
-        )
-        validate_evaluation_outcome(outcome=fidelity_trial_evaluation)  # pyre-ignore[6]
-        validate_evaluation_outcome(outcome=map_trial_evaluation)  # pyre-ignore[6]
+        validate_evaluation_outcome(outcome=trial_evaluation)
+        validate_evaluation_outcome(outcome=trial_evaluation_with_noise)
+        validate_evaluation_outcome(outcome=map_trial_evaluation)
 
-        with self.assertRaises(TypeError):
-            validate_floatlike(floatlike="foo")  # pyre-ignore[6]
+        with self.assertRaisesRegex(TypeError, "Expected FloatLike, found foo"):
+            validate_floatlike(floatlike="foo")
 
-        with self.assertRaises(TypeError):
-            validate_single_metric_data(data=(0, 1, 2))  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError,
+            "Tuple-valued SingleMetricData must have len",
+        ):
+            validate_single_metric_data(data=(0, 1, 2))
 
-        with self.assertRaises(TypeError):
-            validate_trial_evaluation(evaluation={0: 0})  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError, "Keys must be strings in TTrialEvaluation, found 0."
+        ):
+            validate_trial_evaluation(evaluation={0: 0})
 
-        with self.assertRaises(TypeError):
-            validate_param_value(param_value=[])  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError, "Expected None, bool, float, int, or str, found"
+        ):
+            validate_param_value(param_value=[])
 
-        with self.assertRaises(TypeError):
-            validate_parameterization(parameterization={0: 0})  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError, "Keys must be strings in TParameterization, found 0."
+        ):
+            validate_parameterization(parameterization={0: 0})
 
-        with self.assertRaises(TypeError):
-            validate_map_dict(map_dict={0: 0})  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError, "Keys must be strings in TMapDict, found 0."
+        ):
+            validate_map_dict(map_dict={0: 0})
 
-        with self.assertRaises(TypeError):
-            validate_map_dict(map_dict={"foo": []})  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError, "Values must be Hashable in TMapDict, found"
+        ):
+            validate_map_dict(map_dict={"foo": []})

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -8,7 +8,7 @@
 
 import enum
 from collections import defaultdict
-from collections.abc import Callable, Hashable
+from collections.abc import Callable, Hashable, Mapping, Sequence
 from typing import Any, Optional, Union
 
 import numpy as np
@@ -36,25 +36,20 @@ FloatLike = Union[int, float, np.floating, np.integer]
 SingleMetricDataTuple = tuple[FloatLike, Optional[FloatLike]]
 SingleMetricData = Union[FloatLike, tuple[FloatLike, Optional[FloatLike]]]
 # 1-arm `Trial` evaluation data: {metric_name -> (mean, standard error)}}.
-TTrialEvaluation = dict[str, SingleMetricData]
-
-# 1-arm evaluation data with trace fidelities
-TFidelityTrialEvaluation = list[tuple[TParameterization, TTrialEvaluation]]
+TTrialEvaluation = Mapping[str, SingleMetricData]
 
 # 1-arm evaluation data with arbitrary partial results
-TMapDict = dict[str, Hashable]
-TMapTrialEvaluation = list[tuple[TMapDict, TTrialEvaluation]]
+TMapDict = Mapping[str, Hashable]
+TMapTrialEvaluation = Sequence[tuple[TMapDict, TTrialEvaluation]]
 
 # Format for trasmitting evaluation data to Ax is either:
 # 1) {metric_name -> (mean, standard error)} (TTrialEvaluation)
 # 2) (mean, standard error) and we assume metric name == objective name
 # 3) only the mean, and we assume metric name == objective name and standard error == 0
-# 4) [({fidelity_param -> value}, {metric_name} -> (mean, standard error))]
 
 TEvaluationOutcome = Union[
     TTrialEvaluation,
     SingleMetricData,
-    TFidelityTrialEvaluation,
     TMapTrialEvaluation,
 ]
 TEvaluationFunction = Union[
@@ -114,7 +109,7 @@ def merge_model_predict(
     return mu, cov
 
 
-def validate_floatlike(floatlike: FloatLike) -> None:
+def validate_floatlike(floatlike: Any) -> None:
     if not (
         isinstance(floatlike, float)
         or isinstance(floatlike, int)
@@ -124,7 +119,7 @@ def validate_floatlike(floatlike: FloatLike) -> None:
         raise TypeError(f"Expected FloatLike, found {floatlike}")
 
 
-def validate_single_metric_data(data: SingleMetricData) -> None:
+def validate_single_metric_data(data: Any) -> None:
     if isinstance(data, tuple):
         if len(data) != 2:
             raise TypeError(
@@ -141,7 +136,7 @@ def validate_single_metric_data(data: SingleMetricData) -> None:
         validate_floatlike(floatlike=data)
 
 
-def validate_trial_evaluation(evaluation: TTrialEvaluation) -> None:
+def validate_trial_evaluation(evaluation: Mapping[Any, Any]) -> None:
     for key, value in evaluation.items():
         if not isinstance(key, str):
             raise TypeError(f"Keys must be strings in TTrialEvaluation, found {key}.")
@@ -149,7 +144,7 @@ def validate_trial_evaluation(evaluation: TTrialEvaluation) -> None:
         validate_single_metric_data(data=value)
 
 
-def validate_param_value(param_value: TParamValue) -> None:
+def validate_param_value(param_value: Any) -> None:
     if not (
         isinstance(param_value, str)
         or isinstance(param_value, bool)
@@ -160,7 +155,7 @@ def validate_param_value(param_value: TParamValue) -> None:
         raise TypeError(f"Expected None, bool, float, int, or str, found {param_value}")
 
 
-def validate_parameterization(parameterization: TParameterization) -> None:
+def validate_parameterization(parameterization: Mapping[Any, Any]) -> None:
     for key, value in parameterization.items():
         if not isinstance(key, str):
             raise TypeError(f"Keys must be strings in TParameterization, found {key}.")
@@ -168,7 +163,7 @@ def validate_parameterization(parameterization: TParameterization) -> None:
         validate_param_value(param_value=value)
 
 
-def validate_map_dict(map_dict: TMapDict) -> None:
+def validate_map_dict(map_dict: Mapping[Any, Any]) -> None:
     for key, value in map_dict.items():
         if not isinstance(key, str):
             raise TypeError(f"Keys must be strings in TMapDict, found {key}.")
@@ -177,38 +172,23 @@ def validate_map_dict(map_dict: TMapDict) -> None:
             raise TypeError(f"Values must be Hashable in TMapDict, found {value}.")
 
 
-def validate_fidelity_trial_evaluation(evaluation: TFidelityTrialEvaluation) -> None:
-    for parameterization, trial_evaluation in evaluation:
-        validate_parameterization(parameterization=parameterization)
-        validate_trial_evaluation(evaluation=trial_evaluation)
-
-
 def validate_map_trial_evaluation(evaluation: TMapTrialEvaluation) -> None:
     for map_dict, trial_evaluation in evaluation:
         validate_map_dict(map_dict=map_dict)
         validate_trial_evaluation(evaluation=trial_evaluation)
 
 
-def validate_evaluation_outcome(outcome: TEvaluationOutcome) -> None:
+def validate_evaluation_outcome(outcome: Any) -> None:
     """Runtime validate that the supplied outcome has correct structure."""
 
+    # TTrialEvaluation case
     if isinstance(outcome, dict):
-        # Check if outcome is TTrialEvaluation
         validate_trial_evaluation(evaluation=outcome)
 
+    # TMapTrialEvaluation case
     elif isinstance(outcome, list):
-        # Check if outcome is TFidelityTrialEvaluation or TMapTrialEvaluation
-        try:
-            validate_fidelity_trial_evaluation(evaluation=outcome)  # pyre-ignore[6]
-        except Exception:
-            try:
-                validate_map_trial_evaluation(evaluation=outcome)  # pyre-ignore[6]
-            except Exception:
-                raise TypeError(
-                    "Expected either TFidelityTrialEvaluation or TMapTrialEvaluation, "
-                    f"found {outcome}"
-                )
+        validate_map_trial_evaluation(evaluation=outcome)
 
+    # SingleMetricData case
     else:
-        # Check if outcome is SingleMetricData
         validate_single_metric_data(data=outcome)

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -265,18 +265,6 @@ def get_client_with_simple_discrete_moo_problem(
             metrics = [-m for m in metrics]
         y0, y1, y2 = metrics
         raw_data = {"y0": (y0, 0.0), "y1": (y1, 0.0), "y2": (y2, 0.0)}
-        # pyre-fixme[6]: In call `AxClient.complete_trial`, for 2nd parameter
-        #  `raw_data`
-        #  expected `Union[Dict[str, Union[Tuple[Union[float, floating, integer],
-        #  Union[None, float, floating, integer]], float, floating, integer]],
-        #  List[Tuple[Dict[str, Union[None, bool, float, int, str]], Dict[str,
-        #  Union[Tuple[Union[float, floating, integer], Union[None, float, floating,
-        #  integer]], float, floating, integer]]]], List[Tuple[Dict[str, Hashable],
-        #  Dict[str, Union[Tuple[Union[float, floating, integer], Union[None, float,
-        #  floating, integer]], float, floating, integer]]]], Tuple[Union[float,
-        #  floating,
-        #  integer], Union[None, float, floating, integer]], float, floating, integer]`
-        #  but got `Dict[str, Tuple[float, float]]`.
         ax_client.complete_trial(trial_index=trial_index, raw_data=raw_data)
     return ax_client
 
@@ -1644,7 +1632,6 @@ class TestAxClient(TestCase):
         with self.assertRaises(ValueError):
             no_intermediate_data_ax_client.update_running_trial_with_intermediate_data(
                 0,
-                # pyre-fixme[6]: For 2nd param expected `Union[List[Tuple[Dict[str, U...
                 raw_data=[
                     # pyre-fixme[61]: `t` is undefined, or not always defined.
                     ({"t": p_t}, {"branin": (branin(x, y) + t, 0.0)})

--- a/ax/utils/common/timeutils.py
+++ b/ax/utils/common/timeutils.py
@@ -31,12 +31,6 @@ def _ts_to_pandas(ts: int) -> pd.Timestamp:
     return pd.Timestamp(datetime.fromtimestamp(ts))
 
 
-def _pandas_ts_to_int(ts: pd.Timestamp) -> int:
-    """Convert int timestamp into pandas timestamp."""
-    # pyre-fixme[7]: Expected `int` but got `float`.
-    return ts.to_pydatetime().timestamp()
-
-
 def current_timestamp_in_millis() -> int:
     """Grab current timestamp in milliseconds as an int."""
     return int(round(time() * 1000))


### PR DESCRIPTION
Summary:
Context: Ax supported attaching trial evaluations in several formats which can then be parsed as regular data, map data, or fidelity evaluations depending on the format. As of D77904185, I don't think fidelity valuations can be used, although it is possible that someone might find a way to do it. We could consider deprecating this to be safe, but I'm pretty sure this is unused.

This PR:
* Removes `TFidelityTrialEvaluation`, making it no longer one of the possibilities in `TEvaluationOutcome`
* Fixes some type checks

Differential Revision: D77935826


