### PR TITLE
Apply `rounding_func` when using `HitAndRunPolytopeSampler` fallback

### DIFF
--- a/ax/generators/model_utils.py
+++ b/ax/generators/model_utils.py
@@ -99,6 +99,10 @@ def rejection_sample(
         existing_points: A set of previously generated points to use
             for deduplication. These should be provided in the parameter
             space model operates in.
+
+    Returns:
+        2-element tuple containing the generated points and the number of
+        attempted draws.
     """
     # We need to perform the round trip transformation on our generated point
     # in order to deduplicate in the original search space.
@@ -162,8 +166,8 @@ def rejection_sample(
             f", without finding sufficiently many ({n}) candidates). This likely means "
             "that there are no new points left in the search space."
         )
-    else:
-        return (points, attempted_draws)
+
+    return (points, attempted_draws)
 
 
 def check_duplicate(point: npt.NDArray, points: npt.NDArray) -> bool:

--- a/ax/generators/random/base.py
+++ b/ax/generators/random/base.py
@@ -156,7 +156,10 @@ class RandomGenerator(Generator):
         try:
             # Always rejection sample, but this only rejects if there are
             # constraints or actual duplicates and deduplicate is specified.
-            # If rejection sampling fails, fall back to polytope sampling
+            # If rejection sampling fails, fall back to polytope sampling.
+            # NOTE: The rejection sampling logic in `rejection_sample` only
+            # rejects points that do not satisfy the linear constraints;
+            # it does not consider the rounding function.
             points, attempted_draws = rejection_sample(
                 gen_unconstrained=self._gen_unconstrained,
                 n=n,
@@ -204,7 +207,10 @@ class RandomGenerator(Generator):
                     seed=self.seed + num_generated,
                 )
                 points = polytope_sampler.draw(n=n).numpy()
-                # TODO: Should this round & deduplicate?
+                if rounding_func is not None:
+                    points = rounding_func(points)
+                # TODO: Deduplicate points (should refactor deduplication logic
+                # to cover both the rejection sampling and polytope sampling cases.
             else:
                 raise e
 


### PR DESCRIPTION
Summary:
As the title suggests.

 I also started working on enabling deduplication for this, but it was getting rather lengthy with repeated code, we should  consolidate the deduplication logic with that in the standard rejection sampling setup: T231696889

Differential Revision: D78633005


