### PR TITLE
Remove `Data.from_multiple` in favor of `Data.from_multiple_data`

### DIFF
--- a/ax/api/utils/instantiation/from_struct.py
+++ b/ax/api/utils/instantiation/from_struct.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-strict
+
 from ax.api.utils.instantiation.from_config import parameter_from_config
 from ax.api.utils.instantiation.from_string import parse_parameter_constraint
 from ax.api.utils.structs import ExperimentStruct

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -263,10 +263,15 @@ class DataTest(TestCase):
             data = Data.from_multiple_data([Data(), Data()])
             self.assertEqual(data, Data())
 
-        with self.subTest("Can't combine different types"):
+        with self.subTest("Can't use different types"):
 
             class CustomData(Data):
                 pass
+
+            with self.assertRaisesRegex(
+                TypeError, "All data objects must be instances of"
+            ):
+                Data.from_multiple_data([CustomData(), CustomData()])
 
             with self.assertRaisesRegex(
                 TypeError, "All data objects must be instances of"


### PR DESCRIPTION
Summary:
**Context**:

TLDR: `Data.from_multiple` does the same thing as `Data.from_multiple_data` when the arguments are `Data`; it doesn't work when the arguments are `MapData` (nor does the implicitly defined `MapData.from_multiple_data`)

The following very similar methods exist:
* `Data.from_multiple`: A static method that checks that all inputs are of the same class, then returns a new object of that class. However, this will not really work if the inputs are `MapData` since it uses the `df` attribute of each of the input data rather than `full_df`.
* `MapData.from_multiple`: `from_multiple` is not overridden on `MapData`, so it still exists, even though it doesn't work when the arguments are `MapData`s
* `Data.from_multiple_data`: A more widely used method. In `Data`, the base class, it just calls `Data.from_multiple`

And these that are not relevant for this diff:
* `MapData.from_multiple_data`: Converts any data arguments into `MapData` if they are not already and then calls `MapData.from_multiple_map_data`
* `MapData.from_multiple_map_data`: Combines `MapData`s

**This PR**:

* Removes `Data.from_multiple` in favor of `Data.from_multiple_data`.
* Changes `Data.from_multiple_data` so that non-`Data` inputs will error.

The result is that
* `Data.from_multiple_data` will have the same effect as the old `Data.from_multiple_data/Data.from_multiple` when the inputs are `Data`s
* `Data.from_multiple_data` will now produce an informative error rather than silently producing an invalid input when the arguments are `MapData`s
* `Data.from_multiple` and the implicitly defined `MapData.from_multiple` no longer exist

Differential Revision: D84061857
