### PR TITLE
Update test observation transfroms in cross_validate when untransform=False

### DIFF
--- a/ax/adapter/cross_validation.py
+++ b/ax/adapter/cross_validation.py
@@ -162,13 +162,9 @@ def cross_validate(
                 )
             # Get test observations in transformed space.
             for t in model.transforms.values():
-                cv_test_data = t.transform_experiment_data(experiment_data=cv_test_data)
-            # Re-construct the test observations with the transformed data.
-            cv_test_observations = [
-                obs
-                for obs in cv_test_data.convert_to_list_of_observations()
-                if test_selector is None or test_selector(obs)
-            ]
+                cv_test_observations = t.transform_observations(
+                    observations=cv_test_observations
+                )
         # Form CVResult objects
         if len(cv_test_observations) < len(cv_test_predictions):
             msg = (

--- a/ax/adapter/tests/test_cross_validation.py
+++ b/ax/adapter/tests/test_cross_validation.py
@@ -154,16 +154,19 @@ class CrossValidationTest(TestCase):
         # Check that Adapter._transform_inputs_for_cv was called correctly.
         z = mock_transform_cv.mock_calls
         self.assertEqual(len(z), 3)
-        train = [r[2]["cv_training_data"].arm_data["x"].tolist() for r in z]
-        test = [[obsf.parameters["x"] for obsf in r[2]["cv_test_points"]] for r in z]
+        train = [call.kwargs["cv_training_data"].arm_data["x"].tolist() for call in z]
+        test = [
+            [obsf.parameters["x"] for obsf in call.kwargs["cv_test_points"]]
+            for call in z
+        ]
         # Test no overlap between train and test sets, and all points used
         for i in range(3):
             self.assertEqual(len(set(train[i]).intersection(test[i])), 0)
             self.assertEqual(len(train[i]) + len(test[i]), 4)
-        # Test all points used as test points
+        # Test all points used as test points -- these are transformed after call.
         all_test = np.hstack(test)
         self.assertTrue(
-            np.array_equal(sorted(all_test), np.array([2.0, 2.0, 3.0, 4.0]))
+            np.array_equal(sorted(all_test), np.array([0.2, 0.2, 0.3, 0.4]))
         )
         # Test Adapter._cross_validate was called correctly.
         self.assertEqual(mock_cv.call_count, 3)


### PR DESCRIPTION
Summary:
The current implementation transforms `ExperimentData` and extracts the observations from there using the `test_selector`, if appliable. The catch is that the `test_selector` may not be compatible with observations from the transformed space. This may lead to changing the set of observations that are used when constructing the `CVResults`.

This diff replaces the transform on `ExperimentData` objects with transforms on already filtered (by `test_selector)` `cv_test_observations`. This will make sure that the observations that we use for making predictions are consistent with the observations they are being compared to.

Reviewed By: Balandat

Differential Revision: D82984880


