### PR TITLE
Update Adapter to utilize ExperimentData

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -1281,12 +1281,9 @@ def _get_adapter_training_data(
     """
     Get training data for adapter, optionally filtering out out-of-design points.
     """
-    obs = adapter.get_training_data()
-
-    if in_design_only:
-        obs = [obs[i] for i in range(len(obs)) if adapter.training_in_design[i]]
-
-    return _unpack_observations(obs=obs)
+    experiment_data = adapter.get_training_data(filter_in_design=in_design_only)
+    observations = experiment_data.convert_to_list_of_observations()
+    return _unpack_observations(obs=observations)
 
 
 def _unpack_observations(

--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -15,7 +15,12 @@ from logging import Logger
 from typing import Any
 
 import numpy as np
-from ax.adapter.data_utils import DataLoaderConfig
+import pandas as pd
+from ax.adapter.data_utils import (
+    DataLoaderConfig,
+    ExperimentData,
+    extract_experiment_data,
+)
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.cast import Cast
 from ax.adapter.transforms.fill_missing_parameters import FillMissingParameters
@@ -27,7 +32,6 @@ from ax.core.observation import (
     Observation,
     ObservationData,
     ObservationFeatures,
-    observations_from_data,
     recombine_observations,
 )
 from ax.core.optimization_config import OptimizationConfig
@@ -47,6 +51,7 @@ from ax.generators.base import Generator
 from ax.generators.types import TConfig
 from ax.utils.common.logger import get_logger
 from botorch.settings import validate_input_scaling
+from pandas import DataFrame
 from pyre_extensions import assert_is_instance, none_throws
 
 logger: Logger = get_logger(__name__)
@@ -165,12 +170,13 @@ class Adapter:
         """
         if data_loader_config is None:
             data_loader_config = DataLoaderConfig()
-
-        data_loader_config = _legacy_overwrite_data_loader_config(
-            data_loader_config=data_loader_config,
-            fit_out_of_design=fit_out_of_design,
-            fit_abandoned=fit_abandoned,
-            fit_only_completed_map_metrics=fit_only_completed_map_metrics,
+        self._data_loader_config: DataLoaderConfig = (
+            _legacy_overwrite_data_loader_config(
+                data_loader_config=data_loader_config,
+                fit_out_of_design=fit_out_of_design,
+                fit_abandoned=fit_abandoned,
+                fit_only_completed_map_metrics=fit_only_completed_map_metrics,
+            )
         )
 
         t_fit_start = time.monotonic()
@@ -179,16 +185,18 @@ class Adapter:
         transform_configs = {} if transform_configs is None else transform_configs
         if "FillMissingParameters" in transform_configs:
             transforms = [FillMissingParameters] + transforms
+        self._raw_transforms = transforms
+        self._transform_configs: Mapping[str, TConfig] = transform_configs
 
         self.fit_time: float = 0.0
         self.fit_time_since_gen: float = 0.0
         self._metric_names: set[str] = set()
-        self._training_data: list[Observation] = []
+        # pyre-ignore [13] Assigned in _set_and_filter_training_data.
+        self._training_data: ExperimentData
         self._optimization_config: OptimizationConfig | None = optimization_config
-        self._training_in_design: list[bool] = []
+        self._training_in_design_idx: list[bool] = []
         self._status_quo: Observation | None = None
         self._status_quo_name: str | None = None
-        self._arms_by_signature: dict[str, Arm] | None = None
         self.transforms: MutableMapping[str, Transform] = OrderedDict()
         self._model_key: str | None = None
         self._model_kwargs: dict[str, Any] | None = None
@@ -199,21 +207,17 @@ class Adapter:
         # The space used for modeling. Might be larger than the optimization
         # space to cover training data.
         self._model_space: SearchSpace = search_space.clone()
-        self._raw_transforms = transforms
-        self._transform_configs: Mapping[str, TConfig] = transform_configs
-        self._data_loader_config: DataLoaderConfig = data_loader_config
         self._fit_tracking_metrics = fit_tracking_metrics
         self.outcomes: list[str] = []
         self._experiment_has_immutable_search_space_and_opt_config: bool = (
             experiment is not None and experiment.immutable_search_space_and_opt_config
         )
-        self._experiment_properties: dict[str, Any] = {}
+        self._experiment_properties: dict[str, Any] = experiment._properties
         self._experiment: Experiment = experiment
 
         if self._optimization_config is None:
             self._optimization_config = experiment.optimization_config
-        self._arms_by_signature = experiment.arms_by_signature
-        self._experiment_properties = experiment._properties
+        self._arms_by_signature: dict[str, Arm] = experiment.arms_by_signature
 
         if self._fit_tracking_metrics is False:
             if self._optimization_config is None:
@@ -225,11 +229,15 @@ class Adapter:
 
         # Set training data (in the raw / untransformed space). This also omits
         # out-of-design and abandoned observations depending on the corresponding flags.
-        observations_raw = self._prepare_observations(experiment=experiment, data=data)
+        experiment_data = extract_experiment_data(
+            experiment=experiment,
+            data_loader_config=self._data_loader_config,
+            data=data,
+        )
         if expand_model_space:
-            self._set_model_space(observations=observations_raw)
-        observations_raw = self._set_training_data(
-            observations=observations_raw, search_space=self._model_space
+            self._set_model_space(arm_data=experiment_data.arm_data)
+        experiment_data = self._set_and_filter_training_data(
+            experiment_data=experiment_data, search_space=self._model_space
         )
 
         # Set model status quo.
@@ -239,15 +247,15 @@ class Adapter:
         # Save generator, apply terminal transform, and fit.
         self.generator = generator
         if fit_on_init:
-            observations, search_space = self._transform_data(
-                observations=observations_raw,
+            experiment_data, search_space = self._transform_data(
+                experiment_data=experiment_data,
                 search_space=self._model_space,
                 transforms=self._raw_transforms,
                 transform_configs=self._transform_configs,
             )
             self._fit_if_implemented(
                 search_space=search_space,
-                observations=observations,
+                experiment_data=experiment_data,
                 time_so_far=time.monotonic() - t_fit_start,
             )
 
@@ -266,21 +274,21 @@ class Adapter:
     def _fit_if_implemented(
         self,
         search_space: SearchSpace,
-        observations: list[Observation],
+        experiment_data: ExperimentData,
         time_so_far: float,
     ) -> None:
         r"""Fits the generator if `_fit` is implemented and stores fit time.
 
         Args:
             search_space: A transformed search space for fitting the generator.
-            observations: The observations to fit the generator with. These should
-                also be transformed.
+            experiment_data: The ``ExperimentData`` to fit the generator on, with
+                the transforms already applied.
             time_so_far: Time spent in initializing the generator up to
                 `_fit_if_implemented` call.
         """
         try:
             t_fit_start = time.monotonic()
-            self._fit(search_space=search_space, observations=observations)
+            self._fit(search_space=search_space, experiment_data=experiment_data)
             increment = time.monotonic() - t_fit_start + time_so_far
             self.fit_time += increment
             self.fit_time_since_gen += increment
@@ -289,130 +297,110 @@ class Adapter:
 
     def _process_and_transform_data(
         self, experiment: Experiment, data: Data | None = None
-    ) -> tuple[list[Observation], SearchSpace]:
-        r"""Processes the data into observations and returns transformed
-        observations and the search space. This packages the following methods:
-        * self._prepare_observations
-        * self._set_training_data
+    ) -> tuple[ExperimentData, SearchSpace]:
+        r"""Processes the data into ``ExperimentData`` and returns the transformed
+        ``ExperimentData`` and the search space. This packages the following methods:
+        * self._set_and_filter_training_data
         * self._set_status_quo
         * self._transform_data
         """
-        observations = self._prepare_observations(experiment=experiment, data=data)
-        observations_raw = self._set_training_data(
-            observations=observations, search_space=self._model_space
+        experiment_data = extract_experiment_data(
+            experiment=experiment,
+            data_loader_config=self._data_loader_config,
+            data=data,
+        )
+        experiment_data = self._set_and_filter_training_data(
+            experiment_data=experiment_data, search_space=self._model_space
         )
         # This ensures that SQ is up to date when we re-fit the existing Adapter
         # in GeneratorSpec.fit.
         self._set_status_quo(experiment=experiment)
         return self._transform_data(
-            observations=observations_raw,
+            experiment_data=experiment_data,
             search_space=self._model_space,
             transforms=self._raw_transforms,
             transform_configs=self._transform_configs,
         )
 
-    def _prepare_observations(
-        self, experiment: Experiment, data: Data | None = None
-    ) -> list[Observation]:
-        data = data if data is not None else experiment.lookup_data()
-        return observations_from_data(
-            experiment=experiment,
-            data=data,
-            latest_rows_per_group=self._data_loader_config.latest_rows_per_group,
-            limit_rows_per_metric=self._data_loader_config.limit_rows_per_metric,
-            limit_rows_per_group=self._data_loader_config.limit_rows_per_group,
-            statuses_to_include=self._data_loader_config.statuses_to_fit,
-            statuses_to_include_map_metric=(
-                self._data_loader_config.statuses_to_fit_map_metric
-            ),
-        )
-
     def _transform_data(
         self,
-        observations: list[Observation],
+        experiment_data: ExperimentData,
         search_space: SearchSpace,
         transforms: Sequence[type[Transform]] | None,
         transform_configs: Mapping[str, TConfig],
         assign_transforms: bool = True,
-    ) -> tuple[list[Observation], SearchSpace]:
+    ) -> tuple[ExperimentData, SearchSpace]:
         """Initialize transforms and apply them to provided data."""
-        # Initialize transforms
         search_space = search_space.clone()
         if transforms is not None:
             for t in transforms:
                 t_instance = t(
                     search_space=search_space.clone(),
-                    observations=observations,
+                    experiment_data=experiment_data,
                     adapter=self,
                     config=transform_configs.get(t.__name__, None),
                 )
-                search_space = t_instance.transform_search_space(search_space)
-                observations = t_instance.transform_observations(observations)
+                search_space = t_instance.transform_search_space(
+                    search_space=search_space
+                )
+                experiment_data = t_instance.transform_experiment_data(
+                    experiment_data=experiment_data
+                )
                 if assign_transforms:
                     self.transforms[t.__name__] = t_instance
+        return experiment_data, search_space
 
-        return observations, search_space
-
-    def _set_training_data(
-        self, observations: list[Observation], search_space: SearchSpace
-    ) -> list[Observation]:
-        """Store training data, not-transformed.
-
-        If the adapter specifies _fit_out_of_design, all training data is
-        returned. Otherwise, only in design points are returned.
+    def _set_and_filter_training_data(
+        self, experiment_data: ExperimentData, search_space: SearchSpace
+    ) -> ExperimentData:
+        """Store non-transformed training data, and return it after filtering to
+        include only in-design points if
+        ``self._data_loader_config._fit_out_of_design=True``.
         """
-        self._training_data = deepcopy(observations)
-        self._metric_names: set[str] = set()
-        for obs in observations:
-            self._metric_names.update(obs.data.metric_names)
-        return self._process_in_design(
-            search_space=search_space,
-            observations=observations,
-        )
-
-    def _process_in_design(
-        self,
-        search_space: SearchSpace,
-        observations: list[Observation],
-    ) -> list[Observation]:
-        """Set training_in_design, and decide whether to filter out of design points."""
-        # Don't filter points.
+        # NOTE: This is copied in get_training_data, so it won't be modified in-place.
+        self._training_data = experiment_data
+        self._metric_names: set[str] = set(experiment_data.metric_names)
+        # Filter out-of-design points if `fit_out_of_design` is False.
         if self._data_loader_config.fit_out_of_design:
-            # Use all data for training
-            # Set training_in_design to True for all observations so that
-            # all observations are used in CV and plotting
-            self.training_in_design = [True] * len(observations)
-            return observations
-        in_design = self._compute_in_design(
-            search_space=search_space, observations=observations
+            self._training_in_design_idx = [True] * len(experiment_data.arm_data)
+        else:
+            self._training_in_design_idx = self._compute_in_design(
+                search_space=search_space, experiment_data=experiment_data
+            )
+        return self.get_training_data(
+            filter_in_design=self._data_loader_config.fit_out_of_design
         )
-        self.training_in_design = in_design
-        in_design_obs = [
-            observations[i] for i, is_in_design in enumerate(in_design) if is_in_design
-        ]
-        return in_design_obs
 
     def _compute_in_design(
         self,
         search_space: SearchSpace,
-        observations: list[Observation],
+        experiment_data: ExperimentData,
     ) -> list[bool]:
-        """Compute in-design status for each observation, after filling missing
-        values if FillMissingParameters transform is used."""
-        observation_features = [obs.features for obs in observations]
+        """Compute in-design status for each row of ``experiment_data``, after
+        filling missing values if ``FillMissingParameters`` transform is used.
+        """
         if "FillMissingParameters" in self._transform_configs:
             t = FillMissingParameters(
                 config=self._transform_configs["FillMissingParameters"]
             )
-            observation_features = t.transform_observation_features(
-                deepcopy(observation_features)
+            experiment_data = t.transform_experiment_data(
+                experiment_data=experiment_data,
             )
+        # TODO [T230585235]: Implement more efficient membership checks.
         return [
-            search_space.check_membership(obsf.parameters)
-            for obsf in observation_features
+            search_space.check_membership(
+                parameterization={k: v for k, v in params.items() if not pd.isnull(v)}
+            )
+            for params in experiment_data.arm_data.drop(
+                # Ignoring errors which can be raised by missing metadata column
+                # when the data is empty.
+                columns=["metadata"],
+                inplace=False,
+                errors="ignore",
+            ).to_dict(orient="records")
         ]
 
-    def _set_model_space(self, observations: list[Observation]) -> None:
+    def _set_model_space(self, arm_data: DataFrame) -> None:
         """Set model space, possibly expanding range parameters to cover data."""
         # If fill for missing values, include those in expansion.
         fill_values: TParameterization | None = None
@@ -420,25 +408,21 @@ class Adapter:
             fill_values = self._transform_configs[  # pyre-ignore[9]
                 "FillMissingParameters"
             ].get("fill_values", None)
-        # Extract parameter values across arms
-        parameter_dicts = [obs.features.parameters for obs in observations]
-        if fill_values is not None:
-            parameter_dicts.append(fill_values)
-        param_vals = {p_name: [] for p_name in self._model_space.parameters.keys()}
-        for parameter_dict in parameter_dicts:
-            for p_name in self._model_space.parameters.keys():
-                p_val = parameter_dict.get(p_name, None)
-                if p_val is not None:
-                    param_vals[p_name].append(p_val)
-
         # Update model space. Expand bounds as needed to cover the values found
-        # in the data.
-        for p in self._model_space.parameters.values():
-            if len(param_vals[p.name]) == 0:
+        # in the data. Only applies to range parameters.
+        for p_name, p in self._model_space.parameters.items():
+            if not isinstance(p, RangeParameter):
                 continue
-            if isinstance(p, RangeParameter):
-                p.lower = min(p.lower, min(param_vals[p.name]))
-                p.upper = max(p.upper, max(param_vals[p.name]))
+            if p_name in arm_data:
+                param_vals = arm_data[p_name].dropna().tolist()
+            else:
+                param_vals = []
+            if fill_values is not None and p_name in fill_values:
+                param_vals.append(fill_values[p_name])
+            if len(param_vals) == 0:
+                continue
+            p.lower = min(p.lower, min(param_vals))
+            p.upper = max(p.upper, max(param_vals))
         # Remove parameter constraints from the model space.
         self._model_space.set_parameter_constraints([])
 
@@ -467,11 +451,20 @@ class Adapter:
             return
         self._status_quo_name = status_quo_arm.name
         target_trial_index = get_target_trial_index(experiment=experiment)
+        if target_trial_index is None:
+            logger.warning(
+                f"Status quo {self._status_quo_name} is not present in the "
+                "training data."
+            )
+            return
+        # Filter the training data to find the observations for status quo.
+        sq_arm_observations = self._training_data.filter_by_arm_names(
+            arm_names=[none_throws(self.status_quo_name)]
+        ).convert_to_list_of_observations()
         status_quo_observations = [
             obs
-            for obs in self._training_data
-            if (obs.features.parameters == status_quo_arm.parameters)
-            and (obs.features.trial_index == target_trial_index)
+            for obs in sq_arm_observations
+            if obs.features.trial_index == target_trial_index
         ]
         if len(status_quo_observations) == 0:
             logger.warning(
@@ -511,16 +504,23 @@ class Adapter:
 
         If status quo does not exist, return None.
         """
-        # tODO: extract from experiment
+        # TODO: We could possibly extract from the experiment directly. See D72685267.
         # Status quo name will be set if status quo exists. We can just filter by name.
         if self.status_quo_name is None:
             return None
         # Identify status quo data by arm name.
+        obs_data = self._training_data.observation_data
+        sq_data = obs_data.loc[
+            obs_data.index.get_level_values("arm_name") == self.status_quo_name
+        ]
+        metric_names = list(sq_data["mean"].columns)
         return {
-            # NOTE: casting to int here, in case the index is a numpy integer.
-            int(none_throws(obs.features.trial_index)): obs.data
-            for obs in self._training_data
-            if obs.arm_name == self.status_quo_name
+            index[0]: ObservationData(
+                metric_names=metric_names,
+                means=row["mean"].to_numpy(),
+                covariance=np.diag(row["sem"].to_numpy() ** 2),
+            )
+            for index, row in sq_data.iterrows()
         }
 
     @property
@@ -543,40 +543,42 @@ class Adapter:
         """SearchSpace used to fit model."""
         return self._model_space
 
-    def get_training_data(self) -> list[Observation]:
-        """A copy of the (untransformed) data with which the generator was fit."""
-        return deepcopy(self._training_data)
+    def get_training_data(self, filter_in_design: bool = False) -> ExperimentData:
+        """A copy of the (untransformed) data with which the generator was fit.
+
+        Args:
+            filter_in_design: If True, the data is filtered by
+                ``self.training_in_design``. Note that this will include all
+                points if ``self._data_loader_config.fit_out_of_design is True``,
+                since all points will be marked as in-design.
+        """
+        experiment_data = deepcopy(self._training_data)
+        if not filter_in_design or self._data_loader_config.fit_out_of_design:
+            return experiment_data
+        arm_data = experiment_data.arm_data.loc[self.training_in_design]
+        obs_data = experiment_data.observation_data
+        # In-design-ness is determined by the arm parameterization. So, we can
+        # just filter out the observation data by the arms that are in-design.
+        # We can't just use `self.training_in_design`, since there may be multiple
+        # rows of observations for the same arm.
+        obs_data = obs_data[
+            obs_data.index.get_level_values("arm_name").isin(
+                arm_data.index.get_level_values("arm_name")
+            )
+        ]
+        return ExperimentData(arm_data=arm_data, observation_data=obs_data)
 
     @property
     def training_in_design(self) -> list[bool]:
         """For each observation in the training data, a bool indicating if it
         is in-design for the generator.
         """
-        return self._training_in_design
-
-    @training_in_design.setter
-    def training_in_design(self, training_in_design: list[bool]) -> None:
-        if len(training_in_design) != len(self._training_data):
-            raise ValueError(
-                f"In-design indicators not same length ({len(training_in_design)})"
-                f" as training data ({len(self._training_data)})."
-            )
-        # Identify out-of-design arms
-        if sum(training_in_design) < len(training_in_design):
-            ood_names = []
-            for i, obs in enumerate(self._training_data):
-                if not training_in_design[i] and obs.arm_name is not None:
-                    ood_names.append(obs.arm_name)
-            ood_str = ", ".join(set(ood_names))
-            logger.warning(
-                f"Leaving out out-of-design observations for arms: {ood_str}"
-            )
-        self._training_in_design = training_in_design
+        return self._training_in_design_idx
 
     def _fit(
         self,
         search_space: SearchSpace,
-        observations: list[Observation],
+        experiment_data: ExperimentData,
     ) -> None:
         """Apply terminal transform and fit the generator."""
         raise AdapterMethodNotImplementedError(
@@ -928,7 +930,7 @@ class Adapter:
 
     def cross_validate(
         self,
-        cv_training_data: list[Observation],
+        cv_training_data: ExperimentData,
         cv_test_points: list[ObservationFeatures],
         use_posterior_predictive: bool = False,
     ) -> list[ObservationData]:
@@ -973,7 +975,7 @@ class Adapter:
     def _cross_validate(
         self,
         search_space: SearchSpace,
-        cv_training_data: list[Observation],
+        cv_training_data: ExperimentData,
         cv_test_points: list[ObservationFeatures],
         use_posterior_predictive: bool = False,
     ) -> list[ObservationData]:
@@ -986,9 +988,9 @@ class Adapter:
 
     def _transform_inputs_for_cv(
         self,
-        cv_training_data: list[Observation],
+        cv_training_data: ExperimentData,
         cv_test_points: list[ObservationFeatures],
-    ) -> tuple[list[Observation], list[ObservationFeatures], SearchSpace]:
+    ) -> tuple[ExperimentData, list[ObservationFeatures], SearchSpace]:
         """Apply transforms to cv_training_data and cv_test_points,
         and return cv_training_data, cv_test_points, and search space in
         transformed space. This is to prepare data to be used in _cross_validate.
@@ -998,15 +1000,19 @@ class Adapter:
             cv_test_points: The test points at which predictions will be made.
 
         Returns:
-            cv_training_data, cv_test_points, and search space
-            in transformed space."""
+            cv_training_data, cv_test_points, and search_space in transformed space.
+        """
         cv_test_points = deepcopy(cv_test_points)
         cv_training_data = deepcopy(cv_training_data)
         search_space = self._model_space.clone()
         for t in self.transforms.values():
-            cv_training_data = t.transform_observations(cv_training_data)
-            cv_test_points = t.transform_observation_features(cv_test_points)
-            search_space = t.transform_search_space(search_space)
+            cv_training_data = t.transform_experiment_data(
+                experiment_data=cv_training_data
+            )
+            cv_test_points = t.transform_observation_features(
+                observation_features=cv_test_points
+            )
+            search_space = t.transform_search_space(search_space=search_space)
         return cv_training_data, cv_test_points, search_space
 
     def _set_kwargs_to_save(

--- a/ax/adapter/data_utils.py
+++ b/ax/adapter/data_utils.py
@@ -37,7 +37,7 @@ from pyre_extensions import none_throws
 @dataclass(frozen=True)
 class DataLoaderConfig:
     """This dataclass contains parameters that control the behavior
-    of `Adapter._set_training_data`.
+    of `Adapter._set_and_filter_training_data`.
 
     Args:
         fit_out_of_design: If specified, all training data are used.

--- a/ax/adapter/random.py
+++ b/ax/adapter/random.py
@@ -18,10 +18,11 @@ from ax.adapter.adapter_utils import (
     transform_callback,
 )
 from ax.adapter.base import Adapter, DataLoaderConfig, GenResults
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.core.data import Data
 from ax.core.experiment import Experiment
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.generators.random.base import RandomGenerator
@@ -73,7 +74,7 @@ class RandomAdapter(Adapter):
     def _fit(
         self,
         search_space: SearchSpace,
-        observations: list[Observation] | None = None,
+        experiment_data: ExperimentData,
     ) -> None:
         """Extracts the list of parameters from the search space."""
         self.parameters = list(search_space.parameters.keys())
@@ -138,25 +139,6 @@ class RandomAdapter(Adapter):
             observation_features=observation_features,
             weights=w.tolist(),
         )
