### PR TITLE
Improve legibility in arm effects plot xaxis label

### DIFF
--- a/ax/analysis/plotly/arm_effects.py
+++ b/ax/analysis/plotly/arm_effects.py
@@ -74,6 +74,10 @@ RAW_EFFECTS_CARDGROUP_SUBTITLE = (
     "the most favorable outcomes."
 )
 
+# If there are more than this many non-candidate arms to be plotted, change the way we
+# organize the xaxis and its labels to improve legibility.
+ARM_LABEL_THRESHOLD = 20
+
 
 class ArmEffectsPlot(Analysis):
     """
@@ -353,7 +357,6 @@ def _prepare_figure(
 
     # Track trials that get included in the plot
     num_candidate_trials = 0
-    num_non_candidate_trials = 0
     candidate_trial_marker = None
 
     for trial_index in trial_indices:
@@ -400,8 +403,6 @@ def _prepare_figure(
         if trial_df["trial_status"].iloc[0] == TrialStatus.CANDIDATE.name:
             num_candidate_trials += 1
             candidate_trial_marker = marker
-        else:
-            num_non_candidate_trials += 1
 
         text = trial_df.apply(
             lambda row: get_arm_tooltip(row=row, metric_names=[metric_name]), axis=1
@@ -425,8 +426,8 @@ def _prepare_figure(
         )
         scatter_trial_indices.append(trial_index)
 
-    # Determine use_colorscale based on actual included trials
-    use_colorscale = num_non_candidate_trials > 10
+    # Determine use_colorscale based on the number of included arms
+    use_colorscale = len(arm_label) > ARM_LABEL_THRESHOLD
 
     # Update markers and legend settings based on use_colorscale
     for scatter, trial_index in zip(scatters, scatter_trial_indices):
@@ -485,7 +486,20 @@ def _prepare_figure(
         yaxis_tickformat=".2%" if is_relative else None,
         legend=legend_position,
         margin=MARGIN_REDUCUTION,
-        xaxis={"tickvals": arm_order, "ticktext": arm_label},
+        xaxis={
+            "tickvals": [
+                arm_order[i * (len(arm_order) // ARM_LABEL_THRESHOLD)]
+                for i in range(ARM_LABEL_THRESHOLD)
+            ]
+            if use_colorscale
+            else arm_order,
+            "ticktext": [
+                arm_label[i * (len(arm_label) // ARM_LABEL_THRESHOLD)]
+                for i in range(ARM_LABEL_THRESHOLD)
+            ]
+            if use_colorscale
+            else arm_label,
+        },
     )
 
     # Add candidate trial legend at the end

--- a/ax/analysis/plotly/tests/test_arm_effects.py
+++ b/ax/analysis/plotly/tests/test_arm_effects.py
@@ -10,6 +10,7 @@ from itertools import product
 
 from ax.adapter.registry import Generators
 from ax.analysis.plotly.arm_effects import ArmEffectsPlot, compute_arm_effects_adhoc
+from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
 from ax.api.client import Client
 from ax.api.configs import RangeParameterConfig
 from ax.core.arm import Arm
@@ -319,10 +320,12 @@ class TestArmEffectsPlot(TestCase):
                 if with_additional_arms and use_model_predictions:
                     # validate that we plotted the additional arm
                     self.assertTrue(
-                        all(
-                            arm.name
-                            in json.loads(card.blob)["layout"]["xaxis"]["ticktext"]
+                        any(
+                            arm.name in datum["text"][0]
                             for card in cards.flatten()
+                            for datum in assert_is_instance(card, PlotlyAnalysisCard)
+                            .get_figure()
+                            ._data
                         )
                     )
 


### PR DESCRIPTION
Summary: Avoid showing too many ticks on the xaxis, which tend to clober each other with any more than ~10 on a typical work monitor.

Differential Revision: D81604191


