### PR TITLE
Disallow non-zero default values in MapKeyInfo

### DIFF
--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -661,8 +661,10 @@ class BaseAdapterTest(TestCase):
                 )
             mock_combine.assert_called_once()
             call_kwargs = mock_combine.call_args.kwargs
+            # 3 for metric 'branin_map' with timestamp=0, 1, 2, and 1 for metric
+            # 'branin' with timestamp=NaN
             self.assertEqual(
-                len(call_kwargs["status_quo_observations"]), 3 + additional_fetch
+                len(call_kwargs["status_quo_observations"]), 4 + additional_fetch
             )
             if additional_fetch:
                 # Last observation should only include the constraint metric.

--- a/ax/adapter/transforms/tests/test_cast_transform.py
+++ b/ax/adapter/transforms/tests/test_cast_transform.py
@@ -456,8 +456,8 @@ class CastTransformTest(TestCase):
         ).transform_experiment_data(experiment_data=deepcopy(experiment_data))
         # Arm data should only include first three rows.
         assert_frame_equal(transformed_data.arm_data, experiment_data.arm_data.iloc[:2])
-        # Observation data should include all but last row for last trial.
+        # Observation data should include all but rows for last trial.
         assert_frame_equal(
             transformed_data.observation_data,
-            experiment_data.observation_data.iloc[:-1],
+            experiment_data.observation_data.iloc[:-2],
         )

--- a/ax/api/protocols/utils.py
+++ b/ax/api/protocols/utils.py
@@ -37,7 +37,7 @@ class _APIMetric(MapMetric, ABC):
     structure of ax.core.Metric to be more in line with our long term vision for Ax.
     """
 
-    map_key_info: MapKeyInfo = MapKeyInfo(key="step", default_value=0.0)
+    map_key_info: MapKeyInfo = MapKeyInfo(key="step")
 
     def __init__(self, name: str) -> None:
         super().__init__(name=name)

--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -31,4 +31,4 @@ class MapMetric(Metric):
     """
 
     data_constructor: type[MapData] = MapData
-    map_key_info: MapKeyInfo = MapKeyInfo(key=DEFAULT_MAP_KEY, default_value=0.0)
+    map_key_info: MapKeyInfo = MapKeyInfo(key=DEFAULT_MAP_KEY)

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -131,7 +131,7 @@ class TestDataBase(TestCase):
             df_2 = df.copy().assign(epoch=1)
             self.df = pd.concat((df_1, df_2))
             self.data_with_df = MapData(
-                df=self.df, map_key_infos=[MapKeyInfo(key="epoch", default_value=0.0)]
+                df=self.df, map_key_infos=[MapKeyInfo(key="epoch")]
             )
             self.data_without_df = MapData()
 

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -482,10 +482,7 @@ class ObservationsTest(TestCase):
         ]
         data = MapData(
             df=df,
-            map_key_infos=[
-                MapKeyInfo(key="step", default_value=0.0),
-                MapKeyInfo(key="timestamp", default_value=0.0),
-            ],
+            map_key_infos=[MapKeyInfo(key="step"), MapKeyInfo(key="timestamp")],
         )
         observations = observations_from_data(experiment=experiment, data=data)
         self.assertEqual(len(observations), 3)

--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -11,22 +11,19 @@ from __future__ import annotations
 import math
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping
-from random import random
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from ax.core.base_trial import BaseTrial
-from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetricFetchResult
 from ax.core.metric import MetricFetchE
 from ax.metrics.noisy_function_map import NoisyFunctionMapMetric
 from ax.utils.common.result import Err, Ok
 from ax.utils.measurement.synthetic_functions import branin
 from pyre_extensions import assert_is_instance
-
-FIDELITY = [0.1, 0.4, 0.7, 1.0]
 
 
 class BraninTimestampMapMetric(NoisyFunctionMapMetric):
@@ -153,46 +150,3 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
         mean = assert_is_instance(branin(x1=x1, x2=x2), float) * weight
 
         return {"mean": mean, "timestamp": timestamp}
-
-
-class BraninFidelityMapMetric(NoisyFunctionMapMetric):
-    map_key_info: MapKeyInfo = MapKeyInfo(key="fidelity", default_value=0.0)
-
-    def __init__(
-        self,
-        name: str,
-        param_names: Iterable[str],
-        noise_sd: float = 0.0,
-        lower_is_better: bool | None = None,
-    ) -> None:
-        super().__init__(
-            name=name,
-            param_names=param_names,
-            noise_sd=noise_sd,
-            lower_is_better=lower_is_better,
-        )
-
-        self.index = -1
-
-    def fetch_trial_data(
-        self, trial: BaseTrial, noisy: bool = True, **kwargs: Any
-    ) -> MapMetricFetchResult:
-        self.index = -1
-
-        return super().fetch_trial_data(
-            trial=trial,
-            noisy=noisy,
-            **kwargs,
-        )
-
-    def f(self, x: npt.NDArray) -> Mapping[str, Any]:
-        if self.index < len(FIDELITY):
-            self.index += 1
-
-        x1, x2 = x
-        fidelity = FIDELITY[self.index]
-
-        fidelity_penalty = random() * math.pow(1.0 - fidelity, 2.0)
-        mean = assert_is_instance(branin(x1=x1, x2=x2), float) - fidelity_penalty
-
-        return {"mean": mean, "fidelity": fidelity}

--- a/ax/metrics/noisy_function_map.py
+++ b/ax/metrics/noisy_function_map.py
@@ -27,7 +27,7 @@ class NoisyFunctionMapMetric(MapMetric):
     with mean 0 and mean_sd scale added to the result.
     """
 
-    map_key_info: MapKeyInfo = MapKeyInfo(key="timestamp", default_value=0.0)
+    map_key_info: MapKeyInfo = MapKeyInfo(key="timestamp")
 
     def __init__(
         self,

--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -41,7 +41,7 @@ try:
     class TensorboardMetric(MapMetric):
         """A *new* `MapMetric` for getting Tensorboard metrics."""
 
-        map_key_info: MapKeyInfo = MapKeyInfo(key="step", default_value=0.0)
+        map_key_info: MapKeyInfo = MapKeyInfo(key="step")
 
         def __init__(
             self,

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -411,7 +411,6 @@ def map_data_to_dict(map_data: MapData) -> dict[str, Any]:
     return properties
 
 
-# pyre-fixme[24]: Generic type `MapKeyInfo` expects 1 type parameter.
 def map_key_info_to_dict(mki: MapKeyInfo) -> dict[str, Any]:
     """Convert Ax map data metadata to a dictionary."""
     properties = serialize_init_args(obj=mki)

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2661,7 +2661,7 @@ def get_observations_with_invalid_value(invalid_value: float) -> list[Observatio
 
 
 def get_map_key_info() -> MapKeyInfo:
-    return MapKeyInfo(key="epoch", default_value=0.0)
+    return MapKeyInfo(key="epoch")
 
 
 def get_branin_data(


### PR DESCRIPTION
Summary:
**Context**:
* `MapKeyInfo.default_value` never seems to be used meaningfully. It is often written to but only read within `map_data.py`, where it is used to fill in misisng values.
* The default is almost always zero in practice. While that may not seem ideal since it's a real value and doesn't differentiate missings from intentionally attached data, using NaNs has the potential to introduce a lot of downstream issues with equality checks, merges, etc.

**This PR**:
* Makes map default values always 0.

**Considerations**:
Old data will deserialize with MapKeyInfos with 0 default values, even if it has had missings imputed to some other value.

Differential Revision: D80559641


