### PR TITLE
Bump pinned botorch to 0.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "botorch[pymoo]>=0.16.0,<0.16.1dev9999",
+    "botorch[pymoo]>=0.16.1,<0.16.2dev9999",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
Summary: Ahead of Ax 1.2.1 release. This is needed to accomodate botorch.models.heterogeneous_mtgp

Differential Revision: D87642641


