### PR TITLE
Don't return evaluations from `data_and_evaluations_from_raw_data`

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -18,7 +18,7 @@ import pandas as pd
 
 from ax.core.arm import Arm
 from ax.core.data import Data
-from ax.core.formatting_utils import data_and_evaluations_from_raw_data
+from ax.core.formatting_utils import raw_evaluations_to_data
 from ax.core.generator_run import GeneratorRun, GeneratorRunType
 from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
@@ -833,16 +833,12 @@ class BaseTrial(ABC, SortableBase):
     def _unique_id(self) -> str:
         return str(self.index)
 
-    def _make_evaluations_and_data(
-        self,
-        raw_data: dict[str, TEvaluationOutcome],
-    ) -> tuple[dict[str, TEvaluationOutcome], Data]:
-        """Formats given raw data as Ax evaluations and `Data`.
+    def _raw_evaluations_to_data(self, raw_data: dict[str, TEvaluationOutcome]) -> Data:
+        """Formats given raw data as Ax `Data`.
 
         Args:
             raw_data: Map from arm name to
                 metric outcomes.
-            metadata: Additional metadata to track about this run.
         """
 
         metric_name_to_signature = {
@@ -850,13 +846,12 @@ class BaseTrial(ABC, SortableBase):
         }
 
         try:
-            evaluations, data = data_and_evaluations_from_raw_data(
+            return raw_evaluations_to_data(
                 raw_data=raw_data,
                 metric_name_to_signature=metric_name_to_signature,
                 trial_index=self.index,
                 data_type=self.experiment.default_data_type,
             )
-            return evaluations, data
         except UserInputError as e:
             if "not found in metric_name_to_signature." in str(e):
                 raise UserInputError(

--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -836,7 +836,6 @@ class BaseTrial(ABC, SortableBase):
     def _make_evaluations_and_data(
         self,
         raw_data: dict[str, TEvaluationOutcome],
-        metadata: dict[str, str | int] | None,
     ) -> tuple[dict[str, TEvaluationOutcome], Data]:
         """Formats given raw data as Ax evaluations and `Data`.
 
@@ -845,8 +844,6 @@ class BaseTrial(ABC, SortableBase):
                 metric outcomes.
             metadata: Additional metadata to track about this run.
         """
-
-        metadata = metadata if metadata is not None else {}
 
         metric_name_to_signature = {
             name: metric.signature for name, metric in self.experiment.metrics.items()
@@ -858,8 +855,6 @@ class BaseTrial(ABC, SortableBase):
                 metric_name_to_signature=metric_name_to_signature,
                 trial_index=self.index,
                 data_type=self.experiment.default_data_type,
-                start_time=metadata.get("start_time"),
-                end_time=metadata.get("end_time"),
             )
             return evaluations, data
         except UserInputError as e:

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -30,7 +30,7 @@ from ax.exceptions.core import AxError, UnsupportedError, UserInputError
 from ax.utils.common.base import SortableBase
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.equality import datetime_equals, equality_typechecker
-from ax.utils.common.logger import _round_floats_for_logging, get_logger
+from ax.utils.common.logger import get_logger
 from pyre_extensions import assert_is_instance, none_throws
 
 logger: Logger = get_logger(__name__)
@@ -556,16 +556,9 @@ class BatchTrial(BaseTrial):
                 f"Arms {not_trial_arm_names} are not part of trial #{self.index}."
             )
 
-        evaluations, data = self._make_evaluations_and_data(raw_data=raw_data)
+        data = self._raw_evaluations_to_data(raw_data=raw_data)
         self._validate_batch_trial_data(data=data)
         self.experiment.attach_data(data)
-
-        data_for_logging = _round_floats_for_logging(item=evaluations)
-
-        logger.debug(
-            f"Updated trial {self.index} with data: "
-            f"{_round_floats_for_logging(item=data_for_logging)}."
-        )
 
     def __repr__(self) -> str:
         return (

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -530,19 +530,11 @@ class BatchTrial(BaseTrial):
         self._update_trial_attrs_on_clone(new_trial=new_trial)
         return new_trial
 
-    def attach_batch_trial_data(
-        self,
-        raw_data: dict[str, TEvaluationOutcome],
-        metadata: dict[str, str | int] | None = None,
-    ) -> None:
-        """Attaches data to the trial
+    def attach_batch_trial_data(self, raw_data: dict[str, TEvaluationOutcome]) -> None:
+        """Attach data to the trial.
 
         Args:
             raw_data: Map from arm name to metric outcomes.
-            metadata: Additional metadata to track about this run.
-                importantly the start_date and end_date
-            complete_trial: Whether to mark trial as complete after
-                attaching data. Defaults to False.
         """
         # Validate type of raw_data
         if not isinstance(raw_data, dict):
