### PR TITLE
Remove MapKeyInfo, making all map keys "step"

### DIFF
--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -34,7 +34,7 @@ from ax.adapter.transforms.unit_x import UnitX
 from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
 from ax.core.experiment import Experiment
-from ax.core.map_data import MapData
+from ax.core.map_data import MAP_KEY, MapData
 from ax.core.metric import Metric
 from ax.core.objective import Objective, ScalarizedObjective
 from ax.core.observation import ObservationData, ObservationFeatures
@@ -647,7 +647,7 @@ class BaseAdapterTest(TestCase):
                     set(call_kwargs["status_quo_observations"][-1].data.metric_names),
                     {"branin_map_constraint"},
                 )
-            self.assertEqual(call_kwargs["map_key"], "timestamp")
+            self.assertEqual(call_kwargs["map_key"], MAP_KEY)
             opt_config_metrics = set(none_throws(exp.optimization_config).metrics)
             self.assertEqual(call_kwargs["metrics"], opt_config_metrics)
             adapter_sq = none_throws(adapter.status_quo)

--- a/ax/api/protocols/utils.py
+++ b/ax/api/protocols/utils.py
@@ -16,7 +16,7 @@ import pandas as pd
 from ax.api.types import TParameterization
 
 from ax.core.base_trial import BaseTrial, TrialStatus
-from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_data import MAP_KEY, MapData
 from ax.core.map_metric import MapMetric
 from ax.core.metric import MetricFetchE, MetricFetchResult
 from ax.core.runner import Runner
@@ -36,8 +36,6 @@ class _APIMetric(MapMetric, ABC):
     Ideally we will be able to remove this class in the future, once we have stablized
     structure of ax.core.Metric to be more in line with our long term vision for Ax.
     """
-
-    map_key_info: MapKeyInfo = MapKeyInfo(key="step")
 
     def __init__(self, name: str) -> None:
         super().__init__(name=name)
@@ -72,16 +70,11 @@ class _APIMetric(MapMetric, ABC):
                 "trial_index": trial.index,
                 "arm_name": none_throws(trial.arm).name,
                 "metric_name": self.name,
-                self.map_key_info.key: progression,
+                MAP_KEY: progression,
                 "mean": mean,
                 "sem": sem,
             }
-            return Ok(
-                value=MapData(
-                    df=pd.DataFrame.from_records([record]),
-                    map_key_infos=[self.map_key_info],
-                )
-            )
+            return Ok(value=MapData(df=pd.DataFrame.from_records([record])))
         except Exception as e:
             return Err(
                 value=MetricFetchE(message=f"Failed to fetch {self.name}", exception=e)

--- a/ax/benchmark/benchmark_metric.py
+++ b/ax/benchmark/benchmark_metric.py
@@ -259,13 +259,9 @@ class BenchmarkMapMetric(MapMetric, BenchmarkMetricBase):
         return True
 
     def _df_to_result(self, df: DataFrame) -> MetricFetchResult:
-        # Just in case the key was renamed by a subclass
-        df = df.rename(columns={"step": self.map_key_info.key})
-        return Ok(value=MapData(df=df, map_key_infos=[self.map_key_info]))
+        return Ok(value=MapData(df=df))
 
 
 class BenchmarkMapUnavailableWhileRunningMetric(MapMetric, BenchmarkMetricBase):
     def _df_to_result(self, df: DataFrame) -> MetricFetchResult:
-        # Just in case the key was renamed by a subclass
-        df = df.rename(columns={"step": self.map_key_info.key})
-        return Ok(value=MapData(df=df, map_key_infos=[self.map_key_info]))
+        return Ok(value=MapData(df=df))

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1473,17 +1473,7 @@ class Experiment(Base):
                     inplace=True,
                 )
                 # Attach updated data to new trial on experiment.
-                data_constructor = old_experiment.default_data_constructor
-                old_data = (
-                    MapData.from_df(
-                        df=new_df,
-                        map_key=assert_is_instance(
-                            old_experiment.lookup_data(), MapData
-                        ).map_key,
-                    )
-                    if data_constructor == MapData
-                    else data_constructor(df=new_df)
-                )
+                old_data = old_experiment.default_data_constructor(df=new_df)
                 self.attach_data(data=old_data)
             if trial.status == TrialStatus.ABANDONED:
                 new_trial.mark_abandoned(reason=trial.abandoned_reason)

--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from ax.core.data import Data
 
-from ax.core.map_data import MAP_KEY, MapData, MapKeyInfo
+from ax.core.map_data import MapData
 from ax.core.metric import Metric, MetricFetchE
 from ax.utils.common.result import Result
 
@@ -32,4 +32,3 @@ class MapMetric(Metric):
     """
 
     data_constructor: type[Data] = MapData
