### PR TITLE
Make sure deploy workflow always triggers on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,8 @@ name: Deploy
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   tests-and-coverage-latest:


### PR DESCRIPTION
Changes trigger conditions to make sure the workflow triggers when a draft release is published. Also allows it to be triggered manually.

Test plan:
Copied over from BoTorch. This was tested there.