### PR TITLE
Refactor Early-stopping Strategies: Eliminate Duplication and Improve Naming

### DIFF
--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -110,7 +110,7 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         metric_signature, minimize = self._default_objective_and_direction(
             experiment=experiment
         )
-        data = self._check_validity_and_get_data(
+        data = self._lookup_and_validate_data(
             experiment=experiment, metric_signatures=[metric_signature]
         )
         if data is None:

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -216,7 +216,7 @@ class TestBaseEarlyStoppingStrategy(TestCase):
             experiment=experiment
         )
 
-        map_data = es_strategy._check_validity_and_get_data(
+        map_data = es_strategy._lookup_and_validate_data(
             experiment,
             metric_signatures=[metric_signature],
         )
@@ -243,7 +243,7 @@ class TestBaseEarlyStoppingStrategy(TestCase):
             fake_reason, "No data available to make an early stopping decision."
         )
 
-        fake_map_data = es_strategy._check_validity_and_get_data(
+        fake_map_data = es_strategy._lookup_and_validate_data(
             experiment,
             metric_signatures=["fake_metric_name"],
         )
@@ -292,7 +292,7 @@ class TestBaseEarlyStoppingStrategy(TestCase):
             experiment=experiment
         )
 
-        map_data = es_strategy._check_validity_and_get_data(
+        map_data = es_strategy._lookup_and_validate_data(
             experiment,
             metric_signatures=[metric_signature],
         )
@@ -363,7 +363,7 @@ class TestBaseEarlyStoppingStrategy(TestCase):
             experiment=experiment
         )
 
-        map_data = es_strategy._check_validity_and_get_data(
+        map_data = es_strategy._lookup_and_validate_data(
             experiment,
             metric_signatures=[metric_signature],
         )
@@ -846,7 +846,7 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         )
         # Use _should_stop_trial_early directly to get reason for non-stopped trial
         data = none_throws(
-            early_stopping_strategy._check_validity_and_get_data(
+            early_stopping_strategy._lookup_and_validate_data(
                 experiment, metric_signatures=["branin_map"]
             )
         )
@@ -856,8 +856,8 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         should_stop, reason = early_stopping_strategy._should_stop_trial_early(
             trial_index=2,  # Best trial
             experiment=experiment,
-            df=aligned_means,
-            df_raw=data.map_df,
+            wide_df=aligned_means,
+            long_df=data.map_df,
             minimize=True,
         )
         self.assertFalse(should_stop)
@@ -896,7 +896,7 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         )
 
         data = none_throws(
-            early_stopping_strategy._check_validity_and_get_data(exp, ["branin_map"])
+            early_stopping_strategy._lookup_and_validate_data(exp, ["branin_map"])
         )
         aligned_df = align_partial_results(df=data.map_df, metrics=["branin_map"])
         aligned_means = aligned_df["mean"]["branin_map"]
@@ -905,8 +905,8 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         should_stop, reason = early_stopping_strategy._should_stop_trial_early(
             trial_index=1,  # Trial 1 is in top 3 but below percentile
             experiment=exp,
-            df=aligned_means,
-            df_raw=data.map_df,
+            wide_df=aligned_means,
+            long_df=data.map_df,
             minimize=True,
         )
 
@@ -1246,7 +1246,7 @@ def _evaluate_early_stopping_with_df(
     """Helper function for testing PercentileEarlyStoppingStrategy
     on an arbitrary (MapData) df."""
     data = none_throws(
-        early_stopping_strategy._check_validity_and_get_data(experiment, [metric_name])
+        early_stopping_strategy._lookup_and_validate_data(experiment, [metric_name])
     )
     aligned_df = align_partial_results(df=data.map_df, metrics=[metric_name])
     metric_to_aligned_means = aligned_df["mean"]
@@ -1255,8 +1255,8 @@ def _evaluate_early_stopping_with_df(
         trial_index: early_stopping_strategy._should_stop_trial_early(
             trial_index=trial_index,
             experiment=experiment,
-            df=aligned_means,
-            df_raw=data.map_df,
+            wide_df=aligned_means,
+            long_df=data.map_df,
             minimize=cast(
                 OptimizationConfig, experiment.optimization_config
             ).objective.minimize,

--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -19,6 +19,22 @@ from pyre_extensions import assert_is_instance
 logger: Logger = get_logger(__name__)
 
 
+def _is_worse(a: float, b: float, minimize: bool) -> bool:
+    """Determine if value `a` is worse than value `b` based on optimization direction.
+
+    Args:
+        a: The first value to compare.
+        b: The second value (threshold) to compare against.
+        minimize: If True, use minimization logic (a is worse if a > b).
+            If False, use maximization logic (a is worse if a < b).
+
+    Returns:
+        True if `a` is worse than `b` according to the optimization direction,
+        False otherwise.
+    """
+    return a > b if minimize else a < b
+
+
 def _interval_boundary(
     progression: float, min_progression: float, interval: float
 ) -> float:


### PR DESCRIPTION
Summary:
**Context:**

This diff refactors the early stopping strategies codebase to eliminate code duplication and improve code clarity through better naming conventions.

- Eliminated ~50 lines of duplicate data preparation logic
- Established single source of truth for data preparation in base class
- Improved code maintainability and consistency
- No functional changes - purely refactoring

**Changes:**

1. **Moved `_prepare_aligned_data()` to base class** (`BaseEarlyStoppingStrategy`)
   * Previously duplicated in `PercentileEarlyStoppingStrategy` and `MultiObjectiveEarlyStoppingStrategy` (and also in future concrete implements of `_is_harmful`). Now a reusable helper method available to all strategies
2. **Renamed method for clarity**
   * `_check_validity_and_get_data()` → `_lookup_and_validate_data()` (emphasizes "lookup" terminology consistent with Ax codebase conventions; more accurately describes the method's purpose)
3. **Improved parameter naming across all strategies**
   * `df`, `df_raw` → `wide_df`, `long_df`
   * Clearly distinguishes between wide and long format dataframes
   * Updated in all early stopping strategy implementations and tests
4. **Updated documentation**

Differential Revision: D87573286


