### PR TITLE
Add a utility function for trial filtering

### DIFF
--- a/ax/analysis/plotly/parallel_coordinates.py
+++ b/ax/analysis/plotly/parallel_coordinates.py
@@ -19,6 +19,7 @@ from ax.analysis.plotly.plotly_analysis import (
 from ax.analysis.plotly.utils import select_metric, truncate_label
 from ax.analysis.utils import validate_experiment
 from ax.core.experiment import Experiment
+from ax.core.trial_status import TrialStatus
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from plotly import graph_objects as go
 from pyre_extensions import none_throws, override
@@ -105,6 +106,7 @@ def _prepare_data(experiment: Experiment, metric: str) -> pd.DataFrame:
     if filtered_df.empty:
         raise ValueError(f"No data found for metric {metric}")
 
+    trials = experiment.extract_relevant_trials(trial_statuses=[TrialStatus.COMPLETED])
     records = [
         {
             "trial_index": trial.index,
@@ -114,9 +116,8 @@ def _prepare_data(experiment: Experiment, metric: str) -> pd.DataFrame:
                 df=filtered_df, trial_index=trial.index, arm_name=arm.name
             ),
         }
-        for trial in experiment.trials.values()
+        for trial in trials
         for arm in trial.arms
-        if trial.status.is_completed  # Only include completed trials
     ]
 
     return pd.DataFrame.from_records(records).dropna()

--- a/ax/analysis/plotly/progression.py
+++ b/ax/analysis/plotly/progression.py
@@ -101,13 +101,13 @@ class ProgressionPlot(Analysis):
 
         # Get the terminal step of each trial that was early stopped so we can place a
         # marker to inform the user.
+        early_stopped_trials = experiment.extract_relevant_trials(
+            trial_statuses=[TrialStatus.EARLY_STOPPED]
+        )
         data_df = data.df  # Collect dataframe with only the terminal observations
         terminal_points = data_df.loc[
             data_df["trial_index"].isin(
-                [
-                    trial.index
-                    for trial in experiment.trials_by_status[TrialStatus.EARLY_STOPPED]
-                ]
+                [trial.index for trial in early_stopped_trials]
             ),
             ["trial_index", "mean", MAP_KEY],
         ].rename(columns={MAP_KEY: "progression", "mean": metric_name})

--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -238,6 +238,7 @@ def _prepare_data(
     metric_name: str,
     relativize: bool,
 ) -> pd.DataFrame:
+    trials = experiment.extract_relevant_trials(trial_statuses=STATUSES_EXPECTING_DATA)
     sampled = [
         {
             "x_parameter_name": arm.parameters[x_parameter_name],
@@ -245,8 +246,7 @@ def _prepare_data(
             "arm_name": arm.name,
             "trial_index": trial.index,
         }
-        for trial in experiment.trials.values()
-        if trial.status in STATUSES_EXPECTING_DATA  # running, completed, early stopped
+        for trial in trials
         for arm in trial.arms
         # Filter out arms which are not part of the search space (ex. when a parameter
         # is None).

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -231,14 +231,14 @@ def _prepare_data(
     metric_name: str,
     relativize: bool,
 ) -> pd.DataFrame:
+    trials = experiment.extract_relevant_trials(trial_statuses=STATUSES_EXPECTING_DATA)
     sampled_xs = [
         {
             "parameter_value": arm.parameters[parameter_name],
             "arm_name": arm.name,
             "trial_index": trial.index,
         }
-        for trial in experiment.trials.values()
-        if trial.status in STATUSES_EXPECTING_DATA  # running, completed, early stopped
+        for trial in trials
         for arm in trial.arms
         # Exclude parameter values which are not valid (ex. None when the parameter is
         # not known in a status quo arm).

--- a/ax/core/trial_status.py
+++ b/ax/core/trial_status.py
@@ -157,6 +157,11 @@ NON_ABANDONED_STATUSES: set[TrialStatus] = set(TrialStatus) - {TrialStatus.ABAND
 
 NON_STALE_STATUSES: set[TrialStatus] = set(TrialStatus) - {TrialStatus.STALE}
 
+NON_STALE_ABANDONED_STATUSES: set[TrialStatus] = set(TrialStatus) - {
+    TrialStatus.STALE,
+    TrialStatus.ABANDONED,
+}
+
 STATUSES_EXPECTING_DATA: list[TrialStatus] = [
     TrialStatus.RUNNING,
     TrialStatus.COMPLETED,


### PR DESCRIPTION
Summary: This diff adds a utility function for trial filtering in Ax. The function is used to filter trials by trial index, target trial index, and trial statuses. The function is used in the analysis module to filter trials for analysis. The function is also used in the core module to filter trials for display in the experiment summary. The function is tested in the common module.

Differential Revision: D84551769


