### PR TITLE
Support skip_runners_and_metrics for scalarized objective and constraint

### DIFF
--- a/ax/storage/sqa_store/load.py
+++ b/ax/storage/sqa_store/load.py
@@ -308,9 +308,14 @@ def _set_sqa_metric_to_base_type(
     the metric class from the DB.
     """
     sqa_metric.metric_type = base_metric_type_int
-    # Handle multi-objective metrics that are not directly attached to
-    # the experiment
-    if sqa_metric.intent == MetricIntent.MULTI_OBJECTIVE:
+    # Handle composite metrics (multi-objective, scalarized objectives, and
+    # scalarized outcome constraints) that are not directly attached to the experiment
+    composite_metric_intents = {
+        MetricIntent.MULTI_OBJECTIVE,
+        MetricIntent.SCALARIZED_OBJECTIVE,
+        MetricIntent.SCALARIZED_OUTCOME_CONSTRAINT,
+    }
+    if sqa_metric.intent in composite_metric_intents:
         if sqa_metric.properties is None:
             sqa_metric.properties = {}
         sqa_metric.properties["skip_runners_and_metrics"] = True


### PR DESCRIPTION
Summary:
The skip_runners_and_metrics flag didn't work properly for scalarized objective and constraint, since it didn't override the metric type of the child metrics. This diff adds support for this.

Meta: This is a similar change to D53635847

Differential Revision: D80503712


