### PR TITLE
Pin botorch to 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The release log for Ax.
 * Misc. plotting fixes and improvements
 
 #### Other changes
-* Bumped pinned [botorch](https://github.com/pytorch/botorch) version to 0.15.0
+* Bumped pinned [botorch](https://github.com/pytorch/botorch) version to 0.15.1
 * Performance improvements in `SensitivityAnalysis` (#3891)
 * Improved optimization performance in constrained optimization settings (#3585)
 * Augmented logging in `Client`, early stopping module (#4044, #4108)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os
 
 from setuptools import find_packages, setup
 
-PINNED_BOTORCH_VERSION = "0.15.0"
+PINNED_BOTORCH_VERSION = "0.15.1"
 
 if os.environ.get("ALLOW_BOTORCH_LATEST"):
     # allows a more recent previously installed version of botorch to remain


### PR DESCRIPTION
Summary:
We need to repin botorch in Ax since D78560935
 landed in between when we released botorch 0.15.0 and when we tried to deploy Ax 1.1

Reviewed By: esantorella

Differential Revision: D80044408


