### PR TITLE
Make ParameterConstraint store its own inequality string

### DIFF
--- a/ax/adapter/tests/test_torch_moo_adapter.py
+++ b/ax/adapter/tests/test_torch_moo_adapter.py
@@ -437,9 +437,7 @@ class MultiObjectiveTorchAdapterTest(TestCase):
         )
         fixed_features = ObservationFeatures(parameters={"x1": 0.0})
         search_space = exp.search_space.clone()
-        param_constraints = [
-            ParameterConstraint(constraint_dict={"x1": 1.0}, bound=10.0)
-        ]
+        param_constraints = [ParameterConstraint(inequality="x1 <= 10")]
         search_space.add_parameter_constraints(param_constraints)
         oc = none_throws(exp.optimization_config).clone()
         oc.objective._objectives[0].minimize = True

--- a/ax/adapter/transforms/tests/test_choice_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_choice_encode_transform.py
@@ -68,9 +68,7 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
                     sort_values=False,
                 ),
             ],
-            parameter_constraints=[
-                ParameterConstraint(constraint_dict={"x": -0.5, "a": 1}, bound=0.5)
-            ],
+            parameter_constraints=[ParameterConstraint(inequality="-0.5*x + a <= 0.5")],
         )
         self.t = self.t_class(search_space=self.search_space)
         input_params: TParameterization = {

--- a/ax/adapter/transforms/tests/test_one_hot_transform.py
+++ b/ax/adapter/transforms/tests/test_one_hot_transform.py
@@ -46,9 +46,7 @@ class OneHotTransformTest(TestCase):
                     is_ordered=True,
                 ),
             ],
-            parameter_constraints=[
-                ParameterConstraint(constraint_dict={"x": -0.5, "a": 1}, bound=0.5)
-            ],
+            parameter_constraints=[ParameterConstraint(inequality="-0.5*x + a <= 0.5")],
         )
         self.t = OneHot(search_space=self.search_space)
         self.t2 = OneHot(

--- a/ax/adapter/transforms/tests/test_unit_x_transform.py
+++ b/ax/adapter/transforms/tests/test_unit_x_transform.py
@@ -46,8 +46,8 @@ class UnitXTransformTest(TestCase):
                 ),
             ],
             parameter_constraints=[
-                ParameterConstraint(constraint_dict={"x": -0.5, "y": 1}, bound=0.5),
-                ParameterConstraint(constraint_dict={"x": -0.5, "a": 1}, bound=0.5),
+                ParameterConstraint(inequality="-0.5*x + y <= 0.5"),
+                ParameterConstraint(inequality="-0.5*x + a <= 0.5"),
             ],
         )
         self.t = UnitX(search_space=self.search_space)
@@ -157,8 +157,8 @@ class UnitXTransformTest(TestCase):
                 ),
             ],
             parameter_constraints=[
-                ParameterConstraint(constraint_dict={"x": -0.5, "y": 1}, bound=0.5),
-                ParameterConstraint(constraint_dict={"x": -0.5, "a": 1}, bound=0.5),
+                ParameterConstraint(inequality="-0.5*x + y <= 0.5"),
+                ParameterConstraint(inequality="-0.5*x + a <= 0.5"),
             ],
         )
         self.t.transform_search_space(new_ss)

--- a/ax/adapter/transforms/unit_x.py
+++ b/ax/adapter/transforms/unit_x.py
@@ -98,8 +98,14 @@ class UnitX(Transform):
                     bound -= w * l
                 else:
                     constraint_dict[p_name] = w
+
+            expr = " + ".join(
+                f"{coeff} * {param}" for param, coeff in constraint_dict.items()
+            )
             new_constraints.append(
-                ParameterConstraint(constraint_dict=constraint_dict, bound=bound)
+                ParameterConstraint(
+                    inequality=f"{expr} <= {bound}",
+                )
             )
         search_space.set_parameter_constraints(new_constraints)
         return search_space

