### PR TITLE
Enable BoTorch-based BenchmarkProblems with MapMetric

### DIFF
--- a/ax/benchmark/problems/synthetic/from_botorch.py
+++ b/ax/benchmark/problems/synthetic/from_botorch.py
@@ -98,6 +98,8 @@ def create_problem_from_botorch(
         dict[AuxiliaryExperimentPurpose, list[AuxiliaryExperiment]] | None
     ) = None,
     n_dummy_dimensions: int = 0,
+    use_map_metric: bool = False,
+    n_steps: int = 1,
 ) -> BenchmarkProblem:
     """
     Create a ``BenchmarkProblem`` from a BoTorch ``BaseTestProblem``.
@@ -154,6 +156,12 @@ def create_problem_from_botorch(
         n_dummy_dimensions: If >0, the search space will be augmented
             with extra dimensions. The corresponding parameters will have no
             effect on function values.
+        use_map_metric: Whether to use a ``BenchmarkMapMetric`` (rather than a
+            ``BenchmarkMetric``).
+        n_steps: Number of steps (progression values) in each evaluation. The
+            default of 1 reflects a normal synthetic function evaluation. A
+            higher number results in repeating the evaluation and getting the
+            same result ``n_steps`` times (before IID noise is added).
 
     Example:
         >>> from ax.benchmark.benchmark_problem import create_problem_from_botorch
@@ -213,6 +221,7 @@ def create_problem_from_botorch(
         dummy_param_names={
             n for n in search_space.parameters if "embedding_dummy_" in n
         },
+        n_steps=n_steps,
     )
 
     if isinstance(test_problem, MultiObjectiveTestProblem):
@@ -224,12 +233,14 @@ def create_problem_from_botorch(
             observe_noise_sd=observe_noise_sd,
             outcome_names=test_function.outcome_names,
             ref_point=test_problem._ref_point,
+            use_map_metric=use_map_metric,
         )
     else:
         optimization_config = get_soo_opt_config(
             outcome_names=test_function.outcome_names,
             lower_is_better=lower_is_better,
             observe_noise_sd=observe_noise_sd,
+            use_map_metric=use_map_metric,
         )
 
     optimal_value = (

--- a/ax/benchmark/tests/problems/synthetic/test_from_botorch.py
+++ b/ax/benchmark/tests/problems/synthetic/test_from_botorch.py
@@ -8,7 +8,7 @@
 from itertools import product
 
 import torch
-from ax.benchmark.benchmark_metric import BenchmarkMetric
+from ax.benchmark.benchmark_metric import BenchmarkMapMetric, BenchmarkMetric
 from ax.benchmark.benchmark_problem import get_continuous_search_space
 from ax.benchmark.benchmark_test_functions.botorch_test import BoTorchTestFunction
 from ax.benchmark.problems.synthetic.from_botorch import (
@@ -342,3 +342,40 @@ class TestFromBoTorch(TestCase):
                 test_problem=Branin(), n_dummy_dimensions=24, observe_noise_sd=True
             )
             self.assertEqual(name, "Branin_observed_noise_26d")
+
+    def test_with_map_metric(self) -> None:
+        with self.subTest("With default n_steps"):
+            problem = create_problem_from_botorch(
+                test_problem_class=Branin,
+                test_problem_kwargs={},
+                num_trials=1,
+                use_map_metric=True,
+            )
+            self.assertIsInstance(
+                problem.optimization_config.objective.metric, BenchmarkMapMetric
+            )
+            self.assertEqual(problem.test_function.n_steps, 1)
+
+        with self.subTest("With non-default n_steps"):
+            n_steps = 4
+            problem = create_problem_from_botorch(
+                test_problem_class=Branin,
+                test_problem_kwargs={},
+                num_trials=1,
+                use_map_metric=True,
+                n_steps=4,
+            )
+            self.assertIsInstance(
+                problem.optimization_config.objective.metric, BenchmarkMapMetric
+            )
+            self.assertEqual(problem.test_function.n_steps, n_steps)
+
+        with self.subTest("MOO"):
+            problem = create_problem_from_botorch(
+                test_problem_class=BraninCurrin,
+                test_problem_kwargs={},
+                num_trials=1,
+                use_map_metric=True,
+            )
+            metric = next(iter(problem.optimization_config.metrics.values()))
+            self.assertIsInstance(metric, BenchmarkMapMetric)


### PR DESCRIPTION
Summary:
* Enables BoTorchTestFunction to produce data with `steps` and `MapMetric`. The data is simply repeated, so this is not interesting for modeling, but it is useful for measuring runtime.
* Makes outputs 2d in accordance with the docstring.

Differential Revision: D81689093


