### PR TITLE
Deprecate SQ weight override: SQ is now added as a GR right away, so its weight is encoded into that GR

### DIFF
--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -160,20 +160,15 @@ class BatchTrialTest(TestCase):
     def test_status_quo_weight_is_ignored_when_none(self) -> None:
         tot_weight = sum(self.batch.weights)
         self.assertEqual(sum(self.batch.weights), tot_weight)
-        self.assertIsNone(self.batch._status_quo_weight_override)
 
     def test_status_quo_set_on_clone_to(self) -> None:
         batch2 = self.batch.clone_to(include_sq=False)
         self.assertEqual(batch2.status_quo, self.experiment.status_quo)
         # Since should_add_status_quo_arm was False,
-        # _status_quo_weight_override should be False and the
-        # status_quo arm should not appear in arm_weights
-        self.assertIsNone(batch2._status_quo_weight_override)
         self.assertTrue(batch2.status_quo not in batch2.arm_weights)
         self.assertEqual(sum(batch2.weights), sum(self.weights))
         # Test with should_add_status_quo_arm=True
         batch3 = self.experiment.new_batch_trial(should_add_status_quo_arm=True)
-        self.assertEqual(batch3._status_quo_weight_override, 1.0)
         self.assertTrue(batch2.status_quo in batch3.arm_weights)
 
     def test_cannot_add_status_quo_arm_without_status_quo(self) -> None:

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -500,6 +500,7 @@ def trials_from_json(
             # `GeneratorRunStruct` (deprecated) will be decoded into a `GeneratorRun`,
             # so all we have to do here is change the key it's stored under.
             trial_json["generator_runs"] = trial_json.pop("generator_run_structs")
+        trial_json.pop("status_quo_weight_override", None)  # Deprecated.
         loaded_trials[int(index)] = (
             trial_from_json(experiment=experiment, **trial_json)
             if is_trial

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -103,7 +103,6 @@ def batch_trial_from_json(
     abandoned_arms_metadata: dict[str, AbandonedArm],
     num_arms_created: int,
     status_quo: Arm | None,
-    status_quo_weight_override: float,
     # Allowing default values for backwards compatibility with
     # objects stored before these fields were added.
     failed_reason: str | None = None,
@@ -149,11 +148,8 @@ def batch_trial_from_json(
 
     # Trial.arms_by_name only returns arms with weights
     batch.should_add_status_quo_arm = batch.status_quo is not None
-    batch._status_quo_weight_override = status_quo_weight_override
     if batch.should_add_status_quo_arm:
-        batch.add_status_quo_arm(
-            weight=status_quo_weight_override,
-        )
+        batch.add_status_quo_arm()
 
     # Set trial status last, after adding all the arms.
     batch._status = status

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -123,7 +123,6 @@ def batch_to_dict(batch: BatchTrial) -> dict[str, Any]:
         "ttl_seconds": batch.ttl_seconds,
         "status": batch.status,
         "status_quo": batch.status_quo,
-        "status_quo_weight_override": batch._status_quo_weight_override,
         "time_created": batch.time_created,
         "time_completed": batch.time_completed,
         "time_staged": batch.time_staged,

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1017,8 +1017,6 @@ class Decoder:
                     # Most of the time, the status quo arm has its own generator run,
                     # of a dedicated type.
                     if gr.generator_run_type == GeneratorRunType.STATUS_QUO.name:
-                        status_quo_weight = gr.weights[0]
-                        trial._status_quo_weight_override = status_quo_weight
                         trial._status_quo_generator_run_db_id = gr.db_id
                         trial._status_quo_arm_db_id = gr.arms[0].db_id
                         break


### PR DESCRIPTION
Summary:
With SQ always being added as part of a GR and with [this code block](https://fburl.com/code/pnmuwj71) no longer being there as of D80304993, I think we can completely deprecate the weight override –– it's a complication that I believe we don't use, that makes the code a lot harder to follow and the behavior –– hard to predict.

I'd like to know if folks have any objections to this move, especially bletham, sdaulton, eonofrey, ItsMrLin, mgarrard, who may have found themselves needing this in notebook experiments (if you do, please help me understand the use cases) : )

Differential Revision: D80968518
