### PR TITLE
Reap `GeneratorRun.(_)index` (unused; adds complexity)

### DIFF
--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -286,7 +286,6 @@ class BatchTrial(BaseTrial):
         self._generator_run_structs.append(
             GeneratorRunStruct(generator_run=generator_run)
         )
-        generator_run.index = len(self._generator_run_structs) - 1
 
         if self.status_quo is not None and self.should_add_status_quo_arm:
             self.add_status_quo_arm(status_quo=none_throws(self.status_quo), weight=1.0)

--- a/ax/core/generator_run.py
+++ b/ax/core/generator_run.py
@@ -26,7 +26,6 @@ from ax.core.types import (
     TModelPredict,
     TModelPredictArm,
 )
-from ax.exceptions.core import UnsupportedError
 from ax.utils.common.base import Base, SortableBase
 from pyre_extensions import none_throws
 
@@ -180,7 +179,6 @@ class GeneratorRun(SortableBase):
         self._search_space = search_space
         self._model_predictions = model_predictions
         self._best_arm_predictions = best_arm_predictions
-        self._index: int | None = None
         self._fit_time = fit_time
         self._gen_time = gen_time
         self._model_key = model_key
@@ -243,24 +241,6 @@ class GeneratorRun(SortableBase):
     def time_created(self) -> datetime:
         """Creation time of the batch."""
         return self._time_created
-
-    @property
-    def index(self) -> int | None:
-        """The index of this generator run within a trial's list of generator run
-        structs. This field is set when the generator run is added to a trial.
-        """
-        return self._index
-
-    @index.setter
-    def index(self, index: int) -> None:
-        """Sets the index of this generator run within a trial's list of
-        generator runs. Cannot be changed after being set.
-        """
-        if self._index is not None and self._index != index:
-            raise UnsupportedError(
-                "Cannot change the index of a generator run once set."
-            )
-        self._index = index
 
     @property
     def optimization_config(self) -> OptimizationConfig | None:
@@ -368,7 +348,6 @@ class GeneratorRun(SortableBase):
             generation_node_name=self._generation_node_name,
         )
         generator_run._time_created = self._time_created
-        generator_run._index = self._index
         generator_run._model_key = self._model_key
         generator_run._model_kwargs = (
             self._model_kwargs.copy() if self._model_kwargs is not None else None
@@ -409,7 +388,4 @@ class GeneratorRun(SortableBase):
     @property
     def _unique_id(self) -> str:
         """Unique (within a given experiment) identifier for a GeneratorRun."""
-        if self.index is not None:
-            return str(self.index) + str(self.time_created)
-        else:
-            return str(self) + str(self.time_created)
+        return str(self) + str(self.time_created)

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -134,11 +134,15 @@ class BatchTrialTest(TestCase):
         ]
         new_weights = [0.75, 0.25]
         gr = GeneratorRun(arms=new_arms, weights=new_weights)
-        self.batch.add_generator_run(gr, 2.0)
+        new_gr_total_weight = sum(new_weights)
+        self.batch.add_generator_run(gr)
 
         self.assertEqual(len(self.batch.arms), len(self.arms) + 1)
         self.assertEqual(len(self.batch.generator_run_structs), 2)
-        self.assertEqual(sum(self.batch.weights), sum(self.weights) + 2)
+        self.assertEqual(
+            float(sum(self.batch.weights)),
+            float(sum(self.weights)) + new_gr_total_weight,
+        )
         # Check the GS index was not overwritten to None.
         self.assertEqual(self.batch._generation_step_index, 0)
 
@@ -675,13 +679,10 @@ class BatchTrialTest(TestCase):
         self.assertTrue(abandoned_arm < abandoned_arm_2)
 
         generator_run = get_generator_run()
-        generator_run_struct = GeneratorRunStruct(
-            generator_run=generator_run, weight=1.0
-        )
-        generator_run_struct_2 = GeneratorRunStruct(
-            generator_run=generator_run, weight=2.0
-        )
-        self.assertTrue(generator_run_struct < generator_run_struct_2)
+        # Struct with the same GR should have the same unique ID.
+        generator_run_struct = GeneratorRunStruct(generator_run=generator_run)
+        generator_run_struct_2 = GeneratorRunStruct(generator_run=generator_run)
+        self.assertTrue(generator_run_struct == generator_run_struct_2)
 
     def test_attach_batch_trial_data(self) -> None:
         # Verify components before we attach trial data

--- a/ax/core/tests/test_generator_run.py
+++ b/ax/core/tests/test_generator_run.py
@@ -8,7 +8,6 @@
 
 from ax.core.arm import Arm
 from ax.core.generator_run import GeneratorRun
-from ax.exceptions.core import UnsupportedError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_arms,
@@ -108,12 +107,6 @@ class GeneratorRunTest(TestCase):
         )
         self.assertEqual(str(run), GENERATOR_RUN_STR_PLUS_1)
 
-    def test_Index(self) -> None:
-        self.assertIsNone(self.unweighted_run.index)
-        self.unweighted_run.index = 1
-        with self.assertRaises(UnsupportedError):
-            self.unweighted_run.index = 2
-
     def test_ModelPredictions(self) -> None:
         self.assertEqual(self.unweighted_run.model_predictions, get_model_predictions())
         self.assertEqual(
@@ -190,6 +183,4 @@ class GeneratorRunTest(TestCase):
             #  `List[int]`.
             weights=self.weights,
         )
-        generator_run1.index = 1
-        generator_run2.index = 2
         self.assertTrue(generator_run1 < generator_run2)

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -152,11 +152,8 @@ class Trial(BaseTrial):
         self.experiment.search_space.check_types(
             generator_run.arms[0].parameters, raise_error=True
         )
