### PR TITLE
Replace deprecated torchx Runner.stop() with cancel()

### DIFF
--- a/ax/runners/torchx.py
+++ b/ax/runners/torchx.py
@@ -182,7 +182,7 @@ try:
         def stop(self, trial: BaseTrial, reason: str | None = None) -> dict[str, Any]:
             """Kill the given trial."""
             app_handle: str = trial.run_metadata[TORCHX_APP_HANDLE]
-            self._torchx_runner.stop(app_handle)
+            self._torchx_runner.cancel(app_handle)
             return {"reason": reason} if reason else {}
 
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ notebook = [
 unittest_minimal = [
     # For tensorboard unit tests (min req: numpy 2.0 compatibility).
     "tensorboard>=2.18.0",
-    "torchx",  # For torchx unit tests.
+    "torchx>=0.2.0",  # For torchx unit tests
     # Required for building RayTune tutorial notebook and
     # deserializing data for benchmark suites.
     "pyarrow",


### PR DESCRIPTION
Summary:
The torchx `Runner.stop()` method is deprecated in favor of `cancel()`, which provides identical functionality but is consistent with the CLI and scheduler API naming conventions.

This change updates TorchXRunner to use the non-deprecated method, eliminating PendingDeprecationWarning messages during test runs.

Reviewed By: saitcakmak

Differential Revision: D91190296


