### PR TITLE
Fix AnalysisCardGroup rendering in website

### DIFF
--- a/ax/analysis/analysis_card.py
+++ b/ax/analysis/analysis_card.py
@@ -171,11 +171,13 @@ class AnalysisCardBase(SortableBase, ABC):
         such as _body_html_ and _body_papermill_.
         """
 
+        # If in papermill used simplified rendering. This is used for the Ax website.
         if is_running_in_papermill():
             for card in self.flatten():
                 display(Markdown(f"**{card.title}**\n\n{card.subtitle}"))
                 display(card._body_papermill())
-                return
+
+            return
 
         display(HTML(self._repr_html_()))
 


### PR DESCRIPTION
Summary:
What can you say but "lol" 🙃

When building the website we execute tutorial notebooks (using papermill) then convert the ipynb to markdown using a mdx conversion script. The script breaks if we use our typical AnalysisCard._ipython_display_ so we have some special logic which simplifies rendering if we detect we're in papermill which flattens the group and renders each card individually.

We were exiting the *for loop* early instead of exiting the *if statement* because the `return` was indented one level too deep. lol.

Differential Revision: D79726971