-
         self._check_existing_and_name_arm(generator_run.arms[0])
-
         self._generator_run = generator_run
-        generator_run.index = 0
         self._set_generation_step_index(
             generation_step_index=generator_run._generation_step_index
         )

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -134,9 +134,7 @@ class Trial(BaseTrial):
         )
 
     @immutable_once_run
-    def add_generator_run(
-        self, generator_run: GeneratorRun, multiplier: float = 1.0
-    ) -> Trial:
+    def add_generator_run(self, generator_run: GeneratorRun) -> Trial:
         """Add a generator run to the trial.
 
         Note: since trial includes only one arm, this will raise a ValueError if

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -320,7 +320,7 @@ def generator_run_from_json(
     """Load Ax GeneratorRun from JSON."""
     time_created_json = object_json.pop("time_created")
     type_json = object_json.pop("generator_run_type")
-    index_json = object_json.pop("index")
+    object_json.pop("index", None)  # Deprecated.
     # Remove `objective_thresholds` to avoid issues with registries, since
     # `ObjectiveThreshold` depend on `Metric` objects.
     object_json.pop("objective_thresholds", None)
@@ -354,11 +354,6 @@ def generator_run_from_json(
     )
     generator_run._generator_run_type = object_from_json(
         type_json,
-        decoder_registry=decoder_registry,
-        class_decoder_registry=class_decoder_registry,
-    )
-    generator_run._index = object_from_json(
-        index_json,
         decoder_registry=decoder_registry,
         class_decoder_registry=class_decoder_registry,
     )

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -166,6 +166,9 @@ def object_from_json(
         elif _type in class_decoder_registry:
             return class_decoder_registry[_type](object_json)
 
+        elif _type == "GeneratorRunStruct":
+            object_json.pop("weight", None)  # Deprecated.
+
         elif _type not in decoder_registry:
             err = (
                 f"The JSON dictionary passed to `object_from_json` has a type "

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -376,7 +376,6 @@ def generator_run_to_dict(generator_run: GeneratorRun) -> dict[str, Any]:
         "model_predictions": gr.model_predictions,
         "best_arm_predictions": gr.best_arm_predictions,
         "generator_run_type": gr.generator_run_type,
-        "index": gr.index,
         "fit_time": gr.fit_time,
         "gen_time": gr.gen_time,
         "model_key": gr._model_key,

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -836,7 +836,6 @@ class Decoder:
             value=generator_run_sqa.generator_run_type,
             enum=self.config.generator_run_type_enum,
         )
-        generator_run._index = generator_run_sqa.index
         generator_run.db_id = generator_run_sqa.id
         return generator_run
 

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -980,7 +980,6 @@ class Decoder:
                         reduced_state=reduced_state,
                         immutable_search_space_and_opt_config=immutable_ss_and_oc,
                     ),
-                    weight=float(generator_run_sqa.weight or 1.0),
                 )
                 for generator_run_sqa in trial_sqa.generator_runs
             ]

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -995,7 +995,7 @@ class Encoder:
                 )
             for struct in trial.generator_run_structs:
                 gr_sqa = self.generator_run_to_sqa(
-                    generator_run=struct.generator_run, weight=struct.weight
+                    generator_run=struct.generator_run, weight=1.0
                 )
                 generator_runs.append(gr_sqa)
 

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -830,7 +830,6 @@ class Encoder:
             time_created=generator_run.time_created,
             generator_run_type=generator_run_type,
             weight=weight,
-            index=generator_run.index,
             fit_time=generator_run.fit_time,
             gen_time=generator_run.gen_time,
             best_arm_name=best_arm_name,

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -302,7 +302,7 @@ class SQAStoreTest(TestCase):
         # ensure we can save the experiment
         save_experiment(experiment)
 
-    def test_ExperimentSaveAndLoad(self) -> None:
+    def test_experiment_save_load(self) -> None:
         for exp in [
             self.experiment,
             get_experiment_with_map_data_type(),
@@ -1401,7 +1401,7 @@ class SQAStoreTest(TestCase):
 
         generator_run = get_generator_run()
         # pyre-fixme[16]: `BaseTrial` has no attribute `add_generator_run`.
-        trial.add_generator_run(generator_run=generator_run, multiplier=0.5)
+        trial.add_generator_run(generator_run=generator_run)
         save_experiment(experiment)
         self.assertEqual(get_session().query(SQAGeneratorRun).count(), 4)
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1877,7 +1877,7 @@ def get_batch_trial(
     batch = experiment.new_batch_trial()
     arms = get_arms_from_dict(get_arm_weights1())
     weights = get_weights_from_dict(get_arm_weights1())
-    batch.add_arms_and_weights(arms=arms, weights=weights, multiplier=0.75)
+    batch.add_arms_and_weights(arms=arms, weights=weights)
     if abandon_arm:
         batch.mark_arm_abandoned(batch.arms[2].name, "abandoned reason")
     batch.runner = SyntheticRunner()
@@ -1923,7 +1923,7 @@ def get_batch_trial_with_repeated_arms(num_repeated_arms: int) -> BatchTrial:
     arms = prev_arms + next_arms
     weights = prev_weights + next_weights
     batch = experiment.new_batch_trial()
-    batch.add_arms_and_weights(arms=arms, weights=weights, multiplier=1)
+    batch.add_arms_and_weights(arms=arms, weights=weights)
     batch.runner = SyntheticRunner()
     batch.add_status_quo_arm(status_quo=arms[0], weight=0.5)
     return batch


### PR DESCRIPTION
Summary: As titled; we no longer use this index because the order of generator runs does not matter

Differential Revision: D80349887


