### PR TITLE
Fix HSS Search Space Validation

### DIFF
--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -741,11 +741,12 @@ class HierarchicalSearchSpace(SearchSpace):
         Returns:
             Whether the parameterization is contained in the search space.
         """
-        super().check_membership(
+        if not super().check_membership(
             parameterization=parameterization,
             raise_error=raise_error,
             check_all_parameters_present=False,
-        )
+        ):
+            return False
 
         # Check that each arm "belongs" in the hierarchical
         # search space; ensure that it only has the parameters that make sense

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -1100,3 +1100,16 @@ class HierarchicalSearchSpaceTest(TestCase):
             {k: hss_2_flat[k] for k in hss_1_flat_params}, hss_1_flat_params
         )
         self.assertEqual(set(hss_2_flat.keys()), set(self.hss_2.parameters.keys()))
+
+    def test_check_membership(self) -> None:
+        """Test that check_membership properly validates parameter values."""
+        valid_param = {"use_linear": True, "model": "fixed_model"}
+        self.assertTrue(self.hss_with_fixed.check_membership(valid_param))
+
+        # Out-of-design parameterization should fail
+        ood_param = {"use_linear": "invalid", "model": "fixed_model"}
+        self.assertFalse(self.hss_with_fixed.check_membership(ood_param))
+
+        # Should raise an error when raise_error=True
+        with self.assertRaisesRegex(ValueError, "invalid is not a valid value"):
+            self.hss_with_fixed.check_membership(ood_param, raise_error=True)


### PR DESCRIPTION
Summary:
The `HierarchicalSearchSpace.check_membership()` method calls the parent class's `check_membership()` but **doesn't use the result.** This results in adapter attempting trying to transform OOD values and failure in N8593571

This diff puts up a quick fix for that

Differential Revision: D86997723


