### PR TITLE
Supress pandas FutureWarning in OneHot

### DIFF
--- a/ax/adapter/transforms/one_hot.py
+++ b/ax/adapter/transforms/one_hot.py
@@ -215,9 +215,9 @@ class OneHot(Transform):
         arm_data = experiment_data.arm_data
         for p_name, values in self.encoded_values.items():
             # First, replace values with 0, 1, 2, so that column names are as expected.
-            arm_data = arm_data.replace(
-                to_replace={p_name: {v: i for i, v in enumerate(values)}}
-            ).astype({p_name: int})
+            arm_data[p_name] = arm_data[p_name].map(
+                {v: i for i, v in enumerate(values)}
+            )
 
             if len(values) == 2:
                 # Handle the special case. Only need to rename the column.


### PR DESCRIPTION
Summary:
Website's Next version is full of the following warning (ex https://ax.dev/docs/next/tutorials/sklearn/):
```
/home/runner/work/Ax/Ax/ax/adapter/transforms/one_hot.py:218: FutureWarning:
Downcasting behavior in replace is deprecated and will be removed in a future version. To retain the old behavior, explicitly call result.infer_objects(copy=False). To opt-in to the future behavior, set pd.set_option('future.no_silent_downcasting', True)
```

The warning message says `infer_objects(copy=False)` will fix the behavior.

Reviewed By: saitcakmak

Differential Revision: D81039763


