### PR TITLE
Phase 5: asyncio.TaskGroup and modern async patterns

### DIFF
--- a/ax/utils/common/executils.py
+++ b/ax/utils/common/executils.py
@@ -121,9 +121,7 @@ def retry_on_exception(
                             wait_interval = min(
                                 MAX_WAIT_SECONDS, initial_wait_seconds * 2 ** (i - 1)
                             )
-                            # pyre-fixme[1001]: `asyncio.sleep(wait_interval)` is
-                            #  never awaited.
-                            asyncio.sleep(wait_interval)
+                            await asyncio.sleep(wait_interval)
                         return await func(*args, **kwargs)
                 # If we are here, it means the retries were finished but
                 # The error was suppressed. Hence return the default value provided.


### PR DESCRIPTION
Summary:
Migrate to modern Python 3.11+ async patterns using asyncio.TaskGroup for
structured concurrency and fix deprecated asyncio usage.

Files changed:
- ax/fb/runners/chronos.py: Convert run_concurrently() from asyncio.gather(*tasks)
  to asyncio.TaskGroup for better exception handling and structured concurrency.
- ax/fb/storage/external_store/hdf5_utils.py: Replace deprecated
  asyncio.get_event_loop() + run_until_complete() pattern with asyncio.run() and
  asyncio.TaskGroup.
- ax/utils/common/executils.py: Fix missing await before asyncio.sleep() that was
  causing the sleep to have no effect (was flagged with pyre-fixme[1001]).

Differential Revision: D91648881


