### PR TITLE
Unused code cleanup: ax/adapter

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -22,7 +22,6 @@ from ax.adapter.transforms.utils import (
     derelativize_optimization_config_with_raw_status_quo,
 )
 from ax.core.arm import Arm
-from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
@@ -134,21 +133,6 @@ def extract_risk_measure(risk_measure: RiskMeasure) -> RiskMeasureMCObjective:
             f"{risk_measure.risk_measure} exists in  `RISK_MEASURE_NAME_TO_CLASS` "
             f"and accepts arguments {risk_measure.options}."
         )
-
-
-def check_has_multi_objective_and_data(
-    experiment: Experiment,
-    data: Data,
-    optimization_config: OptimizationConfig | None = None,
-) -> None:
-    """Raise an error if not using a `MultiObjective` or if the data is empty."""
-    optimization_config = none_throws(
-        optimization_config or experiment.optimization_config
-    )
-    if not isinstance(optimization_config.objective, MultiObjective):
-        raise ValueError("Multi-objective optimization requires multiple objectives.")
-    if data.df.empty:
-        raise ValueError("MultiObjectiveOptimization requires non-empty data.")
 
 
 def extract_parameter_constraints(

--- a/ax/adapter/factory.py
+++ b/ax/adapter/factory.py
@@ -17,7 +17,6 @@ from pyre_extensions import assert_is_instance
 
 
 DEFAULT_TORCH_DEVICE = torch.device("cpu")
-DEFAULT_EHVI_BATCH_LIMIT = 5
 
 
 """

--- a/ax/adapter/tests/test_factory.py
+++ b/ax/adapter/tests/test_factory.py
@@ -14,38 +14,10 @@ from ax.adapter.factory import (
     get_thompson,
 )
 from ax.adapter.random import RandomAdapter
-from ax.core.experiment import Experiment
-from ax.core.optimization_config import (
-    MultiObjectiveOptimizationConfig,
-    OptimizationConfig,
-)
-from ax.core.outcome_constraint import ComparisonOp, ObjectiveThreshold
 from ax.generators.discrete.eb_thompson import EmpiricalBayesThompsonSampler
 from ax.generators.discrete.thompson import ThompsonSampler
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import (
-    get_branin_experiment,
-    get_branin_experiment_with_multi_objective,
-    get_factorial_experiment,
-)
-from pyre_extensions import assert_is_instance, none_throws
-
-
-def get_multi_obj_exp_and_opt_config() -> tuple[Experiment, OptimizationConfig]:
-    multi_obj_exp = get_branin_experiment_with_multi_objective(with_batch=True)
-    metrics = none_throws(multi_obj_exp.optimization_config).objective.metrics
-    multi_objective_thresholds = [
-        ObjectiveThreshold(
-            metric=metrics[0], bound=5.0, relative=False, op=ComparisonOp.LEQ
-        ),
-        ObjectiveThreshold(
-            metric=metrics[1], bound=10.0, relative=False, op=ComparisonOp.LEQ
-        ),
-    ]
-    optimization_config = assert_is_instance(
-        multi_obj_exp.optimization_config, MultiObjectiveOptimizationConfig
-    ).clone_with_args(objective_thresholds=multi_objective_thresholds)
-    return multi_obj_exp, optimization_config
+from ax.utils.testing.core_stubs import get_branin_experiment, get_factorial_experiment
 
 
 class TestAdapterFactorySingleObjective(TestCase):

--- a/ax/adapter/tests/test_registry.py
+++ b/ax/adapter/tests/test_registry.py
@@ -287,7 +287,7 @@ class ModelRegistryTest(TestCase):
                         model,
                         SaasFullyBayesianMultiTaskGP if use_saas else MultiTaskGP,
                     )
-                    data_covar_module, task_covar_module = model.covar_module.kernels
+                    data_covar_module, _ = model.covar_module.kernels
                     if use_saas is False and default_model is False:
                         self.assertIsInstance(data_covar_module, ScaleKernel)
                         base_kernel = data_covar_module.base_kernel

--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -550,10 +550,7 @@ class TorchAdapterTest(TestCase):
         # Check that no candidate metadata is handled correctly.
         exp = get_branin_experiment(with_status_quo=True, with_completed_trial=True)
         generator = TorchGenerator()
-        with mock.patch(
-            f"{TorchAdapter.__module__}." "TorchAdapter._validate_observation_data",
-            autospec=True,
-        ), mock.patch.object(
+        with mock.patch.object(
             generator, "fit", wraps=generator.fit
         ) as mock_generator_fit:
             adapter = TorchAdapter(experiment=exp, generator=generator)

--- a/ax/adapter/tests/test_transform_utils.py
+++ b/ax/adapter/tests/test_transform_utils.py
@@ -6,31 +6,17 @@
 
 # pyre-strict
 
-import numpy as np
 from ax.adapter import Adapter
 from ax.adapter.transforms.utils import (
     ClosestLookupDict,
     derelativize_optimization_config_with_raw_status_quo,
 )
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.generators.base import Generator
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_experiment_with_observations,
     get_multi_objective_optimization_config,
 )
-
-OBSERVATION_DATA = [
-    Observation(
-        features=ObservationFeatures(parameters={"x": 2.0, "y": 10.0}),
-        data=ObservationData(
-            means=np.array([1.0, 2.0, 6.0]),
-            covariance=np.array([[1.0, 2.0, 0.0], [3.0, 4.0, 0.0], [0.0, 0.0, 4.0]]),
-            metric_signatures=["m1", "m2", "m3"],
-        ),
-        arm_name="1_1",
-    )
-]
 
 
 class TransformUtilsTest(TestCase):

--- a/ax/adapter/tests/test_utils.py
+++ b/ax/adapter/tests/test_utils.py
@@ -75,11 +75,6 @@ class TestAdapterUtils(TestCase):
             trial_index=self.hss_trial.index,
             metadata=self.hss_cand_metadata,
         )
-        self.hss_obs_feat_all_params = ObservationFeatures.from_arm(
-            arm=Arm(self.hss_full_parameterization),
-            trial_index=self.hss_trial.index,
-            metadata={Keys.FULL_PARAMETERIZATION: self.hss_full_parameterization},
-        )
 
     def test_extract_outcome_constraints(self) -> None:
         outcomes = ["m1", "m2", "m3"]

--- a/ax/adapter/torch.py
+++ b/ax/adapter/torch.py
@@ -1093,16 +1093,6 @@ class TorchAdapter(Adapter):
 
         return thresholds
 
-    def _validate_observation_data(
-        self, observation_data: list[ObservationData]
-    ) -> None:
-        if len(observation_data) == 0:
-            raise ValueError(
-                "Torch generators cannot be fit without observation data. Possible "
-                "reasons include empty data being passed to the generator's constructor"
-                " or data being excluded because it is out-of-design. "
-            )
-
     def _extract_observation_data(
         self,
         observation_data: list[ObservationData],

--- a/ax/adapter/transforms/metadata_to_float.py
+++ b/ax/adapter/transforms/metadata_to_float.py
@@ -45,7 +45,6 @@ class MetadataToFloat(MetadataToParameterMixin, Transform):
     requires_data_for_initialization: bool = True
 
     DEFAULT_IS_FIDELITY: bool = False
-    ENFORCE_BOUNDS: bool = False
 
     def __init__(
         self,

--- a/ax/adapter/transforms/tests/test_choice_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_choice_encode_transform.py
@@ -6,10 +6,8 @@
 
 # pyre-strict
 
-from collections.abc import Sized
 from copy import deepcopy
 
-import numpy as np
 from ax.adapter.base import DataLoaderConfig
 from ax.adapter.data_utils import extract_experiment_data
 from ax.adapter.transforms.choice_encode import (
@@ -445,11 +443,3 @@ class OrderedChoiceToIntegerRangeTransformTest(ChoiceToNumericChoiceTransformTes
         Skip the HSS test. `OrderedChoiceToIntegerRange` cannot support hierarchical
         search spaces, because range parameters cannot have dependents.
         """
-
-
-def normalize_values(values: Sized) -> list[float]:
-    values = np.array(values, dtype=float)
-    vmin, vmax = values.min(), values.max()
-    if len(values) > 1:
-        values = (values - vmin) / (vmax - vmin)
-    return values.tolist()

--- a/ax/adapter/transforms/tests/test_deprecated_transform_mixin.py
+++ b/ax/adapter/transforms/tests/test_deprecated_transform_mixin.py
@@ -25,10 +25,6 @@ class DeprecatedTransformTest(TestCase):
         def __init__(self, *args: Any) -> None:
             super().__init__(*args)
 
-    class DeprecatedDummyTransform(DeprecatedTransformMixin, DummyTransform):
-        def __init__(self, *args: Any) -> None:
-            super().__init__(*args)
-
     def setUp(self) -> None:
         super().setUp()
         self.deprecated_t = self.DeprecatedTransform(MagicMock(), MagicMock())

--- a/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
@@ -287,9 +287,6 @@ class MapKeyToFloatTransformTest(TestCase):
         self.hss_experiment = get_hierarchical_search_space_experiment(
             num_observations=5, use_map_data=True
         )
-        self.hss_observations = observations_from_data(
-            experiment=self.hss_experiment, data=self.hss_experiment.lookup_data()
-        )
         self.hss_experiment_data = extract_experiment_data(
             experiment=self.hss_experiment,
             data_loader_config=DataLoaderConfig(),

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -91,11 +91,6 @@ class UtilsTest(TestCase):
             trial_index=self.hss_trial.index,
             metadata=self.hss_cand_metadata,
         )
-        self.hss_obs_feat_all_params = ObservationFeatures.from_arm(
-            arm=Arm(self.hss_full_parameterization),
-            trial_index=self.hss_trial.index,
-            metadata={Keys.FULL_PARAMETERIZATION: self.hss_full_parameterization},
-        )
         self.df = pd.DataFrame(
             [
                 {

--- a/ax/generators/base.py
+++ b/ax/generators/base.py
@@ -54,7 +54,6 @@ class Generator:
         """
         return {}
 
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def feature_importances(self) -> Any:
         raise NotImplementedError(
             "Feature importance not available for this Model type"

--- a/ax/utils/common/typeutils.py
+++ b/ax/utils/common/typeutils.py
@@ -83,7 +83,6 @@ def assert_is_instance_of_tuple(val: V, typ: tuple[type[V], ...]) -> T:
     return val
 
 
-# pyre-fixme[2]: Parameter annotation cannot be `Any`.
 # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use `typing.Type` to
 #  avoid runtime subscripting errors.
 def _argparse_type_encoder(arg: Any) -> type:


### PR DESCRIPTION
Summary: Removes unused code from ax/adapter. Much of this is utilities that were used for now deprecated functionality or corresponding tests. Unused code found using `vulture` tool and validated with manual search (it does need validation!).

Differential Revision: D84848233