@@ -564,12 +556,8 @@ class BatchTrial(BaseTrial):
                 f"Arms {not_trial_arm_names} are not part of trial #{self.index}."
             )
 
-        evaluations, data = self._make_evaluations_and_data(
-            raw_data=raw_data, metadata=metadata
-        )
+        evaluations, data = self._make_evaluations_and_data(raw_data=raw_data)
         self._validate_batch_trial_data(data=data)
-
-        self._run_metadata = self._run_metadata if metadata is None else metadata
         self.experiment.attach_data(data)
 
         data_for_logging = _round_floats_for_logging(item=evaluations)

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -24,7 +24,6 @@ from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import (
     extract_init_args,
     SerializationMixin,
-    serialize_init_args,
     TClassDecoderRegistry,
     TDecoderRegistry,
 )
@@ -191,9 +190,7 @@ class Data(Base, SerializationMixin):
         Used for storage and to help construct new similar Data.
         """
         data = assert_is_instance(obj, cls)
-        return serialize_init_args(
-            obj=data, exclude_fields=["_skip_ordering_and_validation"]
-        )
+        return {"df": data.full_df}
 
     @classmethod
     def deserialize_init_args(
@@ -348,7 +345,7 @@ class Data(Base, SerializationMixin):
 
         return self.__class__(
             df=_filter_df(
-                df=self.df,
+                df=self.full_df,
                 trial_indices=trial_indices,
                 metric_names=metric_names,
                 metric_signatures=metric_signatures,
@@ -369,9 +366,9 @@ class Data(Base, SerializationMixin):
         """
         return cls.from_multiple(data=data)
 
-    def clone(self) -> Data:
+    def clone(self: TData) -> TData:
         """Returns a new Data object with the same underlying dataframe."""
-        return Data(df=deepcopy(self.df))
+        return self.__class__(df=deepcopy(self.full_df))
 
     def __eq__(self, o: Data) -> bool:
         return type(self) is type(o) and dataframe_equals(self.full_df, o.full_df)

