### PR TITLE
MultiAcquisition

### DIFF
--- a/ax/adapter/tests/test_registry.py
+++ b/ax/adapter/tests/test_registry.py
@@ -71,7 +71,7 @@ class ModelRegistryTest(TestCase):
             # Model kwargs
             acquisition_class=Acquisition,
             botorch_acqf_class=qExpectedImprovement,
-            acquisition_options={"best_f": 0.0},
+            botorch_acqf_options={"best_f": 0.0},
             # Adapter kwargs
             experiment=exp,
             data=exp.fetch_data(),
@@ -80,7 +80,7 @@ class ModelRegistryTest(TestCase):
         generator = assert_is_instance(gpei.generator, BoTorchGenerator)
         self.assertEqual(generator.botorch_acqf_class, qExpectedImprovement)
         self.assertEqual(generator.acquisition_class, Acquisition)
-        self.assertEqual(generator.acquisition_options, {"best_f": 0.0})
+        self.assertEqual(generator._botorch_acqf_options, {"best_f": 0.0})
         self.assertIsInstance(generator.surrogate, Surrogate)
         # SingleTaskGP should be picked.
         self.assertIsInstance(generator.surrogate.model, SingleTaskGP)

--- a/ax/generators/torch/botorch_modular/multi_acquisition.py
+++ b/ax/generators/torch/botorch_modular/multi_acquisition.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any
+
+from ax.core.search_space import SearchSpaceDigest
+from ax.exceptions.core import AxError
+
+from ax.generators.torch.botorch_modular.acquisition import Acquisition
+from ax.generators.torch.botorch_modular.surrogate import Surrogate
+from ax.generators.torch_base import TorchOptConfig
+from botorch.acquisition.acquisition import AcquisitionFunction
+from botorch.acquisition.multioutput_acquisition import (
+    MultiOutputAcquisitionFunctionWrapper,
+)
+
+
+class MultiAcquisition(Acquisition):
+    """
+    A MultiAcquisition class for generating points by optimizing multiple
+    acquisition functions jointly.
+    """
+
+    def __init__(
+        self,
+        surrogate: Surrogate,
+        search_space_digest: SearchSpaceDigest,
+        torch_opt_config: TorchOptConfig,
+        botorch_acqf_class: type[AcquisitionFunction] | None,
+        botorch_acqf_options: dict[str, Any] | None = None,
+        botorch_acqf_classes_with_options: list[
+            tuple[type[AcquisitionFunction], dict[str, Any]]
+        ]
+        | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> None:
+        if botorch_acqf_classes_with_options is None:
+            raise AxError(
+                "botorch_acqf_classes_with_options must be specified for "
+                "MultiAcquisition."
+            )
+        elif len(botorch_acqf_classes_with_options) < 2:
+            raise AxError(
+                "botorch_acqf_classes_with_options have at least two elements."
+            )
+        super().__init__(
+            surrogate=surrogate,
+            search_space_digest=search_space_digest,
+            torch_opt_config=torch_opt_config,
+            botorch_acqf_class=botorch_acqf_class,
+            botorch_acqf_options=botorch_acqf_options,
+            botorch_acqf_classes_with_options=botorch_acqf_classes_with_options,
+            options=options,
+        )
+
+    def _instantiate_acquisition(
+        self,
+        botorch_acqf_classes_with_options: list[
+            tuple[type[AcquisitionFunction], dict[str, Any]]
+        ],
+    ) -> None:
+        """Constructs the acquisition function based on the provided AF clases.
+
+        Args:
+            botorch_acqf_classes: A list of BoTorch acquisition function classes.
+        """
+        acqfs = [
+            self._construct_botorch_acquisition(
+                botorch_acqf_class=botorch_acqf_class,
+                botorch_acqf_options=botorch_acqf_options,
+            )
+            for botorch_acqf_class, botorch_acqf_options in (
+                botorch_acqf_classes_with_options
+            )
+        ]
+        self.acqf = MultiOutputAcquisitionFunctionWrapper(acqfs=acqfs)

--- a/ax/generators/torch/botorch_modular/optimizer_argparse.py
+++ b/ax/generators/torch/botorch_modular/optimizer_argparse.py
@@ -13,6 +13,7 @@ from typing import Any
 from ax.exceptions.core import UnsupportedError
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
+from botorch.acquisition.multioutput_acquisition import MultiOutputAcquisitionFunction
 
 # Acquisition defaults
 NUM_RESTARTS = 20
@@ -61,6 +62,7 @@ def optimizer_argparse(
         "optimize_acqf_homotopy",
         "optimize_acqf_mixed",
         "optimize_acqf_mixed_alternating",
+        "optimize_with_nsgaii",
     ]
     if optimizer not in supported_optimizers:
         raise ValueError(
@@ -76,10 +78,19 @@ def optimizer_argparse(
             "continuous using the transform "
             "`ax.adapter.registry.Cont_X_trans`."
         )
+    elif optimizer == "optimize_with_nsgaii" and not isinstance(
+        acqf, MultiOutputAcquisitionFunction
+    ):
+        raise RuntimeError(
+            "Ax is attempting to use a NSGA-II optimizer, "
+            f"`{optimizer}`, but this is not compatible with "
+            "single-objective acquisition functions. To address this, please "
+            "use MultiAcquisitionFunction or use a different optimizer."
+        )
     provided_options = optimizer_options if optimizer_options is not None else {}
 
     # Construct arguments from options that are not `provided_options`.
-    if optimizer == "optimize_acqf_discrete":
+    if optimizer in ("optimize_acqf_discrete", "optimize_with_nsgaii"):
         # `optimize_acqf_discrete` only accepts 'choices', 'max_batch_size', 'unique'.
         options = {}
     else:

--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -1034,16 +1034,18 @@ class Surrogate(Base):
             raise NotImplementedError("Fixed features not yet supported.")
 
         options = options or {}
-        acqf_class, acqf_options = pick_best_out_of_sample_point_acqf_class(
-            outcome_constraints=torch_opt_config.outcome_constraints,
-            seed_inner=assert_is_instance_optional(
-                options.get(Keys.SEED_INNER, None), int
-            ),
-            qmc=assert_is_instance(
-                options.get(Keys.QMC, True),
-                bool,
-            ),
-            risk_measure=torch_opt_config.risk_measure,
+        botorch_acqf_class, botorch_acqf_options = (
+            pick_best_out_of_sample_point_acqf_class(
+                outcome_constraints=torch_opt_config.outcome_constraints,
+                seed_inner=assert_is_instance_optional(
+                    options.get(Keys.SEED_INNER, None), int
+                ),
+                qmc=assert_is_instance(
+                    options.get(Keys.QMC, True),
+                    bool,
+                ),
+                risk_measure=torch_opt_config.risk_measure,
+            )
         )
 
         # Avoiding circular import between `Surrogate` and `Acquisition`.
@@ -1051,10 +1053,10 @@ class Surrogate(Base):
 
         acqf = Acquisition(
             surrogate=self,
-            botorch_acqf_class=acqf_class,
+            botorch_acqf_class=botorch_acqf_class,
             search_space_digest=search_space_digest,
             torch_opt_config=torch_opt_config,
-            options=acqf_options,
+            botorch_acqf_options=botorch_acqf_options,
         )
         candidates, acqf_value, _ = acqf.optimize(
             n=1,

--- a/ax/generators/torch/tests/test_sebo.py
+++ b/ax/generators/torch/tests/test_sebo.py
@@ -105,7 +105,7 @@ class TestSebo(TestCase):
         )
         self.linear_constraints = None
         self.fixed_features = {1: 1.0}
-        self.options = {"best_f": 0.0, "target_point": self.target_point}
+        self.options = {"target_point": self.target_point}
         self.inequality_constraints = [
             (torch.tensor([0, 1], **tkwargs), torch.tensor([1.0, -1.0], **tkwargs), 0)
         ]
@@ -135,6 +135,7 @@ class TestSebo(TestCase):
         fixed_features: dict[int, float] | None = None,
         options: dict[str, str | float] | None = None,
         torch_opt_config: TorchOptConfig | None = None,
+        botorch_acqf_options: dict[str, Any] | None = None,
     ) -> SEBOAcquisition:
         return SEBOAcquisition(
             botorch_acqf_class=qNoisyExpectedHypervolumeImprovement,
@@ -145,6 +146,7 @@ class TestSebo(TestCase):
                 fixed_features=fixed_features or {},
             ),
             options=options or self.options,
+            botorch_acqf_options=botorch_acqf_options or {},
         )
 
     def test_init(self) -> None:
@@ -213,7 +215,8 @@ class TestSebo(TestCase):
         with warnings.catch_warnings(record=True) as ws:
             self.get_acquisition_function(
                 fixed_features=self.fixed_features,
-                options={"cache_root": True, "target_point": self.target_point},
+                options={"target_point": self.target_point},
+                botorch_acqf_options={"cache_root": True},
             )
             self.assertEqual(len(ws), 1)
             self.assertEqual(

--- a/ax/generators/torch/utils.py
+++ b/ax/generators/torch/utils.py
@@ -24,6 +24,7 @@ from ax.utils.common.constants import Keys
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.analytic import PosteriorMean
 from botorch.acquisition.monte_carlo import (
+    MCAcquisitionFunction,
     qSimpleRegret,
     SampleReducingMCAcquisitionFunction,
 )
@@ -450,7 +451,7 @@ def get_botorch_objective_and_transform(
     ):
         # We are doing multi-objective optimization.
         return _get_weighted_mo_objective(objective_weights=objective_weights), None
-    if outcome_constraints:
+    if outcome_constraints and issubclass(botorch_acqf_class, MCAcquisitionFunction):
         # If there are outcome constraints, we use MC Acquisition functions.
         obj_tf: Callable[[Tensor, Tensor | None], Tensor] = (
             get_objective_weights_transform(objective_weights)

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -17,6 +17,8 @@ from ax.generators.torch.botorch_modular.kernels import (
     DefaultRBFKernel,
     ScaleMaternKernel,
 )
+
+from ax.generators.torch.botorch_modular.multi_acquisition import MultiAcquisition
 from ax.generators.torch.botorch_modular.sebo import SEBOAcquisition
 
 # BoTorch `AcquisitionFunction` imports
@@ -26,6 +28,7 @@ from botorch.acquisition.analytic import (
     LogExpectedImprovement,
     LogNoisyExpectedImprovement,
     NoisyExpectedImprovement,
+    PosteriorMean,
 )
 from botorch.acquisition.knowledge_gradient import (
     qKnowledgeGradient,
@@ -34,6 +37,7 @@ from botorch.acquisition.knowledge_gradient import (
 from botorch.acquisition.logei import (
     qLogExpectedImprovement,
     qLogNoisyExpectedImprovement,
+    qLogProbabilityOfFeasibility,
 )
 from botorch.acquisition.max_value_entropy_search import (
     qMaxValueEntropy,
@@ -110,6 +114,7 @@ Mapping of modular Ax `Acquisition` classes to class name strings.
 """
 ACQUISITION_REGISTRY: dict[type[Acquisition], str] = {
     Acquisition: "Acquisition",
+    MultiAcquisition: "MultiAcquisition",
 }
 
 
@@ -137,6 +142,7 @@ MODEL_REGISTRY: dict[type[Model], str] = {
 Mapping of Botorch `AcquisitionFunction` classes to class name strings.
 """
 ACQUISITION_FUNCTION_REGISTRY: dict[type[AcquisitionFunction], str] = {
+    PosteriorMean: "PosteriorMean",
     ExpectedImprovement: "ExpectedImprovement",
     AnalyticExpectedUtilityOfBestOption: "AnalyticExpectedUtilityOfBestOption",
     qExpectedUtilityOfBestOption: "qExpectedUtilityOfBestOption",
@@ -154,6 +160,7 @@ ACQUISITION_FUNCTION_REGISTRY: dict[type[AcquisitionFunction], str] = {
     LogNoisyExpectedImprovement: "LogNoisyExpectedImprovement",
     qLogExpectedImprovement: "qLogExpectedImprovement",
     qLogNoisyExpectedImprovement: "qLogNoisyExpectedImprovement",
+    qLogProbabilityOfFeasibility: "qLogProbabilityOfFeasibility",
     qLogExpectedHypervolumeImprovement: "qLogExpectedHypervolumeImprovement",
     qLogNoisyExpectedHypervolumeImprovement: "qLogNoisyExpectedHypervolumeImprovement",
     qLogNParEGO: "qLogNParEGO",


### PR DESCRIPTION
Summary:
This adds a MultiAcquisition class for batch generation using multiple AFs. The current targeted use case is doing MOO across multiple AFs to generate a batch of candidates.

Future use cases include (not yet implemented):

- Using a single AF class, with different models and optimizing those AFs jointly via MOO or sequentially (individually) following Ben's batch ensembling.
- Using multiple AF classes with multiple models.

Differential Revision: D77697048


