### PR TITLE
Speed up MapDataReplayMetric

### DIFF
--- a/ax/early_stopping/experiment_replay.py
+++ b/ax/early_stopping/experiment_replay.py
@@ -11,7 +11,6 @@ from logging import Logger
 from time import perf_counter
 
 from ax.adapter.registry import Generators
-
 from ax.core.experiment import Experiment
 from ax.core.map_data import MapData
 from ax.core.metric import Metric

--- a/ax/metrics/map_replay.py
+++ b/ax/metrics/map_replay.py
@@ -7,16 +7,11 @@
 # pyre-strict
 
 from collections import defaultdict
-from dataclasses import dataclass
 from logging import Logger
 from typing import Any
 
-import numpy as np
-
 import pandas as pd
-
 from ax.core.base_trial import BaseTrial
-
 from ax.core.map_data import MAP_KEY, MapData
 from ax.core.map_metric import MapMetric, MapMetricFetchResult
 from ax.core.metric import MetricFetchE
@@ -26,13 +21,6 @@ from ax.utils.common.result import Err, Ok
 from pyre_extensions import none_throws
 
 logger: Logger = get_logger(__name__)
-
-
-@dataclass(frozen=True)
-class ReplayPoint:
-    step: float
-    mean: float | None
-    sem: float | None
 
 
 class MapDataReplayMetric(MapMetric):
@@ -62,54 +50,85 @@ class MapDataReplayMetric(MapMetric):
         self.map_data = map_data
         self.max_steps_validation = max_steps_validation
         self.metric_name: str = metric_name
