### PR TITLE
Add ExperimentData.metric_names property

### DIFF
--- a/ax/adapter/data_utils.py
+++ b/ax/adapter/data_utils.py
@@ -261,6 +261,15 @@ class ExperimentData:
             )
         return observations
 
+    @property
+    def metric_names(self) -> list[str]:
+        """The list of metric names that are available on ``observation_data``."""
+        try:
+            return list(self.observation_data["mean"].columns)
+        except KeyError:
+            # No data is available, return empty list.
+            return []
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ExperimentData):
             return False

--- a/ax/adapter/tests/test_data_utils.py
+++ b/ax/adapter/tests/test_data_utils.py
@@ -223,7 +223,7 @@ class TestDataUtils(TestCase):
         )
         # Observation data: By default only includes completed map metrics.
         # There is none, so map metrics are not included.
-        metrics = set(experiment_data.observation_data["mean"])
+        metrics = set(experiment_data.metric_names)
         self.assertEqual(metrics, {"branin"})
         self.assertEqual(len(experiment_data.observation_data), 2)
         # Complete a trial to include map metrics.
@@ -238,7 +238,7 @@ class TestDataUtils(TestCase):
         )
         # Observation data: Map metrics should be included but only with latest
         # timestamp for trial 0.
-        metrics = set(experiment_data.observation_data["mean"])
+        metrics = set(experiment_data.metric_names)
         self.assertEqual(metrics, {"branin", "branin_map"})
         index = MultiIndex.from_tuples(
             [(0, "0_0", 0.0), (0, "0_0", 3.0), (1, "1_0", 0.0)],
@@ -278,7 +278,7 @@ class TestDataUtils(TestCase):
             experiment_data.arm_data.drop("metadata", axis=1), expected_arm_df
         )
         # Observation data: Map metrics should be included for all timestamps.
-        metrics = set(experiment_data.observation_data["mean"])
+        metrics = set(experiment_data.metric_names)
         self.assertEqual(metrics, {"branin", "branin_map"})
         index = MultiIndex.from_tuples(
             [
@@ -404,3 +404,19 @@ class TestDataUtils(TestCase):
             ),
         ]
         self.assertEqual(observations, expected)
+
+    def test_experiment_data_metric_names(self) -> None:
+        for experiment, expected in [
+            (get_branin_experiment(), []),
+            (get_branin_experiment(with_completed_trial=True), ["branin"]),
+            (
+                get_branin_experiment(
+                    with_completed_trial=True, with_absolute_constraint=True
+                ),
+                ["branin", "branin_e"],
+            ),
+        ]:
+            experiment_data = extract_experiment_data(
+                experiment=experiment, data_loader_config=DataLoaderConfig()
+            )
+            self.assertEqual(experiment_data.metric_names, expected)

--- a/ax/api/protocols/utils.py
+++ b/ax/api/protocols/utils.py
@@ -37,7 +37,7 @@ class _APIMetric(MapMetric, ABC):
     structure of ax.core.Metric to be more in line with our long term vision for Ax.
     """
 
-    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="progression", default_value=0.0)
+    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="step", default_value=0.0)
 
     def __init__(self, name: str) -> None:
         super().__init__(name=name)

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -770,7 +770,7 @@ class TestClient(TestCase):
                         "metric_name": {0: "foo", 1: "foo", 2: "foo", 3: "foo"},
                         "mean": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
                         "sem": {0: np.nan, 1: np.nan, 2: np.nan, 3: np.nan},
-                        "progression": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                        "step": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
                     }
                 )
             ),


### PR DESCRIPTION
Summary: This is needed often enough (in D70220094) to justify creating a property for it.

Differential Revision: D78509094


