### PR TITLE
Integrating efficient leave-one-out cross-validation for Gaussian processes

### DIFF
--- a/ax/adapter/tests/test_cross_validation.py
+++ b/ax/adapter/tests/test_cross_validation.py
@@ -8,10 +8,14 @@
 
 import warnings
 from collections.abc import Iterable
+from itertools import product
 from unittest import mock
 
 import numpy as np
+import torch
 from ax.adapter.cross_validation import (
+    _efficient_loo_cross_validate,
+    _fold_cross_validate,
     assess_model_fit,
     compute_diagnostics,
     cross_validate,
@@ -25,9 +29,12 @@ from ax.adapter.cross_validation import (
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.registry import Generators, MBM_X_trans, Y_trans
 from ax.adapter.torch import TorchAdapter
+from ax.adapter.transforms.standardize_y import StandardizeY
 from ax.adapter.transforms.transform_to_new_sq import TransformToNewSQ
 from ax.adapter.transforms.unit_x import UnitX
 from ax.core import ObservationFeatures
+from ax.core.arm import Arm
+from ax.core.data import Data
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
 from ax.core.observation import Observation, ObservationData
@@ -36,10 +43,13 @@ from ax.core.optimization_config import (
     OptimizationConfig,
 )
 from ax.core.outcome_constraint import OutcomeConstraint
+from ax.core.trial import Trial
 from ax.core.types import ComparisonOp, TParameterization
 from ax.exceptions.core import UnsupportedError
 from ax.exceptions.model import CrossValidationError
 from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
+from ax.generators.torch.botorch_modular.surrogate import Surrogate, SurrogateSpec
+from ax.generators.torch.botorch_modular.utils import ModelConfig
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
@@ -50,7 +60,19 @@ from ax.utils.testing.mock import (
     mock_botorch_optimize,
     mock_botorch_optimize_context_manager,
 )
+from botorch.cross_validation import CVResults, efficient_loo_cv, ensemble_loo_cv
 from botorch.exceptions.warnings import InputDataWarning
+from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
+from botorch.models.robust_relevance_pursuit_model import (
+    RobustRelevancePursuitSingleTaskGP,
+)
+from botorch.posteriors.gpytorch import GPyTorchPosterior
+from gpytorch.distributions import MultivariateNormal
+from linear_operator.operators import DiagLinearOperator
+from pandas import DataFrame
+
+# Number of in-design points created by _create_adapter_with_out_of_design_points()
+_OOD_ADAPTER_IN_DESIGN_COUNT = 3
 
 
 class CrossValidationTest(TestCase):
@@ -94,14 +116,14 @@ class CrossValidationTest(TestCase):
     def test_cross_validate_base(self) -> None:
         # Do cross validation
         with self.assertRaisesRegex(ValueError, "which is less than 4 folds"):
-            cross_validate(model=self.adapter, folds=4)
+            cross_validate(adapter=self.adapter, folds=4)
         with self.assertRaisesRegex(ValueError, "Folds must be"):
-            cross_validate(model=self.adapter, folds=0)
+            cross_validate(adapter=self.adapter, folds=0)
         # First 2-fold
         with mock.patch.object(
             self.adapter, "cross_validate", wraps=self.adapter.cross_validate
         ) as mock_cv:
-            result = cross_validate(model=self.adapter, folds=2)
+            result = cross_validate(adapter=self.adapter, folds=2)
         self.assertEqual(len(result), 4)
         # Check that Adapter.cross_validate was called correctly.
         z = mock_cv.mock_calls
@@ -118,11 +140,14 @@ class CrossValidationTest(TestCase):
             np.array_equal(sorted(all_test), np.array([2.0, 2.0, 3.0, 4.0]))
         )
 
-        # Test LOO
-        with mock.patch.object(
+        # Test LOO - use naive CV path by mocking efficient LOO
+        with mock.patch(
+            "ax.adapter.cross_validation._efficient_loo_cross_validate",
+            side_effect=ValueError("Force fallback to naive CV"),
+        ), mock.patch.object(
             self.adapter, "cross_validate", wraps=self.adapter.cross_validate
         ) as mock_cv:
-            result = cross_validate(model=self.adapter, folds=-1)
+            result = cross_validate(adapter=self.adapter, folds=-1)
         self.assertEqual(len(result), 4)
         z = mock_cv.mock_calls
         self.assertEqual(len(z), 3)
@@ -137,8 +162,11 @@ class CrossValidationTest(TestCase):
         self.assertTrue(
             np.array_equal(sorted(all_test), np.array([2.0, 2.0, 3.0, 4.0]))
         )
-        # Test LOO in transformed space
-        with mock.patch.object(
+        # Test LOO in transformed space - use naive path by mocking efficient LOO
+        with mock.patch(
+            "ax.adapter.cross_validation._efficient_loo_cross_validate",
+            side_effect=ValueError("Force fallback to naive CV"),
+        ), mock.patch.object(
             self.adapter,
             "_transform_inputs_for_cv",
             wraps=self.adapter._transform_inputs_for_cv,
@@ -148,7 +176,7 @@ class CrossValidationTest(TestCase):
             side_effect=lambda **kwargs: [self.observation_data]
             * len(kwargs["cv_test_points"]),
         ) as mock_cv:
-            result = cross_validate(model=self.adapter, folds=-1, untransform=False)
+            result = cross_validate(adapter=self.adapter, folds=-1, untransform=False)
         result_predicted_obs_data = [cv_result.predicted for cv_result in result]
         self.assertEqual(result_predicted_obs_data, [self.observation_data] * 4)
         # Check that Adapter._transform_inputs_for_cv was called correctly.
@@ -206,7 +234,7 @@ class CrossValidationTest(TestCase):
             self.adapter, "cross_validate", wraps=self.adapter.cross_validate
         ) as mock_cv:
             result = cross_validate(
-                model=self.adapter, folds=-1, test_selector=test_selector
+                adapter=self.adapter, folds=-1, test_selector=test_selector
             )
         self.assertEqual(len(result), 3)
         z = mock_cv.mock_calls
@@ -216,13 +244,16 @@ class CrossValidationTest(TestCase):
         )
         self.assertTrue(np.array_equal(sorted(all_test), np.array([2.0, 2.0, 3.0])))
 
-        # test observation noise
+        # test observation noise - use naive path by disabling efficient LOO
         for untransform in (True, False):
-            with mock.patch.object(
+            with mock.patch(
+                "ax.adapter.cross_validation._efficient_loo_cross_validate",
+                side_effect=ValueError("Force fallback to naive CV"),
+            ), mock.patch.object(
                 self.adapter, "_cross_validate", wraps=self.adapter._cross_validate
             ) as mock_cv:
                 result = cross_validate(
-                    model=self.adapter,
+                    adapter=self.adapter,
                     folds=-1,
                     use_posterior_predictive=True,
                     untransform=untransform,
@@ -247,7 +278,7 @@ class CrossValidationTest(TestCase):
                 self.adapter, "cross_validate", wraps=self.adapter.cross_validate
             ) as mock_cv:
                 result = cross_validate(
-                    model=self.adapter, fold_generator=fold_generator
+                    adapter=self.adapter, fold_generator=fold_generator
                 )
             self.assertEqual(len(result), 1)
             z = mock_cv.mock_calls
@@ -267,19 +298,19 @@ class CrossValidationTest(TestCase):
             return gen_trial_split(training_data=training_data, test_trials=[])
 
         with self.assertRaisesRegex(ValueError, "No test trials provided"):
-            cross_validate(model=self.adapter, fold_generator=fold_generator)
+            cross_validate(adapter=self.adapter, fold_generator=fold_generator)
 
         def fold_generator(training_data: ExperimentData) -> Iterable[CVData]:
             return gen_trial_split(training_data=training_data, test_trials=[5])
 
         with self.assertRaisesRegex(ValueError, "not all in training data"):
-            cross_validate(model=self.adapter, fold_generator=fold_generator)
+            cross_validate(adapter=self.adapter, fold_generator=fold_generator)
 
         def fold_generator(training_data: ExperimentData) -> Iterable[CVData]:
             return gen_trial_split(training_data=training_data, test_trials=[5])
 
         with self.assertRaisesRegex(ValueError, "not all in training data"):
-            cross_validate(model=self.adapter, fold_generator=fold_generator)
+            cross_validate(adapter=self.adapter, fold_generator=fold_generator)
 
         def fold_generator(training_data: ExperimentData) -> Iterable[CVData]:
             return gen_trial_split(
@@ -287,7 +318,7 @@ class CrossValidationTest(TestCase):
             )
 
         with self.assertRaisesRegex(ValueError, "Test and train trials overlap"):
-            cross_validate(model=self.adapter, fold_generator=fold_generator)
+            cross_validate(adapter=self.adapter, fold_generator=fold_generator)
 
         def fold_generator(training_data: ExperimentData) -> Iterable[CVData]:
             return gen_trial_split(
@@ -295,7 +326,7 @@ class CrossValidationTest(TestCase):
             )
 
         with self.assertRaisesRegex(ValueError, "All trials in data"):
-            cross_validate(model=self.adapter, fold_generator=fold_generator)
+            cross_validate(adapter=self.adapter, fold_generator=fold_generator)
 
     def test_cross_validate_with_data_reducing_transforms(self) -> None:
         # With transforms like TransformToNewSQ, the number of observations
@@ -313,13 +344,13 @@ class CrossValidationTest(TestCase):
         )
         # With untransform=True (default), it just works.
         with self.assertNoLogs(logger=logger):
-            res = cross_validate(model=adapter, folds=-1)
+            res = cross_validate(adapter=adapter, folds=-1)
         # SQ arm is repeated 3 times, so we add +2 for that.
         self.assertEqual(len(res), len(experiment.arms_by_name) + 2)
 
         # With untransform=False, LOOCV should work and log a warning.
         with self.assertLogs(logger=logger):
-            res = cross_validate(model=adapter, folds=-1, untransform=False)
+            res = cross_validate(adapter=adapter, folds=-1, untransform=False)
         # We only have one result for SQ arm here, due to TransformToNewSQ.
         self.assertEqual(len(res), len(experiment.arms_by_name))
 
@@ -328,7 +359,7 @@ class CrossValidationTest(TestCase):
             CrossValidationError,
             "fewer test observations than predictions",
         ):
