### PR TITLE
Silence pandas warnings from choice_encode and trace

### DIFF
--- a/ax/adapter/transforms/choice_encode.py
+++ b/ax/adapter/transforms/choice_encode.py
@@ -142,10 +142,11 @@ class ChoiceToNumericChoice(Transform):
     def transform_experiment_data(
         self, experiment_data: ExperimentData
     ) -> ExperimentData:
+        arm_data = experiment_data.arm_data.copy()
+        for parameter_name, new_values in self.encoded_parameters.items():
+            arm_data[parameter_name] = arm_data[parameter_name].map(new_values)
         return ExperimentData(
-            arm_data=experiment_data.arm_data.replace(
-                to_replace=self.encoded_parameters
-            ),
+            arm_data=arm_data,
             observation_data=experiment_data.observation_data,
         )
 

--- a/ax/adapter/transforms/tests/test_choice_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_choice_encode_transform.py
@@ -317,8 +317,8 @@ class ChoiceEncodeTransformTest(TestCase):
             expected_values = zip(
                 [2.2, 1.0, 1.2],
                 [2, 1, 2],
-                [1.0, 0.0, 2.0],
-                [0.0, 1.0, 2.0],
+                [1, 0, 2],
+                [0, 1, 2],
                 ["r", "q", "z"],
                 ["q", "z", "r"],
             )

--- a/ax/plot/trace.py
+++ b/ax/plot/trace.py
@@ -870,7 +870,7 @@ def compute_running_feasible_optimum_df(
         running_feasible_optimum_df.set_index("trial_index")
         .reindex(new_index)
         .reset_index()
-        .fillna(method="ffill")
+        .ffill()
     )
 
     # Add legend column.


### PR DESCRIPTION
Summary:
This resolves some warnings from pandas:

**`[W 250920 10:01:29 choice_encode:146] Downcasting behavior in `replace` is deprecated and will be removed in a future version.`**

I had ~50 of these warnings in a recent notebook which was very annoying.

Change: Use `map` instead of `replace`. I personally prefer `map` over `replace` anyway as unmapped values will be set to `nan` while `replace` just leaves them `unchanged`. Leaving unmapped values unchanged feels much more error prone.

**`DataFrame.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.`**

Change: As suggested by pandas.

Differential Revision: D82863617


