### PR TITLE
Add best trial vulnerability simulation for early stopping safety

### DIFF
--- a/ax/early_stopping/simulation.py
+++ b/ax/early_stopping/simulation.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from dataclasses import dataclass
+from heapq import nsmallest
+from typing import Iterable
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from ax.early_stopping.utils import _interval_boundary
+
+
+@dataclass
+class EarlyStoppingSimulationResult:
+    """Result of early-stopping vulnerability simulation."""
+
+    # Whether the best eligible trial would have been stopped
+    best_stopped: bool
+
+    # Index of the best eligible trial
+    best_trial_index: int | None
+
+    # Progression where best trial would have been stopped (if best_stopped is True)
+    best_stop_progression: float | None = None
+
+
+def _get_interval_progressions(
+    progressions: npt.NDArray,
+    min_progression: float,
+    interval: float | None,
+) -> npt.NDArray:
+    """Filter progressions to only include those at interval boundaries.
+
+    Interval boundaries are at min_progression + k * interval for k = 0, 1, 2, ...
+    For each interval, we select the first progression that falls within it.
+
+    Args:
+        progressions: Array of progression values to filter.
+        min_progression: The minimum progression (start of first interval).
+        interval: The interval size. If None, returns progressions unchanged.
+
+    Returns:
+        Array of progressions, one per interval that contains data.
+    """
+    if interval is None or len(progressions) == 0:
+        return progressions
+    boundaries = _interval_boundary(
+        progression=progressions,
+        min_progression=min_progression,
+        interval=interval,
+    )
+    # Select first progression in each interval (where boundary changes)
+    return progressions[np.r_[True, np.diff(boundaries) != 0]]
+
+
+def _check_patience_window(
+    wide_df: pd.DataFrame,
+    trial_indices: set[int],
+    progression: float,
+    patience: float,
+    min_progression: float,
+    quantile: float,
+    minimize: bool,
+    n_best_trials_to_complete: int | None,
+    reference_trial_indices: set[int] | None = None,
+) -> pd.Series:
+    """Check which trials underperform at all progressions in the patience window.
+
+    The patience window is defined as [progression - patience, progression]. A trial
+    is considered to be stopped only if it underperforms (relative to the quantile
+    threshold) at ALL progressions within this window.
+
+    Args:
+        wide_df: DataFrame with progressions as index and trial indices as columns.
+        trial_indices: Set of trial indices to check.
+        progression: The current progression (end of the patience window).
+        patience: The patience value defining the window size.
+        min_progression: The minimum progression (window start is clamped to this).
+        quantile: The quantile threshold in [0, 1] range (already adjusted for
+            minimize direction).
+        minimize: Whether we're minimizing the metric.
+        n_best_trials_to_complete: If specified, trials in the top N at any
+            progression in the window are protected from stopping.
+        reference_trial_indices: Set of trial indices to use for computing quantile
+            thresholds. If None, uses all columns in wide_df.
+
+    Returns:
+        Boolean Series indexed by trial indices, True if trial should be stopped.
+    """
+    trial_cols = [*trial_indices]
+    if not trial_indices:
+        return pd.Series(dtype=bool, index=trial_cols)
+
+    window_start = progression - patience
+    window_selector = (wide_df.index >= window_start) & (wide_df.index <= progression)
+    window_values = wide_df.loc[window_selector]
+
+    # Check n_best_trials_to_complete protection
+    if n_best_trials_to_complete is not None:
+        # Rank against reference trials + trials being checked (the "world")
+        rank_cols = (
+            [*reference_trial_indices.union(trial_indices)]
+            if reference_trial_indices is not None
+            else wide_df.columns
+        )
+        # method='dense' assigns same rank to ties
+        window_ranks = window_values[rank_cols].rank(
+            method="dense", axis=1, ascending=minimize
+        )
+        # Protect trials that are in top K at any progression in window
+        is_protected = (window_ranks[trial_cols] <= n_best_trials_to_complete).any(
+            axis=0
+        )
+    else:
+        is_protected = pd.Series(False, index=trial_cols)
+
+    # Calculate threshold at each progression in the window
+    ref_cols = (
+        [*reference_trial_indices]
+        if reference_trial_indices is not None
+        else wide_df.columns
+    )
+    window_thresholds = window_values[ref_cols].quantile(q=quantile, axis=1)
+
+    # Determine if each trial underperforms at each progression (vectorized)
+    # Compare each column (trial) against the threshold series
+    underperforms = (
+        window_values[trial_cols].gt(window_thresholds, axis=0)
+        if minimize
+        else window_values[trial_cols].lt(window_thresholds, axis=0)
+    )
+
+    # A trial should be stopped only if it underperforms at ALL progressions
+    # AND is not protected by n_best_trials_to_complete
+    should_stop = underperforms.all(axis=0) & ~is_protected
+
+    return should_stop
+
+
+def best_trial_vulnerable(
+    wide_df: pd.DataFrame,
+    minimize: bool,
+    completed_trials: Iterable[int],
+    percentile_threshold: float = 50.0,
+    min_progression: float | None = 10,
+    max_progression: float | None = None,
+    min_curves: int | None = 5,
+    patience: float = 0.0,
+    interval: float | None = None,
+    n_best_trials_to_complete: int | None = None,
+) -> EarlyStoppingSimulationResult:
+    """Simulate early stopping to check if the best trial would be stopped.
+
+    This function simulates the behavior of PercentileEarlyStoppingStrategy to
+    determine if the globally best trial (based on final objective value) would
+    have been prematurely stopped. It supports the same configuration options
+    as the real strategy, including patience windows, interval throttling, and
+    best trial protection.
+
+    Args:
+        wide_df: DataFrame with progressions as index and trial indices as columns.
+            Values are the objective metric at each progression for each trial.
+        minimize: Whether we're minimizing the metric.
+        completed_trials: Indices of trials that have completed.
+        percentile_threshold: Percentile threshold for early stopping. Trials
+            falling below this threshold (relative to other trials at the same
+            progression) are candidates for stopping. For example, if
+            percentile_threshold=25.0, the bottom 25% of trials are stopped.
+        min_progression: Minimum progression before early stopping is applied.
+            Trials are not evaluated for stopping until they reach this value.
+        max_progression: Maximum progression where early stopping is applied.
+            Trials past this progression are not stopped.
+        min_curves: Minimum number of trials needed before early stopping begins.
+            The first min_curves completed trials form a protected "startup" set
+            that can never be stopped.
+        patience: If non-zero, requires that a trial underperforms the percentile
+            threshold consistently across all progressions in the patience window
+            [progression - patience, progression] before stopping. This helps avoid
+            stopping trials with noisy curves. If 0, only the current progression
+            is checked. Must be non-negative.
+        interval: Throttles early-stopping evaluation to occur only when trials
+            cross interval boundaries (at min_progression + k * interval, k=0,1,2...).
+            If None, evaluation occurs at every progression.
+        n_best_trials_to_complete: If specified, protects the top N trials (based
+            on current objective value) from being stopped at each evaluation point.
+            When combined with patience, a trial is protected if it is in the top N
+            at ANY progression within the patience window.
+
+    Returns:
+        EarlyStoppingSimulationResult with information about whether the best trial
+        would have been stopped, including the stopping progression and threshold
+        if applicable.
+    """
+    all_trials = set(wide_df.columns)
+
+    # Find the best trial from ALL trials
+    # We want to check if the strategy would stop the overall best trial
+    eventual_scores = wide_df.sort_index(axis=0).apply(
+        lambda col: col.dropna().iloc[-1],
+        axis=0,
+    )
+    best_trial_index = (
+        eventual_scores.idxmin() if minimize else eventual_scores.idxmax()
+    )
+
+    # Get first min_curves trials, but exclude the best trial to avoid
+    # circular dependency (we don't want the best trial contributing to
+    # the threshold that determines if it's stopped)
+    startup_trials = set(
+        nsmallest(
+            n=(min_curves or 0),
+            iterable=set(completed_trials) - {best_trial_index},
+        )
+    )
+
+    # eligible trials: can be stopped (all except protected startup trials)
+    eligible_trials = all_trials - startup_trials
+    # active trials are eligible trials excluding the best
+    active_trials = eligible_trials - {best_trial_index}
+
+    # Adjust percentile for minimization: for minimization, we flip the percentile
+    # (e.g., 25th percentile becomes 75th) to identify the worst-performing trials.
+    # Convert to quantile (0-1 range) for use with quantile/nanpercentile functions.
+    quantile = percentile_threshold / 100.0
+    quantile = 1 - quantile if minimize else quantile
+
+    if min_progression is None:
+        min_progression = 0.0
+    if max_progression is None:
+        max_progression = float("inf")
+
+    start, stop = wide_df.index.searchsorted(
+        [min_progression, max_progression], side="left"
+    )
+    progressions = wide_df.index[start:stop].to_numpy()
+    progressions = _get_interval_progressions(progressions, min_progression, interval)
+
+    for progression in progressions:
+        if len(active_trials) == 0:
+            break
+        reference_trials = startup_trials | active_trials
+
+        # Check if best trial should be stopped (against reference trials)
+        stop_selector = _check_patience_window(
+            wide_df=wide_df,
+            trial_indices={best_trial_index},
+            progression=progression,
+            patience=patience,
+            min_progression=min_progression,
+            quantile=quantile,
+            minimize=minimize,
+            n_best_trials_to_complete=n_best_trials_to_complete,
+            reference_trial_indices=reference_trials,
+        )
+        stop_best = stop_selector[best_trial_index]
+        if stop_best:
+            return EarlyStoppingSimulationResult(
+                best_stopped=True,
+                best_trial_index=best_trial_index,
+                best_stop_progression=progression,
+            )
+
+        # Check which active trials should be stopped (for simulation purposes)
+        stop_selector = _check_patience_window(
+            wide_df=wide_df,
+            trial_indices=active_trials,
+            progression=progression,
+            patience=patience,
+            min_progression=min_progression,
+            quantile=quantile,
+            minimize=minimize,
+            n_best_trials_to_complete=n_best_trials_to_complete,
+            reference_trial_indices=reference_trials,
+        )
+        trials_to_stop = set(stop_selector[stop_selector].index)
+        active_trials -= trials_to_stop
+
+    return EarlyStoppingSimulationResult(
+        best_stopped=False,
+        best_trial_index=best_trial_index,
+    )

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -10,6 +10,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from logging import Logger
+from typing import cast
 
 import pandas as pd
 from ax.adapter.data_utils import _maybe_normalize_map_key
