### PR TITLE
Update SOBOL transition criterion to excldue ABANDONED and FAILED trials in initalization budget

### DIFF
--- a/ax/api/utils/generation_strategy_dispatch.py
+++ b/ax/api/utils/generation_strategy_dispatch.py
@@ -45,8 +45,9 @@ def _get_sobol_node(
         - If the initialization budget is not specified, it defaults to 5.
         - The TC will not block generation if `allow_exceeding_initialization_budget`
             is set to True.
-        - The TC is currently not restricted to any trial statuses and will
-            count all trials.
+        - The TC excludes FAILED and ABANDONED trials from the count, so that
+            more trials can be generated to meet the
+            `min_observed_initialization_trials` requirement.
         - `use_existing_trials_for_initialization` controls whether trials previously
             attached to the experiment are counted as part of the initialization budget.
     - MinTrials enforcing the minimum number of observed initialization trials.
@@ -72,6 +73,7 @@ def _get_sobol_node(
             block_gen_if_met=(not allow_exceeding_initialization_budget),
             block_transition_if_unmet=True,
             use_all_trials_in_exp=use_existing_trials_for_initialization,
+            not_in_statuses=[TrialStatus.FAILED, TrialStatus.ABANDONED],
         ),
         MinTrials(  # This represents minimum observed trials requirement.
             threshold=min_observed_initialization_trials,

--- a/ax/api/utils/structs.py
+++ b/ax/api/utils/structs.py
@@ -59,7 +59,10 @@ class GenerationStrategyDispatchStruct:
                     ``choose_generation_strategy``. This is an advanced option
                     and should not be considered a part of the public API.
         initialization_budget: The number of trials to use for initialization.
-            If ``None``, a default budget of 5 trials is used.
+            If ``None``, a default budget of 5 trials is used. Note that FAILED
+            and ABANDONED trials are excluded from this count, allowing more
+            trials to be generated to meet the
+            `min_observed_initialization_trials` requirement.
         initialization_random_seed: The random seed to use with the Sobol generator
             that generates the initialization trials.
         initialize_with_center: If True, the center of the search space is used as the


### PR DESCRIPTION
Summary:
Exclude ABANDONED and FAILED trials from initalization budget transition criterion

f1020104666 has 3 abandoned trials (missing qps metrics) and 2 completed trials. But it hit a dead end:
  - Can't generate more Sobol trials (blocked by criterion 1 - 'block_gen_if_met': True)
  - Can't transition to BO (blocked by criterion 2 - not enough COMPLETED trials)

`block_gen_if_met = True` is a sensible default as we don't necessarily want to spend more SOBOL trials just to meet the max_parallelism, but we should excldue FAILED/ABANDONED trials to prevent issues like f1020104666

This means that if we have 3 COMPLETED trials and 2 FAILED/ABANDONED trials, we will stay in SOBOL (previous behavior: move to BO). Intuitively it shouldn't make a big difference in optimization result as BO model is probably not good with 3 datapoints, and probably behaves like SOBOL anyway (except for BO is more likely to generate boundary points).

Differential Revision: D90807058


