### PR TITLE
Update reset_gs code to orphan old gs if not indicated for deletion

### DIFF
--- a/ax/storage/sqa_store/sqa_enum.py
+++ b/ax/storage/sqa_store/sqa_enum.py
@@ -16,7 +16,6 @@ from sqlalchemy import types
 class BaseNullableEnum(types.TypeDecorator):
     cache_ok = True
 
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     def __init__(self, enum: Any, *arg: list[Any], **kw: dict[Any, Any]) -> None:
         types.TypeDecorator.__init__(self, *arg, **kw)
         # pyre-fixme[4]: Attribute must be annotated.
@@ -24,8 +23,6 @@ class BaseNullableEnum(types.TypeDecorator):
         # pyre-fixme[4]: Attribute must be annotated.
         self._value2member_map = enum._value2member_map_
 
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     def process_bind_param(self, value: Any, dialect: Any) -> Any:
         if value is None:
             return value
@@ -40,8 +37,6 @@ class BaseNullableEnum(types.TypeDecorator):
             )
         return val._value_
 
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     def process_result_value(self, value: Any, dialect: Any) -> Any:
         if value is None:
             return value

--- a/ax/storage/sqa_store/validation.py
+++ b/ax/storage/sqa_store/validation.py
@@ -51,7 +51,6 @@ def listens_for_multiple(
     return wrapper
 
 
-# pyre-fixme[3]: Return annotation cannot be `Any`.
 def consistency_exactly_one(instance: SQABase, exactly_one_fields: list[str]) -> Any:
     """Ensure that exactly one of `exactly_one_fields` has a value set."""
     values = [getattr(instance, field) is not None for field in exactly_one_fields]


### PR DESCRIPTION
Summary:
I was looking at this method and realized that although it will work within a single instance of client, upon saving/re-loading the experiment load will fail because there will be two instances of gs associated with an experiment and this will cause a merge error. 

This implements:
1. an orphan gs method -- allows the legacy gs to still live in the db and just sets expeirment column to none, essentially orphaning it, but we coud go look it up in the future if we wanted
2. cleans up some pyres taht weren't doing anything i saw along the way
3. extends tests to account for this behavior

Differential Revision: D90064851


