### PR TITLE
Remove support for deserializing MapData with map key other than "step"

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -202,6 +202,12 @@ class Data(Base, SerializationMixin):
     ) -> dict[str, Any]:
         """Given a dictionary, extract the properties needed to initialize the object.
         Used for storage.
+
+        Note: Older Data saved with the `MapData` class may have been stored with
+        progressions represented by a column or columns other than "step" and
+        had `MapKeyInfo`s to indicate which columns corresponded to
+        progressions. This is no longer supported, and such columns will not be
+        recognized as progressions if provided.
         """
         # Extract `df` only if present, since certain inputs to this fn, e.g.
         # SQAData.structure_metadata_json, don't have a `df` attribute.


### PR DESCRIPTION
Summary:
D81363344 / Ax #4255 disallowed having map keys other than "step", providing deserialization support, with warnings, when a map key other than "step" is deserialized. This was released in Ax 1.1.2; we are now on Ax 1.2.1. Since there have been warnings for a while about this, it should be save to remove the deserialization support.

With this change, if a progression was saved with some other column name, such as "epoch," it will be deserialized as another MapData column, with NaN imputed for "step." When this logic goes away in D89820078, it will be deserialized as Data with no "step" column.

Differential Revision: D89888874


