### PR TITLE
Fix pypi upload in cron.yml

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -68,6 +68,12 @@ jobs:
         uv pip install git+https://github.com/pytorch/botorch.git
         uv pip install -e ".[dev,mysql,notebook]"
         uv pip install --upgrade build setuptools setuptools_scm wheel
+    - name: Extract reduced version and save to env var
+      # strip the commit hash from the version to enable upload to pypi
+      # env var will persist for subsequent steps
+      run: |
+        no_local_version=$(python -m setuptools_scm | cut -d "+" -f 1)
+        echo "SETUPTOOLS_SCM_PRETEND_VERSION=${no_local_version}" >> $GITHUB_ENV
     - name: Build wheel
       run: |
         python -m build --sdist --wheel


### PR DESCRIPTION
PyPI upload requires a clean version number (doesn't work with node-and-date we produce by default). This adds the cleanup step from the BoTorch version of the workflow: https://github.com/pytorch/botorch/blob/main/.github/workflows/nightly.yml#L43-L48

NOTE: This is not an issue for releases, since those are built with a clean version number by default. It only affects development versions.

Test Plan:
PyPI upload passes: https://github.com/facebook/Ax/actions/runs/17585334588/job/49951701828