### PR TITLE
Non-empty name check for metric

### DIFF
--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -111,6 +111,10 @@ class Metric(SortableBase, SerializationMixin):
             lower_is_better: Flag for metrics which should be minimized.
             properties: Dictionary of this metric's properties
         """
+        if not isinstance(name, str):
+            raise ValueError(f"Metric name must be a string, got {type(name)}.")
+        if len(name) == 0:
+            raise ValueError("Metric name must be a non-empty string.")
         self._name = name
         self.lower_is_better = lower_is_better
         self.properties: dict[str, Any] = properties or {}

--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -28,10 +28,12 @@ TRefPoint = list[ObjectiveThreshold]
 
 # Sentinels for default arguments when None is a valid input
 _NO_OUTCOME_CONSTRAINTS = [
-    OutcomeConstraint(Metric("", lower_is_better=True), ComparisonOp.GEQ, 0)
+    OutcomeConstraint(Metric("placeholder", lower_is_better=True), ComparisonOp.GEQ, 0)
 ]
-_NO_OBJECTIVE_THRESHOLDS = [ObjectiveThreshold(Metric("", lower_is_better=True), 0)]
-_NO_RISK_MEASURE = RiskMeasure("", {})
+_NO_OBJECTIVE_THRESHOLDS = [
+    ObjectiveThreshold(Metric("placeholder", lower_is_better=True), 0)
+]
+_NO_RISK_MEASURE = RiskMeasure("placeholder", {})
 
 
 class OptimizationConfig(Base):

--- a/ax/core/tests/test_metric.py
+++ b/ax/core/tests/test_metric.py
@@ -34,6 +34,24 @@ class MetricTest(TestCase):
         metric = Metric(name="m1", lower_is_better=False)
         self.assertEqual(str(metric), METRIC_STRING)
 
+    def test_name_validation(self) -> None:
+        # Test that non-string names raise ValueError
+        with self.assertRaisesRegex(
+            ValueError, "Metric name must be a string, got <class 'int'>"
+        ):
+            Metric(name=123)  # pyre-ignore[6]
+
+        # Test that empty string raises ValueError. This is to prevent
+        # downstream issues in the ObservationData class.
+        with self.assertRaisesRegex(
+            ValueError, "Metric name must be a non-empty string"
+        ):
+            Metric(name="")
+
+        # Test that valid string names work
+        metric1 = Metric(name="m")
+        self.assertEqual(metric1.name, "m")
+
     def test_eq(self) -> None:
         metric1 = Metric(name="m1", lower_is_better=False)
         metric2 = Metric(name="m1", lower_is_better=False)


### PR DESCRIPTION
Summary:
This diff adds a non-empty name check for metrics in Ax, since this causes downstream errors in ObservationData.

Example: N7955434.

Differential Revision: D81323314


