### PR TITLE
Data._df -> Data.full_df, MapData._map_df -> MapData.full_df

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -450,7 +450,7 @@ class BaseTrial(ABC, SortableBase):
             results=self.fetch_data_results(metrics=metrics, **kwargs)
         )
         if not isinstance(data, MapData):
-            data._df = sort_by_trial_index_and_arm_name(data._df)
+            data.full_df = sort_by_trial_index_and_arm_name(data.full_df)
 
         return data
 


### PR DESCRIPTION
Summary:
**Context**:
* Currently, `full_df` is a property that is equivalent to either `_df` on `Data` or `_map_df` on `MapData`. We don't really need all these dfs around. (And there is also `Data.df` and `MapData.map_df` -- this is too many ways of referencing what is at most two distinct DataFrames.)

**This PR**:
** Makes `full_df` an attribute; gets rid of `_df` and `_map_df`

Differential Revision: D82846609


