### PR TITLE
(Temporary step) Give Experiment a property `Data`

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1046,6 +1046,11 @@ class Experiment(Base):
 
         return Data.from_multiple_data(data_by_trial)
 
+    # Temporary. This will become an attribute in the next diff.
+    @property
+    def data(self) -> Data:
+        return self.lookup_data()
+
     @property
     def num_trials(self) -> int:
         """How many trials are associated with this experiment."""

--- a/ax/generation_strategy/transition_criterion.py
+++ b/ax/generation_strategy/transition_criterion.py
@@ -335,13 +335,10 @@ class TrialBasedCriterion(TransitionCriterion):
         """
         all_trials_to_check = self.all_trials_to_check(experiment=experiment)
         if self.count_only_trials_with_data:
-            all_trials_to_check = {
-                trial_index
-                for trial_index in all_trials_to_check
-                # TODO[@mgarrard]: determine if we need to actually check data with
-                # more granularity, e.g. number of days of data, etc.
-                if trial_index in experiment._data_by_trial
-            }
+            data_trial_indices = experiment.data.trial_indices
+            # TODO[@mgarrard]: determine if we need to actually check data with
+            # more granularity, e.g. number of days of data, etc.
+            all_trials_to_check = all_trials_to_check.intersection(data_trial_indices)
         # Some criteria may rely on experiment level data, instead of only trials
         # generated from the node associated with the criterion.
         if self.use_all_trials_in_exp:

--- a/ax/orchestration/tests/test_orchestrator.py
+++ b/ax/orchestration/tests/test_orchestrator.py
@@ -1340,7 +1340,7 @@ class TestAxOrchestrator(TestCase):
             return_value=timedelta(hours=1),
         ):
             orchestrator.run_all_trials()
-        self.assertEqual(len(orchestrator.experiment._data_by_trial[0]), 1)
+        self.assertFalse(orchestrator.experiment.lookup_data_for_trial(0).full_df.empty)
 
     def test_run_trials_in_batches(self) -> None:
         gs = self.two_sobol_steps_GS

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -298,9 +298,7 @@ class Decoder:
             # trial_type_to_runner is instantiated to map all trial types to None,
             # so the trial types are associated with the experiment. This is
             # important for adding metrics.
-            trial_type_to_runner.update(
-                {t_type: None for t_type in trial_types_with_metrics}
-            )
+            trial_type_to_runner.update(dict.fromkeys(trial_types_with_metrics))
 
         experiment = MultiTypeExperiment(
             name=experiment_sqa.name,


### PR DESCRIPTION
Summary:
**Context**: In D86452716, we remove `Experiment`'s attribute `_data_by_trial` and give it an attribute `Data`. This is quite a complex change; in addition to the changes on `Experiment`, it requires storage changes and updating many callsites. Solely in order to split that diff up, this diff gives `Experiment` a property `data` (which will become an attribute in D86452716) and updates call sites.

**Changes**:
* Gives `Experiment` a property `Data` that is equivalent to `.lookup_data()`
* Updates many call sites to reference `data` rather than `_data_by_trial`

Differential Revision: D87004539


