### PR TITLE
T248151125 Fix Ax OSS compatibility with scikit-learn version 1.8.0

### DIFF
--- a/ax/benchmark/problems/surrogate/hss/base.py
+++ b/ax/benchmark/problems/surrogate/hss/base.py
@@ -17,6 +17,25 @@ from torch import Tensor
 from xgboost import XGBRegressor
 
 
+def load_xgb_regressor(path: str) -> XGBRegressor:
+    """Load an XGBRegressor model from a file.
+
+    This function sets `_estimator_type` before calling `load_model()` to
+    ensure compatibility with scikit-learn >= 1.8.0, which changed how
+    `_estimator_type` is inherited from `RegressorMixin`.
+
+    Args:
+        path: Path to the saved XGBoost model file.
+
+    Returns:
+        The loaded XGBRegressor model.
+    """
+    model = XGBRegressor()
+    model._estimator_type = "regressor"
+    model.load_model(path)
+    return model
+
+
 @dataclass(kw_only=True)
 class HierarchicalSearchSpaceSurrogate(BenchmarkTestFunction):
     lst_active_param_names: list[list[str]]

--- a/ax/benchmark/problems/surrogate/hss/cifar10_surrogate.py
+++ b/ax/benchmark/problems/surrogate/hss/cifar10_surrogate.py
@@ -9,7 +9,10 @@ import os
 
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 from ax.benchmark.benchmark_problem import BenchmarkProblem
-from ax.benchmark.problems.surrogate.hss.base import HierarchicalSearchSpaceSurrogate
+from ax.benchmark.problems.surrogate.hss.base import (
+    HierarchicalSearchSpaceSurrogate,
+    load_xgb_regressor,
+)
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import (
@@ -135,16 +138,16 @@ def get_cifar10_surrogate_arguments() -> tuple[
         {"use_softplus_activation": True, "use_weight_decay": True},
     ]
 
-    lst_xgb_models: list[XGBRegressor] = [XGBRegressor() for i in range(4)]
-
-    for i, xgb_model in enumerate(lst_xgb_models):
-        xgb_model.load_model(
+    lst_xgb_models: list[XGBRegressor] = [
+        load_xgb_regressor(
             os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "checkpoints",
                 f"cifar10_xgb_model_{i:d}.json",
             )
         )
+        for i in range(4)
+    ]
 
     return lst_active_param_names, flag_param_names, lst_flag_config, lst_xgb_models
 

--- a/ax/benchmark/problems/surrogate/hss/fashion_mnist_surrogate.py
+++ b/ax/benchmark/problems/surrogate/hss/fashion_mnist_surrogate.py
@@ -9,7 +9,10 @@ import os
 
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 from ax.benchmark.benchmark_problem import BenchmarkProblem
-from ax.benchmark.problems.surrogate.hss.base import HierarchicalSearchSpaceSurrogate
+from ax.benchmark.problems.surrogate.hss.base import (
+    HierarchicalSearchSpaceSurrogate,
+    load_xgb_regressor,
+)
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import (
@@ -135,16 +138,16 @@ def get_fashion_mnist_surrogate_arguments() -> tuple[
         {"use_softplus_activation": True, "use_weight_decay": True},
     ]
 
-    lst_xgb_models: list[XGBRegressor] = [XGBRegressor() for i in range(4)]
-
-    for i, xgb_model in enumerate(lst_xgb_models):
-        xgb_model.load_model(
+    lst_xgb_models: list[XGBRegressor] = [
+        load_xgb_regressor(
             os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "checkpoints",
                 f"fashion_mnist_xgb_model_{i:d}.json",
             )
         )
+        for i in range(4)
+    ]
 
     return lst_active_param_names, flag_param_names, lst_flag_config, lst_xgb_models
 

--- a/ax/benchmark/problems/surrogate/hss/mnist_surrogate.py
+++ b/ax/benchmark/problems/surrogate/hss/mnist_surrogate.py
@@ -9,7 +9,10 @@ import os
 
 from ax.benchmark.benchmark_metric import BenchmarkMetric
 from ax.benchmark.benchmark_problem import BenchmarkProblem
-from ax.benchmark.problems.surrogate.hss.base import HierarchicalSearchSpaceSurrogate
+from ax.benchmark.problems.surrogate.hss.base import (
+    HierarchicalSearchSpaceSurrogate,
+    load_xgb_regressor,
+)
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import (
@@ -106,16 +109,16 @@ def get_mnist_surrogate_arguments() -> tuple[
         {"use_dropout": True, "use_weight_decay": True},
     ]
 
-    lst_xgb_models: list[XGBRegressor] = [XGBRegressor() for i in range(4)]
-
-    for i, xgb_model in enumerate(lst_xgb_models):
-        xgb_model.load_model(
+    lst_xgb_models: list[XGBRegressor] = [
+        load_xgb_regressor(
             os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
                 "checkpoints",
                 f"mnist_xgb_model_{i:d}.json",
             )
         )
+        for i in range(4)
+    ]
 
     return lst_active_param_names, flag_param_names, lst_flag_config, lst_xgb_models
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "jinja2",  # also a Plotly dep
     "pandas<3.0.0",
     "scipy",
-    "scikit-learn<1.8.0",
+    "scikit-learn",
     "ipywidgets",
     # Needed for compatibility with ipywidgets >= 8.0.0
     "plotly>=5.12.0",


### PR DESCRIPTION
Summary:
# Problem

  scikit-learn 1.8.0 changed how _estimator_type is inherited from RegressorMixin. When XGBRegressor().load_model() is called, xgboost's _get_type() method checks for the _estimator_type attribute before model attributes are loaded from the file, causing a TypeError.

# Solution

  Added a load_xgb_regressor() utility function that sets _estimator_type = "regressor" on the XGBRegressor instance before calling load_model().

# Changes

- Unpins scikit-learn version 1.8.0 from Ax
- Creates "load_xgb_regressor" which resolves the xgb_model.load_model regression error
- Updates the benchmarks which use load_xgb_regressor

Differential Revision: D91347654
