### PR TITLE
Rename model_gen_kwargs -> generator_gen_kwargs

### DIFF
--- a/ax/benchmark/methods/modular_botorch.py
+++ b/ax/benchmark/methods/modular_botorch.py
@@ -42,7 +42,7 @@ def get_sobol_mbm_generation_strategy(
     name: str | None = None,
     num_sobol_trials: int = 5,
     model_kwargs_override: dict[str, Any] | None = None,
-    model_gen_kwargs: dict[str, Any] | None = None,
+    generator_gen_kwargs: dict[str, Any] | None = None,
     batch_size: int = 1,
 ) -> GenerationStrategy:
     """Get a `BenchmarkMethod` that uses Sobol followed by MBM.
@@ -56,7 +56,7 @@ def get_sobol_mbm_generation_strategy(
             `BatchTrial`s.
         model_kwargs_override: Passed to the MBM BoTorch `GenerationStep` inside
             `model_kwargs`.
-        model_gen_kwargs: Passed to the BoTorch `GenerationStep` and ultimately
+        generator_gen_kwargs: Passed to the BoTorch `GenerationStep` and ultimately
             to the BoTorch `Model`.
 
     Example:
@@ -107,7 +107,7 @@ def get_sobol_mbm_generation_strategy(
                 generator=Generators.BOTORCH_MODULAR,
                 num_trials=-1,
                 model_kwargs=model_kwargs,
-                model_gen_kwargs=model_gen_kwargs or {},
+                generator_gen_kwargs=generator_gen_kwargs or {},
             ),
         ],
     )
@@ -120,7 +120,7 @@ def get_sobol_botorch_modular_acquisition(
     name: str | None = None,
     num_sobol_trials: int = 5,
     model_kwargs_override: dict[str, Any] | None = None,
-    model_gen_kwargs: dict[str, Any] | None = None,
+    generator_gen_kwargs: dict[str, Any] | None = None,
     batch_size: int = 1,
 ) -> BenchmarkMethod:
     """Get a `BenchmarkMethod` that uses Sobol followed by MBM.
