### PR TITLE
Updating conditionals for mutually exclusive cases in _overwite_metric

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -1166,8 +1166,7 @@ class Client(WithDBSettingsBase):
                     if metric.name == multi_objective.objectives[i].metric.name:
                         multi_objective._objectives[i]._metric = metric
                         return
-
-            if isinstance(
+            elif isinstance(
                 scalarized_objective := optimization_config.objective,
                 ScalarizedObjective,
             ):
@@ -1175,8 +1174,7 @@ class Client(WithDBSettingsBase):
                     if metric.name == scalarized_objective.metrics[i].name:
                         scalarized_objective._metrics[i] = metric
                         return
-
-            if (
+            elif (
                 isinstance(optimization_config.objective, Objective)
                 and metric.name == optimization_config.objective.metric.name
             ):


### PR DESCRIPTION
Summary:
### Code Changes

The code changes in `client.py` involve updating the `if` statements to `elif` statements in the `_overwrite_metric` method to ensure that the conditionals are mutually exclusive. This change prevents incorrect metric updates and improves the overall logic of the method.

In `test_client.py`, a new test method `test_overwrite_metric` is added to verify the correct functioning of the `_overwrite_metric` method. The test creates a client, configures an experiment, and tests the replacement of single-objective metrics and outcome constraint metrics.

### Impact

The changes made in this diff improve the reliability and accuracy of the `_overwrite_metric` method, ensuring that the correct metrics are updated in the client.

Reviewed By: mpolson64

Differential Revision: D80005551


