### PR TITLE
Phase 1: Replace typing_extensions.Self with typing.Self

### DIFF
--- a/ax/api/client.py
+++ b/ax/api/client.py
@@ -8,7 +8,7 @@
 import json
 from collections.abc import Iterable, Sequence
 from logging import Logger
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 import numpy as np
 import pandas as pd
@@ -62,7 +62,6 @@ from ax.storage.sqa_store.with_db_settings_base import WithDBSettingsBase
 from ax.utils.common.logger import _round_floats_for_logging, get_logger
 from ax.utils.common.random import with_rng_seed
 from pyre_extensions import assert_is_instance, none_throws
-from typing_extensions import Self
 
 logger: Logger = get_logger(__name__)
 ROUND_FLOATS_IN_LOGS_TO_DECIMAL_PLACES: int = 6

--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Callable
 from copy import deepcopy
 from datetime import datetime, timedelta
-from typing import Any, TYPE_CHECKING
+from typing import Any, Self, TYPE_CHECKING
 
 from ax.core.arm import Arm
 from ax.core.data import Data
@@ -26,7 +26,6 @@ from ax.exceptions.core import TrialMutationError, UnsupportedError, UserInputEr
 from ax.utils.common.base import SortableBase
 from ax.utils.common.constants import Keys
 from pyre_extensions import none_throws
-from typing_extensions import Self
 
 
 if TYPE_CHECKING:

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -17,7 +17,7 @@ from functools import partial
 from logging import Logger
 from math import prod
 from pathlib import Path
-from typing import Any, cast, Sequence
+from typing import Any, cast, Self, Sequence
 
 import numpy as np
 import pandas as pd
@@ -130,7 +130,6 @@ from gpytorch.mlls.exact_marginal_log_likelihood import ExactMarginalLogLikeliho
 from gpytorch.mlls.marginal_log_likelihood import MarginalLogLikelihood
 from gpytorch.priors.torch_priors import GammaPrior, LogNormalPrior
 from pyre_extensions import assert_is_instance, none_throws
-from typing_extensions import Self
 
 logger: Logger = get_logger(__name__)
 


### PR DESCRIPTION
Summary:
Migrate Self type hint from typing_extensions to the standard library typing module,
which is available in Python 3.11+.

Files changed:
- ax/fb/api/internal_client.py
- ax/core/base_trial.py
- ax/api/client.py
- ax/utils/testing/core_stubs.py

Reviewed By: mpolson64

Differential Revision: D91648884


