### PR TITLE
Remove log & logit-scale options from MapKeyToFloat / MetadataToFloat

### DIFF
--- a/ax/adapter/transforms/map_key_to_float.py
+++ b/ax/adapter/transforms/map_key_to_float.py
@@ -6,9 +6,11 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 import warnings
 from math import isnan
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.metadata_to_float import MetadataToFloat
@@ -30,25 +32,21 @@ class MapKeyToFloat(MetadataToFloat):
     and inserts it into the parameter field. If no parameters are specified in the
     config, the transform will extract all map key names from the optimization config.
 
-    Inheriting from the `MetadataToFloat` transform, this transform
-    also adds a range (float) parameter to the search space.
-    Similarly, users can override the default behavior by specifying
-    the `config` with `parameters` as the key, where each entry maps
-    a metadata key to a dictionary of keyword arguments for the
-    corresponding RangeParameter constructor.
+    Inheriting from the `MetadataToFloat` transform, this transform also adds a range
+    (float) parameter to the search space. Similarly, users can override the default
+    behavior by specifying the `config` with `parameters` as the key, where each entry
+    maps a metadata key to a dictionary of keyword arguments for the corresponding
+    RangeParameter constructor. NOTE: log and logit-scale options are not supported.
 
     Transform is done in-place.
     """
-
-    # NOTE: This will be ignored if the lower bound is <= 0.
-    DEFAULT_LOG_SCALE: bool = True
 
     def __init__(
         self,
         search_space: SearchSpace | None = None,
         observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         config = config or {}

--- a/ax/adapter/transforms/metadata_to_float.py
+++ b/ax/adapter/transforms/metadata_to_float.py
@@ -38,18 +38,14 @@ class MetadataToFloat(Transform):
 
     It allows the user to specify the `config` with `parameters` as the key, where
     each entry maps a metadata key to a dictionary of keyword arguments for the
-    corresponding RangeParameter constructor. The `config` can also be used to
-    override `default_log_scale` for all parameters. Note that any parameter
-    with a lower bound <= 0 will not be set to log scale regardless of the
-    specified log scale setting.
+    corresponding RangeParameter constructor. NOTE: log and logit-scale options
+    are not supported.
 
     Transform is done in-place.
     """
 
     requires_data_for_initialization: bool = True
 
-    DEFAULT_LOG_SCALE: bool = False
-    DEFAULT_LOGIT_SCALE: bool = False
     DEFAULT_IS_FIDELITY: bool = False
     ENFORCE_BOUNDS: bool = False
 
@@ -72,7 +68,6 @@ class MetadataToFloat(Transform):
         self.parameters: dict[str, dict[str, Any]] = assert_is_instance(
             config.get("parameters", {}), dict
         )
-        default_log_scale = config.get("default_log_scale", self.DEFAULT_LOG_SCALE)
 
         self._parameter_list: list[RangeParameter] = []
         for name in self.parameters:
@@ -97,10 +92,6 @@ class MetadataToFloat(Transform):
             lower: float = self.parameters[name].get("lower", min(values))
             upper: float = self.parameters[name].get("upper", max(values))
 
