### PR TITLE
(6/6) Port helpers to OSS for the new Complexity Rating Healthcheck - get_tier_msg

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -35,7 +35,7 @@ from ax.core.outcome_constraint import (
     OutcomeConstraint,
     ScalarizedOutcomeConstraint,
 )
-from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
+from ax.core.parameter import ChoiceParameter, Parameter, ParameterType, RangeParameter
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import SearchSpace, SearchSpaceDigest
 from ax.core.types import TBounds, TCandidateMetadata
@@ -1321,3 +1321,56 @@ def _consolidate_comparisons(X: Tensor, Y: Tensor) -> tuple[Tensor, Tensor]:
 
     X, Y, _ = consolidate_duplicates(X, Y)
     return X, Y
+
+
+def is_unordered_choice(
+    p: Parameter, min_choices: int | None = None, max_choices: int | None = None
+) -> bool:
+    """Returns whether a parameter is an unordered choice (categorical) parameter.
+
+    You can also specify `min_choices` and `max_choices` to restrict how many
+    possible values the parameter can take on.
+
+    Args:
+        p: Parameter.
+        min_choices: The minimum number of possible values for the parameter.
+        max_choices: The maximum number of possible values for the parameter.
+
+    Returns:
+        A boolean indicating whether p is an unordered choice parameter or not.
+    """
+    if min_choices is not None and min_choices < 0:
+        raise UserInputError("`min_choices` must be a non-negative integer.")
+    if max_choices is not None and max_choices < 0:
+        raise UserInputError("`max_choices` must be a non-negative integer.")
+    if (
+        min_choices is not None
+        and max_choices is not None
+        and min_choices > max_choices
+    ):
+        raise UserInputError("`min_choices` cannot be larger than `max_choices`.")
+    return (
+        isinstance(p, ChoiceParameter)
+        and not p.is_ordered
+        and (min_choices is None or min_choices <= len(p.values))
+        and (max_choices is None or max_choices >= len(p.values))
+    )
+
+
+def can_map_to_binary(p: Parameter) -> bool:
+    """Returns whether a parameter can be transformed to a binary parameter.
+
+    Any choice/range parameters with exactly two values can be transformed to a
+    binary parameter.
+
+    Args:
+        p: Parameter.
+
+    Returns
+        A boolean indicating whether p can be transformed to a binary parameter.
+    """
+    return (isinstance(p, ChoiceParameter) and len(p.values) == 2) or (
+        isinstance(p, RangeParameter)
+        and p.parameter_type == ParameterType.INT
+        and p.lower == p.upper - 1
+    )

