### PR TITLE
Use Winsorize by default

### DIFF
--- a/ax/adapter/registry.py
+++ b/ax/adapter/registry.py
@@ -47,6 +47,7 @@ from ax.adapter.transforms.task_encode import TaskChoiceToIntTaskChoice
 from ax.adapter.transforms.transform_to_new_sq import TransformToNewSQ
 from ax.adapter.transforms.trial_as_task import TrialAsTask
 from ax.adapter.transforms.unit_x import UnitX
+from ax.adapter.transforms.winsorize import Winsorize
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
@@ -142,11 +143,16 @@ Mixed_transforms: list[type[Transform]] = [
     Logit,
 ]
 
-Y_trans: list[type[Transform]] = [Derelativize, BilogY, StandardizeY]
+Y_trans: list[type[Transform]] = [Derelativize, Winsorize, BilogY, StandardizeY]
 
 # Expected `List[Type[Transform]]` for 2nd anonymous parameter to
 # call `list.__add__` but got `List[Type[SearchSpaceToChoice]]`.
-TS_trans: list[type[Transform]] = Y_trans + [SearchSpaceToChoice]
+TS_trans: list[type[Transform]] = [
+    Derelativize,
+    BilogY,
+    StandardizeY,
+    SearchSpaceToChoice,
+]
 
 MTGP_Y_trans: list[type[Transform]] = [
     Derelativize,

--- a/ax/api/utils/generation_strategy_dispatch.py
+++ b/ax/api/utils/generation_strategy_dispatch.py
@@ -8,8 +8,7 @@
 
 
 import torch
-from ax.adapter.registry import Generators, MBM_X_trans, Y_trans
-from ax.adapter.transforms.winsorize import Winsorize
+from ax.adapter.registry import Generators
 from ax.api.utils.structs import GenerationStrategyDispatchStruct
 from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UnsupportedError
@@ -132,7 +131,6 @@ def _get_mbm_node(
                 model_kwargs={
                     "surrogate_spec": SurrogateSpec(model_configs=model_configs),
                     "torch_device": device,
-                    "transforms": MBM_X_trans + [Winsorize] + Y_trans,
                     "transform_configs": get_derelativize_config(
                         derelativize_with_raw_status_quo=True
                     ),

--- a/ax/api/utils/tests/test_generation_strategy_dispatch.py
+++ b/ax/api/utils/tests/test_generation_strategy_dispatch.py
@@ -10,8 +10,7 @@
 from typing import Any
 
 import torch
-from ax.adapter.registry import Generators, MBM_X_trans, Y_trans
-from ax.adapter.transforms.winsorize import Winsorize
+from ax.adapter.registry import Generators
 from ax.api.utils.generation_strategy_dispatch import choose_generation_strategy
 from ax.api.utils.structs import GenerationStrategyDispatchStruct
 from ax.core.trial import Trial
@@ -123,7 +122,6 @@ class TestDispatchUtils(TestCase):
             {
                 "surrogate_spec": expected_ss,
                 "torch_device": torch.device("cpu"),
-                "transforms": MBM_X_trans + [Winsorize] + Y_trans,
                 "transform_configs": get_derelativize_config(
                     derelativize_with_raw_status_quo=True
                 ),
@@ -191,7 +189,6 @@ class TestDispatchUtils(TestCase):
             {
                 "surrogate_spec": expected_ss,
                 "torch_device": torch.device("cpu"),
-                "transforms": MBM_X_trans + [Winsorize] + Y_trans,
                 "transform_configs": get_derelativize_config(
                     derelativize_with_raw_status_quo=True
                 ),

--- a/ax/generation_strategy/dispatch_utils.py
+++ b/ax/generation_strategy/dispatch_utils.py
@@ -8,13 +8,11 @@
 
 import logging
 from math import ceil
-from typing import Any, cast
+from typing import Any
 
 import torch
 from ax.adapter.base import DataLoaderConfig
 from ax.adapter.registry import GeneratorRegistryBase, Generators
-from ax.adapter.transforms.base import Transform
-from ax.adapter.transforms.winsorize import Winsorize
 from ax.core.experiment import Experiment
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
@@ -106,12 +104,6 @@ def _make_botorch_step(
     model_kwargs["data_loader_config"] = DataLoaderConfig(
         fit_out_of_design=fit_out_of_design
     )
-
-    # Add Winsorize transform.
-    _, default_bridge_kwargs = generator.view_defaults()
-    default_transforms = default_bridge_kwargs["transforms"]
-    transforms = model_kwargs.get("transforms", default_transforms)
-    model_kwargs["transforms"] = [cast(type[Transform], Winsorize)] + transforms
 
     if use_saasbo and (generator is Generators.BOTORCH_MODULAR):
         model_kwargs["surrogate_spec"] = SurrogateSpec(
@@ -384,9 +376,7 @@ def choose_generation_strategy_legacy(
             no max parallelism will be enforced for any step of the generation
             strategy. Be aware that parallelism is limited to improve performance of
             Bayesian optimization, so only disable its limiting if necessary.
-        optimization_config: used to infer whether to use MOO and will be passed in to
-            ``Winsorize`` via its ``transform_config`` in order to determine default
-            winsorization behavior when necessary.
+        optimization_config: Used to infer whether to use MOO.
         should_deduplicate: Whether to deduplicate the parameters of proposed arms
             against those of previous arms via rejection sampling. If this is True,
             the generation strategy will discard generator runs produced from the


### PR DESCRIPTION
Summary: Adds `Winsorize` to `Y_trans`, to have it used by default. With the addition of `derelativize_with_raw_status_quo=True` in recent diffs (for OSS & AutoML usage),`Winsorize` will transform all metrics.

Reviewed By: dme65

Differential Revision: D80366290


