### PR TITLE
prune irrelevant parameters after generating candidates

### DIFF
--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -50,6 +50,7 @@ from botorch.optim.optimize import (
     optimize_acqf_mixed,
 )
 from botorch.optim.optimize_mixed import optimize_acqf_mixed_alternating
+from botorch.optim.parameter_constraints import evaluate_feasibility
 from botorch.utils.constraints import get_outcome_constraint_transforms
 from pyre_extensions import none_throws
 from torch import Tensor
@@ -187,11 +188,11 @@ class Acquisition(Base):
         options: dict[str, Any] | None = None,
     ) -> None:
         self.surrogate = surrogate
-        options = options or {}
+        self.options: dict[str, Any] = options or {}
         botorch_acqf_options = botorch_acqf_options or {}
         self.search_space_digest = search_space_digest
         self.n = n
-        self._should_subset_model: bool = options.get(Keys.SUBSET_MODEL, True)
+        self._should_subset_model: bool = self.options.get(Keys.SUBSET_MODEL, True)
         self._learned_objective_preference_model = None
         self._subset_idcs = None
         self._risk_measure = torch_opt_config.risk_measure
@@ -238,9 +239,10 @@ class Acquisition(Base):
             botorch_acqf_classes_with_options = [
                 (botorch_acqf_class, botorch_acqf_options)
             ]
-        self._instantiate_acquisition(
-            botorch_acqf_classes_with_options=botorch_acqf_classes_with_options
-        )
+        self.botorch_acqf_classes_with_options: list[
+            tuple[type[AcquisitionFunction], dict[str, Any]]
+        ] = none_throws(botorch_acqf_classes_with_options)
+        self._instantiate_acquisition()
 
     def _subset_model(
         self,
@@ -331,21 +333,16 @@ class Acquisition(Base):
                 (Keys.PAIRWISE_PREFERENCE_QUERY.value,)
             ]
 
-    def _instantiate_acquisition(
-        self,
-        botorch_acqf_classes_with_options: list[
-            tuple[type[AcquisitionFunction], dict[str, Any]]
-        ],
-    ) -> None:
+    def _instantiate_acquisition(self) -> None:
         """Constructs the acquisition function based on the provided
         botorch_acqf_classes_with_options.
 
-        Args:
-            botorch_acqf_classes: A list of BoTorch acquisition function classes.
         """
-        if len(botorch_acqf_classes_with_options) != 1:
+        if len(self.botorch_acqf_classes_with_options) != 1:
             raise ValueError("Only one botorch_acqf_class is supported.")
-        botorch_acqf_class, botorch_acqf_options = botorch_acqf_classes_with_options[0]
+        botorch_acqf_class, botorch_acqf_options = (
+            self.botorch_acqf_classes_with_options[0]
+        )
         self.acqf = self._construct_botorch_acquisition(
             botorch_acqf_class=botorch_acqf_class,
             botorch_acqf_options=botorch_acqf_options,
@@ -546,10 +543,9 @@ class Acquisition(Base):
                 acq_function_sequence=self.acq_function_sequence,
                 **optimizer_options_with_defaults,
             )
-            return candidates, acqf_values, arm_weights
 
         # 2. Handle fully discrete search spaces.
