### PR TITLE
Fix typo in automating.ipynb documentation

### DIFF
--- a/tutorials/automating/automating.ipynb
+++ b/tutorials/automating/automating.ipynb
@@ -14,7 +14,7 @@
         "# Automating Orchestration\n",
         "Previously, we've demonstrated [using Ax for ask-tell optimization](../getting_started), a paradigm in which we \"ask\" Ax for candidate configurations and \"tell\" Ax our observations.\n",
         "This can be effective in many scenerios, and it can be automated through use of flow control statements like `for` and `while` loops.\n",
-        "However there are some situations where it would be beneficial to allow Ax to orchestrate the entire optimization: deploying trials to external systems, polling their status, and reading reading their results.\n",
+        "However there are some situations where it would be beneficial to allow Ax to orchestrate the entire optimization: deploying trials to external systems, polling their status, and reading their results.\n",
         "This can be common in a number of real world engineering tasks, including:\n",
         "* **Large scale machine learning experiments** running workloads on high-performance computing clusters\n",
         "* **A/B tests** conducted using an external experimentation platform\n",


### PR DESCRIPTION
double "reading" removed