### PR TITLE
Remove Experiment.default_data_constructor and Experiment.default_data_type

### DIFF
--- a/ax/adapter/tests/test_data_utils.py
+++ b/ax/adapter/tests/test_data_utils.py
@@ -84,11 +84,10 @@ class TestDataUtils(TestCase):
             experiment_data = extract_experiment_data(
                 experiment=empty_exp, data_loader_config=DataLoaderConfig()
             )
+            # no "step" column because empty data is always Data, not MapData
             expected_ind_names = ["trial_index", "arm_name"]
             self.assertEqual(len(experiment_data.arm_data), 0)
             self.assertEqual(experiment_data.arm_data.index.names, expected_ind_names)
-            if is_map:
-                expected_ind_names.append("step")
             self.assertEqual(len(experiment_data.observation_data), 0)
             self.assertEqual(
                 experiment_data.observation_data.index.names, expected_ind_names

--- a/ax/adapter/tests/test_utils.py
+++ b/ax/adapter/tests/test_utils.py
@@ -17,7 +17,7 @@ from ax.adapter.adapter_utils import (
 )
 from ax.adapter.registry import Generators
 from ax.core.arm import Arm
-from ax.core.evaluations_to_data import DataType, raw_evaluations_to_data
+from ax.core.evaluations_to_data import raw_evaluations_to_data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
@@ -254,7 +254,6 @@ class TestAdapterUtils(TestCase):
                 {self.trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
-                data_type=DataType.DATA,
             )
         )
         # With `fetch_data` on trial returning data for metric "m2", that metric
@@ -266,7 +265,6 @@ class TestAdapterUtils(TestCase):
                 {self.trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
-                data_type=DataType.DATA,
             ),
         ):
             pending = none_throws(get_pending_observation_features(self.experiment))

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -24,7 +24,6 @@ from ax.api.protocols.metric import IMetric
 from ax.api.protocols.runner import IRunner
 from ax.api.types import TParameterization
 from ax.core.analysis_card import AnalysisCard
-from ax.core.evaluations_to_data import DataType
 from ax.core.experiment import Experiment
 from ax.core.map_metric import MapMetric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
@@ -117,7 +116,6 @@ class TestClient(TestCase):
                 name="test_experiment",
                 description="test description",
                 properties={"owners": ["miles"]},
-                default_data_type=DataType.MAP_DATA,
             ),
         )
 

--- a/ax/api/utils/instantiation/from_struct.py
+++ b/ax/api/utils/instantiation/from_struct.py
@@ -7,7 +7,6 @@
 
 from ax.api.utils.instantiation.from_config import parameter_from_config
 from ax.api.utils.structs import ExperimentStruct
-from ax.core.evaluations_to_data import DataType
 from ax.core.experiment import Experiment
 from ax.core.parameter_constraint import (
     ParameterConstraint,
@@ -46,5 +45,4 @@ def experiment_from_struct(struct: ExperimentStruct) -> Experiment:
         description=struct.description,
         experiment_type=struct.experiment_type,
         properties={"owners": [struct.owner]},
-        default_data_type=DataType.MAP_DATA,
     )

--- a/ax/api/utils/instantiation/tests/test_from_config.py
+++ b/ax/api/utils/instantiation/tests/test_from_config.py
@@ -15,7 +15,6 @@ from ax.api.utils.instantiation.from_config import (
 )
 from ax.api.utils.instantiation.from_struct import experiment_from_struct
 from ax.api.utils.structs import ExperimentStruct
-from ax.core.evaluations_to_data import DataType
 from ax.core.experiment import Experiment
 from ax.core.parameter import (
     ChoiceParameter,
@@ -286,7 +285,6 @@ class TestFromConfig(TestCase):
                 description="test description",
                 experiment_type="TEST",
                 properties={"owners": ["miles"]},
-                default_data_type=DataType.MAP_DATA,
             ),
         )
 
@@ -347,7 +345,6 @@ class TestFromConfig(TestCase):
                 name="test_experiment",
                 description="test description",
                 properties={"owners": ["miles"]},
-                default_data_type=DataType.MAP_DATA,
             ),
         )
 

