### PR TITLE
Fix bug in polytope sampler

### DIFF
--- a/ax/generators/random/base.py
+++ b/ax/generators/random/base.py
@@ -209,7 +209,7 @@ class RandomGenerator(Generator):
                 )
                 points = polytope_sampler.draw(n=n).numpy()
                 if rounding_func is not None:
-                    points = rounding_func(points)
+                    points = np.array([rounding_func(point) for point in points])
                 # TODO: Deduplicate points (should refactor deduplication logic
                 # to cover both the rejection sampling and polytope sampling cases.
             else:


### PR DESCRIPTION
Summary: Polytope sampler doesn't work coming from Adapter for n>1 because the rounding_func expects points to be provided one at a time, and it's providing them all together. This is the easy fix.

Differential Revision: D81609120


