### PR TITLE
Fix Legend Orientation in ScatterPlot

### DIFF
--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -453,33 +453,7 @@ def _prepare_figure(
                 trial_df["trial_status"].iloc[0] != TrialStatus.CANDIDATE.name
             )
 
-    figure = go.Figure(data=scatters)
-    figure.update_layout(
-        xaxis_title=x_metric_label,
-        yaxis_title=y_metric_label,
-        xaxis_tickformat=".2%" if is_relative else None,
-        yaxis_tickformat=".2%" if is_relative else None,
-        legend=LEGEND_POSITION,
-        margin=MARGIN_REDUCUTION,
-    )
-
-    # Add candidate trial legend at the end
-    if num_candidate_trials > 0:
-        figure.add_trace(
-            go.Scatter(
-                x=[None],
-                y=[None],
-                mode="markers",
-                marker=candidate_trial_marker,
-                name=SINGLE_CANDIDATE_TRIAL_LEGEND
-                if num_candidate_trials == 1
-                else MULTIPLE_CANDIDATE_TRIALS_LEGEND,
-                showlegend=True,
-                hoverinfo="skip",
-                legendgroup="candidate_trials",
-            )
-        )
-
+    # Determine legend position before creating figure
     legend_position = LEGEND_POSITION.copy()
     if use_colorscale:
         # Position legend to the right, align with colorscale
@@ -502,6 +476,23 @@ def _prepare_figure(
         legend=legend_position,
         margin=MARGIN_REDUCUTION,
     )
+
+    # Add candidate trial legend at the end
+    if num_candidate_trials > 0:
+        figure.add_trace(
+            go.Scatter(
+                x=[None],
+                y=[None],
+                mode="markers",
+                marker=candidate_trial_marker,
+                name=SINGLE_CANDIDATE_TRIAL_LEGEND
+                if num_candidate_trials == 1
+                else MULTIPLE_CANDIDATE_TRIALS_LEGEND,
+                showlegend=True,
+                hoverinfo="skip",
+                legendgroup="candidate_trials",
+            )
+        )
 
     # Add a red circle with no fill if any arms are marked as possibly infeasible.
     if (df["p_feasible_mean"] < POSSIBLE_CONSTRAINT_VIOLATION_THRESHOLD).any():


### PR DESCRIPTION
Summary:
Fixed a bug in [scatter.py](https://fburl.com/code/aumwph2i) where duplicate figure creation was causing incorrect legend positioning and lost candidate trial legends. The duplicate figure creation was introduced in D80104354, which created two separate `figure = go.Figure(data=scatters)` calls with separate layout updates, causing the first figure (with candidate legends) to be completely overwritten by the second figure creation.

The fix consolidated the figure creation flow into a single execution path, moved legend position determination before figure creation. This preserves all legend elements including candidate trial markers.

Differential Revision: D81619321