-
-    def _predict(
-        self,
-        observation_features: list[ObservationFeatures],
-        use_posterior_predictive: bool = False,
-    ) -> list[ObservationData]:
-        """Apply terminal transform, predict, and reverse terminal transform on
-        output.
-        """
-        raise NotImplementedError("RandomAdapter does not support prediction.")
-
-    def _cross_validate(
-        self,
-        search_space: SearchSpace,
-        cv_training_data: list[Observation],
-        cv_test_points: list[ObservationFeatures],
-        use_posterior_predictive: bool = False,
-    ) -> list[ObservationData]:
-        raise NotImplementedError
 
     def _set_status_quo(self, experiment: Experiment) -> None:
         pass

--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import warnings
+from copy import deepcopy
 from typing import Any
 from unittest import mock
 from unittest.mock import Mock
@@ -23,10 +24,11 @@ from ax.adapter.base import (
     logger,
     unwrap_observation_data,
 )
+from ax.adapter.data_utils import ExperimentData, extract_experiment_data
 from ax.adapter.factory import get_sobol
-from ax.adapter.registry import Generators, Y_trans
+from ax.adapter.registry import MBM_X_trans, MBM_X_trans_base, Y_trans
+from ax.adapter.transforms.cast import Cast
 from ax.adapter.transforms.fill_missing_parameters import FillMissingParameters
-from ax.adapter.transforms.int_to_float import IntToFloat
 from ax.adapter.transforms.standardize_y import StandardizeY
 from ax.adapter.transforms.unit_x import UnitX
 from ax.core.arm import Arm
@@ -36,17 +38,13 @@ from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
 from ax.core.metric import Metric
 from ax.core.objective import Objective, ScalarizedObjective
-from ax.core.observation import (
-    Observation,
-    ObservationData,
-    ObservationFeatures,
-    observations_from_data,
-)
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import ComparisonOp, OutcomeConstraint
-from ax.core.parameter import FixedParameter, ParameterType, RangeParameter
-from ax.core.parameter_constraint import ParameterConstraint, SumConstraint
+from ax.core.parameter import ParameterType, RangeParameter
+from ax.core.parameter_constraint import SumConstraint
 from ax.core.search_space import SearchSpace
+from ax.core.types import TParameterization
 from ax.core.utils import get_target_trial_index
 from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.exceptions.model import ModelError
