### PR TITLE
Fix TransformToNewSQ.transform_experiment_data

### DIFF
--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -222,19 +222,19 @@ class TransformToNewSQSpecificTest(TestCase):
             experiment_data=deepcopy(experiment_data)
         )
 
-        # Verify that status quo observations are dropped.
-        self.assertFalse(
-            (
-                transformed_data.observation_data.index.get_level_values("arm_name")
+        # Verify that status quo observations are dropped except for the target trial.
+        tf_obs_data = transformed_data.observation_data
+        self.assertEqual(
+            tf_obs_data[
+                tf_obs_data.index.get_level_values("arm_name")
                 == self.adapter.status_quo_name
-            ).any()
+            ]
+            .index.get_level_values("trial_index")
+            .item(),
+            2,  # target trial index from the config.
         )
         # Verify that data from the target trial is not transformed.
         target_trial_data = experiment_data.observation_data.loc[2]
-        target_trial_data = target_trial_data[
-            target_trial_data.index.get_level_values("arm_name")
-            != self.adapter.status_quo_name
-        ]
         transformed_target_trial_data = transformed_data.observation_data.loc[2]
         assert_frame_equal(target_trial_data, transformed_target_trial_data)
 


### PR DESCRIPTION
Summary: The transform is only supposed to drop the status quo observations for trials other than the target trial. The data for the target trial is meant to remain unchanged. This can be inferred from line 204 that skips the transform for target trial and line 225-228 that only drops SQ observations if it is not the target trial. This behavior is also verified by `TransferLearningAdapterTest.test_transform_to_new_sq` which is how I discovered the issue.

Differential Revision: D79290336


