### PR TITLE
Add backfill_value and default_value fields to Parameter

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -392,6 +392,8 @@ class Decoder:
                 digits=parameter_sqa.digits,
                 is_fidelity=parameter_sqa.is_fidelity or False,
                 target_value=parameter_sqa.target_value,
+                backfill_value=parameter_sqa.backfill_value,
+                default_value=parameter_sqa.default_value,
             )
         elif parameter_sqa.domain_type == DomainType.CHOICE:
             target_value = parameter_sqa.target_value
@@ -415,6 +417,8 @@ class Decoder:
                 is_ordered=parameter_sqa.is_ordered,
                 is_task=bool(parameter_sqa.is_task),
                 dependents=parameter_sqa.dependents,
+                backfill_value=parameter_sqa.backfill_value,
+                default_value=parameter_sqa.default_value,
             )
         elif parameter_sqa.domain_type == DomainType.FIXED:
             # Don't throw an error if parameter_sqa.fixed_value is None;
@@ -426,6 +430,8 @@ class Decoder:
                 is_fidelity=parameter_sqa.is_fidelity or False,
                 target_value=parameter_sqa.target_value,
                 dependents=parameter_sqa.dependents,
+                backfill_value=parameter_sqa.backfill_value,
+                default_value=parameter_sqa.default_value,
             )
         elif parameter_sqa.domain_type == DomainType.DERIVED:
             parameter = DerivedParameter(
@@ -544,6 +550,8 @@ class Decoder:
                 digits=parameter_sqa.digits,
                 is_fidelity=parameter_sqa.is_fidelity or False,
                 target_value=parameter_sqa.target_value,
+                backfill_value=parameter_sqa.backfill_value,
+                default_value=parameter_sqa.default_value,
             )
         else:
             raise SQADecodeError(

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -278,6 +278,8 @@ class Encoder:
                 is_fidelity=parameter.is_fidelity,
                 target_value=parameter.target_value,
                 dependents=parameter.dependents if parameter.is_hierarchical else None,
+                backfill_value=parameter.backfill_value,
+                default_value=parameter.default_value,
             )
         elif isinstance(parameter, ChoiceParameter):
             if parameter._bypass_cardinality_check:
@@ -298,6 +300,8 @@ class Encoder:
                 is_fidelity=parameter.is_fidelity,
                 target_value=parameter.target_value,
                 dependents=parameter.dependents if parameter.is_hierarchical else None,
+                backfill_value=parameter.backfill_value,
+                default_value=parameter.default_value,
             )
         elif isinstance(parameter, FixedParameter):
             # pyre-fixme[29]: `SQAParameter` is not a function.
@@ -310,6 +314,8 @@ class Encoder:
                 is_fidelity=parameter.is_fidelity,
                 target_value=parameter.target_value,
                 dependents=parameter.dependents if parameter.is_hierarchical else None,
+                backfill_value=parameter.backfill_value,
+                default_value=parameter.default_value,
             )
         elif isinstance(parameter, DerivedParameter):
             # pyre-fixme[29]: `SQAParameter` is not a function.
@@ -431,6 +437,8 @@ class Encoder:
                 digits=parameter.digits,
                 is_fidelity=parameter.is_fidelity,
                 target_value=parameter.target_value,
+                backfill_value=parameter.backfill_value,
+                default_value=parameter.default_value,
             )
         else:
             raise SQAEncodeError(

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -71,6 +71,8 @@ class SQAParameter(Base):
     )
     is_fidelity: Column[bool | None] = Column(Boolean)
     target_value: Column[TParamValue | None] = Column(JSONEncodedObject)
+    backfill_value: Column[TParamValue | None] = Column(JSONEncodedObject)
+    default_value: Column[TParamValue | None] = Column(JSONEncodedObject)
 
     # Attributes for Range Parameters
     digits: Column[int | None] = Column(Integer)


### PR DESCRIPTION
Summary:
Add two properties to `Parameter`:
1. `backfill_value` - used for parameters added to experiments that already have run trials. Specifies the backfill value to use for trials that have already run.
2. `default_value` - used for parameters disabled in experiments that already have run trials. Specified the default value to use in modeling for future trials.

Differential Revision: D79260975


