### PR TITLE
Add reliable identifier to ModelConfig

### DIFF
--- a/ax/generators/torch/botorch_modular/generator.py
+++ b/ax/generators/torch/botorch_modular/generator.py
@@ -302,13 +302,9 @@ class BoTorchGenerator(TorchGenerator, Base):
             expected_acquisition_value=expected_acquisition_value,
         )
         # log what model was used
-        metric_to_model_config_name = {
-            metric_name: model_config.name or str(model_config)
-            for metric_name, model_config in (
-                self.surrogate.metric_to_best_model_config.items()
-            )
-        }
-        gen_metadata["metric_to_model_config_name"] = metric_to_model_config_name
+        gen_metadata["metric_to_model_config_name"] = (
+            self.surrogate.model_name_by_metric
+        )
         return TorchGenResults(
             points=candidates.detach().cpu(),
             weights=weights,

--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -835,10 +835,9 @@ class Surrogate(Base):
                     f"Model {model_config} failed to fit with error {e}. Skipping."
                 )
                 continue
-            if (mc_name := model_config.name) is not None:
-                self._model_config_to_eval[mc_name] = {
-                    self.surrogate_spec.eval_criterion: eval_metric
-                }
+            self._model_config_to_eval[model_config.identifier] = {
+                self.surrogate_spec.eval_criterion: eval_metric
+            }
             if maximize ^ (eval_metric < best_eval_metric):
                 best_eval_metric = eval_metric
                 best_model = model
@@ -1102,6 +1101,14 @@ class Surrogate(Base):
     @outcomes.setter
     def outcomes(self, value: list[str]) -> None:
         raise RuntimeError("Setting outcomes manually is disallowed.")
+
+    @property
+    def model_name_by_metric(self) -> dict[str, str]:
+        """Returns a dictionary mapping metric names to model names."""
+        return {
+            metric_name: model_config.identifier
+            for metric_name, model_config in (self.metric_to_best_model_config.items())
+        }
 
 
 submodel_input_constructor = Dispatcher(

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
+from functools import cached_property
 from logging import Logger
 from typing import Any, cast, Mapping
 
@@ -133,6 +134,11 @@ class ModelConfig:
     likelihood_class: type[Likelihood] | None = None
     likelihood_options: dict[str, Any] = field(default_factory=dict)
     name: str | None = None
+
+    @cached_property
+    def identifier(self) -> str:
+        """Returns a unique identifier for the model config."""
+        return self.name if self.name is not None else str(self)
 
 
 def use_model_list(

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -13,6 +13,7 @@ import numpy as np
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import AxWarning, UnsupportedError, UserInputError
+from ax.generators.torch.botorch_modular.kernels import ScaleMaternKernel
 from ax.generators.torch.botorch_modular.utils import (
     _get_shared_rows,
     choose_botorch_acqf_class,
@@ -667,3 +668,30 @@ class BoTorchGeneratorUtilsTest(TestCase):
         self.assertTrue(
             torch.equal(cv_fold.train_dataset.Yvar, Yvar[3:])  # pyre-ignore[6]
         )
+
+    def test_model_config(self) -> None:
+        # Test that model identifier is correctly computed.
+        mc1 = ModelConfig(
+            botorch_model_class=SingleTaskGP,
+            covar_module_class=ScaleMaternKernel,
+            covar_module_options={"ard_num_dims": 1},
+            name="GP",
+        )
+        self.assertEqual(mc1.identifier, "GP")
+        mc2 = ModelConfig(
+            botorch_model_class=SingleTaskGP,
+            covar_module_class=ScaleMaternKernel,
+            covar_module_options={"ard_num_dims": 1},
+        )
+        mc_str = (
+            "ModelConfig("
+            "botorch_model_class=<class 'botorch.models.gp_regression.SingleTaskGP'>, "
+            "model_options={}, mll_class=None, mll_options={}, "
+            "input_transform_classes=<class 'botorch.utils.types.DEFAULT'>, "
+            "input_transform_options={}, outcome_transform_classes=None, "
+            "outcome_transform_options={}, "
+            "covar_module_class=<class 'ax.generators.torch.botorch_modular.kernels."
+            "ScaleMaternKernel'>, covar_module_options={'ard_num_dims': 1}, "
+            "likelihood_class=None, likelihood_options={}, name=None)"
+        )
+        self.assertEqual(mc2.identifier, mc_str)


### PR DESCRIPTION
Summary:
ModelConfig has a name field that is optional. MBM Surrogate needs an identifier for model; currently uses name if present, or just drops the model if not when storing eval results. MBM Generator needs an identifier for model and uses name if present, or str(model_config) if not.

This cleans things up a bit by providing an identifier for ModelConfig that will always exist and so can be used in the place of name and clean up logic in the other parts of MBM. The identifier follows what was done in MBM Generator for tracking gen metadata: it is name if name exists, otherwise a string dump of the model config.

Reviewed By: sdaulton

Differential Revision: D78560884


