### PR TITLE
If no target point provided, skip pruning with info log instead of warning

### DIFF
--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -680,7 +680,7 @@ class Acquisition(Base):
         # prune irrelevant parameters post-hoc
         if self.options.get("prune_irrelevant_parameters", False):
             if self._pruning_target_point is None:
-                logger.warning(
+                logger.info(
                     "Must specify pruning_target_point to prune irrelevant "
                     "parameters. Skipping pruning irrelevant parameters."
                 )


### PR DESCRIPTION
Summary: This new warning is the most common warning in AxSweep, with [45k hits in the last week](https://www.internalfb.com/unidash/dashboard/axsweep_analytics/sweep_info/?dimensional_context_242081681686542=%7B%22macros%22%3A[]%2C%22operators%22%3A[]%2C%22movingAggregation%22%3A%22DEFAULT%22%2C%22granularity%22%3A%22DEFAULT%22%2C%22limit%22%3A5%7D). I believe this is expected behavior, in which case it should ideally be an info log.

Reviewed By: sdaulton

Differential Revision: D85864715


