### PR TITLE
Handle NaN and Infinity in JSON serialization | Fixes #4144

### DIFF
--- a/ax/storage/json_store/encoder.py
+++ b/ax/storage/json_store/encoder.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import math
 import dataclasses
 import datetime
 import enum
@@ -77,8 +78,13 @@ def object_to_json(
     if _type in encoder_registry:
         obj_dict = encoder_registry[_type](obj)
         return {k: _object_to_json(v) for k, v in obj_dict.items()}
+    elif _type is float:
+        # Handle NaN and Infinity which are not JSON compliant
+        if math.isnan(obj) or math.isinf(obj):
+            return None
+        return obj
     # Python built-in types + `typing` module types
-    if _type in (str, int, float, bool, type(None)):
+    if _type in (str, int, bool, type(None)):
         return obj
     elif _type is list:
         return [_object_to_json(x) for x in obj]


### PR DESCRIPTION
Fixes #4144
## Problem
When saving a Client to JSON using `save_to_json_file()`, the operation fails with `ValueError: Out of range float values are not JSON compliant` because `NaN` and `Infinity` float values are not valid in standard JSON format.

## Solution
Modified `ax/storage/json_store/encoder.py` to handle non-JSON-compliant float values:
- Added `import math` for NaN/Infinity checking
- Added explicit handling for `float` type that converts `NaN` and `Infinity` to `None` (JSON `null`)

This follows the same pattern as pandas `to_json()` which converts NaN to null by default.

## Testing
```python
import math
from ax.storage.json_store.encoder import object_to_json

# These now work instead of failing
result = object_to_json({"value": float("nan")})
print(result)  # {"value": None}

result = object_to_json({"value": float("inf")})
print(result)  # {"value": None}
```

## Previous Behavior
```
ValueError: Out of range float values are not JSON compliant
"map_key_infos": [ { "key": "step", "default_value": NaN } ]
```

## New Behavior
NaN and Infinity values are converted to `null` in JSON, allowing save/load to work correctly.

## Environment
- Ax version: 1.0.0+
- Python version: 3.11+
- OS: All