### PR TITLE
Pandas: Upgrade to 3.0 and fix compatibility issues

### DIFF
--- a/ax/adapter/tests/test_data_utils.py
+++ b/ax/adapter/tests/test_data_utils.py
@@ -11,7 +11,11 @@ from math import nan
 from unittest import mock
 
 import numpy as np
-from ax.adapter.data_utils import DataLoaderConfig, extract_experiment_data
+from ax.adapter.data_utils import (
+    _use_object_dtype_for_strings,
+    DataLoaderConfig,
+    extract_experiment_data,
+)
 from ax.adapter.registry import Generators
 from ax.core.data import Data, MAP_KEY
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
@@ -97,6 +101,7 @@ class TestDataUtils(TestCase):
             )
             self.assertEqual(experiment_data, experiment_data)
 
+    @_use_object_dtype_for_strings
     def test_extract_experiment_data_non_map(self) -> None:
         # This is a 2 objective experiment with 2 trials, 1 arm each.
         observations = [[0.1, 1.0], [0.2, 2.0]]
@@ -248,6 +253,7 @@ class TestDataUtils(TestCase):
             )
         )
 
+    @_use_object_dtype_for_strings
     def test_extract_experiment_data_map(self) -> None:
         exp = get_branin_experiment_with_timestamp_map_metric(with_trials_and_data=True)
         t_0_metric = 55.602112642270264
