### PR TITLE
Remove deprecated copy=False from pandas operations

### DIFF
--- a/ax/adapter/transforms/cast.py
+++ b/ax/adapter/transforms/cast.py
@@ -311,7 +311,7 @@ class Cast(Transform):
             p: type_map[param.parameter_type]
             for p, param in self.search_space.parameters.items()
         }
-        arm_data = arm_data.astype(dtype=column_to_type, copy=False)
+        arm_data = arm_data.astype(dtype=column_to_type)
         # Round to digits if any parameter specifies it.
         for p_name in parameter_names:
             parameter = self.search_space.parameters[p_name]

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -171,7 +171,7 @@ class Data(Base, SerializationMixin):
             c for c in current_order if c not in overall_order
         ]
         if current_order != desired_order:
-            return df.reindex(columns=desired_order, copy=False)
+            return df.reindex(columns=desired_order)
         return df
 
     @classmethod


### PR DESCRIPTION
Summary:
The `copy=False` parameter in `DataFrame.astype()` and `DataFrame.reindex()` was deprecated in pandas 2.0 and removed in pandas 3.0. These calls now raise warnings or errors.

Remove the deprecated `copy=False` argument from:
- `arm_data.astype(dtype=column_to_type, copy=False)` in `cast.py`
- `df.reindex(columns=desired_order, copy=False)` in `data.py`

This is part of the ongoing pandas 2.0+ compatibility fixes.

Differential Revision: D91186870


