### PR TITLE
Only warn about multiple map keys when there are more than one

### DIFF
--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -382,14 +382,15 @@ class MapData(Data):
 
         if len(map_key_infos) > 0:
             keys = [d.key for d in map_key_infos]
-            warnings.warn(
-                "Received multiple map keys. All but the first will be "
-                f"dropped. Keys are {keys}",
-                stacklevel=2,
-            )
+            if len(map_key_infos) > 1:
+                warnings.warn(
+                    "Received multiple map keys. All but the first will be "
+                    f"dropped. Keys are {keys}",
+                    stacklevel=2,
+                )
+                if deserialized["df"] is not None:
+                    deserialized["df"].drop(columns=keys[1:], inplace=True)
             deserialized["map_key_infos"] = [map_key_infos[0]]
-            if deserialized["df"] is not None:
-                deserialized["df"].drop(columns=keys[1:], inplace=True)
 
         return deserialized
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -9,6 +9,7 @@
 import dataclasses
 import os
 import tempfile
+import warnings
 from functools import partial
 from math import nan
 
@@ -635,11 +636,14 @@ class JSONStoreTest(TestCase):
                 "map_key_infos": [{"key": "epoch", "default_value": nan}],
                 "__type": "MapData",
             }
-            map_data = object_from_json(
-                data_json,
-                decoder_registry=CORE_DECODER_REGISTRY,
-                class_decoder_registry=CORE_CLASS_DECODER_REGISTRY,
-            )
+            with warnings.catch_warnings(record=True) as ws:
+                map_data = object_from_json(
+                    data_json,
+                    decoder_registry=CORE_DECODER_REGISTRY,
+                    class_decoder_registry=CORE_CLASS_DECODER_REGISTRY,
+                )
+            # No warning about multiple map keys
+            self.assertFalse(any("Received multiple" in str(w) for w in ws))
             self.assertEqual(map_data.map_key, "epoch")
             self.assertEqual(map_data.true_df["epoch"].tolist(), [0.0, 1.0])
 


### PR DESCRIPTION
Summary: A previous diff warned when there were more than zero map keys, leading to spurious warnings. The warning should have been for more than one.

Differential Revision: D81275811


