### PR TITLE
Allow `SQAArm.generator_run_id` to be nullable

### DIFF
--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -164,8 +164,8 @@ class SQAMetric(Base):
 class SQAArm(Base):
     __tablename__: str = "arm_v2"
 
-    generator_run_id: Column[int] = Column(
-        Integer, ForeignKey("generator_run_v2.id"), nullable=False
+    generator_run_id: Column[int | None] = Column(
+        Integer, ForeignKey("generator_run_v2.id")
     )
     id: Column[int] = Column(Integer, primary_key=True)
     name: Column[str | None] = Column(String(NAME_OR_TYPE_FIELD_LENGTH))


### PR DESCRIPTION
Summary: **Goal of this stack: attach all arms on the experiment, to the experiment object itself, as the main "ground truth" for them.**

Differential Revision: D83488268


