### PR TITLE
Add base Transform to the storage registry

### DIFF
--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -18,6 +18,7 @@ import numpy as np
 import torch
 from ax.adapter.base import DataLoaderConfig
 from ax.adapter.registry import Generators
+from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.log import Log
 from ax.adapter.transforms.one_hot import OneHot
 from ax.benchmark.methods.sobol import get_sobol_benchmark_method
@@ -338,6 +339,7 @@ TEST_CASES = [
     ("Type[Model]", get_model_type),
     ("Type[MarginalLogLikelihood]", get_mll_type),
     ("Type[Transform]", get_transform_type),
+    ("Type[Transform]", lambda: Transform),
     ("Type[InputTransform]", get_input_transform_type),
     ("Type[OutcomeTransform]", get_outcome_transfrom_type),
     ("Type[TransformToNewSQ]", get_to_new_sq_transform_type),

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -57,6 +57,7 @@ please add it to DEPRECATED_TRANSFORMS. When loading from the DB,
 we will return the replacement class.
 """
 TRANSFORM_REGISTRY: set[type[Transform]] = {
+    Transform,
     # ConvertMetricNames, DEPRECATED
     Derelativize,
     FixedToTunable,


### PR DESCRIPTION
Summary: In the decoder, we replace the deprecated transforms with the base `Transform`. If the replaced `Transform` happens to be stored later (e.g., you loaded the experiment with Client and did some operations that updated in the DB), next time we try to load the GS, we will attempt to decode `Transform`. This errors out since base `Transform` is currently not in the registry.

Differential Revision: D83262852


