### PR TITLE
Computing cumulative best on smoothed values in `TensorboardMetric`

### DIFF
--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -258,14 +258,6 @@ try:
                 )
                 df = df[is_finite]
 
-            # Apply per-metric post-processing
-            # Apply cumulative "best" (min if lower_is_better)
-            if metric.cumulative_best:
-                if metric.lower_is_better:
-                    df["mean"] = df["mean"].cummin()
-                else:
-                    df["mean"] = df["mean"].cummax()
-
             # Apply smoothing
             if metric.smoothing > 0:
                 # Interpolate onto a grid to avoid smoothing artifacts.
@@ -278,6 +270,14 @@ try:
             # Apply rolling percentile
             if metric.percentile is not None:
                 df["mean"] = df["mean"].expanding().quantile(metric.percentile)
+
+            # Apply per-metric post-processing
+            # Apply cumulative "best" (min if lower_is_better)
+            if metric.cumulative_best:
+                if metric.lower_is_better:
+                    df["mean"] = df["mean"].cummin()
+                else:
+                    df["mean"] = df["mean"].cummax()
 
             return df
 


### PR DESCRIPTION
Summary:
### Summary

#### Overview

This diff introduces a change in how cumulative best values are computed in the `TensorboardMetric` class. Specifically, it shifts the computation of cumulative best to operate on smoothed values rather than raw values.

#### Changes

The diff makes the following key changes:

1.  Moves the computation of cumulative best to after smoothing in the `TensorboardMetric` class. This ensures that cumulative best operations are applied to smoothed values, not raw values.
2.  Updates the `test_tensorboard.py` file with a new test case, `test_smoothing_then_cumulative_best_order`, to validate that smoothing is applied before cumulative best.

Differential Revision: D86976138


