### PR TITLE
Alter savings calculation to be a fraction of total compute without early stopping

### DIFF
--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -171,7 +171,7 @@ def estimate_early_stopping_savings(experiment: Experiment) -> float:
     how much resource each early stopped trial would have consumed.
     Savings are computed as:
 
-        savings = total_resources_saved / total_resources_used
+        savings = total_resources_saved / (total_resources_saved + total_resources_used)
 
     Args:
         experiment: The experiment to analyze.
@@ -200,5 +200,8 @@ def estimate_early_stopping_savings(experiment: Experiment) -> float:
         lower=0
     )
 
-    # Return fraction of total resources saved
-    return resources_saved.sum() / resources_used.sum()
+    resources_saved_sum = resources_saved.sum()
+    resources_used_sum = resources_used.sum()
+
+    # Return fraction of savings compared to total resource usage without early stopping
+    return resources_saved_sum / (resources_saved_sum + resources_used_sum)

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -1274,7 +1274,7 @@ class TestAxOrchestrator(TestCase):
         self.assertIsNotNone(ess)
         self.assertAlmostEqual(
             ess.estimate_early_stopping_savings(orchestrator.experiment),
-            0.5,
+            1.0 / 3.0,
         )
 
     def test_orchestrator_with_metric_with_new_data_after_completion(self) -> None:


### PR DESCRIPTION
Summary: Former calculation was resulting in greater than 100% savings. This returns more interpretable savings numbers.

Differential Revision: D87937351


