### PR TITLE
Fixes to InsightsAnalysis and TopSurfacesAnalysis

### DIFF
--- a/ax/analysis/plotly/tests/test_top_surfaces.py
+++ b/ax/analysis/plotly/tests/test_top_surfaces.py
@@ -75,20 +75,31 @@ class TestTopSurfacesAnalysis(TestCase):
 
         second = TopSurfacesAnalysis(metric_name="bar", order="second")
 
-        with_contours = second.compute(
+        second_card_group = second.compute(
             experiment=client._experiment,
             generation_strategy=client._generation_strategy,
-        ).flatten()
+        )
 
-        self.assertEqual(len(with_contours), 4)
+        self.assertEqual(
+            {card.name for card in second_card_group.children},
+            {
+                "TopSurfaceAnalysisSlicePlots",
+                "TopSurfaceAnalysisContourPlots",
+                "SensitivityAnalysisPlot",
+            },
+        )
+
+        with_surfaces = second_card_group.flatten()
+
+        self.assertEqual(len(with_surfaces), 4)
 
         # First card should be the sensitivity analysis.
-        self.assertEqual(with_contours[0].title, "Sensitivity Analysis for bar")
+        self.assertEqual(with_surfaces[0].title, "Sensitivity Analysis for bar")
 
         # Other cards should be slices or contours.
-        self.assertIn("vs. bar", with_contours[1].title)
-        self.assertIn("vs. bar", with_contours[2].title)
-        self.assertIn("vs. bar", with_contours[3].title)
+        self.assertIn("vs. bar", with_surfaces[1].title)
+        self.assertIn("vs. bar", with_surfaces[2].title)
+        self.assertIn("vs. bar", with_surfaces[3].title)
 
     @mock_botorch_optimize
     @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")


### PR DESCRIPTION
Summary:
Two changes grouped together here:
1. Make TopSurfacesAnalysis tolerant to failures in surface computation by calling compute_or_error_card from within _compute_surface_plot instead of just compute (fails gracefull and logs failure).
2. Retrun separate groups of slices and contours from within TopSurfacesAnalysis instead of doing grouping in InsightsAnalysis (where we were getting errors due to wonky indexing

Both of these combine to make a more stable UX

Differential Revision: D79293193