--- a/ax/core/formatting_utils.py
+++ b/ax/core/formatting_utils.py
@@ -105,8 +105,6 @@ def data_and_evaluations_from_raw_data(
     metric_name_to_signature: Mapping[str, str],
     trial_index: int,
     data_type: DataType,
-    start_time: int | str | None = None,
-    end_time: int | str | None = None,
 ) -> tuple[dict[str, TEvaluationOutcome], Data]:
     """Transforms evaluations into Ax Data.
 
@@ -119,14 +117,8 @@ def data_and_evaluations_from_raw_data(
         metric_name_to_signature: Mapping of metric names to signatures used to
             transform raw data to evaluations.
         trial_index: Index of the trial, for which the evaluations are.
-        start_time: Optional start time of run of the trial that produced this
-            data, in milliseconds or iso format.  Milliseconds will eventually be
-            converted to iso format because iso format automatically works with the
-            pandas column type `Timestamp`.
-        end_time: Optional end time of run of the trial that produced this
-            data, in milliseconds or iso format.  Milliseconds will eventually be
-            converted to iso format because iso format automatically works with the
-            pandas column type `Timestamp`.
+        data_type: An element of the ``DataType`` enum.
+
     """
     evaluations = {
         arm_name: raw_data_to_evaluation(
@@ -151,8 +143,6 @@ def data_and_evaluations_from_raw_data(
             evaluations=cast(dict[str, TTrialEvaluation], evaluations),
             metric_name_to_signature=metric_name_to_signature,
             trial_index=trial_index,
-            start_time=start_time,
-            end_time=end_time,
         )
     elif all(isinstance(evaluations[x], list) for x in evaluations.keys()):
         if data_type is DataType.DATA:

--- a/ax/core/formatting_utils.py
+++ b/ax/core/formatting_utils.py
@@ -100,12 +100,12 @@ def raw_data_to_evaluation(
         )
 
 
-def data_and_evaluations_from_raw_data(
+def raw_evaluations_to_data(
     raw_data: Mapping[str, TEvaluationOutcome],
     metric_name_to_signature: Mapping[str, str],
     trial_index: int,
     data_type: DataType,
-) -> tuple[dict[str, TEvaluationOutcome], Data]:
+) -> Data:
     """Transforms evaluations into Ax Data.
 
     Each evaluation is either a trial evaluation: {metric_name -> (mean, SEM)}
@@ -118,7 +118,6 @@ def data_and_evaluations_from_raw_data(
             transform raw data to evaluations.
         trial_index: Index of the trial, for which the evaluations are.
         data_type: An element of the ``DataType`` enum.
-
     """
     evaluations = {
         arm_name: raw_data_to_evaluation(
@@ -163,4 +162,4 @@ def data_and_evaluations_from_raw_data(
             "Evaluations included a mixture of no-fidelity and with-fidelity "
             "evaluations, which is not currently supported."
         )
-    return evaluations, data
+    return data

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -13,7 +13,6 @@ from ax.core.data import Data
 from ax.core.map_data import MAP_KEY, MapData
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
-from ax.utils.common.timeutils import current_timestamp_in_millis
 from pyre_extensions import assert_is_instance
 
 REPR_500: str = (
@@ -255,41 +254,17 @@ class DataTest(TestCase):
         data = CustomData(df=self.df)
         self.assertNotEqual(data, Data(self.df))
 
-    def test_FromEvaluationsIsoFormat(self) -> None:
-        now = pd.Timestamp.now()
-        day = now.day
+    def test_FromEvaluations(self) -> None:
         for sem in (0.5, None):
             eval1 = (3.7, sem) if sem is not None else 3.7
             data = Data.from_evaluations(
                 evaluations={"0_1": {"b": eval1}},
                 metric_name_to_signature=self.metric_name_to_signature,
                 trial_index=0,
-                start_time=now.isoformat(),
-                end_time=now.isoformat(),
             )
             self.assertEqual(data.df["sem"].isnull()[0], sem is None)
             self.assertEqual(len(data.df), 1)
             self.assertNotEqual(data, Data(self.df))
-            self.assertEqual(data.df["start_time"][0].day, day)
-            self.assertEqual(data.df["end_time"][0].day, day)
-
-    def test_FromEvaluationsMillisecondFormat(self) -> None:
-        now_ms = current_timestamp_in_millis()
-        day = pd.Timestamp(now_ms, unit="ms").day
-        for sem in (0.5, None):
-            eval1 = (3.7, sem) if sem is not None else 3.7
-            data = Data.from_evaluations(
-                evaluations={"0_1": {"b": eval1}},
-                metric_name_to_signature=self.metric_name_to_signature,
-                trial_index=0,
-                start_time=now_ms,
-                end_time=now_ms,
-            )
-            self.assertEqual(data.df["sem"].isnull()[0], sem is None)
-            self.assertEqual(len(data.df), 1)
-            self.assertNotEqual(data, Data(self.df))
-            self.assertEqual(data.df["start_time"][0].day, day)
-            self.assertEqual(data.df["end_time"][0].day, day)
 
     def test_FromEvaluationsNameAndSignature(self) -> None:
         data = Data.from_evaluations(

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -366,7 +366,8 @@ class TrialTest(TestCase):
         self.assertEqual(len(data), 0)
 
         # Attach data
-        self.trial.update_trial_data(raw_data={"m1": 1.0, "m2": 2.0})
+        result = self.trial.update_trial_data(raw_data={"m1": 1.0, "m2": 2.0})
+        self.assertEqual(result, str({"m1": 1.0, "m2": 2.0}))
 
         # Confirm the expected state after attaching data
         data = (
@@ -399,7 +400,8 @@ class TrialTest(TestCase):
                 BraninMetric(name="m1", param_names=["x1", "x2"]),
             ]
         )
-        map_trial.update_trial_data(raw_data=[(0, {"m1": 1.0})])
+        result = map_trial.update_trial_data(raw_data=[(0, {"m1": 1.0})])
+        self.assertEqual(result, str({"m1": 1.0}))
 
         with self.assertRaisesRegex(
             UserInputError,

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -290,18 +290,15 @@ class Trial(BaseTrial):
             A string message summarizing the update.
         """
         arm_name = none_throws(self.arm).name
-        raw_data_by_arm = {arm_name: raw_data}
-
-        evaluations, data = self._make_evaluations_and_data(raw_data=raw_data_by_arm)
+        data = self._raw_evaluations_to_data(raw_data={arm_name: raw_data})
 
         self.validate_data_for_trial(data=data)
         self.experiment.attach_data(
             data=data, combine_with_last_data=combine_with_last_data
         )
 
-        return str(
-            round_floats_for_logging(item=evaluations[next(iter(evaluations.keys()))])
-        )
+        evaluations = dict(zip(data.df["metric_name"], data.df["mean"]))
+        return str(round_floats_for_logging(item=evaluations))
 
     def clone_to(
         self,

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -270,10 +270,7 @@ class Trial(BaseTrial):
                 )
 
     def update_trial_data(
-        self,
-        raw_data: TEvaluationOutcome,
-        metadata: dict[str, str | int] | None = None,
-        combine_with_last_data: bool = False,
+        self, raw_data: TEvaluationOutcome, combine_with_last_data: bool = False
     ) -> str:
         """Utility method that attaches data to a trial and
         returns an update message.
@@ -285,7 +282,6 @@ class Trial(BaseTrial):
                 unknown (then Ax will infer observation noise level).
                 Can also be a list of (fidelities, mapping from
                 metric name to a tuple of mean and SEM).
-            metadata: Additional metadata to track about this run, optional.
             combine_with_last_data: Whether to combine the given data with the
                 data that was previously attached to the trial. See
                 `Experiment.attach_data` for a detailed explanation.
@@ -296,13 +292,9 @@ class Trial(BaseTrial):
         arm_name = none_throws(self.arm).name
         raw_data_by_arm = {arm_name: raw_data}
 
-        evaluations, data = self._make_evaluations_and_data(
-            raw_data=raw_data_by_arm, metadata=metadata
-        )
+        evaluations, data = self._make_evaluations_and_data(raw_data=raw_data_by_arm)
 
         self.validate_data_for_trial(data=data)
-        self.update_run_metadata(metadata=metadata or {})
-
         self.experiment.attach_data(
             data=data, combine_with_last_data=combine_with_last_data
         )

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -22,7 +22,7 @@ from ax.adapter.prediction_utils import predict_by_features
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.experiment import DataType, Experiment
-from ax.core.formatting_utils import data_and_evaluations_from_raw_data
+from ax.core.formatting_utils import raw_evaluations_to_data
 from ax.core.generator_run import GeneratorRun
 from ax.core.map_data import MapData
 from ax.core.multi_type_experiment import MultiTypeExperiment
@@ -1668,7 +1668,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
             metric_name: metric.signature
             for metric_name, metric in self.experiment.metrics.items()
         }
-        _, data = data_and_evaluations_from_raw_data(
+        data = raw_evaluations_to_data(
             raw_data={"data": raw_data},
             trial_index=trial_index,
             data_type=self.experiment.default_data_type,

--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -20,7 +20,7 @@ from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import BatchTrial
 from ax.core.experiment import Experiment
-from ax.core.formatting_utils import data_and_evaluations_from_raw_data
+from ax.core.formatting_utils import raw_evaluations_to_data
 from ax.core.trial import Trial
 from ax.core.types import (
     TEvaluationFunction,
@@ -213,7 +213,7 @@ class OptimizationLoop:
             name: metric.signature for name, metric in self.experiment.metrics.items()
         }
 
-        _, data = data_and_evaluations_from_raw_data(
+        data = raw_evaluations_to_data(
             raw_data={
                 arm.name: self._call_evaluation_function(arm.parameters, weight)
                 for arm, weight in self._get_weights_by_arm(trial)


### PR DESCRIPTION
Summary:
`data_and_evaluations_from_raw_data` returns data in both `Data` and evaluations formats. The evaluations format is only used for logging, and only with non-batch trials.

This PR:
* Makes `data_and_evaluations_from_raw_data` return just data, not data and evaluations; renamed it to `raw_evaluations_to_data`
* Gets rid of the trial-completion logging for BatchTrials, which was just debug-level anyway (probably very verbose with all the arms)
* Keeps the logging for Trials -- this seems useful for telling how a notebook experiment is progressing

Differential Revision: D83786450


