### PR TITLE
Remove "fidelities" column from data

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -68,7 +68,6 @@ class Data(Base, SerializationMixin):
         # Metadata columns available for only some subclasses.
         "frac_nonnull": np.float64,
         "random_split": int,
-        "fidelities": np.dtype("O"),  # Dictionary stored as json
     }
 
     _df: pd.DataFrame

--- a/ax/core/observation.py
+++ b/ax/core/observation.py
@@ -37,7 +37,6 @@ OBS_COLS: set[str] = {
     "arm_name",
     "trial_index",
     "random_split",
-    "fidelities",
     *TIME_COLS,
 }
 
@@ -337,9 +336,6 @@ def _observations_from_dataframe(
                 times = d[col]
                 if times.nunique() == 1 and not times.isnull().any():
                     obs_kwargs[col] = times.iloc[0]
-        fidelities = features.get("fidelities")
-        if fidelities is not None:
-            obs_parameters.update(json.loads(fidelities))
 
         if is_map_data:
             obs_kwargs[Keys.METADATA][MAP_KEY] = features[MAP_KEY]


### PR DESCRIPTION
Summary:
**Context**:

Fidelities in Ax are handled as parameters, not as part of Data. D16586847 added fidelities to Data, but most of the functionality for working with fidelities has since been deleted. At this point, "fidelities" is a column that is special only in that it is expected to be json-encoded and is json-decoded in `_observations_from_dataframe` (this isn't really documented in Data).

The "fidelities" column in Data does not seem to be used.

**This PR**:
* Removes the "fidelities" column from `Data`

Reviewed By: saitcakmak

Differential Revision: D82750373


