### PR TITLE
Deprecate Trial.runner

### DIFF
--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -71,13 +71,6 @@ class MultiTypeExperiment(Experiment):
             default_data_type: Enum representing the data type this experiment uses.
         """
 
-        self._default_trial_type = default_trial_type
-
-        # Map from trial type to default runner of that type
-        self._trial_type_to_runner: dict[str, Runner | None] = {
-            default_trial_type: default_runner
-        }
-
         # Specifies which trial type each metric belongs to
         self._metric_to_trial_type: dict[str, str] = {}
 
@@ -99,6 +92,8 @@ class MultiTypeExperiment(Experiment):
             properties=properties,
             default_data_type=default_data_type,
             tracking_metrics=tracking_metrics,
+            runner=default_runner,
+            default_trial_type=default_trial_type,
         )
 
     def add_trial_type(self, trial_type: str, runner: Runner) -> "MultiTypeExperiment":
@@ -138,6 +133,7 @@ class MultiTypeExperiment(Experiment):
             raise ValueError(f"Experiment does not contain trial_type `{trial_type}`")
 
         self._trial_type_to_runner[trial_type] = runner
+        self._runner = runner
         return self
 
     def add_tracking_metric(
@@ -159,7 +155,7 @@ class MultiTypeExperiment(Experiment):
             raise ValueError(f"`{trial_type}` is not a supported trial type.")
 
         super().add_tracking_metric(metric)
-        self._metric_to_trial_type[metric.name] = trial_type
+        self._metric_to_trial_type[metric.name] = none_throws(trial_type)
         if canonical_name is not None:
             self._metric_to_canonical_name[metric.name] = canonical_name
         return self
@@ -307,26 +303,6 @@ class MultiTypeExperiment(Experiment):
         """Default trial type assigned to trials in this experiment."""
         return self._default_trial_type
 
-    def runner_for_trial(self, trial: BaseTrial) -> Runner | None:
-        """The default runner to use for a given trial.
-
-        Looks up the appropriate runner for this trial type in the trial_type_to_runner.
-        """
-        return (
-            trial._runner
-            if trial._runner
-            else self.runner_for_trial_type(trial_type=none_throws(trial.trial_type))
-        )
-
-    def runner_for_trial_type(self, trial_type: str) -> Runner | None:
-        """The default runner to use for a given trial type.
-
-        Looks up the appropriate runner for this trial type in the trial_type_to_runner.
-        """
-        if not self.supports_trial_type(trial_type):
-            raise ValueError(f"Trial type `{trial_type}` is not supported.")
-        return self._trial_type_to_runner[trial_type]
-
     def metrics_for_trial_type(self, trial_type: str) -> list[Metric]:
         """The default runner to use for a given trial type.
 
