### PR TITLE
Dead code sleep statement in orchestrator _sleep_if_too_early_to_poll

### DIFF
--- a/ax/service/orchestrator.py
+++ b/ax/service/orchestrator.py
@@ -1755,12 +1755,22 @@ class Orchestrator(AnalysisBase, BestPointMixin):
         scheduling.
         """
         if self._latest_trial_start_timestamp is not None:
-            seconds_since_run_trial = (
-                current_timestamp_in_millis()
-                - none_throws(self._latest_trial_start_timestamp)
-            ) * 1000
+            seconds_since_run_trial = round(
+                (
+                    current_timestamp_in_millis()
+                    - none_throws(self._latest_trial_start_timestamp)
+                )
+                / 1000
+            )
+
             if seconds_since_run_trial < self.options.min_seconds_before_poll:
-                sleep(self.options.min_seconds_before_poll - seconds_since_run_trial)
+                sleep_duration_seconds = (
+                    self.options.min_seconds_before_poll - seconds_since_run_trial
+                )
+                self.logger.debug(
+                    f"Too early to poll, sleeping for {sleep_duration_seconds} seconds"
+                )
+                sleep(sleep_duration_seconds)
 
     def _set_logger(self, options: OrchestratorOptions) -> None:
         """Set up the logger with appropriate logging levels."""


### PR DESCRIPTION
Summary:
# Change

This fixes a bug in "_sleep_if_too_early_to_poll" which multiplied a millisecond timestamp by 1000 instead of dividing by 1000 when converting to seconds. 

This change fixes this logic, and the process will now sleep when it is too soon after the latest trial starting to begin polling. 


# Details

Investigation orginated from a Github bug report: https://github.com/facebook/Ax/issues/4070?fbclid=IwY2xjawL12vlleHRuA2FlbQIxMQBicmlkETFrNFlnZmdkNFI4S29Mem5VAR69ENhfiUyVobuZUXeqwR9U7ARfcHfbIr-WwPQwL8Q5zzK9Q-EZsLcD_TJVqQ_aem_qs2ioWfyVtRBCFWAArxQCw

# Issue

This orchestrator function `def _sleep_if_too_early_to_poll(self)` calculates the seconds since last trial run like this 

```
seconds_since_run_trial = (
                current_timestamp_in_millis()
                - self._latest_trial_start_timestamp
            ) * 1000

if seconds_since_run_trial < self.options.min_seconds_before_poll:
                sleep(self.options.min_seconds_before_poll - seconds_since_run_trial)

```
but this is wrong - subtracting milliseconds from milliseconds yields milliseconds which should be divivided by 1e3 instead of multiplied to get seconds (1 millisecond becomes 1000 seconds here). This value is compared to SchedulerOptions.min_seconds_before_poll which is in this case off by a factor of a million.

This code is more than 5 years old, and has not been changed in that time. 

# Details

1. "min_seconds_before_poll" is most frequently set to 0, 1, or 8 across the code base 
2. If "current_timestamp_in_millis" is equal to "latest_trial_start_timestamp", i.e executed within the same millisecond, seconds_since_run_trial is set to 0 and sleep is called for exactly `min_seconds_before_poll` (so sleeps for 0, 1, or 8 seconds). This case is **unlikely**

3. If seconds_since_run_trial is non zero (any delay between trial start and current timestamp), it will be greater than 1000. The conditional for the sleep statement will **always** be skipped. This case is **very common**

# Risk

1. The "correct" fix would be to divide by 1000 instead of multiply. However, this will introduce **new sleep statements calls in many calls to `poll_and_process_results`**. This will significantly alter the behavior of the orchestrator
2. Alternatively, we could rework this code to preserve the existing functionality.
3. Remove altogether- there is already a sleep method in the body of the polling loop that is called unconditionally. Removing this nearly dead code will simplify the logic of the orchestrator

To improve performance and match expected behavior, we will try the fix to introduce sleeping when polling too soon after trial start.

Differential Revision: D79184059


