### PR TITLE
Remove unused factory functions

### DIFF
--- a/ax/adapter/__init__.py
+++ b/ax/adapter/__init__.py
@@ -9,13 +9,8 @@
 # flake8: noqa F401
 from ax.adapter import transforms
 from ax.adapter.base import Adapter
-from ax.adapter.factory import (
-    Generators,
-    get_factorial,
-    get_sobol,
-    get_thompson,
-    get_uniform,
-)
+from ax.adapter.factory import get_factorial, get_sobol, get_thompson
+from ax.adapter.registry import Generators
 from ax.adapter.torch import TorchAdapter
 
 __all__ = [
@@ -25,6 +20,5 @@ __all__ = [
     "get_factorial",
     "get_sobol",
     "get_thompson",
-    "get_uniform",
     "transforms",
 ]

--- a/ax/adapter/factory.py
+++ b/ax/adapter/factory.py
@@ -6,32 +6,14 @@
 
 # pyre-strict
 
-from collections.abc import Mapping, Sequence
-
 import torch
 from ax.adapter.base import DataLoaderConfig
 from ax.adapter.discrete import DiscreteAdapter
 from ax.adapter.random import RandomAdapter
-from ax.adapter.registry import Cont_X_trans, Generators, Y_trans
-from ax.adapter.torch import TorchAdapter
-from ax.adapter.transforms.base import Transform
+from ax.adapter.registry import Generators
 from ax.core.data import Data
 from ax.core.experiment import Experiment
-from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
-from ax.generators.torch.botorch import (
-    TAcqfConstructor,
-    TModelConstructor,
-    TModelPredictor,
-    TOptimizer,
-)
-from ax.generators.torch.botorch_defaults import (
-    get_and_fit_model,
-    get_qLogNEI,
-    scipy_optimizer,
-)
-from ax.generators.torch.utils import predict_from_model
-from ax.generators.types import TConfig
 from pyre_extensions import assert_is_instance
 
 
@@ -78,64 +60,6 @@ def get_sobol(
             fallback_to_sample_polytope=fallback_to_sample_polytope,
         ),
         RandomAdapter,
-    )
-
-
-def get_uniform(
-    search_space: SearchSpace, deduplicate: bool = False, seed: int | None = None
-) -> RandomAdapter:
-    """Instantiate uniform generator.
-
-    Args:
-        search_space: Uniform generator search space.
-        kwargs: Custom args for uniform generator.
-
-    Returns:
-        RandomAdapter, with UniformGenerator as model.
-    """
-    return assert_is_instance(
-        Generators.UNIFORM(
-            experiment=Experiment(search_space=search_space),
-            seed=seed,
-            deduplicate=deduplicate,
-        ),
-        RandomAdapter,
-    )
-
-
-def get_botorch(
-    experiment: Experiment,
-    data: Data,
-    search_space: SearchSpace | None = None,
-    device: torch.device = DEFAULT_TORCH_DEVICE,
-    transforms: Sequence[type[Transform]] = Cont_X_trans + Y_trans,
-    transform_configs: Mapping[str, TConfig] | None = None,
-    model_constructor: TModelConstructor = get_and_fit_model,
-    model_predictor: TModelPredictor = predict_from_model,
-    acqf_constructor: TAcqfConstructor = get_qLogNEI,
-    acqf_optimizer: TOptimizer = scipy_optimizer,  # pyre-ignore[9]
-    refit_on_cv: bool = False,
-    optimization_config: OptimizationConfig | None = None,
-) -> TorchAdapter:
-    """Instantiates a LegacyBoTorchGenerator."""
-    if data.df.empty:
-        raise ValueError("`LegacyBoTorchGenerator` requires non-empty data.")
-    return assert_is_instance(
-        Generators.LEGACY_BOTORCH(
-            experiment=experiment,
-            data=data,
-            search_space=search_space or experiment.search_space,
-            torch_device=device,
-            transforms=transforms,
-            transform_configs=transform_configs,
-            model_constructor=model_constructor,
-            model_predictor=model_predictor,
-            acqf_constructor=acqf_constructor,
-            acqf_optimizer=acqf_optimizer,
-            refit_on_cv=refit_on_cv,
-            optimization_config=optimization_config,
-        ),
-        TorchAdapter,
     )
 
 