@@ -135,7 +135,7 @@ def get_sobol_botorch_modular_acquisition(
             `BatchTrial`s.
         model_kwargs_override: Passed to the MBM BoTorch `GenerationStep` inside
             `model_kwargs`.
-        model_gen_kwargs: Passed to the BoTorch `GenerationStep` and ultimately
+        generator_gen_kwargs: Passed to the BoTorch `GenerationStep` and ultimately
             to the BoTorch `Model`.
         batch_size: Passed to the created ``BenchmarkMethod``.
 
@@ -154,7 +154,7 @@ def get_sobol_botorch_modular_acquisition(
         ...     model_cls=SingleTaskGP,
         ...     acquisition_cls=qLogNoisyExpectedImprovement,
         ...     batch_size=5,
-        ...     model_gen_kwargs={
+        ...     generator_gen_kwargs={
         ...         "model_gen_options": {
         ...             "optimizer_kwargs": {"sequential": False}
         ...         }
@@ -168,7 +168,7 @@ def get_sobol_botorch_modular_acquisition(
         name=name,
         num_sobol_trials=num_sobol_trials,
         model_kwargs_override=model_kwargs_override,
-        model_gen_kwargs=model_gen_kwargs,
+        generator_gen_kwargs=generator_gen_kwargs,
         batch_size=batch_size,
     )
 

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -151,7 +151,7 @@ class TestBenchmark(TestCase):
                     model_cls=SingleTaskGP,
                     acquisition_cls=qLogNoisyExpectedImprovement,
                     batch_size=batch_size,
-                    model_gen_kwargs={
+                    generator_gen_kwargs={
                         "model_gen_options": {
                             "optimizer_kwargs": {"sequential": sequential}
                         }

--- a/ax/generation_strategy/external_generation_node.py
+++ b/ax/generation_strategy/external_generation_node.py
@@ -158,7 +158,7 @@ class ExternalGenerationNode(GenerationNode, ABC):
         data: Data | None = None,
         n: int | None = None,
         pending_observations: dict[str, list[ObservationFeatures]] | None = None,
-        **model_gen_kwargs: Any,
+        **generator_gen_kwargs: Any,
     ) -> GeneratorRun:
         """Generate new candidates for evaluation.
 
@@ -173,9 +173,9 @@ class ExternalGenerationNode(GenerationNode, ABC):
             pending_observations: A map from metric signature to pending
                 observations for that metric, used by some methods to avoid
                 re-suggesting candidates that are currently being evaluated.
-            model_gen_kwargs: Keyword arguments, passed through to
+            generator_gen_kwargs: Keyword arguments, passed through to
                 ``GeneratorSpec.gen``; these override any pre-specified in
-                ``GeneratorSpec.model_gen_kwargs``.
+                ``GeneratorSpec.generator_gen_kwargs``.
 
         Returns:
             A ``GeneratorRun`` containing the newly generated candidates.
@@ -187,7 +187,7 @@ class ExternalGenerationNode(GenerationNode, ABC):
                 data=data,
                 n=n,
                 pending_observations=pending_observations,
-                **model_gen_kwargs,
+                **generator_gen_kwargs,
             )
             # Unset self._generator_spec_to_gen_from before returning.
             self._generator_spec_to_gen_from = None

--- a/ax/generation_strategy/generation_node_input_constructors.py
+++ b/ax/generation_strategy/generation_node_input_constructors.py
@@ -253,8 +253,8 @@ def _get_default_n(experiment: Experiment, next_node: GenerationNode) -> int:
         provided to the ``GenerationStrategy``'s gen call.
     """
     # If the generator spec contains `n` use that value first
-    if next_node.generator_spec_to_gen_from.model_gen_kwargs.get("n") is not None:
-        return next_node.generator_spec_to_gen_from.model_gen_kwargs["n"]
+    if next_node.generator_spec_to_gen_from.generator_gen_kwargs.get("n") is not None:
+        return next_node.generator_spec_to_gen_from.generator_gen_kwargs["n"]
 
     n_for_this_trial = None
     total_concurrent_arms = experiment._properties.get(

--- a/ax/generation_strategy/generation_strategy.py
+++ b/ax/generation_strategy/generation_strategy.py
@@ -261,7 +261,7 @@ class GenerationStrategy(Base):
     ) -> GeneratorRun:
         """Produce the next points in the experiment. Additional kwargs passed to
         this method are propagated directly to the underlying node's `gen`, along
-        with the `model_gen_kwargs` set on the current generation node.
+        with the `generator_gen_kwargs` set on the current generation node.
 
         NOTE: Each generator run returned from this function must become a single
         trial on the experiment to comply with assumptions made in generation

--- a/ax/generation_strategy/generator_spec.py
+++ b/ax/generation_strategy/generator_spec.py
@@ -47,7 +47,7 @@ class GeneratorSpec(SortableBase, SerializationMixin):
     # `GeneratorRegistryBase.__call__`.
     model_kwargs: dict[str, Any] = field(default_factory=dict)
     # Kwargs to pass to `Adapter.gen`.
-    model_gen_kwargs: dict[str, Any] = field(default_factory=dict)
+    generator_gen_kwargs: dict[str, Any] = field(default_factory=dict)
     # Kwargs to pass to `cross_validate`.
     model_cv_kwargs: dict[str, Any] = field(default_factory=dict)
     # An optional override for the generator key. Each `GeneratorSpec` in a
@@ -72,7 +72,7 @@ class GeneratorSpec(SortableBase, SerializationMixin):
 
     def __post_init__(self) -> None:
         self.model_kwargs = self.model_kwargs or {}
-        self.model_gen_kwargs = self.model_gen_kwargs or {}
+        self.generator_gen_kwargs = self.generator_gen_kwargs or {}
         self.model_cv_kwargs = self.model_cv_kwargs or {}
 
     @property
@@ -86,14 +86,14 @@ class GeneratorSpec(SortableBase, SerializationMixin):
         """
         Fixed generation features to pass into the Model's `.gen` function.
         """
-        return self.model_gen_kwargs.get("fixed_features", None)
+        return self.generator_gen_kwargs.get("fixed_features", None)
 
     @fixed_features.setter
     def fixed_features(self, value: ObservationFeatures | None) -> None:
         """
         Fixed generation features to pass into the Model's `.gen` function.
         """
-        self.model_gen_kwargs["fixed_features"] = value
+        self.generator_gen_kwargs["fixed_features"] = value
 
     @property
     def generator_key(self) -> str:
@@ -204,7 +204,7 @@ class GeneratorSpec(SortableBase, SerializationMixin):
         """
         return self._diagnostics
 
-    def gen(self, **model_gen_kwargs: Any) -> GeneratorRun:
+    def gen(self, **generator_gen_kwargs: Any) -> GeneratorRun:
         """Generates candidates from the fitted model, using the model gen
         kwargs set on the model spec, alongside any passed as kwargs
         to this function (local kwargs take precedent)
@@ -222,13 +222,13 @@ class GeneratorSpec(SortableBase, SerializationMixin):
                 resuggesting points that are currently being evaluated.
         """
         fitted_adapter = self.fitted_adapter
-        model_gen_kwargs = consolidate_kwargs(
-            kwargs_iterable=[self.model_gen_kwargs, model_gen_kwargs],
+        generator_gen_kwargs = consolidate_kwargs(
+            kwargs_iterable=[self.generator_gen_kwargs, generator_gen_kwargs],
             keywords=get_function_argument_names(fitted_adapter.gen),
         )
         # copy to ensure there is no in-place modification
-        model_gen_kwargs = deepcopy(model_gen_kwargs)
-        generator_run = fitted_adapter.gen(**model_gen_kwargs)
+        generator_gen_kwargs = deepcopy(generator_gen_kwargs)
+        generator_run = fitted_adapter.gen(**generator_gen_kwargs)
 
         generator_run._gen_metadata = (
             {} if generator_run.gen_metadata is None else generator_run.gen_metadata
@@ -243,7 +243,7 @@ class GeneratorSpec(SortableBase, SerializationMixin):
         return self.__class__(
             generator_enum=self.generator_enum,
             model_kwargs=deepcopy(self.model_kwargs),
-            model_gen_kwargs=deepcopy(self.model_gen_kwargs),
+            generator_gen_kwargs=deepcopy(self.generator_gen_kwargs),
             model_cv_kwargs=deepcopy(self.model_cv_kwargs),
             generator_key_override=self.generator_key_override,
         )
@@ -297,8 +297,8 @@ class GeneratorSpec(SortableBase, SerializationMixin):
         model_kwargs = json.dumps(
             self.model_kwargs, sort_keys=True, cls=GeneratorSpecJSONEncoder
         )
-        model_gen_kwargs = json.dumps(
-            self.model_gen_kwargs, sort_keys=True, cls=GeneratorSpecJSONEncoder
+        generator_gen_kwargs = json.dumps(
+            self.generator_gen_kwargs, sort_keys=True, cls=GeneratorSpecJSONEncoder
         )
         model_cv_kwargs = json.dumps(
             self.model_cv_kwargs, sort_keys=True, cls=GeneratorSpecJSONEncoder
@@ -307,7 +307,7 @@ class GeneratorSpec(SortableBase, SerializationMixin):
             "GeneratorSpec("
             f"\tgenerator_enum={self.generator_enum.value}, "
             f"\tmodel_kwargs={model_kwargs}, "
-            f"\tmodel_gen_kwargs={model_gen_kwargs}, "
+            f"\tgenerator_gen_kwargs={generator_gen_kwargs}, "
             f"\tmodel_cv_kwargs={model_cv_kwargs}, "
             f"\tgenerator_key_override={self.generator_key_override}"
             ")"

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -45,12 +45,12 @@ class TestGenerationNode(TestCase):
         self.sobol_generator_spec = GeneratorSpec(
             generator_enum=Generators.SOBOL,
             model_kwargs={"init_position": 3},
-            model_gen_kwargs={"some_gen_kwarg": "some_value"},
+            generator_gen_kwargs={"some_gen_kwarg": "some_value"},
         )
         self.mbm_generator_spec = GeneratorSpec(
             generator_enum=Generators.BOTORCH_MODULAR,
             model_kwargs={},
-            model_gen_kwargs={},
+            generator_gen_kwargs={},
         )
         self.sobol_generation_node = GenerationNode(
             name="test", generator_specs=[self.sobol_generator_spec]
@@ -186,7 +186,7 @@ class TestGenerationNode(TestCase):
                 GeneratorSpec(
                     generator_enum=Generators.BOTORCH_MODULAR,
                     model_kwargs={},
-                    model_gen_kwargs={
+                    generator_gen_kwargs={
                         "n": 1,
                         "fixed_features": ObservationFeatures(
                             parameters={},
@@ -221,7 +221,7 @@ class TestGenerationNode(TestCase):
         self.assertNotIn("trial_type", none_throws(gr.gen_metadata))
 
     @mock_botorch_optimize
-    def test_model_gen_kwargs_deepcopy(self) -> None:
+    def test_generator_gen_kwargs_deepcopy(self) -> None:
         sampler = SobolQMCNormalSampler(torch.Size([1]))
         node = GenerationNode(
             name="test",
@@ -229,7 +229,7 @@ class TestGenerationNode(TestCase):
                 GeneratorSpec(
                     generator_enum=Generators.BOTORCH_MODULAR,
                     model_kwargs={},
-                    model_gen_kwargs={
+                    generator_gen_kwargs={
                         "n": 1,
                         "fixed_features": ObservationFeatures(
                             parameters={},
@@ -249,7 +249,7 @@ class TestGenerationNode(TestCase):
         )
         # verify that sampler is not modified in-place by checking base samples
         self.assertIs(
-            node.generator_spec_to_gen_from.model_gen_kwargs["model_gen_options"][
+            node.generator_spec_to_gen_from.generator_gen_kwargs["model_gen_options"][
                 Keys.ACQF_KWARGS
             ]["sampler"],
             sampler,
@@ -264,7 +264,7 @@ class TestGenerationNode(TestCase):
                 GeneratorSpec(
                     generator_enum=Generators.BOTORCH_MODULAR,
                     model_kwargs={},
-                    model_gen_kwargs={
+                    generator_gen_kwargs={
                         "n": 1,
                         "fixed_features": ObservationFeatures(
                             parameters={},
@@ -289,8 +289,8 @@ class TestGenerationNode(TestCase):
         )
         self.assertEqual(node.generator_to_gen_from_name, "BoTorch")
         self.assertEqual(
-            node.generator_spec_to_gen_from.model_gen_kwargs,
-            node.generator_specs[0].model_gen_kwargs,
+            node.generator_spec_to_gen_from.generator_gen_kwargs,
+            node.generator_specs[0].generator_gen_kwargs,
         )
         self.assertEqual(
             node.generator_spec_to_gen_from.model_cv_kwargs,
@@ -338,7 +338,7 @@ class TestGenerationNode(TestCase):
                 GeneratorSpec(
                     generator_enum=Generators.BOTORCH_MODULAR,
                     model_kwargs={},
-                    model_gen_kwargs={
+                    generator_gen_kwargs={
                         "n": 2,
                         "fixed_features": ObservationFeatures(parameters={"x": 0}),
                     },
@@ -460,13 +460,13 @@ class TestGenerationStep(TestCase):
         step = self.sobol_generation_step
         self.assertEqual(step.generator_spec, self.generator_spec)
         self.assertEqual(step._unique_id, "-1")
-        # Make sure that model_kwargs and model_gen_kwargs are synchronized
+        # Make sure that model_kwargs and generator_gen_kwargs are synchronized
         # to the underlying model spec.
         spec = step.generator_spec
         spec.model_kwargs.update({"new_kwarg": 1})
-        spec.model_gen_kwargs.update({"new_gen_kwarg": 1})
+        spec.generator_gen_kwargs.update({"new_gen_kwarg": 1})
         self.assertEqual(step.model_kwargs, spec.model_kwargs)
-        self.assertEqual(step.model_gen_kwargs, spec.model_gen_kwargs)
+        self.assertEqual(step.generator_gen_kwargs, spec.generator_gen_kwargs)
 
 
 class TestGenerationNodeWithBestModelSelector(TestCase):

--- a/ax/generation_strategy/tests/test_generation_node_input_constructors.py
+++ b/ax/generation_strategy/tests/test_generation_node_input_constructors.py
@@ -59,7 +59,7 @@ class TestGenerationNodeInputConstructors(TestCase):
         self.sobol_generator_spec = GeneratorSpec(
             generator_enum=Generators.SOBOL,
             model_kwargs={"init_position": 3},
-            model_gen_kwargs={"some_gen_kwarg": "some_value"},
+            generator_gen_kwargs={"some_gen_kwarg": "some_value"},
         )
         self.sobol_generation_node = GenerationNode(
             name="test", generator_specs=[self.sobol_generator_spec]

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -242,12 +242,12 @@ class TestGenerationStrategy(TestCase):
         self.sobol_generator_spec = GeneratorSpec(
             generator_enum=Generators.SOBOL,
             model_kwargs=self.step_model_kwargs,
-            model_gen_kwargs={},
+            generator_gen_kwargs={},
         )
         self.mbm_generator_spec = GeneratorSpec(
             generator_enum=Generators.BOTORCH_MODULAR,
             model_kwargs=self.step_model_kwargs,
-            model_gen_kwargs={},
+            generator_gen_kwargs={},
         )
         self.sobol_node = GenerationNode(
             name="sobol_node",
@@ -462,7 +462,7 @@ class TestGenerationStrategy(TestCase):
                         GeneratorSpec(
                             generator_enum=Generators.SOBOL,
                             model_kwargs={},
-                            model_gen_kwargs={},
+                            generator_gen_kwargs={},
                         ),
                     ],
                 )

--- a/ax/generation_strategy/tests/test_generator_spec.py
+++ b/ax/generation_strategy/tests/test_generator_spec.py
@@ -174,13 +174,13 @@ class GeneratorSpecTest(BaseGeneratorSpecTest):
         new_features = ObservationFeatures(parameters={"a": 1.0})
         ms.fixed_features = new_features
         self.assertEqual(ms.fixed_features, new_features)
-        self.assertEqual(ms.model_gen_kwargs["fixed_features"], new_features)
+        self.assertEqual(ms.generator_gen_kwargs["fixed_features"], new_features)
 
     def test_spec_string_representation(self) -> None:
         ms = GeneratorSpec(
             generator_enum=Generators.BOTORCH_MODULAR,
             model_kwargs={"test_model_kwargs": 1},
-            model_gen_kwargs={"test_gen_kwargs": 1},
+            generator_gen_kwargs={"test_gen_kwargs": 1},
             model_cv_kwargs={"test_cv_kwargs": 1},
         )
         ms.generator_key_override = "test_model_key_override"
@@ -197,7 +197,7 @@ class GeneratorSpecTest(BaseGeneratorSpecTest):
         ms = GeneratorSpec(
             generator_enum=Generators.BOTORCH_MODULAR,
             model_kwargs={"test_model_kwargs": 1},
-            model_gen_kwargs={"test_gen_kwargs": 1},
+            generator_gen_kwargs={"test_gen_kwargs": 1},
             model_cv_kwargs={"test_cv_kwargs": 1},
         )
         ms.generator_key_override = "test_model_key_override"

--- a/ax/generation_strategy/tests/test_transition_criterion.py
+++ b/ax/generation_strategy/tests/test_transition_criterion.py
@@ -50,7 +50,7 @@ class TestTransitionCriterion(TestCase):
         self.sobol_generator_spec = GeneratorSpec(
             generator_enum=Generators.SOBOL,
             model_kwargs={"init_position": 3},
-            model_gen_kwargs={"some_gen_kwarg": "some_value"},
+            generator_gen_kwargs={"some_gen_kwarg": "some_value"},
         )
         self.branin_experiment = get_branin_experiment()
 

--- a/ax/generators/discrete/eb_ashr.py
+++ b/ax/generators/discrete/eb_ashr.py
@@ -298,7 +298,7 @@ class EBAshr(ThompsonSampler):
         )
         if not isinstance(regression_prob_threshold, float):
             raise TypeError(
-                "`regression_prob_threshold` is required among `model_gen_kwargs` \
+                "`regression_prob_threshold` is required among `generator_gen_kwargs` \
                 and must be set to a float."
             )
 

--- a/ax/generators/torch_base.py
+++ b/ax/generators/torch_base.py
@@ -57,7 +57,7 @@ class TorchOptConfig:
             models may support additional arguments that are not passed to the
             optimizer. While constructing a generation strategy, these options
             can be passed in as follows:
-            >>> model_gen_kwargs = {
+            >>> generator_gen_kwargs = {
             >>>     "model_gen_options": {
             >>>         "optimizer_kwargs": {
             >>>             "num_restarts": 20,

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -952,7 +952,10 @@ def generation_step_from_json(
         kwargs.pop(k, None)
     if kwargs is not None:
         kwargs = _sanitize_surrogate_spec_input(object_json=kwargs)
-    gen_kwargs = generation_step_json.pop("model_gen_kwargs", None)
+    if "model_gen_kwargs" in generation_step_json:
+        gen_kwargs = generation_step_json.pop("model_gen_kwargs", None)
+    else:
+        gen_kwargs = generation_step_json.pop("generator_gen_kwargs", None)
     completion_criteria = (
         object_from_json(
             generation_step_json.pop("completion_criteria"),
@@ -991,7 +994,7 @@ def generation_step_from_json(
             if kwargs
             else {}
         ),
-        model_gen_kwargs=(
+        generator_gen_kwargs=(
             _decode_callables_from_references(
                 object_from_json(
                     gen_kwargs,
@@ -1023,7 +1026,10 @@ def generator_spec_from_json(
         kwargs.pop(k, None)
     if kwargs is not None:
         kwargs = _sanitize_surrogate_spec_input(object_json=kwargs)
-    gen_kwargs = generator_spec_json.pop("model_gen_kwargs", None)
+    if "model_gen_kwargs" in generator_spec_json:
+        gen_kwargs = generator_spec_json.pop("model_gen_kwargs", None)
+    else:
+        gen_kwargs = generator_spec_json.pop("generator_gen_kwargs", None)
     cv_kwargs = generator_spec_json.pop("model_cv_kwargs", None)
     if "model_enum" in generator_spec_json:
         # Old arg name for backwards compatibility.
@@ -1050,7 +1056,7 @@ def generator_spec_from_json(
             if kwargs
             else {}
         ),
-        model_gen_kwargs=(
+        generator_gen_kwargs=(
             _decode_callables_from_references(
                 object_from_json(
                     object_json=gen_kwargs,

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -430,8 +430,8 @@ def generation_step_to_dict(generation_step: GenerationStep) -> dict[str, Any]:
         "model_kwargs": _encode_callables_as_references(
             generation_step.model_kwargs or {}
         ),
-        "model_gen_kwargs": _encode_callables_as_references(
-            generation_step.model_gen_kwargs or {}
+        "generator_gen_kwargs": _encode_callables_as_references(
+            generation_step.generator_gen_kwargs or {}
         ),
         "index": generation_step.index,
         "should_deduplicate": generation_step.should_deduplicate,
@@ -496,7 +496,7 @@ def generator_spec_to_dict(generator_spec: GeneratorSpec) -> dict[str, Any]:
         "__type": generator_spec.__class__.__name__,
         "generator_enum": generator_spec.generator_enum,
         "model_kwargs": generator_spec.model_kwargs,
-        "model_gen_kwargs": generator_spec.model_gen_kwargs,
+        "generator_gen_kwargs": generator_spec.generator_gen_kwargs,
         "model_cv_kwargs": generator_spec.model_cv_kwargs,
         "generator_key_override": generator_spec.generator_key_override,
     }

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -341,7 +341,7 @@ TEST_CASES = [
             GeneratorSpec,
             generator_enum=Generators.BOTORCH_MODULAR,
             model_kwargs={"some_kwarg": "some_value"},
-            model_gen_kwargs={"n": 5},
+            generator_gen_kwargs={"n": 5},
             model_cv_kwargs={"untransform": False},
             generator_key_override="custom_generator_key",
         ),
@@ -1124,7 +1124,7 @@ class JSONStoreTest(TestCase):
                 "fit_abandoned": True,
                 "fit_only_completed_map_metrics": True,
             },
-            "model_gen_kwargs": {},
+            "model_gen_kwargs": {"dummy": 5.0},
             "index": -1,
             "should_deduplicate": False,
         }
@@ -1132,6 +1132,7 @@ class JSONStoreTest(TestCase):
         self.assertIsInstance(generation_step, GenerationStep)
         self.assertEqual(generation_step.model_kwargs, {"other_kwarg": 5})
         self.assertEqual(generation_step.generator, Generators.BOTORCH_MODULAR)
+        self.assertEqual(generation_step.generator_gen_kwargs, {"dummy": 5.0})
 
     def test_generator_run_backwards_compatibility(self) -> None:
         # Test that we can load a generator run with deprecated kwargs.
@@ -1274,6 +1275,15 @@ class JSONStoreTest(TestCase):
         self.assertEqual(
             node.generator_specs[0].model_kwargs["transforms"],
             [OneHot, Log],
+        )
+        self.assertEqual(
+            node.generator_specs[0].generator_gen_kwargs,
+            {
+                "model_gen_options": {
+                    "optimizer_kwargs": {"num_restarts": 10},
+                    "acquisition_function_kwargs": {},
+                }
+            },
         )
 
     def test_SobolQMCNormalSampler(self) -> None:

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -2974,12 +2974,12 @@ def get_online_sobol_mbm_generation_strategy() -> GenerationStrategy:
     sobol_generator_spec = GeneratorSpec(
         generator_enum=Generators.SOBOL,
         model_kwargs=step_model_kwargs,
-        model_gen_kwargs={},
+        generator_gen_kwargs={},
     )
     mbm_generator_spec = GeneratorSpec(
         generator_enum=Generators.BOTORCH_MODULAR,
         model_kwargs=step_model_kwargs,
-        model_gen_kwargs={},
+        generator_gen_kwargs={},
     )
     sobol_node = GenerationNode(
         name="sobol_node",

--- a/ax/utils/testing/modeling_stubs.py
+++ b/ax/utils/testing/modeling_stubs.py
@@ -245,13 +245,13 @@ def sobol_gpei_generation_node_gs(
     sobol_generator_spec = GeneratorSpec(
         generator_enum=Generators.SOBOL,
         model_kwargs=step_model_kwargs,
-        model_gen_kwargs={},
+        generator_gen_kwargs={},
     )
     mbm_generator_specs = [
         GeneratorSpec(
             generator_enum=Generators.BOTORCH_MODULAR,
             model_kwargs=step_model_kwargs,
-            model_gen_kwargs={},
+            generator_gen_kwargs={},
         )
     ]
     sobol_node = GenerationNode(
@@ -491,7 +491,7 @@ def get_legacy_list_surrogate_generation_step_as_dict() -> dict[str, Any]:
                 "class": "<class 'botorch.acquisition.acquisition.AcquisitionFunction'>",  # noqa
             },
         },
-        "model_gen_kwargs": {},
+        "generator_gen_kwargs": {},
         "index": -1,
         "should_deduplicate": False,
     }

--- a/tutorials/modular_botorch/modular_botorch.ipynb
+++ b/tutorials/modular_botorch/modular_botorch.ipynb
@@ -207,7 +207,7 @@
         "        \"acquisition_options\": {},\n",
         "    },\n",
         "    # We can specify various options for the optimizer here.\n",
-        "    model_gen_kwargs = {\n",
+        "    generator_gen_kwargs = {\n",
         "        \"model_gen_options\": {\n",
         "            \"optimizer_kwargs\": {\n",
         "                \"num_restarts\": 20,\n",


### PR DESCRIPTION
Summary:
As titled. JSON storage is updated to support loading arguments serialized with the old name. There is no direct SQA storage for these fields (serialized through JSONified GeneratorSpec / GenerationStep)

Backwards compatibility for GStep & GSpec inputs are added later in the stack to ensure that this diff updates all internal usage.

Differential Revision: D89299127
