### PR TITLE
Allow arbitrary extra columns in Data

### DIFF
--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -106,11 +106,6 @@ class MapData(Data):
                 raise ValueError(
                     f"Dataframe must contain required columns {missing_columns}."
                 )
-            supported_columns = self.supported_columns(extra_column_names=[MAP_KEY])
-            extra_columns = columns - supported_columns
-            if extra_columns:
-                raise UnsupportedError(f"Columns {extra_columns} are not supported.")
-
             if df["trial_index"].isnull().any():
                 df = df.dropna(axis=0, how="all", ignore_index=True)
             else:
@@ -119,14 +114,7 @@ class MapData(Data):
                 df = df.reset_index(drop=True)
 
             self._map_df = self._safecast_df(df=df, extra_column_types=map_key_to_type)
-
-            col_order = [
-                c
-                for c in self.column_data_types(extra_column_types=map_key_to_type)
-                if c in df.columns
-            ]
-            if not (self._map_df.columns == col_order).all():
-                self._map_df = self._map_df.reindex(columns=col_order)
+            self._map_df = self._get_df_with_cols_in_expected_order(df=self._map_df)
 
         self._memo_df = None
 

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -208,6 +208,14 @@ class TestDataBase(TestCase):
             self.assertEqual(columns[c], t)
         self.assertEqual(columns["foo"], bartype)
 
+    def test_extra_columns(self) -> None:
+        value = 3
+        extra_col_df = self.df.assign(foo=value)
+        data = self.cls(df=extra_col_df)
+        self.assertIn("foo", data.true_df.columns)
+        self.assertIn("foo", data.df.columns)
+        self.assertTrue((data.true_df["foo"] == value).all())
+
 
 class DataTest(TestCase):
     """Tests that are specific to Data and not shared with MapData."""
@@ -232,10 +240,6 @@ class DataTest(TestCase):
 
         data = CustomData(df=self.df)
         self.assertNotEqual(data, Data(self.df))
-
-        # Try making regular data with extra column
-        with self.assertRaisesRegex(ValueError, "cat"):
-            Data(df=self.df.assign(cat="dog"))
 
     def test_FromEvaluationsIsoFormat(self) -> None:
         now = pd.Timestamp.now()


### PR DESCRIPTION
Summary:
**Context:**
* Currently, `Data` can only contain the columns in `Data.COLUMN_DATA_TYPES`, and `MapData` can only contain those plus "step." Those columns have their types checked and force-cast to the expecetd type.
* There is no reason `Data` can't contain more columns. This does not present any challenges for serialization and storage since the whole DataFrame is currently serialized into a JSON blob.
* A storage update for `Data` is planned, and we expect that in the future users may want more columns in `Data`, e.g. for contextual features. Allowing arbitrary extra columns now ensures that storage will be done in a forward-compatible way that accommodates new columns.

**This PR**:
* Removes the errors that comes up when extra columns are provided in `Data` or `MapData`
* Removes now-unneeded `supported_columns` method
* Changes expected column order so that extra columns always go last
* Pulls out a method `_get_df_with_cols_in_expected_order` so that it can be used within both `Data` and `MapData`. This is a little ugly, but a subsequent diff will unify the inits for Data and MapData and allow this to be written in a more compact way.

Differential Revision: D82846595


