### PR TITLE
Optimization trace to return noiseless when add_custom_noise is used

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -189,7 +189,9 @@ def get_oracle_experiment_from_params(
         optimization_config=problem.optimization_config,
     )
 
-    runner = BenchmarkRunner(test_function=problem.test_function, noise_std=0.0)
+    # Ensure noiseless evaluation by replacing any custom noise function with None
+    noiseless_test_function = replace(problem.test_function, add_custom_noise=None)
+    runner = BenchmarkRunner(test_function=noiseless_test_function, noise_std=0.0)
 
     # Silence INFO logs from ax.core.experiment that state "Attached custom
     # parameterizations"

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -995,6 +995,21 @@ class TestBenchmark(TestCase):
                 problem=problem, dict_of_dict_of_params={0: {}}
             )
 
+        with self.subTest("custom noise is ignored for noiseless oracle"):
+            problem_with_custom_noise = dataclasses.replace(
+                problem,
+                test_function=dataclasses.replace(
+                    problem.test_function,
+                    add_custom_noise=lambda df, *args: df.assign(mean=999.0, sem=0.0),
+                ),
+            )
+            oracle_exp = get_oracle_experiment_from_params(
+                problem=problem_with_custom_noise,
+                dict_of_dict_of_params={0: {"0": near_opt_params}},
+            )
+            df = oracle_exp.fetch_data().df
+            self.assertAlmostEqual(df["mean"].iloc[0], Branin._optimal_value, places=5)
+
     def _test_multi_fidelity_or_multi_task(
         self, fidelity_or_task: Literal["fidelity", "task"]
     ) -> None:


### PR DESCRIPTION
Summary:
Adjustment after discussion in D89407340.

Changing optimization trace to return underlying noiseless value instead of noisy for custom noise functions.

Differential Revision:
D89544093

Privacy Context Container: L1307644


