### PR TITLE
Add support for missing tasks in mtgp

### DIFF
--- a/ax/generators/tests/test_botorch_defaults.py
+++ b/ax/generators/tests/test_botorch_defaults.py
@@ -97,6 +97,8 @@ class BotorchDefaultsTest(TestCase):
             "sd_prior": GammaPrior(2.0, 0.44),
             "eta": 0.6,
         }
+        x[0, 1] = 0
+        x[1, 1] = 1
         model = _get_model(
             X=x, Y=y, Yvar=partial_var.clone(), task_feature=1, prior=prior
         )
@@ -116,7 +118,6 @@ class BotorchDefaultsTest(TestCase):
             task_covar_module.IndexKernelPrior.correlation_prior.eta,
             0.6,
         )
-
         model = _get_model(
             X=x,
             Y=y,

--- a/ax/generators/tests/test_botorch_moo_model.py
+++ b/ax/generators/tests/test_botorch_moo_model.py
@@ -507,6 +507,8 @@ class BotorchMOOModelTest(TestCase):
                 [
                     [11.0, 2.0],
                     [9.0, 3.0],
+                    [12.0, 0.0],
+                    [13.0, 0.0],
                 ],
                 **tkwargs,
             )
@@ -556,16 +558,8 @@ class BotorchMOOModelTest(TestCase):
             ckwargs = _mock_model_infer_objective_thresholds.call_args[1]
             X_observed = ckwargs["X_observed"]
             sorted_idcs = X_observed[:, 0].argsort()