--- a/ax/analysis/healthcheck/tests/test_search_space_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_search_space_analysis.py
@@ -97,10 +97,7 @@ class TestSearchSpaceAnalysis(TestCase):
                 ),
             ],
             parameter_constraints=[
-                ParameterConstraint(
-                    constraint_dict={"float_range_1": 1.0, "float_range_2": 1.0},
-                    bound=4.0,
-                )
+                ParameterConstraint(inequality="float_range_1 + float_range_2 <= 4")
             ],
         )
 

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -111,7 +111,7 @@ class TestClient(TestCase):
                     ],
                     parameter_constraints=[
                         ParameterConstraint(
-                            constraint_dict={"int_param": 1, "float_param": -1}, bound=0
+                            inequality="int_param <= float_param",
                         )
                     ],
                 ),

--- a/ax/api/utils/instantiation/from_string.py
+++ b/ax/api/utils/instantiation/from_string.py
@@ -8,7 +8,6 @@
 from collections.abc import Sequence
 
 from ax.core.map_metric import MapMetric
-
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
@@ -20,14 +19,13 @@ from ax.core.outcome_constraint import (
     OutcomeConstraint,
     ScalarizedOutcomeConstraint,
 )
-from ax.core.parameter_constraint import ParameterConstraint
 from ax.exceptions.core import UserInputError
 from ax.utils.common.string_utils import sanitize_name, unsanitize_name
+from ax.utils.common.sympy import extract_coefficient_dict_from_inequality
 from pyre_extensions import assert_is_instance, none_throws
 from sympy.core.add import Add
 from sympy.core.expr import Expr
 from sympy.core.mul import Mul
-from sympy.core.relational import GreaterThan, LessThan
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 
@@ -95,35 +93,6 @@ def optimization_config_from_string(
     )
 
 
-def parse_parameter_constraint(constraint_str: str) -> ParameterConstraint:
-    """
-    Parse a parameter constraint string into a ParameterConstraint object using SymPy.
-    Currently only supports linear constraints of the form "a * x + b * y >= k" or
-    "a * x + b * y <= k".
-    """
-    coefficient_dict = _extract_coefficient_dict_from_inequality(
-        inequality_str=constraint_str
-    )
-
-    # Iterate through the coefficients to extract the parameter names and weights and
-    # the bound
-    constraint_dict = {}
-    bound = 0
-    for term, coefficient in coefficient_dict.items():
-        if term.is_symbol:
-            constraint_dict[unsanitize_name(term.name)] = coefficient
-        elif term.is_number:
-            # Invert because we are "moving" the bound to the right hand side
-            bound = -1 * coefficient
-        else:
-            raise UserInputError(
-                "Only linear inequality parameter constraints are supported, found "
-                f"{constraint_str}"
-            )
-
-    return ParameterConstraint(constraint_dict=constraint_dict, bound=bound)
-
-
 def parse_objective(objective_str: str) -> Objective:
     """
     Parse an objective string into an Objective object using SymPy.
@@ -154,7 +123,7 @@ def parse_outcome_constraint(constraint_str: str) -> OutcomeConstraint:
     multiply your bound by "baseline". For example "qps >= 0.95 * baseline" will
     constrain such that the QPS is at least 95% of the baseline arm's QPS.
     """
-    coefficient_dict = _extract_coefficient_dict_from_inequality(
+    coefficient_dict = extract_coefficient_dict_from_inequality(
         inequality_str=constraint_str
     )
 
@@ -248,31 +217,3 @@ def _create_single_objective(expression: Expr) -> Objective:
         )
 
     raise UserInputError(f"Only linear objectives are supported, found {expression}.")
