### PR TITLE
Add suggested_experiment_status column to GeneratorRun

### DIFF
--- a/ax/core/generator_run.py
+++ b/ax/core/generator_run.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import pandas as pd
 from ax.core.arm import Arm
+from ax.core.experiment_status import ExperimentStatus
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.search_space import SearchSpace
 from ax.core.types import (
@@ -100,6 +101,7 @@ class GeneratorRun(SortableBase):
         candidate_metadata_by_arm_signature: None
         | (dict[str, TCandidateMetadata]) = None,
         generation_node_name: str | None = None,
+        suggested_experiment_status: ExperimentStatus | None = None,
     ) -> None:
         """Inits GeneratorRun.
 
@@ -142,6 +144,10 @@ class GeneratorRun(SortableBase):
                 via a generation strategy (in which case this name should reflect the
                 name of the generation node in a generation strategy) or a standalone
                 generation node (in which case this name should be ``-1``).
+            suggested_experiment_status: Optional ``ExperimentStatus`` that indicates
+                what the experiment's status should be once this generator run is
+                added to a trial. This is propagated from the generation node's
+                suggested_experiment_status field and is advisory only.
         """
         self._arm_weight_table: OrderedDict[str, ArmWeight] = OrderedDict()
         if weights is None:
@@ -191,6 +197,7 @@ class GeneratorRun(SortableBase):
                 )
         self._candidate_metadata_by_arm_signature = candidate_metadata_by_arm_signature
         self._generation_node_name = generation_node_name
+        self._suggested_experiment_status = suggested_experiment_status
 
     @property
     def arms(self) -> list[Arm]:
@@ -288,6 +295,11 @@ class GeneratorRun(SortableBase):
         return self._candidate_metadata_by_arm_signature
 
     @property
