### PR TITLE
Add markers to ProgressionPlot line charts

### DIFF
--- a/ax/analysis/plotly/progression.py
+++ b/ax/analysis/plotly/progression.py
@@ -11,6 +11,7 @@ import numpy as np
 import plotly.express as px
 from ax.adapter.base import Adapter
 from ax.analysis.analysis import Analysis
+from ax.analysis.plotly.color_constants import BOTORCH_COLOR_SCALE
 from ax.analysis.plotly.plotly_analysis import (
     create_plotly_analysis_card,
     PlotlyAnalysisCard,
@@ -139,7 +140,14 @@ class ProgressionPlot(Analysis):
         else:
             x_axis_name = "progression"
 
-        fig = px.line(df, x=x_axis_name, y=metric_name, color="arm_name")
+        fig = px.line(
+            df,
+            x=x_axis_name,
+            y=metric_name,
+            color="arm_name",
+            markers=True,
+            color_discrete_sequence=BOTORCH_COLOR_SCALE,
+        )
 
         # Add a marker for each terminal point on early stopped trials.
         if len(terminal_points) > 0:


### PR DESCRIPTION
Summary:
Adds data point markers to the `ProgressionPlot` line charts by enabling `markers=True` in the Plotly Express line plot.

Previously, the progression plots only displayed lines connecting data points, making it difficult to identify individual observations. This change adds circle markers at each data point, improving readability and making it easier to see where actual measurements were taken along the progression curves.

Differential Revision:
D89722979

Privacy Context Container: L1307644