-
-
-def _extract_coefficient_dict_from_inequality(
-    inequality_str: str,
-) -> dict[Symbol, float]:
-    """
-    Use SymPy to parse a string into an inequality, invert if necessary to enforce a
-    less-than relationship, move all terms to the left side, and return the
-    coefficients as a dictionary. This is useful for parsing parameter and outcome
-    constraints.
-    """
-    # Parse the constraint string into a SymPy inequality
-    inequality = sympify(sanitize_name(inequality_str))
-
-    # Check the SymPy object is a valid inequality
-    if not isinstance(inequality, GreaterThan | LessThan):
-        raise UserInputError(f"Expected an inequality, found {inequality_str}")
-
-    # Move all terms to the left side of the inequality and invert if necessary to
-    # enforce a less-than relationship
-    if isinstance(inequality, LessThan):
-        expression = inequality.lhs - inequality.rhs
-    else:
-        expression = inequality.rhs - inequality.lhs
-
-    return {
-        key: float(value) for key, value in expression.as_coefficients_dict().items()
-    }

--- a/ax/api/utils/instantiation/from_struct.py
+++ b/ax/api/utils/instantiation/from_struct.py
@@ -6,11 +6,13 @@
 # pyre-strict
 
 from ax.api.utils.instantiation.from_config import parameter_from_config
-from ax.api.utils.instantiation.from_string import parse_parameter_constraint
 from ax.api.utils.structs import ExperimentStruct
 from ax.core.evaluations_to_data import DataType
 from ax.core.experiment import Experiment
-from ax.core.parameter_constraint import validate_constraint_parameters
+from ax.core.parameter_constraint import (
+    ParameterConstraint,
+    validate_constraint_parameters,
+)
 from ax.core.search_space import SearchSpace
 
 
@@ -22,8 +24,8 @@ def experiment_from_struct(struct: ExperimentStruct) -> Experiment:
     ]
 
     constraints = [
-        parse_parameter_constraint(constraint_str=constraint_str)
-        for constraint_str in struct.parameter_constraints
+        ParameterConstraint(inequality=inequality)
+        for inequality in struct.parameter_constraints
     ]
 
     # Ensure that all ParameterConstraints are valid and acting on existing parameters

--- a/ax/api/utils/instantiation/tests/test_from_config.py
+++ b/ax/api/utils/instantiation/tests/test_from_config.py
@@ -278,7 +278,7 @@ class TestFromConfig(TestCase):
                     ],
                     parameter_constraints=[
                         ParameterConstraint(
-                            constraint_dict={"int_param": 1, "float_param": -1}, bound=0
+                            inequality="int_param <= float_param",
                         )
                     ],
                 ),
@@ -340,7 +340,7 @@ class TestFromConfig(TestCase):
                     ],
                     parameter_constraints=[
                         ParameterConstraint(
-                            constraint_dict={"int_param": 1, "float_param": -1}, bound=0
+                            inequality="int_param <= float_param",
                         )
                     ],
                 ),

--- a/ax/api/utils/instantiation/tests/test_from_string.py
+++ b/ax/api/utils/instantiation/tests/test_from_string.py
@@ -8,7 +8,6 @@ from ax.api.utils.instantiation.from_string import (
     optimization_config_from_string,
     parse_objective,
     parse_outcome_constraint,
-    parse_parameter_constraint,
 )
 from ax.core.map_metric import MapMetric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
@@ -22,7 +21,6 @@ from ax.core.outcome_constraint import (
     OutcomeConstraint,
     ScalarizedOutcomeConstraint,
 )
-from ax.core.parameter_constraint import ParameterConstraint
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
 
@@ -94,46 +92,6 @@ class TestFromString(TestCase):
                         relative=False,
                     )
                 ],
