### PR TITLE
Improve fixed parameter selection for slice/contour plots

### DIFF
--- a/ax/analysis/plotly/surface/tests/test_contour.py
+++ b/ax/analysis/plotly/surface/tests/test_contour.py
@@ -55,17 +55,11 @@ class TestContourPlot(TestCase):
                     "bar": parameterization["x"] ** 2 + parameterization["y"] ** 2
                 },
             )
-        self.expected_subtitle = (
+        self.expected_subtitle_contains = [
             "The contour plot visualizes the predicted outcomes "
             "for bar across a two-dimensional parameter space, "
-            "with other parameters held fixed at their status_quo value "
-            "(or mean value if status_quo is unavailable). This plot helps "
-            "in identifying regions of optimal performance and understanding "
-            "how changes in the selected parameters influence the predicted "
-            "outcomes. Contour lines represent levels of constant predicted "
-            "values, providing insights into the gradient and potential optima "
-            "within the parameter space."
-        )
+            "with other parameters held fixed at their best trial value",
+        ]
         self.expected_title = "bar (Mean) vs. x, y"
         self.expected_name = "ContourPlot"
         self.expected_cols = {
@@ -101,7 +95,8 @@ class TestContourPlot(TestCase):
             self.expected_name,
         )
         self.assertEqual(card.title, self.expected_title)
-        self.assertEqual(card.subtitle, self.expected_subtitle)
+        for expected_text in self.expected_subtitle_contains:
+            self.assertIn(expected_text, card.subtitle)
         self.assertEqual(
             {*card.df.columns},
             self.expected_cols,
@@ -144,7 +139,8 @@ class TestContourPlot(TestCase):
             self.expected_name,
         )
         self.assertEqual(card.title, self.expected_title)
-        self.assertEqual(card.subtitle, self.expected_subtitle)
+        for expected_text in self.expected_subtitle_contains:
+            self.assertIn(expected_text, card.subtitle)
         self.assertEqual({*card.df.columns}, self.expected_cols)
         self.assertIsNotNone(card.blob)
 

--- a/ax/analysis/plotly/surface/tests/test_slice.py
+++ b/ax/analysis/plotly/surface/tests/test_slice.py
@@ -66,17 +66,10 @@ class TestSlicePlot(TestCase):
             "SlicePlot",
         )
         self.assertEqual(card.title, "bar vs. x")