@@ -67,7 +65,7 @@ from ax.utils.testing.core_stubs import (
     get_map_metric,
     get_non_monolithic_branin_moo_data,
     get_optimization_config_no_constraints,
-    get_search_space_for_range_value,
+    get_search_space_for_range_values,
     get_search_space_for_value,
 )
 from ax.utils.testing.modeling_stubs import (
@@ -75,80 +73,164 @@ from ax.utils.testing.modeling_stubs import (
     get_observation1,
     get_observation1trans,
     get_observation2,
-    get_observation2trans,
-    transform_1,
-    transform_2,
 )
 from botorch.exceptions.warnings import InputDataWarning
 from botorch.models.utils.assorted import validate_input_scaling
+from pandas.testing import assert_frame_equal
 from pyre_extensions import assert_is_instance, none_throws
+
+ADAPTER__GEN_PATH: str = "ax.adapter.base.Adapter._gen"
 
 
 class BaseAdapterTest(TestCase):
-    @mock.patch(
-        "ax.adapter.base.observations_from_data",
-        autospec=True,
-        return_value=([get_observation1(), get_observation2()]),
-    )
+    def test_init_empty(self) -> None:
+        # Test Adapter initialization with an experiment with no data.
+        exp = get_branin_experiment()
+        generator = Generator()
+        with mock.patch("ax.adapter.base.Adapter._fit") as mock_fit:
+            adapter = Adapter(
+                experiment=exp, generator=generator, transforms=MBM_X_trans_base
+            )
+        # Check that the properties are set correctly.
+        self.assertEqual(adapter._data_loader_config, DataLoaderConfig())
+        self.assertEqual(adapter._raw_transforms, [Cast] + MBM_X_trans_base)
+        self.assertEqual(adapter._transform_configs, {})
+        self.assertEqual(
+            list(adapter.transforms), [t.__name__ for t in [Cast] + MBM_X_trans_base]
+        )
+        self.assertEqual(adapter.fit_time, adapter.fit_time_since_gen)
+        self.assertEqual(adapter._metric_names, set())
+        self.assertEqual(adapter._optimization_config, exp.optimization_config)
+        self.assertEqual(adapter._training_in_design_idx, [])
+        self.assertIsNone(adapter._status_quo)
+        self.assertIsNone(adapter._status_quo_name)
+        self.assertIsNone(adapter._model_key)
+        self.assertIsNone(adapter._model_kwargs)
+        self.assertIsNone(adapter._bridge_kwargs)
+        self.assertEqual(adapter._search_space, exp.search_space)
+        self.assertEqual(adapter._model_space, exp.search_space)
+        self.assertTrue(adapter._fit_tracking_metrics)
+        self.assertEqual(adapter.outcomes, [])
+        self.assertEqual(
+            adapter._experiment_has_immutable_search_space_and_opt_config,
+            exp.immutable_search_space_and_opt_config,
+        )
+        self.assertIs(adapter._experiment, exp)
+        self.assertEqual(adapter._experiment_properties, exp._properties)
+        self.assertEqual(adapter._arms_by_signature, {})
+        self.assertIs(adapter.generator, generator)
+        # Check that the experiment data object is empty.
+        self.assertTrue(adapter._training_data.arm_data.empty)
+        self.assertTrue(adapter._training_data.observation_data.empty)
+        # Check that fit was called with the transformed arguments.
+        search_space = adapter._search_space.clone()
+        experiment_data = adapter.get_training_data()
+        for t in adapter.transforms.values():
+            search_space = t.transform_search_space(search_space)
+            experiment_data = t.transform_experiment_data(experiment_data)
+        mock_fit.assert_called_with(
+            search_space=search_space, experiment_data=experiment_data
+        )
+        # Test that fit is not called when fit_on_init = False.
+        mock_fit.reset_mock()
+        adapter = Adapter(experiment=exp, generator=Generator(), fit_on_init=False)
+        self.assertEqual(mock_fit.call_count, 0)
+
+    def _test_init_with_data(self, multi_objective: bool) -> None:
+        # Test Adapter initialization with a simple experiment with (non-map) data.
+        exp_constructor = (
+            get_branin_experiment_with_multi_objective
+            if multi_objective
+            else get_branin_experiment
+        )
+        exp = exp_constructor(with_completed_batch=True, with_status_quo=True)
+        generator = Generator()
+        with mock.patch("ax.adapter.base.Adapter._fit") as mock_fit:
+            adapter = Adapter(
+                experiment=exp, generator=generator, transforms=MBM_X_trans + Y_trans
+            )
+        # Check that the properties are set correctly.
+        # Only checking a subset that are expected to be different than test_init_empty.
+        self.assertEqual(adapter._raw_transforms, [Cast] + MBM_X_trans + Y_trans)
+        metric_names = set(exp.metrics)
+        self.assertEqual(adapter._metric_names, metric_names)
+        self.assertEqual(
+            adapter._training_in_design_idx, [True] * len(exp.arms_by_name)
+        )
+        self.assertEqual(adapter._optimization_config, exp.optimization_config)
+        self.assertEqual(adapter._status_quo_name, none_throws(exp.status_quo).name)
+        # Not checking SQ observation in detail, _set_status_quo is tested separately.
+        self.assertIsNotNone(adapter._status_quo)
+        self.assertEqual(adapter._arms_by_signature, exp.arms_by_signature)
+        # Check the raw training data.
+        exp_df = exp.to_df()
+        self.assertTrue(
+            np.allclose(
+                adapter._training_data.arm_data[["x1", "x2"]], exp_df[["x1", "x2"]]
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                adapter._training_data.observation_data[
+                    [("mean", m) for m in metric_names]
+                ],
+                exp_df.sort_values(by="arm_name")[list(metric_names)],
+            )
+        )
+        # Check that fit was called with the transformed arguments.
+        search_space = adapter._search_space.clone()
+        experiment_data = adapter.get_training_data()
+        for t in adapter.transforms.values():
+            search_space = t.transform_search_space(search_space)
+            experiment_data = t.transform_experiment_data(experiment_data)
+        mock_fit.assert_called_with(
+            search_space=search_space, experiment_data=experiment_data
+        )
+
+    def test_init_with_data_single_objective(self) -> None:
+        self._test_init_with_data(multi_objective=False)
+
+    def test_init_with_data_multi_objective(self) -> None:
+        self._test_init_with_data(multi_objective=True)
+
+    def test_fit_tracking_metrics(self) -> None:
+        # Test error when fit_tracking_metrics is False and optimization
+        # config is not specified.
+        exp = get_branin_experiment(has_optimization_config=False)
+        with self.assertRaisesRegex(UserInputError, "fit_tracking_metrics"):
+            Adapter(experiment=exp, generator=Generator(), fit_tracking_metrics=False)
+
+        # Test error when fit_tracking_metrics is False and optimization
+        # config is updated to include new metrics.
+        adapter = Adapter(
+            experiment=get_branin_experiment(),
+            generator=Generator(),
+            fit_tracking_metrics=False,
+        )
+        new_oc = OptimizationConfig(
+            objective=Objective(metric=Metric(name="test_metric2"), minimize=False),
+        )
+        with self.assertRaisesRegex(UnsupportedError, "fit_tracking_metrics"):
+            adapter.gen(n=1, optimization_config=new_oc)
+
     @mock.patch(
         "ax.adapter.base.gen_arms",
         autospec=True,
-        return_value=([Arm(parameters={})], None),
+        return_value=([Arm(parameters={"x1": 0.5, "x2": 0.5})], None),
     )
     @mock.patch("ax.adapter.base.Adapter._fit", autospec=True)
-    def test_Adapter(
-        self, mock_fit: Mock, mock_gen_arms: Mock, mock_observations_from_data: Mock
-    ) -> None:
-        # Test that on init transforms are stored and applied in the correct order
-        transforms = [transform_1, transform_2]
-        exp = get_experiment_for_value()
+    def test_gen_base(self, mock_fit: Mock, mock_gen_arms: Mock) -> None:
+        transforms = [UnitX, StandardizeY]
+        exp = get_branin_experiment(with_completed_trial=True)
+        search_space = exp.search_space
         adapter = Adapter(experiment=exp, generator=Generator(), transforms=transforms)
-        self.assertFalse(adapter._experiment_has_immutable_search_space_and_opt_config)
-        self.assertEqual(
-            list(adapter.transforms.keys()), ["Cast", "transform_1", "transform_2"]
-        )
-        fit_args = mock_fit.mock_calls[0][2]
-        self.assertTrue(fit_args["search_space"] == get_search_space_for_value(8.0))
-        self.assertTrue(fit_args["observations"] == [])
-        self.assertTrue(mock_observations_from_data.called)
-
-        # Test prediction with arms.
-        with self.assertRaisesRegex(
-            UserInputError, "Input to predict must be a list of `ObservationFeatures`."
-        ):
-            # pyre-ignore[6]: Intentionally wrong argument type.
-            adapter.predict([Arm(parameters={"x": 1.0})])
-
-        # Test errors on prediction.
-        adapter._predict = mock.MagicMock(
-            "ax.adapter.base.Adapter._predict",
-            autospec=True,
-            side_effect=ValueError("Predict failed"),
-        )
-        obs_features = [get_observation2().features]
-        with self.assertRaisesRegex(ValueError, "Predict failed"):
-            adapter.predict(obs_features)
-
-        # Test that transforms are applied correctly on predict
-        mock_predict = mock.MagicMock(
-            "ax.adapter.base.Adapter._predict",
-            autospec=True,
-            return_value=[get_observation2trans().data],
-        )
-        adapter._predict = mock_predict
-        adapter.predict(obs_features)
-        # Observation features sent to _predict are un-transformed afterwards
-        mock_predict.assert_called_with(
-            observation_features=obs_features, use_posterior_predictive=False
-        )
 
         # Test transforms applied on gen
-        adapter._gen = mock.MagicMock(
-            "ax.adapter.base.Adapter._gen",
-            autospec=True,
-            return_value=GenResults(
-                observation_features=[get_observation1trans().features], weights=[2]
-            ),
+        mock_return_value = GenResults(
+            observation_features=[
+                ObservationFeatures(parameters={"x1": 0.0, "x2": 0.0})
+            ],
+            weights=[1.0],
         )
         oc = get_optimization_config_no_constraints()
         adapter._set_kwargs_to_save(
@@ -157,34 +239,52 @@ class BaseAdapterTest(TestCase):
         # Test input error when generating 0 candidates.
         with self.assertRaisesRegex(UserInputError, "Attempted to generate"):
             adapter.gen(n=0)
-        gr = adapter.gen(
-            n=1,
-            search_space=get_search_space_for_value(),
-            optimization_config=oc,
-            pending_observations={"a": [get_observation2().features]},
-            fixed_features=ObservationFeatures({"x": 5}),
-        )
+        with mock.patch(ADAPTER__GEN_PATH, return_value=mock_return_value) as mock_gen:
+            gr = adapter.gen(
+                n=1,
+                search_space=search_space,
+                optimization_config=oc,
+                pending_observations={
+                    "branin": [ObservationFeatures(parameters={"x1": 10.0, "x2": 15.0})]
+                },
+                fixed_features=ObservationFeatures({"x1": -5.0}),
+            )
         self.assertEqual(gr._model_key, "TestModel")
-        # pyre-fixme[16]: Callable `_gen` has no attribute `assert_called_with`.
-        adapter._gen.assert_called_with(
+        tf_search_space = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name=name,
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                )
+                for name in ("x1", "x2")
+            ]
+        )
+        mock_gen.assert_called_with(
             n=1,
-            search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
+            search_space=tf_search_space,
             optimization_config=oc,
-            pending_observations={"a": [get_observation2trans().features]},
-            fixed_features=ObservationFeatures({"x": 36}),
+            pending_observations={
+                "branin": [ObservationFeatures(parameters={"x1": 1.0, "x2": 1.0})]
+            },
+            fixed_features=ObservationFeatures({"x1": 0.0}),
             model_gen_options=None,
         )
         mock_gen_arms.assert_called_with(
-            arms_by_signature={}, observation_features=[get_observation1().features]
+            arms_by_signature=mock.ANY,
+            observation_features=[
+                ObservationFeatures(parameters={"x1": -5.0, "x2": 0.0})
+            ],
         )
 
         # Gen with no pending observations and no fixed features
-        adapter.gen(
-            n=1, search_space=get_search_space_for_value(), optimization_config=None
-        )
-        adapter._gen.assert_called_with(
+        adapter._optimization_config = None
+        with mock.patch(ADAPTER__GEN_PATH, return_value=mock_return_value) as mock_gen:
+            adapter.gen(n=1, search_space=search_space, optimization_config=None)
+        mock_gen.assert_called_with(
             n=1,
-            search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
+            search_space=tf_search_space,
             optimization_config=None,
             pending_observations={},
             fixed_features=ObservationFeatures(parameters={}),
@@ -197,20 +297,46 @@ class BaseAdapterTest(TestCase):
                 metrics=[Metric(name="test_metric"), Metric(name="test_metric_2")]
             )
         )
-        adapter.gen(
-            n=1, search_space=get_search_space_for_value(), optimization_config=oc2
-        )
-        adapter._gen.assert_called_with(
+        with mock.patch(ADAPTER__GEN_PATH, return_value=mock_return_value) as mock_gen:
+            adapter.gen(n=1, search_space=search_space, optimization_config=oc2)
+        mock_gen.assert_called_with(
             n=1,
-            search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
+            search_space=tf_search_space,
             optimization_config=oc2,
             pending_observations={},
             fixed_features=ObservationFeatures(parameters={}),
             model_gen_options=None,
         )
 
+    @mock.patch(
+        "ax.adapter.base.Adapter._gen",
+        autospec=True,
+        return_value=GenResults(
+            observation_features=[get_observation1trans().features], weights=[2]
+        ),
+    )
+    def test_gen_on_experiment_with_imm_ss_and_opt_conf(self, _) -> None:
+        exp = get_experiment_for_value()
+        exp._properties[Keys.IMMUTABLE_SEARCH_SPACE_AND_OPT_CONF] = True
+        exp.optimization_config = get_optimization_config_no_constraints()
+        adapter = Adapter(experiment=exp, generator=Generator())
+        self.assertTrue(adapter._experiment_has_immutable_search_space_and_opt_config)
+        gr = adapter.gen(1)
+        self.assertIsNone(gr.optimization_config)
+        self.assertIsNone(gr.search_space)
+
+    def test_cross_validate_base(self) -> None:
+        exp = get_branin_experiment(with_completed_batch=True)
+        adapter = Adapter(experiment=exp, generator=Generator(), transforms=[UnitX])
         # Test transforms applied on cross_validate and the warning is suppressed.
         called = False
+        mock_predictions: list[ObservationData] = [
+            ObservationData(
+                metric_names=["branin"],
+                means=np.zeros(1),
+                covariance=np.ones((1, 1)),
+            )
+        ]
 
         def warn_and_return_mock_obs(
             *args: Any, **kwargs: Any
@@ -222,7 +348,7 @@ class BaseAdapterTest(TestCase):
                 train_X=torch.randn(2, 5),
                 train_Y=torch.rand(2, 1),
             )
-            return [get_observation1trans().data]
+            return mock_predictions
 
         mock_cv = mock.MagicMock(
             "ax.adapter.base.Adapter._cross_validate",
@@ -230,8 +356,8 @@ class BaseAdapterTest(TestCase):
             side_effect=warn_and_return_mock_obs,
         )
         adapter._cross_validate = mock_cv
-        cv_training_data = [get_observation2()]
-        cv_test_points = [get_observation1().features]
+        cv_training_data = adapter.get_training_data()
+        cv_test_points = [ObservationFeatures(parameters={"x1": -5.0, "x2": 0.0})]
 
         # Test transforms applied on cv_training_data, cv_test_points
         (
@@ -241,10 +367,31 @@ class BaseAdapterTest(TestCase):
         ) = adapter._transform_inputs_for_cv(
             cv_training_data=cv_training_data, cv_test_points=cv_test_points
         )
-        self.assertEqual(transformed_cv_training_data, [get_observation2trans()])
-        self.assertEqual(transformed_cv_test_points, [get_observation1trans().features])
         self.assertEqual(
-            transformed_ss, SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)])
+            transformed_cv_training_data,
+            adapter.transforms["UnitX"].transform_experiment_data(
+                experiment_data=adapter.transforms["Cast"].transform_experiment_data(
+                    experiment_data=deepcopy(cv_training_data)
+                )
+            ),
+        )
+        self.assertEqual(
+            transformed_cv_test_points,
+            [ObservationFeatures(parameters={"x1": 0.0, "x2": 0.0})],
+        )
+        self.assertEqual(
+            transformed_ss,
+            SearchSpace(
+                parameters=[
+                    RangeParameter(
+                        name=name,
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0.0,
+                        upper=1.0,
+                    )
+                    for name in ("x1", "x2")
+                ]
+            ),
         )
 
         with warnings.catch_warnings(record=True) as ws:
@@ -255,12 +402,12 @@ class BaseAdapterTest(TestCase):
         self.assertFalse(any(w.category is InputDataWarning for w in ws))
 
         mock_cv.assert_called_with(
-            search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
-            cv_training_data=[get_observation2trans()],
-            cv_test_points=[get_observation1().features],  # untransformed after
+            search_space=transformed_ss,
+            cv_training_data=transformed_cv_training_data,
+            cv_test_points=cv_test_points,  # in-place untransformed after the call.
             use_posterior_predictive=False,
         )
-        self.assertTrue(cv_predictions == [get_observation1().data])
+        self.assertEqual(cv_predictions, mock_predictions)
 
         # Test use_posterior_predictive in CV
         adapter.cross_validate(
@@ -270,109 +417,19 @@ class BaseAdapterTest(TestCase):
         )
 
         mock_cv.assert_called_with(
-            search_space=SearchSpace([FixedParameter("x", ParameterType.FLOAT, 8.0)]),
-            cv_training_data=[get_observation2trans()],
-            cv_test_points=[get_observation1().features],  # untransformed after
+            search_space=transformed_ss,
+            cv_training_data=transformed_cv_training_data,
+            cv_test_points=cv_test_points,  # in-place untransformed after the call.
             use_posterior_predictive=True,
         )
 
-        # Test stored training data
-        obs = adapter.get_training_data()
-        self.assertTrue(obs == [get_observation1(), get_observation2()])
-        self.assertEqual(adapter.metric_names, {"a", "b"})
-        self.assertIsNone(adapter.status_quo)
-        self.assertTrue(adapter.model_space == get_search_space_for_value())
-        self.assertEqual(adapter.training_in_design, [False, False])
-
-        with self.assertRaises(ValueError):
-            adapter.training_in_design = [True, True, False]
-
-        with self.assertRaises(ValueError):
-            adapter.training_in_design = [True, True, False]
-
-        # Test feature_importances
-        with self.assertRaises(NotImplementedError):
-            adapter.feature_importances("a")
-
-        # Test transform observation features
-        with mock.patch(
-            "ax.adapter.base.Adapter._transform_observation_features",
-            autospec=True,
-        ) as mock_tr:
-            adapter.transform_observation_features([get_observation2().features])
-        mock_tr.assert_called_with(adapter, [get_observation2trans().features])
-
-        # Test that fit is not called when fit_on_init = False.
-        mock_fit.reset_mock()
-        adapter = Adapter(experiment=exp, generator=Generator(), fit_on_init=False)
-        self.assertEqual(mock_fit.call_count, 0)
-
-        # Test error when fit_tracking_metrics is False and optimization
-        # config is not specified.
-        with self.assertRaisesRegex(UserInputError, "fit_tracking_metrics"):
-            Adapter(experiment=exp, generator=Generator(), fit_tracking_metrics=False)
-
-        # Test error when fit_tracking_metrics is False and optimization
-        # config is updated to include new metrics.
-        adapter = Adapter(
-            experiment=exp,
-            generator=Generator(),
-            optimization_config=oc,
-            fit_tracking_metrics=False,
-        )
-        new_oc = OptimizationConfig(
-            objective=Objective(metric=Metric(name="test_metric2"), minimize=False),
-        )
-        with self.assertRaisesRegex(UnsupportedError, "fit_tracking_metrics"):
-            adapter.gen(n=1, optimization_config=new_oc)
-
-    def test_transform_data(self) -> None:
-        search_space = SearchSpace(
-            parameters=[
-                RangeParameter(
-                    name=f"x{i}",
-                    parameter_type=ParameterType.FLOAT,
-                    lower=2.0,
-                    upper=3.0,
-                )
-                for i in [1, 2]
-            ],
-            parameter_constraints=[
-                ParameterConstraint(constraint_dict={"x1": -1, "x2": -1}, bound=1.5)
-            ],
-        )
-        exp = Experiment(search_space=search_space)
-        adapter = Generators.SOBOL(experiment=exp, transforms=[IntToFloat, UnitX])
-        candidate = adapter.gen(n=1)
-
-        with self.subTest("Candidate in search space"):
-            self.assertTrue(
-                search_space.check_membership(
-                    parameterization=candidate.arms[0].parameters
-                )
-            )
-        int_to_float_tf = assert_is_instance(
-            adapter.transforms["IntToFloat"], IntToFloat
-        )
-
-        with self.subTest("IntToFloat uses correct search space"):
-            self.assertEqual(
-                int_to_float_tf.search_space.parameters["x1"],
-                search_space.parameters["x1"],
-            )
-
-    @mock.patch(
-        "ax.adapter.base.observations_from_data",
-        autospec=True,
-        return_value=([get_observation1(), get_observation2()]),
-    )
     @mock.patch(
         "ax.adapter.base.gen_arms",
         autospec=True,
         return_value=([Arm(parameters={})], None),
     )
     @mock.patch("ax.adapter.base.Adapter._fit", autospec=True)
-    def test_repeat_candidates(self, _: Mock, __: Mock, ___: Mock) -> None:
+    def test_repeat_candidates(self, _: Mock, __: Mock) -> None:
         adapter = Adapter(
             experiment=get_experiment_for_value(),
             generator=Generator(),
@@ -413,26 +470,6 @@ class BaseAdapterTest(TestCase):
                 cm.output,
             )
 
-    @mock.patch(
-        "ax.adapter.base.gen_arms",
-        autospec=True,
-        return_value=([Arm(parameters={"x1": 0.0, "x2": 0.0})], None),
-    )
-    def test_with_status_quo(self, _: Mock) -> None:
-        # Test init with a status quo.
-        exp = get_branin_experiment(
-            with_trial=True,
-            with_status_quo=True,
-            with_completed_trial=True,
-        )
-        adapter = Adapter(
-            experiment=exp,
-            generator=Generator(),
-            transforms=Y_trans,
-        )
-        self.assertIsNotNone(adapter.status_quo)
-        self.assertEqual(adapter.status_quo.features.parameters, {"x1": 0.0, "x2": 0.0})
-
     @mock.patch("ax.adapter.base.Adapter._fit", autospec=True)
     @mock.patch("ax.adapter.base.Adapter._gen", autospec=True)
     def test_timing(self, _: Mock, __: Mock) -> None:
@@ -443,13 +480,19 @@ class BaseAdapterTest(TestCase):
         )
         self.assertEqual(adapter.fit_time, 0.0)
         adapter._fit_if_implemented(
-            search_space=search_space, observations=[], time_so_far=3.0
+            search_space=search_space,
+            experiment_data=adapter._training_data,
+            time_so_far=3.0,
         )
         adapter._fit_if_implemented(
-            search_space=search_space, observations=[], time_so_far=2.0
+            search_space=search_space,
+            experiment_data=adapter._training_data,
+            time_so_far=2.0,
         )
         adapter._fit_if_implemented(
-            search_space=search_space, observations=[], time_so_far=1.0
+            search_space=search_space,
+            experiment_data=adapter._training_data,
+            time_so_far=1.0,
         )
         self.assertAlmostEqual(adapter.fit_time, 6.0, places=1)
         self.assertAlmostEqual(adapter.fit_time_since_gen, 6.0, places=1)
@@ -457,12 +500,7 @@ class BaseAdapterTest(TestCase):
         self.assertAlmostEqual(adapter.fit_time, 6.0, places=1)
         self.assertAlmostEqual(adapter.fit_time_since_gen, 0.0, places=1)
 
-    @mock.patch(
-        "ax.adapter.base.observations_from_data",
-        autospec=True,
-        return_value=([get_observation1(), get_observation2()]),
-    )
-    def test_ood_gen(self, _) -> None:
+    def test_ood_gen(self) -> None:
         # Test fit_out_of_design by returning OOD candidates
         ss = SearchSpace([RangeParameter("x", ParameterType.FLOAT, 0.0, 1.0)])
         experiment = Experiment(search_space=ss)
