### PR TITLE
Decouple summarize_ax_optimization_complexity from OrchestratorOptions

### DIFF
--- a/ax/analysis/healthcheck/complexity_rating.py
+++ b/ax/analysis/healthcheck/complexity_rating.py
@@ -138,8 +138,14 @@ class ComplexityRatingAnalysis(Analysis):
         options = none_throws(self.options)
         optimization_summary = summarize_ax_optimization_complexity(
             experiment=experiment,
-            options=options,
             tier_metadata=self.tier_metadata,
+            early_stopping_strategy=options.early_stopping_strategy,
+            global_stopping_strategy=options.global_stopping_strategy,
+            tolerated_trial_failure_rate=options.tolerated_trial_failure_rate,
+            max_pending_trials=options.max_pending_trials,
+            min_failed_trials_for_failure_rate_check=(
+                options.min_failed_trials_for_failure_rate_check
+            ),
         )
 
         # Determine tier

--- a/ax/analysis/plotly/progression.py
+++ b/ax/analysis/plotly/progression.py
@@ -26,6 +26,15 @@ from ax.generation_strategy.generation_strategy import GenerationStrategy
 from plotly import graph_objects as go
 from pyre_extensions import none_throws, override
 
+PROGRESSION_CARDGROUP_TITLE = "Learning Curves: Metric progression over trials"
+PROGRESSION_CARDGROUP_SUBTITLE = (
+    "These plots show curve metrics (learning curves) that track the evolution of "
+    "each metric over the course of the experiment. The plots display how metrics "
+    "change during trial execution, both by progression (e.g., epochs or steps) "
+    "and by wallclock time. This is useful for monitoring optimization progress and "
+    "informing early stopping decisions."
+)
+
 
 @final
 class ProgressionPlot(Analysis):

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -571,7 +571,11 @@ def _prepare_figure(
                 pareto_x.append(sorted_df[f"{x_metric_name}_mean"].iloc[i])
                 pareto_y.append(sorted_df[f"{y_metric_name}_mean"].iloc[i])
 
-        pareto_trace = go.Scatter(x=pareto_x, y=pareto_y, **BEST_LINE_SETTINGS)
+        pareto_trace = go.Scatter(
+            x=pareto_x,
+            y=pareto_y,
+            **{**BEST_LINE_SETTINGS, "showlegend": True, "name": "Pareto Frontier"},
+        )
 
         figure.add_trace(pareto_trace)
 

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -142,6 +142,26 @@ class TestScatterPlot(TestCase):
         self.assertTrue(card.df["foo_sem"].isna().all())
         self.assertTrue(card.df["bar_sem"].isna().all())
 
+    def test_show_pareto_frontier(self) -> None:
+        analysis = ScatterPlot(
+            x_metric_name="foo",
+            y_metric_name="bar",
+            show_pareto_frontier=True,
+            use_model_predictions=False,
+        )
+        card = analysis.compute(
+            experiment=self.client._experiment,
+            generation_strategy=self.client._generation_strategy,
+        )
+        fig_data = json.loads(none_throws(card.blob))
+        pareto_traces = [
+            trace
+            for trace in fig_data.get("data", [])
+            if trace.get("name") == "Pareto Frontier"
+        ]
+        self.assertEqual(len(pareto_traces), 1)
+        self.assertTrue(pareto_traces[0].get("showlegend"))
+
     def test_compute_with_modeled(self) -> None:
         default_analysis = ScatterPlot(
             x_metric_name="foo", y_metric_name="bar", use_model_predictions=True

--- a/ax/analysis/results.py
+++ b/ax/analysis/results.py
@@ -13,6 +13,11 @@ from ax.analysis.analysis import Analysis
 from ax.analysis.best_trials import BestTrials
 from ax.analysis.plotly.arm_effects import ArmEffectsPlot
 from ax.analysis.plotly.bandit_rollout import BanditRollout
+from ax.analysis.plotly.progression import (
+    PROGRESSION_CARDGROUP_SUBTITLE,
+    PROGRESSION_CARDGROUP_TITLE,
+    ProgressionPlot,
+)
 from ax.analysis.plotly.scatter import (
     SCATTER_CARDGROUP_SUBTITLE,
     SCATTER_CARDGROUP_TITLE,
@@ -25,6 +30,8 @@ from ax.core.analysis_card import AnalysisCardGroup
 from ax.core.arm import Arm
 from ax.core.batch_trial import BatchTrial
 from ax.core.experiment import Experiment
+from ax.core.map_data import MapData
+from ax.core.map_metric import MapMetric
 from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
 from ax.core.trial_status import TrialStatus
 from ax.core.utils import is_bandit_experiment
@@ -240,6 +247,33 @@ class ResultsAnalysis(Analysis):
             adapter=adapter,
         )
 
+        # Compute progression plots for MapMetrics (learning curves)
+        progression_group = None
+        data = experiment.lookup_data()
+        has_map_data = isinstance(data, MapData)
+        metrics = experiment.metrics.values()
+        map_metrics = [m for m in metrics if isinstance(m, MapMetric)]
+        if has_map_data and len(map_metrics) > 0:
+            map_metric_names = [m.name for m in map_metrics]
+            progression_cards = [
+                ProgressionPlot(
+                    metric_name=metric_name, by_wallclock_time=by_wallclock_time
+                ).compute_or_error_card(
+                    experiment=experiment,
+                    generation_strategy=generation_strategy,
+                    adapter=adapter,
+                )
+                for metric_name in map_metric_names
+                for by_wallclock_time in (False, True)
+            ]
+            if progression_cards:
+                progression_group = AnalysisCardGroup(
+                    name="ProgressionAnalysis",
+                    title=PROGRESSION_CARDGROUP_TITLE,
+                    subtitle=PROGRESSION_CARDGROUP_SUBTITLE,
+                    children=progression_cards,
+                )
+
         return self._create_analysis_card_group(
             title=RESULTS_CARDGROUP_TITLE,
             subtitle=RESULTS_CARDGROUP_SUBTITLE,
@@ -252,6 +286,7 @@ class ResultsAnalysis(Analysis):
                     bandit_rollout_card,
                     best_trials_card,
                     utility_progression_card,
+                    progression_group,
                     summary,
                 )
                 if child is not None

--- a/ax/analysis/results.py
+++ b/ax/analysis/results.py
@@ -120,7 +120,7 @@ class ResultsAnalysis(Analysis):
         )
 
         # If there are multiple objectives, compute scatter plots of each combination
-        # of two objectives.
+        # of two objectives. For MOO experiments, show the Pareto frontier line.
         objective_scatter_group = (
             AnalysisCardGroup(
                 name="Objective Scatter Plots",
@@ -131,6 +131,7 @@ class ResultsAnalysis(Analysis):
                         x_metric_name=x,
                         y_metric_name=y,
                         relativize=relativize,
+                        show_pareto_frontier=True,
                     ).compute_or_error_card(
                         experiment=experiment,
                         generation_strategy=generation_strategy,

--- a/ax/service/utils/orchestrator_options.py
+++ b/ax/service/utils/orchestrator_options.py
@@ -13,6 +13,11 @@ from typing import Any
 from ax.early_stopping.strategies import BaseEarlyStoppingStrategy
 from ax.global_stopping.strategies.base import BaseGlobalStoppingStrategy
 
+# Default values for OrchestratorOptions fields
+DEFAULT_MAX_PENDING_TRIALS: int = 10
+DEFAULT_TOLERATED_TRIAL_FAILURE_RATE: float = 0.5
+DEFAULT_MIN_FAILED_TRIALS_FOR_FAILURE_RATE_CHECK: int = 5
+
 
 class TrialType(Enum):
     TRIAL = 0
@@ -125,12 +130,14 @@ class OrchestratorOptions:
             Default to False.
     """
 
-    max_pending_trials: int = 10
+    max_pending_trials: int = DEFAULT_MAX_PENDING_TRIALS
     trial_type: TrialType = TrialType.TRIAL
     batch_size: int | None = None
     total_trials: int | None = None
-    tolerated_trial_failure_rate: float = 0.5
-    min_failed_trials_for_failure_rate_check: int = 5
+    tolerated_trial_failure_rate: float = DEFAULT_TOLERATED_TRIAL_FAILURE_RATE
+    min_failed_trials_for_failure_rate_check: int = (
+        DEFAULT_MIN_FAILED_TRIALS_FOR_FAILURE_RATE_CHECK
+    )
     log_filepath: str | None = None
     logging_level: int = INFO
     ttl_seconds_for_trials: int | None = None

--- a/ax/utils/common/tests/test_complexity_utils.py
+++ b/ax/utils/common/tests/test_complexity_utils.py
@@ -8,7 +8,6 @@
 
 from ax.core.metric import Metric
 from ax.exceptions.core import OptimizationNotConfiguredError, UserInputError
-from ax.service.orchestrator import OrchestratorOptions
 from ax.utils.common.complexity_utils import (
     check_if_in_standard,
     DEFAULT_TIER_MESSAGES,
@@ -30,7 +29,6 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.experiment = get_experiment()
-        self.options = OrchestratorOptions()
         self.tier_metadata: dict[str, object] = {}
 
     def test_basic_experiment_summary(self) -> None:
@@ -39,7 +37,6 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
         # WHEN we summarize the experiment
         summary = summarize_ax_optimization_complexity(
             experiment=self.experiment,
-            options=self.options,
             tier_metadata=self.tier_metadata,
         )
 
@@ -58,7 +55,6 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
         # WHEN we summarize the experiment
         summary = summarize_ax_optimization_complexity(
             experiment=experiment,
-            options=self.options,
             tier_metadata=self.tier_metadata,
         )
 
@@ -76,7 +72,6 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
         ):
             summarize_ax_optimization_complexity(
                 experiment=self.experiment,
-                options=self.options,
                 tier_metadata=self.tier_metadata,
             )
 
@@ -107,33 +102,12 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
                 # WHEN we summarize the experiment
                 summary = summarize_ax_optimization_complexity(
                     experiment=self.experiment,
-                    options=self.options,
                     tier_metadata=tier_metadata,
                 )
 
                 # THEN the summary should reflect tier metadata values
                 self.assertEqual(summary.max_trials, expected_max_trials)
                 self.assertEqual(summary.uses_standard_api, expected_all_configs)
-
-    def test_orchestrator_options_extraction(self) -> None:
-        # GIVEN custom orchestrator options
-        options = OrchestratorOptions(
-            tolerated_trial_failure_rate=0.25,
-            max_pending_trials=5,
-            min_failed_trials_for_failure_rate_check=10,
-        )
-
-        # WHEN we summarize the experiment
-        summary = summarize_ax_optimization_complexity(
-            experiment=self.experiment,
-            options=options,
-            tier_metadata=self.tier_metadata,
-        )
-
-        # THEN the summary should reflect orchestrator options
-        self.assertEqual(summary.tolerated_trial_failure_rate, 0.25)
-        self.assertEqual(summary.max_pending_trials, 5)
-        self.assertEqual(summary.min_failed_trials_for_failure_rate_check, 10)
 
     def test_parameter_constraints_counted(self) -> None:
         # GIVEN an experiment with parameter constraints
@@ -142,7 +116,6 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
         # WHEN we summarize the experiment
         summary = summarize_ax_optimization_complexity(
             experiment=experiment,
-            options=self.options,
             tier_metadata=self.tier_metadata,
         )
 
@@ -159,7 +132,6 @@ class TestSummarizeAxOptimizationComplexity(TestCase):
         # WHEN we summarize the experiment
         summary = summarize_ax_optimization_complexity(
             experiment=self.experiment,
-            options=self.options,
             tier_metadata=self.tier_metadata,
         )
 


### PR DESCRIPTION
Summary:
This change decouples `summarize_ax_optimization_complexity` from requiring an `OrchestratorOptions` instance by accepting individual optional fields instead.

Differential Revision: D89778530


