### PR TITLE
MBM: handle errors that can be raised in convert_to_block_design

### DIFF
--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -655,7 +655,15 @@ class Surrogate(Base):
         )
 
         if not should_use_model_list and len(datasets) > 1:
-            datasets = convert_to_block_design(datasets=datasets, force=True)
+            try:
+                datasets = convert_to_block_design(datasets=datasets, force=False)
+            except UnsupportedError as e:
+                # If the block design conversion fails, use model-list.
+                logger.warning(
+                    "Conversion to block design failed. Using model-list instead."
+                    f"Original error: {e}"
+                )
+                should_use_model_list = True
         self._training_data = list(datasets)  # So that it can be modified if needed.
 
         feature_names_set = set(search_space_digest.feature_names)

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -327,9 +327,7 @@ def choose_botorch_acqf_class(
         # NOTE: `convert_to_block_design` will drop points that are only observed by
         # some of the metrics which is natural as we are using observed values to
         # determine feasibility.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=AxWarning)
-            dataset = convert_to_block_design(datasets=datasets, force=True)[0]
+        dataset = convert_to_block_design(datasets=datasets, force=True)[0]
         con_observed = torch.stack([con(dataset.Y) for con in con_tfs], dim=-1)
         feas_point_found = (con_observed <= 0).all(dim=-1).any().item()
 
@@ -432,15 +430,32 @@ def convert_to_block_design(
     datasets: Sequence[SupervisedDataset],
     force: bool = False,
 ) -> list[SupervisedDataset]:
-    # Convert data to "block design". TODO: Figure out a better
-    # solution for this using the data containers (pass outcome
-    # names as properties of the data containers)
+    """Converts a list of datasets to a single block-design dataset that contains
+    all outcomes.
+
+    Args:
+        datasets: A list of datasets to merge.
+        force: If True, will force conversion of data not complying to a block
+            design to block design by dropping observations that are not shared
+            between outcomes.
+            If only a subset of the outcomes have noise observations, all noise
+            observations will be dropped.
+
+    Returns:
+        A single element list containing the merged dataset.
+    """
     is_fixed = [ds.Yvar is not None for ds in datasets]
     if any(is_fixed) and not all(is_fixed):
-        raise UnsupportedError(
-            "Cannot convert mixed data with and without variance "
-            "observations to `block design`."
-        )
+        if force:
+            logger.debug(
+                "Only a subset of datasets have noise observations. "
+                "Dropping all noise observations since `force=True`. "
+            )
+        else:
+            raise UnsupportedError(
+                "Cannot convert mixed data with and without variance "
+                "observations to `block design`."
+            )
     is_fixed = all(is_fixed)
     Xs = [dataset.X for dataset in datasets]
     for dset in datasets[1:]:
@@ -462,12 +477,10 @@ def convert_to_block_design(
                 "To force this and drop data not shared between "
                 "outcomes use `force=True`."
             )
-        warnings.warn(
+        logger.debug(
             "Forcing conversion of data not complying to a block design "
             "to block design by dropping observations that are not shared "
-            "between outcomes.",
-            AxWarning,
-            stacklevel=3,
+            "between outcomes."
         )
         X_shared, idcs_shared = _get_shared_rows(Xs=Xs)
         Y = torch.cat([ds.Y[i] for ds, i in zip(datasets, idcs_shared)], dim=-1)

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -106,9 +106,7 @@ class RegistryKwargs:
     class_decoder_registry: TClassDecoderRegistry
 
 
-# pyre-fixme[3]: Return annotation cannot be `Any`.
 def object_from_json(
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     object_json: Any,
     decoder_registry: TDecoderRegistry = CORE_DECODER_REGISTRY,
     class_decoder_registry: TClassDecoderRegistry = CORE_CLASS_DECODER_REGISTRY,
@@ -288,7 +286,6 @@ def object_from_json(
         raise JSONDecodeError(err)
 
 
-# pyre-fixme[3]: Return annotation cannot be `Any`.
 def ax_class_from_json_dict(
     # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
     #  `typing.Type` to avoid runtime subscripting errors.

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -214,7 +214,6 @@ def outcome_transform_type_from_json(
     return REVERSE_OUTCOME_TRANSFORM_REGISTRY[outcome_transform_type]
 
 
-# pyre-fixme[3]: Return annotation cannot contain `Any`.
 def class_from_json(json: dict[str, Any]) -> type[Any]:
     """Load any class registered in `CLASS_DECODER_REGISTRY` from JSON."""
     index_in_registry = json.pop("index")


### PR DESCRIPTION
Summary:
`convert_to_block_design` is used for two purposes:
- In model fitting, to merge the datasets if a batched model is **allowed**. If something errors out here, we should just use a model-list rather than erroring out model fitting. We should also not use `force=True` here, since it is generally favorable to keep all the training data rather than forcing it to be block design by dropping some observations.
- In acquisition function selection, to see if any feasible points have been observed. We use `force=True` here, since we really need block design observations to evaluate feasibility. But we don't care about noise observations, so we shouldn't error out if only a subset of the datasets have noise. We can simply drop the noise.

Reviewed By: sunnyshen321

Differential Revision: D80205523
