### PR TITLE
Allow nonlinear parameter constraints in MBM

### DIFF
--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -501,8 +501,7 @@ class Acquisition(Base):
         if optimizer_options is not None:
             forbidden_optimizer_options = [
                 "equality_constraints",
-                "inequality_constraints",
-                "nonlinear_inequality_constraints",
+                "inequality_constraints",  # These should be constructed by Ax
                 "batch_initial_conditions",
                 "return_best_only",
                 "return_full_tree",


### PR DESCRIPTION
Summary: Remove nonlinear_inequality_constraints from the list of banned gen options in MBM so they can be used.

Reviewed By: saitcakmak

Differential Revision: D81512728


