### PR TITLE
Make subtitle optional in Analysis groups

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -126,7 +126,7 @@ class Analysis(Protocol):
     def _create_analysis_card_group(
         self,
         title: str,
-        subtitle: str,
+        subtitle: str | None,
         children: Sequence[AnalysisCardBase],
     ) -> AnalysisCardGroup:
         """
@@ -136,7 +136,7 @@ class Analysis(Protocol):
         return AnalysisCardGroup(
             name=self.__class__.__name__,
             title=title,
-            subtitle=subtitle,
+            subtitle=subtitle if subtitle is not None else "",
             children=children,
         )
 

--- a/ax/analysis/analysis_card.py
+++ b/ax/analysis/analysis_card.py
@@ -230,7 +230,7 @@ class AnalysisCardGroup(AnalysisCardBase):
         self,
         name: str,
         title: str,
-        subtitle: str,
+        subtitle: str | None,
         children: Sequence[AnalysisCardBase],
         timestamp: datetime | None = None,
     ) -> None:
@@ -249,7 +249,7 @@ class AnalysisCardGroup(AnalysisCardBase):
         super().__init__(
             name=name,
             title=title,
-            subtitle=subtitle,
+            subtitle=subtitle if subtitle is not None else "",
             timestamp=timestamp,
         )
 

--- a/ax/analysis/healthcheck/tests/test_no_effects_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_no_effects_analysis.py
@@ -75,7 +75,7 @@ class TestTestOfNoEffectAnalysis(TestCase):
         self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
         self.assertEqual(card.name, "TestOfNoEffectAnalysis")
         self.assertEqual(card.title, "Ax Test of No Effect Warning")
-        self.assertIn("no effects have been detected", card.subtitle)
+        self.assertIn("no effects have been detected", card.subtitle or "")
 
     def test_raises_error_with_no_experiment(self) -> None:
         # GIVEN no experiment is provided
@@ -119,5 +119,5 @@ class TestTestOfNoEffectAnalysis(TestCase):
         card = self.tone.compute(experiment=self.moo_experiment)
         # THEN it warns about one of the metrics
         self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
-        self.assertIn("branin_a", card.subtitle)
-        self.assertNotIn("branin_b", card.subtitle)
+        self.assertIn("branin_a", card.subtitle or "")
+        self.assertNotIn("branin_b", card.subtitle or "")

--- a/ax/analysis/healthcheck/tests/test_regression_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_regression_analysis.py
@@ -37,7 +37,8 @@ class TestRegressionAnalysis(TestCase):
         self.assertEqual(card.name, "RegressionAnalysis")
         self.assertEqual(card.title, "Ax Regression Analysis Warning")
         self.assertTrue(
-            "0_4" in card.subtitle
+            card.subtitle is not None
+            and "0_4" in card.subtitle
             and "branin_b" in card.subtitle
             and "Trial 0" in card.subtitle
         )

--- a/ax/analysis/healthcheck/tests/test_search_space_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_search_space_analysis.py
@@ -71,7 +71,7 @@ class TestSearchSpaceAnalysis(TestCase):
         card = ssa.compute(experiment=experiment)
         self.assertEqual(card.name, "SearchSpaceAnalysis")
         self.assertEqual(card.title, "Ax search-space boundary check [Warning]")
-        self.assertTrue("x1" in card.subtitle)
+        self.assertTrue(card.subtitle is not None and "x1" in card.subtitle)
 
     def test_search_space_boundary_proportions(self) -> None:
         ss = SearchSpace(

--- a/ax/analysis/results.py
+++ b/ax/analysis/results.py
@@ -297,7 +297,7 @@ class ArmEffectsPair(Analysis):
             pair = AnalysisCardGroup(
                 name=f"ArmEffects Pair {metric_name}",
                 title=f"Metric Effects Pair for {metric_name}",
-                subtitle="",
+                subtitle=None,
                 children=[
                     predicted_analysis.compute_or_error_card(
                         experiment=experiment,

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1119,16 +1119,12 @@ class Decoder:
             # Sort children by index
             children = [card for _order, card in sorted(index_to_child_card.items())]
 
-            # Title and subtitle may sometimes be None due to legacy format, safely
-            # load them regardless.
+            # Convert None value of title to empty string to ensure compatibility with
+            # AnalysisCardGroup constructor. Subtitle can be None.
             title = (
                 analysis_card_sqa.title if analysis_card_sqa.title is not None else ""
             )
-            subtitle = (
-                analysis_card_sqa.subtitle
-                if analysis_card_sqa.subtitle is not None
-                else ""
-            )
+            subtitle = analysis_card_sqa.subtitle
 
             return AnalysisCardGroup(
                 name=analysis_card_sqa.name,


### PR DESCRIPTION
Summary:
This diff makes the subtitle optional in the Analysis groups.
The code changes include -
1. Updating the AnalysisCardGroup constructor to accept a subtitle of type str | None
2. Updating the _create_analysis_card_group to accept a subtitle of type str | None
3. Updating other files and tests to handle subtitle being None

Reviewed By: mgarrard

Differential Revision: D79367245


