### PR TITLE
Add `is_preference_learning_problem` property to `Experiment`

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -483,6 +483,30 @@ class Experiment(Base):
         return none_throws(self.optimization_config).is_moo_problem
 
     @property
+    def is_bope_problem(self) -> bool:
+        """Whether this experiment is a BO with Preference Exploration (BOPE)
+        experiment.
+
+        An experiment is considered a preference learning experiment if:
+        1. It has a PreferenceOptimizationConfig as its optimization config, OR
+        2. It has a PE_EXPERIMENT (preference exploration) auxiliary experiment attached
+
+        Returns:
+            True if this is a preference learning experiment, False otherwise.
+        """
+        # Check if optimization config indicates preference learning
+        if self.optimization_config is not None:
+            if self.optimization_config.is_bope_problem:
+                return True
+
+        # Check if experiment has a PE_EXPERIMENT auxiliary experiment
+        return bool(
+            self.auxiliary_experiments_by_purpose.get(
+                AuxiliaryExperimentPurpose.PE_EXPERIMENT, []
+            )
+        )
+
+    @property
     def immutable_search_space_and_opt_config(self) -> bool:
         """Boolean representing whether search space and metrics on this experiment
         are mutable (by default they are).

--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -158,6 +158,16 @@ class OptimizationConfig(Base):
     def is_moo_problem(self) -> bool:
         return self.objective is not None and isinstance(self.objective, MultiObjective)
 
+    @property
+    def is_bope_problem(self) -> bool:
+        """Whether this is a preference optimization config for BO with
+        Preference Exploration (BOPE) problems.
+
+        Returns False for base OptimizationConfig. PreferenceOptimizationConfig
+        overrides this to return True.
+        """
+        return False
+
     @outcome_constraints.setter
     def outcome_constraints(self, outcome_constraints: list[OutcomeConstraint]) -> None:
         """Set outcome constraints if valid, else raise."""
@@ -525,6 +535,16 @@ class PreferenceOptimizationConfig(MultiObjectiveOptimizationConfig):
             pruning_target_parameterization=pruning_target_parameterization,
         )
         self.preference_profile_name = preference_profile_name
+
+    @property
+    def is_bope_problem(self) -> bool:
+        """Whether this is a preference optimization config for BO with
+        Preference Exploration (BOPE) problems.
+
+        Returns:
+            True for PreferenceOptimizationConfig.
+        """
+        return True
 
     # pyre-ignore[14]: Inconsistent override.
     def clone_with_args(


### PR DESCRIPTION
Summary: This diff adds a new property to the `Experiment` class called `is_preference_learning_problem`. This property checks if the experiment is a preference learning (BOPE) experiment by checking if the optimization config is a `PreferenceOptimizationConfig` or if there is a `PE_EXPERIMENT` (preference exploration) auxiliary experiment attached. This property is useful for identifying preference learning experiments in Ax.

Differential Revision: D87341771