-            expected_X_observed = torch.tensor(
-                [[1.0, 2.0, 3.0], [0.9, 1.9, 2.9]], **tkwargs
-            )
-            sorted_idcs2 = expected_X_observed[:, 0].argsort()
-            self.assertTrue(
-                torch.equal(
-                    X_observed[sorted_idcs],
-                    expected_X_observed[sorted_idcs2],
-                )
-            )
+            sorted_idcs2 = Xs[:, 0].argsort()
+            self.assertTrue(torch.equal(X_observed[sorted_idcs], Xs[sorted_idcs2]))
             self.assertTrue(
                 torch.equal(
                     ckwargs["objective_weights"],
@@ -785,6 +779,7 @@ class BotorchMOOModelTest(TestCase):
             feature_names,
             _,
         ) = get_torch_test_data(dtype=dtype, cuda=cuda, constant_noise=True)
+        bounds[0] = (0.0, 1.0)  # make one data point out of bounds
         training_data = [
             SupervisedDataset(
                 X=Xs,

--- a/ax/generators/torch/botorch_modular/input_constructors/outcome_transform.py
+++ b/ax/generators/torch/botorch_modular/input_constructors/outcome_transform.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from typing import Any
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
+from ax.generators.torch.botorch_modular.utils import get_all_task_values_from_ssd
 
 from ax.utils.common.typeutils import _argparse_type_encoder
 from botorch.models.transforms.outcome import (
@@ -20,7 +22,7 @@ from botorch.models.transforms.outcome import (
 )
 from botorch.utils.datasets import MultiTaskDataset, SupervisedDataset
 from botorch.utils.dispatcher import Dispatcher
-from pyre_extensions import assert_is_instance
+from pyre_extensions import assert_is_instance, none_throws
 
 outcome_transform_argparse = Dispatcher(
     name="outcome_transform_argparse", encoder=_argparse_type_encoder
@@ -32,6 +34,7 @@ def _outcome_transform_argparse_base(
     outcome_transform_class: type[OutcomeTransform],
     dataset: SupervisedDataset | None = None,
     outcome_transform_options: dict[str, Any] | None = None,
+    search_space_digest: SearchSpaceDigest | None = None,
 ) -> dict[str, Any]:
     """
     Extract the outcome transform kwargs from the given arguments.
@@ -58,6 +61,7 @@ def _outcome_transform_argparse_standardize(
     outcome_transform_class: type[Standardize],
     dataset: SupervisedDataset,
     outcome_transform_options: dict[str, Any] | None = None,
+    search_space_digest: SearchSpaceDigest | None = None,
 ) -> dict[str, Any]:
     """Extract the outcome transform kwargs form the given arguments.
 
@@ -84,6 +88,7 @@ def _outcome_transform_argparse_stratified_standardize(
     outcome_transform_class: type[StratifiedStandardize],
     dataset: SupervisedDataset,
     outcome_transform_options: dict[str, Any] | None = None,
+    search_space_digest: SearchSpaceDigest | None = None,
 ) -> dict[str, Any]:
     """Extract the outcome transform kwargs form the given arguments.
 
@@ -106,7 +111,20 @@ def _outcome_transform_argparse_stratified_standardize(
     else:
         task_feature_index = dataset.task_feature_index
         task_values = dataset.X[..., dataset.task_feature_index].unique().long()
+    ssd = none_throws(search_space_digest)
+    if (ssd.target_values is not None) and (
+        target_value := ssd.target_values.get(none_throws(task_feature_index))
+    ) is not None:
+        outcome_transform_options.setdefault("default_task_value", int(target_value))
     outcome_transform_options.setdefault("stratification_idx", task_feature_index)
-    outcome_transform_options.setdefault("task_values", task_values)
+    outcome_transform_options.setdefault("observed_task_values", task_values)
+    outcome_transform_options.setdefault(
+        "all_task_values",
+        torch.tensor(
+            get_all_task_values_from_ssd(search_space_digest=ssd),
+            dtype=torch.long,
+            device=next(iter(dataset.datasets.values())).X.device,
+        ),
+    )
 
     return outcome_transform_options

--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -36,6 +36,7 @@ from ax.generators.torch.botorch_modular.utils import (
     convert_to_block_design,
     copy_model_config_with_default_values,
     fit_botorch_model,
+    get_all_task_values_from_ssd,
     get_cv_fold,
     ModelConfig,
     subset_state_dict,
@@ -264,6 +265,7 @@ def _make_botorch_outcome_transform(
     outcome_transform_classes: list[type[OutcomeTransform]],
     outcome_transform_options: dict[str, dict[str, Any]],
     dataset: SupervisedDataset,
+    search_space_digest: SearchSpaceDigest,
 ) -> OutcomeTransform | None:
     """
     Makes a BoTorch outcome transform from the provided classes and options.
@@ -283,6 +285,7 @@ def _make_botorch_outcome_transform(
                 outcome_transform_options.get(transform_class.__name__, {})
             ),
             dataset=dataset,
+            search_space_digest=search_space_digest,
         )
         for transform_class in outcome_transform_classes
     ]
@@ -366,6 +369,7 @@ def _construct_submodules(
             outcome_transform_classes=outcome_transform_classes,
             outcome_transform_options=model_config.outcome_transform_options or {},
             dataset=dataset,
+            search_space_digest=search_space_digest,
         )
     elif "outcome_transform" in botorch_model_class_args:
         # This is a temporary solution until all BoTorch models use
@@ -1284,6 +1288,14 @@ def _submodel_input_constructor_mtgp(
             target_value := search_space_digest.target_values.get(task_feature)
         ) is not None:
             formatted_model_inputs["output_tasks"] = [int(target_value)]
+            # This enables making predictions for inputs at unobserved task values,
+            # by making predictions for the target task.
+            # This is important for MTGP models that are used in ModelListGPs where
+            # some metrics have only been observed for some tasks and not others.
+            formatted_model_inputs["validate_task_values"] = False
+            formatted_model_inputs["all_tasks"] = get_all_task_values_from_ssd(
+                search_space_digest=search_space_digest
+            )
         else:
             raise UserInputError(
                 "output_tasks or target task value must be provided for MultiTaskGP."

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -665,3 +665,17 @@ def get_cv_fold(
         test_X=X[idcs],
         test_Y=Y[idcs],
     )
+
+
+def get_all_task_values_from_ssd(search_space_digest: SearchSpaceDigest) -> list[int]:
+    """Get all task values from a search space digest.
+
+    Args:
+        search_space_digest: The search space digest.
+
+    Returns:
+        A list of all task values.
+    """
+    task_feature = search_space_digest.task_features[0]
+    task_bounds = search_space_digest.bounds[task_feature]
+    return list(range(int(task_bounds[0]), int(task_bounds[1] + 1)))

--- a/ax/generators/torch/tests/test_outcome_transform_argparse.py
+++ b/ax/generators/torch/tests/test_outcome_transform_argparse.py
@@ -6,6 +6,7 @@
 # pyre-strict
 
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.generators.torch.botorch_modular.input_constructors.outcome_transform import (
     outcome_transform_argparse,
 )
@@ -17,6 +18,7 @@ from botorch.models.transforms.outcome import (
 )
 from botorch.utils.datasets import MultiTaskDataset, SupervisedDataset
 from pyre_extensions import assert_is_instance
+from torch import Tensor
 
 
 class DummyOutcomeTransform(OutcomeTransform):
@@ -70,39 +72,52 @@ class OutcomeTransformArgparseTest(TestCase):
         X = self.dataset.X
         X[:5, 3] = 0
         X[5:, 3] = 1
+        ssd = SearchSpaceDigest(
+            feature_names=self.dataset.feature_names,
+            bounds=[(0.0, 1.0)] * 3 + [(0.0, 2.0)],
+            task_features=[3],
+            target_values={3: 1},
+        )
         mt_dataset = MultiTaskDataset.from_joint_dataset(
             dataset=self.dataset,
             task_feature_index=3,
             target_task_value=1,
         )
         outcome_transform_kwargs_a = outcome_transform_argparse(
-            StratifiedStandardize, dataset=mt_dataset
+            StratifiedStandardize,
+            dataset=mt_dataset,
+            search_space_digest=ssd,
         )
-        options_b = {
-            "stratification_idx": 2,
-            "task_values": torch.tensor([0, 3]),
-        }
+        options_b = {"stratification_idx": 2, "default_task_value": 4}
         outcome_transform_kwargs_b = outcome_transform_argparse(
             StratifiedStandardize,
             dataset=mt_dataset,
             outcome_transform_options=options_b,
+            search_space_digest=ssd,
         )
         expected_options_a = {
             "stratification_idx": 3,
-            "task_values": torch.tensor([0, 1]),
+            "observed_task_values": torch.tensor([0, 1], dtype=torch.long),
+            "all_task_values": torch.tensor([0, 1, 2], dtype=torch.long),
+            "default_task_value": 1,
+        }
+        expected_options_b = {
+            "stratification_idx": 2,
+            "observed_task_values": torch.tensor([0, 1], dtype=torch.long),
+            "all_task_values": torch.tensor([0, 1, 2], dtype=torch.long),
+            "default_task_value": 4,
         }
         for expected_options, actual_options in zip(
-            (expected_options_a, options_b),
+            (expected_options_a, expected_options_b),
             (outcome_transform_kwargs_a, outcome_transform_kwargs_b),
         ):
-            self.assertEqual(len(actual_options), 2)
-            self.assertEqual(
-                actual_options["stratification_idx"],
-                expected_options["stratification_idx"],
-            )
-            self.assertTrue(
-                torch.equal(
-                    actual_options["task_values"],
-                    assert_is_instance(expected_options["task_values"], torch.Tensor),
+            self.assertEqual(len(actual_options), 4)
+            for k in ("stratification_idx", "stratification_idx"):
+                self.assertEqual(actual_options[k], expected_options[k])
+            for k in ("observed_task_values", "all_task_values"):
+                self.assertTrue(
+                    torch.equal(
+                        actual_options[k],
+                        assert_is_instance(expected_options[k], Tensor),
+                    )
                 )
-            )

--- a/ax/generators/torch/tests/test_surrogate.py
+++ b/ax/generators/torch/tests/test_surrogate.py
@@ -2048,8 +2048,7 @@ class SurrogateWithModelListTest(TestCase):
             ),
         }
 
-        # offset makes task feature point to valid outcome indices
-        Xs, Ys, Yvars, _, _, _, _ = get_torch_test_data(dtype=self.dtype, offset=-1)
+        Xs, Ys, Yvars, _, _, _, _ = get_torch_test_data(dtype=self.dtype)
         ds1 = SupervisedDataset(
             X=Xs,
             Y=Ys,

--- a/ax/utils/testing/torch_stubs.py
+++ b/ax/utils/testing/torch_stubs.py
@@ -46,7 +46,7 @@ def get_torch_test_data(
         Yvar = torch.tensor([[0.0 + offset], [2.0 + offset]], **tkwargs)
 
     bounds = [
-        (0.0 + offset, 1.0 + offset),
+        (0.0 + offset, 2.0 + offset),
         (1.0 + offset, 4.0 + offset),
         (2.0 + offset, 5.0 + offset),
     ]


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/botorch/pull/2960

Currently, cross-validation in Ax fails when using a MTGP if there are multiple metrics and only some metrics have been observed for some tasks. This is a modeling problem, since the model is a ModelListGP and not all MTGPs in the list are required to have the same tasks. Hence when you pass in a test input, the model errors out if there are not observations from that task in the training data.

This avoids the error by mapping (optionally) mapping unexpected tasks to the "target task". This does not change the default behavior. For cross-validation in Ax, predictions are discarded if there are no observations for a given (task, metric) pair.

This will still error out in Ax if data for the target trial is missing.

Differential Revision: D79812024


