### PR TITLE
Remove `trial_indices_to_ignore` argument from ESS

### DIFF
--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -31,7 +31,6 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         min_progression: float | None = 10,
         max_progression: float | None = None,
         min_curves: int | None = 5,
-        trial_indices_to_ignore: list[int] | None = None,
         normalize_progressions: bool = False,
         n_best_trials_to_complete: int | None = None,
         interval: float | None = None,
@@ -60,7 +59,6 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 `min_curves` have completed with curve data attached. That is, if
                 `min_curves` trials are completed but their curve data was not
                 successfully retrieved, further trials may not be early-stopped.
-            trial_indices_to_ignore: Trial indices that should not be early stopped.
             normalize_progressions: Normalizes the progression column of the MapData df
                 by dividing by the max. If the values were originally in [0, `prog_max`]
                 (as we would expect), the transformed values will be in [0, 1]. Useful
@@ -91,7 +89,6 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         """
         super().__init__(
             metric_signatures=metric_signatures,
-            trial_indices_to_ignore=trial_indices_to_ignore,
             min_progression=min_progression,
             max_progression=max_progression,
             min_curves=min_curves,

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -31,7 +31,6 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         min_progression: float | None = 10,
         max_progression: float | None = None,
         min_curves: int | None = 5,
-        trial_indices_to_ignore: list[int] | None = None,
         normalize_progressions: bool = False,
         check_safe: bool = False,
     ) -> None:
@@ -53,7 +52,6 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 `min_curves` have completed with curve data attached. That is, if
                 `min_curves` trials are completed but their curve data was not
                 successfully retrieved, further trials may not be early-stopped.
-            trial_indices_to_ignore: Trial indices that should not be early-stopped.
             normalize_progressions: Normalizes the progression column of the MapData df
                 by dividing by the max. If the values were originally in [0, `prog_max`]
                 (as we would expect), the transformed values will be in [0, 1]. Useful
@@ -70,7 +68,6 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             min_progression=min_progression,
             max_progression=max_progression,
             min_curves=min_curves,
-            trial_indices_to_ignore=trial_indices_to_ignore,
             normalize_progressions=normalize_progressions,
             check_safe=check_safe,
         )

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -713,19 +713,6 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
 
         self.assertEqual(set(should_stop), {0})
 
-        # test ignore trial indices
-        early_stopping_strategy = PercentileEarlyStoppingStrategy(
-            metric_signatures=metric_signatures,
-            percentile_threshold=25,
-            min_curves=4,
-            min_progression=0.1,
-            trial_indices_to_ignore=[0],
-        )
-        should_stop = early_stopping_strategy.should_stop_trials_early(
-            trial_indices=idcs, experiment=exp
-        )
-        self.assertEqual(should_stop, {})
-
         early_stopping_strategy = PercentileEarlyStoppingStrategy(
             metric_signatures=metric_signatures,
             percentile_threshold=50,
@@ -1629,17 +1616,6 @@ class TestThresholdEarlyStoppingStrategy(TestCase):
             trial_indices={0}, experiment=exp
         )
         self.assertEqual(set(should_stop), {0})
-
-        # test ignore trial indices
-        early_stopping_strategy = ThresholdEarlyStoppingStrategy(
-            metric_threshold=50,
-            min_progression=1,
-            trial_indices_to_ignore=[0],
-        )
-        should_stop = early_stopping_strategy.should_stop_trials_early(
-            trial_indices=idcs, experiment=exp
-        )
-        self.assertEqual(set(should_stop), {1, 3})
 
         # test did not reach min progression
         early_stopping_strategy = ThresholdEarlyStoppingStrategy(

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -33,6 +33,9 @@ from ax.core.runner import Runner
 from ax.core.trial import Trial
 from ax.core.trial_status import TrialStatus
 from ax.core.types import TCandidateMetadata
+from ax.early_stopping.strategies.base import REMOVED_EARLY_STOPPING_STRATEGY_KWARGS
+from ax.early_stopping.strategies.percentile import PercentileEarlyStoppingStrategy
+from ax.early_stopping.strategies.threshold import ThresholdEarlyStoppingStrategy
 from ax.exceptions.storage import JSONDecodeError
 from ax.storage.botorch_modular_registry import (
     CLASS_TO_REVERSE_REGISTRY,
@@ -510,3 +513,27 @@ def observation_features_from_json(
         end_time=end_time,
         metadata=metadata,
     )
+
+
+def percentile_early_stopping_strategy_from_json(
+    **kwargs: Any,
+) -> PercentileEarlyStoppingStrategy:
+    """Load PercentileEarlyStoppingStrategy from JSON.
+
+    Discards removed kwargs for backwards compatibility.
+    """
+    for key in REMOVED_EARLY_STOPPING_STRATEGY_KWARGS:
+        kwargs.pop(key, None)
+    return PercentileEarlyStoppingStrategy(**kwargs)
+
+
+def threshold_early_stopping_strategy_from_json(
+    **kwargs: Any,
+) -> ThresholdEarlyStoppingStrategy:
+    """Load ThresholdEarlyStoppingStrategy from JSON.
+
+    Discards removed kwargs for backwards compatibility.
+    """
+    for key in REMOVED_EARLY_STOPPING_STRATEGY_KWARGS:
+        kwargs.pop(key, None)
+    return ThresholdEarlyStoppingStrategy(**kwargs)

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -650,7 +650,6 @@ def percentile_early_stopping_strategy_to_dict(
         "percentile_threshold": strategy.percentile_threshold,
         "min_progression": strategy.min_progression,
         "min_curves": strategy.min_curves,
-        "trial_indices_to_ignore": strategy.trial_indices_to_ignore,
         "normalize_progressions": strategy.normalize_progressions,
     }
 
@@ -664,7 +663,6 @@ def threshold_early_stopping_strategy_to_dict(
         "metric_signatures": strategy.metric_signatures,
         "metric_threshold": strategy.metric_threshold,
         "min_progression": strategy.min_progression,
-        "trial_indices_to_ignore": strategy.trial_indices_to_ignore,
         "normalize_progressions": strategy.normalize_progressions,
     }
 

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -113,6 +113,8 @@ from ax.storage.json_store.decoders import (
     observation_features_from_json,
     outcome_transform_type_from_json,
     pathlib_from_json,
+    percentile_early_stopping_strategy_from_json,
+    threshold_early_stopping_strategy_from_json,
     transform_type_from_json,
 )
 from ax.storage.json_store.encoders import (
@@ -388,7 +390,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "PreferenceOptimizationConfig": PreferenceOptimizationConfig,
     "PurePosixPath": pathlib_from_json,
     "PureWindowsPath": pathlib_from_json,
-    "PercentileEarlyStoppingStrategy": PercentileEarlyStoppingStrategy,
+    "PercentileEarlyStoppingStrategy": percentile_early_stopping_strategy_from_json,
     "RangeParameter": RangeParameter,
     "ReductionCriterion": ReductionCriterion,
     "Round": Round,
@@ -409,7 +411,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "Trial": Trial,
     "TrialType": TrialType,
     "TrialStatus": TrialStatus,
-    "ThresholdEarlyStoppingStrategy": ThresholdEarlyStoppingStrategy,
+    "ThresholdEarlyStoppingStrategy": threshold_early_stopping_strategy_from_json,
     "ObservationFeatures": observation_features_from_json,
     "WinsorizationConfig": WinsorizationConfig,
 }

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2606,7 +2606,6 @@ def get_percentile_early_stopping_strategy() -> PercentileEarlyStoppingStrategy:
         percentile_threshold=0.25,
         min_progression=0.2,
         min_curves=10,
-        trial_indices_to_ignore=[0, 1, 2],
         normalize_progressions=True,
     )
 
@@ -2619,7 +2618,6 @@ def get_percentile_early_stopping_strategy_with_non_objective_metric_signature()
         percentile_threshold=0.25,
         min_progression=0.2,
         min_curves=10,
-        trial_indices_to_ignore=[0, 1, 2],
         normalize_progressions=True,
     )
 
@@ -2628,7 +2626,6 @@ def get_threshold_early_stopping_strategy() -> ThresholdEarlyStoppingStrategy:
     return ThresholdEarlyStoppingStrategy(
         metric_threshold=0.1,
         min_progression=0.2,
-        trial_indices_to_ignore=[0, 1, 2],
         normalize_progressions=True,
     )
 


### PR DESCRIPTION
Summary:
This argument is pretty much redundant with `min_curves`. If we know that we want to not stop first k trials, we can set `min_curves=k`. Beyond that, we don't really know what the trials are going to be, so I don't see a use case where we could specify them to be not-stopped.

Storage code is also updated to discard the kwarg from json objects.

Reviewed By: ltiao

Differential Revision: D88502023