-    map_key_info: MapKeyInfo = MapKeyInfo(key=MAP_KEY)

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pandas as pd
 from ax.core.data import Data
-from ax.core.map_data import MapData
+from ax.core.map_data import MAP_KEY, MapData
 from ax.utils.common.testutils import TestCase
 from ax.utils.common.timeutils import current_timestamp_in_millis
 from pyre_extensions import assert_is_instance
@@ -127,10 +127,10 @@ class TestDataBase(TestCase):
             self.data_with_df = Data(df=self.df)
             self.data_without_df = Data()
         else:
-            df_1 = df.copy().assign(epoch=0)
-            df_2 = df.copy().assign(epoch=1)
+            df_1 = df.copy().assign(**{MAP_KEY: 0})
+            df_2 = df.copy().assign(**{MAP_KEY: 1})
             self.df = pd.concat((df_1, df_2))
-            self.data_with_df = MapData.from_df(df=self.df, map_key="epoch")
+            self.data_with_df = MapData(df=self.df)
             self.data_without_df = MapData()
 
     def test_init(self) -> None:
@@ -173,7 +173,7 @@ class TestDataBase(TestCase):
             if self.cls is Data:
                 Data(df=df)
             else:
-                MapData(df=df, map_key_infos=[])
+                MapData(df=df)
 
     def test_EmptyData(self) -> None:
         data = self.data_without_df
@@ -183,8 +183,11 @@ class TestDataBase(TestCase):
 
         if isinstance(data, MapData):
             self.assertTrue(data.map_df.empty)
-        self.assertEqual(Data.REQUIRED_COLUMNS, data.required_columns())
-        self.assertEqual(set(df.columns), set(Data.REQUIRED_COLUMNS))
+            expected_columns = Data.REQUIRED_COLUMNS.union({MAP_KEY})
+        else:
+            expected_columns = Data.REQUIRED_COLUMNS
+        self.assertEqual(expected_columns, data.required_columns())
+        self.assertEqual(set(df.columns), expected_columns)
 
     def test_from_multiple_with_generator(self) -> None:
         data = self.cls.from_multiple_data(self.data_with_df for _ in range(2))

--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -6,12 +6,9 @@
 # pyre-strict
 
 
-from math import isnan
-
 import numpy as np
 import pandas as pd
-from ax.core.data import Data
-from ax.core.map_data import _tail, MapData, MapKeyInfo
+from ax.core.map_data import MAP_KEY, MapData
 from ax.core.tests.test_data import TestDataBase
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.testutils import TestCase
@@ -21,19 +18,6 @@ class TestMapData(TestDataBase):
     cls: type[MapData] = MapData
 
 