@@ -261,7 +267,8 @@ class TestDataUtils(TestCase):
         expected_arm_df = DataFrame(
             [{"x1": 0.0, "x2": 0.0}, {"x1": 1.0, "x2": 1.0}],
             index=MultiIndex.from_tuples(
-                [(0, "0_0"), (1, "1_0")], names=["trial_index", "arm_name"]
+                [(0, "0_0"), (1, "1_0")],
+                names=["trial_index", "arm_name"],
             ),
         )
         assert_frame_equal(
@@ -359,6 +366,7 @@ class TestDataUtils(TestCase):
         # Check equality with self.
         self.assertEqual(experiment_data, experiment_data)
 
+    @_use_object_dtype_for_strings
     def test_extract_experiment_data_multiple_map(self) -> None:
         # Checks that multiple map metrics are correctly normalized.
         # Using a custom Data input to simplify testing.
@@ -467,6 +475,7 @@ class TestDataUtils(TestCase):
         for df in [experiment_data.arm_data, experiment_data.observation_data]:
             self.assertEqual(set(df.index.get_level_values("arm_name")), expected_arms)
 
+    @_use_object_dtype_for_strings
     def test_extract_experiment_data_with_metadata_columns(self) -> None:
         # Tests the case where the Data.df includes additional columns,
         # such as start_time and end_time, besides the usual required columns.
@@ -522,7 +531,7 @@ class TestDataUtils(TestCase):
                 names=["trial_index", "arm_name"],
             ),
             columns=MultiIndex.from_tuples(
-                tuples=[
+                [
                     ("mean", "branin_a"),
                     ("mean", "branin_b"),
                     ("sem", "branin_a"),

--- a/ax/adapter/transforms/tests/test_cast_transform.py
+++ b/ax/adapter/transforms/tests/test_cast_transform.py
@@ -11,7 +11,11 @@ from unittest.mock import patch
 
 import numpy as np
 from ax.adapter.base import DataLoaderConfig
-from ax.adapter.data_utils import ExperimentData, extract_experiment_data
+from ax.adapter.data_utils import (
+    _use_object_dtype_for_strings,
+    ExperimentData,
+    extract_experiment_data,
+)
 from ax.adapter.transforms.cast import Cast
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.parameter import (
@@ -449,6 +453,7 @@ class CastTransformTest(TestCase):
         )
         self.assertEqual(set(transformed.arm_data.columns), expected_columns)
 
+    @_use_object_dtype_for_strings
     def test_transform_experiment_data_cast(self) -> None:
         # Test for casting to the correct data type and dropping of Nones.
         experiment = get_experiment_with_observations(
@@ -495,6 +500,7 @@ class CastTransformTest(TestCase):
         ]
         assert_frame_equal(transformed.observation_data, expected_obs_data)
 
+    @_use_object_dtype_for_strings
     def test_transform_experiment_data_cast_map_data(self) -> None:
         # Check that indexing for removal of NaNs works correctly with data that
         # has a "step" column.

--- a/ax/adapter/transforms/tests/test_choice_encode_transform.py
+++ b/ax/adapter/transforms/tests/test_choice_encode_transform.py
@@ -9,7 +9,7 @@
 from copy import deepcopy
 
 from ax.adapter.base import DataLoaderConfig
-from ax.adapter.data_utils import extract_experiment_data
+from ax.adapter.data_utils import _use_object_dtype_for_strings, extract_experiment_data
 from ax.adapter.transforms.choice_encode import (
     ChoiceToNumericChoice,
     OrderedChoiceToIntegerRange,
@@ -258,6 +258,7 @@ class ChoiceToNumericChoiceTransformTest(TestCase):
         self.assertEqual(hss.parameters["x2"].parameter_type, ParameterType.INT)
         self.assertEqual(hss.parameters["x2"].dependents, {0: [], 1: ["x3"]})
 
+    @_use_object_dtype_for_strings
     def test_transform_experiment_data(self) -> None:
         parameterizations = [
             {"x": 2.2, "a": 2, "b": 10.0, "c": 10.0, "d": "r", "e": "q"},

--- a/ax/adapter/transforms/tests/test_one_hot_transform.py
+++ b/ax/adapter/transforms/tests/test_one_hot_transform.py
@@ -9,7 +9,7 @@
 from copy import deepcopy
 
 from ax.adapter.base import DataLoaderConfig
-from ax.adapter.data_utils import extract_experiment_data
+from ax.adapter.data_utils import _use_object_dtype_for_strings, extract_experiment_data
 from ax.adapter.transforms.one_hot import OH_PARAM_INFIX, OneHot
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import (
@@ -226,6 +226,7 @@ class OneHotTransformTest(TestCase):
         untf_obs = self.t.untransform_observation_features(obs_ft)
         self.assertFalse(any(obs.parameters.get("b") == "b" for obs in untf_obs))
 
+    @_use_object_dtype_for_strings
     def test_transform_experiment_data(self) -> None:
         parameterizations = [
             {"x": 2.2, "a": 2, "b": "b", "c": False, "d": 10.0},

--- a/ax/adapter/transforms/tests/test_unit_x_transform.py
+++ b/ax/adapter/transforms/tests/test_unit_x_transform.py
@@ -9,7 +9,7 @@
 from copy import deepcopy
 
 from ax.adapter.base import DataLoaderConfig
-from ax.adapter.data_utils import extract_experiment_data
+from ax.adapter.data_utils import _use_object_dtype_for_strings, extract_experiment_data
 from ax.adapter.transforms.unit_x import UnitX
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
@@ -205,6 +205,7 @@ class UnitXTransformTest(TestCase):
         t.transform_search_space(new_search_space_with_target)
         self.assertEqual(new_search_space_with_target.parameters["x"].target_value, 0.5)
 
+    @_use_object_dtype_for_strings
     def test_transform_experiment_data(self) -> None:
         parameterizations = [
             {"x": 1.0, "y": 1.5, "z": 1.0, "a": 1, "b": "b"},

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -24,6 +24,7 @@ from ax.api.protocols.metric import IMetric
 from ax.api.protocols.runner import IRunner
 from ax.api.types import TParameterization
 from ax.core.analysis_card import AnalysisCard
+from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.map_metric import MapMetric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
@@ -581,17 +582,19 @@ class TestClient(TestCase):
         )
         self.assertTrue(
             client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
-                pd.DataFrame(
-                    {
-                        "trial_index": {0: 0},
-                        "arm_name": {0: "0_0"},
-                        "metric_name": {0: "foo"},
-                        "metric_signature": {0: "foo"},
-                        "mean": {0: 1.0},
-                        "sem": {0: np.nan},
-                        "step": {0: np.nan},
-                    }
-                )
+                Data(
+                    df=pd.DataFrame(
+                        {
+                            "trial_index": {0: 0},
+                            "arm_name": {0: "0_0"},
+                            "metric_name": {0: "foo"},
+                            "metric_signature": {0: "foo"},
+                            "mean": {0: 1.0},
+                            "sem": {0: np.nan},
+                            "step": {0: np.nan},
+                        }
+                    )
+                ).full_df
             ),
         )
 
@@ -604,17 +607,19 @@ class TestClient(TestCase):
         )
         self.assertTrue(
             client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
-                pd.DataFrame(
-                    {
-                        "trial_index": {0: 0, 1: 0},
-                        "arm_name": {0: "0_0", 1: "0_0"},
-                        "metric_name": {0: "foo", 1: "foo"},
-                        "metric_signature": {0: "foo", 1: "foo"},
-                        "mean": {0: 1.0, 1: 2.0},
-                        "sem": {0: np.nan, 1: np.nan},
-                        "step": {0: np.nan, 1: 10.0},
-                    }
-                )
+                Data(
+                    df=pd.DataFrame(
+                        {
+                            "trial_index": {0: 0, 1: 0},
+                            "arm_name": {0: "0_0", 1: "0_0"},
+                            "metric_name": {0: "foo", 1: "foo"},
+                            "metric_signature": {0: "foo", 1: "foo"},
+                            "mean": {0: 1.0, 1: 2.0},
+                            "sem": {0: np.nan, 1: np.nan},
+                            "step": {0: np.nan, 1: 10.0},
+                        }
+                    )
+                ).full_df
             ),
         )
 
@@ -640,17 +645,19 @@ class TestClient(TestCase):
         )
         self.assertTrue(
             client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
-                pd.DataFrame(
-                    {
-                        "trial_index": {0: 0, 1: 0, 2: 0},
-                        "arm_name": {0: "0_0", 1: "0_0", 2: "0_0"},
-                        "metric_name": {0: "foo", 1: "foo", 2: "bar"},
-                        "metric_signature": {0: "foo", 1: "foo", 2: "bar"},
-                        "mean": {0: 1.0, 1: 2.0, 2: 2.0},
-                        "sem": {0: np.nan, 1: np.nan, 2: np.nan},
-                        "step": {0: np.nan, 1: 10.0, 2: np.nan},
-                    }
-                )
+                Data(
+                    df=pd.DataFrame(
+                        {
+                            "trial_index": {0: 0, 1: 0, 2: 0},
+                            "arm_name": {0: "0_0", 1: "0_0", 2: "0_0"},
+                            "metric_name": {0: "foo", 1: "foo", 2: "bar"},
+                            "metric_signature": {0: "foo", 1: "foo", 2: "bar"},
+                            "mean": {0: 1.0, 1: 2.0, 2: 2.0},
+                            "sem": {0: np.nan, 1: np.nan, 2: np.nan},
+                            "step": {0: np.nan, 1: 10.0, 2: np.nan},
+                        }
+                    )
+                ).full_df
             ),
         )
 
@@ -680,17 +687,19 @@ class TestClient(TestCase):
         )
         self.assertTrue(
             client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
-                pd.DataFrame(
-                    {
-                        "trial_index": {0: 0, 1: 0},
-                        "arm_name": {0: "0_0", 1: "0_0"},
-                        "metric_name": {0: "foo", 1: "bar"},
-                        "metric_signature": {0: "foo", 1: "bar"},
-                        "mean": {0: 1.0, 1: 2.0},
-                        "sem": {0: np.nan, 1: np.nan},
-                        "step": {0: np.nan, 1: np.nan},
-                    }
-                )
+                Data(
+                    df=pd.DataFrame(
+                        {
+                            "trial_index": {0: 0, 1: 0},
+                            "arm_name": {0: "0_0", 1: "0_0"},
+                            "metric_name": {0: "foo", 1: "bar"},
+                            "metric_signature": {0: "foo", 1: "bar"},
+                            "mean": {0: 1.0, 1: 2.0},
+                            "sem": {0: np.nan, 1: np.nan},
+                            "step": {0: np.nan, 1: np.nan},
+                        }
+                    )
+                ).full_df
             ),
         )
 
