### PR TITLE
Remove serializationmixin from transition criterion

### DIFF
--- a/ax/generation_strategy/transition_criterion.py
+++ b/ax/generation_strategy/transition_criterion.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from ax.generation_strategy.generation_node import GenerationNode
 
 from ax.utils.common.base import SortableBase
-from ax.utils.common.serialization import SerializationMixin, serialize_init_args
+from ax.utils.common.serialization import serialize_init_args
 from pyre_extensions import none_throws
 
 
@@ -32,7 +32,7 @@ DATA_REQUIRED_MSG = (
 )
 
 
-class TransitionCriterion(SortableBase, SerializationMixin):
+class TransitionCriterion(SortableBase):
     """
     Simple class to describe a condition which must be met for this GenerationNode to
     take an action such as generation, transition, etc.

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -440,7 +440,7 @@ def generation_strategy_to_dict(
 
 def transition_criterion_to_dict(criterion: TransitionCriterion) -> dict[str, Any]:
     """Convert Ax TransitionCriterion to a dictionary."""
-    properties = criterion.serialize_init_args(obj=criterion)
+    properties = serialize_init_args(obj=criterion)
     properties["__type"] = criterion.__class__.__name__
     return properties
 

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -87,9 +87,10 @@ from ax.generation_strategy.generation_strategy import (
 )
 from ax.generation_strategy.generator_spec import GeneratorSpec
 from ax.generation_strategy.transition_criterion import (
+    AutoTransitionAfterGen,
     MaxGenerationParallelism,
     MinTrials,
-    TrialBasedCriterion,
+    TransitionCriterion,
 )
 from ax.generators.torch.botorch_modular.acquisition import Acquisition
 from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
@@ -177,7 +178,7 @@ def get_experiment_with_map_data_type() -> Experiment:
     return experiment
 
 
-def get_trial_based_criterion() -> list[TrialBasedCriterion]:
+def get_trial_based_criterion() -> list[TransitionCriterion]:
     return [
         MinTrials(
             threshold=3,
@@ -190,6 +191,9 @@ def get_trial_based_criterion() -> list[TrialBasedCriterion]:
             not_in_statuses=[
                 TrialStatus.RUNNING,
             ],
+        ),
+        AutoTransitionAfterGen(
+            transition_to="next_node",
         ),
     ]
 


### PR DESCRIPTION
Summary: To align with our standards of only using serializationmixin inheritance in ax objects that are comprised of basic properties (ie not composed of other ax objects), this diff removes the serialization mixin inheritance from TransitionCriteria and better leverages custom encoders/decoders instead.

Differential Revision: D90802656