-            ),
-        )
-
-    def test_parse_parameter_constraint(self) -> None:
-        constraint = parse_parameter_constraint(constraint_str="x1 + x2 <= 1")
-        self.assertEqual(
-            constraint,
-            ParameterConstraint(constraint_dict={"x1": 1, "x2": 1}, bound=1.0),
-        )
-
-        with_coefficients = parse_parameter_constraint(
-            constraint_str="2 * x1 + 3 * x2 <= 1"
-        )
-        self.assertEqual(
-            with_coefficients,
-            ParameterConstraint(constraint_dict={"x1": 2, "x2": 3}, bound=1.0),
-        )
-
-        flipped_sign = parse_parameter_constraint(constraint_str="x1 + x2 >= 1")
-        self.assertEqual(
-            flipped_sign,
-            ParameterConstraint(constraint_dict={"x1": -1, "x2": -1}, bound=-1.0),
-        )
-
-        weird = parse_parameter_constraint(constraint_str="x1 + x2 <= 1.5 * x3 + 2")
-        self.assertEqual(
-            weird,
-            ParameterConstraint(
-                constraint_dict={"x1": 1, "x2": 1, "x3": -1.5}, bound=2.0
-            ),
-        )
-
-        with self.assertRaisesRegex(UserInputError, "Only linear"):
-            parse_parameter_constraint(constraint_str="x1 * x2 <= 1")
-        # test with sanitization
-        constraint = parse_parameter_constraint(constraint_str="foo.bar + foo.baz <= 1")
-        self.assertEqual(
-            constraint,
-            ParameterConstraint(
-                constraint_dict={"foo.bar": 1, "foo.baz": 1}, bound=1.0
             ),
         )
 

--- a/ax/core/tests/test_parameter_constraint.py
+++ b/ax/core/tests/test_parameter_constraint.py
@@ -18,28 +18,66 @@ from ax.core.parameter_constraint import (
     ParameterConstraint,
     SumConstraint,
 )
+from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
 
 
 class ParameterConstraintTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.constraint = ParameterConstraint(
-            constraint_dict={"x": 2.0, "y": -3.0}, bound=6.0
-        )
+        self.constraint = ParameterConstraint(inequality="2 * x - 3 * y <= 6.0")
         self.constraint_repr = "ParameterConstraint(2.0*x + -3.0*y <= 6.0)"
+
+    def test_constraint_dict_and_bounds(self) -> None:
+        constraint = ParameterConstraint(inequality="x1 + x2 <= 1")
+
+        self.assertEqual(
+            constraint.constraint_dict,
+            {"x1": 1, "x2": 1},
+        )
+        self.assertEqual(constraint.bound, 1.0)
+
+        with_coefficients = ParameterConstraint(inequality="2 * x1 + 3 * x2 <= 1")
+        self.assertEqual(
+            with_coefficients.constraint_dict,
+            {"x1": 2, "x2": 3},
+        )
+        self.assertEqual(with_coefficients.bound, 1.0)
+
+        flipped_sign = ParameterConstraint(inequality="x1 + x2 >= 1")
+        self.assertEqual(
+            flipped_sign.constraint_dict,
+            {"x1": -1, "x2": -1},
+        )
+        self.assertEqual(flipped_sign.bound, -1.0)
+
+        weird = ParameterConstraint(inequality="x1 + x2 <= 1.5 * x3 + 2")
+        self.assertEqual(
+            weird.constraint_dict,
+            {"x1": 1, "x2": 1, "x3": -1.5},
+        )
+        self.assertEqual(weird.bound, 2.0)
+
+        with self.assertRaisesRegex(UserInputError, "Only linear"):
+            ParameterConstraint(inequality="x1 * x2 <= 1")
+
+        # test with sanitization
+        constraint = ParameterConstraint(inequality="foo.bar + foo.baz <= 1")
+        self.assertEqual(
+            constraint.constraint_dict,
+            {"foo.bar": 1, "foo.baz": 1},
+        )
+        self.assertEqual(constraint.bound, 1.0)
 
     def test_Eq(self) -> None:
         constraint1 = ParameterConstraint(
-            constraint_dict={"x": 2.0, "y": -3.0}, bound=6.0
+            inequality="2 * x - 3 * y <= 6.0",
         )
-        constraint2 = ParameterConstraint(
-            constraint_dict={"y": -3.0, "x": 2.0}, bound=6.0
-        )
+        constraint2 = ParameterConstraint(inequality="2 * x - 3 * y <= 6.0")
         self.assertEqual(constraint1, constraint2)
 
         constraint3 = ParameterConstraint(
-            constraint_dict={"x": 2.0, "y": -5.0}, bound=6.0
+            inequality="2 * x - 5 * y <= 6.0",
         )
         self.assertNotEqual(constraint1, constraint3)
 