@@ -707,17 +716,19 @@ class TestClient(TestCase):
 
         self.assertTrue(
             client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
-                pd.DataFrame(
-                    {
-                        "trial_index": {0: 1, 1: 1},
-                        "arm_name": {0: "1_0", 1: "1_0"},
-                        "metric_name": {0: "foo", 1: "bar"},
-                        "metric_signature": {0: "foo", 1: "bar"},
-                        "mean": {0: 1.0, 1: 2.0},
-                        "sem": {0: np.nan, 1: np.nan},
-                        "step": {0: 10.0, 1: 10.0},
-                    }
-                )
+                Data(
+                    df=pd.DataFrame(
+                        {
+                            "trial_index": {0: 1, 1: 1},
+                            "arm_name": {0: "1_0", 1: "1_0"},
+                            "metric_name": {0: "foo", 1: "bar"},
+                            "metric_signature": {0: "foo", 1: "bar"},
+                            "mean": {0: 1.0, 1: 2.0},
+                            "sem": {0: np.nan, 1: np.nan},
+                            "step": {0: 10.0, 1: 10.0},
+                        }
+                    )
+                ).full_df
             ),
         )
 
@@ -731,17 +742,19 @@ class TestClient(TestCase):
         )
         self.assertTrue(
             client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
-                pd.DataFrame(
-                    {
-                        "trial_index": {0: 2},
-                        "arm_name": {0: "2_0"},
-                        "metric_name": {0: "foo"},
-                        "metric_signature": {0: "foo"},
-                        "mean": {0: 1.0},
-                        "sem": {0: np.nan},
-                        "step": {0: np.nan},
-                    }
-                )
+                Data(
+                    df=pd.DataFrame(
+                        {
+                            "trial_index": {0: 2},
+                            "arm_name": {0: "2_0"},
+                            "metric_name": {0: "foo"},
+                            "metric_signature": {0: "foo"},
+                            "mean": {0: 1.0},
+                            "sem": {0: np.nan},
+                            "step": {0: np.nan},
+                        }
+                    )
+                ).full_df
             ),
         )
 
