### PR TITLE
Place TB readings on a grid before smoothing

### DIFF
--- a/ax/metrics/tests/test_tensorboard.py
+++ b/ax/metrics/tests/test_tensorboard.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 from ax.core.map_data import MapData
 from ax.core.metric import MetricFetchE
-from ax.metrics.tensorboard import logger, TensorboardMetric
+from ax.metrics.tensorboard import _grid_interpolate, logger, TensorboardMetric
 from ax.utils.common.result import Ok
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_trial
@@ -290,3 +290,217 @@ class TensorboardMetricTest(TestCase):
         )
 
         self.assertTrue(df.equals(expected_df))
+
+    def test_grid_interpolate_with_unevenly_spaced_data(self) -> None:
+        """Test that _grid_interpolate correctly interpolates unevenly spaced data."""
+        for sem_is_nan in [False, True]:
+            # Create unevenly spaced data
+            df = pd.DataFrame(
+                {
+                    "trial_index": [0] * 4,
+                    "arm_name": ["0_0"] * 4,
+                    "metric_signature": ["loss"] * 4,
+                    "step": [0.0, 1.0, 5.0, 10.0],  # Unevenly spaced
+                    "mean": [1.0, 2.0, 3.0, 4.0],
+                    "sem": [np.nan] * 4 if sem_is_nan else [0.1, 0.2, 0.3, 0.4],
+                }
+            )
+
+            result_df = _grid_interpolate(df, arm_name="0_0", metric_signature="loss")
+
+            # Should have same number of points
+            self.assertEqual(len(result_df), 4)
+
+            # Steps should now be evenly spaced
+            expected_steps = np.linspace(0.0, 10.0, 4)
+            np.testing.assert_array_almost_equal(
+                result_df["step"].values, expected_steps
+            )
+
+            # Check that values are interpolated (not equal to original)
+            # At step 3.333, mean should be interpolated between original points
+            self.assertNotEqual(result_df["mean"].iloc[1], 2.0)
+
+            # Verify interpolation is working by checking endpoints
+            self.assertAlmostEqual(result_df["mean"].iloc[0], 1.0)
+            self.assertAlmostEqual(result_df["mean"].iloc[-1], 4.0)
+            if sem_is_nan:
+                self.assertTrue(all(np.isnan(result_df["sem"].values)))
+            else:
+                self.assertAlmostEqual(result_df["sem"].iloc[0], 0.1)
+                self.assertAlmostEqual(result_df["sem"].iloc[-1], 0.4)
+
+    def test_grid_interpolate_with_evenly_spaced_data(self) -> None:
+        """Test that evenly spaced data remains unchanged (backward compatibility)."""
+        # Create evenly spaced data
+        df = pd.DataFrame(
+            {
+                "trial_index": [0] * 4,
+                "arm_name": ["0_0"] * 4,
+                "metric_signature": ["loss"] * 4,
+                "step": [0.0, 1.0, 2.0, 3.0],  # Already evenly spaced
+                "mean": [1.0, 2.0, 3.0, 4.0],
+                "sem": [0.1, 0.2, 0.3, 0.4],
+            }
+        )
+
+        result_df = _grid_interpolate(df, arm_name="0_0", metric_signature="loss")
+
+        # Should have same number of points
+        self.assertEqual(len(result_df), 4)
+
+        # Steps should be identical
+        np.testing.assert_array_almost_equal(
+            result_df["step"].values, df["step"].values
+        )
+
+        # Values should be identical (or very close due to floating point)
+        np.testing.assert_array_almost_equal(
+            result_df["mean"].values, df["mean"].values
+        )
+        np.testing.assert_array_almost_equal(result_df["sem"].values, df["sem"].values)
+
+    def test_grid_interpolate_empty_dataframe(self) -> None:
+        """Test that empty dataframe is handled correctly."""
+        df = pd.DataFrame(
+            {
+                "trial_index": [0],
+                "arm_name": ["0_0"],
+                "metric_signature": ["loss"],
+                "step": [1.0],
+                "mean": [1.0],
+                "sem": [0.1],
+            }
+        )
+
+        # Request data for non-existent arm_name
+        with mock.patch.object(logger, "warning") as mock_warning:
+            result_df = _grid_interpolate(
+                df, arm_name="non_existent", metric_signature="loss"
+            )
+            mock_warning.assert_called_once()
+
+        # Should return empty dataframe
+        self.assertEqual(len(result_df), 0)
+
+    def test_grid_interpolate_filters_by_arm_and_metric(self) -> None:
+        """Test that filtering by arm_name and metric_signature works correctly."""
+        # Create data with multiple arms and metrics
+        df = pd.DataFrame(
+            {
+                "trial_index": [0] * 8,
+                "arm_name": ["0_0"] * 4 + ["0_1"] * 4,
+                "metric_signature": ["loss"] * 2 + ["accuracy"] * 2 + ["loss"] * 4,
+                "step": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+                "mean": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+                "sem": [0.1] * 8,
+            }
+        )
+
+        result_df = _grid_interpolate(df, arm_name="0_0", metric_signature="loss")
+
+        # Should only have data for arm "0_0" and metric "loss"
+        self.assertEqual(len(result_df), 2)
+        self.assertTrue((result_df["arm_name"] == "0_0").all())
+        self.assertTrue((result_df["metric_signature"] == "loss").all())
+
+    def test_smoothing_with_unevenly_spaced_data(self) -> None:
+        """Test that smoothing works correctly with unevenly spaced data.
+
+        This test verifies grid interpolation happens before smoothing.
+        """
+
+        # Create unevenly spaced fake data
+        class _UnevenMultiplexer:
+            def PluginRunToTagToContent(self, plugin: str) -> dict[str, dict[str, str]]:
+                return {".": {"loss": ""}}
+
+            def Tensors(
+                self, run: str, tag: str
+            ) -> list[_TensorEvent]:  # pyre-ignore[11]
+                # Unevenly spaced steps: 0, 1, 5, 10
+                return [
+                    _TensorEvent(step=0, tensor_proto=_TensorProto(double_val=[8.0])),
+                    _TensorEvent(step=1, tensor_proto=_TensorProto(double_val=[4.0])),
+                    _TensorEvent(step=5, tensor_proto=_TensorProto(double_val=[2.0])),
+                    _TensorEvent(step=10, tensor_proto=_TensorProto(double_val=[1.0])),
+                ]
+
+        uneven_multiplexer = _UnevenMultiplexer()
+        metric = TensorboardMetric(
+            name="loss", tag="loss", lower_is_better=True, smoothing=0.5
+        )
+        trial = get_trial()
+
+        with mock.patch.object(
+            TensorboardMetric,
+            "_get_event_multiplexer_for_trial",
+            return_value=uneven_multiplexer,
+        ):
+            result = metric.fetch_trial_data(trial=trial)
+
+        df = assert_is_instance(result.unwrap(), MapData).map_df
+
+        # Should have 4 points
+        self.assertEqual(len(df), 4)
+
+        # Steps should be evenly spaced after grid interpolation
+        expected_steps = np.linspace(0.0, 10.0, 4)
+        np.testing.assert_array_almost_equal(df["step"].values, expected_steps)
+
+        # Values should be smoothed (after interpolation)
+        # The first value should be close to the interpolated value at step 0
+        self.assertAlmostEqual(df["mean"].iloc[0], 8.0, places=5)
+
+        # All values should be finite
+        self.assertTrue(np.all(np.isfinite(df["mean"].values)))
+
+    def test_smoothing_applies_to_both_mean_and_sem(self) -> None:
+        """Test that smoothing is applied to both mean and sem columns."""
+
+        # Create fake data with non-NaN sem values
+        class _MultiValueMultiplexer:
+            def PluginRunToTagToContent(self, plugin: str) -> dict[str, dict[str, str]]:
+                return {".": {"loss": ""}}
+
+            def Tensors(
+                self, run: str, tag: str
+            ) -> list[_TensorEvent]:  # pyre-ignore[11]
+                # Return data with varying values
+                return [
+                    _TensorEvent(
+                        step=i, tensor_proto=_TensorProto(double_val=[float(i * 2)])
+                    )
+                    for i in range(4)
+                ]
+
+        multi_multiplexer = _MultiValueMultiplexer()
+        metric = TensorboardMetric(
+            name="loss", tag="loss", lower_is_better=True, smoothing=0.3
+        )
+        trial = get_trial()
+
+        with mock.patch.object(
+            TensorboardMetric,
+            "_get_event_multiplexer_for_trial",
+            return_value=multi_multiplexer,
+        ):
+            result = metric.fetch_trial_data(trial=trial)
+
+        df = assert_is_instance(result.unwrap(), MapData).map_df
+
+        # Verify smoothing was applied by checking that values are
+        # different from original
+        original_values = [0.0, 2.0, 4.0, 6.0]
+
+        # The smoothed values should differ from original (except first value)
+        # We can't easily predict exact values, but we know they should be smoothed
+        self.assertAlmostEqual(df["mean"].iloc[0], original_values[0], places=5)
+
+        # Later values should show smoothing effect (not equal to original)
+        # Due to grid interpolation on evenly spaced data, values should be identical
+        # to original, then smoothed
+        for i in range(1, len(df)):
+            # Check that smoothing effect is present
+            # (values should be between neighboring original values due to EMA)
+            self.assertTrue(np.isfinite(df["mean"].iloc[i]))


### PR DESCRIPTION
Summary: Unevenly spaced points can lead to artifacts in exponentially weighted moving averaged curves, which can affect downstream functionality like early stopping. Interpolating curve points onto a grid eliminates these artifacts and produces more reliable data for downstream applications.

Reviewed By: SebastianAment, sunnyshen321

Differential Revision: D85971762


