### PR TITLE
validate multi-objective optimization config with scalarized constraints

### DIFF
--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -180,12 +180,6 @@ class OptimizationConfig(Base):
                 "Use MultiObjectiveOptimizationConfig instead."
             )
         outcome_constraints = outcome_constraints or []
-        # Only vaidate `outcome_constraints`
-        outcome_constraints = [
-            constraint
-            for constraint in outcome_constraints
-            if isinstance(constraint, ScalarizedOutcomeConstraint) is False
-        ]
         unconstrainable_metrics = objective.get_unconstrainable_metrics()
         OptimizationConfig._validate_outcome_constraints(
             unconstrainable_metrics=unconstrainable_metrics,
@@ -197,20 +191,26 @@ class OptimizationConfig(Base):
         unconstrainable_metrics: list[Metric],
         outcome_constraints: list[OutcomeConstraint],
     ) -> None:
-        constraint_metrics = [
-            constraint.metric.name for constraint in outcome_constraints
-        ]
+        constraint_metrics = []
+        for oc in outcome_constraints:
+            if isinstance(oc, ScalarizedOutcomeConstraint):
+                constraint_metrics.extend([m.name for m in oc.metrics])
+            else:
+                constraint_metrics.append(oc.metric.name)
+
         for metric in unconstrainable_metrics:
             if metric.name in constraint_metrics:
                 raise ValueError("Cannot constrain on objective metric.")
 
-        def get_metric_name(oc: OutcomeConstraint) -> str:
-            return oc.metric.name
+        def constraint_key(oc: OutcomeConstraint) -> str:
+            return (
+                str(oc)
+                if isinstance(oc, ScalarizedOutcomeConstraint)
+                else oc.metric.name
+            )
 
-        sorted_constraints = sorted(outcome_constraints, key=get_metric_name)
-        for metric_name, constraints_itr in groupby(
-            sorted_constraints, get_metric_name
-        ):
+        sorted_constraints = sorted(outcome_constraints, key=constraint_key)
+        for metric_name, constraints_itr in groupby(sorted_constraints, constraint_key):
             constraints: list[OutcomeConstraint] = list(constraints_itr)
             constraints_len = len(constraints)
             if constraints_len == 2:


### PR DESCRIPTION
Summary:
`MultiObjectiveOptimizationConfig` constraint validation will err when trying to extract metric names from `ScalarizedOutcomeConstraint`. This change fixes it.

Meta: this blocks the loading of some experiments.

Differential Revision: D80640567


