### PR TITLE
Make sure log_scale parameter has lower bound > 0 during model expansion

### DIFF
--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -405,7 +405,18 @@ class Adapter:
                 param_vals.append(fill_values[p_name])
             if len(param_vals) == 0:
                 continue
-            p.lower = min(p.lower, min(param_vals))
+            # For log_scale parameters, ensure lower bound is > 0
+            # as OOD arms may have values <= 0
+            if p.log_scale:
+                # Find the smallest positive value from param_vals
+                positive_vals = [v for v in param_vals if v > 0]
+                if positive_vals:
+                    p.lower = min(p.lower, min(positive_vals))
+                else:
+                    # keep original lower bound
+                    continue
+            else:
+                p.lower = min(p.lower, min(param_vals))
             p.upper = max(p.upper, max(param_vals))
         # Remove parameter constraints from the model space.
         self._model_space.set_parameter_constraints([])


### PR DESCRIPTION
Summary:
User may have OOD prod arm where a certain param value is 0 while they want to tune the parameter with values > 0 in log scale, and if that's the case model expansion will include 0 in the model space (https://fburl.com/code/hvwpnaax)

We should add a check to make sure the expanded lower bounds are always positive for log scale RangeParameter

Differential Revision: D85299292


