### PR TITLE
Add user friendly expression representation to ScalarizedObjective

### DIFF
--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -200,6 +200,25 @@ class ScalarizedObjective(Objective):
         """Get the metrics and weights."""
         return zip(self.metrics, self.weights)
 
+    @property
+    def expression(self) -> str:
+        """
+        Get a human-readable mathematical expression of the scalarized objective.
+
+        Returns a string representation showing the weighted combination of metrics,
+        e.g., "m1 + 2.0*m3" or "accuracy - 0.5*latency".
+        """
+        parts = []
+        for metric, weight in self.metric_weights:
+            if weight == 1.0:
+                parts.append(metric.name)
+            elif weight == -1.0:
+                parts.append(f"-{metric.name}")
+            else:
+                parts.append(f"{weight}*{metric.name}")
+
+        return " + ".join(parts).replace(" + -", " - ")
+
     def clone(self) -> ScalarizedObjective:
         """Create a copy of the objective."""
         return ScalarizedObjective(

--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -126,3 +126,43 @@ class ObjectiveTest(TestCase):
             self.scalarized_objective.get_unconstrainable_metrics(),
             [self.metrics["m1"], self.metrics["m2"]],
         )
+
+    def test_ScalarizedObjective_expression(self) -> None:
+        """Test the expression property of ScalarizedObjective."""
+        test_cases = [
+            # (name, metrics, weights, expected_expression)
+            (
+                "default_weights",
+                [self.metrics["m1"], self.metrics["m3"]],
+                None,
+                "m1 + m3",
+            ),
+            (
+                "custom_weights",
+                [self.metrics["m1"], self.metrics["m3"]],
+                [1.0, 2.0],
+                "m1 + 2.0*m3",
+            ),
+            (
+                "negative_weight",
+                [Metric(name="accuracy"), Metric(name="latency")],
+                [1.0, -0.5],
+                "accuracy - 0.5*latency",
+            ),
+            (
+                "negative_one_weight",
+                [Metric(name="reward"), Metric(name="cost")],
+                [2.0, -1.0],
+                "2.0*reward - cost",
+            ),
+        ]
+
+        for name, metrics, weights, expected in test_cases:
+            with self.subTest(name=name, expected=expected):
+                if weights is None:
+                    obj = ScalarizedObjective(metrics=metrics, minimize=False)
+                else:
+                    obj = ScalarizedObjective(
+                        metrics=metrics, weights=weights, minimize=False
+                    )
+                self.assertEqual(obj.expression, expected)


### PR DESCRIPTION
Summary: Add a property to ScalarizedObjective that will help in getting an expression to represent the scalarized objective

Differential Revision: D87879854


