### PR TITLE
Fast MapData.df

### DIFF
--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -2059,8 +2059,8 @@ class ExperimentWithMapDataTest(TestCase):
 
         # Old experiment has already been fetched, and re-fetching will add readings to
         # still-running map metrics.
-        old_df = old_experiment.lookup_data().df
-        new_df = new_experiment.fetch_data().df
+        old_df = old_experiment.lookup_data().full_df
+        new_df = new_experiment.fetch_data().full_df
 
         old_df = old_df.sort_values(by=["arm_name", "metric_name"], ignore_index=True)
         new_df = new_df.sort_values(by=["arm_name", "metric_name"], ignore_index=True)


### PR DESCRIPTION
Summary:
Avoid uneccesary work when extracting non-timeseries like data from MapData by using idxmax instead of sorting + tail.

1. Deleted _tail (only used in MapData.df and MapData.latest)
2. Move body of _tail method directly into MapData.latest
3. Replace _tail call in MapData.df with `self.true_df.loc[self.true_df.groupby(self.DEDUPLICATE_BY_COLUMNS)[MAP_KEY].idxmax()]`

Note that this does mean MapData.df will not be sorted by DEDUPLICATE_BY_COLUMNS, but this hopefully will have no meaningful impact.

Differential Revision: D85981327


