### PR TITLE
Update ChoiceToNumericChoice transform behavior

### DIFF
--- a/ax/adapter/transforms/choice_encode.py
+++ b/ax/adapter/transforms/choice_encode.py
@@ -8,8 +8,6 @@
 
 from typing import Any, Optional, TYPE_CHECKING
 
-import numpy as np
-import numpy.typing as npt
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.deprecated_transform_mixin import DeprecatedTransformMixin
@@ -26,14 +24,12 @@ if TYPE_CHECKING:
 
 
 class ChoiceToNumericChoice(Transform):
-    """Convert general ChoiceParameters to integer or float ChoiceParameters.
+    """Convert non-numeric ChoiceParameters to integer ChoiceParameters.
 
-    If the parameter type is numeric (int, float) and the parameter is ordered,
-    then the values are normalized to the unit interval while retaining relative
-    spacing. If the parameter type is unordered (categorical) or ordered but
-    non-numeric, this transform uses an integer encoding to `0, 1, ..., n_choices - 1`.
-    The resulting choice parameter will be considered ordered iff the original
-    parameter is.
+    If the parameter type is numeric (int, float), the parameter is not modified.
+    If the parameter is non-numeric, this transform uses an integer encoding to
+    `0, 1, ..., n_choices - 1`. The resulting choice parameter will be considered
+    ordered iff the original parameter is.
 
     In the inverse transform, parameters will be mapped back onto the original domain.
 
@@ -67,8 +63,8 @@ class ChoiceToNumericChoice(Transform):
         self.encoded_parameters: dict[str, dict[TParamValue, TParamValue]] = {}
         self.encoded_parameters_inverse: dict[str, ClosestLookupDict] = {}
         for p in search_space.parameters.values():
-            if isinstance(p, ChoiceParameter) and not p.is_task:
-                transformed_values, _ = transform_choice_values(p)
+            if isinstance(p, ChoiceParameter) and not p.is_numeric and not p.is_task:
+                transformed_values = list(range(len(p.values)))
                 self.encoded_parameters[p.name] = dict(
                     zip(p.values, transformed_values)
                 )
@@ -91,26 +87,29 @@ class ChoiceToNumericChoice(Transform):
         transformed_parameters: dict[str, Parameter] = {}
         for p_name, p in search_space.parameters.items():
             if p_name in self.encoded_parameters and isinstance(p, ChoiceParameter):
-                if p.is_fidelity:
-                    raise ValueError(
-                        f"Cannot choice-encode fidelity parameter {p_name}"
-                    )
-                tvals, ptype = transform_choice_values(p)
-
+                encoding = self.encoded_parameters[p_name]
                 dependents = None
                 if p.is_hierarchical:
                     # The dependents of hierarchical parameters need to be updated to
                     # reflect the changes by encoding.
                     dependents = {
-                        self.encoded_parameters[p.name][val]: deps
-                        for val, deps in p.dependents.items()
+                        encoding[val]: deps for val, deps in p.dependents.items()
                     }
 
                 transformed_parameters[p_name] = ChoiceParameter(
                     name=p_name,
-                    parameter_type=ptype,
-                    values=tvals.tolist(),
+                    parameter_type=ParameterType.INT,
+                    # Explicitly extracting values rather than passing
+                    # `list(encoding.values())` should make it possible to correctly
+                    # transform a parameter that has different (a subset of) values
+                    # than the parameter used to initialize the transform.
+                    values=[encoding[val] for val in p.values],
                     is_ordered=p.is_ordered,
+                    is_task=p.is_task,
+                    is_fidelity=p.is_fidelity,
+                    target_value=encoding[p.target_value]
+                    if p.target_value is not None
+                    else None,
                     sort_values=p.sort_values,
                     dependents=dependents,
                 )
