### PR TITLE
Remove no/use_winsorization option

### DIFF
--- a/ax/api/utils/generation_strategy_dispatch.py
+++ b/ax/api/utils/generation_strategy_dispatch.py
@@ -14,6 +14,7 @@ from ax.api.utils.structs import GenerationStrategyDispatchStruct
 from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UnsupportedError
 from ax.generation_strategy.center_generation_node import CenterGenerationNode
+from ax.generation_strategy.dispatch_utils import get_derelativize_config
 from ax.generation_strategy.generation_strategy import (
     GenerationNode,
     GenerationStrategy,
@@ -132,6 +133,9 @@ def _get_mbm_node(
                     "surrogate_spec": SurrogateSpec(model_configs=model_configs),
                     "torch_device": device,
                     "transforms": MBM_X_trans + [Winsorize] + Y_trans,
+                    "transform_configs": get_derelativize_config(
+                        derelativize_with_raw_status_quo=True
+                    ),
                 },
             )
         ],

--- a/ax/api/utils/tests/test_generation_strategy_dispatch.py
+++ b/ax/api/utils/tests/test_generation_strategy_dispatch.py
@@ -17,6 +17,7 @@ from ax.api.utils.structs import GenerationStrategyDispatchStruct
 from ax.core.trial import Trial
 from ax.core.trial_status import TrialStatus
 from ax.generation_strategy.center_generation_node import CenterGenerationNode
+from ax.generation_strategy.dispatch_utils import get_derelativize_config
 from ax.generation_strategy.transition_criterion import MinTrials
 from ax.generators.torch.botorch_modular.surrogate import ModelConfig, SurrogateSpec
 from ax.utils.common.testutils import TestCase
@@ -123,6 +124,9 @@ class TestDispatchUtils(TestCase):
                 "surrogate_spec": expected_ss,
                 "torch_device": torch.device("cpu"),
                 "transforms": MBM_X_trans + [Winsorize] + Y_trans,
+                "transform_configs": get_derelativize_config(
+                    derelativize_with_raw_status_quo=True
+                ),
             },
         )
         self.assertEqual(mbm_node._transition_criteria, [])
@@ -188,6 +192,9 @@ class TestDispatchUtils(TestCase):
                 "surrogate_spec": expected_ss,
                 "torch_device": torch.device("cpu"),
                 "transforms": MBM_X_trans + [Winsorize] + Y_trans,
+                "transform_configs": get_derelativize_config(
+                    derelativize_with_raw_status_quo=True
+                ),
             },
         )
         self.assertEqual(mbm_node._transition_criteria, [])

--- a/ax/generation_strategy/tests/test_dispatch_utils.py
+++ b/ax/generation_strategy/tests/test_dispatch_utils.py
@@ -505,15 +505,6 @@ class TestDispatchUtils(TestCase):
         )
         self.assertDictEqual(tc["Derelativize"], {"use_raw_status_quo": True})
 
-    def test_no_winzorization_wins(self) -> None:
-        unwinsorized = choose_generation_strategy_legacy(
-            search_space=get_branin_search_space(),
-            winsorization_config=WinsorizationConfig(upper_quantile_margin=2),
-            no_winsorization=True,
-        )
-        # Transforms have not been updated to include Winsorize.
-        self.assertNotIn("transforms", unwinsorized._steps[1].model_kwargs)
-
     def test_num_trials(self) -> None:
         ss = get_discrete_search_space()
         with self.subTest(

--- a/ax/generators/torch/botorch_moo.py
+++ b/ax/generators/torch/botorch_moo.py
@@ -49,7 +49,6 @@ from pyre_extensions import assert_is_instance, none_throws
 from torch import Tensor
 
 
-# pyre-fixme[33]: Aliased annotation cannot contain `Any`.
 TOptimizerList = Callable[
     [
         list[AcquisitionFunction],


### PR DESCRIPTION
Summary: With the default set of generation strategies we dispatch to, there is very little benefit to turning off winsorization. These models are not robust to outliers and will regress if winsorization is not used. Removing `no_winsorization` option will simplify the addition of `Winsorize` to `Y_trans` and use of winsorization by default from there on.

Reviewed By: dme65

Differential Revision: D82322529


