### PR TITLE
Various updates to benchmarking setup

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -12,8 +12,8 @@ Key terms used:
 
 * Replication: 1 run of an optimization loop; (BenchmarkProblem, BenchmarkMethod) pair.
 * Test: multiple replications, ran for statistical significance.
-* Full run: multiple tests on many (BenchmarkProblem, BenchmarkMethod) pairs.
 * Method: (one of) the algorithm(s) being benchmarked.
+* Full run: multiple tests on many (BenchmarkProblem, BenchmarkMethod) pairs.
 * Problem: a synthetic function, a surrogate surface, or an ML model, on which
   to assess the performance of algorithms.
 
@@ -36,7 +36,7 @@ from ax.benchmark.benchmark_problem import BenchmarkProblem
 from ax.benchmark.benchmark_result import AggregatedBenchmarkResult, BenchmarkResult
 from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
-from ax.benchmark.methods.sobol import get_sobol_generation_strategy
+from ax.benchmark.methods.sobol import get_sobol_benchmark_method
 from ax.core.arm import Arm
 from ax.core.experiment import Experiment
 from ax.core.map_data import MAP_KEY, MapData
@@ -49,6 +49,7 @@ from ax.core.search_space import SearchSpace
 from ax.core.trial import BaseTrial, Trial
 from ax.core.types import TParameterization, TParamValue
 from ax.core.utils import get_model_times
+from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.service.orchestrator import Orchestrator
 from ax.service.utils.best_point import get_trace
