### PR TITLE
Always make `attach_data` behave as if `combine_with_last_data=True`

### DIFF
--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -617,10 +617,7 @@ class BaseAdapterTest(TestCase):
             if additional_fetch:
                 # Fetch constraint metric an additional time. This will lead to two
                 # separate observations for the status quo arm.
-                exp.fetch_data(
-                    metrics=[exp.metrics["branin_map_constraint"]],
-                    combine_with_last_data=True,
-                )
+                exp.fetch_data(metrics=[exp.metrics["branin_map_constraint"]])
             with self.assertNoLogs(logger=logger, level="WARN"), mock.patch(
                 "ax.adapter.base._combine_multiple_status_quo_observations",
                 wraps=_combine_multiple_status_quo_observations,

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -311,7 +311,7 @@ class TestSummary(TestCase):
         # Store the MapData in the experiment
         for trial in experiment.trials.values():
             trial_data = map_data.filter(trial_indices=[trial.index])
-            experiment.attach_data(trial_data, combine_with_last_data=False)
+            experiment.attach_data(trial_data)
 
         # Compute the summary
         analysis = Summary()

--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -515,9 +515,7 @@ class Client(WithDBSettingsBase):
         ]
 
         trial = assert_is_instance(self._experiment.trials[trial_index], Trial)
-        trial.update_trial_data(
-            raw_data=data_with_progression, combine_with_last_data=True
-        )
+        trial.update_trial_data(raw_data=data_with_progression)
 
         self._save_or_update_trial_in_db_if_possible(
             experiment=self._experiment, trial=trial

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -251,8 +251,6 @@ class MultiTypeExperiment(Experiment):
         self,
         trial_indices: Iterable[int] | None = None,
         metrics: list[Metric] | None = None,
-        combine_with_last_data: bool = False,
-        overwrite_existing_data: bool = False,
         **kwargs: Any,
     ) -> Data:
         # TODO: make this more efficient for fetching

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -269,9 +269,7 @@ class Trial(BaseTrial):
                     "`experiment.lookup_data_for_trial` to get all attached data."
                 )
 
-    def update_trial_data(
-        self, raw_data: TEvaluationOutcome, combine_with_last_data: bool = False
-    ) -> str:
+    def update_trial_data(self, raw_data: TEvaluationOutcome) -> str:
         """Utility method that attaches data to a trial and
         returns an update message.
 
@@ -282,9 +280,6 @@ class Trial(BaseTrial):
                 unknown (then Ax will infer observation noise level).
                 Can also be a list of (fidelities, mapping from
                 metric name to a tuple of mean and SEM).
-            combine_with_last_data: Whether to combine the given data with the
-                data that was previously attached to the trial. See
-                `Experiment.attach_data` for a detailed explanation.
 
         Returns:
             A string message summarizing the update.
@@ -293,9 +288,7 @@ class Trial(BaseTrial):
         data = self._raw_evaluations_to_data(raw_data={arm_name: raw_data})
 
         self.validate_data_for_trial(data=data)
-        self.experiment.attach_data(
-            data=data, combine_with_last_data=combine_with_last_data
-        )
+        self.experiment.attach_data(data=data)
 
         evaluations = dict(zip(data.df["metric_name"], data.df["mean"]))
         return str(round_floats_for_logging(item=evaluations))

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -536,6 +536,9 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
             unaligned_timestamps
         )
         # manually remove timestamps 1 and 2 for arm 3
+        trial_3_data = next(iter(exp._data_by_trial[3].values()))
+        trial_3_data.full_df = trial_3_data.full_df.loc[lambda x: x["step"] < 1]
+
         df = data.map_df
         df.drop(
             df.index[
@@ -545,6 +548,7 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
             ],
             inplace=True,
         )  # TODO this wont work once we make map_df immutable (which we should)
+        # Create a new experiment without those
         exp.attach_data(data=data)
 
         """

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -733,9 +733,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
                 "`DataType.MAP_DATA`."
             )
         data_update_repr = self._update_trial_with_raw_data(
-            trial_index=trial_index,
-            raw_data=raw_data,
-            combine_with_last_data=True,
+            trial_index=trial_index, raw_data=raw_data
         )
         logger.info(f"Updated trial {trial_index} with data: " f"{data_update_repr}.")
 
@@ -775,10 +773,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         if not isinstance(trial_index, int):
             raise ValueError(f"Trial index must be an int, got: {trial_index}.")
         data_update_repr = self._update_trial_with_raw_data(
-            trial_index=trial_index,
-            raw_data=raw_data,
-            complete_trial=True,
-            combine_with_last_data=True,
+            trial_index=trial_index, raw_data=raw_data, complete_trial=True
         )
         logger.info(f"Completed trial {trial_index} with data: " f"{data_update_repr}.")
 
@@ -1468,15 +1463,11 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         trial_index: int,
         raw_data: TEvaluationOutcome,
         complete_trial: bool = False,
-        combine_with_last_data: bool = False,
     ) -> str:
         """Helper method attaches data to a trial, returns a str of update."""
         # Format the data to save.
         trial = self.get_trial(trial_index)
