### PR TITLE
Combine data from all previous timestamps upon deserialization, SQA version

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 import json
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from enum import Enum
 from io import StringIO
 from logging import Logger
@@ -76,6 +76,7 @@ from ax.storage.sqa_store.sqa_classes import (
 from ax.storage.sqa_store.sqa_config import SQAConfig
 from ax.storage.sqa_store.utils import are_relationships_loaded
 from ax.storage.utils import (
+    combine_datas_on_data_by_trial,
     DomainType,
     EXPECT_RELATIVIZED_OUTCOMES,
     MetricIntent,
@@ -373,10 +374,7 @@ class Decoder:
             data_by_trial[trial_index][timestamp] = self.data_from_sqa(
                 data_sqa=data_sqa, data_constructor=default_data_constructor
             )
-        data_by_trial = {
-            trial_index: OrderedDict(sorted(data_by_timestamp.items()))
-            for trial_index, data_by_timestamp in data_by_trial.items()
-        }
+        data_by_trial = combine_datas_on_data_by_trial(data_by_trial=data_by_trial)
 
         trial_type_to_runner = {
             sqa_runner.trial_type: self.runner_from_sqa(sqa_runner)
@@ -1041,8 +1039,7 @@ class Decoder:
         data_sqa: SQAData,
         data_constructor: type[Data] = Data,
     ) -> Data:
-        """Convert SQLAlchemy Data to AE Data."""
-        # TODO: extract data type from SQAData after DataRegistry added.
+        """Convert SQLAlchemy Data to Ax Data."""
         kwargs = data_constructor.deserialize_init_args(
             args=dict(
                 json.loads(data_sqa.structure_metadata_json)

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import logging
+from collections import OrderedDict
 from collections.abc import Callable
 from datetime import datetime
 from decimal import Decimal
@@ -27,6 +28,7 @@ from ax.core.auxiliary import (
     AuxiliaryExperimentPurpose,
     TransferLearningMetadata,
 )
+from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
@@ -812,7 +814,6 @@ class SQAStoreTest(TestCase):
         save_experiment(experiment)
         loaded_experiment = load_experiment(experiment.name)
         self.assertEqual(loaded_experiment.default_trial_type, "type1")
-        # pyre-fixme[16]: `Experiment` has no attribute `_trial_type_to_runner`.
         self.assertEqual(len(loaded_experiment._trial_type_to_runner), 2)
         # pyre-fixme[16]: `Experiment` has no attribute `metric_to_trial_type`.
         self.assertEqual(loaded_experiment.metric_to_trial_type["m1"], "type1")
@@ -3213,3 +3214,22 @@ class SQAStoreTest(TestCase):
             self.assertIsNotNone(tl_metadata_0.overlap_parameters)
             # Should have 2 overlapping parameters (w and x)
             self.assertEqual(len(none_throws(tl_metadata_0.overlap_parameters)), 2)
+
+    def test_experiment_with_data_backward_compatible(self) -> None:
+        name = "data_bc_test_experiment"
+        experiment = get_branin_experiment(with_trial=True, with_completed_trial=True)
+        experiment.name = name
+        data = experiment.lookup_data()
+        # Overwrite _data_by_trial to look the way that it might look on an
+        # older experiment
+        # Trial 0 has data from two different timestamps, 1 and 2
+        experiment._data_by_trial = {
+            0: OrderedDict([(1, data), (2, Data(df=data.full_df))])
+        }
+        save_experiment(experiment=experiment)
+        loaded_experiment = load_experiment(experiment_name=name)
+        data_by_trial = loaded_experiment._data_by_trial
+        self.assertEqual(set(data_by_trial.keys()), {0})
+        # Only the most recent timestamp should be present
+        self.assertEqual(set(data_by_trial[0].keys()), {2})
+        self.assertEqual(data_by_trial[0][2], data)


### PR DESCRIPTION
Summary:
**Context**: D86520152 / https://github.com/facebook/Ax/pull/4518 made changes to decoding from JSON without making the same changes to decoding from SQA.

**Changes** (for decoding from SQA): If there are multiple timestamps for a previous trial, combine them upon deserialization.

Differential Revision: D89487004


