### PR TITLE
Change ScatterPlot CIs to be Light Gray

### DIFF
--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -352,12 +352,8 @@ def get_xy_trial_data(
         error = {
             "type": "data",
             "array": xy_df[sem_name] * Z_SCORE_95_CI,
-            "color": trial_index_to_color(
-                trial_df=trial_df,
-                trials_list=trials_list,
-                trial_index=trial_index,
-                transparent=True,
-            ),
+            "color": "silver",
+            "thickness": 1,
         }
     else:
         error = None


### PR DESCRIPTION
Summary: As titled, this is more readable that what we currently have. Gray was a little too dark, light gray was a little too light and so we ended up with silver.

Differential Revision: D88268035


