### PR TITLE
Remove equality method from MapData

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -19,6 +19,7 @@ import pandas as pd
 from ax.core.types import TTrialEvaluation
 from ax.exceptions.core import UserInputError
 from ax.utils.common.base import Base
+from ax.utils.common.equality import dataframe_equals
 from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import (
     extract_init_args,
@@ -406,6 +407,9 @@ class Data(Base, SerializationMixin):
     def clone(self) -> Data:
         """Returns a new Data object with the same underlying dataframe."""
         return Data(df=deepcopy(self.df))
+
+    def __eq__(self, o: Data) -> bool:
+        return type(self) is type(o) and dataframe_equals(self.full_df, o.full_df)
 
 
 def _ms_epoch_to_isoformat(epoch: int) -> str:

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -136,12 +136,12 @@ class Data(Base, SerializationMixin):
     def _get_df_with_cols_in_expected_order(cls, df: pd.DataFrame) -> pd.DataFrame:
         """Reorder the columns for easier viewing"""
         current_order = list(df.columns)  # Surprisingly slow, so do it once
-        expected_order = list(cls.COLUMN_DATA_TYPES)
-        col_order = [c for c in expected_order if c in current_order] + [
-            c for c in current_order if c not in expected_order
+        overall_order = list(cls.COLUMN_DATA_TYPES)
+        desired_order = [c for c in overall_order if c in current_order] + [
+            c for c in current_order if c not in overall_order
         ]
-        if current_order != expected_order:
-            return df.reindex(columns=col_order, copy=False)
+        if current_order != desired_order:
+            return df.reindex(columns=desired_order, copy=False)
         return df
 
     @classmethod

--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -107,35 +107,11 @@ class MapData(Data):
                 Intended only for use in `MapData.filter`, where the contents
                 of the DataFrame are known to be ordered and valid.
         """
-        if df is None:  # If df is None create an empty dataframe with appropriate cols
-            columns = list(self.required_columns())
-            self.full_df = pd.DataFrame.from_dict(
-                {
-                    col: pd.Series([], dtype=self.COLUMN_DATA_TYPES[col])
-                    for col in columns
-                }
-            )
-        elif _skip_ordering_and_validation:
-            self.full_df = df
-        else:
-            if MAP_KEY not in df.columns:
-                df[MAP_KEY] = nan
-            columns = set(df.columns)
-            missing_columns = self.required_columns() - columns
-            if missing_columns:
-                raise ValueError(
-                    f"Dataframe must contain required columns {missing_columns}."
-                )
-            if df["trial_index"].isnull().any():
-                df = df.dropna(axis=0, how="all", ignore_index=True)
-            else:
-                # Don't do this in place so that we now have a copy, so we won't
-                # mutate the original df
-                df = df.reset_index(drop=True)
-
-            self.full_df = self._safecast_df(df=df)
-            self.full_df = self._get_df_with_cols_in_expected_order(df=self.full_df)
-
+        if df is not None and MAP_KEY not in df.columns:
+            df[MAP_KEY] = nan
+        super().__init__(
+            df=df, _skip_ordering_and_validation=_skip_ordering_and_validation
+        )
         self._memo_df = None
 
     def __eq__(self, o: MapData) -> bool:

--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -23,7 +23,6 @@ from ax.core.data import _filter_df, Data, MAP_KEY
 from ax.core.types import TMapTrialEvaluation, TTrialEvaluation
 from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.utils.common.docutils import copy_doc
-from ax.utils.common.equality import dataframe_equals
 from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import (
     serialize_init_args,
@@ -113,9 +112,6 @@ class MapData(Data):
             df=df, _skip_ordering_and_validation=_skip_ordering_and_validation
         )
         self._memo_df = None
-
-    def __eq__(self, o: MapData) -> bool:
-        return dataframe_equals(self.map_df, o.map_df)
 
     # true_df is being deprecated after the release of Ax 1.1.2, so it will
     # surface in Ax 1.1.3 or 1.2.0, so it can be removed in the minor release

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -385,3 +385,24 @@ class DataTest(TestCase):
         filtered = data.filter(metric_names=["a"])
         self.assertEqual(len(filtered.df), 3)
         self.assertEqual(set(filtered.df["metric_name"]), {"a"})
+
+    def test_safecast_df(self) -> None:
+        # Create a df with unexpected index ([1])
+        df = pd.DataFrame.from_records(
+            [
+                {
+                    "index": 1,
+                    "arm_name": "0_0",
+                    "trial_index": 0.0,
+                    "metric_name": "m",
+                    "metric_signature": "m",
+                    "mean": 0.0,
+                    "sem": None,
+                }
+            ]
+        ).set_index("index")
+        self.assertEqual(df.index.get_level_values(0).tolist(), [1])
+
+        safecast_df = Data._safecast_df(df=df)
+        self.assertEqual(safecast_df.index.get_level_values(0).to_list(), [0])
+        self.assertEqual(df["trial_index"].dtype, int)

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -224,6 +224,12 @@ class TestDataBase(TestCase):
             )
             self.assertIs(df, re_ordered)
 
+    def test_equality(self) -> None:
+        self.assertEqual(self.data_with_df, self.data_with_df)
+        self.assertEqual(
+            self.data_with_df, type(self.data_with_df)(df=self.data_with_df.full_df)
+        )
+
 
 class DataTest(TestCase):
     """Tests that are specific to Data and not shared with MapData."""

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -205,6 +205,25 @@ class TestDataBase(TestCase):
         self.assertIn("foo", data.df.columns)
         self.assertTrue((data.full_df["foo"] == value).all())
 
+    def test_get_df_with_cols_in_expected_order(self) -> None:
+        with self.subTest("Wrong order"):
+            df = pd.DataFrame(columns=["mean", "trial_index", "hat"], data=[[0] * 3])
+            re_ordered = Data._get_df_with_cols_in_expected_order(df=df)
+            self.assertEqual(
+                re_ordered.columns.to_list(), ["trial_index", "mean", "hat"]
+            )
+            self.assertIsNot(df, re_ordered)
+
+        with self.subTest("Correct order"):
+            df = pd.DataFrame(
+                columns=["trial_index", "mean", "hat"], data=[[0 for _ in range(3)]]
+            )
+            re_ordered = Data._get_df_with_cols_in_expected_order(df=df)
+            self.assertEqual(
+                re_ordered.columns.to_list(), ["trial_index", "mean", "hat"]
+            )
+            self.assertIs(df, re_ordered)
+
 
 class DataTest(TestCase):
     """Tests that are specific to Data and not shared with MapData."""


### PR DESCRIPTION
Summary:
**Context**: `MapData` has two instance attributes, `full_df` and `_memo_df`, whereas `Data` has just `full_df`. `MapData.__eq__` checks only for equality of `full_df`, which is good, because `_memo_df` is derived from `full_df`; checking it would be redundant. This logic is also fine for `Data`.

**This PR**: To bring the classes closer together, moves the `__eq__` method from `MapData` to `Data`.

Differential Revision: D83689204


