### PR TITLE
Count tunable parameters consistently

### DIFF
--- a/ax/adapter/transforms/tests/test_remove_fixed_transform.py
+++ b/ax/adapter/transforms/tests/test_remove_fixed_transform.py
@@ -128,7 +128,7 @@ class RemoveFixedTransformTest(TestCase):
         self.t_hss = RemoveFixed(search_space=self.hierarchical_search_space)
 
     def test_Init(self) -> None:
-        self.assertEqual(list(self.t.fixed_or_derived_parameters.keys()), ["c", "d"])
+        self.assertEqual(list(self.t.nontunable_parameters), ["c", "d"])
 
     def test_TransformObservationFeatures(self) -> None:
         observation_features = [

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -110,11 +110,19 @@ class SearchSpace(Base):
         }
 
     @property
-    def tunable_parameters(self) -> dict[str, Parameter]:
+    def tunable_parameters(self) -> dict[str, ChoiceParameter | RangeParameter]:
         return {
             name: parameter
             for name, parameter in self.parameters.items()
-            if not isinstance(parameter, FixedParameter)
+            if isinstance(parameter, (ChoiceParameter, RangeParameter))
+        }
+
+    @property
+    def nontunable_parameters(self) -> dict[str, DerivedParameter | FixedParameter]:
+        return {
+            name: parameter
+            for name, parameter in self.parameters.items()
+            if isinstance(parameter, (DerivedParameter, FixedParameter))
         }
 
     def __getitem__(self, parameter_name: str) -> Parameter:

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -146,8 +146,18 @@ class SearchSpaceTest(TestCase):
     def test_Properties(self) -> None:
         self.assertEqual(len(self.ss1.parameters), TOTAL_PARAMS)
         self.assertTrue("a" in self.ss1.parameters)
+
+        # Check tunable parameters
         self.assertTrue(len(self.ss1.tunable_parameters), TUNABLE_PARAMS)
         self.assertFalse("d" in self.ss1.tunable_parameters)
+        self.assertFalse("h" in self.ss1.tunable_parameters)
+
+        # Each parameter is either tunable or nontunable.
+        self.assertEqual(
+            set(self.ss1.parameters),
+            set(self.ss1.nontunable_parameters).union(self.ss1.tunable_parameters),
+        )
+
         self.assertTrue(len(self.ss1.range_parameters), RANGE_PARAMS)
         self.assertFalse("c" in self.ss1.range_parameters)
         self.assertTrue(len(self.ss1.parameter_constraints) == 0)


### PR DESCRIPTION
Summary:
1. `SearchSpace.tunable_parameters` incorrectly treated derived parameters as tunable parameters. This diff fixes it.
2. `RemovedFixed` had its own implementation for constructing tunable parameters, instead of using the existing one available in `SearchSpace`. This diff reaps some of the code to facilitate code sharing.

Differential Revision: D82986290


