### PR TITLE
Predict support for EnsemblePosterior

### DIFF
--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -8,6 +8,7 @@
 
 import warnings
 from collections import OrderedDict
+from unittest.mock import Mock
 
 import numpy as np
 import torch
@@ -26,7 +27,7 @@ from ax.generators.torch.botorch_modular.utils import (
     subset_state_dict,
     use_model_list,
 )
-from ax.generators.torch.utils import _to_inequality_constraints
+from ax.generators.torch.utils import _to_inequality_constraints, predict_from_model
 from ax.generators.torch_base import TorchOptConfig
 from ax.generators.types import TConfig
 from ax.utils.common.constants import Keys
@@ -43,6 +44,7 @@ from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import MultiTaskGP
+from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.utils.datasets import SupervisedDataset
 from pyre_extensions import assert_is_instance, none_throws
 
@@ -731,3 +733,88 @@ class BoTorchGeneratorUtilsTest(TestCase):
             "likelihood_class=None, likelihood_options={}, name=None)"
         )
         self.assertEqual(mc2.identifier, mc_str)
+
+    def test_predict_from_model_ensemble_posterior(self) -> None:
+        """Test predict_from_model with EnsemblePosterior support."""
+        # Create test data
+        X = torch.rand(2, 3)
+
+        # Create a mock EnsemblePosterior with ndim > 2
+        mock_posterior = Mock(spec=EnsemblePosterior)
+
+        # Set up posterior values with shape (num_models, batch_shape, output_shape)
+        # This simulates an ensemble of 5 models with 2 test points and 2 outputs
+        posterior_values = torch.rand(5, 2, 2)  # (5 models, 2 points, 2 outputs)
+        mock_posterior.values = posterior_values
+
+        # Create a mock model
+        mock_model = Mock()
+        mock_model.posterior.return_value = mock_posterior
+
+        # Test with use_posterior_predictive=False
+        mean, cov = predict_from_model(mock_model, X, use_posterior_predictive=False)
+
+        # Verify the model.posterior was called correctly
+        mock_model.posterior.assert_called_once()
+
+        # Verify output shapes
+        self.assertEqual(mean.shape, (2, 2))  # (n_points, n_outputs)
+        self.assertEqual(cov.shape, (2, 2, 2))  # (n_points, n_outputs, n_outputs)
+
+        # Verify mean calculation (should be mean over ensemble dimension)
+        expected_mean = posterior_values.mean(dim=0)  # Average over first dimension
+        self.assertTrue(torch.allclose(mean, expected_mean))
+
+        # Verify variance calculation (should be variance over ensemble dimension)
+        expected_var = posterior_values.var(dim=0)
+        # Check that the diagonal of the covariance matches expected variance
+        self.assertTrue(
+            torch.allclose(torch.diagonal(cov, dim1=-2, dim2=-1), expected_var)
+        )
+
+        # Test with use_posterior_predictive=True
+        mock_model.reset_mock()
+        predict_from_model(mock_model, X, use_posterior_predictive=True)
+        mock_model.posterior.assert_called_once()
+
+        mock_posterior2 = Mock(spec=EnsemblePosterior)
+        # Shape: (num_models, batch1, batch2, output_shape) - ndim = 4
+        posterior_values_5d = torch.rand(2, 3, 4, 2, 2)
+        mock_posterior2.values = posterior_values_5d
+        mock_model2 = Mock()
+        mock_model2.posterior.return_value = mock_posterior2
+
+        X2 = torch.rand(4, 3)
+        mean2, cov2 = predict_from_model(
+            mock_model2, X2, use_posterior_predictive=False
+        )
+
+        # Should average over first two dimensions (all except last 2)
+        expected_mean_5d = posterior_values_5d.mean(dim=(0, 1, 2))
+        expected_var_5d = posterior_values_5d.var(dim=(0, 1, 2))
+
+        self.assertTrue(torch.allclose(mean2, expected_mean_5d))
+        self.assertTrue(
+            torch.allclose(torch.diagonal(cov2, dim1=-2, dim2=-1), expected_var_5d)
+        )
+
+        # Test case where ensemble size is 1 or non-existant
+        # (variance should be zero, not NaN)
+        posterior_values_singles = [
+            torch.rand(1, 2, 2),
+            torch.rand(1, 1, 2, 2),
+        ]  # Single ensemble model
+        mock_model.reset_mock()
+        mock_posterior_single = Mock(spec=EnsemblePosterior)
+        mock_model.posterior.return_value = mock_posterior_single
+        for i, posterior_values_single in enumerate(posterior_values_singles):
+            with self.subTest(i=i, shape=posterior_values_single.shape):
+                mock_posterior_single.values = posterior_values_single
+                mean_single, cov_single = predict_from_model(
+                    mock_model, X, use_posterior_predictive=False
+                )
+                # Variance should be zero (not NaN) when ensemble size is 1
+                var_single = torch.diagonal(cov_single, dim1=-2, dim2=-1)
+                self.assertTrue(
+                    torch.allclose(var_single, torch.zeros_like(var_single))
+                )

--- a/ax/generators/torch/utils.py
+++ b/ax/generators/torch/utils.py
@@ -53,6 +53,7 @@ from botorch.acquisition.objective import (
 from botorch.acquisition.risk_measures import RiskMeasureMCObjective
 from botorch.acquisition.utils import get_infeasible_cost
 from botorch.models.model import Model
+from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
 from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.constraints import get_outcome_constraint_transforms
@@ -534,6 +535,17 @@ def predict_from_model(
             if isinstance(posterior, GaussianMixturePosterior):
                 mean = posterior.mixture_mean.cpu().detach()
                 var = posterior.mixture_variance.cpu().detach().clamp_min(0)
+            elif isinstance(posterior, EnsemblePosterior) and posterior.values.ndim > 2:
+                # Compute dimensions to average over (all except last 2)
+                # Not using the build-in EnsemblePosterior.variance() since that
+                # does not allow us to compute variance over _all_ batch dimensions
+                avg_dims = tuple(range(posterior.values.ndim - 2))
+                mean = posterior.values.mean(dim=avg_dims).cpu().detach()
+                var = posterior.values.var(dim=avg_dims).cpu().detach()
+
+                # Replace NaN values with zero (occurs when ensemble size is 1)
+                if posterior.values[..., 0, 0].numel() == 1:
+                    var = torch.zeros_like(var)
             else:
                 try:
                     mean = posterior.mean.cpu().detach()  # type: ignore


### PR DESCRIPTION
Summary:
To make use of `DeterministicModel`s in benchmarking,
`predict` is needed for EnsemblePosterior since `DeterministicModel`s produce them in their predictions.

The predict takes the mean of means, and the variance across all dims.

Rollback Plan:

Differential Revision: D80491014