--- a/ax/adapter/tests/test_adapter_utils.py
+++ b/ax/adapter/tests/test_adapter_utils.py
@@ -12,8 +12,10 @@ import torch
 from ax.adapter.adapter_utils import (
     _get_adapter_training_data,
     arm_to_np_array,
+    can_map_to_binary,
     extract_search_space_digest,
     feasible_hypervolume,
+    is_unordered_choice,
     process_contextual_datasets,
     transform_search_space,
     validate_and_apply_final_transform,
@@ -414,3 +416,112 @@ class TestAdapterUtils(TestCase):
 
         # Assert: confirm target point remains None
         self.assertIsNone(target_p)
+
+    def test_is_unordered_choice(self) -> None:
+        # Test cases where is_unordered_choice should return True
+        # (with min_choices=3, max_choices=5)
+        for p in [
+            # Unordered choice (INT), with 3 choices
+            ChoiceParameter("p", ParameterType.INT, values=[0, 1, 2], is_ordered=False),
+            # Unordered choice (STRING), with 5 choices
+            ChoiceParameter(
+                "p",
+                ParameterType.STRING,
+                values=["0", "1", "2", "4", "5"],
+                is_ordered=False,
+            ),
+            # Unordered choice (STRING), with 4 choices
+            ChoiceParameter(
+                "p", ParameterType.STRING, values=["a", "b", "c", "d"], is_ordered=False
+            ),
+        ]:
+            with self.subTest(p=p):
+                self.assertTrue(is_unordered_choice(p, min_choices=3, max_choices=5))
+
+        # Test cases where is_unordered_choice should return False
+        # (with min_choices=3, max_choices=5)
+        for p in [
+            # Too few choices
+            ChoiceParameter("p", ParameterType.INT, values=[0, 1], is_ordered=False),
+            # Ordered choice (INT)
+            ChoiceParameter(
+                "p", ParameterType.INT, values=[0, 1, 2, 4], is_ordered=True
+            ),
+            # Range parameter (non-choice)
+            RangeParameter("p", parameter_type=ParameterType.INT, lower=0, upper=3),
+            # Ordered choice (STRING)
+            ChoiceParameter(
+                "p", ParameterType.STRING, values=["0", "1", "2"], is_ordered=True
+            ),
+        ]:
+            with self.subTest(p=p):
+                self.assertFalse(is_unordered_choice(p, min_choices=3, max_choices=5))
+
+        # Test error cases
+        p = ChoiceParameter("p", ParameterType.INT, values=[0, 1, 2], is_ordered=False)
+        with self.assertRaisesRegex(
+            UserInputError, "`min_choices` must be a non-negative integer."
+        ):
+            is_unordered_choice(p, min_choices=-3)
+        with self.assertRaisesRegex(
+            UserInputError, "`max_choices` must be a non-negative integer."
+        ):
+            is_unordered_choice(p, max_choices=-1)
+        with self.assertRaisesRegex(
+            UserInputError, "`min_choices` cannot be larger than `max_choices`."
+        ):
+            is_unordered_choice(p, min_choices=3, max_choices=2)
+
+    def test_can_map_to_binary(self) -> None:
+        # Test cases where can_map_to_binary should return True
+        for p in [
+            # Int range with exactly 2 values
+            RangeParameter(
+                name="p", parameter_type=ParameterType.INT, lower=0, upper=1
+            ),
+            RangeParameter(
+                name="p", parameter_type=ParameterType.INT, lower=3, upper=4
+            ),
+            # Choice with exactly 2 values
+            ChoiceParameter(
+                name="p",
+                parameter_type=ParameterType.INT,
+                values=[0, 1],
+                is_ordered=False,
+            ),
+            ChoiceParameter(
+                name="p",
+                parameter_type=ParameterType.STRING,
+                values=["a", "b"],
+                is_ordered=False,
+            ),
+        ]:
+            with self.subTest(p=p):
+                self.assertTrue(can_map_to_binary(p))
+
+        # Test cases where can_map_to_binary should return False
+        for p in [
+            # Float range (continuous, not binary)
+            RangeParameter(
+                name="p", parameter_type=ParameterType.FLOAT, lower=0, upper=1
+            ),
+            # Int range with more than 2 values
+            RangeParameter(
+                name="p", parameter_type=ParameterType.INT, lower=0, upper=3
+            ),
+            # Choice with more than 2 values
+            ChoiceParameter(
+                name="p",
+                parameter_type=ParameterType.INT,
+                values=[0, 1, 2],
+                is_ordered=False,
+            ),
+            ChoiceParameter(
+                name="p",
+                parameter_type=ParameterType.STRING,
+                values=["a", "b", "c"],
+                is_ordered=False,
+            ),
+        ]:
+            with self.subTest(p=p):
+                self.assertFalse(can_map_to_binary(p))

--- a/ax/utils/common/complexity_utils.py
+++ b/ax/utils/common/complexity_utils.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any
+
+from ax.adapter.adapter_utils import can_map_to_binary, is_unordered_choice
+from ax.core.experiment import Experiment
+from ax.core.objective import MultiObjective
+from ax.exceptions.core import OptimizationNotConfiguredError
+from ax.service.orchestrator import OrchestratorOptions
+
+
+def summarize_ax_optimization_complexity(
+    experiment: Experiment,
+    options: OrchestratorOptions,
+    tier_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """Summarize the experiment's optimization complexity.
+
+    This function analyzes an experiment's configuration and returns metrics and key
+    characteristics that help assess the difficulty of the optimization problem.
+
+    Args:
+        experiment: The Ax Experiment.
+        options: The orchestrator options.
+        tier_metadata: tier-related meta-data from the orchestrator.
+
+    Returns:
+        A dictionary summarizing the experiment.
+    """
+    search_space = experiment.search_space
+    optimization_config = experiment.optimization_config
+    if optimization_config is None:
+        raise OptimizationNotConfiguredError(
+            "Experiment must have an optimization_config."
+        )
+    params = search_space.tunable_parameters.values()
+
+    max_trials = tier_metadata.get("user_supplied_max_trials", None)
+    num_params = len(search_space.tunable_parameters)
+    num_binary = sum(can_map_to_binary(p) for p in params)
+    num_categorical_3_5 = sum(
+        is_unordered_choice(p, min_choices=3, max_choices=5) for p in params
+    )
+    num_categorical_6_inf = sum(is_unordered_choice(p, min_choices=6) for p in params)
+    num_parameter_constraints = len(search_space.parameter_constraints)
+    num_objectives = (
+        len(optimization_config.objective.objectives)
+        if isinstance(optimization_config.objective, MultiObjective)
+        else 1
+    )
+    num_outcome_constraints = len(optimization_config.outcome_constraints)
+    uses_early_stopping = options.early_stopping_strategy is not None
+    uses_global_stopping = options.global_stopping_strategy is not None
+
+    # Check if any metrics use merge_multiple_curves
+    uses_merge_multiple_curves = False
+    all_metrics = list(optimization_config.metrics.values())
+    if hasattr(experiment, "tracking_metrics"):
+        all_metrics.extend(experiment.tracking_metrics)
+
+    for metric in all_metrics:
+        if getattr(metric, "merge_multiple_curves", False):
+            uses_merge_multiple_curves = True
+            break
+
+    return {
+        "max_trials": max_trials,
+        "num_params": num_params,
+        "num_binary": num_binary,
+        "num_categorical_3_5": num_categorical_3_5,
+        "num_categorical_6_inf": num_categorical_6_inf,
+        "num_parameter_constraints": num_parameter_constraints,
+        "num_objectives": num_objectives,
+        "num_outcome_constraints": num_outcome_constraints,
+        "uses_early_stopping": uses_early_stopping,
+        "uses_global_stopping": uses_global_stopping,
+        "uses_merge_multiple_curves": uses_merge_multiple_curves,
+        "all_inputs_are_configs": tier_metadata.get("all_inputs_are_configs", False),
+        "tolerated_trial_failure_rate": options.tolerated_trial_failure_rate,
+        "max_pending_trials": options.max_pending_trials,
+        "min_failed_trials_for_failure_rate_check": (
+            options.min_failed_trials_for_failure_rate_check
+        ),
+    }

--- a/ax/utils/common/complexity_utils.py
+++ b/ax/utils/common/complexity_utils.py
@@ -6,12 +6,13 @@
 # pyre-strict
 
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any
 
 from ax.adapter.adapter_utils import can_map_to_binary, is_unordered_choice
 from ax.core.experiment import Experiment
 from ax.core.objective import MultiObjective
-from ax.exceptions.core import OptimizationNotConfiguredError
+from ax.exceptions.core import OptimizationNotConfiguredError, UserInputError
 from ax.service.orchestrator import OrchestratorOptions
 
 WHEELHOUSE_TIER_MESSAGE = """This experiment is in tier 'Wheelhouse'.
@@ -38,12 +39,76 @@ well-supported usage tier if possible.
 
 WIKI_TIER_MESSAGE = "https://ax.dev/docs/why-ax"
 
+UNKNOWN_TIER_MESSAGE = """Failed to determine the tier of this experiment.
+
+Please post on our github issues page or reach out to the Ax user group \
+to determine the support tier of your workflow.
+"""
+
+NOT_STANDARD_API_MESSAGE = (
+    "The experiment summary indicates that this workflow is not using a standard \
+    API (`uses_standard_api=False`). Tier classification works best when the full \
+    experiment configuration is known upfront. If you are building a tool on top \
+    of this function, ensure that `uses_standard_api` is set to `True` in the \
+    `OptimizationSummary` when your tool uses a standard API."
+)
+
+
+@dataclass(frozen=True)
+class OptimizationSummary:
+    """Summary of an experiment's configuration for tier classification.
+
+    Required Keys:
+        num_params: Total number of tunable parameters.
+        num_binary: Number of binary (0/1 integer) parameters.
+        num_categorical_3_5: Number of unordered choice parameters with 3-5 options.
+        num_categorical_6_inf: Number of unordered choice parameters with 6+ options.
+        num_parameter_constraints: Number of parameter constraints.
+        num_objectives: Number of optimization objectives.
+        num_outcome_constraints: Number of outcome constraints.
+        uses_early_stopping: Whether early stopping is enabled.
+        uses_global_stopping: Whether global stopping is enabled.
+        all_inputs_are_configs: Whether all inputs are high-level configs
+            (as opposed to low-level Ax abstractions).
+
+    Optional Keys:
+        max_trials: Maximum number of trials (required if all_inputs_are_configs
+            is True).
+        tolerated_trial_failure_rate: Maximum tolerated trial failure rate
+            (should be <= 0.9).
+        max_pending_trials: Maximum number of pending trials.
+        min_failed_trials_for_failure_rate_check: Minimum failed trials before
+            failure rate is checked.
+        non_default_advanced_options: Whether non-default advanced options are set.
+        uses_merge_multiple_curves: Whether merge_multiple_curves is used
+            (not supported).
+    """
+
+    # Required keys
+    num_params: int
+    num_binary: int
+    num_categorical_3_5: int
+    num_categorical_6_inf: int
+    num_parameter_constraints: int
+    num_objectives: int
+    num_outcome_constraints: int
+    uses_early_stopping: bool
+    uses_global_stopping: bool
+    all_inputs_are_configs: bool
+    # Optional keys
+    max_trials: int | None = None
+    tolerated_trial_failure_rate: float | None = None
+    max_pending_trials: int | None = None
+    min_failed_trials_for_failure_rate_check: int | None = None
+    non_default_advanced_options: bool | None = None
+    uses_merge_multiple_curves: bool | None = None
+
 
 def summarize_ax_optimization_complexity(
     experiment: Experiment,
     options: OrchestratorOptions,
     tier_metadata: dict[str, Any],
-) -> dict[str, Any]:
+) -> OptimizationSummary:
     """Summarize the experiment's optimization complexity.
 
     This function analyzes an experiment's configuration and returns metrics and key
@@ -93,25 +158,315 @@ def summarize_ax_optimization_complexity(
             uses_merge_multiple_curves = True
             break
 
-    return {
-        "max_trials": max_trials,
-        "num_params": num_params,
-        "num_binary": num_binary,
-        "num_categorical_3_5": num_categorical_3_5,
-        "num_categorical_6_inf": num_categorical_6_inf,
-        "num_parameter_constraints": num_parameter_constraints,
-        "num_objectives": num_objectives,
-        "num_outcome_constraints": num_outcome_constraints,
-        "uses_early_stopping": uses_early_stopping,
-        "uses_global_stopping": uses_global_stopping,
-        "uses_merge_multiple_curves": uses_merge_multiple_curves,
-        "all_inputs_are_configs": tier_metadata.get("all_inputs_are_configs", False),
-        "tolerated_trial_failure_rate": options.tolerated_trial_failure_rate,
-        "max_pending_trials": options.max_pending_trials,
-        "min_failed_trials_for_failure_rate_check": (
+    return OptimizationSummary(
+        max_trials=max_trials,
+        num_params=num_params,
+        num_binary=num_binary,
+        num_categorical_3_5=num_categorical_3_5,
+        num_categorical_6_inf=num_categorical_6_inf,
+        num_parameter_constraints=num_parameter_constraints,
+        num_objectives=num_objectives,
+        num_outcome_constraints=num_outcome_constraints,
+        uses_early_stopping=uses_early_stopping,
+        uses_global_stopping=uses_global_stopping,
+        uses_merge_multiple_curves=uses_merge_multiple_curves,
+        all_inputs_are_configs=tier_metadata.get("all_inputs_are_configs", False),
+        tolerated_trial_failure_rate=options.tolerated_trial_failure_rate,
+        max_pending_trials=options.max_pending_trials,
+        min_failed_trials_for_failure_rate_check=(
             options.min_failed_trials_for_failure_rate_check
         ),
-    }
+    )
+
+
+def _check_if_is_in_wheelhouse_search_space(
+    optimization_summary: OptimizationSummary,
+    why_not_is_in_wheelhouse: list[str],
+    why_not_supported: list[str],
+) -> tuple[bool, bool]:
+    """Check if the search space configuration is within supported tiers.
+
+    Evaluates the search space complexity including the number of parameters,
+    binary parameters, categorical parameters, and parameter constraints.
+
+    Args:
+        optimization_summary: Summary of the experiment. See ``OptimizationSummary``
+            for the required and optional keys.
+        why_not_is_in_wheelhouse: A list to append reasons for not being in
+            the wheelhouse tier.
+        why_not_supported: A list to append reasons for not being supported.
+
+    Returns:
+        A tuple with information about whether the experiment is in the wheelhouse.
+    """
+    is_in_wheelhouse, is_supported = True, True
+
+    num_params = optimization_summary.num_params
+    if num_params > 50:
+        is_in_wheelhouse = False
+        why_not_is_in_wheelhouse += [
+            f"{num_params} tunable parameter(s) (max in-wheelhouse is 50)"
+        ]
+        if num_params > 200:
+            is_supported = False
+            why_not_supported += [
+                f"{num_params} tunable parameter(s) (max supported is 200)"
+            ]
+
+    num_binary = optimization_summary.num_binary
+    if num_binary > 50:
+        is_in_wheelhouse = False
+        why_not_is_in_wheelhouse += [
+            f"{num_binary} binary tunable parameter(s) (max in-wheelhouse is 50)"
+        ]
+        if num_binary > 100:
+            is_supported = False
+            why_not_supported += [
+                f"{num_binary} binary tunable parameter(s) (max supported is 100)"
+            ]
+
+    num_categorical_3_5 = optimization_summary.num_categorical_3_5
+    num_categorical_6_inf = optimization_summary.num_categorical_6_inf
+    num_categorical_3_inf = num_categorical_3_5 + num_categorical_6_inf
+    if num_categorical_3_inf > 0:
+        is_in_wheelhouse = False
+        why_not_is_in_wheelhouse += [
+            f"{num_categorical_3_inf} unordered choice parameter(s) with more "
+            "than 3 options (max in-wheelhouse is 0)"
+        ]
+        if num_categorical_3_5 > 5:
+            why_not_supported += [
+                f"{num_categorical_3_inf} unordered choice parameters with more "
+                "than 3 options (max supported is 5)"
+            ]
+            is_supported = False
+        elif num_categorical_6_inf > 1:
+            why_not_supported += [
+                f"{num_categorical_6_inf} unordered choice parameters with more "
+                "than 5 options (max supported is 1)"
+            ]
+            is_supported = False
+
+    num_parameter_constraints = optimization_summary.num_parameter_constraints
+    if num_parameter_constraints > 2:
+        is_in_wheelhouse = False
+        why_not_is_in_wheelhouse += [
+            f"{num_parameter_constraints} parameter constraints "
+            "(max in-wheelhouse is 2)"
+        ]
+        if num_parameter_constraints > 5:
+            is_supported = False
+            why_not_supported += [
+                f"{num_parameter_constraints} parameter "
+                "constraints (max supported is 5)"
+            ]
+    return is_in_wheelhouse, is_supported
+
+
+def _check_if_is_in_wheelhouse_optimization_config(
+    optimization_summary: OptimizationSummary,
+    why_not_is_in_wheelhouse: list[str],
+    why_not_supported: list[str],
+) -> tuple[bool, bool]:
+    """Check if the optimization configuration is within supported tiers.
+
+    Evaluates the optimization config complexity including the number of
+    objectives and outcome constraints.
+
+    Args:
+        optimization_summary: Summary of the experiment. See ``OptimizationSummary``
+            for the required and optional keys.
+        why_not_is_in_wheelhouse: A list to append reasons for not being in
+            the wheelhouse tier.
+        why_not_supported: A list to append reasons for not being supported.
+
+    Returns:
+        A tuple with information about whether the experiment is in the wheelhouse.
+    """
+    is_in_wheelhouse, is_supported = True, True
+
+    num_objectives = optimization_summary.num_objectives
+    if num_objectives > 2:
+        is_in_wheelhouse = False
+        why_not_is_in_wheelhouse += [
+            f"{num_objectives} objectives (max in-wheelhouse is 2)"
+        ]
+        if num_objectives > 4:
+            is_supported = False
+            why_not_supported += [f"{num_objectives} objectives (max supported is 4)"]
+
+    num_outcome_constraints = optimization_summary.num_outcome_constraints
+    if num_outcome_constraints > 2:
+        is_in_wheelhouse = False
+        why_not_is_in_wheelhouse += [
+            f"{num_outcome_constraints} outcome constraints (max in-wheelhouse is 2)"
+        ]
+        if num_outcome_constraints > 5:
+            is_supported = False
+            why_not_supported += [
+                f"{num_outcome_constraints} outcome constraints (max supported is 5)"
+            ]
+    return is_in_wheelhouse, is_supported
+
+
+def _check_if_is_in_wheelhouse_other_settings(
+    optimization_summary: OptimizationSummary,
+    why_not_is_in_wheelhouse: list[str],
+    why_not_supported: list[str],
+) -> tuple[bool, bool]:
+    """Check if other experiment settings are within supported tiers.
+
+    Evaluates additional settings including max trials, early stopping,
+    global stopping, failure rate settings, and advanced options.
+
+    Args:
+        optimization_summary: Summary of the experiment. See ``OptimizationSummary``
+            for the required and optional keys.
+        why_not_is_in_wheelhouse: A list to append reasons for not being in
+            the wheelhouse tier.
+        why_not_supported: A list to append reasons for not being supported.
+
+    Returns:
+        A tuple with information about whether the experiment is in the wheelhouse.
+    """
+    is_in_wheelhouse, is_supported = True, True
+    max_trials = optimization_summary.max_trials
+    if not optimization_summary.all_inputs_are_configs:
+        is_in_wheelhouse, is_supported = False, False
+        why_not_supported.append(NOT_STANDARD_API_MESSAGE)
+    elif max_trials is None:
+        raise UserInputError("`max_trials` should not be None!")
+    elif max_trials is not None and max_trials > 200:
+        is_in_wheelhouse = False
+        why_not_is_in_wheelhouse += [
+            f"{max_trials} total trials (max in-wheelhouse is 200)"
+        ]
+        if max_trials > 500:
+            is_supported = False
+            why_not_supported += [f"{max_trials} total trials (max supported is 500)"]
+
+    uses_early_stopping = optimization_summary.uses_early_stopping
+    if uses_early_stopping:
+        is_in_wheelhouse = False
+        why_not_is_in_wheelhouse += ["Early stopping is enabled"]
+
+    uses_global_stopping = optimization_summary.uses_global_stopping
+    if uses_global_stopping:
+        is_in_wheelhouse = False
+        why_not_is_in_wheelhouse += ["Global stopping is enabled"]
+
+    # checking failure rate checking options
+    tolerated_trial_failure_rate = optimization_summary.tolerated_trial_failure_rate
+    if tolerated_trial_failure_rate is not None and tolerated_trial_failure_rate > 0.9:
+        is_in_wheelhouse, is_supported = False, False
+        why_not_supported.append(f"{tolerated_trial_failure_rate=} is larger than 0.9.")
+
+    max_pending_trials = optimization_summary.max_pending_trials
+    min_failed_trials_for_failure_rate_check = (
+        optimization_summary.min_failed_trials_for_failure_rate_check
+    )
+    if (
+        max_pending_trials is not None
+        and min_failed_trials_for_failure_rate_check is not None
+        and max(2 * max_pending_trials, 5) < min_failed_trials_for_failure_rate_check
+    ):
+        is_in_wheelhouse, is_supported = False, False
+        why_not_supported.append(
+            f"{min_failed_trials_for_failure_rate_check=} exceeds "
+            f"{max(2 * max_pending_trials, 5)=}. Please reduce "
+            "min_failed_trials_for_failure_rate_check below the stated threshold for "
+            "this sweep to be in a supported tier."
+        )
+    non_default_advanced_options = optimization_summary.non_default_advanced_options
+    if non_default_advanced_options:
+        is_in_wheelhouse, is_supported = False, False
+        why_not_supported.append(
+            "Non-default advanced_options are set on GenerationStrategyConfig."
+        )
+
+    uses_merge_multiple_curves = optimization_summary.uses_merge_multiple_curves
+    if uses_merge_multiple_curves:
+        is_in_wheelhouse, is_supported = False, False
+        why_not_supported.append(
+            "Metrics with merge_multiple_curves=True are not supported. "
+            "This feature is experimental and caution is advised not to merge "
+            "unrelated curves."
+        )
+
+    return is_in_wheelhouse, is_supported
+
+
+def check_if_in_wheelhouse(
+    optimization_summary: OptimizationSummary,
+) -> tuple[str, list[str] | None, list[str] | None]:
+    """Determine the support tier of an experiment based on its configuration.
+
+    Evaluates the experiment summary and classifies it into one of three tiers:
+
+    - **Wheelhouse**: Well-supported configurations that should work without issues.
+    - **Advanced**: Technically supported but uses advanced features that may not
+      be well-tested or compatible with other advanced features.
+    - **Unsupported**: Configurations that push beyond supported limits.
+
+    Args:
+        optimization_summary: Summary of the experiment. See ``OptimizationSummary``
+            for the required and optional keys. This summary should contain
+            information about:
+
+            - Search space: num_params, num_binary, num_categorical_3_5,
+              num_categorical_6_inf, num_parameter_constraints
+            - Optimization config: num_objectives, num_outcome_constraints
+            - Other settings: max_trials, uses_early_stopping, uses_global_stopping,
+              all_inputs_are_configs, tolerated_trial_failure_rate, max_pending_trials,
+              min_failed_trials_for_failure_rate_check, non_default_advanced_options,
+              uses_merge_multiple_curves
+
+    Returns:
+        A tuple containing:
+
+        - The tier name: "Wheelhouse", "Advanced", or "Unsupported"
+        - A list of reasons for not being in the "Wheelhouse" tier (None if
+          in Wheelhouse)
+        - A list of reasons for not being supported (None if
+          in Wheelhouse or Advanced)
+    """
+
+    is_in_wheelhouse, why_not_is_in_wheelhouse = True, []
+    is_supported, why_not_supported = True, []
+
+    # Check search space
+    search_space_summary = _check_if_is_in_wheelhouse_search_space(
+        optimization_summary=optimization_summary,
+        why_not_is_in_wheelhouse=why_not_is_in_wheelhouse,
+        why_not_supported=why_not_supported,
+    )
+    is_in_wheelhouse &= search_space_summary[0]
+    is_supported &= search_space_summary[1]
+
+    # Check optimization config
+    opt_config_summary = _check_if_is_in_wheelhouse_optimization_config(
+        optimization_summary=optimization_summary,
+        why_not_is_in_wheelhouse=why_not_is_in_wheelhouse,
+        why_not_supported=why_not_supported,
+    )
+    is_in_wheelhouse &= opt_config_summary[0]
+    is_supported &= opt_config_summary[1]
+
+    # Check other options
+    other_settings_summary = _check_if_is_in_wheelhouse_other_settings(
+        optimization_summary=optimization_summary,
+        why_not_is_in_wheelhouse=why_not_is_in_wheelhouse,
+        why_not_supported=why_not_supported,
+    )
+    is_in_wheelhouse &= other_settings_summary[0]
+    is_supported &= other_settings_summary[1]
+
+    # Return tier and messages
+    if is_in_wheelhouse:
+        return "Wheelhouse", None, None
+    if is_supported:
+        return "Advanced", why_not_is_in_wheelhouse, None
+    return "Unsupported", why_not_is_in_wheelhouse, why_not_supported
 
 
 def format_tier_message(
@@ -120,8 +475,20 @@ def format_tier_message(
     why_not_supported: Iterable[str] | None,
 ) -> str:
     """
-    Format the result from `check_if_in_wheelhouse` to a markdown-formatted string
-    explaining the tier.
+    Format the result from `check_if_in_wheelhouse` to a markdown-formatted
+    string explaining the tier.
+
+    Takes the tier classification and the reasons for not being in a higher tier,
+    and formats them into a readable, markdown-formatted message that can be
+    displayed to users.
+
+    Args:
+        tier: The tier name ("Wheelhouse", "Advanced", or "Unsupported").
+        why_not_is_in_wheelhouse: Reasons for not being in the Wheelhouse tier.
+        why_not_supported: Reasons for not being in the Advanced tier.
+
+    Returns:
+        A formatted string explaining the tier and the reasons.
     """
 
     if tier == "Wheelhouse":

--- a/ax/utils/common/complexity_utils.py
+++ b/ax/utils/common/complexity_utils.py
@@ -525,3 +525,33 @@ def format_tier_message(
             )
             msg += why_msg
     return msg
+
+
+def get_tier_msg(
+    experiment: Experiment,
+    options: Any,
+    tier_metadata: dict[str, Any] | None = None,
+) -> str:
+    """Figure out the tier of the experiment.
+
+    Args:
+        experiment: The Ax Experiment.
+        options: The orchestrator options.
+        tier_metadata: tier-related meta-data from the orchestrator.
+
+    Returns:
+        A markdown-formatted string explaining the tier.
+    """
+    tier_metadata = tier_metadata or {}
+    tier, why_not_is_in_wheelhouse, why_not_supported = check_if_in_wheelhouse(
+        summarize_ax_optimization_complexity(
+            experiment=experiment, options=options, tier_metadata=tier_metadata
+        )
+    )
+
+    # Convert to user-friendly message
+    return format_tier_message(
+        tier=tier,
+        why_not_is_in_wheelhouse=why_not_is_in_wheelhouse,
+        why_not_supported=why_not_supported,
+    )

--- a/ax/utils/common/tests/test_complexity_utils.py
+++ b/ax/utils/common/tests/test_complexity_utils.py
@@ -6,15 +6,18 @@
 
 # pyre-strict
 
-from ax.exceptions.core import OptimizationNotConfiguredError
+from ax.exceptions.core import OptimizationNotConfiguredError, UserInputError
 from ax.service.orchestrator import OrchestratorOptions
 from ax.utils.common.complexity_utils import (
     ADVANCED_TIER_MESSAGE,
+    check_if_in_wheelhouse,
     format_tier_message,
+    OptimizationSummary,
     summarize_ax_optimization_complexity,
     UNSUPPORTED_TIER_MESSAGE,
     WHEELHOUSE_TIER_MESSAGE,
 )
+
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_experiment,
@@ -41,31 +44,13 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
             tier_metadata=self.tier_metadata,
         )
 
-        # THEN the summary should contain all expected keys with correct values
-        expected_keys = [
-            "max_trials",
-            "num_params",
-            "num_binary",
-            "num_categorical_3_5",
-            "num_categorical_6_inf",
-            "num_parameter_constraints",
-            "num_objectives",
-            "num_outcome_constraints",
-            "uses_early_stopping",
-            "uses_global_stopping",
-            "uses_merge_multiple_curves",
-            "all_inputs_are_configs",
-            "tolerated_trial_failure_rate",
-            "max_pending_trials",
-            "min_failed_trials_for_failure_rate_check",
-        ]
-        for key in expected_keys:
-            self.assertIn(key, summary)
+        # THEN the summary should be an OptimizationSummary with correct values
+        self.assertIsInstance(summary, OptimizationSummary)
 
         # Validate specific values for single-objective experiment
-        self.assertEqual(summary["num_objectives"], 1)
-        self.assertFalse(summary["uses_early_stopping"])
-        self.assertFalse(summary["uses_global_stopping"])
+        self.assertEqual(summary.num_objectives, 1)
+        self.assertFalse(summary.uses_early_stopping)
+        self.assertFalse(summary.uses_global_stopping)
 
     def test_multi_objective_experiment(self) -> None:
         # GIVEN a multi-objective experiment
@@ -79,7 +64,7 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
         )
 
         # THEN num_objectives should be greater than 1
-        self.assertGreater(summary["num_objectives"], 1)
+        self.assertGreater(summary.num_objectives, 1)
 
     def test_experiment_without_optimization_config_raises(self) -> None:
         # GIVEN an experiment without optimization config
@@ -128,10 +113,8 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
                 )
 
                 # THEN the summary should reflect tier metadata values
-                self.assertEqual(summary["max_trials"], expected_max_trials)
-                self.assertEqual(
-                    summary["all_inputs_are_configs"], expected_all_configs
-                )
+                self.assertEqual(summary.max_trials, expected_max_trials)
+                self.assertEqual(summary.all_inputs_are_configs, expected_all_configs)
 
     def test_orchestrator_options_extraction(self) -> None:
         # GIVEN custom orchestrator options
@@ -149,9 +132,9 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
         )
 
         # THEN the summary should reflect orchestrator options
-        self.assertEqual(summary["tolerated_trial_failure_rate"], 0.25)
-        self.assertEqual(summary["max_pending_trials"], 5)
-        self.assertEqual(summary["min_failed_trials_for_failure_rate_check"], 10)
+        self.assertEqual(summary.tolerated_trial_failure_rate, 0.25)
+        self.assertEqual(summary.max_pending_trials, 5)
+        self.assertEqual(summary.min_failed_trials_for_failure_rate_check, 10)
 
     def test_parameter_constraints_counted(self) -> None:
         # GIVEN an experiment with parameter constraints
@@ -165,7 +148,7 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
         )
 
         # THEN num_parameter_constraints should be greater than 0
