### PR TITLE
Add patience parameter to PercentileEarlyStoppingStrategy

### DIFF
--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 from logging import Logger
+from typing import Any
 
 import pandas as pd
 from ax.core.experiment import Experiment
@@ -19,7 +20,7 @@ from pyre_extensions import assert_is_instance
 logger: Logger = get_logger(__name__)
 
 
-def _is_worse(a: float, b: float, minimize: bool) -> bool:
+def _is_worse(a: Any, b: Any, minimize: bool) -> Any:
     """Determine if value `a` is worse than value `b` based on optimization direction.
 
     Args:


### PR DESCRIPTION
Summary:
Add a `patience` parameter to the percentile-based early stopping strategy to handle noisy metric curves more robustly. This allows trials to be stopped only if they consistently underperform across a window of training steps, rather than based on a single point evaluation. Highlights:

- **Robustness to noise**: Avoids prematurely stopping trials with noisy but promising curves
- **Backward compatible**: Default behavior (patience=0) matches original implementation
- **Efficient**: Calculations/checks across progressions in window are vectorized
- **Clear semantics**: Patience measured in training progressions, naturally handles irregular spacing

## Implementation Notes

- Added `patience: int = 0` parameter to `PercentileEarlyStoppingStrategy.__init__`
  - When `patience=0` (default), uses original behavior: checks only the latest progression step
  - When `patience>0`, evaluates all steps in the window `[step - patience, step]`
  - Stops trials only if they underperform at ALL steps in the patience window
  - Input validation ensures `patience >= 0`
- Generalized `_should_stop_trial_early` method with unified code path
  - Single implementation works for both single-point (patience=0) and multi-point (patience>0) evaluation
  - Uses vectorized pandas operations with `df.quantile(axis=1)`
  - Requires minimum 2 data points when patience>0 to ensure reliable decisions
  - Handles edge cases: sparse data, NaN values, windows extending before first step
  - Patience window boundary respects `min_progression`: `window_start = max(step - patience, min_progression)` ensures evaluations only use trusted data
- Removed numpy dependency in favor of pandas' built-in `quantile` method

Differential Revision: D87509991


