### PR TITLE
Abort Optimization if status_quo Arm did not complete

### DIFF
--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -2714,6 +2714,20 @@ class TestAxOrchestrator(TestCase):
         ):
             orchestrator.run_n_trials(max_trials=1)
 
+        with self.assertRaisesRegex(
+            StatusQuoInfeasibleError,
+            "Status-quo arm 'status_quo' terminatd with status FAILED.",
+        ):
+            status_quo_trial.mark_failed(unsafe=True)
+            orchestrator.run_n_trials(max_trials=1)
+
+        with self.assertRaisesRegex(
+            StatusQuoInfeasibleError,
+            "Status-quo arm 'status_quo' terminatd with status ABANDONED.",
+        ):
+            status_quo_trial.mark_abandoned(unsafe=True)
+            orchestrator.run_n_trials(max_trials=1)
+
 
 class TestAxOrchestratorMultiTypeExperiment(TestAxOrchestrator):
     EXPECTED_orchestrator_REPR: str = (


### PR DESCRIPTION
Summary: As a followup on D86133265, we also terminate axsweep if status quo arm did not complete successfully, which usually indicates setup problems

Differential Revision: D87281802


