### PR TITLE
Fix read-only numpy arrays in cross-validation

### DIFF
--- a/ax/adapter/cross_validation.py
+++ b/ax/adapter/cross_validation.py
@@ -240,12 +240,13 @@ def _efficient_loo_cross_validate(
         # This is a known limitation for fully Bayesian models and models with
         # non-Gaussian posteriors (such as PFNs).
         # Shape: n x 1 x m
-        loo_means = posterior.mixture_mean.detach().cpu().numpy()
-        loo_vars = posterior.mixture_variance.detach().cpu().numpy()
+        # Use .copy() to ensure arrays are writeable (numpy returns read-only views)
+        loo_means = posterior.mixture_mean.detach().cpu().numpy().copy()
+        loo_vars = posterior.mixture_variance.detach().cpu().numpy().copy()
     else:
         # Shape: n x 1 x m
-        loo_means = posterior.mean.detach().cpu().numpy()
-        loo_vars = posterior.variance.detach().cpu().numpy()
+        loo_means = posterior.mean.detach().cpu().numpy().copy()
+        loo_vars = posterior.variance.detach().cpu().numpy().copy()
 
     # Squeeze out the q dimension: n x 1 x m -> n x m
     loo_means = loo_means.squeeze(1)


### PR DESCRIPTION
Summary:
Prompted after some failures in exports not related to my changes: https://github.com/facebook/Ax/actions/runs/21225324302/job/61070638075?fbclid=IwY2xjawPeXMFleHRuA2FlbQIxMQBicmlkETFRTkR6WlE4NHVrd3IyQXNlc3J0YwZhcHBfaWQBMAABHjTAiZi71n24w95hvzEewrKNPKOGzJisgR7t4qJ3APRMYlusgFC-gu7RLiSb_aem_Zk3pmTDonCFsJvZCTkpeMA


Add `.copy()` after `.numpy()` calls to ensure arrays are writeable.
PyTorch tensors converted via `.detach().cpu().numpy()` return read-only
arrays in some cases. The subsequent squeeze operations create read-only
views, and the in-place assignment `loo_covs[:, diag_idx, diag_idx] = loo_vars`
fails with "assignment destination is read-only" error.

Differential Revision: D91185467


