### PR TITLE
Enforce sort_values=True for numeric ordered ChoiceParameter

### DIFF
--- a/ax/adapter/transforms/choice_encode.py
+++ b/ax/adapter/transforms/choice_encode.py
@@ -107,7 +107,9 @@ class ChoiceToNumericChoice(Transform):
                     target_value=encoding[p.target_value]
                     if p.target_value is not None
                     else None,
-                    sort_values=p.sort_values,
+                    # Retain the original sort_values if the parameter is not ordered.
+                    # Ordered numeric parameters are always sorted.
+                    sort_values=p.sort_values if not p.is_ordered else True,
                     dependents=dependents,
                 )
             else:

--- a/ax/adapter/transforms/tests/test_choice_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_choice_encode_transform.py
@@ -53,7 +53,6 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
                     parameter_type=ParameterType.FLOAT,
                     values=[10.0, 100.0, 1000.0],
                     is_ordered=True,
-                    sort_values=False,
                 ),
                 ChoiceParameter(
                     "d",
@@ -128,9 +127,10 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
                 self.assertEqual(
                     transformed_param.is_ordered, original_param.is_ordered
                 )
+                # Transformed param is numeric, so it is sorted if it is ordered.
                 self.assertEqual(
                     transformed_param.sort_values,
-                    original_param.sort_values,
+                    transformed_param.is_ordered or original_param.sort_values,
                 )
                 if self.t_class == ChoiceToNumericChoice:
                     self.assertEqual(
@@ -190,7 +190,6 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
                         values=[0, 1, 2],
                         is_ordered=True,
                         is_fidelity=True,
-                        sort_values=False,
                         target_value=2,
                     )
                 ]

--- a/ax/api/utils/instantiation/from_config.py
+++ b/ax/api/utils/instantiation/from_config.py
@@ -55,7 +55,6 @@ def parameter_from_config(
                 parameter_type=_parameter_type_converter(config.parameter_type),
                 values=[*np.arange(lower, upper + step_size, step_size)],
                 is_ordered=True,
-                sort_values=False,  # already sorted by np.arange.
             )
 
         return RangeParameter(

--- a/ax/api/utils/instantiation/tests/test_from_config.py
+++ b/ax/api/utils/instantiation/tests/test_from_config.py
@@ -109,7 +109,6 @@ class TestFromConfig(TestCase):
                     100.0,
                 ],
                 is_ordered=True,
-                sort_values=False,
             ),
         )
 

--- a/ax/benchmark/problems/synthetic/bandit.py
+++ b/ax/benchmark/problems/synthetic/bandit.py
@@ -44,7 +44,6 @@ def get_bandit_problem(num_choices: int = 30, num_trials: int = 3) -> BenchmarkP
         parameter_type=ParameterType.INT,
         values=list(range(num_choices)),
         is_ordered=False,
-        sort_values=False,
     )
     search_space = SearchSpace(parameters=[parameter])
     test_function = IdentityTestFunction()

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -296,6 +296,18 @@ class ChoiceParameterTest(TestCase):
                 values=["foo", "foo2"],
                 is_task=True,
             )
+        # Test that numeric ordered parameters must have sort_values=True
+        with self.assertRaisesRegex(
+            UserInputError,
+            "Numeric ordered choice parameters must have sort_values=True",
+        ):
+            ChoiceParameter(
+                name="x",
+                parameter_type=ParameterType.INT,
+                values=[1, 2, 3],
+                is_ordered=True,
+                sort_values=False,
+            )
 
     def test_Eq(self) -> None:
         param4 = ChoiceParameter(
@@ -579,7 +591,6 @@ class ChoiceParameterTest(TestCase):
                     name="x",
                     parameter_type=parameter_type,
                     values=values,  # pyre-ignore
-                    sort_values=False,
                 )
                 self.assertEqual(p._is_ordered, True)
 

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -435,6 +435,21 @@ def choice_parameter_from_json(
             for key, value in dependents.items()
         }
 
+    # Backward compatibility: Override sort_values=False for numeric ordered parameters
+    # to prevent validation errors when loading old experiments.
+    if (
+        sort_values is False
+        and parameter_type.is_numeric
+        and (is_ordered or (is_ordered is None and len(values) == 2))
+    ):
+        logger.warning(
+            f"Parameter '{name}' is numeric ordered with sort_values=False. "
+            f"Overriding to sort_values=True for backward compatibility. "
+            f"This parameter was likely stored before the validation requiring "
+            f"sort_values=True for numeric ordered parameters was added."
+        )
+        sort_values = True
+
     return ChoiceParameter(
         name=name,
         parameter_type=parameter_type,

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1891,7 +1891,6 @@ def get_hierarchical_choice_parameter(parameter_type: ParameterType) -> ChoicePa
         parameter_type=parameter_type,
         values=values,  # pyre-ignore [6]
         is_ordered=True,
-        sort_values=False,
         dependents={values[0]: ["y"], values[1]: ["z"]},
     )
 


### PR DESCRIPTION
Summary:
Numeric ordered choice parameters should always have sorted values since the ordering is based on their numerical values. This change adds validation to enforce `sort_values=True` for numeric ordered parameters and suppresses the warning since the value is now required rather than optional.

This simplifies downstream handling of choice parameters, such as in (yet to be implemented for choice) expansion of the model space in `Adapter` using points observed in previous trials. The fewer options we have, the easier it will be to support new features.

Reviewed By: dme65

Differential Revision: D87903513


