### PR TITLE
Rename model_utils to generator_utils

### DIFF
--- a/ax/generators/random/base.py
+++ b/ax/generators/random/base.py
@@ -17,14 +17,14 @@ import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import SearchSpaceExhausted
 from ax.generators.base import Generator
-from ax.generators.model_utils import (
+from ax.generators.types import TConfig
+from ax.generators.utils import (
     add_fixed_features,
     DEFAULT_MAX_RS_DRAWS,
     rejection_sample,
     tunable_feature_indices,
     validate_bounds,
 )
-from ax.generators.types import TConfig
 from ax.utils.common.docutils import copy_doc
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils import assert_is_instance_of_tuple

--- a/ax/generators/random/sobol.py
+++ b/ax/generators/random/sobol.py
@@ -13,9 +13,9 @@ import numpy as np
 import numpy.typing as npt
 import torch
 from ax.core.search_space import SearchSpaceDigest
-from ax.generators.model_utils import tunable_feature_indices
 from ax.generators.random.base import RandomGenerator
 from ax.generators.types import TConfig
+from ax.generators.utils import tunable_feature_indices
 from pyre_extensions import none_throws
 from torch.quasirandom import SobolEngine
 

--- a/ax/generators/tests/test_utils.py
+++ b/ax/generators/tests/test_utils.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 from ax.core.search_space import SearchSpaceDigest
-from ax.generators.model_utils import (
+from ax.generators.utils import (
     best_observed_point,
     enumerate_discrete_combinations,
     mk_discrete_choices,
@@ -20,7 +20,7 @@ from ax.generators.model_utils import (
 from ax.utils.common.testutils import TestCase
 
 
-class ModelUtilsTest(TestCase):
+class UtilsTest(TestCase):
     def test_BestObservedPoint(self) -> None:
         model = MagicMock()
 

--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -19,10 +19,6 @@ from typing import Any, Mapping, Sequence
 import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import AxError, DataRequiredError, SearchSpaceExhausted
-from ax.generators.model_utils import (
-    enumerate_discrete_combinations,
-    mk_discrete_choices,
-)
 from ax.generators.torch.botorch_modular.optimizer_argparse import optimizer_argparse
 from ax.generators.torch.botorch_modular.surrogate import Surrogate
 from ax.generators.torch.botorch_modular.utils import _fix_map_key_to_target
@@ -33,6 +29,7 @@ from ax.generators.torch.utils import (
     subset_model,
 )
 from ax.generators.torch_base import TorchOptConfig
+from ax.generators.utils import enumerate_discrete_combinations, mk_discrete_choices
 from ax.utils.common.base import Base
 from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger

--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -22,7 +22,6 @@ from ax.core.search_space import SearchSpaceDigest
 from ax.core.types import TCandidateMetadata
 from ax.exceptions.core import AxError, UnsupportedError, UserInputError
 from ax.exceptions.model import ModelError
-from ax.generators.model_utils import best_in_sample_point
 from ax.generators.torch.botorch_modular.input_constructors.covar_modules import (
     covar_module_argparse,
 )
@@ -49,6 +48,7 @@ from ax.generators.torch.utils import (
 )
 from ax.generators.torch_base import TorchOptConfig
 from ax.generators.types import TConfig
+from ax.generators.utils import best_in_sample_point
 from ax.utils.common.base import Base
 from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger

--- a/ax/generators/torch/tests/test_surrogate.py
+++ b/ax/generators/torch/tests/test_surrogate.py
@@ -22,7 +22,6 @@ import torch
 from ax.core.search_space import RobustSearchSpaceDigest, SearchSpaceDigest
 from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.exceptions.model import ModelError
-from ax.generators.model_utils import best_in_sample_point
 from ax.generators.torch.botorch_modular.acquisition import Acquisition
 from ax.generators.torch.botorch_modular.kernels import (
     default_loc_and_scale_for_lognormal_lengthscale_prior,
@@ -45,6 +44,7 @@ from ax.generators.torch.botorch_modular.utils import (
 )
 from ax.generators.torch.utils import predict_from_model
 from ax.generators.torch_base import TorchOptConfig
+from ax.generators.utils import best_in_sample_point
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.stats.model_fit_stats import DIAGNOSTIC_FNS

--- a/ax/generators/torch/utils.py
+++ b/ax/generators/torch/utils.py
@@ -13,10 +13,7 @@ from typing import Any, cast
 import numpy.typing as npt
 import torch
 from ax.exceptions.core import UnsupportedError
-from ax.generators.model_utils import (
-    filter_constraints_and_fixed_features,
-    get_observed,
-)
+from ax.generators.utils import filter_constraints_and_fixed_features, get_observed
 from ax.utils.common.constants import Keys
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.analytic import PosteriorMean

--- a/ax/generators/utils.py
+++ b/ax/generators/utils.py
@@ -31,7 +31,7 @@ TTensoray = TypeVar("TTensoray", bound=Tensoray)
 
 
 class TorchGeneratorLike(Protocol):
-    """A protocol that stands in for ``TorchModel`` like objects that
+    """A protocol that stands in for ``TorchGenerator`` like objects that
     have a ``predict`` method.
     """
 


### PR DESCRIPTION
Summary: This was part of a diff that I'm not sure will land. So, splitting it into its own thing to propagate model -> generator re-naming.

Differential Revision: D85794987
