### PR TITLE
Add IMetric to storage layer

### DIFF
--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -14,6 +14,7 @@ import torch
 from ax.adapter.base import DataLoaderConfig
 from ax.adapter.registry import GeneratorRegistryBase, Generators
 from ax.adapter.transforms.base import Transform
+from ax.api.protocols.metric import IMetric
 from ax.benchmark.benchmark_method import BenchmarkMethod
 from ax.benchmark.benchmark_metric import (
     BenchmarkMapMetric,
@@ -216,6 +217,7 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     IsSingleObjective: transition_criterion_to_dict,
     L2NormMetric: metric_to_dict,
     LogNormalPrior: botorch_component_to_dict,
+    IMetric: metric_to_dict,
     MapMetric: metric_to_dict,
     MaxGenerationParallelism: transition_criterion_to_dict,
     Metric: metric_to_dict,
@@ -334,6 +336,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "HierarchicalSearchSpace": HierarchicalSearchSpace,
     "ImprovementGlobalStoppingStrategy": ImprovementGlobalStoppingStrategy,
     "InputConstructorPurpose": InputConstructorPurpose,
+    "IMetric": IMetric,
     "Interval": Interval,
     "IsSingleObjective": IsSingleObjective,
     "Keys": Keys,

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -22,6 +22,7 @@ from ax.adapter.registry import Generators
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.log import Log
 from ax.adapter.transforms.one_hot import OneHot
+from ax.api.protocols.metric import IMetric
 from ax.benchmark.methods.sobol import get_sobol_benchmark_method
 from ax.benchmark.testing.benchmark_stubs import (
     get_aggregated_benchmark_result,
@@ -353,6 +354,7 @@ TEST_CASES = [
         ),
     ),
     ("HierarchicalSearchSpace", get_hierarchical_search_space),
+    ("IMetric", lambda: IMetric(name="test")),
     ("ImprovementGlobalStoppingStrategy", get_improvement_global_stopping_strategy),
     ("Interval", get_interval),
     ("MapData", get_map_data),

--- a/ax/storage/metric_registry.py
+++ b/ax/storage/metric_registry.py
@@ -9,6 +9,7 @@
 from collections.abc import Callable
 from typing import Any
 
+from ax.api.protocols.metric import IMetric
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
 from ax.metrics.branin import BraninMetric
@@ -43,6 +44,7 @@ CORE_METRIC_REGISTRY: dict[type[Metric], int] = {
     ChemistryMetric: 7,
     MapMetric: 8,
     BraninTimestampMapMetric: 9,
+    IMetric: 10,
 }
 
 

--- a/ax/storage/sqa_store/sqa_enum.py
+++ b/ax/storage/sqa_store/sqa_enum.py
@@ -16,7 +16,6 @@ from sqlalchemy import types
 class BaseNullableEnum(types.TypeDecorator):
     cache_ok = True
 
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     def __init__(self, enum: Any, *arg: list[Any], **kw: dict[Any, Any]) -> None:
         types.TypeDecorator.__init__(self, *arg, **kw)
         # pyre-fixme[4]: Attribute must be annotated.
@@ -24,8 +23,6 @@ class BaseNullableEnum(types.TypeDecorator):
         # pyre-fixme[4]: Attribute must be annotated.
         self._value2member_map = enum._value2member_map_
 
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     def process_bind_param(self, value: Any, dialect: Any) -> Any:
         if value is None:
             return value
@@ -40,8 +37,6 @@ class BaseNullableEnum(types.TypeDecorator):
             )
         return val._value_
 
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
-    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     def process_result_value(self, value: Any, dialect: Any) -> Any:
         if value is None:
             return value

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -20,6 +20,7 @@ import pandas as pd
 from ax.adapter.registry import Generators
 from ax.analysis.markdown.markdown_analysis import MarkdownAnalysisCard
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
+from ax.api.protocols.metric import IMetric
 from ax.core.analysis_card import AnalysisCard, AnalysisCardGroup
 from ax.core.arm import Arm
 from ax.core.auxiliary import (
@@ -1863,6 +1864,14 @@ class SQAStoreTest(TestCase):
         metric = cast(Metric, self.decoder.metric_from_sqa(sqa_metric))
         self.assertEqual(metric.name, metric_name)
         self.assertEqual(metric.signature, metric_name)
+
+    def test_IMetricEncodeDecode(self) -> None:
+        metric_name = "test_imetric"
+        imetric = IMetric(name=metric_name)
+        sqa_metric = self.encoder.metric_to_sqa(imetric)
+        decoded_metric = cast(Metric, self.decoder.metric_from_sqa(sqa_metric))
+        self.assertIsInstance(decoded_metric, IMetric)
+        self.assertEqual(decoded_metric.name, metric_name)
 
     def test_MetricDecodeWithSignatureOverride(self) -> None:
         metric_name = "testMetric"

--- a/ax/storage/sqa_store/validation.py
+++ b/ax/storage/sqa_store/validation.py
@@ -51,7 +51,6 @@ def listens_for_multiple(
     return wrapper
 
 
-# pyre-fixme[3]: Return annotation cannot be `Any`.
 def consistency_exactly_one(instance: SQABase, exactly_one_fields: list[str]) -> Any:
     """Ensure that exactly one of `exactly_one_fields` has a value set."""
     values = [getattr(instance, field) is not None for field in exactly_one_fields]


### PR DESCRIPTION
Summary:
User using client API in OSS noticed that IMetric wasn't saved, see issue: https://github.com/facebook/Ax/issues/4671

This adds IMetric to storage layer so OSS API is fully valid. I discussed with mpolson64 if this was intentional, and at the time it was, but i do think we should have this in storage just so tutorials are easy to interchangable use.

Differential Revision:
D90066636

Privacy Context Container: L1307644