-        update_info = trial.update_trial_data(
-            raw_data=raw_data,
-            combine_with_last_data=combine_with_last_data,
-        )
+        update_info = trial.update_trial_data(raw_data=raw_data)
 
         if complete_trial:
             if not self._validate_all_required_metrics_present(

--- a/ax/service/orchestrator.py
+++ b/ax/service/orchestrator.py
@@ -200,10 +200,6 @@ class Orchestrator(AnalysisBase, BestPointMixin):
     # applications where the user wants to run the optimization loop to exhaust
     # the declared number of trials.
     __ignore_global_stopping_strategy: bool = False
-    # Default kwargs when fetching data if not overridden on `OrchestratorOptions`
-    DEFAULT_FETCH_KWARGS = {
-        "overwrite_existing_data": True,
-    }
 
     def __init__(
         self,
@@ -1933,13 +1929,6 @@ class Orchestrator(AnalysisBase, BestPointMixin):
 
         try:
             kwargs = deepcopy(self.options.fetch_kwargs)
-            for k, v in self.DEFAULT_FETCH_KWARGS.items():
-                kwargs.setdefault(k, v)
-            if kwargs.get("overwrite_existing_data") and kwargs.get(
-                "combine_with_last_data"
-            ):
-                # to avoid error https://fburl.com/code/ilix4okj
-                kwargs["overwrite_existing_data"] = False
             if self.trial_type is not None:
                 metrics = assert_is_instance(
                     self.experiment, MultiTypeExperiment

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -1537,7 +1537,6 @@ class TestAxClient(TestCase):
                 trial_index=trial_index,
                 # pyre-fixme[6]: For 2nd param expected `Union[List[Tuple[Dict[...
                 raw_data="invalid data",
-                combine_with_last_data=True,
             )
 
     @mock_botorch_optimize
@@ -1710,9 +1709,7 @@ class TestAxClient(TestCase):
         _, idx = ax_client.get_next_trial()
         ax_client.log_trial_failure(trial_index=idx)
         ax_client._update_trial_with_raw_data(
-            trial_index=idx,
-            raw_data=[(0, {"branin": (3, 0.0)})],
-            combine_with_last_data=True,
+            trial_index=idx, raw_data=[(0, {"branin": (3, 0.0)})]
         )
         df = ax_client.experiment.lookup_data_for_trial(idx)[0].df
         self.assertEqual(df["mean"].item(), 3.0)

--- a/ax/storage/sqa_store/save.py
+++ b/ax/storage/sqa_store/save.py
@@ -710,7 +710,6 @@ def _merge_into_session_in_session_decode(
     return new_sqa
 
 
-# pyre-fixme[2]: Parameter annotation cannot be `Any`.
 def _copy_db_ids_if_possible(new_obj: Any, obj: Any) -> None:
     """Wraps _copy_db_ids in a try/except, and logs warnings on error."""
     try:

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -882,9 +882,7 @@ class SQAStoreTest(TestCase):
         self.assertEqual(self.experiment, loaded_experiment)
 
         # Update a trial by attaching data again
-        self.experiment.attach_data(
-            get_data(trial_index=trial.index), combine_with_last_data=True
-        )
+        self.experiment.attach_data(get_data(trial_index=trial.index))
         save_or_update_trial(experiment=self.experiment, trial=trial)
 
         loaded_experiment = load_experiment(self.experiment.name)


### PR DESCRIPTION
Summary:
## Context
`combine_with_last_data=True`, `overwrite_existing_data=False` are the only arguments that really work with `attach_data`:
* The defaults `combine_with_last_data=False` and `overwrite_existing_data=False` are bad: T219128035 describes a bug in which data is hidden on `lookup_data, because `lookup_data` only uses data from the most recent fetch timestamp, while with these arguments, older data is written to older timestamps.
* `combine_with_last_data=False`, `overwrite_existing_data=True` is also bad because, although there is a check that the same metrics are present in newly added data, it can result in silently dropping data for a subset of arms or steps if they are not present in the new data.
* Thus, we only get reasonable behavior with the remaining option `combine_with_last_data=True`, which combines the last data and the current data into one (for each trial).
* These methods are confusing. Removing the arguments makes them less confusing.


# Changes

Deprecates the  `overwrite_existing_data` and `combine_with_last_data=True` arguments to `Experiment.attach_data`, making behavior equivalent to the current `combine_with_last_data=True`. **This means that no more observations will be stored in `_data_by_trial` than in `lookup_data()`**.

Docstrings and unit tests give a fuller view of the change.

# The future

But what about preserving older fetches for experiments that don't have MapData? Yeah, that won't happen anymore (unless the older fetches contain trial-arm-metric observations not seen more recently). For MapData, the situation is better because observations with distinct steps are preserved. The plan is to migrate some or all Metrics to behave like MapMetrics, producing a "step" that allows for principled deduplication.

# Open question

What do we do about older experiments that have multiple Datas from different timestamps per trial in `_data_by_trial`? We can just leave them be, but having multiple timestamps becomes legacy behavior with this diff.  Generally, timestamp data becomes less useful, but we can't quite get rid of it yet.

Differential Revision: D85948262