-class TestMapKeyInfo(TestCase):
-    def test_init(self) -> None:
-        with self.subTest("No default passed"):
-            map_key_info = MapKeyInfo(key="epoch")
-            self.assertTrue(isnan(map_key_info.default_value))
-
-        with self.subTest("Default passed"):
-            with self.assertWarnsRegex(Warning, "default_value will be treated as NaN"):
-                map_key_info = MapKeyInfo(key="epoch", default_value=5.0)
-            self.assertTrue(isnan(map_key_info.default_value))
-            self.assertEqual(map_key_info.key, "epoch")
-
-
 class MapDataTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -41,7 +25,7 @@ class MapDataTest(TestCase):
             [
                 {
                     "arm_name": "0_0",
-                    "epoch": 0,
+                    MAP_KEY: 0,
                     "mean": 3.0,
                     "sem": 0.3,
                     "trial_index": 0,
@@ -50,7 +34,7 @@ class MapDataTest(TestCase):
                 # repeated arm 0_0
                 {
                     "arm_name": "0_0",
-                    "epoch": 0,
+                    MAP_KEY: 0,
                     "mean": 2.0,
                     "sem": 0.2,
                     "trial_index": 1,
@@ -58,7 +42,7 @@ class MapDataTest(TestCase):
                 },
                 {
                     "arm_name": "0_0",
-                    "epoch": 0,
+                    MAP_KEY: 0,
                     "mean": 1.8,
                     "sem": 0.3,
                     "trial_index": 1,
@@ -66,7 +50,7 @@ class MapDataTest(TestCase):
                 },
                 {
                     "arm_name": "0_1",
-                    "epoch": 0,
+                    MAP_KEY: 0,
                     "mean": 4.0,
                     "sem": 0.6,
                     "trial_index": 1,
@@ -74,7 +58,7 @@ class MapDataTest(TestCase):
                 },
                 {
                     "arm_name": "0_1",
-                    "epoch": 0,
+                    MAP_KEY: 0,
                     "mean": 3.7,
                     "sem": 0.5,
                     "trial_index": 1,
@@ -82,7 +66,7 @@ class MapDataTest(TestCase):
                 },
                 {
                     "arm_name": "0_1",
-                    "epoch": 1,
+                    MAP_KEY: 1,
                     "mean": 0.5,
                     "sem": None,
                     "trial_index": 1,
@@ -90,7 +74,7 @@ class MapDataTest(TestCase):
                 },
                 {
                     "arm_name": "0_1",
-                    "epoch": 1,
+                    MAP_KEY: 1,
                     "mean": 3.0,
                     "sem": None,
                     "trial_index": 1,
@@ -99,37 +83,22 @@ class MapDataTest(TestCase):
             ]
         )
 
-        self.map_key = "epoch"
-        self.map_key_infos = [MapKeyInfo(key=self.map_key)]
-
-        self.mmd = MapData.from_df(df=self.df, map_key=self.map_key)
+        self.mmd = MapData(df=self.df)
 
     def test_df(self) -> None:
         df = self.mmd.df
         self.assertEqual(set(df["trial_index"].drop_duplicates()), {0, 1})
 
-    def test_map_key_info(self) -> None:
-        self.assertEqual(self.map_key, self.mmd.map_key)
-        self.assertEqual(self.map_key_infos, self.mmd.map_key_infos)
-
     def test_init(self) -> None:
-        # Initialize empty with map key infos.
-        empty = MapData(map_key_infos=self.map_key_infos)
+        # Initialize empty
+        empty = MapData()
         self.assertTrue(empty.map_df.empty)
-
-        # Initialize empty with map key.
-        empty = MapData.from_df(map_key=self.map_key)
-        self.assertTrue(empty.map_df.empty)
-        self.assertEqual(empty.map_key, self.map_key)
 
         # Check that the required columns include the map keys.
         self.assertEqual(
-            empty.REQUIRED_COLUMNS.union(["epoch"]), empty.required_columns()
+            empty.REQUIRED_COLUMNS.union([MAP_KEY]), empty.required_columns()
         )
         self.assertEqual(set(empty.map_df.columns), empty.required_columns())
-
-        with self.assertRaisesRegex(ValueError, "map_key_infos may be `None` iff"):
-            MapData(df=self.df, map_key_infos=None)
 
     def test_from_evaluations(self) -> None:
         with self.assertRaisesRegex(
@@ -137,89 +106,14 @@ class MapDataTest(TestCase):
         ):
             MapData.from_evaluations(evaluations={}, trial_index=0)
 
-    def test_properties(self) -> None:
-        self.assertEqual(self.mmd.map_key_infos, self.map_key_infos)
-        self.assertEqual(self.mmd.map_key, self.map_key)
-        self.assertEqual(self.mmd.map_key, "epoch")
-
     def test_combine(self) -> None:
         with self.subTest("From no MapDatas"):
             data = MapData.from_multiple_map_data([])
             self.assertEqual(data.map_df.size, 0)
 
-        with self.subTest("From two MapDatas with same map_key_info"):
+        with self.subTest("From two MapDatas"):
             mmd_double = MapData.from_multiple_map_data([self.mmd, self.mmd])
             self.assertEqual(mmd_double.map_df.size, 2 * self.mmd.map_df.size)
-            self.assertEqual(mmd_double.map_key_infos, self.mmd.map_key_infos)
-            self.assertEqual(mmd_double.map_key, self.mmd.map_key)
-
-        with self.subTest("From two MapDatas with different map_key_info keys"):
-            different_map_df = pd.DataFrame(
-                [
-                    {
-                        "arm_name": "0_3",
-                        "timestamp": 11,
-                        "mean": 2.0,
-                        "sem": 0.2,
-                        "trial_index": 1,
-                        "metric_name": "a",
-                    },
-                    {
-                        "arm_name": "0_3",
-                        "timestamp": 18,
-                        "mean": 1.8,
-                        "sem": 0.3,
-                        "trial_index": 1,
-                        "metric_name": "b",
-                    },
-                ]
-            )
-            different_mmd = MapData.from_df(df=different_map_df, map_key="timestamp")
-
-            with self.assertRaisesRegex(
-                ValueError, "Received MapData with different map keys"
-            ):
-                MapData.from_multiple_map_data([self.mmd, different_mmd])
-
-        with self.subTest("Only one has a map key"):
-            data_df = pd.DataFrame(
-                [
-                    {
-                        "arm_name": "0_4",
-                        "mean": 2.0,
-                        "sem": 0.2,
-                        "trial_index": 1,
-                        "metric_name": "a",
-                    },
-                    {
-                        "arm_name": "0_4",
-                        "mean": 1.8,
-                        "sem": 0.3,
-                        "trial_index": 1,
-                        "metric_name": "b",
-                    },
-                ]
-            )
-            data = Data(df=data_df)
-
-            downcast_combined = MapData.from_multiple_data([self.mmd, data])
-            self.assertEqual(
-                len(downcast_combined.map_df), len(self.mmd.map_df) + len(data.df)
-            )
-            self.assertEqual(
-                downcast_combined.map_df.columns.size, self.mmd.map_df.columns.size
-            )
-            self.assertEqual(downcast_combined.map_key, self.map_key)
-            self.assertEqual(downcast_combined.map_key_infos, self.map_key_infos)
-
-        # Check that the Data's rows' epoch cell has the correct default value
-        self.assertTrue(
-            (
-                downcast_combined.map_df[downcast_combined.map_df["arm_name"] == "0_4"][
-                    "epoch"
-                ].isnull()
-            ).all()
-        )
 
     def test_from_map_evaluations(self) -> None:
         for sem in (0.5, None):
@@ -233,19 +127,21 @@ class MapDataTest(TestCase):
             self.assertEqual(len(map_data.map_df), 2)
 
     def test_upcast(self) -> None:
-        fresh = MapData.from_df(df=self.df, map_key=self.map_key)
-        self.assertIsNone(fresh._memo_df)  # Assert df is not cached before first call
+        fresh = MapData(df=self.df)
+        # Assert df is not cached before first call
+        self.assertIsNone(fresh._memo_df)
 
         self.assertEqual(
             fresh.df.columns.size,
             fresh.map_df.columns.size,
         )
 
-        self.assertIsNotNone(fresh._memo_df)  # Assert df is cached after first call
+        # Assert df is cached after first call
+        self.assertIsNotNone(fresh._memo_df)
 
         self.assertTrue(
             fresh.df.equals(
-                fresh.map_df.sort_values(fresh.map_key).drop_duplicates(
+                fresh.map_df.sort_values(MAP_KEY).drop_duplicates(
                     MapData.DEDUPLICATE_BY_COLUMNS, keep="last"
                 )
             )
@@ -261,7 +157,7 @@ class MapDataTest(TestCase):
             [
                 {
                     "arm_name": arm_name,
-                    "epoch": epoch + 1,
+                    MAP_KEY: epoch + 1,
                     "mean": epoch * 0.1,
                     "sem": 0.1,
                     "trial_index": trial_index,
@@ -274,22 +170,20 @@ class MapDataTest(TestCase):
                 for epoch in range(max_epoch)
             ]
         )
-        large_map_data = MapData.from_df(df=large_map_df, map_key=self.map_key)
+        large_map_data = MapData(df=large_map_df)
 
         shuffled_large_map_df = large_map_data.map_df.groupby(
             MapData.DEDUPLICATE_BY_COLUMNS
         ).sample(frac=1, random_state=seed)
-        shuffled_large_map_data = MapData.from_df(
-            df=shuffled_large_map_df, map_key=self.map_key
-        )
+        shuffled_large_map_data = MapData(df=shuffled_large_map_df)
 
         for rows_per_group in [1, 40]:
             large_map_data_latest = large_map_data.latest(rows_per_group=rows_per_group)
 
             if rows_per_group == 1:
                 self.assertTrue(
-                    large_map_data_latest.map_df.groupby("metric_name")
-                    .epoch.transform(lambda col: set(col) == set(max_epochs))
+                    large_map_data_latest.map_df.groupby("metric_name")[MAP_KEY]
+                    .transform(lambda col: set(col) == set(max_epochs))
                     .all()
                 )
 
@@ -299,14 +193,16 @@ class MapDataTest(TestCase):
                 MapData.DEDUPLICATE_BY_COLUMNS
             ).size()
             expected_rows_per_group = np.minimum(
-                large_map_data_latest.map_df.groupby(MapData.DEDUPLICATE_BY_COLUMNS)
-                .epoch.max()
+                large_map_data_latest.map_df.groupby(MapData.DEDUPLICATE_BY_COLUMNS)[
+                    MAP_KEY
+                ]
+                .max()
                 .astype(int),
                 rows_per_group,
             )
             self.assertTrue(actual_rows_per_group.equals(expected_rows_per_group))
 
-            # behavior should be consistent even if map_keys are not in ascending order
+            # behavior should be consistent despite shuffling
             shuffled_large_map_data_latest = shuffled_large_map_data.latest(
                 rows_per_group=rows_per_group
             )
@@ -316,11 +212,6 @@ class MapDataTest(TestCase):
                 )
             )
 
