### PR TITLE
Increase restritiveness of data requirements for TrialBasedCriteria

### DIFF
--- a/ax/core/utils.py
+++ b/ax/core/utils.py
@@ -528,7 +528,7 @@ def get_target_trial_index(
         return None
 
     # trial indices that have data for required metrics
-    trial_indices_with_required_metrics = _get_trial_indices_with_required_metrics(
+    trial_indices_with_required_metrics = get_trial_indices_with_required_metrics(
         experiment=experiment,
         df=df,
         require_data_for_all_metrics=require_data_for_all_metrics,
@@ -593,7 +593,7 @@ def get_target_trial_index(
     return None
 
 
-def _get_trial_indices_with_required_metrics(
+def get_trial_indices_with_required_metrics(
     experiment: Experiment,
     df: "pd.DataFrame",
     require_data_for_all_metrics: bool,


### PR DESCRIPTION
Summary:
Instead of merely checking for presence of any data, we could unify this transition with the helper method we use in target trial logic. This will allow us to check that all metrics in the opt config  have data before transitioning, which also ensures target trial selection is correct once we are in mbm etc. 

We could add additional checks about amount of data, but i think this is a good start. Happy to hear other thougths

Differential Revision: D91064377