@@ -541,13 +579,8 @@ class BaseAdapterTest(TestCase):
 
         # create data where metrics vary in start and end times
         data = get_non_monolithic_branin_moo_data()
-        with warnings.catch_warnings(record=True) as ws, mock.patch.object(
-            exp, "lookup_data", return_value=data
-        ):
+        with mock.patch.object(exp, "lookup_data", return_value=data):
             adapter = Adapter(experiment=exp, generator=Generator(), data=data)
-        # Check that we get warnings about start and end time columns being discarded.
-        self.assertTrue(any("start_time" in str(w.message) for w in ws))
-        self.assertTrue(any("end_time" in str(w.message) for w in ws))
         # Check that SQ is set.
         self.assertEqual(adapter.status_quo_name, "status_quo")
         self.assertIsNotNone(adapter.status_quo)
@@ -719,15 +752,11 @@ class BaseAdapterTest(TestCase):
         with self.assertRaises(ValueError):
             unwrap_observation_data(observation_data + [od3])
 
-    def test_GenArms(self) -> None:
-        p1 = {"x": 0, "y": 1}
-        p2 = {"x": 4, "y": 8}
+    def test_gen_arms(self) -> None:
+        p1: TParameterization = {"x": 0, "y": 1}
+        p2: TParameterization = {"x": 4, "y": 8}
         observation_features = [
-            # pyre-fixme[6]: For 1st param expected `Dict[str, Union[None, bool,
-            #  float, int, str]]` but got `Dict[str, int]`.
             ObservationFeatures(parameters=p1),
-            # pyre-fixme[6]: For 1st param expected `Dict[str, Union[None, bool,
-            #  float, int, str]]` but got `Dict[str, int]`.
             ObservationFeatures(parameters=p2),
         ]
         arms, candidate_metadata = gen_arms(observation_features=observation_features)
@@ -750,49 +779,6 @@ class BaseAdapterTest(TestCase):
                 arms[1].signature: {"some_key": "some_val_1"},
             },
         )
-
-    @mock.patch(
-        "ax.adapter.base.Adapter._gen",
-        autospec=True,
-        return_value=GenResults(
-            observation_features=[get_observation1trans().features], weights=[2]
-        ),
-    )
-    def test_GenWithDefaults(self, mock_gen: Mock) -> None:
-        exp = get_experiment_for_value()
-        exp.optimization_config = get_optimization_config_no_constraints()
-        ss = get_search_space_for_range_value()
-        adapter = Adapter(experiment=exp, generator=Generator(), search_space=ss)
-        adapter.gen(1)
-        mock_gen.assert_called_with(
-            adapter,
-            n=1,
-            search_space=ss,
-            fixed_features=ObservationFeatures(parameters={}),
-            model_gen_options=None,
-            optimization_config=OptimizationConfig(
-                objective=Objective(metric=Metric("test_metric"), minimize=False),
-                outcome_constraints=[],
-            ),
-            pending_observations={},
-        )
-
-    @mock.patch(
-        "ax.adapter.base.Adapter._gen",
-        autospec=True,
-        return_value=GenResults(
-            observation_features=[get_observation1trans().features], weights=[2]
-        ),
-    )
-    def test_gen_on_experiment_with_imm_ss_and_opt_conf(self, _) -> None:
-        exp = get_experiment_for_value()
-        exp._properties[Keys.IMMUTABLE_SEARCH_SPACE_AND_OPT_CONF] = True
-        exp.optimization_config = get_optimization_config_no_constraints()
-        adapter = Adapter(experiment=exp, generator=Generator())
-        self.assertTrue(adapter._experiment_has_immutable_search_space_and_opt_config)
-        gr = adapter.gen(1)
-        self.assertIsNone(gr.optimization_config)
-        self.assertIsNone(gr.search_space)
 
     def test_ClampObservationFeaturesNearBounds(self) -> None:
         cases = [
@@ -862,10 +848,10 @@ class BaseAdapterTest(TestCase):
                 ),
             ],
         )
-        sq_arm = Arm(name="status_quo", parameters={"x1": None})
+        sq_arm = Arm(name="status_quo", parameters={"x1": None, "x2": None})
         experiment = Experiment(
             name="test",
-            search_space=ss1,
+            search_space=ss2,
             optimization_config=get_branin_optimization_config(),
             status_quo=sq_arm,
             is_test=True,
@@ -890,10 +876,13 @@ class BaseAdapterTest(TestCase):
             ["Cast"],
         )
         # Check that SQ and all trial 1 are OOD
-        arm_names = [obs.arm_name for obs in m.get_training_data()]
-        ood_arms = [a for i, a in enumerate(arm_names) if not m.training_in_design[i]]
+        ood_arms = set(
+            m.get_training_data()
+            .arm_data.loc[~np.array(m.training_in_design)]
+            .index.get_level_values("arm_name")
+        )
         self.assertEqual(
-            set(ood_arms), {"status_quo", "1_0", "1_1", "1_2", "1_3", "1_4"}
+            set(ood_arms), {"status_quo", "0_0", "0_1", "0_2", "0_3", "0_4"}
         )
         # Fit with filling missing parameters
         m = Adapter(
@@ -909,15 +898,18 @@ class BaseAdapterTest(TestCase):
         # All arms are in design now
         self.assertEqual(sum(m.training_in_design), 12)
         # Check the arms with missing values were correctly filled
-        fit_args = mock_fit.mock_calls[1][2]
-        for obs in fit_args["observations"]:
-            if obs.arm_name == "status_quo":
-                self.assertEqual(obs.features.parameters, sq_vals)
-            elif obs.arm_name[0] == "0":
-                # These arms were all missing x2
-                self.assertEqual(obs.features.parameters["x2"], sq_vals["x2"])
+        fit_args = mock_fit.call_args.kwargs
+        arm_data = fit_args["experiment_data"].arm_data
+        sq_params = arm_data.loc[
+            arm_data.index.get_level_values("arm_name") == "status_quo"
+        ][["x1", "x2"]].to_dict(orient="records")
+        self.assertEqual(sq_params, [sq_vals, sq_vals])
+        trial_0_params = arm_data.loc[(0, slice(None))]
+        self.assertEqual(
+            trial_0_params["x2"].to_list(), [sq_vals["x2"]] * len(trial_0_params)
+        )
 
-    def test_SetModelSpace(self) -> None:
+    def test_set_model_space(self) -> None:
         # Set up experiment
         experiment = get_branin_experiment()
         # SQ values are OOD
@@ -953,8 +945,11 @@ class BaseAdapterTest(TestCase):
             search_space=ss,
             expand_model_space=False,
         )
-        arm_names = [obs.arm_name for obs in m.get_training_data()]
-        ood_arms = [a for i, a in enumerate(arm_names) if not m.training_in_design[i]]
+        ood_arms = set(
+            m.get_training_data()
+            .arm_data.loc[~np.array(m.training_in_design)]
+            .index.get_level_values("arm_name")
+        )
         self.assertEqual(set(ood_arms), {"status_quo", "custom"})
         self.assertEqual(m.model_space.parameters["x1"].lower, -5.0)  # pyre-ignore[16]
         self.assertEqual(m.model_space.parameters["x2"].upper, 15.0)  # pyre-ignore[16]
@@ -966,8 +961,11 @@ class BaseAdapterTest(TestCase):
             generator=Generator(),
             search_space=ss,
         )
-        arm_names = [obs.arm_name for obs in m.get_training_data()]
-        ood_arms = [a for i, a in enumerate(arm_names) if not m.training_in_design[i]]
+        ood_arms = set(
+            m.get_training_data()
+            .arm_data.loc[~np.array(m.training_in_design)]
+            .index.get_level_values("arm_name")
+        )
         self.assertEqual(set(ood_arms), {"status_quo"})
         self.assertEqual(m.model_space.parameters["x1"].lower, -20.0)
         self.assertEqual(m.model_space.parameters["x2"].upper, 18.0)
@@ -985,42 +983,38 @@ class BaseAdapterTest(TestCase):
         self.assertEqual(m.model_space.parameters["x2"].upper, 20)
         self.assertEqual(m.model_space.parameter_constraints, [])
 
-    @mock.patch("ax.adapter.base.observations_from_data", wraps=observations_from_data)
+    @mock.patch(
+        "ax.adapter.base.extract_experiment_data", wraps=extract_experiment_data
+    )
     def test_fit_only_completed_map_metrics(
-        self, mock_observations_from_data: Mock
+        self, mock_extract_experiment_data: Mock
     ) -> None:
         # _prepare_observations is called in the constructor and itself calls
         # observations_from_data with expanded statuses to include.
         experiment = get_experiment_for_value()
         experiment.status_quo = Arm(name="1_1", parameters={"x": 3.0})
-        adapter = Adapter(
-            experiment=experiment,
-            generator=Generator(),
-            data=MapData(),
-            data_loader_config=DataLoaderConfig(
-                fit_only_completed_map_metrics=False,
-            ),
-        )
-        kwargs = mock_observations_from_data.call_args.kwargs
-        self.assertEqual(
-            kwargs["statuses_to_include_map_metric"],
-            adapter._data_loader_config.statuses_to_fit,
-        )
-        # assert `latest_rows_per_group` is 1
-        self.assertEqual(kwargs["latest_rows_per_group"], 1)
-        mock_observations_from_data.reset_mock()
-
-        # With fit_only_completed_map_metrics=True, statuses to fit is limited.
+        data_loader_config = DataLoaderConfig(fit_only_completed_map_metrics=False)
         Adapter(
             experiment=experiment,
             generator=Generator(),
-            data_loader_config=DataLoaderConfig(
-                fit_only_completed_map_metrics=True,
-            ),
+            data=MapData(),
+            data_loader_config=data_loader_config,
         )
-        kwargs = mock_observations_from_data.call_args.kwargs
+        kwargs = mock_extract_experiment_data.call_args.kwargs
+        self.assertEqual(kwargs["data_loader_config"], data_loader_config)
+        mock_extract_experiment_data.reset_mock()
+
+        # With fit_only_completed_map_metrics=True, statuses to fit is limited.
+        data_loader_config = DataLoaderConfig(fit_only_completed_map_metrics=True)
+        Adapter(
+            experiment=experiment,
+            generator=Generator(),
+            data_loader_config=data_loader_config,
+        )
+        kwargs = mock_extract_experiment_data.call_args.kwargs
+        self.assertEqual(kwargs["data_loader_config"], data_loader_config)
         self.assertEqual(
-            kwargs["statuses_to_include_map_metric"], {TrialStatus.COMPLETED}
+            data_loader_config.statuses_to_fit_map_metric, {TrialStatus.COMPLETED}
         )
 
     def test_data_extraction_from_experiment(self) -> None:
@@ -1047,12 +1041,37 @@ class BaseAdapterTest(TestCase):
         np_obs = np_obs / np.std(np_obs, ddof=1) * 2.0
         np_obs = np_obs - np.mean(np_obs)
 
-        experiment = get_experiment_with_observations(observations=np_obs.tolist())
+        search_space = get_search_space_for_range_values(min=2.0, max=6.0)
+        experiment = get_experiment_with_observations(
+            observations=np_obs.tolist(), search_space=search_space
+        )
         adapter = Adapter(
             experiment=experiment,
             generator=Generator(),
-            transforms=[StandardizeY],
+            transforms=[UnitX, StandardizeY],
         )
+        obs_features = [
+            ObservationFeatures(parameters={"x": 3.0, "y": 4.0}) for _ in range(3)
+        ]
+        tf_obs_features = UnitX(
+            search_space=search_space
+        ).transform_observation_features(observation_features=obs_features)
+
+        # Test prediction with arms.
+        with self.assertRaisesRegex(
+            UserInputError, "Input to predict must be a list of `ObservationFeatures`."
+        ):
+            # pyre-ignore[6]: Intentionally wrong argument type.
+            adapter.predict([Arm(parameters={"x": 1.0})])
+
+        # Test errors on prediction.
+        adapter._predict = mock.MagicMock(
+            "ax.adapter.base.Adapter._predict",
+            autospec=True,
+            side_effect=ValueError("Predict failed"),
+        )
+        with self.assertRaisesRegex(ValueError, "Predict failed"):
+            adapter.predict(observation_features=obs_features)
 
         def mock_predict(
             observation_features: list[ObservationFeatures],
@@ -1065,15 +1084,13 @@ class BaseAdapterTest(TestCase):
                 for _ in observation_features
             ]
 
-        obs_features = [
-            ObservationFeatures(parameters={"x": 3.0, "y": 4.0}) for _ in range(3)
-        ]
         with mock.patch.object(
             adapter, "_predict", side_effect=mock_predict
         ) as mock_pred:
             f, _ = adapter.predict(observation_features=obs_features)
+        # Check that _predict was called with transformed features.
         mock_pred.assert_called_once_with(
-            observation_features=obs_features, use_posterior_predictive=False
+            observation_features=tf_obs_features, use_posterior_predictive=False
         )
         # Check that the predictions were un-transformed with std dev = 2.0.
         self.assertTrue(np.allclose(f["m1"], np.ones(3) * 2.0))
@@ -1088,3 +1105,32 @@ class BaseAdapterTest(TestCase):
                     ObservationFeatures(parameters={"x": 3.0, "y": None}),
                 ]
             )
+
+    def test_get_training_data(self) -> None:
+        # Construct experiment with some out of design training data.
+        # Search space is x, y; both are range parameters in [0, 1].
+        experiment = get_experiment_with_observations(
+            observations=[[1.0], [2.0], [3.0], [4.0]],
+            parameterizations=[
+                {"x": 0.0, "y": 0.0},
+                {"x": 2.0, "y": 1.0},
+                {"x": 0.5, "y": 1.0},
+                {"x": 0.5},
+            ],
+        )
+        adapter = Adapter(
+            experiment=experiment, generator=Generator(), expand_model_space=False
+        )
+        # Check the default behavior, includes all data.
+        training_data = adapter.get_training_data()
+        self.assertIsInstance(training_data, ExperimentData)
+        self.assertEqual(len(training_data.arm_data), 4)
+        # Check in-design only.
+        in_design_training_data = adapter.get_training_data(filter_in_design=True)
+        assert_frame_equal(
+            in_design_training_data.arm_data, training_data.arm_data.iloc[[0, 2]]
+        )
+        assert_frame_equal(
+            in_design_training_data.observation_data,
+            training_data.observation_data.iloc[[0, 2]],
+        )

--- a/ax/adapter/tests/test_discrete_adapter.py
+++ b/ax/adapter/tests/test_discrete_adapter.py
@@ -269,21 +269,24 @@ class DiscreteAdapterTest(TestCase):
                 cv_training_data=adapter.get_training_data(),
                 cv_test_points=self.observation_features,
             )
