### PR TITLE
change batch limit back to 5 to be safe

### DIFF
--- a/ax/generators/tests/test_botorch_model.py
+++ b/ax/generators/tests/test_botorch_model.py
@@ -444,7 +444,7 @@ class LegacyBoTorchGeneratorTest(TestCase):
                 mock_optimize_acqf.call_args.kwargs["options"]["init_batch_limit"], 32
             )
             self.assertEqual(
-                mock_optimize_acqf.call_args.kwargs["options"]["batch_limit"], 20
+                mock_optimize_acqf.call_args.kwargs["options"]["batch_limit"], 5
             )
 
             # Repeat without mocking optimize_acqf to make sure it runs

--- a/ax/generators/torch/botorch_defaults.py
+++ b/ax/generators/torch/botorch_defaults.py
@@ -498,7 +498,7 @@ def scipy_optimizer(
 
     sequential = not joint_optimization
     optimize_acqf_options: dict[str, bool | float | int | str] = {
-        "batch_limit": 20,  # these are overwritten by the defaults
+        "batch_limit": 5,  # these are overwritten by the defaults
         # in `botorch_modular.optimizer_argparse`
         "init_batch_limit": 32,
         "max_optimization_problem_aggregation_size": 5,  # this is to make sure we

--- a/ax/generators/torch/botorch_modular/optimizer_argparse.py
+++ b/ax/generators/torch/botorch_modular/optimizer_argparse.py
@@ -18,7 +18,7 @@ from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
 NUM_RESTARTS = 20
 RAW_SAMPLES = 1024
 INIT_BATCH_LIMIT = 32
-BATCH_LIMIT = 20
+BATCH_LIMIT = 5
 MAX_OPT_AGG_SIZE = 5
 
 

--- a/ax/generators/torch/tests/test_acquisition.py
+++ b/ax/generators/torch/tests/test_acquisition.py
@@ -327,7 +327,7 @@ class AcquisitionTest(TestCase):
             q=n,
             options={
                 "init_batch_limit": 32,
-                "batch_limit": 20,
+                "batch_limit": 5,
                 "max_optimization_problem_aggregation_size": 5,
             },
             inequality_constraints=self.inequality_constraints,
@@ -673,7 +673,7 @@ class AcquisitionTest(TestCase):
             acq_function=acquisition.acqf,
             bounds=mock.ANY,
             q=3,
-            options={"init_batch_limit": 32, "batch_limit": 20},
+            options={"init_batch_limit": 32, "batch_limit": 5},
             fixed_features_list=[{1: 0}, {1: 1}, {1: 2}],
             inequality_constraints=self.inequality_constraints,
             post_processing_func=self.rounding_func,
@@ -722,7 +722,7 @@ class AcquisitionTest(TestCase):
             q=3,
             options={
                 "init_batch_limit": 32,
-                "batch_limit": 20,
+                "batch_limit": 5,
                 "maxiter_alternating": 2,
             },
             inequality_constraints=self.inequality_constraints,
@@ -760,7 +760,7 @@ class AcquisitionTest(TestCase):
             q=3,
             options={
                 "init_batch_limit": 32,
-                "batch_limit": 20,
+                "batch_limit": 5,
                 "maxiter_alternating": 2,
             },
             inequality_constraints=self.inequality_constraints,

--- a/ax/utils/testing/tests/test_mock.py
+++ b/ax/utils/testing/tests/test_mock.py
@@ -70,7 +70,7 @@ class TestMock(TestCase):
             opt_inputs.options,
             {
                 "init_batch_limit": 32,
-                "batch_limit": 20,
+                "batch_limit": 5,
                 "maxiter_alternating": 1,
                 "maxiter_continuous": 1,
                 "maxiter_init": 1,


### PR DESCRIPTION
Summary: It seems like there might be some non-stochastic worsening of performance on some benchmarks after increasing the batch_limit. This should not happen, as the batch is evaluated independently, but there might be e.g. numerical differences when evaluating models in parallel.

Differential Revision: D78667041


