### PR TITLE
Remove isinstance checks on hss

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -37,7 +37,7 @@ from ax.core.outcome_constraint import (
 )
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.parameter_constraint import ParameterConstraint
-from ax.core.search_space import HierarchicalSearchSpace, SearchSpace, SearchSpaceDigest
+from ax.core.search_space import SearchSpace, SearchSpaceDigest
 from ax.core.types import TBounds, TCandidateMetadata
 from ax.exceptions.core import DataRequiredError, UserInputError
 from ax.generators.torch.botorch_moo_utils import (
@@ -164,7 +164,7 @@ def extract_search_space_digest(
             fidelity_features.append(i)
             target_values[i] = assert_is_instance_of_tuple(p.target_value, (int, float))
 
-    if isinstance(search_space, HierarchicalSearchSpace):
+    if search_space.is_hierarchical:
         hierarchical_dependencies = {}
 
         for p_name, p in search_space.parameters.items():

--- a/ax/adapter/transforms/metadata_to_parameter.py
+++ b/ax/adapter/transforms/metadata_to_parameter.py
@@ -17,6 +17,7 @@ from ax.core.observation import ObservationFeatures
 from ax.core.parameter import Parameter
 from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
 from ax.utils.common.logger import get_logger
+from pyre_extensions import assert_is_instance
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
@@ -42,12 +43,14 @@ class MetadataToParameterMixin:
         for parameter in self._parameter_list:
             search_space.add_parameter(parameter.clone())
 
-        if isinstance(search_space, HierarchicalSearchSpace):
+        if search_space.is_hierarchical:
             # The hierarchical search space does not have a root anymore due to the
             # newly added parameters:
             # 1. Disable the root check;
             # 2. Re-initialize the search space to clear the variable `self._root`.
-            search_space.requires_root = False
+            assert_is_instance(
+                search_space, HierarchicalSearchSpace
+            ).requires_root = False
             search_space = search_space.clone()
 
         return search_space

--- a/ax/adapter/transforms/remove_fixed.py
+++ b/ax/adapter/transforms/remove_fixed.py
@@ -20,6 +20,7 @@ from ax.core.parameter import (
 )
 from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
 from ax.generators.types import TConfig
+from pyre_extensions import assert_is_instance
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
@@ -110,7 +111,7 @@ class RemoveFixed(Transform):
         )
 
         # Also need to update `dependents` if the search space is hierarchical.
-        if isinstance(search_space, HierarchicalSearchSpace):
+        if search_space.is_hierarchical:
             for p in tunable_parameters:
                 # NOTE: Type checking `ChoiceParameter` and `FixedParameter` is entirely
                 # unnecessary, because `is_hierarchical` returns false unless it's
@@ -141,7 +142,9 @@ class RemoveFixed(Transform):
                                 updated_children += find_adoptable_descendants(
                                     # pyre-ignore[6]: It's a fixed parameter for sure.
                                     param=search_space.parameters[child],
-                                    search_space=search_space,
+                                    search_space=assert_is_instance(
+                                        search_space, HierarchicalSearchSpace
+                                    ),
                                 )
                             else:
                                 updated_children.append(child)

--- a/ax/adapter/transforms/tests/test_cast_transform.py
+++ b/ax/adapter/transforms/tests/test_cast_transform.py
@@ -20,7 +20,7 @@ from ax.core.parameter import (
     ParameterType,
     RangeParameter,
 )
-from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
+from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UserInputError
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
@@ -151,7 +151,7 @@ class CastTransformTest(TestCase):
             )
         mock_hss_flatten.assert_called_once()
         self.assertIsNot(flattened_search_space, self.hss)
-        self.assertFalse(isinstance(flattened_search_space, HierarchicalSearchSpace))
+        self.assertFalse(flattened_search_space.is_hierarchical)
 
     def test_transform_observation_features_HSS(self) -> None:
         # Untransform the observation features first to cast them and

--- a/ax/adapter/transforms/utils.py
+++ b/ax/adapter/transforms/utils.py
@@ -17,7 +17,7 @@ from ax.adapter.transforms.derelativize import Derelativize
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import Parameter
 from ax.core.parameter_constraint import ParameterConstraint
-from ax.core.search_space import HierarchicalSearchSpace, SearchSpace
+from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UserInputError
 from numpy import typing as npt
 from pyre_extensions import none_throws
@@ -149,7 +149,7 @@ def construct_new_search_space(
         "parameters": parameters,
         "parameter_constraints": parameter_constraints,
     }