--- a/ax/adapter/tests/test_factory.py
+++ b/ax/adapter/tests/test_factory.py
@@ -12,7 +12,6 @@ from ax.adapter.factory import (
     get_factorial,
     get_sobol,
     get_thompson,
-    get_uniform,
 )
 from ax.adapter.random import RandomAdapter
 from ax.core.experiment import Experiment
@@ -98,10 +97,3 @@ class TestAdapterFactorySingleObjective(TestCase):
         data = exp.fetch_data()
         thompson = get_thompson(experiment=exp, data=data)
         self.assertIsInstance(thompson.generator, ThompsonSampler)
-
-    def test_uniform(self) -> None:
-        exp = get_branin_experiment()
-        uniform = get_uniform(exp.search_space)
-        self.assertIsInstance(uniform, RandomAdapter)
-        uniform_run = uniform.gen(n=5)
-        self.assertEqual(len(uniform_run.arms), 5)

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -11,7 +11,6 @@ import logging
 import warnings
 from collections.abc import Callable, Sequence
 from functools import partial
-
 from logging import Logger
 from typing import Any, TypeVar
 
@@ -33,7 +32,6 @@ from ax.core.observation import ObservationFeatures
 from ax.core.runner import Runner
 from ax.core.trial import Trial
 from ax.core.types import TEvaluationOutcome, TParameterization, TParamValue
-
 from ax.core.utils import get_pending_observation_features_based_on_trial_status
 from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
 from ax.early_stopping.utils import estimate_early_stopping_savings
@@ -1393,11 +1391,9 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
 
     def to_json_snapshot(
         self,
-        # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
         # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
         #  `typing.Type` to avoid runtime subscripting errors.
         encoder_registry: dict[type, Callable[[Any], dict[str, Any]]] | None = None,
-        # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
         # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
         #  `typing.Type` to avoid runtime subscripting errors.
         class_encoder_registry: None
@@ -1435,7 +1431,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         cls: type[AxClientSubclass],
         serialized: dict[str, Any],
         decoder_registry: TDecoderRegistry | None = None,
-        # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
         class_decoder_registry: None
         | (dict[str, Callable[[dict[str, Any]], Any]]) = None,
         # pyre-fixme[2]: Parameter must be annotated.

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -12,8 +12,7 @@ from typing import Any
 
 import torch
 from ax.adapter.base import DataLoaderConfig
-from ax.adapter.factory import Generators
-from ax.adapter.registry import GeneratorRegistryBase
+from ax.adapter.registry import GeneratorRegistryBase, Generators
 from ax.adapter.transforms.base import Transform
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_metric import (
@@ -189,7 +188,6 @@ from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from gpytorch.priors.torch_priors import GammaPrior, LogNormalPrior
 
 
-# pyre-fixme[5]: Global annotation cannot contain `Any`.
 # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use `typing.Type` to
 #  avoid runtime subscripting errors.
 CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
@@ -281,7 +279,6 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
 # NOTE: Avoid putting a class along with its subclass in `CLASS_ENCODER_REGISTRY`.
 # The encoder iterates through this dictionary and uses the first superclass that
 # it finds, which might not be the intended superclass.
-# pyre-fixme[5]: Global annotation cannot contain `Any`.
 # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use `typing.Type` to
 #  avoid runtime subscripting errors.
 CORE_CLASS_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
@@ -425,7 +422,6 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
 
 
 # Registry for class types, not instances.
-# pyre-fixme[5]: Global annotation cannot contain `Any`.
 CORE_CLASS_DECODER_REGISTRY: dict[str, Callable[[dict[str, Any]], Any]] = {
     "Type[Acquisition]": class_from_json,
     "Type[AcquisitionFunction]": class_from_json,

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -22,7 +22,8 @@ from typing import Any, cast, Sequence
 import numpy as np
 import pandas as pd
 import torch
-from ax.adapter.factory import Cont_X_trans, Generators, get_factorial, get_sobol
+from ax.adapter.factory import get_factorial, get_sobol
+from ax.adapter.registry import Cont_X_trans, Generators
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment
 from ax.core.base_trial import BaseTrial, TrialStatus


### PR DESCRIPTION
Summary: Removes `get_uniform` and `get_botorch`. These are not used, are not compatible with GS, and anyone who wants to achieve the same functionality can simply call `Generators.BOTORCH/UNIFORM` instead.

Differential Revision: D78829347


