### PR TITLE
Pass kwargs to polytope sampler

### DIFF
--- a/ax/adapter/tests/test_registry.py
+++ b/ax/adapter/tests/test_registry.py
@@ -180,6 +180,7 @@ class ModelRegistryTest(TestCase):
                     "scramble": True,
                     "generated_points": None,
                     "fallback_to_sample_polytope": False,
+                    "polytope_sampler_kwargs": None,
                 },
                 {
                     "optimization_config": None,

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -548,6 +548,7 @@ class TestGenerationStrategy(TestCase):
                         "init_position": i,
                         "scramble": True,
                         "fallback_to_sample_polytope": False,
+                        "polytope_sampler_kwargs": None,
                         "generated_points": None,
                     },
                 )
@@ -1512,6 +1513,7 @@ class TestGenerationStrategy(TestCase):
                         "init_position": i,
                         "scramble": True,
                         "fallback_to_sample_polytope": False,
+                        "polytope_sampler_kwargs": None,
                         "generated_points": None,
                     },
                 )

--- a/ax/generators/random/sobol.py
+++ b/ax/generators/random/sobol.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -39,6 +40,7 @@ class SobolGenerator(RandomGenerator):
         scramble: bool = True,
         generated_points: npt.NDArray | None = None,
         fallback_to_sample_polytope: bool = False,
+        polytope_sampler_kwargs: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(
             deduplicate=deduplicate,
@@ -46,6 +48,7 @@ class SobolGenerator(RandomGenerator):
             init_position=init_position,
             generated_points=generated_points,
             fallback_to_sample_polytope=fallback_to_sample_polytope,
+            polytope_sampler_kwargs=polytope_sampler_kwargs,
         )
         self.scramble = scramble
         # Initialize engine on gen.

--- a/ax/generators/tests/test_sobol.py
+++ b/ax/generators/tests/test_sobol.py
@@ -190,7 +190,11 @@ class SobolGeneratorTest(TestCase):
         # Ten parameters with sum less than 1. In this example, the rejection
         # sampler gives a search space exhausted error.  Testing fallback to
         # polytope sampler when encountering this error.
-        generator = SobolGenerator(seed=0, fallback_to_sample_polytope=True)
+        generator = SobolGenerator(
+            seed=0,
+            fallback_to_sample_polytope=True,
+            polytope_sampler_kwargs={"n_thinning": 3},
+        )
         ssd = self._create_ssd(n_tunable=10, n_fixed=0)
         A = np.ones((1, 10))
         b = np.array([1]).reshape((1, 1))
@@ -235,6 +239,8 @@ class SobolGeneratorTest(TestCase):
             )
         # last call for (6th generated point) uses seed=5
         self.assertEqual(wrapped_sampler.call_args.kwargs["seed"], 5)
+        self.assertEqual(wrapped_sampler.call_args.kwargs["n_thinning"], 3)
+
         rounding_func.assert_called()
 
     def test_SobolGeneratorFallbackToPolytopeSamplerWithFixedParam(self) -> None:

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -696,12 +696,13 @@ class SQAStoreTest(TestCase):
             # 3. Try case with model state and search space + opt.config on a
             # generator run in the experiment.
             gr = Generators.SOBOL(experiment=exp).gen(1)
-            # Expecting model kwargs to have 6 fields (seed, deduplicate, init_position,
-            # scramble, generated_points, fallback_to_sample_polytope)
+            # Expecting model kwargs to have 7 fields (seed, deduplicate, init_position,
+            # scramble, generated_points, fallback_to_sample_polytope,
+            # polytope_sampler_kwargs)
             # and the rest of model-state info on generator run to have values too.
             mkw = gr._model_kwargs
             self.assertIsNotNone(mkw)
-            self.assertEqual(len(mkw), 6)
+            self.assertEqual(len(mkw), 7)
             bkw = gr._bridge_kwargs
             self.assertIsNotNone(bkw)
             self.assertEqual(len(bkw), 6)


### PR DESCRIPTION
Summary: This enables passing kwargs along to the hit and run polytope sampler, for instance to change the amount of burn-in and thinning used.

Reviewed By: sdaulton

Differential Revision: D84676406
