### PR TITLE
Remove MapData.map_df

### DIFF
--- a/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
+++ b/ax/adapter/transforms/tests/test_map_key_to_float_transform.py
@@ -544,7 +544,7 @@ class MapKeyToFloatTransformTest(TestCase):
     def test_transform_experiment_data(self) -> None:
         # First, set up a case with no NaNs.
         data = self.experiment.lookup_data()
-        data.map_df["step"] = data.map_df["step"].fillna(0)
+        data.full_df["step"] = data.full_df["step"].fillna(0)
         experiment_data = extract_experiment_data(
             experiment=self.experiment,
             data=data,

--- a/ax/analysis/plotly/progression.py
+++ b/ax/analysis/plotly/progression.py
@@ -23,7 +23,7 @@ from ax.core.trial_status import TrialStatus
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 
 from plotly import graph_objects as go
-from pyre_extensions import assert_is_instance, none_throws, override
+from pyre_extensions import none_throws, override
 
 
 @final
@@ -88,14 +88,14 @@ class ProgressionPlot(Analysis):
         adapter: Adapter | None = None,
     ) -> PlotlyAnalysisCard:
         experiment = none_throws(experiment)
-        data = assert_is_instance(experiment.lookup_data(), MapData)
+        data = experiment.lookup_data()
 
         metric_name = self._metric_name or select_metric(experiment=experiment)
 
         # Collect the data necessary to plot each progression curve.
