### PR TITLE
Migration to Noise module

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -147,7 +147,7 @@ def get_benchmark_runner(
 
     return BenchmarkRunner(
         test_function=problem.test_function,
-        noise_std=problem.noise_std,
+        noise=problem.noise,
         step_runtime_function=problem.step_runtime_function,
         max_concurrency=max_concurrency,
         force_use_simulated_backend=force_use_simulated_backend,
@@ -189,9 +189,9 @@ def get_oracle_experiment_from_params(
         optimization_config=problem.optimization_config,
     )
 
-    # Ensure noiseless evaluation by replacing any custom noise function with None
-    noiseless_test_function = replace(problem.test_function, add_custom_noise=None)
-    runner = BenchmarkRunner(test_function=noiseless_test_function, noise_std=0.0)
+    # The test function produces ground-truth values; noise is handled by
+    # BenchmarkRunner's Noise object (default is noiseless GaussianNoise).
+    runner = BenchmarkRunner(test_function=problem.test_function)
 
     # Silence INFO logs from ax.core.experiment that state "Attached custom
     # parameterizations"

--- a/ax/benchmark/benchmark_test_function.py
+++ b/ax/benchmark/benchmark_test_function.py
@@ -6,30 +6,11 @@
 # pyre-strict
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
-import pandas as pd
-from ax.core.base_trial import BaseTrial
 from ax.core.types import TParamValue
 from torch import Tensor
-
-# Type alias for the custom noise function.
-# The callable takes all the arguments that are exposed in the benchmark runner:
-#   - df: The lookup_data().df DataFrame. Mandatory
-#   - trial: The trial being evaluated
-#   - noise_stds: Mapping from metric name to noise std
-#   - arm_weights: Mapping from arm name to weight, or None for single-arm trials
-# And returns a DataFrame with added "mean" and "sem" columns.
-TAddCustomNoise = Callable[
-    [
-        pd.DataFrame,
-        BaseTrial | None,
-        Mapping[str, float] | None,
-        Mapping[str, float] | None,
-    ],
-    pd.DataFrame,
-]
 
 
 @dataclass(kw_only=True)
@@ -37,7 +18,7 @@ class BenchmarkTestFunction(ABC):
     """
     The basic Ax class for generating deterministic data to benchmark against.
 
-    (Noise - if desired - is added by the runner.)
+    (Noise - if desired - is added by the runner using a `Noise` object.)
 
     Args:
         outcome_names: Names of the outcomes.
@@ -45,14 +26,10 @@ class BenchmarkTestFunction(ABC):
             if data is not time-series. If data is time-series, this will
             eventually become the number of values on a `MapMetric` for
             evaluations that run to completion.
-        add_custom_noise: Optional callable to add custom noise to evaluation
-            results. If provided, it will be called instead of the default noise
-            behavior, overriding the noise_std argument.
     """
 
     outcome_names: Sequence[str]
     n_steps: int = 1
-    add_custom_noise: TAddCustomNoise | None = None
 
     @abstractmethod
     def evaluate_true(self, params: Mapping[str, TParamValue]) -> Tensor:

--- a/ax/benchmark/problems/synthetic/bandit.py
+++ b/ax/benchmark/problems/synthetic/bandit.py
@@ -10,6 +10,7 @@ from warnings import warn
 import numpy as np
 from ax.benchmark.benchmark_problem import BenchmarkProblem, get_soo_opt_config
 from ax.benchmark.benchmark_test_functions.synthetic import IdentityTestFunction
+from ax.benchmark.noise import GaussianNoise
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import SearchSpace
 
@@ -71,6 +72,6 @@ def get_bandit_problem(num_choices: int = 30, num_trials: int = 3) -> BenchmarkP
         baseline_value=baseline_value,
         test_function=test_function,
         report_inference_value_as_trace=True,
-        noise_std=1.0,
+        noise=GaussianNoise(noise_std=1.0),
         status_quo_params={"x0": num_choices // 2},
     )

--- a/ax/benchmark/problems/synthetic/from_botorch.py
+++ b/ax/benchmark/problems/synthetic/from_botorch.py
@@ -20,6 +20,7 @@ from ax.benchmark.benchmark_problem import (
 )
 from ax.benchmark.benchmark_step_runtime_function import TBenchmarkStepRuntimeFunction
 from ax.benchmark.benchmark_test_functions.botorch_test import BoTorchTestFunction
+from ax.benchmark.noise import GaussianNoise
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
@@ -127,8 +128,8 @@ def create_problem_from_botorch(
             `test_problem_class`. This should *not* include `noise_std` or
             `negate`, since these are handled through Ax benchmarking (as the
             `noise_std` and `lower_is_better` arguments to `BenchmarkProblem`).
-        noise_std: Standard deviation of synthetic noise added to outcomes. If a
-            float, the same noise level is used for all objectives.
+        noise_std: Dict of standard deviations of synthetic Gaussian noise added
+            to outcomes. If a float, the same noise level is used for all objectives.
         lower_is_better: Whether this is a minimization problem. For MOO, this
             applies to all objectives.
         num_trials: Simply the `num_trials` of the `BenchmarkProblem` created.
@@ -271,7 +272,7 @@ def create_problem_from_botorch(
         search_space=search_space,
         optimization_config=optimization_config,
         test_function=test_function,
-        noise_std=noise_std,
+        noise=GaussianNoise(noise_std=noise_std),
         num_trials=num_trials,
         optimal_value=assert_is_instance(optimal_value, float),
         baseline_value=baseline_value,

--- a/ax/benchmark/problems/synthetic/hss/jenatton.py
+++ b/ax/benchmark/problems/synthetic/hss/jenatton.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 import torch
 from ax.benchmark.benchmark_problem import BenchmarkProblem, get_soo_opt_config
 from ax.benchmark.benchmark_test_function import BenchmarkTestFunction
+from ax.benchmark.noise import GaussianNoise
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from pyre_extensions import none_throws
@@ -116,7 +117,7 @@ def get_jenatton_benchmark_problem(
         search_space=get_jenatton_search_space(),
         optimization_config=optimization_config,
         test_function=Jenatton(outcome_names=[name]),
-        noise_std=noise_std,
+        noise=GaussianNoise(noise_std=noise_std),
         num_trials=num_trials,
         optimal_value=JENATTON_OPTIMAL_VALUE,
         baseline_value=JENATTON_BASELINE_VALUE,

--- a/ax/benchmark/tests/problems/synthetic/hss/test_jenatton.py
+++ b/ax/benchmark/tests/problems/synthetic/hss/test_jenatton.py
@@ -8,6 +8,7 @@
 from random import random
 
 from ax.benchmark.benchmark_metric import BenchmarkMetric
+from ax.benchmark.noise import GaussianNoise
 from ax.benchmark.problems.synthetic.hss.jenatton import (
     get_jenatton_benchmark_problem,
     jenatton_test_function,
@@ -100,7 +101,9 @@ class JenattonTest(TestCase):
         self.assertEqual(metric.signature, "Jenatton")
         self.assertTrue(objective.minimize)
         self.assertTrue(metric.lower_is_better)
-        self.assertEqual(problem.noise_std, 0.0)
+        self.assertEqual(
+            assert_is_instance(problem.noise, GaussianNoise).noise_std, 0.0
+        )
         self.assertFalse(assert_is_instance(metric, BenchmarkMetric).observe_noise_sd)
 
         problem = get_jenatton_benchmark_problem(
@@ -109,5 +112,7 @@ class JenattonTest(TestCase):
         objective = problem.optimization_config.objective
         metric = objective.metric
         self.assertTrue(metric.lower_is_better)
-        self.assertEqual(problem.noise_std, 0.1)
+        self.assertEqual(
+            assert_is_instance(problem.noise, GaussianNoise).noise_std, 0.1
+        )
         self.assertTrue(assert_is_instance(metric, BenchmarkMetric).observe_noise_sd)

--- a/ax/benchmark/tests/problems/synthetic/test_from_botorch.py
+++ b/ax/benchmark/tests/problems/synthetic/test_from_botorch.py
@@ -11,6 +11,7 @@ import torch
 from ax.benchmark.benchmark_metric import BenchmarkMapMetric, BenchmarkMetric
 from ax.benchmark.benchmark_problem import get_continuous_search_space
 from ax.benchmark.benchmark_test_functions.botorch_test import BoTorchTestFunction
+from ax.benchmark.noise import GaussianNoise
 from ax.benchmark.problems.synthetic.from_botorch import (
     _get_name,
     create_problem_from_botorch,
@@ -145,7 +146,9 @@ class TestFromBoTorch(TestCase):
         botorch_problem = assert_is_instance(
             test_problem.botorch_problem, ConstrainedBaseTestProblem
         )
-        self.assertEqual(ax_problem.noise_std, noise_std)
+        self.assertEqual(
+            assert_is_instance(ax_problem.noise, GaussianNoise).noise_std, noise_std
+        )
         opt_config = ax_problem.optimization_config
         outcome_constraints = opt_config.outcome_constraints
         self.assertEqual(

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -995,21 +995,6 @@ class TestBenchmark(TestCase):
                 problem=problem, dict_of_dict_of_params={0: {}}
             )
 
-        with self.subTest("custom noise is ignored for noiseless oracle"):
-            problem_with_custom_noise = dataclasses.replace(
-                problem,
-                test_function=dataclasses.replace(
-                    problem.test_function,
-                    add_custom_noise=lambda df, *args: df.assign(mean=999.0, sem=0.0),
-                ),
-            )
-            oracle_exp = get_oracle_experiment_from_params(
-                problem=problem_with_custom_noise,
-                dict_of_dict_of_params={0: {"0": near_opt_params}},
-            )
-            df = oracle_exp.fetch_data().df
-            self.assertAlmostEqual(df["mean"].iloc[0], Branin._optimal_value, places=5)
-
     def _test_multi_fidelity_or_multi_task(
         self, fidelity_or_task: Literal["fidelity", "task"]
     ) -> None:


### PR DESCRIPTION
Summary: Updates `benchmark.py` to use the new Noise module architecture: passes `problem.noise` instead of `problem.noise_std` to `BenchmarkRunner`, and removes the obsolete `add_custom_noise` replacement since noise is now handled entirely by the `Noise` object on the runner.

Differential Revision: D90597013


