### PR TITLE
Only reindex Data.df when necessary

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -136,12 +136,12 @@ class Data(Base, SerializationMixin):
     def _get_df_with_cols_in_expected_order(cls, df: pd.DataFrame) -> pd.DataFrame:
         """Reorder the columns for easier viewing"""
         current_order = list(df.columns)  # Surprisingly slow, so do it once
-        expected_order = list(cls.COLUMN_DATA_TYPES)
-        col_order = [c for c in expected_order if c in current_order] + [
-            c for c in current_order if c not in expected_order
+        overall_order = list(cls.COLUMN_DATA_TYPES)
+        desired_order = [c for c in overall_order if c in current_order] + [
+            c for c in current_order if c not in overall_order
         ]
-        if current_order != expected_order:
-            return df.reindex(columns=col_order, copy=False)
+        if current_order != desired_order:
+            return df.reindex(columns=desired_order, copy=False)
         return df
 
     @classmethod

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -205,6 +205,25 @@ class TestDataBase(TestCase):
         self.assertIn("foo", data.df.columns)
         self.assertTrue((data.full_df["foo"] == value).all())
 
+    def test_get_df_with_cols_in_expected_order(self) -> None:
+        with self.subTest("Wrong order"):
+            df = pd.DataFrame(columns=["mean", "trial_index", "hat"], data=[[0] * 3])
+            re_ordered = Data._get_df_with_cols_in_expected_order(df=df)
+            self.assertEqual(
+                re_ordered.columns.to_list(), ["trial_index", "mean", "hat"]
+            )
+            self.assertIsNot(df, re_ordered)
+
+        with self.subTest("Correct order"):
+            df = pd.DataFrame(
+                columns=["trial_index", "mean", "hat"], data=[[0 for _ in range(3)]]
+            )
+            re_ordered = Data._get_df_with_cols_in_expected_order(df=df)
+            self.assertEqual(
+                re_ordered.columns.to_list(), ["trial_index", "mean", "hat"]
+            )
+            self.assertIs(df, re_ordered)
+
 
 class DataTest(TestCase):
     """Tests that are specific to Data and not shared with MapData."""


### PR DESCRIPTION
Summary:
**Context**:
* `Data._get_df_with_cols_in_expected_order` changes the order of the columns in a DataFrame if they are not already in the correct order. A recent diff changed this check so that it checks against all supported columns ("start_time", etc.) rather than against the expected column order, with the result that columns are "reordered" even when they don't need to be. This can be slow.

**This PR**:
* Fixes the check
* Gives the variables more intuitive names
* Uses an OrderedDict so that the order is guaranteed to always be the same

Differential Revision: D83682740


