### PR TITLE
Explicitly use ModelList for datasets w/ and w/o Yvar

### DIFF
--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -672,7 +672,7 @@ class Surrogate(Base):
             except UnsupportedError as e:
                 # If the block design conversion fails, use model-list.
                 logger.warning(
-                    "Conversion to block design failed. Using model-list instead."
+                    "Conversion to block design failed. Using model-list instead. "
                     f"Original error: {e}"
                 )
                 should_use_model_list = True

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -149,10 +149,12 @@ def use_model_list(
 ) -> bool:
     model_configs = model_configs or []
     metric_to_model_configs = metric_to_model_configs or {}
+
     if len(datasets) == 1 and datasets[0].Y.shape[-1] == 1:
         # There is only one outcome, so we can use a single model.
         return False
-    elif (
+
+    if (
         len(model_configs) > 1
         or len(metric_to_model_configs) > 0
         or any(len(model_config) for model_config in metric_to_model_configs.values())
@@ -160,8 +162,13 @@ def use_model_list(
         # There are multiple outcomes and outcomes might be modeled with different
         # models
         return True
+
     if len({type(d) for d in datasets}) > 1:
         # Use a `ModelList` if there are multiple dataset classes.
+        return True
+
+    if 0 < len([d.Yvar for d in datasets if d.Yvar is not None]) < len(datasets):
+        # Use a `ModelList` if some datasets have Yvar and some do not.
         return True
 
     botorch_model_class_set = {mc.botorch_model_class for mc in model_configs}

--- a/ax/generators/torch/tests/test_surrogate.py
+++ b/ax/generators/torch/tests/test_surrogate.py
@@ -32,7 +32,6 @@ from ax.generators.torch.botorch_modular.surrogate import (
     _construct_specified_input_transforms,
     _extract_model_kwargs,
     _make_botorch_input_transform,
-    logger,
     submodel_input_constructor,
     Surrogate,
     SurrogateSpec,
@@ -1182,15 +1181,7 @@ class SurrogateTest(TestCase):
                 outcome_names=["metric_noisy"],
             ),
         ]
-        # Should log a message about failure to convert to batched design
-        # and fit a model-list rather than batched model.
-        with self.assertLogs(logger=logger, level="WARNING") as logs:
-            surrogate.fit(
-                datasets=datasets, search_space_digest=self.search_space_digest
-            )
-        self.assertTrue(
-            any("Conversion to block design failed." in str(log) for log in logs)
-        )
+        surrogate.fit(datasets=datasets, search_space_digest=self.search_space_digest)
         m0, m1 = assert_is_instance(surrogate.model, ModelListGP).models
         # Model 0 should be noise free, model 1 should have known noise.
         self.assertIsInstance(m0.likelihood, GaussianLikelihood)


### PR DESCRIPTION
Summary:
Previously, `use_model_list` by default returns False for multiple datasets of the same type but some w/ and some w/o observed Yvar values. The follow-up logic relies on `convert_to_block_design` raising an exception which logs a warning and sets `should_use_model_list=True`.

This change explicitly sets `should_use_model_list=True` for datasets w/ and w/o observed Yvar values, signifying that this behavior is intended while also silencing the warning.

Differential Revision: D83492087


