### PR TITLE
Document when deprecated code should be reaped

### DIFF
--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -112,6 +112,8 @@ class Adapter:
         fit_tracking_metrics: bool = True,
         fit_on_init: bool = True,
         data_loader_config: DataLoaderConfig | None = None,
+        # fit_out_of_design, fit_abandoned, and fit_only_completed_map_metrics
+        # were deprecated in Ax 1.0.0, so they can now be reaped.
         fit_out_of_design: bool | None = None,
         fit_abandoned: bool | None = None,
         fit_only_completed_map_metrics: bool | None = None,

--- a/ax/adapter/pairwise.py
+++ b/ax/adapter/pairwise.py
@@ -9,6 +9,8 @@
 from ax.adapter.torch import TorchAdapter
 
 
+# PairwiseAdapter was deprecated in Ax 1.1.0, so it should be reaped in Ax
+# 1.2.0+
 class PairwiseAdapter(TorchAdapter):
     # pyre-ignore[2]: Missing parameter annotations.
     def __init__(self, **kwargs) -> None:

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -470,6 +470,7 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         outcomes: Sequence[str] | None = None,
         parameters: list[str] | None = None,
     ) -> None:
+        # Deprecated in Ax 1.1.0, so should be removed in Ax 1.2.0+.
         raise DeprecationWarning(
             "`ModelBasedEarlyStoppingStrategy.get_training_data` is deprecated. "
             "Subclasses should either extract the training data manually, "

--- a/ax/generators/random/base.py
+++ b/ax/generators/random/base.py
@@ -83,6 +83,7 @@ class RandomGenerator(Generator):
         self.fallback_to_sample_polytope = fallback_to_sample_polytope
         self.attempted_draws: int = 0
         if generated_points is not None:
+            # generated_points was deprecated in Ax 1.0.0, so it can now be reaped.
             warnings.warn(
                 "The `generated_points` argument is deprecated and will be removed "
                 "in a future version of Ax. It is being ignored in favor of "

--- a/ax/generators/torch/botorch_modular/generator.py
+++ b/ax/generators/torch/botorch_modular/generator.py
@@ -73,7 +73,6 @@ class BoTorchGenerator(TorchGenerator, Base):
             multiple acquisition functions to be used with MultiAcquisition.
         surrogate_spec: An optional ``SurrogateSpec`` object specifying how to
             construct the ``Surrogate`` and the underlying BoTorch ``Model``.
-        surrogate_specs: DEPRECATED. Please use ``surrogate_spec`` instead.
         surrogate: In lieu of ``SurrogateSpec``, an instance of ``Surrogate`` may
             be provided. In most cases, ``surrogate_spec`` should be used instead.
         refit_on_cv: Whether to reoptimize model parameters during call to

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -112,7 +112,7 @@ class ModelConfig:
             and gets passed to the model constructor as ``covar_module``.
         covar_module_options: Covariance module kwargs.
             in favor of model_configs.
-        likelihood: ``Likelihood`` class. This gets initialized with
+        likelihood_class: ``Likelihood`` class. This gets initialized with
             ``likelihood_options`` and gets passed to the model constructor.
             This argument is deprecated in favor of model_configs.
         likelihood_options: Likelihood options.

--- a/ax/service/scheduler.py
+++ b/ax/service/scheduler.py
@@ -6,6 +6,8 @@
 # pyre-strict
 
 
+# Scheduler was deprecated in Ax 1.1.0, so it should be removed in
+# Ax 1.2.0+.
 class Scheduler:
     raise DeprecationWarning(
         "Scheduler is deprecated following renaming of the Scheduler to "
@@ -14,6 +16,8 @@ class Scheduler:
     )
 
 
+# Scheduler was deprecated in Ax 1.1.0, so it should be removed in
+# Ax 1.2.0+.
 class SchedulerInternalError(Exception):
     raise DeprecationWarning(
         "SchedulerInternalError is deprecated following renaming of the Scheduler to "

--- a/ax/service/utils/scheduler_options.py
+++ b/ax/service/utils/scheduler_options.py
@@ -5,6 +5,9 @@
 
 # pyre-strict
 
+# Scheduler was deprecated in Ax 1.1.0, so it should be removed in Ax
+# Ax 1.2.0+.
+
 
 class SchedulerOptions:
     raise DeprecationWarning(


### PR DESCRIPTION
Summary: I am trying to reap deprecated code, but it is tedious to figure out which deprecated code is ready to be reaped. I would hate for someone else to go through the same exercise unnecessarily, so I am adding the deprecation schedule in in as comments.

Differential Revision: D80361779


