### PR TITLE
Soft-deprecate combine_with_last_data arg, setting it as `not overwrite_existing_data`

### DIFF
--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -627,10 +627,7 @@ class BaseAdapterTest(TestCase):
             if additional_fetch:
                 # Fetch constraint metric an additional time. This will lead to two
                 # separate observations for the status quo arm.
-                exp.fetch_data(
-                    metrics=[exp.metrics["branin_map_constraint"]],
-                    combine_with_last_data=True,
-                )
+                exp.fetch_data(metrics=[exp.metrics["branin_map_constraint"]])
             with self.assertNoLogs(logger=logger, level="WARN"), mock.patch(
                 "ax.adapter.base._combine_multiple_status_quo_observations",
                 wraps=_combine_multiple_status_quo_observations,

--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -495,7 +495,7 @@ class Client(WithDBSettingsBase):
 
         trial = assert_is_instance(self._experiment.trials[trial_index], Trial)
         trial.update_trial_data(
-            raw_data=data_with_progression, combine_with_last_data=True
+            raw_data=data_with_progression,
         )
 
         self._save_or_update_trial_in_db_if_possible(

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -253,7 +253,7 @@ class MultiTypeExperiment(Experiment):
         self,
         trial_indices: Iterable[int] | None = None,
         metrics: list[Metric] | None = None,
-        combine_with_last_data: bool = False,
+        combine_with_last_data: bool | None = None,
         overwrite_existing_data: bool = False,
         **kwargs: Any,
     ) -> Data:
@@ -263,7 +263,12 @@ class MultiTypeExperiment(Experiment):
         return self.default_data_constructor.from_multiple_data(
             [
                 (
-                    trial.fetch_data(**kwargs, metrics=metrics)
+                    trial.fetch_data(
+                        **kwargs,
+                        metrics=metrics,
+                        overwrite_existing_data=overwrite_existing_data,
+                        combine_with_last_data=combine_with_last_data,
+                    )
                     if trial.status.expecting_data
                     else Data()
                 )

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -639,7 +639,7 @@ class ExperimentTest(TestCase):
                 ]
             )
         )
-        t3 = exp.attach_data(new_data, combine_with_last_data=True)
+        t3 = exp.attach_data(new_data)
         # still 6 data objs, since we combined last one
         self.assertEqual(len(full_dict[0]), 6)
         self.assertIn("z", exp.lookup_data_for_ts(t3).df["metric_name"].tolist())
@@ -675,12 +675,6 @@ class ExperimentTest(TestCase):
 
         # automatically attaches data
         data = exp.fetch_data()
-
-        # can't set both combine_with_last_data and overwrite_existing_data
-        with self.assertRaises(UnsupportedError):
-            exp.attach_data(
-                data, combine_with_last_data=True, overwrite_existing_data=True
-            )
 
         # data exists for two trials
         # data has been attached once for each trial

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -273,7 +273,7 @@ class Trial(BaseTrial):
         self,
         raw_data: TEvaluationOutcome,
         metadata: dict[str, str | int] | None = None,
-        combine_with_last_data: bool = False,
+        combine_with_last_data: bool | None = None,
     ) -> str:
         """Utility method that attaches data to a trial and
         returns an update message.
@@ -286,8 +286,8 @@ class Trial(BaseTrial):
                 Can also be a list of (fidelities, mapping from
                 metric name to a tuple of mean and SEM).
             metadata: Additional metadata to track about this run, optional.
-            combine_with_last_data: Whether to combine the given data with the
-                data that was previously attached to the trial. See
+            combine_with_last_data [DEPRECATED]: Whether to combine the given data
+                with the data that was previously attached to the trial. See
                 `Experiment.attach_data` for a detailed explanation.
 
         Returns:

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -738,7 +738,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             trial_index=trial_index,
             raw_data=raw_data,
             metadata=metadata,
-            combine_with_last_data=True,
         )
         logger.info(f"Updated trial {trial_index} with data: " f"{data_update_repr}.")
 
@@ -785,7 +784,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             raw_data=raw_data,
             metadata=metadata,
             complete_trial=True,
-            combine_with_last_data=True,
         )
         logger.info(f"Completed trial {trial_index} with data: " f"{data_update_repr}.")
 
@@ -826,7 +824,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             trial_index=trial_index,
             raw_data=raw_data,
             metadata=metadata,
-            combine_with_last_data=True,
         )
         logger.info(f"Added data: {data_update_repr} to trial {trial.index}.")
 
@@ -1519,7 +1516,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         raw_data: TEvaluationOutcome,
         metadata: dict[str, str | int] | None = None,
         complete_trial: bool = False,
-        combine_with_last_data: bool = False,
+        combine_with_last_data: bool | None = None,
     ) -> str:
         """Helper method attaches data to a trial, returns a str of update."""
         # Format the data to save.

--- a/ax/service/orchestrator.py
+++ b/ax/service/orchestrator.py
@@ -1902,11 +1902,6 @@ class Orchestrator(AnalysisBase, BestPointMixin):
             kwargs = deepcopy(self.options.fetch_kwargs)
             for k, v in self.DEFAULT_FETCH_KWARGS.items():
                 kwargs.setdefault(k, v)
-            if kwargs.get("overwrite_existing_data") and kwargs.get(
-                "combine_with_last_data"
-            ):
-                # to avoid error https://fburl.com/code/ilix4okj
-                kwargs["overwrite_existing_data"] = False
             if self.trial_type is not None:
                 metrics = assert_is_instance(
                     self.experiment, MultiTypeExperiment

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -2074,9 +2074,6 @@ class TestAxOrchestrator(TestCase):
             experiment=self.branin_experiment,  # Has runner and metrics.
             generation_strategy=gs,
             options=OrchestratorOptions(
-                fetch_kwargs={
-                    "combine_with_last_data": True,
-                },
                 **self.orchestrator_options_kwargs,
             ),
             db_settings=self.db_settings_if_always_needed,

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -878,9 +878,7 @@ class SQAStoreTest(TestCase):
         self.assertEqual(self.experiment, loaded_experiment)
 
         # Update a trial by attaching data again
-        self.experiment.attach_data(
-            get_data(trial_index=trial.index), combine_with_last_data=True
-        )
+        self.experiment.attach_data(get_data(trial_index=trial.index))
         save_or_update_trial(experiment=self.experiment, trial=trial)
 
         loaded_experiment = load_experiment(self.experiment.name)


### PR DESCRIPTION
Summary:
Diff contents:
* Soft-deprecates `combine_with_last_data` arg in `Experiment.attach_data` signature, docs, and logic.
* For all passthrough callsites, updates signature and docs.
* Removes all direct specification of `combine_with_last_data=True/False`, ensuring that the same behavior remains after the change (i.e., `overwrite_existing_data is not combine_with_last_data`).

Reviewed By: saitcakmak

Differential Revision: D75696517


