### PR TITLE
Skip PredictableMetricsAnalysis for BatchTrials in OverviewAnalysis

### DIFF
--- a/ax/analysis/overview.py
+++ b/ax/analysis/overview.py
@@ -215,11 +215,15 @@ class OverviewAnalysis(Analysis):
             if self.options is not None
             else None,
             ConstraintsFeasibilityAnalysis(),
-            PredictableMetricsAnalysis()
-            if self.model_fit_threshold is None
-            else PredictableMetricsAnalysis(
-                model_fit_threshold=self.model_fit_threshold
-            ),
+            (
+                PredictableMetricsAnalysis()
+                if self.model_fit_threshold is None
+                else PredictableMetricsAnalysis(
+                    model_fit_threshold=self.model_fit_threshold
+                )
+            )
+            if not has_batch_trials
+            else None,
             BaselineImprovementAnalysis() if not has_batch_trials else None,
             *[
                 SearchSpaceAnalysis(trial_index=trial.index)


### PR DESCRIPTION
Summary:
Quick fix to avoid calling PredictableMetricsAnalysis for experiments with BatchTrials until we resolve the shape mismatch issue occurring at https://www.internalfb.com/code/fbsource/[76c3cd2940cf480331df8b1d276e608c60b29d3a]/fbcode/ax/utils/stats/model_fit_stats.py?lines=111

Some users have expressed confusion because of the error raised in this healthcheck hence skipping this healthcheck until the we figure proper fix for this.

Differential Revision: D92184502


