### PR TITLE
Do not `untransform_observation_features` on non-specified status quo for `DerivedParameters`

### DIFF
--- a/ax/adapter/transforms/remove_fixed.py
+++ b/ax/adapter/transforms/remove_fixed.py
@@ -179,11 +179,15 @@ class RemoveFixed(Transform):
         self, observation_features: list[ObservationFeatures]
     ) -> list[ObservationFeatures]:
         for obsf in observation_features:
-            for p_name, p in self.fixed_or_derived_parameters.items():
-                if isinstance(p, DerivedParameter):
-                    obsf.parameters[p_name] = p.compute(parameters=obsf.parameters)
-                else:
-                    obsf.parameters[p_name] = p.value
+            # Only untransform observations with specified parameters
+            # where at least one of them is not a fixed or derived parameter.
+            # This would be empty when status quo param values are not specified
+            if obsf.parameters:
+                for p_name, p in self.fixed_or_derived_parameters.items():
+                    if isinstance(p, DerivedParameter):
+                        obsf.parameters[p_name] = p.compute(parameters=obsf.parameters)
+                    else:
+                        obsf.parameters[p_name] = p.value
         return observation_features
 
     def transform_experiment_data(

--- a/ax/adapter/transforms/tests/test_remove_fixed_transform.py
+++ b/ax/adapter/transforms/tests/test_remove_fixed_transform.py
@@ -155,6 +155,14 @@ class RemoveFixedTransformTest(TestCase):
         )
         self.assertEqual(t_obs, t_obs_different)
 
+        # Test untransform with empty parameters (status quo case)
+        # This would previously fail on p.compute(parameters=obsf.parameters)
+        # when obsf.parameters is {} for DerivedParameter
+        empty_obs_features = [ObservationFeatures(parameters={})]
+        result = self.t.untransform_observation_features(empty_obs_features)
+        # Should return unchanged empty observation features
+        self.assertEqual(result, [ObservationFeatures(parameters={})])
+
     def test_TransformSearchSpace(self) -> None:
         ss2 = self.search_space.clone()
         ss2 = self.t.transform_search_space(ss2)


### PR DESCRIPTION
Summary: Do not `untransform_observation_features` on non-specified status quo parameter values for `DerivedParameters`

Reviewed By: sdaulton

Differential Revision: D82868332


