### PR TITLE
Fix Duplicate Candidate Trial Plotting Bug

### DIFF
--- a/ax/analysis/plotly/arm_effects.py
+++ b/ax/analysis/plotly/arm_effects.py
@@ -38,7 +38,7 @@ from ax.analysis.utils import (
 from ax.core.arm import Arm
 from ax.core.base_trial import sort_by_trial_index_and_arm_name
 from ax.core.experiment import Experiment
-from ax.core.trial_status import FAILED_ABANDONED_STATUSES, TrialStatus
+from ax.core.trial_status import FAILED_ABANDONED_CANDIDATE_STATUSES, TrialStatus
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from plotly import graph_objects as go
@@ -323,7 +323,9 @@ def _prepare_figure(
     ].max()
     # Filter out undesired trials like FAILED and ABANDONED trials from plot.
     trials = df[
-        ~df["trial_status"].isin([ts.name for ts in FAILED_ABANDONED_STATUSES])
+        ~df["trial_status"].isin(
+            [ts.name for ts in FAILED_ABANDONED_CANDIDATE_STATUSES]
+        )
     ]["trial_index"].unique()
 
     # Check if candidate_trial is NaN and handle it

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -39,7 +39,7 @@ from ax.analysis.utils import (
 )
 from ax.core.arm import Arm
 from ax.core.experiment import Experiment
-from ax.core.trial_status import FAILED_ABANDONED_STATUSES, TrialStatus
+from ax.core.trial_status import FAILED_ABANDONED_CANDIDATE_STATUSES, TrialStatus
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.utils.common.logger import get_logger
@@ -330,7 +330,9 @@ def _prepare_figure(
     ].max()
     # Filter out undesired trials like FAILED and ABANDONED trials from plot.
     trials = df[
-        ~df["trial_status"].isin([ts.name for ts in FAILED_ABANDONED_STATUSES])
+        ~df["trial_status"].isin(
+            [ts.name for ts in FAILED_ABANDONED_CANDIDATE_STATUSES]
+        )
     ]["trial_index"].unique()
 
     trials_list = trials.tolist()

--- a/ax/core/trial_status.py
+++ b/ax/core/trial_status.py
@@ -148,7 +148,8 @@ STATUSES_EXPECTING_DATA: list[TrialStatus] = [
     TrialStatus.EARLY_STOPPED,
 ]
 
-FAILED_ABANDONED_STATUSES: list[TrialStatus] = [
+FAILED_ABANDONED_CANDIDATE_STATUSES: list[TrialStatus] = [
     TrialStatus.ABANDONED,
     TrialStatus.FAILED,
+    TrialStatus.CANDIDATE,
 ]


### PR DESCRIPTION
Summary:
Fix bug where `ArmEffectsPlot` and `ScatterPlot` are showing the latest CANDIDATE Trial twice.

This is currently happening because the following line: 

```
~df["trial_status"].isin([ts.name for ts in FAILED_ABANDONED_STATUSES])
``` 
brings in candidates before we additionally append `candidate_trial` a few lines later. By including candidate trials in the exclusion filter (i.e. `FAILED_ABANDONED_CANDIDATE_STATUSES`), we avoid duplicate candidate trials

Differential Revision: D80046532