@@ -475,8 +476,13 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         """
         min_progression = 0.0 if self.min_progression is None else self.min_progression
         interval = none_throws(self.interval)
-        curr_interval_boundary = _interval_boundary(
-            curr_progression, min_progression=min_progression, interval=interval
+        curr_interval_boundary = cast(
+            float,
+            _interval_boundary(
+                progression=curr_progression,
+                min_progression=min_progression,
+                interval=interval,
+            ),
         )
         # We've crossed a boundary if the last check was before the current boundary
         return prev_progression < curr_interval_boundary

--- a/ax/early_stopping/tests/test_simulation.py
+++ b/ax/early_stopping/tests/test_simulation.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+
+import numpy as np
+import pandas as pd
+from ax.early_stopping.simulation import (
+    _check_patience_window,
+    _get_interval_progressions,
+    best_trial_vulnerable,
+    EarlyStoppingSimulationResult,
+)
+from ax.utils.common.testutils import TestCase
+
+
+class TestEarlyStoppingSimulationResult(TestCase):
+    def test_dataclass_fields(self) -> None:
+        with self.subTest("basic creation"):
+            result = EarlyStoppingSimulationResult(
+                best_stopped=False,
+                best_trial_index=0,
+            )
+            self.assertFalse(result.best_stopped)
+            self.assertEqual(result.best_trial_index, 0)
+            self.assertIsNone(result.best_stop_progression)
+
+        with self.subTest("with stop progression"):
+            result = EarlyStoppingSimulationResult(
+                best_stopped=True,
+                best_trial_index=1,
+                best_stop_progression=5.0,
+            )
+            self.assertTrue(result.best_stopped)
+            self.assertEqual(result.best_trial_index, 1)
+            self.assertEqual(result.best_stop_progression, 5.0)
+
+
+class TestGetIntervalProgressions(TestCase):
+    def test_interval_filtering(self) -> None:
+        with self.subTest("basic interval filtering"):
+            result = _get_interval_progressions(
+                np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]),
+                min_progression=0.0,
+                interval=3.0,
+            )
+            np.testing.assert_array_equal(result, [0.0, 3.0, 6.0, 9.0])
+
+        with self.subTest("with min progression offset"):
+            result = _get_interval_progressions(
+                np.array([2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+                min_progression=2.0,
+                interval=2.0,
+            )
+            np.testing.assert_array_equal(result, [2.0, 4.0, 6.0, 8.0])
+
+        with self.subTest("single interval"):
+            result = _get_interval_progressions(
+                np.array([0.0, 1.0, 2.0]),
+                min_progression=0.0,
+                interval=10.0,
+            )
+            np.testing.assert_array_equal(result, [0.0])
+
+        with self.subTest("empty progressions"):
+            result = _get_interval_progressions(
+                np.array([]),
+                min_progression=0.0,
+                interval=5.0,
+            )
+            np.testing.assert_array_equal(result, [])
+
+
+class TestCheckPatienceWindow(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.wide_df = pd.DataFrame(
+            {
+                0: [100.0, 100.0, 100.0, 100.0],
+                1: [50.0, 50.0, 50.0, 50.0],
+                2: [30.0, 30.0, 30.0, 30.0],
+            },
+            index=[0.0, 1.0, 2.0, 3.0],
+        )
+
+    def test_patience_window_behavior(self) -> None:
+        with self.subTest("consistent underperformer is stopped"):
+            result = _check_patience_window(
+                wide_df=self.wide_df,
+                trial_indices={0, 1, 2},
+                progression=2.0,
+                patience=2.0,
+                min_progression=0.0,
+                quantile=0.75,
+                minimize=True,
+                n_best_trials_to_complete=None,
+            )
+            self.assertTrue(result[0])
+            self.assertFalse(result[1])
+            self.assertFalse(result[2])
+
+        with self.subTest("inconsistent underperformer not stopped"):
+            wide_df = pd.DataFrame(
+                {
+                    0: [30.0, 100.0, 100.0],
+                    1: [50.0, 50.0, 50.0],
+                    2: [100.0, 30.0, 30.0],
+                },
+                index=[0.0, 1.0, 2.0],
+            )
+            result = _check_patience_window(
+                wide_df=wide_df,
+                trial_indices={0, 1, 2},
+                progression=2.0,
+                patience=2.0,
+                min_progression=0.0,
+                quantile=0.5,
+                minimize=True,
+                n_best_trials_to_complete=None,
+            )
+            self.assertFalse(result[0])
+
+        with self.subTest("n_best_trials protection"):
+            result = _check_patience_window(
+                wide_df=self.wide_df,
+                trial_indices={0, 1, 2},
+                progression=3.0,
+                patience=1.0,
+                min_progression=0.0,
+                quantile=0.75,
+                minimize=True,
+                n_best_trials_to_complete=2,
+            )
+            self.assertFalse(result[1])
+            self.assertFalse(result[2])
+
+        with self.subTest("single progression in window"):
+            result = _check_patience_window(
+                wide_df=self.wide_df,
+                trial_indices={0, 1, 2},
+                progression=0.0,
+                patience=1.0,
+                min_progression=0.0,
+                quantile=0.75,
+                minimize=True,
+                n_best_trials_to_complete=None,
+            )
+            self.assertTrue(result[0])
+            self.assertFalse(result[1])
+            self.assertFalse(result[2])
+
+        with self.subTest("empty trial indices"):
+            result = _check_patience_window(
+                wide_df=self.wide_df,
+                trial_indices=set(),
+                progression=2.0,
+                patience=1.0,
+                min_progression=0.0,
+                quantile=0.75,
+                minimize=True,
+                n_best_trials_to_complete=None,
+            )
+            self.assertEqual(len(result), 0)
+
+
+class TestBestTrialVulnerable(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.wide_df = pd.DataFrame(
+            {
+                0: [100.0, 90.0, 80.0, 70.0, 60.0],
+                1: [50.0, 45.0, 40.0, 35.0, 30.0],
+                2: [30.0, 28.0, 25.0, 22.0, 20.0],
+                3: [95.0, 85.0, 75.0, 65.0, 55.0],
+                4: [60.0, 55.0, 50.0, 45.0, 40.0],
+            },
+            index=[0.0, 1.0, 2.0, 3.0, 4.0],
+        )
+
+    def test_best_trial_stopping(self) -> None:
+        with self.subTest("best trial not stopped"):
+            result = best_trial_vulnerable(
+                wide_df=self.wide_df,
+                minimize=True,
+                completed_trials=[0, 1, 2, 3, 4],
+                percentile_threshold=50.0,
+                min_progression=0.0,
+                max_progression=5.0,
+                min_curves=2,
+            )
+            self.assertFalse(result.best_stopped)
+            self.assertEqual(result.best_trial_index, 2)
+
+        with self.subTest("best trial stopped"):
+            wide_df = pd.DataFrame(
+                {
+                    0: [100.0, 30.0, 20.0, 10.0],
+                    1: [50.0, 45.0, 40.0, 35.0],
+                    2: [60.0, 55.0, 50.0, 45.0],
+                },
+                index=[0.0, 1.0, 2.0, 3.0],
+            )
+            result = best_trial_vulnerable(
+                wide_df=wide_df,
+                minimize=True,
+                completed_trials=[0, 1, 2],
+                percentile_threshold=50.0,
+                min_progression=0.0,
+                max_progression=4.0,
+                min_curves=1,
+            )
+            self.assertTrue(result.best_stopped)
+            self.assertEqual(result.best_trial_index, 0)
+
+    def test_patience_behavior(self) -> None:
+        with self.subTest("patience prevents stopping"):
+            wide_df = pd.DataFrame(
+                {
+                    0: [10.0, 100.0, 100.0, 100.0],
+                    1: [50.0, 50.0, 50.0, 30.0],
+                    2: [60.0, 60.0, 60.0, 60.0],
+                },
+                index=[0.0, 1.0, 2.0, 3.0],
+            )
+            result = best_trial_vulnerable(
+                wide_df=wide_df,
+                minimize=True,
+                completed_trials=[0, 1, 2],
+                percentile_threshold=50.0,
+                min_progression=1.0,
+                max_progression=4.0,
+                min_curves=1,
+                patience=2.0,
+            )
+            self.assertFalse(result.best_stopped)
+            self.assertEqual(result.best_trial_index, 1)
+
+        with self.subTest("patience allows stopping"):
+            wide_df = pd.DataFrame(
+                {
+                    0: [100.0, 100.0, 100.0, 10.0],
+                    1: [50.0, 50.0, 50.0, 50.0],
+                    2: [60.0, 60.0, 60.0, 60.0],
+                },
+                index=[0.0, 1.0, 2.0, 3.0],
+            )
+            result = best_trial_vulnerable(
+                wide_df=wide_df,
+                minimize=True,
+                completed_trials=[0, 1, 2],
+                percentile_threshold=50.0,
+                min_progression=1.0,
+                max_progression=4.0,
+                min_curves=1,
+                patience=2.0,
+            )
+            self.assertTrue(result.best_stopped)
+            self.assertEqual(result.best_trial_index, 0)
+
+    def test_configuration_options(self) -> None:
+        with self.subTest("interval filtering"):
+            result = best_trial_vulnerable(
+                wide_df=self.wide_df,
+                minimize=True,
+                completed_trials=[0, 1, 2, 3, 4],
+                percentile_threshold=50.0,
+                min_progression=0.0,
+                max_progression=5.0,
+                min_curves=2,
+                interval=2.0,
+            )
+            self.assertFalse(result.best_stopped)
+
+        with self.subTest("n_best_trials protection"):
+            wide_df = pd.DataFrame(
+                {
+                    0: [100.0, 90.0, 80.0, 70.0],
+                    1: [50.0, 45.0, 40.0, 10.0],
+                    2: [30.0, 28.0, 25.0, 22.0],
+                },
+                index=[0.0, 1.0, 2.0, 3.0],
+            )
+            result = best_trial_vulnerable(
+                wide_df=wide_df,
+                minimize=True,
+                completed_trials=[0, 1, 2],
+                percentile_threshold=50.0,
+                min_progression=0.0,
+                max_progression=4.0,
+                min_curves=1,
+                n_best_trials_to_complete=2,
+            )
+            self.assertFalse(result.best_stopped)
+            self.assertEqual(result.best_trial_index, 1)
+
+        with self.subTest("maximization direction"):
+            result = best_trial_vulnerable(
+                wide_df=self.wide_df,
+                minimize=False,
+                completed_trials=[0, 1, 2, 3, 4],
+                percentile_threshold=50.0,
+                min_progression=0.0,
+                max_progression=5.0,
+                min_curves=2,
+            )
+            self.assertFalse(result.best_stopped)
+            self.assertEqual(result.best_trial_index, 0)
+
+        with self.subTest("empty completed trials"):
+            result = best_trial_vulnerable(
+                wide_df=self.wide_df,
+                minimize=True,
+                completed_trials=[],
+                percentile_threshold=50.0,
+                min_progression=0.0,
+                max_progression=5.0,
+                min_curves=5,
+            )
+            self.assertFalse(result.best_stopped)
+            self.assertEqual(result.best_trial_index, 2)
+
+        with self.subTest("low percentile threshold"):
+            result = best_trial_vulnerable(
+                wide_df=self.wide_df,
+                minimize=True,
+                completed_trials=[0, 1, 2, 3, 4],
+                percentile_threshold=25.0,
+                min_progression=0.0,
+                max_progression=5.0,
+                min_curves=0,
+            )
+            self.assertFalse(result.best_stopped)
+            self.assertEqual(result.best_trial_index, 2)


### PR DESCRIPTION
Summary:
This diff introduces a safety mechanism that simulates how the early stopping strategy would have behaved from the start of the experiment, checking whether the eventually-best trial would have been prematurely stopped.

The simulation faithfully replicates PercentileEarlyStoppingStrategy's decision logic, including:
- Patience windows requiring consistent underperformance before stopping
- Interval throttling that limits evaluation frequency
- n_best_trials_to_complete protection for top-performing trials
- Startup trial protection (first min_curves trials are never stopped)

The check is exposed via the `_is_harmful` method on `PercentileEarlyStoppingStrategy`, enabling orchestration layers to gate early stopping decisions when the strategy would harm final outcomes.

Differential Revision: D86477961


