### PR TITLE
Move out of sample filter in ContourPlot

### DIFF
--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -201,6 +201,13 @@ def _prepare_data(
         for trial in experiment.trials.values()
         if trial.status in STATUSES_EXPECTING_DATA  # running, completed, early stopped
         for arm in trial.arms
+        # Filter out arms which are not part of the search space (ex. when a parameter
+        # is None).
+        if experiment.search_space.check_membership(
+            parameterization=arm.parameters,
+            raise_error=False,
+            check_all_parameters_present=False,
+        )
     ]
 
     # Choose which parameter values to predict points for.
@@ -233,15 +240,6 @@ def _prepare_data(
         )
         for x in xs
         for y in ys
-        # Do not create features for any out of sample points
-        if experiment.search_space.check_membership(
-            parameterization={
-                x_parameter_name: x,
-                y_parameter_name: y,
-            },
-            raise_error=False,
-            check_all_parameters_present=False,
-        )
     ]
 
     predictions = model.predict(observation_features=features)


### PR DESCRIPTION
Summary:
See https://github.com/facebook/Ax/issues/4103 for motivation.

We need to check for search space membership when we sample from the surrogate to draw the contour plot, specifically because in experiments where the status quo arm is all None we were getting errors.

However, we dont actually care if points are out of sample is technically out of the search space due to parameter constraint violation (ex. if the value for a non-plotted parameter selected by select_fixed_value causes some parameter constraint to be violated we shouldnt mind and Ax should go ahead and plot regardless). By moving the check higher up we avoid this error entirely.

Reviewed By: mgarrard

Differential Revision: D79917972


