### PR TITLE
Upstream MultiTypeExperiment features into Experiment

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -98,16 +98,15 @@ class BaseTrial(ABC, SortableBase):
         self._ttl_seconds: int | None = ttl_seconds
         self._index: int = self._experiment._attach_trial(self, index=index)
 
-        trial_type = (
+        self._trial_type: str = (
             trial_type
             if trial_type is not None
             else self._experiment.default_trial_type
         )
-        if not self._experiment.supports_trial_type(trial_type):
+        if not self._experiment.supports_trial_type(self._trial_type):
             raise ValueError(
-                f"Trial type {trial_type} is not supported by the experiment."
+                f"Trial type {self._trial_type} is not supported by the experiment."
             )
-        self._trial_type = trial_type
 
         self.__status: TrialStatus | None = None
         # Uses `_status` setter, which updates trial statuses to trial indices
@@ -285,7 +284,7 @@ class BaseTrial(ABC, SortableBase):
         return self._stop_metadata
 
     @property
-    def trial_type(self) -> str | None:
+    def trial_type(self) -> str:
         """The type of the trial.
 
         Relevant for experiments containing different kinds of trials

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -410,8 +410,9 @@ class BatchTrialTest(TestCase):
         cloned_batch._time_created = batch._time_created
         self.assertEqual(cloned_batch, batch)
         # test cloning with clear_trial_type=True
+        # When clear_trial_type=True, uses experiment's default_trial_type
         cloned_batch = batch.clone_to(clear_trial_type=True)
-        self.assertIsNone(cloned_batch.trial_type)
+        self.assertEqual(cloned_batch.trial_type, self.experiment.default_trial_type)
         self.assertEqual(
             cloned_batch.generation_method_str,
             f"{MANUAL_GENERATION_METHOD_STR}, {STATUS_QUO_GENERATION_METHOD_STR}",

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1417,7 +1417,7 @@ class ExperimentTest(TestCase):
         cloned_experiment._time_created = experiment._time_created
         self.assertEqual(cloned_experiment, experiment)
 
-        # test clear_trial_type
+        # test clear_trial_type - uses experiment's default_trial_type
         experiment = get_branin_experiment(
             with_batch=True,
             num_batch_trial=1,
@@ -1427,7 +1427,10 @@ class ExperimentTest(TestCase):
         with self.assertRaisesRegex(ValueError, ".* foo is not supported by the exp"):
             experiment.clone_with()
         cloned_experiment = experiment.clone_with(clear_trial_type=True)
-        self.assertIsNone(cloned_experiment.trials[0].trial_type)
+        self.assertEqual(
+            cloned_experiment.trials[0].trial_type,
+            cloned_experiment.default_trial_type,
+        )
 
         # Test cloning with specific properties to keep
         experiment_w_props = get_branin_experiment()

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -268,6 +268,8 @@ class ObservationsTest(TestCase):
         }
         experiment = Mock()
         experiment._trial_indices_by_status = {status: set() for status in TrialStatus}
+        experiment.default_trial_type = "default"
+        experiment.supports_trial_type = Mock(return_value=True)
         trials = {
             obs["trial_index"]: Trial(
                 experiment, GeneratorRun(arms=[arms[obs["arm_name"]]])
@@ -525,6 +527,8 @@ class ObservationsTest(TestCase):
         }
         experiment = Mock()
         experiment._trial_indices_by_status = {status: set() for status in TrialStatus}
+        experiment.default_trial_type = "default"
+        experiment.supports_trial_type = Mock(return_value=True)
         trials = {
             obs["trial_index"]: (
                 Trial(experiment, GeneratorRun(arms=[arms[obs["arm_name"]]]))
@@ -637,6 +641,8 @@ class ObservationsTest(TestCase):
         }
         experiment = Mock()
         experiment._trial_indices_by_status = {status: set() for status in TrialStatus}
+        experiment.default_trial_type = "default"
+        experiment.supports_trial_type = Mock(return_value=True)
         trials = {
             obs["trial_index"]: Trial(
                 experiment, GeneratorRun(arms=[arms[obs["arm_name"]]])
@@ -744,6 +750,8 @@ class ObservationsTest(TestCase):
         }
         experiment = Mock()
         experiment._trial_indices_by_status = {status: set() for status in TrialStatus}
+        experiment.default_trial_type = "default"
+        experiment.supports_trial_type = Mock(return_value=True)
         trials = {
             0: BatchTrial(experiment, GeneratorRun(arms=list(arms_by_name.values())))
         }
@@ -885,6 +893,8 @@ class ObservationsTest(TestCase):
         }
         experiment = Mock()
         experiment._trial_indices_by_status = {status: set() for status in TrialStatus}
+        experiment.default_trial_type = "default"
+        experiment.supports_trial_type = Mock(return_value=True)
         trials = {
             obs["trial_index"]: Trial(
                 experiment,

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -460,9 +460,9 @@ class TrialTest(TestCase):
         # check that trial_type is cloned correctly
         self.assertEqual(new_trial.trial_type, "foo")
 
-        # test clear_trial_type
+        # test clear_trial_type - uses experiment's default_trial_type
         new_trial = self.trial.clone_to(clear_trial_type=True)
-        self.assertIsNone(new_trial.trial_type)
+        self.assertEqual(new_trial.trial_type, new_experiment.default_trial_type)
 
     def test_update_trial_status_on_clone(self) -> None:
         for status in [

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -59,6 +59,7 @@ from ax.storage.json_store.registry import (
     CORE_DECODER_REGISTRY,
 )
 from ax.storage.utils import data_by_trial_to_data
+from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger
 from ax.utils.common.serialization import (
     extract_init_args,
@@ -727,8 +728,19 @@ def experiment_from_json(
         }
     )
     experiment._arms_by_name = {}
-    if _trial_type_to_runner is not None:
+
+    # Handle backwards compatibility issue where some Experiments support None
+    # trial types.
+    if (
+        _trial_type_to_runner is not None
+        and len(_trial_type_to_runner) > 0
+        and ({*_trial_type_to_runner.keys()} != {None})
+    ):
         experiment._trial_type_to_runner = _trial_type_to_runner
+    else:
+        experiment._trial_type_to_runner = {
+            Keys.DEFAULT_TRIAL_TYPE.value: experiment.runner
+        }
 
     _load_experiment_info(
         exp=experiment,

--- a/ax/storage/json_store/decoders.py
+++ b/ax/storage/json_store/decoders.py
@@ -48,6 +48,7 @@ from ax.storage.transform_registry import (
     REMOVED_TRANSFORMS,
     REVERSE_TRANSFORM_REGISTRY,
 )
+from ax.utils.common.constants import Keys
 from ax.utils.common.kwargs import warn_on_kwargs
 from ax.utils.common.logger import get_logger
 from ax.utils.common.typeutils_torch import torch_type_from_str
@@ -158,7 +159,9 @@ def batch_trial_from_json(
         # the SQ at the end of this function.
     )
     batch._index = index
-    batch._trial_type = trial_type
+    batch._trial_type = (
+        trial_type if trial_type is not None else Keys.DEFAULT_TRIAL_TYPE.value
+    )
     batch._time_created = time_created
     batch._time_completed = time_completed
     batch._time_staged = time_staged
@@ -219,7 +222,9 @@ def trial_from_json(
         experiment=experiment, generator_run=generator_run, ttl_seconds=ttl_seconds
     )
     trial._index = index
-    trial._trial_type = trial_type
+    trial._trial_type = (
+        trial_type if trial_type is not None else Keys.DEFAULT_TRIAL_TYPE.value
+    )
     # Swap `DISPATCHED` for `RUNNING`, since `DISPATCHED` is deprecated and nearly
     # equivalent to `RUNNING`.
     trial._status = status if status != TrialStatus.DISPATCHED else TrialStatus.RUNNING

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -386,11 +386,15 @@ class Decoder:
         experiment.data = data_by_trial_to_data(data_by_trial=data_by_trial)
 
         trial_type_to_runner = {
-            sqa_runner.trial_type: self.runner_from_sqa(sqa_runner)
+            (
+                sqa_runner.trial_type
+                if sqa_runner.trial_type is not None
+                else Keys.DEFAULT_TRIAL_TYPE.value
+            ): self.runner_from_sqa(sqa_runner)
             for sqa_runner in experiment_sqa.runners
         }
         if len(trial_type_to_runner) == 0:
-            trial_type_to_runner = {None: None}
+            trial_type_to_runner = {Keys.DEFAULT_TRIAL_TYPE.value: None}
 
         experiment._trials = {trial.index: trial for trial in trials}
         experiment._arms_by_name = {}
@@ -415,9 +419,24 @@ class Decoder:
         # `_trial_type_to_runner` is set in _init_mt_experiment_from_sqa
         if subclass != "MultiTypeExperiment":
             experiment._trial_type_to_runner = cast(
-                dict[str | None, Runner | None], trial_type_to_runner
+                dict[str, Runner | None], trial_type_to_runner
             )
         experiment.db_id = experiment_sqa.id
+
+        # For non-MultiTypeExperiment, populate _metric_to_trial_type
+        # This is needed because the metrics were added directly to the experiment
+        # without going through the setters that populate this field.
+        if subclass != "MultiTypeExperiment":
+            default_trial_type = Keys.DEFAULT_TRIAL_TYPE.value
+            # Add OC metrics
+            oc = experiment.optimization_config
+            if oc is not None:
+                for metric_name in oc.metrics.keys():
+                    experiment._metric_to_trial_type[metric_name] = default_trial_type
+            # Add tracking metrics
+            for metric_name in experiment._tracking_metrics.keys():
+                experiment._metric_to_trial_type[metric_name] = default_trial_type
+
         return experiment
 
     def parameter_from_sqa(self, parameter_sqa: SQAParameter) -> Parameter:
@@ -996,7 +1015,11 @@ class Decoder:
                     reduced_state=reduced_state,
                     immutable_search_space_and_opt_config=immutable_ss_and_oc,
                 )
-        trial._trial_type = trial_sqa.trial_type
+        trial._trial_type = (
+            trial_sqa.trial_type
+            if trial_sqa.trial_type is not None
+            else Keys.DEFAULT_TRIAL_TYPE.value
+        )
         # Swap `DISPATCHED` for `RUNNING`, since `DISPATCHED` is deprecated and nearly
         # equivalent to `RUNNING`.
         trial._status = (

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -226,7 +226,12 @@ class Encoder:
                         metric.name
                     ]
         elif experiment.runner:
-            runners.append(self.runner_to_sqa(none_throws(experiment.runner)))
+            runners.append(
+                self.runner_to_sqa(
+                    none_throws(experiment.runner),
+                    trial_type=experiment.default_trial_type,
+                )
+            )
         properties = experiment._properties.copy()
         if (
             oc := experiment.optimization_config

--- a/ax/utils/common/constants.py
+++ b/ax/utils/common/constants.py
@@ -53,6 +53,7 @@ class Keys(StrEnum):
     COST_INTERCEPT = "cost_intercept"
     CURRENT_VALUE = "current_value"
     DEFAULT_OBJECTIVE_NAME = "objective"
+    DEFAULT_TRIAL_TYPE = "default"
     EXPAND = "expand"
     EXPECTED_ACQF_VAL = "expected_acquisition_value"
     EXPERIMENT_TOTAL_CONCURRENT_ARMS = "total_concurrent_arms"


### PR DESCRIPTION
Summary:
These changes will enable us to deprecate multitypeexperment, simplifying the Ax data model ahead of storage changes.

1. In Experiment make the default_trial_type a new Key.DEFAULT_TRIAL_TYPE value instead of None
2. Move over logic for bookkeeping metric -> trial_type and runner -> trial_type mappings
3. Treat LONG_ and SHORT_RUN trial types as special cases which map to DEFAULT_TRIAL_TYPE (i.e. if a Trial has trial_type=LONG_RUN then use whichever metrics and runners are mapped to DEFAULT_TRIAL_TYPE
4. Fix tests which expect the default_trial_type of an Experiment to be None

This diff allows us to remove all isinstance(foo, MultiTypeExperiment) checks in Ax in the next diff, then to deprecate MultiTypeExperiment entirely.

Differential Revision: D91618283


