### PR TITLE
Implement PowerTransformY.transform_experiment_data

### DIFF
--- a/ax/adapter/transforms/fill_missing_parameters.py
+++ b/ax/adapter/transforms/fill_missing_parameters.py
@@ -87,7 +87,12 @@ class FillMissingParameters(Transform):
                 "We cannot distinguish between parameters that are missing "
                 "and those that are None in `ExperimentData`. "
             )
+        arm_data = experiment_data.arm_data.fillna(value=self.fill_values)
+        # If any of the fill columns are missing in arm_data, add it.
+        missing_columns = set(none_throws(self.fill_values)) - set(arm_data.columns)
+        for col in missing_columns:
+            arm_data[col] = none_throws(self.fill_values)[col]
         return ExperimentData(
-            arm_data=experiment_data.arm_data.fillna(value=self.fill_values),
+            arm_data=arm_data,
             observation_data=experiment_data.observation_data,
         )

--- a/ax/adapter/transforms/power_transform_y.py
+++ b/ax/adapter/transforms/power_transform_y.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
+from ax.adapter.transforms.log_y import match_ci_width
 from ax.adapter.transforms.utils import get_data, match_ci_width_truncated
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
@@ -22,7 +23,9 @@ from ax.core.search_space import SearchSpace
 from ax.generators.types import TConfig
 from ax.utils.common.typeutils import assert_is_instance_list
 from pyre_extensions import assert_is_instance, none_throws
+from scipy.stats import norm
 from sklearn.preprocessing import PowerTransformer
+
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
@@ -88,7 +91,11 @@ class PowerTransformY(Transform):
         if experiment_data is not None:
             means_df = experiment_data.observation_data["mean"]
             # Dropping NaNs here since the DF will have NaN for missing values.
-            Ys = {name: column.dropna().values for name, column in means_df.items()}
+            Ys = {
+                name: column.dropna().values
+                for name, column in means_df.items()
+                if metric_names is None or name in metric_names
+            }
         else:
             observation_data = [obs.data for obs in none_throws(observations)]
             Ys = get_data(observation_data=observation_data, metric_names=metric_names)
@@ -109,12 +116,10 @@ class PowerTransformY(Transform):
             for i, m in enumerate(obsd.metric_names):
                 if m in self.metric_names:
                     transform = self.power_transforms[m].transform
