### PR TITLE
Remove `BatchTrial._status_quo` attribute

### DIFF
--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -573,7 +573,7 @@ class BaseAdapterTest(TestCase):
         sobol_run = sobol_generator.gen(n=5)
         exp.new_batch_trial(
             sobol_run, should_add_status_quo_arm=False
-        ).add_status_quo_arm(status_quo=exp.status_quo, weight=1.0).run()
+        ).add_status_quo_arm(weight=1.0).run()
 
         # create data where metrics vary in start and end times
         data = get_non_monolithic_branin_moo_data()

--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -33,12 +33,11 @@ from ax.adapter.transforms.standardize_y import StandardizeY
 from ax.adapter.transforms.unit_x import UnitX
 from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
-from ax.core.batch_trial import BatchTrial
 from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
 from ax.core.metric import Metric
 from ax.core.objective import Objective, ScalarizedObjective
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import ComparisonOp, OutcomeConstraint
 from ax.core.parameter import ParameterType, RangeParameter
@@ -61,7 +60,6 @@ from ax.utils.testing.core_stubs import (
     get_branin_optimization_config,
     get_experiment,
     get_experiment_with_observations,
-    get_experiment_with_repeated_arms,
     get_map_metric,
     get_non_monolithic_branin_moo_data,
     get_optimization_config_no_constraints,
@@ -77,7 +75,7 @@ from ax.utils.testing.modeling_stubs import (
 from botorch.exceptions.warnings import InputDataWarning
 from botorch.models.utils.assorted import validate_input_scaling
 from pandas.testing import assert_frame_equal
-from pyre_extensions import assert_is_instance, none_throws
+from pyre_extensions import none_throws
 
 ADAPTER__GEN_PATH: str = "ax.adapter.base.Adapter._gen"
 
@@ -584,29 +582,6 @@ class BaseAdapterTest(TestCase):
         # Check that SQ is set.
         self.assertEqual(adapter.status_quo_name, "status_quo")
         self.assertIsNotNone(adapter.status_quo)
-
-    def test_set_status_quo_with_multiple_trials_with_status_quo(self) -> None:
-        exp = get_experiment_with_repeated_arms(with_data=True)
-        exp.status_quo = assert_is_instance(exp.trials[1], BatchTrial).status_quo
-        adapter = Adapter(experiment=exp, generator=Generator())
-        # Check that for experiments with many trials the status quo is set
-        # to the value of the status quo of the last trial (target trial).
-        self.assertEqual(
-            adapter.status_quo,
-            Observation(
-                features=ObservationFeatures(
-                    parameters={"w": 0.85, "x": 1, "y": "baz", "z": False, "d": 2.7},
-                    trial_index=get_target_trial_index(experiment=exp),
-                    metadata={},
-                ),
-                data=ObservationData(
-                    means=np.array([2.0, 4.0]),
-                    covariance=np.array([[1.0, 0.0], [0.0, 16.0]]),
-                    metric_names=["a", "b"],
-                ),
-                arm_name="0_0",
-            ),
-        )
 
     def test_set_status_quo_with_multiple_observations(self) -> None:
         # Test for the case where the status quo arm has multiple observations

--- a/ax/adapter/tests/test_utils.py
+++ b/ax/adapter/tests/test_utils.py
@@ -49,7 +49,7 @@ class TestAdapterUtils(TestCase):
         self.trial = self.experiment.new_trial(GeneratorRun([self.arm]))
         self.experiment_2 = get_experiment()
         self.batch_trial = self.experiment_2.new_batch_trial(GeneratorRun([self.arm]))
-        self.batch_trial.add_status_quo_arm(self.experiment_2.status_quo, 1)
+        self.batch_trial.add_status_quo_arm(1)
         self.obs_feat = ObservationFeatures.from_arm(
             arm=self.trial.arm, trial_index=self.trial.index
         )

--- a/ax/adapter/transforms/tests/test_derelativize_transform.py
+++ b/ax/adapter/transforms/tests/test_derelativize_transform.py
@@ -91,8 +91,12 @@ class DerelativizeTransformTest(TestCase):
             ]
         )
         experiment.search_space = search_space
