### PR TITLE
Heteroskedastic noise support in benchmarks

### DIFF
--- a/ax/benchmark/benchmark_test_function.py
+++ b/ax/benchmark/benchmark_test_function.py
@@ -6,11 +6,30 @@
 # pyre-strict
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 
+import pandas as pd
+from ax.core.base_trial import BaseTrial
 from ax.core.types import TParamValue
 from torch import Tensor
+
+# Type alias for the custom noise function.
+# The callable takes all the arguments that are exposed in the benchmark runner:
+#   - df: The lookup_data().df DataFrame. Mandatory
+#   - trial: The trial being evaluated
+#   - noise_stds: Mapping from metric name to noise std
+#   - arm_weights: Mapping from arm name to weight, or None for single-arm trials
+# And returns a DataFrame with added "mean" and "sem" columns.
+TAddCustomNoise = Callable[
+    [
+        pd.DataFrame,
+        BaseTrial | None,
+        Mapping[str, float] | None,
+        Mapping[str, float] | None,
+    ],
+    pd.DataFrame,
+]
 
 
 @dataclass(kw_only=True)
@@ -26,10 +45,14 @@ class BenchmarkTestFunction(ABC):
             if data is not time-series. If data is time-series, this will
             eventually become the number of values on a `MapMetric` for
             evaluations that run to completion.
+        add_custom_noise: Optional callable to add custom noise to evaluation
+            results. If provided, it will be called instead of the default noise
+            behavior, overriding the noise_std argument.
     """
 
     outcome_names: Sequence[str]
     n_steps: int = 1
+    add_custom_noise: TAddCustomNoise | None = None
 
     @abstractmethod
     def evaluate_true(self, params: Mapping[str, TParamValue]) -> Tensor:


### PR DESCRIPTION
Summary: Added heteroskedastic noise support in existing benchmark by introducing an add_custom_noise method to the BenchmarkTestFunction. Optionally calls this function in BenchmarkRunner if this method exists.

Differential Revision:
D89406488

Privacy Context Container: L1307644