@@ -89,10 +127,10 @@ class ParameterConstraintTest(TestCase):
 
     def test_Sortable(self) -> None:
         constraint1 = ParameterConstraint(
-            constraint_dict={"x": 2.0, "y": -3.0}, bound=1.0
+            inequality="2 * x - 3 * y <= 1.0",
         )
         constraint2 = ParameterConstraint(
-            constraint_dict={"y": -3.0, "x": 2.0}, bound=6.0
+            inequality="2 * x - 3 * y <= 6.0",
         )
         self.assertTrue(constraint1 < constraint2)
 

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -196,9 +196,7 @@ class SearchSpaceTest(TestCase):
         with self.assertRaises(ValueError):
             SearchSpace(
                 parameters=self.parameters,
-                parameter_constraints=[
-                    ParameterConstraint(constraint_dict={"g": 1}, bound=0)
-                ],
+                parameter_constraints=[ParameterConstraint(inequality="g <= 0")],
             )
 
         # Constraint on non-numeric parameter
@@ -254,9 +252,7 @@ class SearchSpaceTest(TestCase):
         ):
             SearchSpace(
                 parameters=self.parameters,
-                parameter_constraints=[
-                    ParameterConstraint(constraint_dict={"h": 1}, bound=0)
-                ],
+                parameter_constraints=[ParameterConstraint(inequality="h <= 0")],
             )
 
     def test_BadSetter(self) -> None:

--- a/ax/generation_strategy/tests/test_center_generation_node.py
+++ b/ax/generation_strategy/tests/test_center_generation_node.py
@@ -271,7 +271,7 @@ class TestCenterGenerationNode(TestCase):
                 ),
             ],
             parameter_constraints=[  # x1 <= 0
-                ParameterConstraint(constraint_dict={"x1": 1.0}, bound=0.0)
+                ParameterConstraint(inequality="x1 <= 0")
             ],
         )
         exp = Experiment(search_space=ss)

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -1089,11 +1089,12 @@ def _process_linear_constraint(
     comparison_multiplier = (
         1.0 if COMPARISON_OPS[tokens[-2]] is ComparisonOp.LEQ else -1.0
     )
+    constraint_dict = {
+        p: comparison_multiplier * parameter_weights[p] for p in parameter_weights
+    }
+    expr = " + ".join(f"{coeff} * {param}" for param, coeff in constraint_dict.items())
     return ParameterConstraint(
-        constraint_dict={
-            p: comparison_multiplier * parameter_weights[p] for p in parameter_weights
-        },
-        bound=comparison_multiplier * bound,
+        inequality=f"{expr} <= {comparison_multiplier * bound}",
     )
 
 

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -506,13 +506,27 @@ def parameter_constraints_from_json(
                 )
             )
         else:
-            parameter_constraints.append(
-                object_from_json(
-                    constraint,
-                    decoder_registry=decoder_registry,
-                    class_decoder_registry=class_decoder_registry,
+            # Respect legacy json representation of parameter constraints
+            if "constraint_dict" in constraint and "bound" in constraint:
+                expr = " + ".join(
+                    f"{coeff} * {param}"
+                    for param, coeff in constraint["constraint_dict"].items()
                 )
-            )
+
+                parameter_constraints.append(
+                    ParameterConstraint(
+                        inequality=f"{expr} <= {constraint['bound']}",
+                    )
+                )
+
+            else:
+                parameter_constraints.append(
+                    object_from_json(
+                        constraint,
+                        decoder_registry=decoder_registry,
+                        class_decoder_registry=class_decoder_registry,
+                    )
+                )
     return parameter_constraints
 
 

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -258,10 +258,14 @@ def parameter_constraint_to_dict(
     parameter_constraint: ParameterConstraint,
 ) -> dict[str, Any]:
     """Convert Ax sum parameter constraint to a dictionary."""
+    expr = " + ".join(
+        f"{coeff} * {param}"
+        for param, coeff in parameter_constraint.constraint_dict.items()
+    )
+
     return {
         "__type": parameter_constraint.__class__.__name__,
-        "constraint_dict": parameter_constraint.constraint_dict,
-        "bound": parameter_constraint.bound,
+        "inequality": f"{expr} <= {parameter_constraint.bound}",
     }
 
 

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -546,9 +546,12 @@ class Decoder:
                 bound=bound,
             )
         else:
