### PR TITLE
Update MapKeyToFloat.transform_observation_features to fill missing metadata

### DIFF
--- a/ax/adapter/transforms/map_key_to_float.py
+++ b/ax/adapter/transforms/map_key_to_float.py
@@ -106,11 +106,11 @@ class MapKeyToFloat(MetadataToFloat):
         if len(obsf.parameters) == 0:
             obsf.parameters = {p.name: p.upper for p in self._parameter_list}
             return
-        if obsf.metadata is None or len(obsf.metadata) == 0:
-            obsf.metadata = {p.name: p.upper for p in self._parameter_list}
+        if obsf.metadata is None:
+            obsf.metadata = {}
         metadata: dict[str, Any] = none_throws(obsf.metadata)
         for p in self._parameter_list:
-            if isnan(metadata[p.name]):
+            if isnan(metadata.get(p.name, float("nan"))):
                 metadata[p.name] = p.upper
         super()._transform_observation_feature(obsf)
 

--- a/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
@@ -426,8 +426,11 @@ class MapKeyToFloatTransformTest(TestCase):
             obsf.metadata["dummy"] = 1.0
         # should be exactly one parameter
         (p,) = self.t._parameter_list
-        with self.assertRaisesRegex(KeyError, f"'{p.name}'"):
-            self.t.transform_observation_features(obs_ft2)
+        # Transform fills missing values with the upper bound.
+        tf_obs_ft = self.t.transform_observation_features(obs_ft2)
+        for obs in tf_obs_ft:
+            self.assertEqual(obs.parameters[p.name], p.upper)
+            self.assertEqual(obs.metadata, {"dummy": 1.0})
 
     def test_constant_progression(self) -> None:
         for constant in (23, np.nan):


### PR DESCRIPTION
Summary: This was filling missing metadata only if the metadata was None or empty, which leads to errors if there is some other entry in the metadata. This diff updates the logic to avoid such errors.

Reviewed By: Balandat

Differential Revision: D80478961


