### PR TITLE
Phase 4: Exception Groups Migration (PEP 654)

### DIFF
--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -20,7 +20,7 @@ from typing import Any, TYPE_CHECKING
 from ax.core.data import Data
 from ax.utils.common.base import SortableBase
 from ax.utils.common.logger import get_logger
-from ax.utils.common.result import Err, Ok, Result, UnwrapError
+from ax.utils.common.result import Err, Ok, Result
 from ax.utils.common.serialization import SerializationMixin
 
 if TYPE_CHECKING:
@@ -505,7 +505,6 @@ class Metric(SortableBase, SerializationMixin):
                 result for result in results.values() if isinstance(result, Err)
             ]
 
-            # TODO[mpolson64] Raise all errors in a group via PEP 654
             exceptions = [
                 (
                     err.err.exception
@@ -515,8 +514,8 @@ class Metric(SortableBase, SerializationMixin):
                 for err in errs
             ]
 
-            raise UnwrapError(errs) from (
-                exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+            raise ExceptionGroup(
+                f"Failed to fetch data for {len(errs)} trial(s)", exceptions
             )
 
         return Data.from_multiple_data(data=[ok.ok for ok in oks])
@@ -561,7 +560,6 @@ class Metric(SortableBase, SerializationMixin):
             ]
 
             if len(critical_errs) > 0:
-                # TODO[mpolson64] Raise all errors in a group via PEP 654
                 exceptions = [
                     (
                         err.err.exception
@@ -570,8 +568,9 @@ class Metric(SortableBase, SerializationMixin):
                     )
                     for err in critical_errs
                 ]
-                raise UnwrapError(critical_errs) from (
-                    exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+                raise ExceptionGroup(
+                    f"Failed to fetch data for {len(critical_errs)} critical metric(s)",
+                    exceptions,
                 )
 
         return Data.from_multiple_data(data=[ok.ok for ok in oks])
@@ -592,7 +591,6 @@ class Metric(SortableBase, SerializationMixin):
                 result for result in flattened if isinstance(result, Err)
             ]
 
-            # TODO[mpolson64] Raise all errors in a group via PEP 654
             exceptions = [
                 (
                     err.err.exception
@@ -601,8 +599,8 @@ class Metric(SortableBase, SerializationMixin):
                 )
                 for err in errs
             ]
-            raise UnwrapError(errs) from (
-                exceptions[0] if len(exceptions) == 1 else Exception(exceptions)
+            raise ExceptionGroup(
+                f"Failed to fetch data for {len(errs)} metric(s)", exceptions
             )
 
         return Data.from_multiple_data(data=[ok.ok for ok in oks])

--- a/ax/utils/common/result.py
+++ b/ax/utils/common/result.py
@@ -91,7 +91,7 @@ class Result(Generic[T, E], ABC):
         """
         Returns the contained Ok value.
 
-        Because this function may raise an UnwrapError, its use is generally
+        Because this function may raise a RuntimeError, its use is generally
         discouraged. Instead, prefer to handle the Err case explicitly, or call
         unwrap_or, unwrap_or_else, or unwrap_or_default.
         """
@@ -103,7 +103,7 @@ class Result(Generic[T, E], ABC):
         """
         Returns the contained Err value.
 
-        Because this function may raise an UnwrapError, its use is generally
+        Because this function may raise a RuntimeError, its use is generally
         discouraged. Instead, prefer to handle the Err case explicitly, or call
         unwrap_or, unwrap_or_else, or unwrap_or_default.
         """
@@ -178,7 +178,7 @@ class Ok(Generic[T, E], Result[T, E]):
         return self._value
 
     def unwrap_err(self) -> NoReturn:
-        raise UnwrapError(f"Tried to unwrap_err {self}.")
+        raise RuntimeError(f"Tried to unwrap_err {self}.")
 
     def unwrap_or(self, default: U) -> T:
         return self._value
@@ -235,7 +235,7 @@ class Err(Generic[T, E], Result[T, E]):
         return default_op()
 
     def unwrap(self) -> NoReturn:
-        raise UnwrapError(f"Tried to unwrap {self}.")
+        raise RuntimeError(f"Tried to unwrap {self}.")
 
     def unwrap_err(self) -> E:
         return self._value
@@ -247,17 +247,6 @@ class Err(Generic[T, E], Result[T, E]):
 
     def unwrap_or_else(self, op: Callable[[E], T]) -> T:
         return op(self._value)
-
-
-class UnwrapError(Exception):
-    """
-    Exception that indicates something has gone wrong in an unwrap call.
-
-    This should not happen in real world use and indicates a user has improperly
-    or unsafely used the Result abstraction.
-    """
-
-    pass
 
 
 class ExceptionE:

--- a/ax/utils/common/tests/test_result.py
+++ b/ax/utils/common/tests/test_result.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from ax.utils.common.result import Err, Ok, Result, UnwrapError
+from ax.utils.common.result import Err, Ok, Result
 from ax.utils.common.testutils import TestCase
 
 
@@ -59,12 +59,12 @@ class ResultTest(TestCase):
 
     def test_unwrap(self) -> None:
         self.assertEqual(self.ok.unwrap(), 0)
-        with self.assertRaises(UnwrapError):
+        with self.assertRaises(RuntimeError):
             self.ok.unwrap_err()
         self.assertEqual(self.ok.unwrap_or(1), 0)
         self.assertEqual(self.ok.unwrap_or_else(1), 0)
 
-        with self.assertRaises(UnwrapError):
+        with self.assertRaises(RuntimeError):
             self.err.unwrap()
         self.assertEqual(self.err.unwrap_err(), "yikes")
         self.assertEqual(self.err.unwrap_or(1), 1)


### PR DESCRIPTION
Summary:
Convert error collection patterns to use Python 3.11 ExceptionGroup instead
of ad-hoc exception aggregation. This provides better structured exception
handling and enables the use of except* syntax in callers.

Files changed:
- ax/core/metric.py: Update _unwrap_experiment_data(), _unwrap_trial_data_multi(),
  and _unwrap_experiment_data_multi() to raise ExceptionGroup with all collected
  errors instead of chaining to a single exception.
- ax/generation_strategy/generation_node.py: Update new_trial_limit() to collect
  all generation-blocking errors and raise as ExceptionGroup.

Reviewed By: saitcakmak

Differential Revision: D91648883


