### PR TITLE
Add SEM check for bias correction when relativizing data

### DIFF
--- a/ax/utils/stats/statstools.py
+++ b/ax/utils/stats/statstools.py
@@ -236,7 +236,7 @@ def relativize(
         var = (s_t / abs_mean_c) ** 2
     else:
         c = m_t / mean_c
-        if bias_correction:
+        if bias_correction and not np.all(np.isnan(sem_c)):
             r_hat = r_hat - m_t * sem_c**2 / abs_mean_c**3
 
         # If everything's the same, then set r_hat to zero


### PR DESCRIPTION
Summary: Some experiment have status quo but don't have SEMs. Add this check to prevent the bias correction making everything to be NaN.

Differential Revision: D79457652


