### PR TITLE
Add public to_json_snapshot method to Client | Fixes #4143

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -959,6 +959,24 @@ class Client(WithDBSettingsBase):
             for i in range(len(points))
         ]
 
+   def to_json_snapshot(self) -> dict[str, Any]:
+        """
+        Return a JSON-serializable snapshot of this ``Client``'s settings and state
+        as a dictionary.
+
+        This can be used to share experiments programmatically or store them
+        in databases without writing to a file.
+
+        Returns:
+            A JSON-serializable dictionary representing the Client's state.
+
+        Example:
+            >>> snapshot = client.to_json_snapshot()
+            >>> # Store in database, send over network, etc.
+            >>> json_string = json.dumps(snapshot)
+        """
+        return self._to_json_snapshot()
+        
     # -------------------- Section 4: Save/Load -------------------------------------
     # Note: SQL storage handled automatically during regular usage
     def save_to_json_file(self, filepath: str = "ax_client_snapshot.json") -> None:


### PR DESCRIPTION
Fixes #4143

## Problem
Users need to get a JSON snapshot of the Client as a dictionary for sharing experiments programmatically (e.g., storing in databases, sending over network) without writing to a file. Currently they have to use the private method `_to_json_snapshot()`.

## Solution
Added a public `to_json_snapshot()` method to `Client` in `ax/api/client.py` that returns the JSON-serializable dictionary.

## Usage
```python
from ax.api.client import Client
import json

client = Client()
# ... configure experiment ...

# Get snapshot as dictionary (NEW)
snapshot = client.to_json_snapshot()

# Can now use programmatically
json_string = json.dumps(snapshot)  # Convert to string
# Or store in database, send over network, etc.
```

## Previous Behavior
Users had to use the private method `client._to_json_snapshot()` which is not part of the public API and could change without notice.

## New Behavior
Users can use the public method `client.to_json_snapshot()` which is part of the supported API.