-                    obsd.means[i], obsd.covariance[i, i] = match_ci_width_truncated(
+                    obsd.means[i], obsd.covariance[i, i] = match_ci_width(
                         mean=obsd.means[i],
                         variance=obsd.covariance[i, i],
-                        transform=lambda y: transform(np.array(y, ndmin=2)),
-                        lower_bound=-np.inf,
-                        upper_bound=np.inf,
+                        transform=lambda y, t=transform: t(np.array(y, ndmin=2)),
                     )
         return observation_data
 
@@ -135,7 +140,7 @@ class PowerTransformY(Transform):
                     obsd.means[i], obsd.covariance[i, i] = match_ci_width_truncated(
                         mean=obsd.means[i],
                         variance=obsd.covariance[i, i],
-                        transform=lambda y: transform(np.array(y, ndmin=2)),
+                        transform=lambda y, t=transform: t(np.array(y, ndmin=2)),
                         lower_bound=l,
                         upper_bound=u,
                         clip_mean=True,
@@ -183,6 +188,31 @@ class PowerTransformY(Transform):
                     transform = self.power_transforms[c.metric.name].inverse_transform
                     c.bound = transform(np.array(c.bound, ndmin=2)).item()
         return outcome_constraints
+
+    def transform_experiment_data(
+        self, experiment_data: ExperimentData
+    ) -> ExperimentData:
+        obs_data = experiment_data.observation_data
+        metrics_in_data = experiment_data.metric_names
+        # This method applies the power transform to the mean columns and uses
+        # a vectorized implementation of match_ci_width to update sem.
+        fac = norm.ppf(0.975)
+        for metric in self.metric_names:
+            if metric not in metrics_in_data:
+                continue
+            power_transform = self.power_transforms[metric].transform
+            mean = obs_data[("mean", metric)].to_numpy().reshape(-1, 1)
+            obs_data[("mean", metric)] = power_transform(X=mean).flatten()
+            sem = obs_data[("sem", metric)].to_numpy().reshape(-1, 1)
+            if np.isnan(sem).all():
+                # If SEM is NaN, we don't need to transform it.
+                continue
+            d = fac * sem
+            width_asym = power_transform(X=mean + d) - power_transform(X=mean - d)
+            obs_data[("sem", metric)] = width_asym.flatten() / (2 * fac)
+        return ExperimentData(
+            arm_data=experiment_data.arm_data, observation_data=obs_data
+        )
 
 
 def _compute_power_transforms(

--- a/ax/adapter/transforms/tests/test_fill_missing_parameters.py
+++ b/ax/adapter/transforms/tests/test_fill_missing_parameters.py
@@ -74,13 +74,21 @@ class FillMissingParametersTransformTest(TestCase):
         self.assertEqual(experiment_data.arm_data["x"].isna().sum(), 1)
         self.assertEqual(experiment_data.arm_data["y"].isna().sum(), 2)
 
+        fill_x = 2.0
+        fill_y = 1.0
+        fill_z = 0.0
         # Transform and see that NaNs are filled.
-        t = FillMissingParameters(config={"fill_values": {"x": 2.0, "y": 1.0}})
+        t = FillMissingParameters(
+            config={"fill_values": {"x": fill_x, "y": fill_y, "z": fill_z}}
+        )
         transformed_data = t.transform_experiment_data(
             experiment_data=deepcopy(experiment_data)
         )
-        self.assertEqual(transformed_data.arm_data["x"].tolist(), [0.0, 1.0, 2.0])
-        self.assertEqual(transformed_data.arm_data["y"].tolist(), [1.0, 0.0, 1.0])
+        self.assertEqual(transformed_data.arm_data["x"].tolist(), [0.0, 1.0, fill_x])
+        self.assertEqual(transformed_data.arm_data["y"].tolist(), [fill_y, 0.0, fill_y])
+        self.assertEqual(
+            transformed_data.arm_data["z"].tolist(), [fill_z, fill_z, fill_z]
+        )
         assert_frame_equal(
             transformed_data.observation_data, experiment_data.observation_data
         )

--- a/ax/adapter/transforms/tests/test_power_y_transform.py
+++ b/ax/adapter/transforms/tests/test_power_y_transform.py
@@ -12,6 +12,8 @@ from copy import deepcopy
 from math import isfinite, isnan
 
 import numpy as np
+from ax.adapter.base import DataLoaderConfig
+from ax.adapter.data_utils import extract_experiment_data
 from ax.adapter.transforms.power_transform_y import (
     _compute_inverse_bounds,
     _compute_power_transforms,
@@ -20,12 +22,15 @@ from ax.adapter.transforms.power_transform_y import (
 from ax.adapter.transforms.utils import get_data, match_ci_width_truncated
 from ax.core.metric import Metric
 from ax.core.objective import Objective
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.observation import observations_from_data
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.types import ComparisonOp
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_observations_with_invalid_value
+from ax.utils.testing.core_stubs import (
+    get_experiment_with_observations,
+    get_observations_with_invalid_value,
+)
 from sklearn.preprocessing import PowerTransformer
 
 
@@ -42,32 +47,18 @@ def get_constraint(
 class PowerTransformYTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.obsd1 = ObservationData(
-            metric_names=["m1", "m2"],
-            means=np.array([0.5, 0.9]),
-            covariance=np.array([[0.03, 0.0], [0.0, 0.001]]),
+        self.experiment = get_experiment_with_observations(
+            observations=[[0.5, 0.9], [0.1, 0.4], [0.9, 0.8], [0.3, 0.2]],
+            sems=[[0.2, 0.1], [0.03, 0.05], [0.14, 0.1], [float("nan"), float("nan")]],
         )
-        self.obsd2 = ObservationData(
-            metric_names=["m1", "m2"],
-            means=np.array([0.1, 0.4]),
-            covariance=np.array([[0.005, 0.0], [0.0, 0.05]]),
+        self.observations = observations_from_data(
+            experiment=self.experiment, data=self.experiment.lookup_data()
         )
-        self.obsd3 = ObservationData(
-            metric_names=["m1", "m2"],
-            means=np.array([0.9, 0.8]),
-            covariance=np.array([[0.02, 0.0], [0.0, 0.01]]),
+        self.obsd1, self.obsd2, self.obsd3, self.obsd_nan = (
+            obs.data for obs in self.observations
         )
-        self.obsd_nan = ObservationData(
-            metric_names=["m1", "m2"],
-            means=np.array([0.3, 0.2]),
-            covariance=np.array([[float("nan"), 0.0], [0.0, float("nan")]]),
-        )
-        self.observations = [
-            Observation(features=ObservationFeatures({}), data=obsd)
-            for obsd in [self.obsd1, self.obsd2, self.obsd3, self.obsd_nan]
-        ]
 
-    def test_Init(self) -> None:
+    def test_init(self) -> None:
         shared_init_args = {
             "search_space": None,
             "observations": self.observations[:2],
@@ -90,10 +81,9 @@ class PowerTransformYTest(TestCase):
             self.assertIsInstance(tf.inv_bounds[m], tuple)
             self.assertTrue(len(tf.inv_bounds[m]) == 2)
 
-    def test_GetData(self) -> None:
+    def test_get_data(self) -> None:
         for m in ["m1", "m2"]:
-            # pyre-fixme[6]: For 2nd param expected `Optional[List[str]]` but got `str`.
-            Ys = get_data([self.obsd1, self.obsd2, self.obsd3], m)
+            Ys = get_data([self.obsd1, self.obsd2, self.obsd3], [m])
             self.assertIsInstance(Ys, dict)
             self.assertEqual([*Ys], [m])
             if m == "m1":
@@ -101,7 +91,7 @@ class PowerTransformYTest(TestCase):
             else:
                 self.assertEqual(Ys[m], [0.9, 0.4, 0.8])
 
-    def test_ComputePowerTransform(self) -> None:
+    def test_compute_power_transform(self) -> None:
         Ys = get_data([self.obsd1, self.obsd2, self.obsd3], ["m2"])
         pts = _compute_power_transforms(Ys)
         self.assertEqual(pts["m2"].method, "yeo-johnson")
@@ -117,7 +107,7 @@ class PowerTransformYTest(TestCase):
         Y_np2 = pts["m2"].inverse_transform(Y_trans)
         self.assertAlmostEqual(np.max(np.abs(Y_np - Y_np2)), 0.0)
 
-    def test_ComputeInverseBounds(self) -> None:
+    def test_compute_inverse_bounds(self) -> None:
         Ys = get_data([self.obsd1, self.obsd2, self.obsd3], ["m2"])
         pt = _compute_power_transforms(Ys)["m2"]
         # lambda < 0: im(f) = (-inf, -1/lambda) without standardization
@@ -142,7 +132,7 @@ class PowerTransformYTest(TestCase):
         right = pt.inverse_transform(np.array(bounds[0] + 0.01, ndmin=2))
         self.assertTrue(not isnan(right) and isnan(left))
 
-    def test_MatchCIWidth(self) -> None:
+    def test_match_ci_width(self) -> None:
         Ys = get_data([self.obsd1, self.obsd2, self.obsd3], ["m2"])
         pt = _compute_power_transforms(Ys)
         # pyre-fixme[16]: `PowerTransformer` has no attribute `lambdas_`.
@@ -172,7 +162,7 @@ class PowerTransformYTest(TestCase):
         self.assertTrue(isnan(new_mean_1) and isnan(new_var_1))
         self.assertTrue(isfinite(new_mean_2) and isfinite(new_var_2))
 
-    def test_TransformAndUntransformOneMetric(self) -> None:
+    def test_transform_and_untransform_one_metric(self) -> None:
         pt = PowerTransformY(
             search_space=None,
             observations=deepcopy(self.observations[:2]),
@@ -208,7 +198,7 @@ class PowerTransformYTest(TestCase):
             )
         )
 
-    def test_TransformAndUntransformAllMetrics(self) -> None:
+    def test_transform_and_untransform_all_metrics(self) -> None:
         pt = PowerTransformY(
             search_space=None,
             observations=deepcopy(self.observations[:2]),
@@ -238,7 +228,7 @@ class PowerTransformYTest(TestCase):
         cov_results = np.array(transformed_obsd_nan.covariance)
         self.assertTrue(np.all(np.isnan(np.diag(cov_results))))
 
-    def test_CompareToSklearn(self) -> None:
+    def test_compare_to_sklearn(self) -> None:
         # Make sure the transformed values agree with Sklearn
         observation_data = [self.obsd1, self.obsd2, self.obsd3]
 
@@ -255,7 +245,7 @@ class PowerTransformYTest(TestCase):
         for y1_, y2_ in zip(y1, y2):
             self.assertAlmostEqual(y1_, y2_)
 
-    def test_TransformOptimizationConfig(self) -> None:
+    def test_transform_optimization_config(self) -> None:
         # basic test
         m1 = Metric(name="m1")
         objective_m1 = Objective(metric=m1, minimize=False)
@@ -341,3 +331,36 @@ class PowerTransformYTest(TestCase):
                 ValueError, f"Non-finite data found for metric m1: {invalid_value}"
             ):
                 PowerTransformY(observations=observations, config={"metrics": ["m1"]})
+
+    def test_with_experiment_data(self) -> None:
+        experiment_data = extract_experiment_data(
+            experiment=self.experiment, data_loader_config=DataLoaderConfig()
+        )
+        for metrics in (["m1"], ["m1", "m2"]):
+            t = PowerTransformY(
+                search_space=self.experiment.search_space,
+                experiment_data=experiment_data,
+                config={"metrics": metrics},
+            )
+            self.assertEqual(t.metric_names, metrics)
+            self.assertEqual(list(t.power_transforms), metrics)
+            # Check that the transform is the same as if we had
+            # initialized it using observations.
+            t_old = PowerTransformY(
+                search_space=self.experiment.search_space,
+                observations=self.observations,
+                config={"metrics": metrics},
+            )
+            transformed_data = t.transform_experiment_data(
+                experiment_data=deepcopy(experiment_data)
+            )
+            transformed_data_old = t_old.transform_experiment_data(
+                experiment_data=deepcopy(experiment_data)
+            )
+            self.assertEqual(transformed_data, transformed_data_old)
+            # Compare the transformed values to transformed Observation.
+            observations = t.transform_observations(
+                observations=deepcopy(self.observations)
+            )
+            converted_obs = transformed_data.convert_to_list_of_observations()
+            self.assertEqual(observations, converted_obs)

--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -222,19 +222,19 @@ class TransformToNewSQSpecificTest(TestCase):
             experiment_data=deepcopy(experiment_data)
         )
 
-        # Verify that status quo observations are dropped.
-        self.assertFalse(
-            (
-                transformed_data.observation_data.index.get_level_values("arm_name")
+        # Verify that status quo observations are dropped except for the target trial.
+        tf_obs_data = transformed_data.observation_data
+        self.assertEqual(
+            tf_obs_data[
+                tf_obs_data.index.get_level_values("arm_name")
                 == self.adapter.status_quo_name
-            ).any()
+            ]
+            .index.get_level_values("trial_index")
+            .item(),
+            2,  # target trial index from the config.
         )
         # Verify that data from the target trial is not transformed.
         target_trial_data = experiment_data.observation_data.loc[2]
-        target_trial_data = target_trial_data[
-            target_trial_data.index.get_level_values("arm_name")
-            != self.adapter.status_quo_name
-        ]
         transformed_target_trial_data = transformed_data.observation_data.loc[2]
         assert_frame_equal(target_trial_data, transformed_target_trial_data)
 


### PR DESCRIPTION
Summary:
Adds support for transforming `ExperimentData` to `PowerTransformY` transform. The transform constructor is also updated to extract the necessary data from `ExperimentData`.

Background: As part of the larger refactor, we will be using `ExperimentData` in place of `list[Observation]` within the `Adapter`.
- The transforms will be initialized using `ExperimentData`. The `observations` input to the constructors may be deprecated once the use cases are updated.
- The training data for `Adapter` will be represented with `ExperimentData` and will be transformed using `transform_experiment_data`.
- For misc input / output to various `Adapter` and other methods, the `Observation / ObservationFeatures / ObservationData` objects will remain. To support these, we will retain the existing transform methods that service these objects.
- Since `ExperimentData` is not planned to be used as an output of user facing methods, we do not need to untransform it. We are not planning to implement`untransform_experiment_data`.

Differential Revision: D79397720
