### PR TITLE
Fix floating point precision issue in step_size validation

### DIFF
--- a/ax/api/utils/instantiation/from_config.py
+++ b/ax/api/utils/instantiation/from_config.py
@@ -44,7 +44,9 @@ def parameter_from_config(
                     "step_size."
                 )
 
-            if (upper - lower) % step_size != 0:
+            remainder = (upper - lower) % step_size
+            # Use tolerance-based comparison to handle floating point precision issues
+            if not np.isclose(remainder, 0) and not np.isclose(remainder, step_size):
                 raise UserInputError(
                     "The range of the parameter must be evenly divisible by the "
                     "step size."

--- a/ax/api/utils/instantiation/tests/test_from_config.py
+++ b/ax/api/utils/instantiation/tests/test_from_config.py
@@ -112,6 +112,34 @@ class TestFromConfig(TestCase):
             ),
         )
 
+        fractional_step_size_config = RangeParameterConfig(
+            name="fractional_step_size_param",
+            parameter_type="float",
+            bounds=(0, 1),
+            step_size=0.1,
+        )
+        self.assertEqual(
+            parameter_from_config(config=fractional_step_size_config),
+            ChoiceParameter(
+                name="fractional_step_size_param",
+                parameter_type=CoreParameterType.FLOAT,
+                values=[
+                    0.0,
+                    0.1,
+                    0.2,
+                    0.3,
+                    0.4,
+                    0.5,
+                    0.6,
+                    0.7,
+                    0.8,
+                    0.9,
+                    1.0,
+                ],
+                is_ordered=True,
+            ),
+        )
+
         with self.assertRaisesRegex(
             UserInputError,
             "Non-linear parameter scaling is not supported when using step_size",

--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -798,7 +798,7 @@ class ChoiceParameter(Parameter):
                 f'`sort_values` is not specified for `ChoiceParameter` "{self._name}". '
                 f"Defaulting to `{default_bool}` for parameters of `ParameterType` "
                 f"{self.parameter_type.name}. To override this behavior (or avoid this "
-                f"warning), specify `sort_values` during `ChoiceParameter` "
+                "warning), specify `sort_values` during `ChoiceParameter` "
                 "construction.",
                 AxParameterWarning,
                 stacklevel=3,


### PR DESCRIPTION
Summary:
Python's modulo operation with floating point numbers produces inaccurate results due to binary representation limitations (e.g., 1.0 % 0.1 returns ~0.1 instead of 0). This caused valid fractional step sizes to incorrectly fail validation.

The fix uses np.isclose() for tolerance-based comparison when checking if a range is evenly divisible by the step size.

see https://github.com/facebook/Ax/issues/4599

Reviewed By: saitcakmak

Differential Revision: D88077995


