### PR TITLE
Add pymoo to botorch requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "botorch>=0.15.1",
+    "botorch[pymoo]>=0.15.1",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
Summary:
Pymoo is needed for the obj vs pfeasible analysis which is now computed for all optimizations which include a constraint.

Without this the mat sci tutorial on the website also shows an error (though it is handled gracefully, which is why we did not notice the issue when pfeasible was added to overviewanalysis).

{F1981726512}

Differential Revision: D81687319


