### PR TITLE
Treat early-stopped trials as pending

### DIFF
--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -435,6 +435,7 @@ def get_pending_observation_features_based_on_trial_status(
         TrialStatus.CANDIDATE,
         TrialStatus.STAGED,
         TrialStatus.RUNNING,
+        TrialStatus.EARLY_STOPPED,
         TrialStatus.ABANDONED,
     ]:
         for trial in experiment.trials_by_status[status]:


### PR DESCRIPTION
Summary:
## Context

We encounter duplicates in candidate generation when using an early-stopping strategy. So far this has been mitigated by specifying `should_deduplicate=True` in the `GenerationNode`. This appears to stem from an early-stopping trial f(x, t) stopped at progression t < T later being deemed promising by the surrogate when extrapolated to f(x, T) with fixed features.

## Changes

This adds early-stopped trials to the pending observation features, which serves to prevent it from being suggested later.

TODO: Benchmarking

Differential Revision: D84842619