@@ -258,29 +257,3 @@ class OrderedChoiceEncode(DeprecatedTransformMixin, OrderedChoiceToIntegerRange)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-
-
-def transform_choice_values(p: ChoiceParameter) -> tuple[npt.NDArray, ParameterType]:
-    """Transforms the choice values and returns the new parameter type.
-
-    If the choices were numeric (int or float) and ordered, then they're cast
-    to float and rescaled to [0, 1]. Otherwise, they're cast to integers
-    `0, 1, ..., n_choices - 1`.
-    """
-    if p.is_numeric and p.is_ordered:
-        # If values are ordered numeric, retain relative distances.
-        values = np.array(p.values, dtype=float)
-        vmin, vmax = values.min(), values.max()
-        if len(values) > 1:
-            values = (values - vmin) / (vmax - vmin)
-        ptype = ParameterType.FLOAT
-    else:
-        # If values are unordered or not numeric, use integer encoding.
-        # The reason for using integers rather than floats is somewhat arcane - it has
-        # to do with slightly different representation of floats in pure python and in
-        # PyTorch, which require some careful handling when untransform the choices that
-        # a model may generate on the botorch end. Ints do not have this issue, so we
-        # are using them here.
-        values = np.arange(len(p.values))
-        ptype = ParameterType.INT
-    return values, ptype

--- a/ax/adapter/transforms/tests/test_choice_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_choice_encode_transform.py
@@ -26,6 +26,7 @@ from ax.core.parameter import (
 )
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import HierarchicalSearchSpace, RobustSearchSpace, SearchSpace
+from ax.core.types import TParameterization
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_experiment_with_observations,
@@ -79,25 +80,23 @@ class ChoiceEncodeTransformTest(TestCase):
             ],
         )
         self.t = self.t_class(search_space=self.search_space)
