### PR TITLE
Combine data from all previous timestamps in `attach_data`

### DIFF
--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -2072,9 +2072,6 @@ class TestAxOrchestrator(TestCase):
 
         initial_df = self.branin_experiment.lookup_data().df
         metric_name = initial_df["metric_name"].iloc[0]
-        initial_mean = initial_df.loc[
-            initial_df["metric_name"] == metric_name, "mean"
-        ].item()
         self.branin_experiment.attach_data(
             Data(
                 df=pd.DataFrame(
@@ -2095,12 +2092,7 @@ class TestAxOrchestrator(TestCase):
             .df.loc[lambda x: x["metric_name"] == metric_name, "mean"]
             .unique()
         )
-        # For multi-type experiment (TestAxOrchestratorMultiTypeExperiment)
-        if len(self.branin_experiment.trials) == 2:
-            expected_means = {initial_mean, TEST_MEAN}
-        else:
-            # One trial
-            expected_means = {TEST_MEAN}
+        expected_means = {TEST_MEAN}
         self.assertEqual(expected_means, set(attached_means))
 
         orchestrator.run_n_trials(max_trials=1)

--- a/ax/storage/json_store/load.py
+++ b/ax/storage/json_store/load.py
@@ -22,7 +22,6 @@ from ax.utils.common.serialization import TDecoderRegistry
 def load_experiment(
     filepath: str,
     decoder_registry: TDecoderRegistry = CORE_DECODER_REGISTRY,
-    # pyre-fixme[2]: Parameter annotation cannot contain `Any`.
     class_decoder_registry: dict[
         str, Callable[[dict[str, Any]], Any]
     ] = CORE_CLASS_DECODER_REGISTRY,


### PR DESCRIPTION
Summary:
Status: No further changes planned; good for discussion.

Alternately, this could be done upon deserialization so that we would never have more than one fetch timestamp per trial index. Since we intend `_data_by_trial` to die soon and we will want to keep loading old experiments, that is probably a better design since we will eventually need to move this logic to the storage layer.

Differential Revision: D86520152


