### PR TITLE
[Analysis][Plotly] Move color definitions to fix sphinx docs generation

### DIFF
--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -24,15 +24,6 @@ from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from plotly import graph_objects as go
 
-TRANSPARENT_AX_BLUE: str = get_scatter_point_color(
-    hex_color=AX_BLUE,
-    ci_transparency=True,
-)
-FILLED_AX_BLUE: str = get_scatter_point_color(
-    hex_color=AX_BLUE,
-    ci_transparency=False,
-)
-
 CV_CARDGROUP_TITLE = "Cross Validation: Assessing model fit"
 
 CV_CARDGROUP_SUBTITLE = (
@@ -277,6 +268,14 @@ def _prepare_plot(
 ) -> go.Figure:
     # Create a scatter plot using Plotly Graph Objects for more control
     fig = go.Figure()
+    TRANSPARENT_AX_BLUE: str = get_scatter_point_color(
+        hex_color=AX_BLUE,
+        ci_transparency=True,
+    )
+    FILLED_AX_BLUE: str = get_scatter_point_color(
+        hex_color=AX_BLUE,
+        ci_transparency=False,
+    )
     fig.add_trace(
         go.Scatter(
             x=df["observed"],


### PR DESCRIPTION
Our sphinx api docs recently broke. https://ax.readthedocs.io/en/1.1.0/

The build logs include a lot of references such as
```python
 line 87, in get_scatter_point_color\\n    red, green, blue = px.colors.hex_to_rgb(hex_color)\\n    ^^^^^^^^^^^^^^^^\\nValueError: not enough values to unpack (expected 3, got 0)\\n\')\n']
 ```

 These refer to `get_scatter_point_color()` calls at import time within `cross_validation.py`. I'm not sure if there is an underlying problem here but my current priority is fixing our sphinx builds by moving these calls inside the relevant function instead of happening at import time.

## Test plan

 The sphinx build `make html` succeeds with this change.

<img width="1796" height="537" alt="image" src="https://github.com/user-attachments/assets/45daf2c7-5b24-4a3e-8cdf-c24c290cc603" />
