### PR TITLE
Deprecate nearly all internal SQA classes (now that legacy PTS is reaped)

### DIFF
--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -483,8 +483,7 @@ class TorchAdapterTest(TestCase):
         exp = get_branin_experiment(with_status_quo=True, with_completed_batch=True)
         # Check that the metadata is correctly re-added to observation
         # features during `fit`.
-        # pyre-fixme[16]: `BaseTrial` has no attribute `_generator_run_structs`.
-        preexisting_batch_gr = exp.trials[0]._generator_runs[0]
+        preexisting_batch_gr = exp.trials[0].generator_runs[0]
         preexisting_batch_gr._candidate_metadata_by_arm_signature = {
             preexisting_batch_gr.arms[0].signature: {
                 "preexisting_batch_cand_metadata": "some_value"

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -1043,8 +1043,16 @@ class Encoder:
         )
         return trial_sqa
 
-    def experiment_data_to_sqa(self, experiment: Experiment) -> list[SQAData]:
-        """Convert Ax experiment data to SQLAlchemy."""
+    def experiment_data_to_sqa(
+        self,
+        experiment: Experiment,
+    ) -> list[SQAData]:
+        if (
+            experiment.experiment_type
+            in self.config.EXPERIMENT_TYPES_WITH_NO_DATA_STORAGE
+        ):
+            return []
+
         return [
             self.data_to_sqa(data=data, trial_index=trial_index, timestamp=timestamp)
             for trial_index, data_by_timestamp in experiment.data_by_trial.items()

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -218,7 +218,6 @@ class SQAStoreTest(TestCase):
 
     def test_GeneratorRunTypeValidation(self) -> None:
         experiment = get_experiment_with_batch_trial()
-        # pyre-fixme[16]: `BaseTrial` has no attribute `generator_run_structs`.
         generator_run = experiment.trials[0].generator_runs[0]
         generator_run._generator_run_type = "foobar"
         with self.assertRaises(SQAEncodeError):


### PR DESCRIPTION
Summary:
Still figuring out if this is entirely safe, but I _think_ we can lose most of our internal-only SQA classes, because they were meant to accommodate analysis run and scheduler, which we no longer have (now that we deprecated legacy PTS)! Woohoo!

Curious what folks think : )

Differential Revision: D80175881


