### PR TITLE
Allow constructing ChoiceParameter while bypassing the cardinality restriction

### DIFF
--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -430,6 +430,13 @@ class ChoiceParameterTest(TestCase):
                 parameter_type=ParameterType.INT,
                 values=list(range(1001)),
             )
+        # With bypass_cardinality_check=True, this should not raise an error.
+        ChoiceParameter(
+            name="x",
+            parameter_type=ParameterType.INT,
+            values=list(range(1001)),
+            bypass_cardinality_check=True,
+        )
 
     def test_Hierarchical(self) -> None:
         # Test case where only some of the values entail dependents.

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -49,7 +49,7 @@ from ax.early_stopping.strategies import (
     PercentileEarlyStoppingStrategy,
     ThresholdEarlyStoppingStrategy,
 )
-from ax.exceptions.core import AxStorageWarning
+from ax.exceptions.core import AxStorageWarning, UnsupportedError
 from ax.exceptions.storage import JSONEncodeError, STORAGE_DOCS_SUFFIX
 from ax.generation_strategy.best_model_selector import BestModelSelector
 from ax.generation_strategy.generation_node import GenerationNode
@@ -182,6 +182,13 @@ def range_parameter_to_dict(parameter: RangeParameter) -> dict[str, Any]:
 
 def choice_parameter_to_dict(parameter: ChoiceParameter) -> dict[str, Any]:
     """Convert Ax choice parameter to a dictionary."""
+    if parameter._bypass_cardinality_check:
+        raise UnsupportedError(
+            "`bypass_cardinality_check` should only be set to True "
+            "when constructing parameters within the modeling layer. "
+            "It is not supported for storage."
+        )
+
     return {
         "__type": parameter.__class__.__name__,
         "is_ordered": parameter.is_ordered,

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -55,6 +55,7 @@ from ax.core.risk_measures import RiskMeasure
 from ax.core.runner import Runner
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.core.trial import Trial
+from ax.exceptions.core import UnsupportedError
 from ax.exceptions.storage import SQAEncodeError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.storage.json_store.encoder import object_to_json
@@ -279,6 +280,12 @@ class Encoder:
                 dependents=parameter.dependents if parameter.is_hierarchical else None,
             )
         elif isinstance(parameter, ChoiceParameter):
+            if parameter._bypass_cardinality_check:
+                raise UnsupportedError(
+                    "`bypass_cardinality_check` should only be set to `True` "
+                    "when constructing parameters within the modeling layer. "
+                    "It is not supported for storage."
+                )
             # pyre-fixme[29]: `SQAParameter` is not a function.
             return parameter_class(
                 id=parameter.db_id,


### PR DESCRIPTION
Summary: Added `bypass_cardinality_check` kwarg to constructor of `ChoiceParameter` to optionally allow more than 1000 discrete values. This will be used by a log-scale transform for integer range parameters to convert them into choice parameters in log space.

Differential Revision: D82670120


