### PR TITLE
T231841440 : Remove trace hover in contour plot

### DIFF
--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -309,10 +309,8 @@ def _prepare_plot(
 
     if is_relative:
         z_values = z_grid.values * 100
-        hovertemplate = "%{z:.2f}%"
     else:
         z_values = z_grid.values
-        hovertemplate = "%{z:.2f}"
 
     fig = go.Figure(
         data=go.Contour(
@@ -325,7 +323,7 @@ def _prepare_plot(
                 "title": None,
                 "ticksuffix": "%" if is_relative else "",
             },
-            hovertemplate=hovertemplate,
+            hoverinfo="skip",
         ),
         layout=go.Layout(
             xaxis_title=truncate_label(label=x_parameter_name),
@@ -346,6 +344,7 @@ def _prepare_plot(
             },
             name="Sampled",
             showlegend=False,
+            hovertemplate="(%{x}, %{y})<extra>Sampled</extra>",
         )
 
         fig.add_trace(samples)


### PR DESCRIPTION
Summary:
Remove trace hover for all points in contour plot; add hover only for sampled points in Ax analysis.

The contour plot currently shows hover information for all points, which is not very informative. This change removes the trace hover for the contour plot and adds hover information exclusively for the sampled points.

Reviewed By: mgarrard

Differential Revision: D79206300


