### PR TITLE
Add deprecation warning to AxClient

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -179,6 +179,15 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         early_stopping_strategy: BaseEarlyStoppingStrategy | None = None,
         global_stopping_strategy: BaseGlobalStoppingStrategy | None = None,
     ) -> None:
+        if self.__class__.__name__ in ["AxClient", "AxClientInternal"]:
+            warnings.warn(
+                "The `AxClient` class is deprecated and will be removed in Ax 1.4.0. "
+                "Please migrate to the modern Ax API / `Client` class, found under "
+                "ax/api. For example usage, check out the tutorials at https://ax.dev ",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         super().__init__(
             db_settings=db_settings,
             suppress_all_errors=suppress_storage_errors,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -9,6 +9,7 @@
 import math
 import sys
 import time
+import warnings
 from itertools import product
 from math import ceil
 from typing import Any, TYPE_CHECKING
@@ -266,6 +267,20 @@ def get_client_with_simple_discrete_moo_problem(
 
 class TestAxClient(TestCase):
     """Tests service-like API functionality."""
+
+    def test_deprecation_warning(self) -> None:
+        # Should warn for AxClient but not for arbitrary subclasses.
+        with self.assertWarnsRegex(
+            DeprecationWarning, "`AxClient` class is deprecated and will be removed"
+        ):
+            AxClient()
+
+        class TestAxClient(AxClient):
+            pass
+
+        with warnings.catch_warnings(record=True) as ws:
+            TestAxClient()
+        self.assertEqual(len(ws), 0)
 
     @mock_botorch_optimize
     def test_interruption(self) -> None:


### PR DESCRIPTION
Summary: Since this was our primary API for a long time, we should signal its removal with a deprecation warning before removing it for good.

Differential Revision:
D90390538

Privacy Context Container: L1413903


