### PR TITLE
Explicitly disable the use of ScalarizedObjective within MultiObjective

### DIFF
--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -107,6 +107,10 @@ class MultiObjective(Objective):
 
         """
         self._objectives: list[Objective] = objectives
+        if any(isinstance(o, ScalarizedObjective) for o in objectives):
+            raise NotImplementedError(
+                "Scalarized objectives are not supported for a `MultiObjective`."
+            )
 
     @property
     def metric(self) -> Metric:

--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -85,6 +85,25 @@ class ObjectiveTest(TestCase):
             [self.metrics["m1"], self.metrics["m2"], self.metrics["m3"]],
         )
 
+        # Test that ScalarizedObjective is not allowed in MultiObjective
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "Scalarized objectives are not supported for a `MultiObjective`.",
+        ):
+            MultiObjective(objectives=[self.scalarized_objective])
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "Scalarized objectives are not supported for a `MultiObjective`.",
+        ):
+            MultiObjective(
+                objectives=[
+                    self.objectives["o1"],
+                    self.scalarized_objective,
+                    self.objectives["o3"],
+                ]
+            )
+
     def test_ScalarizedObjective(self) -> None:
         with self.assertRaises(NotImplementedError):
             # pyre-fixme[7]: Expected `None` but got `Metric`.


### PR DESCRIPTION
Summary: This isn't supported, e.g., calling `.metrics` on a `MultiObjective` containing a `ScalarizedObjective` will error out.

Differential Revision: D83198375


