### PR TITLE
Filter Trials for Sampled Points on Plots

### DIFF
--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -26,6 +26,7 @@ from ax.analysis.plotly.utils import select_metric, truncate_label
 from ax.analysis.utils import extract_relevant_adapter, relativize_data
 from ax.core.experiment import Experiment
 from ax.core.observation import ObservationFeatures
+from ax.core.trial_status import STATUSES_EXPECTING_DATA
 from ax.core.utils import get_target_trial_index
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
@@ -198,6 +199,7 @@ def _prepare_data(
             "trial_index": trial.index,
         }
         for trial in experiment.trials.values()
+        if trial.status in STATUSES_EXPECTING_DATA  # running, completed, early stopped
         for arm in trial.arms
     ]
 

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -31,6 +31,7 @@ from ax.analysis.plotly.utils import (
 from ax.analysis.utils import extract_relevant_adapter, relativize_data
 from ax.core.experiment import Experiment
 from ax.core.observation import ObservationFeatures
+from ax.core.trial_status import STATUSES_EXPECTING_DATA
 from ax.core.utils import get_target_trial_index
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
@@ -189,6 +190,7 @@ def _prepare_data(
             "trial_index": trial.index,
         }
         for trial in experiment.trials.values()
+        if trial.status in STATUSES_EXPECTING_DATA  # running, completed, early stopped
         for arm in trial.arms
         # Exclude parameter values which are not valid (ex. None when the parameter is
         # not known in a status quo arm).

--- a/ax/analysis/plotly/surface/tests/test_contour.py
+++ b/ax/analysis/plotly/surface/tests/test_contour.py
@@ -161,3 +161,19 @@ class TestContourPlot(TestCase):
 
         # Less-than-or-equal to because we may have removed some duplicates
         self.assertTrue(card.df["sampled"].sum() <= len(self.client.experiment.trials))
+
+    def test_trial_status_filtering(self) -> None:
+        trial_index = self.client.experiment.new_trial().index
+        self.client.experiment.trials[trial_index].mark_abandoned()
+
+        analysis = ContourPlot(
+            x_parameter_name="x", y_parameter_name="y", metric_name="bar"
+        )
+        card = analysis.compute(
+            experiment=self.client.experiment,
+            generation_strategy=self.client.generation_strategy,
+        )
+        self.assertNotIn(
+            trial_index,
+            card.df["trial_index"].values,
+        )

--- a/ax/analysis/plotly/surface/tests/test_slice.py
+++ b/ax/analysis/plotly/surface/tests/test_slice.py
@@ -133,3 +133,18 @@ class TestSlicePlot(TestCase):
                 axis=1,
             ).all()
         )
+
+    def test_trial_status_filtering(self) -> None:
+        trial_index = self.client.experiment.new_trial().index
+        self.client.experiment.trials[trial_index].mark_abandoned()
+
+        analysis = SlicePlot(parameter_name="x", metric_name="bar")
+
+        card = analysis.compute(
+            experiment=self.client.experiment,
+            generation_strategy=self.client.generation_strategy,
+        )
+        self.assertNotIn(
+            trial_index,
+            card.df["trial_index"].values,
+        )


### PR DESCRIPTION
Summary:
`SlicePlot` and `ContourPlot` currently do not filter for `TrialStatus` when plotting sampled points (x's on the plot). This means we plot points as "sampled", even when the Trial has failed and the arms were never run.

This diff adds filtering for `TrialStatus` to be in `STATUSES_EXPECTING_DATA` (completed, running, early stopped) so the sampled points are only from arms that have been run.

Differential Revision: D78353511


