### PR TITLE
Deprecate initializing an `Adapter` from a `SearchSpace`

### DIFF
--- a/ax/adapter/factory.py
+++ b/ax/adapter/factory.py
@@ -61,10 +61,10 @@ def get_sobol(
     )
 
 
-def get_factorial(search_space: SearchSpace) -> DiscreteAdapter:
+def get_factorial(experiment: Experiment) -> DiscreteAdapter:
     """Instantiates a factorial generator."""
     return assert_is_instance(
-        Generators.FACTORIAL(search_space=search_space),
+        Generators.FACTORIAL(experiment=experiment),
         DiscreteAdapter,
     )
 

--- a/ax/adapter/tests/test_factory.py
+++ b/ax/adapter/tests/test_factory.py
@@ -38,7 +38,7 @@ class TestAdapterFactorySingleObjective(TestCase):
     def test_factorial(self) -> None:
         """Tests factorial instantiation."""
         exp = get_factorial_experiment()
-        factorial = get_factorial(exp.search_space)
+        factorial = get_factorial(exp)
         self.assertIsInstance(factorial, DiscreteAdapter)
         factorial_run = factorial.gen(n=-1)
         self.assertEqual(len(factorial_run.arms), 24)
@@ -46,7 +46,7 @@ class TestAdapterFactorySingleObjective(TestCase):
     def test_empirical_bayes_thompson(self) -> None:
         """Tests EB/TS instantiation."""
         exp = get_factorial_experiment()
-        factorial = get_factorial(exp.search_space)
+        factorial = get_factorial(exp)
         self.assertIsInstance(factorial, DiscreteAdapter)
         factorial_run = factorial.gen(n=-1)
         exp.new_batch_trial().add_generator_run(factorial_run).run().mark_completed()
@@ -62,7 +62,7 @@ class TestAdapterFactorySingleObjective(TestCase):
     def test_thompson(self) -> None:
         """Tests TS instantiation."""
         exp = get_factorial_experiment()
-        factorial = get_factorial(exp.search_space)
+        factorial = get_factorial(exp)
         self.assertIsInstance(factorial, DiscreteAdapter)
         factorial_run = factorial.gen(n=-1)
         exp.new_batch_trial().add_generator_run(factorial_run).run().mark_completed()

--- a/ax/adapter/tests/test_registry.py
+++ b/ax/adapter/tests/test_registry.py
@@ -17,7 +17,6 @@ from ax.adapter.registry import (
 from ax.adapter.torch import TorchAdapter
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
-from ax.exceptions.core import UserInputError
 from ax.generators.discrete.eb_thompson import EmpiricalBayesThompsonSampler
 from ax.generators.discrete.thompson import ThompsonSampler
 from ax.generators.random.sobol import SobolGenerator
@@ -34,7 +33,6 @@ from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_branin_experiment_with_status_quo_trials,
-    get_branin_search_space,
     get_factorial_experiment,
 )
 from ax.utils.testing.mock import mock_botorch_optimize
@@ -328,17 +326,3 @@ class ModelRegistryTest(TestCase):
             generator_run=gr, model_class=SobolGenerator
         )
         self.assertEqual(extracted, {})
-
-    def test_initialize_from_search_space(self) -> None:
-        search_space = get_branin_search_space()
-        with self.assertWarnsRegex(
-            DeprecationWarning, "Passing in a `search_space` to initialize"
-        ):
-            adapter = Generators.SOBOL(search_space=search_space)
-        self.assertEqual(adapter._model_space, search_space)
-        self.assertIsNotNone(adapter._experiment)
-        with self.assertRaisesRegex(
-            UserInputError,
-            "`experiment` is required to initialize a model from registry.",
-        ):
-            Generators.BOTORCH_MODULAR(search_space=search_space)

