### PR TITLE
Make all fetch timestamps 0

### DIFF
--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -1891,7 +1891,7 @@ class JSONStoreTest(TestCase):
         self.assertEqual(opt_config, decoded_opt_config)
 
     def test_data_by_trial_backward_compatible(self) -> None:
-        ts0, ts1, ts2 = 2, 3, 4
+        ts0, ts1 = 2, 3
         data_as_dict = {
             "trial_index": 0,
             "arm_name": "0_0",
@@ -1964,8 +1964,8 @@ class JSONStoreTest(TestCase):
             decoded = data_from_json(data_by_trial_json=data_by_trial_json)
 
             self.assertEqual(set(decoded.keys()), {0})
-            self.assertEqual(set(decoded[0].keys()), {ts2})
-            df = decoded[0][ts2].full_df
+            self.assertEqual(set(decoded[0].keys()), {0})
+            df = decoded[0][0].full_df
             # b is present even though it wasn't in the most recent fetch
             self.assertEqual(set(df["metric_name"].to_numpy()), {"a", "b"})
             # We have the old mean of b and the new mean of a
@@ -2005,7 +2005,7 @@ class JSONStoreTest(TestCase):
         An integration test showing that an experiment that has been serialized
         with a `_data_by_trial` attribute deserializes correctly.
         """
-        ts0, ts1, ts2 = 2, 3, 4
+        ts0, ts1 = 2, 3
         data_as_dict = {
             "trial_index": 0,
             "arm_name": "0_0",
@@ -2173,8 +2173,8 @@ class JSONStoreTest(TestCase):
         }
         decoded = object_from_json(object_json=experiment_json)
         self.assertEqual(set(decoded._data_by_trial.keys()), {0})
-        self.assertEqual(set(decoded._data_by_trial[0].keys()), {ts2})
-        df = decoded._data_by_trial[0][ts2].full_df
+        self.assertEqual(set(decoded._data_by_trial[0].keys()), {0})
+        df = decoded._data_by_trial[0][0].full_df
         # b is present even though it wasn't in the most recent fetch
         self.assertEqual(set(df["metric_name"].to_numpy()), {"a", "b"})
         # We have the old mean of b and the new mean of a

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -7,7 +7,6 @@
 # pyre-strict
 
 import logging
-from collections import OrderedDict
 from collections.abc import Callable
 from datetime import datetime
 from decimal import Decimal
@@ -28,7 +27,6 @@ from ax.core.auxiliary import (
     AuxiliaryExperimentPurpose,
     TransferLearningMetadata,
 )
-from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
@@ -3214,22 +3212,3 @@ class SQAStoreTest(TestCase):
             self.assertIsNotNone(tl_metadata_0.overlap_parameters)
             # Should have 2 overlapping parameters (w and x)
             self.assertEqual(len(none_throws(tl_metadata_0.overlap_parameters)), 2)
-
-    def test_experiment_with_data_backward_compatible(self) -> None:
-        name = "data_bc_test_experiment"
-        experiment = get_branin_experiment(with_trial=True, with_completed_trial=True)
-        experiment.name = name
-        data = experiment.lookup_data()
-        # Overwrite _data_by_trial to look the way that it might look on an
-        # older experiment
-        # Trial 0 has data from two different timestamps, 1 and 2
-        experiment._data_by_trial = {
-            0: OrderedDict([(1, data), (2, Data(df=data.full_df))])
-        }
-        save_experiment(experiment=experiment)
-        loaded_experiment = load_experiment(experiment_name=name)
-        data_by_trial = loaded_experiment._data_by_trial
-        self.assertEqual(set(data_by_trial.keys()), {0})
-        # Only the most recent timestamp should be present
-        self.assertEqual(set(data_by_trial[0].keys()), {2})
-        self.assertEqual(data_by_trial[0][2], data)

--- a/ax/storage/utils.py
+++ b/ax/storage/utils.py
@@ -91,15 +91,11 @@ def combine_datas_on_data_by_trial(
     for trial_index, trial_data in data_by_trial.items():
         if len(trial_data) == 0:
             continue
-        sorted_timestamps = sorted(trial_data.keys())
-        timestamp = sorted_timestamps.pop()
-        df = trial_data[timestamp].full_df
-        while len(sorted_timestamps) > 0:
-            old_ts = sorted_timestamps.pop()
-            old_df = trial_data[old_ts].full_df
+        sorted_datas = [data for _, data in sorted(trial_data.items())]
+        df = sorted_datas.pop().full_df
+        while len(sorted_datas) > 0:
+            old_df = sorted_datas.pop().full_df
             df = combine_dfs_favoring_recent(last_df=old_df, new_df=df)
         data_cls = MapData if MAP_KEY in df.columns else Data
-        combined_data_by_trial[trial_index] = OrderedDict(
-            [(timestamp, data_cls(df=df))]
-        )
+        combined_data_by_trial[trial_index] = OrderedDict([(0, data_cls(df=df))])
     return combined_data_by_trial

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -765,7 +765,7 @@ def get_status_quo_branin(
     if with_derived_parameter:
         params["derived"] = 0.0
     if status_quo_unknown_parameters:
-        params = {k: None for k in params}
+        params = dict.fromkeys(params)
 
     return Arm(name="status_quo", parameters=params)
 

--- a/ax/utils/testing/utils.py
+++ b/ax/utils/testing/utils.py
@@ -19,7 +19,6 @@ from pyre_extensions import none_throws
 from torch import Tensor
 
 
-# pyre-fixme[2]: Parameter annotation cannot be `Any`.
 def generic_equals(first: Any, second: Any) -> bool:
     if isinstance(first, Tensor):
         return isinstance(second, Tensor) and torch.equal(first, second)


### PR DESCRIPTION
Summary:
Status: Needs feedback; this is what I am most uncertain about, particularly as it interacts with storage. Once this is done, D86452716 (making _data_by_trial a Data) is easier.

Alternately we could get rid of the timestamps and have `_data_by_trial: {trial_index: Data}`, which would require, for legacy experiments, combining data from multiple timestamps into one upon deserialization. Constructing `Data` upon deserialization for experiments with data in the legacy _data_by_trial format will become necessary regardless once we give `Experiment` a `data` attribute, but I'm not sure it's worth updating the structure of `_data_by_trial` when we're about to change this again.

Differential Revision: D86521191


