### PR TITLE
Consolidate evaluations->Data functionality

### DIFF
--- a/ax/adapter/tests/test_utils.py
+++ b/ax/adapter/tests/test_utils.py
@@ -17,7 +17,7 @@ from ax.adapter.adapter_utils import (
 )
 from ax.adapter.registry import Generators
 from ax.core.arm import Arm
-from ax.core.data import Data
+from ax.core.formatting_utils import DataType, raw_evaluations_to_data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
@@ -255,10 +255,11 @@ class TestAdapterUtils(TestCase):
             [[TEST_PARAMETERIZATON_LIST], [TEST_PARAMETERIZATON_LIST]],
         )
         self.experiment.attach_data(
-            Data.from_evaluations(
+            raw_evaluations_to_data(
                 {self.trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
+                data_type=DataType.DATA,
             )
         )
         # With `fetch_data` on trial returning data for metric "m2", that metric
@@ -266,10 +267,11 @@ class TestAdapterUtils(TestCase):
         with patch.object(
             self.trial,
             "fetch_data",
-            return_value=Data.from_evaluations(
+            return_value=raw_evaluations_to_data(
                 {self.trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
+                data_type=DataType.DATA,
             ),
         ):
             pending = none_throws(get_pending_observation_features(self.experiment))

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -254,50 +254,6 @@ class DataTest(TestCase):
         data = CustomData(df=self.df)
         self.assertNotEqual(data, Data(self.df))
 
-    def test_FromEvaluations(self) -> None:
-        for sem in (0.5, None):
-            eval1 = (3.7, sem) if sem is not None else 3.7
-            data = Data.from_evaluations(
-                evaluations={"0_1": {"b": eval1}},
-                metric_name_to_signature=self.metric_name_to_signature,
-                trial_index=0,
-            )
-            self.assertEqual(data.df["sem"].isnull()[0], sem is None)
-            self.assertEqual(len(data.df), 1)
-            self.assertNotEqual(data, Data(self.df))
-
-    def test_FromEvaluationsNameAndSignature(self) -> None:
-        data = Data.from_evaluations(
-            evaluations={"0_1": {"a": (3.7, 0.5)}},
-            metric_name_to_signature=self.metric_name_to_signature,
-            trial_index=0,
-        )
-
-        self.assertEqual(data.df["metric_name"][0], "a")
-        self.assertEqual(data.df["metric_signature"][0], "a_signature")
-
-    def test_FromEvaluationsMissingMetricSigMappingEntry(self) -> None:
-        eval1 = (3.7, 0.5)
-        with self.assertRaisesRegex(
-            UserInputError, "Metric b not found in metric_name_to_signature"
-        ):
-            Data.from_evaluations(
-                evaluations={"0_1": {"b": eval1}},
-                metric_name_to_signature={"a": "a"},
-                trial_index=0,
-            )
-
-    def test_FromEvaluationsExtraMetricSigMappingEntry(self) -> None:
-        eval1 = (3.7, 0.5)
-        extra_metric_name_to_signature = self.metric_name_to_signature
-        extra_metric_name_to_signature["c"] = "c_signature"
-        data = Data.from_evaluations(
-            evaluations={"0_1": {"b": eval1}},
-            metric_name_to_signature=extra_metric_name_to_signature,
-            trial_index=0,
-        )
-        self.assertEqual(set(data.df["metric_signature"]), {"b_signature"})
-
     def test_from_multiple(self) -> None:
         with self.subTest("Combinining non-empty Data"):
             data = Data.from_multiple_data([Data(df=self.df), Data(df=self.df)])

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -18,6 +18,7 @@ from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.data import Data
 from ax.core.experiment import sort_by_trial_index_and_arm_name
+from ax.core.formatting_utils import DataType, raw_evaluations_to_data
 from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
@@ -1675,8 +1676,8 @@ class ExperimentWithMapDataTest(TestCase):
         )
         self.experiment.new_trial()
         self.experiment.trials[0].mark_running(no_runner_required=True)
-        first_epoch = MapData.from_map_evaluations(
-            evaluations={
+        first_epoch = raw_evaluations_to_data(
+            raw_data={
                 arm_name: partial_results[0:1]
                 for arm_name, partial_results in evaluations.items()
             },
@@ -1684,10 +1685,11 @@ class ExperimentWithMapDataTest(TestCase):
             metric_name_to_signature={
                 "no_fetch_impl_metric": "no_fetch_impl_metric_signature",
             },
+            data_type=DataType.MAP_DATA,
         )
         self.experiment.attach_data(first_epoch)
-        remaining_epochs = MapData.from_map_evaluations(
-            evaluations={
+        remaining_epochs = raw_evaluations_to_data(
+            raw_data={
                 arm_name: partial_results[1:4]
                 for arm_name, partial_results in evaluations.items()
             },
@@ -1695,6 +1697,7 @@ class ExperimentWithMapDataTest(TestCase):
             metric_name_to_signature={
                 "no_fetch_impl_metric": "no_fetch_impl_metric_signature",
             },
+            data_type=DataType.MAP_DATA,
         )
         self.experiment.attach_data(remaining_epochs)
         self.experiment.trials[0].mark_completed()

--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -10,7 +10,6 @@ import numpy as np
 import pandas as pd
 from ax.core.map_data import MAP_KEY, MapData
 from ax.core.tests.test_data import TestDataBase
-from ax.exceptions.core import UnsupportedError
 from ax.utils.common.testutils import TestCase
 
 
@@ -107,14 +106,6 @@ class MapDataTest(TestCase):
         )
         self.assertEqual(set(empty.map_df.columns), empty.required_columns())
 
-    def test_from_evaluations(self) -> None:
-        with self.assertRaisesRegex(
-            UnsupportedError, "MapData.from_evaluations is not supported"
-        ):
-            MapData.from_evaluations(
-                evaluations={}, metric_name_to_signature={}, trial_index=0
-            )
-
     def test_combine(self) -> None:
         with self.subTest("From no MapDatas"):
             data = MapData.from_multiple_map_data([])
@@ -123,19 +114,6 @@ class MapDataTest(TestCase):
         with self.subTest("From two MapDatas"):
             mmd_double = MapData.from_multiple_map_data([self.mmd, self.mmd])
             self.assertEqual(mmd_double.map_df.size, 2 * self.mmd.map_df.size)
-
-    def test_from_map_evaluations(self) -> None:
-        metric_name_to_signature = {"b": "b_signature"}
-        for sem in (0.5, None):
-            eval1 = (3.7, sem) if sem is not None else 3.7
-            eval2 = (3.8, sem) if sem is not None else 3.8
-            map_data = MapData.from_map_evaluations(
-                evaluations={"0_1": [(1.0, {"b": eval1}), (1.0, {"b": eval2})]},
-                trial_index=0,
-                metric_name_to_signature=metric_name_to_signature,
-            )
-            self.assertEqual(map_data.map_df["sem"].isnull().all(), sem is None)
-            self.assertEqual(len(map_data.map_df), 2)
 
     def test_upcast(self) -> None:
         fresh = MapData(df=self.df)

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -14,6 +14,7 @@ import pandas as pd
 from ax.core.arm import Arm
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
+from ax.core.formatting_utils import DataType, raw_evaluations_to_data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.objective import Objective
@@ -235,10 +236,11 @@ class UtilsTest(TestCase):
         with patch.object(
             self.trial,
             "lookup_data",
-            return_value=Data.from_evaluations(
+            return_value=raw_evaluations_to_data(
                 {self.trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
+                data_type=DataType.DATA,
             ),
         ):
             self.assertEqual(
@@ -263,7 +265,7 @@ class UtilsTest(TestCase):
             self.batch_trial,
             "fetch_data",
             return_value=Metric._wrap_trial_data_multi(
-                data=Data.from_evaluations(
+                data=raw_evaluations_to_data(
                     {
                         self.batch_trial.arms[0].name: {
                             "m1": (1, 0),
@@ -277,6 +279,7 @@ class UtilsTest(TestCase):
                         "m2": "m2",
                         "tracking": "tracking",
                     },
+                    data_type=DataType.DATA,
                 ),
             ),
         ):
@@ -293,7 +296,7 @@ class UtilsTest(TestCase):
             self.trial,
             "fetch_data",
             return_value=Metric._wrap_trial_data_multi(
-                data=Data.from_evaluations(
+                data=raw_evaluations_to_data(
                     {
                         self.trial.arm.name: {
                             "m1": (1, 0),
@@ -307,6 +310,7 @@ class UtilsTest(TestCase):
                         "m2": "m2",
                         "tracking": "tracking",
                     },
+                    data_type=DataType.DATA,
                 ),
             ),
         ):
@@ -395,10 +399,11 @@ class UtilsTest(TestCase):
         with patch.object(
             self.trial,
             "lookup_data",
-            return_value=Data.from_evaluations(
+            return_value=raw_evaluations_to_data(
                 {self.trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
+                data_type=DataType.DATA,
             ),
         ):
             self.assertEqual(
@@ -414,19 +419,21 @@ class UtilsTest(TestCase):
         with patch.object(
             self.trial,
             "lookup_data",
-            return_value=Data.from_evaluations(
+            return_value=raw_evaluations_to_data(
                 {self.trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
+                data_type=DataType.DATA,
             ),
         ):
             with patch.object(
                 other_trial,
                 "lookup_data",
-                return_value=Data.from_evaluations(
+                return_value=raw_evaluations_to_data(
                     {other_trial.arm.name: {"m2": (1, 0), "tracking": (1, 0)}},
                     trial_index=other_trial.index,
                     metric_name_to_signature={"m2": "m2", "tracking": "tracking"},
+                    data_type=DataType.DATA,
                 ),
             ):
                 pending = get_pending_observation_features(self.experiment)
@@ -497,10 +504,11 @@ class UtilsTest(TestCase):
         with patch.object(
             self.hss_trial,
             "lookup_data",
-            return_value=Data.from_evaluations(
+            return_value=raw_evaluations_to_data(
                 {self.hss_trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.hss_trial.index,
                 metric_name_to_signature={"m2": "m2"},
+                data_type=DataType.DATA,
             ),
         ):
             self.assertEqual(
@@ -523,7 +531,7 @@ class UtilsTest(TestCase):
             hss_batch_trial,
             "fetch_data",
             return_value=Metric._wrap_trial_data_multi(
-                data=Data.from_evaluations(
+                data=raw_evaluations_to_data(
                     {
                         hss_batch_trial.arms[0].name: {
                             "m1": (1, 0),
@@ -532,6 +540,7 @@ class UtilsTest(TestCase):
                     },
                     trial_index=hss_batch_trial.index,
                     metric_name_to_signature={"m1": "m1", "m2": "m2"},
+                    data_type=DataType.DATA,
                 ),
             ),
         ):
@@ -555,7 +564,7 @@ class UtilsTest(TestCase):
             hss_batch_trial,
             "fetch_data",
             return_value=Metric._wrap_trial_data_multi(
-                data=Data.from_evaluations(
+                data=raw_evaluations_to_data(
                     {
                         hss_batch_trial.arms[0].name: {
                             "m1": (1, 0),
@@ -564,6 +573,7 @@ class UtilsTest(TestCase):
                     },
                     trial_index=hss_batch_trial.index,
                     metric_name_to_signature={"m1": "m1", "m2": "m2"},
+                    data_type=DataType.DATA,
                 ),
             ),
         ):

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -33,7 +33,6 @@ TModelPredictArm = tuple[dict[str, float], Optional[dict[str, dict[str, float]]]
 # pyre-fixme[24]: Generic type `np.floating` expects 1 type parameter.
 # pyre-fixme[24]: Generic type `np.integer` expects 1 type parameter.
 FloatLike = Union[int, float, np.floating, np.integer]
-SingleMetricDataTuple = tuple[FloatLike, Optional[FloatLike]]
 SingleMetricData = Union[FloatLike, tuple[FloatLike, Optional[FloatLike]]]
 # 1-arm `Trial` evaluation data: {metric_name -> (mean, standard error)}}.
 TTrialEvaluation = Mapping[str, SingleMetricData]

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -29,7 +29,8 @@ from ax.core.auxiliary import AuxiliaryExperiment
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.batch_trial import AbandonedArm, BatchTrial
 from ax.core.data import Data
-from ax.core.experiment import DataType, Experiment
+from ax.core.experiment import Experiment
+from ax.core.formatting_utils import DataType, raw_evaluations_to_data
 from ax.core.generator_run import GeneratorRun
 from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
@@ -2760,10 +2761,17 @@ def get_map_data(trial_index: int = 0) -> MapData:
             (4, {"ax_test_metric": (1.0, 0.5)}),
         ],
     }
-    return MapData.from_map_evaluations(
-        evaluations=evaluations,
-        trial_index=trial_index,
-        metric_name_to_signature={"ax_test_metric": "ax_test_metric", "epoch": "epoch"},
+    return assert_is_instance(
+        raw_evaluations_to_data(
+            raw_data=evaluations,
+            trial_index=trial_index,
+            metric_name_to_signature={
+                "ax_test_metric": "ax_test_metric",
+                "epoch": "epoch",
+            },
+            data_type=DataType.MAP_DATA,
+        ),
+        MapData,
     )
 
 


### PR DESCRIPTION
Summary:
**Context**:

Currently, moving data from a "raw evaluations" format to `Data` or `MapData` involves four functions (which themselves call some other functions): `raw_evaluations_to_data`, `raw_data_to_evaluation`, and either `Data.from_evaluations` or `MapData.from_map_evaluations`. These functions are only ever used together.

**This PR**:

* Consolidates those functions into one, rewriting from scratch.
* Does less explicit validation of types -- now some format errors will result in a KeyError rather than a long message. I think this is OK because this is pretty deep in the stack and data should have already been validated before it gets here.

Reviewed By: Balandat

Differential Revision: D83847109


