### PR TITLE
Remove ability to produce either single AnalysisCard or AnalysisCardGroup depending on settings

### DIFF
--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -140,26 +140,6 @@ class Analysis(Protocol):
             children=children,
         )
 
-    def _create_analysis_card_group_or_card(
-        self,
-        title: str,
-        subtitle: str,
-        children: Sequence[AnalysisCardBase],
-    ) -> AnalysisCardBase:
-        """
-        Make an AnalysisCardGroup from this Analysis using provided fields and
-        details about the Analysis class. If there is only one child, return the child
-        directly instead of wrapping it in a group.
-        """
-        if len(children) == 1:
-            return children[0]
-
-        return self._create_analysis_card_group(
-            title=title,
-            subtitle=subtitle,
-            children=children,
-        )
-
 
 class AnalysisE(ExceptionE):
     analysis: Analysis

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -173,7 +173,7 @@ class CrossValidationPlot(Analysis):
 
             cards.append(card)
 
-        return self._create_analysis_card_group_or_card(
+        return self._create_analysis_card_group(
             title=CV_CARDGROUP_TITLE,
             subtitle=CV_CARDGROUP_SUBTITLE,
             children=cards,

--- a/ax/analysis/plotly/marginal_effects.py
+++ b/ax/analysis/plotly/marginal_effects.py
@@ -128,7 +128,7 @@ class MarginalEffectsPlot(Analysis):
                     fig=fig,
                 )
             )
-        return self._create_analysis_card_group_or_card(
+        return self._create_analysis_card_group(
             title=MARGINAL_EFFECTS_CARDGROUP_TITLE,
             subtitle=MARGINAL_EFFECTS_CARDGROUP_SUBTITLE,
             children=cards,

--- a/ax/analysis/plotly/tests/test_arm_effects.py
+++ b/ax/analysis/plotly/tests/test_arm_effects.py
@@ -204,11 +204,11 @@ class TestArmEffectsPlot(TestCase):
                 generation_strategy.current_node._fit(experiment=experiment)
                 adapter = none_throws(generation_strategy.adapter)
 
-                model_metric_names = [
-                    adapter._experiment.signature_to_metric[signature].name
-                    for signature in adapter.metric_signatures
-                ]
-                for metric_name in model_metric_names:
+                for signature in adapter.metric_signatures:
+                    metric_name = adapter._experiment.signature_to_metric[
+                        signature
+                    ].name
+
                     analysis = ArmEffectsPlot(
                         metric_name=metric_name,
                         use_model_predictions=use_model_predictions,

--- a/ax/analysis/plotly/tests/test_sensitivity.py
+++ b/ax/analysis/plotly/tests/test_sensitivity.py
@@ -80,7 +80,7 @@ class TestSensitivityAnalysisPlot(TestCase):
                     },
                 )
 
-        analysis = SensitivityAnalysisPlot(metric_names=["bar"], order="first")
+        analysis = SensitivityAnalysisPlot(metric_name="bar", order="first")
 
         with self.assertRaisesRegex(
             UserInputError, "Must provide either a GenerationStrategy or an Adapter"
@@ -107,7 +107,7 @@ class TestSensitivityAnalysisPlot(TestCase):
         self.assertEqual(len(card.df), 2)
         self.assertIsNotNone(card.blob)
 
-        second_order = SensitivityAnalysisPlot(metric_names=["bar"], order="second")
+        second_order = SensitivityAnalysisPlot(metric_name="bar", order="second")
         (card,) = second_order.compute(
             generation_strategy=client._generation_strategy
         ).flatten()
@@ -135,12 +135,12 @@ class TestSensitivityAnalysisPlot(TestCase):
                 experiment=experiment
             )
             # Select an arbitrary metric from the optimization config
-            metric_names = [
-                none_throws(experiment.optimization_config).objective.metric_names[0]
-            ]
+            metric_name = none_throws(
+                experiment.optimization_config
+            ).objective.metric_names[0]
             for order, top_k in product(["first", "second", "total"], [None, 1]):
                 analysis = SensitivityAnalysisPlot(
-                    metric_names=metric_names,
+                    metric_name=metric_name,
                     # pyre-fixme: Incompatible parameter type [6]: It isn't sure
                     # if "order" has one of the values specified by the Literal
                     order=order,
@@ -159,12 +159,12 @@ class TestSensitivityAnalysisPlot(TestCase):
                 experiment=experiment
             )
             # Select an arbitrary metric from the optimization config
-            metric_names = [
-                none_throws(experiment.optimization_config).objective.metric_names[0]
-            ]
+            metric_name = none_throws(
+                experiment.optimization_config
+            ).objective.metric_names[0]
             for order, top_k in product(["first", "second", "total"], [None, 1]):
                 analysis = SensitivityAnalysisPlot(
-                    metric_names=metric_names,
+                    metric_name=metric_name,
                     # pyre-fixme: Incompatible parameter type [6]: It isn't sure
                     # if "order" has one of the values specified by the Literal
                     order=order,

--- a/ax/analysis/plotly/top_surfaces.py
+++ b/ax/analysis/plotly/top_surfaces.py
@@ -79,17 +79,14 @@ class TopSurfacesAnalysis(Analysis):
         # Process the sensitivity analysis card to find the top K surfaces which
         # consist exclusively of tunable parameters (i.e. no fixed parameters, task
         # parameters, or OneHot parameters).
-        sensitivity_analysis_card = assert_is_instance(
-            SensitivityAnalysisPlot(
-                metric_names=[metric_name],
-                order=self.order,
-                top_k=self.top_k,
-            ).compute(
-                experiment=experiment,
-                generation_strategy=generation_strategy,
-                adapter=adapter,
-            ),
-            AnalysisCard,
+        sensitivity_analysis_card = SensitivityAnalysisPlot(
+            metric_name=metric_name,
+            order=self.order,
+            top_k=self.top_k,
+        ).compute(
+            experiment=experiment,
+            generation_strategy=generation_strategy,
+            adapter=adapter,
         )
         children: list[AnalysisCardBase] = [sensitivity_analysis_card]
 

--- a/ax/analysis/trials.py
+++ b/ax/analysis/trials.py
@@ -133,6 +133,5 @@ class TrialAnalysis(Analysis):
                     adapter=relevant_adapter,
                 )
                 for analysis in analyses
-                if analysis is not None
             ],
         )


### PR DESCRIPTION
Summary:
Removes _create_analysis_card_group_or_card in preparation for more useful validation changes. This affects CrossValidationAnalysis, ArmEffectsPlot, SensitivityAnalysis, and MarginalEffects. Does not affect adhoc methods.

For CrossValidation we keep batch computation (ie provide metric_names) due to how computationally expensive CV can be.

For other Analyses we move to single metric computation, which is how they are used in prod exclusively.

Differential Revision: D83358436


