### PR TITLE
Add interval param for throttling early-stopping checks

### DIFF
--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -19,6 +19,34 @@ from pyre_extensions import assert_is_instance
 logger: Logger = get_logger(__name__)
 
 
+def _interval_boundary(
+    progression: float, min_progression: float, interval: float
+) -> float:
+    """Calculate the interval boundary for a given progression by rounding down.
+
+    Interval boundaries are at: min_prog, min_prog + interval,
+    min_prog + 2*interval, etc. This method rounds down the given
+    progression to the nearest (lower or equal) interval boundary.
+
+    For example, with min_prog=0 and interval=10:
+    - progression=0 -> boundary=0
+    - progression=5 -> boundary=0 (rounds down)
+    - progression=10 -> boundary=10
+    - progression=15 -> boundary=10 (rounds down)
+    - progression=23 -> boundary=20 (rounds down)
+
+    Args:
+        progression: The progression value to calculate boundary for.
+        min_progression: The minimum progression value (start of first interval).
+        interval: The interval size.
+
+    Returns:
+        The interval boundary that this progression is at or past (rounded down).
+    """
+    interval_num = (progression - min_progression) // interval
+    return min_progression + interval_num * interval
+
+
 def align_partial_results(
     df: pd.DataFrame,
     metrics: list[str],


### PR DESCRIPTION
Summary:
This diff adds an `interval` parameter to `BaseEarlyStoppingStrategy` that allows trials to only be evaluated for early-stopping at specific progression intervals.

**Context**
When orchestrators poll frequently, trials can be evaluated for early-stopping at every minor progression update. This creates unnecessary overhead and can lead to premature stopping decisions based on noisy intermediate results. The `interval` parameter allows users to throttle these checks by only evaluating trials when they've crossed interval boundaries.

**Changes**
* Added `interval` parameter to `BaseEarlyStoppingStrategy.__init__` and `ModelBasedEarlyStoppingStrategy.__init__`
* Added interval boundary checking logic in `is_eligible()` that uses a rounding-down approach to prevent drift
* Implemented helper methods:
  - `_compute_interval_boundary()`: Static method that rounds progression down to nearest interval boundary
  - `_get_interval_boundary()`: Instance method wrapper for convenience
  - `_has_crossed_interval_boundary()`: Checks if progression crossed a boundary since last check
  - `_get_next_interval_boundary()`: Calculates the next boundary for logging
  - `_log_and_return_interval_boundary()`: Standardized logging helper
* Added `_last_progression_checked` dict to track when each trial was last evaluated
* Updated `is_eligible()` docstring to document the new check

**How it works:**
With `interval=10` and `min_progression=0`, boundaries are at 0, 10, 20, 30, etc. A trial at progression 15 is eligible on first check. If checked again at progression 18, it's not eligible (same boundary). Once it reaches progression 21, it's eligible again (crossed boundary from 10 to 20).

This approach prevents drift that could occur with simple delta checking (e.g., if a trial progresses slowly, repeated small checks could compound).
This diff adds an `interval` parameter to `BaseEarlyStoppingStrategy` that allows trials to only be evaluated for early-stopping at specific progression intervals.

**Context**
When orchestrators poll frequently, trials can be evaluated for early-stopping at every minor progression update. This creates unnecessary overhead and can lead to premature stopping decisions based on noisy intermediate results. The `interval` parameter allows users to throttle these checks by only evaluating trials when they've crossed interval boundaries.

**Changes**
* Added `interval` parameter to `BaseEarlyStoppingStrategy.__init__` and `ModelBasedEarlyStoppingStrategy.__init__`
* Added interval boundary checking logic in `is_eligible()` that uses a rounding-down approach to prevent drift
* Moved interval boundary calculation to a standalone `interval_boundary()` function in `ax/early_stopping/utils.py` (previously a static method) to improve reusability and avoid code duplication
* Implemented helper methods:
  - `_has_crossed_interval_boundary()`: Checks if progression crossed a boundary since last check (uses the standalone `interval_boundary()` function)
  - `_log_and_return_interval_boundary()`: Standardized logging helper that informs users about:
    - The current and previous progression values
    - That both progressions are in the same interval
    - The specific interval boundaries `[current_boundary, next_boundary)`
    - The next progression value needed to be eligible for early stopping
* Added `_last_check_progressions` dict to track when each trial was last evaluated (renamed from `_last_progression_checked` for clarity)
* Added informative debug logging when a trial is checked for early stopping for the first time
* Updated `is_eligible()` docstring to document the new check

**How it works:**
With `interval=10` and `min_progression=0`, boundaries are at 0, 10, 20, 30, etc. A trial at progression 15 is eligible on first check. If checked again at progression 18, it's not eligible (same interval `[10, 20)`). Once it reaches progression 21, it's eligible again (crossed boundary from `[10, 20)` to `[20, 30)`).

This approach prevents drift that could occur with simple delta checking (e.g., if a trial progresses slowly, repeated small checks could compound).

The `interval_boundary()` utility function is now available in `ax/early_stopping/utils.py` for use by other components that need to calculate interval boundaries.

Differential Revision: D86817286


