### PR TITLE
Add robust trial status polling

### DIFF
--- a/ax/core/runner.py
+++ b/ax/core/runner.py
@@ -10,15 +10,20 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from logging import Logger
 from typing import Any, TYPE_CHECKING
 
+from ax.core.trial_status import TrialStatus
 from ax.utils.common.base import Base
+from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import SerializationMixin
 
 
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
     from ax import core  # noqa F401
+
+logger: Logger = get_logger(__name__)
 
 
 class Runner(Base, SerializationMixin, ABC):
@@ -160,3 +165,51 @@ class Runner(Base, SerializationMixin, ABC):
             obj=self
         ) == other.serialize_init_args(obj=other)
         return same_class and same_init_args
+
+    def robust_poll_trial_status(
+        self,
+        trials: Iterable[core.base_trial.BaseTrial],
+    ) -> dict[core.base_trial.TrialStatus, set[int]]:
+        """Robustly polls trial statuses with automatic fallback to individual polling.
+
+        First attempts to poll all trials at once for efficiency. If this fails,
+        falls back to polling each trial individually, setting trial status to
+        ABANDONED if the fallback fails.
+
+        Args:
+            trials: Trials to poll for status updates.
+
+        Returns:
+            A dictionary mapping TrialStatus to sets of trial indices.
+        """
+        trials_list = list(trials)
+        if len(trials_list) == 0:
+            return {}
+
+        # First, try to poll all trials at once (most efficient).
+        try:
+            return self.poll_trial_status(trials=trials_list)
+        except Exception:
+            logger.warning(
+                "Failed to poll all trial statuses at once. "
+                "Falling back to polling trials individually."
+            )
+
+        # Fallback: poll trials one-at-a-time and capture failures.
+        status_dict: dict[TrialStatus, set[int]] = {}
+        for trial in trials_list:
+            try:
+                single_status_dict = self.poll_trial_status(trials=[trial])
+            except Exception as e:
+                logger.exception(
+                    f"Failed to retrieve status of trial {trial.index} due to error: "
+                    f"{e}. Setting trial status to ABANDONED so that this "
+                    "parameterization is not attempted again."
+                )
+                single_status_dict = {TrialStatus.ABANDONED: {trial.index}}
+            for status, index_set in single_status_dict.items():
+                if status in status_dict:
+                    status_dict[status] |= index_set
+                else:
+                    status_dict[status] = index_set
+        return status_dict

--- a/ax/core/tests/test_runner.py
+++ b/ax/core/tests/test_runner.py
@@ -6,9 +6,10 @@
 
 # pyre-strict
 
+from collections.abc import Iterable
 from unittest import mock
 
-from ax.core.base_trial import BaseTrial
+from ax.core.base_trial import BaseTrial, TrialStatus
 from ax.core.runner import Runner
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_batch_trial, get_trial
@@ -18,6 +19,45 @@ class DummyRunner(Runner):
     # pyre-fixme[3]: Return type must be annotated.
     def run(self, trial: BaseTrial):
         return {"metadatum": f"value_for_trial_{trial.index}"}
+
+
+class RunnerWithSuccessfulBatchPoll(Runner):
+    """Runner where poll_trial_status succeeds for any number of trials."""
+
+    def run(self, trial: BaseTrial) -> dict[str, str]:
+        return {"metadatum": f"value_for_trial_{trial.index}"}
+
+    def poll_trial_status(
+        self, trials: Iterable[BaseTrial]
+    ) -> dict[TrialStatus, set[int]]:
+        return {TrialStatus.COMPLETED: {t.index for t in trials}}
+
+
+class RunnerWithFailingBatchPoll(Runner):
+    """Runner where batch poll fails but individual poll succeeds."""
+
+    def run(self, trial: BaseTrial) -> dict[str, str]:
+        return {"metadatum": f"value_for_trial_{trial.index}"}
+
+    def poll_trial_status(
+        self, trials: Iterable[BaseTrial]
+    ) -> dict[TrialStatus, set[int]]:
+        trials_list = list(trials)
+        if len(trials_list) > 1:
+            raise RuntimeError("Batch poll failure")
+        return {TrialStatus.COMPLETED: {trials_list[0].index}}
+
+
+class RunnerWithAllPollsFailing(Runner):
+    """Runner where poll_trial_status always fails."""
+
+    def run(self, trial: BaseTrial) -> dict[str, str]:
+        return {"metadatum": f"value_for_trial_{trial.index}"}
+
+    def poll_trial_status(
+        self, trials: Iterable[BaseTrial]
+    ) -> dict[TrialStatus, set[int]]:
+        raise RuntimeError("Poll failure")
 
 
 class RunnerTest(TestCase):