-        if optimizer in (
+        elif optimizer in (
             "optimize_acqf_discrete",
             "optimize_acqf_discrete_local_search",
         ):
@@ -604,10 +600,9 @@ class Acquisition(Base):
                 raise SearchSpaceExhausted(
                     "No more feasible choices in a fully discrete search space."
                 )
-            return candidates, acqf_values, arm_weights
 
         # 3. Handle mixed search spaces that have discrete and continuous features.
-        if optimizer == "optimize_acqf_mixed":
+        elif optimizer == "optimize_acqf_mixed":
             candidates, acqf_values = optimize_acqf_mixed(
                 acq_function=self.acqf,
                 bounds=bounds,
@@ -673,6 +668,19 @@ class Acquisition(Base):
             raise AxError(  # pragma: no cover
                 f"Unknown optimizer: {optimizer}. This code should be unreachable."
             )
+        # prune irrelevant parameters post-hoc
+        if self.options.get("prune_irrelevant_parameters", False):
+            if search_space_digest.hierarchical_dependencies is not None:
+                raise NotImplementedError(
+                    "prune_irrelevant_parameters is not supported for hierarchical "
+                    "search spaces."
+                )
+            candidates, acqf_values = self._prune_irrelevant_parameters(
+                candidates=candidates,
+                search_space_digest=search_space_digest,
+                inequality_constraints=inequality_constraints,
+                fixed_features=fixed_features,
+            )
         return candidates, acqf_values, arm_weights
 
     def evaluate(self, X: Tensor) -> Tensor:
@@ -714,3 +722,306 @@ class Acquisition(Base):
             risk_measure=risk_measure,
             learned_objective_preference_model=learned_objective_preference_model,
         )
+
+    def _condition_on_prev_candidates(
+        self, prev_candidates: Tensor, initial_X_pending: Tensor | None
+    ) -> None:
+        """Condition the acquisition function on the candidates.
+
+        Args:
+            prev_candidates: A `q' x d`-dim Tensor of candidates.
+            initial_X_pending: A `q'' x d`-dim Tensor of pending points. These are
+                points that are the initial pending evaluations and should be added
+                to the `X_pending` of the acquisition function.
+        """
+        if prev_candidates.shape[0] > 0:
+            if initial_X_pending is not None and initial_X_pending.shape[0]:
+                self.X_pending = torch.cat([initial_X_pending, prev_candidates], dim=0)
+            else:
+                self.X_pending = prev_candidates
+            self._instantiate_acquisition()
+
+    def _compute_baseline_acqf_value(
+        self, last_candidate: Tensor, fixed_features: dict[int, float] | None = None
+    ) -> float:
+        r"""Compute the baseline acquisition function value.
+
+        If this is the first point, the baseline AF value is the max AF value
+        the previously evaluated points. The otherwise the baseline value is the
+        acquisition value of the last point after conditioning on the previously
+        selected points including the last candidate. For incremental AFs, this is
+        will be near zero. For non-incremental AFs, this will be the AF value of the
+        the batch consisting of the previously selected points (since they are
+        pending).
+
+        Args:
+            last_candidate: A `1 x d`-dim Tensor containing the last candidate.
+            fixed_features: A map `{feature_index: value}` for features that
+                should be fixed to a particular value during generation.
+
+        Returns:
+            The baseline acquisition function value.
+        """
+        if last_candidate.shape[0] > 0:
+            X = last_candidate
+        elif self.X_observed is not None:
+            # if this is the first candidate, compute the acquisition value for
+            # the previously evaluated set of points. Take the max and compute
+            # the incremental value with respect to that baseline value.
+            X = self.X_observed.unsqueeze(1)
+            if fixed_features is not None:
+                for idx, v in fixed_features.items():
+                    X[..., idx] = v
+        else:
+            return 0.0
+        with torch.no_grad():
+            base_af_val = self.evaluate(X=X)
+        base_af_val = base_af_val.exp() if self.acqf._log else base_af_val
+        return base_af_val.max().item()
+
+    def _prune_irrelevant_parameters(
+        self,
+        candidates: Tensor,
+        search_space_digest: SearchSpaceDigest,
+        inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
+        fixed_features: dict[int, float] | None = None,
+    ) -> tuple[Tensor, Tensor]:
+        r"""Prune irrelevant parameters from the candidates.
+
+        The method involves first optimizing the AF without any notion of irrelevance.
+        Then, the irrelevant parameters are pruned via a sequential greedy algorithm
+        that sets each dimension to the target point value, and recomputes the AF value.
+        The dimension that corresponds to the smallest reduction in AF value compared to
+        the AF value of the dense original candidate is then set to the target value,
+        and the algorithm proceeds until removing any dimension causes the reduction in
+        the AF value of the proposed point to be less than some tolerance, relative to
+        the original dense point.
+
+        For `q > 1` cases, this is repeated for each point in the batch, after adding
+        the previously pruned points as pending points. The incremental AF value is
+        used in the stopping rule.
+
+        Args:
+            candidates: A `q x d`-dim Tensor of candidates.
+            search_space_digest: The SearchSpaceDigest.
+            inequality_constraints: A list of tuples (indices, coefficients, rhs),
+                with each tuple encoding an inequality constraint of the form
+                `\sum_i (X[indices[i]] * coefficients[i]) >= rhs`. `indices` and
+                `coefficients` should be torch tensors. See the docstring of
+                `make_scipy_linear_constraints` for an example. When q=1, or when
+                applying the same constraint to each candidate in the batch
+                (intra-point constraint), `indices` should be a 1-d tensor.
+                For inter-point constraints, in which the constraint is applied to the
+                whole batch of candidates, `indices` must be a 2-d tensor, where
+                in each row `indices[i] =(k_i, l_i)` the first index `k_i` corresponds
+                to the `k_i`-th element of the `q`-batch and the second index `l_i`
+                corresponds to the `l_i`-th feature of that element.
+            fixed_features: A map `{feature_index: value}` for features that
+                should be fixed to a particular value during generation.
+
+        Returns:
+            A three-element tuple containing an `q x d`-dim tensor of generated
+            candidates and a `q`-dim tensor with the associated acquisition values.
+        """
+        target_point = self.options.get("target_point")
+        if target_point is None:
+            raise ValueError("Must specify target_point to prune irrelevant parameters")
+        irrelevance_pruning_rtol = self.options.get("irrelevance_pruning_rtol", 0.1)
+        initial_X_pending = self.X_pending
+        pruned_af_vals = []
+        excluded_indices = set(search_space_digest.fidelity_features)
+        excluded_indices.update(set(search_space_digest.task_features))
+        if fixed_features is not None:
+            excluded_indices.update(set(fixed_features.keys()))
+        orig_acqf = self.acqf
+        # iterate over points in the batch and prune each point
+        for i in range(candidates.shape[0]):
+            # condition on previous pruned points
+            self._condition_on_prev_candidates(
+                prev_candidates=candidates[:i], initial_X_pending=initial_X_pending
+            )
+            # compute the AF value for the previous candidates so that we can compute
+            # the incremental EI
+            base_af_val = self._compute_baseline_acqf_value(
+                last_candidate=candidates[i - 1 : i], fixed_features=fixed_features
+            )
+            # compute the AF value of the dense candidate (before pruning)
+            with torch.no_grad():
+                dense_af_val = self.evaluate(X=candidates[i : i + 1])
+            # compute the incremental AF value of the dense candidate, relative to the
+            # base AF value
+            dense_incremental_af_val = (
+                ((dense_af_val.exp() if self.acqf._log else dense_af_val) - base_af_val)
+                .clamp_min(0.0)
+                .item()
+            )
+            # In the base case that no parameters are pruned, the final AF val is the
+            # dense AF val
+            final_af_val = dense_af_val
+            # If the current incremental AF value is zero, then we skip pruning
+            if dense_incremental_af_val > 0.0:
+                remaining_indices = set(range(candidates.shape[-1])) - excluded_indices
+                # remove features that are already set to target_point
+                remaining_indices -= set(
+                    (candidates[i] == target_point).nonzero().view(-1).tolist()
+                )
+                # len(remaining_indices) - 1 is used here so that we do not prune
+                # every dimension
+                for _ in range(len(remaining_indices) - 1):
+                    indices = torch.tensor(
+                        list(remaining_indices),
+                        dtype=torch.long,
+                        device=candidates.device,
+                    )
+                    # create a `b x 1 x d`-dim tensor, where each batch has the
+                    # original candidate with a different dimension set to the
+                    # corresponding target value
+                    pruned_candidates = _expand_and_set_single_feature_to_target(
+                        X=candidates[i : i + 1],
+                        indices=indices,
+                        targets=target_point[indices],
+                    )
+                    # remove candidates that violate constraints after pruning
+                    pruned_candidates, indices = _remove_infeasible_candidates(
+                        candidates=pruned_candidates,
+                        indices=indices,
+                        inequality_constraints=inequality_constraints,
+                    )
+                    if pruned_candidates.shape[0] == 0:
+                        # no feasible points, continue to
+                        # next candidate
+                        break
+                    # determine which dimension to prune based on the reduction
+                    # in incremental AF value relative to original dense candidate
+                    min_idx, best_af_val = self._get_best_pruned_candidate(
+                        pruned_candidates=pruned_candidates,
+                        irrelevance_pruning_rtol=irrelevance_pruning_rtol,
+                        dense_incremental_af_val=dense_incremental_af_val,
+                        base_af_val=base_af_val,
+                    )
+
+                    if min_idx is not None:
+                        candidates[i] = pruned_candidates[min_idx]
+                        remaining_indices.remove(
+                            int(none_throws(indices)[min_idx].item())
+                        )
+                        final_af_val = best_af_val
+                    else:
+                        # if min_idx is None that means that no candidate met
+                        # the relative tolerance threshold, so we stop pruning
+                        # this candidate
+                        break
+            # TODO: log when we prune parameters in gen_metadata
+            pruned_af_vals.append(final_af_val)
+        self.acqf = orig_acqf
+        return candidates, torch.cat(pruned_af_vals, dim=0)
+
+    def _get_best_pruned_candidate(
+        self,
+        pruned_candidates: Tensor,
+        irrelevance_pruning_rtol: float,
+        dense_incremental_af_val: float,
+        base_af_val: float,
+    ) -> tuple[int | None, Tensor | None]:
+        """Determine which pruned candidate is best.
+
+        This computes the relative change in incremental acquisition value for each
+        pruned candidate and returns the index and candidate with the smallest
+        reduction. If no candidate meets the relative tolerance-based stopping rule,
+        then Nones are returned instead of an index and candidate.
+
+        Args:
+            pruned_candidates: A `b x 1 x d`-dim tensor of pruned candidates.
+            irrelevance_pruning_rtol: The relative tolerance on the reduction in
+                incremental AF value, relative to the dense candidate.
+            dense_incremental_af_val: The incremental AF value for the dense
+                candidate.
+            base_af_val: The baseline AF value that should be subtracted from the AF
+                value for each pruned candidate to determine the incremental value.
+
+        Returns:
+            A two-element tuple containing the index and corresponding candidate.
+        """
+        with torch.no_grad():
+            new_af_val = torch.cat(
+                [self.evaluate(X=X_) for X_ in pruned_candidates.split(1024)], dim=0
+            )
+        if self.acqf._log:
+            non_log_new_af_val = new_af_val.exp()
+        else:
+            non_log_new_af_val = new_af_val
+        af_reduction = (
+            dense_incremental_af_val - (non_log_new_af_val - base_af_val).clamp_min(0.0)
+        ) / dense_incremental_af_val
+
+        min_af_reduction, min_idx = af_reduction.min(dim=0)
+        if min_af_reduction <= irrelevance_pruning_rtol:
+            return min_idx.item(), new_af_val[min_idx].view(1)
+        return None, None
+
+
+def _expand_and_set_single_feature_to_target(
+    X: Tensor, indices: Tensor, targets: Tensor
+) -> Tensor:
+    """Return an expanded copy of X, using target values at the specified indices.
+
+    In the returned copy X2, for each `i` in `indices`, `X2[i, 0, indices[i]]` is
+    set to the corresponding target value in `targets`.
+
+    Args:
+        X: A `1 x d`-dim tensor of points.
+        indices: A `k`-dim tensor of indices with values in [0, d).
+        targets: A `k`-dim tensor of target values.
+
+    Returns:
+        A `k x 1 x d`-dim tensor copy of X updated to have the target values
+            at the specified indices.
+    """
+    d = X.shape[1]
+    k = indices.shape[0]
+    X2 = X.unsqueeze(0).expand(k, 1, d).clone()
+    q_idxr = torch.zeros((k, 1), dtype=torch.long, device=X.device)
+    # indices expanded to (k, 1)
+    indices_exp = indices.unsqueeze(1)
+    # targets expanded to (k, 1)
+    targets_exp = targets.unsqueeze(1)
+    # Assign targets to X2 at the specified indices
+    X2[torch.arange(k, device=X.device).unsqueeze(1), q_idxr, indices_exp] = targets_exp
+    return X2
+
+
+def _remove_infeasible_candidates(
+    candidates: Tensor,
+    indices: Tensor,
+    inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
+) -> tuple[Tensor, Tensor]:
+    r"""Filter out infeasible candidates, based on the parameter constraints.
+
+    Args:
+        candidates: A `b x 1 x d`-dim tensor of candidates.
+        indices: A `b`-dim tensor of indices, where the values are integers
+            in [0, d-1).
+        inequality_constraints: A list of tuples (indices, coefficients, rhs),
+            with each tuple encoding an inequality constraint of the form
+            `\sum_i (X[indices[i]] * coefficients[i]) >= rhs`. `indices` and
+            `coefficients` should be torch tensors. See the docstring of
+            `make_scipy_linear_constraints` for an example. When q=1, or when
+            applying the same constraint to each candidate in the batch
+            (intra-point constraint), `indices` should be a 1-d tensor.
+            For inter-point constraints, in which the constraint is applied to the
+            whole batch of candidates, `indices` must be a 2-d tensor, where
+            in each row `indices[i] =(k_i, l_i)` the first index `k_i` corresponds
+            to the `k_i`-th element of the `q`-batch and the second index `l_i`
+            corresponds to the `l_i`-th feature of that element.
+
+    Returns:
+        A two-element tuple containing the filter candidates and indices.
+    """
+    if inequality_constraints is not None:
+        is_feasible = evaluate_feasibility(
+            X=candidates,
+            inequality_constraints=inequality_constraints,
+        )
+        candidates = candidates[is_feasible]
+        indices = indices[is_feasible]
+    return candidates, indices

--- a/ax/generators/torch/botorch_modular/multi_acquisition.py
+++ b/ax/generators/torch/botorch_modular/multi_acquisition.py
@@ -6,10 +6,8 @@
 
 # pyre-strict
 
-from typing import Any
 
 from ax.generators.torch.botorch_modular.acquisition import Acquisition
-from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.multioutput_acquisition import (
     MultiOutputAcquisitionFunctionWrapper,
 )
@@ -23,17 +21,10 @@ class MultiAcquisition(Acquisition):
 
     def _instantiate_acquisition(
         self,
-        botorch_acqf_classes_with_options: list[
-            tuple[type[AcquisitionFunction], dict[str, Any]]
-        ],
     ) -> None:
-        """Constructs the acquisition function based on the provided AF clases.
-
-        Args:
-            botorch_acqf_classes: A list of BoTorch acquisition function classes.
-        """
+        """Constructs the acquisition function based on the provided AF clases."""
         self.acq_function_sequence = None
-        if len(botorch_acqf_classes_with_options) > 1:
+        if len(self.botorch_acqf_classes_with_options) > 1:
             acqfs = [
                 self._construct_botorch_acquisition(
                     botorch_acqf_class=botorch_acqf_class,
@@ -41,7 +32,7 @@ class MultiAcquisition(Acquisition):
                     model=self._model,
                 )
                 for botorch_acqf_class, botorch_acqf_options in (
-                    botorch_acqf_classes_with_options
+                    self.botorch_acqf_classes_with_options
                 )
             ]
             self.acqf = MultiOutputAcquisitionFunctionWrapper(acqfs=acqfs)
@@ -49,7 +40,7 @@ class MultiAcquisition(Acquisition):
         else:
             # Using one acqf with multiple models.
             botorch_acqf_class, botorch_acqf_options = (
-                botorch_acqf_classes_with_options[0]
+                self.botorch_acqf_classes_with_options[0]
             )
             # Default acqf is the surrogate default.
             self.acqf = self._construct_botorch_acquisition(

--- a/ax/generators/torch/tests/test_acquisition.py
+++ b/ax/generators/torch/tests/test_acquisition.py
@@ -20,7 +20,11 @@ import numpy as np
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import AxError, SearchSpaceExhausted
-from ax.generators.torch.botorch_modular.acquisition import Acquisition, logger
+from ax.generators.torch.botorch_modular.acquisition import (
+    _expand_and_set_single_feature_to_target,
+    Acquisition,
+    logger,
+)
 from ax.generators.torch.botorch_modular.multi_acquisition import MultiAcquisition
 from ax.generators.torch.botorch_modular.optimizer_argparse import optimizer_argparse
 from ax.generators.torch.botorch_modular.optimizer_defaults import (
@@ -321,51 +325,77 @@ class AcquisitionTest(TestCase):
 
     @mock_botorch_optimize
     def test_optimize(self) -> None:
-        acquisition = self.get_acquisition_function(fixed_features=self.fixed_features)
-        n = 5
-        with mock.patch(
-            f"{ACQUISITION_PATH}.optimizer_argparse", wraps=optimizer_argparse
-        ) as mock_optimizer_argparse, mock.patch(
-            f"{ACQUISITION_PATH}.optimize_acqf", wraps=optimize_acqf
-        ) as mock_optimize_acqf:
-            acquisition.optimize(
-                n=n,
-                search_space_digest=self.search_space_digest,
+        for prune_irrelevant_parameters in (False, True):
+            if prune_irrelevant_parameters:
+                self.options = {
+                    "prune_irrelevant_parameters": True,
+                    "target_point": torch.zeros(3, dtype=torch.double),
+                }
+            else:
+                self.options = {}
+            acquisition = self.get_acquisition_function(
+                fixed_features=self.fixed_features
+            )
+            n = 5
+            with mock.patch(
+                f"{ACQUISITION_PATH}.optimizer_argparse", wraps=optimizer_argparse
+            ) as mock_optimizer_argparse, mock.patch(
+                f"{ACQUISITION_PATH}.optimize_acqf", wraps=optimize_acqf
+            ) as mock_optimize_acqf, mock.patch.object(
+                acquisition,
+                "_prune_irrelevant_parameters",
+                wraps=acquisition._prune_irrelevant_parameters,
+            ) as mock_prune_irrelevant_parameters:
+                acquisition.optimize(
+                    n=n,
+                    search_space_digest=self.search_space_digest,
+                    inequality_constraints=self.inequality_constraints,
+                    fixed_features=self.fixed_features,
+                    rounding_func=self.rounding_func,
+                    optimizer_options=self.optimizer_options,
+                )
+            mock_optimizer_argparse.assert_called_once_with(
+                acquisition.acqf,
+                optimizer_options=self.optimizer_options,
+                optimizer="optimize_acqf",
+            )
+            mock_optimize_acqf.assert_called_with(
+                acq_function=acquisition.acqf,
+                sequential=True,
+                bounds=mock.ANY,
+                q=n,
+                options={
+                    "init_batch_limit": INIT_BATCH_LIMIT,
+                    "batch_limit": BATCH_LIMIT,
+                    "max_optimization_problem_aggregation_size": MAX_OPT_AGG_SIZE,
+                },
                 inequality_constraints=self.inequality_constraints,
                 fixed_features=self.fixed_features,
-                rounding_func=self.rounding_func,
-                optimizer_options=self.optimizer_options,
+                post_processing_func=self.rounding_func,
+                acq_function_sequence=None,
+                **self.optimizer_options,
             )
-        mock_optimizer_argparse.assert_called_once_with(
-            acquisition.acqf,
-            optimizer_options=self.optimizer_options,
-            optimizer="optimize_acqf",
-        )
-        mock_optimize_acqf.assert_called_with(
-            acq_function=acquisition.acqf,
-            sequential=True,
-            bounds=mock.ANY,
-            q=n,
-            options={
-                "init_batch_limit": INIT_BATCH_LIMIT,
-                "batch_limit": BATCH_LIMIT,
-                "max_optimization_problem_aggregation_size": MAX_OPT_AGG_SIZE,
-            },
-            inequality_constraints=self.inequality_constraints,
-            fixed_features=self.fixed_features,
-            post_processing_func=self.rounding_func,
-            acq_function_sequence=None,
-            **self.optimizer_options,
-        )
-        # can't use assert_called_with on bounds due to ambiguous bool comparison
-        expected_bounds = torch.tensor(
-            self.search_space_digest.bounds,
-            dtype=acquisition.dtype,
-            device=acquisition.device,
-        ).transpose(0, 1)
-        self.assertTrue(
-            torch.equal(mock_optimize_acqf.call_args[1]["bounds"], expected_bounds)
-        )
+            if prune_irrelevant_parameters:
+                mock_prune_irrelevant_parameters.assert_called_once()
+                call_kwargs = mock_prune_irrelevant_parameters.call_args_list[0][1]
+                for kw_name in (
+                    "candidates",
+                    "search_space_digest",
+                    "inequality_constraints",
+                    "fixed_features",
+                ):
+                    self.assertIsNotNone(call_kwargs[kw_name])
+            else:
+                mock_prune_irrelevant_parameters.assert_not_called()
+            # can't use assert_called_with on bounds due to ambiguous bool comparison
+            expected_bounds = torch.tensor(
+                self.search_space_digest.bounds,
+                dtype=acquisition.dtype,
+                device=acquisition.device,
+            ).transpose(0, 1)
+            self.assertTrue(
+                torch.equal(mock_optimize_acqf.call_args[1]["bounds"], expected_bounds)
+            )
 
     def test_optimize_discrete(self) -> None:
         ssd1 = SearchSpaceDigest(
@@ -1064,6 +1094,506 @@ class AcquisitionTest(TestCase):
         self.assertIsInstance(acquisition.acqf, qLogProbabilityOfFeasibility)
         self.assertIsNone(acquisition._full_objective_thresholds)
 
+    def test_expand_and_set_single_feature_to_target(self) -> None:
+        # Test helper function
+        X = torch.tensor([[1.0, 2.0, 3.0]])  # 1 x 3
+        indices = torch.tensor([0, 2])  # indices to modify
+        targets = torch.tensor([10.0, 30.0])  # target values
+
+        result = _expand_and_set_single_feature_to_target(X, indices, targets)
+
+        # Should return a 2 x 1 x 3 tensor
+        self.assertEqual(result.shape, (2, 1, 3))
+        # First row should have X[0] = 10.0
+        self.assertEqual(result[0, 0, 0].item(), 10.0)
+        self.assertEqual(result[0, 0, 1].item(), 2.0)  # unchanged
+        self.assertEqual(result[0, 0, 2].item(), 3.0)  # unchanged
+        # Second row should have X[2] = 30.0
+        self.assertEqual(result[1, 0, 0].item(), 1.0)  # unchanged
+        self.assertEqual(result[1, 0, 1].item(), 2.0)  # unchanged
+        self.assertEqual(result[1, 0, 2].item(), 30.0)  # changed
+
+    def test_prune_irrelevant_parameters_no_target_point(self) -> None:
+        # Test that ValueError is raised when no target_point is provided
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=self.search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={},  # No target_point
+        )
+
+        candidates = torch.tensor([[0.9, 0.1]])
+
+        with self.assertRaisesRegex(ValueError, "Must specify target_point"):
+            acq._prune_irrelevant_parameters(
+                candidates=candidates, search_space_digest=self.search_space_digest
+            )
+
+    def test_optimize_pruning_hierarchical_error(self) -> None:
+        ssd = dataclasses.replace(
+            self.search_space_digest, hierarchical_dependencies={0: [1]}
+        )
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=self.search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={"prune_irrelevant_parameters": True},  # No target_point
+        )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "prune_irrelevant_parameters is not supported for hierarchical "
+            "search spaces.",
+        ):
+            acq.optimize(n=1, search_space_digest=ssd)
+
+    def test_prune_irrelevant_parameters_with_log_acquisition(self) -> None:
+        # Test pruning with log-transformed acquisition function
+
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=self.search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.5, 0.5]),
+                "irrelevance_pruning_rtol": 0.1,
+            },
+        )
+
+        # Create mock acquisition function with log transformation
+        mock_acqf = Mock()
+        mock_acqf._log = True
+        # Log values that when exp() give predictable pruning behavior
+        evaluation_values = [
+            torch.tensor([-30.0]),  # baseline value
+            torch.tensor([0.0]),  # dense value
+            torch.tensor([-0.1, -0.69]),
+        ]
+        acq.evaluate = Mock(side_effect=evaluation_values)
+        acq.acqf = mock_acqf
+        candidates = torch.tensor([[0.9, 0.1]])
+        pruned_candidates, pruned_values = acq._prune_irrelevant_parameters(
+            candidates=candidates, search_space_digest=self.search_space_digest
+        )
+        self.assertTrue(torch.equal(pruned_candidates, torch.tensor([[0.5, 0.1]])))
+        self.assertTrue(torch.equal(pruned_values, torch.tensor([-0.1])))
+
+    def test_prune_irrelevant_parameters_zero_acquisition_value(self) -> None:
+        # Test handling of zero or negative acquisition values
+        torch.manual_seed(0)
+
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=self.search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.5, 0.5]),
+                "irrelevance_pruning_rtol": 0.1,
+            },
+        )
+
+        mock_acqf = Mock()
+        mock_acqf._log = False
+        mock_evaluate = Mock(return_value=torch.tensor([0.0]))  # Zero acquisition value
+        acq.evaluate = mock_evaluate
+        acq.acqf = mock_acqf
+
+        candidates = torch.tensor([[0.9, 0.1]])
+
+        pruned_candidates, pruned_values = acq._prune_irrelevant_parameters(
+            candidates=candidates, search_space_digest=self.search_space_digest
+        )
+
+        # Should handle zero acquisition value gracefully
+        self.assertEqual(pruned_candidates.shape, (1, 2))
+        self.assertEqual(pruned_values.shape, (1,))
+        # Original candidate should be unchanged when acquisition value is zero
+        torch.testing.assert_close(pruned_candidates, candidates)
+
+    def test_prune_irrelevant_parameters_single_dimension(self) -> None:
+        # Test that pruning stops when only one dimension would remain
+        torch.manual_seed(0)
+
+        # Create search space digest for 1D problem
+        search_space_digest_1d = SearchSpaceDigest(
+            feature_names=["x1"], bounds=[(0.0, 1.0)]
+        )
+
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=search_space_digest_1d,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.5]),
+                "irrelevance_pruning_rtol": 0.1,
+            },
+        )
+
+        mock_acqf = Mock()
+        mock_acqf._log = False
+        acq.acqf = mock_acqf
+        acq.evaluate = Mock(side_effect=[torch.tensor([0.0]), torch.tensor([1.0])])
+
+        candidates = torch.tensor([[0.9]])  # 1D candidate
+
+        pruned_candidates, _ = acq._prune_irrelevant_parameters(
+            candidates=candidates, search_space_digest=self.search_space_digest
+        )
+
+        # Should not prune the only dimension
+        torch.testing.assert_close(pruned_candidates, candidates)
+
+    def test_prune_irrelevant_parameters_with_fixed_features(self) -> None:
+        # Test pruning with fixed features that should be excluded from pruning
+        # Create search space with fixed features
+        search_space_digest = SearchSpaceDigest(
+            feature_names=["x1", "x2", "x3"],
+            bounds=[(0.0, 1.0), (0.0, 1.0), (0.0, 1.0)],
+        )
+
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.5, 0.5, 0.5]),
+                "irrelevance_pruning_rtol": 0.1,
+            },
+        )
+
+        mock_acqf = Mock()
+        mock_acqf._log = False
+        # all pruned points will return the same AF value as
+        # the dense point, so we should have pruned the first dimension
+        # if it weren't fixed
+        mock_evaluate = Mock(
+            side_effect=[
+                torch.tensor([1.0]),  # baseline value
+                torch.tensor([1.0]),  # dense value
+                torch.tensor([1.0, 1.0]),  # pruned values
+            ]
+        )
+        acq.evaluate = mock_evaluate
+        acq.acqf = mock_acqf
+        acq._instantiate_acquisition = Mock()
+
+        candidates = torch.tensor([[0.9, 0.1, 0.8]])
+        fixed_features = {0: 0.9}  # Fix feature 0 to 0.9
+
+        pruned_candidates, pruned_values = acq._prune_irrelevant_parameters(
+            candidates=candidates,
+            search_space_digest=search_space_digest,
+            fixed_features=fixed_features,
+        )
+        self.assertTrue(torch.equal(pruned_candidates, torch.tensor([[0.9, 0.5, 0.8]])))
+        self.assertTrue(torch.equal(pruned_values, torch.tensor([1.0])))
+
+    def test_prune_irrelevant_parameters_with_inequality_constraints(self) -> None:
+        # Test pruning with inequality constraints that filter out infeasible candidates
+        search_space_digest = SearchSpaceDigest(
+            feature_names=["x1", "x2"],
+            bounds=[(0.0, 1.0), (0.0, 1.0)],
+        )
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.2, 0.2]),
+                "irrelevance_pruning_rtol": 0.1,
+            },
+        )
+        mock_acqf = Mock()
+        mock_acqf._log = False
+        acq.acqf = mock_acqf
+        mock_evaluate = Mock(
+            side_effect=[
+                torch.tensor([1.0]),  # original dense value
+                torch.tensor([0.91, 0.9]),  # pruned value (after constraint filtering)
+                torch.tensor([0.9]),
+            ]
+        )
+        acq.evaluate = mock_evaluate
+        candidates = torch.tensor([[0.8, 0.8]])
+        # Constraint: x1 + x2 >= 1.0
+        inequality_constraints = [(torch.tensor([0, 1]), torch.tensor([1.0, 1.0]), 1.0)]
+        pruned_candidates, pruned_values = acq._prune_irrelevant_parameters(
+            candidates=candidates,
+            search_space_digest=search_space_digest,
+            inequality_constraints=inequality_constraints,
+        )
+        self.assertTrue(torch.equal(pruned_candidates, torch.tensor([[0.2, 0.8]])))
+        self.assertTrue(torch.equal(pruned_values, torch.tensor([0.91])))
+
+    def test_prune_irrelevant_parameters_already_at_target(self) -> None:
+        # Test that features already at target point are excluded from pruning
+
+        search_space_digest = SearchSpaceDigest(
+            feature_names=["x1", "x2", "x3"],
+            bounds=[(0.0, 1.0), (0.0, 1.0), (0.0, 1.0)],
+        )
+
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.5, 0.5, 0.5]),
+                "irrelevance_pruning_rtol": 0.1,
+            },
+        )
+
+        mock_acqf = Mock()
+        mock_acqf._log = False
+
+        acq.acqf = mock_acqf
+        mock_evaluate = Mock(
+            side_effect=[
+                torch.tensor([1.0]),  # original value
+                torch.tensor([0.88, 0.96]),
+                torch.tensor([0.88]),
+            ]
+        )
+        acq.evaluate = mock_evaluate
+
+        # Candidate where feature 1 is already at target point
+        # only dimension 2 should be pruned
+        candidates = torch.tensor([[0.9, 0.5, 0.8]])
+
+        pruned_candidates, pruned_values = acq._prune_irrelevant_parameters(
+            candidates=candidates, search_space_digest=search_space_digest
+        )
+
+        self.assertTrue(torch.equal(pruned_candidates, torch.tensor([[0.9, 0.5, 0.5]])))
+        self.assertTrue(torch.equal(pruned_values, torch.tensor([0.96])))
+
+    def test_prune_irrelevant_parameters_specific_pruning_behavior(self) -> None:
+        # Test specific pruning behavior with predictable acquisition function responses
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=self.search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.2, 0.8], dtype=torch.double),
+                "irrelevance_pruning_rtol": 0.1,  # 10% tolerance
+            },
+        )
+        mock_acqf = Mock()
+        mock_acqf._log = False
+        acq.acqf = mock_acqf
+        # Test case where first dimension should be pruned but second shouldn't
+        original_candidate = torch.tensor([[0.9, 0.1]], dtype=torch.double)
+        # Mock acquisition function responses:
+        # 1. Original candidate value: 1.0
+        # 2. Pruning dimension 0 to target: 0.95 (5% reduction - below 10% threshold)
+        # 3. Pruning dimension 1 to target: 0.85 (15% reduction - above 10% threshold)
+        acq.evaluate = Mock(
+            side_effect=[
+                torch.tensor([0.0], dtype=torch.double),  # baseline acquisition value
+                torch.tensor(
+                    [1.0], dtype=torch.double
+                ),  # original dense acquisition value
+                torch.tensor(
+                    [0.95, 0.85], dtype=torch.double
+                ),  # pruning dim 0: 5% reduction (should prune)
+            ]
+        )
+        pruned_candidates, pruned_values = acq._prune_irrelevant_parameters(
+            candidates=original_candidate, search_space_digest=self.search_space_digest
+        )
+        self.assertTrue(
+            torch.equal(
+                pruned_candidates, torch.tensor([[0.2, 0.1]], dtype=torch.double)
+            )
+        )
+        self.assertTrue(
+            torch.equal(pruned_values, torch.tensor([0.95], dtype=torch.double))
+        )
+
+    def test_prune_irrelevant_parameters_no_pruning_above_threshold(self) -> None:
+        # Test that no pruning occurs when all reductions are above threshold
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=self.search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.2, 0.8]),
+                "irrelevance_pruning_rtol": 0.1,  # 10% tolerance
+            },
+        )
+
+        mock_acqf = Mock()
+        mock_acqf._log = False
+        acq.acqf = mock_acqf
+
+        original_candidate = torch.tensor([[0.9, 0.1]])
+
+        # All pruning attempts result in reductions above threshold
+        mock_evaluate = Mock(
+            side_effect=[
+                torch.tensor([0.0]),  # baseline acquisition value
+                torch.tensor([1.0]),  # original dense acquisition value
+                torch.tensor([0.8, 0.7]),
+            ]
+        )
+        acq.evaluate = mock_evaluate
+
+        pruned_candidates, pruned_values = acq._prune_irrelevant_parameters(
+            candidates=original_candidate, search_space_digest=self.search_space_digest
+        )
+
+        # Both dimensions should remain unchanged
+        self.assertTrue(torch.equal(pruned_candidates, original_candidate))
+        self.assertTrue(torch.equal(pruned_values, torch.tensor([1.0])))
+
+    def test_prune_irrelevant_parameters_multi_candidate_exact_values(self) -> None:
+        # Test exact pruned values for multiple candidates
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=self.search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.2, 0.8]),
+                "irrelevance_pruning_rtol": 0.1,
+            },
+        )
+        mock_acqf = Mock()
+        mock_acqf._log = False
+        acq.acqf = mock_acqf
+        original_candidates = torch.tensor([[0.9, 0.1], [0.3, 0.7]])
+        # Mock responses for both candidates:
+        # Candidate 1: both dims should be pruned
+        # Candidate 2: only dim 1 should be pruned
+        mock_evaluate = Mock(
+            side_effect=[
+                # Candidate 1 evaluations
+                torch.tensor([0.0]),  # baseline value
+                torch.tensor([1.0]),  # original dense value
+                torch.tensor([0.95, 0.98]),  # prune dim 1
+                torch.tensor([-30.0]),  # compute incremental baseline
+                torch.tensor([0.8]),  # original dense value
+                torch.tensor([0.75, 0.6]),
+            ]
+        )
+        acq.evaluate = mock_evaluate
+        pruned_candidates, pruned_values = acq._prune_irrelevant_parameters(
+            candidates=original_candidates, search_space_digest=self.search_space_digest
+        )
+        expected_candidates = torch.tensor(
+            [
+                [0.9, 0.8],  # Candidate 1: dim 1 pruned to target
+                [0.2, 0.7],  # Candidate 2: only dim 0 pruned to target
+            ]
+        )
+        self.assertTrue(torch.equal(pruned_candidates, expected_candidates))
+        self.assertTrue(torch.equal(pruned_values, torch.tensor([0.98, 0.75])))
+
+    def test_prune_irrelevant_parameters_with_constraints_exact_values(self) -> None:
+        # Test exact pruned values when constraints filter out some candidates
+
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=self.search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.1, 0.1]),
+                "irrelevance_pruning_rtol": 0.1,
+            },
+        )
+        mock_acqf = Mock()
+        mock_acqf._log = False
+        acq.acqf = mock_acqf
+        acq._instantiate_acquisition = Mock()
+
+        original_candidate = torch.tensor([[0.9, 1.0]])
+        # pruning does not reduce AF value, but pruning the dim 1 violates
+        # the constraint
+        mock_evaluate = Mock(
+            side_effect=[
+                torch.tensor([0.0]),  # baseline af val
+                torch.tensor([1.0]),  # dense af val
+                # pruned af val for single pruned_candidate, since the other
+                # pruned candidate is filtered out
+                torch.tensor([1.0]),
+            ]
+        )
+        acq.evaluate = mock_evaluate
+
+        pruned_candidates, pruned_values = acq._prune_irrelevant_parameters(
+            candidates=original_candidate,
+            search_space_digest=self.search_space_digest,
+            inequality_constraints=[
+                (
+                    torch.tensor([[0, 1]], dtype=torch.long),
+                    torch.tensor([[0.0, 1.0]]),
+                    1.0,
+                )
+            ],
+        )
+
+        # Only dimension 0 should be pruned
+        expected_candidate = torch.tensor([[0.1, 1.0]])
+        self.assertTrue(torch.equal(pruned_candidates, expected_candidate))
+        self.assertTrue(torch.equal(pruned_values, torch.tensor([1.0])))
+
+    def test_prune_irrelevant_parameters_with_task_and_fidelity_features(self) -> None:
+        # Test pruning with both task and fidelity features that should be excluded
+        # from pruning
+        acq = Acquisition(
+            surrogate=self.surrogate,
+            search_space_digest=self.search_space_digest,
+            torch_opt_config=self.torch_opt_config,
+            botorch_acqf_class=DummyAcquisitionFunction,
+            options={
+                "target_point": torch.tensor([0.2, 0.0, 0.8, 0.2]),
+                "irrelevance_pruning_rtol": 0.1,
+                "prune_irrelevant_parameters": True,
+            },
+        )
+
+        mock_acqf = Mock()
+        mock_acqf._log = False
+        acq.acqf = mock_acqf
+        acq._instantiate_acquisition = Mock()
+
+        original_candidate = torch.tensor([[0.9, 0.5, 0.1, 0.3]])
+
+        # Only dimensions 2
+        # (dimensions 0 and 1 are task/fidelity features)
+        # dimension 3 is skipped since we don't prune all dimensions.
+        mock_evaluate = Mock(
+            side_effect=[
+                torch.tensor([0.0]),  # baseline af val
+                torch.tensor([1.0]),  # original dense acquisition value
+                torch.tensor([0.92]),  # pruning dim 2
+            ]
+        )
+        acq.evaluate = mock_evaluate
+
+        pruned_candidates, pruned_values = acq._prune_irrelevant_parameters(
+            candidates=original_candidate,
+            search_space_digest=SearchSpaceDigest(
+                feature_names=self.feature_names,
+                bounds=[(0.0, 10.0), (0.0, 10.0), (0.0, 10.0), (0.0, 10.0)],
+                task_features=[0],
+                fidelity_features=[1],
+            ),
+        )
+        expected_candidate = torch.tensor([[0.9, 0.5, 0.8, 0.3]])
+        self.assertTrue(torch.equal(pruned_candidates, expected_candidate))
+        self.assertTrue(torch.equal(pruned_values, torch.tensor([0.92])))
+
 
 class MultiAcquisitionTest(AcquisitionTest):
     acquisition_class = MultiAcquisition