-            cross_validate(model=adapter, folds=2, untransform=False)
+            cross_validate(adapter=adapter, folds=2, untransform=False)
 
     def test_cross_validate_gives_a_useful_error_for_insufficient_data(self) -> None:
         # Sobol with no data and torch with only one point.
@@ -339,7 +370,7 @@ class CrossValidationTest(TestCase):
             Generators.BOTORCH_MODULAR(experiment=exp),
         ]:
             with self.assertRaisesRegex(UnsupportedError, "at least two in-design"):
-                cross_validate(model=adapter)
+                cross_validate(adapter=adapter)
 
     @mock_botorch_optimize
     def test_cross_validate_catches_warnings(self) -> None:
@@ -349,7 +380,7 @@ class CrossValidationTest(TestCase):
         )
         for untransform in [False, True]:
             with warnings.catch_warnings(record=True) as ws:
-                cross_validate(model=model, untransform=untransform)
+                cross_validate(adapter=model, untransform=untransform)
                 self.assertFalse(any(w.category == InputDataWarning for w in ws))
 
     def test_cross_validate_raises_not_implemented_error_for_non_cv_model_with_data(
@@ -361,7 +392,7 @@ class CrossValidationTest(TestCase):
             experiment=exp, search_space=exp.search_space, data=exp.fetch_data()
         )
         with self.assertRaises(NotImplementedError):
