### PR TITLE
Implement colorscale in Arm Effects and Scatter (2/2)

### DIFF
--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -71,6 +71,9 @@ CI_ALPHA: float = 0.5
 # The max length of a hover label to prevent overflow making the hover unreadable
 MAX_HOVER_LABEL_LEN: int = 300
 
+SINGLE_CANDIDATE_TRIAL_LEGEND: str = "Candidate Trial"
+MULTIPLE_CANDIDATE_TRIALS_LEGEND: str = "Candidate Trials"
+
 
 def get_scatter_point_color(
     hex_color: str,


### PR DESCRIPTION
Summary:
This diff implements a colorscale in Ax's Arm Effects and Scatter plots if the number of trials (excluding candidate trials) exceeds 10. The changes include -
1. Using BOTORCH_COLOR_SCALE as the colorscale
2. Keeping count of the non-candidate and candidate trials that end up being plotted
3. Calculating if scale needs to be used based on the no. of non-candidate trials that end up in the plot
4. Updating scale/legend accordingly

Differential Revision: D80104354


