### PR TITLE
Make addition of SQ add an actual `GeneratorRun` for consistency and less storage hacking

### DIFF
--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -484,7 +484,7 @@ class TorchAdapterTest(TestCase):
         # Check that the metadata is correctly re-added to observation
         # features during `fit`.
         # pyre-fixme[16]: `BaseTrial` has no attribute `_generator_run_structs`.
-        preexisting_batch_gr = exp.trials[0]._generator_run_structs[0].generator_run
+        preexisting_batch_gr = exp.trials[0]._generator_runs[0]
         preexisting_batch_gr._candidate_metadata_by_arm_signature = {
             preexisting_batch_gr.arms[0].signature: {
                 "preexisting_batch_cand_metadata": "some_value"

--- a/ax/analysis/healthcheck/tests/test_regression_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_regression_analysis.py
@@ -36,12 +36,10 @@ class TestRegressionAnalysis(TestCase):
         card = ra.compute(experiment=experiment, generation_strategy=None)
         self.assertEqual(card.name, "RegressionAnalysis")
         self.assertEqual(card.title, "Ax Regression Analysis Warning")
-        self.assertTrue(
-            card.subtitle is not None
-            and "0_4" in card.subtitle
-            and "branin_b" in card.subtitle
-            and "Trial 0" in card.subtitle
-        )
+        self.assertTrue(card.subtitle is not None)
+        self.assertTrue("0_4" in card.subtitle)
+        self.assertTrue("branin_b" in card.subtitle)
+        self.assertTrue("Trial 0" in card.subtitle)
 
         df = pd.DataFrame(
             {

--- a/ax/analysis/healthcheck/tests/test_regression_detection_utils.py
+++ b/ax/analysis/healthcheck/tests/test_regression_detection_utils.py
@@ -70,8 +70,8 @@ class TestRegressionDetection(TestCase):
             search_space=experiment.search_space, seed=TEST_SOBOL_SEED + 1
         )
         sobol_run = sobol_generator.gen(n=3)
-        experiment.new_batch_trial(should_add_status_quo_arm=True).add_generator_run(
-            sobol_run
+        experiment.new_batch_trial(
+            generator_runs=[sobol_run], should_add_status_quo_arm=True
         )
 
         df1 = pd.DataFrame(

--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -101,14 +101,16 @@ class BaseTrial(ABC, SortableBase):
         self._ttl_seconds: int | None = ttl_seconds
         self._index: int = self._experiment._attach_trial(self, index=index)
 
-        if trial_type is not None:
-            if not self._experiment.supports_trial_type(trial_type):
-                raise ValueError(
-                    f"Experiment does not support trial_type {trial_type}."
-                )
-        else:
-            trial_type = self._experiment.default_trial_type
-        self._trial_type: str | None = trial_type
+        trial_type = (
+            trial_type
+            if trial_type is not None
+            else self._experiment.default_trial_type
+        )
+        if not self._experiment.supports_trial_type(trial_type):
+            raise ValueError(
+                f"Trial type {trial_type} is not supported by the experiment."
+            )
+        self._trial_type = trial_type
 
         self.__status: TrialStatus | None = None
         # Uses `_status` setter, which updates trial statuses to trial indices
@@ -234,18 +236,6 @@ class BaseTrial(ABC, SortableBase):
         (e.g. different deployment types).
         """
         return self._trial_type
-
-    @trial_type.setter
-    @immutable_once_run
-    def trial_type(self, trial_type: str | None) -> None:
-        """Identifier used to distinguish trial types in experiments
-        with multiple trial types.
-        """
-        if self._experiment is not None:
-            if not self._experiment.supports_trial_type(trial_type):
-                raise ValueError(f"{trial_type} is not supported by the experiment.")
-
-        self._trial_type = trial_type
 
     def assign_runner(self) -> BaseTrial:
         """Assigns default experiment runner if trial doesn't already have one."""

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -15,7 +15,7 @@ from collections.abc import MutableMapping
 from dataclasses import dataclass
 from datetime import datetime
 from logging import Logger
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import numpy as np
 from ax.core.arm import Arm
@@ -70,17 +70,6 @@ class AbandonedArm(SortableBase):
         return self.name
 
 
-@dataclass
-class GeneratorRunStruct(SortableBase):
-    """Stores GeneratorRun object as well as the weight with which it was added."""
-
-    generator_run: GeneratorRun
-
-    @property
-    def _unique_id(self) -> str:
-        return self.generator_run._unique_id
-
-
 class BatchTrial(BaseTrial):
     """Batched trial that has multiple attached arms, meant to be
     *deployed and evaluated together*, and possibly arm weights, which are
@@ -106,10 +95,13 @@ class BatchTrial(BaseTrial):
             trial's associated generator run is immutable once set.  This cannot
             be combined with the `generator_run` argument.
         trial_type: Type of this trial, if used in MultiTypeExperiment.
-        should_add_status_quo_arm: If True, adds the status quo arm to the trial with a
-            weight of 1.0. If False, the _status_quo is still set on the trial for
-            tracking purposes, but without a weight it will not be an Arm present on
-            the trial
+        should_add_status_quo_arm: If True and the status quo arm is not already
+            part of the trial, adds the status quo arm to the trial with a
+            weight of 1.0 (if status quo already had a non-zero weight in the
+            trial, keeps the original weight).
+            If False, the _status_quo is still set on the trial for tracking
+            purposes, but without a weight it will not be an Arm present on
+            the trial.
         ttl_seconds: If specified, trials will be considered failed after
             this many seconds since the time the trial was ran, unless the
             trial is completed before then. Meant to be used to detect
@@ -139,7 +131,7 @@ class BatchTrial(BaseTrial):
             index=index,
         )
         self._arms_by_name: dict[str, Arm] = {}
-        self._generator_run_structs: list[GeneratorRunStruct] = []
+        self._generator_runs: list[GeneratorRun] = []
         self._abandoned_arms_metadata: dict[str, AbandonedArm] = {}
         self._status_quo_weight_override: float | None = None
         self.should_add_status_quo_arm = should_add_status_quo_arm
@@ -154,7 +146,7 @@ class BatchTrial(BaseTrial):
                 self.add_generator_run(generator_run=gr)
 
         status_quo = experiment.status_quo
-        if should_add_status_quo_arm:
+        if should_add_status_quo_arm and status_quo not in self.arm_weights:
             if status_quo is None:
                 raise ValueError(
                     "Experiment does not have a status quo arm so "
@@ -180,14 +172,6 @@ class BatchTrial(BaseTrial):
         return self._index
 
     @property
-    def generator_run_structs(self) -> list[GeneratorRunStruct]:
-        """List of generator run structs attached to this trial.
-
-        Struct holds generator_run object and the weight with which it was added.
-        """
-        return self._generator_run_structs
-
-    @property
     def arm_weights(self) -> MutableMapping[Arm, float]:
         """The set of arms and associated weights for the trial.
 
@@ -195,19 +179,14 @@ class BatchTrial(BaseTrial):
         each generator run that is attached to the trial.
         """
         arm_weights = OrderedDict()
-        if len(self._generator_run_structs) == 0 and self.status_quo is None:
+        if len(self._generator_runs) == 0:
             return arm_weights
-        for struct in self._generator_run_structs:
-            for arm, weight in struct.generator_run.arm_weights.items():
+        for gr in self._generator_runs:
+            for arm, weight in gr.arm_weights.items():
                 if arm in arm_weights:
                     arm_weights[arm] += weight
                 else:
                     arm_weights[arm] = weight
-        if self.status_quo is not None and self._status_quo_weight_override is not None:
-            # If override is specified, this is the weight the status quo gets,
-            # regardless of whether it appeared in any generator runs.
-            # If no override is specified, status quo does not appear in arm_weights.
-            arm_weights[self.status_quo] = self._status_quo_weight_override
         return arm_weights
 
     @arm_weights.setter
@@ -215,36 +194,61 @@ class BatchTrial(BaseTrial):
         raise NotImplementedError("Use `trial.add_arms_and_weights`")
 
     @immutable_once_run
-    def add_arm(self, arm: Arm, weight: float = 1.0) -> BatchTrial:
+    def add_arm(
+        self,
+        arm: Arm,
+        weight: float = 1.0,
+        generator_run_type: GeneratorRunType = GeneratorRunType.MANUAL,
+        candidate_metadata: dict[str, Any] | None = None,
+    ) -> BatchTrial:
         """Add a arm to the trial.
 
         Args:
             arm: The arm to be added.
             weight: The weight with which this arm should be added.
-
+            generator_run_type: The type of the generator run, into which this arm
+                will be wrapped, in order to be added to the `BatchTrial`.
+                Usually "MANUAL" or "STATUS_QUO".
         Returns:
             The trial instance.
         """
-        return self.add_arms_and_weights(arms=[arm], weights=[weight])
+        if candidate_metadata:
+            raise NotImplementedError(
+                "`candidate_metadata` is not yet supported for `BatchTrial`-s."
+            )
+        if generator_run_type == GeneratorRunType.STATUS_QUO:
+            self.experiment._name_and_store_arm_if_not_exists(
+                arm=arm,
+                proposed_name="status_quo_" + str(self.index),
+                replace=True,
+            )
+
+        return self.add_arms_and_weights(
+            arms=[arm], weights=[weight], generator_run_type=generator_run_type
+        )
 
     @immutable_once_run
     def add_arms_and_weights(
         self,
         arms: list[Arm],
         weights: list[float] | None = None,
+        generator_run_type: GeneratorRunType = GeneratorRunType.MANUAL,
     ) -> BatchTrial:
         """Add arms and weights to the trial.
 
         Args:
             arms: The arms to be added.
             weights: The weights associated with the arms.
+            generator_run_type: The type of the generator run, into which these arms
+                will be wrapped, in order to be added to the `BatchTrial`.
+                Usually "MANUAL" or "STATUS_QUO".
 
         Returns:
             The trial instance.
         """
         return self.add_generator_run(
             generator_run=GeneratorRun(
-                arms=arms, weights=weights, type=GeneratorRunType.MANUAL.name
+                arms=arms, weights=weights, type=generator_run_type.name
             ),
         )
 
@@ -262,6 +266,22 @@ class BatchTrial(BaseTrial):
         Returns:
             The trial instance.
         """
+        if (
+            generator_run._generator_run_type == GeneratorRunType.STATUS_QUO.name
+            and any(
+                gr._generator_run_type == GeneratorRunType.STATUS_QUO.name
+                for gr in self.generator_runs
+            )
+        ):
+            if (sq := self.status_quo) is None:
+                raise AxError(
+                    f"Trial {self.index} has a status quo generator run, "
+                    "but its status quo arm is not set. This is an unexpected state."
+                )
+            raise UnsupportedError(
+                f"Trial {self.index} already has a status quo arm: {sq.name}."
+            )
+
         # First validate generator run arms
         for arm in generator_run.arms:
             self.experiment.search_space.check_types(arm.parameters, raise_error=True)
@@ -280,13 +300,7 @@ class BatchTrial(BaseTrial):
         for arm in generator_run.arms:
             self._check_existing_and_name_arm(arm)
 
-        self._generator_run_structs.append(
-            GeneratorRunStruct(generator_run=generator_run)
-        )
-
-        if self.status_quo is not None and self.should_add_status_quo_arm:
-            self.add_status_quo_arm(weight=1.0)
-
+        self._generator_runs.append(generator_run)
         if generator_run._generation_step_index is not None:
             self._set_generation_step_index(
                 generation_step_index=generator_run._generation_step_index
@@ -303,28 +317,24 @@ class BatchTrial(BaseTrial):
     def status_quo(self, status_quo: Arm | None) -> None:
         raise NotImplementedError("Use `add_status_quo_arm` to set the status quo arm.")
 
-    def unset_status_quo(self) -> None:
-        """Set the status quo to None."""
-        self._status_quo_weight_override = None
-        self._refresh_arms_by_name()
-
     @immutable_once_run
-    def add_status_quo_arm(self, weight: float | None) -> BatchTrial:
+    def add_status_quo_arm(self, weight: float = 1.0) -> BatchTrial:
         """Adds the status quo arm from the Experiment to the BatchTrial with a given
         weight. This weight *overrides* any weight the status quo has from generator
         runs attached to this batch. Thus, this function is not the same as
         using add_arm, which will result in the weight being additive over all
         generator runs.
         """
+        if (status_quo := self.status_quo) is None:
+            raise ValueError(
+                "Cannot set weight because status quo is not defined on the "
+                "`Experiment`."
+            )
+
         # Assign a name to this arm if none exists
         if weight is not None:
             if weight <= 0.0:
                 raise ValueError("Status quo weight must be positive.")
-            if self.experiment.status_quo is None:
-                raise ValueError(
-                    "Cannot set weight because status quo is "
-                    "not defined on the Experiment."
-                )
             if (
                 self._status_quo_weight_override is not None
                 and weight != self._status_quo_weight_override
@@ -336,6 +346,25 @@ class BatchTrial(BaseTrial):
                     stacklevel=3,
                 )
 
+        sq_arm_already_added_with_correct_weight = False
+        for existing_arm in self.arm_weights:
+            if existing_arm.signature == status_quo.signature:
+                if float(weight) != self.arm_weights[existing_arm]:
+                    raise UnsupportedError(
+                        f"Status quo arm {existing_arm.name} is already added to the "
+                        f"trial with weight {self.arm_weights[existing_arm]}. "
+                        "Reassigning the weight is no longer supported."
+                    )
+
+                sq_arm_already_added_with_correct_weight = True
+                break
+
+        if not sq_arm_already_added_with_correct_weight:
+            self.add_arm(
+                status_quo,
+                weight=weight,
+                generator_run_type=GeneratorRunType.STATUS_QUO,
+            )
         self._status_quo_weight_override = weight
         self._refresh_arms_by_name()
         return self
@@ -389,7 +418,7 @@ class BatchTrial(BaseTrial):
     @copy_doc(BaseTrial.generator_runs)
     @property
     def generator_runs(self) -> list[GeneratorRun]:
-        return [grs.generator_run for grs in self.generator_run_structs]
+        return self._generator_runs
 
     @property
     def abandoned_arms_metadata(self) -> list[AbandonedArm]:
@@ -507,20 +536,14 @@ class BatchTrial(BaseTrial):
         new_trial = experiment.new_batch_trial(
             trial_type=None if clear_trial_type else self._trial_type,
             ttl_seconds=self._ttl_seconds,
+            generator_runs=[
+                gr if use_old_experiment else gr.clone() for gr in self.generator_runs
+            ],
+            should_add_status_quo_arm=include_sq and self.should_add_status_quo_arm,
         )
-        for struct in self._generator_run_structs:
-            if use_old_experiment:
-                # don't clone gen run in case we are attaching cloned trial to
-                # the same experiment
-                new_trial.add_generator_run(struct.generator_run)
-            else:
-                new_trial.add_generator_run(struct.generator_run.clone())
+        if (sq := self.status_quo) is not None and sq in self.arm_weights:
+            new_trial._status_quo_weight_override = self.arm_weights[sq]
 
-        if (self.status_quo is not None) and include_sq:
-            sq_weight = self._status_quo_weight_override
-            new_trial.add_status_quo_arm(
-                weight=sq_weight,
-            )
         self._update_trial_attrs_on_clone(new_trial=new_trial)
         return new_trial
 
@@ -594,8 +617,7 @@ class BatchTrial(BaseTrial):
         runs containing the arm will be retrieved.
         """
         cand_metadata = {}
-        for gr_struct in self._generator_run_structs:
-            gr = gr_struct.generator_run
+        for gr in self.generator_runs:
             if gr.candidate_metadata_by_arm_signature:
                 gr_cand_metadata = gr.candidate_metadata_by_arm_signature
                 warn = False
@@ -623,8 +645,7 @@ class BatchTrial(BaseTrial):
             raise ValueError(
                 f"Arm by name {arm_name} is not part of trial #{self.index}."
             )
-        for gr_struct in self._generator_run_structs:
-            gr = gr_struct.generator_run
+        for gr in self.generator_runs:
             if gr and gr.candidate_metadata_by_arm_signature and arm in gr.arms:
                 return none_throws(gr.candidate_metadata_by_arm_signature).get(
                     arm.signature

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -361,7 +361,6 @@ class ExperimentTest(TestCase):
         self.experiment.status_quo = Arm(sq_parameters)
         self.assertEqual(self.experiment.status_quo.parameters["w"], 3.5)
         self.assertEqual(self.experiment.status_quo.name, "status_quo_e0")
-        self.assertTrue("status_quo" not in self.experiment.arms_by_name)
 
         # Verify all None values
         self.experiment.status_quo = Arm({n: None for n in sq_parameters.keys()})
@@ -387,9 +386,9 @@ class ExperimentTest(TestCase):
         with self.assertRaises(ValueError):
             self.experiment.status_quo = Arm(sq_parameters)
 
-        # Verify arms_by_signature, arms_by_name only contains status_quo
-        self.assertEqual(len(self.experiment.arms_by_signature), 1)
-        self.assertEqual(len(self.experiment.arms_by_name), 1)
+        # Verify arms_by_signature, arms_by_name contain all three versions of the SQ
+        self.assertEqual(len(self.experiment.arms_by_signature), 3)
+        self.assertEqual(len(self.experiment.arms_by_name), 3)
 
         # Try to change status_quo after trials have been created
         _ = self.experiment.new_batch_trial(should_add_status_quo_arm=True)
@@ -1118,9 +1117,7 @@ class ExperimentTest(TestCase):
             with_completed_batch=True,
         )
         experiment.trials[0]._trial_type = "foo"
-        with self.assertRaisesRegex(
-            ValueError, "Experiment does not support trial_type foo."
-        ):
+        with self.assertRaisesRegex(ValueError, ".* foo is not supported by the exp"):
             experiment.clone_with()
         cloned_experiment = experiment.clone_with(clear_trial_type=True)
         self.assertIsNone(cloned_experiment.trials[0].trial_type)

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -41,8 +41,7 @@ class MultiTypeExperimentTest(TestCase):
         self.assertEqual(b1.run_metadata["dummy_metadata"], "dummy1")
 
         self.experiment.update_runner("type2", SyntheticRunner(dummy_metadata="dummy3"))
-        b2 = self.experiment.new_batch_trial()
-        b2.trial_type = "type2"
+        b2 = self.experiment.new_batch_trial(trial_type="type2")
         b2.add_arms_and_weights(arms=arms)
         self.assertEqual(b2.trial_type, "type2")
         b2.run()

--- a/ax/plot/diagnostic.py
+++ b/ax/plot/diagnostic.py
@@ -434,8 +434,7 @@ def interact_empirical_model_validation(batch: BatchTrial, data: Data) -> AxPlot
     """
     insample_data: dict[str, PlotInSampleArm] = {}
     metric_names = list(data.df["metric_name"].unique())
-    for struct in batch.generator_run_structs:
-        generator_run = struct.generator_run
+    for generator_run in batch.generator_runs:
         if generator_run.model_predictions is None:
             continue
         for i, arm in enumerate(generator_run.arms):

--- a/ax/plot/scatter.py
+++ b/ax/plot/scatter.py
@@ -1361,10 +1361,10 @@ def tile_fitted(
 
     for i, metric in enumerate(metrics):
         data = _single_metric_traces(
-            model,
-            metric,
-            generator_runs_dict,
-            rel,
+            model=model,
+            metric=metric,
+            generator_runs_dict=generator_runs_dict,
+            rel=rel,
             showlegend=i == 0,
             show_arm_details_on_hover=show_arm_details_on_hover,
             show_CI=show_CI,

--- a/ax/plot/tests/test_tile_fitted.py
+++ b/ax/plot/tests/test_tile_fitted.py
@@ -187,13 +187,13 @@ class TileObservationsTest(TestCase):
         )
 
         # Data
-        self.assertEqual(config.data["data"][0]["x"], ["0_0", "0_1"])
-        self.assertEqual(config.data["data"][0]["y"], [3.0, 2.0])
+        self.assertEqual(config.data["data"][0]["x"], ["0_0"])
+        self.assertEqual(config.data["data"][0]["y"], [3.0])
         self.assertEqual(config.data["data"][0]["type"], "scatter")
         self.assertIn("Arm 0_0", config.data["data"][0]["text"][0])
 
         label_dict = {"ax_test_metric": "mapped_name"}
         config = tile_observations(
-            experiment=exp, arm_names=["0_0", "0_1"], rel=False, label_dict=label_dict
+            experiment=exp, arm_names=["0_0"], rel=False, label_dict=label_dict
         )
         self.assertEqual(config.data["layout"]["annotations"][0]["text"], "mapped_name")

--- a/ax/service/orchestrator.py
+++ b/ax/service/orchestrator.py
@@ -1636,11 +1636,9 @@ class Orchestrator(AnalysisBase, BestPointMixin):
                     generator_runs=generator_run_list,
                     ttl_seconds=self.options.ttl_seconds_for_trials,
                     trial_type=self.trial_type,
+                    should_add_status_quo_arm=self.options.status_quo_weight > 0,
                 )
-                if self.options.status_quo_weight > 0:
-                    trial.add_status_quo_arm(
-                        weight=self.options.status_quo_weight,
-                    )
+
             else:
                 trial = self.experiment.new_trial(
                     generator_run=generator_run_list[0],

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -115,7 +115,7 @@ class TestBestPointMixin(TestCase):
         self.assertEqual(get_trace(exp), [])
 
         # test batch trial
-        exp = get_experiment_with_batch_trial()
+        exp = get_experiment_with_batch_trial(with_status_quo=False)
         trial = exp.trials[0]
         exp.optimization_config.outcome_constraints[0].relative = False
         trial.mark_running(no_runner_required=True).mark_completed()
@@ -134,10 +134,10 @@ class TestBestPointMixin(TestCase):
                 ]
             )
         exp.attach_data(Data(df=pd.DataFrame.from_records(df_dict)))
-        self.assertEqual(get_trace(exp), [len(trial.arms) - 2])
+        self.assertEqual(get_trace(exp), [2.0])
         # test that there is performance metric in the trace for each
         # completed/early-stopped trial
-        trial1 = assert_is_instance(trial, BatchTrial).clone_to()
+        trial1 = assert_is_instance(trial, BatchTrial).clone_to(include_sq=False)
         trial1.mark_abandoned(unsafe=True)
         trial2 = exp.new_batch_trial(Generators.SOBOL(experiment=exp).gen(n=3))
         trial2.mark_running(no_runner_required=True).mark_completed()
@@ -156,7 +156,7 @@ class TestBestPointMixin(TestCase):
                 ]
             )
         exp.attach_data(Data(df=pd.DataFrame.from_records(df_dict2)))
-        self.assertEqual(get_trace(exp), [2, 20.0])
+        self.assertEqual(get_trace(exp), [2.0, 20.0])
 
     def test_get_hypervolume(self) -> None:
         # W/ empty data.

--- a/ax/service/tests/test_best_point_utils.py
+++ b/ax/service/tests/test_best_point_utils.py
@@ -30,7 +30,7 @@ from ax.core.optimization_config import (
 )
 from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.types import ComparisonOp
-from ax.exceptions.core import DataRequiredError
+from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.generation_strategy.dispatch_utils import choose_generation_strategy_legacy
 from ax.service.ax_client import AxClient
 from ax.service.utils.best_point import (
@@ -857,7 +857,7 @@ class TestBestPointUtils(TestCase):
         )
 
         with self.assertRaisesRegex(
-            ValueError,
+            UserInputError,
             "Could not find valid baseline arm.",
         ):
             select_baseline_name_default_first_trial(

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -1993,7 +1993,7 @@ class TestAxOrchestrator(TestCase):
             db_settings=self.db_settings_if_always_needed,
         )
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(UserInputError):
             orchestrator.get_improvement_over_baseline(
                 experiment=orchestrator.experiment,
                 generation_strategy=orchestrator.generation_strategy,

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -278,9 +278,9 @@ def get_best_parameters_from_model_predictions_with_trial_index(
         if isinstance(trial, Trial):
             gr = trial.generator_run
         elif isinstance(trial, BatchTrial):
-            if len(trial.generator_run_structs) > 0:
+            if len(trial.generator_runs) > 0:
                 # In theory batch_trial can have >1 gr, grab the first
-                gr = trial.generator_run_structs[0].generator_run
+                gr = trial.generator_runs[0]
         if gr is not None:
             break
 

--- a/ax/service/utils/best_point_utils.py
+++ b/ax/service/utils/best_point_utils.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 from ax.core.experiment import Experiment
+from ax.exceptions.core import UserInputError
 from pyre_extensions import none_throws
 
 BASELINE_ARM_NAME = "baseline_arm"
@@ -50,5 +51,4 @@ def select_baseline_name_default_first_trial(
         baseline_arm_name = experiment.trials[0].arms[0].name
         return baseline_arm_name, True
 
-    else:
-        raise ValueError("Could not find valid baseline arm.")
+    raise UserInputError("Could not find valid baseline arm.")

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -129,7 +129,7 @@ def batch_to_dict(batch: BatchTrial) -> dict[str, Any]:
         "failed_reason": batch.failed_reason,
         "run_metadata": batch.run_metadata,
         "stop_metadata": batch.stop_metadata,
-        "generator_run_structs": batch.generator_run_structs,
+        "generator_runs": batch.generator_runs,
         "runner": batch.runner,
         "abandoned_arms_metadata": batch._abandoned_arms_metadata,
         "num_arms_created": batch._num_arms_created,

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -26,7 +26,7 @@ from ax.benchmark.benchmark_trial_metadata import BenchmarkTrialMetadata
 from ax.core import Experiment, ObservationFeatures
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
-from ax.core.batch_trial import AbandonedArm, BatchTrial, GeneratorRunStruct
+from ax.core.batch_trial import AbandonedArm, BatchTrial
 from ax.core.data import Data
 from ax.core.experiment import DataType
 from ax.core.generator_run import GeneratorRun
@@ -346,7 +346,6 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "GenerationStrategy": GenerationStrategy,
     "GenerationStep": GenerationStep,
     "GeneratorRun": GeneratorRun,
-    "GeneratorRunStruct": GeneratorRunStruct,
     "Generators": Generators,
     "GeneratorSpec": GeneratorSpec,
     "Hartmann6Metric": Hartmann6Metric,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -297,6 +297,7 @@ TEST_CASES = [
     ("MultiObjective", get_multi_objective),
     ("MultiObjectiveOptimizationConfig", get_multi_objective_optimization_config),
     ("MultiTypeExperiment", get_multi_type_experiment),
+    ("MultiTypeExperiment", partial(get_multi_type_experiment, add_trials=True)),
     ("ObservationFeatures", get_observation_features),
     ("Objective", get_objective),
     ("ObjectiveThreshold", get_objective_threshold),

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -219,7 +219,7 @@ class SQAStoreTest(TestCase):
     def test_GeneratorRunTypeValidation(self) -> None:
         experiment = get_experiment_with_batch_trial()
         # pyre-fixme[16]: `BaseTrial` has no attribute `generator_run_structs`.
-        generator_run = experiment.trials[0].generator_run_structs[0].generator_run
+        generator_run = experiment.trials[0].generator_runs[0]
         generator_run._generator_run_type = "foobar"
         with self.assertRaises(SQAEncodeError):
             self.encoder.generator_run_to_sqa(generator_run)
@@ -236,7 +236,7 @@ class SQAStoreTest(TestCase):
     def test_GeneratorRunBestArm(self) -> None:
         experiment = self.experiment
 
-        generator_run = experiment.trials[0].generator_run_structs[0].generator_run
+        generator_run = experiment.trials[0].generator_runs[0]
         generator_run._generator_run_type = "STATUS_QUO"
 
         arm = get_arm()
@@ -253,7 +253,7 @@ class SQAStoreTest(TestCase):
     def test_GeneratorRunNoBestArm(self) -> None:
         experiment = self.experiment
 
-        generator_run = experiment.trials[0].generator_run_structs[0].generator_run
+        generator_run = experiment.trials[0].generator_runs[0]
         generator_run._generator_run_type = "STATUS_QUO"
         generator_run._best_arm_predictions = None
 
@@ -265,7 +265,7 @@ class SQAStoreTest(TestCase):
     def test_GeneratorRunNoBestArmPredictions(self) -> None:
         experiment = self.experiment
 
-        generator_run = experiment.trials[0].generator_run_structs[0].generator_run
+        generator_run = experiment.trials[0].generator_runs[0]
         generator_run._generator_run_type = "STATUS_QUO"
 
         arm = get_arm()
@@ -2327,7 +2327,7 @@ class SQAStoreTest(TestCase):
             should_add_status_quo_arm=True,
         )
         save_experiment(experiment)
-        self.assertEqual(get_session().query(SQAArm).count(), 9)
+        self.assertEqual(get_session().query(SQAArm).count(), 8)
 
         loaded_experiment = load_experiment(experiment.name)
         self.assertEqual(experiment, loaded_experiment)

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -436,7 +436,8 @@ class TestCase(fake_filesystem_unittest.TestCase):
         for field in b:
             a_field = a[field]
             b_field = b[field]
-            msg = f"Dict values differ for key {field}: {a[field]=}, {b[field]=}."
+            msg = f"Dict values differ for key {field}: {a}[{field}]={a[field]}"
+            msg += f"{b}[{field}]={b[field]}."
             # for floating point values, compare approximately and consider NaNs equal
             if isinstance(a_field, float):
                 if consider_nans_equal and np.isnan(a_field):


### PR DESCRIPTION
Summary:
This changeset accomplishes two things (unfortunately deeply intertwined so hard to untangle):

1. Deprecate and remove `GeneratorRunStruct` (unnecessary wrapper),
2. Start adding the SQ arm as an actual `GeneratorRun` (previously we would hack a generator run into the trial during storage and perform SQ additions all throughout the `BatchTrial` class, which was difficult to reason about and prevented migration to direct association between arms and trials.

Differential Revision: D80304993


