### PR TITLE
Ensure that _process_records_to_df method is operating on a single metric_signature and a single arm_name

### DIFF
--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -165,7 +165,9 @@ try:
                                 f"Found tag {metric.tag}, but no data found for it. Is "
                                 "the curve empty in the TensorBoard UI?"
                             )
-                    df = self._process_records_to_df(metric=metric, records=records)
+                    df = self._process_records_to_df(
+                        metric=metric, records=records, arm_name=arm_name
+                    )
                     df.loc[
                         df["metric_signature"] == metric.signature, "metric_name"
                     ] = metric.name
@@ -220,7 +222,10 @@ try:
             pass
 
         def _process_records_to_df(
-            self, metric: TensorboardMetric, records: list[dict[str, Any]]
+            self,
+            metric: TensorboardMetric,
+            records: list[dict[str, Any]],
+            arm_name: str,
         ) -> pd.DataFrame:
             """Process records to a MapData dataframe."""
             df = (
@@ -231,6 +236,12 @@ try:
                 .mean()
                 .reset_index()
             )
+            # Ensure we are only processing records for a single arm and a single
+            # metric, since this affects curve processing below.
+            df = df[
+                (df["metric_signature"] == metric.signature)
+                & (df["arm_name"] == arm_name)
+            ]
 
             # If all values are NaNs or Infs, we raise an error
             # If some values are NaNs or Infs, we log a warning and filter out the


### PR DESCRIPTION
Summary:
This change is a no-op, since use of this private method is limited to cases where `arm_name` and `metric_signature` were already unique. This diff is to ensure desired behavior and prevent unintended usage in the future.

Some of the learning curve processing in `_process_records_to_df` behaves unexpectedly when applying to sets of records which span multiple arm/metric groups, e.g., taking a cumulative max would be highly problematic across the row boundary between different groups.

We don't subset by `trial_index` since readings are averaged per `(metric_signature, arm_name)` pair at the top of `_process_records_to_df`, so `df` has no `trial_index` column.

Reviewed By: saitcakmak

Differential Revision: D85955419


