### PR TITLE
Bandit Experiments: Exclude CVs

### DIFF
--- a/ax/analysis/tests/test_overview.py
+++ b/ax/analysis/tests/test_overview.py
@@ -263,6 +263,11 @@ class TestOverview(TestCase):
         self.assertIn("BanditRollout", card_names)
         self.assertIn("MarginalEffectsPlot", card_names)
 
+        # Check that cross validation plots and top surfaces are excluded for bandit
+        # experiments
+        self.assertNotIn("CrossValidationPlot", card_names)
+        self.assertNotIn("TopSurfacesAnalysis", card_names)
+
         # Ensure BanditRollout card is not an error card
         bandit_rollout_cards = [c for c in all_cards if c.name == "BanditRollout"]
         self.assertEqual(len(bandit_rollout_cards), 1)


### PR DESCRIPTION
Summary:
Remove CVs from Diagnostic Analysis for Bandit Experiments. The changes include -
1. Adding a check to see if the experiment is a bandit experiment and excluding the relevant CV cards from Diagnostic Analysis
2. Updating bandit experiment dispatch test to ensure that CV plots are excluded from the overview

Reviewed By: eonofrey

Differential Revision: D80737971


