### PR TITLE
Debug `testutils._build_comparison_str`

### DIFF
--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -149,7 +149,6 @@ def object_attribute_dicts_equal(
     return not bool(unequal_type or unequal_value)
 
 
-# pyre-fixme[3]: Return annotation cannot contain `Any`.
 def object_attribute_dicts_find_unequal_fields(
     one_dict: dict[str, Any],
     other_dict: dict[str, Any],

--- a/ax/utils/common/tests/test_testutils.py
+++ b/ax/utils/common/tests/test_testutils.py
@@ -46,8 +46,8 @@ class TestTestUtils(TestCase):
             self.assertEqual(MyBase("red"), MyBase("panda"))
         except AssertionError as err:
             expected_suffix = (
-                "\n\nFields with different values:\n\n1) field: red "
-                "(type <class 'str'>) != panda (type <class 'str'>)"
+                "Fields with different values:\n\n1) field: \nred "
+                "(type <class 'str'>) \n!=\npanda (type <class 'str'>)"
             )
             self.assertIn(expected_suffix, str(err))
 


### PR DESCRIPTION
Summary:
Previously we could get absent (and thus confusing) output in some edge cases (unequal type in top-level objects; unequal type for two instances of Ax `Base); this covers.

{F1984377139}

Differential Revision: D89909334


