### PR TITLE
Add TorchAdapter.botorch_model property

### DIFF
--- a/ax/benchmark/benchmark_test_functions/surrogate.py
+++ b/ax/benchmark/benchmark_test_functions/surrogate.py
@@ -104,12 +104,7 @@ class SurrogateTestFunction(BenchmarkTestFunction):
     def surrogate(self) -> TorchAdapter:
         if self._surrogate is None:
             self._surrogate = none_throws(self.get_surrogate)()
-        if not isinstance(
-            # pyre-ignore[16]: `ax.generators.torch_base.TorchGenerator` has no
-            # attribute `surrogate`.
-            self._surrogate.generator.surrogate.model,
-            DeterministicModel,
-        ):
+        if not isinstance(self._surrogate.botorch_model, DeterministicModel):
             self.wrap_surrogate_in_deterministic_model()
         return none_throws(self._surrogate)
 

--- a/ax/benchmark/tests/benchmark_test_functions/test_surrogate_test_function.py
+++ b/ax/benchmark/tests/benchmark_test_functions/test_surrogate_test_function.py
@@ -24,6 +24,7 @@ from ax.utils.testing.core_stubs import (
 )
 from botorch.models.deterministic import PosteriorMeanModel
 from botorch.sampling.pathwise.posterior_samplers import MatheronPathModel
+from pyre_extensions import assert_is_instance
 
 
 class TestSurrogateTestFunction(TestCase):
@@ -237,11 +238,11 @@ class TestSurrogateTestFunction(TestCase):
 
         # Access surrogate to trigger wrapping
         surrogate = test_function.surrogate
-        # pyre-ignore[16]: Access base_model through deterministic wrapper
-        wrapped_model = surrogate.generator.surrogate.model
+        # Access base_model through deterministic wrapper
+        wrapped_model = assert_is_instance(surrogate.botorch_model, PosteriorMeanModel)
 
         # Check that exactly one model has weight 1.0 and others have weight 0.0
-        weights = wrapped_model.ensemble_weights
+        weights = assert_is_instance(wrapped_model.ensemble_weights, torch.Tensor)
         self.assertEqual(weights.sum().item(), 1.0)
         self.assertEqual((weights == 1.0).sum().item(), 1)
         self.assertEqual((weights == 0.0).sum().item(), len(weights) - 1)
@@ -262,5 +263,4 @@ class TestSurrogateTestFunction(TestCase):
 
         # Access surrogate to trigger wrapping
         surrogate = test_function.surrogate
-        # pyre-ignore[16]: Access base_model through deterministic wrapper
-        self.assertIsNone(surrogate.generator.surrogate.model.ensemble_weights)
+        self.assertIsNone(surrogate.botorch_model.ensemble_weights)

--- a/ax/utils/sensitivity/tests/test_sensitivity.py
+++ b/ax/utils/sensitivity/tests/test_sensitivity.py
@@ -73,8 +73,8 @@ class SensitivityAnalysisTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         set_rng_seed(0)
-        self.model = get_adapter().generator.surrogate.model
-        self.saas_model = get_adapter(saasbo=True).generator.surrogate.model
+        self.model = get_adapter().botorch_model
+        self.saas_model = get_adapter(saasbo=True).botorch_model
 
     def test_DgsmGpMean(self) -> None:
         bounds = torch.tensor([(0.0, 1.0) for _ in range(2)]).t()
@@ -418,7 +418,7 @@ class SensitivityAnalysisTest(TestCase):
                     **sobol_kwargs,
                 )
                 ind_deriv = compute_derivatives_from_model_list(
-                    model_list=[adapter.generator.surrogate.model],
+                    model_list=[adapter.botorch_model],
                     bounds=torch.tensor(adapter.generator.search_space_digest.bounds).T,
                     discrete_features=discrete_features,
                     fixed_features=None,


### PR DESCRIPTION
Summary: This is a convenience method that should save us from doing calls like `client._generation_strategy.adapter.generator.surrogate.model` and instead simplify it to `client._generation_strategy.adapter.botorch_model`.

Differential Revision: D91588495


