### PR TITLE
Silence excessive warnings from ESS

### DIFF
--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -356,7 +356,7 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         each objective in the experiment or in `self.metric_names`, if specified.
         """
         if self.metric_names is None:
-            logger.warning(
+            logger.debug(
                 "No metric names specified. Defaulting to the objective metric(s).",
                 stacklevel=2,
             )

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -315,19 +315,13 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         self.assertEqual(should_stop, {})
 
     def test_percentile_early_stopping_strategy(self) -> None:
-        with patch.object(
-            logger,
-            "warning",
-        ) as logger_mock:
+        with patch.object(logger, "debug") as logger_mock:
             self._test_percentile_early_stopping_strategy(
                 logger_mock=logger_mock, non_objective_metric=False
             )
 
     def test_percentile_early_stopping_strategy_non_objective_metric(self) -> None:
-        with patch.object(
-            logger,
-            "warning",
-        ) as logger_mock:
+        with patch.object(logger, "debug") as logger_mock:
             self._test_percentile_early_stopping_strategy(
                 logger_mock=logger_mock, non_objective_metric=True
             )


### PR DESCRIPTION
Summary:
Looking at any tutorial with early stopping (ex: https://ax.dev/docs/next/tutorials/sklearn/) shows a ton of these warnings: `[WARNING 08-06 05:15:48] ax.early_stopping.strategies.base: No metric names specified. Defaulting to the objective metric(s).`

The docstring specifies this to be the behavior when metrics are not explicitly specifies. This warning does not need to be this intrusive, we can reduce it to debug level.

Differential Revision: D79740162


