### PR TITLE
Update target trial selection logic to only consider trials with data for optimization config metrics

### DIFF
--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -182,18 +182,6 @@ class TransformToNewSQSpecificTest(TestCase):
             )
 
         self.assertEqual(t.default_trial_idx, 0)
-        # test falling back to latest trial with SQ data
-        with mock.patch(
-            "ax.adapter.transforms.transform_to_new_sq.get_target_trial_index",
-            return_value=10,
-        ):
-            t = TransformToNewSQ(
-                search_space=self.exp.search_space,
-                experiment_data=experiment_data,
-                adapter=self.adapter,
-            )
-
-        self.assertEqual(t.default_trial_idx, 1)
 
     def test_transform_experiment_data(self) -> None:
         # Create two more trials with different SQ observations.

--- a/ax/adapter/transforms/tests/test_winsorize_transform.py
+++ b/ax/adapter/transforms/tests/test_winsorize_transform.py
@@ -535,7 +535,13 @@ class WinsorizeTransformTest(TestCase):
                         "trial_index": t.index,
                         "metric_signature": metric_name,
                     }
-                    for metric_name, mean, sem in (("a", 1.0, 2.0), ("b", 2.0, 4.0))
+                    # Needs data for all metrics in opt config to identify target
+                    # trial for transforms
+                    for metric_name, mean, sem in (
+                        ("a", 1.0, 2.0),
+                        ("b", 2.0, 4.0),
+                        ("c", 3.0, 1.0),
+                    )
                 ]
             )
         )
@@ -553,7 +559,7 @@ class WinsorizeTransformTest(TestCase):
                 adapter=adapter,
             )
         self.assertDictEqual(
-            t.cutoffs, {"a": (-INF, INF), "b": (-INF, INF), "c": (0.5, INF)}
+            t.cutoffs, {"a": (-INF, INF), "b": (-INF, INF), "c": (-3.25, INF)}
         )
         # Winsorizes with `derelativize_with_raw_status_quo`.
         t = Winsorize(
@@ -563,7 +569,7 @@ class WinsorizeTransformTest(TestCase):
             config={"derelativize_with_raw_status_quo": True},
         )
         self.assertDictEqual(
-            t.cutoffs, {"a": (-INF, 4.25), "b": (-INF, 4.25), "c": (0.5, INF)}
+            t.cutoffs, {"a": (-INF, 4.25), "b": (-INF, 4.25), "c": (-3.25, INF)}
         )
 
     def test_transform_experiment_data(self) -> None:

--- a/ax/adapter/transforms/transform_to_new_sq.py
+++ b/ax/adapter/transforms/transform_to_new_sq.py
@@ -77,13 +77,6 @@ class TransformToNewSQ(BaseRelativize):
             target_trial_index = get_target_trial_index(
                 experiment=none_throws(adapter)._experiment
             )
