### PR TITLE
Use node-and-date for versioning local builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ find = {}
 
 [tool.setuptools_scm]
 write_to = "ax/version.py"
-local_scheme = "no-local-version"
+local_scheme = "node-and-date"
 
 [tool.usort]
 first_party_detection = false


### PR DESCRIPTION
Testing various options with BoTorch, we get the following:
- unspecified / default / node-and-date: botorch-0.15.2.dev25+g883d49b95.d20250905
- no-local-version: botorch-0.15.2.dev25
- node-and-timestamp: botorch-0.15.2.dev25+g883d49b95.d20250905140945
- dirty-tag: botorch-0.15.2.dev25+dirty

Node-and-date retains the shortened commit hash and the date, which seems like a useful information when debugging issues.