### PR TITLE
Support additional metadata columns in ExperimentData.observation_data

### DIFF
--- a/ax/adapter/data_utils.py
+++ b/ax/adapter/data_utils.py
@@ -121,6 +121,10 @@ class ExperimentData:
             metric. The columns of the dataframe are multi-indexed, with the first level
             being "mean" or "sem" and the second level being the metric name.
             This is typically constructed by pivoting `(Map)Data.true_df`.
+            If the `Data` object contains additional metadata columns like `start_time`
+            and `end_time`, these will be carried onto `observation_data`. The metadata
+            columns will be indexed with the first level being "metadata" and the second
+            level keeping the original column name.
 
     Example with non-map data:
         >>> experiment = Experiment(...)  # An experiment with non-map Data.
@@ -352,6 +356,13 @@ def _extract_observation_data(
         A dataframe filtered to only include observations from the given statuses
         to include, and pivoted to be indexed by (trial_index, arm_name, *map_keys)
         and to have columns "mean" & "sem" for each metric.
+        If `data` contains additional metadata columns like `start_time` and `end_time`
+        they will be added to the pivoted dataframe as additional columns. The columns
+        are labeled hierarchically (with a ``pd.MultiIndex`` structure) where the top
+        level is "metadata" and the lower level keeps the original column name.
+        For example, if the original DataFrame from ``Data`` includes a column
+        ``start_time``, then ``observation_data`` will have a column that can be
+        retrived with ``("metadata", "start_time")``.
     """
     data = data if data is not None else experiment.lookup_data()
     if isinstance(data, MapData):
@@ -396,6 +407,18 @@ def _extract_observation_data(
     # If df is empty, add mean & sem columns to facilitate pivoting.
     if df.empty:
         df = df.assign(mean=None, sem=None)
+
+    # Identify potential metadata columns.
+    standard_columns = {
+        "trial_index",
+        "arm_name",
+        "metric_name",
+        "mean",
+        "sem",
+        *map_keys,
+    }
+    metadata_columns = [col for col in df.columns if col not in standard_columns]
+
     # Pivot the df to be indexed by (trial_index, arm_name, *map_keys)
     # and to have columns "mean" & "sem" for each metric.
     observation_data = df.pivot(
@@ -407,4 +430,23 @@ def _extract_observation_data(
         ],
         values=["mean", "sem"],
     )
+
+    # If metadata columns exist, add them to the pivoted dataframe.
+    if metadata_columns:
+        # Create a dataframe with just the index columns and metadata columns.
+        metadata_df = df[["trial_index", "arm_name", *map_keys, *metadata_columns]]
+        # Set the index to match the observation_data index.
+        # All null rows are dropped to still capture the metadata in the next step
+        # if it exists for only a subset of metrics.
+        metadata_df = metadata_df.set_index(
+            ["trial_index", "arm_name", *map_keys]
+        ).dropna(how="all")
+        # Drop duplicates to ensure we have only one row per unique index.
+        # This is necessary when there are multiple metrics.
+        metadata_df = metadata_df.loc[~metadata_df.index.duplicated(keep="first")]
+        # Create a multi-index for the columns to facilitate the merge.
+        metadata_df.columns = MultiIndex.from_product([["metadata"], metadata_columns])
+        # Join to the main dataframe.
+        observation_data = observation_data.join(metadata_df)
+
     return observation_data


### PR DESCRIPTION
Summary:
In some cases, `Data.df` may contain additional metadata columns like `start_time` and `end_time`. In the old `Observation/Features/Data` setup, these would be extracted and added to the `ObservationFeatures` object. With `ExperimentData`, adding an input that originates from `Data` to `arm_data` is quite inconvenient. So, we're instead keeping these on `observation_data`.

**This diff** implements a version that keeps a single copy of the metadata for each `(trial_index, arm_name, *map_keys)` combination. Technically speaking, this is a reduction on the original metadata from `Data.df`, which is available for each `metric`, in addition to the keys mentioned before. However, these are often the same values for all metrics, which make it possible to add a singular value to the corresponding `ObservationFeatures` object. This form can easily be leveraged in `TimeAsFeature` transform, which makes it an appealing design choice.

With this design, `observation_data[("metadata", "start_time")]` contains the `start_time` for each `(trial_index, arm_name, *map_keys)` combination.

**An alternative implementation** would keep all metadata, converting it into one column for each metric. In that case we would have `observation_data[("start_time", "metric_name")]` containing the `start_time` for that metric and for each `(trial_index, arm_name, *map_keys)` combination.

This version would keep all information from the original `Data.df`, however how to utilize this data downstream is a bit more complicated. `TimeAsFeature` adds a single feature for a given `(trial_index, arm_name, *map_keys)` combination. How do we decide what metric to extract that feature from?

Differential Revision: D78499874