-        self.replay_data: dict[int, list[ReplayPoint]] = construct_replay_dict(
+        # Store pre-processed DataFrame sorted by trial_index and step
+        self._replay_df: pd.DataFrame = _prepare_replay_dataframe(
             map_data=map_data, metric_name=self.metric_name
         )
-        self.offset: float = min(r[0].step for r in self.replay_data.values())
-        self.scaling_factor: float = compute_scaling_factor(
-            replay_data=self.replay_data,
-            offset=self.offset,
+        # Pre-group by trial_index for O(1) trial lookups instead of O(n) filtering
+        self._trial_groups: dict[int, pd.DataFrame] = {
+            int(trial_idx): group
+            for trial_idx, group in self._replay_df.groupby("trial_index")
+        }
+        # Pre-compute trial statistics using vectorized groupby, then extract
+        # offset and scaling_factor once, and store only last_step as a dict
+        trial_stats = _compute_trial_stats(self._replay_df)
+        self.offset: float = trial_stats["first_step"].min()
+        self.scaling_factor: float = _compute_scaling_factor(
+            trial_stats=trial_stats, offset=self.offset
         )
+        # Store only last_step as dict for O(1) lookups in hot paths
+        # Explicitly convert keys to int for consistency with _trial_groups
+        self._trial_last_step: dict[int, float] = {
+            int(k): float(v) for k, v in trial_stats["last_step"].items()
+        }
         self._trial_index_to_step: dict[int, int] = defaultdict(int)
         super().__init__(name=name, lower_is_better=lower_is_better)
-        self._validate_replay_feasibility()
+        self._validate_replay_feasibility(trial_stats=trial_stats)
 
     @classmethod
     def is_available_while_running(cls) -> bool:
         return True
 
-    def _validate_replay_feasibility(self) -> None:
+    def _validate_replay_feasibility(self, trial_stats: pd.DataFrame) -> None:
         """Check that the offset and scaling factor results in a reasonable number
         of steps for all trials (i.e., we don't want an intractable number of trials
         if (trial_max_step - offset) / scaling_factor is too large).
+
+        Args:
+            trial_stats: DataFrame with trial statistics (first_step, last_step,
+                num_points). Passed in to avoid recomputing or storing it.
         """
-        if self.max_steps_validation is not None:
-            max_steps = 0
-            for trial_idx, replay_data in self.replay_data.items():
-                max_steps_trial = (
-                    replay_data[-1].step - self.offset
-                ) / self.scaling_factor
-                if max_steps_trial > self.max_steps_validation:  # pyre-ignore[58]
-                    raise ValueError(
-                        f"For trial {trial_idx}, the computed offset {self.offset} and "
-                        f"scaling factor {self.scaling_factor} lead to "
-                        f"{max_steps_trial} steps, which is larger than "
-                        f"{self.max_steps_validation} steps to replay."
-                    )
-                max_steps = max(max_steps_trial, max_steps)
-            logger.debug(
-                f"Validated MapReplayMetric {self.name} with "
-                f"{len(self.replay_data)} trials, scaling factor = "
-                f"{self.scaling_factor:.2f}, and offset = {self.offset:.2f}, "
-                f"resulting in maximum steps = {max_steps}."
+        if self.max_steps_validation is None:
+            return
+
+        # Vectorized computation of max steps per trial
+        max_steps_per_trial = (
+            trial_stats["last_step"] - self.offset
+        ) / self.scaling_factor
+        max_steps = max_steps_per_trial.max()
+
+        # Find violating trials
+        violating = max_steps_per_trial[max_steps_per_trial > self.max_steps_validation]
+        if not violating.empty:
+            trial_idx = violating.index[0]
+            max_steps_trial = violating.iloc[0]
+            raise ValueError(
+                f"For trial {trial_idx}, the computed offset {self.offset} and "
+                f"scaling factor {self.scaling_factor} lead to "
+                f"{max_steps_trial} steps, which is larger than "
+                f"{self.max_steps_validation} steps to replay."
             )
+        logger.debug(
+            f"Validated MapReplayMetric {self.name} with "
+            f"{len(trial_stats)} trials, scaling factor = "
+            f"{self.scaling_factor:.2f}, and offset = {self.offset:.2f}, "
+            f"resulting in maximum steps = {max_steps}."
+        )
+
+    def has_trial_data(self, trial_idx: int) -> bool:
+        """Check if any replay data exists for a given trial."""
+        # Use pre-grouped dict for O(1) lookup instead of checking DataFrame index
+        return trial_idx in self._trial_groups
 
     def more_replay_available(self, trial_idx: int) -> bool:
-        trial_max_step = self.replay_data[trial_idx][-1].step
-        return (
+        """Check if more replay data is available for a given trial."""
+        trial_max_step = self._trial_last_step.get(trial_idx)
+        if trial_max_step is None:
+            return False
+        current_step = (
             self.offset + self._trial_index_to_step[trial_idx] * self.scaling_factor
-            < trial_max_step
         )
+        return current_step < trial_max_step
 
     def fetch_trial_data(self, trial: BaseTrial, **kwargs: Any) -> MapMetricFetchResult:
         try:
@@ -119,7 +138,7 @@ class MapDataReplayMetric(MapMetric):
                     f"{self.__class__.__name__}."
                 )
             trial_idx = trial.index
-            # increment the step counter if we can
+            # Increment the step counter if we can.
             if trial.status.is_running and self.more_replay_available(
                 trial_idx=trial_idx
             ):
@@ -128,24 +147,32 @@ class MapDataReplayMetric(MapMetric):
                 self.offset + self._trial_index_to_step[trial_idx] * self.scaling_factor
             )
             logger.info(f"Trial {trial_idx} is at step {trial_scaled_step}.")
-            datas = []
-            for replay_point in self.replay_data[trial_idx]:
-                if replay_point.step > trial_scaled_step:
-                    break
-                df = pd.DataFrame(
-                    {
-                        "arm_name": [none_throws(trial.arm).name],
-                        "metric_name": [self.name],
-                        "mean": [replay_point.mean],
-                        "sem": [replay_point.sem],
-                        "trial_index": [trial.index],
-                        "metric_signature": [self.signature],
-                        MAP_KEY: [replay_point.step],
-                    }
-                )
-                datas.append(MapData(df=df))
 
-            return Ok(value=MapData.from_multiple_data(data=datas))
+            # Use pre-grouped data for O(1) lookup instead of filtering full DataFrame
+            trial_group = self._trial_groups.get(trial_idx)
+            if trial_group is None:
+                return Ok(value=MapData.from_multiple_data(data=[]))
+
+            # Filter only the trial's subset (much smaller than full DataFrame)
+            trial_data = trial_group[trial_group[MAP_KEY] <= trial_scaled_step]
+
+            if trial_data.empty:
+                return Ok(value=MapData())
+
+            # Create the result DataFrame in one operation
+            result_df = pd.DataFrame(
+                {
+                    "arm_name": none_throws(trial.arm).name,
+                    "metric_name": self.name,
+                    "mean": trial_data["mean"].values,
+                    "sem": trial_data["sem"].values,
+                    "trial_index": trial.index,
+                    "metric_signature": self.signature,
+                    MAP_KEY: trial_data[MAP_KEY].values,
+                }
+            )
+
+            return Ok(value=MapData(df=result_df))
 
         except Exception as e:
             return Err(
@@ -153,42 +180,50 @@ class MapDataReplayMetric(MapMetric):
             )
 
 
-def construct_replay_dict(
-    map_data: MapData, metric_name: str
-) -> dict[int, list[ReplayPoint]]:
-    """Construct a dictionary of replay data mapping trials to
-    lists of ReplayPoints.
+def _prepare_replay_dataframe(map_data: MapData, metric_name: str) -> pd.DataFrame:
+    """Prepare a pre-sorted DataFrame for efficient replay lookups.
+
+    Filters the data to the specified metric and sorts by trial_index and step.
+    This allows efficient vectorized filtering during fetch_trial_data.
     """
-    map_data_metric = map_data.filter(metric_names=[metric_name])
-    map_df = map_data_metric.map_df
-    replay_data = defaultdict(list)
-    for trial_idx, sub_df in map_df.groupby("trial_index"):
-        sub_df = sub_df.sort_values(by=MAP_KEY, ascending=True)
-        replay_data[trial_idx] = [
-            ReplayPoint(step=step, mean=mean, sem=sem)
-            for mean, sem, step in zip(
-                sub_df["mean"].tolist(),
-                sub_df["sem"].tolist(),
-                sub_df[MAP_KEY].tolist(),
-            )
-        ]
-    return replay_data
+    df = map_data.full_df
+    df = df[df["metric_name"] == metric_name]
+    # Sort once upfront for efficient lookups
+    return df.sort_values(
+        by=["trial_index", MAP_KEY], ascending=True, ignore_index=True
+    )
 
 
-def compute_scaling_factor(
-    replay_data: dict[int, list[ReplayPoint]], offset: float
-) -> float:
-    """Compute the scaling factor for replay data. The scaling factor is set to be:
+def _compute_trial_stats(replay_df: pd.DataFrame) -> pd.DataFrame:
+    """Compute per-trial statistics using vectorized groupby operations.
+
+    Returns a DataFrame indexed by trial_index with columns:
+    - first_step: the first (minimum) step value for each trial
+    - last_step: the last (maximum) step value for each trial
+    - num_points: the number of data points per trial
+    """
+    stats = replay_df.groupby("trial_index")[MAP_KEY].agg(
+        first_step="first",  # Data is pre-sorted, so first/last are min/max
+        last_step="last",
+        num_points="count",
+    )
+    return stats
+
+
+def _compute_scaling_factor(trial_stats: pd.DataFrame, offset: float) -> float:
+    """Compute the scaling factor for replay data using vectorized operations.
+
+    The scaling factor is:
     `mean_{trial in trials} (max_steps_trial - offset) / num_points_trial`.
     """
-    scaling_factors = []
-    for replay_points in replay_data.values():
-        num_replay_points = len(replay_points)
-        final_replay_step = float(replay_points[-1].step)
-        if num_replay_points > 0 and final_replay_step > offset:
-            scaling_factor_trial = (final_replay_step - offset) / num_replay_points
-            scaling_factors.append(scaling_factor_trial)
-    scaling_factor = (
-        float(np.mean(scaling_factors)) if len(scaling_factors) > 0 else 1.0
-    )
+    # Vectorized computation of per-trial scaling factors
+    valid_mask = (trial_stats["num_points"] > 0) & (trial_stats["last_step"] > offset)
+    if not valid_mask.any():
+        return 1.0
+
+    scaling_factors = (
+        trial_stats.loc[valid_mask, "last_step"] - offset
+    ) / trial_stats.loc[valid_mask, "num_points"]
+    scaling_factor = float(scaling_factors.mean())
+
     return scaling_factor if scaling_factor > 0.0 else 1.0

--- a/ax/metrics/tests/test_map_replay.py
+++ b/ax/metrics/tests/test_map_replay.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-import numpy as np
 import pandas as pd
 from ax.core.arm import Arm
 from ax.core.experiment import Experiment
@@ -14,13 +13,14 @@ from ax.core.map_data import MAP_KEY, MapData
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
 from ax.metrics.map_replay import MapDataReplayMetric
-
 from ax.runners.synthetic import SyntheticRunner
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_branin_search_space,
     get_test_map_data_experiment,
 )
+from pandas import DataFrame
+from pandas.testing import assert_frame_equal
 from pyre_extensions import assert_is_instance
 
 
@@ -32,38 +32,54 @@ class MapDataReplayMetricTest(TestCase):
         historical_data: MapData = assert_is_instance(
             historical_experiment.lookup_data(), MapData
         )
+        replay_metric = MapDataReplayMetric(
+            name="test_metric",
+            map_data=historical_data,
+            metric_name="branin_map",
+            lower_is_better=True,
+        )
+
+        # Verify offset and scaling factor for uniform step data.
+        # The test data has 2 trials, each with 2 fetches, resulting in steps 0 and 1.
+        # offset = min(first step of each trial) = min(0, 0) = 0
+        self.assertEqual(replay_metric.offset, 0)
+        # scaling_factor = mean((final_step - offset) / num_points)
+        #                = mean((1 - 0) / 2, (1 - 0) / 2) = mean(0.5, 0.5) = 0.5
+        self.assertEqual(replay_metric.scaling_factor, 0.5)
+
         experiment = Experiment(
             name="dummy_experiment",
             search_space=get_branin_search_space(),
             optimization_config=OptimizationConfig(
                 objective=Objective(
-                    metric=MapDataReplayMetric(
-                        name="test_metric",
-                        map_data=historical_data,
-                        metric_name="branin_map",
-                        lower_is_better=True,
-                    ),
+                    metric=replay_metric,
                     minimize=True,
                 )
             ),
             runner=SyntheticRunner(),
         )
-        for _ in range(0, 2):
+        for i in range(0, 2):
             trial = experiment.new_trial()
-            trial.add_arm(Arm(parameters={"x1": 0.0, "x2": 0.0}))
+            trial.add_arm(Arm(parameters={"x1": float(i), "x2": 0.0}))
             trial.run()
 
         # fetch once for MAP_KEY = 0
         experiment.fetch_data()
         # the second fetch will be for MAP_KEY = 0 and MAP_KEY = 1
         data = experiment.fetch_data()
-        self.assertTrue(
-            np.allclose(
-                # pyre-fixme[16]: `Data` has no attribute `map_df`.
-                data.map_df["mean"].to_numpy(),
-                np.array([146.138620, 117.388086, 113.057480, 90.815154]),
-            )
+        metric_name = [replay_metric.name] * 4
+        expected_df = DataFrame(
+            {
+                "trial_index": [0, 0, 1, 1],
+                "arm_name": ["0_0", "0_0", "1_0", "1_0"],
+                "metric_name": metric_name,
+                "metric_signature": metric_name,
+                "mean": [146.138620, 117.388086, 113.057480, 90.815154],
+                "sem": [0.0, 0.0, 0.0, 0.0],
+                MAP_KEY: [0.0, 1.0, 0.0, 1.0],
+            }
         )
+        assert_frame_equal(data.full_df, expected_df)
 
     def test_map_replay_non_uniform(self) -> None:
         historical_experiment = get_test_map_data_experiment(
@@ -72,16 +88,25 @@ class MapDataReplayMetricTest(TestCase):
         map_data: MapData = assert_is_instance(
             historical_experiment.lookup_data(), MapData
         )
-        map_df = map_data.map_df
-        map_df[MAP_KEY] = pd.Series([0.25, 0.95, 0.0, 0.25, 1.0, 0.0])
-        historical_data = MapData(df=map_df)
+        full_df = map_data.full_df
+        # The original data has 6 rows: 4 for branin_map and 2 for branin.
+        # After assinging steps, we have following steps for branin_map:
+        # Trial 0: steps [0.25, 0.95]
+        # Trial 1: steps [0.25, 1.0]
+        full_df[MAP_KEY] = pd.Series([0.25, 0.95, 0.0, 0.25, 1.0, 0.0])
+        historical_data = MapData(df=full_df)
         replay_metric = MapDataReplayMetric(
             name="test_metric",
             map_data=historical_data,
             metric_name="branin_map",
             lower_is_better=True,
         )
+        # Verify offset: min(first step of each trial after sorting)
         self.assertEqual(replay_metric.offset, 0.25)
+        # Verify scaling_factor: mean((final_step - offset) / num_points) across trials
+        # Trial 0: (0.95 - 0.25) / 2 = 0.35
+        # Trial 1: (1.0 - 0.25) / 2 = 0.375
+        # scaling_factor = (0.35 + 0.375) / 2 = 0.3625
         self.assertEqual(replay_metric.scaling_factor, 0.3625)
 
         experiment = Experiment(
@@ -95,20 +120,35 @@ class MapDataReplayMetricTest(TestCase):
             ),
             runner=SyntheticRunner(),
         )
-        for _ in range(0, 2):
+        for i in range(0, 2):
             trial = experiment.new_trial()
-            trial.add_arm(Arm(parameters={"x1": 0.0, "x2": 0.0}))
+            trial.add_arm(Arm(parameters={"x1": float(i), "x2": 0.0}))
             trial.run()
+
+        metric_name = [replay_metric.name] * 4
+        full_expected_df = DataFrame(
+            {
+                "trial_index": [0, 0, 1, 1],
+                "arm_name": ["0_0", "0_0", "1_0", "1_0"],
+                "metric_name": metric_name,
+                "metric_signature": metric_name,
+                "mean": [146.138620, 117.388086, 113.057480, 90.815154],
+                "sem": [0.0, 0.0, 0.0, 0.0],
+                MAP_KEY: [0.25, 0.95, 0.25, 1.0],
+            }
+        )
 
         # Test that as we step through with steps of size 0.3625, we
         # first get both points at step 0.25.
-        data: MapData = assert_is_instance(experiment.fetch_data(), MapData)
-        self.assertEqual(len(data.map_df), 2)
+        data = experiment.fetch_data()
+        assert_frame_equal(
+            data.full_df, full_expected_df.iloc[[0, 2]].reset_index(drop=True)
+        )
 
         # Next, we add the point at step 0.95 of Trial 0.
-        data: MapData = assert_is_instance(experiment.fetch_data(), MapData)
-        self.assertEqual(len(data.map_df), 3)
+        data = experiment.fetch_data()
+        assert_frame_equal(data.full_df, full_expected_df.iloc[:3])
 
         # Finally, we get the point at step 1.0 of Trial 1.
-        data: MapData = assert_is_instance(experiment.fetch_data(), MapData)
-        self.assertEqual(len(data.map_df), 4)
+        data = experiment.fetch_data()
+        assert_frame_equal(data.full_df, full_expected_df.iloc[:4])

--- a/ax/runners/map_replay.py
+++ b/ax/runners/map_replay.py
@@ -41,10 +41,9 @@ class MapDataReplayRunner(Runner):
         # depending on whether or not there is more data available,
         # mark it either RUNNING or COMPLETED.
         for t in trials:
-            started = t.run_metadata.get(STARTED_KEY, "False")
-            if not started:
+            if not t.run_metadata.get(STARTED_KEY, "False"):
                 result[TrialStatus.CANDIDATE].add(t.index)
-            elif len(self.replay_metric.replay_data[t.index]) == 0:
+            elif not self.replay_metric.has_trial_data(t.index):
                 result[TrialStatus.ABANDONED].add(t.index)
             elif self.replay_metric.more_replay_available(t.index):
                 result[TrialStatus.RUNNING].add(t.index)


### PR DESCRIPTION
Summary:
Worked with devmate to replace some of the dict extraction and row by row loops with vectorized pandas operations.

Cost of replaying
```
    historical_experiment = get_test_map_data_experiment(
        num_trials=25,
        num_fetches=100,
        num_complete=25,
    )
```
with default ess reduced by ~27% (1.565s vs 2.132s).

Time spent in `Orchestrator._fetch_and_process_trials_data_results` is reduced to 0.306s from 0.809 (62% reduction).

Differential Revision: D88517021


