### PR TITLE
Show Pareto frontier on MOO objective scatter plots

### DIFF
--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -571,7 +571,11 @@ def _prepare_figure(
                 pareto_x.append(sorted_df[f"{x_metric_name}_mean"].iloc[i])
                 pareto_y.append(sorted_df[f"{y_metric_name}_mean"].iloc[i])
 
-        pareto_trace = go.Scatter(x=pareto_x, y=pareto_y, **BEST_LINE_SETTINGS)
+        pareto_trace = go.Scatter(
+            x=pareto_x,
+            y=pareto_y,
+            **{**BEST_LINE_SETTINGS, "showlegend": True, "name": "Pareto Frontier"},
+        )
 
         figure.add_trace(pareto_trace)
 

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -142,6 +142,26 @@ class TestScatterPlot(TestCase):
         self.assertTrue(card.df["foo_sem"].isna().all())
         self.assertTrue(card.df["bar_sem"].isna().all())
 
+    def test_show_pareto_frontier(self) -> None:
+        analysis = ScatterPlot(
+            x_metric_name="foo",
+            y_metric_name="bar",
+            show_pareto_frontier=True,
+            use_model_predictions=False,
+        )
+        card = analysis.compute(
+            experiment=self.client._experiment,
+            generation_strategy=self.client._generation_strategy,
+        )
+        fig_data = json.loads(none_throws(card.blob))
+        pareto_traces = [
+            trace
+            for trace in fig_data.get("data", [])
+            if trace.get("name") == "Pareto Frontier"
+        ]
+        self.assertEqual(len(pareto_traces), 1)
+        self.assertTrue(pareto_traces[0].get("showlegend"))
+
     def test_compute_with_modeled(self) -> None:
         default_analysis = ScatterPlot(
             x_metric_name="foo", y_metric_name="bar", use_model_predictions=True

--- a/ax/analysis/results.py
+++ b/ax/analysis/results.py
@@ -120,7 +120,7 @@ class ResultsAnalysis(Analysis):
         )
 
         # If there are multiple objectives, compute scatter plots of each combination
-        # of two objectives.
+        # of two objectives. For MOO experiments, show the Pareto frontier line.
         objective_scatter_group = (
             AnalysisCardGroup(
                 name="Objective Scatter Plots",
@@ -131,6 +131,7 @@ class ResultsAnalysis(Analysis):
                         x_metric_name=x,
                         y_metric_name=y,
                         relativize=relativize,
+                        show_pareto_frontier=True,
                     ).compute_or_error_card(
                         experiment=experiment,
                         generation_strategy=generation_strategy,


### PR DESCRIPTION
Summary:
When `ResultsAnalysis` creates scatter plots for multi-objective optimization (MOO) experiments, the Pareto frontier line was not being displayed.

The Pareto frontier is rendered as a dashed gold line connecting the non-dominated points, helping users identify the set of optimal solutions.

Differential Revision:
D89775987

Privacy Context Container: L1307644


