### PR TITLE
Remove deprecated transforms

### DIFF
--- a/ax/adapter/transforms/choice_encode.py
+++ b/ax/adapter/transforms/choice_encode.py
@@ -6,11 +6,10 @@
 
 # pyre-strict
 
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-from ax.adapter.transforms.deprecated_transform_mixin import DeprecatedTransformMixin
 from ax.adapter.transforms.utils import ClosestLookupDict, construct_new_search_space
 from ax.core.observation import Observation, ObservationFeatures
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
@@ -151,13 +150,6 @@ class ChoiceToNumericChoice(Transform):
         )
 
 
-class ChoiceEncode(DeprecatedTransformMixin, ChoiceToNumericChoice):
-    """Deprecated alias for ChoiceToNumericChoice."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-
-
 class OrderedChoiceToIntegerRange(ChoiceToNumericChoice):
     """Convert ordered ChoiceParameters to integer RangeParameters.
 
@@ -251,10 +243,3 @@ class OrderedChoiceToIntegerRange(ChoiceToNumericChoice):
                 for pc in search_space.parameter_constraints
             ],
         )
-
-
-class OrderedChoiceEncode(DeprecatedTransformMixin, OrderedChoiceToIntegerRange):
-    """Deprecated alias for OrderedChoiceToIntegerRange."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)

--- a/ax/adapter/transforms/task_encode.py
+++ b/ax/adapter/transforms/task_encode.py
@@ -6,11 +6,10 @@
 
 # pyre-strict
 
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.choice_encode import OrderedChoiceToIntegerRange
-from ax.adapter.transforms.deprecated_transform_mixin import DeprecatedTransformMixin
 from ax.adapter.transforms.utils import construct_new_search_space
 from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType
@@ -108,10 +107,3 @@ class TaskChoiceToIntTaskChoice(OrderedChoiceToIntegerRange):
                 for pc in search_space.parameter_constraints
             ],
         )
-
-
-class TaskEncode(DeprecatedTransformMixin, TaskChoiceToIntTaskChoice):
-    """Deprecated alias for TaskChoiceToIntTaskChoice."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)

--- a/ax/adapter/transforms/tests/test_choice_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_choice_encode_transform.py
@@ -14,7 +14,6 @@ from ax.adapter.base import DataLoaderConfig
 from ax.adapter.data_utils import extract_experiment_data
 from ax.adapter.transforms.choice_encode import (
     ChoiceToNumericChoice,
-    OrderedChoiceEncode,
     OrderedChoiceToIntegerRange,
 )
 from ax.core.observation import ObservationFeatures
@@ -37,7 +36,7 @@ from pandas.testing import assert_frame_equal
 from pyre_extensions import assert_is_instance
 
 
-class ChoiceEncodeTransformTest(TestCase):
+class ChoiceToNumericChoiceTransformTest(TestCase):
     t_class = ChoiceToNumericChoice
 
     def setUp(self) -> None:
@@ -359,7 +358,7 @@ class ChoiceEncodeTransformTest(TestCase):
         )
 
 
-class OrderedChoiceToIntegerRangeTransformTest(ChoiceEncodeTransformTest):
+class OrderedChoiceToIntegerRangeTransformTest(ChoiceToNumericChoiceTransformTest):
     t_class = OrderedChoiceToIntegerRange
 
     def setUp(self) -> None:
@@ -446,24 +445,6 @@ class OrderedChoiceToIntegerRangeTransformTest(ChoiceEncodeTransformTest):
         t_ss = self.t.transform_search_space(ss)
         self.assertEqual(t_ss.parameters["b"].lower, 1)
         self.assertEqual(t_ss.parameters["b"].upper, 2)
