### PR TITLE
address steps bw issue related to nodes check

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -820,7 +820,8 @@ class Decoder:
                 "Cannot decode a generation strategy with a non-zero number of "
                 "generator runs without an experiment."
             )
-        if gs_sqa.nodes is None:  # Backward compat. for pre-nodes strategies.
+        # Backward compat: use steps if nodes is None or empty
+        if not gs_sqa.nodes:
             nodes = object_from_json(
                 gs_sqa.steps,
                 decoder_registry=self.config.json_decoder_registry,


### PR DESCRIPTION
Summary: In we use a check for if there are nodes with if gs.nodes is None, instead we should be checking if it is None *or* the list is empty. By not doing both, the empty list is being used and then we end up getting a gs doesn't have either steps or nodes error

Differential Revision: D91653649


