### PR TITLE
Fix pyre errors in hierarchical parameter test cases

### DIFF
--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -403,9 +403,7 @@ class ChoiceParameterTest(TestCase):
                 name="x",
                 parameter_type=ParameterType.BOOL,
                 values=[True, False],
-                # pyre-fixme[6]: For 4th param expected `Optional[Dict[Union[None,
-                #  bool, float, int, str], List[str]]]` but got `Dict[str, str]`.
-                dependents={"not_a_value": "other_param"},
+                dependents={"not_a_value": ["other_param"]},
             )
         # Check that empty dependents doesn't flag as hierarchical.
         self.param4._dependents = {}
@@ -447,25 +445,22 @@ class ChoiceParameterTest(TestCase):
             name="x",
             parameter_type=ParameterType.BOOL,
             values=[True, False],
-            # pyre-fixme[6]: For 4th param expected `Optional[Dict[Union[None, bool,
-            #  float, int, str], List[str]]]` but got `Dict[bool, str]`.
-            dependents={True: "other_param"},
+            dependents={True: ["other_param"]},
         )
         self.assertTrue(hierarchical_param.is_hierarchical)
-        self.assertEqual(hierarchical_param.dependents, {True: "other_param"})
+        self.assertEqual(hierarchical_param.dependents, {True: ["other_param"]})
 
         # Test case where all of the values entail dependents.
         hierarchical_param_2 = ChoiceParameter(
             name="x",
             parameter_type=ParameterType.STRING,
             values=["a", "b"],
-            # pyre-fixme[6]: For 4th param expected `Optional[Dict[Union[None, bool,
-            #  float, int, str], List[str]]]` but got `Dict[str, str]`.
-            dependents={"a": "other_param", "b": "third_param"},
+            dependents={"a": ["other_param"], "b": ["third_param"]},
         )
         self.assertTrue(hierarchical_param_2.is_hierarchical)
         self.assertEqual(
-            hierarchical_param_2.dependents, {"a": "other_param", "b": "third_param"}
+            hierarchical_param_2.dependents,
+            {"a": ["other_param"], "b": ["third_param"]},
         )
 
         # Test case where nonexisted value entails dependents.
@@ -474,9 +469,7 @@ class ChoiceParameterTest(TestCase):
                 name="x",
                 parameter_type=ParameterType.STRING,
                 values=["a", "b"],
-                # pyre-fixme[6]: For 4th param expected `Optional[Dict[Union[None,
-                #  bool, float, int, str], List[str]]]` but got `Dict[str, str]`.
-                dependents={"c": "other_param"},
+                dependents={"c": ["other_param"]},
             )
 
     def test_available_flags(self) -> None:
@@ -675,12 +668,10 @@ class FixedParameterTest(TestCase):
             name="x",
             parameter_type=ParameterType.BOOL,
             value=True,
-            # pyre-fixme[6]: For 4th param expected `Optional[Dict[Union[None, bool,
-            #  float, int, str], List[str]]]` but got `Dict[bool, str]`.
-            dependents={True: "other_param"},
+            dependents={True: ["other_param"]},
         )
         self.assertTrue(hierarchical_param.is_hierarchical)
-        self.assertEqual(hierarchical_param.dependents, {True: "other_param"})
+        self.assertEqual(hierarchical_param.dependents, {True: ["other_param"]})
 
         # Test case where nonexistent value entails dependents.
         with self.assertRaises(UserInputError):
@@ -688,9 +679,7 @@ class FixedParameterTest(TestCase):
                 name="x",
                 parameter_type=ParameterType.BOOL,
                 value=True,
-                # pyre-fixme[6]: For 4th param expected `Optional[Dict[Union[None,
-                #  bool, float, int, str], List[str]]]` but got `Dict[bool, str]`.
-                dependents={False: "other_param"},
+                dependents={False: ["other_param"]},
             )
 
     def test_available_flags(self) -> None:


### PR DESCRIPTION
Summary: Some nit fixes in the test cases. The values of the dictionary `dependents` should always be lists.

Differential Revision: D83753058


