### PR TITLE
Stop unnecessarily constructing init args when making new Data

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -885,13 +885,7 @@ class Experiment(Base):
                     rows that share the same values
                     for "trial_index", "metric_name", and "arm_name" in new_df
         """
-        last_ts, last_data = list(current_trial_data.items())[-1]
-        # Get the init args other than 'df' for last data
-        # in case it was a child class of `Data`
-        last_data_init_args = last_data.deserialize_init_args(
-            last_data.serialize_init_args(last_data)
-        )
-        del last_data_init_args["df"]
+        _, last_data = list(current_trial_data.items())[-1]
 
         last_data_type = type(last_data)
         merge_keys = ["trial_index", "metric_name", "arm_name"]
@@ -922,7 +916,7 @@ class Experiment(Base):
         # Remove the "_left" suffix from the column names
         last_df.columns = last_df.columns.str.replace(r"_left$", "", regex=True)
 
-        return type(last_data), last_data_type(df=last_df, **last_data_init_args)
+        return type(last_data), last_data_type(df=last_df)
 
     def attach_fetch_results(
         self,


### PR DESCRIPTION
Summary: `_get_last_data_without_similar_rows` serializes and deserializes the init args to Data/MapData in order to pass similar arguments to create a new Data/MapData that will have a different `df`. These classes now have no init arguments other than `df`, so this logic is unnecessary. It is also quite slow because `serialize_init_args` calls `MapData.df`, which is expensive to construct.

Differential Revision: D81732311


