### PR TITLE
Create IndividualConstraintsFeasibilityAnalysis

### DIFF
--- a/ax/analysis/healthcheck/__init__.py
+++ b/ax/analysis/healthcheck/__init__.py
@@ -17,6 +17,9 @@ from ax.analysis.healthcheck.healthcheck_analysis import (
     HealthcheckAnalysisCard,
     HealthcheckStatus,
 )
+from ax.analysis.healthcheck.individual_constraints_feasibility import (
+    IndividualConstraintsFeasibilityAnalysis,
+)
 from ax.analysis.healthcheck.regression_analysis import RegressionAnalysis
 
 from ax.analysis.healthcheck.search_space_analysis import SearchSpaceAnalysis
@@ -25,6 +28,7 @@ from ax.analysis.healthcheck.should_generate_candidates import ShouldGenerateCan
 __all__ = [
     "create_healthcheck_analysis_card",
     "ConstraintsFeasibilityAnalysis",
+    "IndividualConstraintsFeasibilityAnalysis",
     "CanGenerateCandidatesAnalysis",
     "HealthcheckAnalysisCard",
     "HealthcheckStatus",

--- a/ax/analysis/healthcheck/individual_constraints_feasibility.py
+++ b/ax/analysis/healthcheck/individual_constraints_feasibility.py
@@ -1,0 +1,284 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import final
+
+import pandas as pd
+from ax.adapter.base import Adapter
+from ax.analysis.analysis import Analysis
+from ax.analysis.healthcheck.healthcheck_analysis import (
+    create_healthcheck_analysis_card,
+    HealthcheckAnalysisCard,
+    HealthcheckStatus,
+)
+from ax.analysis.utils import (
+    extract_relevant_adapter,
+    prepare_arm_data,
+    validate_adapter_can_predict,
+    validate_experiment,
+)
+from ax.core.experiment import Experiment
+from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
+from ax.core.trial_status import TrialStatus
+from ax.generation_strategy.generation_strategy import GenerationStrategy
+from pyre_extensions import none_throws, override
+
+
+RESTRICTIVE_P_FEAS_THRESHOLD: float = 0.5
+RESTRICTIVE_ARM_FRACTION: float = 0.9
+
+
+def _format_constraint_label(
+    outcome_constraint: OutcomeConstraint | ScalarizedOutcomeConstraint,
+    constraint_name: str,
+) -> str:
+    """
+    Format an outcome constraint as a string for display.
+
+    Args:
+        outcome_constraint: The outcome constraint to format.
+        constraint_name: The constraint name (metric name or string representation).
+
+    Returns:
+        A formatted string like "capacity >= 3" or "latency <= 100".
+    """
+    if isinstance(outcome_constraint, ScalarizedOutcomeConstraint):
+        # For scalarized constraints, use the string representation
+        return str(outcome_constraint)
+
+    # Format as "metric_name op bound" with optional % for relative constraints
+    op_symbol = ">=" if outcome_constraint.op.name == "GEQ" else "<="
+    bound_str = f"{outcome_constraint.bound}"
+
+    # Add % suffix for relative constraints
+    if outcome_constraint.relative:
+        bound_str += "%"
+
+    return f"{constraint_name} {op_symbol} {bound_str}"
+
+
+@final
+class IndividualConstraintsFeasibilityAnalysis(Analysis):
+    """
+    Analysis for checking the feasibility of individual constraints on the experiment.
+
+    Unlike ConstraintsFeasibilityAnalysis which checks joint feasibility across all
+    constraints, this analysis evaluates each constraint independently to identify
+    which specific constraints are overly restrictive.
+
+    A constraint is considered overly restrictive if at least half of the arms on the
+    experiment have a probability of satisfying that constraint below the threshold
+    (default: 0.5).
+    """
+
+    def __init__(
+        self,
+        restrictive_threshold: float = RESTRICTIVE_P_FEAS_THRESHOLD,
+        fraction_arms_threshold: float = RESTRICTIVE_ARM_FRACTION,
+    ) -> None:
+        r"""
+        Args:
+            restrictive_threshold: The p(feasible) threshold below which an arm is
+                considered to have difficulty satisfying a constraint. Default is 0.5.
+            fraction_arms_threshold: The fraction of arms that must fall below
+                restrictive_threshold for a constraint to be flagged as overly
+                restrictive. Default is 0.9 (i.e., 90% of arms).
+        """
+        self.restrictive_threshold = restrictive_threshold
+        self.fraction_arms_threshold = fraction_arms_threshold
+
+    @override
+    def validate_applicable_state(
+        self,
+        experiment: Experiment | None = None,
+        generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
+    ) -> str | None:
+        """
+        IndividualConstraintsFeasibilityAnalysis requires an experiment. If the
+        experiment has outcome constraints, it also requires an adapter that can
+        predict the constraint metrics.
+        """
+        experiment_validation_str = validate_experiment(experiment=experiment)
+        if experiment_validation_str is not None:
+            return experiment_validation_str
+
+        experiment = none_throws(experiment)
+
+        # Just validate adapter. Edge cases like
+        # No opt config / no constraints are handled in compute
+        if (
+            experiment.optimization_config is not None
+            and experiment.optimization_config.outcome_constraints
+        ):
+            optimization_config = none_throws(experiment.optimization_config)
+            constraint_metric_names = [
+                outcome_constraint.metric.name
+                for outcome_constraint in optimization_config.outcome_constraints
+            ]
+
+            adapter_can_predict_validation_str = validate_adapter_can_predict(
+                experiment=experiment,
+                generation_strategy=generation_strategy,
+                adapter=adapter,
+                required_metric_names=constraint_metric_names,
+            )
+            if adapter_can_predict_validation_str is not None:
+                return adapter_can_predict_validation_str
+
+        return None
+
+    @override
+    def compute(
+        self,
+        experiment: Experiment | None = None,
+        generation_strategy: GenerationStrategy | None = None,
+        adapter: Adapter | None = None,
+    ) -> HealthcheckAnalysisCard:
+        r"""
+        Compute the feasibility of individual constraints for the experiment.
+
+        Args:
+            experiment: Ax experiment.
+            generation_strategy: Ax generation strategy.
+            adapter: Adaptor to be used for predictions.
+
+        Returns:
+            A HealthcheckAnalysisCard object with information on overly restrictive
+            constraints, i.e., constraints for which a significant fraction of arms
+            have low probability of satisfaction.
+        """
+        experiment = none_throws(experiment)
+
+        # If no optimization config or constraints, return early with PASS
+        # Note, a bit of duplication here since validate_applicable_state already
+        # does some checking on opt config
+        if (
+            experiment.optimization_config is None
+            or not experiment.optimization_config.outcome_constraints
+        ):
+            subtitle = (
+                "No optimization config is specified."
+                if experiment.optimization_config is None
+                else "No constraints are specified."
+            )
+            return create_healthcheck_analysis_card(
+                name=self.__class__.__name__,
+                title="Ax Individual Constraints Feasibility Success",
+                subtitle=subtitle,
+                df=pd.DataFrame(),
+                status=HealthcheckStatus.PASS,
+            )
+
+        optimization_config = experiment.optimization_config
+
+        # adapter validated in validate_applicable_state
+        relevant_adapter = extract_relevant_adapter(
+            experiment=experiment,
+            generation_strategy=generation_strategy,
+            adapter=adapter,
+        )
+
+        arm_data = prepare_arm_data(
+            experiment=experiment,
+            metric_names=[*optimization_config.metrics.keys()],
+            use_model_predictions=True,
+            adapter=relevant_adapter,
+            trial_statuses=[TrialStatus.COMPLETED, TrialStatus.RUNNING],
+            compute_p_feasible_per_constraint=True,
+        )
+
+        # Analyze each constraint individually
+        restrictive_constraints = []
+        constraint_stats = []
+
+        # Get individual constraint p_feasible columns
+        p_feasible_cols = [
+            col
+            for col in arm_data.columns
+            if col.startswith("p_feasible_")
+            and col not in ["p_feasible_mean", "p_feasible_sem"]
+        ]
+
+        # Create a mapping from metric names to outcome constraints for formatting
+        constraint_map = {}
+        for oc in optimization_config.outcome_constraints:
+            if isinstance(oc, ScalarizedOutcomeConstraint):
+                constraint_map[str(oc)] = oc
+            else:
+                constraint_map[oc.metric.name] = oc
+
+        for col in p_feasible_cols:
+            constraint_name = col.replace("p_feasible_", "")
+
+            # Get the formatted constraint label
+            if constraint_name in constraint_map:
+                formatted_constraint = _format_constraint_label(
+                    constraint_map[constraint_name], constraint_name
+                )
+            else:
+                formatted_constraint = constraint_name
+
+            # Count how many arms fall below the threshold
+            num_arms = len(arm_data)
+            num_below_threshold = (arm_data[col] < self.restrictive_threshold).sum()
+            fraction_below = num_below_threshold / num_arms if num_arms > 0 else 0
+
+            constraint_stats.append(
+                {
+                    "constraint": formatted_constraint,
+                    "num_arms_below_threshold": num_below_threshold,
+                    "total_arms": num_arms,
+                    "fraction_below_threshold": fraction_below,
+                }
+            )
+
+            # Check if this constraint is overly restrictive
+            if fraction_below >= self.fraction_arms_threshold:
+                restrictive_constraints.append(formatted_constraint)
+
+        df = pd.DataFrame(constraint_stats)
+
+        if restrictive_constraints:
+            status = HealthcheckStatus.WARNING
+            num_restrictive = len(restrictive_constraints)
+            constraint_list = ", ".join(
+                [f"<b>{c}</b>" for c in restrictive_constraints]
+            )
+
+            if num_restrictive == 1:
+                subtitle = (
+                    f"Found 1 overly restrictive constraint: {constraint_list}. "
+                    "For this constraint, at least "
+                    f"{self.fraction_arms_threshold * 100:.0f}% "
+                    "of arms have a probability of satisfaction below "
+                    f"{self.restrictive_threshold}. Consider relaxing the bounds for "
+                    "this constraint to improve optimization performance."
+                )
+            else:
+                subtitle = (
+                    f"Found {num_restrictive} overly restrictive constraints: "
+                    f"{constraint_list}. "
+                    "For these constraints, at least "
+                    f" {self.fraction_arms_threshold * 100:.0f}% "
+                    "of arms have a probability of satisfaction below "
+                    f"{self.restrictive_threshold}. Consider relaxing the bounds for "
+                    "these constraints to improve optimization performance."
+                )
+            title_status = "Warning"
+        else:
+            subtitle = "All constraints are individually feasible."
+            title_status = "Success"
+            status = HealthcheckStatus.PASS
+
+        return create_healthcheck_analysis_card(
+            name=self.__class__.__name__,
+            title=f"Ax Individual Constraints Feasibility {title_status}",
+            subtitle=subtitle,
+            df=df,
+            status=status,
+        )

--- a/ax/analysis/healthcheck/tests/test_individual_constraints_feasibility.py
+++ b/ax/analysis/healthcheck/tests/test_individual_constraints_feasibility.py
@@ -1,0 +1,309 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import numpy as np
+import pandas as pd
+from ax.adapter.factory import get_sobol
+from ax.adapter.registry import Generators
+
+from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckStatus
+from ax.analysis.healthcheck.individual_constraints_feasibility import (
+    IndividualConstraintsFeasibilityAnalysis,
+    RESTRICTIVE_P_FEAS_THRESHOLD,
+)
+from ax.core.batch_trial import BatchTrial
+from ax.core.data import Data
+from ax.core.experiment import Experiment
+from ax.core.metric import Metric
+from ax.core.objective import Objective
+from ax.core.optimization_config import OptimizationConfig
+from ax.generation_strategy.generation_node import GenerationNode
+from ax.generation_strategy.generation_strategy import GenerationStrategy
+from ax.generation_strategy.generator_spec import GeneratorSpec
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import (
+    get_branin_experiment,
+    get_branin_experiment_with_multi_objective,
+)
+from ax.utils.testing.mock import mock_botorch_optimize
+from pyre_extensions import assert_is_instance
+
+
+class TestIndividualConstraintsFeasibilityAnalysis(TestCase):
+    def _create_experiment_with_data(
+        self, branin_d_means: list[float]
+    ) -> tuple[Experiment, GenerationStrategy]:
+        """
+        Helper method to create an experiment with specified branin_d means.
+
+        Args:
+            branin_d_means: List of 6 mean values for branin_d metric
+
+        Returns:
+            Tuple of (experiment, generation_strategy)
+        """
+        experiment = get_branin_experiment_with_multi_objective(
+            with_batch=False,
+            with_status_quo=True,
+            with_relative_constraint=True,  # Constraint is >= -0.25%
+        )
+        df_metric_a = pd.DataFrame(
+            {
+                "arm_name": ["status_quo", "0_0", "0_1", "0_2", "0_3", "0_4"],
+                "metric_name": ["branin_a"] * 6,
+                "mean": list(np.random.normal(0, 1, 6)),
+                "sem": [0.1] * 6,
+                "trial_index": [0] * 6,
+                "metric_signature": ["branin_a"] * 6,
+            }
+        )
+        df_metric_b = pd.DataFrame(
+            {
+                "arm_name": ["status_quo", "0_0", "0_1", "0_2", "0_3", "0_4"],
+                "metric_name": ["branin_b"] * 6,
+                "mean": list(np.random.normal(0, 1, 6)),
+                "sem": [0.1] * 6,
+                "trial_index": [0] * 6,
+                "metric_signature": ["branin_b"] * 6,
+            }
+        )
+        df_metric_d = pd.DataFrame(
+            {
+                "arm_name": ["status_quo", "0_0", "0_1", "0_2", "0_3", "0_4"],
+                "metric_name": ["branin_d"] * 6,
+                "mean": branin_d_means,
+                "sem": [0.1] * 6,
+                "trial_index": [0] * 6,
+                "metric_signature": ["branin_d"] * 6,
+            }
+        )
+        df = pd.concat([df_metric_a, df_metric_b, df_metric_d], ignore_index=True)
+
+        sobol = get_sobol(search_space=experiment.search_space)
+        experiment.new_batch_trial(generator_run=sobol.gen(5))
+
+        batch_trial = assert_is_instance(experiment.trials[0], BatchTrial)
+        batch_trial.add_arm(experiment.status_quo)
+        batch_trial.add_status_quo_arm(weight=1.0)
+        experiment.trials[0].mark_running(no_runner_required=True)
+        experiment.trials[0].mark_completed()
+
+        experiment.attach_data(data=Data(df=df))
+
+        generation_strategy = GenerationStrategy(
+            name="gs",
+            nodes=[
+                GenerationNode(
+                    name="test_node",
+                    generator_specs=[
+                        GeneratorSpec(
+                            generator_enum=Generators.BOTORCH_MODULAR,
+                        )
+                    ],
+                )
+            ],
+        )
+        generation_strategy.experiment = experiment
+        generation_strategy._curr._fit(experiment=experiment)
+
+        return experiment, generation_strategy
+
+    @mock_botorch_optimize
+    def test_compute_all_feasible(self) -> None:
+        """Test when all constraints are individually feasible."""
+        experiment, generation_strategy = self._create_experiment_with_data(
+            branin_d_means=[1.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        )
+
+        icfa = IndividualConstraintsFeasibilityAnalysis()
+        card = icfa.compute(
+            experiment=experiment, generation_strategy=generation_strategy
+        )
+        self.assertEqual(card.name, "IndividualConstraintsFeasibilityAnalysis")
+        self.assertEqual(card.title, "Ax Individual Constraints Feasibility Success")
+        self.assertEqual(card.subtitle, "All constraints are individually feasible.")
+        self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
+
+        # Verify the dataframe has the expected structure
+        df = card.df
+        self.assertIn("constraint", df.columns)
+        self.assertIn("num_arms_below_threshold", df.columns)
+        self.assertIn("total_arms", df.columns)
+        self.assertIn("fraction_below_threshold", df.columns)
+
+    @mock_botorch_optimize
+    def test_compute_restrictive_constraint(self) -> None:
+        """Test when a constraint is overly restrictive."""
+        # Create data where branin_d constraint is overly restrictive
+        # (most arms have very negative values, making them violate the constraint)
+        experiment, generation_strategy = self._create_experiment_with_data(
+            branin_d_means=[1.0, -5.0, -5.0, -5.0, -5.0, -5.0]
+        )
+
+        icfa = IndividualConstraintsFeasibilityAnalysis(
+            restrictive_threshold=0.5, fraction_arms_threshold=0.5
+        )
+        card = icfa.compute(
+            experiment=experiment, generation_strategy=generation_strategy
+        )
+
+        self.assertEqual(card.name, "IndividualConstraintsFeasibilityAnalysis")
+        self.assertEqual(card.title, "Ax Individual Constraints Feasibility Warning")
+        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+
+        # The subtitle should mention the restrictive constraint(s)
+        self.assertIn("overly restrictive constraint", card.subtitle)
+        self.assertIn("Consider relaxing the bounds", card.subtitle)
+
+        # Verify the dataframe has at least one constraint marked as restrictive
+        df_result = card.df
+        restrictive_constraints = df_result[
+            df_result["fraction_below_threshold"] >= icfa.fraction_arms_threshold
+        ]
+        self.assertGreater(len(restrictive_constraints), 0)
+
+    @mock_botorch_optimize
+    def test_custom_thresholds(self) -> None:
+        """Test with custom restrictive and fraction thresholds."""
+        # Create data with moderately restrictive constraint
+        experiment, generation_strategy = self._create_experiment_with_data(
+            branin_d_means=[1.0, -2.0, -2.0, 3.0, 4.0, 5.0]
+        )
+
+        # Use a more lenient fraction threshold (only 30% of arms need to be below)
+        icfa = IndividualConstraintsFeasibilityAnalysis(
+            restrictive_threshold=RESTRICTIVE_P_FEAS_THRESHOLD,
+            fraction_arms_threshold=0.3,
+        )
+        card = icfa.compute(
+            experiment=experiment, generation_strategy=generation_strategy
+        )
+
+        # This should catch the moderately restrictive constraint
+        self.assertIn(
+            card.get_status(), [HealthcheckStatus.WARNING, HealthcheckStatus.PASS]
+        )
+
+    @mock_botorch_optimize
+    def test_no_constraints(self) -> None:
+        """Test when experiment has no constraints."""
+        # Create experiment with data, then remove constraints
+        experiment, generation_strategy = self._create_experiment_with_data(
+            branin_d_means=[1.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        )
+        experiment.optimization_config = OptimizationConfig(
+            objective=Objective(metric=Metric(name="branin_a"), minimize=False),
+            outcome_constraints=[],
+        )
+
+        icfa = IndividualConstraintsFeasibilityAnalysis()
+        card = icfa.compute(
+            experiment=experiment, generation_strategy=generation_strategy
+        )
+
+        self.assertEqual(card.name, "IndividualConstraintsFeasibilityAnalysis")
+        self.assertEqual(card.title, "Ax Individual Constraints Feasibility Success")
+        self.assertEqual(card.subtitle, "No constraints are specified.")
+        self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
+
+    def test_no_optimization_config(self) -> None:
+        """Test when experiment has no optimization config."""
+        experiment = get_branin_experiment(has_optimization_config=False)
+        icfa = IndividualConstraintsFeasibilityAnalysis()
+        card = icfa.compute(experiment=experiment, generation_strategy=None)
+
+        self.assertEqual(card.name, "IndividualConstraintsFeasibilityAnalysis")
+        self.assertEqual(card.title, "Ax Individual Constraints Feasibility Success")
+        self.assertEqual(card.subtitle, "No optimization config is specified.")
+        self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
+
+    @mock_botorch_optimize
+    def test_dataframe_structure(self) -> None:
+        """Test that the returned dataframe has the correct structure and values."""
+        experiment, generation_strategy = self._create_experiment_with_data(
+            branin_d_means=[1.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        )
+
+        icfa = IndividualConstraintsFeasibilityAnalysis()
+        card = icfa.compute(
+            experiment=experiment, generation_strategy=generation_strategy
+        )
+
+        df = card.df
+
+        # Check all expected columns are present
+        expected_columns = [
+            "constraint",
+            "num_arms_below_threshold",
+            "total_arms",
+            "fraction_below_threshold",
+        ]
+        for col in expected_columns:
+            self.assertIn(col, df.columns)
+
+        # Check that we have one row per constraint
+        # The experiment has one constraint (branin_d)
+        self.assertEqual(len(df), 1)
+
+        # Check that fraction_below_threshold is between 0 and 1
+        self.assertTrue((df["fraction_below_threshold"] >= 0).all())
+        self.assertTrue((df["fraction_below_threshold"] <= 1).all())
+
+    @mock_botorch_optimize
+    def test_validate_applicable_state(self) -> None:
+        """Test validate_applicable_state for various scenarios."""
+        icfa = IndividualConstraintsFeasibilityAnalysis()
+
+        # Test 1: No experiment provided
+        validation_error = icfa.validate_applicable_state(
+            experiment=None, generation_strategy=None, adapter=None
+        )
+        self.assertIsNotNone(validation_error)
+        self.assertIn("experiment", validation_error.lower())
+
+        # Test 2: Experiment with no optimization config (should be valid)
+        experiment_no_opt_config = get_branin_experiment(has_optimization_config=False)
+        validation_error = icfa.validate_applicable_state(
+            experiment=experiment_no_opt_config, generation_strategy=None, adapter=None
+        )
+        self.assertIsNone(validation_error)
+
+        # Test 3: Experiment with optimization config but no constraints
+        # (should be valid)
+        experiment_no_constraints = get_branin_experiment(with_status_quo=True)
+        experiment_no_constraints.optimization_config = OptimizationConfig(
+            objective=Objective(metric=Metric(name="branin"), minimize=True),
+            outcome_constraints=[],
+        )
+        validation_error = icfa.validate_applicable_state(
+            experiment=experiment_no_constraints, generation_strategy=None, adapter=None
+        )
+        self.assertIsNone(validation_error)
+
+        # Test 4: Experiment with constraints but no adapter (should fail)
+        experiment_with_constraints, _ = self._create_experiment_with_data(
+            branin_d_means=[1.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+        )
+        validation_error = icfa.validate_applicable_state(
+            experiment=experiment_with_constraints,
+            generation_strategy=None,
+            adapter=None,
+        )
+        self.assertIsNotNone(validation_error)
+
+        # Test 5: Experiment with constraints and valid adapter (should be valid)
+        experiment_with_adapter, generation_strategy = (
+            self._create_experiment_with_data(
+                branin_d_means=[1.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+            )
+        )
+        validation_error = icfa.validate_applicable_state(
+            experiment=experiment_with_adapter,
+            generation_strategy=generation_strategy,
+            adapter=None,
+        )
+        self.assertIsNone(validation_error)

--- a/ax/analysis/plotly/constraint_feasibility.py
+++ b/ax/analysis/plotly/constraint_feasibility.py
@@ -206,11 +206,11 @@ class ConstraintFeasibilityPlot(Analysis):
         subtitle = (
             "The parallel coordinates plot displays the probability of satisfying "
             "each individual constraint along with the joint probability of satisfying "
-            "all constraints (first dimension). Each line represents an arm, "
-            "and each dimension after the first represents a constraint. "
-            "This visualization helps identify which constraints are most difficult "
-            "to satisfy and how different arms perform across the constraint "
-            "landscape. Lines colored by trial_index."
+            "all constraints (last dimension). Each line represents an arm, "
+            "and each dimension represents a constraint, with the overall probability "
+            "shown last. This visualization helps identify which constraints are "
+            "most difficult to satisfy and how different arms perform across the "
+            "constraint landscape. Lines colored by trial_index."
         )
 
         return create_plotly_analysis_card(
@@ -293,16 +293,6 @@ def _prepare_plot(
     color_values = df["trial_index"].tolist()
     dimensions = []
 
-    # Add overall p_feasible as the first dimension
-    if "p_feasible_mean" in df.columns:
-        dimensions.append(
-            {
-                "label": "Overall p(feasible)",
-                "values": df["p_feasible_mean"].tolist(),
-                "range": [0, 1],
-            }
-        )
-
     # Add p_feasible dimensions for each constraint
     for oc, constraint_name in zip(outcome_constraints, constraint_names):
         col_name = f"p_feasible_{constraint_name}"
@@ -315,6 +305,16 @@ def _prepare_plot(
                     "range": [0, 1],
                 }
             )
+
+    # Add overall p_feasible as the last dimension
+    if "p_feasible_mean" in df.columns:
+        dimensions.append(
+            {
+                "label": "Overall p(feasible)",
+                "values": df["p_feasible_mean"].tolist(),
+                "range": [0, 1],
+            }
+        )
 
     colorscale = BOTORCH_COLOR_SCALE
 


### PR DESCRIPTION
Summary:
Create `IndividualConstraintsFeasibilityAnalysis`. This is similar to `ConstraintsFeasibilityAnalysis`, except this look at constraints on an individual-basis and can provide more actionable feedback on which specific constraints are overly restrictive.

Currently, the heuristic used in this Analysis to deem an arm overly restrictive is pretty simple:

If `RESTRICTIVE_ARM_FRACTION` of arms are below `RESTRICTIVE_P_FEAS_THRESHOLD` for a given constraint, then that constraint is classified as overly-restrictive. Both `RESTRICTIVE_ARM_FRACTION` and `RESTRICTIVE_P_FEAS_THRESHOLD` are 0.5 as of writing this summary

Differential Revision: D86263537


