### PR TITLE
`Deprecate BatchTrial._status_quo` - Rename `BatchTrial.set_status_quo_with_weight`

### DIFF
--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -574,7 +574,7 @@ class BaseAdapterTest(TestCase):
         )
         sobol_run = sobol_generator.gen(n=5)
         exp.new_batch_trial(
-            sobol_run, add_status_quo_arm=False
+            sobol_run, should_add_status_quo_arm=False
         ).set_status_quo_with_weight(status_quo=exp.status_quo, weight=1.0).run()
 
         # create data where metrics vary in start and end times
@@ -862,7 +862,7 @@ class BaseAdapterTest(TestCase):
         gr2 = generator2.gen(n=5)
         sq_vals = {"x1": 5.0, "x2": 5.0}
         for gr in [gr1, gr2]:
-            trial = experiment.new_batch_trial(add_status_quo_arm=True)
+            trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
             trial.add_generator_run(gr)
             trial.mark_running(no_runner_required=True)
             trial.mark_completed()

--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -575,7 +575,7 @@ class BaseAdapterTest(TestCase):
         sobol_run = sobol_generator.gen(n=5)
         exp.new_batch_trial(
             sobol_run, should_add_status_quo_arm=False
-        ).set_status_quo_with_weight(status_quo=exp.status_quo, weight=1.0).run()
+        ).add_status_quo_arm(status_quo=exp.status_quo, weight=1.0).run()
 
         # create data where metrics vary in start and end times
         data = get_non_monolithic_branin_moo_data()

--- a/ax/adapter/tests/test_torch_moo_adapter.py
+++ b/ax/adapter/tests/test_torch_moo_adapter.py
@@ -560,7 +560,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
             init_position=len(exp.arms_by_name) - 1,
         )
         sobol_run = sobol_generator.gen(n=2)
-        trial = exp.new_batch_trial(add_status_quo_arm=True)
+        trial = exp.new_batch_trial(should_add_status_quo_arm=True)
         trial.add_generator_run(sobol_run)
         trial.mark_running(no_runner_required=True).mark_completed()
         data = exp.fetch_data()

--- a/ax/adapter/tests/test_utils.py
+++ b/ax/adapter/tests/test_utils.py
@@ -51,7 +51,7 @@ class TestAdapterUtils(TestCase):
         self.trial = self.experiment.new_trial(GeneratorRun([self.arm]))
         self.experiment_2 = get_experiment()
         self.batch_trial = self.experiment_2.new_batch_trial(GeneratorRun([self.arm]))
-        self.batch_trial.set_status_quo_with_weight(self.experiment_2.status_quo, 1)
+        self.batch_trial.add_status_quo_arm(self.experiment_2.status_quo, 1)
         self.obs_feat = ObservationFeatures.from_arm(
             arm=self.trial.arm, trial_index=self.trial.index
         )

--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -152,7 +152,9 @@ class TransformToNewSQSpecificTest(TestCase):
 
     def test_target_trial_index(self) -> None:
         sobol = get_sobol(search_space=self.exp.search_space)
-        self.exp.new_batch_trial(generator_run=sobol.gen(2), add_status_quo_arm=True)
+        self.exp.new_batch_trial(
+            generator_run=sobol.gen(2), should_add_status_quo_arm=True
+        )
         t = self.exp.trials[1]
         t = assert_is_instance(t, BatchTrial)
         t.mark_running(no_runner_required=True)
@@ -204,7 +206,7 @@ class TransformToNewSQSpecificTest(TestCase):
         sobol = get_sobol(search_space=self.exp.search_space)
         for sq_val in (2.0, 3.0):
             t = self.exp.new_batch_trial(
-                generator_run=sobol.gen(2), add_status_quo_arm=True
+                generator_run=sobol.gen(2), should_add_status_quo_arm=True
             ).mark_completed(unsafe=True)
             data = get_branin_data_batch(batch=t)
             data.df.loc[(data.df["arm_name"] == "status_quo"), "mean"] = sq_val

--- a/ax/analysis/healthcheck/tests/test_constraints_feasibility.py
+++ b/ax/analysis/healthcheck/tests/test_constraints_feasibility.py
@@ -77,9 +77,7 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
         batch_trial = assert_is_instance(experiment.trials[0], BatchTrial)
 
         batch_trial.add_arm(experiment.status_quo)
