### PR TITLE
Add SEM display option to ContourPlot

### DIFF
--- a/ax/analysis/plotly/surface/tests/test_contour.py
+++ b/ax/analysis/plotly/surface/tests/test_contour.py
@@ -60,7 +60,7 @@ class TestContourPlot(TestCase):
             "values, providing insights into the gradient and potential optima "
             "within the parameter space."
         )
-        self.expected_title = "bar vs. x, y"
+        self.expected_title = "bar (Mean) vs. x, y"
         self.expected_name = "ContourPlot"
         self.expected_cols = {
             "x",
@@ -180,3 +180,37 @@ class TestContourPlot(TestCase):
             trial_index,
             card.df["trial_index"].values,
         )
+
+    def test_display_sem(self) -> None:
+        """Test that display='sem' shows standard error contour."""
+        analysis = ContourPlot(
+            x_parameter_name="x",
+            y_parameter_name="y",
+            metric_name="bar",
+            display="sem",
+        )
+        card = analysis.compute(
+            experiment=self.client.experiment,
+            generation_strategy=self.client.generation_strategy,
+        )
+
+        # Title should indicate Standard Error
+        self.assertEqual(card.title, "bar (Standard Error) vs. x, y")
+        self.assertEqual(card.name, "ContourPlot")
+        # DataFrame should still have both mean and sem columns
+        self.assertIn("bar_mean", card.df.columns)
+        self.assertIn("bar_sem", card.df.columns)
+
+    def test_invalid_display_value(self) -> None:
+        """Test that invalid display value raises UserInputError at compute time."""
+        analysis = ContourPlot(
+            x_parameter_name="x",
+            y_parameter_name="y",
+            metric_name="bar",
+            display="invalid",
+        )
+        with self.assertRaisesRegex(UserInputError, "display must be 'mean' or 'sem'"):
+            analysis.compute(
+                experiment=self.client.experiment,
+                generation_strategy=self.client.generation_strategy,
+            )

--- a/ax/analysis/plotly/tests/test_top_surfaces.py
+++ b/ax/analysis/plotly/tests/test_top_surfaces.py
@@ -159,7 +159,7 @@ class TestTopSurfacesAnalysis(TestCase):
         # Other cards should be slices or contours.
         self.assertIn("bar vs.", with_surfaces[1].title)
         self.assertIn("bar vs.", with_surfaces[2].title)
-        self.assertIn("bar vs.", with_surfaces[3].title)
+        self.assertIn("bar (Mean) vs.", with_surfaces[3].title)
 
     @mock_botorch_optimize
     @TestCase.ax_long_test(reason="Expensive to compute Sobol indicies")


### PR DESCRIPTION
Summary:
Adds support for displaying standard error (SEM) contour plots in addition to default mean contour plots. This will enable AxSweep to create both mean and SEM contour plots using Ax Analyses and enables parity with the axsweep's `interact_contour_plotly` function which showed both mean and standard error contours side-by-side.

**Changes:**
- Added `display` parameter to `ContourPlot` with options `"mean"` (default) or `"sem"`
- Updated title format to include display type: `"{metric} (Mean) vs. x, y"` or `"{metric} (Standard Error) vs. x, y"`
- Updated `_prepare_plot` to select the appropriate column based on `display` parameter
- Fixed docstring typo: "predected" → "predicted"
- Added documentation for `METRIC_NAME_sem` column in DataFrame

**Usage:**
```python
# Mean contour (default, same as before)
ContourPlot(x_parameter_name="x", y_parameter_name="y", metric_name="foo")

# Standard error contour
ContourPlot(x_parameter_name="x", y_parameter_name="y", metric_name="foo", display="sem")
```

Differential Revision:
D89636799

Privacy Context Container: L1307644