@@ -857,17 +870,19 @@ class TestClient(TestCase):
         )
         self.assertTrue(
             client._experiment.lookup_data(trial_indices=[trial_index]).full_df.equals(
-                pd.DataFrame(
-                    {
-                        "trial_index": {0: 0},
-                        "arm_name": {0: "0_0"},
-                        "metric_name": {0: "foo"},
-                        "metric_signature": {0: "foo"},
-                        "mean": {0: 0.0},
-                        "sem": {0: np.nan},
-                        "step": {0: 1.0},
-                    }
-                )
+                Data(
+                    df=pd.DataFrame(
+                        {
+                            "trial_index": {0: 0},
+                            "arm_name": {0: "0_0"},
+                            "metric_name": {0: "foo"},
+                            "metric_signature": {0: "foo"},
+                            "mean": {0: 0.0},
+                            "sem": {0: np.nan},
+                            "step": {0: 1.0},
+                        }
+                    )
+                ).full_df
             ),
         )
 
@@ -917,17 +932,24 @@ class TestClient(TestCase):
 
         self.assertTrue(
             client._experiment.lookup_data().full_df.equals(
-                pd.DataFrame(
-                    {
-                        "trial_index": {0: 0, 1: 1, 2: 2, 3: 3},
-                        "arm_name": {0: "0_0", 1: "1_0", 2: "2_0", 3: "3_0"},
-                        "metric_name": {0: "foo", 1: "foo", 2: "foo", 3: "foo"},
-                        "metric_signature": {0: "foo", 1: "foo", 2: "foo", 3: "foo"},
-                        "mean": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                        "sem": {0: np.nan, 1: np.nan, 2: np.nan, 3: np.nan},
-                        "step": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
-                    }
-                )
+                Data(
+                    df=pd.DataFrame(
+                        {
+                            "trial_index": {0: 0, 1: 1, 2: 2, 3: 3},
+                            "arm_name": {0: "0_0", 1: "1_0", 2: "2_0", 3: "3_0"},
+                            "metric_name": {0: "foo", 1: "foo", 2: "foo", 3: "foo"},
+                            "metric_signature": {
+                                0: "foo",
+                                1: "foo",
+                                2: "foo",
+                                3: "foo",
+                            },
+                            "mean": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                            "sem": {0: np.nan, 1: np.nan, 2: np.nan, 3: np.nan},
+                            "step": {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0},
+                        }
+                    )
+                ).full_df
             ),
         )
 

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -1402,12 +1402,11 @@ class Experiment(Base):
             has_data = not dat.df.empty
             if has_data:
                 new_df = dat.full_df.copy()
