### PR TITLE
Introduce Metric.has_map_data property for use in MapData-related gating logic

### DIFF
--- a/ax/adapter/data_utils.py
+++ b/ax/adapter/data_utils.py
@@ -418,7 +418,7 @@ def _extract_observation_data(
     for metric in experiment.metrics.values():
         valid_statuses = (
             data_loader_config.statuses_to_fit_map_metric
-            if isinstance(metric, MapMetric)
+            if isinstance(metric, MapMetric) and metric.has_map_data
             else data_loader_config.statuses_to_fit
         )
         to_keep |= (df["metric_name"] == metric.name) & trial_statuses.isin(

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -404,10 +404,7 @@ class Experiment(Base):
             for metric_name in metrics_to_track:
                 self.add_tracking_metric(prev_optimization_config.metrics[metric_name])
 
-        if any(
-            isinstance(metric, MapMetric)
-            for metric in optimization_config.metrics.values()
-        ):
+        if any(metric.has_map_data for metric in optimization_config.metrics.values()):
             self._default_data_type = DataType.MAP_DATA
 
     @property
@@ -464,7 +461,7 @@ class Experiment(Base):
                 "before adding it to tracking metrics."
             )
 
-        if isinstance(metric, MapMetric):
+        if metric.has_map_data:
             self._default_data_type = DataType.MAP_DATA
 
         self._tracking_metrics[metric.name] = metric

--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -20,6 +20,7 @@ from logging import Logger
 from typing import Any, TYPE_CHECKING
 
 from ax.core.data import Data
+from ax.core.map_data import MapData
 from ax.utils.common.base import SortableBase
 from ax.utils.common.logger import get_logger
 from ax.utils.common.result import Err, Ok, Result, UnwrapError
@@ -389,6 +390,10 @@ class Metric(SortableBase, SerializationMixin):
             for trial_index, results_by_metric_name in trials_results.items()
         }
         return results, contains_new_data
+
+    @property
+    def has_map_data(self) -> bool:
+        return issubclass(self.data_constructor, MapData)
 
     @property
     def _unique_id(self) -> str:

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -414,7 +414,7 @@ def _filter_data_on_status(
         metric = experiment.metrics[metric_name]
         statuses_to_include_metric = (
             statuses_to_include_map_metric
-            if isinstance(metric, MapMetric)
+            if isinstance(metric, MapMetric) and metric.has_map_data
             else statuses_to_include
         )
         if trial_status is not None and trial_status not in statuses_to_include_metric:

--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -664,7 +664,7 @@ def extract_map_keys_from_opt_config(
     map_metrics = {
         name: metric
         for name, metric in optimization_config.metrics.items()
-        if isinstance(metric, MapMetric)
+        if isinstance(metric, MapMetric) and metric.has_map_data
     }
     map_key_names = {m.map_key_info.key for m in map_metrics.values()}
     return map_key_names

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -425,7 +425,9 @@ def get_standard_plots(
     try:
         logger.debug("Starting MapMetric plots.")
         map_metrics = [
-            m for m in experiment.metrics.values() if isinstance(m, MapMetric)
+            m
+            for m in experiment.metrics.values()
+            if isinstance(m, MapMetric) and m.has_map_data
         ]
         if map_metrics:
             # Sort so that objective metrics appear first


### PR DESCRIPTION
Summary: Some Ax logic is gated on whether a metric inherits from MapMetric or not, whereas a more accurate test is whether the metric produces MapData or not. This should be a no-op for open-source use-cases.

Differential Revision: D80838237


