### PR TITLE
Add SQLAlchemy>=1.4.17 to Ax GitHub pyproject dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "sympy",
     "markdown",
     "graphviz",
+    "SQLAlchemy>=1.4.17",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Summary:
Adds SQLAlchemy (>=1.4.17) to the project's dependencies in fbcode/ax/github/pyproject.toml to resolve failing import signals

Session: DEV44263986

Differential Revision: D91230914


