### PR TITLE
Percentile and quantile should not simultaneously be set

### DIFF
--- a/ax/metrics/tensorboard.py
+++ b/ax/metrics/tensorboard.py
@@ -102,7 +102,7 @@ try:
             self.smoothing = smoothing
             self.tag = tag
             self.cumulative_best = cumulative_best
-            self.percentile = quantile  # deprecated, left for backwards compatibility
+            self.percentile: None = None  # deprecated, left for backwards compatibility
             self.quantile = quantile
 
         @classmethod


### PR DESCRIPTION
Summary: Percentile is deprecated, so we should set the corresponding attribute to None. Having percentile and quantile attributes both not-None is leading to saving/loading errors when it hits the validation above.

Reviewed By: saitcakmak

Differential Revision: D89693597


