### PR TITLE
Exclude out-of-design arms at dedup

### DIFF
--- a/ax/adapter/random.py
+++ b/ax/adapter/random.py
@@ -98,12 +98,15 @@ class RandomAdapter(Adapter):
             search_space.parameter_constraints, self.parameters
         )
         # Extract generated points to deduplicate against.
+        # Exclude out-of-design arms (which can only be manual arms
+        # instead of adapter-generated arms).
         generated_points = None
         if self.generator.deduplicate:
             arms_to_deduplicate = self._experiment.arms_by_signature_for_deduplication
             generated_obs = [
                 ObservationFeatures.from_arm(arm=arm)
                 for arm in arms_to_deduplicate.values()
+                if self._search_space.check_membership(parameterization=arm.parameters)
             ]
             # Transform
             for t in self.transforms.values():

--- a/ax/adapter/tests/test_random_adapter.py
+++ b/ax/adapter/tests/test_random_adapter.py
@@ -224,3 +224,66 @@ class RandomAdapterTest(TestCase):
         with mock.patch.object(generator, "gen", return_value=gen_res) as mock_gen:
             adapter.gen(n=1, pending_observations=pending_observations)
         self.assertIsNone(mock_gen.call_args.kwargs["generated_points"])
+
+        # Test filtering out-of-design arms during deduplication
+        # Create experiment with in-design and out-of-design arms
+        exp_with_ood_arms = Experiment(
+            search_space=get_search_space_for_range_values(min=0.0, max=5.0)
+        )
+        in_design_arm = Arm(
+            name="in_design", parameters={"x": 2.0, "y": 3.0}
+        )  # Within [0, 5]
+        out_of_design_arm = Arm(
+            name="out_of_design", parameters={"x": 6.0, "y": 7.0}
+        )  # Outside [0, 5]
+
+        exp_with_ood_arms.new_trial().add_arm(in_design_arm).mark_running(
+            no_runner_required=True
+        )
+        exp_with_ood_arms.new_trial().add_arm(out_of_design_arm).mark_running(
+            no_runner_required=True
+        )
+
+        generator = SobolGenerator(deduplicate=True)
+        adapter_mixed = RandomAdapter(
+            experiment=exp_with_ood_arms,
+            generator=generator,
+            transforms=Cont_X_trans,
+        )
+
+        # Only the in-design arm should be included in generated_points
+        with mock.patch.object(generator, "gen", return_value=gen_res) as mock_gen:
+            adapter_mixed.gen(n=1)
+
+        generated_points = mock_gen.call_args.kwargs["generated_points"]
+        self.assertEqual(len(generated_points), 1)
+
+        # Test case where all arms are out-of-design
+        exp_all_out_of_design = Experiment(
+            search_space=get_search_space_for_range_values(min=0.0, max=5.0)
+        )
+        out_of_design_arm1 = Arm(name="out1", parameters={"x": 6.0, "y": 7.0})
+        out_of_design_arm2 = Arm(name="out2", parameters={"x": -1.0, "y": 8.0})
+
+        exp_all_out_of_design.new_trial().add_arm(out_of_design_arm1).mark_running(
+            no_runner_required=True
+        )
+        exp_all_out_of_design.new_trial().add_arm(out_of_design_arm2).mark_running(
+            no_runner_required=True
+        )
+
+        generator_all_out = SobolGenerator(deduplicate=True)
+        adapter_all_out = RandomAdapter(
+            experiment=exp_all_out_of_design,
+            generator=generator_all_out,
+            transforms=Cont_X_trans,
+        )
+
+        # When all arms are out-of-design, generated_points should be empty
+        with mock.patch.object(
+            generator_all_out, "gen", return_value=gen_res
+        ) as mock_gen:
+            adapter_all_out.gen(n=1)
+
+        generated_points_all_out = mock_gen.call_args.kwargs["generated_points"]
+        self.assertIsNone(generated_points_all_out)


### PR DESCRIPTION
Summary:
f784259720 errored out when `RandomAdapter` is trying to transform arms to dedup, which includes a custom arm that is out-of-design.

As a fix, we filter out-of-design arms at dedup to avoid failure at `Transform`. Since we will not actually generate any arms that are out-of-design, this filtering should be safe / is only used for custom arms.

Differential Revision: D81171470


