### PR TITLE
Return the reason for precentile early stop to log

### DIFF
--- a/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
@@ -152,10 +152,12 @@ class ClientTest(TestCase):
                         raw_data={self.metric_name: result},
                         progression=step if attach_with_progression else None,
                     )
-                    if stopped := self.client.should_stop_trial_early(
+                    should_stop, _ = self.client.should_stop_trial_early(
                         trial_index=trial_index
-                    ):
+                    )
+                    if should_stop:
                         self.client.mark_trial_early_stopped(trial_index=trial_index)
+                        stopped = True
                         break
 
             if not stopped:

--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -576,7 +576,7 @@ class Client(WithDBSettingsBase):
         return trial_index
 
     # -------------------- Section 2.2 Early Stopping -------------------------------
-    def should_stop_trial_early(self, trial_index: int) -> bool:
+    def should_stop_trial_early(self, trial_index: int) -> tuple[bool, str | None]:
         """
         Check if the trial should be stopped early. If True and the user wishes to heed
         Ax's recommendation the user should manually stop the trial and call
@@ -584,7 +584,9 @@ class Client(WithDBSettingsBase):
         selected automatically or set manually via ``set_early_stopping_strategy``.
 
         Returns:
-            Whether the trial should be stopped early.
+            A tuple of (should_stop, reason) where should_stop is a boolean indicating
+            whether the trial should be stopped early, and reason is an optional string
+            explaining why the trial should be stopped.
         """
 
         es_response = none_throws(
@@ -596,13 +598,11 @@ class Client(WithDBSettingsBase):
         )
 
         if trial_index in es_response:
-            logger.info(
-                f"Trial {trial_index} should be stopped early: "
-                f"{es_response[trial_index]}"
-            )
-            return True
+            reason = es_response[trial_index]
+            logger.info(f"Trial {trial_index} should be stopped early: {reason}")
+            return True, reason
 
-        return False
+        return False, None
 
     # -------------------- Section 2.3 Marking trial status manually ----------------
     def mark_trial_failed(

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -807,7 +807,9 @@ class TestClient(TestCase):
         )
 
         client.get_next_trials(max_trials=1)
-        self.assertFalse(client.should_stop_trial_early(trial_index=0))
+        should_stop, reason = client.should_stop_trial_early(trial_index=0)
+        self.assertFalse(should_stop)
+        self.assertIsNone(reason)
 
     def test_run_trials(self) -> None:
         client = Client()


### PR DESCRIPTION
Summary: We want to log the reason for percentile early stopping. Made changes to return the reason.

Differential Revision: D86737383


