### PR TITLE
`Deprecate BatchTrial._status_quo` - Rename `BatchTrial.add_status_quo_arm`

### DIFF
--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -574,7 +574,7 @@ class BaseAdapterTest(TestCase):
         )
         sobol_run = sobol_generator.gen(n=5)
         exp.new_batch_trial(
-            sobol_run, add_status_quo_arm=False
+            sobol_run, should_add_status_quo_arm=False
         ).set_status_quo_with_weight(status_quo=exp.status_quo, weight=1.0).run()
 
         # create data where metrics vary in start and end times
@@ -862,7 +862,7 @@ class BaseAdapterTest(TestCase):
         gr2 = generator2.gen(n=5)
         sq_vals = {"x1": 5.0, "x2": 5.0}
         for gr in [gr1, gr2]:
-            trial = experiment.new_batch_trial(add_status_quo_arm=True)
+            trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
             trial.add_generator_run(gr)
             trial.mark_running(no_runner_required=True)
             trial.mark_completed()

--- a/ax/adapter/tests/test_torch_moo_adapter.py
+++ b/ax/adapter/tests/test_torch_moo_adapter.py
@@ -560,7 +560,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
             init_position=len(exp.arms_by_name) - 1,
         )
         sobol_run = sobol_generator.gen(n=2)
-        trial = exp.new_batch_trial(add_status_quo_arm=True)
+        trial = exp.new_batch_trial(should_add_status_quo_arm=True)
         trial.add_generator_run(sobol_run)
         trial.mark_running(no_runner_required=True).mark_completed()
         data = exp.fetch_data()

--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -152,7 +152,9 @@ class TransformToNewSQSpecificTest(TestCase):
 
     def test_target_trial_index(self) -> None:
         sobol = get_sobol(search_space=self.exp.search_space)
-        self.exp.new_batch_trial(generator_run=sobol.gen(2), add_status_quo_arm=True)
+        self.exp.new_batch_trial(
+            generator_run=sobol.gen(2), should_add_status_quo_arm=True
+        )
         t = self.exp.trials[1]
         t = assert_is_instance(t, BatchTrial)
         t.mark_running(no_runner_required=True)
@@ -204,7 +206,7 @@ class TransformToNewSQSpecificTest(TestCase):
         sobol = get_sobol(search_space=self.exp.search_space)
         for sq_val in (2.0, 3.0):
             t = self.exp.new_batch_trial(
-                generator_run=sobol.gen(2), add_status_quo_arm=True
+                generator_run=sobol.gen(2), should_add_status_quo_arm=True
             ).mark_completed(unsafe=True)
             data = get_branin_data_batch(batch=t)
             data.df.loc[(data.df["arm_name"] == "status_quo"), "mean"] = sq_val

--- a/ax/analysis/healthcheck/tests/test_regression_detection_utils.py
+++ b/ax/analysis/healthcheck/tests/test_regression_detection_utils.py
@@ -70,7 +70,9 @@ class TestRegressionDetection(TestCase):
             search_space=experiment.search_space, seed=TEST_SOBOL_SEED + 1
         )
         sobol_run = sobol_generator.gen(n=3)
-        experiment.new_batch_trial(add_status_quo_arm=True).add_generator_run(sobol_run)
+        experiment.new_batch_trial(should_add_status_quo_arm=True).add_generator_run(
+            sobol_run
+        )
 
         df1 = pd.DataFrame(
             {

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -107,7 +107,7 @@ class BatchTrial(BaseTrial):
             trial's associated generator run is immutable once set.  This cannot
             be combined with the `generator_run` argument.
         trial_type: Type of this trial, if used in MultiTypeExperiment.
-        add_status_quo_arm: If True, adds the status quo arm to the trial with a
+        should_add_status_quo_arm: If True, adds the status quo arm to the trial with a
             weight of 1.0. If False, the _status_quo is still set on the trial for
             tracking purposes, but without a weight it will not be an Arm present on
             the trial
@@ -129,7 +129,7 @@ class BatchTrial(BaseTrial):
         generator_run: GeneratorRun | None = None,
         generator_runs: list[GeneratorRun] | None = None,
         trial_type: str | None = None,
-        add_status_quo_arm: bool | None = False,
+        should_add_status_quo_arm: bool | None = False,
         ttl_seconds: int | None = None,
         index: int | None = None,
     ) -> None:
@@ -154,9 +154,9 @@ class BatchTrial(BaseTrial):
             for gr in generator_runs:
                 self.add_generator_run(generator_run=gr)
 
-        self.add_status_quo_arm = add_status_quo_arm
+        self.should_add_status_quo_arm = should_add_status_quo_arm
         status_quo = experiment.status_quo
-        if add_status_quo_arm:
+        if should_add_status_quo_arm:
             if status_quo is None:
                 raise ValueError(
                     "Experiment does not have a status quo arm so "
@@ -301,7 +301,7 @@ class BatchTrial(BaseTrial):
         )
         generator_run.index = len(self._generator_run_structs) - 1
 
-        if self.status_quo is not None and self.add_status_quo_arm:
+        if self.status_quo is not None and self.should_add_status_quo_arm:
             self.set_status_quo_with_weight(
                 status_quo=none_throws(self.status_quo), weight=1.0
             )

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1166,7 +1166,7 @@ class Experiment(Base):
         self,
         generator_run: GeneratorRun | None = None,
         generator_runs: list[GeneratorRun] | None = None,
-        add_status_quo_arm: bool | None = False,
+        should_add_status_quo_arm: bool | None = False,
         trial_type: str | None = None,
         ttl_seconds: int | None = None,
     ) -> BatchTrial:
