### PR TITLE
Allow for importing "save_analysis_card" to fail in non sqlalchemy environments

### DIFF
--- a/ax/service/tests/test_with_db_settings_base_minimal_dependencies.py
+++ b/ax/service/tests/test_with_db_settings_base_minimal_dependencies.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest.mock import patch
+
+from ax.utils.common.testutils import TestCase
+
+
+class TestWithDbSetingsBaseMinimalDependencies(TestCase):
+    @patch.dict("sys.modules", {"sqlalchemy": None})
+    def test_with_db_settings_base_no_sql_alchemy(self) -> None:
+        from ax.service.utils.with_db_settings_base import WithDBSettingsBase  # noqa

--- a/ax/service/utils/with_db_settings_base.py
+++ b/ax/service/utils/with_db_settings_base.py
@@ -22,7 +22,7 @@ from ax.exceptions.core import (
     UnsupportedError,
 )
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from ax.storage.sqa_store.save import save_analysis_card
+
 from ax.utils.common.executils import retry_on_exception
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
 from pyre_extensions import none_throws
@@ -60,11 +60,13 @@ try:  # We don't require SQLAlchemy by default.
         _load_generation_strategy_by_experiment_name,
         get_generation_strategy_id,
     )
+
     from ax.storage.sqa_store.save import (
         _save_experiment,
         _save_generation_strategy,
         _save_or_update_trials,
         _update_generation_strategy,
+        save_analysis_card,
         update_properties_on_experiment,
         update_runner_on_experiment,
     )


### PR DESCRIPTION
Summary:
Nightly cron jobs are failing "Tests with latest BoTorch & minimal dependencies / tests-and-coverage (3.10)"
https://github.com/facebook/Ax/actions/runs/16212247566/job/45774446848 

```
> Install dependencies with latest Botorch (minimal dependencies true)

> Run python scripts/import_ax.py
  ...
    from ax.storage.sqa_store.save import save_analysis_card
  File "/home/runner/work/Ax/Ax/ax/storage/sqa_store/__init__.py", line 11, in <module>
    from ax.storage.sqa_store import validation
  File "/home/runner/work/Ax/Ax/ax/storage/sqa_store/validation.py", line 13, in <module>
    from ax.storage.sqa_store.db import SQABase
  File "/home/runner/work/Ax/Ax/ax/storage/sqa_store/db.py", line 16, in <module>
    from sqlalchemy import create_engine
ModuleNotFoundError: No module named 'sqlalchemy'
Error: Process completed with exit code 1.
```

# Fix

Move the import of "save_analysis_card" into the try block that allows for sqlalchemy to not be included.

Rollback Plan:

Differential Revision: D78163052