-        batch_trial.set_status_quo_with_weight(
-            status_quo=experiment.status_quo, weight=1.0
-        )
+        batch_trial.add_status_quo_arm(status_quo=experiment.status_quo, weight=1.0)
         experiment.trials[0].mark_running(no_runner_required=True)
         experiment.trials[0].mark_completed()
 

--- a/ax/analysis/healthcheck/tests/test_regression_detection_utils.py
+++ b/ax/analysis/healthcheck/tests/test_regression_detection_utils.py
@@ -70,7 +70,9 @@ class TestRegressionDetection(TestCase):
             search_space=experiment.search_space, seed=TEST_SOBOL_SEED + 1
         )
         sobol_run = sobol_generator.gen(n=3)
-        experiment.new_batch_trial(add_status_quo_arm=True).add_generator_run(sobol_run)
+        experiment.new_batch_trial(should_add_status_quo_arm=True).add_generator_run(
+            sobol_run
+        )
 
         df1 = pd.DataFrame(
             {

--- a/ax/analysis/plotly/tests/test_arm_effects.py
+++ b/ax/analysis/plotly/tests/test_arm_effects.py
@@ -389,7 +389,7 @@ class TestArmEffectsPlotRel(TestCase):
                 generator_runs=self.generation_strategy._gen_with_multiple_nodes(
                     experiment=self.experiment, n=3
                 )
-            ).set_status_quo_with_weight(
+            ).add_status_quo_arm(
                 status_quo=self.experiment.status_quo, weight=1.0
             ).mark_completed(unsafe=True)
             self.experiment.fetch_data()

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -163,7 +163,7 @@ class BatchTrial(BaseTrial):
                     "no weight can be set for it."
                 )
             else:
-                self.set_status_quo_with_weight(status_quo=status_quo, weight=1.0)
+                self.add_status_quo_arm(status_quo=status_quo, weight=1.0)
         else:
             # Set the status quo for tracking purposes
             # It will not be included in arm_weights
@@ -302,9 +302,7 @@ class BatchTrial(BaseTrial):
         generator_run.index = len(self._generator_run_structs) - 1
 
         if self.status_quo is not None and self.should_add_status_quo_arm:
