### PR TITLE
Add "quality" method to configure_generation_strategy

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -173,7 +173,7 @@ class Client(WithDBSettingsBase):
 
     def configure_generation_strategy(
         self,
-        method: Literal["fast", "random_search"] = "fast",
+        method: Literal["quality", "fast", "random_search"] = "fast",
         # Initialization options
         initialization_budget: int | None = None,
         initialization_random_seed: int | None = None,
@@ -1030,7 +1030,7 @@ class Client(WithDBSettingsBase):
 
     def _choose_generation_strategy(
         self,
-        method: Literal["fast", "random_search"] = "fast",
+        method: Literal["quality", "fast", "random_search"] = "fast",
         # Initialization options
         initialization_budget: int | None = None,
         initialization_random_seed: int | None = None,

--- a/ax/api/utils/generation_strategy_dispatch.py
+++ b/ax/api/utils/generation_strategy_dispatch.py
@@ -20,6 +20,7 @@ from ax.generation_strategy.generation_strategy import (
 from ax.generation_strategy.generator_spec import GeneratorSpec
 from ax.generation_strategy.transition_criterion import MinTrials
 from ax.generators.torch.botorch_modular.surrogate import ModelConfig, SurrogateSpec
+from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 
 
 def _get_sobol_node(
@@ -103,7 +104,18 @@ def _get_mbm_node(
     - FAST: An empty model config that utilizes MBM defaults.
     """
     # Construct the surrogate spec.
-    if method == "fast":
+    if method == "quality":
+        model_configs = [
+            ModelConfig(
+                botorch_model_class=SaasFullyBayesianSingleTaskGP,
+                model_options={"use_input_warping": True},
+                mll_options={
+                    "disable_progbar": True,
+                },
+                name="WarpedSAAS",
+            )
+        ]
+    elif method == "fast":
         model_configs = [ModelConfig(name="MBM defaults")]
     else:
         raise UnsupportedError(f"Unsupported generation method: {method}.")

--- a/ax/api/utils/structs.py
+++ b/ax/api/utils/structs.py
@@ -75,7 +75,7 @@ class GenerationStrategyDispatchStruct:
             input corresponds to a valid device.
     """
 
-    method: Literal["fast", "random_search"] = "fast"
+    method: Literal["quality", "fast", "random_search"] = "fast"
     # Initialization options
     initialization_budget: int | None = None
     initialization_random_seed: int | None = None


### PR DESCRIPTION
Summary:
Add a new option on the "method" parameter called "quality". This parameter controls the relative computational expense of computing the next candidate during optimization -- users can specify "quality" to indicate they would like Ax to generate the highest quality candidates it is able to, at the expense of slow runtime.

Under the hood this dispatches to SaasFullyBayesianSingleTaskGP with input warping

Differential Revision: D78428692


