### PR TITLE
Do not require map key in map evaluations

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -490,7 +490,7 @@ class Client(WithDBSettingsBase):
         # If no progression is provided assume the data is not timeseries-like and
         # set step=NaN
         data_with_progression = [
-            ({"step": progression if progression is not None else np.nan}, raw_data)
+            (progression if progression is not None else np.nan, raw_data)
         ]
 
         trial = assert_is_instance(self._experiment.trials[trial_index], Trial)

--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 
 from ax.core.data import Data
 
-from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_data import MAP_KEY, MapData, MapKeyInfo
 from ax.core.metric import Metric, MetricFetchE
 from ax.utils.common.result import Result
 
 MapMetricFetchResult = Result[MapData, MetricFetchE]
-DEFAULT_MAP_KEY = "step"
 
 
 class MapMetric(Metric):
@@ -33,4 +32,4 @@ class MapMetric(Metric):
     """
 
     data_constructor: type[Data] = MapData
-    map_key_info: MapKeyInfo = MapKeyInfo(key=DEFAULT_MAP_KEY)
+    map_key_info: MapKeyInfo = MapKeyInfo(key=MAP_KEY)

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1500,10 +1500,10 @@ class ExperimentWithMapDataTest(TestCase):
     def test_FetchDataWithMapData(self) -> None:
         evaluations = {
             "0_0": [
-                ({"epoch": 1}, {"no_fetch_impl_metric": (3.7, 0.5)}),
-                ({"epoch": 2}, {"no_fetch_impl_metric": (3.8, 0.5)}),
-                ({"epoch": 3}, {"no_fetch_impl_metric": (3.9, 0.5)}),
-                ({"epoch": 4}, {"no_fetch_impl_metric": (4.0, 0.5)}),
+                (1, {"no_fetch_impl_metric": (3.7, 0.5)}),
+                (2, {"no_fetch_impl_metric": (3.8, 0.5)}),
+                (3, {"no_fetch_impl_metric": (3.9, 0.5)}),
+                (4, {"no_fetch_impl_metric": (4.0, 0.5)}),
             ],
         }
 

--- a/ax/core/tests/test_formatting_utils.py
+++ b/ax/core/tests/test_formatting_utils.py
@@ -58,8 +58,8 @@ class TestRawDataToEvaluation(TestCase):
                 metric_names=["objective_a", "objective_b"],
             )
 
-    def test_it_accepts_a_list_for_single_objectives(self) -> None:
-        raw_data = [({"arm__0": (0, 1)}, {"objective_a": (1.4, None)})]
+    def test_it_accepts_a_list_for_map_evaluations(self) -> None:
+        raw_data = [(0.0, {"objective_a": (0, 1)}), (1.0, {"objective_a": (1.4, None)})]
         result = raw_data_to_evaluation(raw_data=raw_data, metric_names=["objective_a"])
         self.assertEqual(raw_data, result)
 

--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -226,17 +226,11 @@ class MapDataTest(TestCase):
             eval1 = (3.7, sem) if sem is not None else 3.7
             eval2 = (3.8, sem) if sem is not None else 3.8
             map_data = MapData.from_map_evaluations(
-                evaluations={
-                    "0_1": [
-                        ({"f1": 1.0}, {"b": eval1}),
-                        ({"f1": 1.0}, {"b": eval2}),
-                    ]
-                },
+                evaluations={"0_1": [(1.0, {"b": eval1}), (1.0, {"b": eval2})]},
                 trial_index=0,
             )
             self.assertEqual(map_data.map_df["sem"].isnull().all(), sem is None)
             self.assertEqual(len(map_data.map_df), 2)
-            self.assertEqual(map_data.map_key, "f1")
 
     def test_upcast(self) -> None:
         fresh = MapData.from_df(df=self.df, map_key=self.map_key)

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -329,11 +329,11 @@ class TrialTest(TestCase):
             len(self.trial.experiment.metrics)
             - len(self.trial.experiment.tracking_metrics),
         )
-        self.assertTrue("m1" in self.trial.experiment.metrics)
-        self.assertTrue("m2" in self.trial.experiment.metrics)
+        self.assertIn("m1", self.trial.experiment.metrics)
+        self.assertIn("m2", self.trial.experiment.metrics)
 
         data = self.trial.lookup_data().df.to_dict(orient="index")
-        self.assertTrue(len(data) == 0)
+        self.assertEqual(len(data), 0)
 
         # Attach data
         self.trial.update_trial_data(raw_data={"m1": 1.0, "m2": 2.0})
@@ -353,7 +353,7 @@ class TrialTest(TestCase):
             UserInputError,
             "The format of the `raw_data` is not compatible with `Data`. ",
         ):
-            self.trial.update_trial_data(raw_data=[({"time": 0}, {"m1": 1.0})])
+            self.trial.update_trial_data(raw_data=[(0, {"m1": 1.0})])
 
         # Try to attach Data to a MapData experiment.
         map_experiment = get_test_map_data_experiment(
@@ -362,7 +362,7 @@ class TrialTest(TestCase):
         map_trial = map_experiment.new_trial().add_arm(
             arm=get_branin_arms(n=1, seed=0)[0]
         )
-        map_trial.update_trial_data(raw_data=[({"time": 0}, {"m1": 1.0})])
+        map_trial.update_trial_data(raw_data=[(0, {"m1": 1.0})])
         with self.assertRaisesRegex(
             UserInputError,
             "The format of the `raw_data` is not compatible with `MapData`. ",

--- a/ax/core/tests/test_types.py
+++ b/ax/core/tests/test_types.py
@@ -10,10 +10,10 @@ from ax.core.types import (
     merge_model_predict,
     validate_evaluation_outcome,
     validate_floatlike,
-    validate_map_dict,
     validate_param_value,
     validate_parameterization,
     validate_single_metric_data,
+    validate_step,
     validate_trial_evaluation,
 )
 from ax.utils.common.testutils import TestCase
@@ -56,7 +56,7 @@ class TypesTest(TestCase):
     def test_Validate(self) -> None:
         trial_evaluation = {"foo": 0.0}
         trial_evaluation_with_noise = {"foo": (0.0, 0.0)}
-        map_trial_evaluation = [({"a": 0.0}, trial_evaluation)]
+        map_trial_evaluation = [(0.0, trial_evaluation)]
 
         validate_evaluation_outcome(outcome=trial_evaluation)
         validate_evaluation_outcome(outcome=trial_evaluation_with_noise)
@@ -86,12 +86,8 @@ class TypesTest(TestCase):
         ):
             validate_parameterization(parameterization={0: 0})
 
-        with self.assertRaisesRegex(
-            TypeError, "Keys must be strings in TMapDict, found 0."
-        ):
-            validate_map_dict(map_dict={0: 0})
-
-        with self.assertRaisesRegex(
-            TypeError, "Values must be Hashable in TMapDict, found"
-        ):
-            validate_map_dict(map_dict={"foo": []})
+        with self.assertRaisesRegex(TypeError, "Steps must be float"):
+            # pyre-fixme[6]: Incompatible parameter type: In call
+            # `validate_step`, for argument `step`, expected `float` but got
+            # `str`
+            validate_step(step="0")

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -693,13 +693,13 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
 
         NOTE: This method will raise an Exception if it is called multiple times
         with the same ``raw_data``. These cases typically arise when ``raw_data``
-        does not change over time. To avoid this, pass a timestep metric in
-        ``raw_data``, for example:
+        does not change over time. To avoid this, pass a "step" (progression)
+        metric in ``raw_data``, for example:
 
         .. code-block:: python
 
             for ts in range(100):
-                raw_data = [({"ts": ts}, {"my_objective": (1.0, 0.0)})]
+                raw_data = [(ts, {"my_objective": (1.0, 0.0)})]
                 ax_client.update_running_trial_with_intermediate_data(
                     trial_index=0, raw_data=raw_data
                 )

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2663,27 +2663,26 @@ def get_non_monolithic_branin_moo_data() -> Data:
 def get_map_data(trial_index: int = 0) -> MapData:
     evaluations = {
         "status_quo": [
-            ({"epoch": 1}, {"ax_test_metric": (1.0, 0.5)}),
-            ({"epoch": 2}, {"ax_test_metric": (2.0, 0.5)}),
-            ({"epoch": 3}, {"ax_test_metric": (3.0, 0.5)}),
-            ({"epoch": 4}, {"ax_test_metric": (4.0, 0.5)}),
+            (1, {"ax_test_metric": (1.0, 0.5)}),
+            (2, {"ax_test_metric": (2.0, 0.5)}),
+            (3, {"ax_test_metric": (3.0, 0.5)}),
+            (4, {"ax_test_metric": (4.0, 0.5)}),
         ],
         "0_0": [
-            ({"epoch": 1}, {"ax_test_metric": (3.7, 0.5)}),
-            ({"epoch": 2}, {"ax_test_metric": (3.8, 0.5)}),
-            ({"epoch": 3}, {"ax_test_metric": (3.9, 0.5)}),
-            ({"epoch": 4}, {"ax_test_metric": (4.0, 0.5)}),
+            (1, {"ax_test_metric": (3.7, 0.5)}),
+            (2, {"ax_test_metric": (3.8, 0.5)}),
+            (3, {"ax_test_metric": (3.9, 0.5)}),
+            (4, {"ax_test_metric": (4.0, 0.5)}),
         ],
         "0_1": [
-            ({"epoch": 1}, {"ax_test_metric": (3.0, 0.5)}),
-            ({"epoch": 2}, {"ax_test_metric": (5.0, 0.5)}),
-            ({"epoch": 3}, {"ax_test_metric": (6.0, 0.5)}),
-            ({"epoch": 4}, {"ax_test_metric": (1.0, 0.5)}),
+            (1, {"ax_test_metric": (3.0, 0.5)}),
+            (2, {"ax_test_metric": (5.0, 0.5)}),
+            (3, {"ax_test_metric": (6.0, 0.5)}),
+            (4, {"ax_test_metric": (1.0, 0.5)}),
         ],
     }
     return MapData.from_map_evaluations(
-        evaluations=evaluations,  # pyre-ignore [6]: Spurious param type mismatch.
-        trial_index=trial_index,
+        evaluations=evaluations, trial_index=trial_index
     )
 
 


### PR DESCRIPTION
Summary:
**Context**:
* This diff is one of several that will remove the ability to customize map keys so that they are always the default "step." This is already the case with the API, and other metrics currently in use seem to use "step."
* Data can be attached via AxClient with map evaluations. Map evaluations take the format [({map_key: map_value}, {metric_name: (mean, sem)})]. The map key is no longer needed if the map key is to always be "step."

**This PR**:
* Moves DEFAULT_MAP_KEY ("step") from MapMetric's module to MapData's module to avoid circular imports and renames it to MAP_KEY
* Change MapEvaluations to the format `[(map_value, {metric_name: (mean, sem)})]`, removing the map key. This mostly affects internal data movement within Ax; the one potentially user-affecting changes are in AxClient, e.g. `ax_client.complete_trial(trial_index=0, raw_data=some_t_map_evaluation)`.
* Adds validation that the map value must always be able to be cast to a float, which is what MapData expects.

Differential Revision: D81335900


