### PR TITLE
Update discrete_dims input to optimize_acqf_mixed_alternating for compatibility

### DIFF
--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -499,7 +499,11 @@ class Acquisition(Base):
             candidates, acqf_values = optimize_acqf_mixed_alternating(
                 acq_function=self.acqf,
                 bounds=bounds,
-                discrete_dims=search_space_digest.ordinal_features,
+                discrete_dims={
+                    k: list(v)
+                    for k, v in discrete_choices.items()
+                    if k in search_space_digest.ordinal_features
+                },
                 cat_dims=search_space_digest.categorical_features,
                 q=n,
                 post_processing_func=rounding_func,

--- a/ax/generators/torch/tests/test_acquisition.py
+++ b/ax/generators/torch/tests/test_acquisition.py
@@ -717,7 +717,7 @@ class AcquisitionTest(TestCase):
         mock_alternating.assert_called_with(
             acq_function=acquisition.acqf,
             bounds=mock.ANY,
-            discrete_dims=[1],
+            discrete_dims={1: list(range(16))},
             cat_dims=[],
             q=3,
             options={
@@ -755,7 +755,7 @@ class AcquisitionTest(TestCase):
         mock_alternating.assert_called_with(
             acq_function=acquisition.acqf,
             bounds=mock.ANY,
-            discrete_dims=[],
+            discrete_dims={},
             cat_dims=[1],
             q=3,
             options={


### PR DESCRIPTION
Summary: Updates `discrete_dims` from a list of indices to a dict of `{index: values}` for compatibility with https://github.com/pytorch/botorch/pull/2923

Differential Revision: D78902131


