### PR TITLE
Consolidate match_ci_width implementations

### DIFF
--- a/ax/adapter/transforms/bilog_y.py
+++ b/ax/adapter/transforms/bilog_y.py
@@ -18,7 +18,6 @@ from ax.adapter.transforms.log_y import match_ci_width
 from ax.core.observation import Observation, ObservationData
 from ax.core.search_space import SearchSpace
 from ax.generators.types import TConfig
-from scipy.stats import norm
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
@@ -101,8 +100,7 @@ class BilogY(Transform):
     def _reusable_transform(
         self,
         observation_data: list[ObservationData],
-        # pyre-fixme[11]: Annotation `npt.NDarray` is not defined as a type.
-        transform: Callable[[npt.NDArray, npt.NDarray], npt.NDarray],
+        transform: Callable[[npt.NDArray, npt.NDArray], npt.NDArray],
     ) -> list[ObservationData]:
         for obsd in observation_data:
             for i, m in enumerate(obsd.metric_names):
@@ -110,8 +108,9 @@ class BilogY(Transform):
                     bound = self.metric_to_bound[m]
                     obsd.means[i], obsd.covariance[i, i] = match_ci_width(
                         mean=obsd.means[i],
+                        sem=None,
                         variance=obsd.covariance[i, i],
-                        transform=lambda y, bound=bound: transform(y, bound=bound),
+                        transform=lambda y, bound=bound: transform(y, bound),
                     )
         return observation_data
 
@@ -119,32 +118,25 @@ class BilogY(Transform):
         self, experiment_data: ExperimentData
     ) -> ExperimentData:
         obs_data = experiment_data.observation_data
-        # This method applies match_ci_width to the corresponding columns.
-        fac = norm.ppf(0.975)
         for metric, bound in self.metric_to_bound.items():
-            mean = obs_data[("mean", metric)]
-            obs_data[("mean", metric)] = bilog_transform(y=mean, bound=bound)
-            sem = obs_data[("sem", metric)]
-            if sem.isnull().all():
-                # If SEM is NaN, we don't need to transform it.
-                continue
-            d = fac * sem
-            width_asym = bilog_transform(y=mean + d, bound=bound) - bilog_transform(
-                y=mean - d, bound=bound
+            obs_data[("mean", metric)], obs_data[("sem", metric)] = match_ci_width(
+                mean=obs_data[("mean", metric)].to_numpy(),
+                sem=obs_data[("sem", metric)].to_numpy(),
+                variance=None,
+                transform=lambda y, bound=bound: bilog_transform(y, bound),
             )
-            obs_data[("sem", metric)] = width_asym / (2 * fac)
         return ExperimentData(
             arm_data=experiment_data.arm_data, observation_data=obs_data
         )
 
 
-def bilog_transform(y: npt.NDarray, bound: npt.NDarray) -> npt.NDarray:
+def bilog_transform(y: npt.NDArray, bound: npt.NDArray | float) -> npt.NDArray:
     """Bilog transform: f(y) = bound + sign(y - bound) * log(|y - bound| + 1)"""
     diff = y - bound
     return bound + np.sign(diff) * np.log(np.abs(diff) + 1)
 
 
-def inv_bilog_transform(y: npt.NDarray, bound: npt.NDarray) -> npt.NDarray:
+def inv_bilog_transform(y: npt.NDArray, bound: npt.NDArray | float) -> npt.NDArray:
     """Inverse bilog transform: f(y) = bound + sign(y - bound) * expm1(|y - bound|)"""
     diff = y - bound
     sign = np.sign(diff)

--- a/ax/adapter/transforms/log_y.py
+++ b/ax/adapter/transforms/log_y.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from logging import Logger
 from typing import TYPE_CHECKING
 
@@ -16,13 +16,14 @@ import numpy as np
 import numpy.typing as npt
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
+from ax.adapter.transforms.utils import match_ci_width, T_MATCH_CI_WIDTH
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.search_space import SearchSpace
 from ax.generators.types import TConfig
 from ax.utils.common.logger import get_logger
-from scipy.stats import norm
+from pyre_extensions import assert_is_instance
 
 
 if TYPE_CHECKING:
@@ -57,12 +58,11 @@ class LogY(Transform):
         adapter: base_adapter.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
-        if config is None:
-            raise ValueError("LogY requires a config.")
-        # pyre-fixme[6]: Expected `Iterable[Variable[_T]]` for 1st param but got
-        #  `Union[List[Variable[_T]],
-        #  botorch.acquisition.acquisition.AcquisitionFunction, float, int, str]`.
-        metric_names = list(config.get("metrics", []))
+        config = config or {}
+        metric_names = [
+            assert_is_instance(m, str)
+            for m in list(assert_is_instance(config.get("metrics", []), Iterable))
+        ]
         if len(metric_names) == 0:
             raise ValueError("Must specify at least one metric in the config.")
         super().__init__(
@@ -72,15 +72,16 @@ class LogY(Transform):
             adapter=adapter,
             config=config,
         )
-        # pyre-fixme[4]: Attribute must be annotated.
-        self.metric_names = metric_names
+        self.metric_names: list[str] = metric_names
         if config.get("match_ci_width", False):
             # perform moment-matching to compute variance that results in a CI
             # of same width as the when transforming the moments
-            # pyre-fixme[4]: Attribute must be annotated.
-            self._transform = lambda m, v: match_ci_width(m, v, np.log)
-            # pyre-fixme[4]: Attribute must be annotated.
-            self._untransform = lambda m, v: match_ci_width(m, v, np.exp)
+            self._transform: T_MATCH_CI_WIDTH = lambda m, v: match_ci_width(
+                mean=m, sem=None, variance=v, transform=np.log
+            )
+            self._untransform: T_MATCH_CI_WIDTH = lambda m, v: match_ci_width(
+                mean=m, sem=None, variance=v, transform=np.exp
+            )
         else:
             self._transform = lognorm_to_norm
             self._untransform = norm_to_lognorm
@@ -128,16 +129,12 @@ class LogY(Transform):
                     )
                 for i, m in enumerate(obsd.metric_names):
                     if m in self.metric_names:
