### PR TITLE
Fix broken import path and lint (#4782)

### DIFF
--- a/ax/adapter/torch.py
+++ b/ax/adapter/torch.py
@@ -781,7 +781,8 @@ class TorchAdapter(Adapter):
             self.outcomes = ordered_outcomes
         else:
             assert ordered_outcomes == self.outcomes, (
-                f"Unexpected ordering of outcomes: {ordered_outcomes} != "
+                "Unexpected ordering of outcomes: "
+                f"{ordered_outcomes} != "
                 f"{self.outcomes}"
             )
         return datasets, candidate_metadata, search_space_digest

--- a/ax/analysis/healthcheck/complexity_rating.py
+++ b/ax/analysis/healthcheck/complexity_rating.py
@@ -17,7 +17,7 @@ from ax.analysis.healthcheck.healthcheck_analysis import (
 )
 from ax.core.experiment import Experiment
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from ax.orchestration.orchestrator import OrchestratorOptions
+from ax.orchestration.orchestrator_options import OrchestratorOptions
 from ax.utils.common.complexity_utils import (
     check_if_in_standard,
     DEFAULT_TIER_MESSAGES,

--- a/ax/analysis/healthcheck/tests/test_complexity_rating.py
+++ b/ax/analysis/healthcheck/tests/test_complexity_rating.py
@@ -20,7 +20,7 @@ from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import SearchSpace
 from ax.core.types import ComparisonOp
-from ax.orchestration.orchestrator import OrchestratorOptions
+from ax.orchestration.orchestrator_options import OrchestratorOptions
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_experiment
 

--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -44,7 +44,8 @@ from ax.early_stopping.strategies import (
 )
 from ax.exceptions.core import ObjectNotFoundError, UnsupportedError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from ax.orchestration.orchestrator import Orchestrator, OrchestratorOptions
+from ax.orchestration.orchestrator import Orchestrator
+from ax.orchestration.orchestrator_options import OrchestratorOptions
 from ax.service.utils.best_point_mixin import BestPointMixin
 from ax.storage.json_store.decoder import (
     generation_strategy_from_json,

--- a/ax/early_stopping/experiment_replay.py
+++ b/ax/early_stopping/experiment_replay.py
@@ -26,7 +26,7 @@ from ax.generation_strategy.generation_strategy import (
     GenerationStrategy,
 )
 from ax.metrics.map_replay import MapDataReplayMetric
-from ax.orchestration.orchestrator import Orchestrator, OrchestratorOptions
+from ax.orchestration.orchestrator_options import OrchestratorOptions
 from ax.runners.map_replay import MapDataReplayRunner
 from ax.utils.common.logger import get_logger
 
@@ -92,6 +92,9 @@ def replay_experiment(
     )
 
     # Setup a Orchestrator with a dummy gs to replay the historical experiment
+    # Lazy import to avoid sqlalchemy dependency at module load time
+    from ax.orchestration.orchestrator import Orchestrator
+
     dummy_sobol_gs = GenerationStrategy(
         name="sobol",
         steps=[

--- a/ax/utils/common/complexity_utils.py
+++ b/ax/utils/common/complexity_utils.py
@@ -13,7 +13,7 @@ from ax.adapter.adapter_utils import can_map_to_binary, is_unordered_choice
 from ax.core.experiment import Experiment
 from ax.core.objective import MultiObjective
 from ax.exceptions.core import OptimizationNotConfiguredError, UserInputError
-from ax.orchestration.orchestrator import OrchestratorOptions
+from ax.orchestration.orchestrator_options import OrchestratorOptions
 
 STANDARD_TIER_MESSAGE = """This experiment is in tier 'Standard'.
 

--- a/ax/utils/common/tests/test_complexity_utils.py
+++ b/ax/utils/common/tests/test_complexity_utils.py
@@ -8,7 +8,7 @@
 
 from ax.core.metric import Metric
 from ax.exceptions.core import OptimizationNotConfiguredError, UserInputError
-from ax.orchestration.orchestrator import OrchestratorOptions
+from ax.orchestration.orchestrator_options import OrchestratorOptions
 from ax.utils.common.complexity_utils import (
     check_if_in_standard,
     DEFAULT_TIER_MESSAGES,


### PR DESCRIPTION
Summary:


Import `OrchestratorOptions` from `ax.orchestration.orchestrator_options` instead of `ax.orchestration.orchestrator`

Reviewed By: mpolson64

Differential Revision: D90551128


