### PR TITLE
Update syntax of calls to `optimize_acqf_mixed_alternating`

### DIFF
--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -504,7 +504,11 @@ class Acquisition(Base):
                     for k, v in discrete_choices.items()
                     if k in search_space_digest.ordinal_features
                 },
-                cat_dims=search_space_digest.categorical_features,
+                cat_dims={
+                    k: list(v)
+                    for k, v in discrete_choices.items()
+                    if k in search_space_digest.categorical_features
+                },
                 q=n,
                 post_processing_func=rounding_func,
                 fixed_features=fixed_features,


### PR DESCRIPTION
Summary:
Ax: Update a call to `optimize_acqf_mixed_alternating` to match D79091028 / https://github.com/pytorch/botorch/pull/2942

BoTorch: Update type annotations to clarify that the argument will not be mutated, allowing Pyre to pass for Ax.

Differential Revision: D79107891


