### PR TITLE
Make SQLAlchemy a required core dependency (#4789)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -66,7 +66,7 @@ jobs:
         uv pip install git+https://github.com/cornellius-gp/linear_operator.git
         uv pip install git+https://github.com/cornellius-gp/gpytorch.git
         uv pip install git+https://github.com/pytorch/botorch.git
-        uv pip install -e ".[dev,mysql,notebook]"
+        uv pip install -e ".[dev,notebook]"
         uv pip install --upgrade build setuptools setuptools_scm wheel
     - name: Extract reduced version and save to env var
       # strip the commit hash from the version to enable upload to pypi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install dependencies
       run: |
         # use stable Botorch
-        uv pip install -e ".[dev,mysql,notebook]"
+        uv pip install -e ".[dev,notebook]"
         uv pip install --upgrade build setuptools setuptools_scm wheel
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow

--- a/README.md
+++ b/README.md
@@ -113,9 +113,8 @@ install Ax with the `notebook` extra:
 pip install "ax-platform[notebook]"
 ```
 
-Extras for using Ax with MySQL storage (`mysql`), for running Ax's tutorial's
-locally (`tutorials`), and for installing all dependencies necessary for
-developing Ax (`dev`) are also available.
+Extras for running Ax's tutorial's locally (`tutorials`) and for installing all
+dependencies necessary for developing Ax (`dev`) are also available.
 
 ## Install Ax from source
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -33,9 +33,8 @@ install Ax with the `notebook` extra:
 pip install "ax-platform[notebook]"
 ```
 
-Extras for using Ax with MySQL storage (`mysql`), for running Ax's tutorial's
-locally (`tutorials`), and for installing all dependencies necessary for
-developing Ax (`dev`) are also available.
+Extras for running Ax's tutorial's locally (`tutorials`) and for installing all
+dependencies necessary for developing Ax (`dev`) are also available.
 
 ## Install Ax from source
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "sympy",
     "markdown",
     "graphviz",
+    "SQLAlchemy==1.4.17",
 ]
 
 [project.optional-dependencies]
@@ -46,10 +47,6 @@ dev = [
     "sphinx_rtd_theme",
     "lxml",
     "mdformat-myst",
-]
-
-mysql = [
-    "SQLAlchemy==1.4.17",
 ]
 
 notebook = [
@@ -67,7 +64,7 @@ unittest_minimal = [
 ]
 
 unittest = [
-    "ax-platform[dev,mysql,notebook,unittest_minimal]",
+    "ax-platform[dev,notebook,unittest_minimal]",
 ]
 
 tutorial = [


### PR DESCRIPTION
Summary:

- Moves SQLAlchemy from optional `mysql` extra to core dependencies, as SQL storage is now integral to Ax functionality
- Removes the `mysql` optional extra
- Updates workflow files and documentation to reflect this change

Reviewed By: mgrange1998

Differential Revision: D91094313


