### PR TITLE
Address PytestCollection Warning (#4815)

### DIFF
--- a/ax/analysis/healthcheck/no_effects_analysis.py
+++ b/ax/analysis/healthcheck/no_effects_analysis.py
@@ -31,6 +31,8 @@ class TestOfNoEffectAnalysis(Analysis):
     groups are identical assuming unequal variances across groups.
     """
 
+    __test__ = False  # Not a pytest test class (statistical "Test of No Effect")
+
     def __init__(self, no_effect_alpha: float = 0.05) -> None:
         r"""
         Args:

--- a/ax/analysis/healthcheck/tests/test_metric_fetching_errors.py
+++ b/ax/analysis/healthcheck/tests/test_metric_fetching_errors.py
@@ -35,7 +35,7 @@ TEST_DATA = Data(
 )
 
 
-class TestMetricWithException(Metric):
+class MockMetricWithException(Metric):
     @classmethod
     def is_available_while_running(cls) -> bool:
         return True
@@ -60,7 +60,7 @@ class TestMetricWithException(Metric):
         }
 
 
-class TestMetricNoException(Metric):
+class MockMetricNoException(Metric):
     @classmethod
     def is_available_while_running(cls) -> bool:
         return True
@@ -78,7 +78,7 @@ class TestMetricNoException(Metric):
         }
 
 
-class TestMetricSuccess(Metric):
+class MockMetricSuccess(Metric):
     @classmethod
     def is_available_while_running(cls) -> bool:
         return True
@@ -114,7 +114,7 @@ class TestMetricFetchingErrors(TestCase):
         exp = get_branin_experiment(with_batch=True)
         # it won't fetch an already completed trial
         exp.trials[0].mark_running(no_runner_required=True, unsafe=True)
