### PR TITLE
Disallow attaching data for trials that have not been attached

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -923,6 +923,11 @@ class Experiment(Base):
             )
         cur_time_millis = current_timestamp_in_millis()
         for trial_index, trial_df in data.full_df.groupby("trial_index"):
+            if trial_index not in self.trials:
+                raise ValueError(
+                    f"Cannot attach data for trial {trial_index} because it has"
+                    " not been attached to the experiment."
+                )
             if not isinstance(data, MapData):
                 trial_df = sort_by_trial_index_and_arm_name(df=trial_df)
             current_trial_data = (


### PR DESCRIPTION
Summary:
Disallows attaching data for trials that have not been attached. `Experiment`'s data-lookup functions typically assume that `experiment.trials.keys()` is the set of all trials with data, which is not necessarily true if data has been attached for trial indices that have not been attached.

**Question**: Should this be a warning first?

Differential Revision: D87002982


