### PR TITLE
more fault tolerant mast benchmarking

### DIFF
--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -41,6 +41,7 @@ def get_sobol_mbm_generation_strategy(
     acquisition_cls: type[AcquisitionFunction],
     name: str | None = None,
     num_sobol_trials: int = 5,
+    model_kwargs_override: dict[str, Any] | None = None,
     model_gen_kwargs: dict[str, Any] | None = None,
     batch_size: int = 1,
 ) -> GenerationStrategy:
@@ -53,6 +54,8 @@ def get_sobol_mbm_generation_strategy(
         name: Name that will be attached to the `GenerationStrategy`.
         num_sobol_trials: Number of Sobol trials; can refer to the number of
             `BatchTrial`s.
+        model_kwargs_override: Passed to the MBM BoTorch `GenerationStep` inside
+            `model_kwargs`.
         model_gen_kwargs: Passed to the BoTorch `GenerationStep` and ultimately
             to the BoTorch `Model`.
 
@@ -72,6 +75,9 @@ def get_sobol_mbm_generation_strategy(
             model_configs=[ModelConfig(botorch_model_class=model_cls)]
         ),
     }
+
+    if model_kwargs_override is not None:
+        model_kwargs.update(model_kwargs_override)
 
     model_name = model_names_abbrevations.get(model_cls.__name__, model_cls.__name__)
     acqf_name = acqf_name_abbreviations.get(
@@ -107,6 +113,7 @@ def get_sobol_botorch_modular_acquisition(
     acquisition_cls: type[AcquisitionFunction],
     name: str | None = None,
     num_sobol_trials: int = 5,
+    model_kwargs_override: dict[str, Any] | None = None,
     model_gen_kwargs: dict[str, Any] | None = None,
     batch_size: int = 1,
 ) -> BenchmarkMethod:
@@ -120,6 +127,8 @@ def get_sobol_botorch_modular_acquisition(
         num_sobol_trials: Number of Sobol trials; if the orchestrator_options
             specify to use `BatchTrial`s, then this refers to the number of
             `BatchTrial`s.
+        model_kwargs_override: Passed to the MBM BoTorch `GenerationStep` inside
+            `model_kwargs`.
         model_gen_kwargs: Passed to the BoTorch `GenerationStep` and ultimately
             to the BoTorch `Model`.
         batch_size: Passed to the created ``BenchmarkMethod``.
@@ -152,6 +161,7 @@ def get_sobol_botorch_modular_acquisition(
         acquisition_cls=acquisition_cls,
         name=name,
         num_sobol_trials=num_sobol_trials,
+        model_kwargs_override=model_kwargs_override,
         model_gen_kwargs=model_gen_kwargs,
         batch_size=batch_size,
     )


### PR DESCRIPTION
Summary:
The MAST-calling jobs now have a retry count s.t. they are restarted if they fail e.g. due to manifold errors. Additionally, I have added a timeout of 12 hours s.t. a job that gets stuck fails after that time.

This of course has the downside, that if a job is meant to take this long it will be failed, I'd say we should not really have any jobs like this, though, if we properly parallelize, no? Our nightlies for example take 5 hours at most (which is already a little unnecessarily long, given that we can parallelize things basically ad infinitum, no?)

Differential Revision: D81128135


