### PR TITLE
New methods to add/remove search space parameters

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -186,6 +186,20 @@ class Parameter(SortableBase, metaclass=ABCMeta):
     def clone(self) -> Parameter:
         pass
 
+    def disable(self, default_value: TParamValue) -> None:
+        """
+        Effectively remove parameter from the search space for future trial generation.
+        Existing trials remain valid, and the disabled parameter is replaced with the
+        default_value for all subsequent trials.
+        """
+        if self.is_disabled:
+            logger.warning(
+                f"Parameter {self.name} is already disabled with "
+                f"default value {self.default_value}. "
+                f"Updating default value to {default_value}."
+            )
+        self._default_value = default_value
+
     @property
     def _unique_id(self) -> str:
         return str(self)

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -349,6 +349,29 @@ class TestGenerationNode(TestCase):
             ObservationFeatures(parameters={"x": 0}),
         )
 
+    def test_disabled_parameters(self) -> None:
+        input_constructors = self.sobol_generation_node.apply_input_constructors(
+            experiment=self.branin_experiment, gen_kwargs={}
+        )
+        self.assertIsNone(input_constructors["fixed_features"])
+        # Disable parameter
+        self.branin_experiment.disable_parameters_in_search_space({"x1": 1.2345})
+        input_constructors = self.sobol_generation_node.apply_input_constructors(
+            experiment=self.branin_experiment, gen_kwargs={}
+        )
+        expected_fixed_features = ObservationFeatures(parameters={"x1": 1.2345})
+        self.assertEqual(input_constructors["fixed_features"], expected_fixed_features)
+        # Test fixed features override
+        input_constructors = self.sobol_generation_node.apply_input_constructors(
+            experiment=self.branin_experiment,
+            gen_kwargs={
+                "fixed_features": ObservationFeatures(parameters={"x1": 0.0, "x2": 0.0})
+            },
+        )
+        # The passed fixed feature overrides the disabled parameter default value
+        expected_fixed_features = ObservationFeatures(parameters={"x1": 0.0, "x2": 0.0})
+        self.assertEqual(input_constructors["fixed_features"], expected_fixed_features)
+
 
 class TestGenerationStep(TestCase):
     def setUp(self) -> None:

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -392,6 +392,8 @@ class Decoder:
                 digits=parameter_sqa.digits,
                 is_fidelity=parameter_sqa.is_fidelity or False,
                 target_value=parameter_sqa.target_value,
+                backfill_value=parameter_sqa.backfill_value,
+                default_value=parameter_sqa.default_value,
             )
         elif parameter_sqa.domain_type == DomainType.CHOICE:
             target_value = parameter_sqa.target_value
@@ -415,6 +417,8 @@ class Decoder:
                 is_ordered=parameter_sqa.is_ordered,
                 is_task=bool(parameter_sqa.is_task),
                 dependents=parameter_sqa.dependents,
+                backfill_value=parameter_sqa.backfill_value,
+                default_value=parameter_sqa.default_value,
             )
         elif parameter_sqa.domain_type == DomainType.FIXED:
             # Don't throw an error if parameter_sqa.fixed_value is None;
@@ -426,6 +430,8 @@ class Decoder:
                 is_fidelity=parameter_sqa.is_fidelity or False,
                 target_value=parameter_sqa.target_value,
                 dependents=parameter_sqa.dependents,
+                backfill_value=parameter_sqa.backfill_value,
+                default_value=parameter_sqa.default_value,
             )
         elif parameter_sqa.domain_type == DomainType.DERIVED:
             parameter = DerivedParameter(
@@ -544,6 +550,8 @@ class Decoder:
                 digits=parameter_sqa.digits,
                 is_fidelity=parameter_sqa.is_fidelity or False,
                 target_value=parameter_sqa.target_value,
+                backfill_value=parameter_sqa.backfill_value,
+                default_value=parameter_sqa.default_value,
             )
         else:
             raise SQADecodeError(

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -278,6 +278,8 @@ class Encoder:
                 is_fidelity=parameter.is_fidelity,
                 target_value=parameter.target_value,
                 dependents=parameter.dependents if parameter.is_hierarchical else None,
+                backfill_value=parameter.backfill_value,
+                default_value=parameter.default_value,
             )
         elif isinstance(parameter, ChoiceParameter):
             if parameter._bypass_cardinality_check:
@@ -298,6 +300,8 @@ class Encoder:
                 is_fidelity=parameter.is_fidelity,
                 target_value=parameter.target_value,
                 dependents=parameter.dependents if parameter.is_hierarchical else None,
+                backfill_value=parameter.backfill_value,
+                default_value=parameter.default_value,
             )
         elif isinstance(parameter, FixedParameter):
             # pyre-fixme[29]: `SQAParameter` is not a function.
@@ -310,6 +314,8 @@ class Encoder:
                 is_fidelity=parameter.is_fidelity,
                 target_value=parameter.target_value,
                 dependents=parameter.dependents if parameter.is_hierarchical else None,
+                backfill_value=parameter.backfill_value,
+                default_value=parameter.default_value,
             )
         elif isinstance(parameter, DerivedParameter):
             # pyre-fixme[29]: `SQAParameter` is not a function.
@@ -431,6 +437,8 @@ class Encoder:
                 digits=parameter.digits,
                 is_fidelity=parameter.is_fidelity,
                 target_value=parameter.target_value,
+                backfill_value=parameter.backfill_value,
+                default_value=parameter.default_value,
             )
         else:
             raise SQAEncodeError(

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -71,6 +71,8 @@ class SQAParameter(Base):
     )
     is_fidelity: Column[bool | None] = Column(Boolean)
     target_value: Column[TParamValue | None] = Column(JSONEncodedObject)
+    backfill_value: Column[TParamValue | None] = Column(JSONEncodedObject)
+    default_value: Column[TParamValue | None] = Column(JSONEncodedObject)
 
     # Attributes for Range Parameters
     digits: Column[int | None] = Column(Integer)


### PR DESCRIPTION
Summary:
In `Experiment` add two methods `add_parameters_to_search_space` and `disable_parameters_in_search_space`.

In `Adapter._process_and_transform_data` check if the experiment's search space has been updated and update the adapter's search space and model space. Use `backfill_values` for `FillMissingParameters` transform.

In `GenerationNode._determine_fixed_features_from_node` check for any disabled parameters. Add their `default_value` as fixed features.

Differential Revision: D79263457


