### PR TITLE
Improve Summary Analysis by excluding stale trials from the summary

### DIFF
--- a/ax/analysis/results.py
+++ b/ax/analysis/results.py
@@ -54,6 +54,10 @@ ARM_EFFECTS_PAIR_CARDGROUP_SUBTITLE = (
     "will manifest in a long-term validation experiment. "
 )
 
+NON_STALE_TRIAL_STATUSES: list[TrialStatus] = list(
+    set(TrialStatus) - {TrialStatus.STALE}
+)
+
 
 class ResultsAnalysis(Analysis):
     """
@@ -221,7 +225,9 @@ class ResultsAnalysis(Analysis):
             else None
         )
 
-        summary = Summary().compute_or_error_card(
+        summary = Summary(
+            trial_statuses=NON_STALE_TRIAL_STATUSES
+        ).compute_or_error_card(
             experiment=experiment,
             generation_strategy=generation_strategy,
             adapter=adapter,


### PR DESCRIPTION
Summary: This diff improves summary analysis shown in the AX UI by excluding the stale trials. Note that the changes don't apply to the api call that provide summary to clients.

Differential Revision: D81135243


