### PR TITLE
Retain bypass_cardinality_check when cloning ChoiceParameter

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -798,6 +798,7 @@ class ChoiceParameter(Parameter):
             target_value=self._target_value,
             sort_values=self._sort_values,
             dependents=deepcopy(self._dependents),
+            bypass_cardinality_check=self._bypass_cardinality_check,
         )
 
     def __repr__(self) -> str:

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -431,12 +431,15 @@ class ChoiceParameterTest(TestCase):
                 values=list(range(1001)),
             )
         # With bypass_cardinality_check=True, this should not raise an error.
-        ChoiceParameter(
+        p = ChoiceParameter(
             name="x",
             parameter_type=ParameterType.INT,
             values=list(range(1001)),
             bypass_cardinality_check=True,
         )
+        # Make sure the parameter can clone successfully.
+        clone = p.clone()
+        self.assertEqual(clone, p)
 
     def test_Hierarchical(self) -> None:
         # Test case where only some of the values entail dependents.


### PR DESCRIPTION
Summary: As titled. Without this, cloning within the modeling layer  triggers the cardinality error.

Reviewed By: Balandat

Differential Revision: D83246193


