### PR TITLE
Restrict BoTorch version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "botorch[pymoo]>=0.15.1",
+    "botorch[pymoo]>=0.15.1,<0.15.2dev9999",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
We've noticed that a version requirement like `botorch[pymoo]>=0.15.1` might cause issues if we release BoTorch versions before new Ax versions. This diff updates the requirement to allow the development versions but not the full release of the next BoTorch version.

The catch is that once the BoTorch version is released, the Ax GHA workflows will not use it until the pin is updated (which we tend to do right after the release). I think this is a fair compromise.