### PR TITLE
Add validate_applicable_state to analyses in analysis/plotly/...

### DIFF
--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -14,15 +14,13 @@ from ax.adapter.cross_validation import cross_validate, CVResult
 from ax.analysis.analysis import Analysis
 from ax.analysis.analysis_card import AnalysisCardBase
 from ax.analysis.plotly.color_constants import AX_BLUE
-
 from ax.analysis.plotly.plotly_analysis import create_plotly_analysis_card
-
 from ax.analysis.plotly.utils import get_scatter_point_color, Z_SCORE_95_CI
-
-from ax.analysis.utils import extract_relevant_adapter
+from ax.analysis.utils import extract_relevant_adapter, validate_adapter_can_predict
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from plotly import graph_objects as go
+from pyre_extensions import override
 
 CV_CARDGROUP_TITLE = "Cross Validation: Assessing model fit"
 
@@ -102,6 +100,23 @@ class CrossValidationPlot(Analysis):
         self.untransform = untransform
         self.trial_index = trial_index
         self.labels: dict[str, str] = {**labels} if labels is not None else {}
+
+    @override
+    def validate_applicable_state(
+        self,
+        experiment: Experiment | None = None,
+        generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
+    ) -> str | None:
+        """
+        CrossValidationPlot requires only an Adapter which can predict.
+        """
+        return validate_adapter_can_predict(
+            experiment=experiment,
+            generation_strategy=generation_strategy,
+            adapter=adapter,
+            required_metric_names=None,
+        )
 
     def compute(
         self,

--- a/ax/analysis/plotly/marginal_effects.py
+++ b/ax/analysis/plotly/marginal_effects.py
@@ -10,14 +10,12 @@ from typing import final
 import pandas as pd
 from ax.adapter.base import Adapter
 from ax.analysis.analysis import Analysis
-from ax.analysis.analysis_card import AnalysisCardBase
+from ax.analysis.analysis_card import AnalysisCardGroup
 from ax.analysis.plotly.color_constants import COLOR_FOR_DECREASES, COLOR_FOR_INCREASES
 from ax.analysis.plotly.plotly_analysis import create_plotly_analysis_card
-
-from ax.analysis.utils import extract_relevant_adapter
+from ax.analysis.utils import extract_relevant_adapter, validate_experiment
 from ax.core.experiment import Experiment
 from ax.core.parameter import ChoiceParameter
-from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.plot.helper import get_plot_data
 from ax.utils.stats.statstools import marginal_effects
@@ -68,14 +66,26 @@ class MarginalEffectsPlot(Analysis):
         self.parameters = parameters
 
     @override
-    def compute(
+    def validate_applicable_state(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> AnalysisCardBase:
-        if experiment is None:
-            raise UserInputError("MarginalEffectsPlot requires an Experiment")
+    ) -> str | None:
+        """
+        MarginalEffectsPlot requires an Experiment with trials with data, and can only
+        be computed for SearchSpaces with ChoiceParameters.
+        """
+        if (
+            experiment_invalid_reason := validate_experiment(
+                experiment=experiment,
+                require_trials=True,
+                require_data=True,
+            )
+        ) is not None:
+            return experiment_invalid_reason
+
+        experiment = none_throws(experiment)
 
         # Either extract ChoiceParameters from experiment or check the ones passed in
         if self.parameters is None:
@@ -85,7 +95,7 @@ class MarginalEffectsPlot(Analysis):
                 if isinstance(param, ChoiceParameter)
             ]
             if len(self.parameters) == 0:
-                raise UserInputError(
+                return (
                     "MarginalEffectsPlot is only for `ChoiceParameter`s, "
                     "but no ChoiceParameters were found in the experiment."
                 )
@@ -93,10 +103,26 @@ class MarginalEffectsPlot(Analysis):
             for param_name in none_throws(self.parameters):
                 parameter = experiment.parameters.get(param_name)
                 if not isinstance(parameter, ChoiceParameter):
-                    raise UserInputError(
+                    return (
                         "MarginalEffectsPlot is only for `ChoiceParameter`s, but got."
                         f"'{param_name}' which is of type {type(parameter).__name__}."
                     )
+
+    @override
+    def compute(
+        self,
+        experiment: Experiment | None = None,
+        generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
+    ) -> AnalysisCardGroup:
+        experiment = none_throws(experiment)
+
+        if self.parameters is None:
+            self.parameters = [
+                param_name
+                for param_name, param in experiment.parameters.items()
+                if isinstance(param, ChoiceParameter)
+            ]
 
         relevant_adapter = extract_relevant_adapter(
             experiment=experiment,
@@ -144,7 +170,7 @@ def compute_marginal_effects_adhoc(
     parameters: list[str] | None = None,
     generation_strategy: GenerationStrategy | None = None,
     adapter: Adapter | None = None,
-) -> AnalysisCardBase:
+) -> AnalysisCardGroup:
     """
     Helper method to expose adhoc marginal effects plotting. Only for
     advanced users in a notebook setting.

--- a/ax/analysis/plotly/objective_p_feasible_frontier.py
+++ b/ax/analysis/plotly/objective_p_feasible_frontier.py
@@ -16,18 +16,21 @@ from ax.analysis.plotly.plotly_analysis import (
     PlotlyAnalysisCard,
 )
 from ax.analysis.plotly.scatter import _prepare_figure as _prepare_figure_scatter
-from ax.analysis.utils import extract_relevant_adapter, prepare_arm_data
+from ax.analysis.utils import (
+    extract_relevant_adapter,
+    prepare_arm_data,
+    validate_experiment,
+)
 from ax.core.arm import Arm
 from ax.core.experiment import Experiment
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
-from ax.exceptions.core import AxError, UnsupportedError, UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
 from ax.generators.torch.botorch_modular.multi_acquisition import MultiAcquisition
 from ax.utils.common.logger import get_logger
 from botorch.acquisition.analytic import LogProbabilityOfFeasibility, PosteriorMean
-from pyre_extensions import override
+from pyre_extensions import assert_is_instance, none_throws, override
 
 logger: Logger = get_logger(__name__)
 OBJ_PFEAS_CARDGROUP_SUBTITLE = (
@@ -83,34 +86,46 @@ class ObjectivePFeasibleFrontierPlot(Analysis):
         self.num_points_to_generate = num_points_to_generate
 
     @override
-    def compute(
+    def validate_applicable_state(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
-    ) -> PlotlyAnalysisCard:
-        if experiment is None:
-            raise UserInputError(
-                "ObjectivePFeasibleFrontierPlot requires an Experiment."
+    ) -> str | None:
+        """
+        ObjectivePFeasibleFrontierPlot requires an Experiment with trials and data, and
+        is only valid for single objective constrained problems. Additionally, the
+        supplied adapter must be a TorchAdapter using a BoTorchGenerator.
+        """
+        if (
+            experiment_invalid_reason := validate_experiment(
+                experiment=experiment,
+                require_trials=True,
+                require_data=True,
             )
+        ) is not None:
+            return experiment_invalid_reason
+
+        experiment = none_throws(experiment)
+
         if experiment.optimization_config is None:
-            raise UserInputError("Optimization_config must be set to compute frontier.")
-        elif isinstance(
-            experiment.optimization_config, MultiObjectiveOptimizationConfig
-        ):
-            raise UnsupportedError("Multi-objective optimization is not supported.")
-        elif len(experiment.optimization_config.outcome_constraints) == 0:
-            raise UserInputError(
+            return "Optimization_config must be set to compute frontier."
+
+        if isinstance(experiment.optimization_config, MultiObjectiveOptimizationConfig):
+            return "Multi-objective optimization is not supported."
+
+        if len(experiment.optimization_config.outcome_constraints) == 0:
+            return (
                 "Plotting the objective-p(feasible) frontier requires at least one "
                 "outcome constraint."
             )
-        elif any(
+
+        if any(
             isinstance(oc, ScalarizedOutcomeConstraint)
             for oc in experiment.optimization_config.outcome_constraints
         ):
-            raise UnsupportedError(
-                "Scalarized outcome constraints are not supported yet."
-            )
+            return "Scalarized outcome constraints are not supported yet."
+
         relevant_adapter = extract_relevant_adapter(
             experiment=experiment,
             generation_strategy=generation_strategy,
@@ -120,17 +135,31 @@ class ObjectivePFeasibleFrontierPlot(Analysis):
         if not isinstance(relevant_adapter, TorchAdapter) or not isinstance(
             relevant_adapter.generator, BoTorchGenerator
         ):
-            raise AxError(
+            return (
                 "The Objective vs P(feasible) plot cannot be computed using the"
                 f" current Adapter ({relevant_adapter}) and generator"
                 f" ({relevant_adapter.generator}). Only TorchAdapters using"
                 " BoTorchGenerators are supported."
             )
+
+    @override
+    def compute(
+        self,
+        experiment: Experiment | None = None,
+        generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
+    ) -> PlotlyAnalysisCard:
+        experiment = none_throws(experiment)
+        relevant_adapter = extract_relevant_adapter(
+            experiment=experiment,
+            generation_strategy=generation_strategy,
+            adapter=adapter,
+        )
         # Generate arms on the objective p_feasible frontier
         # Specify to optimize multiple acquisition functions (via
         # MultiAcquisition). This will optimize the PosteriorMean and the
         # LogProbabilityOfFeasibility using MOO.
-        generator = relevant_adapter.generator
+        generator = assert_is_instance(relevant_adapter.generator, BoTorchGenerator)
         orig_acquisition_class = generator.acquisition_class
 
         orig_acquisition_options = generator.acquisition_options
@@ -159,16 +188,18 @@ class ObjectivePFeasibleFrontierPlot(Analysis):
         if self.additional_arms is not None:
             arms += self.additional_arms
 
+        optimization_config = none_throws(experiment.optimization_config)
+
         df = prepare_arm_data(
             experiment=experiment,
-            metric_names=[*experiment.optimization_config.metrics.keys()],
+            metric_names=[*optimization_config.metrics.keys()],
             adapter=relevant_adapter,
             use_model_predictions=True,
             relativize=self.relativize,
             additional_arms=arms,
         )
 
-        objective_name = experiment.optimization_config.objective.metric.name
+        objective_name = optimization_config.objective.metric.name
 
         fig = _prepare_figure_scatter(
             df=df,
@@ -178,7 +209,7 @@ class ObjectivePFeasibleFrontierPlot(Analysis):
             y_metric_label="% Chance of Satisfying the Constraints",
             is_relative=self.relativize,
             show_pareto_frontier=False,
-            x_lower_is_better=experiment.optimization_config.objective.minimize,
+            x_lower_is_better=optimization_config.objective.minimize,
             y_lower_is_better=False,
         )
 

--- a/ax/analysis/plotly/parallel_coordinates.py
+++ b/ax/analysis/plotly/parallel_coordinates.py
@@ -17,11 +17,11 @@ from ax.analysis.plotly.plotly_analysis import (
     PlotlyAnalysisCard,
 )
 from ax.analysis.plotly.utils import select_metric, truncate_label
+from ax.analysis.utils import validate_experiment
 from ax.core.experiment import Experiment
-from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from plotly import graph_objects as go
-from pyre_extensions import override
+from pyre_extensions import none_throws, override
 
 
 @final
@@ -50,14 +50,29 @@ class ParallelCoordinatesPlot(Analysis):
         self.metric_name = metric_name
 
     @override
+    def validate_applicable_state(
+        self,
+        experiment: Experiment | None = None,
+        generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
+    ) -> str | None:
+        """
+        ParallelCoordinatesPlot requires an experiment with trials and data.
+        """
+        return validate_experiment(
+            experiment=experiment,
+            require_trials=True,
+            require_data=True,
+        )
+
+    @override
     def compute(
         self,
         experiment: Experiment | None = None,
         generation_strategy: GenerationStrategy | None = None,
         adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
-        if experiment is None:
-            raise UserInputError("ParallelCoordinatesPlot requires an Experiment")
+        experiment = none_throws(experiment)
 
         metric_name = self.metric_name or select_metric(experiment=experiment)
 

--- a/ax/analysis/plotly/tests/test_bandit_rollout.py
+++ b/ax/analysis/plotly/tests/test_bandit_rollout.py
@@ -13,13 +13,13 @@ from ax.core.metric import Metric
 from ax.core.optimization_config import Objective, OptimizationConfig
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import SearchSpace
-from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_discrete_search_space,
     get_online_experiments,
     get_sobol,
 )
+from pyre_extensions import none_throws
 
 
 class TestBanditRollout(TestCase):
@@ -36,11 +36,14 @@ class TestBanditRollout(TestCase):
             self.experiment.new_batch_trial(generator_run=gr)
             self.experiment.new_batch_trial(generator_run=gr)
 
+    def test_validate_applicable_state(self) -> None:
+        self.assertIn(
+            "Requires an Experiment",
+            none_throws(BanditRollout().validate_applicable_state()),
+        )
+
     def test_compute(self) -> None:
         analysis = BanditRollout()
-
-        with self.assertRaisesRegex(UserInputError, "requires an Experiment"):
-            analysis.compute()
 
         card = analysis.compute(experiment=self.experiment)
 

--- a/ax/analysis/plotly/tests/test_parallel_coordinates.py
+++ b/ax/analysis/plotly/tests/test_parallel_coordinates.py
@@ -11,7 +11,7 @@ from ax.analysis.plotly.parallel_coordinates import (
     ParallelCoordinatesPlot,
 )
 from ax.analysis.plotly.utils import select_metric
-from ax.exceptions.core import UnsupportedError, UserInputError
+from ax.exceptions.core import UnsupportedError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
@@ -24,12 +24,15 @@ from pyre_extensions import none_throws
 
 
 class TestParallelCoordinatesPlot(TestCase):
+    def test_validate_applicable_state(self) -> None:
+        self.assertIn(
+            "Requires an Experiment",
+            none_throws(ParallelCoordinatesPlot("branin").validate_applicable_state()),
+        )
+
     def test_compute(self) -> None:
         analysis = ParallelCoordinatesPlot("branin")
         experiment = get_branin_experiment(with_completed_trial=True)
-
-        with self.assertRaisesRegex(UserInputError, "requires an Experiment"):
-            analysis.compute()
 
         card = analysis.compute(experiment=experiment)
         self.assertEqual(card.name, "ParallelCoordinatesPlot")

--- a/ax/analysis/plotly/tests/test_progression.py
+++ b/ax/analysis/plotly/tests/test_progression.py
@@ -10,17 +10,22 @@ from ax.analysis.plotly.progression import (
     _calculate_wallclock_timeseries,
     ProgressionPlot,
 )
-from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_test_map_data_experiment
+from pyre_extensions import none_throws
 
 
 class TestProgression(TestCase):
+    def test_validate_applicable_state(self) -> None:
+        self.assertIn(
+            "Requires an Experiment",
+            none_throws(
+                ProgressionPlot(metric_name="branin_map").validate_applicable_state()
+            ),
+        )
+
     def test_compute(self) -> None:
         analysis = ProgressionPlot(metric_name="branin_map")
-
-        with self.assertRaisesRegex(UserInputError, "requires an Experiment"):
-            analysis.compute()
 
         experiment = get_test_map_data_experiment(
             num_trials=2, num_fetches=5, num_complete=2

--- a/ax/analysis/plotly/tests/test_top_surfaces.py
+++ b/ax/analysis/plotly/tests/test_top_surfaces.py
@@ -7,7 +7,6 @@
 from ax.analysis.plotly.top_surfaces import TopSurfacesAnalysis
 from ax.api.client import Client
 from ax.api.configs import ChoiceParameterConfig, RangeParameterConfig
-from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_offline_experiments_subset,
@@ -19,6 +18,12 @@ from pyre_extensions import assert_is_instance, none_throws
 
 
 class TestTopSurfacesAnalysis(TestCase):
+    def test_validate_applicable_state(self) -> None:
+        self.assertIn(
+            "Requires an Experiment",
+            none_throws(TopSurfacesAnalysis().validate_applicable_state()),
+        )
+
     @mock_botorch_optimize
     def test_compute(self) -> None:
         client = Client()
@@ -52,14 +57,6 @@ class TestTopSurfacesAnalysis(TestCase):
                 )
 
         analysis = TopSurfacesAnalysis(metric_name="bar", order="first")
-
-        with self.assertRaisesRegex(UserInputError, "requires an Experiment"):
-            analysis.compute()
-
-        with self.assertRaisesRegex(
-            UserInputError, "Must provide either a GenerationStrategy or an Adapter"
-        ):
-            analysis.compute(experiment=client._experiment)
 
         cards = analysis.compute(
             experiment=client._experiment,

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -1080,21 +1080,22 @@ class TestClient(TestCase):
         client.configure_optimization(objective="foo")
         client.configure_generation_strategy()
 
-        with self.assertLogs(logger="ax.analysis", level="ERROR") as lg:
-            analysis = ParallelCoordinatesPlot()
-            cards = client.compute_analyses(analyses=[analysis])
+        # Test Analysis when Experiment is not in applicable state
+        analysis = ParallelCoordinatesPlot()
+        cards = client.compute_analyses(analyses=[analysis])
 
-            self.assertEqual(len(cards), 1)
-            self.assertEqual(cards[0].name, "ParallelCoordinatesPlot")
-            self.assertEqual(cards[0].title, "ParallelCoordinatesPlot Error")
-            self.assertEqual(
-                cards[0].subtitle,
-                "ValueError encountered while computing ParallelCoordinatesPlot.",
-            )
-            self.assertIn("Traceback", assert_is_instance(cards[0], AnalysisCard).blob)
-            self.assertTrue(
-                any(("No data found for metric") in msg for msg in lg.output)
-            )
+        self.assertEqual(len(cards), 1)
+        self.assertEqual(cards[0].name, "ParallelCoordinatesPlot")
+        self.assertEqual(cards[0].title, "ParallelCoordinatesPlot Error")
+        self.assertEqual(
+            cards[0].subtitle,
+            "AnalysisNotApplicableStateError encountered while computing "
+            "ParallelCoordinatesPlot.",
+        )
+        self.assertIn(
+            "Experiment has no trials",
+            assert_is_instance(cards[0], AnalysisCard).blob,
+        )
 
         for trial_index, _ in client.get_next_trials(max_trials=1).items():
             client.complete_trial(trial_index=trial_index, raw_data={"foo": 1.0})

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -2668,22 +2668,23 @@ class TestAxOrchestrator(TestCase):
             db_settings=self.db_settings,
         )
 
-        with self.assertLogs(logger="ax.analysis", level="ERROR") as lg:
-            analysis = ParallelCoordinatesPlot()
-            cards = orchestrator.compute_analyses(analyses=[analysis])
+        # Test Analysis when Experiment is not in applicable state
+        analysis = ParallelCoordinatesPlot()
+        cards = orchestrator.compute_analyses(analyses=[analysis])
 
-            self.assertEqual(len(cards), 1)
-            # TODO[mpolson64] Rethink these tests as we work on storage
-            # it saved the error card
-            # self.assertIsNotNone(cards[0].db_id)
-            self.assertEqual(cards[0].name, "ParallelCoordinatesPlot")
-            self.assertEqual(cards[0].title, "ParallelCoordinatesPlot Error")
-            self.assertEqual(
-                cards[0].subtitle,
-                "ValueError encountered while computing ParallelCoordinatesPlot.",
-            )
-            self.assertIn("Traceback", assert_is_instance(cards[0], AnalysisCard).blob)
-            self.assertTrue(any("No data found for metric" in msg for msg in lg.output))
+        self.assertEqual(len(cards), 1)
+        self.assertEqual(cards[0].name, "ParallelCoordinatesPlot")
+        self.assertEqual(cards[0].title, "ParallelCoordinatesPlot Error")
+        self.assertEqual(
+            cards[0].subtitle,
+            "AnalysisNotApplicableStateError encountered while computing "
+            "ParallelCoordinatesPlot.",
+        )
+        self.assertIn(
+            "Experiment has no trials",
+            assert_is_instance(cards[0], AnalysisCard).blob,
+        )
+
         sobol_generator = get_sobol(search_space=self.branin_experiment.search_space)
         sobol_run = sobol_generator.gen(n=1)
         trial = self.branin_experiment.new_trial(generator_run=sobol_run)


### PR DESCRIPTION
Summary: Additionally, added a number of new validation utils to be shared across all analyses, including validate_experiment_has_trials, validate_adapter_can_predict, and extract_relevant_trial_indices (for getting if any trials exist after both trial_indices filter and trial_status filter are applied)

Differential Revision: D84733870