--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -21,7 +21,6 @@ from ax.core.data import Data
 from ax.core.evaluations_to_data import raw_evaluations_to_data
 from ax.core.generator_run import GeneratorRun, GeneratorRunType
 from ax.core.map_data import MapData
-from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric, MetricFetchResult
 from ax.core.runner import Runner
 from ax.core.trial_status import TrialStatus
@@ -447,11 +446,7 @@ class BaseTrial(ABC, SortableBase):
         Returns:
             Data for this trial.
         """
-        base_metric_cls = (
-            MapMetric if self.experiment.default_data_constructor == MapData else Metric
-        )
-
-        data = base_metric_cls._unwrap_trial_data_multi(
+        data = Metric._unwrap_trial_data_multi(
             results=self.fetch_data_results(metrics=metrics, **kwargs)
         )
         if not isinstance(data, MapData):
@@ -857,7 +852,6 @@ class BaseTrial(ABC, SortableBase):
                 raw_data=raw_data,
                 metric_name_to_signature=metric_name_to_signature,
                 trial_index=self.index,
-                data_type=self.experiment.default_data_type,
             )
         except UserInputError as e:
             if "not found in metric_name_to_signature." in str(e):

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -12,7 +12,9 @@ from typing import Any
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.data import Data
-from ax.core.experiment import DataType, Experiment
+from ax.core.evaluations_to_data import DataType
+from ax.core.experiment import Experiment
+from ax.core.map_data import combine_datas_infer_type
 from ax.core.metric import Metric, MetricFetchResult
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.runner import Runner
@@ -68,7 +70,7 @@ class MultiTypeExperiment(Experiment):
             is_test: Convenience metadata tracker for the user to mark test experiments.
             experiment_type: The class of experiments this one belongs to.
             properties: Dictionary of this experiment's properties.
-            default_data_type: Enum representing the data type this experiment uses.
+            default_data_type: Deprecated and ignored.
         """
 
         # Specifies which trial type each metric belongs to
@@ -90,7 +92,6 @@ class MultiTypeExperiment(Experiment):
             is_test=is_test,
             experiment_type=experiment_type,
             properties=properties,
-            default_data_type=default_data_type,
             tracking_metrics=tracking_metrics,
             runner=default_runner,
             default_trial_type=default_trial_type,
@@ -252,7 +253,7 @@ class MultiTypeExperiment(Experiment):
         # TODO: make this more efficient for fetching
         # data for multiple trials of the same type
         # by overriding Experiment._lookup_or_fetch_trials_results
