### PR TITLE
Upgrade Docusaurus to 3.8.1-canary-6401

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,10 +14,11 @@
     "docusaurus": "docusaurus"
   },
   "devDependencies": {},
+  "//": "TODO: T239136996 Unpin Docusaurus canary after 3.8.2 or 3.9 is released",
   "dependencies": {
-    "@docusaurus/core": "3.6.3",
-    "@docusaurus/plugin-client-redirects": "3.6.3",
-    "@docusaurus/preset-classic": "3.6.3",
+    "@docusaurus/core": "3.8.1-canary-6401",
+    "@docusaurus/plugin-client-redirects": "3.8.1-canary-6401",
+    "@docusaurus/preset-classic": "3.8.1-canary-6401",
     "clsx": "^1.1.1",
     "plotly.js": "^2.8.1",
     "react": "^18.3.1",


### PR DESCRIPTION
Summary:
We recently noticed that the copy feature on our website codeblocks were excluding indentation.  There's a github issue on the docusaurus repo tracking this https://github.com/facebook/docusaurus/issues/11414 with a fix that was just merged today https://github.com/facebook/docusaurus/pull/11422.

To avoid waiting until their next release we have two options:

1. update our website package.json to use a docusaurus canary until they release 3.9

2. swizzle the relevant docusaurus code and fix it ourselves using their
well documented api. There's an example of another project replacing this same logic that we can use. Though it will become unnecessary once docusaurus 3.9 releases

We're going with option (1) here and upgrading Docusaurus to version 3.8.1-canary-6401 across Ax and BoTorch. The docusaurus team releases canaries regularly and are what they use to build their website. https://docusaurus.io/community/canary

Differential Revision: D83068096


