### PR TITLE
omit hypervolume trace plot when no objective thresholds (i.e., reference point) is provided

### DIFF
--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -471,7 +471,7 @@ class ReportUtilsTest(TestCase):
             experiment=exp,
             model=Generators.BOTORCH_MODULAR(experiment=exp, data=exp.fetch_data()),
         )
-        self.assertEqual(len(plots), 8)
+        self.assertEqual(len(plots), 7)
 
     @mock_botorch_optimize
     def test_get_standard_plots_map_data(self) -> None:


### PR DESCRIPTION
Summary:
Hypervolume is a measure of multi-objective optimization progress, which corresponds to the volume enclosed by the Pareto Frontier and a reference point, set by the user via ObjectiveThresholds in Ax.

Currently, if there is no provided reference point, Ax infers the reference point based on the observed data in order to perform optimization, however its position changes as the experiment progresses and more data is observed.

This plot currently produces all zeros when no reference point is provided, which is misleading. For this reason, this diff omits this plot in this case. We should eventually decide what we want to show the user in this situation (T244212440).

Reviewed By: lena-kashtelyan

Differential Revision: D84190250