@@ -1180,10 +1180,10 @@ class Experiment(Base):
                 also be set later through `add_arm` or `add_generator_run`, but a
                 trial's associated generator run is immutable once set.  This cannot
                 be combined with the `generator_run` argument.
-            add_status_quo_arm: If True, adds the status quo arm to the trial with a
-            weight of 1.0. If False, the _status_quo is still set on the trial for
-            tracking purposes, but without a weight it will not be an Arm present on
-            the trial
+            should_add_status_quo_arm: If True, adds the status quo arm to the trial
+                with a weight of 1.0. If False, the _status_quo is still set on the
+                trial for tracking purposes, but without a weight it will not be an
+                Arm present on the trial
             trial_type: Type of this trial, if used in MultiTypeExperiment.
             ttl_seconds: If specified, trials will be considered failed after
                 this many seconds since the time the trial was ran, unless the
@@ -1199,7 +1199,7 @@ class Experiment(Base):
             trial_type=trial_type,
             generator_run=generator_run,
             generator_runs=generator_runs,
-            add_status_quo_arm=add_status_quo_arm,
+            should_add_status_quo_arm=should_add_status_quo_arm,
             ttl_seconds=ttl_seconds,
         )
 
@@ -1610,7 +1610,7 @@ class Experiment(Base):
         self,
         parameterizations: list[TParameterization],
         arm_names: list[str] | None = None,
-        add_status_quo_arm: bool = False,
+        should_add_status_quo_arm: bool = False,
         ttl_seconds: int | None = None,
         run_metadata: dict[str, Any] | None = None,
     ) -> tuple[dict[str, TParameterization], int]:
@@ -1621,10 +1621,10 @@ class Experiment(Base):
                 only one is provided a single-arm Trial is created. If multiple
                 arms are provided a BatchTrial is created.
             arm_names: Names of arm(s) in the new trial.
-            add_status_quo_arm: If True, adds the status quo arm to the trial with a
-            weight of 1.0. If False, the _status_quo is still set on the trial for
-            tracking purposes, but without a weight it will not be an Arm present on
-            the trial
+            should_add_status_quo_arm: If True, adds the status quo arm to the trial
+                with a weight of 1.0. If False, the _status_quo is still set on the
+                trial for tracking purposes, but without a weight it will not be an
+                Arm present on the trial
             ttl_seconds: If specified, will consider the trial failed after this
                 many seconds. Used to detect dead trials that were not marked
                 failed properly.
@@ -1681,7 +1681,8 @@ class Experiment(Base):
         trial = None
         if is_batch:
             trial = self.new_batch_trial(
-                ttl_seconds=ttl_seconds, add_status_quo_arm=add_status_quo_arm
+                ttl_seconds=ttl_seconds,
+                should_add_status_quo_arm=should_add_status_quo_arm,
             ).add_arms_and_weights(arms=arms)
 
         else:

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -203,14 +203,14 @@ class BatchTrialTest(TestCase):
         self.experiment.status_quo = self.status_quo
         batch2 = self.batch.clone()
         self.assertEqual(batch2.status_quo, self.experiment.status_quo)
-        # Since add_status_quo_arm was False,
+        # Since should_add_status_quo_arm was False,
         # _status_quo_weight_override should be False and the
         # status_quo arm should not appear in arm_weights
         self.assertIsNone(batch2._status_quo_weight_override)
         self.assertTrue(batch2.status_quo not in batch2.arm_weights)
         self.assertEqual(sum(batch2.weights), sum(self.weights))
-        # Test with add_status_quo_arm=True
-        batch3 = self.experiment.new_batch_trial(add_status_quo_arm=True)
+        # Test with should_add_status_quo_arm=True
+        batch3 = self.experiment.new_batch_trial(should_add_status_quo_arm=True)
         self.assertEqual(batch3._status_quo_weight_override, 1.0)
         self.assertTrue(batch2.status_quo in batch3.arm_weights)
 
@@ -225,7 +225,7 @@ class BatchTrialTest(TestCase):
     def test_cannot_set_status_quo_with_weight_without_status_quo(self) -> None:
         self.experiment.status_quo = None
         with self.assertRaises(ValueError):
