### PR TITLE
Require non-None map key on MapData

### DIFF
--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 
 from ax.core.data import Data
 
-from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_data import DEFAULT_MAP_KEY, MapData, MapKeyInfo
 from ax.core.metric import Metric, MetricFetchE
 from ax.utils.common.result import Result
 
 MapMetricFetchResult = Result[MapData, MetricFetchE]
-DEFAULT_MAP_KEY = "step"
 
 
 class MapMetric(Metric):

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -117,7 +117,7 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             # don't stop any trials if we don't get data back
             return {}
 
-        map_key = none_throws(data.map_key)
+        map_key = data.map_key
         df = data.map_df
 
         # default checks on `min_progression` and `min_curves`; if not met, don't do

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -15,7 +15,6 @@ from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.exceptions.core import UnsupportedError
 from ax.generation_strategy.generation_node import GenerationNode
 from ax.utils.common.logger import get_logger
-from pyre_extensions import none_throws
 
 logger: Logger = get_logger(__name__)
 
@@ -110,7 +109,7 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             # don't stop any trials if we don't get data back
             return {}
 
-        map_key = none_throws(data.map_key)
+        map_key = data.map_key
         df = data.map_df
 
         # default checks on `min_progression` and `min_curves`; if not met, don't do


### PR DESCRIPTION
Summary:
**Context**:
* Currently, `Data` does not have a map key, whereas `MapData` does, unless it has an empty DataFrame, in which case it doesn't have to. This is a bit confusing and makes syntax clunky, with lots of checks for None.
* All map keys currently in use have the default name of "step," so there is no downside to giving the default name of "step" to MapData with no map key specified.
* In the future, we will get rid of `MapKeyInfo` and make all map keys be named "step." If we don't require all `MapData` to have a map key, then we would need to introduce some extra variable like `has_map_key` even though it doesn't contain any information.

Also, confusingly, the case of `MapData(..., map_key_infos=None, ...)` is treated differently from `MapData(..., map_key_infos=[], ...)`.

**This diff**:
Forces the map key to be not None by setting it to the default of "step" when it is not provided. This means that once we require all map keys to be "step," all MapData DataFrames will have the same columns.

I started taking out some `none_throws` but then realized a ton of map_key related logic will go away anyway if/when "step" becomes the only map key.

This diff also removes the different treatment between `None` and `[]` `map_key_infos`.

Differential Revision: D80853382