-        return self.default_data_constructor.from_multiple_data(
+        return combine_datas_infer_type(
             [
                 (
                     trial.fetch_data(**kwargs, metrics=metrics)

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -17,7 +17,7 @@ from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.data import Data
-from ax.core.evaluations_to_data import DataType, raw_evaluations_to_data
+from ax.core.evaluations_to_data import raw_evaluations_to_data
 from ax.core.experiment import sort_by_trial_index_and_arm_name
 from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
@@ -693,7 +693,7 @@ class ExperimentTest(TestCase):
         # Verify that `metrics` kwarg to `experiment.fetch_data` is respected
         # when pulling looked-up data.
         self.assertEqual(
-            exp.fetch_data(metrics=[Metric(name="not_on_experiment")]), Data()
+            exp.fetch_data(metrics=[Metric(name="not_on_experiment")]), MapData()
         )
 
         with self.subTest("Invalid legacy data format"):
@@ -963,8 +963,6 @@ class ExperimentTest(TestCase):
         )
         exp.attach_trial(parameterizations=[{"x1": 0.0, "x2": 0.0}])
         exp.attach_trial(parameterizations=[{"x1": 0.0, "x2": 0.0}])
-        # Set the default data type to the unexpected type
-        exp._default_data_type = DataType.MAP_DATA
         # Add a trial
         attached_df = pd.DataFrame(
             {
@@ -990,7 +988,7 @@ class ExperimentTest(TestCase):
 
         with self.subTest("Empty trial indices"):
             looked_up = exp.lookup_data(trial_indices=[])
-            self.assertIsInstance(looked_up, MapData)
+            self.assertIsInstance(looked_up, Data)
             self.assertTrue(looked_up.full_df.empty)
 
     def test_attach_and_sort_data(self) -> None:
@@ -1927,7 +1925,6 @@ class ExperimentWithMapDataTest(TestCase):
             metric_name_to_signature={
                 "no_fetch_impl_metric": "no_fetch_impl_metric_signature",
             },
-            data_type=DataType.MAP_DATA,
         )
         self.experiment.attach_data(first_epoch)
 
@@ -1941,7 +1938,6 @@ class ExperimentWithMapDataTest(TestCase):
             metric_name_to_signature={
                 "no_fetch_impl_metric": "no_fetch_impl_metric_signature",
             },
-            data_type=DataType.MAP_DATA,
         )
         self.experiment.attach_data(remaining_epochs)
         self.experiment.trials[0].mark_completed()

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -22,6 +22,7 @@ from ax.core.base_trial import (
 )
 from ax.core.data import Data
 from ax.core.generator_run import GeneratorRun, GeneratorRunType
+from ax.core.map_data import MapData
 from ax.core.runner import Runner
 from ax.exceptions.core import TrialMutationError, UnsupportedError, UserInputError
 from ax.metrics.branin import BraninMetric
@@ -394,12 +395,9 @@ class TrialTest(TestCase):
         self.assertEqual(1.0, data[(arm_name, "m1")]["mean"])
         self.assertEqual(2.0, data[(arm_name, "m2")]["mean"])
 
-        # Try to attach MapData.
-        with self.assertRaisesRegex(
-            UserInputError,
-            "The format of the `raw_data` is not compatible with `Data`. ",
-        ):
+        with self.subTest("Attach map data"):
             self.trial.update_trial_data(raw_data=[(0, {"m1": 1.0})])
+            self.assertIsInstance(self.trial.lookup_data(), MapData)
 
         # Try to attach Data to a MapData experiment.
         map_experiment = get_test_map_data_experiment(
@@ -424,11 +422,10 @@ class TrialTest(TestCase):
         ):
             map_trial.update_trial_data(raw_data=[(0, {"m2": 1.0})])
 
-        with self.assertRaisesRegex(
-            UserInputError,
-            "The format of the `raw_data` is not compatible with `MapData`. ",
-        ):
+        with self.subTest("Add Data to MapData trial"):
             map_trial.update_trial_data(raw_data={"m1": 1.0})
+            self.assertIsInstance(map_trial.lookup_data(), MapData)
+            self.assertEqual(map_trial.lookup_data().df["step"].isnull().sum(), 1)
 
         # Error if the MapData inputs are not formatted correctly.
         with self.assertRaisesRegex(

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -14,7 +14,7 @@ import pandas as pd
 from ax.core.arm import Arm
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
-from ax.core.evaluations_to_data import DataType, raw_evaluations_to_data
+from ax.core.evaluations_to_data import raw_evaluations_to_data
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.objective import Objective
@@ -234,7 +234,6 @@ class UtilsTest(TestCase):
                 {self.trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
-                data_type=DataType.DATA,
             ),
         ):
             self.assertEqual(
@@ -273,7 +272,6 @@ class UtilsTest(TestCase):
                         "m2": "m2",
                         "tracking": "tracking",
                     },
-                    data_type=DataType.DATA,
                 ),
             ),
         ):
@@ -304,7 +302,6 @@ class UtilsTest(TestCase):
                         "m2": "m2",
                         "tracking": "tracking",
                     },
-                    data_type=DataType.DATA,
                 ),
             ),
         ):
@@ -397,7 +394,6 @@ class UtilsTest(TestCase):
                 {self.trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
-                data_type=DataType.DATA,
             ),
         ):
             self.assertEqual(
@@ -417,7 +413,6 @@ class UtilsTest(TestCase):
                 {self.trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
-                data_type=DataType.DATA,
             ),
         ):
             with patch.object(
@@ -427,7 +422,6 @@ class UtilsTest(TestCase):
                     {other_trial.arm.name: {"m2": (1, 0), "tracking": (1, 0)}},
                     trial_index=other_trial.index,
                     metric_name_to_signature={"m2": "m2", "tracking": "tracking"},
-                    data_type=DataType.DATA,
                 ),
             ):
                 pending = get_pending_observation_features(self.experiment)