+            expr = " + ".join(
+                f"{coeff} * {param}"
+                for param, coeff in parameter_constraint_sqa.constraint_dict.items()
+            )
             constraint = ParameterConstraint(
-                constraint_dict=dict(parameter_constraint_sqa.constraint_dict),
-                bound=float(parameter_constraint_sqa.bound),
+                inequality=f"{expr} <= {parameter_constraint_sqa.bound}",
             )
 
         constraint.db_id = parameter_constraint_sqa.id

--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-
 from datetime import datetime
 from typing import Any
 
@@ -229,6 +228,10 @@ def object_attribute_dicts_find_unequal_fields(
                     and hasattr(other_val, "model")
                     and isinstance(one_val.model, type(other_val.model))
                 )
+        # Do not check the inequality_str for ParameterConstraints, checking the bound
+        # and coefficients dict is sufficient.
+        elif field == "_inequality_str":
+            equal = True
         else:
             equal = is_ax_equal(one_val, other_val)
 

--- a/ax/utils/common/sympy.py
+++ b/ax/utils/common/sympy.py
@@ -1,0 +1,40 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.exceptions.core import UserInputError
+from ax.utils.common.string_utils import sanitize_name
+from sympy.core.relational import GreaterThan, LessThan
+from sympy.core.symbol import Symbol
+from sympy.core.sympify import sympify
+
+
+def extract_coefficient_dict_from_inequality(
+    inequality_str: str,
+) -> dict[Symbol, float]:
+    """
+    Use SymPy to parse a string into an inequality, invert if necessary to enforce a
+    less-than relationship, move all terms to the left side, and return the
+    coefficients as a dictionary. This is useful for parsing parameter and outcome
+    constraints.
+    """
+    # Parse the constraint string into a SymPy inequality
+    inequality = sympify(sanitize_name(inequality_str))
+
+    # Check the SymPy object is a valid inequality
+    if not isinstance(inequality, GreaterThan | LessThan):
+        raise UserInputError(f"Expected an inequality, found {inequality_str}")
+
+    # Move all terms to the left side of the inequality and invert if necessary to
+    # enforce a less-than relationship
+    if isinstance(inequality, LessThan):
+        expression = inequality.lhs - inequality.rhs
+    else:
+        expression = inequality.rhs - inequality.lhs
+
+    return {
+        key: float(value) for key, value in expression.as_coefficients_dict().items()
+    }

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -1579,9 +1579,7 @@ def get_branin_search_space(
         )
 
     if with_parameter_constraint:
-        constraints = [
-            ParameterConstraint(constraint_dict={"x1": 1, "x2": 1}, bound=15.0)
-        ]
+        constraints = [ParameterConstraint(inequality="x1 + x2 <= 15")]
     else:
         constraints = None
 
@@ -1981,7 +1979,7 @@ def get_order_constraint() -> OrderConstraint:
 def get_parameter_constraint(
     param_x: str = "x", param_y: str = "w"
 ) -> ParameterConstraint:
-    return ParameterConstraint(constraint_dict={param_x: 1.0, param_y: -1.0}, bound=1.0)
+    return ParameterConstraint(inequality=f"{param_x} - {param_y} <= 1")
 
 
 def get_sum_constraint1() -> SumConstraint:


### PR DESCRIPTION
Summary:
Move some of the string parsing from ax/api into core Ax to allow a ParameterConstraint to be defined and constructed from its inequality string.

This will allow more flexibility in the future, but is primarily motivated by a want to store only the inequality string when saving ParameterConstraints and to eliminiate unnnecessary subclasses SumConstraint and OrderConstraint

Differential Revision: D88880607


