### PR TITLE
Remove support for passing `sample_sizes`

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -786,7 +786,6 @@ class BaseTrial(ABC, SortableBase):
         self,
         raw_data: dict[str, TEvaluationOutcome],
         metadata: dict[str, str | int] | None,
-        sample_sizes: dict[str, int] | None = None,
     ) -> tuple[dict[str, TEvaluationOutcome], Data]:
         """Formats given raw data as Ax evaluations and `Data`.
 
@@ -794,8 +793,6 @@ class BaseTrial(ABC, SortableBase):
             raw_data: Map from arm name to
                 metric outcomes.
             metadata: Additional metadata to track about this run.
-            sample_size: Integer sample size for 1-arm trials, dict from arm
-                name to sample size for batched trials. Optional.
         """
 
         metadata = metadata if metadata is not None else {}
@@ -804,7 +801,6 @@ class BaseTrial(ABC, SortableBase):
             raw_data=raw_data,
             metric_names=list(set(self.experiment.metrics)),
             trial_index=self.index,
-            sample_sizes=sample_sizes or {},
             data_type=self.experiment.default_data_type,
             start_time=metadata.get("start_time"),
             end_time=metadata.get("end_time"),

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -535,14 +535,12 @@ class BatchTrial(BaseTrial):
     def attach_batch_trial_data(
         self,
         raw_data: dict[str, TEvaluationOutcome],
-        sample_sizes: dict[str, int] | None = None,
         metadata: dict[str, str | int] | None = None,
     ) -> None:
         """Attaches data to the trial
 
         Args:
             raw_data: Map from arm name to metric outcomes.
-            sample_sizes: Dict from arm name to sample size.
             metadata: Additional metadata to track about this run.
                 importantly the start_date and end_date
             complete_trial: Whether to mark trial as complete after
@@ -569,7 +567,7 @@ class BatchTrial(BaseTrial):
             )
 
         evaluations, data = self._make_evaluations_and_data(
-            raw_data=raw_data, metadata=metadata, sample_sizes=sample_sizes
+            raw_data=raw_data, metadata=metadata
         )
         self._validate_batch_trial_data(data=data)
 

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -246,7 +246,6 @@ class Data(Base, SerializationMixin):
         cls: type[TData],
         evaluations: Mapping[str, TTrialEvaluation],
         trial_index: int,
-        sample_sizes: Mapping[str, int] | None = None,
         start_time: int | str | None = None,
         end_time: int | str | None = None,
     ) -> TData:
@@ -258,7 +257,6 @@ class Data(Base, SerializationMixin):
                 outcome names to values, means, or tuples of mean and SEM. If SEM is
                 not specified, it will be set to None and inferred from data.
             trial_index: Trial index to which this data belongs.
-            sample_sizes: Number of samples collected for each arm.
             start_time: Optional start time of run of the trial that produced this
                 data, in milliseconds or iso format.  Milliseconds will be automatically
                 converted to iso format because iso format automatically works with the
@@ -274,7 +272,6 @@ class Data(Base, SerializationMixin):
         records = cls._get_records(evaluations=evaluations, trial_index=trial_index)
         records = cls._add_cols_to_records(
             records=records,
-            sample_sizes=sample_sizes,
             start_time=start_time,
             end_time=end_time,
         )
@@ -283,7 +280,6 @@ class Data(Base, SerializationMixin):
     @staticmethod
     def _add_cols_to_records(
         records: list[dict[str, Any]],
-        sample_sizes: Mapping[str, int] | None = None,
         start_time: int | str | None = None,
         end_time: int | str | None = None,
     ) -> list[dict[str, Any]]:
@@ -298,9 +294,6 @@ class Data(Base, SerializationMixin):
 
             for record in records:
                 record.update({"start_time": start_time, "end_time": end_time})
-        if sample_sizes:
-            for record in records:
-                record["n"] = sample_sizes[str(record["arm_name"])]
 
         return records
 

--- a/ax/core/formatting_utils.py
+++ b/ax/core/formatting_utils.py
@@ -104,7 +104,6 @@ def data_and_evaluations_from_raw_data(
     raw_data: Mapping[str, TEvaluationOutcome],
     metric_names: Sequence[str],
     trial_index: int,
-    sample_sizes: Mapping[str, int],
     data_type: DataType,
     start_time: int | str | None = None,
     end_time: int | str | None = None,
@@ -119,8 +118,6 @@ def data_and_evaluations_from_raw_data(
         raw_data: Mapping from arm name to raw_data.
         metric_names: Names of metrics used to transform raw data to evaluations.
         trial_index: Index of the trial, for which the evaluations are.
-        sample_sizes: Number of samples collected for each arm, may be empty
-            if unavailable.
         start_time: Optional start time of run of the trial that produced this
             data, in milliseconds or iso format.  Milliseconds will eventually be
             converted to iso format because iso format automatically works with the
@@ -151,7 +148,6 @@ def data_and_evaluations_from_raw_data(
         data = Data.from_evaluations(
             evaluations=cast(dict[str, TTrialEvaluation], evaluations),
             trial_index=trial_index,
-            sample_sizes=sample_sizes,
             start_time=start_time,
             end_time=end_time,
         )

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -238,7 +238,6 @@ class DataTest(TestCase):
             data = Data.from_evaluations(
                 evaluations={"0_1": {"b": eval1}},
                 trial_index=0,
-                sample_sizes={"0_1": 2},
                 start_time=now.isoformat(),
                 end_time=now.isoformat(),
             )
@@ -256,7 +255,6 @@ class DataTest(TestCase):
             data = Data.from_evaluations(
                 evaluations={"0_1": {"b": eval1}},
                 trial_index=0,
-                sample_sizes={"0_1": 2},
                 start_time=now_ms,
                 end_time=now_ms,
             )

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -279,7 +279,6 @@ class Trial(BaseTrial):
         self,
         raw_data: TEvaluationOutcome,
         metadata: dict[str, str | int] | None = None,
-        sample_size: int | None = None,
         combine_with_last_data: bool = False,
     ) -> str:
         """Utility method that attaches data to a trial and
