### PR TITLE
Allow only float map keys

### DIFF
--- a/ax/api/protocols/utils.py
+++ b/ax/api/protocols/utils.py
@@ -37,7 +37,7 @@ class _APIMetric(MapMetric, ABC):
     structure of ax.core.Metric to be more in line with our long term vision for Ax.
     """
 
-    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="step", default_value=0.0)
+    map_key_info: MapKeyInfo = MapKeyInfo(key="step", default_value=0.0)
 
     def __init__(self, name: str) -> None:
         super().__init__(name=name)

--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -31,4 +31,4 @@ class MapMetric(Metric):
     """
 
     data_constructor: type[MapData] = MapData
-    map_key_info: MapKeyInfo[float] = MapKeyInfo(key=DEFAULT_MAP_KEY, default_value=0.0)
+    map_key_info: MapKeyInfo = MapKeyInfo(key=DEFAULT_MAP_KEY, default_value=0.0)

--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -15,8 +15,21 @@ from ax.exceptions.core import UnsupportedError
 from ax.utils.common.testutils import TestCase
 
 
-class TestMapData2XYZ(TestDataBase):
+class TestMapData(TestDataBase):
     cls: type[MapData] = MapData
+
+
+class TestMapKeyInfo(TestCase):
+    def test_init(self) -> None:
+        with self.subTest("Cast to float"):
+            map_key_info = MapKeyInfo(key="epoch", default_value=0)
+            self.assertIsInstance(map_key_info.default_value, float)
+            self.assertEqual(map_key_info.default_value, 0.0)
+
+        with self.subTest("Normal case"):
+            map_key_info = MapKeyInfo(key="epoch", default_value=5.0)
+            self.assertIsInstance(map_key_info.default_value, float)
+            self.assertEqual(map_key_info.key, "epoch")
 
 
 class MapDataTest(TestCase):
@@ -96,8 +109,7 @@ class MapDataTest(TestCase):
         self.assertEqual(self.map_key_infos, self.mmd.map_key_infos)
 
         self.assertEqual(self.mmd.map_key_infos[0].key, "epoch")
-        self.assertEqual(self.mmd.map_key_infos[0].default_value, 0)
-        self.assertEqual(self.mmd.map_key_infos[0].value_type, int)
+        self.assertEqual(self.mmd.map_key_infos[0].default_value, 0.0)
 
     def test_init(self) -> None:
         # Initialize empty with map key infos.
@@ -121,7 +133,7 @@ class MapDataTest(TestCase):
     def test_properties(self) -> None:
         self.assertEqual(self.mmd.map_key_infos, self.map_key_infos)
         self.assertEqual(self.mmd.map_keys, ["epoch"])
-        self.assertEqual(self.mmd.map_key_to_type, {"epoch": int})
+        self.assertEqual(self.mmd.map_key_to_type, {"epoch": float})
 
     def test_combine(self) -> None:
         data = MapData.from_multiple_map_data([])
@@ -306,9 +318,9 @@ class MapDataTest(TestCase):
                 MapData.DEDUPLICATE_BY_COLUMNS
             ).size()
             expected_rows_per_group = np.minimum(
-                large_map_data_latest.map_df.groupby(
-                    MapData.DEDUPLICATE_BY_COLUMNS
-                ).epoch.max(),
+                large_map_data_latest.map_df.groupby(MapData.DEDUPLICATE_BY_COLUMNS)
+                .epoch.max()
+                .astype(int),
                 rows_per_group,
             )
             self.assertTrue(actual_rows_per_group.equals(expected_rows_per_group))

--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -156,7 +156,7 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
 
 
 class BraninFidelityMapMetric(NoisyFunctionMapMetric):
-    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="fidelity", default_value=0.0)
+    map_key_info: MapKeyInfo = MapKeyInfo(key="fidelity", default_value=0.0)
 
     def __init__(
         self,

--- a/ax/metrics/noisy_function_map.py
+++ b/ax/metrics/noisy_function_map.py
@@ -27,7 +27,7 @@ class NoisyFunctionMapMetric(MapMetric):
     with mean 0 and mean_sd scale added to the result.
     """
 
-    map_key_info: MapKeyInfo[float] = MapKeyInfo(key="timestamp", default_value=0.0)
+    map_key_info: MapKeyInfo = MapKeyInfo(key="timestamp", default_value=0.0)
 
     def __init__(
         self,

--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -41,7 +41,7 @@ try:
     class TensorboardMetric(MapMetric):
         """A *new* `MapMetric` for getting Tensorboard metrics."""
 
-        map_key_info: MapKeyInfo[float] = MapKeyInfo(key="step", default_value=0.0)
+        map_key_info: MapKeyInfo = MapKeyInfo(key="step", default_value=0.0)
 
         def __init__(
             self,

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2621,7 +2621,7 @@ def get_observations_with_invalid_value(invalid_value: float) -> list[Observatio
     return observations
 
 
-def get_map_key_info() -> MapKeyInfo[float]:
+def get_map_key_info() -> MapKeyInfo:
     return MapKeyInfo(key="epoch", default_value=0.0)
 
 


### PR DESCRIPTION
Summary:
**Context**:

Map values must satisfy two properties:
* They need to be ordered such that it makes sense to take the largest value and modeled that or to sort on those values.
* They shouldn't be typed as ints, since as we learned in D79938692 / Ax #4126, this can result in floats getting cast to ints later.
* They shouldn't be weird since they need to be serializable.

This leaves one obvious candidate: float. Fortunately, existing usages seem to be floats.

**This PR**:

* Makes all map keys floats
* Removes some type annotation logic that is now extraneous
* Renames a silly test class (I had used "TestMapDataXYZ" to make it easier to run several related groups of tests via CLI then forgot to change it back.)

Differential Revision: D80473359


