### PR TITLE
Implement get_default_ess_or_none dispatcher

### DIFF
--- a/ax/early_stopping/dispatch.py
+++ b/ax/early_stopping/dispatch.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.core.experiment import Experiment
+from ax.core.optimization_config import MultiObjectiveOptimizationConfig
+from ax.early_stopping.strategies.percentile import PercentileEarlyStoppingStrategy
+
+
+def get_default_ess_or_none(
+    experiment: Experiment,
+) -> PercentileEarlyStoppingStrategy | None:
+    """Get the default ESS for the given experiment.
+
+    Returns a PercentileEarlyStoppingStrategy with a conservative configuration
+    for single objective unconstrained problems. For all other problem types
+    (multi-objective, constrained, or no optimization config), returns None.
+
+    Args:
+        experiment: The experiment to create an early stopping strategy for.
+
+    Returns:
+        A PercentileEarlyStoppingStrategy with default configuration if the
+        experiment is a single objective unconstrained problem, None otherwise.
+    """
+    opt_config = experiment.optimization_config
+    if (
+        opt_config is None
+        or isinstance(opt_config, MultiObjectiveOptimizationConfig)
+        or len(opt_config.outcome_constraints) > 0
+    ):
+        return None
+
+    return PercentileEarlyStoppingStrategy(
+        percentile_threshold=50,
+        min_curves=3,
+        min_progression=0.2,
+        max_progression=0.9,
+        normalize_progressions=True,
+        n_best_trials_to_complete=3,
+        check_safe=True,
+    )

--- a/ax/early_stopping/tests/test_dispatch.py
+++ b/ax/early_stopping/tests/test_dispatch.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.early_stopping.dispatch import get_default_ess_or_none
+from ax.early_stopping.strategies.percentile import PercentileEarlyStoppingStrategy
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import (
+    get_branin_experiment,
+    get_branin_experiment_with_multi_objective,
+)
+from pyre_extensions import none_throws
+
+
+class TestGetDefaultEss(TestCase):
+    def test_get_default_ess_single_objective_unconstrained(self) -> None:
+        exp = get_branin_experiment()
+        strategy = none_throws(get_default_ess_or_none(experiment=exp))
+        self.assertIsInstance(strategy, PercentileEarlyStoppingStrategy)
+
+        # Verify configuration.
+        self.assertEqual(strategy.percentile_threshold, 50)
+        self.assertEqual(strategy.min_curves, 3)
+        self.assertEqual(strategy.min_progression, 0.2)
+        self.assertEqual(strategy.max_progression, 0.9)
+        self.assertTrue(strategy.normalize_progressions)
+        self.assertEqual(strategy.n_best_trials_to_complete, 3)
+        self.assertTrue(strategy.check_safe)
+
+    def test_get_default_ess_null_conditions(self) -> None:
+        # Checks that None is returned for currently unsupported conditions.
+        for exp in [
+            get_branin_experiment(has_optimization_config=False),
+            get_branin_experiment(
+                has_optimization_config=True, with_absolute_constraint=True
+            ),
+            get_branin_experiment_with_multi_objective(has_optimization_config=True),
+        ]:
+            self.assertIsNone(get_default_ess_or_none(experiment=exp))


### PR DESCRIPTION
Summary: Currently only supports single-objective, unconstrained problems. A PercentileESS with conservative settings is returned for these experiments, and None otherwise.

Reviewed By: bernardbeckerman

Differential Revision: D88111342


