### PR TITLE
Reduce MAX_CHOICES_ENUMERATE to 10k

### DIFF
--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -64,7 +64,7 @@ logger: Logger = get_logger(__name__)
 
 
 # For fully discrete search spaces.
-MAX_CHOICES_ENUMERATE = 100_000
+MAX_CHOICES_ENUMERATE = 10_000
 MAX_CARDINALITY_FOR_LOCAL_SEARCH = 100
 # For mixed search spaces.
 ALTERNATING_OPTIMIZER_THRESHOLD = 10


### PR DESCRIPTION
Summary: Enumerating 100k values to optimize an acqf is way too slow. With MOO (2 obj) and only 5 trials, enumerating 50k options takes 1.5 mins with SingleTaskGP and around 9 mins with SAASBO.

Reviewed By: dme65

Differential Revision: D82346948