-            cross_validate(model=sobol)
+            cross_validate(adapter=sobol)
 
     def test_compute_diagnostics(self) -> None:
         # Compute diagnostics
@@ -465,3 +496,563 @@ class CrossValidationTest(TestCase):
             assess_model_fit_result=assess_model_fit_result,
         )
         self.assertFalse(has_good_fit)
+
+    def test_efficient_loo_cv_is_attempted(self) -> None:
+        """Test that efficient LOO CV is attempted only when all conditions are met."""
+        # Setup adapter with a BoTorchGenerator
+        with mock.patch(
+            "botorch.cross_validation.efficient_loo_cv"
+        ) as mock_efficient_loo, mock.patch("botorch.cross_validation.ensemble_loo_cv"):
+            # Create mock LOO results
+            # Create a mock posterior
+            mock_mean = torch.tensor([[1.0], [2.0], [3.0], [4.0]])
+            mock_var = torch.tensor([[0.1], [0.1], [0.1], [0.1]])
+            mock_mvn = MultivariateNormal(
+                mean=mock_mean.squeeze(-1),
+                covariance_matrix=DiagLinearOperator(mock_var.squeeze(-1)),
+            )
+            mock_posterior = GPyTorchPosterior(distribution=mock_mvn)
+
+            # Get the surrogate model from the adapter
+            surrogate = self.adapter.generator.surrogate
+            model = surrogate.model
+
+            mock_loo_results = CVResults(
+                model=model,
+                posterior=mock_posterior,
+                observed_Y=torch.tensor([[1.0], [2.0], [3.0], [4.0]]),
+                observed_Yvar=None,
+            )
+            mock_efficient_loo.return_value = mock_loo_results
+
+            # Run cross_validate which will call _cross_validate for each fold
+            result = cross_validate(adapter=self.adapter, folds=-1)
+
+            # Verify we get results (either from efficient or fallback path)
+            self.assertEqual(len(result), 4)
+
+        # Test conditions that should prevent efficient LOO CV from being used
+        # Each tuple: (kwargs_override, adapter_override, description)
+        # pyre-ignore[9]: Type is correct for cross_validate kwargs
+        conditions_preventing_efficient_loo: list[
+            tuple[dict[str, object], TorchAdapter | None, str]
+        ] = [
+            ({"folds": 2}, None, "folds != -1"),
+            ({"test_selector": lambda _: True}, None, "test_selector provided"),
+        ]
+
+        def _fold_gen(td: ExperimentData) -> Iterable[CVData]:
+            return gen_trial_split(td, test_trials=[0])
+
+        conditions_preventing_efficient_loo.append(
+            ({"fold_generator": _fold_gen}, None, "fold_generator provided")
+        )
+
+        # Add refit_on_cv=True condition with separate adapter
+        with mock_botorch_optimize_context_manager():
+            adapter_refit = TorchAdapter(
+                experiment=self.experiment,
+                generator=BoTorchGenerator(refit_on_cv=True),
+                transforms=[UnitX],
+            )
+        conditions_preventing_efficient_loo.append(
+            ({}, adapter_refit, "refit_on_cv=True")
+        )
+
+        # Add auxiliary experiments condition
+        # We test that the condition is checked correctly by mocking
+        # get_training_data to avoid needing a fully functional adapter
+        exp_with_aux = mock.MagicMock()
+        exp_with_aux.auxiliary_experiments_by_purpose = {"some_purpose": ["aux_exp"]}
+        adapter_with_aux = mock.MagicMock(spec=TorchAdapter)
+        adapter_with_aux._experiment = exp_with_aux
+        adapter_with_aux.generator = BoTorchGenerator()
+
+        # For adapter with aux experiments, directly verify the condition check
+        # rather than running through the full cross_validate path
+        with self.subTest(condition="has auxiliary experiments"), mock.patch(
+            "ax.adapter.cross_validation._efficient_loo_cross_validate"
+        ) as mock_efficient, mock.patch(
+            "ax.adapter.cross_validation._fold_cross_validate"
+        ) as mock_fold:
+            mock_fold.return_value = []
+            cross_validate(adapter=adapter_with_aux)
+            self.assertFalse(
+                mock_efficient.called,
+                "Efficient LOO should not be called when has auxiliary experiments",
+            )
+
+        for kwargs, adapter_override, desc in conditions_preventing_efficient_loo:
+            adapter = adapter_override or self.adapter
+            with self.subTest(condition=desc), mock.patch(
+                "ax.adapter.cross_validation._efficient_loo_cross_validate"
+            ) as mock_efficient:
+                # pyre-ignore[6]: kwargs is properly typed for cross_validate
+                cross_validate(adapter=adapter, **kwargs)
+                self.assertFalse(
+                    mock_efficient.called,
+                    f"Efficient LOO should not be called when {desc}",
+                )
+
+        # Test logger when efficient LOO fails even though all conditions were met
+        with self.subTest(condition="efficient LOO fails with exception"):
+            with mock.patch(
+                "ax.adapter.cross_validation._efficient_loo_cross_validate"
+            ) as mock_efficient, mock.patch(
+                "ax.adapter.cross_validation._fold_cross_validate"
+            ) as mock_fold, mock.patch(
+                "ax.adapter.cross_validation.logger"
+            ) as mock_logger:
+                # Force efficient LOO to fail
+                mock_efficient.side_effect = ValueError("Test failure reason")
+                mock_fold.return_value = []
+
+                # Run cross_validate - should fall back to fold CV
+                cross_validate(adapter=self.adapter, folds=-1)
+
+                # Verify efficient LOO was attempted
+                self.assertTrue(mock_efficient.called)
+                # Verify fold CV was used as fallback
+                self.assertTrue(mock_fold.called)
+                # Verify the failure was logged
+                mock_logger.debug.assert_called_once()
+                log_message = mock_logger.debug.call_args[0][0]
+                self.assertIn("Efficient LOO CV failed", log_message)
+                self.assertIn("Test failure reason", log_message)
+
+    def test_efficient_loo_cv_matches_naive(self) -> None:
+        """End-to-end test: Ax.Adapter.cross_validate returns same results
+        whether using efficient LOO CV or naive implementation.
+
+        With refit_on_cv=False, both approaches should produce mathematically
+        identical results because:
+        1. Same hyperparameters are used (no refitting)
+        2. Same LOO training/test splits (with unique arm names)
+        3. Same posterior computation
+
+        Tests all combinations of:
+        - untransform: True and False
+        - use_posterior_predictive: True and False
+        - with_out_of_design_points: True and False
+
+        This test uses StandardizeY (a Y-transform) to verify that the efficient
+        LOO CV path correctly handles observation transforms. The Y-transform is
+        critical because it changes the Y values between original and transformed
+        space, and bugs in transform/untransform handling would cause observations
+        and predictions to be compared in different spaces.
+
+        It also tests out-of-design filtering by using expand_model_space=False
+        to prevent automatic expansion of the model space bounds.
+        """
+        # Test all configurations
+        for untransform, use_posterior_predictive, with_ood in product(
+            [True, False], [True, False], [False, True]
+        ):
+            with mock_botorch_optimize_context_manager():
+                if with_ood:
+                    adapter = _create_adapter_with_out_of_design_points()
+                    expected_count = _OOD_ADAPTER_IN_DESIGN_COUNT
+                else:
+                    adapter = _create_adapter_with_all_in_design_points()
+                    expected_count = None
+
+            with self.subTest(
+                with_out_of_design=with_ood,
+                untransform=untransform,
+                use_posterior_predictive=use_posterior_predictive,
+            ):
+                self._test_efficient_loo_cv_matches_naive(
+                    adapter=adapter,
+                    untransform=untransform,
+                    use_posterior_predictive=use_posterior_predictive,
+                    expected_in_design_count=expected_count,
+                )
+
+    def _test_efficient_loo_cv_matches_naive(
+        self,
+        adapter: TorchAdapter,
+        untransform: bool,
+        use_posterior_predictive: bool,
+        expected_in_design_count: int | None,
+    ) -> None:
+        """Run efficient vs naive CV and compare results.
+
+        Args:
+            adapter: The TorchAdapter to test.
+            untransform: Whether to untransform predictions to original space.
+            use_posterior_predictive: Whether to use posterior predictive.
+            expected_in_design_count: Expected number of in-design points,
+                or None if all points are in-design.
+        """
+        # Verify OOD setup if expected
+        if expected_in_design_count is not None:
+            all_data = adapter.get_training_data(filter_in_design=False)
+            in_design_data = adapter.get_training_data(filter_in_design=True)
+            self.assertGreater(
+                len(all_data.arm_data),
+                len(in_design_data.arm_data),
+                "Test setup error: expected some out-of-design points",
+            )
+            self.assertEqual(
+                len(in_design_data.arm_data),
+                expected_in_design_count,
+                f"Test setup error: expected {expected_in_design_count} in-design "
+                "points",
+            )
+
+        # Run naive CV (by forcing fallback)
+        with mock.patch(
+            "ax.adapter.cross_validation._efficient_loo_cross_validate",
+            side_effect=ValueError("Force fallback to naive CV"),
+        ), mock.patch(
+            "ax.adapter.cross_validation._fold_cross_validate",
+            wraps=_fold_cross_validate,
+        ) as mock_naive_cv:
+            result_naive = cross_validate(
+                adapter=adapter,
+                folds=-1,
+                untransform=untransform,
+                use_posterior_predictive=use_posterior_predictive,
+            )
+
+            # Verify naive path was used
+            self.assertTrue(mock_naive_cv.called, "Naive CV not called")
+
+        # Run efficient CV
+        with mock.patch(
+            "ax.adapter.cross_validation._efficient_loo_cross_validate",
+            wraps=_efficient_loo_cross_validate,
+        ) as mock_efficient, mock.patch(
+            "ax.adapter.cross_validation._fold_cross_validate",
+        ) as mock_naive:
+            result_efficient = cross_validate(
+                adapter=adapter,
+                folds=-1,
+                untransform=untransform,
+                use_posterior_predictive=use_posterior_predictive,
+            )
+
+            # Verify efficient path was used successfully
+            self.assertTrue(mock_efficient.called, "Efficient LOO CV not called")
+            self.assertFalse(
+                mock_naive.called,
+                "Naive CV was called (efficient failed)",
+            )
+
+        # Verify result counts match
+        self.assertEqual(len(result_efficient), len(result_naive))
+
+        # Verify OOD filtering if expected
+        if expected_in_design_count is not None:
+            self.assertEqual(
+                len(result_efficient),
+                expected_in_design_count,
+                "Should only include in-design points",
+            )
+
+        # Sort for consistent comparison
+        def sort_key(cv_result: CVResult) -> tuple[float, ...]:
+            return tuple(cv_result.observed.data.means.tolist())
+
+        result_efficient_sorted = sorted(result_efficient, key=sort_key)
+        result_naive_sorted = sorted(result_naive, key=sort_key)
+
+        # Verify observations are in correct space (only for non-OOD case
+        # where we have StandardizeY with controlled Y values)
+        if expected_in_design_count is None:
+            for cv_result in result_efficient_sorted:
+                obs_means = cv_result.observed.data.means
+                if untransform:
+                    self.assertTrue(
+                        np.all(obs_means > 5.0),
+                        f"untransform=True: expected original space, "
+                        f"got {obs_means}",
+                    )
+                else:
+                    self.assertTrue(
+                        np.all(np.abs(obs_means) < 3.0),
+                        f"untransform=False: expected standardized, "
+                        f"got {obs_means}",
+                    )
+
+        # Compare predictions
+        for cv_efficient, cv_naive in zip(
+            result_efficient_sorted, result_naive_sorted, strict=True
+        ):
+            np.testing.assert_array_equal(
+                cv_efficient.observed.data.means,
+                cv_naive.observed.data.means,
+            )
+            np.testing.assert_allclose(
+                cv_efficient.predicted.means,
+                cv_naive.predicted.means,
+                rtol=1e-4,
+                atol=1e-6,
+                err_msg="Predicted means don't match",
+            )
+            np.testing.assert_allclose(
+                cv_efficient.predicted.covariance,
+                cv_naive.predicted.covariance,
+                rtol=1e-4,
+                atol=1e-6,
+                err_msg="Predicted covariances don't match",
+            )
+
+    def test_efficient_loo_cv_with_robust_relevance_pursuit_model(self) -> None:
+        """Test that RobustRelevancePursuitSingleTaskGP uses efficient LOO CV.
+
+        This test verifies that:
+        1) An Adapter with a RobustRelevancePursuitSingleTaskGP surrogate can
+           execute CV successfully using the efficient implementation.
+        2) If the efficient implementation fails, the entire CV fails because
+           the robust relevance pursuit model doesn't support the regular CV path
+           (due to state incompatibility when refitting).
+        """
+        # Create a simple experiment with data
+        experiment = get_branin_experiment(with_batch=True, with_completed_batch=True)
+
+        # Create adapter with RobustRelevancePursuitSingleTaskGP
+        adapter = TorchAdapter(
+            experiment=experiment,
+            generator=BoTorchGenerator(
+                surrogate=Surrogate(
+                    surrogate_spec=SurrogateSpec(
+                        model_configs=[
+                            ModelConfig(
+                                botorch_model_class=RobustRelevancePursuitSingleTaskGP,
+                            )
+                        ],
+                    ),
+                ),
+            ),
+            transforms=[UnitX],
+        )
+
+        # Part 1: Verify that efficient LOO CV works with this model
+        # The efficient implementation should be called and succeed
+        with mock.patch(
+            "botorch.cross_validation.efficient_loo_cv",
+            wraps=efficient_loo_cv,
+        ) as mock_efficient_loo:
+            result = cross_validate(adapter=adapter, folds=-1)
+
+            # Verify we got results
+            self.assertGreater(len(result), 0)
+
+            # Verify efficient_loo_cv was called (at least once per unique fold)
+            self.assertTrue(mock_efficient_loo.called)
+
+        # Part 2: Verify that if efficient implementation fails, CV fails entirely
+        # because RobustRelevancePursuitSingleTaskGP doesn't support naive CV
+        # (due to state_dict size mismatch when the model is refitted with LOO data)
+        with mock.patch(
+            "ax.adapter.cross_validation._efficient_loo_cross_validate",
+            side_effect=ValueError("Simulated efficient LOO CV failure"),
+        ):
+            # The naive CV path should fail for RobustRelevancePursuitSingleTaskGP
+            # because it uses SparseOutlierGaussianLikelihood which has state
+            # (raw_rho) that changes during fitting and can't be transferred
+            # to a model fitted on different data
+            with self.assertRaises((ValueError, RuntimeError)):
+                cross_validate(adapter=adapter, folds=-1)
+
+    def test_efficient_loo_cv_with_fully_bayesian_model(self) -> None:
+        """Test that FullyBayesianSAAS models use efficient LOO CV via ensemble_loo_cv.
+
+        This test verifies that:
+        1) An Adapter with a SaasFullyBayesianSingleTaskGP surrogate triggers
+           the efficient LOO CV path.
+        2) The ensemble_loo_cv function is used (not efficient_loo_cv) because
+           SaasFullyBayesianSingleTaskGP has _is_ensemble=True.
+        3) The efficient and naive implementations produce matching results.
+        """
+        # Create a simple experiment with data
+        experiment = get_branin_experiment(with_batch=True, with_completed_batch=True)
+
+        # Create adapter with SaasFullyBayesianSingleTaskGP
+        adapter = TorchAdapter(
+            experiment=experiment,
+            generator=BoTorchGenerator(
+                surrogate=Surrogate(
+                    surrogate_spec=SurrogateSpec(
+                        model_configs=[
+                            ModelConfig(
+                                botorch_model_class=SaasFullyBayesianSingleTaskGP,
+                            )
+                        ],
+                    ),
+                )
+            ),
+            transforms=[UnitX],
+        )
+
+        # We need to mock the MCMC fitting to avoid running actual NUTS sampling
+        # which is very slow. Instead, we'll inject mock MCMC samples.
+        surrogate = adapter.generator.surrogate  # pyre-ignore[16]
+        model = surrogate.model
+
+        # Verify the model is a SaasFullyBayesianSingleTaskGP
+        self.assertIsInstance(model, SaasFullyBayesianSingleTaskGP)
+
+        # Get training data shape info
+        train_X = model.train_inputs[0]
+        d = train_X.shape[-1]
+        num_models = 4  # Number of MCMC samples
+
+        # Create mock MCMC samples
+        tkwargs = {"dtype": train_X.dtype, "device": train_X.device}
+        mcmc_samples = {
+            "lengthscale": torch.rand(num_models, 1, d, **tkwargs),
+            "outputscale": torch.rand(num_models, **tkwargs),
+            "mean": torch.randn(num_models, **tkwargs),
+            "noise": torch.rand(num_models, 1, **tkwargs) * 0.1 + 0.01,
+        }
+        model.load_mcmc_samples(mcmc_samples)
+
+        # Verify the model is an ensemble model
+        self.assertTrue(model._is_ensemble)
+
+        # Part 1: Run cross_validate with efficient LOO CV disabled first
+        # (by making _efficient_loo_cross_validate raise a ValueError so it uses naive)
+        with mock.patch(
+            "ax.adapter.cross_validation._efficient_loo_cross_validate",
+            side_effect=ValueError("Force fallback to naive CV"),
+        ):
+            result_naive = cross_validate(adapter=adapter, folds=-1)
+
+        # Part 2: Run cross_validate with efficient LOO CV enabled (default path)
+        # Also verify that ensemble_loo_cv is called
+        with mock.patch(
+            "botorch.cross_validation.ensemble_loo_cv",
+            wraps=ensemble_loo_cv,
+        ) as mock_ensemble_loo:
+            result_efficient = cross_validate(adapter=adapter, folds=-1)
+
+            # Verify ensemble_loo_cv was called (at least once per unique fold)
+            self.assertTrue(mock_ensemble_loo.called)
+
+        # Part 3: Compare the predictions from both methods
+        # Both should return the same number of results
+        self.assertEqual(len(result_efficient), len(result_naive))
+
+        # Sort both results by observed means to ensure consistent comparison
+        # (ordering may differ between efficient and naive implementations)
+        def sort_key(cv_result: CVResult) -> tuple[float, ...]:
+            return tuple(cv_result.observed.data.means.tolist())
+
+        result_efficient_sorted = sorted(result_efficient, key=sort_key)
+        result_naive_sorted = sorted(result_naive, key=sort_key)
+
+        for cv_efficient, cv_naive in zip(
+            result_efficient_sorted, result_naive_sorted, strict=True
+        ):
+            # The observed values should be identical
+            np.testing.assert_array_equal(
+                cv_efficient.observed.data.means,
+                cv_naive.observed.data.means,
+            )
+
+            # The predicted means should be very close
+            np.testing.assert_allclose(
+                cv_efficient.predicted.means,
+                cv_naive.predicted.means,
+                rtol=1e-4,
+                atol=1e-6,
+                err_msg="Efficient and naive LOO CV predicted means don't match",
+            )
+
+            # The predicted covariances should be very close
+            np.testing.assert_allclose(
+                cv_efficient.predicted.covariance,
+                cv_naive.predicted.covariance,
+                rtol=1e-4,
+                atol=1e-6,
+                err_msg="Efficient and naive LOO CV predicted covariances don't match",
+            )
+
+
+def _create_adapter_with_all_in_design_points() -> TorchAdapter:
+    """Create a test adapter where all points are in-design.
+
+    Creates an experiment with 4 unique parameterizations and Y values
+    with clear variation for StandardizeY testing.
+
+    Returns:
+        A TorchAdapter with all points in-design.
+    """
+    # pyre-ignore [9]: Pyre is too picky with union types.
+    parameterizations: list[TParameterization] = [
+        {"x": x} for x in [1.0, 2.0, 3.0, 4.0]
+    ]
+    # Use Y values with clear variation for StandardizeY
+    means = [[10.0, 20.0], [20.0, 30.0], [30.0, 40.0], [40.0, 50.0]]
+    sems = [[1.0, 2.0], [1.0, 2.0], [1.0, 2.0], [1.0, 2.0]]
+    experiment = get_experiment_with_observations(
+        observations=means,
+        sems=sems,
+        search_space=get_search_space_for_range_value(min=0.0, max=10.0),
+        parameterizations=parameterizations,
+    )
+
+    return TorchAdapter(
+        experiment=experiment,
+        generator=BoTorchGenerator(refit_on_cv=False),
+        transforms=[UnitX, StandardizeY],
+    )
+
+
+def _create_adapter_with_out_of_design_points() -> TorchAdapter:
+    """Create a test adapter with out-of-design points.
+
+    Creates a branin experiment with 3 in-design trials and 1 out-of-design
+    trial (outside the search space bounds). Uses expand_model_space=False
+    to prevent automatic expansion of model space bounds.
+
+    Returns:
+        A TorchAdapter with 3 in-design points and 1 out-of-design point.
+    """
+    # Create branin experiment with manually added OOD trial
+    experiment = get_branin_experiment(with_batch=False)
+
+    # Add in-design trials
+    # NOTE: The number of in-design points must match _OOD_ADAPTER_IN_DESIGN_COUNT
+    in_design_points = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)]
+    assert len(in_design_points) == _OOD_ADAPTER_IN_DESIGN_COUNT
+    for i, (x1, x2) in enumerate(in_design_points):
+        trial = experiment.new_trial()
+        arm = Arm(parameters={"x1": x1, "x2": x2}, name=f"in_design_{i}")
+        trial.add_arm(arm)
+        trial.run()
+        trial.mark_completed()
+
+    # Add out-of-design trial (outside bounds)
+    ood_trial = experiment.new_trial()
+    ood_arm = Arm(parameters={"x1": 100.0, "x2": 100.0}, name="out_of_design")
+    ood_trial.add_arm(ood_arm)
+    ood_trial.run()
+    ood_trial.mark_completed()
+
+    # Attach data
+    branin_metric = experiment.metrics["branin"]
+    metric_signature = branin_metric.signature
+    data_rows = []
+    for trial_index, trial in experiment.trials.items():
+        if isinstance(trial, Trial) and trial.arm is not None:
+            data_rows.append(
+                {
+                    "arm_name": trial.arm.name,
+                    "trial_index": trial_index,
+                    "metric_name": "branin",
+                    "metric_signature": metric_signature,
+                    "mean": float(trial_index) + 1.0,
+                    "sem": 0.1,
+                }
+            )
+    experiment.attach_data(Data(df=DataFrame(data_rows)))
+
+    return TorchAdapter(
+        experiment=experiment,
+        generator=BoTorchGenerator(refit_on_cv=False),
+        transforms=[UnitX, StandardizeY],
+        expand_model_space=False,
+    )

