### PR TITLE
Subsetting of trial indices with MapData

### DIFF
--- a/ax/core/trial.py
+++ b/ax/core/trial.py
@@ -301,6 +301,10 @@ class Trial(BaseTrial):
         """Clone the trial and attach it to the specified experiment.
         If no experiment is provided, the original experiment will be used.
 
+        When cloning to a different experiment, the trial's index is preserved.
+        When cloning to the same experiment, a new index is auto-assigned to
+        avoid collision.
+
         Args:
             experiment: The experiment to which the cloned trial will belong.
                 If unspecified, uses the current experiment.
@@ -310,10 +314,17 @@ class Trial(BaseTrial):
         Returns:
             A new instance of the trial.
         """
+        cloning_to_same_experiment = (
+            experiment is None or experiment is self._experiment
+        )
         experiment = self._experiment if experiment is None else experiment
-        new_trial = experiment.new_trial(
+        # Preserve trial index when cloning to a different experiment;
+        # auto-assign new index when cloning to the same experiment.
+        new_trial = Trial(
+            experiment=experiment,
             ttl_seconds=self.ttl_seconds,
             trial_type=None if clear_trial_type else self.trial_type,
+            index=None if cloning_to_same_experiment else self.index,
         )
         if self.generator_run is not None:
             new_trial.add_generator_run(self.generator_run.clone())


### PR DESCRIPTION
Summary:
**Issue:**
N8887885

Previously, when using Experiment.clone_with() in Ax to clone a subset of trials, the cloned trials were assigned new auto-incremented indices (e.g., 0, 1, 2...) rather than preserving their original indices from the source experiment. This led to downstream issues in extraction methods (_extract_arm_data / _extract_observation_data) which rely on trial indices being consistent between the experiment and its associated data. As a result, extracted arm and observation data would be incomplete.


**Fix:**
Modified both Trial.clone_to() and BatchTrial.clone_to() so that when cloning to a different experiment, the original trial index is preserved (index=self.index).
When cloning to the same experiment, a new index is auto-assigned to avoid index collision (maintaining previous behavior for this use case).

Differential Revision:
D89661997

Privacy Context Container: L1307644


