### PR TITLE
Support parameter specific priors for default kernels

### DIFF
--- a/ax/generators/torch/botorch_modular/kernels.py
+++ b/ax/generators/torch/botorch_modular/kernels.py
@@ -187,6 +187,7 @@ class DefaultRBFKernel(RBFKernel):
         active_dims: Sequence[int] | None = None,
         batch_shape: torch.Size | None = None,
         mle: bool = False,
+        lengthscale_prior: LogNormalPrior | None = None,
     ) -> None:
         """Initialize Matern kernel with dimension-scaling prior or MLE.
 
@@ -197,10 +198,14 @@ class DefaultRBFKernel(RBFKernel):
             batch_shape: The batch shape for the kernel.
             mle: A boolean indicating whether to use MLE (no priors) or a dimension
                 scaling prior.
+            lengthscale_prior: The lengthscale prior. If None, a default prior is used.
         """
-        lengthscale_prior, initial_value = get_lengthscale_prior_and_initial_value(
-            ard_num_dims=ard_num_dims, mle=mle
-        )
+        if lengthscale_prior is not None:
+            initial_value = lengthscale_prior.mode[0].item()
+        else:
+            lengthscale_prior, initial_value = get_lengthscale_prior_and_initial_value(
+                ard_num_dims=ard_num_dims, mle=mle
+            )
         super().__init__(
             ard_num_dims=ard_num_dims,
             batch_shape=batch_shape,
@@ -229,10 +234,14 @@ class DefaultMaternKernel(MaternKernel):
         batch_shape: torch.Size | None = None,
         nu: float = 2.5,
         mle: bool = False,
+        lengthscale_prior: LogNormalPrior | None = None,
     ) -> None:
-        lengthscale_prior, initial_value = get_lengthscale_prior_and_initial_value(
-            ard_num_dims=ard_num_dims, mle=mle
-        )
+        if lengthscale_prior is not None:
+            initial_value = lengthscale_prior.mode[0].item()
+        else:
+            lengthscale_prior, initial_value = get_lengthscale_prior_and_initial_value(
+                ard_num_dims=ard_num_dims, mle=mle
+            )
         super().__init__(
             ard_num_dims=ard_num_dims,
             batch_shape=batch_shape,

--- a/ax/generators/torch/tests/test_covar_modules_argparse.py
+++ b/ax/generators/torch/tests/test_covar_modules_argparse.py
@@ -180,6 +180,7 @@ class CovarModuleArgparseTest(TestCase):
                 "active_dims": list(range(9)),
                 "batch_shape": torch.Size([2]),  # For 2 outputs.
                 "ard_num_dims": 9,
+                "lengthscale_prior": None,
             }
             self.assertEqual(covar_module_kwargs, expected)
             # Test other inputs.
@@ -195,6 +196,7 @@ class CovarModuleArgparseTest(TestCase):
                 "active_dims": [7, 8],
                 "batch_shape": torch.Size([]),
                 "ard_num_dims": 1,
+                "lengthscale_prior": None,
             }
             self.assertEqual(covar_module_kwargs, expected)
 


### PR DESCRIPTION
Summary: Allows for specifying parameter specific priors for default Matern & RBF kernels. We can fit priors to empirical model fit data from past experiments, and use these priors instead of the generic priors when fitting the model to the new experiments that use the same metric & parameters.

Differential Revision: D82560153