-            self.experiment.new_batch_trial(add_status_quo_arm=True)
+            self.experiment.new_batch_trial(should_add_status_quo_arm=True)
 
     def test_ArmsByName(self) -> None:
         # Initializes empty

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -112,7 +112,7 @@ def batch_trial_from_json(
     batch._refresh_arms_by_name()  # Trigger cache build
 
     # Trial.arms_by_name only returns arms with weights
-    batch.add_status_quo_arm = (
+    batch.should_add_status_quo_arm = (
         batch.status_quo is not None and batch.status_quo.name in batch.arms_by_name
     )
 

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1011,7 +1011,7 @@ class Decoder:
             trial._refresh_arms_by_name()  # Trigger cache build
 
             # Trial.arms_by_name only returns arms with weights
-            trial.add_status_quo_arm = (
+            trial.should_add_status_quo_arm = (
                 trial.status_quo is not None
                 and trial.status_quo.name in trial.arms_by_name
             )

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -326,7 +326,7 @@ def get_branin_experiment(
         for _ in range(num_batch_trial):
             sobol_generator = get_sobol(search_space=exp.search_space)
             sobol_run = sobol_generator.gen(n=num_arms_per_trial)
-            trial = exp.new_batch_trial(add_status_quo_arm=with_status_quo)
+            trial = exp.new_batch_trial(should_add_status_quo_arm=with_status_quo)
             trial.add_generator_run(sobol_run)
 
             if with_completed_batch:
@@ -708,9 +708,9 @@ def get_factorial_experiment(
             for p in exp.search_space.parameters.values()
         )
         factorial_run = factorial_generator.gen(n=n)
-        exp.new_batch_trial(add_status_quo_arm=with_status_quo).add_generator_run(
-            factorial_run
-        )
+        exp.new_batch_trial(
+            should_add_status_quo_arm=with_status_quo
+        ).add_generator_run(factorial_run)
 
     return exp
 
@@ -889,7 +889,7 @@ def get_branin_experiment_with_multi_objective(
         sobol_generator = get_sobol(search_space=exp.search_space, seed=TEST_SOBOL_SEED)
         sobol_run = sobol_generator.gen(n=5)
         trial = exp.new_batch_trial(
-            add_status_quo_arm=with_status_quo
+            should_add_status_quo_arm=with_status_quo
         ).add_generator_run(sobol_run)
 
         if with_completed_batch:
@@ -943,9 +943,9 @@ def get_branin_with_multi_task(with_multi_objective: bool = False) -> Experiment
 
     sobol_generator = get_sobol(search_space=exp.search_space, seed=TEST_SOBOL_SEED)
     sobol_run = sobol_generator.gen(n=5)
-    exp.new_batch_trial(add_status_quo_arm=True).add_generator_run(sobol_run)
+    exp.new_batch_trial(should_add_status_quo_arm=True).add_generator_run(sobol_run)
     none_throws(exp.trials.get(0)).run()
-    exp.new_batch_trial(add_status_quo_arm=True).add_generator_run(sobol_run)
+    exp.new_batch_trial(should_add_status_quo_arm=True).add_generator_run(sobol_run)
     none_throws(exp.trials.get(1)).run()
 
     return exp
@@ -1313,31 +1313,31 @@ def _configure_online_experiments(experiments: list[Experiment]) -> None:
 
         # Add a candidate to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial(add_status_quo_arm=True)
+        trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
         trial.add_generator_run(sobol_run)
 
         # Add a RUNNING trial to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial(add_status_quo_arm=True)
+        trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
         trial.add_generator_run(sobol_run)
         trial.mark_running(no_runner_required=True)
 
         # Add a FAILED trial to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial(add_status_quo_arm=True)
+        trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
         trial.add_generator_run(sobol_run)
         trial.mark_running(no_runner_required=True)
         trial.mark_failed()
 
         # Add an ABANDONED trial to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial(add_status_quo_arm=True)
+        trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
         trial.add_generator_run(sobol_run)
         trial.mark_abandoned()
 
         # Add a custom arm to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial(add_status_quo_arm=True)
+        trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
         # Detatch the arms from the GeneratorRun so they appear as custom arms
         trial.add_arms_and_weights(arms=sobol_run.arms)
 
@@ -1843,7 +1843,7 @@ def get_batch_trial(
         batch.mark_arm_abandoned(batch.arms[2].name, "abandoned reason")
     batch.runner = SyntheticRunner()
     batch.set_status_quo_with_weight(status_quo=arms[0], weight=0.5)
-    batch.add_status_quo_arm = True
+    batch.should_add_status_quo_arm = True
     batch._generation_step_index = 0
     return batch
 


### PR DESCRIPTION
Summary:
Deprecate `BatchTrial._status_quo` 

1. Rename `BatchTrial.add_status_quo_arm` attribute to `should_add_status_quo_arm`
2. Rename `BatchTrial.set_status_quo_with_weight` to `BatchTrial.add_status_quo_arm`
3. Remove `BatchTrial._status_quo` attribute and replace it with a deprecation warning to use `Experiment.status_quo`

Reviewed By: mgarrard

Differential Revision: D79266451


