### PR TITLE
Do not error out in base Transform.transform_experiment_data

### DIFF
--- a/ax/adapter/transforms/base.py
+++ b/ax/adapter/transforms/base.py
@@ -301,7 +301,7 @@ class Transform:
 
         Returns: The transformed experiment data.
         """
-        if self.no_op_for_experiment_data:
+        if self.no_op_for_experiment_data or self.__class__ == Transform:
             return experiment_data
         else:
             raise NotImplementedError(

--- a/ax/adapter/transforms/tests/test_base_transform.py
+++ b/ax/adapter/transforms/tests/test_base_transform.py
@@ -18,6 +18,10 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
 
 
+class SomeTransform(Transform):
+    pass
+
+
 class TransformsTest(TestCase):
     def test_IdentityTransform(self) -> None:
         # Test that the identity transform does not mutate anything
@@ -63,12 +67,19 @@ class TransformsTest(TestCase):
         experiment_data = extract_experiment_data(
             experiment=experiment, data_loader_config=DataLoaderConfig()
         )
-        t = Transform(experiment_data=experiment_data)
+        t = SomeTransform(experiment_data=experiment_data)
         # Errors out since no_op_for_experiment_data defaults to False.
         with self.assertRaisesRegex(NotImplementedError, "transform_experiment_data"):
             t.transform_experiment_data(experiment_data=experiment_data)
         # No-op when no_op_for_experiment_data is True.
         t.no_op_for_experiment_data = True
+        self.assertIs(
+            t.transform_experiment_data(experiment_data=experiment_data),
+            experiment_data,
+        )
+        # Base transform itself doesn't error out.
+        t = Transform(experiment_data=experiment_data)
+        self.assertFalse(t.no_op_for_experiment_data)
         self.assertIs(
             t.transform_experiment_data(experiment_data=experiment_data),
             experiment_data,


### PR DESCRIPTION
Summary: In storage, we replace deprecated transforms with `Transform`. If we then try to generate with these, we currently get an error. This diff makes `Transform.transform_experiment_data` a no-op for the base class without affecting the downstream classes / changing the default `no_op_for_experiment_data` flag.

Differential Revision: D83277957


