### PR TITLE
Skip derived parameters when dependencies missing in RemoveFixed

### DIFF
--- a/ax/adapter/transforms/tests/test_remove_fixed_transform.py
+++ b/ax/adapter/transforms/tests/test_remove_fixed_transform.py
@@ -160,6 +160,61 @@ class RemoveFixedTransformTest(TestCase):
         # Should return unchanged empty observation features
         self.assertEqual(result, [ObservationFeatures(parameters={})])
 
+    def test_UntransformPartialObservationFeatures(self) -> None:
+        """Test untransforming observation features with partial parameters.
+
+        This tests partial fixed_features, which could happen in
+        _untransform_objective_thresholds method where it creats partial
+        fixed_features_obs for context, but RemoveFixed should skip computing
+        derived parameters when dependencies are missing.
+
+        Derived parameters are never needed as context for outcome constraint
+        untransformation - only tunable parameters serve as context (e.g., task
+        IDs for stratified transforms).
+        """
+        # Test case 1: Partial observation with only "b" parameter
+        # The derived parameter "d" depends on "a", which is missing
+        partial_obs_features = [ObservationFeatures(parameters={"b": "a"})]
+        result = self.t.untransform_observation_features(partial_obs_features)
+
+        # Should add fixed parameter "c" but NOT compute derived parameter "d"
+        # since its dependency "a" is missing
+        self.assertEqual(result, [ObservationFeatures(parameters={"b": "a", "c": "a"})])
+
+        # Test case 2: Partial observation with "a" and "b" parameters
+        # Now "d" can be computed since its dependency "a" is present
+        partial_obs_features_with_dep = [
+            ObservationFeatures(parameters={"a": 2.0, "b": "b"})
+        ]
+        result_with_dep = self.t.untransform_observation_features(
+            partial_obs_features_with_dep
+        )
+
+        # Should add both fixed parameter "c" and compute derived parameter "d"
+        # d = 2.0 * a + 1.0 = 2.0 * 2.0 + 1.0 = 5.0
+        self.assertEqual(
+            result_with_dep,
+            [ObservationFeatures(parameters={"a": 2.0, "b": "b", "c": "a", "d": 5.0})],
+        )
+
+        # Test case 3: Multiple partial observations with different missing deps
+        mixed_obs_features = [
+            ObservationFeatures(parameters={"b": "a"}),  # missing "a"
+            ObservationFeatures(parameters={"a": 1.5, "b": "c"}),  # has "a"
+        ]
+        result_mixed = self.t.untransform_observation_features(mixed_obs_features)
+
+        # First should not have "d", second should have "d" = 2.0 * 1.5 + 1.0 = 4.0
+        self.assertEqual(
+            result_mixed,
+            [
+                ObservationFeatures(parameters={"b": "a", "c": "a"}),
+                ObservationFeatures(
+                    parameters={"a": 1.5, "b": "c", "c": "a", "d": 4.0}
+                ),
+            ],
+        )
+
     def test_TransformSearchSpace(self) -> None:
         ss2 = self.search_space.clone()
         ss2 = self.t.transform_search_space(ss2)


### PR DESCRIPTION
Summary:
Fix `KeyError` in candidate generation when using partial fixed_features. The _untransform_objective_thresholds method creates a partial fixed_features_obs for context, but RemoveFixed tried to compute all derived parameters without checking if dependencies exist.

This diff added check to skip computing derived parameters when dependencies are missing. This works because derived parameters are never needed as context for outcome constraint untransformation - only tunable parameters serve as context (e.g., task IDs for stratified transforms).

meta: this unblocks experiment `pymk_edge_weights_tuning_adding_additional_param`

Differential Revision: D87686531


