### PR TITLE
Rename default map key of _APIMetric to "step" for consistency

### DIFF
--- a/ax/api/protocols/utils.py
+++ b/ax/api/protocols/utils.py
@@ -37,7 +37,7 @@ class _APIMetric(MapMetric, ABC):
     structure of ax.core.Metric to be more in line with our long term vision for Ax.
     """
 
-    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="progression", default_value=0.0)
+    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="step", default_value=0.0)
 
     def __init__(self, name: str) -> None:
         super().__init__(name=name)

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -770,7 +770,7 @@ class TestClient(TestCase):
                         "metric_name": {0: "foo", 1: "foo", 2: "foo", 3: "foo"},
                         "mean": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
                         "sem": {0: np.nan, 1: np.nan, 2: np.nan, 3: np.nan},
-                        "progression": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                        "step": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
                     }
                 )
             ),


### PR DESCRIPTION
Summary:
The rest of the API uses the map key "step".  Using
"progression" here was causing addition of two separate map key columns in MapData, which leads to errors when constructing `ExperimentData` (which requires single map key)

Differential Revision: D78678165


