### PR TITLE
Remove `metadata` argument from internal functions in which user-facing functions never pass it

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -836,7 +836,6 @@ class BaseTrial(ABC, SortableBase):
     def _make_evaluations_and_data(
         self,
         raw_data: dict[str, TEvaluationOutcome],
-        metadata: dict[str, str | int] | None,
     ) -> tuple[dict[str, TEvaluationOutcome], Data]:
         """Formats given raw data as Ax evaluations and `Data`.
 
@@ -845,8 +844,6 @@ class BaseTrial(ABC, SortableBase):
                 metric outcomes.
             metadata: Additional metadata to track about this run.
         """
-
-        metadata = metadata if metadata is not None else {}
 
         metric_name_to_signature = {
             name: metric.signature for name, metric in self.experiment.metrics.items()
@@ -858,8 +855,6 @@ class BaseTrial(ABC, SortableBase):
                 metric_name_to_signature=metric_name_to_signature,
                 trial_index=self.index,
                 data_type=self.experiment.default_data_type,
-                start_time=metadata.get("start_time"),
-                end_time=metadata.get("end_time"),
             )
             return evaluations, data
         except UserInputError as e:

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -530,19 +530,11 @@ class BatchTrial(BaseTrial):
         self._update_trial_attrs_on_clone(new_trial=new_trial)
         return new_trial
 
-    def attach_batch_trial_data(
-        self,
-        raw_data: dict[str, TEvaluationOutcome],
-        metadata: dict[str, str | int] | None = None,
-    ) -> None:
-        """Attaches data to the trial
+    def attach_batch_trial_data(self, raw_data: dict[str, TEvaluationOutcome]) -> None:
+        """Attach data to the trial.
 
         Args:
             raw_data: Map from arm name to metric outcomes.
-            metadata: Additional metadata to track about this run.
-                importantly the start_date and end_date
-            complete_trial: Whether to mark trial as complete after
-                attaching data. Defaults to False.
         """
         # Validate type of raw_data
         if not isinstance(raw_data, dict):
@@ -564,12 +556,8 @@ class BatchTrial(BaseTrial):
                 f"Arms {not_trial_arm_names} are not part of trial #{self.index}."
             )
 
-        evaluations, data = self._make_evaluations_and_data(
-            raw_data=raw_data, metadata=metadata
-        )
+        evaluations, data = self._make_evaluations_and_data(raw_data=raw_data)
         self._validate_batch_trial_data(data=data)
-
-        self._run_metadata = self._run_metadata if metadata is None else metadata
         self.experiment.attach_data(data)
 
         data_for_logging = _round_floats_for_logging(item=evaluations)

--- a/ax/core/formatting_utils.py
+++ b/ax/core/formatting_utils.py
@@ -105,8 +105,6 @@ def data_and_evaluations_from_raw_data(
     metric_name_to_signature: Mapping[str, str],
     trial_index: int,
     data_type: DataType,
-    start_time: int | str | None = None,
-    end_time: int | str | None = None,
 ) -> tuple[dict[str, TEvaluationOutcome], Data]:
     """Transforms evaluations into Ax Data.
 
