### PR TITLE
Add MarginalEffectsPlot and BanditRollout to init

### DIFF
--- a/ax/analysis/plotly/__init__.py
+++ b/ax/analysis/plotly/__init__.py
@@ -6,7 +6,9 @@
 # pyre-strict
 
 from ax.analysis.plotly.arm_effects import ArmEffectsPlot
+from ax.analysis.plotly.bandit_rollout import BanditRollout
 from ax.analysis.plotly.cross_validation import CrossValidationPlot
+from ax.analysis.plotly.marginal_effects import MarginalEffectsPlot
 from ax.analysis.plotly.parallel_coordinates import ParallelCoordinatesPlot
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
 from ax.analysis.plotly.progression import ProgressionPlot
@@ -18,8 +20,10 @@ from ax.analysis.plotly.top_surfaces import TopSurfacesAnalysis
 
 __all__ = [
     "ArmEffectsPlot",
+    "BanditRollout",
     "ContourPlot",
     "CrossValidationPlot",
+    "MarginalEffectsPlot",
     "ParallelCoordinatesPlot",
     "PlotlyAnalysisCard",
     "ProgressionPlot",


### PR DESCRIPTION
Summary: As titled, add these two analyses to be included in the __init__ file

Differential Revision: D78524654


