### PR TITLE
Update pyproject.toml to fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ax-platform"
-dynamic = ["version", "dependencies", "optional-dependencies"]
+dynamic = ["version", "dependencies", "optional-dependencies", "classifiers"]
 
 [build-system]
 requires = ["setuptools>=34.4", "wheel", "setuptools_scm"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[project]
+name = "ax-platform"
+dynamic = ["version"]
+
 [build-system]
 requires = ["setuptools>=34.4", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ax-platform"
-dynamic = ["version", "optional-dependencies"]
+dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [build-system]
 requires = ["setuptools>=34.4", "wheel", "setuptools_scm"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ax-platform"
-dynamic = ["version"]
+dynamic = ["version", "optional-dependencies"]
 
 [build-system]
 requires = ["setuptools>=34.4", "wheel", "setuptools_scm"]


### PR DESCRIPTION
Dependency installation in CI is failing with `ValueError: pyproject.toml: setuptools-scm is present in [build-system].requires but dynamic=['version'] is not set in [project]. Either add dynamic=['version'] to [project] or add a [tool.setuptools_scm] section.`. This is the recommended fix.

https://github.com/facebook/Ax/actions/runs/16761469381/job/47457511203