### PR TITLE
Add relativization to Insights, TopSurfaces

### DIFF
--- a/ax/analysis/insights.py
+++ b/ax/analysis/insights.py
@@ -13,6 +13,7 @@ from ax.analysis.analysis_card import (
     ErrorAnalysisCard,
 )
 from ax.analysis.plotly.top_surfaces import TopSurfacesAnalysis
+from ax.core.batch_trial import BatchTrial
 from ax.core.experiment import Experiment
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
@@ -44,6 +45,12 @@ class InsightsAnalysis(Analysis):
                 "Cannot compute InsightsAnalysis, Experiment has no data."
             )
 
+        # Relativize the effects if the status quo is set and there are BatchTrials
+        # present.
+        relativize = experiment.status_quo is not None and any(
+            isinstance(trial, BatchTrial) for trial in experiment.trials.values()
+        )
+
         # If the Experiment has an OptimizationConfig set, extract the objective and
         # constraint names.
         objective_names = []
@@ -66,6 +73,7 @@ class InsightsAnalysis(Analysis):
             maybe_top_surfaces_group = TopSurfacesAnalysis(
                 metric_name=metric_name,
                 top_k=3,
+                relativize=relativize,
             ).compute_or_error_card(
                 experiment=experiment,
                 generation_strategy=generation_strategy,

--- a/ax/analysis/plotly/top_surfaces.py
+++ b/ax/analysis/plotly/top_surfaces.py
@@ -27,10 +27,12 @@ class TopSurfacesAnalysis(PlotlyAnalysis):
         metric_name: str | None = None,
         order: Literal["first", "second", "total"] = "second",
         top_k: int = 5,
+        relativize: bool = False,
     ) -> None:
         self.metric_name = metric_name
         self.order = order
         self.top_k = top_k
+        self.relativize = relativize
 
     @override
     def compute(
@@ -86,6 +88,7 @@ class TopSurfacesAnalysis(PlotlyAnalysis):
                 experiment=experiment,
                 generation_strategy=generation_strategy,
                 adapter=adapter,
+                relativize=self.relativize,
             )
             for surface_name in top_surfaces
         ]
@@ -125,6 +128,7 @@ def _compute_surface_plot(
     experiment: Experiment | None,
     generation_strategy: GenerationStrategy | None,
     adapter: Adapter | None,
+    relativize: bool = False,
 ) -> PlotlyAnalysisCard:
     """Computes either a Slice or Contour plot for a given surface.
     Args:
@@ -145,10 +149,13 @@ def _compute_surface_plot(
             x_parameter_name=x_parameter_name,
             y_parameter_name=y_parameter_name,
             metric_name=metric_name,
+            relativize=relativize,
         )
 
     else:
-        analysis = SlicePlot(parameter_name=surface_name, metric_name=metric_name)
+        analysis = SlicePlot(
+            parameter_name=surface_name, metric_name=metric_name, relativize=relativize
+        )
 
     return analysis.compute(
         experiment=experiment,


### PR DESCRIPTION
Summary: use same logic as implemented for `ResultsAnalysis` to enable relativization for `SlicePlot` and `ContourPlot` within `InsightsAnalysis` and `TopSurfacesAnalysis`

Differential Revision: D78125703


