### PR TITLE
[Website][Tutorials] Handle multiple image paths in same md doc

### DIFF
--- a/scripts/convert_ipynb_to_mdx.py
+++ b/scripts/convert_ipynb_to_mdx.py
@@ -282,22 +282,20 @@ def handle_image_paths_found_in_markdown(
     if not searches:
         return markdown
 
-    # Convert the given Markdown to a list so we can delete the old path with the new
-    # standard path.
-    markdown_list = list(markdown)
-    for search in searches:
+    # Process searches in reverse order so that each replacement doesn't affect the
+    # start/end indices for the next replacements
+    for search in reversed(searches):
         # Find the old image path and replace it with the new one.
         old_path, _ = search.groups()
-        start = 0
-        end = 0
-        search = re.search(old_path, markdown)
-        if search is not None:
-            start, end = search.span()
+        # Get the span of the old_path within the full match
+        start, end = search.span(1)
+
         old_path = Path(old_path)
         name = old_path.name.strip()
         new_path = f"assets/img/{name}"
-        del markdown_list[start:end]
-        markdown_list.insert(start, new_path)
+
+        # Replace the old path with the new path in the markdown
+        markdown = markdown[:start] + new_path + markdown[end:]
 
         # Copy the original image to the new location.
         if old_path.exists():
@@ -309,7 +307,7 @@ def handle_image_paths_found_in_markdown(
         new_img_path = str(new_img_dir / name)
         shutil.copy(str(old_img_path), new_img_path)
 
-    return "".join(markdown_list)
+    return markdown
 
 
 def transform_style_attributes(markdown: str) -> str:


### PR DESCRIPTION
The ipynb to mdx conversion script has a step to copy images to the mdx destination and update the relative image paths. The issue was that modifying the md buffer causes the static regex match indices to become out of date.

The fix here here is to process the matches in reverse order, that way modifications at the end of the buffer don't affect the indices for the next replacements (which are earlier in the buffer). This is the same solution used in the `handle_image_attachments()` function which experienced a similar problem

@eonofrey found this issue while adding images to a tutorial in f2186fd9fbbfc403c443e80d7cbc5011f9bb376b

| Before    | After |
| -------- | ------- |
|        <img width="1290" height="722" alt="image" src="https://github.com/user-attachments/assets/8c68e78c-c78e-4c61-87e7-3610a2229372" />         |     <img width="1296" height="1308" alt="image" src="https://github.com/user-attachments/assets/f5abea10-af97-41f7-9a9c-8c21c28d7a25" />       |