@@ -59,3 +99,59 @@ class RunnerTest(TestCase):
 
     def test_run_metadata_report_keys(self) -> None:
         self.assertEqual(self.dummy_runner.run_metadata_report_keys, [])
+
+    def test_robust_poll_trial_status_empty_trials(self) -> None:
+        """Test that robust_poll_trial_status returns empty dict for empty trials."""
+        runner = RunnerWithSuccessfulBatchPoll()
+        result = runner.robust_poll_trial_status(trials=[])
+        self.assertEqual(result, {})
+
+    def test_robust_poll_trial_status_batch_success(self) -> None:
+        """Test that robust_poll_trial_status uses batch poll when it succeeds."""
+        runner = RunnerWithSuccessfulBatchPoll()
+        result = runner.robust_poll_trial_status(trials=self.trials)
+        self.assertEqual(
+            result, {TrialStatus.COMPLETED: {t.index for t in self.trials}}
+        )
+
+    def test_robust_poll_trial_status_fallback_to_individual(self) -> None:
+        """Test fallback to individual polling when batch poll fails."""
+        runner = RunnerWithFailingBatchPoll()
+        with self.assertLogs(logger="ax.core.runner", level="WARNING") as lg:
+            result = runner.robust_poll_trial_status(trials=self.trials)
+
+        # Check that the fallback warning was logged
+        self.assertTrue(
+            any(
+                "Failed to poll all trial statuses at once" in msg
+                and "Falling back to polling trials individually" in msg
+                for msg in lg.output
+            )
+        )
+
+        # All trials should still be marked as completed via individual polling
+        self.assertEqual(
+            result, {TrialStatus.COMPLETED: {t.index for t in self.trials}}
+        )
+
+    def test_robust_poll_trial_status_abandons_on_individual_failure(self) -> None:
+        """Test that trials are marked ABANDONED when individual polling fails."""
+        runner = RunnerWithAllPollsFailing()
+        with self.assertLogs(logger="ax.core.runner", level="WARNING") as lg:
+            result = runner.robust_poll_trial_status(trials=self.trials)
+
+        # Check that the abandonment warning was logged for each trial
+        for trial in self.trials:
+            self.assertTrue(
+                any(
+                    f"Failed to retrieve status of trial {trial.index}" in msg
+                    and "Setting trial status to ABANDONED" in msg
+                    for msg in lg.output
+                ),
+                f"Expected abandonment warning for trial {trial.index} not found",
+            )
+
+        # All trials should be marked as abandoned
+        self.assertEqual(
+            result, {TrialStatus.ABANDONED: {t.index for t in self.trials}}
+        )

--- a/ax/orchestration/orchestrator.py
+++ b/ax/orchestration/orchestrator.py
@@ -838,6 +838,10 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
         are running; that logic is handled in ``orchestrator.poll``, which calls
         this function.
 
+        NOTE: If polling all trials at once fails, falls back to polling trials
+        one-at-a-time and abandons any trial whose status check fails. This
+        reduces polling efficiency but enhances robustness.
+
         Returns:
             A dictionary mapping TrialStatus to a list of trial indices that have
             the respective status at the time of the polling. This does not need to
@@ -852,7 +856,8 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
         trials = filter_trials_by_type(trials=trials, trial_type=self.trial_type)
         if len(trials) == 0:
             return {}
