### PR TITLE
Fix progression normalization logic in early-stopping strategies

### DIFF
--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -59,13 +59,16 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 `min_curves` have completed with curve data attached. That is, if
                 `min_curves` trials are completed but their curve data was not
                 successfully retrieved, further trials may not be early-stopped.
-            normalize_progressions: Normalizes the progression column of the MapData df
-                by dividing by the max. If the values were originally in [0, `prog_max`]
-                (as we would expect), the transformed values will be in [0, 1]. Useful
-                for inferring the max progression and allows `min_progression` to be
-                specified in the transformed space. IMPORTANT: Typically, `min_curves`
-                should be > 0 to ensure that at least one trial has completed and that
-                we have a reliable approximation for `prog_max`.
+            normalize_progressions: If True, normalizes the progression values
+                for each metric to the [0, 1] range using the observed minimum and
+                maximum progression values for that metric. This transformation maps
+                the original progression range [`min_prog`, `max_prog`] to [0, 1]
+                via (x - min_prog) / (max_prog - min_prog). Useful when progression
+                values have arbitrary scales or when you want to specify
+                `min_progression` and `max_progression` in a normalized [0, 1]
+                space. Note: At least one trial should have completed (i.e.,
+                `min_curves` > 0) to ensure reliable estimates of the progression
+                range.
             n_best_trials_to_complete: If specified, guarantees that the top
                 `n_best_trials_to_complete` trials (based on current objective value
                 at the last progression) will never be early stopped, even if they


### PR DESCRIPTION
Summary:
This diff fixes the progression normalization logic in early stopping strategies to use proper min-max normalization instead of dividing by the absolute maximum value.

The main changes include:
* **Corrected normalization logic**: Replaced the previous implementation (dividing by `abs().max()`) with `_maybe_normalize_map_key()`, which properly performs min-max normalization: `(x - min) / (max - min)`. This ensures progression values are correctly mapped to the [0, 1] range regardless of the original scale.
* **Updated documentation**: Improved docstrings for the `normalize_progressions` parameter across `BaseEarlyStoppingStrategy`, `BayesianEarlyStoppingStrategy`, and `PercentileEarlyStoppingStrategy` to accurately describe the min-max normalization behavior.
* **Added dependency**: Added `//ax/adapter:data_utils` to BUCK file to use the `_maybe_normalize_map_key` utility function.

The previous normalization approach of dividing by the max was incorrect because:
1. It didn't guarantee a [0, 1] range when the minimum wasn't 0
2. It was inconsistent with the documented behavior
3. It can't handle negative progression values

The new approach uses standard min-max scaling which correctly handles arbitrary progression ranges and ensures the transformed values are in [0, 1].

Differential Revision: D86770422