@@ -293,8 +292,6 @@ class Trial(BaseTrial):
                 Can also be a list of (fidelities, mapping from
                 metric name to a tuple of mean and SEM).
             metadata: Additional metadata to track about this run, optional.
-            sample_size: Number of samples collected for the underlying arm,
-                optional.
             combine_with_last_data: Whether to combine the given data with the
                 data that was previously attached to the trial. See
                 `Experiment.attach_data` for a detailed explanation.
@@ -303,13 +300,10 @@ class Trial(BaseTrial):
             A string message summarizing the update.
         """
         arm_name = none_throws(self.arm).name
-        sample_sizes = {arm_name: sample_size} if sample_size else {}
         raw_data_by_arm = {arm_name: raw_data}
 
         evaluations, data = self._make_evaluations_and_data(
-            raw_data=raw_data_by_arm,
-            metadata=metadata,
-            sample_sizes=sample_sizes,
+            raw_data=raw_data_by_arm, metadata=metadata
         )
 
         self.validate_data_for_trial(data=data)

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -681,7 +681,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         trial_index: int,
         raw_data: TEvaluationOutcome,
         metadata: dict[str, str | int] | None = None,
-        sample_size: int | None = None,
     ) -> None:
         """
         Updates the trial with given metric values without completing it. Also
@@ -725,8 +724,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
                 Can also be a list of (fidelities, mapping from
                 metric name to a tuple of mean and SEM).
             metadata: Additional metadata to track about this run.
-            sample_size: Number of samples collected for the underlying arm,
-                optional.
         """
         if not isinstance(trial_index, int):
             raise ValueError(f"Trial index must be an int, got: {trial_index}.")
@@ -741,7 +738,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             trial_index=trial_index,
             raw_data=raw_data,
             metadata=metadata,
-            sample_size=sample_size,
             combine_with_last_data=True,
         )
         logger.info(f"Updated trial {trial_index} with data: " f"{data_update_repr}.")
@@ -751,7 +747,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         trial_index: int,
         raw_data: TEvaluationOutcome,
         metadata: dict[str, str | int] | None = None,
-        sample_size: int | None = None,
     ) -> None:
         """
         Completes the trial with given metric values and adds optional metadata
