### PR TITLE
Fix Relativize.transform_experiment_data

### DIFF
--- a/ax/adapter/tests/test_data_utils.py
+++ b/ax/adapter/tests/test_data_utils.py
@@ -23,7 +23,7 @@ from ax.utils.testing.core_stubs import (
     get_branin_experiment_with_timestamp_map_metric,
     get_experiment_with_observations,
 )
-from pandas import DataFrame, MultiIndex
+from pandas import DataFrame, MultiIndex, Timestamp
 from pandas.testing import assert_frame_equal
 
 
@@ -307,6 +307,56 @@ class TestDataUtils(TestCase):
         )
         # Check equality with self.
         self.assertEqual(experiment_data, experiment_data)
+
+    def test_extract_experiment_data_with_metadata_columns(self) -> None:
+        # Tests the case where the Data.df includes additional columns
+        # besides the usual required columns, such as start_time and end_time.
+        # In this case, observation_data will include additional columns like
+        # (metadata, start_time) and (metadata, end_time).
+        exp = get_branin_experiment(with_trial=True, num_trial=3)
+        # Add data with start_time and end_time.
+        data = Data(
+            df=DataFrame.from_records(
+                [
+                    {
+                        "arm_name": t.arms[0].name,
+                        "metric_name": "branin",
+                        "mean": 0.4 * t.index,
+                        "sem": 0.2 + 0.1 * t.index,
+                        "trial_index": t.index,
+                        "start_time": float(t.index),
+                        "end_time": t.index + 5.0,
+                    }
+                    for t in exp.trials.values()
+                ]
+            )
+        )
+        exp.attach_data(data)
+        # Extract experiment data.
+        experiment_data = extract_experiment_data(
+            experiment=exp, data_loader_config=DataLoaderConfig()
+        )
+        # Arm data has been tested above, just checking observation data here.
+        expected_obs_data = DataFrame(
+            data=[
+                [0.0, 0.2, Timestamp(0.0), Timestamp(5.0)],
+                [0.4, 0.3, Timestamp(1.0), Timestamp(6.0)],
+                [0.8, 0.4, Timestamp(2.0), Timestamp(7.0)],
+            ],
+            index=MultiIndex.from_tuples(
+                [(0, "0_0"), (1, "1_0"), (2, "2_0")],
+                names=["trial_index", "arm_name"],
+            ),
+            columns=MultiIndex.from_tuples(
+                tuples=[
+                    ("mean", "branin"),
+                    ("sem", "branin"),
+                    ("metadata", "start_time"),
+                    ("metadata", "end_time"),
+                ]
+            ),
+        )
+        assert_frame_equal(expected_obs_data, experiment_data.observation_data)
 
     def test_filter_by_arm_name(self) -> None:
         # This is a 2 objective experiment with 5 trials, 1 arm each.

--- a/ax/adapter/transforms/relativize.py
+++ b/ax/adapter/transforms/relativize.py
@@ -188,7 +188,7 @@ class BaseRelativize(Transform, ABC):
             )
 
         trial_indices = observation_data.index.get_level_values("trial_index")
-        for metric in observation_data["mean"].columns:
+        for metric in experiment_data.metric_names:
             # Create arrays of control values for each row based on trial_index.
             mean_c, sem_c = [], []
             for idx in trial_indices:
@@ -208,6 +208,14 @@ class BaseRelativize(Transform, ABC):
                     control_as_constant=self.control_as_constant,
                 )
             )
+
+        # Set the SQ values to 0.
+        mask = (
+            observation_data.index.get_level_values("arm_name")
+            == self.adapter.status_quo_name
+        )
+        observation_data.loc[mask, "mean"] = 0
+        observation_data.loc[mask, "sem"] = 0
 
         return ExperimentData(
             arm_data=experiment_data.arm_data,

--- a/ax/adapter/transforms/standardize_y.py
+++ b/ax/adapter/transforms/standardize_y.py
@@ -64,7 +64,6 @@ class StandardizeY(Transform):
             observation_data = [obs.data for obs in none_throws(observations)]
             Ys = get_data(observation_data=observation_data)
         # Compute means and SDs
-        # pyre-fixme[6]: Expected `DefaultDict[Union[str, Tuple[str, Optional[Union[b...
         # pyre-fixme[4]: Attribute must be annotated.
         self.Ymean, self.Ystd = compute_standardization_parameters(Ys=Ys)
 

--- a/ax/adapter/transforms/tests/test_relativize_transform.py
+++ b/ax/adapter/transforms/tests/test_relativize_transform.py
@@ -434,18 +434,24 @@ class RelativizeDataTest(TestCase):
             assert_frame_equal(relativized_data.arm_data, experiment_data.arm_data)
             # Check that observation data was relativized correctly.
             expected_mean, expected_sem = [], []
-            for index, row in experiment_data.observation_data.iterrows():
+            for (  # pyre-ignore [23]: Pyre doesn't know about the index structure.
+                trial_index,
+                arm_name,
+            ), row in experiment_data.observation_data.iterrows():
                 sq_row = experiment_data.observation_data.loc[
-                    (assert_is_instance(index, tuple)[0], "status_quo")
+                    (trial_index, "status_quo")
                 ]
-                mean, sem = relativize(
-                    means_t=row["mean", "branin"],
-                    sems_t=row["sem", "branin"],
-                    mean_c=sq_row["mean", "branin"],
-                    sem_c=sq_row["sem", "branin"],
-                    as_percent=True,
-                    control_as_constant=t.control_as_constant,
-                )
+                if arm_name == "status_quo":
+                    mean, sem = 0, 0
+                else:
+                    mean, sem = relativize(
+                        means_t=row["mean", "branin"],
+                        sems_t=row["sem", "branin"],
+                        mean_c=sq_row["mean", "branin"],
+                        sem_c=sq_row["sem", "branin"],
+                        as_percent=True,
+                        control_as_constant=t.control_as_constant,
+                    )
                 expected_mean.append(mean)
                 expected_sem.append(sem)
             self.assertEqual(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1011,6 +1011,7 @@ def get_experiment_with_observations(
     sems: list[list[float]] | None = None,
     optimization_config: OptimizationConfig | None = None,
     candidate_metadata: Sequence[TCandidateMetadata] | None = None,
+    additional_data_columns: Sequence[Mapping[str, Any]] | None = None,
 ) -> Experiment:
     if observations:
         multi_objective = (len(observations[0]) - constrained) > 1
@@ -1097,6 +1098,10 @@ def get_experiment_with_observations(
             metadata = {arm.signature: candidate_metadata[i]}
         else:
             metadata = None
+        if additional_data_columns is not None:
+            additional_cols = additional_data_columns[i]
+        else:
+            additional_cols = {}
         trial = exp.new_trial(
             generator_run=GeneratorRun(
                 arms=[arm], candidate_metadata_by_arm_signature=metadata
@@ -1112,6 +1117,7 @@ def get_experiment_with_observations(
                         "mean": o,
                         "sem": s,
                         "trial_index": trial.index,
+                        **additional_cols,
                     }
                     for m, o, s in zip(metrics, obs_i, sems_i, strict=True)
                 ]


### PR DESCRIPTION
Summary:
At line 315, an exception is made for the status quo:
```
        if means_t == mean_c and sems_t == sem_c:
            return 0, 0
```
setting the mean & sem to `0` if we're relativizing the status quo itself. This diff replicates the same when transforming the `ExperimentData`.
It took half a day of debugging a regression detection analysis test to discover this omission.

Differential Revision: D79200327


