### PR TITLE
Overwrite specified model with HeterogeneousMTGP when needed

### DIFF
--- a/ax/generators/torch/tests/test_generator.py
+++ b/ax/generators/torch/tests/test_generator.py
@@ -286,6 +286,7 @@ class BoTorchGeneratorTest(TestCase):
         mock_choose_model_class.assert_called_with(
             dataset=self.block_design_training_data[0],
             search_space_digest=self.mf_search_space_digest,
+            specified_model_class=None,
         )
 
     # This mock is hard to remove since it is mocks a method on a surrogate that


### PR DESCRIPTION
Summary:
If there are heterogeneous search spaces in the multi-task datasets, using a different model class will lead to errors. This makes it so that we overwrite the model class (with a warning) rather than leavivng it to error out.

Also makes sure that `Normalize` transform with `bounds=None` is used whenever `HeterogeneousMTGP` is selected.

Differential Revision: D87457028