-
-    def test_deprecated_OrderedChoiceEncode(self) -> None:
-        # Ensure we error if we try to transform a fidelity parameter
-        ss3 = SearchSpace(
-            parameters=[
-                ChoiceParameter(
-                    "b",
-                    parameter_type=ParameterType.FLOAT,
-                    values=[1.0, 10.0, 100.0],
-                    is_ordered=True,
-                    is_fidelity=True,
-                    target_value=100.0,
-                )
-            ]
-        )
-        t = OrderedChoiceToIntegerRange(search_space=ss3, observations=[])
-        t_deprecated = OrderedChoiceEncode(search_space=ss3, observations=[])
-        self.assertEqual(t.__dict__, t_deprecated.__dict__)
 
     def test_hss_dependents_are_preserved(self) -> None:
         """

--- a/ax/adapter/transforms/tests/test_task_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_task_encode_transform.py
@@ -8,8 +8,7 @@
 
 from copy import deepcopy
 
-from ax.adapter.transforms.task_encode import TaskChoiceToIntTaskChoice, TaskEncode
-
+from ax.adapter.transforms.task_encode import TaskChoiceToIntTaskChoice
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import RobustSearchSpace, SearchSpace
@@ -17,7 +16,7 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_robust_search_space
 
 
-class TaskEncodeTransformTest(TestCase):
+class TaskChoiceToIntTaskChoiceTransformTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.search_space = SearchSpace(
@@ -130,47 +129,6 @@ class TaskEncodeTransformTest(TestCase):
             search_space=rss,
             observations=[],
         )
-        rss_new = t.transform_search_space(rss)
-        self.assertIsInstance(rss_new, RobustSearchSpace)
-        self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
-        self.assertEqual(rss.parameter_distributions, rss_new.parameter_distributions)
-        # pyre-fixme[16]: `SearchSpace` has no attribute `_environmental_variables`.
-        self.assertEqual(rss._environmental_variables, rss_new._environmental_variables)
-        self.assertEqual(rss_new.parameters.get("c").parameter_type, ParameterType.INT)
-
-    def test_deprecated_w_parameter_distributions(self) -> None:
-        rss = get_robust_search_space()
-        # pyre-fixme[16]: `Parameter` has no attribute `_is_task`.
-        rss.parameters["c"]._is_task = True
-        rss.parameters["c"]._target_value = "red"
-        # Transform a non-distributional parameter.
-        t = TaskEncode(
-            search_space=rss,
-            observations=[],
-        )
-        self.assertIsInstance(t, TaskChoiceToIntTaskChoice)
-        rss_new = t.transform_search_space(rss)
-        # Make sure that the return value is still a RobustSearchSpace.
-        self.assertIsInstance(rss_new, RobustSearchSpace)
-        self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
-        # pyre-fixme[16]: `SearchSpace` has no attribute `parameter_distributions`.
-        self.assertEqual(rss.parameter_distributions, rss_new.parameter_distributions)
-        # pyre-fixme[16]: Optional type has no attribute `parameter_type`.
-        self.assertEqual(rss_new.parameters.get("c").parameter_type, ParameterType.INT)
-        # Test with environmental variables.
-        all_params = list(rss.parameters.values())
-        rss = RobustSearchSpace(
-            parameters=all_params[2:],
-            parameter_distributions=rss.parameter_distributions,
-            num_samples=rss.num_samples,
-            environmental_variables=all_params[:2],
-        )
-        t = TaskEncode(
-            search_space=rss,
-            observations=[],
-        )
-        self.assertIsInstance(t, TaskChoiceToIntTaskChoice)
-
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
         self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))

--- a/ax/storage/json_store/tests/test_transform_encode.py
+++ b/ax/storage/json_store/tests/test_transform_encode.py
@@ -11,14 +11,12 @@ import unittest
 
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.choice_encode import (
-    ChoiceEncode,
     ChoiceToNumericChoice,
-    OrderedChoiceEncode,
     OrderedChoiceToIntegerRange,
 )
 from ax.adapter.transforms.int_range_to_choice import IntRangeToChoice
 from ax.adapter.transforms.map_key_to_float import MapKeyToFloat
-from ax.adapter.transforms.task_encode import TaskChoiceToIntTaskChoice, TaskEncode
+from ax.adapter.transforms.task_encode import TaskChoiceToIntTaskChoice
 from ax.storage.json_store.decoder import object_from_json
 from ax.storage.json_store.decoders import transform_type_from_json
 from ax.storage.json_store.encoder import object_to_json
@@ -31,9 +29,9 @@ class TestTransformEncode(unittest.TestCase):
         super().setUp()
 
         self.deprecatedTestCases = [
-            (OrderedChoiceEncode, OrderedChoiceToIntegerRange),
-            (ChoiceEncode, ChoiceToNumericChoice),
-            (TaskEncode, TaskChoiceToIntTaskChoice),
+            ("OrderedChoiceEncode", OrderedChoiceToIntegerRange),
+            ("ChoiceEncode", ChoiceToNumericChoice),
+            ("TaskEncode", TaskChoiceToIntTaskChoice),
         ]
 
     def test_encode_and_decode_transform(self) -> None:
@@ -55,10 +53,10 @@ class TestTransformEncode(unittest.TestCase):
 
     def test_encode_and_decode_deprecated_transforms(self) -> None:
         for deprecated_type, current_type in self.deprecatedTestCases:
-            transform_dict = transform_type_to_dict(deprecated_type)
-            self.assertEqual(transform_dict["__type"], "Type[Transform]")
-            self.assertIn(deprecated_type.__name__, transform_dict["transform_type"])
-
+            transform_dict = {
+                "__type": "Type[Transform]",
+                "transform_type": deprecated_type,
+            }
             decoded_transform_type = transform_type_from_json(transform_dict)
             # Deprecated type is decoded into the current type.
             self.assertNotEqual(decoded_transform_type, deprecated_type)

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -10,9 +10,7 @@
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.bilog_y import BilogY
 from ax.adapter.transforms.choice_encode import (
-    ChoiceEncode,
     ChoiceToNumericChoice,
-    OrderedChoiceEncode,
     OrderedChoiceToIntegerRange,
 )
 from ax.adapter.transforms.convert_metric_names import ConvertMetricNames
@@ -37,7 +35,7 @@ from ax.adapter.transforms.remove_fixed import RemoveFixed
 from ax.adapter.transforms.search_space_to_choice import SearchSpaceToChoice
 from ax.adapter.transforms.standardize_y import StandardizeY
 from ax.adapter.transforms.stratified_standardize_y import StratifiedStandardizeY
-from ax.adapter.transforms.task_encode import TaskChoiceToIntTaskChoice, TaskEncode
+from ax.adapter.transforms.task_encode import TaskChoiceToIntTaskChoice
 from ax.adapter.transforms.time_as_feature import TimeAsFeature
 from ax.adapter.transforms.transform_to_new_sq import TransformToNewSQ
 from ax.adapter.transforms.trial_as_task import TrialAsTask
@@ -68,7 +66,7 @@ TRANSFORM_REGISTRY: set[type[Transform]] = {
     IVW,
     Log,
     OneHot,
-    OrderedChoiceEncode,  # TO BE DEPRECATED
+    # OrderedChoiceEncode,  # DEPRECATED
     OrderedChoiceToIntegerRange,
     # This transform was upstreamed into the base adapter.
     # DEPRECATED: OutOfDesign
@@ -76,14 +74,14 @@ TRANSFORM_REGISTRY: set[type[Transform]] = {
     SearchSpaceToChoice,
     StandardizeY,
     StratifiedStandardizeY,
-    TaskEncode,  # TO BE DEPRECATED
+    # TaskEncode,  # DEPRECATED
     TaskChoiceToIntTaskChoice,
     TrialAsTask,
     UnitX,
     Winsorize,
     # CapParameter,  DEPRECATED
     PowerTransformY,
-    ChoiceEncode,  # TO BE DEPRECATED
+    # ChoiceEncode,  # DEPRECATED
     ChoiceToNumericChoice,
     Logit,
     # MapUnitX, DEPRECATED


### PR DESCRIPTION
Summary: These have been deprecated for about a year. No need to keep them around any longer. The transform layer already maps them to the replacements, so we don't need to any more updates for BC.

Reviewed By: Balandat

Differential Revision: D82988673


