### PR TITLE
Remove HadamardGaussianLikelihood from ax/generators test case

### DIFF
--- a/ax/generators/tests/test_botorch_defaults.py
+++ b/ax/generators/tests/test_botorch_defaults.py
@@ -45,7 +45,7 @@ from gpytorch.likelihoods.gaussian_likelihood import (
     FixedNoiseGaussianLikelihood,
     GaussianLikelihood,
 )
-from gpytorch.likelihoods.hadamard_gaussian_likelihood import HadamardGaussianLikelihood
+
 from gpytorch.module import Module
 from gpytorch.priors import GammaPrior
 from gpytorch.priors.lkj_prior import LKJCovariancePrior
@@ -78,7 +78,7 @@ class BotorchDefaultsTest(TestCase):
         self.assertEqual(model.covar_module.lengthscale_prior.scale, 3**0.5)
         model = _get_model(X=x, Y=y, Yvar=unknown_var, task_feature=1)
         self.assertIs(type(model), MultiTaskGP)  # Don't accept subclasses.
-        self.assertIsInstance(model.likelihood, HadamardGaussianLikelihood)
+
         model = _get_model(X=x, Y=y, Yvar=var, task_feature=1)
         self.assertIsInstance(model, MultiTaskGP)
         self.assertIsInstance(model.likelihood, FixedNoiseGaussianLikelihood)
@@ -177,7 +177,7 @@ class BotorchDefaultsTest(TestCase):
             prior=deepcopy(prior),
         )
         self.assertIs(type(model), MultiTaskGP)
-        self.assertIsInstance(model.likelihood, HadamardGaussianLikelihood)
+
         # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute
         #  `kernels`.
         data_covar_module, task_covar_module = model.covar_module.kernels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "botorch>=0.15.1",
+    "botorch[pymoo]>=0.15.1",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
Summary:
We intend to release Ax 1.1.1 soon, but are currently unable to without releasing new gpytorch and botorch versions due to the inclusion of HadamardGaussianLikelihood.

In the interest of time, we can remove references to HadamardGaussianLikelihood from Ax, release Ax 1.1.1 without moving the botorch pin from 0.15.1, and quickly re-add this test with the intention of releasing a new botorch and gpytorch version before Ax 1.1.2

Differential Revision: D81687318


