### PR TITLE
Add SelectiveRelativizeWithConstantControl conditional transform

### DIFF
--- a/ax/adapter/torch.py
+++ b/ax/adapter/torch.py
@@ -47,7 +47,10 @@ from ax.adapter.transforms.derelativize import Derelativize
 from ax.adapter.transforms.fill_missing_parameters import FillMissingParameters
 from ax.adapter.transforms.int_range_to_choice import IntRangeToChoice
 from ax.adapter.transforms.log import Log
-from ax.adapter.transforms.relativize import RelativizeWithConstantControl
+from ax.adapter.transforms.relativize import (
+    RelativizeWithConstantControl,
+    SelectiveRelativizeWithConstantControl,
+)
 from ax.adapter.transforms.remove_fixed import RemoveFixed
 from ax.adapter.transforms.search_space_to_choice import SearchSpaceToChoice
 from ax.adapter.transforms.task_encode import TaskChoiceToIntTaskChoice
@@ -117,7 +120,8 @@ BOPE_ALLOWED_TRANSFORMS: set[type[Transform]] = {
     TransformToNewSQ,  # Doesn't distort outcome scales
     # not allowing Relativize here as it doesn't guarantee
     # the untransformed SEM is always valid
-    RelativizeWithConstantControl,  # Outcome transfom used by BOPE
+    RelativizeWithConstantControl,  # Outcome transfom for BOPE
+    SelectiveRelativizeWithConstantControl,  # Conditional transform for BOPE
 }
 
 

--- a/ax/storage/transform_registry.py
+++ b/ax/storage/transform_registry.py
@@ -28,7 +28,11 @@ from ax.adapter.transforms.metadata_to_task import MetadataToTask
 from ax.adapter.transforms.metrics_as_task import MetricsAsTask
 from ax.adapter.transforms.one_hot import OneHot
 from ax.adapter.transforms.power_transform_y import PowerTransformY
-from ax.adapter.transforms.relativize import Relativize, RelativizeWithConstantControl
+from ax.adapter.transforms.relativize import (
+    Relativize,
+    RelativizeWithConstantControl,
+    SelectiveRelativizeWithConstantControl,
+)
 from ax.adapter.transforms.remove_fixed import RemoveFixed
 from ax.adapter.transforms.search_space_to_choice import SearchSpaceToChoice
 from ax.adapter.transforms.standardize_y import StandardizeY
@@ -90,6 +94,7 @@ TRANSFORM_REGISTRY: set[type[Transform]] = {
     LogY,
     Relativize,
     RelativizeWithConstantControl,
+    SelectiveRelativizeWithConstantControl,
     MergeRepeatedMeasurements,
     TimeAsFeature,
     TransformToNewSQ,


### PR DESCRIPTION
Summary: Enables BOPE/PLBO to work with any MBM generation node by conditionally applying relativization based on the optimization config type. This transform applies SelectiveRelativizeWithConstantControl only when PreferenceOptimizationConfig.expect_relativized_outcomes=True, otherwise it acts as a no-op pass-through. This allows a single transform pipeline to support both regular BO and preference-based optimization.

Differential Revision: D88682775


