### PR TITLE
Refactor LogY transform to use variances and add transform_experiment_data

### DIFF
--- a/ax/adapter/transforms/tests/test_log_y_transform.py
+++ b/ax/adapter/transforms/tests/test_log_y_transform.py
@@ -10,6 +10,11 @@ import math
 from copy import deepcopy
 
 import numpy as np
+import numpy.typing as npt
+import torch
+from ax.adapter.base import DataLoaderConfig
+from ax.adapter.data_utils import extract_experiment_data
+from ax.adapter.torch import TorchAdapter
 from ax.adapter.transforms.log_y import (
     lognorm_to_norm,
     LogY,
@@ -24,18 +29,25 @@ from ax.core.optimization_config import (
     OptimizationConfig,
 )
 from ax.core.outcome_constraint import ObjectiveThreshold
+from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
+from ax.generators.types import TConfig
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_outcome_constraint
+from ax.utils.testing.core_stubs import (
+    get_experiment_with_observations,
+    get_outcome_constraint,
+)
+from ax.utils.testing.mock import mock_botorch_optimize
+from pandas.testing import assert_frame_equal
 
 
 class LogYTransformTest(TestCase):
     def test_Init(self) -> None:
-        # test error for not specifying a config
-        with self.assertRaises(ValueError):
-            LogY()
-        # test error for not specifying at least one metric
-        with self.assertRaises(ValueError):
-            LogY(config={"metrics": []})
+        # test default init with no config (no-op transform)
+        tf = LogY()
+        self.assertEqual(len(tf.metric_signatures), 0)
+        # test init with empty metrics list (no-op transform)
+        tf = LogY(config={"metrics": []})
+        self.assertEqual(len(tf.metric_signatures), 0)
         # test default init
         tf = LogY(config={"metrics": ["m1"]})
         self.assertEqual(tf._transform, lognorm_to_norm)
@@ -46,17 +58,24 @@ class LogYTransformTest(TestCase):
         )
         self.assertTrue("<lambda>" in tf._transform.__name__)
         self.assertTrue("<lambda>" in tf._untransform.__name__)
-        self.assertEqual(
-            tf._transform(np.array(1.0), np.array(0.1)),
-            match_ci_width(
-                mean=np.array(1.0), sem=None, variance=np.array(0.1), transform=np.log
-            ),
+        # Test with variance (1D array)
+        test_mean = np.array([1.0])
+        test_var = np.array([0.1])
+        expected_mean, expected_var = match_ci_width(
+            mean=test_mean, sem=None, variance=test_var, transform=np.log
         )
         self.assertEqual(
-            tf._untransform(np.array(0.0), np.array(0.1)),
-            match_ci_width(
-                mean=np.array(0.0), sem=None, variance=np.array(0.1), transform=np.exp
-            ),
+            tf._transform(test_mean, test_var),
+            (expected_mean, expected_var),
+        )
+        test_mean_exp = np.array([0.0])
+        test_var_exp = np.array([0.1])
+        expected_mean_exp, expected_var_exp = match_ci_width(
+            mean=test_mean_exp, sem=None, variance=test_var_exp, transform=np.exp
+        )
+        self.assertEqual(
+            tf._untransform(test_mean_exp, test_var_exp),
+            (expected_mean_exp, expected_var_exp),
         )
 
     def test_TransformObservations(self) -> None:
@@ -87,7 +106,7 @@ class LogYTransformTest(TestCase):
         obsd1_.covariance[2, 0] = 0.1
         with self.assertRaises(NotImplementedError):
             tf._transform_observation_data([obsd1_])
-        # test full covariance for single metric
+        # test raise on full covariance for single metric (no longer supported)
         Z = np.zeros((3, 3))
         Z[0, 2] = np.sqrt(np.exp(1)) - 1
         Z[2, 0] = np.sqrt(np.exp(1)) - 1
@@ -96,10 +115,8 @@ class LogYTransformTest(TestCase):
             means=np.ones(3),
             covariance=np.diag(np.ones(3) * (np.exp(1) - 1)) + Z,
         )
