### PR TITLE
Enforce `smoothing` in `[0, 1)` in `TensorBoardMetric

### DIFF
--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -56,7 +56,7 @@ try:
                 lower_is_better: If True, lower curve values are considered better.
                 smoothing: If > 0, apply exponential weighted mean to the curve. This
                     is the same postprocessing as the "smoothing" slider in the
-                    Tensorboard UI.
+                    Tensorboard UI. Needs to be smaller than 1.0.
                 cumulative_best: If True, for each trial, apply cumulative best to
                     the curve (i.e., if lower is better, then we return a curve
                     representing the cumulative min of the raw curve).
@@ -68,6 +68,10 @@ try:
             """
             super().__init__(name=name, lower_is_better=lower_is_better)
 
+            if not (0 <= smoothing < 1):
+                raise ValueError(
+                    f"smoothing must be in the range [0, 1), got {smoothing}."
+                )
             self.smoothing = smoothing
             self.tag = tag
             self.cumulative_best = cumulative_best

--- a/ax/metrics/tests/test_tensorboard.py
+++ b/ax/metrics/tests/test_tensorboard.py
@@ -217,6 +217,19 @@ class TensorboardMetricTest(TestCase):
 
         self.assertTrue(df.equals(expected_df))
 
+        # Test that smoothing must be in the range [0, 1).
+        # Valid smoothing values
+        for smoothing in [0, 0.5, 0.99]:
+            with self.subTest(f"smoothing={smoothing}"):
+                TensorboardMetric(name="loss", tag="loss", smoothing=smoothing)
+
+        # Invalid smoothing values
+        expected_str = r"smoothing must be in the range \[0, 1\)"
+        for smoothing in [1, 1.5, -0.1]:
+            with self.subTest(f"smoothing={smoothing}"):
+                with self.assertRaisesRegex(ValueError, expected_str):
+                    TensorboardMetric(name="loss", tag="loss", smoothing=smoothing)
+
     def test_cumulative_best(self) -> None:
         fake_data = [4.0, 8.0, 2.0, 1.0]
         cummin_data = pd.Series(fake_data).cummin().tolist()


### PR DESCRIPTION
Summary: Checks the `smoothing` parameter in the constructor.

Differential Revision: D89211791


