### PR TITLE
Handle GraphViz objects in storage and UI

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -13,6 +13,7 @@ from logging import Logger
 from typing import Any, Callable, cast, Union
 
 import pandas as pd
+from ax.analysis.graphviz.graphviz_analysis import GraphvizAnalysisCard
 from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckAnalysisCard
 from ax.analysis.markdown.markdown_analysis import MarkdownAnalysisCard
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
@@ -1111,6 +1112,15 @@ class Decoder:
             )
         if blob_annotation == "healthcheck":
             return HealthcheckAnalysisCard(
+                name=analysis_card_sqa.name,
+                title=title,
+                subtitle=subtitle,
+                df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
+                blob=blob,
+                timestamp=analysis_card_sqa.timestamp,
+            )
+        if blob_annotation == "graphviz":
+            return GraphvizAnalysisCard(
                 name=analysis_card_sqa.name,
                 title=title,
                 subtitle=subtitle,

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -10,6 +10,7 @@ from enum import Enum
 from logging import Logger
 from typing import Any, cast
 
+from ax.analysis.graphviz.graphviz_analysis import GraphvizAnalysisCard
 from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckAnalysisCard
 from ax.analysis.markdown.markdown_analysis import MarkdownAnalysisCard
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
@@ -1167,6 +1168,8 @@ class Encoder:
             blob_annotation = "markdown"
         elif isinstance(card, HealthcheckAnalysisCard):
             blob_annotation = "healthcheck"
+        elif isinstance(card, GraphvizAnalysisCard):
+            blob_annotation = "graphviz"
         else:
             blob_annotation = "dataframe"
 


### PR DESCRIPTION
Summary:
In [analysis_card_to_sqa](https://www.internalfb.com/code/fbsource/[f35aae2adf7e14e81702f0f3cd5584af5ce363fd]/fbcode/ax/storage/sqa_store/encoder.py?lines=1161-1171) we support every type of AnalysisCard except GraphViz. This diff adds encoding and decoding for `GraphVizAnalysisCard` so `GenerationStrategyGraph` can be properly stored and rendered in the UI since currently it does not render:

 {F1985181889}

Differential Revision: D92208435


