### PR TITLE
Update RemoveFixed.untransform_observation_features to transform even if parameterization is empty

### DIFF
--- a/ax/adapter/tests/test_random_adapter.py
+++ b/ax/adapter/tests/test_random_adapter.py
@@ -29,6 +29,7 @@ from ax.utils.testing.core_stubs import (
     get_search_space_for_range_values,
     get_small_discrete_search_space,
 )
+from ax.utils.testing.modeling_stubs import get_experiment_for_value
 
 
 class RandomAdapterTest(TestCase):
@@ -302,3 +303,13 @@ class RandomAdapterTest(TestCase):
 
         generated_points_all_out = mock_gen.call_args.kwargs["generated_points"]
         self.assertIsNone(generated_points_all_out)
+
+    def test_generation_with_all_fixed(self) -> None:
+        # Make sure candidate generation succeeds and returns correct parameters
+        # when all parameters are fixed.
+        exp = get_experiment_for_value()
+        adapter = RandomAdapter(
+            experiment=exp, generator=SobolGenerator(), transforms=Cont_X_trans
+        )
+        gr = adapter.gen(n=1)
+        self.assertEqual(gr.arms[0].parameters, {"x": 3.0})

--- a/ax/adapter/transforms/remove_fixed.py
+++ b/ax/adapter/transforms/remove_fixed.py
@@ -168,28 +168,22 @@ class RemoveFixed(Transform):
         self, observation_features: list[ObservationFeatures]
     ) -> list[ObservationFeatures]:
         for obsf in observation_features:
-            # Only untransform observations with specified parameters
-            # where at least one of them is not a fixed or derived parameter.
-            # This would be empty when status quo param values are not specified
-            if obsf.parameters:
-                for p_name, p in self.nontunable_parameters.items():
-                    if isinstance(p, DerivedParameter):
-                        # Compute only when all dependencies present. Partial
-                        # observations occur in _untransform_objective_thresholds
-                        # where fixed_features provides context for outcome
-                        # constraint untransformation. Derived parameters are
-                        # never needed as context since: (1) they're removed from
-                        # search space, (2) context parameters (e.g., task IDs)
-                        # must be tunable parameters in transformed space.
-                        if all(
-                            dep_name in obsf.parameters
-                            for dep_name in p._parameter_names_to_weights
-                        ):
-                            obsf.parameters[p_name] = p.compute(
-                                parameters=obsf.parameters
-                            )
-                    else:
-                        obsf.parameters[p_name] = p.value
+            for p_name, p in self.nontunable_parameters.items():
+                if isinstance(p, DerivedParameter):
+                    # Compute only when all dependencies present. Partial
+                    # observations occur in _untransform_objective_thresholds
+                    # where fixed_features provides context for outcome
+                    # constraint untransformation. Derived parameters are
+                    # never needed as context since: (1) they're removed from
+                    # search space, (2) context parameters (e.g., task IDs)
+                    # must be tunable parameters in transformed space.
+                    if all(
+                        dep_name in obsf.parameters
+                        for dep_name in p._parameter_names_to_weights
+                    ):
+                        obsf.parameters[p_name] = p.compute(parameters=obsf.parameters)
+                else:
+                    obsf.parameters[p_name] = p.value
         return observation_features
 
     def transform_experiment_data(

--- a/ax/adapter/transforms/tests/test_remove_fixed_transform.py
+++ b/ax/adapter/transforms/tests/test_remove_fixed_transform.py
@@ -152,13 +152,11 @@ class RemoveFixedTransformTest(TestCase):
         )
         self.assertEqual(t_obs, t_obs_different)
 
-        # Test untransform with empty parameters (status quo case)
-        # This would previously fail on p.compute(parameters=obsf.parameters)
-        # when obsf.parameters is {} for DerivedParameter
+        # Test untransform with empty parameters
         empty_obs_features = [ObservationFeatures(parameters={})]
         result = self.t.untransform_observation_features(empty_obs_features)
         # Should return unchanged empty observation features
-        self.assertEqual(result, [ObservationFeatures(parameters={})])
+        self.assertEqual(result, [ObservationFeatures(parameters={"c": "a"})])
 
     def test_UntransformPartialObservationFeatures(self) -> None:
         """Test untransforming observation features with partial parameters.


### PR DESCRIPTION
Summary:
This effectively reverts D82868332. The issue with `DerivedParameter` has been resolved in D87686531 by not computing it if the dependencies are missing. D89500685 also added an additional logic for `DerivedParameter` to re-compute its value in `Cast.untransform_observation_features`, which will ensure it is computed on generated candidates.
The first two diffs here were actually addressing the untransforming of fixed features in https://www.internalfb.com/code/fbsource/[4525505f9929f98140518c740d4d40009d7d4aaf]/fbcode/ax/adapter/torch.py?lines=1108-1127 (which skips Cast, so computation there won't be attempted), which will work even after reverting D82868332 since the checks added in D87686531 will skip its computation.

Why do we need to revert: If the search space is fully fixed (no-tunable parameters -- an edge case that we've ran into) this check would lead to returning empty parameterization rather than returning the parameterization with all fixed parameters.

Differential Revision:
D90343254

Privacy Context Container: L1413903


