### PR TITLE
Fix np.int64 vs int type mismatch in Data.trial_indices

### DIFF
--- a/ax/adapter/transforms/winsorize.py
+++ b/ax/adapter/transforms/winsorize.py
@@ -140,6 +140,8 @@ class Winsorize(Transform):
     ) -> list[ObservationData]:
         """Winsorize observation data in place."""
         for obsd in observation_data:
+            # Ensure means is writeable
+            obsd.means = obsd.means.copy()
             for idx, metric_signature in enumerate(obsd.metric_signatures):
                 if metric_signature not in self.cutoffs:
                     continue

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -88,15 +88,14 @@ class Data(Base, SerializationMixin):
     }
 
     # Note on text data: https://pandas.pydata.org/docs/user_guide/text.html
-    # Its type can either be `numpy.dtypes.ObjectDType` or StringDtype extension
-    # type; the later is still experimental. So we are using object.
+    # Using StringDtype for string columns, which is the default in pandas 3.0+.
     COLUMN_DATA_TYPES: dict[str, Any] = {
         # Ubiquitous columns.
         "trial_index": int,
-        "arm_name": np.dtype("O"),
+        "arm_name": pd.StringDtype(),
         # Metric data-related columns.
-        "metric_name": np.dtype("O"),
-        "metric_signature": np.dtype("O"),
+        "metric_name": pd.StringDtype(),
+        "metric_signature": pd.StringDtype(),
         "mean": np.float64,
         "sem": np.float64,
         "start_time": pd.Timestamp,
@@ -393,9 +392,9 @@ class Data(Base, SerializationMixin):
         """Return the set of trial indices in the data."""
         if self._memo_df is not None:
             # Use a smaller df if available
-            return set(self.df["trial_index"].unique())
+            return {int(idx) for idx in self.df["trial_index"].unique()}
         # If no small df is available, use the full df
-        return set(self.full_df["trial_index"].unique())
+        return {int(idx) for idx in self.full_df["trial_index"].unique()}
 
     def latest(self, rows_per_group: int = 1) -> Data:
         """Return a new Data with the most recently observed `rows_per_group`

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1409,12 +1409,13 @@ class Experiment(Base):
             has_data = not dat.df.empty
             if has_data:
                 new_df = dat.full_df.copy()
-                new_df["trial_index"].replace(
-                    {trial.index: new_trial.index}, inplace=True
+            if has_data:
+                new_df = dat.full_df.copy()
+                new_df["trial_index"] = new_df["trial_index"].replace(
+                    {trial.index: new_trial.index}
                 )
-                new_df["arm_name"].replace(
-                    {none_throws(trial.arm).name: none_throws(new_trial.arm).name},
-                    inplace=True,
+                new_df["arm_name"] = new_df["arm_name"].replace(
+                    {none_throws(trial.arm).name: none_throws(new_trial.arm).name}
                 )
                 # Attach updated data to new trial on experiment.
                 self.attach_data(data=Data(df=new_df))

--- a/ax/core/observation_utils.py
+++ b/ax/core/observation_utils.py
@@ -122,7 +122,7 @@ def _observations_from_dataframe(
                 features=ObservationFeatures(**obs_kwargs),
                 data=ObservationData(
                     metric_signatures=d["metric_signature"].tolist(),
-                    means=d["mean"].values,
+                    means=d["mean"].values.copy(),
                     covariance=np.diag(d["sem"].values ** 2),
                 ),
                 arm_name=arm_name,

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -798,7 +798,7 @@ def get_hypervolume_trace_of_outcomes_multi_objective(
 
     objective_thresholds = torch.tensor(objective_thresholds, dtype=torch.double)
 
-    metrics_tensor = torch.from_numpy(df_wide[objective.metric_names].to_numpy())
+    metrics_tensor = torch.from_numpy(df_wide[objective.metric_names].to_numpy().copy())
     return _compute_hv_trace(
         ref_point=objective_thresholds,
         metrics_tensor=metrics_tensor,

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1058,7 +1058,7 @@ class Decoder:
                 name=analysis_card_sqa.name,
                 title=title,
                 subtitle=subtitle,
-                df=read_json(analysis_card_sqa.dataframe_json),
+                df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
             )
@@ -1067,7 +1067,7 @@ class Decoder:
                 name=analysis_card_sqa.name,
                 title=title,
                 subtitle=subtitle,
-                df=read_json(analysis_card_sqa.dataframe_json),
+                df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
             )
@@ -1076,7 +1076,7 @@ class Decoder:
                 name=analysis_card_sqa.name,
                 title=title,
                 subtitle=subtitle,
-                df=read_json(analysis_card_sqa.dataframe_json),
+                df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
             )
@@ -1085,7 +1085,7 @@ class Decoder:
                 name=analysis_card_sqa.name,
                 title=title,
                 subtitle=subtitle,
-                df=read_json(analysis_card_sqa.dataframe_json),
+                df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
             )
@@ -1093,7 +1093,7 @@ class Decoder:
             name=analysis_card_sqa.name,
             title=title,
             subtitle=subtitle,
-            df=read_json(analysis_card_sqa.dataframe_json),
+            df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
             blob=blob,
             timestamp=analysis_card_sqa.timestamp,
         )


### PR DESCRIPTION
Summary:
Prompted after some failures in exports not related to my changes: https://github.com/facebook/Ax/actions/runs/21225324302/job/61070638075?fbclid=IwY2xjawPeXMFleHRuA2FlbQIxMQBicmlkETFRTkR6WlE4NHVrd3IyQXNlc3J0YwZhcHBfaWQBMAABHjTAiZi71n24w95hvzEewrKNPKOGzJisgR7t4qJ3APRMYlusgFC-gu7RLiSb_aem_Zk3pmTDonCFsJvZCTkpeMA

The `trial_indices` property returns `set[np.int64]` from `.unique()` on
numpy-backed dataframes, but `experiment.trials.keys()` returns Python `int`.
Set operations fail because `np.int64` and `int` are treated as different
types in set comparisons.

Convert numpy types to Python int using set comprehension.

Differential Revision: D91185468


