### PR TITLE
Fix for the map key error when using BatchClient for experiments that are configured using PTSClinet

### DIFF
--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -376,7 +376,15 @@ class MapData(Data):
         Used for storage.
         """
         args["map_key_infos"] = [
-            MapKeyInfo(d["key"], d["default_value"]) for d in args["map_key_infos"]
+            MapKeyInfo(d["key"], d["default_value"])
+            # Using .get() with a default empty list to handle cases where
+            # map_key_infos might not exist. This is important when decoding experiments
+            # that were originally not using MapData but were encoded as if they were
+            # using MapData due to some underlying method call's side effects.
+            # example: when when configure_optimization is called, it overrights metric
+            # to mapmetric even if no mapkeyinfo is provided. This would inturn change
+            # Experiment.default_data_type to MapData when this opt_config is being set.
+            for d in args.get("map_key_infos", [])
         ]
         return super().deserialize_init_args(args=args)
 


### PR DESCRIPTION
Summary:
With the way client is configured now, whenever configure_optmization is called it default overrides the metric type to mapmetric which would in turn change the default_data_type attribute type to MapData for the experiment. With this the encoder encodes this experiment thinking it's a mapdata but when the decoder decodes it results in map key error since originally that metric is not a map metric.

Consequently, we have decided to loosen up the grip for the decoder by using .get() method in python dictionaries and have a fall back default value whenever it tries to get the key thinking it's a map metric. We believe that this won't have an extreme adverse effect.

Reviewed By: mpolson64

Differential Revision: D78506131


