### PR TITLE
automatically fall back to the hit and run sampler in RandomGenerator when there are continuous parameters

### DIFF
--- a/ax/adapter/random.py
+++ b/ax/adapter/random.py
@@ -130,7 +130,7 @@ class RandomAdapter(Adapter):
         # Generate the candidates
         X, w = self.generator.gen(
             n=n,
-            bounds=search_space_digest.bounds,
+            search_space_digest=search_space_digest,
             linear_constraints=linear_constraints,
             fixed_features=fixed_features_dict,
             model_gen_options=model_gen_options,

--- a/ax/generators/model_utils.py
+++ b/ax/generators/model_utils.py
@@ -116,7 +116,7 @@ def rejection_sample(
     if max_draws is None:
         max_draws = DEFAULT_MAX_RS_DRAWS
 
-    while points.shape[0] < n and attempted_draws <= max_draws:
+    while points.shape[0] < n and attempted_draws < max_draws:
         # _gen_unconstrained returns points including fixed features.
         # pyre-ignore: Anonymous function w/ named args.
         point = gen_unconstrained(

--- a/ax/generators/random/base.py
+++ b/ax/generators/random/base.py
@@ -14,13 +14,13 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import SearchSpaceExhausted
 from ax.generators.base import Generator
 from ax.generators.model_utils import (
     add_fixed_features,
     DEFAULT_MAX_RS_DRAWS,
     rejection_sample,
-    remove_duplicates,
     tunable_feature_indices,
     validate_bounds,
 )
@@ -109,7 +109,7 @@ class RandomGenerator(Generator):
     def gen(
         self,
         n: int,
-        bounds: list[tuple[float, float]],
+        search_space_digest: SearchSpaceDigest,
         linear_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
         fixed_features: dict[int, float] | None = None,
         model_gen_options: TConfig | None = None,
@@ -120,8 +120,8 @@ class RandomGenerator(Generator):
 
         Args:
             n: Number of candidates to generate.
-            bounds: A list of (lower, upper) tuples for each column of X.
-                Defined on [0, 1]^d.
+            search_space_digest: A ``SearchSpaceDigest`` object containing
+                metadata on the features in the datasets.
             linear_constraints: A tuple of (A, b). For k linear constraints on
                 d-dimensional x, A is (k x d) and b is (k x 1) such that
                 A x <= b.
@@ -142,16 +142,29 @@ class RandomGenerator(Generator):
 
         """
         tf_indices = tunable_feature_indices(
-            bounds=bounds, fixed_features=fixed_features
+            bounds=search_space_digest.bounds, fixed_features=fixed_features
         )
         if fixed_features:
             fixed_feature_indices = np.array(list(fixed_features.keys()))
         else:
             fixed_feature_indices = np.array([])
 
-        validate_bounds(bounds=bounds, fixed_feature_indices=fixed_feature_indices)
-        attempted_draws = 0
+        validate_bounds(
+            bounds=search_space_digest.bounds,
+            fixed_feature_indices=fixed_feature_indices,
+        )
         max_draws = DEFAULT_MAX_RS_DRAWS
+        discrete_indices = set(search_space_digest.discrete_choices.keys())
+        continuous_indices = {
+            i
+            for i in range(len(search_space_digest.feature_names))
+            if i not in discrete_indices
+        }
+        if fixed_features is not None:
+            for i in fixed_features.keys():
+                if i in continuous_indices:
+                    continuous_indices.remove(i)
+        has_continuous_parameters = len(continuous_indices) > 0
         if model_gen_options:
             max_draws = model_gen_options.get("max_rs_draws", DEFAULT_MAX_RS_DRAWS)
             max_draws = int(assert_is_instance_of_tuple(max_draws, (int, float)))
@@ -159,13 +172,10 @@ class RandomGenerator(Generator):
             # Always rejection sample, but this only rejects if there are
             # constraints or actual duplicates and deduplicate is specified.
             # If rejection sampling fails, fall back to polytope sampling.
-            # NOTE: The rejection sampling logic in `rejection_sample` only
-            # rejects points that do not satisfy the linear constraints;
-            # it does not consider the rounding function.
             points, attempted_draws = rejection_sample(
                 gen_unconstrained=self._gen_unconstrained,
                 n=n,
-                d=len(bounds),
+                d=len(search_space_digest.bounds),
                 tunable_feature_indices=tf_indices,
                 linear_constraints=linear_constraints,
                 deduplicate=self.deduplicate,
@@ -175,7 +185,7 @@ class RandomGenerator(Generator):
                 existing_points=generated_points,
             )
         except SearchSpaceExhausted as e:
-            if self.fallback_to_sample_polytope:
+            if has_continuous_parameters or self.fallback_to_sample_polytope:
                 logger.warning(
                     "Parameter constraints are very restrictive, this makes "
                     "candidate generation difficult. "
@@ -194,37 +204,48 @@ class RandomGenerator(Generator):
                     if generated_points is not None
                     else None
                 )
-                polytope_sampler = HitAndRunPolytopeSampler(
+                polytope_sampler: HitAndRunPolytopeSampler = HitAndRunPolytopeSampler(
                     inequality_constraints=self._convert_inequality_constraints(
                         linear_constraints,
                     ),
                     equality_constraints=self._convert_equality_constraints(
-                        d=len(bounds),
+                        d=len(search_space_digest.bounds),
                         fixed_features=fixed_features,
                     ),
-                    bounds=self._convert_bounds(bounds),
+                    bounds=self._convert_bounds(bounds=search_space_digest.bounds),
                     interior_point=interior_point,
                     n_burnin=100,
                     n_thinning=20,
                     seed=self.seed + num_generated,
                 )
-                points = np.zeros((0, len(bounds)))
-                while points.shape[0] < n and attempted_draws < max_draws:
-                    n_remaining = n - points.shape[0]
-                    more_points = polytope_sampler.draw(n=n_remaining).numpy()
 
-                    if rounding_func is not None:
-                        more_points = np.array([rounding_func(p) for p in more_points])
+                def gen_polytope_sampler(
+                    n: int,
+                    d: int,
+                    tunable_feature_indices: npt.NDArray,
+                    fixed_features: dict[int, float] | None = None,
+                ) -> npt.NDArray:
+                    # Note: the fixed features are applied as equality constraints
+                    # in the polytope sampler, so we don't need to apply them here.
+                    return polytope_sampler.draw(n=n).numpy()
 
-                    points = np.concatenate([points, more_points], axis=0)
-                    attempted_draws += n_remaining
-
-                    if self.deduplicate:
-                        points = remove_duplicates(points, generated_points)
+                # we call rejection_sample here to reuse all the deduplication
+                # logic
+                points, _ = rejection_sample(
+                    gen_unconstrained=gen_polytope_sampler,
+                    n=n,
+                    d=len(search_space_digest.bounds),
+                    tunable_feature_indices=tf_indices,
+                    linear_constraints=linear_constraints,
+                    deduplicate=self.deduplicate,
+                    max_draws=max_draws,
+                    fixed_features=fixed_features,
+                    rounding_func=rounding_func,
+                    existing_points=generated_points,
+                )
             else:
                 raise e
 
-        self.attempted_draws = attempted_draws
         return points, np.ones(len(points))
 
     @copy_doc(Generator._get_state)
@@ -259,13 +280,12 @@ class RandomGenerator(Generator):
 
         """
         tunable_points = self._gen_samples(n=n, tunable_d=len(tunable_feature_indices))
-        points = add_fixed_features(
+        return add_fixed_features(
             tunable_points=tunable_points,
             d=d,
             tunable_feature_indices=tunable_feature_indices,
             fixed_features=fixed_features,
         )
-        return points
 
     def _gen_samples(self, n: int, tunable_d: int) -> npt.NDArray:
         """Generate n samples on [0, 1]^d.

--- a/ax/generators/random/sobol.py
+++ b/ax/generators/random/sobol.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 import numpy as np
 import numpy.typing as npt
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.generators.model_utils import tunable_feature_indices
 from ax.generators.random.base import RandomGenerator
 from ax.generators.types import TConfig
@@ -75,7 +76,7 @@ class SobolGenerator(RandomGenerator):
     def gen(
         self,
         n: int,
-        bounds: list[tuple[float, float]],
+        search_space_digest: SearchSpaceDigest,
         linear_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
         fixed_features: dict[int, float] | None = None,
         model_gen_options: TConfig | None = None,
@@ -86,7 +87,8 @@ class SobolGenerator(RandomGenerator):
 
         Args:
             n: Number of candidates to generate.
-            bounds: A list of (lower, upper) tuples for each column of X.
+            search_space_digest: A ``SearchSpaceDigest`` object containing
+                metadata on the features in the datasets.
             linear_constraints: A tuple of (A, b). For k linear constraints on
                 d-dimensional x, A is (k x d) and b is (k x 1) such that
                 A x <= b.
@@ -104,13 +106,13 @@ class SobolGenerator(RandomGenerator):
 
         """
         tf_indices = tunable_feature_indices(
-            bounds=bounds, fixed_features=fixed_features
+            bounds=search_space_digest.bounds, fixed_features=fixed_features
         )
         if len(tf_indices) > 0:
             self.init_engine(len(tf_indices))
         points, weights = super().gen(
             n=n,
-            bounds=bounds,
+            search_space_digest=search_space_digest,
             linear_constraints=linear_constraints,
             fixed_features=fixed_features,
             model_gen_options=model_gen_options,

--- a/ax/generators/tests/test_torch_model_utils.py
+++ b/ax/generators/tests/test_torch_model_utils.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import numpy as np
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.generators.torch.utils import (
     _generate_sobol_points,
     subset_model,
@@ -38,7 +39,9 @@ class TorchUtilsTest(TestCase):
 
         gen_sobol = _generate_sobol_points(
             n_sobol=100,
-            bounds=bounds,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=["a", "b", "c"], bounds=bounds
+            ),
             device=torch.device("cpu"),
             linear_constraints=linear_constraints,
             rounding_func=test_rounding_func,

--- a/ax/generators/torch/utils.py
+++ b/ax/generators/torch/utils.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 import numpy as np
 import numpy.typing as npt
 import torch
+from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import UnsupportedError
 from ax.generators.model_utils import (
     filter_constraints_and_fixed_features,
@@ -201,7 +202,7 @@ def _get_X_pending_and_observed(
 
 def _generate_sobol_points(
     n_sobol: int,
-    bounds: list[tuple[float, float]],
+    search_space_digest: SearchSpaceDigest,
     device: torch.device,
     linear_constraints: tuple[Tensor, Tensor] | None = None,
     fixed_features: dict[int, float] | None = None,
@@ -225,7 +226,7 @@ def _generate_sobol_points(
     sobol = SobolGenerator(deduplicate=False, seed=np.random.randint(10000))
     array_X, _ = sobol.gen(
         n=n_sobol,
-        bounds=bounds,
+        search_space_digest=search_space_digest,
         linear_constraints=linear_constraints_array,
         fixed_features=fixed_features,
         rounding_func=array_rounding_func,


### PR DESCRIPTION
Summary:
see title.

There is context in this comment on why we didn't do this previously: https://www.internalfb.com/diff/D31431838?dst_version_fbid=611591606519560&transaction_fbid=304592317864246

The TL;DR is that we needed to distinguish (a) when the search space was actually exhausted (in the case of all discrete parameters) from (b) when the search space is not exhausted, but rather the rejection sampling failed due to the constraints being hard to satisfy.

We are always in setting (b) when there is at least one continuous parameter, so we should fallback to the hit and run sampler automatically.

This also re-uses de-duplication logic from rejection sample when using the hit and run sampler.

This came up recently in experiment that andycylmeta was running

Differential Revision: D82250529


