### PR TITLE
Simplify infer_objective_thresholds helper

### DIFF
--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -306,8 +306,8 @@ class Acquisition(Base):
             self._full_objective_thresholds = infer_objective_thresholds(
                 model=self._model,
                 objective_weights=self._full_objective_weights,
-                outcome_constraints=torch_opt_config.outcome_constraints,
                 X_observed=self.X_observed,
+                outcome_constraints=torch_opt_config.outcome_constraints,
                 subset_idcs=self._subset_idcs,
                 objective_thresholds=self._full_objective_thresholds,
             )


### PR DESCRIPTION
Summary:
Instead of accepting both `Xs` and `X_baseline`, this now requires `X_baseline`, which eliminates the need for a few other inputs. The only use case that passes in `Xs` is updated to extract `X_baseline` before passing it in.

I am hoping to eliminate some filtering logic in `_get_X_pending_and_observed` (and remove `fit_out_of_design`) and isolating the callsites away from other helpers will simplify this change.

Differential Revision: D84542070


