### PR TITLE
Pin pandas dependency to <3.0.0 in Ax GitHub pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 dependencies = [
     "botorch[pymoo]>=0.16.1,<0.16.2dev9999",
     "jinja2",  # also a Plotly dep
-    "pandas",
+    "pandas<3.0.0",
     "scipy",
     "scikit-learn<1.8.0",
     "ipywidgets",


### PR DESCRIPTION
Summary:
Pins pandas to < 3.0.0 in fbcode/ax/github/pyproject.toml to prevent breaking from release pandas 3.x.

This ensures compatibility with the current Ax/BoTorch ecosystem until pandas 3 support is added.

Session: DEV45028385

Differential Revision: D91332544