-                        mu, cov = transform(
+                        obsd.means[i], obsd.covariance[i, i] = transform(
                             np.array(obsd.means[i], ndmin=1),
                             np.array(obsd.covariance[i, i], ndmin=1),
                         )
-                        obsd.means[i] = mu
-                        obsd.covariance[i, i] = cov
             else:
-                mu, cov = transform(obsd.means, obsd.covariance)
-                obsd.means = mu
-                obsd.covariance = cov
+                obsd.means, obsd.covariance = transform(obsd.means, obsd.covariance)
         return observation_data
 
     def _transform_observation_data(
@@ -163,21 +160,6 @@ class LogY(Transform):
                     raise ValueError("Unexpected relative transform.")
                 c.bound = np.exp(c.bound)
         return outcome_constraints
-
-
-def match_ci_width(
-    mean: npt.NDArray,
-    variance: npt.NDArray,
-    transform: Callable[[npt.NDArray], npt.NDArray],
-    level: float = 0.95,
-) -> npt.NDArray:
-    fac = norm.ppf(1 - (1 - level) / 2)
-    d = fac * np.sqrt(variance)
-    width_asym = transform(mean + d) - transform(mean - d)
-    new_mean = transform(mean)
-    new_variance = (width_asym / 2 / fac) ** 2
-    # pyre-fixme[7]: Expected `ndarray` but got `Tuple[ndarray, float]`.
-    return new_mean, new_variance
 
 
 def lognorm_to_norm(

--- a/ax/adapter/transforms/tests/test_bilog_y.py
+++ b/ax/adapter/transforms/tests/test_bilog_y.py
@@ -12,6 +12,8 @@ from copy import deepcopy
 from functools import partial
 from itertools import product
 
+import numpy as np
+
 from ax.adapter.base import Adapter, DataLoaderConfig
 from ax.adapter.data_utils import extract_experiment_data
 from ax.adapter.transforms.bilog_y import bilog_transform, BilogY, inv_bilog_transform
@@ -59,23 +61,27 @@ class BilogYTest(TestCase):
 
     def test_Bilog(self) -> None:
         self.assertAlmostEqual(
-            float(bilog_transform(y=7.3, bound=3)), 4.667706820558076
+            float(bilog_transform(y=np.array(7.3), bound=3)), 4.667706820558076
         )
         self.assertAlmostEqual(
-            float(bilog_transform(y=7.3, bound=10)), 8.691667180349821
+            float(bilog_transform(y=np.array(7.3), bound=10)), 8.691667180349821
         )
         self.assertAlmostEqual(
-            float(inv_bilog_transform(y=4.3, bound=3)), 5.669296667619244
+            float(inv_bilog_transform(y=np.array(4.3), bound=3)), 5.669296667619244
         )
         self.assertAlmostEqual(
-            float(inv_bilog_transform(y=2.3, bound=3)), 1.9862472925295231
+            float(inv_bilog_transform(y=np.array(2.3), bound=3)), 1.9862472925295231
         )
         self.assertAlmostEqual(
-            float(inv_bilog_transform(bilog_transform(y=0.3, bound=3), bound=3)),
+            float(
+                inv_bilog_transform(bilog_transform(y=np.array(0.3), bound=3), bound=3)
+            ),
             0.3,
         )
         self.assertAlmostEqual(
-            float(bilog_transform(inv_bilog_transform(y=0.3, bound=3), bound=3)),
+            float(
+                bilog_transform(inv_bilog_transform(y=np.array(0.3), bound=3), bound=3)
+            ),
             0.3,
         )
 
@@ -194,6 +200,7 @@ class BilogYTest(TestCase):
         # Compare against transforming the old way.
         mean, var = match_ci_width(
             mean=experiment_data.observation_data[("mean", "branin_e")],
+            sem=None,
             variance=experiment_data.observation_data[("sem", "branin_e")] ** 2,
             transform=partial(bilog_transform, bound=self.bound),
         )

--- a/ax/adapter/transforms/tests/test_log_y_transform.py
+++ b/ax/adapter/transforms/tests/test_log_y_transform.py
@@ -46,12 +46,18 @@ class LogYTransformTest(TestCase):
         )
         self.assertTrue("<lambda>" in tf._transform.__name__)
         self.assertTrue("<lambda>" in tf._untransform.__name__)
-        # pyre-fixme[6]: For 1st param expected `ndarray` but got `float`.
-        # pyre-fixme[6]: For 2nd param expected `ndarray` but got `float`.
-        self.assertEqual(tf._transform(1.0, 0.1), match_ci_width(1.0, 0.1, np.log))
-        # pyre-fixme[6]: For 1st param expected `ndarray` but got `float`.
-        # pyre-fixme[6]: For 2nd param expected `ndarray` but got `float`.
-        self.assertEqual(tf._untransform(0.0, 0.1), match_ci_width(0.0, 0.1, np.exp))
+        self.assertEqual(
+            tf._transform(np.array(1.0), np.array(0.1)),
+            match_ci_width(
+                mean=np.array(1.0), sem=None, variance=np.array(0.1), transform=np.log
+            ),
+        )
+        self.assertEqual(
+            tf._untransform(np.array(0.0), np.array(0.1)),
+            match_ci_width(
+                mean=np.array(0.0), sem=None, variance=np.array(0.1), transform=np.exp
+            ),
+        )
 
     def test_TransformObservations(self) -> None:
         obsd_with_noise = ObservationData(
@@ -110,8 +116,6 @@ class LogYTransformTest(TestCase):
                 tf_obsd[0].covariance, obsd_without_noise.covariance, equal_nan=True
             )
         )
-
-        # TODO: match_ci_width test
 
     def test_TransformOptimizationConfig(self) -> None:
         # basic test

--- a/ax/adapter/transforms/tests/test_utils.py
+++ b/ax/adapter/transforms/tests/test_utils.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import numpy as np
+from ax.adapter.transforms.log_y import match_ci_width
+from ax.utils.common.testutils import TestCase
+from numpy import typing as npt
+
+
+class TestUtils(TestCase):
+    def test_match_ci_width(self) -> None:
+        # Tests the behavior of match_ci_width using a simple transform.
+
+        def transform(y: npt.NDArray) -> npt.NDArray:
+            return y * 2.0
+
+        mean = np.array([1.0, 2.0])
+        variance = np.array([0.1, 0.2])
+        # Transform using variance.
+        new_mean, new_variance = match_ci_width(
+            mean=mean,
+            sem=None,
+            variance=variance,
+            transform=transform,
+        )
+        self.assertTrue(np.allclose(new_mean, np.array([2.0, 4.0])))
+        self.assertTrue(np.allclose(new_variance, np.array([0.4, 0.8])))
+        # Transform using sem.
+        new_mean, new_sem = match_ci_width(
+            mean=mean,
+            sem=np.sqrt(variance),
+            variance=None,
+            transform=transform,
+        )
+        self.assertTrue(np.allclose(new_mean, np.array([2.0, 4.0])))
+        self.assertTrue(np.allclose(new_sem, np.array([np.sqrt(0.4), np.sqrt(0.8)])))
+        # Transform with NaN variance.
+        new_mean, new_variance = match_ci_width(
+            mean=mean,
+            sem=None,
+            variance=np.array([np.nan, np.nan]),
+            transform=transform,
+        )
+        self.assertTrue(np.allclose(new_mean, np.array([2.0, 4.0])))
+        self.assertTrue(np.all(np.isnan(new_variance)))
+        # Test with upper and lower bounds.
+        new_mean, new_sem = match_ci_width(
+            mean=mean,
+            sem=np.array([0.1, 0.2]),
+            variance=None,
+            transform=transform,
+            lower_bound=1.0,
+            upper_bound=1.9,
+        )
+        self.assertTrue(np.allclose(new_mean, np.array([2.0, 3.8])))
+        # Bounds are set to clip the CI to the mean from one side only.
+        # We end up with doubling the halved CI width, ending up with the original sem.
+        self.assertTrue(np.allclose(new_sem, np.array([0.1, 0.2])))


### PR DESCRIPTION
Summary:
We had two marginally different implementations of `match_ci_width` and a need for a version of it that supports both transforming `sem` directly and doing the operation over the full array at once. This diff
- Removes `match_ci_width_truncated` and adds the bounds to the base `match_ci_width`.
- Adds a docstring explaining the behavior of the function.
- Updates `match_ci_width` to support `sem` as an alternative to the `variance` input. The function returns the transformed variance if it was called with variance and transformed sem if it was called with sem.
- Updates `BilogY.transform_experimen_data` to utilize the updated `match_ci_width` rather than implementing the same logic from scratch.

Differential Revision: D79581920


