### PR TITLE
Update dependents in the `RemoveFixed` transform

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -165,7 +165,7 @@ class Parameter(SortableBase, metaclass=ABCMeta):
     @property
     def dependents(self) -> dict[TParamValue, list[str]]:
         raise NotImplementedError(
-            "Only choice hierarchical parameters are currently supported."
+            "Only fixed and choice hierarchical parameters are currently supported."
         )
 
     # pyre-fixme[7]: Expected `Parameter` but got implicit return value of `None`.
@@ -775,6 +775,10 @@ class ChoiceParameter(Parameter):
             )
         return none_throws(self._dependents)
 
+    @dependents.setter
+    def dependents(self, dependents: dict[TParamValue, list[str]] | None) -> None:
+        self._dependents = dependents
+
     def _cast_values(self, values: list[TParamValue]) -> list[TParamValue]:
         return [self.cast(value) for value in values]
 
@@ -900,6 +904,10 @@ class FixedParameter(Parameter):
                 "Only hierarchical parameters support the `dependents` property."
             )
         return none_throws(self._dependents)
+
+    @dependents.setter
+    def dependents(self, dependents: dict[TParamValue, list[str]] | None) -> None:
+        self._dependents = dependents
 
     def clone(self) -> FixedParameter:
         return FixedParameter(


### PR DESCRIPTION
Summary:
1. If the dependents contain fixed or derived parameters, they should be removed after applying `RemoveFixed`.
2. If all children are removed, then set `.dependents=None` so that the parameter is not hierarchical anymore. Otherwise, the dependents would be a dictionary of empty lists `{value1: [], value2: [], ...}`, which would make downstream modeling inefficient.
3. If there exist non-root hierarchical choice (or derived) parameters, raise an error. This is a tricky case that requires a BFS traversal, which is tabled for now. For example, `P1` in the figure below is a fixed parameter.  If removed, then we need the grandparent `root` to adopt its children `C1`. Thus, a general implementation would need to bottom-up traverse the representation tree, and let grandparents adopt grandchildren recursively.

{F1981752647, width=500}

Differential Revision: D81743029