-    def test_tail(self) -> None:
-        """`_tail` is tested more thoroughly but implicitly in `test_latest`."""
-        with self.assertRaisesRegex(ValueError, "`map_key` can only be None when"):
-            _tail(map_df=self.mmd.map_df, map_key=None)
-
     def test_subsample(self) -> None:
         arm_names = ["0_0", "1_0", "2_0", "3_0"]
         max_epochs = [25, 50, 75, 100]
@@ -329,7 +220,7 @@ class MapDataTest(TestCase):
             [
                 {
                     "arm_name": arm_name,
-                    "epoch": epoch + 1,
+                    MAP_KEY: epoch + 1,
                     "mean": epoch * 0.1,
                     "sem": 0.1,
                     "trial_index": trial_index,
@@ -342,12 +233,12 @@ class MapDataTest(TestCase):
                 for epoch in range(max_epoch)
             ]
         )
-        large_map_data = MapData.from_df(df=large_map_df, map_key=self.map_key)
+        large_map_data = MapData(df=large_map_df)
         large_map_df_sparse_metric = pd.DataFrame(
             [
                 {
                     "arm_name": arm_name,
-                    "epoch": epoch + 1,
+                    MAP_KEY: epoch + 1,
                     "mean": epoch * 0.1,
                     "sem": 0.1,
                     "trial_index": trial_index,
@@ -360,9 +251,7 @@ class MapDataTest(TestCase):
                 for epoch in range(max_epoch if metric_name == "a" else max_epoch // 5)
             ]
         )
-        large_map_data_sparse_metric = MapData.from_df(
-            df=large_map_df_sparse_metric, map_key=self.map_key
-        )
+        large_map_data_sparse_metric = MapData(df=large_map_df_sparse_metric)
 
         # test keep_every
         subsample = large_map_data.subsample(keep_every=10)
@@ -396,14 +285,14 @@ class MapDataTest(TestCase):
         )
         self.assertEqual(len(subsample.map_df), 40)
         # check that we 1 and 100 are included
-        self.assertEqual(subsample.map_df["epoch"].min(), 1)
-        self.assertEqual(subsample.map_df["epoch"].max(), 100)
+        self.assertEqual(subsample.map_df[MAP_KEY].min(), 1)
+        self.assertEqual(subsample.map_df[MAP_KEY].max(), 100)
         subsample = large_map_data.subsample(
             limit_rows_per_metric=20, include_first_last=False
         )
         self.assertEqual(len(subsample.map_df), 40)
-        self.assertEqual(subsample.map_df["epoch"].min(), 1)
-        self.assertEqual(subsample.map_df["epoch"].max(), 92)
+        self.assertEqual(subsample.map_df[MAP_KEY].min(), 1)
+        self.assertEqual(subsample.map_df[MAP_KEY].max(), 92)
 
         # test limit_rows_per_metric when some metrics are sparsely
         # reported (we shouldn't subsample those)

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -469,7 +469,7 @@ class ObservationsTest(TestCase):
         df = pd.DataFrame(truth)[
             ["arm_name", "trial_index", "mean", "sem", "metric_name", "step"]
         ]
-        data = MapData.from_df(df=df, map_key="step")
+        data = MapData(df=df)
         observations = observations_from_data(experiment=experiment, data=data)
         self.assertEqual(len(observations), 3)
 

--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -21,6 +21,7 @@ from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
+from ax.core.map_data import MAP_KEY
 from ax.core.map_metric import MapMetric
 from ax.core.objective import MultiObjective
 from ax.core.observation import ObservationFeatures
@@ -661,12 +662,11 @@ def extract_map_keys_from_opt_config(
     Returns:
         A set of map keys.
     """
-    map_metrics = {
-        name: metric
-        for name, metric in optimization_config.metrics.items()
-        if isinstance(metric, MapMetric) and metric.has_map_data
-    }
-    map_key_names = {m.map_key_info.key for m in map_metrics.values()}
+    has_map_data = any(
+        isinstance(metric, MapMetric) and metric.has_map_data
+        for metric in optimization_config.metrics.values()
+    )
+    map_key_names = {MAP_KEY} if has_map_data else set()
     return map_key_names
 
 

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -49,7 +49,7 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 absolute values; if `minimize` is False, then "bottom" actually refers
                 to the top trials in terms of metric value.
             min_progression: Only stop trials if the latest progression value
-                (e.g. timestamp, epochs, training data used) is greater than this
+                (i.e. "step") is greater than this
                 threshold. Prevents stopping prematurely before enough data is gathered
                 to make a decision.
             max_progression: Do not stop trials that have passed `max_progression`.

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 from ax.core import OptimizationConfig
 from ax.core.experiment import Experiment
-from ax.core.map_data import MapData
+from ax.core.map_data import MAP_KEY, MapData
 from ax.core.objective import MultiObjective
 from ax.core.trial_status import TrialStatus
 from ax.early_stopping.strategies import (
@@ -468,7 +468,7 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         data = assert_is_instance(exp.fetch_data(), MapData)
 
         unaligned_timestamps = [0, 1, 4, 1, 2, 3, 1, 3, 4, 0, 1, 2, 0, 2, 4]
-        data.map_df.loc[data.map_df["metric_name"] == "branin_map", "timestamp"] = (
+        data.map_df.loc[data.map_df["metric_name"] == "branin_map", MAP_KEY] = (
             unaligned_timestamps
         )
         exp.attach_data(data=data)
@@ -512,7 +512,7 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         data.map_df.reset_index(drop=True, inplace=True)
 
         unaligned_timestamps = [0, 1, 4, 1, 2, 3, 1, 3, 4, 0, 1, 2, 0, 2, 4]
-        data.map_df.loc[data.map_df["metric_name"] == "branin_map", "timestamp"] = (
+        data.map_df.loc[data.map_df["metric_name"] == "branin_map", MAP_KEY] = (
             unaligned_timestamps
         )
         # manually remove timestamps 1 and 2 for arm 3
@@ -521,7 +521,7 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
             df.index[
                 (df["metric_name"] == "branin_map")
                 & (df["trial_index"] == 3)
-                & (df["timestamp"].isin([1.0, 2.0]))
+                & (df[MAP_KEY].isin([1.0, 2.0]))
             ],
             inplace=True,
         )  # TODO this wont work once we make map_df immutable (which we should)
@@ -571,7 +571,7 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         ):
             align_partial_results(
                 df=df_with_single_arm_name,
-                progr_key="timestamp",
+                progr_key=MAP_KEY,
                 metrics=["branin_map"],
             )
 
@@ -583,7 +583,7 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         ):
             align_partial_results(
                 df=df_with_single_trial_index,
-                progr_key="timestamp",
+                progr_key=MAP_KEY,
                 metrics=["branin_map"],
             )
 
@@ -786,7 +786,7 @@ def _evaluate_early_stopping_with_df(
     )
     metric_to_aligned_means, _ = align_partial_results(
         df=data.map_df,
-        progr_key="timestamp",
+        progr_key=MAP_KEY,
         metrics=[metric_name],
     )
     aligned_means = metric_to_aligned_means[metric_name]
@@ -796,7 +796,7 @@ def _evaluate_early_stopping_with_df(
             experiment=experiment,
             df=aligned_means,
             df_raw=data.map_df,
-            map_key="timestamp",
+            map_key=MAP_KEY,
             minimize=cast(
                 OptimizationConfig, experiment.optimization_config
             ).objective.minimize,

--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -17,7 +17,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from ax.core.base_trial import BaseTrial
-from ax.core.map_data import MapData
+from ax.core.map_data import MAP_KEY, MapData
 from ax.core.map_metric import MapMetricFetchResult
 from ax.core.metric import MetricFetchE
 from ax.metrics.noisy_function_map import NoisyFunctionMapMetric
@@ -122,13 +122,11 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
                             else 0.0
                             for item in res
                         ],
-                        self.map_key_info.key: [
-                            item[self.map_key_info.key] for item in res
-                        ],
+                        MAP_KEY: [item[MAP_KEY] for item in res],
                     }
                 )
 
-                datas.append(MapData(df=df, map_key_infos=[self.map_key_info]))
+                datas.append(MapData(df=df))
 
             return Ok(value=MapData.from_multiple_map_data(datas))
 
@@ -149,4 +147,4 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
 
         mean = assert_is_instance(branin(x1=x1, x2=x2), float) * weight
 
-        return {"mean": mean, "timestamp": timestamp}
+        return {"mean": mean, MAP_KEY: timestamp}

--- a/ax/metrics/noisy_function_map.py
+++ b/ax/metrics/noisy_function_map.py
@@ -16,7 +16,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from ax.core.base_trial import BaseTrial
-from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_data import MAP_KEY, MapData
 from ax.core.map_metric import MapMetric, MapMetricFetchResult
 from ax.core.metric import MetricFetchE
 from ax.utils.common.result import Err, Ok
@@ -26,8 +26,6 @@ class NoisyFunctionMapMetric(MapMetric):
     """A metric defined by a generic deterministic function, with normal noise
     with mean 0 and mean_sd scale added to the result.
     """
-
-    map_key_info: MapKeyInfo = MapKeyInfo(key="timestamp")
 
     def __init__(
         self,
@@ -101,12 +99,10 @@ class NoisyFunctionMapMetric(MapMetric):
                         else 0.0
                         for item in res
                     ],
-                    self.map_key_info.key: [
-                        item[self.map_key_info.key] for item in res
-                    ],
+                    MAP_KEY: [item[MAP_KEY] for item in res],
                 }
             )
-            return Ok(value=MapData(df=df, map_key_infos=[self.map_key_info]))
+            return Ok(value=MapData(df=df))
 
         except Exception as e:
             return Err(

--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -17,7 +17,7 @@ import numpy as np
 
 import pandas as pd
 from ax.core.base_trial import BaseTrial
-from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_data import MAP_KEY, MapData
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
 from ax.core.trial import Trial
@@ -40,8 +40,6 @@ try:
 
     class TensorboardMetric(MapMetric):
         """A *new* `MapMetric` for getting Tensorboard metrics."""
-
-        map_key_info: MapKeyInfo = MapKeyInfo(key="step")
 
         def __init__(
             self,
@@ -138,7 +136,7 @@ try:
                             "trial_index": trial.index,
                             "arm_name": arm_name,
                             "metric_name": metric.name,
-                            self.map_key_info.key: t.step,
+                            MAP_KEY: t.step,
                             "mean": (
                                 t.tensor_proto.double_val[0]
                                 if t.tensor_proto.double_val
@@ -173,7 +171,6 @@ try:
                     res[metric.name] = Ok(
                         MapData(
                             df=df,
-                            map_key_infos=[self.map_key_info],
                         )
                     )
 
@@ -227,7 +224,7 @@ try:
                 pd.DataFrame(records)
                 # If a metric has multiple records for the same arm, metric, and
                 # step (sometimes caused by restarts, etc) take the mean
-                .groupby(["arm_name", "metric_name", self.map_key_info.key])
+                .groupby(["arm_name", "metric_name", MAP_KEY])
                 .mean()
                 .reset_index()
             )

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -25,7 +25,6 @@ from ax.core.experiment import DataType, Experiment
 from ax.core.formatting_utils import data_and_evaluations_from_raw_data
 from ax.core.generator_run import GeneratorRun
 from ax.core.map_data import MapData
-from ax.core.map_metric import MapMetric
 from ax.core.multi_type_experiment import MultiTypeExperiment
 from ax.core.objective import MultiObjective, Objective
 from ax.core.observation import ObservationFeatures
@@ -1325,14 +1324,9 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             experiment=self.experiment, trial=trial
         )
 
-    def estimate_early_stopping_savings(self, map_key: str | None = None) -> float:
+    def estimate_early_stopping_savings(self) -> float:
         """Estimate early stopping savings using progressions of the MapMetric present
         on the EarlyStoppingConfig as a proxy for resource usage.
-
-        Args:
-            map_key: The name of the map_key by which to estimate early stopping
-                savings, usually steps. If none is specified use some arbitrary map_key
-                in the experiment's MapData
 
         Returns:
             The estimated resource savings as a fraction of total resource usage (i.e.
@@ -1342,26 +1336,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         if self.experiment.default_data_constructor is not MapData:
             return 0
 
-        strategy = self.early_stopping_strategy
-        map_key = (
-            map_key
-            if map_key is not None
-            else (
-                assert_is_instance(
-                    self.experiment.metrics[list(strategy.metric_names)[0]],
-                    MapMetric,
-                ).map_key_info.key
-                if strategy is not None
-                and strategy.metric_names is not None
-                and len(list(strategy.metric_names)) > 0
-                else None
-            )
-        )
-
-        return estimate_early_stopping_savings(
-            experiment=self.experiment,
-            map_key=map_key,
-        )
+        return estimate_early_stopping_savings(experiment=self.experiment)
 
     # ------------------ JSON serialization & storage methods. -----------------
 

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -26,7 +26,7 @@ from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
-from ax.core.map_data import MapData
+from ax.core.map_data import MAP_KEY, MapData
 from ax.core.metric import Metric
 from ax.core.multi_type_experiment import MultiTypeExperiment
 from ax.core.objective import Objective
@@ -1619,7 +1619,7 @@ class TestAxOrchestrator(TestCase):
         gs = self.two_sobol_steps_GS
         with patch(
             f"{BraninTimestampMapMetric.__module__}.BraninTimestampMapMetric.f",
-            side_effect=[Exception("yikes!"), {"mean": 0, "timestamp": 12345}],
+            side_effect=[Exception("yikes!"), {"mean": 0, MAP_KEY: 12345}],
         ), patch(
             f"{BraninMetric.__module__}.BraninMetric.f",
             side_effect=[Exception("yikes!"), 0],

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -30,7 +30,7 @@ from ax.adapter.torch import TorchAdapter
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRunType
-from ax.core.map_data import MapData
+from ax.core.map_data import MAP_KEY, MapData
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
 from ax.core.multi_type_experiment import MultiTypeExperiment
@@ -513,7 +513,6 @@ def _get_curve_plot_dropdown(
             always_include_field_columns=True,
         )
     for m in map_metrics:
-        map_key = m.map_key_info.key
         subsampled_data = (
             data
             if limit_points_per_plot is None
@@ -531,14 +530,14 @@ def _get_curve_plot_dropdown(
                 continue
             if by_walltime:
                 x = _transform_progression_to_walltime(
-                    progressions=df_g[map_key].to_numpy(),
+                    progressions=df_g[MAP_KEY].to_numpy(),
                     exp_df=exp_df,
                     trial_idx=trial_idx,
                 )
                 if x is None:
                     continue
             else:
-                x = df_g[map_key].to_numpy()
+                x = df_g[MAP_KEY].to_numpy()
             xs.append(x)
             ys.append(df_g["mean"].to_numpy())
             legend_labels.append(f"Trial {trial_idx}")
@@ -569,8 +568,7 @@ def _get_curve_plot_dropdown(
         stopping_markers_by_metric=stopping_markers_by_metric,
         title=title,
         xlabels_by_metric={
-            m.name: "wall time" if by_walltime else m.map_key_info.key
-            for m in map_metrics
+            m.name: "wall time" if by_walltime else MAP_KEY for m in map_metrics
         },
         lower_is_better_by_metric={m.name: m.lower_is_better for m in map_metrics},
     )

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -19,7 +19,7 @@ from ax.core.auxiliary import AuxiliaryExperiment
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun
-from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_data import MapData
 from ax.core.metric import Metric
 from ax.core.multi_type_experiment import MultiTypeExperiment
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
@@ -424,13 +424,6 @@ def map_data_to_dict(map_data: MapData) -> dict[str, Any]:
     """Convert Ax map data to a dictionary."""
     properties = map_data.serialize_init_args(obj=map_data)
     properties["__type"] = map_data.__class__.__name__
-    return properties
-
-
-def map_key_info_to_dict(mki: MapKeyInfo) -> dict[str, Any]:
-    """Convert Ax map data metadata to a dictionary."""
-    properties = serialize_init_args(obj=mki)
-    properties["__type"] = mki.__class__.__name__
     return properties
 
 

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -30,7 +30,7 @@ from ax.core.batch_trial import AbandonedArm, BatchTrial, GeneratorRunStruct
 from ax.core.data import Data
 from ax.core.experiment import DataType
 from ax.core.generator_run import GeneratorRun
-from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
 from ax.core.multi_type_experiment import MultiTypeExperiment
@@ -140,7 +140,6 @@ from ax.storage.json_store.encoders import (
     improvement_global_stopping_strategy_to_dict,
     logical_early_stopping_strategy_to_dict,
     map_data_to_dict,
-    map_key_info_to_dict,
     metric_to_dict,
     multi_objective_optimization_config_to_dict,
     multi_objective_to_dict,
@@ -229,7 +228,6 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     L2NormMetric: metric_to_dict,
     LogNormalPrior: botorch_component_to_dict,
     MapData: map_data_to_dict,
-    MapKeyInfo: map_key_info_to_dict,
     MapMetric: metric_to_dict,
     MaxGenerationParallelism: transition_criterion_to_dict,
     MaxTrials: transition_criterion_to_dict,
@@ -365,7 +363,6 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "LogNormalPrior": LogNormalPrior,
     "MapData": MapData,
     "MapMetric": MapMetric,
-    "MapKeyInfo": MapKeyInfo,
     "MaxTrials": MaxTrials,
     "MaxGenerationParallelism": MaxGenerationParallelism,
     "Metric": Metric,

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -31,7 +31,7 @@ from ax.core.batch_trial import AbandonedArm, BatchTrial
 from ax.core.data import Data
 from ax.core.experiment import DataType, Experiment
 from ax.core.generator_run import GeneratorRun
-from ax.core.map_data import MapData, MapKeyInfo
+from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
 from ax.core.multi_type_experiment import MultiTypeExperiment
@@ -2696,10 +2696,6 @@ def get_observations_with_invalid_value(invalid_value: float) -> list[Observatio
         Observation(features=ObservationFeatures({}), data=obsd_with_non_finite)
     ]
     return observations
-
-
-def get_map_key_info() -> MapKeyInfo:
-    return MapKeyInfo(key="epoch")
 
 
 def get_branin_data(


### PR DESCRIPTION
Summary:
With this change, a map key can no longer be specified on a MapMetric or MapData; the key will be "step." D81254898 will clean up various references to map keys.

* Remove MapKeyInfo (no longer an attribute on MapData or MapMetric)
* All map keys become "step" by default, so map keys were renamed in various places
* As needed, I either updated various references to `MapKeyInfo`s to point to the default map key or changed them to None (in cases in which that will preserve the correct behavior). D81254898 will remove various references to map_key.

Note: `MapKeyInfo` does not appear to have ever been serialized and stored. It is not used with serialization for `MapMetric` because it is not an init arg, and serialization for `MapData` deals with `MapKeyInfo` only in a serialized format. I added storage backwards compatibility for `MapData`; it should work automatically with `MapMetric`, and I don't think serialization backwards compatibility is needed for `MapKeyInfo` itself. However, this would be a regression if there are custom `MapMetric` subclasses that I haven't found that use `MapKeyInfo` as an init arg.

Differential Revision: D81363344


