### PR TITLE
Reap deprecated `BatchTrial.clone`

### DIFF
--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -8,8 +8,6 @@
 
 from __future__ import annotations
 
-import warnings
-
 from collections import defaultdict, OrderedDict
 from collections.abc import MutableMapping
 from dataclasses import dataclass
@@ -497,15 +495,6 @@ class BatchTrial(BaseTrial):
         abandoned_arm = AbandonedArm(name=arm_name, time=datetime.now(), reason=reason)
         self._abandoned_arms_metadata[arm_name] = abandoned_arm
         return self
-
-    def clone(self) -> BatchTrial:
-        """Clone the trial and attach it to the current experiment."""
-        warnings.warn(
-            "clone() method is getting deprecated. Please use clone_to() instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        return self.clone_to(include_sq=False)
 
     def clone_to(
         self,

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -197,11 +197,9 @@ class BatchTrialTest(TestCase):
         self.assertIsNone(self.batch.status_quo)
         self.assertIsNone(self.batch._status_quo_weight_override)
 
-    def test_status_quo_set_on_clone(
-        self,
-    ) -> None:
+    def test_status_quo_set_on_clone_to(self) -> None:
         self.experiment.status_quo = self.status_quo
-        batch2 = self.batch.clone()
+        batch2 = self.batch.clone_to(include_sq=False)
         self.assertEqual(batch2.status_quo, self.experiment.status_quo)
         # Since should_add_status_quo_arm was False,
         # _status_quo_weight_override should be False and the


### PR DESCRIPTION
Summary: This was deprecated two years ago. It does not appear to be used.

Differential Revision: D80360371


