### PR TITLE
Clean up configuration of derelativize_with_raw_status_quo

### DIFF
--- a/ax/generators/torch/botorch_moo.py
+++ b/ax/generators/torch/botorch_moo.py
@@ -49,7 +49,6 @@ from pyre_extensions import assert_is_instance, none_throws
 from torch import Tensor
 
 
-# pyre-fixme[33]: Aliased annotation cannot contain `Any`.
 TOptimizerList = Callable[
     [
         list[AcquisitionFunction],


### PR DESCRIPTION
Summary:
Instead of a Winsorize specific `_get_winsorization_transform_config` helper that rarely does more than simply adding `dereleativize_with_raw_status_quo`, this diff adds a helper `get_derelativize_config` that returns the necessary configs with `dereleativize_with_raw_status_quo` for all three transforms that care about this option. This will make it easier to apply the config consistently to all transforms that are affected by it.

All use cases are updated to replace `_get_winsorization_transform_config` with `get_derelativize_config`. Note that it is safe to have configs for additional transforms even if they're not used in the `Adapter`, since they will simply be ignored.

Differential Revision: D82487281


