### PR TITLE
Remove print statement from Getting Started

### DIFF
--- a/tutorials/getting_started/getting_started.ipynb
+++ b/tutorials/getting_started/getting_started.ipynb
@@ -222,9 +222,7 @@
         "        raw_data = {metric_name: result}\n",
         "\n",
         "        # Complete the trial with the result\n",
-        "        client.complete_trial(trial_index=trial_index, raw_data=raw_data)\n",
-        "\n",
-        "        print(f\"Completed trial {trial_index} with {raw_data=}\")"
+        "        client.complete_trial(trial_index=trial_index, raw_data=raw_data)"
       ]
     },
     {


### PR DESCRIPTION
Summary:
With logging changes from D78183140 these print statements are extraneous, see screenshot. This tidies things up quite a bit.

{F1981106230}

Differential Revision: D80030926


