### PR TITLE
Add generic `botorch_synthetic` problem registry entry

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -730,7 +730,7 @@ def compute_baseline_value_from_sobol(
         )
         values[i] = result.optimization_trace[-1]
 
-    return values.mean()
+    return values.mean().item()
 
 
 def benchmark_one_method_problem(

--- a/ax/benchmark/problems/registry.py
+++ b/ax/benchmark/problems/registry.py
@@ -59,6 +59,15 @@ BENCHMARK_PROBLEM_REGISTRY: dict[str, BenchmarkProblemRegistryEntry] = {
     "Bandit": BenchmarkProblemRegistryEntry(
         factory_fn=get_bandit_problem, factory_kwargs={}
     ),
+    "botorch_synthetic": BenchmarkProblemRegistryEntry(
+        factory_fn=create_problem_from_botorch,
+        # NOTE: This is the only problem that require a mandatory argument,
+        # in this case `test_problem_class`.
+        factory_kwargs={
+            "test_problem_kwargs": {},
+            "num_trials": 30,
+        },
+    ),
     "branin": BenchmarkProblemRegistryEntry(
         factory_fn=create_problem_from_botorch,
         factory_kwargs={

--- a/ax/benchmark/tests/problems/synthetic/test_from_botorch.py
+++ b/ax/benchmark/tests/problems/synthetic/test_from_botorch.py
@@ -379,3 +379,45 @@ class TestFromBoTorch(TestCase):
             )
             metric = next(iter(problem.optimization_config.metrics.values()))
             self.assertIsInstance(metric, BenchmarkMapMetric)
+
+    def test_string_test_problem_class(self) -> None:
+        """Test that test_problem_class can be provided as a string."""
+
+        problem_from_string = create_problem_from_botorch(
+            test_problem_class="Branin",
+            test_problem_kwargs={"negate": True},
+            num_trials=1,
+            baseline_value=10.0,
+        )
+        problem_from_class = create_problem_from_botorch(
+            test_problem_class=Branin,
+            test_problem_kwargs={"negate": True},
+            num_trials=1,
+            baseline_value=10.0,
+        )
+
+        string_test_function = assert_is_instance(
+            problem_from_string.test_function, BoTorchTestFunction
+        )
+        class_test_function = assert_is_instance(
+            problem_from_class.test_function, BoTorchTestFunction
+        )
+        self.assertEqual(problem_from_string.name, "Branin")
+        string_botorch_problem = string_test_function.botorch_problem
+        class_botorch_problem = class_test_function.botorch_problem
+        self.assertIsInstance(string_botorch_problem, Branin)
+        self.assertIsInstance(class_botorch_problem, Branin)
+        self.assertTrue(string_botorch_problem.negate)
+        self.assertTrue(class_botorch_problem.negate)
+
+        self.assertEqual(
+            problem_from_string.search_space,
+            problem_from_class.search_space,
+        )
+        self.assertEqual(
+            problem_from_string.optimal_value, problem_from_class.optimal_value
+        )
+        self.assertEqual(
+            problem_from_string.optimization_config,
+            problem_from_class.optimization_config,
+        )


### PR DESCRIPTION
Summary:
Currenlty, any test function we'd want to run benchmarks against would need to be added explicitly to the registry. However, it would be convenient to be able to do this simply by name without having to register each individually, especially since all the botorch test functions are importable anyway.

This diff adds the capability for this by enabling the `test_problem_class` argument in `create_problem_from_botorch` to be a string (in additon to a class). If the test function class name is provided as a string, the class will be loaded dynamically via `getattr` from the module `botorch.test_functions.synthetic`.

Reviewed By: esantorella

Differential Revision: D84467574


