### PR TITLE
Reset index when filtering data

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -284,7 +284,7 @@ class Data(Base, SerializationMixin):
                 trial_indices=trial_indices,
                 metric_names=metric_names,
                 metric_signatures=metric_signatures,
-            ),
+            ).reset_index(drop=True),
             _skip_ordering_and_validation=True,
         )
 

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -309,6 +309,7 @@ class DataTest(TestCase):
         self.assertEqual(len(filtered.df), 3)
         self.assertEqual(set(filtered.df["metric_name"]), {"a"})
         self.assertEqual(set(filtered.df["trial_index"]), {1})
+        self.assertIsInstance(filtered.df.index, pd.RangeIndex)
 
         # Test that filter works when we provide metric signatures and trial indices
         filtered = data.filter(metric_signatures=["a_signature"], trial_indices=[1])


### PR DESCRIPTION
Summary:
**Context**: `Data.filter` doesn't include a `reset_index` call, so the index of the DataFrame looks odd and it is hard to write unit tests for what it should look like. We never use the index, so it is harmless to reset it.

**This PR**: Adds a `reset_index(drop=True)` call so that the resulting DataFrame has a `pd.RangeIndex`.

Reviewed By: mpolson64

Differential Revision: D86889368