--- a/ax/generation_strategy/tests/test_generator_spec.py
+++ b/ax/generation_strategy/tests/test_generator_spec.py
@@ -24,7 +24,7 @@ class BaseGeneratorSpecTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.experiment = get_branin_experiment()
-        sobol = Generators.SOBOL(search_space=self.experiment.search_space)
+        sobol = Generators.SOBOL(experiment=self.experiment)
         sobol_run = sobol.gen(n=20)
         self.experiment.new_batch_trial().add_generator_run(
             sobol_run

--- a/ax/plot/tests/long_running/test_pareto_utils.py
+++ b/ax/plot/tests/long_running/test_pareto_utils.py
@@ -26,7 +26,7 @@ class ComputePosteriorParetoFrontierTest(TestCase):
         experiment.add_tracking_metric(
             BraninMetric(name="m2", param_names=["x1", "x2"])
         )
-        sobol = Generators.SOBOL(experiment.search_space)
+        sobol = Generators.SOBOL(experiment)
         a = sobol.gen(5)
         experiment.new_batch_trial(generator_run=a).run()
         self.experiment = experiment

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -55,7 +55,7 @@ class ParetoUtilsTest(TestCase):
         experiment.add_tracking_metric(
             BraninMetric(name="m2", param_names=["x1", "x2"])
         )
-        sobol = Generators.SOBOL(experiment.search_space)
+        sobol = Generators.SOBOL(experiment)
         a = sobol.gen(5)
         experiment.new_batch_trial(generator_run=a).run()
         self.experiment = experiment
@@ -183,7 +183,7 @@ class ParetoUtilsTest(TestCase):
         experiment = get_branin_experiment_with_multi_objective(
             has_objective_thresholds=True,
         )
-        sobol = Generators.SOBOL(experiment.search_space)
+        sobol = Generators.SOBOL(experiment)
         a = sobol.gen(5)
         experiment.new_batch_trial(generator_run=a).run()
         experiment.fetch_data()

--- a/ax/plot/tests/test_traces.py
+++ b/ax/plot/tests/test_traces.py
@@ -77,7 +77,7 @@ class TracesTest(TestCase):
         # Generate some trials with different model types, including batch trial.
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].mark_completed(unsafe=True)
-        sobol = Generators.SOBOL(search_space=exp.search_space)
+        sobol = Generators.SOBOL(experiment=exp)
         for _ in range(2):
             t = exp.new_trial(sobol.gen(1)).run()
             t.mark_completed()

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -478,9 +478,7 @@ class ReportUtilsTest(TestCase):
         exp = get_branin_experiment_with_timestamp_map_metric(with_status_quo=True)
         exp.new_trial().add_arm(exp.status_quo)
         exp.trials[0].run()
-        exp.new_trial(
-            generator_run=Generators.SOBOL(search_space=exp.search_space).gen(n=1)
-        )
+        exp.new_trial(generator_run=Generators.SOBOL(experiment=exp).gen(n=1))
         exp.trials[1].run()
         for t in exp.trials.values():
             t.mark_completed()
@@ -510,7 +508,7 @@ class ReportUtilsTest(TestCase):
     def test_skip_contour_high_dimensional(self) -> None:
         exp = get_high_dimensional_branin_experiment()
         # Initial Sobol points
-        sobol = Generators.SOBOL(search_space=exp.search_space)
+        sobol = Generators.SOBOL(experiment=exp)
         for _ in range(1):
             exp.new_trial(sobol.gen(1)).run()
         model = Generators.BOTORCH_MODULAR(

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -915,7 +915,7 @@ class SQAStoreTest(TestCase):
 
         exp = get_branin_experiment_with_timestamp_map_metric()
         save_experiment(exp)
-        generator_run = Generators.SOBOL(search_space=exp.search_space).gen(n=1)
+        generator_run = Generators.SOBOL(experiment=exp).gen(n=1)
         trial = exp.new_trial(generator_run=generator_run)
         exp.attach_data(trial.run().fetch_data())
         save_or_update_trials(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -715,7 +715,7 @@ def get_factorial_experiment(
         )
 
     if with_batch:
-        factorial_generator = get_factorial(search_space=exp.search_space)
+        factorial_generator = get_factorial(experiment=exp)
         # compute cardinality of discrete search space
         n = prod(
             len(assert_is_instance(p, ChoiceParameter).values)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/Kats/pull/346

`Adapter` should be initialized from an `Experiment` instead

Differential Revision: D85103718


