### PR TITLE
Log-scale ChoiceParameter

### DIFF
--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -424,6 +424,7 @@ def choice_parameter_from_json(
     is_fidelity: bool = False,
     target_value: TParamValue = None,
     sort_values: bool | None = None,
+    log_scale: bool | None = None,
     dependents: dict[TParamValue, list[str]] | None = None,
 ) -> ChoiceParameter:
     # JSON converts dictionary keys to strings. We need to convert them back.
@@ -443,6 +444,7 @@ def choice_parameter_from_json(
         is_fidelity=is_fidelity,
         target_value=target_value,
         sort_values=sort_values,
+        log_scale=log_scale,
         dependents=dependents,
     )
 

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -194,6 +194,7 @@ def choice_parameter_to_dict(parameter: ChoiceParameter) -> dict[str, Any]:
         "name": parameter.name,
         "parameter_type": parameter.parameter_type,
         "values": parameter.values,
+        "log_scale": parameter.log_scale,
         "is_fidelity": parameter.is_fidelity,
         "target_value": parameter.target_value,
         "dependents": parameter.dependents if parameter.is_hierarchical else None,

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -440,6 +440,7 @@ class Decoder:
                 target_value=target_value,
                 is_ordered=parameter_sqa.is_ordered,
                 is_task=bool(parameter_sqa.is_task),
+                log_scale=parameter_sqa.log_scale,
                 dependents=parameter_sqa.dependents,
                 backfill_value=parameter_sqa.backfill_value,
                 default_value=parameter_sqa.default_value,

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -300,6 +300,7 @@ class Encoder:
                 choice_values=parameter.values,
                 is_ordered=parameter.is_ordered,
                 is_task=parameter.is_task,
+                log_scale=parameter.log_scale,
                 is_fidelity=parameter.is_fidelity,
                 target_value=parameter.target_value,
                 dependents=parameter.dependents if parameter.is_hierarchical else None,


### PR DESCRIPTION
Summary:
Adds support for log-scale modeling to ChoiceParameter. By default, any numeric choice parameter that demonstrates exponentially scaled values (2, 4, 8, 16, 32, ...) will set `log_scale=True`.

Both SQA & JSON storage is updated to write & read the new field, mirrored after the logic for RangeParameter.

Next diff will add support for this in Log-transform.

NOTE: This is irrelevant if we're using `OrderedChoiceToIntegerRange` transform (since it will become range, ignoring the log-scale input). It will make a difference if we use `ChoiceToNumericChoice`.

Reviewed By: mpolson64

Differential Revision: D87233839