-        Xs = [
-            [[0, "foo", True], [1, "foo", True], [1, "bar", True]],
-            [[0, "foo", True], [1, "foo", True]],
+
+        Xs_array = [
+            [[0.0, "foo", True], [1.0, "foo", True], [1.0, "bar", True]],  # m1
+            [[0.0, "foo", True], [1.0, "foo", True]],  # m2
         ]
-        Ys = [[[1.0], [2.0], [3.0]], [[-1.0], [-2.0]]]
-        Yvars = [[[1.0], [2.25], [1.44]], [[4.0], [9.0]]]
+        Ys_array = [
+            [1.0, 2.0, 3.0],  # m1
+            [-1.0, -2.0],  # m2
+        ]
+        Yvars_array = [
+            [1.0, 2.25, 1.44],  # m1
+            [4.0, 9.0],  # m2
+        ]
         Xtest = [[0, "foo", True], [1, "foo", True], [1, "bar", True]]
-        # Transform to arrays:
         model_cv_args = mock_cv.call_args.kwargs
-        for i, x in enumerate(model_cv_args["Xs_train"]):
-            self.assertEqual(x, Xs[i])
-        for i, y in enumerate(model_cv_args["Ys_train"]):
-            self.assertEqual(y, Ys[i])
-        for i, v in enumerate(model_cv_args["Yvars_train"]):
-            self.assertEqual(v, Yvars[i])
+        self.assertEqual(model_cv_args["Xs_train"], Xs_array)
+        self.assertEqual(model_cv_args["Ys_train"], Ys_array)
+        self.assertEqual(model_cv_args["Yvars_train"], Yvars_array)
         self.assertEqual(model_cv_args["X_test"], Xtest)
         # Transform from arrays:
         for i, od in enumerate(observation_data):

--- a/ax/adapter/tests/test_random_adapter.py
+++ b/ax/adapter/tests/test_random_adapter.py
@@ -61,7 +61,8 @@ class RandomAdapterTest(TestCase):
     def test_cross_validate(self) -> None:
         adapter = RandomAdapter(experiment=self.experiment, generator=RandomGenerator())
         with self.assertRaises(NotImplementedError):
-            adapter._cross_validate(self.search_space, [], [])
+            # pyre-ignore[6]: None input for testing.
+            adapter._cross_validate(self.search_space, None, None)
 
     def test_gen_w_constraints(self) -> None:
         adapter = RandomAdapter(experiment=self.experiment, generator=RandomGenerator())

--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from collections.abc import Sequence, Sized
+from collections.abc import Sized
 from contextlib import ExitStack
 from typing import Any
 from unittest import mock
@@ -18,7 +18,7 @@ from ax.adapter.base import Adapter
 from ax.adapter.cross_validation import cross_validate
 from ax.adapter.registry import MBM_X_trans
 from ax.adapter.torch import TorchAdapter
-from ax.adapter.transforms.base import Transform
+from ax.adapter.transforms.one_hot import OneHot
 from ax.adapter.transforms.standardize_y import StandardizeY
 from ax.adapter.transforms.unit_x import UnitX
 from ax.core.arm import Arm
@@ -28,14 +28,9 @@ from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
-from ax.core.observation import (
-    Observation,
-    ObservationData,
-    ObservationFeatures,
-    recombine_observations,
-)
+from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig, PreferenceOptimizationConfig
-from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
+from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace, SearchSpaceDigest
 from ax.core.types import ComparisonOp
@@ -48,15 +43,14 @@ from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.stats.model_fit_stats import MSE
 from ax.utils.testing.core_stubs import (
-    get_branin_data,
     get_branin_experiment,
     get_branin_experiment_with_multi_objective,
+    get_data,
     get_experiment_with_observations,
     get_search_space_for_range_value,
     get_search_space_for_range_values,
 )
 from ax.utils.testing.mock import mock_botorch_optimize
-from ax.utils.testing.modeling_stubs import transform_1, transform_2
 from ax.utils.testing.preference_stubs import get_pbo_experiment
 from botorch.acquisition.logei import qLogNoisyExpectedImprovement
 from botorch.acquisition.preference import (
@@ -79,92 +73,100 @@ from pandas import DataFrame
 from pyre_extensions import assert_is_instance, none_throws
 
 
-def _get_adapter_from_experiment(
-    experiment: Experiment,
-    transforms: Sequence[type[Transform]] | None = None,
-    device: torch.device | None = None,
-    fit_on_init: bool = True,
-) -> TorchAdapter:
-    return TorchAdapter(
-        experiment=experiment,
-        generator=BoTorchGenerator(),
-        transforms=transforms or [],
-        torch_device=device,
-        fit_on_init=fit_on_init,
-    )
-
-
 class TorchAdapterTest(TestCase):
     @mock_botorch_optimize
     def test_TorchAdapter(self, device: torch.device | None = None) -> None:
+        tkwargs: dict[str, Any] = {"dtype": torch.double, "device": device}
+        # Construct an experiment with known data.
         feature_names = ["x1", "x2", "x3"]
         search_space = get_search_space_for_range_values(
             min=0.0, max=5.0, parameter_names=feature_names
         )
-        experiment = Experiment(search_space=search_space, name="test")
-        adapter = _get_adapter_from_experiment(
+        opt_config = OptimizationConfig(
+            objective=Objective(metric=Metric("y1"), minimize=True),
+            outcome_constraints=[
+                OutcomeConstraint(
+                    metric=Metric("y2"), op=ComparisonOp.GEQ, bound=0.0, relative=False
+                )
+            ],
+        )
+        experiment = Experiment(
+            search_space=search_space, optimization_config=opt_config, name="test"
+        )
+        X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **tkwargs)
+        for x in X.tolist():
+            experiment.new_trial().add_arm(
+                Arm(parameters=dict(zip(feature_names, x)))
+            ).mark_running(no_runner_required=True).mark_completed()
+        experiment.attach_data(
+            data=Data(
+                df=DataFrame.from_records(
+                    {
+                        "trial_index": [0, 0, 1, 1],
+                        "metric_name": ["y1", "y2", "y1", "y2"],
+                        "arm_name": ["0_0", "0_0", "1_0", "1_0"],
+                        "mean": [3.0, 2.0, 1.0, 0.0],
+                        "sem": [3.0, 1e-4, 2.0, 1e-3],
+                    }
+                )
+            )
+        )
+        # Construct the adapter and test key methods.
+        adapter = TorchAdapter(
             experiment=experiment,
-            device=device,
+            generator=BoTorchGenerator(),
+            torch_device=device,
             fit_on_init=False,
         )
         self.assertTrue(adapter.can_predict)
         self.assertTrue(adapter.can_model_in_sample)
         self.assertEqual(adapter.device, device)
-        self.assertIsNone(adapter._last_observations)
-        tkwargs: dict[str, Any] = {"dtype": torch.double, "device": device}
+        self.assertIsNone(adapter._last_experiment_data)
+        experiment_data = adapter.get_training_data()
         # Test `_fit`.
         X = torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]], **tkwargs)