--- a/ax/adapter/tests/test_hierarchical_search_space.py
+++ b/ax/adapter/tests/test_hierarchical_search_space.py
@@ -219,7 +219,7 @@ class TestHierarchicalSearchSpace(TestCase):
                     )
                 ]
             )
-        cv_res = cross_validate(model=mbm)
+        cv_res = cross_validate(adapter=mbm)
         self.assertEqual(len(cv_res), len(experiment.trials))
 
     def test_with_non_hierarchical_hss(self) -> None:

--- a/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
@@ -200,7 +200,7 @@ class ClientTest(TestCase):
         self.assertListEqual(dataset.feature_names, ["width", "height"])
 
         # Check that cross validation works.
-        cross_validate(model=adapter)
+        cross_validate(adapter=adapter)
 
     def _test_early_stopping(self, complete_with_progression: bool) -> None:
         self._simulate(
@@ -247,7 +247,7 @@ class ClientTest(TestCase):
         self.assertEqual(int(candidate_metadata["step"]), 1.0)
 
         # Check that cross validation works.
-        cross_validate(model=adapter)
+        cross_validate(adapter=adapter)
 
     def test_no_early_stopping_with_progression(self) -> None:
         self._test_no_early_stopping(with_progression=True)

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -132,7 +132,7 @@ class CrossValidationPlot(Analysis):
 
         cards = []
         cv_results = cross_validate(
-            model=relevant_adapter, folds=self.folds, untransform=self.untransform
+            adapter=relevant_adapter, folds=self.folds, untransform=self.untransform
         )
         relevant_adapter_metric_names = [
             relevant_adapter._experiment.signature_to_metric[signature].name

--- a/ax/generation_strategy/generator_spec.py
+++ b/ax/generation_strategy/generator_spec.py
@@ -177,7 +177,7 @@ class GeneratorSpec(SortableBase, SerializationMixin):
 
         self._assert_fitted()
         try:
-            self._cv_results = cross_validate(model=self.fitted_adapter, **cv_kwargs)
+            self._cv_results = cross_validate(adapter=self.fitted_adapter, **cv_kwargs)
         except NotImplementedError:
             warnings.warn(
                 f"{self.generator_enum.value} cannot be cross validated", stacklevel=2

--- a/ax/generation_strategy/tests/test_generator_spec.py
+++ b/ax/generation_strategy/tests/test_generator_spec.py
@@ -95,7 +95,7 @@ class GeneratorSpecTest(BaseGeneratorSpecTest):
             data=self.experiment.trials[0].fetch_data(),
         )
         cv_results, cv_diagnostics = ms.cross_validate()
-        mock_cv.assert_called_with(model=fake_mb, test_key="test-value")
+        mock_cv.assert_called_with(adapter=fake_mb, test_key="test-value")
         mock_diagnostics.assert_called_with(["fake-cv-result"])
 
         self.assertIsNotNone(cv_results)
@@ -125,7 +125,7 @@ class GeneratorSpecTest(BaseGeneratorSpecTest):
 
             self.assertIsNotNone(cv_results)
             self.assertIsNotNone(cv_diagnostics)
-            mock_cv.assert_called_with(model=fake_mb, test_key="test-value")
+            mock_cv.assert_called_with(adapter=fake_mb, test_key="test-value")
             mock_diagnostics.assert_called_with(["fake-cv-result"])
 
         with self.subTest("pass in optional kwargs"):
@@ -138,7 +138,7 @@ class GeneratorSpecTest(BaseGeneratorSpecTest):
 
             self.assertIsNotNone(cv_results)
             self.assertIsNotNone(cv_diagnostics)
-            mock_cv.assert_called_with(model=fake_mb, test_key="test-value", test=1)
+            mock_cv.assert_called_with(adapter=fake_mb, test_key="test-value", test=1)
             self.assertEqual(ms._last_cv_kwargs, {"test": 1, "test_key": "test-value"})
 
     @patch(f"{GeneratorSpec.__module__}.compute_diagnostics")
@@ -165,7 +165,7 @@ class GeneratorSpecTest(BaseGeneratorSpecTest):
         self.assertIsNone(cv_results)
         self.assertIsNone(cv_diagnostics)
 
-        mock_cv.assert_called_with(model="fake-adapter", test_key="test-value")
+        mock_cv.assert_called_with(adapter="fake-adapter", test_key="test-value")
         mock_diagnostics.assert_not_called()
 
     def test_fixed_features(self) -> None:

--- a/ax/plot/tests/test_diagnostic.py
+++ b/ax/plot/tests/test_diagnostic.py
@@ -25,7 +25,7 @@ class DiagnosticTest(TestCase):
         super().setUp()
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].run()
-        self.model = Generators.BOTORCH_MODULAR(
+        self.adapter = Generators.BOTORCH_MODULAR(
             # Adapter kwargs
             experiment=exp,
             data=exp.fetch_data(),
@@ -33,7 +33,7 @@ class DiagnosticTest(TestCase):
 
     def test_cross_validation(self) -> None:
         for autoset_axis_limits in [False, True]:
-            cv = cross_validate(self.model)
+            cv = cross_validate(adapter=self.adapter)
             # Assert that each type of plot can be constructed successfully
             label_dict = {"branin": "BrAnIn"}
             plot = interact_cross_validation_plotly(

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -288,7 +288,7 @@ def get_best_parameters_from_model_predictions_with_trial_index(
         return _extract_best_arm_from_gr(gr=gr, trials=experiment.trials)
 
     # Check to see if the adapter is worth using.
-    cv_results = cross_validate(model=adapter)
+    cv_results = cross_validate(adapter=adapter)
     diagnostics = compute_diagnostics(result=cv_results)
     assess_model_fit_results = assess_model_fit(diagnostics=diagnostics)
 

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -92,8 +92,8 @@ UNPREDICTABLE_METRICS_MESSAGE = (
 )
 
 
-def _get_cross_validation_plots(model: Adapter) -> list[go.Figure]:
-    cv = cross_validate(model=model)
+def _get_cross_validation_plots(adapter: Adapter) -> list[go.Figure]:
+    cv = cross_validate(adapter=adapter)
     return [
         interact_cross_validation_plotly(
             cv_results=cv, caption=CROSS_VALIDATION_CAPTION
@@ -407,7 +407,7 @@ def get_standard_plots(
 
         try:
             logger.debug("Starting cross validation plot.")
-            output_plot_list.extend(_get_cross_validation_plots(model=model))
+            output_plot_list.extend(_get_cross_validation_plots(adapter=model))
             logger.debug("Finished cross validation plot.")
         except Exception as e:
             logger.exception(f"Cross-validation plot failed with error: {e}")


### PR DESCRIPTION
Summary: This commit integrates the newly introduced efficient leave-one-out cross-validation functionality for BoTorch's Gaussian process models into Ax's cross-validation stack.

Differential Revision: D88274647


