### PR TITLE
Fix hover <> x-axis tick label mismatch

### DIFF
--- a/ax/analysis/plotly/arm_effects.py
+++ b/ax/analysis/plotly/arm_effects.py
@@ -380,7 +380,7 @@ def _prepare_figure(
         else:
             num_non_candidate_trials += 1
 
-        text = trial_df.apply(
+        text = xy_df.apply(
             lambda row: get_arm_tooltip(row=row, metric_names=[metric_name]), axis=1
         )
 


### PR DESCRIPTION
Summary:
There is a mismatch between the hover tip and the x-axis labels for ArmEffectsPlot (see test plan for comparisons). This is caused by us filtering out NaNs from `trial_df` into `xy_df`, but continuing to use trial_df to create the hover text inside of `_prepare_function`.


Issue brought to our attentio by a user [here](https://fb.workplace.com/groups/ae.feedback/posts/25399242543017088/?comment_id=25423933367214672)

Differential Revision: D85797624


