### PR TITLE
Update Winsorize transform to be usable without a config

### DIFF
--- a/ax/exceptions/core.py
+++ b/ax/exceptions/core.py
@@ -172,3 +172,7 @@ class AxStorageWarning(AxWarning):
 
 class AxParameterWarning(AxWarning):
     """Ax warning used for concerns related to parameter setups."""
+
+
+class AxOptimizationWarning(AxWarning):
+    """Ax warning used for concerns related to modeling and optimization."""


### PR DESCRIPTION
Summary:
This diff updates `Winsorize` transform to not error out when it encounters a relative outcome constraint when `derelativize_with_raw_sq` option is not set. The transform will now transform the metrics that are not relative and leave the relative ones unchanged (unless `derelativize_with_raw_status_quo` is set to True, in which case they'll also be winsorized).

This will make it possible to use winsorization by default.

Differential Revision: D80361484


