### PR TITLE
Use floating-point map key types in Benchmark MapMetrics

### DIFF
--- a/ax/benchmark/benchmark_metric.py
+++ b/ax/benchmark/benchmark_metric.py
@@ -94,7 +94,7 @@ from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
 from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
-from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
 from ax.utils.common.result import Err, Ok
@@ -254,11 +254,6 @@ class BenchmarkTimeVaryingMetric(BenchmarkMetricBase):
 class BenchmarkMapMetric(MapMetric, BenchmarkMetricBase):
     """MapMetric for benchmarking. It is available while running."""
 
-    # pyre-fixme: Inconsistent override [15]: `map_key_info` overrides attribute
-    # defined in `MapMetric` inconsistently. Type `MapKeyInfo[int]` is not a
-    # subtype of the overridden attribute `MapKeyInfo[float]`
-    map_key_info: MapKeyInfo[int] = MapKeyInfo(key="step", default_value=0)
-
     @classmethod
     def is_available_while_running(cls) -> bool:
         return True
@@ -270,11 +265,6 @@ class BenchmarkMapMetric(MapMetric, BenchmarkMetricBase):
 
 
 class BenchmarkMapUnavailableWhileRunningMetric(MapMetric, BenchmarkMetricBase):
-    # pyre-fixme: Inconsistent override [15]: `map_key_info` overrides attribute
-    # defined in `MapMetric` inconsistently. Type `MapKeyInfo[int]` is not a
-    # subtype of the overridden attribute `MapKeyInfo[float]`
-    map_key_info: MapKeyInfo[int] = MapKeyInfo(key="step", default_value=0)
-
     def _df_to_result(self, df: DataFrame) -> MetricFetchResult:
         # Just in case the key was renamed by a subclass
         df = df.rename(columns={"step": self.map_key_info.key})


### PR DESCRIPTION
Summary:
### Context

In the benchmarking set-up, the `normalize_progression=True` option in early-stopping strategies is currently not working properly as zero trials are early-stopped. Specifically, it appears that `is_eligible_any` returns `False` for all trials. 

All early-stopping strategies (all subclasses of `BaseEarlyStoppingStrategy`) are impacted. Specifically the instantiation of `MapData` in the return call of `_check_validity_and_get_data` casts the progression column to `int64`, which rounds all the float-valued progressions `[0.0, 1.0)` to `0`, leading `is_eligible_any` to always return `False`

### Changes

This diff removes the specification of `map_key_info` as integer-typed in `BenchmarkMapMetric` and `BenchmarkMapUnavailableWhileRunningMetric`.

Differential Revision: D79938692