@@ -346,11 +322,6 @@ class MultiTypeExperiment(Experiment):
         Only trial types defined in the trial_type_to_runner are allowed.
         """
         return trial_type in self._trial_type_to_runner.keys()
-
-    def reset_runners(self, runner: Runner) -> None:
-        raise NotImplementedError(
-            "MultiTypeExperiment does not support resetting all runners."
-        )
 
 
 def filter_trials_by_type(

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -92,7 +92,7 @@ class BatchTrialTest(TestCase):
             self.batch.status = TrialStatus.RUNNING
 
     def test_BasicSetter(self) -> None:
-        self.batch.runner = SyntheticRunner()
+        self.experiment.runner = SyntheticRunner()
         self.assertIsNotNone(self.batch.runner)
 
     def test_AddArm(self) -> None:
@@ -209,7 +209,7 @@ class BatchTrialTest(TestCase):
         with patch.object(SyntheticRunner, "staging_required", staging_mock):
             mock_runner = SyntheticRunner()
             staging_mock.return_value = True
-            self.batch.runner = mock_runner
+            self.experiment.runner = mock_runner
             self.batch.run()
             self.assertEqual(self.batch.status, TrialStatus.STAGED)
             # Check that the trial statuses mapping on experiment has been updated.
@@ -231,7 +231,7 @@ class BatchTrialTest(TestCase):
             with self.assertRaises(TrialMutationError):
                 self.batch.add_arms_and_weights(arms=self.arms, weights=self.weights)
 
-            with self.assertRaises(TrialMutationError):
+            with self.assertRaises(UnsupportedError):
                 self.batch.runner = None
 
             # Cannot run batch that was already run
@@ -317,7 +317,7 @@ class BatchTrialTest(TestCase):
         self.assertEqual(self.batch.abandoned_reason, reason)
 
     def test_FailedBatchTrial(self) -> None:
-        self.batch.runner = SyntheticRunner()
+        self.experiment.runner = SyntheticRunner()
         self.batch.run()
         self.batch.mark_failed()
 
@@ -332,7 +332,7 @@ class BatchTrialTest(TestCase):
         self.assertIsNotNone(self.batch.time_completed)
 
     def test_EarlyStoppedBatchTrial(self) -> None:
-        self.batch.runner = SyntheticRunner()
+        self.experiment.runner = SyntheticRunner()
         self.batch.run()
         self.batch.attach_batch_trial_data(
             raw_data={
@@ -431,7 +431,7 @@ class BatchTrialTest(TestCase):
         with self.assertRaises(ValueError):
             self.batch.mark_running()
 
-        self.batch.runner = SyntheticRunner()
+        self.experiment.runner = SyntheticRunner()
         self.batch.run()
         self.assertEqual(self.batch.deployed_name, "test_0")
         self.assertNotEqual(len(self.batch.run_metadata.keys()), 0)

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -798,11 +798,10 @@ class ExperimentTest(TestCase):
         # pyre-fixme[6]: For 1st param expected `Optional[str]` but got `Dict[str,
         #  bool]`.
         new_runner = SyntheticRunner(dummy_metadata=identifier)
-
-        self.experiment.reset_runners(new_runner)
         # Don't update trials that have been run.
         self.assertEqual(batch.runner, original_runner)
         # Update default runner
+        self.experiment.runner = new_runner
         self.assertEqual(self.experiment.runner, new_runner)
         # Update candidate trial runners.
         self.assertEqual(self.experiment.trials[1].runner, new_runner)

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -141,15 +141,11 @@ class MultiTypeExperimentTest(TestCase):
         batch = self.experiment.new_batch_trial()
         batch._trial_type = "type3"  # Force override trial type
         with self.assertRaises(ValueError):
-            self.experiment.runner_for_trial(batch)
+            self.experiment.runner_for_trial_type(batch.trial_type)
 
         # Try making trial with unsupported trial type
         with self.assertRaises(ValueError):
             self.experiment.new_batch_trial(trial_type="type3")
-
-        # Try resetting runners.
-        with self.assertRaises(NotImplementedError):
-            self.experiment.reset_runners(SyntheticRunner())
 
     def test_setting_opt_config(self) -> None:
         self.assertDictEqual(

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -168,7 +168,7 @@ class TrialTest(TestCase):
 
     def test_failed(self) -> None:
         fail_reason = "testing"
-        self.trial.runner = SyntheticRunner()
+        self.trial.experiment.runner = SyntheticRunner()
         self.trial.run()
         self.trial.mark_failed(reason=fail_reason)
 
@@ -196,7 +196,7 @@ class TrialTest(TestCase):
             self.trial.mark_stale()
 
     def test_trial_run_does_not_overwrite_existing_metadata(self) -> None:
-        self.trial.runner = SyntheticRunner(dummy_metadata="y")
+        self.trial.experiment.runner = SyntheticRunner(dummy_metadata="y")
         self.trial.update_run_metadata({"orig_metadata": "x"})
         self.trial.run()
         self.assertDictEqual(
@@ -286,7 +286,7 @@ class TrialTest(TestCase):
             (TrialStatus.COMPLETED, TrialStatus.ABANDONED, TrialStatus.EARLY_STOPPED),
         ):
             self.setUp()
-            self.trial._runner = DummyStopRunner()
+            self.experiment.runner = DummyStopRunner()
             self.trial.mark_running()
             self.assertEqual(self.trial.status, TrialStatus.RUNNING)
             self.trial.update_trial_data(raw_data={"m1": 1.0, "m2": 2.0})

--- a/ax/runners/tests/test_single_running_trial_mixin.py
+++ b/ax/runners/tests/test_single_running_trial_mixin.py
@@ -25,7 +25,6 @@ class SingleRunningTrialMixinTest(TestCase):
         exp.runner = runner
         trials = exp.trials.values()
         for trial in trials:
-            trial.assign_runner()
             trial.run()
         trial_statuses = runner.poll_trial_status(trials=trials)
         self.assertEqual(trial_statuses[TrialStatus.COMPLETED], {0})
@@ -41,7 +40,6 @@ class SingleRunningTrialMixinTest(TestCase):
         exp = get_branin_experiment(with_trial=True)
         exp.runner = runner
         trial = exp.trials[0]
-        trial.assign_runner()
         trial.mark_abandoned()
         trial_statuses = runner.poll_trial_status(trials=[trial])
         self.assertEqual(trial_statuses, {})

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1550,7 +1550,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
 
     def _set_runner(self, experiment: Experiment) -> None:
         """Overridable method to sets a runner on the experiment."""
-        experiment.runner = None
+        pass
 
     def _set_generation_strategy(
         self, choose_generation_strategy_kwargs: dict[str, Any] | None = None

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -529,13 +529,11 @@ class TestAxOrchestrator(TestCase):
         trial = self.branin_experiment.new_trial(generator_run=sobol_run)
         trial.mark_running(no_runner_required=True)
         trial.mark_completed()
-        trial0 = self.branin_experiment.trials[0]
-        trial0.assign_runner()
+        _ = self.branin_experiment.trials[0]
         sobol_generator = get_sobol(search_space=self.branin_experiment.search_space)
         sobol_run = sobol_generator.gen(n=15)
         trial1 = self.branin_experiment.new_batch_trial()
         trial1.add_generator_run(sobol_run)
-        trial1.assign_runner()
         trial1.mark_running()
         if all_completed_trials:
             trial1.mark_completed()
@@ -1088,6 +1086,7 @@ class TestAxOrchestrator(TestCase):
 
     def test_from_stored_experiment(self) -> None:
         init_test_engine_and_session_factory(force_init=True)
+        self.branin_experiment.runner = self.runner
         save_experiment(self.branin_experiment, config=self.db_config)
         with self.subTest("it errors by default without a generation strategy"):
             with self.assertRaisesRegex(

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -939,6 +939,7 @@ class InstantiationBase:
             properties=properties,
             auxiliary_experiments_by_purpose=auxiliary_experiments_by_purpose,
             is_test=is_test,
+            runner=default_runner,
         )
 
     @classmethod

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -146,7 +146,6 @@ def batch_trial_from_json(
     batch._run_metadata = run_metadata or {}
     batch._stop_metadata = stop_metadata or {}
     batch._generator_runs = generator_runs
-    batch._runner = runner
     batch._abandoned_arms_metadata = abandoned_arms_metadata
     batch._num_arms_created = num_arms_created
     batch._generation_step_index = generation_step_index
@@ -210,7 +209,6 @@ def trial_from_json(
     trial._failed_reason = failed_reason
     trial._run_metadata = run_metadata or {}
     trial._stop_metadata = stop_metadata or {}
-    trial._runner = runner
     trial._num_arms_created = num_arms_created
     trial._generation_step_index = generation_step_index
     trial._properties = properties or {}

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -98,6 +98,7 @@ def experiment_to_dict(experiment: Experiment) -> dict[str, Any]:
         "data_by_trial": experiment._data_by_trial,
         "properties": experiment._properties,
         "default_data_type": experiment._default_data_type,
+        "_trial_type_to_runner": experiment._trial_type_to_runner,
     }
 
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -2066,6 +2066,7 @@ class JSONStoreTest(TestCase):
                 }
             },
             "properties": {},
+            "_trial_type_to_runner": {None: None},
             "default_data_type": {"__type": "DataType", "name": "DATA"},
         }
         decoded = object_from_json(object_json=experiment_json)

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -383,6 +383,13 @@ class Decoder:
             for trial_index, data_by_timestamp in data_by_trial.items()
         }
 
+        trial_type_to_runner = {
+            sqa_runner.trial_type: self.runner_from_sqa(sqa_runner)
+            for sqa_runner in experiment_sqa.runners
+        }
+        if len(trial_type_to_runner) == 0:
+            trial_type_to_runner = {None: None}
+
         experiment._trials = {trial.index: trial for trial in trials}
         experiment._arms_by_name = {}
         for trial in trials:
@@ -398,6 +405,11 @@ class Decoder:
             value=experiment_sqa.experiment_type, enum=self.config.experiment_type_enum
         )
         experiment._data_by_trial = dict(data_by_trial)
+        # `_trial_type_to_runner` is set in _init_mt_experiment_from_sqa
+        if subclass != "MultiTypeExperiment":
+            experiment._trial_type_to_runner = cast(
+                dict[str | None, Runner | None], trial_type_to_runner
+            )
         experiment.db_id = experiment_sqa.id
         return experiment
 
@@ -1066,13 +1078,6 @@ class Decoder:
             else None
         )
         trial._num_arms_created = trial_sqa.num_arms_created
-        trial._runner = (
-            self.runner_from_sqa(
-                trial_sqa.runner,
-            )
-            if trial_sqa.runner
-            else None
-        )
         trial._generation_step_index = trial_sqa.generation_step_index
         trial._properties = dict(trial_sqa.properties or {})
         trial.db_id = trial_sqa.id

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -1006,9 +1006,6 @@ class Encoder:
         """
 
         runner = None
