### PR TITLE
Feed Benchmarks

### DIFF
--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -72,6 +72,7 @@ from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
+from botorch.models.map_saas import AdditiveMapSaasSingleTaskGP
 from botorch.models.model import Model
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import MultiTaskGP
@@ -126,6 +127,7 @@ MODEL_REGISTRY: dict[type[Model], str] = {
     # NOTE: Fixed noise models are deprecated. They point to their
     # supported parent classes, so that we can reap them with minimal
     # concern for backwards compatibility when the time comes.
+    AdditiveMapSaasSingleTaskGP: "AdditiveMapSaasSingleTaskGP",
     MixedSingleTaskGP: "MixedSingleTaskGP",
     ModelListGP: "ModelListGP",
     MultiTaskGP: "MultiTaskGP",


### PR DESCRIPTION
Summary:
Added 5 Feed benchmarks, three of which are constrained. The


Benchmark construction: N7625716
Optimal values from 990 sobol + 10 BO:
N7637108

Each benchmark is a MatheronPathModel (using Posterior Mean makes these benchmarks too easy). Optimal and default values are computed for seed 0.

Differential Revision: D78686518