+    def suggested_experiment_status(self) -> ExperimentStatus | None:
+        """Optional suggested experiment status for this generator run."""
+        return self._suggested_experiment_status
+
+    @property
     def param_df(self) -> pd.DataFrame:
         """
         Constructs a Pandas dataframe with the parameter values for each arm.
@@ -327,6 +339,7 @@ class GeneratorRun(SortableBase):
             generator_state_after_gen=self._generator_state_after_gen,
             candidate_metadata_by_arm_signature=cand_metadata,
             generation_node_name=self._generation_node_name,
+            suggested_experiment_status=self.suggested_experiment_status,
         )
         generator_run._time_created = self._time_created
         generator_run._generator_key = self._generator_key

--- a/ax/core/tests/test_generator_run.py
+++ b/ax/core/tests/test_generator_run.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 from ax.core.arm import Arm
+from ax.core.experiment_status import ExperimentStatus
 from ax.core.generator_run import GeneratorRun
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
@@ -47,6 +48,10 @@ class GeneratorRunTest(TestCase):
             optimization_config=self.optimization_config,
             search_space=self.search_space,
             model_predictions=self.model_predictions,
+        )
+        self.run_with_suggested_status = GeneratorRun(
+            arms=self.arms,
+            suggested_experiment_status=ExperimentStatus.INITIALIZATION,
         )
 
     def test_Init(self) -> None:
@@ -184,3 +189,18 @@ class GeneratorRunTest(TestCase):
             weights=self.weights,
         )
         self.assertTrue(generator_run1 < generator_run2)
+
+    def test_SuggestedExperimentStatus(self) -> None:
+        self.assertEqual(
+            self.run_with_suggested_status.suggested_experiment_status,
+            ExperimentStatus.INITIALIZATION,
+        )
+
+    def test_SuggestedExperimentStatusDefaultNone(self) -> None:
+        self.assertIsNone(self.unweighted_run.suggested_experiment_status)
+
+    def test_ClonePreservesSuggestedExperimentStatus(self) -> None:
+        cloned = self.run_with_suggested_status.clone()
+        self.assertEqual(
+            cloned.suggested_experiment_status, ExperimentStatus.INITIALIZATION
+        )

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -367,6 +367,7 @@ def generator_run_to_dict(generator_run: GeneratorRun) -> dict[str, Any]:
         "generator_state_after_gen": gr._generator_state_after_gen,
         "candidate_metadata_by_arm_signature": cand_metadata,
         "generation_node_name": gr._generation_node_name,
+        "suggested_experiment_status": gr.suggested_experiment_status,
     }
 
 

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -813,6 +813,7 @@ class Decoder:
                 class_decoder_registry=self.config.json_class_decoder_registry,
             ),
             generation_node_name=generator_run_sqa.generation_node_name,
+            suggested_experiment_status=generator_run_sqa.suggested_experiment_status,
         )
         # Remove deprecated kwargs from generator kwargs & adapter kwargs.
         if generator_run._generator_kwargs is not None:

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -897,6 +897,7 @@ class Encoder:
                 class_encoder_registry=self.config.json_class_encoder_registry,
             ),
             generation_node_name=generator_run._generation_node_name,
+            suggested_experiment_status=generator_run.suggested_experiment_status,
         )
         return gr_sqa
 

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -215,6 +215,9 @@ class SQAGeneratorRun(Base):
         JSONEncodedTextDict
     )
     generation_node_name: Column[str | None] = Column(String(NAME_OR_TYPE_FIELD_LENGTH))
+    suggested_experiment_status: Column[ExperimentStatus | None] = Column(
+        IntEnum(ExperimentStatus), nullable=True
+    )
 
     # relationships
     # Use selectin loading for collections to prevent idle timeout errors

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -2539,6 +2539,35 @@ class SQAStoreTest(TestCase):
         )
         self.assertEqual(decoded_gr.gen_metadata, gen_metadata)
 
+    def test_generator_run_suggested_experiment_status(self) -> None:
+        # Test round-trip with a status set.
+        gr = GeneratorRun(
+            arms=[],
+            suggested_experiment_status=ExperimentStatus.OPTIMIZATION,
+        )
+        generator_run_sqa = self.encoder.generator_run_to_sqa(gr)
+        self.assertEqual(
+            generator_run_sqa.suggested_experiment_status,
+            ExperimentStatus.OPTIMIZATION,
+        )
+        decoded_gr = self.decoder.generator_run_from_sqa(
+            generator_run_sqa, False, False
+        )
+        self.assertEqual(
+            decoded_gr.suggested_experiment_status,
+            ExperimentStatus.OPTIMIZATION,
+        )
+
+    def test_generator_run_suggested_experiment_status_none(self) -> None:
+        # Test round-trip with None (default).
+        gr = GeneratorRun(arms=[])
+        generator_run_sqa = self.encoder.generator_run_to_sqa(gr)
+        self.assertIsNone(generator_run_sqa.suggested_experiment_status)
+        decoded_gr = self.decoder.generator_run_from_sqa(
+            generator_run_sqa, False, False
+        )
+        self.assertIsNone(decoded_gr.suggested_experiment_status)
+
     def test_update_generation_strategy_incrementally(self) -> None:
         experiment = get_branin_experiment()
         generation_strategy = choose_generation_strategy(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -31,6 +31,7 @@ from ax.core.batch_trial import AbandonedArm, BatchTrial
 from ax.core.data import Data
 from ax.core.evaluations_to_data import raw_evaluations_to_data
 from ax.core.experiment import Experiment
+from ax.core.experiment_status import ExperimentStatus
 from ax.core.generator_run import GeneratorRun
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
@@ -2383,6 +2384,7 @@ def get_generator_run() -> GeneratorRun:
         candidate_metadata_by_arm_signature={
             a.signature: {"md_key": f"md_val_{a.signature}"} for a in arms
         },
+        suggested_experiment_status=ExperimentStatus.OPTIMIZATION,
     )
 
 


### PR DESCRIPTION
Summary:
## Summary

Add `suggested_experiment_status` column to `GeneratorRun`. Some benefits:

1. We don't need to modify the GS.gen() or Orchestrator methods to pass along a suggested status via tuple, instead it's baked into the GeneratorRuns that are already being passed along
2. The suggested status are more clearly stored in the database for historical tracking

Prior to this approach I tried changing `GS.gen()` to return a tuple including the `suggested_experiment_status` but that over-complicated callsites.

## AOSC DIFF

D92476170

Differential Revision: D88091530