-            trials_indices_with_sq_data = self.status_quo_data_by_trial.keys()
-            if target_trial_index not in trials_indices_with_sq_data:
-                target_trial_index = max(trials_indices_with_sq_data)
-                logger.warning(
-                    "No status quo data for target trial. Failing back to "
-                    f"{target_trial_index}."
-                )
 
         if target_trial_index is not None:
             self.default_trial_idx: int = assert_is_instance(

--- a/ax/analysis/healthcheck/tests/test_early_stopping_healthcheck.py
+++ b/ax/analysis/healthcheck/tests/test_early_stopping_healthcheck.py
@@ -321,7 +321,6 @@ class TestEarlyStoppingAnalysis(TestCase):
     def test_hypothetical_savings_nudge(self) -> None:
         """Test hypothetical savings reporting via the nudge path."""
         healthcheck = EarlyStoppingAnalysis(early_stopping_strategy=None)
-
         with self.subTest("basic_nudge"):
             with (
                 patch(

--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -323,7 +323,12 @@ def _prepare_data(
     )
 
     if relativize:
-        target_trial_index = none_throws(get_target_trial_index(experiment=experiment))
+        target_trial_index = none_throws(
+            get_target_trial_index(
+                experiment=experiment,
+                require_data_for_all_metrics=True,
+            )
+        )
         df = relativize_data(
             experiment=experiment,
             df=df,

--- a/ax/analysis/plotly/surface/slice.py
+++ b/ax/analysis/plotly/surface/slice.py
@@ -285,7 +285,12 @@ def _prepare_data(
     ).sort_values(by=parameter_name)
 
     if relativize:
-        target_trial_index = none_throws(get_target_trial_index(experiment=experiment))
+        target_trial_index = none_throws(
+            get_target_trial_index(
+                experiment=experiment,
+                require_data_for_all_metrics=True,
+            )
+        )
         df = relativize_data(
             experiment=experiment,
             df=df,

--- a/ax/analysis/utils.py
+++ b/ax/analysis/utils.py
@@ -170,7 +170,10 @@ def prepare_arm_data(
     # Compute the trial index of the target trial both to pass as a fixed feature
     # during prediction if using model predictions, and to relativize against the
     # status quo arm from the target trial if relativizing.
-    target_trial_index = get_target_trial_index(experiment=experiment)
+    target_trial_index = get_target_trial_index(
+        experiment=experiment,
+        require_data_for_all_metrics=True,
+    )
     if use_model_predictions:
         if adapter is None:
             raise UserInputError(

--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -8,13 +8,14 @@
 
 from collections.abc import Callable, Iterable
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import wraps
 from logging import Logger
 from typing import Any, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
+import pandas as pd
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.batch_trial import BatchTrial
@@ -37,6 +38,7 @@ TArmTrial = tuple[str, int]
 
 # Threshold for switching to pending points extraction based on trial status.
 MANY_TRIALS_IN_EXPERIMENT = 100
+TRIAL_STALE_THRESHOLD_DAYS = 10
 
 # --------------------------- Data integrity utils. ---------------------------
 
@@ -490,16 +492,19 @@ def extend_pending_observations(
 # -------------------- Get target trial utils. ---------------------
 
 
-def get_target_trial_index(experiment: Experiment) -> int | None:
+def get_target_trial_index(
+    experiment: Experiment,
+    require_data_for_all_metrics: bool = False,
+) -> int | None:
     """Get the index of the target trial in the ``Experiment``.
 
-    Find the target trial, among the trials with data for status quo arm, giving
-    priority in the following order:
-        1. a running long-run trial. Note if there is a running long-run trial on the
-            experiment without data, or if there is no data on the experiment, then
-            this will return None.
-        2. Most recent trial expecting data with running trials be considered the most
-            recent.
+    Find the target trial, among the trials with data for status quo arm and
+    required metrics, giving priority in the following order:
+        1. A running long-run trial. If the long-run trial
+           doesn't have data for sq + required metrics, fallback to short-run.
+        2. Longest running trial with data that is still currently running.
+        3. Longest running completed trial with data, excluding trials
+           completed over 10 days ago as they are likely stale.
 
     In the event of any ties, the tie breaking order is:
         a. longest running trial by duration
@@ -508,56 +513,75 @@ def get_target_trial_index(experiment: Experiment) -> int | None:
 
     Args:
         experiment: The experiment associated with this ``GenerationStrategy``.
+        require_data_for_all_metrics: If True, filter to trials with data for
+            ALL metrics on the experiment (including tracking). If False,
+            filter to trials with data for all optimization config metrics only.
+            Typically, this is True for plotting, and false for other purposes
 
     Returns:
-        The index of the target trial in the ``Experiment``.
+        The index of the target trial in the ``Experiment``, or None if no
+        valid trial is found.
     """
-    # TODO: @mgarrard improve logic to include trial_obsolete_threshold that
-    # takes into account the age of the trial, and consider more heavily weighting
-    # long run trials.
     df = experiment.lookup_data().df
     status_quo = experiment.status_quo
     if df.empty or status_quo is None:
         return None
-    # Filter to only trials with data for status quo arm.
-    df = df[df["arm_name"] == status_quo.name]
-    trial_indices_with_data = set(df.trial_index.unique())
-    # only consider running trials with data
+
+    # trial indices that have data for required metrics
+    trial_indices_with_required_metrics = _get_trial_indices_with_required_metrics(
+        experiment=experiment,
+        df=df,
+        require_data_for_all_metrics=require_data_for_all_metrics,
+    )
+
+    # trial indices that have data for status quo arm
+    sq_df = df[df["arm_name"] == status_quo.name]
+    trial_indices_with_sq_data = set(sq_df.trial_index.unique())
+
+    # trials with both SQ data and required metrics
+    valid_trial_indices = (
+        trial_indices_with_sq_data & trial_indices_with_required_metrics
+    )
+
+    # only consider running trials with valid data
     running_trials = [
         trial
         for trial in experiment.trials_by_status[TrialStatus.RUNNING]
-        if trial.index in trial_indices_with_data
+        if trial.index in valid_trial_indices
     ]
     sorted_running_trials = _sort_trials(trials=running_trials, trials_are_running=True)
+
     # Priority 1: Any running long-run trial
     has_running_long_run_trial = any(
         trial.trial_type == Keys.LONG_RUN
         for trial in experiment.trials_by_status[TrialStatus.RUNNING]
     )
     if has_running_long_run_trial:
-        # This returns a running long-run trial with data or None
-        # if there are running long-run trials on the experiment, but
-        # no data for that trial
-        return next(
-            (
-                trial.index
-                for trial in sorted_running_trials
-                if trial.trial_type == Keys.LONG_RUN
-            ),
-            None,
-        )
+        # try to find a long-run trial on the experiment, if multiple exist, it will
+        # return the one with longest duration
+        for trial in sorted_running_trials:
+            if trial.trial_type == Keys.LONG_RUN:
+                return trial.index
 
     # Priority 2: longest running currently running trial with data
     if len(sorted_running_trials) > 0:
         return sorted_running_trials[0].index
 
-    # Priortiy 3: the longest running trial with data, discounting running trials
-    # as we handled those above
-    non_running_trial_indices_with_data = trial_indices_with_data - {
-        t.index for t in running_trials
-    }
+    # Priority 3: the longest running trial with data. At this point all valid trials
+    # are non-running because we would have returned above otherwise.
+    stale_threshold = datetime.now() - timedelta(days=TRIAL_STALE_THRESHOLD_DAYS)
+    non_stale_trial_indices = set()
+    for trial_idx in valid_trial_indices:
+        trial = experiment.trials[trial_idx]
+        if trial.time_completed is None or trial.time_completed >= stale_threshold:
+            non_stale_trial_indices.add(trial_idx)
+
+    # if all trials are stale fallback to using stale trials instead of nothing
+    if len(non_stale_trial_indices) == 0 and len(valid_trial_indices) > 0:
+        non_stale_trial_indices = valid_trial_indices
+
     non_running_trials_with_data = [
-        experiment.trials[i] for i in non_running_trial_indices_with_data
+        experiment.trials[i] for i in non_stale_trial_indices
     ]
     sorted_non_running_trials_with_data = _sort_trials(
         trials=non_running_trials_with_data, trials_are_running=False
@@ -566,6 +590,43 @@ def get_target_trial_index(experiment: Experiment) -> int | None:
         return sorted_non_running_trials_with_data[0].index
 
     return None
+
+
+def _get_trial_indices_with_required_metrics(
+    experiment: Experiment,
+    df: "pd.DataFrame",
+    require_data_for_all_metrics: bool,
+) -> set[int]:
+    """Return trial indicies in an experiment which have data for required metrics
+
+    Args:
+        experiment: an Ax experiment
+        df: experiment data to search through
+        require_data_for_all_metrics: If True, require data for all metrics
+            on the experiment. If False, only require data for optimization
+            config metrics.
+
+    Returns:
+        Set of trial indices with data for required metrics.
+    """
+    if require_data_for_all_metrics:
+        required_metrics = set(experiment.metrics.keys())
+    else:
+        if experiment.optimization_config is None:
+            # if there is no optimization config set, any trial with data
+            # is valid
+            return set(df.trial_index.unique())
+        required_metrics = set(experiment.optimization_config.metrics.keys())
+
+    # Find trials that have data for all required metrics
+    valid_trial_indices = set()
+    for trial_idx in set(df.trial_index.unique()):
+        trial_df = df[df.trial_index == trial_idx]
+        metrics_in_trial = set(trial_df.metric_name.unique())
+        if required_metrics.issubset(metrics_in_trial):
+            valid_trial_indices.add(trial_idx)
+
+    return valid_trial_indices
 
 
 def _sort_trials(


### PR DESCRIPTION
Summary:
This updates target trial selection logic in the following ways:
1. We only consider trials that either (a) have data for *all* opt config metrics or (b) have data for *all* metrics -- previously if a trial had data for some opt config metrics it passed the check, but this partial data setup causes issues downstream
2. If there is no long run trial, we fallback to short run instead of not identifying a target trial
3. filters out "stale" trials, ie trials that were completed over 10 days ago -- hitting this point would be pretty far down our priority list, but was an idea ItsMrLin initially had that i thought was really interesting
4. lastly if no trials exist after stale is filtered out, use the stale ones anyway (necessary for benchmarking)
5. if we still can't find anything, it will return none

Differential Revision:
D90089411

Privacy Context Container: L1307644


