### PR TITLE
Fix regex in _sanitize_name

### DIFF
--- a/ax/api/utils/instantiation/from_string.py
+++ b/ax/api/utils/instantiation/from_string.py
@@ -297,17 +297,17 @@ def _sanitize_name(s: str) -> str:
     # Replace occurances of "." and "/" when they appear after a valid Python variable
     # name and before any alphanumeric character.
     sans_dots = re.sub(
-        r"([a-zA-Z_][a-zA-Z0-9_])\.([a-zA-Z0-9_])",
+        r"([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z0-9_])",
         rf"\1{DOT_PLACEHOLDER}\2",
         s,
     )
     sans_slash = re.sub(
-        r"([a-zA-Z_][a-zA-Z0-9_])\/([a-zA-Z0-9_])",
+        r"([a-zA-Z_][a-zA-Z0-9_]*)\/([a-zA-Z0-9_])",
         rf"\1{SLASH_PLACEHOLDER}\2",
         sans_dots,
     )
     sans_colon = re.sub(
-        r"([a-zA-Z_][a-zA-Z0-9_]):([a-zA-Z0-9_])",
+        r"([a-zA-Z_][a-zA-Z0-9_]*):([a-zA-Z0-9_])",
         rf"\1{COLON_PLACEHOLDER}\2",
         sans_slash,
     )

--- a/ax/api/utils/instantiation/tests/test_from_string.py
+++ b/ax/api/utils/instantiation/tests/test_from_string.py
@@ -241,7 +241,7 @@ class TestFromString(TestCase):
     def test_sanitize_name(self) -> None:
         self.assertEqual(_sanitize_name("foo.bar.baz"), "foo__dot__bar__dot__baz")
         self.assertEqual(
-            _sanitize_name("foo.bar/1:Baz"), "foo__dot__bar__slash__1__colon__Baz"
+            _sanitize_name("foo.bar/11:Baz"), "foo__dot__bar__slash__11__colon__Baz"
         )
         self.assertEqual(
             _sanitize_name("foo.bar + 0.1 * baz"), "foo__dot__bar + 0.1 * baz"


### PR DESCRIPTION
Summary:
Previous regex was not allowing us to sanitize away all expected special characters because it was not capturing multiple digits which came directly before an illegal character (ex. `task_11:foo` 's colon was not getting picked up).

This fixes the issue and adds a unit test.

Differential Revision: D78347931


