### PR TITLE
Use MBM_X_trans in HSS GS

### DIFF
--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -103,7 +103,9 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
             for timestamp in range(self._trial_index_to_timestamp[trial.index]):
                 res = [
                     self.f(
-                        np.fromiter(arm.parameters.values(), dtype=float),
+                        np.array(
+                            [arm.parameters[p] for p in self.param_names], dtype=float
+                        ),
                         timestamp=timestamp,
                     )
                     for arm in trial.arms


### PR DESCRIPTION
Summary: With recent changes to `MBM_X_trans` (choice transform changes), `MBM_X_trans` is just the previous set of HSS transforms + `MapKeyToFloat` (now compatible thanks to update for HSS to not require a root). Addition of `MapKeyToFloat` should ensure that the HSS models handle data from early stopped triials just like any other model.

Reviewed By: Balandat

Differential Revision:
D89245032

Privacy Context Container: L1307644


