### PR TITLE
Combine init methods of Data/MapData

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -136,12 +136,12 @@ class Data(Base, SerializationMixin):
     def _get_df_with_cols_in_expected_order(cls, df: pd.DataFrame) -> pd.DataFrame:
         """Reorder the columns for easier viewing"""
         current_order = list(df.columns)  # Surprisingly slow, so do it once
-        expected_order = list(cls.COLUMN_DATA_TYPES)
-        col_order = [c for c in expected_order if c in current_order] + [
-            c for c in current_order if c not in expected_order
+        overall_order = list(cls.COLUMN_DATA_TYPES)
+        desired_order = [c for c in overall_order if c in current_order] + [
+            c for c in current_order if c not in overall_order
         ]
-        if current_order != expected_order:
-            return df.reindex(columns=col_order, copy=False)
+        if current_order != desired_order:
+            return df.reindex(columns=desired_order, copy=False)
         return df
 
     @classmethod

--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -107,35 +107,11 @@ class MapData(Data):
                 Intended only for use in `MapData.filter`, where the contents
                 of the DataFrame are known to be ordered and valid.
         """
-        if df is None:  # If df is None create an empty dataframe with appropriate cols
-            columns = list(self.required_columns())
-            self.full_df = pd.DataFrame.from_dict(
-                {
-                    col: pd.Series([], dtype=self.COLUMN_DATA_TYPES[col])
-                    for col in columns
-                }
-            )
-        elif _skip_ordering_and_validation:
-            self.full_df = df
-        else:
-            if MAP_KEY not in df.columns:
-                df[MAP_KEY] = nan
-            columns = set(df.columns)
-            missing_columns = self.required_columns() - columns
-            if missing_columns:
-                raise ValueError(
-                    f"Dataframe must contain required columns {missing_columns}."
-                )
-            if df["trial_index"].isnull().any():
-                df = df.dropna(axis=0, how="all", ignore_index=True)
-            else:
-                # Don't do this in place so that we now have a copy, so we won't
-                # mutate the original df
-                df = df.reset_index(drop=True)
-
-            self.full_df = self._safecast_df(df=df)
-            self.full_df = self._get_df_with_cols_in_expected_order(df=self.full_df)
-
+        if df is not None and MAP_KEY not in df.columns:
+            df[MAP_KEY] = nan
+        super().__init__(
+            df=df, _skip_ordering_and_validation=_skip_ordering_and_validation
+        )
         self._memo_df = None
 
     def __eq__(self, o: MapData) -> bool:

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -385,3 +385,24 @@ class DataTest(TestCase):
         filtered = data.filter(metric_names=["a"])
         self.assertEqual(len(filtered.df), 3)
         self.assertEqual(set(filtered.df["metric_name"]), {"a"})
+
+    def test_safecast_df(self) -> None:
+        # Create a df with unexpected index ([1])
+        df = pd.DataFrame.from_records(
+            [
+                {
+                    "index": 1,
+                    "arm_name": "0_0",
+                    "trial_index": 0.0,
+                    "metric_name": "m",
+                    "metric_signature": "m",
+                    "mean": 0.0,
+                    "sem": None,
+                }
+            ]
+        ).set_index("index")
+        self.assertEqual(df.index.get_level_values(0).tolist(), [1])
+
+        safecast_df = Data._safecast_df(df=df)
+        self.assertEqual(safecast_df.index.get_level_values(0).to_list(), [0])
+        self.assertEqual(df["trial_index"].dtype, int)

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -205,6 +205,25 @@ class TestDataBase(TestCase):
         self.assertIn("foo", data.df.columns)
         self.assertTrue((data.full_df["foo"] == value).all())
 
+    def test_get_df_with_cols_in_expected_order(self) -> None:
+        with self.subTest("Wrong order"):
+            df = pd.DataFrame(columns=["mean", "trial_index", "hat"], data=[[0] * 3])
+            re_ordered = Data._get_df_with_cols_in_expected_order(df=df)
+            self.assertEqual(
+                re_ordered.columns.to_list(), ["trial_index", "mean", "hat"]
+            )
+            self.assertIsNot(df, re_ordered)
+
+        with self.subTest("Correct order"):
+            df = pd.DataFrame(
+                columns=["trial_index", "mean", "hat"], data=[[0 for _ in range(3)]]
+            )
+            re_ordered = Data._get_df_with_cols_in_expected_order(df=df)
+            self.assertEqual(
+                re_ordered.columns.to_list(), ["trial_index", "mean", "hat"]
+            )
+            self.assertIs(df, re_ordered)
+
 
 class DataTest(TestCase):
     """Tests that are specific to Data and not shared with MapData."""


### PR DESCRIPTION
Summary: This change brings `Data` and `MapData` closer together. The only substantive change is that when `Data` is initialized with an empty DataFrame, the DataFrame will have the correct column t ypes.

Differential Revision: D82916192


