### PR TITLE
Refactor timestamp alignment utility for early-stopping strategies (2-3x speed-up)

### DIFF
--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -91,51 +91,42 @@ def align_partial_results(
                 f"{arm_group['trial_index'].unique()}."
             )
 
-    df = df.drop("arm_name", axis=1)
+    df.drop("arm_name", axis=1, inplace=True)
     # remove duplicates (same trial, metric, step), which can happen
     # if the same progression is erroneously reported more than once
-    df = df.drop_duplicates(
-        subset=["trial_index", "metric_signature", MAP_KEY], keep="first"
+    df.drop_duplicates(
+        subset=["trial_index", "metric_signature", MAP_KEY], keep="first", inplace=True
     )
-    # set multi-index over trial, metric, and progression key
-    df = df.set_index(["trial_index", "metric_signature", MAP_KEY])
-    # sort index
-    df = df.sort_index()
-    # drop sem if all NaN (assumes presence of sem column)
-    has_sem = not df["sem"].isnull().all()
-    if not has_sem:
-        df = df.drop("sem", axis=1)
-    # create the common index that every map result will be re-indexed w.r.t.
-    index_union = df.index.levels[2].unique()
-    # loop through (trial, metric) combos and align data
-    dfs_mean = defaultdict(list)
-    dfs_sem = defaultdict(list)
-    for tidx in df.index.levels[0]:  # this could be slow if there are many trials
-        for metric in df.index.levels[1]:
-            # grab trial+metric sub-df and reindex to common index
-            df_ridx = df.loc[(tidx, metric)].reindex(index_union)
-            # interpolate / fill missing results
-            # TODO: Allow passing of additional kwargs to `interpolate`
-            # TODO: Allow using an arbitrary prediction model for this instead
-            try:
-                df_interp = df_ridx.interpolate(
-                    method=interpolation, limit_area="inside"
-                )
-                if do_forward_fill:
-                    # do forward fill (with valid observations) to handle instances
-                    # where one task only has data for early progressions
-                    df_interp = df_interp.fillna(method="pad")
-            except ValueError:
-                df_interp = df_ridx
+    # wide dataframe with hierarchical columns aligned to common index
+    # (outer join of map keys across "trial_index", "metric_signature")
+    wide_df: pd.DataFrame = df.pivot(
+        index=MAP_KEY,
+        columns=["metric_signature", "trial_index"],
+        values=["mean", "sem"],
+    )
+    # interpolation is only possible for columns with at least 2 entries,
+    # will raise `ValueError` otherwise
+    active = wide_df.notna().sum(axis=0) > 1
+    active_cols = wide_df.columns[active]
+    # interpolate / fill missing results
+    wide_df[active_cols] = wide_df[active_cols].interpolate(
+        method=interpolation, limit_area="inside", axis=0
+    )
+    if do_forward_fill:
+        # do forward fill (with valid observations) to handle instances
+        # where one task only has data for early progressions
+        wide_df[active_cols] = wide_df[active_cols].fillna(method="pad", axis=0)
 
-            # renaming column to trial index, append results
-            dfs_mean[metric].append(df_interp["mean"].rename(tidx))
-            if has_sem:
-                dfs_sem[metric].append(df_interp["sem"].rename(tidx))
+    def _to_dict(column: str) -> dict[str, pd.DataFrame]:
+        """Helper function to convert wide dataframe to dict of dataframes."""
+        return {
+            m: wide_df[column][m]
+            for m in wide_df[column].columns.unique(level="metric_signature")
+        }
 
     # combine results into output dataframes
-    dfs_mean = {metric: pd.concat(dfs, axis=1) for metric, dfs in dfs_mean.items()}
-    dfs_sem = {metric: pd.concat(dfs, axis=1) for metric, dfs in dfs_sem.items()}
+    dfs_mean = _to_dict("mean")
+    dfs_sem = _to_dict("sem")
 
     return dfs_mean, dfs_sem
 


### PR DESCRIPTION
Summary:
## Context

The timestep interpolation logic our early-stopping utilities previously processed data through nested for-loops, iterating over each trial and metric combination separately. This updates the implementation to follow conventional pandas patterns and better leverage vectorized operations to improve both performance and code maintainability.

## Changes
This change restructures the timestamp interpolation to operate on a "wide" dataframe format with hierarchical columns, where all trials and metrics share a common index created from the union of all timestep. The input long-format dataframes are first transformed using `pivot` to create this wide structure. The interpolation logic then executes in a single vectorized operation across the entire dataframe rather than through nested iterations.

In addition to providing significant performance improvements, this change aims to improve maintainability by following conventional pandas patterns instead of relying on inefficient custom iteration logic.

## Profiling

We see a 2x speed-up from dataframes with a small number of trials (5) and short curves (length < 15):

{F1982241738}

We see a ~2.5x speed-up from dataframes with a larger number of trials (50) and longer curves (length < 40):

{F1982241796}

Differential Revision: D83116280


