### PR TITLE
Add tests for contour & slice plots with choice parameter

### DIFF
--- a/ax/analysis/plotly/surface/tests/test_contour.py
+++ b/ax/analysis/plotly/surface/tests/test_contour.py
@@ -36,6 +36,13 @@ class TestContourPlot(TestCase):
                     "type": "range",
                     "bounds": [-1.0, 1.0],
                 },
+                {
+                    "name": "z",
+                    "type": "choice",
+                    "values": [1, 2, 3, 4],
+                    "value_type": "int",
+                    "is_ordered": True,
+                },
             ],
             objectives={"bar": ObjectiveProperties(minimize=True)},
         )
@@ -213,3 +220,25 @@ class TestContourPlot(TestCase):
                 experiment=self.client.experiment,
                 generation_strategy=self.client.generation_strategy,
             )
+
+    def test_compute_with_choice_parameter(self) -> None:
+        """Test contour plot with ordered ChoiceParameter on one axis."""
+        analysis = ContourPlot(
+            x_parameter_name="x", y_parameter_name="z", metric_name="bar"
+        )
+        card = analysis.compute(
+            experiment=self.client.experiment,
+            generation_strategy=self.client.generation_strategy,
+        )
+
+        # Assert: Verify the contour plot was created successfully
+        self.assertEqual(card.name, "ContourPlot")
+        self.assertEqual(card.title, "bar (Mean) vs. x, z")
+        self.assertIn("x", card.df.columns)
+        self.assertIn("z", card.df.columns)
+        self.assertIn("bar_mean", card.df.columns)
+
+        # Assert: Verify that z only contains the discrete choice values
+        unique_z_values = card.df["z"].unique()
+        for value in unique_z_values:
+            self.assertIn(value, [1, 2, 3, 4])

--- a/ax/analysis/plotly/surface/tests/test_slice.py
+++ b/ax/analysis/plotly/surface/tests/test_slice.py
@@ -27,7 +27,14 @@ class TestSlicePlot(TestCase):
                     "name": "x",
                     "type": "range",
                     "bounds": [-1.0, 1.0],
-                }
+                },
+                {
+                    "name": "z",
+                    "type": "choice",
+                    "values": [1, 2, 3, 4],
+                    "value_type": "int",
+                    "is_ordered": True,
+                },
             ],
             objectives={"bar": ObjectiveProperties(minimize=True)},
         )
@@ -147,3 +154,22 @@ class TestSlicePlot(TestCase):
             trial_index,
             card.df["trial_index"].values,
         )
+
+    def test_compute_with_choice_parameter(self) -> None:
+        """Test slice plot with ordered ChoiceParameter."""
+        analysis = SlicePlot(parameter_name="z", metric_name="bar")
+        card = analysis.compute(
+            experiment=self.client.experiment,
+            generation_strategy=self.client.generation_strategy,
+        )
+
+        # Assert: Verify the slice plot was created successfully
+        self.assertEqual(card.name, "SlicePlot")
+        self.assertEqual(card.title, "bar vs. z")
+        self.assertIn("z", card.df.columns)
+        self.assertIn("bar_mean", card.df.columns)
+
+        # Assert: Verify that z only contains the discrete choice values
+        unique_z_values = card.df["z"].unique()
+        for value in unique_z_values:
+            self.assertIn(value, [1, 2, 3, 4])


### PR DESCRIPTION
Summary: Both analyses already support choice parameters but weren't being tested with it. Extended existing tests to cover choice params.

Reviewed By: bernardbeckerman

Differential Revision: D90694372