-        return self.runner.poll_trial_status(trials=trials)
+
+        return self.runner.robust_poll_trial_status(trials=trials)
 
     def wait_for_completed_trials_and_report_results(
         self,

--- a/ax/orchestration/tests/test_orchestrator.py
+++ b/ax/orchestration/tests/test_orchestrator.py
@@ -69,8 +69,10 @@ from ax.orchestration.tests.orchestrator_test_utils import (
     NoReportResultsRunner,
     RunnerToAllowMultipleMapMetricFetches,
     RunnerWithAllFailedTrials,
+    RunnerWithAllPollsFailing,
     RunnerWithEarlyStoppingStrategy,
     RunnerWithFailedAndAbandonedTrials,
+    RunnerWithFailingPollTrialStatus,
     RunnerWithFrequentFailedTrials,
     SyntheticRunnerWithPredictableStatusPolling,
     SyntheticRunnerWithSingleRunningTrial,
@@ -1628,6 +1630,81 @@ class TestAxOrchestrator(TestCase):
             DUMMY_EXCEPTION,
         )
         self.assertIsNone(orchestrator.experiment.trials[completed_idx]._failed_reason)
+
+    def test_poll_trial_status_fallback_to_individual_polling(self) -> None:
+        """Test that poll_trial_status falls back to individual polling when
+        batch polling fails, and successfully completes trials."""
+        self.branin_experiment.runner = RunnerWithFailingPollTrialStatus()
+        gs = self.two_sobol_steps_GS
+        orchestrator = Orchestrator(
+            experiment=self.branin_experiment,
+            generation_strategy=gs,
+            options=OrchestratorOptions(
+                total_trials=3,
+                init_seconds_between_polls=0,
+                **self.orchestrator_options_kwargs,
+            ),
+            db_settings=self.db_settings_if_always_needed,
+        )
+        with self.assertLogs(logger="ax.core.runner") as lg:
+            orchestrator.run_all_trials()
+
+        # Check that the fallback warning was logged
+        self.assertTrue(
+            any(
+                "Failed to poll all trial statuses at once" in msg
+                and "Falling back to polling trials individually" in msg
+                for msg in lg.output
+            ),
+            f"Expected fallback warning not found in logs: {lg.output}",
+        )
+
+        # All trials should have completed successfully despite batch poll failures
+        self.assertTrue(
+            all(
+                t.completed_successfully
+                for t in orchestrator.experiment.trials.values()
+            )
+        )
+        self.assertEqual(len(orchestrator.experiment.trials), 3)
+
+    def test_poll_trial_status_abandons_trial_on_individual_failure(self) -> None:
+        """Test that poll_trial_status marks individual trials as ABANDONED when
+        their status cannot be retrieved."""
+        self.branin_experiment.runner = RunnerWithAllPollsFailing()
+        gs = self.sobol_GS_no_parallelism
+        orchestrator = Orchestrator(
+            experiment=self.branin_experiment,
+            generation_strategy=gs,
+            options=OrchestratorOptions(
+                total_trials=2,
+                init_seconds_between_polls=0,
+                **self.orchestrator_options_kwargs,
+            ),
+            db_settings=self.db_settings_if_always_needed,
+        )
+        with self.assertLogs(logger="ax.core.runner") as lg:
+            # Expect FailureRateExceededError since all trials will be abandoned
+            with self.assertRaises(FailureRateExceededError):
+                orchestrator.run_all_trials()
+
+        # Check that the abandonment warning was logged
+        self.assertTrue(
+            any(
+                "Failed to retrieve status of trial" in msg
+                and "Setting trial status to ABANDONED" in msg
+                for msg in lg.output
+            ),
+            f"Expected abandonment warning not found in logs: {lg.output}",
+        )
+
+        # All trials should be abandoned due to poll failures
+        self.assertTrue(
+            all(
+                t.status == TrialStatus.ABANDONED
+                for t in orchestrator.experiment.trials.values()
+            )
+        )
 
     def test_fetch_and_process_trials_data_results_failed_objective_available_while_running(  # noqa
         self,


### PR DESCRIPTION
Summary:
Adds a robust wrapper method for poll_trial_status that:
1. If poll_trial_status fails, falls back to polling trials one-at-a-time.
2. Each trial for which individual status polling fails is marked as abandoned.

This is important for runners whose status-polling logic can undergo sporadic exceptions, in order to avoid failing the entire orchestrator process.

Alternatives considered:
* **Institute a PollStatusResult analogous to [MetricFetchResult](https://fburl.com/code/yyp9j66m).** Decided against because I don't think this logic belongs in runner.poll_trial_status, since it's good to have this centralized instead of replicated across all runners' poll_trial_status methods. Also this would require migration across all runner.poll_trial_status methods.
* **Add this to Orchestrator.poll_trial_status (V1 of this diff)**. This could make sense because this logic is mainly for use in the Orchestrator anyway, but I prefer keeping retry logic closer to where polling happens.

Differential Revision: D90390842


