### PR TITLE
Bump required botorch to 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "botorch[pymoo]>=0.15.1,<0.15.2dev9999",
+    "botorch[pymoo]>=0.16.0,<0.16.1dev9999",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
Summary: Do not land until botorch release is live

Reviewed By: saitcakmak

Differential Revision: D85321803


