### PR TITLE
Use named arguments when instantiating objects / calling functions

### DIFF
--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -505,7 +505,13 @@ class BaseAdapterTest(TestCase):
         self.assertAlmostEqual(adapter.fit_time_since_gen, 0.0, places=1)
 
     def test_ood_gen(self) -> None:
-        ss = SearchSpace([RangeParameter("x", ParameterType.FLOAT, 0.0, 1.0)])
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x", parameter_type=ParameterType.FLOAT, lower=0.0, upper=1.0
+                )
+            ]
+        )
         experiment = Experiment(search_space=ss)
         adapter = Adapter(experiment=experiment, generator=Generator())
         obs = ObservationFeatures(parameters={"x": 3.0})

--- a/ax/adapter/tests/test_discrete_adapter.py
+++ b/ax/adapter/tests/test_discrete_adapter.py
@@ -40,7 +40,7 @@ class DiscreteAdapterTest(TestCase):
         self.parameters = [
             ChoiceParameter("x", ParameterType.FLOAT, values=[0, 1]),
             ChoiceParameter("y", ParameterType.STRING, values=["foo", "bar"]),
-            FixedParameter("z", ParameterType.BOOL, value=True),
+            FixedParameter(name="z", parameter_type=ParameterType.BOOL, value=True),
         ]
         self.search_space = SearchSpace(parameters=self.parameters)
         self.parameterizations: list[TParameterization] = [
@@ -143,9 +143,14 @@ class DiscreteAdapterTest(TestCase):
     def test_gen(self) -> None:
         # Test with constraints
         optimization_config = OptimizationConfig(
-            objective=Objective(Metric("m1"), minimize=True),
+            objective=Objective(metric=Metric(name="m1"), minimize=True),
             outcome_constraints=[
-                OutcomeConstraint(Metric("m2"), ComparisonOp.GEQ, 2, False)
+                OutcomeConstraint(
+                    metric=Metric(name="m2"),
+                    op=ComparisonOp.GEQ,
+                    bound=2,
+                    relative=False,
+                )
             ],
         )
         with mock.patch("ax.generators.discrete_base.DiscreteGenerator.fit"):
@@ -229,9 +234,14 @@ class DiscreteAdapterTest(TestCase):
 
         # Test validation
         optimization_config = OptimizationConfig(
-            objective=Objective(Metric("m1"), minimize=False),
+            objective=Objective(metric=Metric(name="m1"), minimize=False),
             outcome_constraints=[
-                OutcomeConstraint(Metric("m2"), ComparisonOp.GEQ, 2, True)
+                OutcomeConstraint(
+                    metric=Metric(name="m2"),
+                    op=ComparisonOp.GEQ,
+                    bound=2,
+                    relative=True,
+                )
             ],
         )
         with self.assertRaisesRegex(ValueError, "relative constraint"):

--- a/ax/adapter/tests/test_random_adapter.py
+++ b/ax/adapter/tests/test_random_adapter.py
@@ -38,13 +38,19 @@ from ax.utils.testing.core_stubs import (
 class RandomAdapterTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        x = RangeParameter("x", ParameterType.FLOAT, lower=0, upper=1)
-        y = RangeParameter("y", ParameterType.FLOAT, lower=1, upper=2)
-        z = RangeParameter("z", ParameterType.FLOAT, lower=0, upper=5)
+        x = RangeParameter(
+            name="x", parameter_type=ParameterType.FLOAT, lower=0, upper=1
+        )
+        y = RangeParameter(
+            name="y", parameter_type=ParameterType.FLOAT, lower=1, upper=2
+        )
+        z = RangeParameter(
+            name="z", parameter_type=ParameterType.FLOAT, lower=0, upper=5
+        )
         self.parameters = [x, y, z]
         parameter_constraints: list[ParameterConstraint] = [
-            OrderConstraint(x, y),
-            SumConstraint([x, z], False, 3.5),
+            OrderConstraint(lower_parameter=x, upper_parameter=y),
+            SumConstraint(parameters=[x, z], is_upper_bound=False, bound=3.5),
         ]
         self.search_space = SearchSpace(self.parameters, parameter_constraints)
         self.experiment = Experiment(search_space=self.search_space)
@@ -177,7 +183,7 @@ class RandomAdapterTest(TestCase):
         trial.add_arm(sq_arm)
         trial.mark_running(no_runner_required=True)
         trial.mark_completed()
-        experiment.add_tracking_metric(metric=Metric("ax_test_metric"))
+        experiment.add_tracking_metric(metric=Metric(name="ax_test_metric"))
         sobol = RandomAdapter(
             search_space=self.search_space,
             generator=SobolGenerator(),

--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -83,10 +83,13 @@ class TorchAdapterTest(TestCase):
             min=0.0, max=5.0, parameter_names=feature_names
         )
         opt_config = OptimizationConfig(
-            objective=Objective(metric=Metric("y1"), minimize=True),
+            objective=Objective(metric=Metric(name="y1"), minimize=True),
             outcome_constraints=[
                 OutcomeConstraint(
-                    metric=Metric("y2"), op=ComparisonOp.GEQ, bound=0.0, relative=False
+                    metric=Metric(name="y2"),
+                    op=ComparisonOp.GEQ,
+                    bound=0.0,
+                    relative=False,
                 )
             ],
         )
@@ -200,7 +203,7 @@ class TorchAdapterTest(TestCase):
         )
         best_point_return_value = torch.tensor([1.0, 2.0, 3.0], **tkwargs)
         opt_config = OptimizationConfig(
-            objective=Objective(metric=Metric("y1"), minimize=False),
+            objective=Objective(metric=Metric(name="y1"), minimize=False),
         )
         pending_observations = {
             "y2": [ObservationFeatures(parameters={"x1": 1.0, "x2": 2.0, "x3": 3.0})]
@@ -388,7 +391,7 @@ class TorchAdapterTest(TestCase):
     def test_best_point(self) -> None:
         search_space = get_search_space_for_range_value()
         oc = OptimizationConfig(
-            objective=Objective(metric=Metric("a"), minimize=False),
+            objective=Objective(metric=Metric(name="a"), minimize=False),
             outcome_constraints=[],
         )
         exp = Experiment(search_space=search_space, optimization_config=oc, name="test")
@@ -446,10 +449,10 @@ class TorchAdapterTest(TestCase):
             adapter.gen(
                 n=1,
                 optimization_config=OptimizationConfig(
-                    objective=Objective(metric=Metric("a"), minimize=False),
+                    objective=Objective(metric=Metric(name="a"), minimize=False),
                     outcome_constraints=[
                         ScalarizedOutcomeConstraint(
-                            metrics=[Metric("wrong_metric_name")],
+                            metrics=[Metric(name="wrong_metric_name")],
                             weights=[1.0],
                             op=ComparisonOp.LEQ,
                             bound=0,
@@ -715,10 +718,10 @@ class TorchAdapterTest(TestCase):
         )
         # Make an optimization config that includes all metrics.
         opt_config = OptimizationConfig(
-            objective=Objective(metric=Metric("y"), minimize=True),
+            objective=Objective(metric=Metric(name="y"), minimize=True),
             outcome_constraints=[
                 OutcomeConstraint(
-                    metric=Metric(f"y:c{i}"), op=ComparisonOp.GEQ, bound=0
+                    metric=Metric(name=f"y:c{i}"), op=ComparisonOp.GEQ, bound=0
                 )
                 for i in range(3)
             ],

--- a/ax/adapter/tests/test_utils.py
+++ b/ax/adapter/tests/test_utils.py
@@ -46,9 +46,11 @@ class TestAdapterUtils(TestCase):
         super().setUp()
         self.experiment = get_experiment()
         self.arm = Arm({"x": 5, "y": "foo", "z": True, "w": 5, "d": 11.0})
-        self.trial = self.experiment.new_trial(GeneratorRun([self.arm]))
+        self.trial = self.experiment.new_trial(GeneratorRun(arms=[self.arm]))
         self.experiment_2 = get_experiment()
-        self.batch_trial = self.experiment_2.new_batch_trial(GeneratorRun([self.arm]))
+        self.batch_trial = self.experiment_2.new_batch_trial(
+            GeneratorRun(arms=[self.arm])
+        )
         self.batch_trial.add_status_quo_arm(1)
         self.obs_feat = ObservationFeatures.from_arm(
             arm=self.trial.arm, trial_index=self.trial.index
@@ -82,7 +84,7 @@ class TestAdapterUtils(TestCase):
         self.assertIsNone(extract_outcome_constraints([], outcomes))
 
         outcome_constraints = [
-            OutcomeConstraint(metric=Metric("m1"), op=ComparisonOp.LEQ, bound=0)
+            OutcomeConstraint(metric=Metric(name="m1"), op=ComparisonOp.LEQ, bound=0)
         ]
         res = extract_outcome_constraints(outcome_constraints, outcomes)
         # pyre-fixme[16]: Optional type has no attribute `__getitem__`.
@@ -91,9 +93,9 @@ class TestAdapterUtils(TestCase):
         self.assertEqual(res[1][0][0], 0)
 
         outcome_constraints = [
-            OutcomeConstraint(metric=Metric("m1"), op=ComparisonOp.LEQ, bound=0),
+            OutcomeConstraint(metric=Metric(name="m1"), op=ComparisonOp.LEQ, bound=0),
             ScalarizedOutcomeConstraint(
-                metrics=[Metric("m2"), Metric("m3")],
+                metrics=[Metric(name="m2"), Metric(name="m3")],
                 weights=[0.5, 0.5],
                 op=ComparisonOp.GEQ,
                 bound=1,
@@ -153,7 +155,7 @@ class TestAdapterUtils(TestCase):
         self.assertTrue(np.isnan(obj_t[-2:]).all())
 
         # Fails if a threshold does not have a corresponding metric.
-        objective2 = Objective(Metric("m1"), minimize=False)
+        objective2 = Objective(Metric(name="m1"), minimize=False)
         with self.assertRaisesRegex(ValueError, "corresponding metrics"):
             extract_objective_thresholds(
                 objective_thresholds=objective_thresholds,
@@ -173,7 +175,7 @@ class TestAdapterUtils(TestCase):
 
         # Fails if relative
         objective_thresholds[2] = ObjectiveThreshold(
-            metric=Metric("m3"), op=ComparisonOp.LEQ, bound=3
+            metric=Metric(name="m3"), op=ComparisonOp.LEQ, bound=3
         )
         with self.assertRaises(ValueError):
             extract_objective_thresholds(
@@ -182,7 +184,7 @@ class TestAdapterUtils(TestCase):
                 outcomes=outcomes,
             )
         objective_thresholds[2] = ObjectiveThreshold(
-            metric=Metric("m3"), op=ComparisonOp.LEQ, bound=3, relative=True
+            metric=Metric(name="m3"), op=ComparisonOp.LEQ, bound=3, relative=True
         )
         with self.assertRaises(ValueError):
             extract_objective_thresholds(

--- a/ax/adapter/transforms/tests/test_choice_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_choice_encode_transform.py
@@ -42,30 +42,32 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x", lower=1, upper=3, parameter_type=ParameterType.FLOAT
+                    name="x", parameter_type=ParameterType.FLOAT, lower=1, upper=3
                 ),
-                RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),
+                RangeParameter(
+                    name="a", parameter_type=ParameterType.INT, lower=1, upper=2
+                ),
                 ChoiceParameter(
-                    "b",
+                    name="b",
                     parameter_type=ParameterType.FLOAT,
                     values=[1.0, 10.0, 100.0],
                     is_ordered=True,
                 ),
                 ChoiceParameter(
-                    "c",
+                    name="c",
                     parameter_type=ParameterType.FLOAT,
                     values=[10.0, 100.0, 1000.0],
                     is_ordered=True,
                     sort_values=False,
                 ),
                 ChoiceParameter(
-                    "d",
+                    name="d",
                     parameter_type=ParameterType.STRING,
                     values=["r", "q", "z"],
                     sort_values=True,
                 ),
                 ChoiceParameter(
-                    "e",
+                    name="e",
                     parameter_type=ParameterType.STRING,
                     values=["r", "q", "z"],
                     is_ordered=False,
@@ -172,7 +174,7 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
         ss3 = SearchSpace(
             parameters=[
                 ChoiceParameter(
-                    "b",
+                    name="b",
                     parameter_type=ParameterType.STRING,
                     values=["a", "b", "c"],
                     is_ordered=True,
@@ -188,7 +190,7 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
             SearchSpace(
                 parameters=[
                     ChoiceParameter(
-                        "b",
+                        name="b",
                         parameter_type=ParameterType.INT,
                         values=[0, 1, 2],
                         is_ordered=True,
@@ -215,13 +217,13 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
                     dependents={True: ["x1", "x2"]},
                 ),
                 RangeParameter(
-                    "x1",
+                    name="x1",
                     parameter_type=ParameterType.FLOAT,
                     lower=0.0,
                     upper=1.0,
                 ),
                 ChoiceParameter(
-                    "x2",
+                    name="x2",
                     parameter_type=ParameterType.STRING,
                     values=["NO", "YES"],
                     is_ordered=True,
@@ -229,7 +231,7 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
                     dependents={"NO": [], "YES": ["x3"]},
                 ),
                 RangeParameter(
-                    "x3",
+                    name="x3",
                     parameter_type=ParameterType.FLOAT,
                     lower=0.0,
                     upper=1.0,
@@ -392,7 +394,7 @@ class OrderedChoiceToIntegerRangeTransformTest(ChoiceToNumericChoiceTransformTes
         ss3 = SearchSpace(
             parameters=[
                 ChoiceParameter(
-                    "b",
+                    name="b",
                     parameter_type=ParameterType.FLOAT,
                     values=[1.0, 10.0, 100.0],
                     is_ordered=True,

--- a/ax/adapter/transforms/tests/test_derelativize_transform.py
+++ b/ax/adapter/transforms/tests/test_derelativize_transform.py
@@ -85,8 +85,12 @@ class DerelativizeTransformTest(TestCase):
         # Adapter with in-design status quo
         search_space = SearchSpace(
             parameters=[
-                RangeParameter("x", ParameterType.FLOAT, 0, 20),
-                RangeParameter("y", ParameterType.FLOAT, 0, 20),
+                RangeParameter(
+                    name="x", parameter_type=ParameterType.FLOAT, lower=0, upper=20
+                ),
+                RangeParameter(
+                    name="y", parameter_type=ParameterType.FLOAT, lower=0, upper=20
+                ),
             ]
         )
         experiment.search_space = search_space
@@ -98,15 +102,15 @@ class DerelativizeTransformTest(TestCase):
         g = Adapter(experiment=experiment_1, generator=Generator())
 
         # Test with no relative constraints
-        objective = Objective(Metric("c"), minimize=True)
+        objective = Objective(Metric(name="c"), minimize=True)
         oc = OptimizationConfig(
             objective=objective,
             outcome_constraints=[
                 OutcomeConstraint(
-                    Metric("m1"), ComparisonOp.LEQ, bound=2, relative=False
+                    Metric(name="m1"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 ScalarizedOutcomeConstraint(
-                    metrics=[Metric("m1"), Metric("m2")],
+                    metrics=[Metric(name="m1"), Metric(name="m2")],
                     op=ComparisonOp.LEQ,
                     bound=2,
                     weights=[0.5, 0.5],
@@ -123,13 +127,16 @@ class DerelativizeTransformTest(TestCase):
             objective=objective,
             outcome_constraints=[
                 OutcomeConstraint(
-                    Metric("m1"), ComparisonOp.LEQ, bound=2, relative=False
+                    Metric(name="m1"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 OutcomeConstraint(
-                    Metric("m2"), ComparisonOp.LEQ, bound=relative_bound, relative=True
+                    Metric(name="m2"),
+                    ComparisonOp.LEQ,
+                    bound=relative_bound,
+                    relative=True,
                 ),
                 ScalarizedOutcomeConstraint(
-                    metrics=[Metric("m1"), Metric("m2")],
+                    metrics=[Metric(name="m1"), Metric(name="m2")],
                     weights=[0.0, 1.0],
                     op=ComparisonOp.LEQ,
                     bound=relative_bound,
@@ -144,13 +151,16 @@ class DerelativizeTransformTest(TestCase):
             oc2.outcome_constraints
             == [
                 OutcomeConstraint(
-                    Metric("m1"), ComparisonOp.LEQ, bound=2, relative=False
+                    Metric(name="m1"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 OutcomeConstraint(
-                    Metric("m2"), ComparisonOp.LEQ, bound=absolute_bound, relative=False
+                    Metric(name="m2"),
+                    ComparisonOp.LEQ,
+                    bound=absolute_bound,
+                    relative=False,
                 ),
                 ScalarizedOutcomeConstraint(
-                    metrics=[Metric("m1"), Metric("m2")],
+                    metrics=[Metric(name="m1"), Metric(name="m2")],
                     weights=[0.0, 1.0],
                     op=ComparisonOp.LEQ,
                     bound=absolute_bound,
@@ -179,13 +189,16 @@ class DerelativizeTransformTest(TestCase):
             objective=objective,
             outcome_constraints=[
                 OutcomeConstraint(
-                    Metric("m1"), ComparisonOp.LEQ, bound=2, relative=False
+                    Metric(name="m1"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 OutcomeConstraint(
-                    Metric("m2"), ComparisonOp.LEQ, bound=relative_bound, relative=True
+                    Metric(name="m2"),
+                    ComparisonOp.LEQ,
+                    bound=relative_bound,
+                    relative=True,
                 ),
                 ScalarizedOutcomeConstraint(
-                    metrics=[Metric("m1"), Metric("m2")],
+                    metrics=[Metric(name="m1"), Metric(name="m2")],
                     weights=[0.0, 1.0],
                     op=ComparisonOp.LEQ,
                     bound=relative_bound,
@@ -200,13 +213,16 @@ class DerelativizeTransformTest(TestCase):
             oc2.outcome_constraints,
             [
                 OutcomeConstraint(
-                    Metric("m1"), ComparisonOp.LEQ, bound=2, relative=False
+                    Metric(name="m1"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 OutcomeConstraint(
-                    Metric("m2"), ComparisonOp.LEQ, bound=absolute_bound, relative=False
+                    Metric(name="m2"),
+                    ComparisonOp.LEQ,
+                    bound=absolute_bound,
+                    relative=False,
                 ),
                 ScalarizedOutcomeConstraint(
-                    metrics=[Metric("m1"), Metric("m2")],
+                    metrics=[Metric(name="m1"), Metric(name="m2")],
                     weights=[0.0, 1.0],
                     op=ComparisonOp.LEQ,
                     bound=absolute_bound,
@@ -227,10 +243,10 @@ class DerelativizeTransformTest(TestCase):
             objective=objective,
             outcome_constraints=[
                 OutcomeConstraint(
-                    Metric("m1"), ComparisonOp.LEQ, bound=2, relative=False
+                    Metric(name="m1"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 OutcomeConstraint(
-                    Metric("m2"), ComparisonOp.LEQ, bound=-10, relative=True
+                    Metric(name="m2"), ComparisonOp.LEQ, bound=-10, relative=True
                 ),
             ],
         )
@@ -254,7 +270,7 @@ class DerelativizeTransformTest(TestCase):
             objective=objective,
             outcome_constraints=[
                 ScalarizedOutcomeConstraint(
-                    metrics=[Metric("m1"), Metric("m2")],
+                    metrics=[Metric(name="m1"), Metric(name="m2")],
                     weights=[0.0, 1.0],
                     op=ComparisonOp.LEQ,
                     bound=-10,
@@ -284,15 +300,19 @@ class DerelativizeTransformTest(TestCase):
     def test_errors(self) -> None:
         t = Derelativize(search_space=None)
         oc = OptimizationConfig(
-            objective=Objective(Metric("c"), minimize=False),
+            objective=Objective(Metric(name="c"), minimize=False),
             outcome_constraints=[
                 OutcomeConstraint(
-                    Metric("m1"), ComparisonOp.LEQ, bound=2, relative=True
+                    Metric(name="m1"), ComparisonOp.LEQ, bound=2, relative=True
                 )
             ],
         )
         search_space = SearchSpace(
-            parameters=[RangeParameter("x", ParameterType.FLOAT, 0, 20)]
+            parameters=[
+                RangeParameter(
+                    name="x", parameter_type=ParameterType.FLOAT, lower=0, upper=20
+                )
+            ]
         )
         adapter = Adapter(
             experiment=Experiment(search_space=search_space), generator=Generator()

--- a/ax/adapter/transforms/tests/test_fixed_to_tunable.py
+++ b/ax/adapter/transforms/tests/test_fixed_to_tunable.py
@@ -33,14 +33,14 @@ class FixedToTunableTransformTest(TestCase):
         self.search_space_with_fixed = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "a", lower=1, upper=3, parameter_type=ParameterType.FLOAT
+                    name="a", parameter_type=ParameterType.FLOAT, lower=1, upper=3
                 ),
-                FixedParameter("b", parameter_type=ParameterType.FLOAT, value=2.0),
+                FixedParameter(name="b", parameter_type=ParameterType.FLOAT, value=2.0),
                 ChoiceParameter(
                     "c", parameter_type=ParameterType.STRING, values=["x", "y", "z"]
                 ),
-                FixedParameter("d", parameter_type=ParameterType.INT, value=5),
-                FixedParameter("e", parameter_type=ParameterType.FLOAT, value=3.0),
+                FixedParameter(name="d", parameter_type=ParameterType.INT, value=5),
+                FixedParameter(name="e", parameter_type=ParameterType.FLOAT, value=3.0),
             ]
         )
 
@@ -48,18 +48,18 @@ class FixedToTunableTransformTest(TestCase):
         self.joint_search_space = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "a", lower=1, upper=3, parameter_type=ParameterType.FLOAT
+                    name="a", parameter_type=ParameterType.FLOAT, lower=1, upper=3
                 ),
                 RangeParameter(
-                    "b", lower=1, upper=5, parameter_type=ParameterType.FLOAT
+                    name="b", parameter_type=ParameterType.FLOAT, lower=1, upper=5
                 ),
                 ChoiceParameter(
                     "c", parameter_type=ParameterType.STRING, values=["x", "y", "z"]
                 ),
                 RangeParameter(
-                    "d", lower=1, upper=10, parameter_type=ParameterType.INT
+                    name="d", parameter_type=ParameterType.INT, lower=1, upper=10
                 ),
-                FixedParameter("e", parameter_type=ParameterType.FLOAT, value=4.0),
+                FixedParameter(name="e", parameter_type=ParameterType.FLOAT, value=4.0),
             ]
         )
 
@@ -114,9 +114,13 @@ class FixedToTunableTransformTest(TestCase):
     def test_transform_search_space_with_constraints(self) -> None:
         # Create search space with parameter constraints
         parameters = [
-            RangeParameter("x", lower=1, upper=3, parameter_type=ParameterType.FLOAT),
-            RangeParameter("y", lower=1, upper=3, parameter_type=ParameterType.FLOAT),
-            FixedParameter("z", parameter_type=ParameterType.FLOAT, value=2.0),
+            RangeParameter(
+                name="x", parameter_type=ParameterType.FLOAT, lower=1, upper=3
+            ),
+            RangeParameter(
+                name="y", parameter_type=ParameterType.FLOAT, lower=1, upper=3
+            ),
+            FixedParameter(name="z", parameter_type=ParameterType.FLOAT, value=2.0),
         ]
         search_space_with_constraints = SearchSpace(
             parameters=parameters,
@@ -131,13 +135,13 @@ class FixedToTunableTransformTest(TestCase):
         joint_space_with_y_range = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x", lower=1, upper=3, parameter_type=ParameterType.FLOAT
+                    name="x", parameter_type=ParameterType.FLOAT, lower=1, upper=3
                 ),
                 RangeParameter(
-                    "y", lower=1, upper=5, parameter_type=ParameterType.FLOAT
+                    name="y", parameter_type=ParameterType.FLOAT, lower=1, upper=5
                 ),
                 RangeParameter(
-                    "z", lower=1, upper=5, parameter_type=ParameterType.FLOAT
+                    name="z", parameter_type=ParameterType.FLOAT, lower=1, upper=5
                 ),
             ]
         )

--- a/ax/adapter/transforms/tests/test_int_range_to_choice_transform.py
+++ b/ax/adapter/transforms/tests/test_int_range_to_choice_transform.py
@@ -22,7 +22,9 @@ class IntRangeToChoiceTransformTest(TestCase):
         super().setUp()
         self.search_space = SearchSpace(
             parameters=[
-                RangeParameter("a", lower=1, upper=5, parameter_type=ParameterType.INT),
+                RangeParameter(
+                    name="a", parameter_type=ParameterType.INT, lower=1, upper=5
+                ),
                 ChoiceParameter(
                     "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
                 ),
@@ -85,19 +87,19 @@ class IntRangeToChoiceTransformTest(TestCase):
     def test_num_choices(self) -> None:
         parameters = {
             "a": RangeParameter(
-                "a", lower=1, upper=3, parameter_type=ParameterType.FLOAT
+                name="a", parameter_type=ParameterType.FLOAT, lower=1, upper=3
             ),
             "b": RangeParameter(
-                "b", lower=1, upper=2, parameter_type=ParameterType.INT
+                name="b", parameter_type=ParameterType.INT, lower=1, upper=2
             ),
             "c": ChoiceParameter(
                 "c", parameter_type=ParameterType.STRING, values=["x1", "x2", "x3"]
             ),
             "d": RangeParameter(
-                "d", lower=1, upper=9, parameter_type=ParameterType.INT
+                name="d", parameter_type=ParameterType.INT, lower=1, upper=9
             ),
             "e": RangeParameter(
-                "e", lower=3, upper=5, parameter_type=ParameterType.INT
+                name="e", parameter_type=ParameterType.INT, lower=3, upper=5
             ),
         }
         search_space = SearchSpace(parameters=parameters.values())  # pyre-ignore[6]

--- a/ax/adapter/transforms/tests/test_int_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_int_to_float_transform.py
@@ -31,9 +31,15 @@ class IntToFloatTransformTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         parameters: list[Parameter] = [
-            RangeParameter("x", lower=1, upper=3, parameter_type=ParameterType.FLOAT),
-            RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),
-            RangeParameter("d", lower=1, upper=3, parameter_type=ParameterType.INT),
+            RangeParameter(
+                name="x", parameter_type=ParameterType.FLOAT, lower=1, upper=3
+            ),
+            RangeParameter(
+                name="a", parameter_type=ParameterType.INT, lower=1, upper=2
+            ),
+            RangeParameter(
+                name="d", parameter_type=ParameterType.INT, lower=1, upper=3
+            ),
             ChoiceParameter(
                 "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
             ),
@@ -242,8 +248,12 @@ class IntToFloatTransformTest(TestCase):
 
     def test_RoundingWithConstrainedIntRanges(self) -> None:
         parameters = [
-            RangeParameter("x", lower=1, upper=3, parameter_type=ParameterType.INT),
-            RangeParameter("y", lower=1, upper=3, parameter_type=ParameterType.INT),
+            RangeParameter(
+                name="x", parameter_type=ParameterType.INT, lower=1, upper=3
+            ),
+            RangeParameter(
+                name="y", parameter_type=ParameterType.INT, lower=1, upper=3
+            ),
         ]
         constrained_int_search_space = SearchSpace(
             parameters=parameters,
@@ -291,8 +301,12 @@ class IntToFloatTransformTest(TestCase):
     @mock.patch("ax.adapter.transforms.int_to_float.DEFAULT_MAX_ROUND_ATTEMPTS", 100)
     def test_RoundingWithImpossiblyConstrainedIntRanges(self) -> None:
         parameters = [
-            RangeParameter("x", lower=1, upper=5, parameter_type=ParameterType.INT),
-            RangeParameter("y", lower=1, upper=5, parameter_type=ParameterType.INT),
+            RangeParameter(
+                name="x", parameter_type=ParameterType.INT, lower=1, upper=5
+            ),
+            RangeParameter(
+                name="y", parameter_type=ParameterType.INT, lower=1, upper=5
+            ),
         ]
         constrained_int_search_space = SearchSpace(
             parameters=parameters,

--- a/ax/adapter/transforms/tests/test_log_transform.py
+++ b/ax/adapter/transforms/tests/test_log_transform.py
@@ -33,21 +33,23 @@ class LogTransformTest(TestCase):
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x",
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
                     lower=1,
                     upper=3,
-                    parameter_type=ParameterType.FLOAT,
                     log_scale=True,
                     digits=3,
                 ),
                 RangeParameter(
-                    "y",
+                    name="y",
+                    parameter_type=ParameterType.INT,
                     lower=1,
                     upper=10,
-                    parameter_type=ParameterType.INT,
                     log_scale=True,
                 ),
-                RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),
+                RangeParameter(
+                    name="a", parameter_type=ParameterType.INT, lower=1, upper=2
+                ),
                 ChoiceParameter(
                     "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
                 ),
@@ -58,19 +60,19 @@ class LogTransformTest(TestCase):
         self.search_space_with_target = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x",
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
                     lower=1,
                     upper=3,
-                    parameter_type=ParameterType.FLOAT,
                     log_scale=True,
                     is_fidelity=True,
                     target_value=3,
                 ),
                 RangeParameter(
-                    "y",
+                    name="y",
+                    parameter_type=ParameterType.INT,
                     lower=1,
                     upper=10,
-                    parameter_type=ParameterType.INT,
                     log_scale=True,
                     is_fidelity=True,
                     target_value=5,

--- a/ax/adapter/transforms/tests/test_logit_transform.py
+++ b/ax/adapter/transforms/tests/test_logit_transform.py
@@ -30,13 +30,15 @@ class LogitTransformTest(TestCase):
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x",
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
                     lower=0.9,
                     upper=0.999,
-                    parameter_type=ParameterType.FLOAT,
                     logit_scale=True,
                 ),
-                RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),
+                RangeParameter(
+                    name="a", parameter_type=ParameterType.INT, lower=1, upper=2
+                ),
                 ChoiceParameter(
                     "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
                 ),
@@ -46,10 +48,10 @@ class LogitTransformTest(TestCase):
         self.search_space_with_target = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x",
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
                     lower=0.1,
                     upper=0.3,
-                    parameter_type=ParameterType.FLOAT,
                     logit_scale=True,
                     is_fidelity=True,
                     target_value=0.123,
@@ -61,10 +63,10 @@ class LogitTransformTest(TestCase):
         self, lower: float, upper: float, log_scale: bool = False
     ) -> RangeParameter:
         return RangeParameter(
-            "x",
+            name="x",
+            parameter_type=ParameterType.FLOAT,
             lower=lower,
             upper=upper,
-            parameter_type=ParameterType.FLOAT,
             log_scale=log_scale,
             logit_scale=True,
         )

--- a/ax/adapter/transforms/tests/test_one_hot_transform.py
+++ b/ax/adapter/transforms/tests/test_one_hot_transform.py
@@ -32,12 +32,14 @@ class OneHotTransformTest(TestCase):
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x",
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
                     lower=1,
                     upper=3,
-                    parameter_type=ParameterType.FLOAT,
                 ),
-                RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),
+                RangeParameter(
+                    name="a", parameter_type=ParameterType.INT, lower=1, upper=2
+                ),
                 ChoiceParameter(
                     "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
                 ),

--- a/ax/adapter/transforms/tests/test_relativize_transform.py
+++ b/ax/adapter/transforms/tests/test_relativize_transform.py
@@ -491,7 +491,7 @@ class RelativizeDataOptConfigTest(TestCase):
             optimization_config.pruning_target_parameterization = pruning_target
             optimization_config.outcome_constraints = [
                 OutcomeConstraint(
-                    metric=BraninMetric("b2", ["x2", "x1"]),
+                    metric=BraninMetric(name="b2", param_names=["x2", "x1"]),
                     op=ComparisonOp.GEQ,
                     bound=-200.0,
                     relative=True,
@@ -525,7 +525,7 @@ class RelativizeDataOptConfigTest(TestCase):
             optimization_config = get_branin_optimization_config()
             optimization_config.outcome_constraints = [
                 OutcomeConstraint(
-                    metric=BraninMetric("b2", ["x2", "x1"]),
+                    metric=BraninMetric(name="b2", param_names=["x2", "x1"]),
                     op=ComparisonOp.GEQ,
                     bound=-200.0,
                     relative=False,

--- a/ax/adapter/transforms/tests/test_remove_fixed_transform.py
+++ b/ax/adapter/transforms/tests/test_remove_fixed_transform.py
@@ -39,7 +39,9 @@ class RemoveFixedTransformTest(TestCase):
                 ChoiceParameter(
                     "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
                 ),
-                FixedParameter("c", parameter_type=ParameterType.STRING, value="a"),
+                FixedParameter(
+                    name="c", parameter_type=ParameterType.STRING, value="a"
+                ),
                 DerivedParameter(
                     "d",
                     parameter_type=ParameterType.FLOAT,
@@ -185,7 +187,7 @@ class RemoveFixedTransformTest(TestCase):
     def test_w_parameter_distributions(self) -> None:
         rss = get_robust_search_space()
         rss.add_parameter(
-            FixedParameter("d", parameter_type=ParameterType.STRING, value="a"),
+            FixedParameter(name="d", parameter_type=ParameterType.STRING, value="a"),
         )
         # Transform a non-distributional parameter.
         t = RemoveFixed(search_space=rss)
@@ -206,7 +208,7 @@ class RemoveFixedTransformTest(TestCase):
             environmental_variables=all_params[:2],
         )
         rss.add_parameter(
-            FixedParameter("d", parameter_type=ParameterType.STRING, value="a"),
+            FixedParameter(name="d", parameter_type=ParameterType.STRING, value="a"),
         )
         t = RemoveFixed(search_space=rss)
         rss = t.transform_search_space(rss)

--- a/ax/adapter/transforms/tests/test_unit_x_transform.py
+++ b/ax/adapter/transforms/tests/test_unit_x_transform.py
@@ -33,19 +33,21 @@ class UnitXTransformTest(TestCase):
         self.search_space = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x", lower=1, upper=3, parameter_type=ParameterType.FLOAT
+                    name="x", parameter_type=ParameterType.FLOAT, lower=1, upper=3
                 ),
                 RangeParameter(
-                    "y", lower=1, upper=2, parameter_type=ParameterType.FLOAT
+                    name="y", parameter_type=ParameterType.FLOAT, lower=1, upper=2
                 ),
                 RangeParameter(
-                    "z",
+                    name="z",
+                    parameter_type=ParameterType.FLOAT,
                     lower=1,
                     upper=2,
-                    parameter_type=ParameterType.FLOAT,
                     log_scale=True,
                 ),
-                RangeParameter("a", lower=1, upper=2, parameter_type=ParameterType.INT),
+                RangeParameter(
+                    name="a", parameter_type=ParameterType.INT, lower=1, upper=2
+                ),
                 ChoiceParameter(
                     "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
                 ),
@@ -59,10 +61,10 @@ class UnitXTransformTest(TestCase):
         self.search_space_with_target = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x",
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
                     lower=1,
                     upper=3,
-                    parameter_type=ParameterType.FLOAT,
                     is_fidelity=True,
                     target_value=3,
                 )
@@ -142,20 +144,20 @@ class UnitXTransformTest(TestCase):
         new_ss = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x", lower=1.5, upper=2.0, parameter_type=ParameterType.FLOAT
+                    name="x", parameter_type=ParameterType.FLOAT, lower=1.5, upper=2.0
                 ),
                 RangeParameter(
-                    "y", lower=1.25, upper=2.0, parameter_type=ParameterType.FLOAT
+                    name="y", parameter_type=ParameterType.FLOAT, lower=1.25, upper=2.0
                 ),
                 RangeParameter(
-                    "z",
+                    name="z",
+                    parameter_type=ParameterType.FLOAT,
                     lower=1.0,
                     upper=1.5,
-                    parameter_type=ParameterType.FLOAT,
                     log_scale=True,
                 ),
                 RangeParameter(
-                    "a", lower=0.0, upper=2, parameter_type=ParameterType.INT
+                    name="a", parameter_type=ParameterType.INT, lower=0.0, upper=2
                 ),
                 ChoiceParameter(
                     "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
@@ -198,10 +200,10 @@ class UnitXTransformTest(TestCase):
         new_search_space_with_target = SearchSpace(
             parameters=[
                 RangeParameter(
-                    "x",
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
                     lower=1,
                     upper=2,
-                    parameter_type=ParameterType.FLOAT,
                     is_fidelity=True,
                     target_value=2,
                 )

--- a/ax/adapter/transforms/tests/test_winsorize_transform.py
+++ b/ax/adapter/transforms/tests/test_winsorize_transform.py
@@ -422,7 +422,7 @@ class WinsorizeTransformTest(TestCase):
             )
         # Multi-objective without objective thresholds should warn and winsorize
         moo_objective = MultiObjective(
-            [Objective(m1, minimize=False), Objective(m2, minimize=True)]
+            [Objective(metric=m1, minimize=False), Objective(metric=m2, minimize=True)]
         )
         optimization_config = MultiObjectiveOptimizationConfig(objective=moo_objective)
         experiment._optimization_config = optimization_config
@@ -441,8 +441,8 @@ class WinsorizeTransformTest(TestCase):
         self.assertEqual(transform.cutoffs["m3"], (-INF, INF))
         # Add relative objective thresholds. Should warn and skip.
         objective_thresholds = [
-            ObjectiveThreshold(m1, 3, relative=True),
-            ObjectiveThreshold(m2, 4, relative=True),
+            ObjectiveThreshold(metric=m1, bound=3, relative=True),
+            ObjectiveThreshold(metric=m2, bound=4, relative=True),
         ]
         optimization_config = MultiObjectiveOptimizationConfig(
             objective=moo_objective,
@@ -480,22 +480,26 @@ class WinsorizeTransformTest(TestCase):
         # Adapter with in-design status quo
         search_space = SearchSpace(
             parameters=[
-                RangeParameter("x", ParameterType.FLOAT, 0, 20),
-                RangeParameter("y", ParameterType.FLOAT, 0, 20),
+                RangeParameter(
+                    name="x", parameter_type=ParameterType.FLOAT, lower=0, upper=20
+                ),
+                RangeParameter(
+                    name="y", parameter_type=ParameterType.FLOAT, lower=0, upper=20
+                ),
             ]
         )
         # Test with relative constraint, in-design status quo
         oc = OptimizationConfig(
-            objective=Objective(Metric("c"), minimize=False),
+            objective=Objective(Metric(name="c"), minimize=False),
             outcome_constraints=[
                 OutcomeConstraint(
-                    Metric("a"), ComparisonOp.LEQ, bound=2, relative=False
+                    Metric(name="a"), ComparisonOp.LEQ, bound=2, relative=False
                 ),
                 OutcomeConstraint(
-                    Metric("b"), ComparisonOp.LEQ, bound=-10, relative=True
+                    Metric(name="b"), ComparisonOp.LEQ, bound=-10, relative=True
                 ),
                 ScalarizedOutcomeConstraint(
-                    metrics=[Metric("a"), Metric("b")],
+                    metrics=[Metric(name="a"), Metric(name="b")],
                     weights=[0.0, 1.0],
                     op=ComparisonOp.LEQ,
                     bound=-10,

--- a/ax/analysis/plotly/tests/test_marginal_effects.py
+++ b/ax/analysis/plotly/tests/test_marginal_effects.py
@@ -30,7 +30,7 @@ class TestMarginalEffectsPlot(TestCase):
             name="test_experiment",
             is_test=True,
             optimization_config=OptimizationConfig(
-                objective=Objective(Metric("metric_1", lower_is_better=False))
+                objective=Objective(Metric(name="metric_1", lower_is_better=False))
             ),
         )
         num_arms = 3

--- a/ax/analysis/tests/test_utils.py
+++ b/ax/analysis/tests/test_utils.py
@@ -280,7 +280,7 @@ class TestUtils(TestCase):
             ],
             is_test=True,
         )
-        trial = BatchTrial(test_exp)
+        trial = BatchTrial(experiment=test_exp)
 
         # set 2 arms and abandon one
         trial.add_arms_and_weights(

--- a/ax/benchmark/tests/test_benchmark_problem.py
+++ b/ax/benchmark/tests/test_benchmark_problem.py
@@ -36,7 +36,7 @@ class TestBenchmarkProblem(TestCase):
 
     def test_mismatch_of_names_on_test_function_and_opt_config_raises(self) -> None:
         objectives = [
-            Objective(metric=BenchmarkMetric(name, lower_is_better=True))
+            Objective(metric=BenchmarkMetric(name=name, lower_is_better=True))
             for name in ["Branin", "Currin"]
         ]
         test_function = BoTorchTestFunction(
@@ -65,7 +65,7 @@ class TestBenchmarkProblem(TestCase):
             objective=objectives[0],
             outcome_constraints=[
                 OutcomeConstraint(
-                    BenchmarkMetric("c", lower_is_better=False),
+                    BenchmarkMetric(name="c", lower_is_better=False),
                     ComparisonOp.LEQ,
                     0.0,
                 )
@@ -91,7 +91,7 @@ class TestBenchmarkProblem(TestCase):
     def test_missing_names_on_test_function_with_scalarized_objective(self) -> None:
         objective = ScalarizedObjective(
             metrics=[
-                BenchmarkMetric(name, lower_is_better=True)
+                BenchmarkMetric(name=name, lower_is_better=True)
                 for name in ["BraninCurrin_0", "BraninCurrin_missing"]
             ],
             weights=[1.0, 1.0],

--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -74,7 +74,7 @@ class Objective(SortableBase):
 
     def clone(self) -> Objective:
         """Create a copy of the objective."""
-        return Objective(self.metric.clone(), self.minimize)
+        return Objective(metric=self.metric.clone(), minimize=self.minimize)
 
     def __repr__(self) -> str:
         return 'Objective(metric_name="{}", minimize={})'.format(

--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -30,10 +30,14 @@ TRefPoint = list[ObjectiveThreshold]
 
 # Sentinels for default arguments when None is a valid input
 _NO_OUTCOME_CONSTRAINTS = [
-    OutcomeConstraint(Metric("placeholder", lower_is_better=True), ComparisonOp.GEQ, 0)
+    OutcomeConstraint(
+        metric=Metric(name="placeholder", lower_is_better=True),
+        op=ComparisonOp.GEQ,
+        bound=0,
+    )
 ]
 _NO_OBJECTIVE_THRESHOLDS = [
-    ObjectiveThreshold(Metric("placeholder", lower_is_better=True), 0)
+    ObjectiveThreshold(metric=Metric(name="placeholder", lower_is_better=True), bound=0)
 ]
 _NO_RISK_MEASURE = RiskMeasure("placeholder", {})
 

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -415,7 +415,7 @@ class SearchSpace(Base):
                 new_parameters[name] = value
             else:
                 new_parameters[name] = self.parameters[name].cast(value)
-        return Arm(new_parameters, arm.name if arm.has_name else None)
+        return Arm(parameters=new_parameters, name=arm.name if arm.has_name else None)
 
     def out_of_design_arm(self) -> Arm:
         """Create a default out-of-design arm.

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -456,7 +456,9 @@ class BatchTrialTest(TestCase):
         # Insufficient factors
         small_experiment = Experiment(
             name="small_test",
-            search_space=SearchSpace([FixedParameter("a", ParameterType.INT, 4)]),
+            search_space=SearchSpace(
+                [FixedParameter(name="a", parameter_type=ParameterType.INT, value=4)]
+            ),
         )
         small_trial = small_experiment.new_batch_trial().add_arm(Arm({"a": 4}))
         self.assertFalse(small_trial.is_factorial)

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -358,7 +358,9 @@ class ExperimentTest(TestCase):
 
         # Try search space with additional parameters
         extra_param_ss = get_search_space()
-        extra_param_ss.add_parameter(FixedParameter("l", ParameterType.FLOAT, 0.5))
+        extra_param_ss.add_parameter(
+            FixedParameter(name="l", parameter_type=ParameterType.FLOAT, value=0.5)
+        )
         with self.assertRaises(ValueError):
             self.experiment.search_space = extra_param_ss
 
@@ -1501,7 +1503,7 @@ class ExperimentTest(TestCase):
             self.assertEqual(trials, {0})
         with self.subTest("all metrics, no data"):
             # add tracking metric and require all metrics, should be empty set
-            exp.add_tracking_metric(metric=Metric("test", lower_is_better=True))
+            exp.add_tracking_metric(metric=Metric(name="test", lower_is_better=True))
             trials = exp.trial_indices_with_data(critical_metrics_only=False)
             self.assertEqual(len(trials), 0)
         with self.subTest(

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -63,7 +63,7 @@ class MultiTypeExperimentTest(TestCase):
         self.assertEqual(self.experiment.default_trials, {0})
         # Set 2 metrics to be equal
         self.experiment.update_tracking_metric(
-            BraninMetric("m2", ["x1", "x2"]), trial_type="type2"
+            BraninMetric(name="m2", param_names=["x1", "x2"]), trial_type="type2"
         )
         df = self.experiment.fetch_data().df
         arm_0_slice = df.loc[df["arm_name"] == "0_0"]
@@ -83,21 +83,27 @@ class MultiTypeExperimentTest(TestCase):
         self.assertTrue(self.experiment == exp2)
 
         self.experiment.add_tracking_metric(
-            BraninMetric("m3", ["x2", "x1"]), trial_type="type1", canonical_name="m4"
+            BraninMetric(name="m3", param_names=["x2", "x1"]),
+            trial_type="type1",
+            canonical_name="m4",
         )
 
         # Test different set of metrics
         self.assertFalse(self.experiment == exp2)
 
         exp2.add_tracking_metric(
-            BraninMetric("m3", ["x2", "x1"]), trial_type="type1", canonical_name="m5"
+            BraninMetric(name="m3", param_names=["x2", "x1"]),
+            trial_type="type1",
+            canonical_name="m5",
         )
 
         # Test different metric definitions
         self.assertFalse(self.experiment == exp2)
 
         exp2.update_tracking_metric(
-            BraninMetric("m3", ["x2", "x1"]), trial_type="type1", canonical_name="m4"
+            BraninMetric(name="m3", param_names=["x2", "x1"]),
+            trial_type="type1",
+            canonical_name="m4",
         )
 
         # Should be the same
@@ -118,7 +124,7 @@ class MultiTypeExperimentTest(TestCase):
         # Add metric for trial_type that doesn't exist
         with self.assertRaises(ValueError):
             self.experiment.add_tracking_metric(
-                BraninMetric("m2", ["x1", "x2"]), "type3"
+                BraninMetric(name="m2", param_names=["x1", "x2"]), "type3"
             )
 
         # Try to remove metric that doesn't exist
@@ -128,13 +134,13 @@ class MultiTypeExperimentTest(TestCase):
         # Try to change optimization metric to non-primary trial type
         with self.assertRaises(ValueError):
             self.experiment.update_tracking_metric(
-                BraninMetric("m1", ["x1", "x2"]), "type2"
+                BraninMetric(name="m1", param_names=["x1", "x2"]), "type2"
             )
 
         # Update metric definition for trial_type that doesn't exist
         with self.assertRaises(ValueError):
             self.experiment.update_tracking_metric(
-                BraninMetric("m2", ["x1", "x2"]), "type3"
+                BraninMetric(name="m2", param_names=["x1", "x2"]), "type3"
             )
 
         # Try to get runner for trial_type that's not supported
@@ -156,7 +162,10 @@ class MultiTypeExperimentTest(TestCase):
             self.experiment._metric_to_trial_type, {"m1": "type1", "m2": "type2"}
         )
         self.experiment.optimization_config = OptimizationConfig(
-            Objective(BraninMetric("m3", ["x1", "x2"]), minimize=True)
+            objective=Objective(
+                metric=BraninMetric(name="m3", param_names=["x1", "x2"]),
+                minimize=True,
+            )
         )
         self.assertDictEqual(
             self.experiment._metric_to_trial_type,
@@ -173,15 +182,15 @@ class MultiTypeExperimentTest(TestCase):
 
     def test_add_tracking_metrics(self) -> None:
         type1_metrics = [
-            BraninMetric("m3_type1", ["x1", "x2"]),
-            BraninMetric("m4_type1", ["x1", "x2"]),
+            BraninMetric(name="m3_type1", param_names=["x1", "x2"]),
+            BraninMetric(name="m4_type1", param_names=["x1", "x2"]),
         ]
         type2_metrics = [
-            BraninMetric("m3_type2", ["x1", "x2"]),
-            BraninMetric("m4_type2", ["x1", "x2"]),
+            BraninMetric(name="m3_type2", param_names=["x1", "x2"]),
+            BraninMetric(name="m4_type2", param_names=["x1", "x2"]),
         ]
         default_type_metrics = [
-            BraninMetric("m5_default_type", ["x1", "x2"]),
+            BraninMetric(name="m5_default_type", param_names=["x1", "x2"]),
         ]
         self.experiment.add_tracking_metrics(
             metrics=type1_metrics + type2_metrics + default_type_metrics,

--- a/ax/core/tests/test_parameter_constraint.py
+++ b/ax/core/tests/test_parameter_constraint.py
@@ -100,8 +100,12 @@ class ParameterConstraintTest(TestCase):
 class OrderConstraintTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.x = RangeParameter("x", ParameterType.INT, lower=0, upper=1)
-        self.y = RangeParameter("y", ParameterType.INT, lower=0, upper=1)
+        self.x = RangeParameter(
+            name="x", parameter_type=ParameterType.INT, lower=0, upper=1
+        )
+        self.y = RangeParameter(
+            name="y", parameter_type=ParameterType.INT, lower=0, upper=1
+        )
         self.constraint = OrderConstraint(
             lower_parameter=self.x, upper_parameter=self.y
         )
@@ -144,11 +148,13 @@ class OrderConstraintTest(TestCase):
         )
 
     def test_InvalidSetup(self) -> None:
-        z = FixedParameter("z", ParameterType.INT, 0)
+        z = FixedParameter(name="z", parameter_type=ParameterType.INT, value=0)
         with self.assertRaises(ValueError):
             self.constraint = OrderConstraint(lower_parameter=self.x, upper_parameter=z)
 
-        z = ChoiceParameter("z", ParameterType.STRING, ["a", "b", "c"])
+        z = ChoiceParameter(
+            name="z", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
+        )
         with self.assertRaises(ValueError):
             self.constraint = OrderConstraint(lower_parameter=self.x, upper_parameter=z)
 
@@ -156,8 +162,12 @@ class OrderConstraintTest(TestCase):
 class SumConstraintTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.x = RangeParameter("x", ParameterType.INT, lower=-5, upper=5)
-        self.y = RangeParameter("y", ParameterType.INT, lower=-5, upper=5)
+        self.x = RangeParameter(
+            name="x", parameter_type=ParameterType.INT, lower=-5, upper=5
+        )
+        self.y = RangeParameter(
+            name="y", parameter_type=ParameterType.INT, lower=-5, upper=5
+        )
         self.constraint1 = SumConstraint(
             parameters=[self.x, self.y], is_upper_bound=True, bound=5
         )
@@ -171,7 +181,9 @@ class SumConstraintTest(TestCase):
     def test_BadConstruct(self) -> None:
         with self.assertRaises(ValueError):
             SumConstraint(parameters=[self.x, self.x], is_upper_bound=False, bound=-5.0)
-        z = ChoiceParameter("z", ParameterType.STRING, ["a", "b", "c"])
+        z = ChoiceParameter(
+            name="z", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
+        )
         with self.assertRaises(ValueError):
             # pyre-fixme[16]: `SumConstraintTest` has no attribute `constraint`.
             self.constraint = SumConstraint(

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -384,9 +384,13 @@ class SearchSpaceTest(TestCase):
         self.assertTrue(isinstance(new_arm.parameters["q"], int))
 
     def test_Copy(self) -> None:
-        a = RangeParameter("a", ParameterType.FLOAT, 1.0, 5.5)
-        b = RangeParameter("b", ParameterType.FLOAT, 2.0, 5.5)
-        c = ChoiceParameter("c", ParameterType.INT, [2, 3])
+        a = RangeParameter(
+            name="a", parameter_type=ParameterType.FLOAT, lower=1.0, upper=5.5
+        )
+        b = RangeParameter(
+            name="b", parameter_type=ParameterType.FLOAT, lower=2.0, upper=5.5
+        )
+        c = ChoiceParameter(name="c", parameter_type=ParameterType.INT, values=[2, 3])
         ss = SearchSpace(
             parameters=[a, b, c],
             parameter_constraints=[
@@ -399,7 +403,9 @@ class SearchSpaceTest(TestCase):
             len(ss_copy.parameter_constraints), len(ss_copy.parameter_constraints)
         )
 
-        ss_copy.add_parameter(FixedParameter("d", ParameterType.STRING, "h"))
+        ss_copy.add_parameter(
+            FixedParameter(name="d", parameter_type=ParameterType.STRING, value="h")
+        )
         self.assertNotEqual(len(ss_copy.parameters), len(ss.parameters))
 
     def test_OutOfDesignArm(self) -> None:
@@ -462,16 +468,18 @@ class SearchSpaceTest(TestCase):
                     is_fidelity=True,
                     target_value=10,
                 ),
-                FixedParameter("x3", parameter_type=ParameterType.BOOL, value=True),
+                FixedParameter(
+                    name="x3", parameter_type=ParameterType.BOOL, value=True
+                ),
                 ChoiceParameter(
-                    "x4",
+                    name="x4",
                     parameter_type=ParameterType.STRING,
                     values=["a", "b", "c"],
                     is_ordered=False,
                     dependents={"a": ["x1", "x2"], "b": ["x4", "x5"], "c": ["x6"]},
                 ),
                 ChoiceParameter(
-                    "x5",
+                    name="x5",
                     parameter_type=ParameterType.STRING,
                     values=["d", "e", "f"],
                     is_ordered=True,

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -57,9 +57,11 @@ class UtilsTest(TestCase):
         self.empty_experiment = get_experiment()
         self.experiment = get_experiment()
         self.arm = Arm({"x": 5, "y": "foo", "z": True, "w": 5, "d": 11.0})
-        self.trial = self.experiment.new_trial(GeneratorRun([self.arm]))
+        self.trial = self.experiment.new_trial(GeneratorRun(arms=[self.arm]))
         self.experiment_2 = get_experiment()
-        self.batch_trial = self.experiment_2.new_batch_trial(GeneratorRun([self.arm]))
+        self.batch_trial = self.experiment_2.new_batch_trial(
+            GeneratorRun(arms=[self.arm])
+        )
         self.batch_trial.add_status_quo_arm(weight=1)
         self.obs_feat = ObservationFeatures.from_arm(
             arm=self.trial.arm, trial_index=self.trial.index
@@ -328,7 +330,7 @@ class UtilsTest(TestCase):
 
         # Make sure optimization_config is not None
         self.assertIsNotNone(experiment.optimization_config)
-        trial = experiment.new_trial(GeneratorRun([self.arm]))
+        trial = experiment.new_trial(GeneratorRun(arms=[self.arm]))
         trial.mark_running(no_runner_required=True)
 
         # Attach data for only one metric (not all required by optimization config)
@@ -372,7 +374,7 @@ class UtilsTest(TestCase):
             experiment._optimization_config = None
             self.assertIsNone(experiment.optimization_config)
 
-            trial = experiment.new_trial(GeneratorRun([self.arm]))
+            trial = experiment.new_trial(GeneratorRun(arms=[self.arm]))
             trial.mark_running(no_runner_required=True)
             original_status = trial.status
 
@@ -408,7 +410,7 @@ class UtilsTest(TestCase):
 
         # Make sure that trial_index is set correctly
         other_obs_feat = ObservationFeatures.from_arm(arm=self.trial.arm, trial_index=1)
-        other_trial = self.experiment.new_trial(GeneratorRun([self.arm]))
+        other_trial = self.experiment.new_trial(GeneratorRun(arms=[self.arm]))
         other_trial.mark_running(no_runner_required=True)
 
         with patch.object(

--- a/ax/global_stopping/tests/test_strategies.py
+++ b/ax/global_stopping/tests/test_strategies.py
@@ -154,9 +154,13 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
             An experiment with len(metric_values) trials.
         """
         search_space = SearchSpace(
-            [
-                RangeParameter("x", ParameterType.FLOAT, 0.0, 1.0),
-                RangeParameter("y", ParameterType.FLOAT, 0.0, 1.0),
+            parameters=[
+                RangeParameter(
+                    name="x", parameter_type=ParameterType.FLOAT, lower=0.0, upper=1.0
+                ),
+                RangeParameter(
+                    name="y", parameter_type=ParameterType.FLOAT, lower=0.0, upper=1.0
+                ),
             ]
         )
         objective = Objective(metric=Metric(name="m1"), minimize=False)
@@ -209,9 +213,13 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
             An experiment with len(metric_values) trials.
         """
         search_space = SearchSpace(
-            [
-                RangeParameter("x", ParameterType.FLOAT, 0.0, 1.0),
-                RangeParameter("y", ParameterType.FLOAT, 0.0, 1.0),
+            parameters=[
+                RangeParameter(
+                    name="x", parameter_type=ParameterType.FLOAT, lower=0.0, upper=1.0
+                ),
+                RangeParameter(
+                    name="y", parameter_type=ParameterType.FLOAT, lower=0.0, upper=1.0
+                ),
             ]
         )
 

--- a/ax/runners/tests/test_torchx.py
+++ b/ax/runners/tests/test_torchx.py
@@ -189,4 +189,4 @@ class TorchXRunnerTest(TestCase):
         )
 
         with self.assertRaises(ValueError):
-            self._runner.run(trial=BatchTrial(experiment))
+            self._runner.run(trial=BatchTrial(experiment=experiment))

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -576,7 +576,7 @@ class TestAxClient(TestCase):
     def test_sobol_generation_strategy_completion(self) -> None:
         ax_client = get_branin_optimization(
             generation_strategy=GenerationStrategy(
-                [GenerationStep(Generators.SOBOL, num_trials=3)]
+                steps=[GenerationStep(generator=Generators.SOBOL, num_trials=3)]
             )
         )
         # All Sobol trials should be able to be generated at once and optimization
@@ -596,7 +596,7 @@ class TestAxClient(TestCase):
         decoder = Decoder(config=config)
         db_settings = DBSettings(encoder=encoder, decoder=decoder)
         generation_strategy = GenerationStrategy(
-            [GenerationStep(Generators.SOBOL, num_trials=3)]
+            steps=[GenerationStep(generator=Generators.SOBOL, num_trials=3)]
         )
         ax_client = AxClient(
             db_settings=db_settings, generation_strategy=generation_strategy
@@ -2887,7 +2887,7 @@ class TestAxClient(TestCase):
         with self.assertWarnsRegex(RuntimeWarning, "a `torch_device` were specified."):
             AxClient(
                 generation_strategy=GenerationStrategy(
-                    [GenerationStep(Generators.SOBOL, num_trials=3)]
+                    steps=[GenerationStep(generator=Generators.SOBOL, num_trials=3)]
                 ),
                 torch_device=device,
             )

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -2808,7 +2808,9 @@ class TestAxOrchestratorMultiTypeExperiment(TestAxOrchestrator):
         self.branin_experiment = get_multi_type_experiment()
         self.branin_experiment.name = "branin_test_experiment"
         self.branin_experiment.optimization_config = OptimizationConfig(
-            objective=Objective(metric=BraninMetric("m1", ["x1", "x2"]), minimize=True)
+            objective=Objective(
+                metric=BraninMetric(name="m1", param_names=["x1", "x2"]), minimize=True
+            )
         )
 
         self.runner = SyntheticRunnerWithStatusPolling()
@@ -2922,7 +2924,7 @@ class TestAxOrchestratorMultiTypeExperiment(TestAxOrchestrator):
     ) -> None:
         # add a tracking metric
         self.branin_timestamp_map_metric_experiment.add_tracking_metric(
-            BraninMetric("branin", ["x1", "x2"]), trial_type="type1"
+            BraninMetric(name="branin", param_names=["x1", "x2"]), trial_type="type1"
         )
         super().test_fetch_and_process_trials_data_results_failed_non_objective()
 

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1541,4 +1541,4 @@ def auxiliary_experiment_from_name(
         load_auxiliary_experiments=False,
         reduced_state=reduced_state,
     )
-    return AuxiliaryExperiment(experiment, is_active=is_active)
+    return AuxiliaryExperiment(experiment=experiment, is_active=is_active)

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -651,7 +651,11 @@ def get_test_map_data_experiment(
 def get_multi_type_experiment(
     add_trial_type: bool = True, add_trials: bool = False, num_arms: int = 10
 ) -> MultiTypeExperiment:
-    oc = OptimizationConfig(Objective(BraninMetric("m1", ["x1", "x2"]), minimize=True))
+    oc = OptimizationConfig(
+        objective=Objective(
+            metric=BraninMetric(name="m1", param_names=["x1", "x2"]), minimize=True
+        )
+    )
     experiment = MultiTypeExperiment(
         name="test_exp",
         search_space=get_branin_search_space(),
@@ -666,7 +670,9 @@ def get_multi_type_experiment(
     )
     # Switch the order of variables so metric gives different results
     experiment.add_tracking_metric(
-        BraninMetric("m2", ["x2", "x1"]), trial_type="type2", canonical_name="m1"
+        BraninMetric(name="m2", param_names=["x2", "x1"]),
+        trial_type="type2",
+        canonical_name="m1",
     )
 
     if add_trials and add_trial_type:
@@ -769,7 +775,7 @@ def get_experiment_with_map_data() -> Experiment:
     experiment = get_experiment_with_map_data_type()
     experiment._properties = {"owners": [DEFAULT_USER]}
     experiment.new_trial()
-    experiment.add_tracking_metric(MapMetric("ax_test_metric"))
+    experiment.add_tracking_metric(MapMetric(name="ax_test_metric"))
     experiment.attach_data(data=get_map_data())
     return experiment
 
@@ -1222,7 +1228,7 @@ def get_high_dimensional_branin_experiment(
         search_space=search_space,
         optimization_config=optimization_config,
         runner=SyntheticRunner(),
-        status_quo=Arm(sq_parameters) if with_status_quo else None,
+        status_quo=Arm(parameters=sq_parameters) if with_status_quo else None,
     )
     exp._properties = {"owners": [DEFAULT_USER]}
     if with_batch:
@@ -1690,11 +1696,19 @@ def get_large_ordinal_search_space(
 
 
 def get_search_space_for_value(val: float = 3.0) -> SearchSpace:
-    return SearchSpace([FixedParameter("x", ParameterType.FLOAT, val)])
+    return SearchSpace(
+        [FixedParameter(name="x", parameter_type=ParameterType.FLOAT, value=val)]
+    )
 
 
 def get_search_space_for_range_value(min: float = 3.0, max: float = 6.0) -> SearchSpace:
-    return SearchSpace([RangeParameter("x", ParameterType.FLOAT, min, max)])
+    return SearchSpace(
+        parameters=[
+            RangeParameter(
+                name="x", parameter_type=ParameterType.FLOAT, lower=min, upper=max
+            )
+        ]
+    )
 
 
 def get_search_space_for_range_values(
@@ -1704,7 +1718,9 @@ def get_search_space_for_range_values(
         parameter_names = ["x", "y"]
     return SearchSpace(
         [
-            RangeParameter(name, ParameterType.FLOAT, min, max)
+            RangeParameter(
+                name=name, parameter_type=ParameterType.FLOAT, lower=min, upper=max
+            )
             for name in parameter_names
         ]
     )
@@ -1713,9 +1729,17 @@ def get_search_space_for_range_values(
 def get_discrete_search_space() -> SearchSpace:
     return SearchSpace(
         [
-            RangeParameter("x", ParameterType.INT, 0, 3),
-            RangeParameter("y", ParameterType.INT, 5, 7),
-            ChoiceParameter("z", ParameterType.STRING, ["red", "panda", "bear"]),
+            RangeParameter(
+                name="x", parameter_type=ParameterType.INT, lower=0, upper=3
+            ),
+            RangeParameter(
+                name="y", parameter_type=ParameterType.INT, lower=5, upper=7
+            ),
+            ChoiceParameter(
+                name="z",
+                parameter_type=ParameterType.STRING,
+                values=["red", "panda", "bear"],
+            ),
         ]
     )
 
@@ -1723,8 +1747,12 @@ def get_discrete_search_space() -> SearchSpace:
 def get_small_discrete_search_space() -> SearchSpace:
     return SearchSpace(
         [
-            RangeParameter("x", ParameterType.INT, 0, 1),
-            ChoiceParameter("y", ParameterType.STRING, ["red", "panda"]),
+            RangeParameter(
+                name="x", parameter_type=ParameterType.INT, lower=0, upper=1
+            ),
+            ChoiceParameter(
+                name="y", parameter_type=ParameterType.STRING, values=["red", "panda"]
+            ),
         ]
     )
 
@@ -1776,13 +1804,17 @@ def get_robust_search_space(
     num_samples: int = 4,  # dummy
 ) -> RobustSearchSpace:
     parameters = [
-        RangeParameter("x", ParameterType.FLOAT, lb, ub),
-        RangeParameter("y", ParameterType.FLOAT, lb, ub),
-        RangeParameter("z", ParameterType.INT, lb, ub),
+        RangeParameter(
+            name="x", parameter_type=ParameterType.FLOAT, lower=lb, upper=ub
+        ),
+        RangeParameter(
+            name="y", parameter_type=ParameterType.FLOAT, lower=lb, upper=ub
+        ),
+        RangeParameter(name="z", parameter_type=ParameterType.INT, lower=lb, upper=ub),
         ChoiceParameter(
-            "c",
-            ParameterType.STRING,
-            ["red", "blue", "green"],
+            name="c",
+            parameter_type=ParameterType.STRING,
+            values=["red", "blue", "green"],
             is_ordered=False,
             sort_values=False,
         ),
@@ -1840,11 +1872,15 @@ def get_robust_search_space_environmental(
     ub: float = 5.0,
 ) -> RobustSearchSpace:
     parameters = [
-        RangeParameter("x", ParameterType.FLOAT, lb, ub),
-        RangeParameter("y", ParameterType.FLOAT, lb, ub),
+        RangeParameter(
+            name="x", parameter_type=ParameterType.FLOAT, lower=lb, upper=ub
+        ),
+        RangeParameter(
+            name="y", parameter_type=ParameterType.FLOAT, lower=lb, upper=ub
+        ),
     ]
     environmental_variables = [
-        RangeParameter("z", ParameterType.INT, lb, ub),
+        RangeParameter(name="z", parameter_type=ParameterType.INT, lower=lb, upper=ub),
     ]
     distributions = [
         ParameterDistribution(
@@ -2327,7 +2363,7 @@ def get_optimization_config_no_constraints(
     minimize: bool = False,
 ) -> OptimizationConfig:
     return OptimizationConfig(
-        objective=Objective(metric=Metric("test_metric"), minimize=minimize)
+        objective=Objective(metric=Metric(name="test_metric"), minimize=minimize)
     )
 
 
@@ -2444,7 +2480,7 @@ def get_arm_weights1() -> MutableMapping[Arm, float]:
         {"w": 0.75, "x": 1, "y": "foo", "z": True, "d": 2.5},
         {"w": 1.4, "x": 2, "y": "bar", "z": True, "d": 3.8},
     ]
-    arms = [Arm(param_dict) for param_dict in parameters_dicts]
+    arms = [Arm(parameters=param_dict) for param_dict in parameters_dicts]
     weights = [0.25, 0.3, 0.25, 0.2]
     return OrderedDict(zip(arms, weights))
 
@@ -2455,7 +2491,7 @@ def get_arm_weights2() -> MutableMapping[Arm, float]:  # update
         {"w": 0.16, "x": 4, "y": "dear", "z": True, "d": 1.32},
         {"w": 3.1, "x": 5, "y": "world", "z": False, "d": 7.2},
     ]
-    arms = [Arm(param_dict) for param_dict in parameters_dicts]
+    arms = [Arm(parameters=param_dict) for param_dict in parameters_dicts]
     weights = [0.25, 0.3, 0.25, 0.2]
     return OrderedDict(zip(arms, weights))
 

--- a/ax/utils/testing/preference_stubs.py
+++ b/ax/utils/testing/preference_stubs.py
@@ -171,9 +171,9 @@ def get_pbo_experiment(
             arm[param_name] = none_throws(X)[t, i].item()
         gr = (
             # pyre-ignore: Incompatible parameter type [6]
-            GeneratorRun([Arm(arm), Arm(sq)])
+            GeneratorRun(arms=[Arm(parameters=arm), Arm(parameters=sq)])
             if include_sq
-            else GeneratorRun([Arm(arm)])
+            else GeneratorRun(arms=[Arm(parameters=arm)])
         )
         trial = experiment.new_batch_trial(generator_run=gr)
         raw_data = experimental_metric_eval(
@@ -207,7 +207,7 @@ def get_pbo_experiment(
                 else:
                     param_dict[param_name] = none_throws(X)[t * 2 + j, i].item()
             arms.append(Arm(parameters=param_dict))
-        gr = GeneratorRun(arms)
+        gr = GeneratorRun(arms=arms)
 
         trial = experiment.new_batch_trial(generator_run=gr)
         trial.attach_batch_trial_data(


### PR DESCRIPTION
Summary: Asked devmate to find usage of positional arguments and replace them with named arguments. It finds a few classes that are commonly used with positional args & updates those. I ask for more and it repeats. After a bunch of iterations, we end up with this. Seemed like a good background task when working on other stuff.

Differential Revision: D85887957
