### PR TITLE
Remove callable serialization and pydoc.locate in Ax

### DIFF
--- a/ax/utils/common/serialization.py
+++ b/ax/utils/common/serialization.py
@@ -9,9 +9,7 @@
 from __future__ import annotations
 
 import inspect
-import pydoc
 from collections.abc import Callable
-from types import FunctionType
 from typing import Any, TypeVar, Union
 
 
@@ -48,26 +46,6 @@ def _is_named_tuple(x: Any) -> bool:
     if not isinstance(f, tuple):
         return False  # pragma nocover
     return all(isinstance(n, str) for n in f)
-
-
-def callable_to_reference(callable: Callable) -> str:
-    """Obtains path to the callable of form <module>.<name>."""
-    if not isinstance(callable, (FunctionType, type)):
-        raise TypeError(f"Expected to encode function or class, got: {callable}.")
-    name = f"{callable.__module__}.{callable.__qualname__}"
-    try:
-        assert pydoc.locate(name) is callable
-        return name
-    except Exception as err:
-        raise TypeError(
-            f"Callable {callable.__qualname__} is not properly exposed in "
-            f"{callable.__module__} (exception: {err})."
-        )
-
-
-def callable_from_reference(path: str) -> Callable:
-    """Retrieves a callable by its path."""
-    return pydoc.locate(path)  # pyre-ignore[7]
 
 
 def serialize_init_args(


### PR DESCRIPTION
Summary:
Remove callable serialization and deserialization across Ax. Both occurances of "pydoc.locate" are now removed. 

**_encode_callables_as_references => _filter_callables**
Encode callables are filtered with a warning

**_decode_callables_as_reference => _filter_legacy_callable_refs**

Legacy callable refs are ignored to maintain backwards compatibility, but decoding is allowed to continue.

Differential Revision: D91149300


