### PR TITLE
Update MetadataToParameter.transform_experiment_data to retain the original

### DIFF
--- a/ax/adapter/transforms/metadata_to_parameter.py
+++ b/ax/adapter/transforms/metadata_to_parameter.py
@@ -74,9 +74,8 @@ class MetadataToParameterMixin:
         self, experiment_data: ExperimentData
     ) -> ExperimentData:
         arm_data = experiment_data.arm_data
-        metadata = arm_data["metadata"]
         for name in self.parameters:
-            arm_data[name] = metadata.apply(lambda x: x.pop(name))  # noqa B023
+            arm_data[name] = [md.get(name) for md in arm_data["metadata"]]
         return ExperimentData(
             arm_data=arm_data,
             observation_data=experiment_data.observation_data,

--- a/ax/adapter/transforms/tests/test_metadata_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_metadata_to_float_transform.py
@@ -169,13 +169,10 @@ class MetadataToFloatTransformTest(TestCase):
             3.0 * s for steps in STEPS_ENDS for s in range(1, steps + 1)
         ]
         self.assertEqual(transformed_data.arm_data["bar"].tolist(), expected_bar_values)
-        # Metadata has been updated to remove the transform parameter.
-        for m in transformed_data.arm_data["metadata"]:
-            self.assertNotIn("bar", m)
         # Remaining columns are unchanged.
         assert_frame_equal(
-            transformed_data.arm_data.drop(columns=["bar", "metadata"]),
-            self.experiment_data.arm_data.drop(columns=["metadata"]),
+            transformed_data.arm_data.drop(columns=["bar"]),
+            self.experiment_data.arm_data,
         )
         # Observation data is not changed.
         assert_frame_equal(

--- a/ax/adapter/transforms/tests/test_metadata_to_task.py
+++ b/ax/adapter/transforms/tests/test_metadata_to_task.py
@@ -112,15 +112,10 @@ class MetadataToTaskTransformTest(TestCase):
             transformed_data.arm_data[Keys.TASK_FEATURE_NAME.value].tolist(),
             expected_task_values,
         )
-        # Metadata has been updated to remove the transform parameter.
-        for m in transformed_data.arm_data["metadata"]:
-            self.assertNotIn(Keys.TASK_FEATURE_NAME.value, m)
         # Remaining columns are unchanged.
         assert_frame_equal(
-            transformed_data.arm_data.drop(
-                columns=[Keys.TASK_FEATURE_NAME.value, "metadata"]
-            ),
-            self.experiment_data.arm_data.drop(columns=["metadata"]),
+            transformed_data.arm_data.drop(columns=[Keys.TASK_FEATURE_NAME.value]),
+            self.experiment_data.arm_data,
         )
         # Observation data is not changed.
         assert_frame_equal(


### PR DESCRIPTION
Summary:
This transform was popping the corresponding element from the metadata before adding it as a feature. This is fine for the most part, but it doesn't really have a significant benefit over just leaving the original in the metadata.

The problem with popping the element from the metadata is when doing this with `ExperimentData`. Even if we `deepcopy` a pandas dataframe, it does not deepcopy the underlying dictionary values. If we then transform the copy, we end up removing the metadata from the original as well, which leads to errors when doing cross validation with an adapter that uses these transforms (since we end up transforming multiple copies, and only the first one has the metadata).

This diff updates the transfrom to not remove the element from metadata.

Differential Revision: D79805146


