### PR TITLE
Remove the check `all_ordinal_features_are_integer_valued`

### DIFF
--- a/ax/generators/model_utils.py
+++ b/ax/generators/model_utils.py
@@ -632,22 +632,3 @@ def enumerate_discrete_combinations(
         for c in itertools.product(*discrete_choices.values())
     ]
     return fixed_features_list
-
-
-def all_ordinal_features_are_integer_valued(
-    ssd: SearchSpaceDigest,
-) -> bool:
-    """Check if all ordinal features are integer-valued.
-
-    Args:
-        ssd: A SearchSpaceDigest.
-
-    Returns:
-        True if all ordinal features are integer-valued, False otherwise.
-    """
-    for feature_idx in ssd.ordinal_features:
-        choices = ssd.discrete_choices[feature_idx]
-        int_choices = [int(c) for c in choices]
-        if choices != int_choices:
-            return False
-    return True

--- a/ax/generators/tests/test_model_utils.py
+++ b/ax/generators/tests/test_model_utils.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock
 import numpy as np
 from ax.core.search_space import SearchSpaceDigest
 from ax.generators.model_utils import (
-    all_ordinal_features_are_integer_valued,
     best_observed_point,
     check_duplicate,
     enumerate_discrete_combinations,
@@ -188,31 +187,3 @@ class ModelUtilsTest(TestCase):
                 {1: 2, 2: 4},
             ],
         )
-
-    def test_all_ordinal_features_are_integer_valued(self) -> None:
-        # No ordinal features.
-        ssd = SearchSpaceDigest(
-            feature_names=["a", "b"],
-            bounds=[(0, 1), (0, 2)],
-            categorical_features=[0],
-            discrete_choices={0: [0, 1]},
-        )
-        self.assertTrue(all_ordinal_features_are_integer_valued(ssd=ssd))
-        # Non-integer ordinal features.
-        ssd = SearchSpaceDigest(
-            feature_names=["a", "b"],
-            bounds=[(0, 1), (0, 2)],
-            categorical_features=[0],
-            ordinal_features=[1],
-            discrete_choices={0: [0, 1], 1: [0.5, 1.5]},
-        )
-        self.assertFalse(all_ordinal_features_are_integer_valued(ssd=ssd))
-        # Integer ordinal features.
-        ssd = SearchSpaceDigest(
-            feature_names=["a", "b"],
-            bounds=[(0, 1), (0, 2)],
-            categorical_features=[0],
-            ordinal_features=[1],
-            discrete_choices={0: [0.5, 1.0], 1: [0.0, 1.0]},
-        )
-        self.assertTrue(all_ordinal_features_are_integer_valued(ssd=ssd))

--- a/ax/generators/torch/tests/test_acquisition.py
+++ b/ax/generators/torch/tests/test_acquisition.py
@@ -626,7 +626,7 @@ class AcquisitionTest(TestCase):
     @mock_botorch_optimize
     def test_optimize_acqf_discrete_too_many_choices(self) -> None:
         # Check that mixed optimizer is used when there are too many choices.
-        # If there are non-integer valued discrete features, it should use local search.
+        # Otherwise, it should use local search.
         ssd_ordinal_integer = SearchSpaceDigest(
             feature_names=["a", "b", "c"],
             bounds=[(0, 100 * (i + 1)) for i in range(3)],
@@ -639,19 +639,28 @@ class AcquisitionTest(TestCase):
             categorical_features=[0, 1, 2],
             discrete_choices={i: list(range(100 * (i + 1) + 1)) for i in range(3)},
         )
-        ssd_ordinal_noninteger = SearchSpaceDigest(
+        ssd_ordinal_noninteger_small = SearchSpaceDigest(
             feature_names=["a", "b", "c"],
-            bounds=[(0, 50 * (i + 1)) for i in range(3)],
+            bounds=[(0, 99) for i in range(3)],
             ordinal_features=[0, 1, 2],
             discrete_choices={
-                i: np.arange(0, 50 * (i + 1) + 0.1, 0.5).tolist() for i in range(3)
+                i: np.arange(0, 100, dtype=np.float64).tolist() for i in range(3)
+            },
+        )
+        ssd_ordinal_noninteger_large = SearchSpaceDigest(
+            feature_names=["a", "b", "c"],
+            bounds=[(0, 100) for i in range(3)],
+            ordinal_features=[0, 1, 2],
+            discrete_choices={
+                i: np.arange(0, 100 + 1, dtype=np.float64).tolist() for i in range(3)
             },
         )
         acquisition = self.get_acquisition_function()
         for ssd, expected_optimizer in [
             (ssd_ordinal_integer, "optimize_acqf_mixed_alternating"),
             (ssd_categorical_integer, "optimize_acqf_mixed_alternating"),
-            (ssd_ordinal_noninteger, "optimize_acqf_discrete_local_search"),
+            (ssd_ordinal_noninteger_small, "optimize_acqf_discrete_local_search"),
+            (ssd_ordinal_noninteger_large, "optimize_acqf_mixed_alternating"),
         ]:
             # Mock optimize_acqf_discrete_local_search because it isn't handled
             # by `mock_botorch_optimize`
@@ -805,18 +814,22 @@ class AcquisitionTest(TestCase):
         self.assertTrue((acqf_values >= 0).all())
         self.assertTrue((arm_weights == 1).all())
 
-        # Check that it is not used if there are non-integer discrete dimensions.
+        # Check that it is used even if there are non-integer discrete dimensions.
         ssd_nonint = dataclasses.replace(
             ssd,
+            bounds=[(0, 10), (0, 10), (0, 10)],
             ordinal_features=[0, 1],
-            discrete_choices={0: [0.1, 0.6], 1: list(range(26))},
+            discrete_choices={
+                0: np.arange(10 + 1, dtype=np.float64).tolist(),
+                1: np.arange(10 + 1, dtype=np.float64).tolist(),
+            },
         )
         with mock.patch(
             f"{ACQUISITION_PATH}.optimize_acqf_mixed_alternating",
             wraps=optimize_acqf_mixed_alternating,
         ) as mock_alternating:
             acquisition.optimize(n=3, search_space_digest=ssd_nonint)
-        mock_alternating.assert_not_called()
+        mock_alternating.assert_called()
 
         # Check if the `fixed_features` argument works for discrete features.
         ub = 10


### PR DESCRIPTION
Summary: This check is here for legacy reasons. At that time, `optimize_acqf_mixed_alternating` didn't support non-integer discrete parameters. Remove this check now that the alternating minimization optimizer support it.

Differential Revision: D81939867