-            self.set_status_quo_with_weight(
-                status_quo=none_throws(self.status_quo), weight=1.0
-            )
+            self.add_status_quo_arm(status_quo=none_throws(self.status_quo), weight=1.0)
 
         if generator_run._generation_step_index is not None:
             self._set_generation_step_index(
@@ -320,9 +318,7 @@ class BatchTrial(BaseTrial):
 
     @status_quo.setter
     def status_quo(self, status_quo: Arm | None) -> None:
-        raise NotImplementedError(
-            "Use `set_status_quo_with_weight` to set the status quo arm."
-        )
+        raise NotImplementedError("Use `add_status_quo_arm` to set the status quo arm.")
 
     def unset_status_quo(self) -> None:
         """Set the status quo to None."""
@@ -331,9 +327,7 @@ class BatchTrial(BaseTrial):
         self._refresh_arms_by_name()
 
     @immutable_once_run
-    def set_status_quo_with_weight(
-        self, status_quo: Arm, weight: float | None
-    ) -> BatchTrial:
+    def add_status_quo_arm(self, status_quo: Arm, weight: float | None) -> BatchTrial:
         """Sets status quo arm with given weight. This weight *overrides* any
         weight the status quo has from generator runs attached to this batch.
         Thus, this function is not the same as using add_arm, which will
@@ -547,7 +541,7 @@ class BatchTrial(BaseTrial):
 
         if (self._status_quo is not None) and include_sq:
             sq_weight = self._status_quo_weight_override
-            new_trial.set_status_quo_with_weight(
+            new_trial.add_status_quo_arm(
                 self._status_quo.clone(),
                 weight=sq_weight,
             )

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -107,7 +107,7 @@ class BatchTrial(BaseTrial):
             trial's associated generator run is immutable once set.  This cannot
             be combined with the `generator_run` argument.
         trial_type: Type of this trial, if used in MultiTypeExperiment.
-        add_status_quo_arm: If True, adds the status quo arm to the trial with a
+        should_add_status_quo_arm: If True, adds the status quo arm to the trial with a
             weight of 1.0. If False, the _status_quo is still set on the trial for
             tracking purposes, but without a weight it will not be an Arm present on
             the trial
@@ -129,7 +129,7 @@ class BatchTrial(BaseTrial):
         generator_run: GeneratorRun | None = None,
         generator_runs: list[GeneratorRun] | None = None,
         trial_type: str | None = None,
-        add_status_quo_arm: bool | None = False,
+        should_add_status_quo_arm: bool | None = False,
         ttl_seconds: int | None = None,
         index: int | None = None,
     ) -> None:
@@ -154,9 +154,9 @@ class BatchTrial(BaseTrial):
             for gr in generator_runs:
                 self.add_generator_run(generator_run=gr)
 
-        self.add_status_quo_arm = add_status_quo_arm
+        self.should_add_status_quo_arm = should_add_status_quo_arm
         status_quo = experiment.status_quo
-        if add_status_quo_arm:
+        if should_add_status_quo_arm:
             if status_quo is None:
                 raise ValueError(
                     "Experiment does not have a status quo arm so "
@@ -301,7 +301,7 @@ class BatchTrial(BaseTrial):
         )
         generator_run.index = len(self._generator_run_structs) - 1
 
-        if self.status_quo is not None and self.add_status_quo_arm:
+        if self.status_quo is not None and self.should_add_status_quo_arm:
             self.set_status_quo_with_weight(
                 status_quo=none_throws(self.status_quo), weight=1.0
             )

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1166,7 +1166,7 @@ class Experiment(Base):
         self,
         generator_run: GeneratorRun | None = None,
         generator_runs: list[GeneratorRun] | None = None,
-        add_status_quo_arm: bool | None = False,
+        should_add_status_quo_arm: bool | None = False,
         trial_type: str | None = None,
         ttl_seconds: int | None = None,
     ) -> BatchTrial:
@@ -1180,10 +1180,10 @@ class Experiment(Base):
                 also be set later through `add_arm` or `add_generator_run`, but a
                 trial's associated generator run is immutable once set.  This cannot
                 be combined with the `generator_run` argument.
-            add_status_quo_arm: If True, adds the status quo arm to the trial with a
-            weight of 1.0. If False, the _status_quo is still set on the trial for
-            tracking purposes, but without a weight it will not be an Arm present on
-            the trial
+            should_add_status_quo_arm: If True, adds the status quo arm to the trial
+                with a weight of 1.0. If False, the _status_quo is still set on the
+                trial for tracking purposes, but without a weight it will not be an
+                Arm present on the trial
             trial_type: Type of this trial, if used in MultiTypeExperiment.
             ttl_seconds: If specified, trials will be considered failed after
                 this many seconds since the time the trial was ran, unless the
@@ -1199,7 +1199,7 @@ class Experiment(Base):
             trial_type=trial_type,
             generator_run=generator_run,
             generator_runs=generator_runs,
-            add_status_quo_arm=add_status_quo_arm,
+            should_add_status_quo_arm=should_add_status_quo_arm,
             ttl_seconds=ttl_seconds,
         )
 
@@ -1610,7 +1610,7 @@ class Experiment(Base):
         self,
         parameterizations: list[TParameterization],
         arm_names: list[str] | None = None,
-        add_status_quo_arm: bool = False,
+        should_add_status_quo_arm: bool = False,
         ttl_seconds: int | None = None,
         run_metadata: dict[str, Any] | None = None,
     ) -> tuple[dict[str, TParameterization], int]:
@@ -1621,10 +1621,10 @@ class Experiment(Base):
                 only one is provided a single-arm Trial is created. If multiple
                 arms are provided a BatchTrial is created.
             arm_names: Names of arm(s) in the new trial.
-            add_status_quo_arm: If True, adds the status quo arm to the trial with a
-            weight of 1.0. If False, the _status_quo is still set on the trial for
-            tracking purposes, but without a weight it will not be an Arm present on
-            the trial
+            should_add_status_quo_arm: If True, adds the status quo arm to the trial
+                with a weight of 1.0. If False, the _status_quo is still set on the
+                trial for tracking purposes, but without a weight it will not be an
+                Arm present on the trial
             ttl_seconds: If specified, will consider the trial failed after this
                 many seconds. Used to detect dead trials that were not marked
                 failed properly.
@@ -1681,7 +1681,8 @@ class Experiment(Base):
         trial = None
         if is_batch:
             trial = self.new_batch_trial(
-                ttl_seconds=ttl_seconds, add_status_quo_arm=add_status_quo_arm
+                ttl_seconds=ttl_seconds,
+                should_add_status_quo_arm=should_add_status_quo_arm,
             ).add_arms_and_weights(arms=arms)
 
         else:

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -153,7 +153,7 @@ class BatchTrialTest(TestCase):
 
     def test_StatusQuoOverlap(self) -> None:
         # Set status quo to existing arm
-        self.batch.set_status_quo_with_weight(self.arms[0], self.sq_weight)
+        self.batch.add_status_quo_arm(self.arms[0], self.sq_weight)
         # Status quo weight is set to the average of other arms' weights.
         # In this case, there are only two arms: 0_0 (SQ) and 0_1 (not SQ).
         # So their weights are equal, as weight(0_0) = avg(weight(0_1)).
@@ -164,7 +164,7 @@ class BatchTrialTest(TestCase):
         self.assertEqual(sum(self.batch.weights), self.weights[1] + self.sq_weight)
 
         # Set status quo to new arm, add it
-        self.batch.set_status_quo_with_weight(self.new_sq, self.sq_weight)
+        self.batch.add_status_quo_arm(self.new_sq, self.sq_weight)
         self.assertEqual(self.batch.status_quo.name, "status_quo_0")
         self.batch.add_arms_and_weights([self.new_sq])
         self.assertEqual(
@@ -174,7 +174,7 @@ class BatchTrialTest(TestCase):
 
     def test_status_quo_cannot_have_negative_weight(self) -> None:
         with self.assertRaises(ValueError):
-            self.batch.set_status_quo_with_weight(self.new_sq, -1)
+            self.batch.add_status_quo_arm(self.new_sq, -1)
 
     def test_status_quo_cannot_be_set_directly(self) -> None:
         # Test that directly setting the status quo raises an error
@@ -184,7 +184,7 @@ class BatchTrialTest(TestCase):
     def test_status_quo_can_be_set_to_a_new_arm(self) -> None:
         tot_weight = sum(self.batch.weights)
         # Set status quo to new arm
-        self.batch.set_status_quo_with_weight(self.new_sq, self.sq_weight)
+        self.batch.add_status_quo_arm(self.new_sq, self.sq_weight)
         self.assertTrue(self.batch.status_quo == self.new_sq)
         self.assertEqual(self.batch.status_quo.name, "status_quo_0")
         self.assertEqual(sum(self.batch.weights), tot_weight + self.sq_weight)
@@ -216,13 +216,13 @@ class BatchTrialTest(TestCase):
 
     def test_status_quo_cannot_be_set_with_different_name(self) -> None:
         # Set status quo to new arm
-        self.batch.set_status_quo_with_weight(self.status_quo, self.sq_weight)
+        self.batch.add_status_quo_arm(self.status_quo, self.sq_weight)
         with self.assertRaises(ValueError):
-            self.batch.set_status_quo_with_weight(
+            self.batch.add_status_quo_arm(
                 Arm(self.status_quo.parameters, name="new_name"), 1
             )
 
-    def test_cannot_set_status_quo_with_weight_without_status_quo(self) -> None:
+    def test_cannot_add_status_quo_arm_without_status_quo(self) -> None:
         self.experiment.status_quo = None
         with self.assertRaises(ValueError):
             self.experiment.new_batch_trial(should_add_status_quo_arm=True)
@@ -241,7 +241,7 @@ class BatchTrialTest(TestCase):
         self.assertEqual(newbatch.arms_by_name, {"0_0": self.batch.arms[0]})
 
         # Refreshed when status quo is set
-        newbatch.set_status_quo_with_weight(self.batch.arms[1], 1.0)
+        newbatch.add_status_quo_arm(self.batch.arms[1], 1.0)
         self.assertEqual(
             newbatch.arms_by_name,
             {"0_0": self.batch.arms[0], "0_1": self.batch.arms[1]},
@@ -458,7 +458,7 @@ class BatchTrialTest(TestCase):
         status_quo = Arm(
             name="status_quo", parameters={"w": 0.0, "x": 1, "y": "foo", "z": True}
         )
-        batch.set_status_quo_with_weight(status_quo=status_quo, weight=1.0)
+        batch.add_status_quo_arm(status_quo=status_quo, weight=1.0)
         batch.mark_running(no_runner_required=True)
         new_batch_trial = batch.clone_to()
         self.assertEqual(new_batch_trial.index, 2)

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -203,14 +203,14 @@ class BatchTrialTest(TestCase):
         self.experiment.status_quo = self.status_quo
         batch2 = self.batch.clone()
         self.assertEqual(batch2.status_quo, self.experiment.status_quo)
-        # Since add_status_quo_arm was False,
+        # Since should_add_status_quo_arm was False,
         # _status_quo_weight_override should be False and the
         # status_quo arm should not appear in arm_weights
         self.assertIsNone(batch2._status_quo_weight_override)
         self.assertTrue(batch2.status_quo not in batch2.arm_weights)
         self.assertEqual(sum(batch2.weights), sum(self.weights))
-        # Test with add_status_quo_arm=True
-        batch3 = self.experiment.new_batch_trial(add_status_quo_arm=True)
+        # Test with should_add_status_quo_arm=True
+        batch3 = self.experiment.new_batch_trial(should_add_status_quo_arm=True)
         self.assertEqual(batch3._status_quo_weight_override, 1.0)
         self.assertTrue(batch2.status_quo in batch3.arm_weights)
 
@@ -225,7 +225,7 @@ class BatchTrialTest(TestCase):
     def test_cannot_set_status_quo_with_weight_without_status_quo(self) -> None:
         self.experiment.status_quo = None
         with self.assertRaises(ValueError):
-            self.experiment.new_batch_trial(add_status_quo_arm=True)
+            self.experiment.new_batch_trial(should_add_status_quo_arm=True)
 
     def test_ArmsByName(self) -> None:
         # Initializes empty

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -388,7 +388,7 @@ class ExperimentTest(TestCase):
 
         # Make a batch, add status quo to it, then change exp status quo, verify 2 arms
         batch = self.experiment.new_batch_trial()
-        batch.set_status_quo_with_weight(self.experiment.status_quo, 1)
+        batch.add_status_quo_arm(self.experiment.status_quo, 1)
         sq_parameters["w"] = 3.7
         self.experiment.status_quo = Arm(sq_parameters)
         self.assertEqual(len(self.experiment.arms_by_signature), 2)

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -58,7 +58,7 @@ class UtilsTest(TestCase):
         self.trial = self.experiment.new_trial(GeneratorRun([self.arm]))
         self.experiment_2 = get_experiment()
         self.batch_trial = self.experiment_2.new_batch_trial(GeneratorRun([self.arm]))
-        self.batch_trial.set_status_quo_with_weight(self.experiment_2.status_quo, 1)
+        self.batch_trial.add_status_quo_arm(self.experiment_2.status_quo, 1)
         self.obs_feat = ObservationFeatures.from_arm(
             arm=self.trial.arm, trial_index=self.trial.index
         )
@@ -588,7 +588,7 @@ class UtilsTest(TestCase):
         )
         exp.status_quo = in_design_status_quo
         batch = exp.new_batch_trial().add_arm(self.arm)
-        batch.set_status_quo_with_weight(exp.status_quo, 1)
+        batch.add_status_quo_arm(exp.status_quo, 1)
         self.assertEqual(batch.status_quo, in_design_status_quo)
         self.assertTrue(
             exp.search_space.check_membership(

--- a/ax/generation_strategy/tests/test_generation_node_input_constructors.py
+++ b/ax/generation_strategy/tests/test_generation_node_input_constructors.py
@@ -547,7 +547,7 @@ class TestGenerationNodeInputConstructors(TestCase):
         )
         if with_status_quo:
             experiment.status_quo = Arm(parameters={"x1": 0, "x2": 0})
-            trial.set_status_quo_with_weight(
+            trial.add_status_quo_arm(
                 status_quo=self.experiment.status_quo,
                 weight=1.0,
             )

--- a/ax/service/orchestrator.py
+++ b/ax/service/orchestrator.py
@@ -1638,7 +1638,7 @@ class Orchestrator(AnalysisBase, BestPointMixin):
                     trial_type=self.trial_type,
                 )
                 if self.options.status_quo_weight > 0:
-                    trial.set_status_quo_with_weight(
+                    trial.add_status_quo_arm(
                         status_quo=self.experiment.status_quo,
                         weight=self.options.status_quo_weight,
                     )

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -112,7 +112,7 @@ def batch_trial_from_json(
     batch._refresh_arms_by_name()  # Trigger cache build
 
     # Trial.arms_by_name only returns arms with weights
-    batch.add_status_quo_arm = (
+    batch.should_add_status_quo_arm = (
         batch.status_quo is not None and batch.status_quo.name in batch.arms_by_name
     )
 

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1011,7 +1011,7 @@ class Decoder:
             trial._refresh_arms_by_name()  # Trigger cache build
 
             # Trial.arms_by_name only returns arms with weights
-            trial.add_status_quo_arm = (
+            trial.should_add_status_quo_arm = (
                 trial.status_quo is not None
                 and trial.status_quo.name in trial.arms_by_name
             )

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -326,7 +326,7 @@ def get_branin_experiment(
         for _ in range(num_batch_trial):
             sobol_generator = get_sobol(search_space=exp.search_space)
             sobol_run = sobol_generator.gen(n=num_arms_per_trial)
-            trial = exp.new_batch_trial(add_status_quo_arm=with_status_quo)
+            trial = exp.new_batch_trial(should_add_status_quo_arm=with_status_quo)
             trial.add_generator_run(sobol_run)
 
             if with_completed_batch:
@@ -708,9 +708,9 @@ def get_factorial_experiment(
             for p in exp.search_space.parameters.values()
         )
         factorial_run = factorial_generator.gen(n=n)
-        exp.new_batch_trial(add_status_quo_arm=with_status_quo).add_generator_run(
-            factorial_run
-        )
+        exp.new_batch_trial(
+            should_add_status_quo_arm=with_status_quo
+        ).add_generator_run(factorial_run)
 
     return exp
 
@@ -889,7 +889,7 @@ def get_branin_experiment_with_multi_objective(
         sobol_generator = get_sobol(search_space=exp.search_space, seed=TEST_SOBOL_SEED)
         sobol_run = sobol_generator.gen(n=5)
         trial = exp.new_batch_trial(
-            add_status_quo_arm=with_status_quo
+            should_add_status_quo_arm=with_status_quo
         ).add_generator_run(sobol_run)
 
         if with_completed_batch:
@@ -943,9 +943,9 @@ def get_branin_with_multi_task(with_multi_objective: bool = False) -> Experiment
 
     sobol_generator = get_sobol(search_space=exp.search_space, seed=TEST_SOBOL_SEED)
     sobol_run = sobol_generator.gen(n=5)
-    exp.new_batch_trial(add_status_quo_arm=True).add_generator_run(sobol_run)
+    exp.new_batch_trial(should_add_status_quo_arm=True).add_generator_run(sobol_run)
     none_throws(exp.trials.get(0)).run()
-    exp.new_batch_trial(add_status_quo_arm=True).add_generator_run(sobol_run)
+    exp.new_batch_trial(should_add_status_quo_arm=True).add_generator_run(sobol_run)
     none_throws(exp.trials.get(1)).run()
 
     return exp
@@ -1313,31 +1313,31 @@ def _configure_online_experiments(experiments: list[Experiment]) -> None:
 
         # Add a candidate to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial(add_status_quo_arm=True)
+        trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
         trial.add_generator_run(sobol_run)
 
         # Add a RUNNING trial to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial(add_status_quo_arm=True)
+        trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
         trial.add_generator_run(sobol_run)
         trial.mark_running(no_runner_required=True)
 
         # Add a FAILED trial to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial(add_status_quo_arm=True)
+        trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
         trial.add_generator_run(sobol_run)
         trial.mark_running(no_runner_required=True)
         trial.mark_failed()
 
         # Add an ABANDONED trial to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial(add_status_quo_arm=True)
+        trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
         trial.add_generator_run(sobol_run)
         trial.mark_abandoned()
 
         # Add a custom arm to each Experiment
         sobol_run = sobol_generator.gen(n=len(experiment.trials[0].arms))
-        trial = experiment.new_batch_trial(add_status_quo_arm=True)
+        trial = experiment.new_batch_trial(should_add_status_quo_arm=True)
         # Detatch the arms from the GeneratorRun so they appear as custom arms
         trial.add_arms_and_weights(arms=sobol_run.arms)
 
@@ -1843,7 +1843,7 @@ def get_batch_trial(
         batch.mark_arm_abandoned(batch.arms[2].name, "abandoned reason")
     batch.runner = SyntheticRunner()
     batch.set_status_quo_with_weight(status_quo=arms[0], weight=0.5)
-    batch.add_status_quo_arm = True
+    batch.should_add_status_quo_arm = True
     batch._generation_step_index = 0
     return batch
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -368,7 +368,7 @@ def get_branin_experiment_with_status_quo_trials(
     for _ in range(num_sobol_trials):
         sobol_run = sobol.gen(n=1)
         t = exp.new_batch_trial().add_generator_run(sobol_run)
-        t.set_status_quo_with_weight(status_quo=exp.status_quo, weight=0.5)
+        t.add_status_quo_arm(status_quo=exp.status_quo, weight=0.5)
         exp.attach_data(get_branin_data_batch(batch=t))
         t.run().mark_completed()
     return exp
@@ -633,8 +633,8 @@ def get_multi_type_experiment(
         gr = generator.gen(num_arms)
         t1 = experiment.new_batch_trial(generator_run=gr, trial_type="type1")
         t2 = experiment.new_batch_trial(generator_run=gr, trial_type="type2")
-        t1.set_status_quo_with_weight(status_quo=t1.arms[0], weight=0.5)
-        t2.set_status_quo_with_weight(status_quo=t2.arms[0], weight=0.5)
+        t1.add_status_quo_arm(status_quo=t1.arms[0], weight=0.5)
+        t2.add_status_quo_arm(status_quo=t2.arms[0], weight=0.5)
         t1.run()
         t2.run()
 
@@ -662,8 +662,8 @@ def get_multi_type_experiment_with_multi_objective(
         gr = generator.gen(10)
         t1 = experiment.new_batch_trial(generator_run=gr, trial_type="type1")
         t2 = experiment.new_batch_trial(generator_run=gr, trial_type="type2")
-        t1.set_status_quo_with_weight(status_quo=t1.arms[0], weight=0.5)
-        t2.set_status_quo_with_weight(status_quo=t2.arms[0], weight=0.5)
+        t1.add_status_quo_arm(status_quo=t1.arms[0], weight=0.5)
+        t2.add_status_quo_arm(status_quo=t2.arms[0], weight=0.5)
         t1.run()
         t2.run()
 
@@ -1842,7 +1842,7 @@ def get_batch_trial(
     if abandon_arm:
         batch.mark_arm_abandoned(batch.arms[2].name, "abandoned reason")
     batch.runner = SyntheticRunner()
-    batch.set_status_quo_with_weight(status_quo=arms[0], weight=0.5)
+    batch.add_status_quo_arm(status_quo=arms[0], weight=0.5)
     batch.should_add_status_quo_arm = True
     batch._generation_step_index = 0
     return batch
@@ -1886,7 +1886,7 @@ def get_batch_trial_with_repeated_arms(num_repeated_arms: int) -> BatchTrial:
     batch = experiment.new_batch_trial()
     batch.add_arms_and_weights(arms=arms, weights=weights, multiplier=1)
     batch.runner = SyntheticRunner()
-    batch.set_status_quo_with_weight(status_quo=arms[0], weight=0.5)
+    batch.add_status_quo_arm(status_quo=arms[0], weight=0.5)
     return batch
 
 


### PR DESCRIPTION
Summary:
Deprecate `BatchTrial._status_quo` 

1. Rename `BatchTrial.add_status_quo_arm` attribute to `should_add_status_quo_arm`
2. Rename `BatchTrial.set_status_quo_with_weight` to `BatchTrial.add_status_quo_arm`
3. Remove `BatchTrial._status_quo` attribute and replace it with a deprecation warning to use `Experiment.status_quo`

Reviewed By: lena-kashtelyan

Differential Revision: D79266452