-        datasets = {
-            "y1": SupervisedDataset(
+        datasets = [
+            SupervisedDataset(
                 X=X,
                 Y=torch.tensor([[3.0], [1.0]], **tkwargs),
-                Yvar=torch.tensor([[4.0], [2.0]], **tkwargs),
+                Yvar=torch.tensor([[9.0], [4.0]], **tkwargs),
                 feature_names=feature_names,
                 outcome_names=["y1"],
+                group_indices=torch.tensor([0, 1], device=device),
             ),
-            "y2": SupervisedDataset(
+            SupervisedDataset(
                 X=X,
                 Y=torch.tensor([[2.0], [0.0]], **tkwargs),
-                Yvar=torch.tensor([[1e-8], [1e-9]], **tkwargs),
+                Yvar=torch.tensor([[1e-8], [1e-6]], **tkwargs),
                 feature_names=feature_names,
                 outcome_names=["y2"],
+                group_indices=torch.tensor([0, 1], device=device),
             ),
-        }
+        ]
         observation_features = [
             ObservationFeatures(parameters=dict(zip(feature_names, Xi.tolist())))
             for Xi in X
         ]
-        observation_data = [
-            ObservationData(
-                metric_names=["y1", "y2"],
-                means=np.array(y1 + y2),  # here y is already a list
-                covariance=np.diag(yvar1 + yvar2),  # here yvar is already a list
-            )
-            for y1, y2, yvar1, yvar2 in zip(
-                datasets["y1"].Y.tolist(),
-                datasets["y2"].Y.tolist(),
-                none_throws(datasets["y1"].Yvar).tolist(),
-                none_throws(datasets["y2"].Yvar).tolist(),
-            )
-        ]
-        observations = recombine_observations(observation_features, observation_data)
 
         generator = adapter.generator
         with mock.patch.object(generator, "fit", wraps=generator.fit) as mock_fit:
-            adapter._fit(search_space=search_space, observations=observations)
+            adapter._fit(search_space=search_space, experiment_data=experiment_data)
         generator_fit_args = mock_fit.call_args.kwargs
-        self.assertEqual(generator_fit_args["datasets"], list(datasets.values()))
+        self.assertEqual(generator_fit_args["datasets"], datasets)
         expected_ssd = SearchSpaceDigest(
             feature_names=feature_names, bounds=[(0, 5)] * 3
         )
         self.assertEqual(generator_fit_args["search_space_digest"], expected_ssd)
-        self.assertIsNone(generator_fit_args["candidate_metadata"])
-        self.assertEqual(adapter._last_observations, observations)
+        self.assertEqual(
+            generator_fit_args["candidate_metadata"],
+            [[{Keys.TRIAL_COMPLETION_TIMESTAMP: mock.ANY}] * 2] * 2,
+        )
+        self.assertEqual(adapter._last_experiment_data, experiment_data)
 
         with mock.patch(f"{TorchAdapter.__module__}.logger.debug") as mock_logger:
-            adapter._fit(search_space=search_space, observations=observations)
+            adapter._fit(search_space=search_space, experiment_data=experiment_data)
         mock_logger.assert_called_once_with(
-            "The observations are identical to the last set of observations "
+            "The experiment data is identical to the last experiment data "
             "used to fit the generator. Skipping generator fitting."
         )
 
@@ -190,7 +192,6 @@ class TorchAdapterTest(TestCase):
         self.assertEqual(pr_obs_data, [pr_obs_data_expected])
 
         # Test `_gen`
-
         gen_return_value = TorchGenResults(
             points=torch.tensor([[1.0, 2.0, 3.0]], **tkwargs),
             weights=torch.tensor([1.0], **tkwargs),
@@ -277,11 +278,11 @@ class TorchAdapterTest(TestCase):
         ) as mock_cross_validate:
             cv_obs_data = adapter._cross_validate(
                 search_space=search_space,
-                cv_training_data=observations,
+                cv_training_data=experiment_data,
                 cv_test_points=cv_test_points,
             )
         generator_cv_args = mock_cross_validate.mock_calls[0][2]
-        self.assertEqual(generator_cv_args["datasets"], list(datasets.values()))
+        self.assertEqual(generator_cv_args["datasets"], datasets)
         self.assertTrue(torch.equal(generator_cv_args["X_test"], X_test))
         self.assertEqual(generator_cv_args["search_space_digest"], expected_ssd)
         self.assertEqual(cv_obs_data, [cv_obs_data_expected])
@@ -289,7 +290,11 @@ class TorchAdapterTest(TestCase):
         # Transform observations
         # This functionality is likely to be deprecated (T134940274)
         # so this is not a thorough test.
-        adapter.transform_observations(observations=observations)
+        adapter.transform_observations(
+            observations=[
+                Observation(features=cv_test_points[0], data=cv_obs_data_expected)
+            ]
+        )
 
         # Transform observation features
         obsf = [ObservationFeatures(parameters={"x": 1.0, "y": 2.0})]
@@ -304,8 +309,10 @@ class TorchAdapterTest(TestCase):
     @mock_botorch_optimize
     def test_evaluate_acquisition_function(self) -> None:
         experiment = get_branin_experiment(with_completed_trial=True)
-        adapter = _get_adapter_from_experiment(
-            experiment=experiment, transforms=[UnitX, StandardizeY]
+        adapter = TorchAdapter(
+            experiment=experiment,
+            generator=BoTorchGenerator(),
+            transforms=[UnitX, StandardizeY],
         )
         obsf = ObservationFeatures(parameters={"x1": 1.0, "x2": 2.0})
 
@@ -379,33 +386,29 @@ class TorchAdapterTest(TestCase):
 
     def test_best_point(self) -> None:
         search_space = get_search_space_for_range_value()
-        exp = Experiment(search_space=search_space, name="test")
         oc = OptimizationConfig(
             objective=Objective(metric=Metric("a"), minimize=False),
             outcome_constraints=[],
         )
+        exp = Experiment(search_space=search_space, optimization_config=oc, name="test")
+        exp.new_trial().add_arm(Arm(parameters={"x": 1.0})).mark_running(
+            no_runner_required=True
+        ).mark_completed()
+        exp.attach_data(get_data(metric_name="a", num_non_sq_arms=1, include_sq=False))
         adapter = TorchAdapter(
-            search_space=search_space,
-            generator=TorchGenerator(),
-            transforms=[transform_1, transform_2],
             experiment=exp,
-            data=Data(),
-            optimization_config=oc,
+            generator=TorchGenerator(),
+            transforms=[OneHot, UnitX],
         )
-
         self.assertEqual(
             list(adapter.transforms.keys()),
-            ["Cast", "transform_1", "transform_2"],
+            ["Cast", "OneHot", "UnitX"],
         )
-
-        # _fit is mocked, which sets these
-        adapter.parameters = list(search_space.parameters.keys())
-        adapter.outcomes = ["a"]
 
         mean = 1.0
         cov = 2.0
         predict_return_value = ({"m": [mean]}, {"m": {"m": [cov]}})
-        best_point_value = 25
+        best_point_value = 0.6
         gen_return_value = TorchGenResults(
             points=torch.tensor([[1.0]]), weights=torch.tensor([1.0])
         )
@@ -424,10 +427,13 @@ class TorchAdapterTest(TestCase):
         arm, predictions = none_throws(run.best_arm_predictions)
         predictions = none_throws(predictions)
         model_predictions = none_throws(model_predictions)
-        # The transforms add one and square, and need to be reversed
-        self.assertEqual(arm.parameters, {"x": (best_point_value**0.5) - 1})
-        # Gets clamped to the search space
-        self.assertEqual(run.arms[0].parameters, {"x": 3.0})
+        # UnitX removes 1 and divides by 5. Reversing here.
+        self.assertEqual(arm.parameters.keys(), {"x"})
+        self.assertAlmostEqual(
+            float(arm.parameters["x"]), (best_point_value * 5.0) + 1.0, places=5
+        )
+        # 1.0 in transformed space is 6.0 in original space.
+        self.assertEqual(run.arms[0].parameters, {"x": 6.0})
         self.assertEqual(predictions[0], {"m": mean})
         self.assertEqual(predictions[1], {"m": {"m": cov}})
         self.assertEqual(model_predictions[0], {"m": mean})
@@ -464,7 +470,7 @@ class TorchAdapterTest(TestCase):
         experiment = get_branin_experiment_with_multi_objective(
             with_completed_trial=True
         )
-        adapter = _get_adapter_from_experiment(experiment=experiment)
+        adapter = TorchAdapter(experiment=experiment, generator=BoTorchGenerator())
         # generator doesn't have enough data for training, so equal importances.
         self.assertEqual(
             adapter.feature_importances("branin_a"), {"x1": 0.5, "x2": 0.5}
@@ -474,7 +480,7 @@ class TorchAdapterTest(TestCase):
         )
 
     def test_candidate_metadata_propagation(self) -> None:
-        exp = get_branin_experiment(with_status_quo=True, with_batch=True)
+        exp = get_branin_experiment(with_status_quo=True, with_completed_batch=True)
         # Check that the metadata is correctly re-added to observation
         # features during `fit`.
         # pyre-fixme[16]: `BaseTrial` has no attribute `_generator_run_structs`.
@@ -488,25 +494,27 @@ class TorchAdapterTest(TestCase):
         with mock.patch.object(
             generator, "fit", wraps=generator.fit
         ) as mock_generator_fit:
-            adapter = TorchAdapter(
-                experiment=exp,
-                search_space=exp.search_space,
-                generator=generator,
-                transforms=[],
-                data=get_branin_data(),
-            )
+            adapter = TorchAdapter(experiment=exp, generator=generator)
 
-        datasets = mock_generator_fit.call_args[1].get("datasets")
+        datasets = mock_generator_fit.call_args.kwargs.get("datasets")
         X_expected = torch.tensor(
-            [list(exp.trials[0].arms[0].parameters.values())],
+            [list(arm.parameters.values()) for arm in exp.trials[0].arms],
             dtype=torch.double,
         )
         for dataset in datasets:
             self.assertTrue(torch.equal(dataset.X, X_expected))
 
+        candidate_metadata = mock_generator_fit.call_args.kwargs.get(
+            "candidate_metadata"
+        )
+        self.assertEqual(len(candidate_metadata), 1)
+        self.assertEqual(len(candidate_metadata[0]), len(exp.trials[0].arms))
         self.assertEqual(
-            mock_generator_fit.call_args[1].get("candidate_metadata"),
-            [[{"preexisting_batch_cand_metadata": "some_value"}]],
+            candidate_metadata[0][0],
+            {
+                "preexisting_batch_cand_metadata": "some_value",
+                Keys.TRIAL_COMPLETION_TIMESTAMP: mock.ANY,
+            },
         )
 
         # Check that `gen` correctly propagates the metadata to the GR.
@@ -540,8 +548,7 @@ class TorchAdapterTest(TestCase):
         self.assertIsNone(gr.candidate_metadata_by_arm_signature)
 
         # Check that no candidate metadata is handled correctly.
-        exp = get_branin_experiment(with_status_quo=True)
-
+        exp = get_branin_experiment(with_status_quo=True, with_completed_trial=True)
         generator = TorchGenerator()
         with mock.patch(
             f"{TorchAdapter.__module__}." "TorchAdapter._validate_observation_data",
@@ -549,21 +556,10 @@ class TorchAdapterTest(TestCase):
         ), mock.patch.object(
             generator, "fit", wraps=generator.fit
         ) as mock_generator_fit:
-            adapter = TorchAdapter(
-                search_space=exp.search_space,
-                experiment=exp,
-                generator=generator,
-                data=Data(),
-                transforms=[],
-            )
-        # Hack in outcome names to bypass validation (since we did not pass any
-        # to the generator so _fit did not populate this)
-        metric_name = next(iter(exp.metrics))
-        adapter.outcomes = [metric_name]
-        adapter._metric_names = {metric_name}
+            adapter = TorchAdapter(experiment=exp, generator=generator)
         with mock.patch.object(generator, "gen", return_value=gen_results):
             gr = adapter.gen(n=1)
-        self.assertIsNone(mock_generator_fit.call_args[1].get("candidate_metadata"))
+        # This should be None since gen_results doesn't include any metadata.
         self.assertIsNone(gr.candidate_metadata_by_arm_signature)
 
     def test_fit_tracking_metrics(self) -> None:
@@ -593,29 +589,25 @@ class TorchAdapterTest(TestCase):
             self.assertEqual(adapter.outcomes, expected_outcomes)
             self.assertEqual(len(call_kwargs["datasets"]), len(expected_outcomes))
 
-    def test_convert_observations(self) -> None:
-        experiment = get_branin_experiment(with_completed_trial=True)
-        mb = _get_adapter_from_experiment(experiment=experiment)
+    def test_convert_experiment_data(self) -> None:
+        feature_names = ["x0", "x1", "x2"]
+        search_space = get_search_space_for_range_values(
+            min=0.0, max=5.0, parameter_names=feature_names
+        )
         raw_X = torch.rand(10, 3) * 5
         raw_X[:, -1].round_()  # Make sure last column is integer.
         raw_X[0, -1] = 0  # Make sure task value 0 exists.
-        raw_Y = torch.sin(raw_X).sum(-1)
-        feature_names = ["x0", "x1", "x2"]
-        metric_names = ["y"]
-        observation_features = [
-            ObservationFeatures(
-                parameters={feature_names[i]: x_[i].item() for i in range(3)}
-            )
-            for x_ in raw_X
-        ]
-        observation_data = [
-            ObservationData(
-                metric_names=metric_names,
-                means=np.asarray([y]),
-                covariance=np.array([[float("nan")]]),
-            )
-            for y in raw_Y
-        ]
+        raw_Y = torch.sin(raw_X).sum(-1, keepdim=True)
+        experiment = get_experiment_with_observations(
+            parameterizations=[
+                {f"x{i}": x_[i].item() for i in range(3)} for x_ in raw_X
+            ],
+            observations=raw_Y.tolist(),
+            search_space=search_space,
+        )
+        adapter = TorchAdapter(experiment=experiment, generator=BoTorchGenerator())
+        metric_names = ["m1"]
+        experiment_data = adapter.get_training_data()
         for use_task, expected_class in (
             (True, MultiTaskDataset),
             (False, SupervisedDataset),
@@ -628,9 +620,8 @@ class TorchAdapterTest(TestCase):
                 task_features=[2] if use_task else [],
                 target_values={2: 0} if use_task else {},  # pyre-ignore
             )
-            converted_datasets, ordered_outcomes, _ = mb._convert_observations(
-                observation_data=observation_data,
-                observation_features=observation_features,
+            converted_datasets, ordered_outcomes, _ = adapter._convert_experiment_data(
+                experiment_data=experiment_data,
                 outcomes=metric_names,
                 parameters=feature_names,
                 search_space_digest=search_space_digest,
@@ -641,10 +632,10 @@ class TorchAdapterTest(TestCase):
             if use_task:
                 sort_idx = torch.argsort(raw_X[:, -1])
                 expected_X = raw_X[sort_idx]
-                expected_Y = raw_Y[sort_idx].unsqueeze(-1)
+                expected_Y = raw_Y[sort_idx]
             else:
                 expected_X = raw_X
-                expected_Y = raw_Y.unsqueeze(-1)
+                expected_Y = raw_Y
             self.assertTrue(torch.equal(dataset.X, expected_X.to(torch.double)))
             self.assertTrue(torch.equal(dataset.Y, expected_Y))
             self.assertIsNone(dataset.Yvar)
@@ -652,10 +643,9 @@ class TorchAdapterTest(TestCase):
             self.assertEqual(dataset.outcome_names, metric_names)
             self.assertEqual(ordered_outcomes, metric_names)
 
-            with self.assertRaisesRegex(ValueError, "was not observed."):
-                mb._convert_observations(
-                    observation_data=observation_data,
-                    observation_features=observation_features,
+            with self.assertRaisesRegex(DataRequiredError, "no corresponding data"):
+                adapter._convert_experiment_data(
+                    experiment_data=experiment_data,
                     outcomes=metric_names + ["extra"],
                     parameters=feature_names,
                     search_space_digest=search_space_digest,
@@ -665,7 +655,7 @@ class TorchAdapterTest(TestCase):
         raw_X = torch.rand(10, 3) * 5
         raw_X[:, -1].round_()  # Make sure last column is integer.
         raw_X[0, -1] = 0  # Make sure task value 0 exists.
-        raw_Y = torch.sin(raw_X).sum(-1)
+        raw_Y = torch.sin(raw_X).sum(-1, keepdim=True).expand(-1, 4)
         feature_names = ["x0", "x1", "x2"]
         metric_names = ["y", "y:c0", "y:c1", "y:c2"]
         parameter_decomposition = {f"c{i}": [f"x{i}"] for i in range(3)}
@@ -674,36 +664,32 @@ class TorchAdapterTest(TestCase):
         search_space = get_search_space_for_range_values(
             min=0.0, max=5.0, parameter_names=feature_names
         )
-        experiment = Experiment(
-            search_space=search_space,
-            name="test",
-            properties={
-                "parameter_decomposition": parameter_decomposition,
-                "metric_decomposition": metric_decomposition,
-            },
+        # Make an optimization config that includes all metrics.
+        opt_config = OptimizationConfig(
+            objective=Objective(metric=Metric("y"), minimize=True),
+            outcome_constraints=[
+                OutcomeConstraint(
+                    metric=Metric(f"y:c{i}"), op=ComparisonOp.GEQ, bound=0
+                )
+                for i in range(3)
+            ],
         )
-        mb = _get_adapter_from_experiment(experiment=experiment, fit_on_init=False)
-
-        observation_features = [
-            ObservationFeatures(
-                parameters={feature_names[i]: x_[i].item() for i in range(3)}
-            )
-            for x_ in raw_X
-        ]
-        num_m = len(metric_names)
-        observation_data = [
-            ObservationData(
-                metric_names=metric_names,
-                means=np.asarray([y for _ in range(num_m)]),
-                covariance=np.array(
-                    [float("nan") for _ in range(num_m * num_m)]
-                ).reshape([num_m, num_m]),
-            )
-            for y in raw_Y
-        ]
-        converted_datasets, ordered_outcomes, _ = mb._convert_observations(
-            observation_data=observation_data,
-            observation_features=observation_features,
+        experiment = get_experiment_with_observations(
+            parameterizations=[
+                {f"x{i}": x_[i].item() for i in range(3)} for x_ in raw_X
+            ],
+            observations=raw_Y.tolist(),
+            search_space=search_space,
+            optimization_config=opt_config,
+        )
+        experiment._properties = {
+            "parameter_decomposition": parameter_decomposition,
+            "metric_decomposition": metric_decomposition,
+        }
+        adapter = TorchAdapter(experiment=experiment, generator=BoTorchGenerator())
+        experiment_data = adapter.get_training_data()
+        converted_datasets, ordered_outcomes, _ = adapter._convert_experiment_data(
+            experiment_data=experiment_data,
             outcomes=metric_names,
             parameters=feature_names,
             search_space_digest=SearchSpaceDigest(
@@ -711,8 +697,6 @@ class TorchAdapterTest(TestCase):
                 bounds=[(0.0, 5.0)] * 3,
                 ordinal_features=[2],
                 discrete_choices={2: list(range(0, 11))},
-                task_features=[],
-                target_values={},
             ),
         )
         self.assertEqual(len(converted_datasets), 2)
@@ -729,7 +713,7 @@ class TorchAdapterTest(TestCase):
             if len(dataset.outcome_names) == 1:
                 self.assertListEqual(dataset.outcome_names, ["y"])
                 self.assertTrue(torch.equal(dataset.X, raw_X))
-                self.assertTrue(torch.equal(dataset.Y, raw_Y.unsqueeze(-1)))
+                self.assertTrue(torch.equal(dataset.Y, raw_Y[:, :1]))
             else:
                 self.assertListEqual(dataset.outcome_names, ["y:c0", "y:c1", "y:c2"])
                 self.assertListEqual(
@@ -745,45 +729,26 @@ class TorchAdapterTest(TestCase):
                     metric_decomposition,
                 )
                 self.assertTrue(torch.equal(dataset.X, raw_X))
-                self.assertTrue(
-                    torch.equal(
-                        dataset.Y,
-                        torch.cat([raw_Y.unsqueeze(-1) for _ in range(3)], dim=-1),
-                    )
-                )
+                self.assertTrue(torch.equal(dataset.Y, raw_Y[:, 1:]))
         # Test _get_fit_args handling of outcome names
-        mb._fit_tracking_metrics = True
-        search_space = SearchSpace(
-            parameters=[
-                RangeParameter(
-                    name=f"x{i}",
-                    lower=0.0,
-                    upper=5.0,
-                    parameter_type=ParameterType.FLOAT,
-                )
-                for i in range(3)
-            ]
-        )
-        observations = []
-        for i, od in enumerate(observation_data):
-            observations.append(Observation(data=od, features=observation_features[i]))
-        converted_datasets2, _, _ = mb._get_fit_args(
+        adapter._fit_tracking_metrics = True
+        converted_datasets2, _, _ = adapter._get_fit_args(
             search_space=search_space,
-            observations=observations,
+            experiment_data=experiment_data,
             parameters=feature_names,
             update_outcomes_and_parameters=True,
         )
-        self.assertEqual(mb.outcomes, expected_outcomes)
+        self.assertEqual(adapter.outcomes, expected_outcomes)
         self.assertEqual(converted_datasets, converted_datasets2)
         # Check that outcomes are not updated when
         # `update_outcomes_and_parameters` is False
-        mb._get_fit_args(
+        adapter._get_fit_args(
             search_space=search_space,
-            observations=observations,
+            experiment_data=experiment_data,
             parameters=feature_names,
             update_outcomes_and_parameters=False,
         )
-        self.assertEqual(mb.outcomes, expected_outcomes)
+        self.assertEqual(adapter.outcomes, expected_outcomes)
 
     @mock_botorch_optimize
     def test_gen_metadata_untransform(self) -> None:
@@ -791,13 +756,7 @@ class TorchAdapterTest(TestCase):
             observations=[[0.0, 1.0], [2.0, 3.0]]
         )
         generator = BoTorchGenerator()
-        mb = TorchAdapter(
-            experiment=experiment,
-            search_space=experiment.search_space,
-            data=experiment.lookup_data(),
-            generator=generator,
-            transforms=[],
-        )
+        adapter = TorchAdapter(experiment=experiment, generator=generator)
         for additional_metadata in (
             {},
             {"objective_thresholds": None},
@@ -809,15 +768,15 @@ class TorchAdapterTest(TestCase):
                 gen_metadata={Keys.EXPECTED_ACQF_VAL: [1.0], **additional_metadata},
             )
             with mock.patch.object(
-                mb,
+                adapter,
                 "_untransform_objective_thresholds",
-                wraps=mb._untransform_objective_thresholds,
+                wraps=adapter._untransform_objective_thresholds,
             ) as mock_untransform, mock.patch.object(
                 generator,
                 "gen",
                 return_value=gen_return_value,
             ):
-                mb.gen(n=1)
+                adapter.gen(n=1)
             if additional_metadata.get("objective_thresholds", None) is None:
                 mock_untransform.assert_not_called()
             else:
@@ -868,8 +827,8 @@ class TorchAdapterTest(TestCase):
         )
         experiment.attach_data(data)
         trial.run().complete()
-        adapter = _get_adapter_from_experiment(
-            experiment=experiment, transforms=MBM_X_trans
+        adapter = TorchAdapter(
+            experiment=experiment, generator=BoTorchGenerator(), transforms=MBM_X_trans
         )
         # Check the expanded model space. Range is expanded, Choice is not.
         model_space = adapter._model_space
@@ -1116,10 +1075,8 @@ class TorchAdapterTest(TestCase):
                 )
 
     @mock_botorch_optimize
-    def test_pairwise_preference_model(self) -> None:
+    def test_pairwise_preference_generator(self) -> None:
         experiment = get_pbo_experiment()
-        data = experiment.lookup_data()
-
         surrogate = Surrogate(
             surrogate_spec=SurrogateSpec(
                 model_configs=[
@@ -1148,13 +1105,10 @@ class TorchAdapterTest(TestCase):
         for botorch_acqf_class, model_gen_options, n in cases:
             pmb = TorchAdapter(
                 experiment=experiment,
-                search_space=experiment.search_space,
-                data=data,
                 generator=BoTorchGenerator(
                     botorch_acqf_class=botorch_acqf_class,
                     surrogate=surrogate,
                 ),
-                transforms=[],
                 optimization_config=OptimizationConfig(
                     Objective(
                         Metric(Keys.PAIRWISE_PREFERENCE_QUERY.value), minimize=False
@@ -1167,54 +1121,18 @@ class TorchAdapterTest(TestCase):
             generator_run = pmb.gen(n=n, model_gen_options=model_gen_options)
             self.assertEqual(len(generator_run.arms), n)
 
-        observation_data = [
-            ObservationData(
-                metric_names=[Keys.PAIRWISE_PREFERENCE_QUERY.value],
-                means=np.array([0]),
-                covariance=np.array([[np.nan]]),
-            ),
-            ObservationData(
-                metric_names=[Keys.PAIRWISE_PREFERENCE_QUERY.value],
-                means=np.array([1]),
-                covariance=np.array([[np.nan]]),
-            ),
-        ]
-        observation_features = [
-            ObservationFeatures(parameters={"x1": 0.1, "x2": 0.2}, trial_index=0),
-            ObservationFeatures(parameters={"x1": 0.3, "x2": 0.4}, trial_index=0),
-        ]
-        observation_features_with_metadata = [
-            ObservationFeatures(parameters={"x1": 0.1, "x2": 0.2}, trial_index=0),
-            ObservationFeatures(
-                parameters={"x1": 0.3, "x2": 0.4},
-                trial_index=0,
-                metadata={"metadata_key": "metadata_val"},
-            ),
-        ]
         parameter_names = list(experiment.parameters.keys())
         outcomes = [assert_is_instance(Keys.PAIRWISE_PREFERENCE_QUERY.value, str)]
 
-        datasets, _, candidate_metadata = pmb._convert_observations(
-            observation_data=observation_data,
-            observation_features=observation_features,
+        datasets, _, candidate_metadata = pmb._convert_experiment_data(
+            experiment_data=pmb._training_data,
             outcomes=outcomes,
             parameters=parameter_names,
             search_space_digest=None,
         )
         self.assertTrue(len(datasets) == 1)
-        self.assertTrue(isinstance(datasets[0], RankingDataset))
-        self.assertTrue(candidate_metadata is None)
-
-        datasets, _, candidate_metadata = pmb._convert_observations(
-            observation_data=observation_data,
-            observation_features=observation_features_with_metadata,
-            outcomes=outcomes,
-            parameters=parameter_names,
-            search_space_digest=None,
-        )
-        self.assertTrue(len(datasets) == 1)
-        self.assertTrue(isinstance(datasets[0], RankingDataset))
-        self.assertTrue(candidate_metadata is not None)
+        self.assertIsInstance(datasets[0], RankingDataset)
+        self.assertIsNotNone(candidate_metadata)
 
         # Test individual helper methods
         X = torch.tensor(

--- a/ax/adapter/tests/test_torch_moo_adapter.py
+++ b/ax/adapter/tests/test_torch_moo_adapter.py
@@ -47,7 +47,6 @@ from ax.utils.testing.core_stubs import (
     TEST_SOBOL_SEED,
 )
 from ax.utils.testing.mock import mock_botorch_optimize, skip_fit_gpytorch_mll
-from ax.utils.testing.modeling_stubs import transform_1, transform_2
 from botorch.utils.multi_objective.pareto import is_non_dominated
 from pyre_extensions import assert_is_instance, none_throws
 
@@ -104,12 +103,8 @@ class MultiObjectiveTorchAdapterTest(TestCase):
             ),
         )
         adapter = TorchAdapter(
-            search_space=exp.search_space,
-            generator=MultiObjectiveLegacyBoTorchGenerator(),
-            optimization_config=exp.optimization_config,
-            transforms=[transform_1, transform_2],
             experiment=exp,
-            data=exp.fetch_data(),
+            generator=MultiObjectiveLegacyBoTorchGenerator(),
         )
         with patch(
             PARETO_FRONTIER_EVALUATOR_PATH, wraps=pareto_frontier_evaluator

--- a/ax/adapter/torch.py
+++ b/ax/adapter/torch.py
@@ -37,6 +37,7 @@ from ax.adapter.adapter_utils import (
     validate_and_apply_final_transform,
 )
 from ax.adapter.base import Adapter, DataLoaderConfig, gen_arms, GenResults
+from ax.adapter.data_utils import ExperimentData, extract_experiment_data
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.cast import Cast
 from ax.core.arm import Arm
@@ -49,7 +50,6 @@ from ax.core.observation import (
     Observation,
     ObservationData,
     ObservationFeatures,
-    observations_from_data,
     separate_observations,
 )
 from ax.core.optimization_config import (
@@ -151,9 +151,9 @@ class TorchAdapter(Adapter):
                     optimization_config.preference_profile_name
                 )
 
-        # Tracks last set of observations used to fit the generator, to skip
+        # Tracks last experiment data used to fit the generator, to skip
         # generator fitting when it's not necessary.
-        self._last_observations: list[Observation] | None = None
+        self._last_experiment_data: ExperimentData | None = None
 
         # These are set in _fit.
         self.parameters: list[str] = []
@@ -321,116 +321,107 @@ class TorchAdapter(Adapter):
         )
         return tensor_func
 
-    def _array_list_to_tensors(self, arrays: list[npt.NDArray]) -> list[Tensor]:
-        return [self._array_to_tensor(x) for x in arrays]
-
     def _array_to_tensor(self, array: npt.NDArray | list[float]) -> Tensor:
         return torch.as_tensor(array, dtype=torch.double, device=self.device)
 
-    def _create_dataset(
+    def _convert_experiment_data(
         self,
-        Xs: dict[str, list[Tensor]],
-        Ys: dict[str, list[Tensor]],
-        Yvars: dict[str, list[Tensor]],
-        outcome: str,
-        parameters: list[str],
-        trial_indices: dict[str, list[int]] | None,
-    ) -> SupervisedDataset:
-        if outcome not in Xs:
-            raise ValueError(f"Outcome `{outcome}` was not observed.")
-        X = torch.stack(Xs[outcome], dim=0)
-        if outcome == Keys.PAIRWISE_PREFERENCE_QUERY.value:
-            Y = torch.tensor(
-                Ys[outcome], dtype=torch.long, device=self.device
-            ).unsqueeze(-1)
-            dataset = prep_pairwise_data(
-                X=X,
-                Y=Y,
-                group_indices=torch.tensor(none_throws(trial_indices)[outcome]),
-                outcome=outcome,
-                parameters=parameters,
-            )
-        else:
-            Yvar = torch.tensor(
-                Yvars[outcome], dtype=torch.double, device=self.device
-            ).unsqueeze(-1)
-            if Yvar.isnan().all():
-                Yvar = None
-            Y = torch.tensor(
-                Ys[outcome], dtype=torch.double, device=self.device
-            ).unsqueeze(-1)
-            dataset = SupervisedDataset(
-                X=X,
-                Y=Y,
-                Yvar=Yvar,
-                feature_names=parameters,
-                outcome_names=[outcome],
-                group_indices=torch.tensor(trial_indices[outcome])
-                if trial_indices
-                else None,
-            )
-        return dataset
-
-    def _convert_observations(
-        self,
-        observation_data: list[ObservationData],
-        observation_features: list[ObservationFeatures],
+        experiment_data: ExperimentData,
         outcomes: list[str],
         parameters: list[str],
         search_space_digest: SearchSpaceDigest | None,
     ) -> tuple[
         list[SupervisedDataset], list[str], list[list[TCandidateMetadata]] | None
     ]:
-        """Converts observations to a dictionary of `Dataset` containers and (optional)
-        candidate metadata.
+        """Converts ``ExperimentData`` to a dictionary of ``Dataset`` containers, a list
+        of outcomes -- in the same order as the datasets -- and candidate metadata.
+        The rows that have missing / NaN mean observations are dropped before
+        constructing the dataset for the corresponding outcome.
 
         Args:
-            observation_data: A list of `ObservationData` from which to extract
-                mean `Y` and variance `Yvar` observations. Must correspond 1:1 to
-                the `observation_features`.
-            observation_features: A list of `ObservationFeatures` from which to extract
-                parameter values. Must correspond 1:1 to the `observation_data`.
+            experiment_data: A container of two dataframes ``arm_data`` and
+                ``observation_data``, containing parameterizations, observations,
+                and metadata extracted from ``Trial``s and ``Data`` of the experiment.
             outcomes: The names of the outcomes to extract observations for.
-            parameters: The names of the parameters to extract. Any observation features
-                that are not included in `parameters` will be ignored.
-            search_space_digest: An optional `SearchSpaceDigest` containing information
+            parameters: The names of the parameters to extract. Any additional columns
+                of ``arm_data`` that is not included in `parameters` will be ignored.
+            search_space_digest: Optional ``SearchSpaceDigest`` containing information
                 about the search space. This is used to convert datasets into a
-                `MultiTaskDataset` where applicable.
+                ``MultiTaskDataset`` where applicable.
 
         Returns:
-            - A list of `Dataset` objects. The datsets will be for the set of outcomes
-                specified in `outcomes`, not necessarily in that order. Some outcomes
-                will be grouped into a single dataset if there are contextual datasets.
+            - A list of ``Dataset`` objects. The datasets will be for the set of
+                outcomes specified in ``outcomes``, not necessarily in that order.
+                Some outcomes will be grouped into a single dataset if there are
+                contextual datasets.
             - A list of outcomes in the order that they appear in the datasets,
                 accounting for reordering made necessary by contextual datasets.
             - An optional list of lists of candidate metadata. Each inner list
                 corresponds to one outcome. Each element in the inner list corresponds
                 to one observation.
+                NOTE: Candidate metadata is currently only utilized in TRBO generator.
         """
-        (
-            Xs,
-            Ys,
-            Yvars,
-            candidate_metadata_dict,
-            any_candidate_metadata_is_not_none,
-            trial_indices,
-        ) = self._extract_observation_data(
-            observation_data, observation_features, parameters
+        if len(outcomes) == 0:
+            return [], [], None
+        arm_data = experiment_data.arm_data
+        obs_data = experiment_data.observation_data
+        sems_df = obs_data["sem"]
+        # Join mean & arms to align and repeat the arm rows if necessary.
+        mean_and_params = obs_data["mean"].join(arm_data, how="left")
+        # Reindex to only trial_index and arm_name, to move
+        # any progression columns out of the index.
+        levels_to_move = list(
+            set(mean_and_params.index.names).difference({"trial_index", "arm_name"})
         )
-
+        if len(levels_to_move) > 0:
+            # This is a copy of the original df. We can modify in-place for cheaper.
+            mean_and_params.reset_index(level=levels_to_move, inplace=True)
+        # This will include the progression if it is in parameters.
+        # This is also tolerant to missing columns, which is relevant for TL.
+        params_np = mean_and_params.filter(parameters).to_numpy()
+        trial_indices_np = mean_and_params.index.get_level_values(
+            "trial_index"
+        ).to_numpy()
+        metadata = mean_and_params["metadata"]
         datasets: list[SupervisedDataset] = []
         candidate_metadata = []
         for outcome in outcomes:
-            dataset = self._create_dataset(
-                Xs=Xs,
-                Ys=Ys,
-                Yvars=Yvars,
-                outcome=outcome,
-                parameters=parameters,
-                trial_indices=trial_indices,
-            )
+            if outcome not in mean_and_params:
+                raise DataRequiredError(
+                    f"Attempting to extract a dataset for {outcome=} but no "
+                    "corresponding data was found in the experiment data."
+                )
+            # Drop NaN columns from means & corresponding params.
+            outcome_means = mean_and_params[outcome].to_numpy()
+            to_keep = ~np.isnan(outcome_means)
+            Y = torch.from_numpy(outcome_means[to_keep]).double().view(-1, 1)
+            X = torch.from_numpy(params_np[to_keep]).double()
+            sem = sems_df[outcome].to_numpy()[to_keep]
+            if np.all(np.isnan(sem)):
+                Yvar = None
+            else:
+                Yvar = torch.from_numpy(sem).double().square().view(-1, 1)
+            group_indices = torch.from_numpy(trial_indices_np[to_keep])
+            if outcome == Keys.PAIRWISE_PREFERENCE_QUERY.value:
+                dataset = prep_pairwise_data(
+                    X=X,
+                    Y=Y.to(dtype=torch.long),
+                    group_indices=group_indices,
+                    outcome=outcome,
+                    parameters=parameters,
+                )
+            else:
+                dataset = SupervisedDataset(
+                    X=X,
+                    Y=Y,
+                    Yvar=Yvar,
+                    feature_names=parameters,
+                    outcome_names=[outcome],
+                    group_indices=group_indices,
+                )
             datasets.append(dataset)
-            candidate_metadata.append(candidate_metadata_dict[outcome])
+            candidate_metadata.append(metadata.loc[to_keep].to_list())
+
         # If the search space digest specifies a task feature,
         # convert the datasets into MultiTaskDataset.
         if search_space_digest is not None and (
@@ -479,7 +470,7 @@ class TorchAdapter(Adapter):
         for d in datasets:
             ordered_outcomes.extend(d.outcome_names)
         # Re-order candidate metadata
-        if any_candidate_metadata_is_not_none:
+        if not metadata.isnull().all():
             ordered_metadata = []
             for outcome in ordered_outcomes:
                 ordered_metadata.append(candidate_metadata[outcomes.index(outcome)])
@@ -491,19 +482,19 @@ class TorchAdapter(Adapter):
     def _cross_validate(
         self,
         search_space: SearchSpace,
-        cv_training_data: list[Observation],
+        cv_training_data: ExperimentData,
         cv_test_points: list[ObservationFeatures],
         parameters: list[str] | None = None,
         use_posterior_predictive: bool = False,
     ) -> list[ObservationData]:
-        """Make predictions at cv_test_points using only the data in obs_feats
-        and obs_data.
+        """Make predictions at ``cv_test_points`` using only the data
+        in ``cv_training_data``.
         """
         if not self.parameters:
             raise ValueError(FIT_MODEL_ERROR.format(action="_cross_validate"))
         datasets, _, search_space_digest = self._get_fit_args(
             search_space=search_space,
-            observations=cv_training_data,
+            experiment_data=cv_training_data,
             parameters=parameters,
             update_outcomes_and_parameters=False,
         )
@@ -656,8 +647,11 @@ class TorchAdapter(Adapter):
                     "preference profile with recorded preference data."
                 )
 
-            pe_obs = observations_from_data(experiment=pe_exp, data=pe_data)
-            pe_obs_features, pe_obs_data = separate_observations(pe_obs)
+            pe_experiment_data = extract_experiment_data(
+                experiment=pe_exp,
+                data=pe_data,
+                data_loader_config=self._data_loader_config,
+            )
             pe_exp_param_names = list(pe_exp.search_space.parameters.keys())
 
             # Get all relevant information on the parameters
@@ -666,9 +660,8 @@ class TorchAdapter(Adapter):
             )
             pe_outcomes = [Keys.PAIRWISE_PREFERENCE_QUERY.value]
 
-            pe_datasets, _, _ = self._convert_observations(
-                observation_data=pe_obs_data,
-                observation_features=pe_obs_features,
+            pe_datasets, _, _ = self._convert_experiment_data(
+                experiment_data=pe_experiment_data,
                 outcomes=pe_outcomes,
                 parameters=pe_exp_param_names,
                 search_space_digest=pe_ssd,
@@ -679,7 +672,7 @@ class TorchAdapter(Adapter):
     def _get_fit_args(
         self,
         search_space: SearchSpace,
-        observations: list[Observation],
+        experiment_data: ExperimentData,
         parameters: list[str] | None,
         update_outcomes_and_parameters: bool,
     ) -> tuple[
@@ -688,13 +681,14 @@ class TorchAdapter(Adapter):
         SearchSpaceDigest,
     ]:
         """Helper for consolidating some common argument processing between
-        fit and cross validate methods. Extracts datasets and candidate metadate
-        from observations and the search space digest from the search space.
+        ``fit`` and ``cross_validate`` methods. Extracts datasets and candidate metadata
+        from ``experiment_data``, and ``search_space_digest`` from the ``search_space``.
 
         Args:
             search_space: A transformed search space for fitting the generator.
-            observations: The observations to fit the generator with. These should
-                also be transformed.
+            experiment_data: A container of two dataframes ``arm_data`` and
+                ``observation_data``, containing parameterizations, observations,
+                and metadata extracted from ``Trial``s and ``Data`` of the experiment.
             parameters: Names of parameters to be used in the generator. Defaults to
                 all parameters in the search space.
             update_outcomes_and_parameters: Whether to update `self.outcomes` with
@@ -702,10 +696,10 @@ class TorchAdapter(Adapter):
                 all parameters in the search space. Typically only used in `_fit`.
 
         Returns:
-            The datasets & metadata extracted from the observations and the
-            search space digest.
+            The datasets & metadata, extracted from the ``experiment_data``, and the
+            ``search_space_digest``.
         """
-        self._last_observations = observations
+        self._last_experiment_data = experiment_data
         if update_outcomes_and_parameters:
             self.parameters = list(search_space.parameters.keys())
             # Make sure that task feature is the last parameter. This is important
@@ -720,23 +714,18 @@ class TorchAdapter(Adapter):
                     )
         if parameters is None:
             parameters = self.parameters
-        all_metric_names: set[str] = set()
-        observation_features, observation_data = separate_observations(observations)
         # Only update outcomes if fitting a model on tracking metrics. Otherwise,
         # we will only fit models to the outcomes that are extracted from optimization
         # config in Adapter.__init__.
         if update_outcomes_and_parameters and self._fit_tracking_metrics:
-            for od in observation_data:
-                all_metric_names.update(od.metric_names)
-            self.outcomes = sorted(all_metric_names)  # Deterministic order
+            self.outcomes = sorted(experiment_data.metric_names)
         # Get all relevant information on the parameters
         search_space_digest = extract_search_space_digest(
             search_space=search_space, param_names=self.parameters
         )
         # Convert observations to datasets
-        datasets, ordered_outcomes, candidate_metadata = self._convert_observations(
-            observation_data=observation_data,
-            observation_features=observation_features,
+        datasets, ordered_outcomes, candidate_metadata = self._convert_experiment_data(
+            experiment_data=experiment_data,
             outcomes=self.outcomes,
             parameters=parameters,
             search_space_digest=search_space_digest,
@@ -757,19 +746,19 @@ class TorchAdapter(Adapter):
     def _fit(
         self,
         search_space: SearchSpace,
-        observations: list[Observation],
+        experiment_data: ExperimentData,
         parameters: list[str] | None = None,
         **kwargs: Any,
     ) -> None:
-        if observations == self._last_observations:
+        if experiment_data == self._last_experiment_data:
             logger.debug(
-                "The observations are identical to the last set of observations "
+                "The experiment data is identical to the last experiment data "
                 "used to fit the generator. Skipping generator fitting."
             )
             return
         datasets, candidate_metadata, search_space_digest = self._get_fit_args(
             search_space=search_space,
-            observations=observations,
+            experiment_data=experiment_data,
             parameters=parameters,
             update_outcomes_and_parameters=True,
         )

--- a/ax/adapter/transforms/bilog_y.py
+++ b/ax/adapter/transforms/bilog_y.py
@@ -118,7 +118,10 @@ class BilogY(Transform):
         self, experiment_data: ExperimentData
     ) -> ExperimentData:
         obs_data = experiment_data.observation_data
+        metric_names = experiment_data.metric_names
         for metric, bound in self.metric_to_bound.items():
+            if metric not in metric_names:
+                continue
             obs_data[("mean", metric)], obs_data[("sem", metric)] = match_ci_width(
                 mean=obs_data[("mean", metric)].to_numpy(),
                 sem=obs_data[("sem", metric)].to_numpy(),

--- a/ax/adapter/transforms/merge_repeated_measurements.py
+++ b/ax/adapter/transforms/merge_repeated_measurements.py
@@ -55,7 +55,7 @@ class MergeRepeatedMeasurements(Transform):
             str, defaultdict[str, defaultdict[str, list[float]]]
         ] = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         if experiment_data is not None:
-            metrics = list(experiment_data.observation_data["mean"])
+            metrics = experiment_data.metric_names
             for arm_name, df in experiment_data.observation_data.groupby(
                 level="arm_name"
             ):

--- a/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
@@ -12,6 +12,7 @@ from typing import cast
 import numpy as np
 from ax.adapter import Adapter
 from ax.adapter.base import DataLoaderConfig
+from ax.adapter.cross_validation import cross_validate
 from ax.adapter.data_utils import extract_experiment_data
 from ax.adapter.registry import Generators, MBM_X_trans, Y_trans
 from ax.adapter.torch import TorchAdapter
@@ -197,6 +198,9 @@ class ClientTest(TestCase):
         # progression information is omitted from data propagated to the model
         self.assertListEqual(dataset.feature_names, ["width", "height"])
 
+        # Check that cross validation works.
+        cross_validate(model=adapter)
+
     def _test_early_stopping(self, complete_with_progression: bool) -> None:
         self._simulate(
             with_early_stopping=True,
@@ -240,6 +244,9 @@ class ClientTest(TestCase):
 
         # check that candidate is generated at the target progression
         self.assertEqual(int(candidate_metadata["step"]), self.max_steps)
+
+        # Check that cross validation works.
+        cross_validate(model=adapter)
 
     def test_no_early_stopping_with_progression(self) -> None:
         self._test_no_early_stopping(with_progression=True)

--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -143,8 +143,11 @@ class TransformToNewSQSpecificTest(TestCase):
             observations=[],
             adapter=self.adapter,
         )
-        obs = self.adapter._prepare_observations(experiment=self.exp, data=self.data)
-        obs2 = tf.transform_observations(obs)
+        obs = observations_from_data(
+            experiment=self.exp,
+            data=self.exp.lookup_data(),
+        )[:1]
+        obs2 = tf.transform_observations(observations=deepcopy(obs))
         self.assertEqual(obs, obs2)
 
     def test_target_trial_index(self) -> None:

--- a/ax/adapter/transforms/transform_to_new_sq.py
+++ b/ax/adapter/transforms/transform_to_new_sq.py
@@ -136,7 +136,7 @@ class TransformToNewSQ(BaseRelativize):
         # Get the target trial's status quo data
         target_sq_data = self.status_quo_data_by_trial[self.default_trial_idx]
 
-        metrics = observation_data["mean"].columns
+        metrics = experiment_data.metric_names
         if not transform_mask.any():
             # Nothing to transform, set metrics to empty list to skip the loop.
             # We still need to drop SQ after.

--- a/ax/adapter/transforms/unit_x.py
+++ b/ax/adapter/transforms/unit_x.py
@@ -244,7 +244,8 @@ class UnitX(Transform):
         if arm_data.empty:
             return experiment_data
         for p_name, (l, u) in self.bounds.items():
-            arm_data[p_name] = (arm_data[p_name] - l) / (u - l)
+            if p_name in arm_data.columns:
+                arm_data[p_name] = (arm_data[p_name] - l) / (u - l)
         return ExperimentData(
             arm_data=arm_data, observation_data=experiment_data.observation_data
         )

--- a/ax/analysis/healthcheck/regression_detection_utils.py
+++ b/ax/analysis/healthcheck/regression_detection_utils.py
@@ -103,11 +103,9 @@ def compute_regression_probabilities_single_trial(
 
     adapter = DiscreteAdapter(
         experiment=experiment,
-        search_space=experiment.search_space,
         data=target_data,
         generator=EBAshr(),
         transforms=rel_EB_ashr_trans,
-        optimization_config=experiment.optimization_config,
     )
 
     metric_names = adapter.outcomes
@@ -132,9 +130,7 @@ def compute_regression_probabilities_single_trial(
         data=target_data,
     )
 
-    arm_names = [
-        observations[i].arm_name for i in range(regression_probabilities.shape[0])
-    ]
+    arm_names = [obs.arm_name for obs in observations]
 
     return arm_names, metric_names, regression_probabilities
 

--- a/ax/benchmark/tests/problems/test_lcbench_benchmark.py
+++ b/ax/benchmark/tests/problems/test_lcbench_benchmark.py
@@ -12,6 +12,7 @@ from ax.benchmark.problems.surrogate.lcbench.transfer_learning import (
     DEFAULT_AND_OPTIMAL_VALUES,
     get_lcbench_benchmark_problem,
 )
+from ax.core.observation import ObservationFeatures
 from ax.utils.common.testutils import TestCase
 from pyre_extensions import assert_is_instance
 
@@ -41,13 +42,9 @@ class TestLCBenchBenchmark(TestCase):
         surrogate = test_function.surrogate
 
         # Predict for arm 0_0 and make sure it matches the expected value
-        obs_0_0 = [
-            obs for obs in surrogate.get_training_data() if obs.arm_name == "0_0"
-        ]
-        self.assertEqual(len(obs_0_0), 1)
-        pred, _ = surrogate.predict(observation_features=[obs_0_0[0].features])
-        self.assertAlmostEqual(
-            pred["Train/val_accuracy"][0],
-            default_val,
-            places=3,
+        training_data = surrogate.get_training_data()
+        features = training_data.arm_data.loc[0, "0_0"].to_dict()
+        pred, _ = surrogate.predict(
+            observation_features=[ObservationFeatures(parameters=features)]
         )
+        self.assertAlmostEqual(pred["Train/val_accuracy"][0], default_val, places=3)

--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -652,16 +652,14 @@ def extract_map_keys_from_opt_config(
 # -------------------- Context manager and decorator utils. ---------------------
 
 
-# pyre-ignore[3]: Allowing `Any` in this case
 def batch_trial_only(msg: str | None = None) -> Callable[..., Any]:
     """A decorator to verify that the value passed to the `trial`
     argument to `func` is a `BatchTrial`.
     """
 
-    # pyre-ignore[2,3]: Allowing `Any` in this case
     def batch_trial_only_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(func)
-        def _batch_trial_only(*args: Any, **kwargs: Any) -> Any:  # pyre-ignore[3]
+        def _batch_trial_only(*args: Any, **kwargs: Any) -> Any:
             if "trial" not in kwargs:
                 raise AxError(
                     f"Expected a keyword argument `trial` to `{func.__name__}`."

--- a/ax/generation_strategy/generator_spec.py
+++ b/ax/generation_strategy/generator_spec.py
@@ -125,13 +125,15 @@ class GeneratorSpec(SortableBase, SerializationMixin):
         ):
             # Update the data on the adapter and call `_fit`.
             # This will skip model fitting if the data has not changed.
-            observations, search_space = (
+            experiment_data, search_space = (
                 self.fitted_adapter._process_and_transform_data(
                     experiment=experiment, data=data
                 )
             )
             self.fitted_adapter._fit_if_implemented(
-                search_space=search_space, observations=observations, time_so_far=0.0
+                search_space=search_space,
+                experiment_data=experiment_data,
+                time_so_far=0.0,
             )
 
         else:

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -27,7 +27,7 @@ from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, FixedParameter, Parameter, ParameterType
-from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
+from ax.core.search_space import SearchSpace
 from ax.core.trial_status import TrialStatus
 from ax.core.utils import (
     get_pending_observation_features_based_on_trial_status as get_pending,
@@ -909,13 +909,11 @@ class TestGenerationStrategy(TestCase):
                 self.sobol_GS.gen_single_trial(experiment=experiment)
                 # We should only fit once for each model
                 self.assertEqual(mock_model_fit.call_count, 1)
-                observations = mock_model_fit.call_args[1].get("observations")
-                all_parameter_names = assert_is_instance(
-                    experiment.search_space, HierarchicalSearchSpace
-                )._all_parameter_names.copy()
-                for obs in observations:
-                    for p_name in all_parameter_names:
-                        self.assertIn(p_name, obs.features.parameters)
+                experiment_data = mock_model_fit.call_args.kwargs["experiment_data"]
+                all_parameter_names = list(experiment.search_space.parameters)
+                self.assertFalse(
+                    experiment_data.arm_data[all_parameter_names].isnull().any().any()
+                )
 
             trial = (
                 experiment.new_trial(

--- a/ax/generation_strategy/tests/test_generator_spec.py
+++ b/ax/generation_strategy/tests/test_generator_spec.py
@@ -60,7 +60,7 @@ class GeneratorSpecTest(BaseGeneratorSpecTest):
         with mock.patch("ax.adapter.torch.logger") as mock_logger:
             ms.fit(experiment=self.experiment, data=self.data)
         mock_logger.debug.assert_called_with(
-            "The observations are identical to the last set of observations "
+            "The experiment data is identical to the last experiment data "
             "used to fit the generator. Skipping generator fitting."
         )
         wrapped_extract_ssd.assert_called_once()

--- a/ax/generators/discrete/eb_ashr.py
+++ b/ax/generators/discrete/eb_ashr.py
@@ -255,12 +255,11 @@ class EBAshr(ThompsonSampler):
                 lower = A[:, i] < 0
                 ub = np.min(b[upper] / A[upper, i]) if np.any(upper) else np.inf
                 lb = np.max(b[lower] / A[lower, i]) if np.any(lower) else -np.inf
+                # per i-th metric, across arms; probability a metric strictly
+                # smaller than lb or strictly larger than ub
                 prob_infeasibility[:, i] = 1.0 - none_throws(
                     self.posterior_feasibility
-                )[i](
-                    lb, ub
-                )  # per i-th metric, across arms; probability a metric strictly
-                # smaller than lb or strictly larger than ub
+                )[i](lb, ub)
 
         # for each arm check if it is infeasible with respect to any metric
         regressions = np.apply_along_axis(

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -2088,7 +2088,9 @@ class TestAxOrchestrator(TestCase):
                 df=pd.DataFrame(
                     {
                         "arm_name": ["0_0"],
-                        "metric_name": ["branin"],
+                        "metric_name": [
+                            next(iter(self.branin_experiment.metrics.keys()))
+                        ],
                         "mean": [TEST_MEAN],
                         "sem": [0.1],
                         "trial_index": [0],

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -218,7 +218,6 @@ OUTCOME_TRANSFORM_REGISTRY: dict[type[OutcomeTransform], str] = {
 """
 Overarching mapping from encoded classes to registry map.
 """
-# pyre-fixme[5]: Global annotation cannot contain `Any`.
 CLASS_TO_REGISTRY: dict[Any, dict[type[Any], str]] = {
     Acquisition: ACQUISITION_REGISTRY,
     AcquisitionFunction: ACQUISITION_FUNCTION_REGISTRY,
@@ -280,7 +279,6 @@ REVERSE_OUTCOME_TRANSFORM_REGISTRY: dict[str, type[OutcomeTransform]] = {
 """
 Overarching mapping from encoded classes to reverse registry map.
 """
-# pyre-fixme[5]: Global annotation cannot contain `Any`.
 CLASS_TO_REVERSE_REGISTRY: dict[Any, dict[str, type[Any]]] = {
     Acquisition: REVERSE_ACQUISITION_REGISTRY,
     AcquisitionFunction: REVERSE_ACQUISITION_FUNCTION_REGISTRY,

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -173,7 +173,7 @@ def _build_comparison_str(
     from the DB).
     """
 
-    def _unequal_str(first: Any, second: Any) -> str:  # pyre-ignore[2]
+    def _unequal_str(first: Any, second: Any) -> str:
         return f"{first} (type {type(first)}) != {second} (type {type(second)})."
 
     if first == second:
@@ -346,8 +346,8 @@ class TestCase(fake_filesystem_unittest.TestCase):
 
     def assertEqual(
         self,
-        first: Any,  # pyre-ignore[2]
-        second: Any,  # pyre-ignore[2]
+        first: Any,
+        second: Any,
         msg: str | None = None,
     ) -> None:
         if isinstance(first, Base) and isinstance(second, Base):
@@ -542,9 +542,7 @@ class TestCase(fake_filesystem_unittest.TestCase):
     # Copied from BoTorch assertAllClose
     def assertAllClose(
         self,
-        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
         input: Any,
-        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
         other: Any,
         rtol: float = 1e-05,
         atol: float = 1e-08,

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -197,11 +197,9 @@ class SensitivityAnalysisTest(TestCase):
         )
         self._test_sobol_gp_mean(
             sensitivity=sensitivity_mean_saas,
-            expected_first_order=torch.tensor([0.5757, 0.50996], dtype=torch.double),
-            expected_total_order=torch.tensor(
-                [0.991728, 0.096759], dtype=torch.float64
-            ),
-            expected_second_order=torch.tensor([0.8327], dtype=torch.double),
+            expected_first_order=torch.tensor([0.5752, 0.5143], dtype=torch.double),
+            expected_total_order=torch.tensor([0.9897, 0.0979], dtype=torch.float64),
+            expected_second_order=torch.tensor([0.8300], dtype=torch.double),
         )
 
         sensitivity_mean_bootstrap = SobolSensitivityGPMean(
@@ -215,15 +213,15 @@ class SensitivityAnalysisTest(TestCase):
         self._test_sobol_gp_mean(
             sensitivity=sensitivity_mean_bootstrap,
             expected_first_order=torch.tensor(
-                [[0.552428, 0.022773, 0.047721], [0.084449, 0.220925, 0.148635]],
+                [[0.5511, 0.0237, 0.0487], [0.0878, 0.2175, 0.1475]],
                 dtype=torch.float64,
             ),
             expected_total_order=torch.tensor(
-                [[0.696474, 0.024747, 0.049746], [0.840529, 0.111385, 0.105539]],
+                [[0.6946, 0.0242, 0.0497], [0.8412, 0.1112, 0.1062]],
                 dtype=torch.float64,
             ),
             expected_second_order=torch.tensor(
-                [[0.312184, 0.528756, 0.229947]], dtype=torch.float64
+                [[0.3119, 0.5284, 0.2299]], dtype=torch.float64
             ),
         )
 
@@ -238,15 +236,15 @@ class SensitivityAnalysisTest(TestCase):
         self._test_sobol_gp_mean(
             sensitivity=sensitivity_mean_bootstrap,
             expected_first_order=torch.tensor(
-                [[0.480626, 0.139699, 0.118194], [1.940658, 2.749022, 0.524311]],
+                [[0.4812, 0.1397, 0.1182], [1.9419, 2.7505, 0.5245]],
                 dtype=torch.float64,
             ),
             expected_total_order=torch.tensor(
-                [[0.223900, 0.094295, 0.097105], [0.674058, 0.288103, 0.169736]],
+                [[0.2238, 0.0941, 0.0970], [0.6736, 0.2878, 0.1697]],
                 dtype=torch.float64,
             ),
             expected_second_order=torch.tensor(
-                [[0.833348, 7.983371, 0.893497]], dtype=torch.float64
+                [[0.8344, 7.9860, 0.8936]], dtype=torch.float64
             ),
         )
 
@@ -255,12 +253,8 @@ class SensitivityAnalysisTest(TestCase):
         )
         self._test_sobol_gp_mean(
             sensitivity=sensitivity_mean,
-            expected_first_order=torch.tensor(
-                [-0.040627, 0.445627], dtype=torch.float64
-            ),
-            expected_total_order=torch.tensor(
-                [0.440288, 0.632583], dtype=torch.float64
-            ),
+            expected_first_order=torch.tensor([-0.0408, 0.4454], dtype=torch.float64),
+            expected_total_order=torch.tensor([0.4405, 0.6326], dtype=torch.float64),
         )
 
         with self.assertRaisesRegex(ValueError, "Second order indices"):

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -450,6 +450,7 @@ def get_branin_experiment_with_timestamp_map_metric(
     multi_objective: bool = False,
     has_objective_thresholds: bool = False,
     bounds: list[float] | None = None,
+    with_choice_parameter: bool = False,
 ) -> Experiment:
     """Returns an experiment with the search space including parameters
 
@@ -465,6 +466,9 @@ def get_branin_experiment_with_timestamp_map_metric(
             objective thresholds.
         bounds: For multi-objective experiments where has_objective_thresholds is True,
             bounds determines the precise objective thresholds.
+        with_choice_parameter: Whether to include a choice parameter.
+            If true, `x2` will be a ChoiceParameter.
+
 
     Returns:
         A Branin single or multi-objective experiment with map metrics.
@@ -529,7 +533,9 @@ def get_branin_experiment_with_timestamp_map_metric(
 
     exp = Experiment(
         name=experiment_name,
-        search_space=get_branin_search_space(),
+        search_space=get_branin_search_space(
+            with_choice_parameter=with_choice_parameter
+        ),
         optimization_config=optimization_config,
         tracking_metrics=cast(list[Metric], tracking_metrics),
         runner=SyntheticRunner(),
@@ -1732,7 +1738,13 @@ def get_robust_search_space(
         RangeParameter("x", ParameterType.FLOAT, lb, ub),
         RangeParameter("y", ParameterType.FLOAT, lb, ub),
         RangeParameter("z", ParameterType.INT, lb, ub),
-        ChoiceParameter("c", ParameterType.STRING, ["red", "blue", "green"]),
+        ChoiceParameter(
+            "c",
+            ParameterType.STRING,
+            ["red", "blue", "green"],
+            is_ordered=False,
+            sort_values=False,
+        ),
     ]
     if multivariate:
         if use_discrete:


### PR DESCRIPTION
Summary:
Implements the refactor outlined in https://docs.google.com/document/d/13xZsjJ_x-_-Msl-A8b49EoLdw96aIiUkfZGilzjCWj0/edit?tab=t.0, which replaces the use of `list[Observation]` objects within the `Adapter` and `Transform` objects with `ExperimentData` where possible.

- Instead of using `observations_from_data` to extract `list[Observation]`, `Adapter` uses `extract_experiment_data` to convert the trials & data into `ExperimentData`, which contains two dataframes `arm_data` and `observation_data`.
- The `Adapter.training_data` is contained in `ExperimentData` and transformed (using vectorized operations where possible) using `Transform.transform_experiment_data`.
- For misc input / output to various `Adapter` and other methods, the `Observation / ObservationFeatures / ObservationData` objects remain. To support these, we retain the existing transform methods that service these objects.

TODO:
- Go over the code once more.
- Update docstrings.
- Split up anything that can be its own diff (e.g. AuxiliarySource changes)

Differential Revision: D70220094
