### PR TITLE
Use use_all_trials_in_exp to simplify initialization logic in choose_generation_strategy_legacy

### DIFF
--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -2804,7 +2804,7 @@ class TestAxClient(TestCase):
                 },
             ],
             objectives={"objective": ObjectiveProperties(minimize=True)},
-            choose_generation_strategy_kwargs={"num_initialization_trials": 2},
+            choose_generation_strategy_kwargs={"num_initialization_trials": 4},
         )
         hss = assert_is_instance(
             ax_client.experiment.search_space, HierarchicalSearchSpace


### PR DESCRIPTION
Summary: Using `use_all_trials_in_exp` is preferable, as it allows us to count the manually attached trials for transition as well, rather than having to pre-determine and commit to the number of Sobol trials.

Differential Revision: D82226905