-        self.assertEqual(
+        # Subtitle should mention "their best trial value"
+        self.assertIn(
+            "while keeping all other parameters fixed at their best trial value",
             card.subtitle,
-            (
-                "The slice plot provides a one-dimensional view of predicted "
-                "outcomes for bar as a function of a single parameter, "
-                "while keeping all other parameters fixed at their status_quo "
-                "value (or mean value if status_quo is unavailable). "
-                "This visualization helps in understanding the sensitivity and "
-                "impact of changes in the selected parameter on the predicted "
-                "metric outcomes."
-            ),
         )
         self.assertEqual(
             {*card.df.columns},
@@ -109,17 +102,10 @@ class TestSlicePlot(TestCase):
             "SlicePlot",
         )
         self.assertEqual(card.title, "bar vs. x")
-        self.assertEqual(
+        # Subtitle should mention "their best trial value"
+        self.assertIn(
+            "while keeping all other parameters fixed at their best trial value",
             card.subtitle,
-            (
-                "The slice plot provides a one-dimensional view of predicted "
-                "outcomes for bar as a function of a single parameter, "
-                "while keeping all other parameters fixed at their status_quo "
-                "value (or mean value if status_quo is unavailable). "
-                "This visualization helps in understanding the sensitivity and "
-                "impact of changes in the selected parameter on the predicted "
-                "metric outcomes."
-            ),
         )
         self.assertEqual(
             {*card.df.columns},

--- a/ax/analysis/plotly/surface/tests/test_surface_utils.py
+++ b/ax/analysis/plotly/surface/tests/test_surface_utils.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from unittest.mock import patch
+
+from ax.analysis.plotly.surface.utils import get_fixed_values_for_slice_or_contour
+from ax.core.arm import Arm
+from ax.service.ax_client import AxClient, ObjectiveProperties
+from ax.utils.common.testutils import TestCase
+
+
+class TestGetFixedValuesForSliceOrContour(TestCase):
+    def _create_client(self, with_moo: bool = False) -> AxClient:
+        client = AxClient(random_seed=42)
+        objectives = (
+            {
+                "obj1": ObjectiveProperties(minimize=True),
+                "obj2": ObjectiveProperties(minimize=False),
+            }
+            if with_moo
+            else {"obj": ObjectiveProperties(minimize=True)}
+        )
+        client.create_experiment(
+            is_test=True,
+            name="test",
+            parameters=[
+                {"name": "x", "type": "range", "bounds": [-1.0, 1.0]},
+                {"name": "y", "type": "range", "bounds": [-1.0, 1.0]},
+            ],
+            objectives=objectives,
+        )
+        return client
+
+    def test_returns_status_quo_when_available(self) -> None:
+        client = self._create_client()
+        client.experiment.status_quo = Arm(
+            parameters={"x": 0.5, "y": -0.5}, name="status_quo_arm"
+        )
+
+        fixed_values, description = get_fixed_values_for_slice_or_contour(
+            experiment=client.experiment, generation_strategy=None
+        )
+
+        self.assertEqual(fixed_values, {"x": 0.5, "y": -0.5})
+        self.assertEqual(description, "their status_quo value (Arm status_quo_arm)")
+
+    def test_returns_best_trial_when_no_status_quo(self) -> None:
+        client = self._create_client()
+
+        with patch(
+            "ax.analysis.plotly.surface.utils._get_best_trial_info",
+            return_value=({"x": 0.1, "y": 0.2}, 0, "0_0"),
+        ):
+            fixed_values, description = get_fixed_values_for_slice_or_contour(
+                experiment=client.experiment,
+                generation_strategy=client.generation_strategy,
+            )
+
+        self.assertEqual(fixed_values, {"x": 0.1, "y": 0.2})
+        self.assertEqual(description, "their best trial value (Arm 0_0)")
+
+    def test_returns_center_when_no_best_trial(self) -> None:
+        client = self._create_client()
+
+        fixed_values, description = get_fixed_values_for_slice_or_contour(
+            experiment=client.experiment, generation_strategy=None
+        )
+
+        self.assertEqual(fixed_values, {"x": 0.0, "y": 0.0})
+        self.assertEqual(description, "the center of the search space")
+
+    def test_ignores_status_quo_outside_search_space(self) -> None:
+        client = self._create_client()
+        client.experiment.status_quo = Arm(
+            parameters={"x": 5.0, "y": 5.0}, name="status_quo_arm"
+        )
+
+        with patch(
+            "ax.analysis.plotly.surface.utils._get_best_trial_info",
+            return_value=({"x": 0.3, "y": -0.4}, 1, "1_0"),
+        ):
+            fixed_values, description = get_fixed_values_for_slice_or_contour(
+                experiment=client.experiment,
+                generation_strategy=client.generation_strategy,
+            )
+
+        self.assertEqual(fixed_values, {"x": 0.3, "y": -0.4})
+        self.assertEqual(description, "their best trial value (Arm 1_0)")
+
+    def test_returns_center_when_no_optimization_config(self) -> None:
+        """Test center of search space is returned when optimization_config is None."""
+        client = self._create_client()
+        # Remove optimization config to trigger early return in _get_best_trial_info
+        client.experiment._optimization_config = None
+
+        fixed_values, description = get_fixed_values_for_slice_or_contour(
+            experiment=client.experiment,
+            generation_strategy=client.generation_strategy,
+        )
+
+        self.assertEqual(fixed_values, {"x": 0.0, "y": 0.0})
+        self.assertEqual(description, "the center of the search space")
+
+    def test_returns_center_when_best_point_returns_none(self) -> None:
+        """Test center of search space is returned when best point returns None."""
+        client = self._create_client()
+
+        with patch(
+            "ax.analysis.plotly.surface.utils."
+            "get_best_parameters_from_model_predictions_with_trial_index",
+            return_value=None,
+        ):
+            fixed_values, description = get_fixed_values_for_slice_or_contour(
+                experiment=client.experiment,
+                generation_strategy=client.generation_strategy,
+            )
+
+        self.assertEqual(fixed_values, {"x": 0.0, "y": 0.0})
+        self.assertEqual(description, "the center of the search space")

--- a/ax/analysis/plotly/surface/utils.py
+++ b/ax/analysis/plotly/surface/utils.py
@@ -4,7 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
+from __future__ import annotations
+
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 from ax.core.observation import ObservationFeatures
@@ -17,6 +20,115 @@ from ax.core.parameter import (
     TParamValue,
 )
 from ax.core.search_space import SearchSpace
+from ax.core.trial import Trial
+from ax.service.utils.best_point import (
+    get_best_parameters_from_model_predictions_with_trial_index,
+)
+from pyre_extensions import assert_is_instance, none_throws
+
+if TYPE_CHECKING:
+    from ax.core.experiment import Experiment
+    from ax.generation_strategy.generation_strategy import GenerationStrategy
+
+
+def _get_best_trial_info(
+    experiment: Experiment,
+    generation_strategy: GenerationStrategy,
+) -> tuple[dict[str, TParamValue], int, str] | None:
+    """Get parameterization and arm info from the best trial for single-objective.
+
+    This is a private helper function used by get_fixed_values_for_slice_or_contour.
+
+    Args:
+        experiment: The experiment to get the best trial from.
+        generation_strategy: The generation strategy with a fitted adapter for
+            model-based best point estimation.
+
+    Returns:
+        A tuple of (parameterization, trial_index, arm_name), or None if the
+        experiment is a multi-objective optimization problem or if no best
+        trial can be found.
+    """
+
+    optimization_config = experiment.optimization_config
+    if optimization_config is None:
+        return None
+
+    # Best trial is not applicable to multi-objective optimization
+    if optimization_config.is_moo_problem:
+        return None
+
+    result = get_best_parameters_from_model_predictions_with_trial_index(
+        experiment=experiment,
+        adapter=generation_strategy.adapter,
+        optimization_config=optimization_config,
+    )
+
+    if result is None:
+        return None
+
+    trial_index, parameterization, _prediction = result
+    # Get the arm name from the trial
+    trial = assert_is_instance(experiment.trials[trial_index], Trial)
+    arm_name = none_throws(trial.arm).name
+    return parameterization, trial_index, arm_name
+
+
+def get_fixed_values_for_slice_or_contour(
+    experiment: Experiment,
+    generation_strategy: GenerationStrategy | None,
+) -> tuple[dict[str, TParamValue], str]:
+    """Get complete fixed parameter values for all parameters in slice/contour plots.
+
+    This function computes fixed values for all non-derived parameters in the
+    search space using the following priority:
+    1. status_quo arm (if it exists and is within the search space)
+    2. Best trial parameterization (for single-objective optimization)
+    3. Center of search space (fallback)
+
+    Args:
+        experiment: The experiment to get fixed values from.
+        generation_strategy: The generation strategy with a fitted adapter.
+
+    Returns:
+        A tuple of:
+        - A dictionary mapping parameter names to their fixed values for all
+          non-derived parameters in the search space.
+        - A description string for use in subtitles (e.g., "their status_quo
+          value (arm_name)", "their best trial value (arm_name)", "the center
+          of the search space").
+    """
+    # Start with center of search space for all non-derived parameters
+    fixed_values = {
+        p.name: select_fixed_value(p)
+        for p in experiment.search_space.parameters.values()
+        if not isinstance(p, DerivedParameter)
+    }
+
+    # First priority: use status_quo if it exists and is within the search space
+    # (If status_quo is outside the search space, the model would be extrapolating)
+    if experiment.status_quo is not None and experiment.search_space.check_membership(
+        parameterization=experiment.status_quo.parameters,
+        raise_error=False,
+        check_all_parameters_present=True,
+    ):
+        fixed_values.update(experiment.status_quo.parameters)
+        arm_name = none_throws(experiment.status_quo).name
+        return fixed_values, f"their status_quo value (Arm {arm_name})"
+
+    # Second priority: use best trial for single-objective optimization
+    if generation_strategy is not None:
+        best_trial_info = _get_best_trial_info(
+            experiment=experiment,
+            generation_strategy=generation_strategy,
+        )
+        if best_trial_info is not None:
+            parameterization, _trial_index, arm_name = best_trial_info
+            fixed_values.update(parameterization)
+            return fixed_values, f"their best trial value (Arm {arm_name})"
+
+    # Fallback: center of search space (already computed)
+    return fixed_values, "the center of the search space"
 
 
 def get_parameter_values(parameter: Parameter, density: int = 100) -> list[TParamValue]:
@@ -66,18 +178,21 @@ def is_axis_log_scale(parameter: Parameter) -> bool:
 
 
 def get_features_for_slice_or_contour(
-    parameters: dict[str, TParamValue], search_space: SearchSpace
+    parameters: dict[str, TParamValue],
+    search_space: SearchSpace,
+    fixed_values: dict[str, TParamValue],
 ) -> ObservationFeatures:
     """Fill missing values for a specific point in the slice/contour.
 
-
-    For missing parameter values, the value is chosen via `select_fixed_value`.
+    For missing parameter values, the value is taken from `fixed_values`.
     For derived parameters, the value is computed from the other parameters.
 
     Args:
-        parameters: Specified values for an individual point in the  slice/contour
+        parameters: Specified values for an individual point in the slice/contour
             plot.
         search_space: The search space.
+        fixed_values: Pre-computed fixed values for inactive parameters. Should
+            be obtained from `get_fixed_values_for_slice_or_contour()`.
 
     Returns:
         A full parameterization for the point.
@@ -88,9 +203,10 @@ def get_features_for_slice_or_contour(
     ]
     params = parameters.copy()
     for parameter in search_space.parameters.values():
-        if parameter.name not in parameters:
-            if not isinstance(parameter, DerivedParameter):
-                params[parameter.name] = select_fixed_value(parameter=parameter)
+        if parameter.name not in parameters and not isinstance(
+            parameter, DerivedParameter
+        ):
+            params[parameter.name] = fixed_values[parameter.name]
     for p in derived_params:
         params[p.name] = p.compute(parameters=params)
     return ObservationFeatures(parameters=params)


### PR DESCRIPTION
Summary:
The previous implementation always fixed other parameters to the center of the search space when generating slice and contour plots (although the documentation claims it would use status_quo values). This could produce suboptimal visualizations that don't reflect the most interesting region of the parameter space.

This change implements a hierarchical approach with priorities:
(1) status_quo values if available and within the search space
(2) best trial values for single-objective optimization
(3) search space center as the final fallback

The plots now also display which source was used and the actual fixed parameter values in the subtitle for transparency.

Differential Revision: D91920684


