### PR TITLE
Disable the root check after adding metadata to the search

### DIFF
--- a/ax/analysis/plotly/surface/tests/test_contour.py
+++ b/ax/analysis/plotly/surface/tests/test_contour.py
@@ -19,7 +19,10 @@ class TestContourPlot(TestCase):
     @mock_botorch_optimize
     def setUp(self) -> None:
         super().setUp()
-        self.client = AxClient()
+
+        # There were some flaky test failures on the github side. Fix the random seed
+        # to reduce the flakiness.
+        self.client = AxClient(random_seed=42)
         self.client.create_experiment(
             is_test=True,
             name="foo",


### PR DESCRIPTION
Summary:
`MapKeyToFloat` was broken for hierarchical search spaces when the experiment contains `MapData`. This transform adds new parameters to the search space, and those added parameters have no parents. This would fail the root check in `HierarchicalSearchSpace`, which requires the root to be the only independent parameter.

Note that the same issue also applies to other transforms involving metadata, e.g., `MetadataToFloat` and `MetadataToTask`.

To resolve this issue, this diff modifies `MetadataToParameterMixin` to disable the root check once the parameters are added.

Differential Revision: D82679645