@@ -217,37 +218,46 @@ def get_oracle_experiment_from_params(
 
 
 def get_benchmark_orchestrator_options(
-    method: BenchmarkMethod,
-    include_sq: bool = False,
+    batch_size: int | None,
+    run_trials_in_batches: bool,
+    max_pending_trials: int,
+    early_stopping_strategy: BaseEarlyStoppingStrategy | None,
+    include_status_quo: bool = False,
     logging_level: int = DEFAULT_LOG_LEVEL,
 ) -> OrchestratorOptions:
     """
     Get the ``OrchestratorOptions`` for the given ``BenchmarkMethod``.
 
     Args:
-        method: The ``BenchmarkMethod``.
-        include_sq: Whether to include the status quo in each trial.
+        batch_size: The batch size to use for the optimiation.
+        run_trials_in_batches: Whether to run trials in batches. This is used
+            for high-throughput settings where there are many trials and
+            generating them in bulk reduces overhead (not to be confused with
+            `BatchTrial`s, which are different).
+        max_pending_trials: The maximum number of pending trials allowed.
+        early_stopping_strategy: The early stopping strategy to use (if any).
+        include_status_quo: Whether to include the status quo in each trial.
+        logging_level: The logging level to use for the Orchestrator.
 
     Returns:
         ``OrchestratorOptions``
     """
-    if method.batch_size is None or method.batch_size > 1 or include_sq:
+    if batch_size is None or batch_size > 1 or include_status_quo:
         trial_type = TrialType.BATCH_TRIAL
     else:
         trial_type = TrialType.TRIAL
     return OrchestratorOptions(
         # No new candidates can be generated while any are pending.
-        # If batched, an entire batch must finish before the next can be
-        # generated.
-        max_pending_trials=method.max_pending_trials,
+        # If batched, an entire batch must finish before the next can be generated.
+        max_pending_trials=max_pending_trials,
         # Do not throttle, as is often necessary when polling real endpoints
         init_seconds_between_polls=0,
         min_seconds_before_poll=0,
         trial_type=trial_type,
-        batch_size=method.batch_size,
-        run_trials_in_batches=method.run_trials_in_batches,
-        early_stopping_strategy=method.early_stopping_strategy,
-        status_quo_weight=1.0 if include_sq else 0.0,
+        batch_size=batch_size,
+        run_trials_in_batches=run_trials_in_batches,
+        early_stopping_strategy=early_stopping_strategy,
+        status_quo_weight=1.0 if include_status_quo else 0.0,
         logging_level=logging_level,
     )
 
@@ -449,11 +459,11 @@ def get_benchmark_result_from_experiment_and_gs(
         name=experiment.name,
         seed=seed,
         experiment=experiment,
-        oracle_trace=oracle_trace,
-        inference_trace=inference_trace,
-        optimization_trace=optimization_trace,
-        score_trace=score_trace,
-        cost_trace=cost_trace,
+        oracle_trace=oracle_trace.tolist(),
+        inference_trace=inference_trace.tolist(),
+        optimization_trace=optimization_trace.tolist(),
+        score_trace=score_trace.tolist(),
+        cost_trace=cost_trace.tolist(),
         fit_time=fit_time,
         gen_time=gen_time,
     )
@@ -463,6 +473,8 @@ def run_optimization_with_orchestrator(
     problem: BenchmarkProblem,
     method: BenchmarkMethod,
     seed: int,
+    run_trials_in_batches: bool = False,
+    timeout_hours: float | None = None,
     orchestrator_logging_level: int = DEFAULT_LOG_LEVEL,
 ) -> Experiment:
     """
@@ -473,10 +485,16 @@ def run_optimization_with_orchestrator(
         problem: The BenchmarkProblem to test against (can be synthetic or real)
         method: The BenchmarkMethod to test
         seed: The seed to use for this replication.
+        run_trials_in_batches: Whether to run trials in batches. This is used
+            for high-throughput settings where there are many trials and
+            generating them in bulk reduces overhead (not to be confused with
+            `BatchTrial`s, which are different).
+        timeout_hours: The maximum number of hours for which to run the
+            optimization loop before timing out.
         orchestrator_logging_level: If >INFO, logs will only appear when unexpected
             things happen. If INFO, logs will update when a trial is completed
             and when an early stopping strategy, if present, decides whether or
-            not to continue a trial. If DEBUG, logs additionaly include
+            not to continue a trial. If DEBUG, logs additionally include
             information from a `BackendSimulator`, if present.
 
     Return:
@@ -488,8 +506,11 @@ def run_optimization_with_orchestrator(
         else Arm(name="status_quo", parameters=problem.status_quo_params)
     )
     orchestrator_options = get_benchmark_orchestrator_options(
-        method=method,
-        include_sq=sq_arm is not None,
+        batch_size=method.batch_size,
+        run_trials_in_batches=run_trials_in_batches,
+        max_pending_trials=method.max_pending_trials,
+        early_stopping_strategy=method.early_stopping_strategy,
+        include_status_quo=sq_arm is not None,
         logging_level=orchestrator_logging_level,
     )
     runner = get_benchmark_runner(
@@ -520,7 +541,7 @@ def run_optimization_with_orchestrator(
             module="ax.adapter.cross_validation",
         )
         orchestrator.run_n_trials(
-            max_trials=problem.num_trials, timeout_hours=method.timeout_hours
+            max_trials=problem.num_trials, timeout_hours=timeout_hours
         )
 
     sim_runner = runner.simulated_backend_runner
@@ -537,8 +558,10 @@ def benchmark_replication(
     problem: BenchmarkProblem,
     method: BenchmarkMethod,
     seed: int,
-    strip_runner_before_saving: bool = True,
+    run_trials_in_batches: bool = False,
+    timeout_hours: float = 4.0,
     orchestrator_logging_level: int = DEFAULT_LOG_LEVEL,
+    strip_runner_before_saving: bool = True,
 ) -> BenchmarkResult:
     """
     Run one benchmarking replication (equivalent to one optimization loop).
@@ -552,13 +575,19 @@ def benchmark_replication(
         problem: The BenchmarkProblem to test against (can be synthetic or real)
         method: The BenchmarkMethod to test
         seed: The seed to use for this replication.
-        strip_runner_before_saving: Whether to strip the runner from the
-            experiment before saving it. This enables serialization.
+        run_trials_in_batches: Whether to run trials in batches. This is used
+            for high-throughput settings where there are many trials and
+            generating them in bulk reduces overhead (not to be confused with
+            `BatchTrial`s, which are different).
+        timeout_hours: The maximum number of hours for which to run the
+            optimization loop before timing out.
         orchestrator_logging_level: If >INFO, logs will only appear when unexpected
             things happen. If INFO, logs will update when a trial is completed
             and when an early stopping strategy, if present, decides whether or
             not to continue a trial. If DEBUG, logs additionally include
             information from a ``BackendSimulator``, if present.
+        strip_runner_before_saving: Whether to strip the runner from the
+            experiment before saving it. This enables serialization.
 
     Return:
         ``BenchmarkResult`` object.
@@ -567,15 +596,17 @@ def benchmark_replication(
         problem=problem,
         method=method,
         seed=seed,
+        run_trials_in_batches=run_trials_in_batches,
+        timeout_hours=timeout_hours,
         orchestrator_logging_level=orchestrator_logging_level,
     )
 
     benchmark_result = get_benchmark_result_from_experiment_and_gs(
-        seed=seed,
         experiment=experiment,
         generation_strategy=method.generation_strategy,
-        strip_runner_before_saving=strip_runner_before_saving,
         problem=problem,
+        seed=seed,
+        strip_runner_before_saving=strip_runner_before_saving,
     )
     return benchmark_result
 
@@ -605,8 +636,7 @@ def compute_baseline_value_from_sobol(
             `BenchmarkProblem`.
         n_repeats: Number of times to repeat the five Sobol trials.
     """
-    gs = get_sobol_generation_strategy()
-    method = BenchmarkMethod(generation_strategy=gs)
+    method = get_sobol_benchmark_method()
     target_fidelity_and_task = {} if target_fidelity_and_task is None else {}
 
     # set up a dummy problem so we can use `benchmark_replication`
@@ -617,15 +647,14 @@ def compute_baseline_value_from_sobol(
     dummy_problem = BenchmarkProblem(
         name="dummy",
         optimization_config=optimization_config,
-        search_space=search_space,
         num_trials=5,
         test_function=test_function,
-        # Optimal value and baseline value are only used
-        # to compute the score_trace, which we don't use here.
-        # The order of baseline and optimal value needs to be correct,
-        # though, as a ValueError is raised otherwise.
+        # Optimal value and baseline value are only used to compute the score_trace,
+        # which we don't use here. The order of baseline and optimal value needs to
+        # be correct, though, as a ValueError is raised otherwise.
         optimal_value=1.0 if higher_is_better else -1.0,
         baseline_value=0.0,
+        search_space=search_space,
         target_fidelity_and_task=target_fidelity_and_task,
     )
 
@@ -635,6 +664,8 @@ def compute_baseline_value_from_sobol(
             problem=dummy_problem,
             method=method,
             seed=i,
+            run_trials_in_batches=False,
+            timeout_hours=0.1,
             orchestrator_logging_level=WARNING,
         )
         values[i] = result.optimization_trace[-1]
@@ -646,6 +677,8 @@ def benchmark_one_method_problem(
     problem: BenchmarkProblem,
     method: BenchmarkMethod,
     seeds: Iterable[int],
+    run_trials_in_batches: bool = False,
+    timeout_hours: float = 4.0,
     orchestrator_logging_level: int = DEFAULT_LOG_LEVEL,
 ) -> AggregatedBenchmarkResult:
     return AggregatedBenchmarkResult.from_benchmark_results(
@@ -654,6 +687,8 @@ def benchmark_one_method_problem(
                 problem=problem,
                 method=method,
                 seed=seed,
+                run_trials_in_batches=run_trials_in_batches,
+                timeout_hours=timeout_hours,
                 orchestrator_logging_level=orchestrator_logging_level,
             )
             for seed in seeds
@@ -665,6 +700,8 @@ def benchmark_multiple_problems_methods(
     problems: Iterable[BenchmarkProblem],
     methods: Iterable[BenchmarkMethod],
     seeds: Iterable[int],
+    run_trials_in_batches: bool = False,
+    timeout_hours: float = 4.0,
     orchestrator_logging_level: int = DEFAULT_LOG_LEVEL,
 ) -> list[AggregatedBenchmarkResult]:
     """
@@ -678,6 +715,8 @@ def benchmark_multiple_problems_methods(
             problem=p,
             method=m,
             seeds=seeds,
+            run_trials_in_batches=run_trials_in_batches,
+            timeout_hours=timeout_hours,
             orchestrator_logging_level=orchestrator_logging_level,
         )
         for p, m in product(problems, methods)

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -20,27 +20,19 @@ class BenchmarkMethod(Base):
     information like maximum parallelism, early stopping configuration, etc.).
 
     Args:
-        name: String description.
+        name: String description. Defaults to the name of the generation strategy.
         generation_strategy: The `GenerationStrategy` to use.
-        timeout_hours: Number of hours after which to stop a benchmark
-            replication.
-        distribute_replications: Indicates whether the replications should be
-            run in a distributed manner. Ax itself does not use this attribute.
-        batch_size: Number of arms per trial. If greater than 1, trials are
-            ``BatchTrial``s; otherwise, they are ``Trial``s. Defaults to 1. This
-            and the following arguments are passed to ``OrchestratorOptions``.
-        run_trials_in_batches: Passed to ``OrchestratorOptions``.
+        batch_size: Number of arms per trial. Defaults to 1. If greater than 1,
+            trials are ``BatchTrial``s; otherwise, they are ``Trial``s.
+            Passed to ``OrchestratorOptions``.
         max_pending_trials: Passed to ``OrchestratorOptions``.
+        early_stopping_strategy: Passed to ``OrchestratorOptions``.
     """
 
     name: str = "DEFAULT"
     generation_strategy: GenerationStrategy
-
-    timeout_hours: float = 4.0
-    distribute_replications: bool = False
-
+    # Options for the Orchestrator.
     batch_size: int | None = 1
-    run_trials_in_batches: bool = False
     max_pending_trials: int = 1
     early_stopping_strategy: BaseEarlyStoppingStrategy | None = None
 

--- a/ax/benchmark/benchmark_problem.py
+++ b/ax/benchmark/benchmark_problem.py
@@ -42,6 +42,14 @@ class BenchmarkProblem(Base):
             be `BenchmarkMetric`s.
         num_trials: Number of optimization iterations to run. BatchTrials count
             as one trial.
+        test_function: A `BenchmarkTestFunction`, which will generate noiseless
+            data. This will be used by a `BenchmarkRunner`.
+        noise_std: Describes how noise is added to the output of the
+            `test_function`. If a float, IID random normal noise with that
+            standard deviation is added. A list of floats, or a dict whose keys
+            match `test_functions.outcome_names`, sets different noise
+            standard deviations for the different outcomes produced by the
+            `test_function`. This will be used by a `BenchmarkRunner`.
         optimal_value: The best ground-truth objective value, used for scoring
             optimization results on a scale from 0 to 100, where achieving the
             `optimal_value` receives a score of 100. The `optimal_value` should
@@ -55,14 +63,6 @@ class BenchmarkProblem(Base):
             `compute_baseline_value_from_sobol`, which takes the best of five
             quasi-random Sobol trials.
         search_space: The search space.
-        test_function: A `BenchmarkTestFunction`, which will generate noiseless
-            data. This will be used by a `BenchmarkRunner`.
-        noise_std: Describes how noise is added to the output of the
-            `test_function`. If a float, IID random normal noise with that
-            standard deviation is added. A list of floats, or a dict whose keys
-            match `test_functions.outcome_names`, sets different noise
-            standard deviations for the different outcomes produced by the
-            `test_function`. This will be used by a `BenchmarkRunner`.
         report_inference_value_as_trace: Whether the ``optimization_trace`` on a
             ``BenchmarkResult`` should use the ``oracle_trace`` (if False,
             default) or the ``inference_trace``. See ``BenchmarkResult`` for
@@ -73,6 +73,10 @@ class BenchmarkProblem(Base):
             returns the runtime of an step. If ``step_runtime_function`` is
             left as ``None``, each step will take one simulated second.  (When
             data is not time-series, the whole trial consists of one step.)
+        target_fidelity_and_task: A mapping from names of task and fidelity
+            parameters to their respective target values.
+        status_quo_params: The parameterization of the status quo arm. Required
+            when using relative constraints.
         auxiliary_experiments_by_purpose: A mapping from experiment purpose to
             a list of auxiliary experiments.
     """

--- a/ax/benchmark/benchmark_result.py
+++ b/ax/benchmark/benchmark_result.py
@@ -95,11 +95,11 @@ class BenchmarkResult(Base):
     name: str
     seed: int
 
-    oracle_trace: npt.NDArray
-    inference_trace: npt.NDArray
-    optimization_trace: npt.NDArray
-    score_trace: npt.NDArray
-    cost_trace: npt.NDArray
+    oracle_trace: list[float]
+    inference_trace: list[float]
+    optimization_trace: list[float]
+    score_trace: list[float]
+    cost_trace: list[float]
 
     fit_time: float
     gen_time: float
@@ -149,7 +149,9 @@ class AggregatedBenchmarkResult(Base):
         """
         # Extract average wall times and standard errors thereof
         fit_time, gen_time = (
-            [nanmean(Ts), float(sem(Ts, ddof=1, nan_policy="propagate"))]
+            # pyre-fixme [16]: Item `float` of `typing.Union[numpy.ndarray[typing.Any,
+            # typing.Any], float]` has no attribute `item`.
+            [nanmean(Ts).item(), sem(Ts, ddof=1, nan_policy="propagate").item()]
             for Ts in zip(*((res.fit_time, res.gen_time) for res in results))
         )
 

--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -64,7 +64,6 @@ def get_sobol_mbm_generation_strategy(
         >>> gs = get_sobol_mbm_generation_strategy(
         ...     model_cls=SingleTaskGP,
         ...     acquisition_cls=qLogNoisyExpectedImprovement,
-        ...     distribute_replications=False,
         ... )
     """
     model_kwargs: dict[str, type[AcquisitionFunction] | SurrogateSpec | bool] = {
@@ -106,7 +105,6 @@ def get_sobol_mbm_generation_strategy(
 def get_sobol_botorch_modular_acquisition(
     model_cls: type[Model],
     acquisition_cls: type[AcquisitionFunction],
-    distribute_replications: bool,
     name: str | None = None,
     num_sobol_trials: int = 5,
     model_gen_kwargs: dict[str, Any] | None = None,
@@ -118,7 +116,6 @@ def get_sobol_botorch_modular_acquisition(
         model_cls: BoTorch model class, e.g. SingleTaskGP
         acquisition_cls: Acquisition function class, e.g.
             `qLogNoisyExpectedImprovement`.
-        distribute_replications: Whether to use multiple machines
         name: Name that will be attached to the `GenerationStrategy`.
         num_sobol_trials: Number of Sobol trials; if the orchestrator_options
             specify to use `BatchTrial`s, then this refers to the number of
@@ -136,13 +133,11 @@ def get_sobol_botorch_modular_acquisition(
         >>> method = get_sobol_botorch_modular_acquisition(
         ...     model_cls=SingleTaskGP,
         ...     acquisition_cls=qLogNoisyExpectedImprovement,
-        ...     distribute_replications=False,
         ... )
         >>> # Pass sequential=False to BoTorch's optimize_acqf
         >>> batch_method = get_sobol_botorch_modular_acquisition(
         ...     model_cls=SingleTaskGP,
         ...     acquisition_cls=qLogNoisyExpectedImprovement,
-        ...     distribute_replications=False,
         ...     batch_size=5,
         ...     model_gen_kwargs={
         ...         "model_gen_options": {
@@ -163,6 +158,5 @@ def get_sobol_botorch_modular_acquisition(
 
     return BenchmarkMethod(
         generation_strategy=generation_strategy,
-        distribute_replications=distribute_replications,
         batch_size=batch_size,
     )

--- a/ax/benchmark/methods/sobol.py
+++ b/ax/benchmark/methods/sobol.py
@@ -24,11 +24,9 @@ def get_sobol_generation_strategy() -> GenerationStrategy:
 
 
 def get_sobol_benchmark_method(
-    distribute_replications: bool,
     batch_size: int = 1,
 ) -> BenchmarkMethod:
     return BenchmarkMethod(
         generation_strategy=get_sobol_generation_strategy(),
         batch_size=batch_size,
-        distribute_replications=distribute_replications,
     )

--- a/ax/benchmark/testing/benchmark_stubs.py
+++ b/ax/benchmark/testing/benchmark_stubs.py
@@ -9,7 +9,6 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
-import numpy as np
 import pandas as pd
 import torch
 from ax.adapter.torch import TorchAdapter
@@ -175,11 +174,11 @@ def get_benchmark_result() -> BenchmarkResult:
             optimization_config=problem.optimization_config,
             is_test=True,
         ),
-        inference_trace=np.ones(4),
-        oracle_trace=np.zeros(4),
-        cost_trace=np.zeros(4),
-        optimization_trace=np.array([3, 2, 1, 0.1]),
-        score_trace=np.array([3, 2, 1, 0.1]),
+        inference_trace=[1.0, 1.0, 1.0, 1.0],
+        oracle_trace=[0.0, 0.0, 0.0, 0.0],
+        cost_trace=[0.0, 0.0, 0.0, 0.0],
+        optimization_trace=[3.0, 2.0, 1.0, 0.1],
+        score_trace=[3.0, 2.0, 1.0, 0.1],
         fit_time=0.1,
         gen_time=0.2,
     )
@@ -298,7 +297,6 @@ def get_async_benchmark_method(
     )
     return BenchmarkMethod(
         generation_strategy=gs,
-        distribute_replications=False,
         max_pending_trials=max_pending_trials,
         batch_size=1,
         early_stopping_strategy=early_stopping_strategy,

--- a/ax/benchmark/tests/methods/test_methods.py
+++ b/ax/benchmark/tests/methods/test_methods.py
@@ -30,7 +30,6 @@ class TestMethods(TestCase):
             model_cls=SingleTaskGP,
             acquisition_cls=qKnowledgeGradient,
             batch_size=batch_size,
-            distribute_replications=False,
         )
         is_batched = batch_size > 1
         expected_name = "MBM::SingleTaskGP_qKnowledgeGradient" + (
@@ -64,7 +63,6 @@ class TestMethods(TestCase):
             acquisition_cls=acqf_cls,
             num_sobol_trials=2,
             name="test",
-            distribute_replications=False,
         )
         n_sobol_trials = method.generation_strategy._steps[0].num_trials
         self.assertEqual(n_sobol_trials, 2)
@@ -78,7 +76,7 @@ class TestMethods(TestCase):
             problem=problem, method=method, seed=0, orchestrator_logging_level=WARNING
         )
         self.assertTrue(np.isfinite(result.score_trace).all())
-        self.assertEqual(result.optimization_trace.shape, (n_total_trials,))
+        self.assertEqual(len(result.optimization_trace), n_total_trials)
 
         self.assertEqual(
             len(none_throws(result.experiment).arms_by_name),
@@ -103,7 +101,7 @@ class TestMethods(TestCase):
             )
 
     def test_sobol(self) -> None:
-        method = get_sobol_benchmark_method(distribute_replications=False)
+        method = get_sobol_benchmark_method()
         self.assertEqual(method.name, "Sobol")
         gs = method.generation_strategy
         self.assertEqual(len(gs._steps), 1)

--- a/ax/benchmark/tests/test_benchmark_method.py
+++ b/ax/benchmark/tests/test_benchmark_method.py
@@ -20,11 +20,9 @@ class TestBenchmarkMethod(TestCase):
         # test that `fit_tracking_metrics` has been correctly set to False
         for step in method.generation_strategy._steps:
             self.assertFalse(none_throws(step.model_kwargs).get("fit_tracking_metrics"))
-        self.assertEqual(method.timeout_hours, 4)
 
-        method = BenchmarkMethod(generation_strategy=gs, timeout_hours=10)
+        method = BenchmarkMethod(generation_strategy=gs)
         self.assertEqual(method.name, method.generation_strategy.name)
-        self.assertEqual(method.timeout_hours, 10)
 
         # test that instantiation works with node-based strategies
         method = BenchmarkMethod(name="Sobol10", generation_strategy=gs)

--- a/ax/benchmark/tests/test_benchmark_result.py
+++ b/ax/benchmark/tests/test_benchmark_result.py
@@ -5,8 +5,6 @@
 
 # pyre-strict
 
-
-import numpy as np
 from ax.benchmark.benchmark_result import BenchmarkResult
 from ax.utils.common.testutils import TestCase
 
@@ -23,11 +21,11 @@ class TestBenchmarkResult(TestCase):
             BenchmarkResult(
                 name="name",
                 seed=0,
-                inference_trace=np.array([]),
-                oracle_trace=np.array([]),
-                optimization_trace=np.array([]),
-                score_trace=np.array([]),
-                cost_trace=np.array([]),
+                inference_trace=[],
+                oracle_trace=[],
+                optimization_trace=[],
+                score_trace=[],
+                cost_trace=[],
                 fit_time=0.0,
                 gen_time=0.0,
                 experiment=get_experiment(),
@@ -40,11 +38,11 @@ class TestBenchmarkResult(TestCase):
             BenchmarkResult(
                 name="name",
                 seed=0,
-                inference_trace=np.array([]),
-                oracle_trace=np.array([]),
-                optimization_trace=np.array([]),
-                score_trace=np.array([]),
-                cost_trace=np.array([]),
+                inference_trace=[],
+                oracle_trace=[],
+                optimization_trace=[],
+                score_trace=[],
+                cost_trace=[],
                 fit_time=0.0,
                 gen_time=0.0,
             )

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -12,7 +12,6 @@ from typing import Any
 
 from ax.adapter.registry import _encode_callables_as_references
 from ax.adapter.transforms.base import Transform
-
 from ax.core import Experiment, ObservationFeatures
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -177,10 +177,7 @@ TEST_CASES = [
     ("AuxiliaryExperimentPurpose", lambda: AuxiliaryExperimentPurpose.PE_EXPERIMENT),
     ("BackendSimulator", get_backend_simulator_with_trials),
     ("BatchTrial", get_batch_trial),
-    (
-        "BenchmarkMethod",
-        lambda: get_sobol_benchmark_method(distribute_replications=True),
-    ),
+    ("BenchmarkMethod", get_sobol_benchmark_method),
     ("BenchmarkMetric", get_benchmark_metric),
     ("BenchmarkMapMetric", get_benchmark_map_metric),
     ("BenchmarkTimeVaryingMetric", get_benchmark_time_varying_metric),


### PR DESCRIPTION
Summary:
This diff makes various updates to the Ax benchmarking setup, which will simplify the redesign of the benchmarking setup to run on other backends and support execution on heterogeneous hardware.

The main changes are:
* Removes the `timeout_hours`, `distribute_replications`, and `run_trials_in_batches` attributes from `BenchmarkMethod` and moves those to a new `BenchmarkExecutionSettings` container.
* Removes the `get_best_parameters` method from `BenchmarkMethod` and instead moves this into a new best_point_utils module. This is more a band aid than a proper solution, which will come as part of a larger "best point recommendation" refactor to Ax.
* Adds json storage support for `BenchmarkExecutionSettings` so that they can easily be serialized and sent over the wire. 
* Changes the various traces on `BenchmarkResult` to be python lists rather than numpy arrays to simplify serialization.

Reviewed By: esantorella

Differential Revision: D76235984


