### PR TITLE
Set trials to abandon on _mark_err_trial_status

### DIFF
--- a/ax/orchestration/orchestrator.py
+++ b/ax/orchestration/orchestrator.py
@@ -2121,9 +2121,10 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
         metric_name: str | None = None,
         metric_fetch_e: MetricFetchE | None = None,
     ) -> TrialStatus:
-        trial.mark_failed(unsafe=True)
-
-        return TrialStatus.FAILED
+        trial.mark_abandoned(
+            reason=metric_fetch_e.message if metric_fetch_e else None, unsafe=True
+        )
+        return TrialStatus.ABANDONED
 
     def _get_failure_rate_exceeded_error(
         self,

--- a/ax/orchestration/tests/test_orchestrator.py
+++ b/ax/orchestration/tests/test_orchestrator.py
@@ -1857,14 +1857,16 @@ class TestAxOrchestrator(TestCase):
             any(
                 re.search(
                     r"Because (branin|m1) is an objective, marking trial 0 as "
-                    "TrialStatus.FAILED",
+                    "TrialStatus.ABANDONED",
                     warning,
                 )
                 is not None
                 for warning in lg.output
             )
         )
-        self.assertEqual(orchestrator.experiment.trials[0].status, TrialStatus.FAILED)
+        self.assertEqual(
+            orchestrator.experiment.trials[0].status, TrialStatus.ABANDONED
+        )
 
     def test_fetch_and_process_trials_data_results_failed_objective_but_recoverable(
         self,
@@ -1957,14 +1959,16 @@ class TestAxOrchestrator(TestCase):
             any(
                 re.search(
                     r"Because (branin|m1) is an objective, marking trial 0 as "
-                    "TrialStatus.FAILED",
+                    "TrialStatus.ABANDONED",
                     warning,
                 )
                 is not None
                 for warning in lg.output
             )
         )
-        self.assertEqual(orchestrator.experiment.trials[0].status, TrialStatus.FAILED)
+        self.assertEqual(
+            orchestrator.experiment.trials[0].status, TrialStatus.ABANDONED
+        )
 
     def test_should_consider_optimization_complete(self) -> None:
         # Tests non-GSS parts of the completion criterion.


### PR DESCRIPTION
Summary: When a metric used in the OptimizationConfig fails to fetch, mark the trial as ABANDONED rather than FAILED so that it is less likely to be tried again.

Differential Revision: D90884185


