### PR TITLE
Clean up usage of fit_out_of_design input from dispatch layer

### DIFF
--- a/ax/adapter/factory.py
+++ b/ax/adapter/factory.py
@@ -7,7 +7,6 @@
 # pyre-strict
 
 import torch
-from ax.adapter.base import DataLoaderConfig
 from ax.adapter.discrete import DiscreteAdapter
 from ax.adapter.random import RandomAdapter
 from ax.adapter.registry import Generators
@@ -66,10 +65,7 @@ def get_sobol(
 def get_factorial(search_space: SearchSpace) -> DiscreteAdapter:
     """Instantiates a factorial generator."""
     return assert_is_instance(
-        Generators.FACTORIAL(
-            search_space=search_space,
-            data_loader_config=DataLoaderConfig(fit_out_of_design=True),
-        ),
+        Generators.FACTORIAL(search_space=search_space),
         DiscreteAdapter,
     )
 
@@ -89,11 +85,10 @@ def get_empirical_bayes_thompson(
         Generators.EMPIRICAL_BAYES_THOMPSON(
             experiment=experiment,
             data=data,
-            search_space=search_space or experiment.search_space,
+            search_space=search_space,
             num_samples=num_samples,
             min_weight=min_weight,
             uniform_weights=uniform_weights,
-            data_loader_config=DataLoaderConfig(fit_out_of_design=True),
         ),
         DiscreteAdapter,
     )
@@ -114,11 +109,10 @@ def get_thompson(
         Generators.THOMPSON(
             experiment=experiment,
             data=data,
-            search_space=search_space or experiment.search_space,
+            search_space=search_space,
             num_samples=num_samples,
             min_weight=min_weight,
             uniform_weights=uniform_weights,
-            data_loader_config=DataLoaderConfig(fit_out_of_design=True),
         ),
         DiscreteAdapter,
     )

--- a/ax/generation_strategy/tests/test_dispatch_utils.py
+++ b/ax/generation_strategy/tests/test_dispatch_utils.py
@@ -11,7 +11,6 @@ from itertools import product
 from typing import Any
 
 import torch
-from ax.adapter.base import DataLoaderConfig
 from ax.adapter.registry import Generators
 from ax.adapter.transforms.log_y import LogY
 from ax.core.objective import MultiObjective
@@ -57,7 +56,6 @@ class TestDispatchUtils(TestCase):
             expected_model_kwargs: dict[str, Any] = {
                 "torch_device": None,
                 "transform_configs": expected_transform_configs,
-                "data_loader_config": DataLoaderConfig(fit_out_of_design=False),
                 "acquisition_options": {"prune_irrelevant_parameters": False},
             }
             self.assertEqual(sobol_gpei._steps[1].model_kwargs, expected_model_kwargs)
@@ -119,12 +117,7 @@ class TestDispatchUtils(TestCase):
             model_kwargs = none_throws(sobol_gpei._steps[1].model_kwargs)
             self.assertEqual(
                 set(model_kwargs.keys()),
-                {
-                    "torch_device",
-                    "transform_configs",
-                    "data_loader_config",
-                    "acquisition_options",
-                },
+                {"torch_device", "transform_configs", "acquisition_options"},
             )
             self.assertTrue(
                 model_kwargs["acquisition_options"]["prune_irrelevant_parameters"]
@@ -200,7 +193,6 @@ class TestDispatchUtils(TestCase):
             expected_model_kwargs = {
                 "torch_device": None,
                 "transform_configs": expected_transform_configs,
-                "data_loader_config": DataLoaderConfig(fit_out_of_design=False),
             }
             self.assertEqual(bo_mixed._steps[1].model_kwargs, expected_model_kwargs)
         with self.subTest("BO_MIXED (mixed search space)"):
@@ -214,7 +206,6 @@ class TestDispatchUtils(TestCase):
             expected_model_kwargs = {
                 "torch_device": None,
                 "transform_configs": expected_transform_configs,
-                "data_loader_config": DataLoaderConfig(fit_out_of_design=False),
             }
             self.assertEqual(bo_mixed._steps[1].model_kwargs, expected_model_kwargs)
         with self.subTest("BO_MIXED (mixed multi-objective optimization)"):
@@ -232,11 +223,7 @@ class TestDispatchUtils(TestCase):
             model_kwargs = none_throws(moo_mixed._steps[1].model_kwargs)
             self.assertEqual(
                 set(model_kwargs.keys()),
-                {
-                    "torch_device",
-                    "transform_configs",
-                    "data_loader_config",
-                },
+                {"torch_device", "transform_configs"},
             )
         with self.subTest("SAASBO"):
             sobol_fullybayesian = choose_generation_strategy_legacy(


### PR DESCRIPTION
Summary:
As discussed in Ax & BoTorch sync, the cases where `fit_out_of_design` would lead to a larger model space than `expand_model_space` will just lead to errors.

This diff removes the argument from the dispatch layer.

Differential Revision: D84614238