-        self.assertGreater(summary["num_parameter_constraints"], 0)
+        self.assertGreater(summary.num_parameter_constraints, 0)
 
 
 class TestFormatTierMessage(TestCase):
@@ -241,3 +224,164 @@ class TestFormatTierMessage(TestCase):
                 why_not_is_in_wheelhouse=None,
                 why_not_supported=None,
             )
+
+
+def get_experiment_summary(
+    max_trials: int | None = 100,
+    num_params: int = 10,
+    num_binary: int = 0,
+    num_categorical_3_5: int = 0,
+    num_categorical_6_inf: int = 0,
+    num_parameter_constraints: int = 0,
+    num_objectives: int = 1,
+    num_outcome_constraints: int = 0,
+    uses_early_stopping: bool = False,
+    uses_global_stopping: bool = False,
+    all_inputs_are_configs: bool = True,
+    tolerated_trial_failure_rate: float | None = 0.5,
+    max_pending_trials: int | None = 5,
+    min_failed_trials_for_failure_rate_check: int | None = 5,
+    non_default_advanced_options: bool | None = None,
+    uses_merge_multiple_curves: bool | None = None,
+) -> OptimizationSummary:
+    """Create an OptimizationSummary for testing."""
+    return OptimizationSummary(
+        max_trials=max_trials,
+        num_params=num_params,
+        num_binary=num_binary,
+        num_categorical_3_5=num_categorical_3_5,
+        num_categorical_6_inf=num_categorical_6_inf,
+        num_parameter_constraints=num_parameter_constraints,
+        num_objectives=num_objectives,
+        num_outcome_constraints=num_outcome_constraints,
+        uses_early_stopping=uses_early_stopping,
+        uses_global_stopping=uses_global_stopping,
+        all_inputs_are_configs=all_inputs_are_configs,
+        tolerated_trial_failure_rate=tolerated_trial_failure_rate,
+        max_pending_trials=max_pending_trials,
+        min_failed_trials_for_failure_rate_check=(
+            min_failed_trials_for_failure_rate_check
+        ),
+        non_default_advanced_options=non_default_advanced_options,
+        uses_merge_multiple_curves=uses_merge_multiple_curves,
+    )
+
+
+class TestCheckIfInWheelhouse(TestCase):
+    """Tests for check_if_in_wheelhouse."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.base_summary = get_experiment_summary()
+
+    def test_wheelhouse_tier_for_simple_experiment(self) -> None:
+        """Test that a simple experiment is classified as Wheelhouse tier."""
+        tier, why_not_wheelhouse, why_not_supported = check_if_in_wheelhouse(
+            self.base_summary
+        )
+
+        self.assertEqual(tier, "Wheelhouse")
+        self.assertEqual(why_not_wheelhouse, None)
+        self.assertEqual(why_not_supported, None)
+
+    def test_advanced_tier_conditions(self) -> None:
+        """Test conditions that result in Advanced tier."""
+        test_cases: list[tuple[OptimizationSummary, str]] = [
+            (get_experiment_summary(max_trials=250), "250 total trials"),
+            (get_experiment_summary(num_params=60), "60 tunable parameter(s)"),
+            (get_experiment_summary(num_binary=75), "75 binary tunable parameter(s)"),
+            (
+                get_experiment_summary(num_categorical_3_5=1),
+                "1 unordered choice parameter(s)",
+            ),
+            (
+                get_experiment_summary(num_parameter_constraints=4),
+                "4 parameter constraints",
+            ),
+            (get_experiment_summary(num_objectives=3), "3 objectives"),
+            (
+                get_experiment_summary(num_outcome_constraints=3),
+                "3 outcome constraints",
+            ),
+            (
+                get_experiment_summary(uses_early_stopping=True),
+                "Early stopping is enabled",
+            ),
+            (
+                get_experiment_summary(uses_global_stopping=True),
+                "Global stopping is enabled",
+            ),
+        ]
+
+        for summary, expected_msg in test_cases:
+            with self.subTest(expected_msg=expected_msg):
+                tier, why_not_wheelhouse, why_not_supported = check_if_in_wheelhouse(
+                    summary
+                )
+
+                self.assertEqual(tier, "Advanced")
+                self.assertIsNotNone(why_not_wheelhouse)
+                self.assertIn(expected_msg, why_not_wheelhouse[0])
+                self.assertEqual(why_not_supported, None)
+
+    def test_unsupported_tier_conditions(self) -> None:
+        """Test conditions that result in Unsupported tier."""
+        test_cases: list[tuple[OptimizationSummary, str]] = [
+            (get_experiment_summary(max_trials=510), "510 total trials"),
+            (get_experiment_summary(num_params=201), "201 tunable parameter(s)"),
+            (get_experiment_summary(num_binary=101), "101 binary tunable parameter(s)"),
+            (
+                get_experiment_summary(num_categorical_3_5=6),
+                "unordered choice parameters with more than 3 options",
+            ),
+            (
+                get_experiment_summary(num_categorical_6_inf=2),
+                "unordered choice parameters with more than 5 options",
+            ),
+            (
+                get_experiment_summary(num_parameter_constraints=6),
+                "6 parameter constraints",
+            ),
+            (get_experiment_summary(num_objectives=5), "5 objectives"),
+            (
+                get_experiment_summary(num_outcome_constraints=6),
+                "6 outcome constraints",
+            ),
+            (
+                get_experiment_summary(all_inputs_are_configs=False),
+                "uses_standard_api=False",
+            ),
+            (
+                get_experiment_summary(tolerated_trial_failure_rate=0.99),
+                "tolerated_trial_failure_rate=0.99",
+            ),
+            (
+                get_experiment_summary(non_default_advanced_options=True),
+                "Non-default advanced_options",
+            ),
+            (
+                get_experiment_summary(uses_merge_multiple_curves=True),
+                "merge_multiple_curves=True",
+            ),
+            (
+                get_experiment_summary(
+                    max_pending_trials=3, min_failed_trials_for_failure_rate_check=7
+                ),
+                "min_failed_trials_for_failure_rate_check=7",
+            ),
+        ]
+
+        for summary, expected_msg in test_cases:
+            with self.subTest(expected_msg=expected_msg):
+                tier, _, why_not_supported = check_if_in_wheelhouse(summary)
+
+                self.assertEqual(tier, "Unsupported")
+                self.assertIsNotNone(why_not_supported)
+                self.assertIn(expected_msg, why_not_supported[0])
+
+    def test_max_trials_none_raises(self) -> None:
+        """Test max_trials=None with all_inputs_are_configs=True raises error."""
+        summary = get_experiment_summary(all_inputs_are_configs=True, max_trials=None)
+
+        with self.assertRaisesRegex(UserInputError, "`max_trials` should not be None!"):
+            check_if_in_wheelhouse(summary)

--- a/ax/utils/common/tests/test_complexity_utils.py
+++ b/ax/utils/common/tests/test_complexity_utils.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.exceptions.core import OptimizationNotConfiguredError
+from ax.service.orchestrator import OrchestratorOptions
+from ax.utils.common.complexity_utils import summarize_ax_optimization_complexity
+from ax.utils.common.testutils import TestCase
+from ax.utils.testing.core_stubs import (
+    get_experiment,
+    get_experiment_with_multi_objective,
+)
+
+
+class TestSummarizeAxOptimizationComplexity(TestCase):
+    """Tests for the summarize_ax_optimization_complexity function."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.experiment = get_experiment()
+        self.options = OrchestratorOptions()
+        self.tier_metadata: dict[str, object] = {}
+
+    def test_basic_experiment_summary(self) -> None:
+        # GIVEN a basic experiment with single objective (from setUp)
+
+        # WHEN we summarize the experiment
+        summary = summarize_ax_optimization_complexity(
+            experiment=self.experiment,
+            options=self.options,
+            tier_metadata=self.tier_metadata,
+        )
+
+        # THEN the summary should contain all expected keys with correct values
+        expected_keys = [
+            "max_trials",
+            "num_params",
+            "num_binary",
+            "num_categorical_3_5",
+            "num_categorical_6_inf",
+            "num_parameter_constraints",
+            "num_objectives",
+            "num_outcome_constraints",
+            "uses_early_stopping",
+            "uses_global_stopping",
+            "uses_merge_multiple_curves",
+            "all_inputs_are_configs",
+            "tolerated_trial_failure_rate",
+            "max_pending_trials",
+            "min_failed_trials_for_failure_rate_check",
+        ]
+        for key in expected_keys:
+            self.assertIn(key, summary)
+
+        # Validate specific values for single-objective experiment
+        self.assertEqual(summary["num_objectives"], 1)
+        self.assertFalse(summary["uses_early_stopping"])
+        self.assertFalse(summary["uses_global_stopping"])
+
+    def test_multi_objective_experiment(self) -> None:
+        # GIVEN a multi-objective experiment
+        experiment = get_experiment_with_multi_objective()
+
+        # WHEN we summarize the experiment
+        summary = summarize_ax_optimization_complexity(
+            experiment=experiment,
+            options=self.options,
+            tier_metadata=self.tier_metadata,
+        )
+
+        # THEN num_objectives should be greater than 1
+        self.assertGreater(summary["num_objectives"], 1)
+
+    def test_experiment_without_optimization_config_raises(self) -> None:
+        # GIVEN an experiment without optimization config
+        self.experiment._optimization_config = None
+
+        # WHEN/THEN summarizing should raise OptimizationNotConfiguredError
+        with self.assertRaisesRegex(
+            OptimizationNotConfiguredError,
+            "Experiment must have an optimization_config",
+        ):
+            summarize_ax_optimization_complexity(
+                experiment=self.experiment,
+                options=self.options,
+                tier_metadata=self.tier_metadata,
+            )
+
+    def test_tier_metadata_extraction(self) -> None:
+        # Test that tier_metadata values are correctly extracted
+        test_cases = [
+            (
+                "with_values",
+                {"user_supplied_max_trials": 50, "all_inputs_are_configs": True},
+                50,
+                True,
+            ),
+            (
+                "empty_defaults",
+                {},
+                None,
+                False,
+            ),
+        ]
+
+        for (
+            name,
+            tier_metadata,
+            expected_max_trials,
+            expected_all_configs,
+        ) in test_cases:
+            with self.subTest(name=name):
+                # WHEN we summarize the experiment
+                summary = summarize_ax_optimization_complexity(
+                    experiment=self.experiment,
+                    options=self.options,
+                    tier_metadata=tier_metadata,
+                )
+
+                # THEN the summary should reflect tier metadata values
+                self.assertEqual(summary["max_trials"], expected_max_trials)
+                self.assertEqual(
+                    summary["all_inputs_are_configs"], expected_all_configs
+                )
+
+    def test_orchestrator_options_extraction(self) -> None:
+        # GIVEN custom orchestrator options
+        options = OrchestratorOptions(
+            tolerated_trial_failure_rate=0.25,
+            max_pending_trials=5,
+            min_failed_trials_for_failure_rate_check=10,
+        )
+
+        # WHEN we summarize the experiment
+        summary = summarize_ax_optimization_complexity(
+            experiment=self.experiment,
+            options=options,
+            tier_metadata=self.tier_metadata,
+        )
+
+        # THEN the summary should reflect orchestrator options
+        self.assertEqual(summary["tolerated_trial_failure_rate"], 0.25)
+        self.assertEqual(summary["max_pending_trials"], 5)
+        self.assertEqual(summary["min_failed_trials_for_failure_rate_check"], 10)
+
+    def test_parameter_constraints_counted(self) -> None:
+        # GIVEN an experiment with parameter constraints
+        experiment = get_experiment(constrain_search_space=True)
+
+        # WHEN we summarize the experiment
+        summary = summarize_ax_optimization_complexity(
+            experiment=experiment,
+            options=self.options,
+            tier_metadata=self.tier_metadata,
+        )
+
+        # THEN num_parameter_constraints should be greater than 0
+        self.assertGreater(summary["num_parameter_constraints"], 0)


### PR DESCRIPTION
Summary: Move `get_tier_msg` utility method to OSS. This method will be used in the new Complexity Rating Healthcheck.

Differential Revision: D89044911


