### PR TITLE
Remove support for observations in transform constructors

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -1340,7 +1340,6 @@ def transform_search_space(
         try:
             t_instance = t(
                 search_space=search_space,
-                observations=[],
                 adapter=None,
                 config=transform_configs.get(t.__name__),
             )

--- a/ax/adapter/transforms/base.py
+++ b/ax/adapter/transforms/base.py
@@ -64,39 +64,26 @@ class Transform:
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         """Do any initial computations for preparing the transform.
 
-        This takes in search space and observations, but they are not modified.
-
         Args:
             search_space: The search space of the experiment.
-            observations: A list of observations from the experiment.
             experiment_data: A container for the parameterizations, metadata and
                 observations for the trials in the experiment.
                 Constructed using ``extract_experiment_data``.
             adapter: Adapter for referencing experiment, status quo, etc.
             config: A dictionary of options specific to each transform.
         """
-        if experiment_data is not None and observations is not None:
-            raise UnsupportedError(
-                "Only one of `experiment_data` or `observations` should be provided. "
-                f"Got {experiment_data=}, {observations=}."
+        if self.requires_data_for_initialization and (
+            experiment_data is None or experiment_data.observation_data.empty
+        ):
+            raise DataRequiredError(
+                f"`{self.__class__.__name__}` transform requires non-empty data."
             )
-        if self.requires_data_for_initialization:
-            has_non_empty_observations = observations is not None and len(observations)
-            has_non_empty_experiment_data = (
-                experiment_data is not None
-                and not experiment_data.observation_data.empty
-            )
-            if not (has_non_empty_observations or has_non_empty_experiment_data):
-                raise DataRequiredError(
-                    f"`{self.__class__.__name__}` transform requires non-empty data."
-                )
         if config is None:
             config = {}
         self.config = config

--- a/ax/adapter/transforms/bilog_y.py
+++ b/ax/adapter/transforms/bilog_y.py
@@ -15,7 +15,7 @@ import numpy.typing as npt
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.log_y import match_ci_width
-from ax.core.observation import Observation, ObservationData
+from ax.core.observation import ObservationData
 from ax.core.search_space import SearchSpace
 from ax.generators.types import TConfig
 
@@ -44,7 +44,6 @@ class BilogY(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
@@ -53,7 +52,6 @@ class BilogY(Transform):
 
         Args:
             search_space: The search space of the experiment.
-            observations: A list of observations from the experiment.
             experiment_data: A container for the parameterizations, metadata and
                 observations for the trials in the experiment.
                 Constructed using ``extract_experiment_data``.
@@ -62,7 +60,6 @@ class BilogY(Transform):
         """
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/cast.py
+++ b/ax/adapter/transforms/cast.py
@@ -46,7 +46,6 @@ class Cast(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
@@ -54,7 +53,6 @@ class Cast(Transform):
         self.search_space: SearchSpace = none_throws(search_space).clone()
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/choice_encode.py
+++ b/ax/adapter/transforms/choice_encode.py
@@ -11,7 +11,7 @@ from typing import Optional, TYPE_CHECKING
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import ClosestLookupDict, construct_new_search_space
-from ax.core.observation import Observation, ObservationFeatures
+from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
@@ -45,7 +45,6 @@ class ChoiceToNumericChoice(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
@@ -53,7 +52,6 @@ class ChoiceToNumericChoice(Transform):
         assert search_space is not None, "ChoiceToNumericChoice requires search space"
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,
@@ -168,14 +166,12 @@ class OrderedChoiceToIntegerRange(ChoiceToNumericChoice):
     def __init__(
         self,
         search_space: SearchSpace,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/fill_missing_parameters.py
+++ b/ax/adapter/transforms/fill_missing_parameters.py
@@ -10,7 +10,7 @@ from typing import Optional, TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-from ax.core.observation import Observation, ObservationFeatures
+from ax.core.observation import ObservationFeatures
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParameterization
 from ax.exceptions.core import UnsupportedError
@@ -37,14 +37,12 @@ class FillMissingParameters(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/fixed_to_tunable.py
+++ b/ax/adapter/transforms/fixed_to_tunable.py
@@ -11,7 +11,6 @@ from typing import Optional, TYPE_CHECKING
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import construct_new_search_space
-from ax.core.observation import Observation
 from ax.core.parameter import FixedParameter, Parameter, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.generators.types import TConfig
@@ -33,7 +32,6 @@ class FixedToTunable(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
@@ -41,7 +39,6 @@ class FixedToTunable(Transform):
         assert search_space is not None, "FixedToTunable requires search space"
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/int_range_to_choice.py
+++ b/ax/adapter/transforms/int_range_to_choice.py
@@ -12,7 +12,6 @@ from typing import cast, Optional, TYPE_CHECKING
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import construct_new_search_space
-from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.generators.types import TConfig
@@ -33,14 +32,12 @@ class IntRangeToChoice(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/int_to_float.py
+++ b/ax/adapter/transforms/int_to_float.py
@@ -16,7 +16,7 @@ from ax.adapter.transforms.rounding import (
     randomized_round_parameters,
 )
 from ax.adapter.transforms.utils import construct_new_search_space
-from ax.core.observation import Observation, ObservationFeatures
+from ax.core.observation import ObservationFeatures
 from ax.core.parameter import Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.generators.types import TConfig
@@ -50,7 +50,6 @@ class IntToFloat(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
@@ -60,7 +59,6 @@ class IntToFloat(Transform):
         )
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/log.py
+++ b/ax/adapter/transforms/log.py
@@ -12,7 +12,7 @@ from typing import Optional, TYPE_CHECKING
 import numpy as np
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-from ax.core.observation import Observation, ObservationFeatures
+from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import TNumeric, TParamValue
@@ -34,7 +34,6 @@ class Log(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
@@ -42,7 +41,6 @@ class Log(Transform):
         assert search_space is not None, "Log requires search space"
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/log_y.py
+++ b/ax/adapter/transforms/log_y.py
@@ -17,7 +17,7 @@ import numpy.typing as npt
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import match_ci_width, T_MATCH_CI_WIDTH
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.observation import ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.search_space import SearchSpace
@@ -53,7 +53,6 @@ class LogY(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: base_adapter.Adapter | None = None,
         config: TConfig | None = None,
@@ -67,7 +66,6 @@ class LogY(Transform):
             raise ValueError("Must specify at least one metric in the config.")
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/logit.py
+++ b/ax/adapter/transforms/logit.py
@@ -10,7 +10,7 @@ from typing import Optional, TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-from ax.core.observation import Observation, ObservationFeatures
+from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.generators.types import TConfig
@@ -30,7 +30,6 @@ class Logit(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
@@ -38,7 +37,6 @@ class Logit(Transform):
         assert search_space is not None, "Logit requires search space"
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/metadata_to_task.py
+++ b/ax/adapter/transforms/metadata_to_task.py
@@ -15,7 +15,6 @@ from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.metadata_to_parameter import MetadataToParameterMixin
 from ax.core import ParameterType
-from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, TParamValue
 from ax.core.search_space import SearchSpace
 from ax.generators.types import TConfig
@@ -46,7 +45,6 @@ class MetadataToTask(MetadataToParameterMixin, Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
@@ -54,7 +52,6 @@ class MetadataToTask(MetadataToParameterMixin, Transform):
         Transform.__init__(
             self,
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/metrics_as_task.py
+++ b/ax/adapter/transforms/metrics_as_task.py
@@ -43,14 +43,12 @@ class MetricsAsTask(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/one_hot.py
+++ b/ax/adapter/transforms/one_hot.py
@@ -14,7 +14,7 @@ from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.rounding import randomized_onehot_round, strict_onehot_round
 from ax.adapter.transforms.utils import construct_new_search_space
-from ax.core.observation import Observation, ObservationFeatures
+from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParameterization, TParamValue
@@ -87,7 +87,6 @@ class OneHot(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
@@ -95,7 +94,6 @@ class OneHot(Transform):
         assert search_space is not None, "OneHot requires search space"
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/relativize.py
+++ b/ax/adapter/transforms/relativize.py
@@ -53,7 +53,6 @@ class BaseRelativize(Transform, ABC):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
@@ -61,7 +60,6 @@ class BaseRelativize(Transform, ABC):
         cls_name = self.__class__.__name__
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/remove_fixed.py
+++ b/ax/adapter/transforms/remove_fixed.py
@@ -11,7 +11,7 @@ from typing import Optional, TYPE_CHECKING
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import construct_new_search_space
-from ax.core.observation import Observation, ObservationFeatures
+from ax.core.observation import ObservationFeatures
 from ax.core.parameter import (
     ChoiceParameter,
     DerivedParameter,
@@ -79,7 +79,6 @@ class RemoveFixed(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
@@ -87,7 +86,6 @@ class RemoveFixed(Transform):
         assert search_space is not None, "RemoveFixed requires search space"
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/task_encode.py
+++ b/ax/adapter/transforms/task_encode.py
@@ -11,7 +11,6 @@ from typing import Optional, TYPE_CHECKING
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.choice_encode import OrderedChoiceToIntegerRange
 from ax.adapter.transforms.utils import construct_new_search_space
-from ax.core.observation import Observation
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
@@ -37,7 +36,6 @@ class TaskChoiceToIntTaskChoice(OrderedChoiceToIntegerRange):
     def __init__(
         self,
         search_space: SearchSpace,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
@@ -47,7 +45,6 @@ class TaskChoiceToIntTaskChoice(OrderedChoiceToIntegerRange):
         ), "TaskChoiceToIntTaskChoice requires search space"
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/tests/test_base_transform.py
+++ b/ax/adapter/transforms/tests/test_base_transform.py
@@ -14,7 +14,6 @@ from ax.adapter.base import DataLoaderConfig
 from ax.adapter.data_utils import extract_experiment_data
 from ax.adapter.transforms.base import Transform
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
-from ax.exceptions.core import UnsupportedError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
 
@@ -64,8 +63,6 @@ class TransformsTest(TestCase):
         experiment_data = extract_experiment_data(
             experiment=experiment, data_loader_config=DataLoaderConfig()
         )
-        with self.assertRaisesRegex(UnsupportedError, "Only one of"):
-            Transform(observations=[], experiment_data=experiment_data)
         t = Transform(experiment_data=experiment_data)
         # Errors out since no_op_for_experiment_data defaults to False.
         with self.assertRaisesRegex(NotImplementedError, "transform_experiment_data"):

--- a/ax/adapter/transforms/tests/test_cast_transform.py
+++ b/ax/adapter/transforms/tests/test_cast_transform.py
@@ -55,9 +55,9 @@ class CastTransformTest(TestCase):
             ],
             parameter_constraints=[],
         )
-        self.t = Cast(search_space=self.search_space, observations=[])
+        self.t = Cast(search_space=self.search_space)
         self.hss = get_hierarchical_search_space()
-        self.t_hss = Cast(search_space=self.hss, observations=[])
+        self.t_hss = Cast(search_space=self.hss)
         self.obs_feats_hss = ObservationFeatures(
             parameters={
                 "model": "Linear",
@@ -135,9 +135,9 @@ class CastTransformTest(TestCase):
         )
 
     def test_flatten_hss_setting(self) -> None:
-        t = Cast(search_space=self.hss, observations=[])
+        t = Cast(search_space=self.hss)
         self.assertTrue(t.flatten_hss)
-        t = Cast(search_space=self.hss, config={"flatten_hss": False}, observations=[])
+        t = Cast(search_space=self.hss, config={"flatten_hss": False})
         self.assertFalse(t.flatten_hss)
         self.assertFalse(self.t.flatten_hss)  # `self.t` does not have HSS
         self.assertTrue(self.t_hss.flatten_hss)  # `self.t_hss` does have HSS
@@ -204,7 +204,6 @@ class CastTransformTest(TestCase):
                 "inject_dummy_values_to_complete_flat_parameterization": True,
                 "use_random_dummy_values": True,
             },
-            observations=[],
         )
         self.assertTrue(t.inject_dummy_values_to_complete_flat_parameterization)
         with patch.object(

--- a/ax/adapter/transforms/tests/test_choice_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_choice_encode_transform.py
@@ -184,7 +184,7 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
                 )
             ]
         )
-        t = ChoiceToNumericChoice(search_space=ss3, observations=[])
+        t = ChoiceToNumericChoice(search_space=ss3)
         self.assertEqual(
             t.transform_search_space(ss3.clone()),
             SearchSpace(
@@ -258,10 +258,7 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
         rss = get_robust_search_space()
         assert_is_instance(rss.parameters["c"], ChoiceParameter)._is_ordered = True
         # Transform a non-distributional parameter.
-        t = self.t_class(
-            search_space=rss,
-            observations=[],
-        )
+        t = self.t_class(search_space=rss)
         rss_new = assert_is_instance(t.transform_search_space(rss), RobustSearchSpace)
         self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
         self.assertEqual(rss.parameter_distributions, rss_new.parameter_distributions)
@@ -274,10 +271,7 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
             num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
-        t = self.t_class(
-            search_space=rss,
-            observations=[],
-        )
+        t = self.t_class(search_space=rss)
         rss_new = assert_is_instance(t.transform_search_space(rss), RobustSearchSpace)
         self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
         self.assertEqual(rss.parameter_distributions, rss_new.parameter_distributions)
@@ -409,7 +403,7 @@ class OrderedChoiceToIntegerRangeTransformTest(ChoiceToNumericChoiceTransformTes
                 )
             ]
         )
-        t = OrderedChoiceToIntegerRange(search_space=ss3, observations=[])
+        t = OrderedChoiceToIntegerRange(search_space=ss3)
         with self.assertRaises(ValueError):
             t.transform_search_space(ss3)
 

--- a/ax/adapter/transforms/tests/test_derelativize_transform.py
+++ b/ax/adapter/transforms/tests/test_derelativize_transform.py
@@ -81,8 +81,7 @@ class DerelativizeTransformTest(TestCase):
         sq_b_observed: float,
         sq_b_predicted: float,
     ) -> None:
-        t = Derelativize(search_space=None, observations=[])
-
+        t = Derelativize(search_space=None)
         # Adapter with in-design status quo
         search_space = SearchSpace(
             parameters=[
@@ -239,11 +238,7 @@ class DerelativizeTransformTest(TestCase):
             t.transform_optimization_config(oc, g, None)
 
         # Bypasses error if use_raw_sq
-        t2 = Derelativize(
-            search_space=None,
-            observations=[],
-            config={"use_raw_status_quo": True},
-        )
+        t2 = Derelativize(search_space=None, config={"use_raw_status_quo": True})
         t2.transform_optimization_config(deepcopy(oc), g, None)
 
         # But not if sq arm is not available.
@@ -287,10 +282,7 @@ class DerelativizeTransformTest(TestCase):
             t.transform_optimization_config(deepcopy(oc), None, None)
 
     def test_errors(self) -> None:
-        t = Derelativize(
-            search_space=None,
-            observations=[],
-        )
+        t = Derelativize(search_space=None)
         oc = OptimizationConfig(
             objective=Objective(Metric("c"), minimize=False),
             outcome_constraints=[

--- a/ax/adapter/transforms/tests/test_int_range_to_choice_transform.py
+++ b/ax/adapter/transforms/tests/test_int_range_to_choice_transform.py
@@ -9,7 +9,6 @@
 from copy import deepcopy
 
 from ax.adapter.transforms.int_range_to_choice import IntRangeToChoice
-
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import RobustSearchSpace, SearchSpace
@@ -30,10 +29,7 @@ class IntRangeToChoiceTransformTest(TestCase):
             ],
             parameter_constraints=[],
         )
-        self.t = IntRangeToChoice(
-            search_space=self.search_space,
-            observations=[],
-        )
+        self.t = IntRangeToChoice(search_space=self.search_space)
 
     def test_Init(self) -> None:
         self.assertEqual(self.t.transform_parameters, {"a"})
@@ -56,10 +52,7 @@ class IntRangeToChoiceTransformTest(TestCase):
     def test_w_robust_search_space(self) -> None:
         rss = get_robust_search_space()
         # Transform a non-distributional parameter.
-        t = IntRangeToChoice(
-            search_space=rss,
-            observations=[],
-        )
+        t = IntRangeToChoice(search_space=rss)
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -75,10 +68,7 @@ class IntRangeToChoiceTransformTest(TestCase):
             num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
-        t = IntRangeToChoice(
-            search_space=rss,
-            observations=[],
-        )
+        t = IntRangeToChoice(search_space=rss)
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
         self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
@@ -88,10 +78,7 @@ class IntRangeToChoiceTransformTest(TestCase):
         self.assertIsInstance(rss_new.parameters.get("z"), ChoiceParameter)
         # Error with distributional parameter.
         rss = get_robust_search_space(use_discrete=True)
-        t = IntRangeToChoice(
-            search_space=rss,
-            observations=[],
-        )
+        t = IntRangeToChoice(search_space=rss)
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)
 

--- a/ax/adapter/transforms/tests/test_int_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_int_to_float_transform.py
@@ -57,7 +57,6 @@ class IntToFloatTransformTest(TestCase):
         )._log_scale = True
         self.t4 = IntToFloat(
             search_space=self.search_space_with_log,
-            observations=[],
             config={"min_choices": 3},
         )
 
@@ -254,10 +253,7 @@ class IntToFloatTransformTest(TestCase):
                 SumConstraint(parameters=parameters, is_upper_bound=True, bound=5)
             ],
         )
-        t = IntToFloat(
-            search_space=constrained_int_search_space,
-            observations=[],
-        )
+        t = IntToFloat(search_space=constrained_int_search_space)
         self.assertEqual(t.rounding, "randomized")
         observation_features = [ObservationFeatures(parameters={"x": 2.6, "y": 2.6})]
         self.assertTrue(
@@ -306,10 +302,7 @@ class IntToFloatTransformTest(TestCase):
                 SumConstraint(parameters=parameters, is_upper_bound=True, bound=3)
             ],
         )
-        t = IntToFloat(
-            search_space=constrained_int_search_space,
-            observations=[],
-        )
+        t = IntToFloat(search_space=constrained_int_search_space)
         self.assertEqual(t.rounding, "randomized")
         observation_features = [ObservationFeatures(parameters={"x": 2.6, "y": 2.6})]
         self.assertFalse(
@@ -333,10 +326,7 @@ class IntToFloatTransformTest(TestCase):
     def test_w_parameter_distributions(self) -> None:
         rss = get_robust_search_space()
         # Transform a non-distributional parameter.
-        t = IntToFloat(
-            search_space=rss,
-            observations=[],
-        )
+        t = IntToFloat(search_space=rss)
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -356,10 +346,7 @@ class IntToFloatTransformTest(TestCase):
             num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
-        t = IntToFloat(
-            search_space=rss,
-            observations=[],
-        )
+        t = IntToFloat(search_space=rss)
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
         self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))
@@ -371,9 +358,6 @@ class IntToFloatTransformTest(TestCase):
         )
         # Error with distributional parameter.
         rss = get_robust_search_space(use_discrete=True)
-        t = IntToFloat(
-            search_space=rss,
-            observations=[],
-        )
+        t = IntToFloat(search_space=rss)
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)

--- a/ax/adapter/transforms/tests/test_ivw_transform.py
+++ b/ax/adapter/transforms/tests/test_ivw_transform.py
@@ -95,7 +95,7 @@ class IVWTransformTest(TestCase):
             covariance=np.array([[0.5, 0.14], [0.14, 1.584]]),
         )
         observation_data = [obsd1_0, obsd1_1]
-        t = IVW(None, [])
+        t = IVW(search_space=None)
         observation_data2 = t._transform_observation_data(observation_data)
         observation_data2_true = [obsd2_0, obsd2_1]
         for i, obsd in enumerate(observation_data2_true):

--- a/ax/adapter/transforms/tests/test_log_transform.py
+++ b/ax/adapter/transforms/tests/test_log_transform.py
@@ -137,10 +137,7 @@ class LogTransformTest(TestCase):
         self.assertEqual(param_a.upper, 2)
 
         # Test target values transformation
-        t2 = Log(
-            search_space=self.search_space_with_target,
-            observations=[],
-        )
+        t2 = Log(search_space=self.search_space_with_target)
 
         t2.transform_search_space(self.search_space_with_target)
         self.assertEqual(
@@ -158,19 +155,13 @@ class LogTransformTest(TestCase):
         # pyre-fixme[16]: `Parameter` has no attribute `set_log_scale`.
         rss.parameters["y"].set_log_scale(True)
         # Transform a non-distributional parameter.
-        t = Log(
-            search_space=rss,
-            observations=[],
-        )
+        t = Log(search_space=rss)
         t.transform_search_space(rss)
         # pyre-fixme[16]: Optional type has no attribute `log_scale`.
         self.assertFalse(rss.parameters.get("y").log_scale)
         # Error with distributional parameter.
         rss.parameters["x"].set_log_scale(True)
-        t = Log(
-            search_space=rss,
-            observations=[],
-        )
+        t = Log(search_space=rss)
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)
 

--- a/ax/adapter/transforms/tests/test_log_y_transform.py
+++ b/ax/adapter/transforms/tests/test_log_y_transform.py
@@ -122,7 +122,7 @@ class LogYTransformTest(TestCase):
         m1 = Metric(name="m1")
         objective_m1 = Objective(metric=m1, minimize=False)
         oc = OptimizationConfig(objective=objective_m1, outcome_constraints=[])
-        tf = LogY(search_space=None, observations=[], config={"metrics": ["m1"]})
+        tf = LogY(search_space=None, config={"metrics": ["m1"]})
         oc_tf = tf.transform_optimization_config(deepcopy(oc), None, None)
         self.assertEqual(oc_tf, oc)
         # output constraint on a different metric should work
@@ -209,7 +209,7 @@ class LogYTransformTest(TestCase):
             objective=mo,
             objective_thresholds=objective_thresholds,
         )
-        tf = LogY(search_space=None, observations=[], config={"metrics": ["m1"]})
+        tf = LogY(search_space=None, config={"metrics": ["m1"]})
         oc_tf = tf.transform_optimization_config(deepcopy(oc), None, None)
         oc.objective_thresholds[0].bound = math.log(1.234)
         self.assertEqual(oc_tf, oc)

--- a/ax/adapter/transforms/tests/test_logit_transform.py
+++ b/ax/adapter/transforms/tests/test_logit_transform.py
@@ -42,10 +42,7 @@ class LogitTransformTest(TestCase):
                 ),
             ]
         )
-        self.t = Logit(
-            search_space=self.search_space,
-            observations=[],
-        )
+        self.t = Logit(search_space=self.search_space)
         self.search_space_with_target = SearchSpace(
             parameters=[
                 RangeParameter(
@@ -117,10 +114,7 @@ class LogitTransformTest(TestCase):
         self.assertEqual(ss2.parameters["x"].lower, logit(0.9))
         # pyre-fixme[16]: `Parameter` has no attribute `upper`.
         self.assertEqual(ss2.parameters["x"].upper, logit(0.999))
-        t2 = Logit(
-            search_space=self.search_space_with_target,
-            observations=[],
-        )
+        t2 = Logit(search_space=self.search_space_with_target)
         ss_target = deepcopy(self.search_space_with_target)
         t2.transform_search_space(ss_target)
         self.assertEqual(ss_target.parameters["x"].target_value, logit(0.123))
@@ -132,19 +126,13 @@ class LogitTransformTest(TestCase):
         # pyre-fixme[16]: `Parameter` has no attribute `set_logit_scale`.
         rss.parameters["y"].set_logit_scale(True)
         # Transform a non-distributional parameter.
-        t = Logit(
-            search_space=rss,
-            observations=[],
-        )
+        t = Logit(search_space=rss)
         t.transform_search_space(rss)
         # pyre-fixme[16]: Optional type has no attribute `logit_scale`.
         self.assertFalse(rss.parameters.get("y").logit_scale)
         # Error with distributional parameter.
         rss.parameters["x"].set_logit_scale(True)
-        t = Logit(
-            search_space=rss,
-            observations=[],
-        )
+        t = Logit(search_space=rss)
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             t.transform_search_space(rss)
 

--- a/ax/adapter/transforms/tests/test_metadata_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_metadata_to_float_transform.py
@@ -83,12 +83,6 @@ class MetadataToFloatTransformTest(TestCase):
         )
 
         self.t = MetadataToFloat(
-            observations=self.observations,
-            config={
-                "parameters": {"bar": {"digits": 4}},
-            },
-        )
-        self.t2 = MetadataToFloat(
             experiment_data=self.experiment_data,
             config={
                 "parameters": {"bar": {"digits": 4}},
@@ -96,23 +90,20 @@ class MetadataToFloatTransformTest(TestCase):
         )
 
     def test_Init(self) -> None:
-        for t in (self.t, self.t2):
-            self.assertEqual(len(t._parameter_list), 1)
-            p = t._parameter_list[0]
-            # check that the parameter options are specified in a sensible manner
-            # by default if the user does not specify them explicitly
-            self.assertEqual(p.name, "bar")
-            self.assertEqual(p.parameter_type, ParameterType.FLOAT)
-            self.assertEqual(p.lower, 3.0)
-            self.assertEqual(p.upper, 15.0)
-            self.assertFalse(p.log_scale)
-            self.assertFalse(p.logit_scale)
-            self.assertEqual(p.digits, 4)
-            self.assertFalse(p.is_fidelity)
-            self.assertIsNone(p.target_value)
+        self.assertEqual(len(self.t._parameter_list), 1)
+        p = self.t._parameter_list[0]
+        # check that the parameter options are specified in a sensible manner
+        # by default if the user does not specify them explicitly
+        self.assertEqual(p.name, "bar")
+        self.assertEqual(p.parameter_type, ParameterType.FLOAT)
+        self.assertEqual(p.lower, 3.0)
+        self.assertEqual(p.upper, 15.0)
+        self.assertFalse(p.log_scale)
+        self.assertFalse(p.logit_scale)
+        self.assertEqual(p.digits, 4)
+        self.assertFalse(p.is_fidelity)
+        self.assertIsNone(p.target_value)
 
-        with self.assertRaisesRegex(DataRequiredError, "requires non-empty data"):
-            MetadataToFloat(search_space=None, observations=None)
         with self.assertRaisesRegex(DataRequiredError, "requires non-empty data"):
             MetadataToFloat(search_space=None)
 

--- a/ax/adapter/transforms/tests/test_metadata_to_task.py
+++ b/ax/adapter/transforms/tests/test_metadata_to_task.py
@@ -49,7 +49,7 @@ class MetadataToTaskTransformTest(TestCase):
         )
         self.transform_config: TConfig = {"task_values": [0, 1]}
         self.t = MetadataToTask(
-            observations=self.observations, config=self.transform_config
+            experiment_data=self.experiment_data, config=self.transform_config
         )
 
     def test_Init(self) -> None:

--- a/ax/adapter/transforms/tests/test_metrics_as_task_transform.py
+++ b/ax/adapter/transforms/tests/test_metrics_as_task_transform.py
@@ -90,15 +90,12 @@ class MetricsAsTaskTransformTest(TestCase):
         ]
         self.t = MetricsAsTask(
             search_space=self.search_space,
-            observations=self.observations,
             config={"metric_task_map": self.metric_task_map},
         )
 
     def test_Init(self) -> None:
         with self.assertRaises(ValueError):
-            MetricsAsTask(
-                search_space=self.search_space, observations=self.observations
-            )
+            MetricsAsTask(search_space=self.search_space)
 
     def test_TransformObservations(self) -> None:
         new_obs = self.t.transform_observations(deepcopy(self.observations))

--- a/ax/adapter/transforms/tests/test_one_hot_transform.py
+++ b/ax/adapter/transforms/tests/test_one_hot_transform.py
@@ -149,14 +149,14 @@ class OneHotTransformTest(TestCase):
                 )
             ]
         )
-        t = OneHot(search_space=ss3, observations=[])
+        t = OneHot(search_space=ss3)
         with self.assertRaises(ValueError):
             t.transform_search_space(ss3)
 
     def test_w_parameter_distributions(self) -> None:
         rss = get_robust_search_space()
         # Transform a non-distributional parameter.
-        t = OneHot(search_space=rss, observations=[])
+        t = OneHot(search_space=rss)
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -172,10 +172,7 @@ class OneHotTransformTest(TestCase):
             num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
-        t = OneHot(
-            search_space=rss,
-            observations=[],
-        )
+        t = OneHot(search_space=rss)
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
         self.assertEqual(len(rss_new.parameters.keys()), 6)

--- a/ax/adapter/transforms/tests/test_relativize_transform.py
+++ b/ax/adapter/transforms/tests/test_relativize_transform.py
@@ -254,7 +254,6 @@ class RelativizeDataTest(TestCase):
         for relativize_cls, expected_mean_and_covar in self.cases:
             tf = relativize_cls(
                 search_space=None,
-                observations=observations,
                 adapter=adapter,
             )
             # check transform and untransform on observations
@@ -275,7 +274,6 @@ class RelativizeDataTest(TestCase):
                 )
                 tf = relativize_cls(
                     search_space=None,
-                    observations=observations,
                     adapter=adapter,
                 )
                 observations2 = deepcopy(observations)
@@ -294,11 +292,7 @@ class RelativizeDataTest(TestCase):
 
         for abstract_cls in [BaseRelativize, BadRelativize]:
             with self.assertRaisesRegex(TypeError, "Can't instantiate abstract class"):
-                abstract_cls(
-                    search_space=None,
-                    observations=None,
-                    adapter=None,
-                )
+                abstract_cls(search_space=None, adapter=None)
 
     def test_transform_status_quos_always_zero(self) -> None:
         for _ in range(1000):
@@ -481,7 +475,6 @@ class RelativizeDataOptConfigTest(TestCase):
         for relativize_cls in [Relativize, RelativizeWithConstantControl]:
             relativize = relativize_cls(
                 search_space=None,
-                observations=[],
                 adapter=self.model,
             )
             optimization_config = get_branin_optimization_config()
@@ -496,7 +489,6 @@ class RelativizeDataOptConfigTest(TestCase):
         for relativize_cls in [Relativize, RelativizeWithConstantControl]:
             relativize = relativize_cls(
                 search_space=None,
-                observations=[],
                 adapter=self.model,
             )
             optimization_config = get_branin_optimization_config()
@@ -530,7 +522,6 @@ class RelativizeDataOptConfigTest(TestCase):
         for relativize_cls in [Relativize, RelativizeWithConstantControl]:
             relativize = relativize_cls(
                 search_space=None,
-                observations=[],
                 adapter=self.model,
             )
             optimization_config = get_branin_optimization_config()
@@ -553,7 +544,6 @@ class RelativizeDataOptConfigTest(TestCase):
         for relativize_cls in [Relativize, RelativizeWithConstantControl]:
             relativize = relativize_cls(
                 search_space=None,
-                observations=[],
                 adapter=self.model,
             )
             optimization_config = get_branin_multi_objective_optimization_config(
@@ -585,7 +575,6 @@ class RelativizeDataOptConfigTest(TestCase):
         for relativize_cls in [Relativize, RelativizeWithConstantControl]:
             relativize = relativize_cls(
                 search_space=None,
-                observations=[],
                 adapter=self.model,
             )
             optimization_config = get_branin_multi_objective_optimization_config(

--- a/ax/adapter/transforms/tests/test_remove_fixed_transform.py
+++ b/ax/adapter/transforms/tests/test_remove_fixed_transform.py
@@ -188,10 +188,7 @@ class RemoveFixedTransformTest(TestCase):
             FixedParameter("d", parameter_type=ParameterType.STRING, value="a"),
         )
         # Transform a non-distributional parameter.
-        t = RemoveFixed(
-            search_space=rss,
-            observations=[],
-        )
+        t = RemoveFixed(search_space=rss)
         rss = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
         self.assertIsInstance(rss, RobustSearchSpace)
@@ -211,10 +208,7 @@ class RemoveFixedTransformTest(TestCase):
         rss.add_parameter(
             FixedParameter("d", parameter_type=ParameterType.STRING, value="a"),
         )
-        t = RemoveFixed(
-            search_space=rss,
-            observations=[],
-        )
+        t = RemoveFixed(search_space=rss)
         rss = t.transform_search_space(rss)
         self.assertIsInstance(rss, RobustSearchSpace)
         self.assertEqual(len(rss.parameters.keys()), 4)

--- a/ax/adapter/transforms/tests/test_search_space_to_choice_transform.py
+++ b/ax/adapter/transforms/tests/test_search_space_to_choice_transform.py
@@ -83,22 +83,28 @@ class SearchSpaceToChoiceTest(TestCase):
         self.t = SearchSpaceToChoice(
             search_space=self.search_space, experiment_data=self.experiment_data
         )
+        # Convert first observation to experiment data for t2
+        experiment_single = get_experiment_with_observations(
+            observations=[[1.0]],
+            search_space=self.search_space,
+            parameterizations=[{"a": 1, "b": "a"}],
+        )
+        experiment_data_single = extract_experiment_data(
+            experiment=experiment_single, data_loader_config=DataLoaderConfig()
+        )
         self.t2 = SearchSpaceToChoice(
-            search_space=self.search_space, observations=self.observations[:1]
+            search_space=self.search_space, experiment_data=experiment_data_single
         )
         self.t3 = SearchSpaceToChoice(
             search_space=self.search_space,
-            observations=self.observations,
+            experiment_data=self.experiment_data,
             config={"use_ordered": True},
         )
 
     def test_validation(self) -> None:
         # Test with no data.
         with self.assertRaisesRegex(DataRequiredError, "non-empty data"):
-            SearchSpaceToChoice(
-                search_space=self.search_space,
-                observations=[],
-            )
+            SearchSpaceToChoice(search_space=self.search_space)
         # Test with empty experiment data.
         with self.assertRaisesRegex(DataRequiredError, "non-empty data"):
             SearchSpaceToChoice(
@@ -123,20 +129,14 @@ class SearchSpaceToChoiceTest(TestCase):
             ]
         )
         with self.assertRaisesRegex(ValueError, "fidelity"):
-            SearchSpaceToChoice(
-                search_space=ss,
-                observations=self.observations,
-            )
+            SearchSpaceToChoice(search_space=ss, experiment_data=self.experiment_data)
 
         # Test for error with robust search space.
         rss = get_robust_search_space()
         with self.assertRaisesRegex(
             UnsupportedError, "not supported for RobustSearchSpace"
         ):
-            SearchSpaceToChoice(
-                search_space=rss,
-                observations=self.observations,
-            )
+            SearchSpaceToChoice(search_space=rss, experiment_data=self.experiment_data)
 
     def test_TransformSearchSpace(self) -> None:
         ss2 = self.search_space.clone()

--- a/ax/adapter/transforms/tests/test_task_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_task_encode_transform.py
@@ -39,10 +39,7 @@ class TaskChoiceToIntTaskChoiceTransformTest(TestCase):
                 ),
             ]
         )
-        self.t = TaskChoiceToIntTaskChoice(
-            search_space=self.search_space,
-            observations=[],
-        )
+        self.t = TaskChoiceToIntTaskChoice(search_space=self.search_space)
 
     def test_Init(self) -> None:
         self.assertEqual(list(self.t.encoded_parameters.keys()), ["c"])
@@ -94,10 +91,7 @@ class TaskChoiceToIntTaskChoiceTransformTest(TestCase):
             ]
         )
         with self.assertRaises(ValueError):
-            TaskChoiceToIntTaskChoice(
-                search_space=ss3,
-                observations=[],
-            )
+            TaskChoiceToIntTaskChoice(search_space=ss3)
 
     def test_w_parameter_distributions(self) -> None:
         rss = get_robust_search_space()
@@ -105,10 +99,7 @@ class TaskChoiceToIntTaskChoiceTransformTest(TestCase):
         rss.parameters["c"]._is_task = True
         rss.parameters["c"]._target_value = "red"
         # Transform a non-distributional parameter.
-        t = TaskChoiceToIntTaskChoice(
-            search_space=rss,
-            observations=[],
-        )
+        t = TaskChoiceToIntTaskChoice(search_space=rss)
         rss_new = t.transform_search_space(rss)
         # Make sure that the return value is still a RobustSearchSpace.
         self.assertIsInstance(rss_new, RobustSearchSpace)
@@ -125,10 +116,7 @@ class TaskChoiceToIntTaskChoiceTransformTest(TestCase):
             num_samples=rss.num_samples,
             environmental_variables=all_params[:2],
         )
-        t = TaskChoiceToIntTaskChoice(
-            search_space=rss,
-            observations=[],
-        )
+        t = TaskChoiceToIntTaskChoice(search_space=rss)
         rss_new = t.transform_search_space(rss)
         self.assertIsInstance(rss_new, RobustSearchSpace)
         self.assertEqual(set(rss.parameters.keys()), set(rss_new.parameters.keys()))

--- a/ax/adapter/transforms/tests/test_time_as_feature_transform.py
+++ b/ax/adapter/transforms/tests/test_time_as_feature_transform.py
@@ -9,11 +9,11 @@
 from copy import deepcopy
 from unittest import mock
 
-import numpy as np
+import pandas as pd
 from ax.adapter.base import DataLoaderConfig
 from ax.adapter.data_utils import extract_experiment_data
 from ax.adapter.transforms.time_as_feature import TimeAsFeature
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
+from ax.core.observation import ObservationFeatures, observations_from_data
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UnsupportedError
@@ -37,26 +37,22 @@ class TimeAsFeatureTransformTest(TestCase):
                 )
             ]
         )
-        self.training_feats = [
-            ObservationFeatures(
-                {"x": i + 1},
-                trial_index=i,
-                start_time=unixtime_to_pandas_ts(float(i)),
-                end_time=unixtime_to_pandas_ts(float(i + 1 + i)),
-            )
-            for i in range(4)
-        ]
-        self.training_obs = [
-            Observation(
-                data=ObservationData(
-                    metric_signatures=[],
-                    means=np.array([]),
-                    covariance=np.empty((0, 0)),
-                ),
-                features=obsf,
-            )
-            for obsf in self.training_feats
-        ]
+        experiment = get_experiment_with_observations(
+            observations=[[0.1], [0.2], [0.3], [0.4]],
+            search_space=self.search_space,
+            parameterizations=[{"x": i + 1} for i in range(4)],
+            additional_data_columns=[
+                {
+                    "start_time": unixtime_to_pandas_ts(float(i)),
+                    "end_time": unixtime_to_pandas_ts(float(i + 1 + i)),
+                }
+                for i in range(4)
+            ],
+        )
+        self.training_obs = observations_from_data(
+            experiment=experiment, data=experiment.lookup_data()
+        )
+        self.training_feats = [obs.features for obs in self.training_obs]
         self.time_return_value = 5.0
         time_patcher = mock.patch(
             "ax.adapter.transforms.time_as_feature.time",
@@ -64,12 +60,16 @@ class TimeAsFeatureTransformTest(TestCase):
         )
         self.time_patcher = time_patcher.start()
         self.addCleanup(time_patcher.stop)
+
+        self.experiment_data = extract_experiment_data(
+            experiment=experiment, data_loader_config=DataLoaderConfig()
+        )
         self.t = TimeAsFeature(
             search_space=self.search_space,
-            observations=self.training_obs,
+            experiment_data=self.experiment_data,
         )
 
-    def test_init(self) -> None:
+    def test_init__(self) -> None:
         self.assertEqual(self.t.current_time, self.time_return_value)
         self.assertEqual(self.t.min_duration, 1.0)
         self.assertEqual(self.t.max_duration, 4.0)
@@ -77,24 +77,52 @@ class TimeAsFeatureTransformTest(TestCase):
         self.assertEqual(self.t.min_start_time, 0.0)
         self.assertEqual(self.t.max_start_time, 3.0)
 
-        # Test validation
-        obsf = ObservationFeatures({"x": 2})
-        obs = Observation(
-            data=ObservationData([], np.array([]), np.empty((0, 0))), features=obsf
+        # Test validation with missing start time data.
+        experiment = get_experiment_with_observations(
+            observations=[[0.1], [0.2]],
+            search_space=self.search_space,
+            additional_data_columns=[
+                {
+                    "start_time": unixtime_to_pandas_ts(0.0),
+                    "end_time": unixtime_to_pandas_ts(1.0),
+                },
+                {
+                    "start_time": pd.NaT,
+                    "end_time": pd.NaT,
+                },
+            ],
         )
-        msg = (
+        experiment_data_no_time = extract_experiment_data(
+            experiment=experiment, data_loader_config=DataLoaderConfig()
+        )
+        with self.assertRaisesRegex(
+            ValueError,
             "Unable to use TimeAsFeature since not all observations have "
-            "start time specified."
-        )
-        with self.assertRaisesRegex(ValueError, msg):
+            "start time specified.",
+        ):
             TimeAsFeature(
                 search_space=self.search_space,
-                observations=self.training_obs + [obs],
+                experiment_data=experiment_data_no_time,
             )
 
+        # Create experiment data with just one observation.
+        experiment = get_experiment_with_observations(
+            observations=[[0.1]],
+            search_space=self.search_space,
+            parameterizations=[{"x": 1}],
+            additional_data_columns=[
+                {
+                    "start_time": unixtime_to_pandas_ts(0.0),
+                    "end_time": unixtime_to_pandas_ts(1.0),
+                }
+            ],
+        )
+        experiment_data_one = extract_experiment_data(
+            experiment=experiment, data_loader_config=DataLoaderConfig()
+        )
         t2 = TimeAsFeature(
             search_space=self.search_space,
-            observations=self.training_obs[:1],
+            experiment_data=experiment_data_one,
         )
         self.assertEqual(t2.duration_range, 1.0)
 
@@ -143,7 +171,7 @@ class TimeAsFeatureTransformTest(TestCase):
         with self.assertRaisesRegex(UnsupportedError, "transform is not supported"):
             TimeAsFeature(
                 search_space=rss,
-                observations=self.training_obs,
+                experiment_data=self.experiment_data,
             )
 
     def test_with_experiment_data(self) -> None:

--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -95,14 +95,12 @@ class TransformToNewSQSpecificTest(TestCase):
         ):
             TransformToNewSQ(
                 search_space=None,
-                observations=[],
                 adapter=self.adapter,
             )
 
     def test_transform_optimization_config(self) -> None:
         tf = TransformToNewSQ(
             search_space=None,
-            observations=[],
             adapter=self.adapter,
         )
         oc = get_branin_optimization_config()
@@ -112,7 +110,6 @@ class TransformToNewSQSpecificTest(TestCase):
     def test_untransform_outcome_constraints(self) -> None:
         tf = TransformToNewSQ(
             search_space=None,
-            observations=[],
             adapter=self.adapter,
         )
         oc = get_branin_optimization_config()
@@ -124,14 +121,12 @@ class TransformToNewSQSpecificTest(TestCase):
     def test_custom_target_trial(self) -> None:
         tf = TransformToNewSQ(
             search_space=None,
-            observations=[],
             adapter=self.adapter,
         )
         self.assertEqual(tf.default_trial_idx, 0)
 
         tf = TransformToNewSQ(
             search_space=None,
-            observations=[],
             adapter=self.adapter,
             config={"target_trial_index": 1},
         )
@@ -140,7 +135,6 @@ class TransformToNewSQSpecificTest(TestCase):
     def test_single_trial_is_not_transformed(self) -> None:
         tf = TransformToNewSQ(
             search_space=None,
-            observations=[],
             adapter=self.adapter,
         )
         obs = observations_from_data(
@@ -164,14 +158,14 @@ class TransformToNewSQSpecificTest(TestCase):
 
         self._refresh_adapter()
 
-        observations = observations_from_data(
+        experiment_data = extract_experiment_data(
             experiment=self.exp,
-            data=self.exp.lookup_data(),
+            data_loader_config=DataLoaderConfig(),
         )
 
         t = TransformToNewSQ(
             search_space=self.exp.search_space,
-            observations=observations,
+            experiment_data=experiment_data,
             adapter=self.adapter,
         )
 
@@ -183,7 +177,7 @@ class TransformToNewSQSpecificTest(TestCase):
         ):
             t = TransformToNewSQ(
                 search_space=self.exp.search_space,
-                observations=observations,
+                experiment_data=experiment_data,
                 adapter=self.adapter,
             )
 
@@ -195,7 +189,7 @@ class TransformToNewSQSpecificTest(TestCase):
         ):
             t = TransformToNewSQ(
                 search_space=self.exp.search_space,
-                observations=observations,
+                experiment_data=experiment_data,
                 adapter=self.adapter,
             )
 

--- a/ax/adapter/transforms/tests/test_unit_x_transform.py
+++ b/ax/adapter/transforms/tests/test_unit_x_transform.py
@@ -259,10 +259,7 @@ class UnitXTransformTest(TestCase):
         # Error if trying to transform non-normal multivariate distributions.
         rss = get_robust_search_space(multivariate=True)
         rss.parameter_distributions[0].distribution_class = "multivariate_t"
-        t = UnitX(
-            search_space=rss,
-            observations=[],
-        )
+        t = UnitX(search_space=rss)
         with self.assertRaisesRegex(UnsupportedError, "multivariate"):
             t.transform_search_space(rss)
         # Transform multivariate normal.

--- a/ax/adapter/transforms/tests/test_winsorize_transform.py
+++ b/ax/adapter/transforms/tests/test_winsorize_transform.py
@@ -8,12 +8,13 @@
 
 import warnings
 from copy import deepcopy
+from functools import partial
 from math import sqrt
-from typing import Any, SupportsIndex
+from typing import Any
 
 import numpy as np
 from ax.adapter.base import Adapter, DataLoaderConfig
-from ax.adapter.data_utils import extract_experiment_data
+from ax.adapter.data_utils import ExperimentData, extract_experiment_data
 from ax.adapter.transforms.winsorize import (
     _get_auto_winsorization_cutoffs_outcome_constraint,
     _get_auto_winsorization_cutoffs_single_objective,
@@ -23,10 +24,8 @@ from ax.adapter.transforms.winsorize import (
 )
 from ax.core.arm import Arm
 from ax.core.data import Data
-from ax.core.experiment import Experiment
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
@@ -45,92 +44,48 @@ from ax.generators.winsorization_config import WinsorizationConfig
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_experiment_with_observations,
-    get_observations_with_invalid_value,
     get_optimization_config,
 )
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
+from pyre_extensions import none_throws
 
 INF = float("inf")
-OBSERVATION_DATA = [
-    Observation(
-        features=ObservationFeatures(parameters={"x": 2.0, "y": 10.0}),
-        data=ObservationData(
-            means=np.array([1.0, 2.0, 6.0]),
-            covariance=np.array([[1.0, 2.0, 0.0], [3.0, 4.0, 0.0], [0.0, 0.0, 4.0]]),
-            metric_signatures=["a", "b", "b"],
-        ),
-        arm_name="1_1",
-    )
-]
 
 
 class WinsorizeTransformTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.obsd1 = ObservationData(
-            metric_signatures=["m1", "m2", "m2"],
-            means=np.array([0.0, 0.0, 1.0]),
-            covariance=np.array([[1.0, 0.2, 0.4], [0.2, 2.0, 0.8], [0.4, 0.8, 3.0]]),
-        )
-        self.obsd2 = ObservationData(
-            metric_signatures=["m1", "m1", "m2", "m2"],
-            means=np.array([1.0, 2.0, 2.0, 1.0]),
-            covariance=np.array(
-                [
-                    [1.0, 0.0, 0.0, 0.0],
-                    [0.0, 1.0, 0.2, 0.4],
-                    [0.0, 0.2, 2.0, 0.8],
-                    [0.0, 0.4, 0.8, 3.0],
-                ]
-            ),
-        )
-        self.observations = [
-            Observation(features=ObservationFeatures({}), data=obsd)
-            for obsd in [self.obsd1, self.obsd2]
+        observations = [[0.0, 0.0], [float("nan"), 1.0], [1.0, 2.0], [2.0, 1.0]]
+        sems = [
+            [1.0, sqrt(2.0)],
+            [float("nan"), sqrt(3.0)],
+            [1.0, sqrt(2.0)],
+            [1.0, sqrt(3.0)],
         ]
         self.experiment_data = extract_experiment_data(
             experiment=get_experiment_with_observations(
-                observations=[  # Same means as above.
-                    [0.0, 0.0],
-                    [0.0, 1.0],
-                    [1.0, 2.0],
-                    [2.0, 1.0],
-                ],
-                sems=[
-                    [1.0, sqrt(2.0)],
-                    [1.0, sqrt(3.0)],
-                    [1.0, sqrt(2.0)],
-                    [1.0, sqrt(3.0)],
-                ],
+                observations=observations, sems=sems
             ),
             data_loader_config=DataLoaderConfig(),
         )
-
-        self.t = Winsorize(
-            search_space=None,
-            experiment_data=self.experiment_data,
+        self.observations = self.experiment_data.convert_to_list_of_observations()
+        self.t = self._get_transform(
             config={
                 "winsorization_config": WinsorizationConfig(upper_quantile_margin=0.2)
             },
         )
-        self.t1 = Winsorize(
-            search_space=None,
-            observations=deepcopy(self.observations),
+        self.t1 = self._get_transform(
             config={
                 "winsorization_config": WinsorizationConfig(upper_quantile_margin=0.8)
             },
         )
-        self.t2 = Winsorize(
-            search_space=None,
-            observations=deepcopy(self.observations),
+        self.t2 = self._get_transform(
             config={
                 "winsorization_config": WinsorizationConfig(lower_quantile_margin=0.2)
             },
         )
-        self.t3 = Winsorize(
-            search_space=None,
-            observations=deepcopy(self.observations),
+        self.t3 = self._get_transform(
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(upper_quantile_margin=0.6),
@@ -140,9 +95,7 @@ class WinsorizeTransformTest(TestCase):
                 }
             },
         )
-        self.t4 = Winsorize(
-            search_space=None,
-            observations=deepcopy(self.observations),
+        self.t4 = self._get_transform(
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(lower_quantile_margin=0.8),
@@ -152,16 +105,7 @@ class WinsorizeTransformTest(TestCase):
                 }
             },
         )
-
-        self.obsd3 = ObservationData(
-            metric_signatures=["m3", "m3", "m3", "m3"],
-            means=np.array([0.0, 1.0, 5.0, 3.0]),
-            covariance=np.eye(4),
-        )
-        self.obs3 = Observation(features=ObservationFeatures({}), data=self.obsd3)
-        self.t5 = Winsorize(
-            search_space=None,
-            observations=deepcopy(self.observations) + deepcopy([self.obs3]),
+        self.t5 = self._get_transform(
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(upper_quantile_margin=0.6),
@@ -169,9 +113,7 @@ class WinsorizeTransformTest(TestCase):
                 }
             },
         )
-        self.t6 = Winsorize(
-            search_space=None,
-            observations=deepcopy(self.observations),
+        self.t6 = self._get_transform(
             config={
                 "winsorization_config": {
                     "m1": WinsorizationConfig(upper_quantile_margin=0.6),
@@ -181,19 +123,33 @@ class WinsorizeTransformTest(TestCase):
                 }
             },
         )
+        self.values = [-100.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 50.0]
+
+    def _get_transform(
+        self, config: dict[str, Any], experiment_data: ExperimentData | None = None
+    ) -> Winsorize:
+        return Winsorize(
+            search_space=None,
+            experiment_data=experiment_data or self.experiment_data,
+            config=config,
+        )
 
     def test_Init(self) -> None:
-        self.assertEqual(self.t.cutoffs["m1"], (-INF, 2.0))
-        self.assertEqual(self.t.cutoffs["m2"], (-INF, 2.0))
-        self.assertEqual(self.t1.cutoffs["m1"], (-INF, 1.0))
-        self.assertEqual(self.t1.cutoffs["m2"], (-INF, 1.0))
-        self.assertEqual(self.t2.cutoffs["m1"], (0.0, INF))
-        self.assertEqual(self.t2.cutoffs["m2"], (0.0, INF))
+        for t, expected_cutoffs in [
+            (self.t, {"m1": (-INF, 2.0), "m2": (-INF, 2.0)}),
+            (self.t1, {"m1": (-INF, 1.0), "m2": (-INF, 1.0)}),
+            (self.t2, {"m1": (0.0, INF), "m2": (0.0, INF)}),
+            (self.t3, {"m1": (-INF, 1.0), "m2": (-INF, 1.9)}),
+            (self.t4, {"m1": (1.0, INF), "m2": (0.3, INF)}),
+            (self.t5, {"m1": (-INF, 1.0), "m2": (1.0, INF)}),
+            (self.t6, {"m1": (-INF, 1.0), "m2": (0.0, INF)}),
+        ]:
+            self.assertEqual(t.cutoffs, expected_cutoffs)
         with self.assertRaisesRegex(
             DataRequiredError,
             "`Winsorize` transform requires non-empty data.",
         ):
-            Winsorize(search_space=None, observations=[])
+            Winsorize(search_space=None)
         with self.assertRaisesRegex(
             UserInputError,
             "Transform config for `Winsorize` transform must be specified and "
@@ -201,7 +157,7 @@ class WinsorizeTransformTest(TestCase):
         ):
             Winsorize(
                 search_space=None,
-                observations=deepcopy(self.observations[:1]),
+                experiment_data=self.experiment_data,
             )
         with self.assertRaisesRegex(
             UserInputError,
@@ -209,81 +165,40 @@ class WinsorizeTransformTest(TestCase):
         ):
             Winsorize(
                 search_space=None,
-                observations=deepcopy(self.observations[:1]),
+                experiment_data=self.experiment_data,
                 config={"derelativize_with_raw_status_quo": 1234},
             )
 
     def test_TransformObservations(self) -> None:
-        observation_data = self.t1._transform_observation_data([deepcopy(self.obsd1)])[
-            0
-        ]
-        self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t1._transform_observation_data([deepcopy(self.obsd2)])[
-            0
-        ]
-        self.assertListEqual(list(observation_data.means), [1.0, 1.0, 1.0, 1.0])
-        observation_data = self.t2._transform_observation_data([deepcopy(self.obsd1)])[
-            0
-        ]
-        self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t2._transform_observation_data([deepcopy(self.obsd2)])[
-            0
-        ]
-        self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
-
-    def test_InitPercentileBounds(self) -> None:
-        self.assertEqual(self.t3.cutoffs["m1"], (-INF, 1.0))
-        self.assertEqual(self.t3.cutoffs["m2"], (-INF, 1.9))
-        self.assertEqual(self.t4.cutoffs["m1"], (1.0, INF))
-        self.assertEqual(self.t4.cutoffs["m2"], (0.3, INF))
-
-    def test_TransformObservationsPercentileBounds(self) -> None:
-        observation_data = self.t3._transform_observation_data([deepcopy(self.obsd1)])[
-            0
-        ]
-        self.assertListEqual(list(observation_data.means), [0.0, 0.0, 1.0])
-        observation_data = self.t3._transform_observation_data([deepcopy(self.obsd2)])[
-            0
-        ]
-        self.assertListEqual(list(observation_data.means), [1.0, 1.0, 1.9, 1.0])
-        observation_data = self.t4._transform_observation_data([deepcopy(self.obsd1)])[
-            0
-        ]
-        self.assertListEqual(list(observation_data.means), [1.0, 0.3, 1.0])
-        observation_data = self.t4._transform_observation_data([deepcopy(self.obsd2)])[
-            0
-        ]
-        self.assertListEqual(list(observation_data.means), [1.0, 2.0, 2.0, 1.0])
-
-    def test_TransformObservationsDifferentLowerUpper(self) -> None:
-        observation_data = self.t5._transform_observation_data([deepcopy(self.obsd2)])[
-            0
-        ]
-        self.assertEqual(self.t5.cutoffs["m1"], (-INF, 1.0))
-        self.assertEqual(self.t5.cutoffs["m2"], (1.0, INF))
-        self.assertEqual(self.t5.cutoffs["m3"], (-INF, INF))
-        self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
-        # Nothing should happen to m3
-        observation_data = self.t5._transform_observation_data([deepcopy(self.obsd3)])[
-            0
-        ]
-        self.assertListEqual(list(observation_data.means), [0.0, 1.0, 5.0, 3.0])
-        # With winsorization boundaries
-        observation_data = self.t6._transform_observation_data([deepcopy(self.obsd2)])[
-            0
-        ]
-        self.assertEqual(self.t6.cutoffs["m1"], (-INF, 1.0))
-        self.assertEqual(self.t6.cutoffs["m2"], (0.0, INF))
-        self.assertListEqual(list(observation_data.means), [1.0, 1.0, 2.0, 1.0])
+        obsd_list = [obs.data for obs in self.observations]
+        for t, expected in [
+            (self.t1, [[0.0, 0.0], [1.0], [1.0, 1.0], [1.0, 1.0]]),
+            (self.t2, [[0.0, 0.0], [1.0], [1.0, 2.0], [2.0, 1.0]]),
+            (self.t3, [[0.0, 0.0], [1.0], [1.0, 1.9], [1.0, 1.0]]),
+            (self.t4, [[1.0, 0.3], [1.0], [1.0, 2.0], [2.0, 1.0]]),
+            (self.t5, [[0.0, 1.0], [1.0], [1.0, 2.0], [1.0, 1.0]]),
+            (self.t6, [[0.0, 0.0], [1.0], [1.0, 2.0], [1.0, 1.0]]),
+        ]:
+            observation_data = t._transform_observation_data(deepcopy(obsd_list))
+            tf_means = [obsd.means.tolist() for obsd in observation_data]
+            self.assertListEqual(tf_means, expected)
 
     def test_optimization_config_default(self) -> None:
         # Specify the winsorization
-        optimization_config = get_optimization_config()
-        percentiles = get_default_transform_cutoffs(
-            optimization_config=optimization_config,
-            winsorization_config={"m1": WinsorizationConfig(0.2, 0.0)},
+        experiment = get_experiment_with_observations(
+            observations=[[m, 0.2] for m in range(6)],
+            optimization_config=get_optimization_config(),
         )
-        self.assertDictEqual(percentiles, {"m1": (1, INF)})
+        adapter = Adapter(experiment=experiment, generator=Generator())
+        percentiles = Winsorize(
+            search_space=None,
+            adapter=adapter,
+            experiment_data=adapter.get_training_data(),
+            config={
+                "winsorization_config": {"m1": WinsorizationConfig(0.2, 0.0)},
+            },
+        ).cutoffs
+        self.assertDictEqual(percentiles, {"m1": (1, INF), "m2": (-INF, INF)})
 
     def test_tukey_cutoffs(self) -> None:
         Y = np.array([-100, 0, 1, 2, 50])
@@ -291,7 +206,6 @@ class WinsorizeTransformTest(TestCase):
         self.assertEqual(_get_tukey_cutoffs(Y=Y, lower=False), 5.0)
 
     def test_winsorize_outcome_constraints(self) -> None:
-        metric_values = [-100, 0, 1, 2, 3, 4, 5, 6, 7, 50]
         ma, mb = Metric(name="a"), Metric(name="b")
         outcome_constraint_leq = OutcomeConstraint(
             metric=ma, op=ComparisonOp.LEQ, bound=10, relative=False
@@ -301,143 +215,143 @@ class WinsorizeTransformTest(TestCase):
         )
         # From above with a loose bound
         cutoffs = _get_auto_winsorization_cutoffs_outcome_constraint(
-            # pyre-fixme[6]: For 1st param expected `List[float]` but got `List[int]`.
-            metric_values=metric_values,
-            outcome_constraints=[outcome_constraint_leq],
+            metric_values=self.values, outcome_constraints=[outcome_constraint_leq]
         )
         self.assertEqual(cutoffs, (-INF, 23.5))
         # From above with a tight bound
         outcome_constraint_leq.bound = 2
         cutoffs = _get_auto_winsorization_cutoffs_outcome_constraint(
-            # pyre-fixme[6]: For 1st param expected `List[float]` but got `List[int]`.
-            metric_values=metric_values,
-            outcome_constraints=[outcome_constraint_leq],
+            metric_values=self.values, outcome_constraints=[outcome_constraint_leq]
         )
         self.assertEqual(cutoffs, (-INF, 13.5))
         # From below with a loose bound
         cutoffs = _get_auto_winsorization_cutoffs_outcome_constraint(
-            # pyre-fixme[6]: For 1st param expected `List[float]` but got `List[int]`.
-            metric_values=metric_values,
-            outcome_constraints=[outcome_constraint_geq],
+            metric_values=self.values, outcome_constraints=[outcome_constraint_geq]
         )
         self.assertEqual(cutoffs, (-31.5, INF))
         # From below with a tight bound
         outcome_constraint_geq.bound = 5
         cutoffs = _get_auto_winsorization_cutoffs_outcome_constraint(
-            # pyre-fixme[6]: For 1st param expected `List[float]` but got `List[int]`.
-            metric_values=metric_values,
-            outcome_constraints=[outcome_constraint_geq],
+            metric_values=self.values, outcome_constraints=[outcome_constraint_geq]
         )
         self.assertEqual(cutoffs, (-6.5, INF))
         # Both with the tight bounds
         outcome_constraint_geq.bound = 5
         cutoffs = _get_auto_winsorization_cutoffs_outcome_constraint(
-            # pyre-fixme[6]: For 1st param expected `List[float]` but got `List[int]`.
-            metric_values=metric_values,
+            metric_values=self.values,
             outcome_constraints=[outcome_constraint_leq, outcome_constraint_geq],
         )
         self.assertEqual(cutoffs, (-6.5, 13.5))
 
     def test_winsorization_single_objective(self) -> None:
-        metric_values = [-100.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 50.0]
         cutoffs = _get_auto_winsorization_cutoffs_single_objective(
-            metric_values=metric_values, minimize=True
+            metric_values=self.values, minimize=True
         )
         self.assertEqual(cutoffs, (-INF, 13.5))
         cutoffs = _get_auto_winsorization_cutoffs_single_objective(
-            metric_values=metric_values, minimize=False
+            metric_values=self.values, minimize=False
         )
         self.assertEqual(cutoffs, (-6.5, INF))
 
     def test_winsorization_without_optimization_config(self) -> None:
-        means = np.array([-100, 0, 1, 2, 3, 4, 5, 6, 7, 50])
-        obsd = ObservationData(
-            metric_signatures=["m1"] * 10,
-            means=means,
-            covariance=np.eye(10),
+        experiment = get_experiment_with_observations(
+            observations=[[o] for o in self.values]
         )
-        config = {
-            "winsorization_config": {
-                # pyre-fixme[6]: For 1st param expected `float` but got `None`.
-                # pyre-fixme[6]: For 2nd param expected `float` but got `None`.
-                "m1": WinsorizationConfig(None, None),
-            }
-        }
-        transform = get_transform(observation_data=[deepcopy(obsd)], config=config)
+        experiment_data = extract_experiment_data(
+            experiment=experiment,
+            data_loader_config=DataLoaderConfig(),
+        )
+        get_transform = partial(self._get_transform, experiment_data=experiment_data)
+        transform = get_transform(
+            config={"winsorization_config": {"m1": WinsorizationConfig(None, None)}}
+        )
         self.assertEqual(transform.cutoffs["m1"], (-INF, INF))
         # None and 0.0 should be treated the same way
-        config["winsorization_config"]["m1"] = WinsorizationConfig(0.0, 0.0)
-        transform = get_transform(observation_data=[deepcopy(obsd)], config=config)
+        transform = get_transform(
+            config={"winsorization_config": {"m1": WinsorizationConfig(0.0, 0.0)}}
+        )
         self.assertEqual(transform.cutoffs["m1"], (-INF, INF))
         # From above
-        config["winsorization_config"]["m1"] = WinsorizationConfig(0.0, 0.2)
-        transform = get_transform(observation_data=[deepcopy(obsd)], config=config)
+        transform = get_transform(
+            config={"winsorization_config": {"m1": WinsorizationConfig(0.0, 0.2)}}
+        )
         self.assertEqual(transform.cutoffs["m1"], (-INF, 7))
         # From below
-        config["winsorization_config"]["m1"] = WinsorizationConfig(0.2, 0.0)
-        transform = get_transform(observation_data=[deepcopy(obsd)], config=config)
+        transform = get_transform(
+            config={"winsorization_config": {"m1": WinsorizationConfig(0.2, 0.0)}}
+        )
         self.assertEqual(transform.cutoffs["m1"], (0, INF))
         # Do both automatically
-        config["winsorization_config"]["m1"] = WinsorizationConfig(
-            AUTO_WINS_QUANTILE, AUTO_WINS_QUANTILE
+        transform = get_transform(
+            config={
+                "winsorization_config": {
+                    "m1": WinsorizationConfig(AUTO_WINS_QUANTILE, AUTO_WINS_QUANTILE)
+                }
+            }
         )
-        transform = get_transform(observation_data=[deepcopy(obsd)], config=config)
         self.assertEqual(transform.cutoffs["m1"], (-6.5, 13.5))
         # Add a second metric that shouldn't be winsorized
-        config["winsorization_config"]["m1"] = WinsorizationConfig(
-            0.0, AUTO_WINS_QUANTILE
+        experiment = get_experiment_with_observations(
+            observations=[[o, o] for o in self.values]
         )
-        obsd2 = ObservationData(
-            metric_signatures=["m2"] * 10,
-            means=means,
-            covariance=np.eye(10),
+        experiment_data = extract_experiment_data(
+            experiment=experiment,
+            data_loader_config=DataLoaderConfig(),
         )
-        transform = get_transform(
-            observation_data=[deepcopy(obsd), deepcopy(obsd2)], config=config
+        transform = self._get_transform(
+            config={
+                "winsorization_config": {
+                    "m1": WinsorizationConfig(0.0, AUTO_WINS_QUANTILE)
+                }
+            },
+            experiment_data=experiment_data,
         )
         self.assertEqual(transform.cutoffs["m1"], (-INF, 13.5))
         self.assertEqual(transform.cutoffs["m2"], (-INF, INF))
         # Winsorize both
-        config["winsorization_config"]["m2"] = WinsorizationConfig(0.2, 0.0)
-        transform = get_transform(
-            observation_data=[deepcopy(obsd), deepcopy(obsd2)], config=config
+        transform = self._get_transform(
+            config={
+                "winsorization_config": {
+                    "m1": WinsorizationConfig(0.0, AUTO_WINS_QUANTILE),
+                    "m2": WinsorizationConfig(0.2, 0.0),
+                }
+            },
+            experiment_data=experiment_data,
         )
         self.assertEqual(transform.cutoffs["m1"], (-INF, 13.5))
         self.assertEqual(transform.cutoffs["m2"], (0.0, INF))
 
     def test_winsorization_with_optimization_config(self) -> None:
-        obsd_1 = ObservationData(
-            metric_signatures=["m1"] * 10,
-            means=np.array([-100, 0, 1, 2, 3, 4, 5, 6, 7, 50]),
-            covariance=np.eye(10),
+        experiment = get_experiment_with_observations(
+            observations=[
+                [-100.0, -10.0, -456.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 1.0, 2.0],
+                [2.0, 2.0, 3.0],
+                [3.0, 3.0, 4.0],
+                [4.0, 4.0, 9.0],
+                [5.0, 47.0, float("nan")],
+                [6.0, float("nan"), float("nan")],
+                [7.0, float("nan"), float("nan")],
+                [50.0, float("nan"), float("nan")],
+            ],
+            constrained=True,
         )
-        obsd_2 = ObservationData(
-            metric_signatures=["m2"] * 7,
-            means=np.array([-10, 0, 1, 2, 3, 4, 47]),
-            covariance=np.eye(7),
+        experiment_data = extract_experiment_data(
+            experiment=experiment,
+            data_loader_config=DataLoaderConfig(),
         )
-        obsd_3 = ObservationData(
-            metric_signatures=["m3"] * 6,
-            means=np.array([-456, 1, 2, 3, 4, 9]),
-            covariance=np.eye(6),
-        )
-        all_obsd = [obsd_1, obsd_2, obsd_3]
-        m1 = Metric(name="m1", lower_is_better=False)
-        m2 = Metric(name="m2", lower_is_better=True)
-        m3 = Metric(name="m3")
         # Scalarized objective
         for minimize in [True, False]:
-            optimization_config = OptimizationConfig(
+            experiment.optimization_config = OptimizationConfig(
                 objective=ScalarizedObjective(
                     metrics=[Metric(name="m1"), Metric(name="m2")],
                     weights=[1, -1],
                     minimize=minimize,
                 )
             )
-            transform = get_transform(
-                observation_data=deepcopy(all_obsd),
-                optimization_config=optimization_config,
-            )
+            adapter = Adapter(experiment=experiment, generator=Generator())
+            transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
             if minimize:
                 self.assertEqual(
                     transform.cutoffs,
@@ -449,12 +363,14 @@ class WinsorizeTransformTest(TestCase):
                     {"m1": (-6.5, INF), "m2": (-INF, 10.0), "m3": (-INF, INF)},
                 )
         # Simple single-objective problem
-        optimization_config = OptimizationConfig(
+        m1 = Metric(name="m1", lower_is_better=False)
+        m2 = Metric(name="m2", lower_is_better=True)
+        m3 = Metric(name="m3")
+        experiment.optimization_config = OptimizationConfig(
             objective=Objective(metric=m2, minimize=True)
         )
-        transform = get_transform(
-            observation_data=deepcopy(all_obsd), optimization_config=optimization_config
-        )
+        adapter = Adapter(experiment=experiment, generator=Generator())
+        transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
         self.assertEqual(transform.cutoffs["m1"], (-INF, INF))
         self.assertEqual(transform.cutoffs["m2"], (-INF, 10.0))  # 4 + 1.5 * 4
         self.assertEqual(transform.cutoffs["m3"], (-INF, INF))
@@ -462,50 +378,41 @@ class WinsorizeTransformTest(TestCase):
         outcome_constraint = OutcomeConstraint(
             metric=m1, op=ComparisonOp.LEQ, bound=3, relative=True
         )
-        optimization_config = OptimizationConfig(
+        experiment.optimization_config = OptimizationConfig(
             objective=Objective(metric=m2, minimize=True),
             outcome_constraints=[outcome_constraint],
         )
+        adapter = Adapter(experiment=experiment, generator=Generator())
         with self.assertWarnsRegex(
             AxOptimizationWarning,
             "Automatic winsorization doesn't support relative outcome constraints "
             "or objective thresholds when `derelativize_with_raw_status_quo` is not "
             "set to `True`.",
         ):
-            transform = get_transform(
-                observation_data=deepcopy(all_obsd),
-                optimization_config=optimization_config,
-            )
+            transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
         self.assertEqual(transform.cutoffs["m1"], (-INF, INF))
         self.assertEqual(transform.cutoffs["m2"], (-INF, 10.0))  # 4 + 1.5 * 4
         self.assertEqual(transform.cutoffs["m3"], (-INF, INF))
         # Make the constraint absolute, which should trigger winsorization
-        optimization_config.outcome_constraints[0].relative = False
-        transform = get_transform(
-            observation_data=deepcopy(all_obsd), optimization_config=optimization_config
-        )
+        outcome_constraint.relative = False
+        transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
         self.assertEqual(transform.cutoffs["m1"], (-INF, 13.5))  # 6 + 1.5 * 5
         self.assertEqual(transform.cutoffs["m2"], (-INF, 10.0))  # 4 + 1.5 * 4
         self.assertEqual(transform.cutoffs["m3"], (-INF, INF))
         # Change to a GEQ constraint
-        optimization_config.outcome_constraints[0].op = ComparisonOp.GEQ
-        transform = get_transform(
-            observation_data=deepcopy(all_obsd), optimization_config=optimization_config
-        )
+        outcome_constraint.op = ComparisonOp.GEQ
+        transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
         self.assertEqual(transform.cutoffs["m1"], (-6.5, INF))  # 1 - 1.5 * 5
         self.assertEqual(transform.cutoffs["m2"], (-INF, 10.0))  # 4 + 1.5 * 4
         self.assertEqual(transform.cutoffs["m3"], (-INF, INF))
         # Add a scalarized outcome constraint which should print a warning
-        optimization_config.outcome_constraints = [
+        none_throws(experiment.optimization_config).outcome_constraints = [
             ScalarizedOutcomeConstraint(
                 metrics=[m1, m3], op=ComparisonOp.GEQ, bound=3, relative=False
             )
         ]
         with warnings.catch_warnings(record=True) as ws:
-            transform = get_transform(
-                observation_data=deepcopy(all_obsd),
-                optimization_config=optimization_config,
-            )
+            transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
         for i in range(2):
             self.assertTrue(
                 "Automatic winsorization isn't supported for a "
@@ -518,11 +425,10 @@ class WinsorizeTransformTest(TestCase):
             [Objective(m1, minimize=False), Objective(m2, minimize=True)]
         )
         optimization_config = MultiObjectiveOptimizationConfig(objective=moo_objective)
+        experiment._optimization_config = optimization_config
+        adapter = Adapter(experiment=experiment, generator=Generator())
         with warnings.catch_warnings(record=True) as ws:
-            transform = get_transform(
-                observation_data=deepcopy(all_obsd),
-                optimization_config=optimization_config,
-            )
+            transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
         for _ in range(2):
             self.assertTrue(
                 "Encountered a `MultiObjective` without objective thresholds. We "
@@ -543,24 +449,21 @@ class WinsorizeTransformTest(TestCase):
             objective_thresholds=objective_thresholds,
             outcome_constraints=[],
         )
+        experiment.optimization_config = optimization_config
+        adapter = Adapter(experiment=experiment, generator=Generator())
         with self.assertWarnsRegex(
             AxOptimizationWarning,
             "Automatic winsorization doesn't support relative outcome constraints or "
             "objective thresholds when `derelativize_with_raw_status_quo` is not set "
             "to `True`.",
         ):
-            transform = get_transform(
-                observation_data=deepcopy(all_obsd),
-                optimization_config=optimization_config,
-            )
+            transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
         for i in range(1, 4):
             self.assertEqual(transform.cutoffs[f"m{i}"], (-INF, INF))
         # Make the objective thresholds absolute (should trigger winsorization)
         optimization_config.objective_thresholds[0].relative = False
         optimization_config.objective_thresholds[1].relative = False
-        transform = get_transform(
-            observation_data=deepcopy(all_obsd), optimization_config=optimization_config
-        )
+        transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
         self.assertEqual(transform.cutoffs["m1"], (-6.5, INF))  # 1 - 1.5 * 5
         self.assertEqual(transform.cutoffs["m2"], (-INF, 10.0))  # 4 + 1.5 * 4
         self.assertEqual(transform.cutoffs["m3"], (-INF, INF))
@@ -568,9 +471,7 @@ class WinsorizeTransformTest(TestCase):
         optimization_config.outcome_constraints = [
             OutcomeConstraint(metric=m3, op=ComparisonOp.GEQ, bound=3, relative=False)
         ]
-        transform = get_transform(
-            observation_data=deepcopy(all_obsd), optimization_config=optimization_config
-        )
+        transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
         self.assertEqual(transform.cutoffs["m1"], (-6.5, INF))  # 1 - 1.5 * 5
         self.assertEqual(transform.cutoffs["m2"], (-INF, 10.0))  # 4 + 1.5 * 4
         self.assertEqual(transform.cutoffs["m3"], (-3.5, INF))  # 1 - 1.5 * 3
@@ -583,11 +484,9 @@ class WinsorizeTransformTest(TestCase):
                 RangeParameter("y", ParameterType.FLOAT, 0, 20),
             ]
         )
-        objective = Objective(Metric("c"), minimize=False)
-
         # Test with relative constraint, in-design status quo
         oc = OptimizationConfig(
-            objective=objective,
+            objective=Objective(Metric("c"), minimize=False),
             outcome_constraints=[
                 OutcomeConstraint(
                     Metric("a"), ComparisonOp.LEQ, bound=2, relative=False
@@ -604,14 +503,18 @@ class WinsorizeTransformTest(TestCase):
                 ),
             ],
         )
-        experiment = Experiment(search_space=search_space, optimization_config=oc)
+        experiment = get_experiment_with_observations(
+            observations=[[0.5, 0.5, 0.5]],
+            optimization_config=oc,
+            search_space=search_space,
+        )
         adapter = Adapter(experiment=experiment, generator=Generator())
         with self.assertRaisesRegex(
             DataRequiredError, "model was not fit with status quo"
         ):
             Winsorize(
                 search_space=search_space,
-                observations=OBSERVATION_DATA,
+                experiment_data=adapter.get_training_data(),
                 adapter=adapter,
                 config={"derelativize_with_raw_status_quo": True},
             )
@@ -649,31 +552,22 @@ class WinsorizeTransformTest(TestCase):
         ):
             t = Winsorize(
                 search_space=search_space,
-                observations=OBSERVATION_DATA,
+                experiment_data=adapter.get_training_data(),
                 adapter=adapter,
             )
-        self.assertDictEqual(t.cutoffs, {"a": (-INF, INF), "b": (-INF, INF)})
+        self.assertDictEqual(
+            t.cutoffs, {"a": (-INF, INF), "b": (-INF, INF), "c": (0.5, INF)}
+        )
         # Winsorizes with `derelativize_with_raw_status_quo`.
         t = Winsorize(
             search_space=search_space,
-            observations=OBSERVATION_DATA,
+            experiment_data=adapter.get_training_data(),
             adapter=adapter,
             config={"derelativize_with_raw_status_quo": True},
         )
-        self.assertDictEqual(t.cutoffs, {"a": (-INF, 3.5), "b": (-INF, 12.0)})
-
-    def test_non_finite_data_raises(self) -> None:
-        for invalid_value in [float("nan"), float("inf")]:
-            observations = get_observations_with_invalid_value(
-                invalid_value=invalid_value
-            )
-            config: dict[str, Any] = {
-                "winsorization_config": WinsorizationConfig(upper_quantile_margin=0.2)
-            }
-            with self.assertRaisesRegex(
-                ValueError, f"Non-finite data found for metric m1: {invalid_value}"
-            ):
-                Winsorize(search_space=None, observations=observations, config=config)
+        self.assertDictEqual(
+            t.cutoffs, {"a": (-INF, 4.25), "b": (-INF, 4.25), "c": (0.5, INF)}
+        )
 
     def test_transform_experiment_data(self) -> None:
         transformed_data = self.t.transform_experiment_data(
@@ -694,7 +588,7 @@ class WinsorizeTransformTest(TestCase):
             columns=transformed_data.observation_data["mean"].columns,
             data=[
                 [0.5, 0.0],
-                [0.5, 1.0],
+                [float("nan"), 1.0],
                 [1.0, 1.5],
                 [1.0, 1.0],
             ],
@@ -706,65 +600,3 @@ class WinsorizeTransformTest(TestCase):
             self.experiment_data.observation_data["sem"],
         )
         assert_frame_equal(transformed_data.arm_data, self.experiment_data.arm_data)
-
-
-def get_transform(
-    observation_data: list[ObservationData],
-    config: dict[str, Any] | None = None,
-    optimization_config: OptimizationConfig | None = None,
-) -> Winsorize:
-    observations = [
-        Observation(features=ObservationFeatures({}), data=obsd)
-        for obsd in observation_data
-    ]
-    if optimization_config is not None:
-        adapter = _wrap_optimization_config_in_adapter(
-            optimization_config=optimization_config
-        )
-        return Winsorize(
-            search_space=None,
-            observations=observations,
-            config=config,
-            adapter=adapter,
-        )
-    return Winsorize(
-        search_space=None,
-        observations=observations,
-        config=config,
-    )
-
-
-def get_default_transform_cutoffs(
-    optimization_config: OptimizationConfig,
-    winsorization_config: dict[str, WinsorizationConfig] | None = None,
-    obs_data_len: SupportsIndex = 6,
-) -> dict[str, tuple[float, float]]:
-    obsd = ObservationData(
-        metric_signatures=["m1"] * obs_data_len,
-        means=np.array(range(obs_data_len)),
-        # pyre-fixme[6]: For 1st argument expected `int` but got `SupportsIndex`.
-        covariance=np.eye(obs_data_len),
-    )
-    obs = Observation(features=ObservationFeatures({}), data=obsd)
-    adapter = _wrap_optimization_config_in_adapter(
-        optimization_config=optimization_config
-    )
-    transform = Winsorize(
-        search_space=None,
-        observations=[deepcopy(obs)],
-        adapter=adapter,
-        config={
-            "winsorization_config": winsorization_config,
-        },
-    )
-    return transform.cutoffs
-
-
-def _wrap_optimization_config_in_adapter(
-    optimization_config: OptimizationConfig,
-) -> Adapter:
-    return Adapter(
-        experiment=Experiment(search_space=SearchSpace(parameters=[])),
-        generator=Generator(),
-        optimization_config=optimization_config,
-    )

--- a/ax/adapter/transforms/time_as_feature.py
+++ b/ax/adapter/transforms/time_as_feature.py
@@ -87,14 +87,15 @@ class TimeAsFeature(Transform):
                 raise UnsupportedError(
                     "TimeAsFeature transform is not supported with map data."
                 )
-            # Dividing by 1e9 to convert from nanoseconds to seconds, to be consistent
-            # with usage of seconds in the `Observation` version.
-            start_times = obs_data[("metadata", "start_time")].astype("int64") / 1e9
-            if start_times.isna().any():
+            # Check with raw values, because coversion to int eliminates NaNs.
+            if obs_data[("metadata", "start_time")].isna().any():
                 raise ValueError(
                     "Unable to use TimeAsFeature since not all observations have "
                     "start time specified."
                 )
+            # Dividing by 1e9 to convert from nanoseconds to seconds, to be consistent
+            # with usage of seconds in the `Observation` version.
+            start_times = obs_data[("metadata", "start_time")].astype("int64") / 1e9
             current_time_ts = unixtime_to_pandas_ts(self.current_time)
             end_times = (
                 obs_data[("metadata", "end_time")]

--- a/ax/adapter/transforms/transform_to_new_sq.py
+++ b/ax/adapter/transforms/transform_to_new_sq.py
@@ -49,7 +49,6 @@ class TransformToNewSQ(BaseRelativize):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
@@ -64,7 +63,6 @@ class TransformToNewSQ(BaseRelativize):
         """
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/trial_as_task.py
+++ b/ax/adapter/transforms/trial_as_task.py
@@ -11,7 +11,7 @@ from typing import Optional, TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-from ax.core.observation import Observation, ObservationFeatures
+from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import RobustSearchSpace, SearchSpace
 from ax.core.utils import get_target_trial_index
@@ -62,14 +62,12 @@ class TrialAsTask(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
     ) -> None:
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,
@@ -80,10 +78,9 @@ class TrialAsTask(Transform):
                 "TrialAsTask transform is not supported for RobustSearchSpace."
             )
         # Identify values of trial.
-        if experiment_data is not None:
-            trials = set(experiment_data.arm_data.index.get_level_values("trial_index"))
-        else:
-            trials = {obs.features.trial_index for obs in none_throws(observations)}
+        trials = set(
+            none_throws(experiment_data).arm_data.index.get_level_values("trial_index")
+        )
         if None in trials:
             raise ValueError(
                 "Unable to use trial as task since not all observations have "

--- a/ax/adapter/transforms/unit_x.py
+++ b/ax/adapter/transforms/unit_x.py
@@ -11,7 +11,7 @@ from typing import Optional, TYPE_CHECKING
 import numpy as np
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-from ax.core.observation import Observation, ObservationFeatures
+from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.parameter_distribution import ParameterDistribution
@@ -37,7 +37,6 @@ class UnitX(Transform):
     def __init__(
         self,
         search_space: SearchSpace | None = None,
-        observations: list[Observation] | None = None,
         experiment_data: ExperimentData | None = None,
         adapter: Optional["adapter_module.base.Adapter"] = None,
         config: TConfig | None = None,
@@ -45,7 +44,6 @@ class UnitX(Transform):
         assert search_space is not None, "UnitX requires search space"
         super().__init__(
             search_space=search_space,
-            observations=observations,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,

--- a/ax/adapter/transforms/utils.py
+++ b/ax/adapter/transforms/utils.py
@@ -8,14 +8,12 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Callable
 from numbers import Number
 from typing import Any, TYPE_CHECKING
 
 import numpy as np
 from ax.adapter.transforms.derelativize import Derelativize
-from ax.core.observation import ObservationData
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import Parameter
 from ax.core.parameter_constraint import ParameterConstraint
@@ -72,34 +70,6 @@ class ClosestLookupDict(dict):
                 return super().__getitem__(lkey)
             else:
                 return super().__getitem__(rkey)
-
-
-def get_data(
-    observation_data: list[ObservationData],
-    metric_signatures: list[str] | None = None,
-    raise_on_non_finite_data: bool = True,
-) -> dict[str, list[float]]:
-    """Extract all metrics if `metric_names` is None.
-
-    Raises a value error if any data is non-finite.
-
-    Args:
-        observation_data: List of observation data.
-        metric_names: List of metric names.
-        raise_on_non_finite_data: If true, raises an exception on nan/inf.
-
-    Returns:
-        A dictionary mapping metric names to lists of metric values.
-    """
-    Ys = defaultdict(list)
-    for obsd in observation_data:
-        for i, m in enumerate(obsd.metric_signatures):
-            if metric_signatures is None or m in metric_signatures:
-                val = obsd.means[i]
-                if raise_on_non_finite_data and (not np.isfinite(val)):
-                    raise ValueError(f"Non-finite data found for metric {m}: {val}")
-                Ys[m].append(val)
-    return Ys
 
 
 def match_ci_width(

--- a/ax/generators/winsorization_config.py
+++ b/ax/generators/winsorization_config.py
@@ -28,7 +28,7 @@ class WinsorizationConfig:
         ``upper_boundary`` and leave smaller values unaffected.
     """
 
-    lower_quantile_margin: float = 0.0
-    upper_quantile_margin: float = 0.0
+    lower_quantile_margin: float | None = 0.0
+    upper_quantile_margin: float | None = 0.0
     lower_boundary: float | None = None
     upper_boundary: float | None = None

--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -229,7 +229,7 @@ def _get_in_sample_arms(
 
     # Merge multiple measurements within each Observation with IVW to get
     # un-modeled prediction
-    t = IVW(None, [])
+    t = IVW()
     observations = t.transform_observations(observations)
     # Start filling in plot data
     in_sample_plot: dict[str, PlotInSampleArm] = {}

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -57,9 +57,7 @@ def derelativize_opt_config(
     experiment: Experiment,
     trial_indices: Iterable[int] | None = None,
 ) -> OptimizationConfig:
-    tf = Derelativize(
-        search_space=None, observations=None, config={"use_raw_status_quo": True}
-    )
+    tf = Derelativize(search_space=None, config={"use_raw_status_quo": True})
     optimization_config = tf.transform_optimization_config(
         optimization_config=optimization_config.clone(),
         adapter=get_tensor_converter_adapter(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -36,7 +36,6 @@ from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
 from ax.core.multi_type_experiment import MultiTypeExperiment
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
     OptimizationConfig,
@@ -2766,18 +2765,6 @@ def get_map_data(trial_index: int = 0) -> MapData:
         trial_index=trial_index,
         metric_name_to_signature={"ax_test_metric": "ax_test_metric", "epoch": "epoch"},
     )
-
-
-def get_observations_with_invalid_value(invalid_value: float) -> list[Observation]:
-    obsd_with_non_finite = ObservationData(
-        metric_signatures=["m1"] * 4,
-        means=np.array([-100, 4, invalid_value, 2]),
-        covariance=np.eye(4),
-    )
-    observations = [
-        Observation(features=ObservationFeatures({}), data=obsd_with_non_finite)
-    ]
-    return observations
 
 
 def get_branin_data(


### PR DESCRIPTION
Summary: With the migration to `ExperimentData` usage in `Transform`, `Adapter` always uses `ExperimentData` when constructing the `Transform` objects. We do not need to support `observations` argument in the `Transform` constructors anymore. Removing it now will simplify the planned work around improved transform configs, so I decided to clean it up.

Differential Revision: D83095274
