### PR TITLE
Fix step numbering in automating.ipynb

### DIFF
--- a/tutorials/automating/automating.ipynb
+++ b/tutorials/automating/automating.ipynb
@@ -94,7 +94,7 @@
         "showInput": false
       },
       "source": [
-        "# Step 2: Defining our custom Runner and Metric\n",
+        "## Step 2: Defining our custom Runner and Metric\n",
         "\n",
         "As stated before, we will be creating custom Runner and Metric classes to mimic an external system.\n",
         "Let's start by defining our Hartmann6 function as before."
@@ -444,7 +444,7 @@
         "showInput": false
       },
       "source": [
-        "## Step 5: Run trials\n",
+        "## Step 4: Run trials\n",
         "Once the `Client` has been configured, we can begin running trials.\n",
         "\n",
         "Internally, Ax uses a class named `Scheduler` to orchestrate the trial deployment, polling, data fetching, and candidate generation.\n",
@@ -494,7 +494,7 @@
         "showInput": true
       },
       "source": [
-        "## Step 6: Analyze Results\n",
+        "## Step 5: Analyze Results\n",
         "As before, Ax can compute the best parameterization observed and produce a number of analyses to help interpret the results of the experiment.\n",
         "\n",
         "It is also worth noting that the experiment can be resumed at any time using Ax's storage functionality.\n",


### PR DESCRIPTION
- corrected heading level of step 2 to match the level of others steps.
- moved step 5 -> 4, 6 -> 5 as there were no step 5