### PR TITLE
Update ExperimentData.convert_to_list_of_observations to support map data

### DIFF
--- a/ax/adapter/transforms/fill_missing_parameters.py
+++ b/ax/adapter/transforms/fill_missing_parameters.py
@@ -87,7 +87,12 @@ class FillMissingParameters(Transform):
                 "We cannot distinguish between parameters that are missing "
                 "and those that are None in `ExperimentData`. "
             )
+        arm_data = experiment_data.arm_data.fillna(value=self.fill_values)
+        # If any of the fill columns are missing in arm_data, add it.
+        missing_columns = set(none_throws(self.fill_values)) - set(arm_data.columns)
+        for col in missing_columns:
+            arm_data[col] = none_throws(self.fill_values)[col]
         return ExperimentData(
-            arm_data=experiment_data.arm_data.fillna(value=self.fill_values),
+            arm_data=arm_data,
             observation_data=experiment_data.observation_data,
         )

--- a/ax/adapter/transforms/tests/test_fill_missing_parameters.py
+++ b/ax/adapter/transforms/tests/test_fill_missing_parameters.py
@@ -74,13 +74,21 @@ class FillMissingParametersTransformTest(TestCase):
         self.assertEqual(experiment_data.arm_data["x"].isna().sum(), 1)
         self.assertEqual(experiment_data.arm_data["y"].isna().sum(), 2)
 
+        fill_x = 2.0
+        fill_y = 1.0
+        fill_z = 0.0
         # Transform and see that NaNs are filled.
-        t = FillMissingParameters(config={"fill_values": {"x": 2.0, "y": 1.0}})
+        t = FillMissingParameters(
+            config={"fill_values": {"x": fill_x, "y": fill_y, "z": fill_z}}
+        )
         transformed_data = t.transform_experiment_data(
             experiment_data=deepcopy(experiment_data)
         )
-        self.assertEqual(transformed_data.arm_data["x"].tolist(), [0.0, 1.0, 2.0])
-        self.assertEqual(transformed_data.arm_data["y"].tolist(), [1.0, 0.0, 1.0])
+        self.assertEqual(transformed_data.arm_data["x"].tolist(), [0.0, 1.0, fill_x])
+        self.assertEqual(transformed_data.arm_data["y"].tolist(), [fill_y, 0.0, fill_y])
+        self.assertEqual(
+            transformed_data.arm_data["z"].tolist(), [fill_z, fill_z, fill_z]
+        )
         assert_frame_equal(
             transformed_data.observation_data, experiment_data.observation_data
         )

--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -222,19 +222,19 @@ class TransformToNewSQSpecificTest(TestCase):
             experiment_data=deepcopy(experiment_data)
         )
 
-        # Verify that status quo observations are dropped.
-        self.assertFalse(
-            (
-                transformed_data.observation_data.index.get_level_values("arm_name")
+        # Verify that status quo observations are dropped except for the target trial.
+        tf_obs_data = transformed_data.observation_data
+        self.assertEqual(
+            tf_obs_data[
+                tf_obs_data.index.get_level_values("arm_name")
                 == self.adapter.status_quo_name
-            ).any()
+            ]
+            .index.get_level_values("trial_index")
+            .item(),
+            2,  # target trial index from the config.
         )
         # Verify that data from the target trial is not transformed.
         target_trial_data = experiment_data.observation_data.loc[2]
-        target_trial_data = target_trial_data[
-            target_trial_data.index.get_level_values("arm_name")
-            != self.adapter.status_quo_name
-        ]
         transformed_target_trial_data = transformed_data.observation_data.loc[2]
         assert_frame_equal(target_trial_data, transformed_target_trial_data)
 


### PR DESCRIPTION
Summary: Previously, conversion to list of observations was only allowed if the `observation_data` did not include any map keys in its index. Some CV test failures in D70220094 revealed the need for including the progression / map key in the `ObservationFeatures` metadata for it to be transformed as part of the CV test points. The fix for adding map key to metadata seemed pretty close to supporting the map key more generally in this method (i.e., when there are multiple rows of data for each arm), so this diff implements that.

Reviewed By: ltiao

Differential Revision: D79356456


