### PR TITLE
Add supports_relativization attribute to Data classes

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -68,6 +68,11 @@ class Data(Base, SerializationMixin):
     # Note: Although the SEM (standard error of the mean) is a required column,
     # downstream models can infer missing SEMs. Simply specify NaN as the SEM value,
     # either in your Metric class or in Data explicitly.
+
+    # Indicates whether this data type supports relativization.
+    # Subclasses can override this if they don't support relativization.
+    supports_relativization: bool = True
+
     REQUIRED_COLUMNS = {
         "trial_index",
         "arm_name",

--- a/ax/core/map_data.py
+++ b/ax/core/map_data.py
@@ -53,8 +53,8 @@ class MapData(Data):
             user as ``df``; by contrast, the property ``self.df`` is be a subset
             of the full data used for modeling. Constructing ``df`` can be
             expensive, so it is better to reference ``full_df`` than ``df`` for
-            operations that do not require scanning the full data, such as
-            accessing the columns of the DataFrame.
+            operations that do not require scanning the full data, such as accessing the
+            columns of the DataFrame.
         _memo_df: Either ``None``, if ``self.df`` has never been accessed, or
             equivalent to ``self.df``.
 
@@ -68,6 +68,9 @@ class MapData(Data):
         map_df: Equivalent to ``full_df``. ``map_df`` exists only on
             ``MapData``, whereas ``full_df`` exists for any ``Data`` subclass.
     """
+
+    # Override to indicate MapData does not support relativization
+    supports_relativization: bool = False
 
     DEDUPLICATE_BY_COLUMNS = [
         "trial_index",

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -254,6 +254,14 @@ class DataTest(TestCase):
         data = CustomData(df=self.df)
         self.assertNotEqual(data, Data(self.df))
 
+    def test_supports_relativization(self) -> None:
+        # Execute: Check supports_relativization attribute on Data class and instance
+        data = Data(df=self.df)
+
+        # Assert: Data should support relativization by default
+        self.assertTrue(Data.supports_relativization)
+        self.assertTrue(data.supports_relativization)
+
     def test_from_multiple(self) -> None:
         with self.subTest("Combinining non-empty Data"):
             data = Data.from_multiple_data([Data(df=self.df), Data(df=self.df)])

--- a/ax/core/tests/test_map_data.py
+++ b/ax/core/tests/test_map_data.py
@@ -317,6 +317,14 @@ class MapDataTest(TestCase):
         data = MapData(df=df)
         self.assertEqual(data.map_df[MAP_KEY].dtype, float)
 
+    def test_supports_relativization(self) -> None:
+        # Execute: Check supports_relativization attribute on MapData class and instance
+        map_data = MapData(df=self.df)
+
+        # Assert: MapData should not support relativization
+        self.assertFalse(MapData.supports_relativization)
+        self.assertFalse(map_data.supports_relativization)
+
     def test_true_df_deprecation(self) -> None:
         with self.assertWarnsRegex(DeprecationWarning, "true_df"):
             true_df = self.mmd.true_df


### PR DESCRIPTION
Summary:
Add a class attribute `supports_relativization` to the `Data` class hierarchy to indicate whether a data type supports relativization. This infrastructure change will be used in a follow-up diff to improve the Summary analysis by checking this attribute instead of using isinstance checks and would provide a cleaner, more extensible way to check for relativization support compared to type checking.

**Why this change:**
- Provides a more maintainable and extensible design pattern
- Eliminates the need for external isinstance() checks against specific data types
- Makes it easy for future data types to declare relativization support

**Changes:**
- Add `supports_relativization: bool = True` class attribute to the base `Data` class
- Override `supports_relativization = False` in `MapData` class since it raises NotImplementedError in its relativize() method
- Add documentation comments explaining the purpose of the attribute

Differential Revision: D85807192


