### PR TITLE
Skip UtilityProgressionAnalysis for online experiments

### DIFF
--- a/ax/analysis/results.py
+++ b/ax/analysis/results.py
@@ -220,13 +220,16 @@ class ResultsAnalysis(Analysis):
         # Add utility progression if there are objectives
         # Skip for experiments with ScalarizedOutcomeConstraint as feasibility
         # evaluation for scalarized outcome constraints is not yet implemented
+        # Skip for online experiments (those with BatchTrials)
         utility_progression_card = (
             UtilityProgressionAnalysis().compute_or_error_card(
                 experiment=experiment,
                 generation_strategy=generation_strategy,
                 adapter=adapter,
             )
-            if len(objective_names) > 0 and not has_scalarized_outcome_constraints
+            if len(objective_names) > 0
+            and not has_scalarized_outcome_constraints
+            and not has_batch_trials
             else None
         )
 
@@ -242,12 +245,12 @@ class ResultsAnalysis(Analysis):
             children=[
                 child
                 for child in (
-                    utility_progression_card,
                     arm_effect_pair_group,
                     objective_scatter_group,
                     constraint_scatter_group,
                     bandit_rollout_card,
                     best_trials_card,
+                    utility_progression_card,
                     summary,
                 )
                 if child is not None

--- a/ax/analysis/tests/test_results.py
+++ b/ax/analysis/tests/test_results.py
@@ -468,6 +468,14 @@ class TestResultsAnalysis(TestCase):
             self.assertIsNotNone(card_group)
             self.assertGreater(len(card_group.children), 0)
 
+            # Assert: UtilityProgressionAnalysis should NOT be computed
+            child_names = [child.name for child in card_group.flatten()]
+            self.assertFalse(
+                any("UtilityProgression" in name for name in child_names),
+                "UtilityProgressionAnalysis should not be computed for online "
+                "experiments",
+            )
+
     @mock_botorch_optimize
     def test_offline_experiments(self) -> None:
         # Test ResultsAnalysis can be computed for a variety of experiments which


### PR DESCRIPTION
Summary:
Skip computing UtilityProgressionAnalysis for online experiments in ResultsAnalysis until we make it more robust in the future.

Also moved the utility progression card lower in the children order, placing it towards the end of the result analysis cards.

Differential Revision:
D89628022

Privacy Context Container: L1307644


