### PR TITLE
Audit & cleanup for Transforms

### DIFF
--- a/ax/adapter/tests/test_transform_utils.py
+++ b/ax/adapter/tests/test_transform_utils.py
@@ -8,7 +8,6 @@
 
 from ax.adapter import Adapter
 from ax.adapter.transforms.utils import (
-    ClosestLookupDict,
     derelativize_optimization_config_with_raw_status_quo,
 )
 from ax.generators.base import Generator
@@ -20,24 +19,6 @@ from ax.utils.testing.core_stubs import (
 
 
 class TransformUtilsTest(TestCase):
-    def test_closest_lookup_dict(self) -> None:
-        # test empty lookup
-        d = ClosestLookupDict()
-        with self.assertRaises(RuntimeError):
-            d[0]
-        # basic test
-        keys = (1.0, 2, 4)
-        vals = ("a", "b", "c")
-        d = ClosestLookupDict(zip(keys, vals))
-        for k, v in zip(keys, vals):
-            self.assertEqual(d[k], v)
-        self.assertEqual(d[2.5], "b")
-        self.assertEqual(d[0], "a")
-        self.assertEqual(d[6], "c")
-        with self.assertRaises(ValueError):
-            # pyre-fixme[6]: For 1st param expected `Number` but got `str`.
-            d["str_key"] = 3
-
     def test_derelativize_optimization_config_with_raw_status_quo(self) -> None:
         optimization_config = get_multi_objective_optimization_config()
         experiment = get_experiment_with_observations(

--- a/ax/adapter/transforms/base.py
+++ b/ax/adapter/transforms/base.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
@@ -83,7 +84,7 @@ class Transform:
             )
         if config is None:
             config = {}
-        self.config = config
+        self.config = deepcopy(config)
         self.adapter = adapter
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:

--- a/ax/adapter/transforms/cast.py
+++ b/ax/adapter/transforms/cast.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
@@ -54,7 +56,7 @@ class Cast(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         self.search_space: SearchSpace = none_throws(search_space).clone()
@@ -64,7 +66,6 @@ class Cast(Transform):
             adapter=adapter,
             config=config,
         )
-        config = (config or {}).copy()
 
         # 1. The default behavior for non-hierarchical search spaces: The flag
         # `flatten_hss` is irrelevant. It's simply ignored.
@@ -80,20 +81,20 @@ class Cast(Transform):
         # exploit the hierarchical structure, it infers which parameter is active based
         # on `search_space_digest.hierarchical_dependencies`.
         self.flatten_hss: bool = assert_is_instance(
-            config.pop("flatten_hss", none_throws(search_space).is_hierarchical),
+            self.config.pop("flatten_hss", none_throws(search_space).is_hierarchical),
             bool,
         )
         self.inject_dummy_values_to_complete_flat_parameterization: bool = (
             assert_is_instance(
-                config.pop(
+                self.config.pop(
                     "inject_dummy_values_to_complete_flat_parameterization", True
                 ),
                 bool,
             )
         )
-        if config:
+        if self.config:
             raise UserInputError(
-                f"Unexpected config parameters for `Cast` transform: {config}."
+                f"Unexpected config parameters for `Cast` transform: {self.config}."
             )
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:

--- a/ax/adapter/transforms/choice_encode.py
+++ b/ax/adapter/transforms/choice_encode.py
@@ -6,16 +6,20 @@
 
 # pyre-strict
 
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
-from ax.adapter.transforms.utils import ClosestLookupDict, construct_new_search_space
+from ax.adapter.transforms.utils import construct_new_search_space
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.core.types import TParamValue
+from ax.exceptions.core import UserInputError
 from ax.generators.types import TConfig
+from pyre_extensions import assert_is_instance
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
@@ -46,28 +50,41 @@ class ChoiceToNumericChoice(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
-        assert search_space is not None, "ChoiceToNumericChoice requires search space"
+        if search_space is None:
+            raise UserInputError(f"{self.__class__.__name__} requires search space.")
         super().__init__(
             search_space=search_space,
             experiment_data=experiment_data,
             adapter=adapter,
             config=config,
         )
-        # Identify parameters that should be transformed
-        self.encoded_parameters: dict[str, dict[TParamValue, TParamValue]] = {}
-        self.encoded_parameters_inverse: dict[str, ClosestLookupDict] = {}
-        for p in search_space.parameters.values():
-            if isinstance(p, ChoiceParameter) and not p.is_numeric and not p.is_task:
-                transformed_values = list(range(len(p.values)))
-                self.encoded_parameters[p.name] = dict(
-                    zip(p.values, transformed_values)
+        # Identify parameters that should be transformed.
+        self.encoded_parameters: dict[str, dict[TParamValue, int]] = {
+            p.name: {
+                original_value: transformed_value
+                for transformed_value, original_value in enumerate(
+                    assert_is_instance(p, ChoiceParameter).values
                 )
-                self.encoded_parameters_inverse[p.name] = ClosestLookupDict(
-                    zip(transformed_values, p.values)
-                )
+            }
+            for p in search_space.parameters.values()
+            if self._should_encode(p=p)
+        }
+        self.encoded_parameters_inverse: dict[str, dict[int, TParamValue]] = {
+            p_name: {
+                transformed_value: original_value
+                for original_value, transformed_value in transforms.items()
+            }
+            for p_name, transforms in self.encoded_parameters.items()
+        }
+
+    def _should_encode(self, p: Parameter) -> bool:
+        """Check if a parameter should be encoded.
+        Encodes non-numeric choice parameters that are not task parameters.
+        """
+        return isinstance(p, ChoiceParameter) and not p.is_numeric and not p.is_task
 
     def transform_observation_features(
         self, observation_features: list[ObservationFeatures]
@@ -110,7 +127,7 @@ class ChoiceToNumericChoice(Transform):
                     # Retain the original sort_values if the parameter is not ordered.
                     # Ordered numeric parameters are always sorted.
                     sort_values=p.sort_values if not p.is_ordered else True,
-                    dependents=dependents,
+                    dependents=dependents,  # pyre-ignore[6]
                 )
             else:
                 transformed_parameters[p.name] = p
@@ -131,9 +148,9 @@ class ChoiceToNumericChoice(Transform):
         for obsf in observation_features:
             for p_name, reverse_transform in self.encoded_parameters_inverse.items():
                 if p_name in obsf.parameters:
-                    # pyre: pval is declared to have type `int` but is used as
-                    # pyre-fixme[9]: type `Union[bool, float, str]`.
-                    pval: int = obsf.parameters[p_name]
+                    # Rounding & casting to int in case a floating point value was
+                    # generated. This can happen since generation uses float tensors.
+                    pval = int(round(obsf.parameters[p_name]))  # pyre-ignore [6]
                     if pval in reverse_transform:
                         obsf.parameters[p_name] = reverse_transform[pval]
         return observation_features
@@ -165,34 +182,11 @@ class OrderedChoiceToIntegerRange(ChoiceToNumericChoice):
     Transform is done in-place.
     """
 
-    def __init__(
-        self,
-        search_space: SearchSpace,
-        experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
-        config: TConfig | None = None,
-    ) -> None:
-        super().__init__(
-            search_space=search_space,
-            experiment_data=experiment_data,
-            adapter=adapter,
-            config=config,
-        )
-        # Identify parameters that should be transformed
-        self.encoded_parameters: dict[str, dict[TParamValue, int]] = {}
-        for p in search_space.parameters.values():
-            if isinstance(p, ChoiceParameter) and p.is_ordered and not p.is_task:
-                self.encoded_parameters[p.name] = {
-                    original_value: transformed_value
-                    for transformed_value, original_value in enumerate(p.values)
-                }
-        self.encoded_parameters_inverse: dict[str, dict[int, TParamValue]] = {
-            p_name: {
-                transformed_value: original_value
-                for original_value, transformed_value in transforms.items()
-            }
-            for p_name, transforms in self.encoded_parameters.items()
-        }
+    def _should_encode(self, p: Parameter) -> bool:
+        """Check if a parameter should be encoded.
+        Encodes ordered choice parameters that are not task parameters.
+        """
+        return isinstance(p, ChoiceParameter) and p.is_ordered and not p.is_task
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:
         transformed_parameters: dict[str, Parameter] = {}

--- a/ax/adapter/transforms/derelativize.py
+++ b/ax/adapter/transforms/derelativize.py
@@ -6,8 +6,10 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 from logging import Logger
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import numpy as np
 from ax.adapter.base import unwrap_observation_data
@@ -50,7 +52,7 @@ class Derelativize(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         fixed_features: ObservationFeatures | None = None,
     ) -> OptimizationConfig:
         use_raw_sq = self.config.get("use_raw_status_quo", False)

--- a/ax/adapter/transforms/fill_missing_parameters.py
+++ b/ax/adapter/transforms/fill_missing_parameters.py
@@ -6,8 +6,10 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 from logging import Logger
-from typing import cast, Optional, TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
@@ -33,7 +35,7 @@ class FillMissingParameters(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,  # Deprecated
     ) -> None:
         super().__init__(

--- a/ax/adapter/transforms/fixed_to_tunable.py
+++ b/ax/adapter/transforms/fixed_to_tunable.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
@@ -33,7 +35,7 @@ class FixedToTunable(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "FixedToTunable requires search space"

--- a/ax/adapter/transforms/int_range_to_choice.py
+++ b/ax/adapter/transforms/int_range_to_choice.py
@@ -6,8 +6,10 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 from numbers import Real
-from typing import cast, Optional, TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
@@ -33,7 +35,7 @@ class IntRangeToChoice(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         super().__init__(
@@ -43,9 +45,8 @@ class IntRangeToChoice(Transform):
             config=config,
         )
         assert search_space is not None, "IntRangeToChoice requires search space"
-        config = config or {}
         self.max_choices: float = float(
-            cast(Real, (config.get("max_choices", float("inf"))))
+            cast(Real, (self.config.get("max_choices", float("inf"))))
         )
         # Identify parameters that should be transformed
         self.transform_parameters: set[str] = {

--- a/ax/adapter/transforms/int_to_float.py
+++ b/ax/adapter/transforms/int_to_float.py
@@ -6,8 +6,10 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 from logging import Logger
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
@@ -51,7 +53,7 @@ class IntToFloat(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         self.search_space: SearchSpace = none_throws(
@@ -63,12 +65,15 @@ class IntToFloat(Transform):
             adapter=adapter,
             config=config,
         )
-        config = config or {}
-        self.rounding: str = assert_is_instance(config.get("rounding", "strict"), str)
-        self.max_round_attempts: int = assert_is_instance(
-            config.get("max_round_attempts", DEFAULT_MAX_ROUND_ATTEMPTS), int
+        self.rounding: str = assert_is_instance(
+            self.config.get("rounding", "strict"), str
         )
-        self.min_choices: int = assert_is_instance(config.get("min_choices", 0), int)
+        self.max_round_attempts: int = assert_is_instance(
+            self.config.get("max_round_attempts", DEFAULT_MAX_ROUND_ATTEMPTS), int
+        )
+        self.min_choices: int = assert_is_instance(
+            self.config.get("min_choices", 0), int
+        )
 
         # Identify parameters that should be transformed
         self.transform_parameters: set[str] = self._get_transform_parameters()

--- a/ax/adapter/transforms/log.py
+++ b/ax/adapter/transforms/log.py
@@ -6,8 +6,10 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 import math
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import numpy as np
 from ax.adapter.data_utils import ExperimentData
@@ -36,7 +38,7 @@ class Log(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "Log requires search space"

--- a/ax/adapter/transforms/log_y.py
+++ b/ax/adapter/transforms/log_y.py
@@ -57,7 +57,6 @@ class LogY(Transform):
         adapter: base_adapter.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
-        config = config or {}
         super().__init__(
             search_space=search_space,
             experiment_data=experiment_data,
@@ -66,9 +65,9 @@ class LogY(Transform):
         )
         self.metric_signatures: list[str] = [
             assert_is_instance(m, str)
-            for m in list(assert_is_instance(config.get("metrics", []), Iterable))
+            for m in list(assert_is_instance(self.config.get("metrics", []), Iterable))
         ]
-        if config.get("match_ci_width", False):
+        if self.config.get("match_ci_width", False):
             # perform moment-matching to compute variance that results in a CI
             # of same width as the when transforming the moments
             self._transform: T_MATCH_CI_WIDTH = lambda m, v: match_ci_width(

--- a/ax/adapter/transforms/logit.py
+++ b/ax/adapter/transforms/logit.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
@@ -31,7 +33,7 @@ class Logit(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "Logit requires search space"

--- a/ax/adapter/transforms/map_key_to_float.py
+++ b/ax/adapter/transforms/map_key_to_float.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 from logging import Logger
 from math import isnan
 from typing import Any, TYPE_CHECKING
@@ -68,13 +67,12 @@ class MapKeyToFloat(MetadataToParameterMixin, Transform):
             adapter=adapter,
             config=config,
         )
-        config = config or {}
         # pyre-fixme[9]: Incompatible variable type [9]: parameters is declared
         # to have type `Dict[str, Dict[str, typing.Any]]` but is used as type
         # `Union[None, Dict[int, typing.Any], Dict[str, typing.Any], List[int],
         # List[str], OptimizationConfig, WinsorizationConfig,
         # AcquisitionFunction, float, int, str]`.
-        parameters: dict[str, dict[str, Any]] = deepcopy(config.get("parameters", {}))
+        parameters: dict[str, dict[str, Any]] = self.config.get("parameters", {})
         is_map_data = (
             # Note: experiment_data can't be None because
             # `requires_data_for_initialization` is True; if it is None, there
@@ -84,10 +82,10 @@ class MapKeyToFloat(MetadataToParameterMixin, Transform):
         )
 
         # Check if config contains unsupported config options.
-        if set(config.keys()).difference({"parameters"}):
+        if set(self.config.keys()).difference({"parameters"}):
             raise UserInputError(
                 "MapKeyToFloat only supports the `parameters` key in the config. "
-                f"Got {config=}."
+                f"Got {self.config=}."
             )
         # Check if any disallowed parameters were provided.
         # The only parameter allowed is "step" (MAP_KEY)

--- a/ax/adapter/transforms/metadata_to_task.py
+++ b/ax/adapter/transforms/metadata_to_task.py
@@ -56,10 +56,9 @@ class MetadataToTask(MetadataToParameterMixin, Transform):
             adapter=adapter,
             config=config,
         )
-        config = config or {}
         task_values: list[TParamValue] = [
             assert_is_instance(v, TParamValue)
-            for v in assert_is_instance(config["task_values"], list)
+            for v in assert_is_instance(self.config["task_values"], list)
         ]
         self.parameters: dict[str, dict[str, Any]] = {Keys.TASK_FEATURE_NAME.value: {}}
         self._parameter_list = [

--- a/ax/adapter/transforms/metrics_as_task.py
+++ b/ax/adapter/transforms/metrics_as_task.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 from ax.adapter.data_utils import ExperimentData
@@ -44,7 +46,7 @@ class MetricsAsTask(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         super().__init__(
@@ -54,9 +56,9 @@ class MetricsAsTask(Transform):
             config=config,
         )
         # Use config to specify metric task map
-        if config is None or "metric_task_map" not in config:
+        if "metric_task_map" not in self.config:
             raise ValueError("config must specify metric_task_map")
-        self.metric_task_map: dict[str, list[str]] = config[  # pyre-ignore
+        self.metric_task_map: dict[str, list[str]] = self.config[  # pyre-ignore
             "metric_task_map"
         ]
         self.task_values: list[str] = list(self.metric_task_map.keys())

--- a/ax/adapter/transforms/one_hot.py
+++ b/ax/adapter/transforms/one_hot.py
@@ -6,7 +6,10 @@
 
 # pyre-strict
 
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -88,7 +91,7 @@ class OneHot(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "OneHot requires search space"
@@ -101,15 +104,16 @@ class OneHot(Transform):
         # Identify parameters that should be transformed
         # pyre-fixme[4]: Attribute must be annotated.
         self.rounding = "strict"
-        if config is not None:
-            self.rounding = config.get("rounding", "strict")
+        if self.config is not None:
+            self.rounding = self.config.get("rounding", "strict")
         self.encoder: dict[str, OneHotEncoder] = {}
         self.encoded_parameters: dict[str, list[str]] = {}
         self.encoded_values: dict[str, list[TParamValue]] = {}
         for p in search_space.parameters.values():
             if isinstance(p, ChoiceParameter) and not p.is_ordered and not p.is_task:
-                self.encoded_values[p.name] = p.values
-                self.encoder[p.name] = OneHotEncoder(p.values)
+                values = deepcopy(p.values)
+                self.encoded_values[p.name] = values
+                self.encoder[p.name] = OneHotEncoder(values)
                 encoded_len = self.encoder[p.name].encoded_len
                 if encoded_len == 1:
                     # Two levels handled in one parameter

--- a/ax/adapter/transforms/power_transform_y.py
+++ b/ax/adapter/transforms/power_transform_y.py
@@ -79,11 +79,9 @@ class PowerTransformY(Transform):
             config=config,
         )
         # pyre-fixme[9]: Can't annotate config["metrics"] properly.
-        metric_signatures: list[str] | None = (
-            config.get("metrics", None) if config else None
-        )
-        self.clip_mean: bool = (
-            assert_is_instance(config.get("clip_mean", True), bool) if config else True
+        metric_signatures: list[str] | None = self.config.get("metrics", None)
+        self.clip_mean: bool = assert_is_instance(
+            self.config.get("clip_mean", True), bool
         )
         means_df = none_throws(experiment_data).observation_data["mean"]
         # Dropping NaNs here since the DF will have NaN for missing values.

--- a/ax/adapter/transforms/remove_fixed.py
+++ b/ax/adapter/transforms/remove_fixed.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
@@ -81,7 +83,7 @@ class RemoveFixed(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "RemoveFixed requires search space"

--- a/ax/adapter/transforms/search_space_to_choice.py
+++ b/ax/adapter/transforms/search_space_to_choice.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
@@ -41,7 +43,7 @@ class SearchSpaceToChoice(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "SearchSpaceToChoice requires search space"

--- a/ax/adapter/transforms/stratified_standardize_y.py
+++ b/ax/adapter/transforms/stratified_standardize_y.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 from ax.adapter.data_utils import ExperimentData
@@ -49,7 +51,7 @@ class StratifiedStandardizeY(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         """Initialize StratifiedStandardizeY.
@@ -76,20 +78,20 @@ class StratifiedStandardizeY(Transform):
         )
         # Get parameter name for standardization.
         self.strata_mapping = None  # pyre-ignore [8]
-        if config is not None and "parameter_name" in config:
+        if "parameter_name" in self.config:
             # pyre: Attribute `p_name` declared in class `ax.adapter.
             # pyre: transforms.stratified_standardize_y.
             # pyre: StratifiedStandardizeY` has type `str` but is used as type
             # pyre-fixme[8]: `typing.Union[float, int, str]`.
-            self.p_name: str = config["parameter_name"]
+            self.p_name: str = self.config["parameter_name"]
             strat_p = search_space.parameters[self.p_name]
             if not isinstance(strat_p, ChoiceParameter):
                 raise ValueError(f"{self.p_name} not a ChoiceParameter")
-            if "strata_mapping" in config:
+            if "strata_mapping" in self.config:
                 # pyre-ignore [8]
                 self.strata_mapping: dict[
                     bool | float | int | str, bool | float | int | str
-                ] = config["strata_mapping"]
+                ] = self.config["strata_mapping"]
                 if set(strat_p.values) != set(self.strata_mapping.keys()):
                     raise ValueError(
                         f"{self.p_name} values {strat_p.values} do not match "
@@ -170,7 +172,7 @@ class StratifiedStandardizeY(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         fixed_features: ObservationFeatures | None = None,
     ) -> OptimizationConfig:
         if len(optimization_config.all_constraints) == 0:

--- a/ax/adapter/transforms/transform_to_new_sq.py
+++ b/ax/adapter/transforms/transform_to_new_sq.py
@@ -67,19 +67,16 @@ class TransformToNewSQ(BaseRelativize):
             adapter=adapter,
             config=config,
         )
-        self._status_quo_name: str = none_throws(none_throws(adapter).status_quo_name)
 
-        target_trial_index = None
-
-        if config is not None:
-            target_trial_index = config.get("target_trial_index", None)
-
+        target_trial_index = self.config.get("target_trial_index", None)
         if (
             target_trial_index is None
             and adapter is not None
             and adapter._experiment is not None
         ):
-            target_trial_index = get_target_trial_index(experiment=adapter._experiment)
+            target_trial_index = get_target_trial_index(
+                experiment=none_throws(adapter)._experiment
+            )
             trials_indices_with_sq_data = self.status_quo_data_by_trial.keys()
             if target_trial_index not in trials_indices_with_sq_data:
                 target_trial_index = max(trials_indices_with_sq_data)
@@ -181,7 +178,7 @@ class TransformToNewSQ(BaseRelativize):
         observation_data = observation_data[
             (
                 observation_data.index.get_level_values("arm_name")
-                != self._status_quo_name
+                != self.status_quo_name
             )
             | (
                 observation_data.index.get_level_values("trial_index")
@@ -190,7 +187,7 @@ class TransformToNewSQ(BaseRelativize):
         ]
         arm_data = experiment_data.arm_data
         arm_data = arm_data[
-            (arm_data.index.get_level_values("arm_name") != self._status_quo_name)
+            (arm_data.index.get_level_values("arm_name") != self.status_quo_name)
             | (arm_data.index.get_level_values("trial_index") == self.default_trial_idx)
         ]
         return ExperimentData(
@@ -230,7 +227,7 @@ class TransformToNewSQ(BaseRelativize):
             for obs in rel_observations
             # drop SQ observations
             if (
-                obs.arm_name != self._status_quo_name
+                obs.arm_name != self.status_quo_name
                 or obs.features.trial_index == self.default_trial_idx
             )
         ]

--- a/ax/adapter/transforms/trial_as_task.py
+++ b/ax/adapter/transforms/trial_as_task.py
@@ -6,8 +6,10 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 from logging import Logger
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
@@ -63,7 +65,7 @@ class TrialAsTask(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         super().__init__(
@@ -83,9 +85,9 @@ class TrialAsTask(Transform):
                 "trial specified."
             )
         # Get trial level map
-        if config is not None and "trial_level_map" in config:
+        if "trial_level_map" in self.config:
             # pyre-ignore [9]
-            trial_level_map: dict[str, dict[int | str, int | str]] = config[
+            trial_level_map: dict[str, dict[int | str, int | str]] = self.config[
                 "trial_level_map"
             ]
             # Validate
@@ -103,7 +105,7 @@ class TrialAsTask(Transform):
                         f"Not all trials in data ({trials}) contained "
                         f"in trial level map for {_p_name} ({level_map})"
                     )
-        elif config is not None and config.get("trial_type_as_task", False):
+        elif self.config.get("trial_type_as_task", False):
             # map long run trials to 0 and short run trials to 1
             self.trial_level_map = {TRIAL_PARAM: {}}
             for trial_index in trials:
@@ -132,8 +134,8 @@ class TrialAsTask(Transform):
                 # create a task parameter and the transform is a no-op.
                 del self.trial_level_map[p_name]
                 continue
-            if config is not None and "target_trial" in config:
-                target_trial = int(config["target_trial"])
+            if "target_trial" in self.config:
+                target_trial = int(self.config["target_trial"])
             else:
                 target_trial = none_throws(
                     get_target_trial_index(

--- a/ax/adapter/transforms/unit_x.py
+++ b/ax/adapter/transforms/unit_x.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
-from typing import Optional, TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.transforms.base import Transform
@@ -35,7 +37,7 @@ class UnitX(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["adapter_module.base.Adapter"] = None,
+        adapter: adapter_module.base.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         assert search_space is not None, "UnitX requires search space"

--- a/ax/adapter/transforms/utils.py
+++ b/ax/adapter/transforms/utils.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from numbers import Number
 from typing import Any, TYPE_CHECKING
 
 import numpy as np
@@ -29,47 +28,6 @@ T_MATCH_CI_WIDTH = Callable[[npt.NDArray, npt.NDArray], tuple[npt.NDArray, npt.N
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
     from ax import adapter as adapter_module  # noqa F401
-
-
-# pyre-fixme[24]: Generic type `dict` expects 2 type parameters, use `typing.Dict`
-#  to avoid runtime subscripting errors.
-class ClosestLookupDict(dict):
-    """A dictionary with numeric keys that looks up the closest key."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        # pyre-fixme[4]: Attribute must be annotated.
-        self._keys = sorted(self.keys())
-
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
-    def __setitem__(self, key: Number, val: Any) -> None:
-        if not isinstance(key, Number):
-            raise ValueError("ClosestLookupDict only allows numerical keys.")
-        super().__setitem__(key, val)
-        # pyre-fixme[6]: For 2nd argument expected `Union[bytes, complex, float,
-        #  int, generic, str]` but got `Number`.
-        ipos = np.searchsorted(self._keys, key)
-        self._keys.insert(ipos, key)
-
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
-    def __getitem__(self, key: Number) -> Any:
-        try:
-            return super().__getitem__(key)
-        except KeyError:
-            if not self.keys():
-                raise RuntimeError("ClosestLookupDict is empty.")
-            # pyre-fixme[6]: For 2nd argument expected `Union[bytes, complex, float,
-            #  int, generic, str]` but got `Number`.
-            ipos = np.searchsorted(self._keys, key)
-            if ipos == 0:
-                return super().__getitem__(self._keys[0])
-            elif ipos == len(self._keys):
-                return super().__getitem__(self._keys[-1])
-            lkey, rkey = self._keys[ipos - 1 : ipos + 1]
-            if np.abs(key - lkey) <= np.abs(key - rkey):  # pyre-ignore [58]
-                return super().__getitem__(lkey)
-            else:
-                return super().__getitem__(rkey)
 
 
 def match_ci_width(


### PR DESCRIPTION
Summary:
Audited transforms and made minor improvements based, partially based on devmate suggestions (P2063730976). The main goal is to make sure that in-place modifications of transform inputs do not affect expected transform behaviors.

- `ChoiceToNumericChoice`  & `OrderedChoiceToIntegerRange`: rather than assigning encoded parameters and later overwriting it in the `OrderedChoiceToIntegerRange` constructor, added a `_should_encode` method that identifies parameters to encode and deduplicated `__init__` methods.
- Similarly, deduplicated `TaskChoiceToIntTaskChoice` constructor.
- Removed `ClosestLookupDict`. Since the encoding always maps to an int, this is redundant.
- In `BaseRelativize` and subclasses, reduced direct references to `adapter`, and replaced them from attributes extracted in `__init__` instead.
- Added a `copy` in `OneHot` to protect against in-place modifications of parameter values.
- Cleaned up `Optional[Adapter]` typing and replaced it with `Adapter | None`.
- Added a `deepcopy` for `config` in base `Transform.__init__` and updated all references of `config` to `self.config`. Even if the original config is modified in-place, transforms should not be affected. If the transform itself modifies the config (i.e., using `pop`) this will not affect future usage of the config either.

Differential Revision: D88180358


