### PR TITLE
Use trusted publishing for cron test.pypi uploads

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -73,8 +73,6 @@ jobs:
     - name: Deploy to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
         verbose: true

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -43,6 +43,8 @@ jobs:
   deploy-test-pypi:
 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for PyPI OIDC authentication.
     env:
       # `uv pip ...` requires venv by default. This skips that requirement.
       UV_SYSTEM_PYTHON: 1


### PR DESCRIPTION
This should resolve the following warnings. We've been using trusted publishing for BoTorch for some time now.

```
Warning: The workflow was run with the 'attestations: true' input, but an explicit password was also set, disabling Trusted Publishing. As a result, the attestations input is ignored.
Warning: Trusted Publishers allows publishing packages to PyPI from automated environments like GitHub Actions without needing to use username/password combinations or API tokens to authenticate with PyPI. Read more: https://docs.pypi.org/trusted-publishers
Warning: A new Trusted Publisher for the currently running publishing workflow can be created by accessing the following link(s) while logged-in as an owner of the package(s):
- https://test.pypi.org/manage/project/ax-platform/settings/publishing/?provider=github&owner=facebook&repository=Ax&workflow_filename=cron.yml
```

Test Plan:
Cron https://github.com/facebook/Ax/actions/runs/16782534901/job/47524781864
succesfully uploads without above warnings.