### PR TITLE
(1/3) Move relativize function out of statstools to avoid circular dependency in imports

### DIFF
--- a/ax/adapter/transforms/relativize.py
+++ b/ax/adapter/transforms/relativize.py
@@ -27,7 +27,8 @@ from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import DataRequiredError
 from ax.generators.types import TConfig
-from ax.utils.stats.statstools import relativize, unrelativize
+from ax.utils.stats.math_utils import relativize
+from ax.utils.stats.statstools import unrelativize
 from pyre_extensions import none_throws
 
 if TYPE_CHECKING:

--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -22,7 +22,7 @@ from ax.core.observation_utils import observations_from_data
 from ax.exceptions.core import DataRequiredError
 from ax.generators.base import Generator
 from ax.utils.common.testutils import TestCase
-from ax.utils.stats.statstools import relativize
+from ax.utils.stats.math_utils import relativize
 from ax.utils.testing.core_stubs import (
     get_branin_data_batch,
     get_branin_experiment,

--- a/ax/adapter/transforms/transform_to_new_sq.py
+++ b/ax/adapter/transforms/transform_to_new_sq.py
@@ -23,7 +23,8 @@ from ax.core.search_space import SearchSpace
 from ax.core.utils import get_target_trial_index
 from ax.generators.types import TConfig
 from ax.utils.common.logger import get_logger
-from ax.utils.stats.statstools import relativize, unrelativize
+from ax.utils.stats.math_utils import relativize
+from ax.utils.stats.statstools import unrelativize
 from pyre_extensions import assert_is_instance, none_throws
 
 if TYPE_CHECKING:

--- a/ax/analysis/utils.py
+++ b/ax/analysis/utils.py
@@ -27,7 +27,7 @@ from ax.exceptions.core import AxError, UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger
-from ax.utils.stats.statstools import relativize
+from ax.utils.stats.math_utils import relativize
 from botorch.utils.probability.utils import compute_log_prob_feas_from_bounds
 from pyre_extensions import none_throws
 

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -41,7 +41,7 @@ from ax.core.types import TParameterization
 from ax.exceptions.core import AxError, UnsupportedError, UserInputError
 from ax.generators.torch_base import TorchGenerator
 from ax.utils.common.logger import get_logger
-from ax.utils.stats.statstools import relativize
+from ax.utils.stats.math_utils import relativize
 from botorch.acquisition.monte_carlo import qSimpleRegret
 from botorch.utils.multi_objective import is_non_dominated
 from botorch.utils.multi_objective.hypervolume import infer_reference_point

--- a/ax/plot/scatter.py
+++ b/ax/plot/scatter.py
@@ -45,7 +45,7 @@ from ax.plot.helper import (
 )
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import assert_is_instance_optional
-from ax.utils.stats.statstools import relativize
+from ax.utils.stats.math_utils import relativize
 from plotly import subplots
 
 logger: Logger = get_logger(__name__)

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -38,7 +38,7 @@ from ax.plot.pareto_utils import (
 )
 
 from ax.utils.common.testutils import TestCase
-from ax.utils.stats.statstools import relativize
+from ax.utils.stats.math_utils import relativize
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_branin_experiment_with_multi_objective,

--- a/ax/utils/stats/math_utils.py
+++ b/ax/utils/stats/math_utils.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import numpy as np
+import numpy.typing as npt
+
+
+def relativize(
+    means_t: npt.NDArray | list[float] | float,
+    sems_t: npt.NDArray | list[float] | float,
+    mean_c: npt.NDArray | float,
+    sem_c: npt.NDArray | float,
+    bias_correction: bool = True,
+    cov_means: npt.NDArray | list[float] | float = 0.0,
+    as_percent: bool = False,
+    control_as_constant: bool = False,
+) -> tuple[npt.NDArray, npt.NDArray]:
+    """Ratio estimator based on the delta method.
+
+    This uses the delta method (i.e. a Taylor series approximation) to estimate
+    the mean and standard deviation of the sampling distribution of the ratio
+    between test and control -- that is, the sampling distribution of an
+    estimator of the true population value under the assumption that the means
+    in test and control have a known covariance:
+
+        (mu_t / mu_c) - 1.
+
+    Under a second-order Taylor expansion, the sampling distribution of the
+    relative change in empirical means, which is `m_t / m_c - 1`, is
+    approximately normally distributed with mean
+
+        [(mu_t - mu_c) / mu_c] - [(sigma_c)^2 * mu_t] / (mu_c)^3
+
+    and variance
+
+        (sigma_t / mu_c)^2
+        - 2 * mu_t _ sigma_tc / mu_c^3
+        + [(sigma_c * mu_t)^2 / (mu_c)^4]
+
+    as the higher terms are assumed to be close to zero in the full Taylor
+    series. To estimate these parameters, we plug in the empirical means and
+    standard errors. This gives us the estimators:
+
+        [(m_t - m_c) / m_c] - [(s_c)^2 * m_t] / (m_c)^3
+
+    and
+
+        (s_t / m_c)^2 - 2 * m_t * s_tc / m_c^3 + [(s_c * m_t)^2 / (m_c)^4]
+
+    Note that the delta method does NOT take as input the empirical standard
+    deviation of a metric, but rather the standard error of the mean of that
+    metric -- that is, the standard deviation of the metric after division by
+    the square root of the total number of observations.
+
+    Args:
+        means_t: Sample means (test)
+        sems_t: Sample standard errors of the means (test)
+        mean_c: Sample mean (control). Can be a scalar representing a single control
+            group, or an array of control means (one per test mean) for cases where
+            different test observations have different control values (e.g., multi-trial
+            experiments with per-trial status quos).
+        sem_c: Sample standard error of the mean (control). Can be a scalar or an array
+            matching the shape of mean_c.
+        bias_correction: Whether to apply bias correction when computing relativized
+            metric values. Uses a second-order Taylor expansion for approximating
+            the means and standard errors of the ratios.
+        cov_means: Sample covariance between test and control
+        as_percent: If true, return results in percent (* 100)
+        control_as_constant: If true, control is treated as a constant.
+            bias_correction, sem_c, and cov_means are ignored when this is true.
+
+
+    Returns:
+        rel_hat: Inferred means of the sampling distribution of
+            the relative change `(mean_t - mean_c) / abs(mean_c)`
+        sem_hat: Inferred standard deviation of the sampling
+            distribution of rel_hat -- i.e. the standard error.
+
+    """
+    # if mean_c is too small, bail
+    epsilon = 1e-10
+    if np.any(np.abs(mean_c) < epsilon):
+        raise ValueError(
+            "mean_control ({} +/- {}) is smaller than 1 in 10 billion, "
+            "which is too small to reliably analyze ratios using the delta "
+            "method. This usually occurs because winsorization has truncated "
+            "all values down to zero. Try using a delta type that applies "
+            "no winsorization.".format(mean_c, sem_c)
+        )
+    m_t = np.array(means_t)
+    s_t = np.array(sems_t)
+    cov_t = np.array(cov_means)
+    abs_mean_c = np.abs(mean_c)
+    r_hat = (m_t - mean_c) / abs_mean_c
+
+    if control_as_constant:
+        var = (s_t / abs_mean_c) ** 2
+    else:
+        c = m_t / mean_c
+        if bias_correction and not np.all(np.isnan(sem_c)):
+            r_hat = r_hat - m_t * sem_c**2 / abs_mean_c**3
+
+        # If everything's the same, then set r_hat to zero
+        same = (m_t == mean_c) & (s_t == sem_c)
+        r_hat = ~same * r_hat
+        var = ((s_t**2) - 2 * c * cov_t + (c**2) * (sem_c**2)) / (mean_c**2)
+    if as_percent:
+        return (r_hat * 100, np.sqrt(var) * 100)
+    else:
+        return (r_hat, np.sqrt(var))

--- a/ax/utils/stats/no_effects.py
+++ b/ax/utils/stats/no_effects.py
@@ -12,7 +12,7 @@ import pandas as pd
 import scipy
 
 from ax.core.data import Data
-from ax.utils.stats.statstools import relativize
+from ax.utils.stats.math_utils import relativize
 from scipy.stats import norm
 
 

--- a/ax/utils/stats/tests/test_math_utils.py
+++ b/ax/utils/stats/tests/test_math_utils.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from itertools import product
+
+import numpy as np
+from ax.utils.common.testutils import TestCase
+from ax.utils.stats.math_utils import relativize
+
+
+class RelativizeTest(TestCase):
+    def setUp(self) -> None:
+        """Set up common test data."""
+        self.means_t = np.array([3.0, 4.0, 5.0])
+        self.sems_t = np.array([0.3, 0.4, 0.5])
+        self.mean_c = 2.0
+        self.sem_c = 0.2
+
+    def test_relativize_bias_correction(self) -> None:
+        """Test relativize with bias correction."""
+        rel_means_bc, _ = relativize(
+            means_t=self.means_t,
+            sems_t=self.sems_t,
+            mean_c=self.mean_c,
+            sem_c=self.sem_c,
+            bias_correction=True,
+        )
+
+        rel_means_no_bc, _ = relativize(
+            means_t=self.means_t,
+            sems_t=self.sems_t,
+            mean_c=self.mean_c,
+            sem_c=self.sem_c,
+            bias_correction=False,
+        )
+
+        # The relativize function computes the relative change:
+        # (m_t - mean_c) / mean_c
+        # When bias_correction=True, it subtracts a correction term:
+        #
+        # Without correction: rel_change = (m_t - mean_c) / mean_c
+        # With correction:    rel_change = (m_t - mean_c) / mean_c
+        #                                  - (m_t * sem_c^2 / mean_c^3)
+        #
+        # In this test, means_t=[3.0, 4.0, 5.0] are all positive and
+        # > mean_c=2.0, so the correction term (m_t * sem_c^2 / mean_c^3)
+        # is positive. Subtracting a positive value makes the relative
+        # change smaller.
+        # Result: |bias_corrected| < |non_bias_corrected|
+        self.assertTrue(np.all(np.abs(rel_means_bc) < np.abs(rel_means_no_bc)))
+
+    def test_relativize_bias_correction_special_cases(self) -> None:
+        """Test special cases where bias correction has no effect or specific
+        behavior."""
+
+        # Case 1: sem_c = 0 (no control uncertainty)
+        with self.subTest(case="sem_c_zero"):
+            rel_mean_bc, _ = relativize(
+                means_t=self.means_t,
+                sems_t=self.sems_t,
+                mean_c=self.mean_c,
+                sem_c=0.0,
+                bias_correction=True,
+            )
+            rel_mean_no_bc, _ = relativize(
+                means_t=self.means_t,
+                sems_t=self.sems_t,
+                mean_c=self.mean_c,
+                sem_c=0.0,
+                bias_correction=False,
+            )
+            # When sem_c = 0, correction term = m_t * 0^2 / mean_c^3 = 0
+            # So bias correction makes no difference
+            self.assertAllClose(rel_mean_bc, rel_mean_no_bc)
+
+        # Case 2: m_t = 0 (test mean is zero)
+        with self.subTest(case="m_t_zero"):
+            rel_mean_bc, _ = relativize(
+                means_t=0.0,
+                sems_t=0.1,
+                mean_c=self.mean_c,
+                sem_c=self.sem_c,
+                bias_correction=True,
+            )
+            rel_mean_no_bc, _ = relativize(
+                means_t=0.0,
+                sems_t=0.1,
+                mean_c=self.mean_c,
+                sem_c=self.sem_c,
+                bias_correction=False,
+            )
+            # When m_t = 0, correction term = 0 * sem_c^2 / mean_c^3 = 0
+            # So bias correction makes no difference
+            self.assertAllClose(rel_mean_bc, rel_mean_no_bc)
+
+        # Case 3: control_as_constant = True
+        with self.subTest(case="control_as_constant"):
+            rel_mean_constant_bc, _ = relativize(
+                means_t=self.means_t,
+                sems_t=self.sems_t,
+                mean_c=self.mean_c,
+                sem_c=self.sem_c,
+                control_as_constant=True,
+                bias_correction=True,
+            )
+            rel_mean_constant_no_bc, _ = relativize(
+                means_t=self.means_t,
+                sems_t=self.sems_t,
+                mean_c=self.mean_c,
+                sem_c=self.sem_c,
+                control_as_constant=True,
+                bias_correction=False,
+            )
+            # When control_as_constant=True, bias_correction parameter is ignored
+            # Both calls should produce the same result
+            self.assertAllClose(rel_mean_constant_bc, rel_mean_constant_no_bc)
+
+            # Verify the result matches the expected formula (m_t - mean_c) / mean_c
+            expected = (self.means_t - self.mean_c) / self.mean_c
+            self.assertAllClose(rel_mean_constant_bc, expected)
+
+        # Case 4: sem_c is NaN
+        with self.subTest(case="sem_c_nan"):
+            rel_mean_bc, _ = relativize(
+                means_t=self.means_t,
+                sems_t=self.sems_t,
+                mean_c=self.mean_c,
+                sem_c=np.nan,
+                bias_correction=True,
+            )
+            rel_mean_no_bc, _ = relativize(
+                means_t=self.means_t,
+                sems_t=self.sems_t,
+                mean_c=self.mean_c,
+                sem_c=np.nan,
+                bias_correction=False,
+            )
+            # When sem_c is NaN, bias correction is skipped (line 105 check)
+            self.assertAllClose(rel_mean_bc, rel_mean_no_bc)
+
+        # Case 5: test mean equals control mean (both values and SEMs equal)
+        with self.subTest(case="equal_means_and_sems"):
+            rel_mean_bc, _ = relativize(
+                means_t=self.mean_c,
+                sems_t=self.sem_c,
+                mean_c=self.mean_c,
+                sem_c=self.sem_c,
+                bias_correction=True,
+            )
+            rel_mean_no_bc, _ = relativize(
+                means_t=self.mean_c,
+                sems_t=self.sem_c,
+                mean_c=self.mean_c,
+                sem_c=self.sem_c,
+                bias_correction=False,
+            )
+            # When m_t == mean_c and s_t == sem_c, r_hat is set to 0 (lines 109-110)
+            self.assertAllClose(rel_mean_bc, 0.0)
+            self.assertAllClose(rel_mean_no_bc, 0.0)
+
+    def test_relativize_control_as_constant(self) -> None:
+        """Test relativize with control as constant."""
+        _, rel_sems = relativize(
+            means_t=self.means_t,
+            sems_t=self.sems_t,
+            mean_c=self.mean_c,
+            sem_c=self.sem_c,
+            control_as_constant=True,
+        )
+
+        # With control as constant, variance calculation is simplified
+        expected_rel_sems = self.sems_t / np.abs(self.mean_c)
+        self.assertAllClose(rel_sems, expected_rel_sems)
+
+    def test_relativize_with_covariance(self) -> None:
+        """Test relativize with non-zero covariance."""
+        _, rel_sems_cov = relativize(
+            means_t=self.means_t[:1],
+            sems_t=self.sems_t[:1],
+            mean_c=self.mean_c,
+            sem_c=self.sem_c,
+            cov_means=0.1,
+            control_as_constant=False,
+        )
+
+        _, rel_sems_no_cov = relativize(
+            means_t=self.means_t[:1],
+            sems_t=self.sems_t[:1],
+            mean_c=self.mean_c,
+            sem_c=self.sem_c,
+            cov_means=0.0,
+            control_as_constant=False,
+        )
+
+        # Different covariance should produce different results
+        self.assertFalse(np.allclose(rel_sems_cov, rel_sems_no_cov))
+
+    def test_relativize_scalar_inputs(self) -> None:
+        """Test relativize with scalar inputs returns scalars."""
+        rel_mean, rel_sem = relativize(
+            means_t=4.0,
+            sems_t=0.5,
+            mean_c=self.mean_c,
+            sem_c=self.sem_c,
+            bias_correction=False,
+        )
+
+        # With scalar inputs, numpy operations return scalars
+        self.assertIsInstance(rel_mean, (float, np.floating))
+        self.assertIsInstance(rel_sem, (float, np.floating))
+        # Expected: (means_t - mean_c) / mean_c = (4.0 - 2.0) / 2.0
+        self.assertAlmostEqual(float(rel_mean), 1.0)
+
+    def test_relativize_zero_control_error(self) -> None:
+        """Test that relativize raises error when control mean is too small."""
+        with self.assertRaisesRegex(
+            ValueError, "mean_control .* is smaller than 1 in 10 billion"
+        ):
+            relativize(
+                means_t=np.array([1.0]),
+                sems_t=np.array([0.1]),
+                mean_c=1e-15,  # Very small control mean
+                sem_c=0.1,
+            )
+
+    def test_relativize_same_values(self) -> None:
+        """Test relativize when test and control values are the same."""
+        means_t = np.array([2.0, 2.0])
+        sems_t = np.array([0.1, 0.1])
+
+        rel_means, _ = relativize(
+            means_t=means_t,
+            sems_t=sems_t,
+            mean_c=2.0,
+            sem_c=0.1,
+            bias_correction=True,
+        )
+
+        # When values are the same, relative change should be zero
+        expected_rel_means = np.array([0.0, 0.0])
+        self.assertAllClose(rel_means, expected_rel_means)
+
+    def test_relativize_parameter_combinations(self) -> None:
+        """Test relativize with various parameter combinations."""
+        for bias_correction, as_percent, control_as_constant in product(
+            [True, False], [True, False], [True, False]
+        ):
+            with self.subTest(
+                bias_correction=bias_correction,
+                as_percent=as_percent,
+                control_as_constant=control_as_constant,
+            ):
+                rel_means, rel_sems = relativize(
+                    means_t=self.means_t,
+                    sems_t=self.sems_t,
+                    mean_c=self.mean_c,
+                    sem_c=self.sem_c,
+                    bias_correction=bias_correction,
+                    as_percent=as_percent,
+                    control_as_constant=control_as_constant,
+                )
+
+                # Should return numpy arrays
+                self.assertIsInstance(rel_means, np.ndarray)
+                self.assertIsInstance(rel_sems, np.ndarray)
+
+                # Should have same length as input
+                self.assertEqual(rel_means.shape, (len(self.means_t),))
+                self.assertEqual(rel_sems.shape, (len(self.sems_t),))
+
+                # SEMs should be non-negative
+                self.assertTrue(np.all(rel_sems >= 0))
+
+    def test_relativize_negative_control_mean(self) -> None:
+        """Test relativize with negative control mean."""
+        means_t = np.array([1.0, 3.0])
+        sems_t = np.array([0.1, 0.3])
+
+        rel_means, _ = relativize(
+            means_t=means_t,
+            sems_t=sems_t,
+            mean_c=-2.0,
+            sem_c=0.2,
+            bias_correction=False,
+        )
+
+        # Should handle negative control mean using absolute value
+        # Expected: (means_t - mean_c) / |mean_c|
+        # For means_t=[1.0, 3.0] and mean_c=-2.0: (1-(-2))/2 = 1.5, (3-(-2))/2 = 2.5
+        expected_rel_means = np.array([1.5, 2.5])
+        self.assertAllClose(rel_means, expected_rel_means)

--- a/ax/utils/stats/tests/test_statstools.py
+++ b/ax/utils/stats/tests/test_statstools.py
@@ -12,10 +12,10 @@ import numpy as np
 import pandas as pd
 from ax.core.data import Data
 from ax.utils.common.testutils import TestCase
+from ax.utils.stats.math_utils import relativize
 from ax.utils.stats.statstools import (
     inverse_variance_weight,
     marginal_effects,
-    relativize,
     relativize_data,
     unrelativize,
 )


### PR DESCRIPTION
Summary:
This diff is part of a series of changes to resolve a circular dependency between `ax.core` and `statstools`. Currently, the relativize function (in `statstools`) cannot be imported from within the `ax.core` package because `statstools` itself depends on `ax.core`. In this specific diff, the `relativize` function is moved out of the `statstools` module. 
To address this:
- The `relativize` function has been moved from `statstools` to a new file `math_utils`.
- Previously, there were no dedicated unit tests for `relativize`, though its basic functionality was covered by [RelativizeDataTest](https://www.internalfb.com/code/fbsource/[6fbf07b1c6a1826d6e3dbe7c8e3df9bd47b60043]/fbcode/ax/utils/stats/tests/test_statstools.py?lines=81) in test_statstools.py. This diff adds new tests to cover previously untested parts of `relativize`.
- Imports in `ax.utils.stats.statstools` have been updated to reference the new location of `relativize`.

Differential Revision: D84262111