@@ -779,8 +774,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
                 Can also be a list of (fidelities, mapping from
                 metric name to a tuple of mean and SEM).
             metadata: Additional metadata to track about this run.
-            sample_size: Number of samples collected for the underlying arm,
-                optional.
         """
         # Validate that trial can be completed.
         trial = self.get_trial(trial_index)
@@ -791,7 +784,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             trial_index=trial_index,
             raw_data=raw_data,
             metadata=metadata,
-            sample_size=sample_size,
             complete_trial=True,
             combine_with_last_data=True,
         )
@@ -802,7 +794,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         trial_index: int,
         raw_data: TEvaluationOutcome,
         metadata: dict[str, str | int] | None = None,
-        sample_size: int | None = None,
     ) -> None:
         """
         Attaches additional data or updates the existing data for a trial in a
@@ -820,8 +811,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
                 is no SEM.  Can also be a list of (fidelities, mapping from
                 metric name to a tuple of mean and SEM).
             metadata: Additional metadata to track about this run.
-            sample_size: Number of samples collected for the underlying arm,
-                optional.
         """
         if not isinstance(trial_index, int):
             raise ValueError(f"Trial index must be an int, got: {trial_index}.")
@@ -837,7 +826,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             trial_index=trial_index,
             raw_data=raw_data,
             metadata=metadata,
-            sample_size=sample_size,
             combine_with_last_data=True,
         )
         logger.info(f"Added data: {data_update_repr} to trial {trial.index}.")
@@ -1530,7 +1518,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         trial_index: int,
         raw_data: TEvaluationOutcome,
         metadata: dict[str, str | int] | None = None,
-        sample_size: int | None = None,
         complete_trial: bool = False,
         combine_with_last_data: bool = False,
     ) -> str:
@@ -1540,7 +1527,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         update_info = trial.update_trial_data(
             raw_data=raw_data,
             metadata=metadata,
-            sample_size=sample_size,
             combine_with_last_data=combine_with_last_data,
         )
 
@@ -1733,7 +1719,6 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
 
         _, data = data_and_evaluations_from_raw_data(
             raw_data={"data": raw_data},
-            sample_sizes={},
             trial_index=trial_index,
             data_type=self.experiment.default_data_type,
             metric_names=opt_config.objective.metric_names,

--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -215,7 +215,6 @@ class OptimizationLoop:
                 for arm, weight in self._get_weights_by_arm(trial)
             },
             trial_index=self.current_trial,
-            sample_sizes={},
             data_type=self.experiment.default_data_type,
             metric_names=none_throws(
                 self.experiment.optimization_config

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -504,7 +504,6 @@ class TestAxClient(TestCase):
                         0.0,
                     )
                 },
-                sample_size=i,
             )
         self.assertEqual(
             none_throws(ax_client.generation_strategy.adapter)._model_key, "BoTorch"
@@ -705,7 +704,6 @@ class TestAxClient(TestCase):
                         0.0,
                     ),
                 },
-                sample_size=i,
             )
         # pyre-fixme[16]: `Optional` has no attribute `_model_key`.
         self.assertEqual(ax_client.generation_strategy.adapter._model_key, "BoTorch")


### PR DESCRIPTION
Summary:
**Context**:

When `sample_sizes` are passed in Ax, e.g. via `AxClient.complete_trial`, they ultimately become the "n" column in Data. Sample sizes do not have any real use within OSS Ax and are never passed this way (although "n" can be passed directly when creating `Data`).

I think `sample_size` has the potential to be misleading since a user might think Ax will do something with it or that they have to pass it.

**This PR**:

Removes `sample_sizes` from various calls that update trial data. There is no change to the API because this is already not supported in the API.

Differential Revision: D82770222


