### PR TITLE
set `observe_noise_sd=False` for MNIST and FashionMNIST surrogates

### DIFF
--- a/ax/benchmark/problems/surrogate/hss/fashion_mnist_surrogate.py
+++ b/ax/benchmark/problems/surrogate/hss/fashion_mnist_surrogate.py
@@ -183,7 +183,9 @@ def get_fashion_mnist_surrogate_benchmark(
     optimization_config = OptimizationConfig(
         objective=Objective(
             metric=BenchmarkMetric(
-                name="FashionMNIST Test Accuracy", lower_is_better=False
+                name="FashionMNIST Test Accuracy",
+                lower_is_better=False,
+                observe_noise_sd=False,
             ),
             minimize=False,
         )

--- a/ax/benchmark/problems/surrogate/hss/mnist_surrogate.py
+++ b/ax/benchmark/problems/surrogate/hss/mnist_surrogate.py
@@ -148,7 +148,11 @@ def get_mnist_surrogate_benchmark(
 
     optimization_config = OptimizationConfig(
         objective=Objective(
-            metric=BenchmarkMetric(name="MNIST Test Accuracy", lower_is_better=False),
+            metric=BenchmarkMetric(
+                name="MNIST Test Accuracy",
+                lower_is_better=False,
+                observe_noise_sd=False,
+            ),
             minimize=False,
         )
     )


### PR DESCRIPTION
Summary:
By default, `BenchmarkMetric` sets `observe_noise_sd=True`, which generates tons of warnings during MNIST benchmark. 
```
[INFO 08-19 17:56:30] Orchestrator: Retrieved COMPLETED trials: [12].
[W 250819 17:56:30 noise_models:150] Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.
[W 250819 17:56:31 noise_models:150] Very small noise values detected. This will likely lead to numerical instabilities. Rounding small noise values up to 1e-06.
...
```

Disable the flag for MNIST and FashionMNIST benchmark problems, as noises shouldn't be observable in hyperparameter tuning in the first place.

Differential Revision: D80624538


