### PR TITLE
Update return type of timestamp alignment utility to wide dataframe with hierarchical columns

### DIFF
--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -127,7 +127,7 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             return {}
 
         try:
-            metric_to_aligned_means, _ = align_partial_results(
+            aligned_df = align_partial_results(
                 df=df,
                 metrics=[metric_signature],
             )
@@ -138,6 +138,7 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             )
             return {}
 
+        metric_to_aligned_means = aligned_df["mean"]
         aligned_means = metric_to_aligned_means[metric_signature]
         decisions = {
             trial_index: self._should_stop_trial_early(

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -773,9 +773,8 @@ def _evaluate_early_stopping_with_df(
     data = none_throws(
         early_stopping_strategy._check_validity_and_get_data(experiment, [metric_name])
     )
-    metric_to_aligned_means, _ = align_partial_results(
-        df=data.map_df, metrics=[metric_name]
-    )
+    aligned_df = align_partial_results(df=data.map_df, metrics=[metric_name])
+    metric_to_aligned_means = aligned_df["mean"]
     aligned_means = metric_to_aligned_means[metric_name]
     decisions = {
         trial_index: early_stopping_strategy._should_stop_trial_early(

--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -7,7 +7,6 @@
 # pyre-strict
 
 from logging import Logger
-from typing import Literal
 
 import pandas as pd
 from ax.core.experiment import Experiment
@@ -26,7 +25,7 @@ def align_partial_results(
     interpolation: str = "slinear",
     do_forward_fill: bool = False,
     # TODO: Allow normalizing step (e.g. subtract min time stamp)
-) -> tuple[dict[str, pd.DataFrame], dict[str, pd.DataFrame]]:
+) -> pd.DataFrame:
     """Helper function to align partial results with heterogeneous index
 
     Args:
@@ -118,18 +117,7 @@ def align_partial_results(
         # where one task only has data for early progressions
         wide_df[active_cols] = wide_df[active_cols].fillna(method="pad", axis=0)
 
-    def _to_dict(key: Literal["mean", "sem"]) -> dict[str, pd.DataFrame]:
-        """Helper function to convert wide dataframe to dict of dataframes."""
-        return {
-            m: wide_df[key][m]
-            for m in wide_df[key].columns.unique(level="metric_signature")
-        }
-
-    # combine results into output dataframes
-    dfs_mean = _to_dict("mean")
-    dfs_sem = _to_dict("sem") if has_sem else {}
-
-    return dfs_mean, dfs_sem
+    return wide_df
 
 
 def estimate_early_stopping_savings(experiment: Experiment) -> float:


### PR DESCRIPTION
Summary:
This updates the function signature of `align_partial_results`, the utility used align progression and perform necessary interpolations for the purpose of making early-stopping decisions, by returning a single "wide-format" dataframe with hierarchical columns (MultiIndex), instead of two dictionaries (for `mean` and `sem`) with metric names as keys and dataframes (with progression and trial as index and and columns, resp.) as values. This diff also makes the necessary updates to functionalities that depend on.

Overall, this format is easier to work with in our early-stopping strategies, particularly in the multi-objective case where it would have other necessitated converting to and from dictionaries of dataframes and wide hierarchical dataframes for no particular reason.

**Example output dataframe format:**

```
                     mean                                                   sem
metric_signature      foo                        bar                        foo                        bar
trial_index             0        1        2        0        1        2        0        1        2        0        1        2
step
============================================================================================================================
1                     NaN      NaN     0.76      NaN      NaN    -0.28      NaN      NaN     0.77      NaN      NaN     0.58
2                    0.76     0.94     0.07     0.95    -0.74     0.17     0.06     0.07     0.14     1.16     5.15     0.73
3                   -0.72      NaN     0.39     1.50      NaN     0.78     0.52      NaN     0.67     0.12      NaN     0.56
4                     NaN     1.04      NaN      NaN     0.09      NaN      NaN     2.75      NaN      NaN     0.28      NaN
6                   -0.58     0.46      NaN     0.59     2.08      NaN     0.80     0.35      NaN     2.54     0.13      NaN
7                    1.55      NaN    -1.50     0.76      NaN     1.14     0.01      NaN     2.67     0.21      NaN     2.37
9                    0.21     0.31      NaN    -0.54     0.04      NaN     1.28     3.89      NaN     0.42     1.15      NaN
10                  -1.27    -1.30     1.52     0.87     0.86    -0.24     0.17     0.76     0.15     4.64     0.08     0.16
11                  -0.92      NaN      NaN    -0.92      NaN      NaN     2.72      NaN      NaN     1.48      NaN      NaN
12                  -0.10    -0.27      NaN     0.74    -1.00      NaN     2.03     0.02      NaN     0.32     0.71      NaN
13                  -1.58      NaN    -1.04    -0.54      NaN     0.09     5.07      NaN     0.23     1.12      NaN     8.66
14                   1.57      NaN     0.62     1.35      NaN     0.37     0.08      NaN     0.96     0.01      NaN     0.12
```

Differential Revision: D83198036