@@ -119,14 +117,8 @@ def data_and_evaluations_from_raw_data(
         metric_name_to_signature: Mapping of metric names to signatures used to
             transform raw data to evaluations.
         trial_index: Index of the trial, for which the evaluations are.
-        start_time: Optional start time of run of the trial that produced this
-            data, in milliseconds or iso format.  Milliseconds will eventually be
-            converted to iso format because iso format automatically works with the
-            pandas column type `Timestamp`.
-        end_time: Optional end time of run of the trial that produced this
-            data, in milliseconds or iso format.  Milliseconds will eventually be
-            converted to iso format because iso format automatically works with the
-            pandas column type `Timestamp`.
+        data_type: An element of the ``DataType`` enum.
+
     """
     evaluations = {
         arm_name: raw_data_to_evaluation(
@@ -151,8 +143,6 @@ def data_and_evaluations_from_raw_data(
             evaluations=cast(dict[str, TTrialEvaluation], evaluations),
             metric_name_to_signature=metric_name_to_signature,
             trial_index=trial_index,
-            start_time=start_time,
-            end_time=end_time,
         )
     elif all(isinstance(evaluations[x], list) for x in evaluations.keys()):
         if data_type is DataType.DATA:

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -13,7 +13,6 @@ from ax.core.data import Data
 from ax.core.map_data import MAP_KEY, MapData
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
-from ax.utils.common.timeutils import current_timestamp_in_millis
 from pyre_extensions import assert_is_instance
 
 REPR_500: str = (
@@ -255,41 +254,17 @@ class DataTest(TestCase):
         data = CustomData(df=self.df)
         self.assertNotEqual(data, Data(self.df))
 
-    def test_FromEvaluationsIsoFormat(self) -> None:
-        now = pd.Timestamp.now()
-        day = now.day
+    def test_FromEvaluations(self) -> None:
         for sem in (0.5, None):
             eval1 = (3.7, sem) if sem is not None else 3.7
             data = Data.from_evaluations(
                 evaluations={"0_1": {"b": eval1}},
                 metric_name_to_signature=self.metric_name_to_signature,
                 trial_index=0,
-                start_time=now.isoformat(),
-                end_time=now.isoformat(),
             )
             self.assertEqual(data.df["sem"].isnull()[0], sem is None)
             self.assertEqual(len(data.df), 1)
             self.assertNotEqual(data, Data(self.df))
-            self.assertEqual(data.df["start_time"][0].day, day)
-            self.assertEqual(data.df["end_time"][0].day, day)
-
-    def test_FromEvaluationsMillisecondFormat(self) -> None:
-        now_ms = current_timestamp_in_millis()
-        day = pd.Timestamp(now_ms, unit="ms").day
-        for sem in (0.5, None):
-            eval1 = (3.7, sem) if sem is not None else 3.7
-            data = Data.from_evaluations(
-                evaluations={"0_1": {"b": eval1}},
-                metric_name_to_signature=self.metric_name_to_signature,
-                trial_index=0,
-                start_time=now_ms,
-                end_time=now_ms,
-            )
-            self.assertEqual(data.df["sem"].isnull()[0], sem is None)
-            self.assertEqual(len(data.df), 1)
-            self.assertNotEqual(data, Data(self.df))
-            self.assertEqual(data.df["start_time"][0].day, day)
-            self.assertEqual(data.df["end_time"][0].day, day)
 
     def test_FromEvaluationsNameAndSignature(self) -> None:
         data = Data.from_evaluations(

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -270,10 +270,7 @@ class Trial(BaseTrial):
                 )
 
     def update_trial_data(
-        self,
-        raw_data: TEvaluationOutcome,
-        metadata: dict[str, str | int] | None = None,
-        combine_with_last_data: bool = False,
+        self, raw_data: TEvaluationOutcome, combine_with_last_data: bool = False
     ) -> str:
         """Utility method that attaches data to a trial and
         returns an update message.
@@ -285,7 +282,6 @@ class Trial(BaseTrial):
                 unknown (then Ax will infer observation noise level).
                 Can also be a list of (fidelities, mapping from
                 metric name to a tuple of mean and SEM).
-            metadata: Additional metadata to track about this run, optional.
             combine_with_last_data: Whether to combine the given data with the
                 data that was previously attached to the trial. See
                 `Experiment.attach_data` for a detailed explanation.
@@ -296,13 +292,9 @@ class Trial(BaseTrial):
         arm_name = none_throws(self.arm).name
         raw_data_by_arm = {arm_name: raw_data}
 
-        evaluations, data = self._make_evaluations_and_data(
-            raw_data=raw_data_by_arm, metadata=metadata
-        )
+        evaluations, data = self._make_evaluations_and_data(raw_data=raw_data_by_arm)
 
         self.validate_data_for_trial(data=data)
-        self.update_run_metadata(metadata=metadata or {})
-
         self.experiment.attach_data(
             data=data, combine_with_last_data=combine_with_last_data
         )


### PR DESCRIPTION
Summary:
**Context**:

With D83702552 and D83703363, `AxClient` no longer consumes trial `metadata`, so it also no longer passes it. This means there are various internal functions (that is, functions that were never intended to be user-facing) that now never receive metadata.

**This PR**:
* Removes the `metadata` argument from `BaseTrial._make_evaluations_and_data`, `BatchTrial.attach_batch_trial_data`, and `Trial.update_trial_data`
* Removes `start_time` and `end_time` from `Data.from_evaluations`; removes `Data._add_cols_to_records` since it would otherwise become the identity function
* Removes  `start_time` and `end_time` from `data_and_evaluations_from_raw_data`

Differential Revision: D83754568