-                new_df["trial_index"].replace(
-                    {trial.index: new_trial.index}, inplace=True
+                new_df["trial_index"] = new_df["trial_index"].replace(
+                    {trial.index: new_trial.index}
                 )
-                new_df["arm_name"].replace(
-                    {none_throws(trial.arm).name: none_throws(new_trial.arm).name},
-                    inplace=True,
+                new_df["arm_name"] = new_df["arm_name"].replace(
+                    {none_throws(trial.arm).name: none_throws(new_trial.arm).name}
                 )
                 # Attach updated data to new trial on experiment.
                 self.attach_data(data=Data(df=new_df))

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -988,40 +988,44 @@ class ExperimentTest(TestCase):
 
         sorted_dfs = []
         sorted_dfs.append(
-            pd.DataFrame(
-                {
-                    "trial_index": [0] * 5,
-                    "arm_name": [
-                        "status_quo",
-                        "0_0",
-                        "0_1",
-                        "0_2",
-                        "0_11",
-                    ],
-                    "metric_name": ["b"] * 5,
-                    "metric_signature": ["b"] * 5,
-                    "mean": [5.0, 1.0, 4.0, 2.0, 3.0],
-                    "sem": [0.3, 0.1, 0.25, 0.15, 0.2],
-                }
-            )
+            Data(
+                df=pd.DataFrame(
+                    {
+                        "trial_index": [0] * 5,
+                        "arm_name": [
+                            "status_quo",
+                            "0_0",
+                            "0_1",
+                            "0_2",
+                            "0_11",
+                        ],
+                        "metric_name": ["b"] * 5,
+                        "metric_signature": ["b"] * 5,
+                        "mean": [5.0, 1.0, 4.0, 2.0, 3.0],
+                        "sem": [0.3, 0.1, 0.25, 0.15, 0.2],
+                    }
+                )
+            ).df
         )
 
         sorted_dfs.append(
-            pd.DataFrame(
-                {
-                    "trial_index": [1] * 4,
-                    "arm_name": [
-                        "1_0",
-                        "1_1",
-                        "1_2",
-                        "1_13",
-                    ],
-                    "metric_name": ["b"] * 4,
-                    "metric_signature": ["b"] * 4,
-                    "mean": [6.0, 7.0, 8.0, 9.0],
-                    "sem": [0.35, 0.4, 0.45, 0.5],
-                }
-            )
+            Data(
+                df=pd.DataFrame(
+                    {
+                        "trial_index": [1] * 4,
+                        "arm_name": [
+                            "1_0",
+                            "1_1",
+                            "1_2",
+                            "1_13",
+                        ],
+                        "metric_name": ["b"] * 4,
+                        "metric_signature": ["b"] * 4,
+                        "mean": [6.0, 7.0, 8.0, 9.0],
+                        "sem": [0.35, 0.4, 0.45, 0.5],
+                    }
+                )
+            ).df
         )
 
         exp.attach_data(Data(df=unsorted_df))

--- a/ax/metrics/tests/test_map_replay.py
+++ b/ax/metrics/tests/test_map_replay.py
@@ -65,17 +65,19 @@ class MapDataReplayMetricTest(TestCase):
         # the second fetch will be for MAP_KEY = 0 and MAP_KEY = 1
         data = experiment.fetch_data()
         metric_name = [replay_metric.name] * 4
-        expected_df = DataFrame(
-            {
-                "trial_index": [0, 0, 1, 1],
-                "arm_name": ["0_0", "0_0", "1_0", "1_0"],
-                "metric_name": metric_name,
-                "metric_signature": metric_name,
-                "mean": [146.138620, 117.388086, 113.057480, 90.815154],
-                "sem": [0.0, 0.0, 0.0, 0.0],
-                MAP_KEY: [0.0, 1.0, 0.0, 1.0],
-            }
-        )
+        expected_df = Data(
+            df=DataFrame(
+                {
+                    "trial_index": [0, 0, 1, 1],
+                    "arm_name": ["0_0", "0_0", "1_0", "1_0"],
+                    "metric_name": metric_name,
+                    "metric_signature": metric_name,
+                    "mean": [146.138620, 117.388086, 113.057480, 90.815154],
+                    "sem": [0.0, 0.0, 0.0, 0.0],
+                    MAP_KEY: [0.0, 1.0, 0.0, 1.0],
+                }
+            )
+        ).full_df
         assert_frame_equal(data.full_df, expected_df)
 
     def test_map_replay_non_uniform(self) -> None:
@@ -120,17 +122,19 @@ class MapDataReplayMetricTest(TestCase):
             trial.run()
 
         metric_name = [replay_metric.name] * 4
-        full_expected_df = DataFrame(
-            {
-                "trial_index": [0, 0, 1, 1],
-                "arm_name": ["0_0", "0_0", "1_0", "1_0"],
-                "metric_name": metric_name,
-                "metric_signature": metric_name,
-                "mean": [146.138620, 117.388086, 113.057480, 90.815154],
-                "sem": [0.0, 0.0, 0.0, 0.0],
-                MAP_KEY: [0.25, 0.95, 0.25, 1.0],
-            }
-        )
+        full_expected_df = Data(
+            df=DataFrame(
+                {
+                    "trial_index": [0, 0, 1, 1],
+                    "arm_name": ["0_0", "0_0", "1_0", "1_0"],
+                    "metric_name": metric_name,
+                    "metric_signature": metric_name,
+                    "mean": [146.138620, 117.388086, 113.057480, 90.815154],
+                    "sem": [0.0, 0.0, 0.0, 0.0],
+                    MAP_KEY: [0.25, 0.95, 0.25, 1.0],
+                }
+            )
+        ).full_df
 
         # Test that as we step through with steps of size 0.3625, we
         # first get both points at step 0.25.

--- a/ax/metrics/tests/test_tensorboard.py
+++ b/ax/metrics/tests/test_tensorboard.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
+from ax.core.data import Data
 from ax.core.metric import MetricFetchE
 from ax.metrics.tensorboard import _grid_interpolate, logger, TensorboardMetric
 from ax.storage.json_store.decoder import object_from_json
@@ -103,20 +104,22 @@ class TensorboardMetricTest(TestCase):
 
         df = result.unwrap().full_df
 
-        expected_df = pd.DataFrame(
-            [
-                {
-                    "trial_index": 0,
-                    "arm_name": "0_0",
-                    "metric_name": "loss",
-                    "metric_signature": "loss",
-                    "mean": fake_data[i],
-                    "sem": float("nan"),
-                    "step": float(i),
-                }
-                for i in range(len(fake_data))
-            ]
-        )
+        expected_df = Data(
+            df=pd.DataFrame(
+                [
+                    {
+                        "trial_index": 0,
+                        "arm_name": "0_0",
+                        "metric_name": "loss",
+                        "metric_signature": "loss",
+                        "mean": fake_data[i],
+                        "sem": float("nan"),
+                        "step": float(i),
+                    }
+                    for i in range(len(fake_data))
+                ]
+            )
+        ).full_df
 
         self.assertTrue(df.equals(expected_df))
 
@@ -211,20 +214,22 @@ class TensorboardMetricTest(TestCase):
 
         df = result.unwrap().full_df
 
-        expected_df = pd.DataFrame(
-            [
-                {
-                    "trial_index": 0,
-                    "arm_name": "0_0",
-                    "metric_name": "loss",
-                    "metric_signature": "loss",
-                    "mean": smooth_data[i],
-                    "sem": float("nan"),
-                    "step": float(i),
-                }
-                for i in range(len(fake_data))
-            ]
-        )
+        expected_df = Data(
+            df=pd.DataFrame(
+                [
+                    {
+                        "trial_index": 0,
+                        "arm_name": "0_0",
+                        "metric_name": "loss",
+                        "metric_signature": "loss",
+                        "mean": smooth_data[i],
+                        "sem": float("nan"),
+                        "step": float(i),
+                    }
+                    for i in range(len(fake_data))
+                ]
+            )
+        ).full_df
 
         self.assertTrue(df.equals(expected_df))
 
@@ -264,20 +269,22 @@ class TensorboardMetricTest(TestCase):
 
         df = result.unwrap().full_df
 
-        expected_df = pd.DataFrame(
-            [
-                {
-                    "trial_index": 0,
-                    "arm_name": "0_0",
-                    "metric_name": "loss",
-                    "metric_signature": "loss",
-                    "mean": cummin_data[i],
-                    "sem": float("nan"),
-                    "step": float(i),
-                }
-                for i in range(len(fake_data))
-            ]
-        )
+        expected_df = Data(
+            df=pd.DataFrame(
+                [
+                    {
+                        "trial_index": 0,
+                        "arm_name": "0_0",
+                        "metric_name": "loss",
+                        "metric_signature": "loss",
+                        "mean": cummin_data[i],
+                        "sem": float("nan"),
+                        "step": float(i),
+                    }
+                    for i in range(len(fake_data))
+                ]
+            )
+        ).full_df
 
         self.assertTrue(df.equals(expected_df))
 
@@ -378,20 +385,22 @@ class TensorboardMetricTest(TestCase):
             )
             result = metric.fetch_trial_data(trial=trial)
         df = result.unwrap().full_df
-        expected_df = pd.DataFrame(
-            [
-                {
-                    "trial_index": 0,
-                    "arm_name": "0_0",
-                    "metric_name": "loss",
-                    "metric_signature": "loss",
-                    "mean": percentile_data[i],
-                    "sem": float("nan"),
-                    "step": float(i),
-                }
-                for i in range(len(fake_data))
-            ]
-        )
+        expected_df = Data(
+            df=pd.DataFrame(
+                [
+                    {
+                        "trial_index": 0,
+                        "arm_name": "0_0",
+                        "metric_name": "loss",
+                        "metric_signature": "loss",
+                        "mean": percentile_data[i],
+                        "sem": float("nan"),
+                        "step": float(i),
+                    }
+                    for i in range(len(fake_data))
+                ]
+            )
+        ).full_df
 
         self.assertTrue(df.equals(expected_df))
 

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -804,7 +804,7 @@ def get_hypervolume_trace_of_outcomes_multi_objective(
 
     objective_thresholds = torch.tensor(objective_thresholds, dtype=torch.double)
 
-    metrics_tensor = torch.from_numpy(df_wide[objective.metric_names].to_numpy())
+    metrics_tensor = torch.from_numpy(df_wide[objective.metric_names].to_numpy().copy())
     return _compute_hv_trace(
         ref_point=objective_thresholds,
         metrics_tensor=metrics_tensor,

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1062,7 +1062,7 @@ class Decoder:
                 name=analysis_card_sqa.name,
                 title=title,
                 subtitle=subtitle,
-                df=read_json(analysis_card_sqa.dataframe_json),
+                df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
             )
@@ -1071,7 +1071,7 @@ class Decoder:
                 name=analysis_card_sqa.name,
                 title=title,
                 subtitle=subtitle,
-                df=read_json(analysis_card_sqa.dataframe_json),
+                df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
             )
@@ -1080,7 +1080,7 @@ class Decoder:
                 name=analysis_card_sqa.name,
                 title=title,
                 subtitle=subtitle,
-                df=read_json(analysis_card_sqa.dataframe_json),
+                df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
             )
