### PR TITLE
Fix ChainedAssignmentError in warm_start_from_old_experiment

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1409,12 +1409,11 @@ class Experiment(Base):
             has_data = not dat.df.empty
             if has_data:
                 new_df = dat.full_df.copy()
-                new_df["trial_index"].replace(
-                    {trial.index: new_trial.index}, inplace=True
+                new_df["trial_index"] = new_df["trial_index"].replace(
+                    {trial.index: new_trial.index}
                 )
-                new_df["arm_name"].replace(
-                    {none_throws(trial.arm).name: none_throws(new_trial.arm).name},
-                    inplace=True,
+                new_df["arm_name"] = new_df["arm_name"].replace(
+                    {none_throws(trial.arm).name: none_throws(new_trial.arm).name}
                 )
                 # Attach updated data to new trial on experiment.
                 self.attach_data(data=Data(df=new_df))


### PR DESCRIPTION
Summary:
Pandas 3.0 introduced Copy-on-Write (CoW) which makes chained assignment with `inplace=True` ineffective. The pattern `df["col"].replace(..., inplace=True)` no longer modifies the original DataFrame because the column selection creates a copy.

Replace the chained `inplace=True` pattern with explicit assignment:
- `df["col"].replace(..., inplace=True)` → `df["col"] = df["col"].replace(...)`

This eliminates the `ChainedAssignmentError` warning and ensures the DataFrame is actually modified as intended.

Differential Revision: D91187974


