### PR TITLE
Require mean and sem on MapData

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -479,10 +479,7 @@ class Client(WithDBSettingsBase):
 
         trial = assert_is_instance(self._experiment.trials[trial_index], Trial)
         trial.update_trial_data(
-            # pyre-fixme[6]: Type narrowing broken because core Ax TParameterization
-            # is dict not Mapping
-            raw_data=data_with_progression,
-            combine_with_last_data=True,
+            raw_data=data_with_progression, combine_with_last_data=True
         )
 
         self._save_or_update_trial_in_db_if_possible(

--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -95,7 +95,6 @@ class MapData(Data):
     `experiment.attach_data()` (this requires a description to be set.)
     """
 
-    REQUIRED_COLUMNS = {"trial_index", "arm_name", "metric_name"}
     DEDUPLICATE_BY_COLUMNS = ["trial_index", "arm_name", "metric_name"]
 
     _map_df: pd.DataFrame

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1388,7 +1388,6 @@ class ExperimentWithMapDataTest(TestCase):
         self.experiment.new_trial()
         self.experiment.trials[0].mark_running(no_runner_required=True)
         first_epoch = MapData.from_map_evaluations(
-            # pyre-fixme[6]: For 1st param expected `Dict[str, List[Tuple[Dict[str, H...
             evaluations={
                 arm_name: partial_results[0:1]
                 for arm_name, partial_results in evaluations.items()
@@ -1397,7 +1396,6 @@ class ExperimentWithMapDataTest(TestCase):
         )
         self.experiment.attach_data(first_epoch)
         remaining_epochs = MapData.from_map_evaluations(
-            # pyre-fixme[6]: For 1st param expected `Dict[str, List[Tuple[Dict[str, H...
             evaluations={
                 arm_name: partial_results[1:4]
                 for arm_name, partial_results in evaluations.items()

--- a/ax/core/tests/test_formatting_utils.py
+++ b/ax/core/tests/test_formatting_utils.py
@@ -60,11 +60,7 @@ class TestRawDataToEvaluation(TestCase):
 
     def test_it_accepts_a_list_for_single_objectives(self) -> None:
         raw_data = [({"arm__0": (0, 1)}, {"objective_a": (1.4, None)})]
-        result = raw_data_to_evaluation(
-            # pyre-fixme[6]: For 1st param expected `Union[Dict[str, Union[Tuple[Unio...
-            raw_data=raw_data,
-            metric_names=["objective_a"],
-        )
+        result = raw_data_to_evaluation(raw_data=raw_data, metric_names=["objective_a"])
         self.assertEqual(raw_data, result)
 
     def test_it_turns_a_tuple_into_a_dict(self) -> None:

--- a/ax/core/tests/test_types.py
+++ b/ax/core/tests/test_types.py
@@ -56,33 +56,42 @@ class TypesTest(TestCase):
     def test_Validate(self) -> None:
         trial_evaluation = {"foo": 0.0}
         trial_evaluation_with_noise = {"foo": (0.0, 0.0)}
-        fidelity_trial_evaluation = [({"a": 0.0}, trial_evaluation)]
         map_trial_evaluation = [({"a": 0.0}, trial_evaluation)]
 
-        validate_evaluation_outcome(outcome=trial_evaluation)  # pyre-ignore[6]
-        validate_evaluation_outcome(
-            outcome=trial_evaluation_with_noise  # pyre-ignore[6]
-        )
-        validate_evaluation_outcome(outcome=fidelity_trial_evaluation)  # pyre-ignore[6]
-        validate_evaluation_outcome(outcome=map_trial_evaluation)  # pyre-ignore[6]
+        validate_evaluation_outcome(outcome=trial_evaluation)
+        validate_evaluation_outcome(outcome=trial_evaluation_with_noise)
+        validate_evaluation_outcome(outcome=map_trial_evaluation)
 
-        with self.assertRaises(TypeError):
-            validate_floatlike(floatlike="foo")  # pyre-ignore[6]
+        with self.assertRaisesRegex(TypeError, "Expected FloatLike, found foo"):
+            validate_floatlike(floatlike="foo")
 
-        with self.assertRaises(TypeError):
-            validate_single_metric_data(data=(0, 1, 2))  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError,
+            "Tuple-valued SingleMetricData must have len",
+        ):
+            validate_single_metric_data(data=(0, 1, 2))
 
-        with self.assertRaises(TypeError):
-            validate_trial_evaluation(evaluation={0: 0})  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError, "Keys must be strings in TTrialEvaluation, found 0."
+        ):
+            validate_trial_evaluation(evaluation={0: 0})
 
-        with self.assertRaises(TypeError):
-            validate_param_value(param_value=[])  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError, "Expected None, bool, float, int, or str, found"
+        ):
+            validate_param_value(param_value=[])
 
-        with self.assertRaises(TypeError):
-            validate_parameterization(parameterization={0: 0})  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError, "Keys must be strings in TParameterization, found 0."
+        ):
+            validate_parameterization(parameterization={0: 0})
 
-        with self.assertRaises(TypeError):
-            validate_map_dict(map_dict={0: 0})  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError, "Keys must be strings in TMapDict, found 0."
+        ):
+            validate_map_dict(map_dict={0: 0})
 
-        with self.assertRaises(TypeError):
-            validate_map_dict(map_dict={"foo": []})  # pyre-ignore[6]
+        with self.assertRaisesRegex(
+            TypeError, "Values must be Hashable in TMapDict, found"
+        ):
+            validate_map_dict(map_dict={"foo": []})

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -8,7 +8,7 @@
 
 import enum
 from collections import defaultdict
-from collections.abc import Callable, Hashable
+from collections.abc import Callable, Hashable, Mapping, Sequence
 from typing import Any, Optional, Union
 
 import numpy as np
@@ -36,25 +36,20 @@ FloatLike = Union[int, float, np.floating, np.integer]
 SingleMetricDataTuple = tuple[FloatLike, Optional[FloatLike]]
 SingleMetricData = Union[FloatLike, tuple[FloatLike, Optional[FloatLike]]]
 # 1-arm `Trial` evaluation data: {metric_name -> (mean, standard error)}}.
-TTrialEvaluation = dict[str, SingleMetricData]
-
-# 1-arm evaluation data with trace fidelities
-TFidelityTrialEvaluation = list[tuple[TParameterization, TTrialEvaluation]]
+TTrialEvaluation = Mapping[str, SingleMetricData]
 
 # 1-arm evaluation data with arbitrary partial results
-TMapDict = dict[str, Hashable]
-TMapTrialEvaluation = list[tuple[TMapDict, TTrialEvaluation]]
+TMapDict = Mapping[str, Hashable]
+TMapTrialEvaluation = Sequence[tuple[TMapDict, TTrialEvaluation]]
 
 # Format for trasmitting evaluation data to Ax is either:
 # 1) {metric_name -> (mean, standard error)} (TTrialEvaluation)
 # 2) (mean, standard error) and we assume metric name == objective name
 # 3) only the mean, and we assume metric name == objective name and standard error == 0
-# 4) [({fidelity_param -> value}, {metric_name} -> (mean, standard error))]
 
 TEvaluationOutcome = Union[
     TTrialEvaluation,
     SingleMetricData,
-    TFidelityTrialEvaluation,
     TMapTrialEvaluation,
 ]
 TEvaluationFunction = Union[
@@ -114,7 +109,7 @@ def merge_model_predict(
     return mu, cov
 
 
-def validate_floatlike(floatlike: FloatLike) -> None:
+def validate_floatlike(floatlike: Any) -> None:
     if not (
         isinstance(floatlike, float)
         or isinstance(floatlike, int)
@@ -124,7 +119,7 @@ def validate_floatlike(floatlike: FloatLike) -> None:
         raise TypeError(f"Expected FloatLike, found {floatlike}")
 
 
-def validate_single_metric_data(data: SingleMetricData) -> None:
+def validate_single_metric_data(data: Any) -> None:
     if isinstance(data, tuple):
         if len(data) != 2:
             raise TypeError(
@@ -141,7 +136,7 @@ def validate_single_metric_data(data: SingleMetricData) -> None:
         validate_floatlike(floatlike=data)
 
 
-def validate_trial_evaluation(evaluation: TTrialEvaluation) -> None:
+def validate_trial_evaluation(evaluation: Mapping[Any, Any]) -> None:
     for key, value in evaluation.items():
         if not isinstance(key, str):
             raise TypeError(f"Keys must be strings in TTrialEvaluation, found {key}.")
@@ -149,7 +144,7 @@ def validate_trial_evaluation(evaluation: TTrialEvaluation) -> None:
         validate_single_metric_data(data=value)
 
 
-def validate_param_value(param_value: TParamValue) -> None:
+def validate_param_value(param_value: Any) -> None:
     if not (
         isinstance(param_value, str)
         or isinstance(param_value, bool)
@@ -160,7 +155,7 @@ def validate_param_value(param_value: TParamValue) -> None:
         raise TypeError(f"Expected None, bool, float, int, or str, found {param_value}")
 
 
-def validate_parameterization(parameterization: TParameterization) -> None:
+def validate_parameterization(parameterization: Mapping[Any, Any]) -> None:
     for key, value in parameterization.items():
         if not isinstance(key, str):
             raise TypeError(f"Keys must be strings in TParameterization, found {key}.")
@@ -168,7 +163,7 @@ def validate_parameterization(parameterization: TParameterization) -> None:
         validate_param_value(param_value=value)
 
 
-def validate_map_dict(map_dict: TMapDict) -> None:
+def validate_map_dict(map_dict: Mapping[Any, Any]) -> None:
     for key, value in map_dict.items():
         if not isinstance(key, str):
             raise TypeError(f"Keys must be strings in TMapDict, found {key}.")
@@ -177,38 +172,23 @@ def validate_map_dict(map_dict: TMapDict) -> None:
             raise TypeError(f"Values must be Hashable in TMapDict, found {value}.")
 
 
-def validate_fidelity_trial_evaluation(evaluation: TFidelityTrialEvaluation) -> None:
-    for parameterization, trial_evaluation in evaluation:
-        validate_parameterization(parameterization=parameterization)
-        validate_trial_evaluation(evaluation=trial_evaluation)
-
-
 def validate_map_trial_evaluation(evaluation: TMapTrialEvaluation) -> None:
     for map_dict, trial_evaluation in evaluation:
         validate_map_dict(map_dict=map_dict)
         validate_trial_evaluation(evaluation=trial_evaluation)
 
 
-def validate_evaluation_outcome(outcome: TEvaluationOutcome) -> None:
+def validate_evaluation_outcome(outcome: Any) -> None:
     """Runtime validate that the supplied outcome has correct structure."""
 
+    # TTrialEvaluation case
     if isinstance(outcome, dict):
-        # Check if outcome is TTrialEvaluation
         validate_trial_evaluation(evaluation=outcome)
 
+    # TMapTrialEvaluation case
     elif isinstance(outcome, list):
-        # Check if outcome is TFidelityTrialEvaluation or TMapTrialEvaluation
-        try:
-            validate_fidelity_trial_evaluation(evaluation=outcome)  # pyre-ignore[6]
-        except Exception:
-            try:
-                validate_map_trial_evaluation(evaluation=outcome)  # pyre-ignore[6]
-            except Exception:
-                raise TypeError(
-                    "Expected either TFidelityTrialEvaluation or TMapTrialEvaluation, "
-                    f"found {outcome}"
-                )
+        validate_map_trial_evaluation(evaluation=outcome)
 
+    # SingleMetricData case
     else:
-        # Check if outcome is SingleMetricData
         validate_single_metric_data(data=outcome)

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -265,18 +265,6 @@ def get_client_with_simple_discrete_moo_problem(
             metrics = [-m for m in metrics]
         y0, y1, y2 = metrics
         raw_data = {"y0": (y0, 0.0), "y1": (y1, 0.0), "y2": (y2, 0.0)}
-        # pyre-fixme[6]: In call `AxClient.complete_trial`, for 2nd parameter
-        #  `raw_data`
-        #  expected `Union[Dict[str, Union[Tuple[Union[float, floating, integer],
-        #  Union[None, float, floating, integer]], float, floating, integer]],
-        #  List[Tuple[Dict[str, Union[None, bool, float, int, str]], Dict[str,
-        #  Union[Tuple[Union[float, floating, integer], Union[None, float, floating,
-        #  integer]], float, floating, integer]]]], List[Tuple[Dict[str, Hashable],
-        #  Dict[str, Union[Tuple[Union[float, floating, integer], Union[None, float,
-        #  floating, integer]], float, floating, integer]]]], Tuple[Union[float,
-        #  floating,
-        #  integer], Union[None, float, floating, integer]], float, floating, integer]`
-        #  but got `Dict[str, Tuple[float, float]]`.
         ax_client.complete_trial(trial_index=trial_index, raw_data=raw_data)
     return ax_client
 
@@ -1644,7 +1632,6 @@ class TestAxClient(TestCase):
         with self.assertRaises(ValueError):
             no_intermediate_data_ax_client.update_running_trial_with_intermediate_data(
                 0,
-                # pyre-fixme[6]: For 2nd param expected `Union[List[Tuple[Dict[str, U...
                 raw_data=[
                     # pyre-fixme[61]: `t` is undefined, or not always defined.
                     ({"t": p_t}, {"branin": (branin(x, y) + t, 0.0)})


### PR DESCRIPTION
Summary:
Context: Currently, Data.REQUIRED_COLUMNS is `{"trial_index", "arm_name", "metric_name", "mean", "sem"}` and `MapData.REQUIRED_COLUMNS` is `{"trial_index", "arm_name", "metric_name"}`, excluding "mean" and "sem."  It seems like when these different data classes were introduced, there was an intent to support different data types on each, but now we always use mean and sem.

Also, this is a step on the way to consolidating Data and MapData.

This PR: Removes `MapData.REQUIRED_COLUMNS` so that it gets its required columns from its super class, `Data`. This means that mean and sem are now required.

Differential Revision: D77948104