@@ -502,7 +496,6 @@ class UtilsTest(TestCase):
                 {self.hss_trial.arm.name: {"m2": (1, 0)}},
                 trial_index=self.hss_trial.index,
                 metric_name_to_signature={"m2": "m2"},
-                data_type=DataType.DATA,
             ),
         ):
             self.assertEqual(
@@ -534,7 +527,6 @@ class UtilsTest(TestCase):
                     },
                     trial_index=hss_batch_trial.index,
                     metric_name_to_signature={"m1": "m1", "m2": "m2"},
-                    data_type=DataType.DATA,
                 ),
             ),
         ):
@@ -567,7 +559,6 @@ class UtilsTest(TestCase):
                     },
                     trial_index=hss_batch_trial.index,
                     metric_name_to_signature={"m1": "m1", "m2": "m2"},
-                    data_type=DataType.DATA,
                 ),
             ),
         ):

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -213,8 +213,8 @@ class BaseEarlyStoppingStrategy(ABC, Base):
             0.11 estimated savings indicates we would expect the experiment to have used
             11% more resources without early stopping present)
         """
-        if experiment.default_data_constructor is not MapData:
-            return 0
+        if not isinstance(experiment.lookup_data(), MapData):
+            return 0.0
 
         return estimate_early_stopping_savings(experiment=experiment)
 

--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -220,7 +220,6 @@ class OptimizationLoop:
                 for arm, weight in self._get_weights_by_arm(trial)
             },
             trial_index=self.current_trial,
-            data_type=self.experiment.default_data_type,
             metric_name_to_signature=metric_name_to_signature,
         )
 

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -16,7 +16,7 @@ from typing import Any, Union
 
 from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
-from ax.core.experiment import DataType, Experiment
+from ax.core.experiment import Experiment
 from ax.core.metric import Metric
 from ax.core.multi_type_experiment import MultiTypeExperiment
 from ax.core.objective import MultiObjective, Objective
@@ -892,10 +892,6 @@ class InstantiationBase:
             ]
         )
 
-        default_data_type = (
-            DataType.MAP_DATA if support_intermediate_data else DataType.DATA
-        )
-
         properties: dict[str, Any] = {}
 
         if immutable_search_space_and_opt_config:
@@ -920,7 +916,6 @@ class InstantiationBase:
                 is_test=is_test,
                 experiment_type=experiment_type,
                 properties=properties,
-                default_data_type=default_data_type,
             )
 
         return Experiment(
@@ -931,7 +926,6 @@ class InstantiationBase:
             status_quo=status_quo_arm,
             experiment_type=experiment_type,
             tracking_metrics=tracking_metrics,
-            default_data_type=default_data_type,
             properties=properties,
             auxiliary_experiments_by_purpose=auxiliary_experiments_by_purpose,
             is_test=is_test,

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -93,7 +93,6 @@ def experiment_to_dict(experiment: Experiment) -> dict[str, Any]:
         "is_test": experiment.is_test,
         "data_by_trial": experiment._data_by_trial,
         "properties": experiment._properties,
-        "default_data_type": experiment._default_data_type,
         "_trial_type_to_runner": experiment._trial_type_to_runner,
     }
 

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -28,7 +28,7 @@ from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
 from ax.core.batch_trial import AbandonedArm, BatchTrial
 from ax.core.data import Data
-from ax.core.experiment import DataType
+from ax.core.evaluations_to_data import DataType
 from ax.core.generator_run import GeneratorRun
 from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -24,6 +24,7 @@ from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
 from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import AbandonedArm, BatchTrial
 from ax.core.data import Data
+from ax.core.evaluations_to_data import DataType
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
@@ -254,7 +255,9 @@ class Encoder:
             data=experiment_data,
             properties=properties,
             default_trial_type=experiment.default_trial_type,
-            default_data_type=experiment.default_data_type,
+            # In for backward compatibility. Experiment._default_data_type no
+            # longer exists.
+            default_data_type=DataType.DATA,
             auxiliary_experiments_by_purpose=auxiliary_experiments_by_purpose,
             auxiliary_experiments=auxiliary_experiments,
         )

--- a/ax/storage/sqa_store/save.py
+++ b/ax/storage/sqa_store/save.py
@@ -320,10 +320,7 @@ def save_or_update_data_for_trials(
         encode_func=encoder.data_to_sqa,
         decode_func=decoder.data_from_sqa,
         encode_args_list=data_encode_args,
-        decode_args_list=[
-            {"data_constructor": experiment.default_data_constructor}
-            for _ in range(len(datas))
-        ],
+        decode_args_list=[],
         modify_sqa=add_experiment_id,
         batch_size=batch_size,
     )

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
+from ax.core.evaluations_to_data import DataType
+
 from ax.core.parameter import ParameterType
 
 from ax.core.trial_status import TrialStatus
@@ -37,7 +39,7 @@ from ax.storage.sqa_store.json import (
 )
 from ax.storage.sqa_store.sqa_enum import IntEnum, StringEnum
 from ax.storage.sqa_store.timestamp import IntTimestamp
-from ax.storage.utils import DataType, DomainType, MetricIntent, ParameterConstraintType
+from ax.storage.utils import DomainType, MetricIntent, ParameterConstraintType
 from sqlalchemy import (
     BigInteger,
     Boolean,

--- a/ax/storage/utils.py
+++ b/ax/storage/utils.py
@@ -12,7 +12,6 @@ from collections.abc import Mapping
 from hashlib import md5
 
 from ax.core.data import combine_dfs_favoring_recent, Data, MAP_KEY
-from ax.core.evaluations_to_data import DataType  # noqa F401
 from ax.core.map_data import MapData
 
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -29,7 +29,7 @@ from ax.core.auxiliary import AuxiliaryExperiment
 from ax.core.base_trial import BaseTrial
 from ax.core.batch_trial import AbandonedArm, BatchTrial
 from ax.core.data import Data
-from ax.core.evaluations_to_data import DataType, raw_evaluations_to_data
+from ax.core.evaluations_to_data import raw_evaluations_to_data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.map_data import MapData
@@ -173,7 +173,6 @@ def get_experiment_with_map_data_type() -> Experiment:
         description="test description",
         tracking_metrics=[MapMetric(name="tracking")],
         is_test=True,
-        default_data_type=DataType.MAP_DATA,
     )
     experiment._properties = {"owners": [DEFAULT_USER]}
     return experiment
@@ -536,7 +535,6 @@ def get_branin_experiment_with_timestamp_map_metric(
         optimization_config=optimization_config,
         tracking_metrics=cast(list[Metric], tracking_metrics),
         runner=SyntheticRunner(),
-        default_data_type=DataType.MAP_DATA,
     )
     exp._properties = {"owners": [DEFAULT_USER]}
 
@@ -2499,7 +2497,6 @@ def get_map_data(trial_index: int = 0) -> MapData:
                 "ax_test_metric": "ax_test_metric",
                 "epoch": "epoch",
             },
-            data_type=DataType.MAP_DATA,
         ),
         MapData,
     )


### PR DESCRIPTION
Summary:
**Context:**

`default_data_constructor` and `default_data_type` are used for a few purposes:
1. Determining the type of empty data
2. Determining the type of data that results from combining multiple `Data`s
3. Validating that observations passed match the `default_data_type` on the experiment

Now that we have reduced our data classes down to just `Data` and `MapData`, and there is only one map key, and those two classes now differ mainly in whether they have a "step" column, there is little reason to worry so much about tracking the intended type of data.

This PR brings us closer to unifying Data and MapData, because with this change, it should always be the case that a data is a MapData if and only if it has a "step" column; thus, there is no information contained in the class that can't be obtained by chacking whether there is a "step" column.

**This PR:**
1. Makes empty data `Data`
2a. When combining multiple datas, the result is MapData if one of the constituent objects is a MapData.
2b. When making a Data from a DataFrame, it should be a MapData if there is a "step" column
3. Removes some validations that are no longer necessary

**TODO for this PR:**
* Think more about backward compatibility and deprecation messages
* Reverse the removal of `Experiment`'s `default_data_type` argument


**Some TODOs for follow-up diffs:**
* Stop letting Experiment accept a `default_data_type` argument
* Remove `Metric.data_constructor` (if needed, replacing it with a boolean attribute indicating whether a progression will be produced)
* Convert some `Metric` methods such as `_unwrap_experiment_data` into static methods or move them off `Metric` entirely now that they do not reference the `data_constructor` attribute

Differential Revision: D89689313


