### PR TITLE
Label slice and contour plotly analyses as "y vs x" rather than "x vs y"

### DIFF
--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -171,8 +171,8 @@ class ContourPlot(Analysis):
         return create_plotly_analysis_card(
             name=self.__class__.__name__,
             title=(
-                f"{self.x_parameter_name}, {self.y_parameter_name} vs. "
-                f"{metric_name}"
+                f"{metric_name} vs. "
+                f"{self.x_parameter_name}, {self.y_parameter_name}"
             ),
             subtitle=(
                 "The contour plot visualizes the predicted outcomes "

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -169,7 +169,7 @@ class SlicePlot(Analysis):
 
         return create_plotly_analysis_card(
             name=self.__class__.__name__,
-            title=f"{self.parameter_name} vs. {metric_name}",
+            title=f"{metric_name} vs. {self.parameter_name}",
             subtitle=(
                 "The slice plot provides a one-dimensional view of predicted "
                 f"outcomes for {metric_name} as a function of a single parameter, "

--- a/ax/analysis/plotly/surface/tests/test_contour.py
+++ b/ax/analysis/plotly/surface/tests/test_contour.py
@@ -60,7 +60,7 @@ class TestContourPlot(TestCase):
             "values, providing insights into the gradient and potential optima "
             "within the parameter space."
         )
-        self.expected_title = "x, y vs. bar"
+        self.expected_title = "bar vs. x, y"
         self.expected_name = "ContourPlot"
         self.expected_cols = {
             "x",

--- a/ax/analysis/plotly/surface/tests/test_slice.py
+++ b/ax/analysis/plotly/surface/tests/test_slice.py
@@ -59,7 +59,7 @@ class TestSlicePlot(TestCase):
             card.name,
             "SlicePlot",
         )
-        self.assertEqual(card.title, "x vs. bar")
+        self.assertEqual(card.title, "bar vs. x")
         self.assertEqual(
             card.subtitle,
             (
@@ -102,7 +102,7 @@ class TestSlicePlot(TestCase):
             card.name,
             "SlicePlot",
         )
-        self.assertEqual(card.title, "x vs. bar")
+        self.assertEqual(card.title, "bar vs. x")
         self.assertEqual(
             card.subtitle,
             (

--- a/ax/analysis/plotly/tests/test_top_surfaces.py
+++ b/ax/analysis/plotly/tests/test_top_surfaces.py
@@ -130,8 +130,8 @@ class TestTopSurfacesAnalysis(TestCase):
         self.assertEqual(cards[0].title, "Sensitivity Analysis for bar")
 
         # Other cards should be slices.
-        self.assertIn("vs. bar", cards[1].title)
-        self.assertIn("vs. bar", cards[2].title)
+        self.assertIn("bar vs.", cards[1].title)
+        self.assertIn("bar vs.", cards[2].title)
 
         second = TopSurfacesAnalysis(metric_name="bar", order="second")
 
@@ -157,9 +157,9 @@ class TestTopSurfacesAnalysis(TestCase):
         self.assertEqual(with_surfaces[0].title, "Sensitivity Analysis for bar")
 
         # Other cards should be slices or contours.
-        self.assertIn("vs. bar", with_surfaces[1].title)
-        self.assertIn("vs. bar", with_surfaces[2].title)
-        self.assertIn("vs. bar", with_surfaces[3].title)
+        self.assertIn("bar vs.", with_surfaces[1].title)
+        self.assertIn("bar vs.", with_surfaces[2].title)
+        self.assertIn("bar vs.", with_surfaces[3].title)
 
     @mock_botorch_optimize
     @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")
@@ -205,7 +205,7 @@ class TestTopSurfacesAnalysis(TestCase):
         # Only plot x1 vs bar since x2 is categorical.
         self.assertEqual(len(cards), 2)
         self.assertEqual(cards[0].title, "Sensitivity Analysis for bar")
-        self.assertEqual(cards[1].title, "x1 vs. bar")
+        self.assertEqual(cards[1].title, "bar vs. x1")
 
     @mock_botorch_optimize
     @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")


### PR DESCRIPTION
Summary:
Switch the order in which the axes are referred to in slice and contour plots to match convention ([stackexchange discussion](https://math.stackexchange.com/questions/733234/what-does-versus-mean-in-the-context-of-a-graph)).

Current state shows x vs y: {F1983661765}

Differential Revision: D87473874


