### PR TITLE
Remove unused parameters input from TorchAdapter._fit, _cross_validate & _get_fit_args

### DIFF
--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -787,7 +787,6 @@ class TorchAdapterTest(TestCase):
         converted_datasets2, _, _ = adapter._get_fit_args(
             search_space=search_space,
             experiment_data=experiment_data,
-            parameters=feature_names,
             update_outcomes_and_parameters=True,
         )
         self.assertEqual(adapter.outcomes, expected_outcomes)
@@ -797,7 +796,6 @@ class TorchAdapterTest(TestCase):
         adapter._get_fit_args(
             search_space=search_space,
             experiment_data=experiment_data,
-            parameters=feature_names,
             update_outcomes_and_parameters=False,
         )
         self.assertEqual(adapter.outcomes, expected_outcomes)


### PR DESCRIPTION
Summary:
Allowing a different set of parameters than the parameters available on the search space can lead to inconsistencies between model fitting and subsequent use of the fitted model. Since this argument is not used, let's just remove it.

After removing it from `_fit` and `_cross_validate`, it becomes `None` everywhere for `_get_fit_args` as well, so it is removed from there too.

Reviewed By: dme65

Differential Revision: D81511134


