### PR TITLE
Update get_default_ess_or_none to check for a MapMetric

### DIFF
--- a/ax/early_stopping/dispatch.py
+++ b/ax/early_stopping/dispatch.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 from ax.core.experiment import Experiment
+from ax.core.map_metric import MapMetric
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.early_stopping.strategies.percentile import PercentileEarlyStoppingStrategy
 
@@ -20,6 +21,8 @@ def get_default_ess_or_none(
     for single objective unconstrained problems. For all other problem types
     (multi-objective, constrained, or no optimization config), returns None.
 
+    Experiment objective must be a MapMetric. Will return None otherwise.
+
     Args:
         experiment: The experiment to create an early stopping strategy for.
 
@@ -32,6 +35,7 @@ def get_default_ess_or_none(
         opt_config is None
         or isinstance(opt_config, MultiObjectiveOptimizationConfig)
         or len(opt_config.outcome_constraints) > 0
+        or not any(isinstance(m, MapMetric) for m in opt_config.metrics.values())
     ):
         return None
 

--- a/ax/early_stopping/tests/test_dispatch.py
+++ b/ax/early_stopping/tests/test_dispatch.py
@@ -11,14 +11,14 @@ from ax.early_stopping.strategies.percentile import PercentileEarlyStoppingStrat
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
-    get_branin_experiment_with_multi_objective,
+    get_branin_experiment_with_timestamp_map_metric,
 )
 from pyre_extensions import none_throws
 
 
 class TestGetDefaultEss(TestCase):
     def test_get_default_ess_single_objective_unconstrained(self) -> None:
-        exp = get_branin_experiment()
+        exp = get_branin_experiment_with_timestamp_map_metric()
         strategy = none_throws(get_default_ess_or_none(experiment=exp))
         self.assertIsInstance(strategy, PercentileEarlyStoppingStrategy)
 
@@ -34,10 +34,12 @@ class TestGetDefaultEss(TestCase):
     def test_get_default_ess_null_conditions(self) -> None:
         # Checks that None is returned for currently unsupported conditions.
         for exp in [
-            get_branin_experiment(has_optimization_config=False),
-            get_branin_experiment(
-                has_optimization_config=True, with_absolute_constraint=True
+            get_branin_experiment(has_optimization_config=True),  # No MapMetric.
+            get_branin_experiment(has_optimization_config=False),  # No opt config.
+            get_branin_experiment_with_timestamp_map_metric(  # Outcome constraint.
+                with_outcome_constraint=True
             ),
-            get_branin_experiment_with_multi_objective(has_optimization_config=True),
+            # Multi-objective.
+            get_branin_experiment_with_timestamp_map_metric(multi_objective=True),
         ]:
             self.assertIsNone(get_default_ess_or_none(experiment=exp))

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -438,6 +438,7 @@ def get_branin_experiment_with_timestamp_map_metric(
     has_objective_thresholds: bool = False,
     bounds: list[float] | None = None,
     with_choice_parameter: bool = False,
+    with_outcome_constraint: bool = False,
 ) -> Experiment:
     """Returns an experiment with the search space including parameters
 
@@ -455,6 +456,8 @@ def get_branin_experiment_with_timestamp_map_metric(
             bounds determines the precise objective thresholds.
         with_choice_parameter: Whether to include a choice parameter.
             If true, `x2` will be a ChoiceParameter.
+        with_outcome_constraint: If True, adds an outcome constraint with an additional
+            non-map Branin metric.
 
 
     Returns:
@@ -467,6 +470,16 @@ def get_branin_experiment_with_timestamp_map_metric(
         decay_function_name=decay_function_name,
     )
     experiment_name = "branin_with_timestamp_map_metric"
+    if with_outcome_constraint:
+        outcome_constraints = [
+            OutcomeConstraint(
+                metric=BraninMetric(name="branin_constraint", param_names=["x1", "x2"]),
+                op=ComparisonOp.LEQ,
+                bound=100.0,
+            )
+        ]
+    else:
+        outcome_constraints = None
     if multi_objective:
         experiment_name = "multi_objective_" + experiment_name
         num_objectives = 2
@@ -499,6 +512,7 @@ def get_branin_experiment_with_timestamp_map_metric(
         optimization_config = MultiObjectiveOptimizationConfig(
             objective=MultiObjective(objectives=objectives),
             objective_thresholds=objective_thresholds,
+            outcome_constraints=outcome_constraints,
         )
 
     else:  # single objective case
@@ -506,7 +520,8 @@ def get_branin_experiment_with_timestamp_map_metric(
             objective=Objective(
                 metric=local_get_map_metric(name="branin_map"),
                 minimize=True,
-            )
+            ),
+            outcome_constraints=outcome_constraints,
         )
 
         if map_tracking_metric:


### PR DESCRIPTION
Summary: ESS should not be used if there are no MapMetrics.

Reviewed By: bernardbeckerman

Differential Revision:
D89065356

Privacy Context Container: L1307644