-        experiment.status_quo = Arm(parameters={"x": 2.0, "y": 10.0}, name="0_0")
-        g = Adapter(experiment=experiment, generator=Generator())
+        # clone experiment since we can't overwrite sq in subsequent tests
+        experiment_1 = experiment.clone_with(
+            name="experiment_1",
+            status_quo=Arm(parameters={"x": 2.0, "y": 10.0}, name="0_0"),
+        )
+        g = Adapter(experiment=experiment_1, generator=Generator())
 
         # Test with no relative constraints
         objective = Objective(Metric("c"), minimize=True)
@@ -167,8 +171,11 @@ class DerelativizeTransformTest(TestCase):
 
         # Test with relative constraint, out-of-design status quo
         mock_predict.side_effect = RuntimeError()
-        experiment.status_quo = Arm(parameters={"x": None, "y": None}, name="1_0")
-        g = Adapter(experiment=experiment, generator=Generator())
+        experiment_2 = experiment.clone_with(
+            name="experiment_2",
+            status_quo=Arm(parameters={"x": None, "y": None}, name="1_0"),
+        )
+        g = Adapter(experiment=experiment_2, generator=Generator())
         oc = OptimizationConfig(
             objective=objective,
             outcome_constraints=[
@@ -211,8 +218,12 @@ class DerelativizeTransformTest(TestCase):
         self.assertEqual(mock_predict.call_count, 1)
 
         # Raises error if predict fails with in-design status quo
-        experiment.status_quo = Arm(parameters={"x": 2.0, "y": 10.0}, name="0_0")
-        g = Adapter(experiment=experiment, generator=Generator())
+        experiment_3 = experiment.clone_with(name="experiment_3")
+        experiment_3 = experiment.clone_with(
+            name="experiment_3",
+            status_quo=Arm(parameters={"x": 2.0, "y": 10.0}, name="0_0"),
+        )
+        g = Adapter(experiment=experiment_3, generator=Generator())
         oc = OptimizationConfig(
             objective=objective,
             outcome_constraints=[

--- a/ax/analysis/healthcheck/tests/test_constraints_feasibility.py
+++ b/ax/analysis/healthcheck/tests/test_constraints_feasibility.py
@@ -77,7 +77,7 @@ class TestConstraintsFeasibilityAnalysis(TestCase):
         batch_trial = assert_is_instance(experiment.trials[0], BatchTrial)
 
         batch_trial.add_arm(experiment.status_quo)
-        batch_trial.add_status_quo_arm(status_quo=experiment.status_quo, weight=1.0)
+        batch_trial.add_status_quo_arm(weight=1.0)
         experiment.trials[0].mark_running(no_runner_required=True)
         experiment.trials[0].mark_completed()
 

--- a/ax/analysis/plotly/tests/test_arm_effects.py
+++ b/ax/analysis/plotly/tests/test_arm_effects.py
@@ -389,9 +389,7 @@ class TestArmEffectsPlotRel(TestCase):
                 generator_runs=self.generation_strategy._gen_with_multiple_nodes(
                     experiment=self.experiment, n=3
                 )
-            ).add_status_quo_arm(
-                status_quo=self.experiment.status_quo, weight=1.0
-            ).mark_completed(unsafe=True)
+            ).add_status_quo_arm(weight=1.0).mark_completed(unsafe=True)
             self.experiment.fetch_data()
 
     def test_compute_with_relativize(self) -> None:

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -284,6 +284,12 @@ class Experiment(Base):
 
     @status_quo.setter
     def status_quo(self, status_quo: Arm | None) -> None:
+        # Make status_quo immutable once any trial has been created.
+        if self._status_quo is not None and len(self.trials) > 0:
+            raise UnsupportedError(
+                "Modifications of status_quo are disabled after trials have been "
+                "created."
+            )
         if status_quo is not None:
             self.search_space.check_types(
                 parameterization=status_quo.parameters,

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -59,7 +59,7 @@ class UtilsTest(TestCase):
         self.trial = self.experiment.new_trial(GeneratorRun([self.arm]))
         self.experiment_2 = get_experiment()
         self.batch_trial = self.experiment_2.new_batch_trial(GeneratorRun([self.arm]))
-        self.batch_trial.add_status_quo_arm(self.experiment_2.status_quo, 1)
+        self.batch_trial.add_status_quo_arm(weight=1)
         self.obs_feat = ObservationFeatures.from_arm(
             arm=self.trial.arm, trial_index=self.trial.index
         )
@@ -589,7 +589,7 @@ class UtilsTest(TestCase):
         )
         exp.status_quo = in_design_status_quo
         batch = exp.new_batch_trial().add_arm(self.arm)
-        batch.add_status_quo_arm(exp.status_quo, 1)
+        batch.add_status_quo_arm(weight=1)
         self.assertEqual(batch.status_quo, in_design_status_quo)
         self.assertTrue(
             exp.search_space.check_membership(

--- a/ax/generation_strategy/tests/test_generation_node_input_constructors.py
+++ b/ax/generation_strategy/tests/test_generation_node_input_constructors.py
@@ -549,7 +549,6 @@ class TestGenerationNodeInputConstructors(TestCase):
             if experiment.status_quo is None:
                 experiment.status_quo = Arm(parameters={"x1": 0, "x2": 0})
             trial.add_status_quo_arm(
-                status_quo=self.experiment.status_quo,
                 weight=1.0,
             )
         trial.run()

--- a/ax/generation_strategy/tests/test_generation_node_input_constructors.py
+++ b/ax/generation_strategy/tests/test_generation_node_input_constructors.py
@@ -546,7 +546,8 @@ class TestGenerationNodeInputConstructors(TestCase):
             generator_runs=grs,
         )
         if with_status_quo:
-            experiment.status_quo = Arm(parameters={"x1": 0, "x2": 0})
+            if experiment.status_quo is None:
+                experiment.status_quo = Arm(parameters={"x1": 0, "x2": 0})
             trial.add_status_quo_arm(
                 status_quo=self.experiment.status_quo,
                 weight=1.0,

--- a/ax/service/orchestrator.py
+++ b/ax/service/orchestrator.py
@@ -1639,7 +1639,6 @@ class Orchestrator(AnalysisBase, BestPointMixin):
                 )
                 if self.options.status_quo_weight > 0:
                     trial.add_status_quo_arm(
-                        status_quo=self.experiment.status_quo,
                         weight=self.options.status_quo_weight,
                     )
             else:

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -134,7 +134,7 @@ class TestBestPointMixin(TestCase):
                 ]
             )
         exp.attach_data(Data(df=pd.DataFrame.from_records(df_dict)))
-        self.assertEqual(get_trace(exp), [len(trial.arms) - 1])
+        self.assertEqual(get_trace(exp), [len(trial.arms) - 2])
         # test that there is performance metric in the trace for each
         # completed/early-stopped trial
         trial1 = assert_is_instance(trial, BatchTrial).clone_to()

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -1981,6 +1981,7 @@ class TestAxOrchestrator(TestCase):
         experiment.runner = self.runner
 
         gs = self.two_sobol_steps_GS
+        self.branin_experiment.status_quo = None
         orchestrator = Orchestrator(
             experiment=self.branin_experiment,  # Has runner and metrics.
             generation_strategy=gs,

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -106,7 +106,6 @@ def batch_trial_from_json(
     batch._runner = runner
     batch._abandoned_arms_metadata = abandoned_arms_metadata
     batch._num_arms_created = num_arms_created
-    batch._status_quo = status_quo
     batch._status_quo_weight_override = status_quo_weight_override
     batch._generation_step_index = generation_step_index
     batch._properties = properties

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1004,7 +1004,6 @@ class Decoder:
                         == GeneratorRunType.STATUS_QUO.name
                     ):
                         status_quo_weight = struct.generator_run.weights[0]
-                        trial._status_quo = struct.generator_run.arms[0]
                         trial._status_quo_weight_override = status_quo_weight
                         trial._status_quo_generator_run_db_id = (
                             struct.generator_run.db_id

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -1016,7 +1016,7 @@ class SQAStoreTest(TestCase):
         )
 
     def test_ExperimentUpdates(self) -> None:
-        experiment = get_experiment_with_batch_trial()
+        experiment = get_experiment()
         save_experiment(experiment)
         self.assertEqual(get_session().query(SQAExperiment).count(), 1)
 
@@ -2318,10 +2318,11 @@ class SQAStoreTest(TestCase):
         # we create completely new arms in DB for the
         # new trials
         experiment.new_batch_trial(
-            generator_run=GeneratorRun(arms=experiment.trials[0].arms)
+            generator_run=GeneratorRun(arms=experiment.trials[0].arms),
+            should_add_status_quo_arm=True,
         )
         save_experiment(experiment)
-        self.assertEqual(get_session().query(SQAArm).count(), 7)
+        self.assertEqual(get_session().query(SQAArm).count(), 9)
 
         loaded_experiment = load_experiment(experiment.name)
         self.assertEqual(experiment, loaded_experiment)

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -1016,7 +1016,7 @@ class SQAStoreTest(TestCase):
         )
 
     def test_ExperimentUpdates(self) -> None:
-        experiment = get_experiment()
+        experiment = get_experiment(with_status_quo=False)
         save_experiment(experiment)
         self.assertEqual(get_session().query(SQAExperiment).count(), 1)
 
@@ -2310,7 +2310,7 @@ class SQAStoreTest(TestCase):
             )
 
     def test_RepeatedArmStorage(self) -> None:
-        experiment = get_experiment_with_batch_trial()
+        experiment = get_experiment_with_batch_trial(with_status_quo=True)
         save_experiment(experiment)
         self.assertEqual(get_session().query(SQAArm).count(), 4)
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -776,6 +776,10 @@ def get_experiment_with_repeated_arms(with_data: bool = False) -> Experiment:
                         ("0_1", "b", 4.0, 4.0, 0),
                         ("0_1", "a", 2.0, 1.0, 1),
                         ("0_1", "b", 1.0, 5.0, 1),
+                        ("status_quo", "a", 2.0, 1.0, 0),
+                        ("status_quo", "b", 4.0, 4.0, 0),
+                        ("status_quo", "a", 2.0, 1.0, 1),
+                        ("status_quo", "b", 4.0, 4.0, 1),
                     )
                 ]
             )
@@ -1876,14 +1880,13 @@ def get_batch_trial(
     experiment = experiment or get_experiment(
         constrain_search_space=constrain_search_space
     )
-    batch = experiment.new_batch_trial()
+    batch = experiment.new_batch_trial(should_add_status_quo_arm=True)
     arms = get_arms_from_dict(get_arm_weights1())
     weights = get_weights_from_dict(get_arm_weights1())
     batch.add_arms_and_weights(arms=arms, weights=weights)
     if abandon_arm:
         batch.mark_arm_abandoned(batch.arms[2].name, "abandoned reason")
     batch.runner = SyntheticRunner()
-    batch.add_status_quo_arm(status_quo=arms[0], weight=0.5)
     batch.should_add_status_quo_arm = True
     batch._generation_step_index = 0
     return batch
@@ -1924,10 +1927,9 @@ def get_batch_trial_with_repeated_arms(num_repeated_arms: int) -> BatchTrial:
     # Add num_repeated_arms to the new trial.
     arms = prev_arms + next_arms
     weights = prev_weights + next_weights
-    batch = experiment.new_batch_trial()
+    batch = experiment.new_batch_trial(should_add_status_quo_arm=True)
     batch.add_arms_and_weights(arms=arms, weights=weights)
     batch.runner = SyntheticRunner()
-    batch.add_status_quo_arm(status_quo=arms[0], weight=0.5)
     return batch
 
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -406,7 +406,7 @@ def get_branin_experiment_with_status_quo_trials(
     for _ in range(num_sobol_trials):
         sobol_run = sobol.gen(n=1)
         t = exp.new_batch_trial().add_generator_run(sobol_run)
-        t.add_status_quo_arm(status_quo=exp.status_quo, weight=0.5)
+        t.add_status_quo_arm(weight=0.5)
         exp.attach_data(get_branin_data_batch(batch=t))
         t.run().mark_completed()
     return exp
@@ -656,6 +656,7 @@ def get_multi_type_experiment(
         default_trial_type="type1",
         default_runner=SyntheticRunner(dummy_metadata="dummy1"),
         optimization_config=oc,
+        status_quo=Arm(parameters={"x1": 0.0, "x2": 0.0}),
     )
     experiment._properties = {"owners": [DEFAULT_USER]}
     experiment.add_trial_type(
@@ -671,8 +672,8 @@ def get_multi_type_experiment(
         gr = generator.gen(num_arms)
         t1 = experiment.new_batch_trial(generator_run=gr, trial_type="type1")
         t2 = experiment.new_batch_trial(generator_run=gr, trial_type="type2")
-        t1.add_status_quo_arm(status_quo=t1.arms[0], weight=0.5)
-        t2.add_status_quo_arm(status_quo=t2.arms[0], weight=0.5)
+        t1.add_status_quo_arm(weight=0.5)
+        t2.add_status_quo_arm(weight=0.5)
         t1.run()
         t2.run()
 
@@ -700,8 +701,8 @@ def get_multi_type_experiment_with_multi_objective(
         gr = generator.gen(10)
         t1 = experiment.new_batch_trial(generator_run=gr, trial_type="type1")
         t2 = experiment.new_batch_trial(generator_run=gr, trial_type="type2")
-        t1.add_status_quo_arm(status_quo=t1.arms[0], weight=0.5)
-        t2.add_status_quo_arm(status_quo=t2.arms[0], weight=0.5)
+        t1.add_status_quo_arm(weight=0.5)
+        t2.add_status_quo_arm(weight=0.5)
         t1.run()
         t2.run()
 
@@ -802,8 +803,12 @@ def get_experiment_with_trial() -> Experiment:
     return trial.experiment
 
 
-def get_experiment_with_batch_trial(constrain_search_space: bool = True) -> Experiment:
-    batch_trial = get_batch_trial(constrain_search_space=constrain_search_space)
+def get_experiment_with_batch_trial(
+    constrain_search_space: bool = True, with_status_quo: bool = True
+) -> Experiment:
+    batch_trial = get_batch_trial(
+        constrain_search_space=constrain_search_space, with_status_quo=with_status_quo
+    )
     return batch_trial.experiment
 
 
@@ -1876,9 +1881,10 @@ def get_batch_trial(
     abandon_arm: bool = True,
     experiment: Experiment | None = None,
     constrain_search_space: bool = True,
+    with_status_quo: bool = True,
 ) -> BatchTrial:
     experiment = experiment or get_experiment(
-        constrain_search_space=constrain_search_space
+        constrain_search_space=constrain_search_space, with_status_quo=with_status_quo
     )
     batch = experiment.new_batch_trial(should_add_status_quo_arm=True)
     arms = get_arms_from_dict(get_arm_weights1())

--- a/ax/utils/testing/preference_stubs.py
+++ b/ax/utils/testing/preference_stubs.py
@@ -103,7 +103,7 @@ def get_pbo_experiment(
     param_bounds = [10.0, 30.0] if not unbounded_search_space else [-1e9, 1e9]
     if include_sq:
         sq = {param_name: np.mean(param_bounds) for param_name in parameter_names}
-        sq_arm = Arm(parameters=sq)
+        sq_arm = Arm(parameters=sq, name="status_quo")
     else:
         sq = None
         sq_arm = None


### PR DESCRIPTION
Summary:
Deprecate `BatchTrial._status_quo`

1. Rename `BatchTrial.add_status_quo_arm` attribute to `should_add_status_quo_arm`
2. Rename `BatchTrial.set_status_quo_with_weight` to `BatchTrial.add_status_quo_arm`
3. Remove `BatchTrial._status_quo` attribute and replace it with a deprecation warning to use `Experiment.status_quo`

Differential Revision: D79389272
