### PR TITLE
Update scikit-learn version constraint to <1.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",
-    "scikit-learn==1.7.2",
+    "scikit-learn<1.8.0",
     "ipywidgets",
     # Needed for compatibility with ipywidgets >= 8.0.0
     "plotly>=5.12.0",


### PR DESCRIPTION
Summary:
Updating the scikit-learn version constraint from ==1.7.2 to <1.8.0 to allow compatibility with older versions of scikit-learn while still avoiding the breaking changes in 1.8.0.


(Created w/ Devmate)

Differential Revision: D88881037


