### PR TITLE
retain all metrics when changing the optimization config

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -390,7 +390,16 @@ class Experiment(Base):
         for metric_name in optimization_config.metrics.keys():
             if metric_name in self._tracking_metrics:
                 self.remove_tracking_metric(metric_name)
+        # add metrics from the previous optimization config that are not in the new
+        # optimization config as tracking metrics
+        prev_optimization_config = self._optimization_config
         self._optimization_config = optimization_config
+        if prev_optimization_config is not None:
+            metrics_to_track = set(prev_optimization_config.metrics.keys()) - set(
+                optimization_config.metrics.keys()
+            )
+            for metric_name in metrics_to_track:
+                self.add_tracking_metric(prev_optimization_config.metrics[metric_name])
 
         if any(
             isinstance(metric, MapMetric)

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -126,10 +126,6 @@ class MultiTypeExperiment(Experiment):
             self._metric_to_trial_type[metric_name] = none_throws(
                 self.default_trial_type
             )
-        # prune metrics that are no longer attached to the experiment
-        for metric_name in list(self._metric_to_trial_type.keys()):
-            if metric_name not in self.metrics:
-                del self._metric_to_trial_type[metric_name]
 
     def update_runner(self, trial_type: str, runner: Runner) -> "MultiTypeExperiment":
         """Update the default runner for an existing trial_type.
@@ -147,7 +143,10 @@ class MultiTypeExperiment(Experiment):
     # pyre-fixme[14]: `add_tracking_metric` overrides method defined in `Experiment`
     #  inconsistently.
     def add_tracking_metric(
-        self, metric: Metric, trial_type: str, canonical_name: str | None = None
+        self,
+        metric: Metric,
+        trial_type: str | None = None,
+        canonical_name: str | None = None,
     ) -> "MultiTypeExperiment":
         """Add a new metric to the experiment.
 
@@ -156,6 +155,8 @@ class MultiTypeExperiment(Experiment):
             trial_type: The trial type for which this metric is used.
             canonical_name: The default metric for which this metric is a proxy.
         """
+        if trial_type is None:
+            trial_type = self._default_trial_type
         if not self.supports_trial_type(trial_type):
             raise ValueError(f"`{trial_type}` is not a supported trial type.")
 

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -258,9 +258,9 @@ class ExperimentTest(TestCase):
         opt_config.outcome_constraints[0].metric = Metric(name="m3")
         self.experiment.optimization_config = opt_config
 
-        # Verify total metrics size is the same.
+        # Verify total metrics has increaed by 1.
         self.assertEqual(
-            len(get_optimization_config().metrics) + 1, len(self.experiment.metrics)
+            len(get_optimization_config().metrics) + 2, len(self.experiment.metrics)
         )
 
         # Add optimization config with 1 scalarized constraint composed of 2 metrics
@@ -271,9 +271,9 @@ class ExperimentTest(TestCase):
         self.experiment.optimization_config = opt_config
 
         # Verify total metrics size is the same.
-        self.assertEqual(len(opt_config.metrics) + 1, len(self.experiment.metrics))
+        self.assertEqual(len(opt_config.metrics) + 2, len(self.experiment.metrics))
         self.assertEqual(
-            len(get_optimization_config().metrics) + 3, len(self.experiment.metrics)
+            len(get_optimization_config().metrics) + 4, len(self.experiment.metrics)
         )
         # set back
         self.experiment.optimization_config = get_optimization_config()
@@ -281,13 +281,13 @@ class ExperimentTest(TestCase):
         # Test adding new tracking metric
         self.experiment.add_tracking_metric(Metric(name="m4"))
         self.assertEqual(
-            len(get_optimization_config().metrics) + 2, len(self.experiment.metrics)
+            len(get_optimization_config().metrics) + 5, len(self.experiment.metrics)
         )
 
         # Test adding new tracking metrics
         self.experiment.add_tracking_metrics([Metric(name="z1")])
         self.assertEqual(
-            len(get_optimization_config().metrics) + 3, len(self.experiment.metrics)
+            len(get_optimization_config().metrics) + 6, len(self.experiment.metrics)
         )
 
         # Verify update_tracking_metric updates the metric definition

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -160,7 +160,8 @@ class MultiTypeExperimentTest(TestCase):
             Objective(BraninMetric("m3", ["x1", "x2"]), minimize=True)
         )
         self.assertDictEqual(
-            self.experiment._metric_to_trial_type, {"m2": "type2", "m3": "type1"}
+            self.experiment._metric_to_trial_type,
+            {"m1": "type1", "m2": "type2", "m3": "type1"},
         )
 
     def test_runner_for_trial_type(self) -> None:


### PR DESCRIPTION
Summary: It is a pretty confusing that metrics in the previous optimization config, but not the new optimization config are dropped when you change the optimization config. E.g. if you remove a constraint, you still likely want to track that metric. This change makes it so that metrics are not silently dropped when the optimization config changes.

Differential Revision: D79475986