-        map_df = data.map_df
-        df = map_df.loc[
-            map_df["metric_name"] == metric_name,
+        full_df = data.full_df
+        df = full_df.loc[
+            full_df["metric_name"] == metric_name,
             ["trial_index", "arm_name", "mean", MAP_KEY],
         ].rename(columns={MAP_KEY: "progression", "mean": metric_name})
 
@@ -205,8 +205,8 @@ def _calculate_wallclock_timeseries(
         for idx, trial in experiment.trials.items()
     }
 
-    data = assert_is_instance(experiment.lookup_data(), MapData)
-    df = data.map_df[data.map_df["metric_name"] == metric_name]
+    data = experiment.lookup_data()
+    df = data.full_df[data.full_df["metric_name"] == metric_name]
 
     return {
         trial_index: dict(

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -26,7 +26,6 @@ from ax.api.types import TParameterization
 from ax.core.analysis_card import AnalysisCard
 from ax.core.evaluations_to_data import DataType
 from ax.core.experiment import Experiment
-from ax.core.map_data import MapData
 from ax.core.map_metric import MapMetric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.optimization_config import OptimizationConfig
@@ -477,10 +476,7 @@ class TestClient(TestCase):
             TrialStatus.RUNNING,
         )
         self.assertTrue(
-            assert_is_instance(
-                client._experiment.lookup_data(trial_indices=[trial_index]),
-                MapData,
-            ).map_df.equals(
+            client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
                 pd.DataFrame(
                     {
                         "trial_index": {0: 0},
@@ -503,10 +499,7 @@ class TestClient(TestCase):
             TrialStatus.RUNNING,
         )
         self.assertTrue(
-            assert_is_instance(
-                client._experiment.lookup_data(trial_indices=[trial_index]),
-                MapData,
-            ).map_df.equals(
+            client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
                 pd.DataFrame(
                     {
                         "trial_index": {0: 0, 1: 0},
@@ -542,10 +535,7 @@ class TestClient(TestCase):
             TrialStatus.RUNNING,
         )
         self.assertTrue(
-            assert_is_instance(
-                client._experiment.lookup_data(trial_indices=[trial_index]),
-                MapData,
-            ).map_df.equals(
+            client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
                 pd.DataFrame(
                     {
                         "trial_index": {0: 0, 1: 0, 2: 0},
@@ -585,10 +575,7 @@ class TestClient(TestCase):
             TrialStatus.COMPLETED,
         )
         self.assertTrue(
-            assert_is_instance(
-                client._experiment.lookup_data(trial_indices=[trial_index]),
-                MapData,
-            ).map_df.equals(
+            client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
                 pd.DataFrame(
                     {
                         "trial_index": {0: 0, 1: 0},
@@ -615,10 +602,7 @@ class TestClient(TestCase):
         )
 
         self.assertTrue(
-            assert_is_instance(
-                client._experiment.lookup_data(trial_indices=[trial_index]),
-                MapData,
-            ).map_df.equals(
+            client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
                 pd.DataFrame(
                     {
                         "trial_index": {0: 1, 1: 1},
@@ -642,10 +626,7 @@ class TestClient(TestCase):
             TrialStatus.FAILED,
         )
         self.assertTrue(
-            assert_is_instance(
-                client._experiment.lookup_data(trial_indices=[trial_index]),
-                MapData,
-            ).map_df.equals(
+            client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
                 pd.DataFrame(
                     {
                         "trial_index": {0: 2},
@@ -771,10 +752,7 @@ class TestClient(TestCase):
             TrialStatus.EARLY_STOPPED,
         )
         self.assertTrue(
-            assert_is_instance(
-                client._experiment.lookup_data(trial_indices=[trial_index]),
-                MapData,
-            ).map_df.equals(
+            client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
                 pd.DataFrame(
                     {
                         "trial_index": {0: 0},
@@ -834,10 +812,7 @@ class TestClient(TestCase):
         )
 
         self.assertTrue(
-            assert_is_instance(
-                client._experiment.lookup_data(),
-                MapData,
-            ).map_df.equals(
+            client._experiment.lookup_data().full_df.equals(
                 pd.DataFrame(
                     {
                         "trial_index": {0: 0, 1: 1, 2: 2, 3: 3},

--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -39,8 +39,8 @@ from ax.benchmark.benchmark_runner import BenchmarkRunner
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
 from ax.benchmark.methods.sobol import get_sobol_benchmark_method
 from ax.core.arm import Arm
+from ax.core.data import MAP_KEY
 from ax.core.experiment import Experiment
-from ax.core.map_data import MAP_KEY, MapData
 from ax.core.objective import MultiObjective
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
@@ -807,10 +807,10 @@ def get_opt_trace_by_steps(experiment: Experiment) -> npt.NDArray:
         )
 
     objective_name = optimization_config.objective.metric.name
-    data = assert_is_instance(experiment.lookup_data(), MapData)
-    map_df = data.map_df
+    data = experiment.lookup_data()
+    full_df = data.full_df
 
-    # Has timestamps; needs to be merged with map_df because it contains
+    # Has timestamps; needs to be merged with full_df because it contains
     # data on epochs that didn't actually run due to early stopping, and we need
     # to know which actually ran
     def _get_df(trial: Trial) -> pd.DataFrame:
@@ -837,8 +837,8 @@ def get_opt_trace_by_steps(experiment: Experiment) -> npt.NDArray:
     )[["trial_index", MAP_KEY, "time"]]
 
     df = (
-        map_df.loc[
-            map_df["metric_name"] == objective_name,
+        full_df.loc[
+            full_df["metric_name"] == objective_name,
             ["trial_index", "arm_name", "mean", MAP_KEY],
         ]
         .merge(with_timestamps, how="left")

--- a/ax/benchmark/tests/test_benchmark_metric.py
+++ b/ax/benchmark/tests/test_benchmark_metric.py
@@ -275,7 +275,7 @@ class TestBenchmarkMetric(TestCase):
                 has_simulator=has_simulator,
             )
             data = metric.fetch_trial_data(trial=trial).value
-            df_or_map_df = data.map_df if isinstance(metric, MapMetric) else data.df
+            df_or_map_df = data.full_df if isinstance(metric, MapMetric) else data.df
             returns_full_data = (not has_simulator) and isinstance(metric, MapMetric)
             self.assertEqual(
                 len(df_or_map_df), len(trial.arms) * (3 if returns_full_data else 1)
@@ -317,9 +317,9 @@ class TestBenchmarkMetric(TestCase):
             self.assertEqual(backend_simulator.time, 2)
             data = metric.fetch_trial_data(trial=trial).value
             if isinstance(metric, MapMetric):
-                map_df = data.map_df
-                self.assertEqual(len(map_df), 2 * len(trial.arms))
-                self.assertEqual(set(map_df["step"].tolist()), {0, 1})
+                full_df = data.full_df
+                self.assertEqual(len(full_df), 2 * len(trial.arms))
+                self.assertEqual(set(full_df["step"].tolist()), {0, 1})
             df = data.df
             self.assertEqual(len(df), len(trial.arms))
             expected_df = _get_one_step_df(

--- a/ax/core/observation_utils.py
+++ b/ax/core/observation_utils.py
@@ -283,7 +283,7 @@ def observations_from_data(
                 include_first_last=True,
             )
         is_map_data = True
-        df = data.map_df
+        df = data.full_df
     else:
         is_map_data = False
         df = data.df

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -14,7 +14,6 @@ from ax.core.data import combine_dfs_favoring_recent, Data
 from ax.core.map_data import MAP_KEY, MapData
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
-from pyre_extensions import assert_is_instance
 
 REPR_500: str = (
     "Data(df=\n"
@@ -139,7 +138,6 @@ class TestDataBase(TestCase):
             self.data_without_df = MapData()
 
     def test_init(self) -> None:
-        # For Data, this is Data(). For MapData, this is MapData(map_keys=[]).
         self.assertEqual(self.data_without_df, self.data_without_df)
         self.assertEqual(self.data_with_df, self.data_with_df)
 
@@ -164,10 +162,8 @@ class TestDataBase(TestCase):
         self.assertIsNot(data.df, data_clone.df)
         self.assertIsNone(data_clone._db_id)
         if self.cls is MapData:
-            data = assert_is_instance(data, MapData)
-            data_clone = assert_is_instance(data_clone, MapData)
-            self.assertIsNot(data.map_df, data_clone.map_df)
-            self.assertTrue(data.map_df.equals(data_clone.map_df))
+            self.assertIsNot(data.full_df, data_clone.full_df)
+            self.assertTrue(data.full_df.equals(data_clone.full_df))
 
     def test_BadData(self) -> None:
         df = pd.DataFrame([{"bad_field": "0_0", "bad_field_2": {"x": 0, "y": "a"}}])
@@ -186,7 +182,7 @@ class TestDataBase(TestCase):
         self.assertTrue(self.cls.from_multiple_data([]).df.empty)
 
         if isinstance(data, MapData):
-            self.assertTrue(data.map_df.empty)
+            self.assertTrue(data.full_df.empty)
             expected_columns = Data.REQUIRED_COLUMNS.union({MAP_KEY})
         else:
             expected_columns = Data.REQUIRED_COLUMNS

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -119,7 +119,7 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
             # don't stop any trials if we don't get data back
             return {}
 
-        df = data.map_df
+        df = data.full_df
 
         # default checks on `min_progression` and `min_curves`; if not met, don't do
         # early stopping at all and return {}

--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -12,11 +12,10 @@ from typing import Any
 import numpy.typing as npt
 import pandas as pd
 from ax.core.experiment import Experiment
-from ax.core.map_data import MAP_KEY, MapData
+from ax.core.map_data import MAP_KEY
 from ax.core.trial_status import TrialStatus
 from ax.exceptions.core import UnsupportedError
 from ax.utils.common.logger import get_logger
-from pyre_extensions import assert_is_instance
 
 logger: Logger = get_logger(__name__)
 
@@ -189,11 +188,11 @@ def estimate_early_stopping_savings(experiment: Experiment) -> float:
         the experiment would have used 11% more resources without early stopping.
     """
 
-    map_data = assert_is_instance(experiment.lookup_data(), MapData)
-    if map_data.df.empty:
+    map_data = experiment.lookup_data()
+    if map_data.full_df.empty:
         return 0
     # Get max progression (resources used) for each trial
-    resources_used = map_data.map_df.groupby("trial_index")[MAP_KEY].max()
+    resources_used = map_data.full_df.groupby("trial_index")[MAP_KEY].max()
 
     trials_by_status = experiment.trial_indices_by_status
     stopped_trials = trials_by_status[TrialStatus.EARLY_STOPPED]

--- a/ax/metrics/tests/test_map_replay.py
+++ b/ax/metrics/tests/test_map_replay.py
@@ -85,10 +85,7 @@ class MapDataReplayMetricTest(TestCase):
         historical_experiment = get_test_map_data_experiment(
             num_trials=2, num_fetches=2, num_complete=2
         )
-        map_data: MapData = assert_is_instance(
-            historical_experiment.lookup_data(), MapData
-        )
-        full_df = map_data.full_df
+        full_df = historical_experiment.lookup_data().full_df
         # The original data has 6 rows: 4 for branin_map and 2 for branin.
         # After assinging steps, we have following steps for branin_map:
         # Trial 0: steps [0.25, 0.95]

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -1609,10 +1609,9 @@ class TestAxClient(TestCase):
                 )
             if t == 2:
                 ax_client.complete_trial(0, raw_data=raw_data)
-            # pyre-fixme[16]: `Data` has no attribute `map_df`.
-            fetch_data = ax_client.experiment.fetch_data().map_df
+            fetch_data = ax_client.experiment.fetch_data().full_df
             self.assertEqual(len(fetch_data), 0 if t < 2 else 3)
-            lookup_data = ax_client.experiment.lookup_data().map_df
+            lookup_data = ax_client.experiment.lookup_data().full_df
             self.assertEqual(len(lookup_data), t + 1)
 
         no_intermediate_data_ax_client = AxClient()

--- a/ax/service/tests/test_orchestrator.py
+++ b/ax/service/tests/test_orchestrator.py
@@ -22,10 +22,9 @@ from ax.adapter.registry import Generators, MBM_MTGP_trans
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.batch_trial import BatchTrial
-from ax.core.data import Data
+from ax.core.data import Data, MAP_KEY
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
-from ax.core.map_data import MAP_KEY, MapData
 from ax.core.metric import Metric
 from ax.core.multi_type_experiment import MultiTypeExperiment
 from ax.core.objective import Objective
@@ -1312,12 +1311,8 @@ class TestAxOrchestrator(TestCase):
         # For MultiTypeExperiment there are two metrics
         # for trial type "type1"
         expected_num_rows = 7
-        self.assertEqual(
-            len(assert_is_instance(looked_up_data, MapData).map_df), expected_num_rows
-        )
-        self.assertEqual(
-            len(assert_is_instance(fetched_data, MapData).map_df), expected_num_rows
-        )
+        self.assertEqual(len(looked_up_data.full_df), expected_num_rows)
+        self.assertEqual(len(fetched_data.full_df), expected_num_rows)
         ess = orchestrator.options.early_stopping_strategy
         self.assertIsNotNone(ess)
         self.assertAlmostEqual(

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -389,18 +389,18 @@ class BestPointMixin(ABC):
         map_data = experiment.lookup_data()
         if not isinstance(map_data, MapData):
             raise ValueError("`get_trace_by_progression` requires MapData.")
-        map_df = map_data.map_df
+        full_df = map_data.full_df
 
-        map_df = map_df[map_df["metric_name"] == objective]
-        map_df = map_df.sort_values(by=["trial_index", MAP_KEY])
+        full_df = full_df[full_df["metric_name"] == objective]
+        full_df = full_df.sort_values(by=["trial_index", MAP_KEY])
         df = (
-            map_df.drop_duplicates(MapData.DEDUPLICATE_BY_COLUMNS, keep="last")
+            full_df.drop_duplicates(MapData.DEDUPLICATE_BY_COLUMNS, keep="last")
             if final_progression_only
-            else map_df
+            else full_df
         )
 
         # compute cumulative steps
-        prev_steps_df = map_df.drop_duplicates(
+        prev_steps_df = full_df.drop_duplicates(
             MapData.DEDUPLICATE_BY_COLUMNS, keep="last"
         )[["trial_index", MAP_KEY]].copy()
 

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -532,8 +532,8 @@ def _get_curve_plot_dropdown(
             if limit_points_per_plot is None
             else data.subsample(limit_rows_per_metric=limit_points_per_plot)
         )
-        map_df = subsampled_data.map_df
-        metric_df = map_df[map_df["metric_name"] == m.name]
+        full_df = subsampled_data.full_df
+        metric_df = full_df[full_df["metric_name"] == m.name]
         xs, ys, legend_labels, plot_stopping_markers = [], [], [], []
         is_early_stopping_metric = m.name in early_stopping_metrics
         for trial_idx, df_g in metric_df.groupby("trial_index"):


### PR DESCRIPTION
Summary:
**Context**:

`MapData.map_df` is an alias of `MapData.full_df`, so it isn't needed.

With this change, `MapData` and `Data` have the same attributes, making it easier to unify them in the future:
* `full_df` contains all of the data available
* `df` contains data at the trial-arm-metric level (and they are the same for `Data`)

**Changes**:
* Remove `MapData.map_df`
* Update references: `map_df` -> `full_df`
* Remove a lot of `assert_is_instance` checks

Differential Revision: D89733551


