### PR TITLE
Remove property Experiment.data_by_trial in favor of having only _data_by_trial

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -484,16 +484,6 @@ class Experiment(Base):
         return none_throws(self.optimization_config).is_moo_problem
 
     @property
-    def data_by_trial(self) -> dict[int, OrderedDict[int, Data]]:
-        """Data stored on the experiment, indexed by trial index and storage time.
-
-        First key is trial index and second key is storage time in milliseconds.
-        For a given trial, data is ordered by storage time, so first added data
-        will appear first in the list.
-        """
-        return self._data_by_trial
-
-    @property
     def immutable_search_space_and_opt_config(self) -> bool:
         """Boolean representing whether search space and metrics on this experiment
         are mutable (by default they are).

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -607,7 +607,7 @@ class ExperimentTest(TestCase):
         t1 = exp.attach_data(batch_data)
         t2 = exp.attach_data(exp_data)
 
-        full_dict = exp.data_by_trial
+        full_dict = exp._data_by_trial
         self.assertEqual(len(full_dict), 2)  # data for 2 trials
         self.assertEqual(len(full_dict[0]), 6)  # 6 data objs for batch 0
 
@@ -898,7 +898,7 @@ class ExperimentTest(TestCase):
         )
         for trial_index in [0, 1]:
             assert_frame_equal(
-                list(exp.data_by_trial[trial_index].values())[0].df,
+                list(exp._data_by_trial[trial_index].values())[0].df,
                 sorted_dfs[trial_index],
             )
 
@@ -1299,7 +1299,7 @@ class ExperimentTest(TestCase):
                 expected_data_by_trial[trial_index] = OrderedDict(
                     list(original_trial_data.items())[-1:]
                 )
-        self.assertEqual(cloned_experiment.data_by_trial, expected_data_by_trial)
+        self.assertEqual(cloned_experiment._data_by_trial, expected_data_by_trial)
 
         experiment = get_experiment()
         cloned_experiment = experiment.clone_with()

--- a/ax/generation_strategy/transition_criterion.py
+++ b/ax/generation_strategy/transition_criterion.py
@@ -340,7 +340,7 @@ class TrialBasedCriterion(TransitionCriterion):
                 for trial_index in all_trials_to_check
                 # TODO[@mgarrard]: determine if we need to actually check data with
                 # more granularity, e.g. number of days of data, etc.
-                if trial_index in experiment.data_by_trial
+                if trial_index in experiment._data_by_trial
             }
         # Some criteria may rely on experiment level data, instead of only trials
         # generated from the node associated with the criterion.

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -1022,7 +1022,7 @@ class TestAxOrchestrator(TestCase):
         # There should only be one data object for each trial, since by default the
         # `Orchestrator` should override previous data objects when it gets new ones in
         # a subsequent `fetch` call.
-        for _, datas in exp.data_by_trial.items():
+        for _, datas in exp._data_by_trial.items():
             self.assertEqual(len(datas), 1)
 
         # We also should have attempted the fetch more times
@@ -1035,7 +1035,7 @@ class TestAxOrchestrator(TestCase):
         num_attach_calls = mock_experiment_attach_data.call_count
         expected_ts_last_trial = len(exp.trials) * 1000 + num_attach_calls
         self.assertEqual(
-            next(iter(exp.data_by_trial[len(exp.trials) - 1])),
+            next(iter(exp._data_by_trial[len(exp.trials) - 1])),
             expected_ts_last_trial,
         )
 
@@ -1254,7 +1254,7 @@ class TestAxOrchestrator(TestCase):
 
         # There should be 3 dataframes for Trial 0 -- one from its *last* intermediate
         # poll and one from when the trial was completed.
-        self.assertEqual(len(orchestrator.experiment.data_by_trial[0]), 3)
+        self.assertEqual(len(orchestrator.experiment._data_by_trial[0]), 3)
 
         looked_up_data = orchestrator.experiment.lookup_data()
         fetched_data = orchestrator.experiment.fetch_data()
@@ -1320,7 +1320,7 @@ class TestAxOrchestrator(TestCase):
         # the first iteration.
         # If it's 1 it means period_of_new_data_after_trial_completion is
         # being disregarded.
-        self.assertGreater(len(orchestrator.experiment.data_by_trial[0]), 1)
+        self.assertGreater(len(orchestrator.experiment._data_by_trial[0]), 1)
 
     def test_run_trials_in_batches(self) -> None:
         gs = self.two_sobol_steps_GS

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -96,7 +96,7 @@ def experiment_to_dict(experiment: Experiment) -> dict[str, Any]:
         "time_created": experiment.time_created,
         "trials": experiment.trials,
         "is_test": experiment.is_test,
-        "data_by_trial": experiment.data_by_trial,
+        "data_by_trial": experiment._data_by_trial,
         "properties": experiment._properties,
         "default_data_type": experiment._default_data_type,
     }

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -1087,7 +1087,7 @@ class Encoder:
 
         return [
             self.data_to_sqa(data=data, trial_index=trial_index, timestamp=timestamp)
-            for trial_index, data_by_timestamp in experiment.data_by_trial.items()
+            for trial_index, data_by_timestamp in experiment._data_by_trial.items()
             for timestamp, data in data_by_timestamp.items()
         ]
 

--- a/ax/storage/sqa_store/save.py
+++ b/ax/storage/sqa_store/save.py
@@ -294,7 +294,7 @@ def save_or_update_data_for_trials(
     )
     for trial in trials:
         trial_idcs.append(trial.index)
-        trial_datas = experiment.data_by_trial.get(trial.index, {})
+        trial_datas = experiment._data_by_trial.get(trial.index, {})
         for ts, data in trial_datas.items():
             if data.db_id is None:
                 # This is data we have not saved before; we should add it to the


### PR DESCRIPTION
Summary: `Experiment.data_by_trial` is a property that evaluates to `Experiment._data_by_trial`. `data_by_trial` is rarely referenced, so it is just confusing to have both. Having only one will make it easier to make changes involving `(_)data_by_trial`.

Reviewed By: saitcakmak

Differential Revision: D85692911