-        if trial.runner:
-            runner = self.runner_to_sqa(runner=none_throws(trial.runner))
-
         abandoned_arms, generator_runs = [], []
 
         if isinstance(trial, Trial) and trial.generator_run:

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -280,7 +280,6 @@ def get_experiment_with_custom_runner_and_metric(
             ),
         )
         trial = experiment.new_trial(generator_run=sobol_run)
-        trial.runner = experiment.runner
         trial.mark_running()
         data = Data.from_multiple_data(
             get_data(
@@ -1735,7 +1734,7 @@ def get_batch_trial(
     batch.add_arms_and_weights(arms=arms, weights=weights)
     if abandon_arm:
         batch.mark_arm_abandoned(batch.arms[2].name, "abandoned reason")
-    batch.runner = SyntheticRunner()
+    experiment.runner = SyntheticRunner()
     batch.should_add_status_quo_arm = True
     batch._generation_step_index = 0
     return batch
@@ -1746,7 +1745,7 @@ def get_trial() -> Trial:
     trial = experiment.new_trial(ttl_seconds=72)
     arm = get_arms_from_dict(get_arm_weights1())[0]
     trial.add_arm(arm)
-    trial.runner = SyntheticRunner()
+    experiment.runner = SyntheticRunner()
     trial._generation_step_index = 0
     trial.update_run_metadata({"workflow_run_id": [12345]})
     return trial


### PR DESCRIPTION
Summary:
Upstream functionality from MultiTypeExperiment._runner_by_trial_type

Full details in: T222906773 and [doc](https://docs.google.com/document/d/1u0J0VA2VzMkJO4n-J-8ngR0PNdd4CgCmePp8HUFRuTA/edit?tab=t.z51rdls4788k), but a summary is: 

 {F1982739301}

Differential Revision: D83001393


