### PR TITLE
MBM: Do not error out if infer_objective_thresholds fails

### DIFF
--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -13,6 +13,7 @@ import operator
 from collections.abc import Callable
 from functools import partial, reduce
 from itertools import product
+from logging import Logger
 from typing import Any, Mapping, Sequence
 
 import torch
@@ -34,13 +35,14 @@ from ax.generators.torch.utils import (
 from ax.generators.torch_base import TorchOptConfig
 from ax.utils.common.base import Base
 from ax.utils.common.constants import Keys
+from ax.utils.common.logger import get_logger
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.input_constructors import get_acqf_input_constructor
 from botorch.acquisition.knowledge_gradient import qKnowledgeGradient
 from botorch.acquisition.multioutput_acquisition import MultiOutputAcquisitionFunction
 from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
 from botorch.acquisition.risk_measures import RiskMeasureMCObjective
-from botorch.exceptions.errors import InputDataError
+from botorch.exceptions.errors import BotorchError, InputDataError
 from botorch.models.model import Model
 from botorch.optim.optimize import (
     optimize_acqf,
@@ -57,6 +59,9 @@ try:
     from botorch.utils.multi_objective.optimize import optimize_with_nsgaii
 except ImportError:
     optimize_with_nsgaii = None
+
+
+logger: Logger = get_logger(__name__)
 
 
 # For fully discrete search spaces.
@@ -278,10 +283,18 @@ class Acquisition(Base):
         )
 
     def _update_objective_thresholds(self, torch_opt_config: TorchOptConfig) -> None:
-        # If MOO and some objective thresholds are not specified, infer them using
-        # the model that has already been subset to avoid re-subsetting it within
-        # `infer_objective_thresholds`.
-        if (
+        """If MOO and some objective thresholds are not specified, infer them using
+        the model that has already been subset to avoid re-subsetting it within
+        `infer_objective_thresholds`.
+
+        If risk measures are used, objective thresholds must be provided. If not,
+        this will error out.
+
+        If `infer_objective_thresholds` errors out, e.g., due to no feasible point,
+        this will log an error and let the optimization continue. Not all acquisition
+        functions require objective thresholds, so this is not necessarily a problem.
+        """
+        if not (
             torch_opt_config.is_moo
             and (
                 self._full_objective_thresholds is None
@@ -291,10 +304,12 @@ class Acquisition(Base):
             )
             and self.X_observed is not None
         ):
-            if torch_opt_config.risk_measure is not None:
-                raise NotImplementedError(
-                    "Objective thresholds must be provided when using risk measures."
-                )
+            return
+        if torch_opt_config.risk_measure is not None:
+            raise NotImplementedError(
+                "Objective thresholds must be provided when using risk measures."
+            )
+        try:
             self._full_objective_thresholds = infer_objective_thresholds(
                 model=self._model,
                 objective_weights=self._full_objective_weights,
@@ -307,6 +322,12 @@ class Acquisition(Base):
                 none_throws(self._full_objective_thresholds)[self._subset_idcs]
                 if self._subset_idcs is not None
                 else self._full_objective_thresholds
+            )
+        except (AxError, BotorchError) as e:
+            logger.warning(
+                "Failed to infer objective thresholds. Resuming optimization "
+                "without objective thresholds, which may or may not work depending "
+                f"on the acquisition function. Original error: {e}."
             )
 
     def _set_preference_model(self, torch_opt_config: TorchOptConfig) -> None:

--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -655,7 +655,15 @@ class Surrogate(Base):
         )
 
         if not should_use_model_list and len(datasets) > 1:
-            datasets = convert_to_block_design(datasets=datasets, force=True)
+            try:
+                datasets = convert_to_block_design(datasets=datasets, force=False)
+            except UnsupportedError as e:
+                # If the block design conversion fails, use model-list.
+                logger.warning(
+                    "Conversion to block design failed. Using model-list instead."
+                    f"Original error: {e}"
+                )
+                should_use_model_list = True
         self._training_data = list(datasets)  # So that it can be modified if needed.
 
         feature_names_set = set(search_space_digest.feature_names)

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -327,9 +327,7 @@ def choose_botorch_acqf_class(
         # NOTE: `convert_to_block_design` will drop points that are only observed by
         # some of the metrics which is natural as we are using observed values to
         # determine feasibility.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=AxWarning)
-            dataset = convert_to_block_design(datasets=datasets, force=True)[0]
+        dataset = convert_to_block_design(datasets=datasets, force=True)[0]
         con_observed = torch.stack([con(dataset.Y) for con in con_tfs], dim=-1)
         feas_point_found = (con_observed <= 0).all(dim=-1).any().item()
 
@@ -432,15 +430,32 @@ def convert_to_block_design(
     datasets: Sequence[SupervisedDataset],
     force: bool = False,
 ) -> list[SupervisedDataset]:
-    # Convert data to "block design". TODO: Figure out a better
-    # solution for this using the data containers (pass outcome
-    # names as properties of the data containers)
+    """Converts a list of datasets to a single block-design dataset that contains
+    all outcomes.
+
+    Args:
+        datasets: A list of datasets to merge.
+        force: If True, will force conversion of data not complying to a block
+            design to block design by dropping observations that are not shared
+            between outcomes.
+            If only a subset of the outcomes have noise observations, all noise
+            observations will be dropped.
+
+    Returns:
+        A single element list containing the merged dataset.
+    """
     is_fixed = [ds.Yvar is not None for ds in datasets]
     if any(is_fixed) and not all(is_fixed):
-        raise UnsupportedError(
-            "Cannot convert mixed data with and without variance "
-            "observations to `block design`."
-        )
+        if force:
+            logger.debug(
+                "Only a subset of datasets have noise observations. "
+                "Dropping all noise observations since `force=True`. "
+            )
+        else:
+            raise UnsupportedError(
+                "Cannot convert mixed data with and without variance "
+                "observations to `block design`."
+            )
     is_fixed = all(is_fixed)
     Xs = [dataset.X for dataset in datasets]
     for dset in datasets[1:]:
@@ -462,12 +477,10 @@ def convert_to_block_design(
                 "To force this and drop data not shared between "
                 "outcomes use `force=True`."
             )
-        warnings.warn(
+        logger.debug(
             "Forcing conversion of data not complying to a block design "
             "to block design by dropping observations that are not shared "
-            "between outcomes.",
-            AxWarning,
-            stacklevel=3,
+            "between outcomes."
         )
         X_shared, idcs_shared = _get_shared_rows(Xs=Xs)
         Y = torch.cat([ds.Y[i] for ds, i in zip(datasets, idcs_shared)], dim=-1)

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -106,9 +106,7 @@ class RegistryKwargs:
     class_decoder_registry: TClassDecoderRegistry
 
 
-# pyre-fixme[3]: Return annotation cannot be `Any`.
 def object_from_json(
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     object_json: Any,
     decoder_registry: TDecoderRegistry = CORE_DECODER_REGISTRY,
     class_decoder_registry: TClassDecoderRegistry = CORE_CLASS_DECODER_REGISTRY,
@@ -288,7 +286,6 @@ def object_from_json(
         raise JSONDecodeError(err)
 
 
-# pyre-fixme[3]: Return annotation cannot be `Any`.
 def ax_class_from_json_dict(
     # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
     #  `typing.Type` to avoid runtime subscripting errors.

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -214,7 +214,6 @@ def outcome_transform_type_from_json(
     return REVERSE_OUTCOME_TRANSFORM_REGISTRY[outcome_transform_type]
 
 
-# pyre-fixme[3]: Return annotation cannot contain `Any`.
 def class_from_json(json: dict[str, Any]) -> type[Any]:
     """Load any class registered in `CLASS_DECODER_REGISTRY` from JSON."""
     index_in_registry = json.pop("index")


### PR DESCRIPTION
Summary:
`Acquisition._update_objective_thresholds` or `infer_objective_thresholds` call within can lead to errors during `Acquisition` initialization, even if the corresponding acquisition function doesn't need objective thresholds. We have some conditional logic to protect against this but it is not comprehensive enough.

The particular example that triggered this diff is the use of P_Feasible acquisition function when there are no feasible points. In this case, we can't infer objective thresholds since we need feasible points.

This diff adds a `try/except` block to catch errors raised in `infer_objective_thresholds` and logs a warning if any error is caught. This should make it possible to easily debug any related errors (thanks to the log) while letting the acquisition functions that don't need the thresholds run without issues.

Differential Revision: D80259199
