### PR TITLE
Make GeneratonNode._fitted_adapter work correctly for multi-spec nodes

### DIFF
--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -300,10 +300,15 @@ class GenerationNode(SerializationMixin, SortableBase):
     def _fitted_adapter(self) -> Adapter | None:
         """Private property to return optional fitted_adapter from
         self.generator_spec_to_gen_from for convenience. If no model is fit,
-        will return None. If using the non-private `fitted_adapter` property,
-        and no model is fit, a UserInput error will be raised.
+        this will return None.
         """
-        return self.generator_spec_to_gen_from._fitted_adapter
+        try:
+            # Using the private attribute since using the non-private `fitted_adapter`
+            # property will raise a UserInputError if there is no fitted model.
+            return self.generator_spec_to_gen_from._fitted_adapter
+        except ModelError:
+            # ModelError is raised if there are no fitted adapters to select from.
+            return None
 
     def __repr__(self) -> str:
         """String representation of this ``GenerationNode`` (note that it

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -468,6 +468,9 @@ class TestGenerationNodeWithBestModelSelector(TestCase):
         with self.assertRaisesRegex(ModelError, "No fitted models were found"):
             self.model_selection_node.generator_spec_to_gen_from
 
+        # node._fitted_adapter returns None (rather than erroring out).
+        self.assertIsNone(self.model_selection_node._fitted_adapter)
+
         # Only one spec errors out.
         with patch.object(
             self.ms_mixed, "fit", side_effect=RuntimeError


### PR DESCRIPTION
Summary: If no model / adapter is yet fit, `GNode.generator_spec_to_gen_from` will fail in model selection with `ModelError`. We can simply return `None` in this case.

Differential Revision: D81527529


