### PR TITLE
Fix broken OSS tests for python 3.12 from new scikit 1.8.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",
-    "scikit-learn",
+    "scikit-learn==1.7.2",
     "ipywidgets",
     # Needed for compatibility with ipywidgets >= 8.0.0
     "plotly>=5.12.0",


### PR DESCRIPTION
Summary:
The recent release of scikit-learn to 1.8.0 was picked up in Ax which is causing some tests to break. 

The only difference in package versions between the newly failing tests and the old passing ones from the nightly run is the scikit-learn library. 
Pinning the scikit-learn to the most recent package version to resolve.

Differential Revision: D88866173