-        self.observation_features = [
-            ObservationFeatures(
-                parameters={"x": 2.2, "a": 2, "b": 10.0, "c": 10.0, "d": "r"}
-            )
-        ]
-        # expected parameters after transform
-        self.expected_transformed_params = {
+        input_params: TParameterization = {
             "x": 2.2,
             "a": 2,
-            # ordered float choice originally; transformed normalized value
-            "b": normalize_values([1.0, 10.0, 100.0])[1],
-            # ordered float choice originally; transformed normalized value
-            "c": normalize_values([10.0, 100.0, 1000.0])[0],
+            "b": 10.0,
+            "c": 10.0,
+            "d": "r",
+        }
+        self.observation_features = [ObservationFeatures(parameters=input_params)]
+        # expected parameters after transform
+        self.expected_transformed_params: TParameterization = {
+            **input_params,
             # string choice originally; transformed to int index.
-            "d": 1,
+            **{"d": 1},
         }
 
     def test_init(self) -> None:
-        self.assertEqual(list(self.t.encoded_parameters.keys()), ["b", "c", "d", "e"])
+        self.assertEqual(list(self.t.encoded_parameters.keys()), ["d", "e"])
 
     def test_transform_observation_features(self) -> None:
         observation_features = self.observation_features
@@ -126,25 +125,27 @@ class ChoiceEncodeTransformTest(TestCase):
         ss2 = self.t.transform_search_space(ss2)
         for p in ("d", "e"):
             with self.subTest(p):
-                tranformed_param = assert_is_instance(
+                transformed_param = assert_is_instance(
                     ss2.parameters[p], ChoiceParameter
                 )
                 original_param = assert_is_instance(
                     self.search_space.parameters[p], ChoiceParameter
                 )
-                self.assertEqual(tranformed_param.is_ordered, original_param.is_ordered)
                 self.assertEqual(
-                    tranformed_param.sort_values,
+                    transformed_param.is_ordered, original_param.is_ordered
+                )
+                self.assertEqual(
+                    transformed_param.sort_values,
                     original_param.sort_values,
                 )
                 if self.t_class == ChoiceToNumericChoice:
                     self.assertEqual(
-                        tranformed_param.values,
+                        transformed_param.values,
                         [i for i, _ in enumerate(original_param.values)],
                     )
                 else:
                     self.assertEqual(
-                        tranformed_param.values,
+                        transformed_param.values,
                         original_param.values,
                     )
 
@@ -161,30 +162,46 @@ class ChoiceEncodeTransformTest(TestCase):
         for p in ("a", "d"):
             self.assertEqual(ss2.parameters[p].parameter_type, ParameterType.INT)
 
-        self.assertEqual(
-            ss2.parameters["b"].values, normalize_values([1.0, 10.0, 100.0])
-        )
-        self.assertEqual(
-            ss2.parameters["c"].values, normalize_values([10.0, 100.0, 1000.0])
-        )
+        for param_name in ["b", "c"]:
+            self.assertEqual(
+                ss2.parameters[param_name].values,
+                assert_is_instance(
+                    self.search_space[param_name], ChoiceParameter
+                ).values,
+            )
         self.assertEqual(ss2.parameters["d"].values, [0, 1, 2])
 
-        # Ensure we error if we try to transform a fidelity parameter
+        # Fidelity parameter is transformed correctly.
         ss3 = SearchSpace(
             parameters=[
                 ChoiceParameter(
                     "b",
-                    parameter_type=ParameterType.FLOAT,
-                    values=[1.0, 10.0, 100.0],
+                    parameter_type=ParameterType.STRING,
+                    values=["a", "b", "c"],
                     is_ordered=True,
                     is_fidelity=True,
-                    target_value=100.0,
+                    sort_values=False,
+                    target_value="c",
                 )
             ]
         )
-        t = OrderedChoiceToIntegerRange(search_space=ss3, observations=[])
-        with self.assertRaises(ValueError):
-            t.transform_search_space(ss3)
+        t = ChoiceToNumericChoice(search_space=ss3, observations=[])
+        self.assertEqual(
+            t.transform_search_space(ss3.clone()),
+            SearchSpace(
+                parameters=[
+                    ChoiceParameter(
+                        "b",
+                        parameter_type=ParameterType.INT,
+                        values=[0, 1, 2],
+                        is_ordered=True,
+                        is_fidelity=True,
+                        sort_values=False,
+                        target_value=2,
+                    )
+                ]
+            ),
+        )
 
     def test_hss_dependents_are_preserved(self) -> None:
         # x0
@@ -291,8 +308,8 @@ class ChoiceEncodeTransformTest(TestCase):
             expected_values = zip(
                 [2.2, 1.0, 1.2],
                 [2, 1, 2],
-                normalize_values([10.0, 1.0, 100.0]),
-                normalize_values([10.0, 100.0, 1000.0]),
+                [10.0, 1.0, 100.0],
+                [10.0, 100.0, 1000.0],
                 [1, 0, 2],
                 [1, 2, 0],
             )


### PR DESCRIPTION
Summary:
Removes some functionality that I never liked from `ChoiceToNumericChoice` transform. This transform is currently only used by the rarely used `BO_MIXED` generator, so making changes to it should be pretty safe.
- Previously, ordered choice parameters with numeric values would be mapped to [0, 1] while keeping the spacing between values the same. This brings no benefit in the world of MBM where we use `Normalize` transform in the models. With this diff, numerical valued parameters are not modified by the transform.
- This used to differentiate between ordered and unordered parameters, which is gone in this diff. MBM supports arbitrary values for both ordinal and categorical features in mixed optimizer, so no distinction is needed. `CategoricalKernel` doesn't seem to care about exact values of the categorical features either.
- There was an error raised for fidelity parameters. Updated to transform the target value instead.

With these changes, this becomes the choice transform that I'd want us to use broadly in all GSs. There are some gaps to close (and lots of benchmarking) before we can get there but simplifying the transform behavior seems like a good place to start from.

Differential Revision: D80654441


