### PR TITLE
Explicit int cast for trial_index

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -180,7 +180,9 @@ class Data(Base, SerializationMixin):
             self._data_rows = [
                 DataRow(
                     # pyre-ignore[16] Intentional unsafe namedtuple access
-                    trial_index=row.trial_index,
+                    # int() cast needed because pd.read_json with dtype=False
+                    # can return string trial indices from storage
+                    trial_index=int(row.trial_index),
                     # pyre-ignore[16] Intentional unsafe namedtuple access
                     arm_name=row.arm_name,
                     # pyre-ignore[16] Intentional unsafe namedtuple access

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1010,6 +1010,9 @@ class Decoder:
         # NOTE: Need dtype=False, otherwise infers arm_names like
         # "4_1" should be int 41.
         df = pd.read_json(StringIO(data_sqa.data_json), dtype=False)
+        # Ensure trial_index is int (dtype=False can leave it as string)
+        if "trial_index" in df.columns:
+            df["trial_index"] = df["trial_index"].astype(int)
         if "metric_signature" not in df.columns:
             df["metric_signature"] = df["metric_name"]
 


### PR DESCRIPTION
Summary:
f1028514505 failed bc we weren't able to attach data as data indices were `str` type. This is because

1. At Load: pd.read_json(StringIO(data_sqa.data_json), dtype=False) -- no type enforcement https://fburl.com/code/2emkm30n
2. At data construction, although we have `trial_index=row.trial_index` and RowData have int type hint for trial_index, it is not enforced at run time.

Putting up a diff to explicitly cast trial index to int

{F1985100756}

Reviewed By: mpolson64

Differential Revision: D91949517


