### PR TITLE
Update Cast.transform_experiment_data to add any missing columns to arm_data

### DIFF
--- a/ax/adapter/transforms/cast.py
+++ b/ax/adapter/transforms/cast.py
@@ -289,11 +289,14 @@ class Cast(Transform):
                     arm_data.index
                 )
             ]
-
+        # Add any missing columns to the arm_data to complete it.
+        arm_data = arm_data.reindex(
+            columns=list(self.search_space.parameters) + ["metadata"], fill_value=None
+        )
         # Cast columns to the correct datatype & round RangeParameters, if applicable.
         column_to_type = {
-            p: PARAMETER_PYTHON_TYPE_MAP[self.search_space.parameters[p].parameter_type]
-            for p in parameter_names
+            p: PARAMETER_PYTHON_TYPE_MAP[param.parameter_type]
+            for p, param in self.search_space.parameters.items()
         }
         arm_data = arm_data.astype(dtype=column_to_type, copy=False)
         # Round to digits if any parameter specifies it.

--- a/ax/adapter/transforms/tests/test_cast_transform.py
+++ b/ax/adapter/transforms/tests/test_cast_transform.py
@@ -405,6 +405,48 @@ class CastTransformTest(TestCase):
         expected_arm_data.index.names = ["trial_index", "arm_name"]
         assert_frame_equal(transformed.arm_data, expected_arm_data)
 
+    def test_transform_experiment_data_flatten_with_missing_columns(self) -> None:
+        columns = ["model", "learning_rate", "l2_reg_weight", "metadata"]
+        arm_data = (
+            DataFrame.from_dict(  # Data intentionally missing `num_boost_rounds`.
+                {
+                    (0, "0_0"): {
+                        "model": "Linear",
+                        "learning_rate": 0.01,
+                        "l2_reg_weight": 0.0001,
+                        "metadata": {
+                            Keys.FULL_PARAMETERIZATION: {
+                                "model": "Linear",
+                                "learning_rate": 0.01,
+                                "l2_reg_weight": 0.0001,
+                            }
+                        },
+                    }
+                },
+                orient="index",
+                columns=columns,
+            )
+        )
+        arm_data.index.names = ["trial_index", "arm_name"]
+        experiment_data = ExperimentData(
+            arm_data=arm_data, observation_data=DataFrame()
+        )
+        transformed = self.t_hss.transform_experiment_data(
+            experiment_data=experiment_data
+        )
+        expected_columns = set(columns + ["num_boost_rounds"])
+        self.assertEqual(set(transformed.arm_data.columns), expected_columns)
+        # Test with empty DF w/ missing columns.
+        arm_data = arm_data.iloc[:0]
+        arm_data.index.names = ["trial_index", "arm_name"]
+        experiment_data = ExperimentData(
+            arm_data=arm_data, observation_data=DataFrame()
+        )
+        transformed = self.t_hss.transform_experiment_data(
+            experiment_data=experiment_data
+        )
+        self.assertEqual(set(transformed.arm_data.columns), expected_columns)
+
     def test_transform_experiment_data_cast(self) -> None:
         # Test for casting to the correct data type and dropping of Nones.
         experiment = get_experiment_with_observations(


### PR DESCRIPTION
Summary: Updates `Cast.transform_experiment_data` to add any missing parameters to the columns of `arm_data` to prevent errors in downstream transforms.

Differential Revision: D80832465


