### PR TITLE
Propagate early stopping reason to trial reason string

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1262,7 +1262,7 @@ class Experiment(Base):
                     "for experiment or trial."
                 )
             runner.stop(trial=trial, reason=reason)
-            trial.mark_early_stopped()
+            trial.mark_early_stopped(reason=reason)
 
     def _attach_trial(self, trial: BaseTrial, index: int | None = None) -> int:
         """Attach a trial to this experiment.

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1636,6 +1636,7 @@ class ExperimentTest(TestCase):
 
     def test_stop_trial(self) -> None:
         self.experiment.new_trial()
+        test_reason = "Early stopping due to poor performance"
         with (
             patch.object(self.experiment, "runner"),
             patch.object(
@@ -1643,9 +1644,13 @@ class ExperimentTest(TestCase):
             ) as mock_runner_stop,
             patch.object(BaseTrial, "mark_early_stopped") as mock_mark_stopped,
         ):
-            self.experiment.stop_trial_runs(trials=[self.experiment.trials[0]])
-            mock_runner_stop.assert_called_once()
-            mock_mark_stopped.assert_called_once()
+            self.experiment.stop_trial_runs(
+                trials=[self.experiment.trials[0]], reasons=[test_reason]
+            )
+            mock_runner_stop.assert_called_once_with(
+                trial=self.experiment.trials[0], reason=test_reason
+            )
+            mock_mark_stopped.assert_called_once_with(reason=test_reason)
 
     def test_stop_trial_without_runner(self) -> None:
         self.experiment.new_trial()

--- a/ax/orchestration/tests/test_orchestrator.py
+++ b/ax/orchestration/tests/test_orchestrator.py
@@ -1256,7 +1256,11 @@ class TestAxOrchestrator(TestCase):
                 experiment: Experiment,
                 current_node: GenerationNode | None = None,
             ) -> dict[int, str | None]:
-                return {idx: None for idx in trial_indices if idx % 2 == 1}
+                return {
+                    idx: f"Trial {idx} stopped by OddIndexEarlyStoppingStrategy"
+                    for idx in trial_indices
+                    if idx % 2 == 1
+                }
 
         self.branin_timestamp_map_metric_experiment.runner = (
             RunnerWithEarlyStoppingStrategy()
@@ -1313,6 +1317,14 @@ class TestAxOrchestrator(TestCase):
         self.assertAlmostEqual(
             ess.estimate_early_stopping_savings(orchestrator.experiment),
             1.0 / 3.0,
+        )
+
+        # Verify that the status reason from early stopping strategy is retained.
+        early_stopped_trial = orchestrator.experiment.trials[1]
+        self.assertEqual(early_stopped_trial.status, TrialStatus.EARLY_STOPPED)
+        self.assertEqual(
+            early_stopped_trial.status_reason,
+            "Trial 1 stopped by OddIndexEarlyStoppingStrategy",
         )
 
     def test_orchestrator_with_metric_with_new_data_after_completion(self) -> None:


### PR DESCRIPTION
Summary: This will make sure that the stopping reason is available at the trial level and can be easily surfaced to the users.

Differential Revision: D90619515


