### PR TITLE
- Update docstrings to better convey the updated logic for ttl_seconds

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -72,11 +72,11 @@ class BaseTrial(ABC, SortableBase):
     Args:
         experiment: Experiment, of which this trial is a part
         trial_type: Type of this trial, if used in MultiTypeExperiment.
-        ttl_seconds: If specified, trials will be considered failed after
+        ttl_seconds: If specified, trials will be considered stale after
             this many seconds since the time the trial was ran, unless the
             trial is completed before then. Meant to be used to detect
             'dead' trials, for which the evaluation process might have
-            crashed etc., and which should be considered failed after
+            crashed etc., and which should be considered stale after
             their 'time to live' has passed.
         index: If specified, the trial's index will be set accordingly.
             This should generally not be specified, as in the index will be
@@ -216,18 +216,18 @@ class BaseTrial(ABC, SortableBase):
     @property
     def ttl_seconds(self) -> int | None:
         """This trial's time-to-live once ran, in seconds. If not set, trial
-        will never be automatically considered failed (i.e. infinite TTL).
+        will never be automatically considered stale (i.e. infinite TTL).
         Reflects after how many seconds since the time the trial was run it
-        will be considered failed unless completed.
+        will be considered stale unless completed.
         """
         return self._ttl_seconds
 
     @ttl_seconds.setter
     def ttl_seconds(self, ttl_seconds: int | None) -> None:
         """Sets this trial's time-to-live once ran, in seconds. If None, trial
-        will never be automatically considered failed (i.e. infinite TTL).
+        will never be automatically considered stale (i.e. infinite TTL).
         Reflects after how many seconds since the time the trial was run it
-        will be considered failed unless completed.
+        will be considered stale unless completed.
         """
         if ttl_seconds is not None and ttl_seconds <= 0:
             raise ValueError("TTL must be a positive integer (or None).")

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -100,11 +100,11 @@ class BatchTrial(BaseTrial):
             If False, the _status_quo is still set on the trial for tracking
             purposes, but without a weight it will not be an Arm present on
             the trial.
-        ttl_seconds: If specified, trials will be considered failed after
+        ttl_seconds: If specified, trials will be considered stale after
             this many seconds since the time the trial was ran, unless the
             trial is completed before then. Meant to be used to detect
             'dead' trials, for which the evaluation process might have
-            crashed etc., and which should be considered failed after
+            crashed etc., and which should be considered stale after
             their 'time to live' has passed.
         index: If specified, the trial's index will be set accordingly.
             This should generally not be specified, as in the index will be

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1168,11 +1168,11 @@ class Experiment(Base):
                 through `add_arm` or `add_generator_run`, but a trial's
                 associated generator run is immutable once set.
             trial_type: Type of this trial, if used in MultiTypeExperiment.
-            ttl_seconds: If specified, trials will be considered failed after
+            ttl_seconds: If specified, trials will be considered stale after
                 this many seconds since the time the trial was ran, unless the
                 trial is completed before then. Meant to be used to detect
                 'dead' trials, for which the evaluation process might have
-                crashed etc., and which should be considered failed after
+                crashed etc., and which should be considered stale after
                 their 'time to live' has passed.
         """
         if ttl_seconds is not None:
@@ -1207,11 +1207,11 @@ class Experiment(Base):
                 trial for tracking purposes, but without a weight it will not be an
                 Arm present on the trial
             trial_type: Type of this trial, if used in MultiTypeExperiment.
-            ttl_seconds: If specified, trials will be considered failed after
+            ttl_seconds: If specified, trials will be considered stale after
                 this many seconds since the time the trial was ran, unless the
                 trial is completed before then. Meant to be used to detect
                 'dead' trials, for which the evaluation process might have
-                crashed etc., and which should be considered failed after
+                crashed etc., and which should be considered stale after
                 their 'time to live' has passed.
         """
         if ttl_seconds is not None:
@@ -1668,9 +1668,8 @@ class Experiment(Base):
                 with a weight of 1.0. If False, the _status_quo is still set on the
                 trial for tracking purposes, but without a weight it will not be an
                 Arm present on the trial
-            ttl_seconds: If specified, will consider the trial failed after this
-                many seconds. Used to detect dead trials that were not marked
-                failed properly.
+            ttl_seconds: If specified, will consider the trial stale after this
+                many seconds. Used to detect dead trials that did not complete.
             run_metadata: Metadata to attach to the trial.
 
         Returns:

--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -47,11 +47,11 @@ class Trial(BaseTrial):
             or `add_generator_run`, but a trial's associated genetor run is
             immutable once set.
         trial_type: Type of this trial, if used in MultiTypeExperiment.
-        ttl_seconds: If specified, trials will be considered failed after
+        ttl_seconds: If specified, trials will be considered stale after
             this many seconds since the time the trial was ran, unless the
             trial is completed before then. Meant to be used to detect
             'dead' trials, for which the evaluation process might have
-            crashed etc., and which should be considered failed after
+            crashed etc., and which should be considered stale after
             their 'time to live' has passed.
         index: If specified, the trial's index will be set accordingly.
             This should generally not be specified, as in the index will be

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -528,9 +528,8 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         Note: Service API currently supports only 1-arm trials.
 
         Args:
-            ttl_seconds: If specified, will consider the trial failed after this
-                many seconds. Used to detect dead trials that were not marked
-                failed properly.
+            ttl_seconds: If specified, will consider the trial stale after this
+                many seconds. Used to detect dead trials that did not complete.
             force: If set to True, this function will bypass the global stopping
                 strategy's decision and generate a new trial anyway.
             fixed_features: A FixedFeatures object containing any
@@ -628,9 +627,8 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
 
         Args:
             max_trials: Limit on how many trials the call to this method should produce.
-            ttl_seconds: If specified, will consider the trial failed after this
-                many seconds. Used to detect dead trials that were not marked
-                failed properly.
+            ttl_seconds: If specified, will consider the trial stale after this
+                many seconds. Used to detect dead trials that did not complete.
             fixed_features: A FixedFeatures object containing any
                 features that should be fixed at specified values during
                 generation.
@@ -805,9 +803,8 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
 
         Args:
             parameters: Parameterization of the new trial.
-            ttl_seconds: If specified, will consider the trial failed after this
-                many seconds. Used to detect dead trials that were not marked
-                failed properly.
+            ttl_seconds: If specified, will consider the trial stale after this
+                many seconds. Used to detect dead trials that did not complete.
 
         Returns:
             Tuple of parameterization and trial index from newly created trial.


### PR DESCRIPTION
Summary:
Updated ttl_seconds docstrings to remove misleading "failed" references.
Trials with TTL are marked as STALE (not FAILED) when TTL expires

Differential Revision: D87107256


