### PR TITLE
Make sure `model_key_override` is set as the model_key for fitted adapter

### DIFF
--- a/ax/adapter/registry.py
+++ b/ax/adapter/registry.py
@@ -298,6 +298,7 @@ class GeneratorRegistryBase(Enum):
         experiment: Experiment | None = None,
         data: Data | None = None,
         silently_filter_kwargs: bool = False,
+        model_key_override: str | None = None,
         **kwargs: Any,
     ) -> Adapter:
         if self.value not in self.model_key_to_model_setup:
@@ -395,8 +396,9 @@ class GeneratorRegistryBase(Enum):
                 model_kwargs.pop(key, None)
 
         # Store all kwargs on adapter, to be saved on generator run.
+        model_key = model_key_override if model_key_override else self.value
         adapter._set_kwargs_to_save(
-            model_key=self.value,
+            model_key=model_key,
             model_kwargs=_encode_callables_as_references(model_kwargs),
             bridge_kwargs=_encode_callables_as_references(bridge_kwargs),
         )

--- a/ax/generation_strategy/generator_spec.py
+++ b/ax/generation_strategy/generator_spec.py
@@ -141,6 +141,7 @@ class GeneratorSpec(SortableBase, SerializationMixin):
             self._fitted_adapter = self.generator_enum(
                 experiment=experiment,
                 data=data,
+                model_key_override=self.model_key_override,
                 **combined_model_kwargs,
             )
             self._last_fit_arg_ids = self._get_fit_arg_ids(

--- a/ax/generation_strategy/tests/test_center_generation_node.py
+++ b/ax/generation_strategy/tests/test_center_generation_node.py
@@ -83,7 +83,8 @@ class TestCenterGenerationNode(TestCase):
         exp.new_trial().add_arm(arm=Arm({"x1": 2.5, "x2": 7.5})).run()
         node = CenterGenerationNode(next_node_name="test")
         gr = none_throws(node.gen(experiment=exp, pending_observations=None))
-        self.assertEqual(gr._model_key, "Sobol")
+        # The existing arm is the center of search space
+        self.assertEqual(gr._model_key, "Fallback_Sobol")
 
     def test_repr(self) -> None:
         node = CenterGenerationNode(next_node_name="test")
@@ -142,4 +143,4 @@ class TestCenterGenerationNode(TestCase):
                 for log in logs.records
             )
         )
-        self.assertEqual(gr._model_key, "Sobol")
+        self.assertEqual(gr._model_key, "Fallback_Sobol")

--- a/ax/generation_strategy/tests/test_generator_spec.py
+++ b/ax/generation_strategy/tests/test_generator_spec.py
@@ -73,6 +73,9 @@ class GeneratorSpecTest(BaseGeneratorSpecTest):
             model_key_override="MBM with defaults",
         )
         self.assertEqual(ms.model_key, "MBM with defaults")
+        ms.fit(experiment=self.experiment, data=self.data)
+        gr = ms.gen(n=1)
+        self.assertEqual(gr._model_key, "MBM with defaults")
 
     @patch(f"{GeneratorSpec.__module__}.compute_diagnostics")
     @patch(


### PR DESCRIPTION
Summary:
Currently, the `model_key_override` isn't respected at generation time because we always set adapter model key to GeneratorRegistryBase default value (https://fburl.com/code/354ghdww). This can be repro in N8027697

The fix added the option to pass in `model_key_override` to generator enum so that we can properly set the model_key

Reviewed By: saitcakmak

Differential Revision: D81986866


