### PR TITLE
Remove Metric.data_constructor

### DIFF
--- a/ax/core/map_metric.py
+++ b/ax/core/map_metric.py
@@ -8,8 +8,6 @@
 
 from __future__ import annotations
 
-from ax.core.data import Data
-
 from ax.core.map_data import MapData
 from ax.core.metric import Metric, MetricFetchE
 from ax.utils.common.result import Result
@@ -23,12 +21,9 @@ class MapMetric(Metric):
     The `fetch_trial_data` method is the essential method to override when
     subclassing, which specifies how to retrieve a Metric, for a given trial.
 
-    A MapMetric must return a MapData object, which requires (at minimum) the following:
-        https://ax.dev/api/_modules/ax/core/data.html#Data.required_columns
-
-    Attributes:
-        lower_is_better: Flag for metrics which should be minimized.
-        properties: Properties specific to a particular metric.
+    A MapMetric must return a MapData object, which has a "step" column in
+    addition to the columns that are usually present in Data. Empty data is
+    permitted to be Data.
     """
 
-    data_constructor: type[Data] = MapData
+    has_map_data: bool = True


### PR DESCRIPTION
Summary:
This is no longer needed following D89689313.

Changes:
* Remove `Metric.data_constructor` class attribute
* Change `Metric.has_map_data` from a property into a class attribute based on whether the metric is a MapMetric

The longer-term plan is to
* Remove `has_map_data` in favor of an attribute `step_should_be_modeled`
* Remove `MapMetric`; these will become `Metric`s with `step_should_be_model=True`
* Update logic (e.g. `Experiment.lookup_data`) to reflect the possibility that a Metric may return MapData yet have `step_should_be_modeled = False`
* Have all metrics return MapData (with NaN step values by default and some having more interesting step values)
* Make all data into `MapData` (by updating cases where `Data` is constructed other than by reading it directly from a metric, e.g. by deserializing it)

Differential Revision: D89748011
