### PR TITLE
Make ImprovementGlobalStoppingStrategy compatible with MapData

### DIFF
--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -835,10 +835,6 @@ def get_experiment_with_data() -> Experiment:
 
 
 def get_experiment_with_map_data() -> Experiment:
-    # WARNING: The data for this experiment uses map key "epoch"
-    # but the metrics on the experiment use the default map key "step".
-    # The attached data only includes "ax_test_metric" and ignores
-    # the other two metrics.
     experiment = get_experiment_with_map_data_type()
     experiment._properties = {"owners": [DEFAULT_USER]}
     experiment.new_trial()


### PR DESCRIPTION
Summary:
**Context:**

`ImprovementGlobalStoppingStrategy` does not work with `MapData` because it assumes that the experiment has `Data`. This came up in https://github.com/facebook/Ax/issues/4269

**This PR:**

* Fixes that by producing the needed data using `experiment.lookup_data(trial_indices=...)` rather than `df = experiment.lookup_data().df; df = df[trial_filter]; Data(df)`.
* Removes a comment that is no longer accurate (even before this diff)

Differential Revision: D81960916