-        exp.add_tracking_metric(TestMetricWithException(name="test_metric"))
+        exp.add_tracking_metric(MockMetricWithException(name="test_metric"))
         # AND GIVEN that experiment has tried to fetch data through the orchestrator
         orchestrator = Orchestrator(
             experiment=exp,
@@ -173,7 +173,7 @@ class TestMetricFetchingErrors(TestCase):
         exp = get_branin_experiment(with_batch=True)
         # it won't fetch an already completed trial
         exp.trials[0].mark_running(no_runner_required=True, unsafe=True)
-        exp.add_tracking_metric(TestMetricNoException(name="test_metric"))
+        exp.add_tracking_metric(MockMetricNoException(name="test_metric"))
         # AND GIVEN that experiment has tried to fetch data through the orchestrator
         orchestrator = Orchestrator(
             experiment=exp,
@@ -226,8 +226,8 @@ class TestMetricFetchingErrors(TestCase):
         exp = get_branin_experiment(with_batch=True)
         # it won't fetch an already completed trial
         exp.trials[0].mark_running(no_runner_required=True, unsafe=True)
-        exp.add_tracking_metric(TestMetricWithException(name="test_metric1"))
-        exp.add_tracking_metric(TestMetricWithException(name="test_metric2"))
+        exp.add_tracking_metric(MockMetricWithException(name="test_metric1"))
+        exp.add_tracking_metric(MockMetricWithException(name="test_metric2"))
         # AND GIVEN that experiment has tried to fetch data through the orchestrator
         orchestrator = Orchestrator(
             experiment=exp,
@@ -251,7 +251,7 @@ class TestMetricFetchingErrors(TestCase):
         # This tests that an error in exp._metric_fetching_errors is updated
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].mark_running(no_runner_required=True, unsafe=True)
-        exp.add_tracking_metric(TestMetricWithException(name="test_metric"))
+        exp.add_tracking_metric(MockMetricWithException(name="test_metric"))
 
         orchestrator = Orchestrator(
             experiment=exp,
@@ -275,7 +275,7 @@ class TestMetricFetchingErrors(TestCase):
         # on a successful fetch
         exp = get_branin_experiment(with_batch=True)
         exp.trials[0].mark_running(no_runner_required=True, unsafe=True)
-        exp.add_tracking_metric(TestMetricWithException(name="test_metric"))
+        exp.add_tracking_metric(MockMetricWithException(name="test_metric"))
 
         orchestrator = Orchestrator(
             experiment=exp,
@@ -289,7 +289,7 @@ class TestMetricFetchingErrors(TestCase):
 
         exp.trials[0].mark_running(no_runner_required=True, unsafe=True)
         exp.remove_tracking_metric("test_metric")
-        exp.add_tracking_metric(TestMetricSuccess(name="test_metric"))
+        exp.add_tracking_metric(MockMetricSuccess(name="test_metric"))
         orchestrator.poll_and_process_results()
 
         self.assertEqual(len(exp._metric_fetching_errors), 0)

--- a/ax/orchestration/tests/orchestrator_test_utils.py
+++ b/ax/orchestration/tests/orchestrator_test_utils.py
@@ -51,8 +51,8 @@ class SyntheticRunnerWithPredictableStatusPolling(SyntheticRunner):
         return {TrialStatus.COMPLETED: completed}
 
 
-class TestOrchestrator(Orchestrator):
-    """Test Orchestrator that only implements ``report_results`` for convenience in
+class MockOrchestrator(Orchestrator):
+    """Mock Orchestrator that only implements ``report_results`` for convenience in
     testing.
     """
 

--- a/ax/orchestration/tests/test_orchestrator.py
+++ b/ax/orchestration/tests/test_orchestrator.py
@@ -67,6 +67,7 @@ from ax.orchestration.tests.orchestrator_test_utils import (
     BrokenRunnerValueError,
     DUMMY_EXCEPTION,
     InfinitePollRunner,
+    MockOrchestrator,
     NoReportResultsRunner,
     RunnerToAllowMultipleMapMetricFetches,
     RunnerWithAllFailedTrials,
@@ -79,7 +80,6 @@ from ax.orchestration.tests.orchestrator_test_utils import (
     SyntheticRunnerWithSingleRunningTrial,
     SyntheticRunnerWithStatusPolling,
     TEST_MEAN,
-    TestOrchestrator,
 )
 from ax.storage.json_store.encoders import runner_to_dict
 from ax.storage.json_store.registry import CORE_DECODER_REGISTRY, CORE_ENCODER_REGISTRY
@@ -1110,7 +1110,7 @@ class TestAxOrchestrator(TestCase):
     def test_run_trials_and_yield_results(self) -> None:
         total_trials = 3
         gs = self.two_sobol_steps_GS
-        orchestrator = TestOrchestrator(
+        orchestrator = MockOrchestrator(
             experiment=self.branin_experiment,  # Has runner and metrics.
             generation_strategy=gs,
             options=OrchestratorOptions(
@@ -1142,7 +1142,7 @@ class TestAxOrchestrator(TestCase):
         total_trials = 3
         self.branin_experiment.runner = InfinitePollRunner()
         gs = self.two_sobol_steps_GS
-        orchestrator = TestOrchestrator(
+        orchestrator = MockOrchestrator(
             experiment=self.branin_experiment,  # Has runner and metrics.
             generation_strategy=gs,
             options=OrchestratorOptions(
@@ -1216,7 +1216,7 @@ class TestAxOrchestrator(TestCase):
 
         self.branin_experiment.runner = RunnerWithIntermittentData()
         gs = self.two_sobol_steps_GS
-        orchestrator = TestOrchestrator(
+        orchestrator = MockOrchestrator(
             experiment=self.branin_experiment,
             generation_strategy=gs,
             options=OrchestratorOptions(
@@ -1285,7 +1285,7 @@ class TestAxOrchestrator(TestCase):
             RunnerWithEarlyStoppingStrategy()
         )
         gs = self.two_sobol_steps_GS
-        orchestrator = TestOrchestrator(
+        orchestrator = MockOrchestrator(
             experiment=self.branin_timestamp_map_metric_experiment,
             generation_strategy=gs,
             options=OrchestratorOptions(
@@ -1472,7 +1472,7 @@ class TestAxOrchestrator(TestCase):
     def test_max_pending_trials(self) -> None:
         # With runners & metrics, `BareBonesTestOrchestrator.run_all_trials` should run.
         gs = self.sobol_MBM_GS
-        orchestrator = TestOrchestrator(
+        orchestrator = MockOrchestrator(
             experiment=self.branin_experiment,  # Has runner and metrics.
             generation_strategy=gs,
             options=OrchestratorOptions(
@@ -2826,7 +2826,7 @@ class TestAxOrchestrator(TestCase):
         self.assertIn("status_quo", data.df["arm_name"].values)
 
         gs = self.two_sobol_steps_GS
-        orchestrator = TestOrchestrator(
+        orchestrator = MockOrchestrator(
             experiment=experiment,
             generation_strategy=gs,
             options=OrchestratorOptions(

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -162,7 +162,9 @@ GET_GS_SQA_IMM_FUNC = _get_generation_strategy_sqa_immutable_opt_config_and_sear
 T = TypeVar("T")
 
 
-class TestExperimentTypeEnum(Enum):
+class MockExperimentTypeEnum(Enum):
+    """Mock enum for testing experiment types (not a pytest test class)."""
+
     TEST = 0
 
 
@@ -517,7 +519,7 @@ class SQAStoreTest(TestCase):
         self.experiment.experiment_type = "TEST"
         save_experiment(
             self.experiment,
-            config=SQAConfig(experiment_type_enum=TestExperimentTypeEnum),
+            config=SQAConfig(experiment_type_enum=MockExperimentTypeEnum),
         )
         self.assertIsNotNone(self.experiment.db_id)
 
@@ -528,7 +530,7 @@ class SQAStoreTest(TestCase):
         with self.assertRaises(SQAEncodeError):
             save_experiment(
                 self.experiment,
-                config=SQAConfig(experiment_type_enum=TestExperimentTypeEnum),
+                config=SQAConfig(experiment_type_enum=MockExperimentTypeEnum),
             )
 
     def test_load_experiment_trials_in_batches(self) -> None:
@@ -3011,7 +3013,7 @@ class SQAStoreTest(TestCase):
 
     def test_query_historical_experiments_given_parameters(self) -> None:
         # This test validates the query behavior for historical experiments.
-        config = SQAConfig(experiment_type_enum=TestExperimentTypeEnum)
+        config = SQAConfig(experiment_type_enum=MockExperimentTypeEnum)
 
         with self.subTest("returns_empty_when_no_matching_experiments"):
             # Query with empty experiment_types list should return empty
@@ -3068,7 +3070,7 @@ class SQAStoreTest(TestCase):
         self,
     ) -> None:
         with self.subTest("returns_empty_when_no_experiments"):
-            config = SQAConfig(experiment_type_enum=TestExperimentTypeEnum)
+            config = SQAConfig(experiment_type_enum=MockExperimentTypeEnum)
 
             # No experiments are saved, so should return empty
             search_space = get_search_space()
@@ -3082,7 +3084,7 @@ class SQAStoreTest(TestCase):
             self.assertEqual(result, {})
 
         with self.subTest("returns_transferable_experiments_with_overlap"):
-            config = SQAConfig(experiment_type_enum=TestExperimentTypeEnum)
+            config = SQAConfig(experiment_type_enum=MockExperimentTypeEnum)
 
             # Create and save a source experiment with data
             # Use get_experiment_with_batch_trial which has search space with w, x, y, z
@@ -3123,7 +3125,7 @@ class SQAStoreTest(TestCase):
             self.assertEqual(len(none_throws(metadata.overlap_parameters)), 2)
 
         with self.subTest("filters_by_overlap_threshold"):
-            config = SQAConfig(experiment_type_enum=TestExperimentTypeEnum)
+            config = SQAConfig(experiment_type_enum=MockExperimentTypeEnum)
 
             # Create and save a source experiment with parameters w, x, y, z
             source_experiment = get_experiment_with_batch_trial()
@@ -3200,7 +3202,7 @@ class SQAStoreTest(TestCase):
             self.assertNotIn("exp_with_partial_overlap", result_below)
 
         with self.subTest("respects_max_num_exps"):
-            config = SQAConfig(experiment_type_enum=TestExperimentTypeEnum)
+            config = SQAConfig(experiment_type_enum=MockExperimentTypeEnum)
 
             # Create multiple experiments with the same type and matching params
             for i in range(3):
@@ -3264,7 +3266,7 @@ class SQAStoreTest(TestCase):
                 )
 
         with self.subTest("returns_candidate_experiments_for_transfer_learning"):
-            config = SQAConfig(experiment_type_enum=TestExperimentTypeEnum)
+            config = SQAConfig(experiment_type_enum=MockExperimentTypeEnum)
 
             # Create and save source experiments with data attached
             # (required by the query which joins on SQAData)


### PR DESCRIPTION
Summary:

Using `test` for non-test objects raises warnings from Pytest, this diff renames test classes to mock classes, and puts a flag on testofnoeffect to allow it to not trigger the warning

Differential Revision: D91506813


