### PR TITLE
Let `is_row_feasible` return None for any row whose feasibilitity cannot be determined

### DIFF
--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -883,9 +883,11 @@ def exp_to_df(
                     optimization_config=optimization_config,
                     experiment=exp,
                 )
+            # Will return None for those rows whose feasibility cannot be determined.
             results[FEASIBLE_COL_NAME] = _is_row_feasible(
                 df=results,
                 optimization_config=optimization_config,
+                undetermined_value=None,
             )
         except (KeyError, ValueError, DataRequiredError) as e:
             logger.warning(f"Feasibility calculation failed with error: {e}")


### PR DESCRIPTION
Summary:
This diff makes `_is_row_feasible` return `undetermined_value=None` for any row where feasibility cannot be determined, i.e.
1) If the optimization config hasn't been de-relativized, and there are relative constraints, feasibility determination is currently not supported.
2) If some metrics have missing (e.g. NaN) observations in the `mean` column, we return `undetermined_value=None` instead of `False` as the corresponding "feasibility" value.

Differential Revision: D77754492


