### PR TITLE
Add expect_relativized_outcomes flag to PreferenceOptimizationConfig

### DIFF
--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -497,6 +497,7 @@ class PreferenceOptimizationConfig(MultiObjectiveOptimizationConfig):
         objective: MultiObjective,
         preference_profile_name: str,
         outcome_constraints: list[OutcomeConstraint] | None = None,
+        expect_relativized_outcomes: bool = False,
         pruning_target_parameterization: Arm | None = None,
     ) -> None:
         """Inits PreferenceOptimizationConfig.
@@ -509,6 +510,12 @@ class PreferenceOptimizationConfig(MultiObjectiveOptimizationConfig):
                 this name and purpose PE_EXPERIMENT should be attached to
                 the experiment.
             outcome_constraints: Constraints on metrics. Not yet supported.
+            expect_relativized_outcomes: Whether the learned objective expects outcomes
+                in relative percentage scale (e.g., -1 means -1% change vs. status quo)
+                after transforms. When True, TorchAdapter validates that a
+                RelativizeWithConstantControl transform exists in the pipeline
+                to convert absolute outcomes to relative scale before reaching the
+                preference model.
             pruning_target_parameterization: Arm containing the target values for
                 irrelevant parameters. The target values are used to prune irrelevant
                 parameters from candidates generated via Bayesian optimization: when
@@ -535,6 +542,7 @@ class PreferenceOptimizationConfig(MultiObjectiveOptimizationConfig):
             pruning_target_parameterization=pruning_target_parameterization,
         )
         self.preference_profile_name = preference_profile_name
+        self.expect_relativized_outcomes = expect_relativized_outcomes
 
     @property
     def is_bope_problem(self) -> bool:
@@ -552,6 +560,7 @@ class PreferenceOptimizationConfig(MultiObjectiveOptimizationConfig):
         objective: MultiObjective | None = None,
         preference_profile_name: str | None = None,
         outcome_constraints: list[OutcomeConstraint] | None = _NO_OUTCOME_CONSTRAINTS,
+        expect_relativized_outcomes: bool | None = None,
         pruning_target_parameterization: Arm
         | None = _NO_PRUNING_TARGET_PARAMETERIZATION,
     ) -> PreferenceOptimizationConfig:
@@ -572,6 +581,11 @@ class PreferenceOptimizationConfig(MultiObjectiveOptimizationConfig):
             if outcome_constraints is _NO_OUTCOME_CONSTRAINTS
             else outcome_constraints
         )
+        expect_relativized_outcomes = (
+            self.expect_relativized_outcomes
+            if expect_relativized_outcomes is None
+            else expect_relativized_outcomes
+        )
         pruning_target_parameterization = (
             self.pruning_target_parameterization
             if pruning_target_parameterization is _NO_PRUNING_TARGET_PARAMETERIZATION
@@ -582,6 +596,7 @@ class PreferenceOptimizationConfig(MultiObjectiveOptimizationConfig):
             objective=objective,
             preference_profile_name=preference_profile_name,
             outcome_constraints=outcome_constraints,
+            expect_relativized_outcomes=expect_relativized_outcomes,
             pruning_target_parameterization=pruning_target_parameterization,
         )
 
@@ -590,5 +605,8 @@ class PreferenceOptimizationConfig(MultiObjectiveOptimizationConfig):
             f"{self.__class__.__name__}("
             "objective=" + repr(self.objective) + ", "
             "preference_profile_name=" + repr(self.preference_profile_name) + ", "
-            "outcome_constraints=" + repr(self.outcome_constraints)
+            "outcome_constraints=" + repr(self.outcome_constraints) + ", "
+            "expect_relativized_outcomes="
+            + repr(self.expect_relativized_outcomes)
+            + ")"
         )


### PR DESCRIPTION
Summary:
Adds an `expect_relativized_outcomes` boolean flag to `PreferenceOptimizationConfig` to validate that outcomes are in the expected scale (relative percentage vs. absolute) before reaching the preference model. This flag will be used in later steps by the adapter layer to validate that appropriate transform pipelines are in place.

meta: although we expect relativized outcomes in PTS where BOPE is primarily used, it is a natural default to expect the outcomes to be on their raw, original scale. This is part of [the plan](https://docs.google.com/document/d/185KQovo9WAkBsIzpERZR6apRg6lbayUI0o1wZjF9EnY/edit?usp=sharing) to replace PLBO node with regular MBM node + PrefOptConfig in PTS

Differential Revision: D87721201


