### PR TITLE
Implement an input constructor for FilterFeatures transform

### DIFF
--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -77,6 +77,7 @@ from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import MultiTaskGP
 from botorch.models.transforms.input import (
     ChainedInputTransform,
+    FilterFeatures,
     InputPerturbation,
     InputTransform,
     Normalize,
@@ -204,6 +205,7 @@ INPUT_TRANSFORM_REGISTRY: dict[type[InputTransform], str] = {
     Round: "Round",
     Warp: "Warp",
     InputPerturbation: "InputPerturbation",
+    FilterFeatures: "FilterFeatures",
 }
 
 """

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -179,7 +179,13 @@ from ax.utils.testing.backend_simulator import (
 )
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.models.model import Model
-from botorch.models.transforms.input import ChainedInputTransform, Normalize, Round
+from botorch.models.transforms.input import (
+    ChainedInputTransform,
+    FilterFeatures,
+    InputTransform,
+    Normalize,
+    Round,
+)
 from botorch.sampling.normal import SobolQMCNormalSampler
 from botorch.utils.types import DEFAULT
 from gpytorch.constraints import Interval
@@ -237,6 +243,7 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     MultiObjectiveOptimizationConfig: multi_objective_optimization_config_to_dict,
     MultiTypeExperiment: multi_type_experiment_to_dict,
     Normalize: botorch_component_to_dict,
+    FilterFeatures: botorch_component_to_dict,
     PercentileEarlyStoppingStrategy: percentile_early_stopping_strategy_to_dict,
     SklearnMetric: metric_to_dict,
     ChemistryMetric: metric_to_dict,
@@ -285,6 +292,7 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
 CORE_CLASS_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     Acquisition: botorch_modular_to_dict,  # Ax MBM component
     AcquisitionFunction: botorch_modular_to_dict,  # BoTorch component
+    InputTransform: botorch_modular_to_dict,  # BoTorch input transform component
     Likelihood: botorch_modular_to_dict,  # BoTorch component
     torch.nn.Module: botorch_modular_to_dict,  # BoTorch module
     MarginalLogLikelihood: botorch_modular_to_dict,  # BoTorch component
@@ -333,6 +341,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "DomainType": DomainType,
     "Experiment": Experiment,
     "FactorialMetric": FactorialMetric,
+    "FilterFeatures": FilterFeatures,
     "FixedParameter": fixed_parameter_from_json,
     "GammaPrior": GammaPrior,
     "GenerationNode": GenerationNode,


### PR DESCRIPTION
Summary: In AMOS, we need an option to filter out certain features for a given metric, and we need an input constructor to match parameter name to feature indices.

Differential Revision: D80666129


