### PR TITLE
Modernize calls to parallax - HTE

### DIFF
--- a/ax/utils/common/string_utils.py
+++ b/ax/utils/common/string_utils.py
@@ -12,6 +12,7 @@ DOT_PLACEHOLDER = "__dot__"
 SLASH_PLACEHOLDER = "__slash__"
 COLON_PLACEHOLDER = "__colon__"
 PIPE_PLACEHOLDER = "__pipe__"
+TILDE_PLACEHOLDER = "__tilde__"
 _forbidden_re: re.Pattern[str] = re.compile(r"[\;\[\'\\]")
 
 
@@ -28,7 +29,7 @@ def sanitize_name(s: str) -> str:
 
 
     This does not allow obvious attack vectors  `;`, `[`, backslashes, and quotations.
-    Colons, dots, and slashes are sanitized.
+    Colons, dots, slashes, and tildes are sanitized.
     """
     if _forbidden_re.search(s) is not None:
         raise ValueError(f"Expression {s} has forbidden control characters.")
@@ -54,8 +55,14 @@ def sanitize_name(s: str) -> str:
         rf"\1{PIPE_PLACEHOLDER}\2",
         sans_colon,
     )
+    # Replace tilde at the start of a variable name or after alphanumeric characters
+    sans_tilde = re.sub(
+        r"~([a-zA-Z_][a-zA-Z0-9_]*)",
+        rf"{TILDE_PLACEHOLDER}\1",
+        sans_pipe,
+    )
 
-    return sans_pipe
+    return sans_tilde
 
 
 def unsanitize_name(s: str) -> str:
@@ -67,7 +74,8 @@ def unsanitize_name(s: str) -> str:
     """
 
     # Unsanitize in the reverse order of sanitization
-    with_pipe = re.sub(rf"{PIPE_PLACEHOLDER}", "|", s)
+    with_tilde = re.sub(rf"{TILDE_PLACEHOLDER}", "~", s)
+    with_pipe = re.sub(rf"{PIPE_PLACEHOLDER}", "|", with_tilde)
     with_colon = re.sub(rf"{COLON_PLACEHOLDER}", ":", with_pipe)
     with_slash = re.sub(rf"{SLASH_PLACEHOLDER}", "/", with_colon)
     with_dot = re.sub(rf"{DOT_PLACEHOLDER}", ".", with_slash)

--- a/ax/utils/common/tests/test_string_utils.py
+++ b/ax/utils/common/tests/test_string_utils.py
@@ -20,6 +20,10 @@ class StringUtilsTest(TestCase):
         self.assertEqual(
             sanitize_name("foo.bar + 0.1 * baz"), "foo__dot__bar + 0.1 * baz"
         )
+        self.assertEqual(
+            sanitize_name("~treatment_percent_"), "__tilde__treatment_percent_"
+        )
+        self.assertEqual(sanitize_name("foo, ~bar"), "foo, __tilde__bar")
         for s in ("foo;", "foo\\", "'foo"):
             with self.assertRaisesRegex(
                 ValueError, "has forbidden control characters."


### PR DESCRIPTION
Summary: Remove usage of parallax in HTE and replace with calls to Client API instead

Differential Revision: D82929195