@@ -1226,35 +1756,6 @@ class MultiAcquisitionTest(AcquisitionTest):
             torch_opt_config=self.torch_opt_config,
             botorch_acqf_class=DummyAcquisitionFunction,
             n=1,
-        )
-        self.assertEqual(acq.acqf.model, model_mocks[0])
-        self.assertEqual(acq.acq_function_sequence, None)
-        self.assertEqual(len(acq.models_used), 1)
-        acq = MultiAcquisition(
-            surrogate=surrogate,
-            search_space_digest=self.search_space_digest,
-            torch_opt_config=self.torch_opt_config,
-            botorch_acqf_class=DummyAcquisitionFunction,
-            n=2,
-        )
-        models_for_gen_mock.assert_called_once_with(n=2)
-        self.assertEqual(acq.acqf.model, model_mocks[0])
-        acqf_sequence_models = [acqf.model for acqf in acq.acq_function_sequence]
-        self.assertEqual(acqf_sequence_models, [model_mocks[1], model_mocks[2]])
-        self.assertEqual(len(acq.models_used), 2)
-        # Test gen_for_models returns only one model
-        models_for_gen_mock = mock.MagicMock()
-        models_for_gen_mock.return_value = (
-            ["a"],
-            [model_mocks[1]],
-        )
-        surrogate.models_for_gen = models_for_gen_mock
-        acq = MultiAcquisition(
-            surrogate=surrogate,
-            search_space_digest=self.search_space_digest,
-            torch_opt_config=self.torch_opt_config,
-            botorch_acqf_class=DummyAcquisitionFunction,
-            n=3,
         )
         self.assertEqual(acq.acqf.model, model_mocks[0])
         self.assertEqual(acq.acq_function_sequence, None)


### PR DESCRIPTION
Summary:
See title. The method involves first optimizing the AF without any notion of irrelevance. Then, the irrelevant parameters are pruned via a sequential greedy algorithm that sets each dimension to the target point value, and recomputes the AF value. The dimension that corresponds to the smallest reduction in Ax value (compared the AF value of the dense original candidate) is then set to the target value and the algorithm proceeds until removing any dimension causes the reduction of the AF value of the proposed point to be less than some tolerance, relative to the original point.

For q>1 cases, this is repeated for each point in the batch, after adding the previously pruned points as pending points. The stopping rule is applied to the incremental AF value

This first diff adds support for pruning irrelevant parameters where the target_point is passed via `acquisition_options`. A subsequent diff will implement support for storing and passing a target point through Ax transforms, down to the modeling layer.

Differential Revision: D83097348