-            log_scale = self.parameters[name].get("log_scale", default_log_scale)
-            logit_scale = self.parameters[name].get(
-                "logit_scale", self.DEFAULT_LOGIT_SCALE
-            )
             digits = self.parameters[name].get("digits")
             is_fidelity = self.parameters[name].get(
                 "is_fidelity", self.DEFAULT_IS_FIDELITY
@@ -113,8 +104,6 @@ class MetadataToFloat(Transform):
                 parameter_type=ParameterType.FLOAT,
                 lower=lower,
                 upper=upper,
-                log_scale=log_scale and lower > 0.0,
-                logit_scale=logit_scale,
                 digits=digits,
                 is_fidelity=is_fidelity,
                 target_value=target_value,

--- a/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
@@ -285,7 +285,7 @@ class MapKeyToFloatTransformTest(TestCase):
             self.assertEqual(p.parameter_type, ParameterType.FLOAT)
             self.assertEqual(p.lower, 0.0)
             self.assertEqual(p.upper, 4.0)
-            self.assertFalse(p.log_scale)  # False since lower is 0.0.
+            self.assertFalse(p.log_scale)
 
         # specifying a parameter name that is not in the observation features' metadata
         with self.assertRaisesRegex(KeyError, "'baz'"):
@@ -298,13 +298,9 @@ class MapKeyToFloatTransformTest(TestCase):
         with self.subTest(msg="override default config"):
             t = MapKeyToFloat(
                 observations=self.observations,
-                config={
-                    "parameters": {self.map_key: {"lower": 0.1, "log_scale": True}}
-                },
+                config={"parameters": {self.map_key: {"lower": 0.1}}},
             )
-            self.assertDictEqual(
-                t.parameters, {self.map_key: {"lower": 0.1, "log_scale": True}}
-            )
+            self.assertDictEqual(t.parameters, {self.map_key: {"lower": 0.1}})
             self.assertEqual(len(t._parameter_list), 1)
 
             p = t._parameter_list[0]
@@ -313,7 +309,7 @@ class MapKeyToFloatTransformTest(TestCase):
             self.assertEqual(p.parameter_type, ParameterType.FLOAT)
             self.assertEqual(p.lower, 0.1)
             self.assertEqual(p.upper, 4.0)
-            self.assertTrue(p.log_scale)
+            self.assertFalse(p.log_scale)
 
     def test_TransformSearchSpace(self) -> None:
         ss2 = deepcopy(self.search_space)

--- a/ax/adapter/transforms/tests/test_metadata_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_metadata_to_float_transform.py
@@ -85,13 +85,13 @@ class MetadataToFloatTransformTest(TestCase):
         self.t = MetadataToFloat(
             observations=self.observations,
             config={
-                "parameters": {"bar": {"log_scale": True}},
+                "parameters": {"bar": {"digits": 4}},
             },
         )
         self.t2 = MetadataToFloat(
             experiment_data=self.experiment_data,
             config={
-                "parameters": {"bar": {"log_scale": True}},
+                "parameters": {"bar": {"digits": 4}},
             },
         )
 
@@ -105,9 +105,9 @@ class MetadataToFloatTransformTest(TestCase):
             self.assertEqual(p.parameter_type, ParameterType.FLOAT)
             self.assertEqual(p.lower, 3.0)
             self.assertEqual(p.upper, 15.0)
-            self.assertTrue(p.log_scale)
+            self.assertFalse(p.log_scale)
             self.assertFalse(p.logit_scale)
-            self.assertIsNone(p.digits)
+            self.assertEqual(p.digits, 4)
             self.assertFalse(p.is_fidelity)
             self.assertIsNone(p.target_value)
 
@@ -131,9 +131,9 @@ class MetadataToFloatTransformTest(TestCase):
         self.assertEqual(p.parameter_type, ParameterType.FLOAT)
         self.assertEqual(p.lower, 3.0)
         self.assertEqual(p.upper, 15.0)
-        self.assertTrue(p.log_scale)
+        self.assertFalse(p.log_scale)
         self.assertFalse(p.logit_scale)
-        self.assertIsNone(p.digits)
+        self.assertEqual(p.digits, 4)
         self.assertFalse(p.is_fidelity)
         self.assertIsNone(p.target_value)
 


### PR DESCRIPTION
Summary: The log / logit scale options in these transfroms necessitate applying the corresponding transform to the parameters & parameter values added by these transforms. This creates some complications when using the transforms with `ExperimentData`, which was discussed in detail in D78094423. Based on that discussion, we're opting to disallow log / logit scale in these generated parameters, which simplifies the setup.

Reviewed By: Balandat

Differential Revision: D78168504


