### PR TITLE
Update Search Space Analysis Warning wording to capture bound

### DIFF
--- a/ax/analysis/healthcheck/search_space_analysis.py
+++ b/ax/analysis/healthcheck/search_space_analysis.py
@@ -240,17 +240,17 @@ def boundary_proportions_message(
             parameter = row["parameter_or_constraint"]
             bound = row["bound"]
             prop = row["proportion"]
+            boundary = row["boundary"]
             if prop >= boundary_proportion_threshold:
                 change_dir = "decreasing" if bound == "lower" else "increasing"
                 msg += (
                     f"\n - **Relax {bound} bound of `{parameter.name!r}`:** Ax is "
                     f"frequently suggesting values at the {bound} bound of "
-                    f"`{parameter.name!r}`. This may indicate that the optimal value "
-                    f"of this parameter is outside this bound, in which case "
-                    f"{change_dir} this {bound} bound would improve optimization "
-                    f"performance. Details: {prop * 100:.2f}% of "
-                    f"suggested arms are on the parameter's "
-                    f"{bound} bound (threshold for this alert is "
+                    f"`{parameter.name!r}`, `{boundary}`. This may indicate that the "
+                    f"optimal value of this parameter is outside this bound, in which "
+                    f"case {change_dir} this {bound} bound would improve optimization "
+                    f"performance. Details: {prop * 100:.2f}% of suggested arms are on "
+                    f"the parameter's {bound} bound (threshold for this alert is "
                     f"{boundary_proportion_threshold * 100:.2f}%)."
                 )
         elif isinstance(row["parameter_or_constraint"], ParameterConstraint):

--- a/ax/analysis/healthcheck/tests/test_search_space_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_search_space_analysis.py
@@ -39,11 +39,11 @@ class TestSearchSpaceAnalysis(TestCase):
         self.assertEqual(card.title, "Ax search-space boundary check [Warning]")
         subtitle = SUBTITLE_BASE + (
             "\n - **Relax lower bound of `'x1'`:** Ax is frequently suggesting values "
-            "at the lower bound of `'x1'`. This may indicate that the optimal value of "
-            "this parameter is outside this bound, in which case decreasing this lower "
-            "bound would improve optimization performance. Details: 66.67% of "
-            "suggested arms are on the parameter's lower bound (threshold for "
-            "this alert is 50.00%)."
+            "at the lower bound of `'x1'`, `x1 = -5.0`. This may indicate that the "
+            "optimal value of this parameter is outside this bound, in which case "
+            "decreasing this lower bound would improve optimization performance. "
+            "Details: 66.67% of suggested arms are on the parameter's lower bound "
+            "(threshold for this alert is 50.00%)."
         )
         self.assertEqual(card.subtitle, subtitle)
 


### PR DESCRIPTION
Summary: D77956177 updated the search space analysis warning wording to be more transparent. Even more transparent would be to include the bound value in the warning message, so users can more quickly interpret this warning.

Reviewed By: saitcakmak

Differential Revision: D79730040


