### PR TITLE
Guard against missing dataframes during notebook conversion

### DIFF
--- a/scripts/convert_ipynb_to_mdx.py
+++ b/scripts/convert_ipynb_to_mdx.py
@@ -557,6 +557,8 @@ def handle_pandas(
             # pd.read_html() raises an error if there's no dataframe.
             continue
         df = pd.read_html(io.StringIO(data), flavor="lxml")
+        if len(df) == 0:
+            continue
         # NOTE: The return is a list of dataframes and we only care about the first
         #       one.
         md_df = df[0]


### PR DESCRIPTION
Summary:
Guard against errors such as this one:

```
-----------------------------------
Generating tutorials
-----------------------------------
Traceback (most recent call last):
--------------------------------------------
  File "/home/runner/work/Ax/Ax/scripts/convert_ipynb_to_mdx.py", line 1040, in <module>
Converting tutorial notebooks into mdx files
    mdx = transform_notebook(path, metadata)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/Ax/Ax/scripts/convert_ipynb_to_mdx.py", line 990, in transform_notebook
    mdx += handle_code_cell(cell, plot_data_folder)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/Ax/Ax/scripts/convert_ipynb_to_mdx.py", line 958, in handle_code_cell
    cell_output_mdx = handle_cell_outputs(cell, plot_data_folder)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/Ax/Ax/scripts/convert_ipynb_to_mdx.py", line 941, in handle_cell_outputs
--------------------------------------------
quickstart
getting_started
automating
early_stopping
    md = aggregate_mdx(cell_outputs_to_process, plot_data_folder)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/Ax/Ax/scripts/convert_ipynb_to_mdx.py", line 727, in aggregate_mdx
    processed_mdx.extend(handle_pandas(values))
                         ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/Ax/Ax/scripts/convert_ipynb_to_mdx.py", line 562, in handle_pandas
    md_df = df[0]
            ~~^^^
IndexError: list index out of range
```

As seen here: https://github.com/facebook/Ax/actions/runs/16640371220/job/47089455518

Differential Revision: D79356693


