### PR TITLE
Add deprecation warning to "optimize" (loop API)

### DIFF
--- a/ax/service/managed_loop.py
+++ b/ax/service/managed_loop.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import warnings
 from collections.abc import Iterable
 
 # Manual import to avoid strange error, see Diff for details.
@@ -282,6 +283,12 @@ def optimize(
     generation_strategy: GenerationStrategy | None = None,
 ) -> tuple[TParameterization, TModelPredictArm | None, Experiment, Adapter | None]:
     """Construct and run a full optimization loop."""
+    warnings.warn(
+        "optimize is deprecated and will be removed in Ax 1.3. Please use "
+        "Client from ax.api.client instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     loop = OptimizationLoop.with_evaluation_function(
         parameters=parameters,
         objective_name=objective_name,

--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -252,17 +252,20 @@ class TestManagedLoop(TestCase):
 
     def test_optimize(self) -> None:
         """Tests optimization as a single call."""
-        best, vals, exp, model = optimize(
-            parameters=[
-                {"name": "x1", "type": "range", "bounds": [-10.0, 10.0]},
-                {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
-            ],
-            # Booth function.
-            evaluation_function=lambda p: (p["x1"] + 2 * p["x2"] - 7) ** 2
-            + (2 * p["x1"] + p["x2"] - 5) ** 2,
-            minimize=True,
-            total_trials=5,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning, expected_regex="optimize is deprecated"
+        ):
+            best, vals, exp, model = optimize(
+                parameters=[
+                    {"name": "x1", "type": "range", "bounds": [-10.0, 10.0]},
+                    {"name": "x2", "type": "range", "bounds": [-10.0, 10.0]},
+                ],
+                # Booth function.
+                evaluation_function=lambda p: (p["x1"] + 2 * p["x2"] - 7) ** 2
+                + (2 * p["x1"] + p["x2"] - 5) ** 2,
+                minimize=True,
+                total_trials=5,
+            )
         self.assertIn("x1", best)
         self.assertIn("x2", best)
         assert vals is not None


### PR DESCRIPTION
Summary:
**Context**:

We have been recommending `Client` as the main API for a while, and even before that we recommended `AxClient`, so the loop API hasn't been recommended for a while.

**Changes**: Adds a deprecation warning when `optimize` is called.

Differential Revision:
D89738424

Privacy Context Container: L1307644


