### PR TITLE
Allow using `int` values for `float` parameters

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -136,7 +136,10 @@ class Parameter(SortableBase, metaclass=ABCMeta):
 
     def is_valid_type(self, value: TParamValue) -> bool:
         """Whether a given value's type is allowed by this parameter."""
-        return type(value) is self.python_type
+        return type(value) is self.python_type or (
+            # ints are floats
+            type(value) is int and self.python_type is float
+        )
 
     @property
     def is_numeric(self) -> bool:


### PR DESCRIPTION
Summary:
With the current `is_valid_type` implementation:

```
> p = ChoiceParameter("p", values=[1, 2, 3], parameter_type=ParameterType.FLOAT)
> p.is_valid_type(1.0)
True
> p.is_valid_type(1)
False
```
Which is not the desired behavior

Differential Revision: D85098538


