### PR TITLE
Fix OOD arms filtering

### DIFF
--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -381,7 +381,7 @@ class Adapter:
                 search_space=search_space, experiment_data=experiment_data
             )
         return self.get_training_data(
-            filter_in_design=self._data_loader_config.fit_out_of_design
+            filter_in_design=not self._data_loader_config.fit_out_of_design
         )
 
     def _compute_in_design(

--- a/ax/plot/tests/test_tile_fitted.py
+++ b/ax/plot/tests/test_tile_fitted.py
@@ -164,7 +164,7 @@ class TileObservationsTest(TestCase):
         exp.search_space = SearchSpace(
             parameters=list(exp.search_space.parameters.values())
         )
-        config = tile_observations(experiment=exp, arm_names=["0_0", "0_1"], rel=False)
+        config = tile_observations(experiment=exp, arm_names=["0_1", "0_2"], rel=False)
 
         for key in ["layout", "data"]:
             self.assertIn(key, config.data)
@@ -187,13 +187,13 @@ class TileObservationsTest(TestCase):
         )
 
         # Data
-        self.assertEqual(config.data["data"][0]["x"], ["0_0"])
-        self.assertEqual(config.data["data"][0]["y"], [3.0])
+        self.assertEqual(config.data["data"][0]["x"], ["0_2"])
+        self.assertEqual(config.data["data"][0]["y"], [2.25])
         self.assertEqual(config.data["data"][0]["type"], "scatter")
-        self.assertIn("Arm 0_0", config.data["data"][0]["text"][0])
+        self.assertIn("Arm 0_2", config.data["data"][0]["text"][0])
 
         label_dict = {"ax_test_metric": "mapped_name"}
         config = tile_observations(
-            experiment=exp, arm_names=["0_0"], rel=False, label_dict=label_dict
+            experiment=exp, arm_names=["0_1", "0_2"], rel=False, label_dict=label_dict
         )
         self.assertEqual(config.data["layout"]["annotations"][0]["text"], "mapped_name")


### PR DESCRIPTION
Summary:
In `Adapter.get_training_data`, `filter_in_design` should be the opposite of `fit_out_of_design` of `DataLoaderConfig`. If we don't want to fit out of design, we should filter for in design : )

f803680643 failed bc the ood custom arm ended up in training datasets due to filtering failure at Adapter.

Differential Revision: D83796117


