### PR TITLE
Let `Data` know expected dtype of "step"

### DIFF
--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -106,11 +106,6 @@ class MapData(Data):
                 raise ValueError(
                     f"Dataframe must contain required columns {missing_columns}."
                 )
-            supported_columns = self.supported_columns(extra_column_names=[MAP_KEY])
-            extra_columns = columns - supported_columns
-            if extra_columns:
-                raise UnsupportedError(f"Columns {extra_columns} are not supported.")
-
             if df["trial_index"].isnull().any():
                 df = df.dropna(axis=0, how="all", ignore_index=True)
             else:
@@ -119,14 +114,7 @@ class MapData(Data):
                 df = df.reset_index(drop=True)
 
             self._map_df = self._safecast_df(df=df, extra_column_types=map_key_to_type)
-
-            col_order = [
-                c
-                for c in self.column_data_types(extra_column_types=map_key_to_type)
-                if c in df.columns
-            ]
-            if not (self._map_df.columns == col_order).all():
-                self._map_df = self._map_df.reindex(columns=col_order)
+            self._map_df = self._get_df_with_cols_in_expected_order(df=self._map_df)
 
         self._memo_df = None
 

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -208,6 +208,14 @@ class TestDataBase(TestCase):
             self.assertEqual(columns[c], t)
         self.assertEqual(columns["foo"], bartype)
 
+    def test_extra_columns(self) -> None:
+        value = 3
+        extra_col_df = self.df.assign(foo=value)
+        data = self.cls(df=extra_col_df)
+        self.assertIn("foo", data.true_df.columns)
+        self.assertIn("foo", data.df.columns)
+        self.assertTrue((data.true_df["foo"] == value).all())
+
 
 class DataTest(TestCase):
     """Tests that are specific to Data and not shared with MapData."""
@@ -232,10 +240,6 @@ class DataTest(TestCase):
 
         data = CustomData(df=self.df)
         self.assertNotEqual(data, Data(self.df))
-
-        # Try making regular data with extra column
-        with self.assertRaisesRegex(ValueError, "cat"):
-            Data(df=self.df.assign(cat="dog"))
 
     def test_FromEvaluationsIsoFormat(self) -> None:
         now = pd.Timestamp.now()

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-import random
 from unittest.mock import patch
 
 import pandas as pd
@@ -197,16 +196,6 @@ class TestDataBase(TestCase):
     def test_from_multiple_with_generator(self) -> None:
         data = self.cls.from_multiple_data(self.data_with_df for _ in range(2))
         self.assertEqual(len(data.true_df), 2 * len(self.data_with_df.true_df))
-
-    def test_data_column_data_types_default(self) -> None:
-        self.assertEqual(self.cls.column_data_types(), self.cls.COLUMN_DATA_TYPES)
-
-    def test_data_column_data_types_with_extra_columns(self) -> None:
-        bartype = random.choice([str, int, float])
-        columns = self.cls.column_data_types(extra_column_types={"foo": bartype})
-        for c, t in self.cls.COLUMN_DATA_TYPES.items():
-            self.assertEqual(columns[c], t)
-        self.assertEqual(columns["foo"], bartype)
 
     def test_extra_columns(self) -> None:
         value = 3

--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -322,3 +322,9 @@ class MapDataTest(TestCase):
             len(subsample_map_df[subsample_map_df["metric_name"] == "b"]),
             len(map_df[map_df["metric_name"] == "b"]),
         )
+
+    def test_dtype_conversion(self) -> None:
+        df = self.df
+        df[MAP_KEY] = df[MAP_KEY].astype(int)
+        data = MapData(df=df)
+        self.assertEqual(data.map_df[MAP_KEY].dtype, float)


### PR DESCRIPTION
Summary:
**This PR**:
* Lets `Data` know that the expected dtype of "step" is `float`
* Removes various arguments and methods that existed just to pass expected dtype info around. Previously, since column and dtype info existed on the class level and were never a real user input, all this did was let `MapData` specify that "step" should be a `float`. If that information is on `Data`, there is no need to

**Functionality changes**:
* For `MapData`, no change.
* Other user-defined `Data` subclasses would have to override methods or the `COLUMN_DATA_TYPES` class attribute; that is fine because (1) that is a more normal way to write a subclass than passing arguments around internally within the class, and (2) we don't really want more `Data` subclasses anyway.
* In `Data`, if "step" were included, it previously would be ignored, and now it will be cast to a float. This isn't harmful and we are moving towards unifying `Data` and `MapData` anyway.

Differential Revision: D82914699