-        obsd1_ = tf._transform_observation_data([obsd1])
-        cov_expected = np.array([[1.0, 0.0, 0.5], [0.0, 1.0, 0.0], [0.5, 0.0, 1.0]])
-        self.assertTrue(np.allclose(obsd1_[0].means, -0.5 * np.ones(3)))
-        self.assertTrue(np.allclose(obsd1_[0].covariance, cov_expected))
+        with self.assertRaises(NotImplementedError):
+            tf._transform_observation_data([obsd1])
 
         # Test with unknown noise.
         obsd_without_noise = ObservationData(
@@ -214,33 +231,174 @@ class LogYTransformTest(TestCase):
         oc.objective_thresholds[0].bound = math.log(1.234)
         self.assertEqual(oc_tf, oc)
 
+    def _base_test_transform_experiment_data(
+        self,
+        config: TConfig,
+        observations: list[list[float]],
+        sems: list[list[float]],
+        expected_m1_means: npt.NDArray[np.float64],
+        expected_m1_sems: npt.NDArray[np.float64],
+        expected_m2_means: npt.NDArray[np.float64],
+        expected_m2_sems: npt.NDArray[np.float64],
+    ) -> None:
+        # Setup: Create experiment data with observations
+        experiment_data = extract_experiment_data(
+            experiment=get_experiment_with_observations(
+                observations=observations, sems=sems
+            ),
+            data_loader_config=DataLoaderConfig(),
+        )
+
+        # Execute: Transform the experiment data
+        tf = LogY(config=config)
+        transformed_data = tf.transform_experiment_data(
+            experiment_data=deepcopy(experiment_data)
+        )
+
+        # Assert: Arm data should be identical
+        assert_frame_equal(
+            experiment_data.arm_data,
+            transformed_data.arm_data,
+        )
+
+        # Assert: Observation data should be transformed correctly
+        observation_data = transformed_data.observation_data
+
+        # Check m1 transformation
+        self.assertTrue(
+            np.allclose(
+                observation_data["mean", "m1"].values,
+                expected_m1_means,
+                equal_nan=True,
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                observation_data["sem", "m1"].values,
+                expected_m1_sems,
+                equal_nan=True,
+            )
+        )
+
+        # Check m2 transformation
+        self.assertTrue(
+            np.allclose(
+                observation_data["mean", "m2"].values,
+                expected_m2_means,
+                equal_nan=True,
+            )
+        )
+        self.assertTrue(
+            np.allclose(
+                observation_data["sem", "m2"].values,
+                expected_m2_sems,
+                equal_nan=True,
+            )
+        )
+
+    def test_transform_experiment_data(self) -> None:
+        # For m1: means are [1.0, 1.0], variances are [0.25, 0.25]
+        m1_var = 0.25
+        m1_mean = 1.0
+        expected_m1_mean = np.log(m1_mean) - 0.5 * np.log(1 + m1_var / (m1_mean**2))
+        expected_m1_var = np.log(1 + m1_var / (m1_mean**2))
+
+        # For m2: means are [2.0, 3.0], variances are [1.0, 2.25]
+        m2_mean_0 = 2.0
+        m2_var_0 = 1.0
+        expected_m2_mean_0 = np.log(m2_mean_0) - 0.5 * np.log(
+            1 + m2_var_0 / (m2_mean_0**2)
+        )
+        expected_m2_var_0 = np.log(1 + m2_var_0 / (m2_mean_0**2))
+
+        m2_mean_1 = 3.0
+        m2_var_1 = 2.25
+        expected_m2_mean_1 = np.log(m2_mean_1) - 0.5 * np.log(
+            1 + m2_var_1 / (m2_mean_1**2)
+        )
+        expected_m2_var_1 = np.log(1 + m2_var_1 / (m2_mean_1**2))
+
+        self._base_test_transform_experiment_data(
+            config={"metrics": ["m1", "m2"]},
+            observations=[[1.0, 2.0], [1.0, 3.0]],
+            sems=[[0.5, 1.0], [0.5, 1.5]],
+            expected_m1_means=np.array([expected_m1_mean, expected_m1_mean]),
+            expected_m1_sems=np.array(
+                [np.sqrt(expected_m1_var), np.sqrt(expected_m1_var)]
+            ),
+            expected_m2_means=np.array([expected_m2_mean_0, expected_m2_mean_1]),
+            expected_m2_sems=np.array(
+                [np.sqrt(expected_m2_var_0), np.sqrt(expected_m2_var_1)]
+            ),
+        )
+
+    def test_transform_experiment_data_with_match_ci_width(self) -> None:
+        # m1 should be transformed using match_ci_width
+        expected_m1_mean, expected_m1_var = match_ci_width(
+            mean=np.array([1.0]),
+            sem=None,
+            variance=np.array([0.25]),
+            transform=np.log,
+        )
+
+        self._base_test_transform_experiment_data(
+            config={"metrics": ["m1"], "match_ci_width": True},
+            observations=[[1.0, 2.0]],
+            sems=[[0.5, 1.0]],
+            expected_m1_means=expected_m1_mean,
+            expected_m1_sems=np.sqrt(expected_m1_var),
+            expected_m2_means=np.array([2.0]),  # m2 should remain unchanged
+            expected_m2_sems=np.array([1.0]),
+        )
+
+    def test_transform_experiment_data_with_all_nan_sems(self) -> None:
+        # When SEM is NaN, the transform should use zero variance
+        self._base_test_transform_experiment_data(
+            config={"metrics": ["m1", "m2"]},
+            observations=[[1.0, 2.0], [np.e, 3.0]],
+            sems=[[np.nan, np.nan], [np.nan, np.nan]],
+            expected_m1_means=np.array([0.0, 1.0]),  # log([1.0, e]) = [0.0, 1.0]
+            expected_m1_sems=np.array([np.nan, np.nan]),
+            expected_m2_means=np.log(np.array([2.0, 3.0])),
+            expected_m2_sems=np.array([np.nan, np.nan]),
+        )
+
+    @mock_botorch_optimize
+    def test_gen_with_log_y_transform(self) -> None:
+        observations = [[1.0, 2.0], [1.0, 3.0]]
+        experiment = get_experiment_with_observations(
+            observations=observations, scalarized=True
+        )
+        generator = BoTorchGenerator()
+        adapter = TorchAdapter(
+            experiment=experiment,
+            generator=generator,
+            transforms=[LogY],
+            transform_configs={
+                "LogY": {"metrics": ["m1", "m2"]},
+            },
+        )
+        adapter.gen(n=1)
+        # Check that model training data is log-transformed.
+        model = generator.surrogate.model
+        self.assertAllClose(
+            model.train_targets, torch.tensor(observations, dtype=torch.float64).log().T
+        )
+
 
 class LogNormTest(TestCase):
     def test_lognorm_to_norm(self) -> None:
+        # Test with variance (diagonal elements only)
         mu_ln = np.ones(3)
-        Cov_ln = np.diag(mu_ln * (np.exp(1) - 1))
-        mu_n, Cov_n = lognorm_to_norm(mu_ln, Cov_ln)
+        var_ln = mu_ln * (np.exp(1) - 1)
+        mu_n, var_n = lognorm_to_norm(mu_ln, var_ln)
         self.assertTrue(np.allclose(mu_n, -0.5 * np.ones_like(mu_n)))
-        self.assertTrue(np.allclose(Cov_n, np.eye(3)))
-        Z = np.zeros_like(Cov_ln)
-        Z[0, 2] = np.sqrt(np.exp(1)) - 1
-        Z[2, 0] = np.sqrt(np.exp(1)) - 1
-        Cov_ln2 = Cov_ln + Z
-        mu_n2, Cov_n2 = lognorm_to_norm(mu_ln, Cov_ln2)
-        self.assertTrue(np.allclose(mu_n2, -0.5 * np.ones_like(mu_n2)))
-        Cov_n2_expected = np.array([[1.0, 0.0, 0.5], [0.0, 1.0, 0.0], [0.5, 0.0, 1.0]])
-        self.assertTrue(np.allclose(Cov_n2, Cov_n2_expected))
+        self.assertTrue(np.allclose(var_n, np.ones(3)))
 
     def test_norm_to_lognorm(self) -> None:
+        # Test with variance (diagonal elements only)
         mu_n = -0.5 * np.ones(3)
-        Cov_n = np.eye(3)
-        mu_ln, Cov_ln = norm_to_lognorm(mu_n, Cov_n)
+        var_n = np.ones(3)
+        mu_ln, var_ln = norm_to_lognorm(mu_n, var_n)
         self.assertTrue(np.allclose(mu_ln, np.ones(3)))
-        self.assertTrue(np.allclose(Cov_ln, (np.exp(1) - 1) * np.eye(3)))
-        Cov_n2 = np.array([[1.0, 0.0, 0.5], [0.0, 1.0, 0.0], [0.5, 0.0, 1.0]])
-        mu_ln2, Cov_ln2 = norm_to_lognorm(mu_n, Cov_n2)
-        Z = np.zeros_like(Cov_ln2)
-        Z[0, 2] = np.sqrt(np.exp(1)) - 1
-        Z[2, 0] = np.sqrt(np.exp(1)) - 1
-        self.assertTrue(np.allclose(mu_ln2, np.ones(3)))
-        self.assertTrue(np.allclose(Cov_ln2, np.exp(np.eye(3)) + Z - 1))
+        self.assertTrue(np.allclose(var_ln, (np.exp(1) - 1) * np.ones(3)))


### PR DESCRIPTION
Summary:
This diff implements `LogY.transform_experiment_data` and refactors the `LogY` transform implementation to work with variances instead of full covariance matrices (which rarely exist in Ax), which simplifies the implementation and makes it more efficient (and avoids some if/else statements). The key changes include:

1. **Simplified transformation functions**: Updated `lognorm_to_norm` and `norm_to_lognorm` to operate on variances (1D arrays) instead of full covariance matrices (2D arrays). This is more appropriate since the LogY transform doesn't support correlated observations.

2. **Added `transform_experiment_data` method**: Implements a new method to transform `ExperimentData` objects directly, which is needed for data adapter workflows. This method transforms means and variances for the specified metrics.

3. **No-op if no metrics are specified**. This should help simplify the dispatch logic if we want to add it more broadly to Y_trans etc down the line.

4. **Updated `_apply_transform` implementation**: Refactored to work with diagonal variances instead of full covariance matrices, which aligns with the constraint that correlated observations are not supported.

5. **Comprehensive test coverage**: Added extensive tests for `transform_experiment_data` including tests with match_ci_width transform, all NaN SEMs, and multiple observations.

Differential Revision: D87962588