-    if isinstance(search_space, HierarchicalSearchSpace):
+    if search_space.is_hierarchical:
         # Temporarily relax the `requires_root` flag for the new search space. This is
         # fine because this function is typically called during transforms.
         new_kwargs["requires_root"] = False

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -38,7 +38,7 @@ from ax.exceptions.core import AxWarning, UnsupportedError, UserInputError
 from ax.utils.common.base import Base
 from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger
-from pyre_extensions import none_throws
+from pyre_extensions import none_throws, override
 from scipy.special import expit, logit
 
 
@@ -85,7 +85,7 @@ class SearchSpace(Base):
 
     @property
     def is_hierarchical(self) -> bool:
-        return isinstance(self, HierarchicalSearchSpace)
+        return False
 
     @property
     def parameters(self) -> dict[str, Parameter]:
@@ -486,7 +486,7 @@ class SearchSpace(Base):
         # `check_membership` uses int and float interchangeably, which we don't
         # want here.
         for p_name, parameter in self.parameters.items():
-            if isinstance(self, HierarchicalSearchSpace) and p_name not in parameters:
+            if self.is_hierarchical and p_name not in parameters:
                 # Parameterizations in HSS-s can be missing some of the dependent
                 # parameters based on the hierarchical structure and values of
                 # the parameters those depend on.
@@ -600,6 +600,11 @@ class HierarchicalSearchSpace(SearchSpace):
             logger.debug(f"Found root: {self.root}.")
 
         self.requires_root = requires_root
+
+    @override
+    @property
+    def is_hierarchical(self) -> bool:
+        return True
 
     @property
     def root(self) -> Parameter:

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -793,7 +793,7 @@ class HierarchicalSearchSpaceTest(TestCase):
         flattened_hss_1 = self.hss_1.flatten()
         self.assertIsNot(flattened_hss_1, self.hss_1)
         self.assertEqual(type(flattened_hss_1), SearchSpace)
-        self.assertFalse(isinstance(flattened_hss_1, HierarchicalSearchSpace))
+        self.assertFalse(flattened_hss_1.is_hierarchical)
         self.assertEqual(flattened_hss_1.parameters, self.hss_1.parameters)
         self.assertEqual(
             flattened_hss_1.parameter_constraints, self.hss_1.parameter_constraints
@@ -805,9 +805,7 @@ class HierarchicalSearchSpaceTest(TestCase):
         flattened_hss_with_constraints = self.hss_with_constraints.flatten()
         self.assertIsNot(flattened_hss_with_constraints, self.hss_with_constraints)
         self.assertEqual(type(flattened_hss_with_constraints), SearchSpace)
-        self.assertFalse(
-            isinstance(flattened_hss_with_constraints, HierarchicalSearchSpace)
-        )
+        self.assertFalse(flattened_hss_with_constraints.is_hierarchical)
         self.assertEqual(
             flattened_hss_with_constraints.parameters,
             self.hss_with_constraints.parameters,

--- a/ax/generation_strategy/center_generation_node.py
+++ b/ax/generation_strategy/center_generation_node.py
@@ -24,7 +24,7 @@ from ax.exceptions.generation_strategy import AxGenerationException
 from ax.generation_strategy.external_generation_node import ExternalGenerationNode
 from ax.generation_strategy.generator_spec import GeneratorSpec
 from ax.generation_strategy.transition_criterion import AutoTransitionAfterGen
-from pyre_extensions import none_throws
+from pyre_extensions import assert_is_instance, none_throws
 
 
 @dataclass(init=False)
@@ -99,8 +99,10 @@ class CenterGenerationNode(ExternalGenerationNode):
                 raise NotImplementedError(f"Parameter type {type(p)} is not supported.")
         for p in derived_params:
             parameters[p.name] = p.compute(parameters=parameters)
-        if isinstance(search_space, HierarchicalSearchSpace):
-            parameters = search_space._cast_parameterization(parameters=parameters)
+        if search_space.is_hierarchical:
+            parameters = assert_is_instance(
+                search_space, HierarchicalSearchSpace
+            )._cast_parameterization(parameters=parameters)
 
         # Check for search space membership, which will check if the generated
         # point satisfies the parameter constraints.


### PR DESCRIPTION
Summary:
We plan on giving base SearchSpace hierarchical properties, so we'll have to stop making checks like this.

Ahead of that major change, we can do this no-op to make the larger change less wide-sweeping and touch fewer files overall.

Reviewed By: Balandat, saitcakmak

Differential Revision: D87102473