@@ -1089,7 +1089,7 @@ class Decoder:
                 name=analysis_card_sqa.name,
                 title=title,
                 subtitle=subtitle,
-                df=read_json(analysis_card_sqa.dataframe_json),
+                df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
             )
@@ -1097,7 +1097,7 @@ class Decoder:
             name=analysis_card_sqa.name,
             title=title,
             subtitle=subtitle,
-            df=read_json(analysis_card_sqa.dataframe_json),
+            df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
             blob=blob,
             timestamp=analysis_card_sqa.timestamp,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 dependencies = [
     "botorch[pymoo]>=0.16.1,<0.16.2dev9999",
     "jinja2",  # also a Plotly dep
-    "pandas<3.0.0",
+    "pandas",
     "scipy",
     "scikit-learn",
     "ipywidgets",


### PR DESCRIPTION
Pandas 3.0 introduces several breaking changes (https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#other-api-changes) that required fixes across the codebase:

1. StringDtype inference: Pandas 3.0 infers string columns to use StringDtype instead of object dtype. This breaks DataFrame comparisons since our Data class expects object dtype (defined in COLUMN_DATA_TYPES). Fixed by setting `pd.options.future.infer_string = False` in modules that construct DataFrames.

2. Deprecated inplace on replace(): The `inplace=True` parameter on Series.replace() is deprecated. Changed to assignment pattern: `df["col"] = df["col"].replace(...)`.

3. read_json() no longer accepts strings: pd.read_json() now requires file paths or file-like objects, not raw JSON strings. Wrapped JSON strings with StringIO().

4. Read-only arrays from DataFrame.to_numpy(): Arrays returned by to_numpy() are now read-only views. Added .copy() before passing to torch.from_numpy() which requires writable arrays.

5. Test dtype mismatches: Tests comparing DataFrames failed because manually constructed expected DataFrames had different dtypes than production code. Fixed by wrapping expected DataFrames with Data(df=...).df to ensure consistent dtype casting.