### PR TITLE
Fix broken link to storage tutorial

### DIFF
--- a/ax/exceptions/storage.py
+++ b/ax/exceptions/storage.py
@@ -10,10 +10,11 @@
 from ax.exceptions.core import AxError
 
 
-STORAGE_DOCS_SUFFIX = (
-    "Please see our storage tutorial (https://ax.dev/docs/storage.html) "
-    "for more details ('Customizing' section will be "
-    "relevant for saving Ax object subclasses)."
+JSON_STORAGE_DOCS_SUFFIX = (
+    "Please see our JSON storage tutorial "
+    "(https://ax.dev/docs/recipes/experiment-to-json) for more details. "
+    "The 'Customizing the Serialization Process' section will be "
+    "relevant for saving Ax object subclasses."
 )
 
 

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -35,7 +35,7 @@ from ax.core.parameter_constraint import (
     SumConstraint,
 )
 from ax.core.search_space import SearchSpace
-from ax.exceptions.storage import JSONDecodeError, STORAGE_DOCS_SUFFIX
+from ax.exceptions.storage import JSON_STORAGE_DOCS_SUFFIX, JSONDecodeError
 from ax.generation_strategy.generation_node_input_constructors import (
     InputConstructorPurpose,
 )
@@ -183,7 +183,7 @@ def object_from_json(
             err = (
                 f"The JSON dictionary passed to `object_from_json` has a type "
                 f"{_type} that is not registered with a corresponding class in "
-                f"DECODER_REGISTRY. {STORAGE_DOCS_SUFFIX}"
+                f"DECODER_REGISTRY. {JSON_STORAGE_DOCS_SUFFIX}"
             )
             raise JSONDecodeError(err)
 

--- a/ax/storage/json_store/encoder.py
+++ b/ax/storage/json_store/encoder.py
@@ -18,7 +18,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import torch
-from ax.exceptions.storage import JSONEncodeError, STORAGE_DOCS_SUFFIX
+from ax.exceptions.storage import JSON_STORAGE_DOCS_SUFFIX, JSONEncodeError
 from ax.storage.json_store.encoders import tensor_to_dict
 from ax.storage.json_store.registry import (
     CORE_CLASS_ENCODER_REGISTRY,
@@ -128,6 +128,6 @@ def object_to_json(
     err = (
         f"Object {obj} passed to `object_to_json` (of type {_type}, module: "
         f"{_type.__module__}) is not registered with a corresponding encoder "
-        f"in ENCODER_REGISTRY. {STORAGE_DOCS_SUFFIX}"
+        f"in ENCODER_REGISTRY. {JSON_STORAGE_DOCS_SUFFIX}"
     )
     raise JSONEncodeError(err)

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -50,7 +50,7 @@ from ax.early_stopping.strategies import (
     ThresholdEarlyStoppingStrategy,
 )
 from ax.exceptions.core import AxStorageWarning, UnsupportedError
-from ax.exceptions.storage import JSONEncodeError, STORAGE_DOCS_SUFFIX
+from ax.exceptions.storage import JSON_STORAGE_DOCS_SUFFIX, JSONEncodeError
 from ax.generation_strategy.best_model_selector import BestModelSelector
 from ax.generation_strategy.generation_node import GenerationNode
 from ax.generation_strategy.generation_strategy import (
@@ -615,7 +615,7 @@ def botorch_modular_to_dict(class_type: type[Any]) -> dict[str, Any]:
                     f"Class `{class_type.__name__}` not in Type[{_class.__name__}] "
                     "registry, please add it. BoTorch object registries are "
                     "located in `ax/storage/botorch_modular_registry.py`. "
-                    f"{STORAGE_DOCS_SUFFIX}"
+                    f"{JSON_STORAGE_DOCS_SUFFIX}"
                 )
             return {
                 "__type": f"Type[{_class.__name__}]",
@@ -624,7 +624,7 @@ def botorch_modular_to_dict(class_type: type[Any]) -> dict[str, Any]:
             }
     raise ValueError(
         f"{class_type} does not have a corresponding parent class in "
-        f"CLASS_TO_REGISTRY. {STORAGE_DOCS_SUFFIX}"
+        f"CLASS_TO_REGISTRY. {JSON_STORAGE_DOCS_SUFFIX}"
     )
 
 


### PR DESCRIPTION
Summary:
See https://github.com/facebook/Ax/issues/4461

This message was linking to https://ax.dev/docs/storage.html which no longer exists. The information there has been moved to https://ax.dev/docs/recipes/experiment-to-json.

Differential Revision: D85350961


