### PR TITLE
Deprecate `deduplicate` setting for SOBOL `Generator`; Set `GenerationNode.should_deduplicate=True` by default

### DIFF
--- a/ax/adapter/factory.py
+++ b/ax/adapter/factory.py
@@ -34,7 +34,6 @@ optimization model for subsequent trials).
 def get_sobol(
     search_space: SearchSpace,
     seed: int | None = None,
-    deduplicate: bool = False,
     init_position: int = 0,
     scramble: bool = True,
     fallback_to_sample_polytope: bool = False,
@@ -52,7 +51,6 @@ def get_sobol(
         Generators.SOBOL(
             experiment=Experiment(search_space=search_space),
             seed=seed,
-            deduplicate=deduplicate,
             init_position=init_position,
             scramble=scramble,
             fallback_to_sample_polytope=fallback_to_sample_polytope,

--- a/ax/adapter/tests/test_random_adapter.py
+++ b/ax/adapter/tests/test_random_adapter.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-import dataclasses
 from unittest import mock
 
 import numpy as np
@@ -20,15 +19,10 @@ from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ParameterType, RangeParameter
 from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import SearchSpace
-from ax.exceptions.core import SearchSpaceExhausted
 from ax.generators.random.base import RandomGenerator
 from ax.generators.random.sobol import SobolGenerator
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import (
-    get_data,
-    get_search_space_for_range_values,
-    get_small_discrete_search_space,
-)
+from ax.utils.testing.core_stubs import get_data
 from ax.utils.testing.modeling_stubs import get_experiment_for_value
 
 
@@ -147,22 +141,6 @@ class RandomAdapterTest(TestCase):
         self.assertIsNone(gen_args["linear_constraints"])
         self.assertIsNone(gen_args["fixed_features"])
 
-    def test_deduplicate(self) -> None:
-        exp = Experiment(search_space=get_small_discrete_search_space())
-        sobol = RandomAdapter(
-            experiment=exp,
-            generator=SobolGenerator(deduplicate=True),
-            transforms=Cont_X_trans,
-        )
-        for _ in range(4):  # Search space is {[0, 1], {"red", "panda"}}
-            # Generate & attach trials to the experiment so that the
-            # generated points are used for deduplication.
-            gr = sobol.gen(1)
-            exp.new_trial(generator_run=gr).mark_running(no_runner_required=True)
-            self.assertEqual(len(gr.arms), 1)
-        with self.assertRaises(SearchSpaceExhausted):
-            sobol.gen(1)
-
     def test_search_space_not_expanded(self) -> None:
         data = get_data(num_non_sq_arms=0)
         sq_arm = Arm(name="status_quo", parameters={"x": 10.0, "y": 1.0, "z": 1.0})
@@ -185,124 +163,6 @@ class RandomAdapterTest(TestCase):
         # test that search space is not expanded
         sobol.gen(1)
         self.assertEqual(sobol._model_space, sobol._search_space)
-
-    def test_generated_points(self) -> None:
-        # Checks for generated points argument passed to Generator.gen.
-        # Search space has two range parameters in [0, 5].
-        exp = Experiment(
-            search_space=get_search_space_for_range_values(min=0.0, max=5.0)
-        )
-        ssd = extract_search_space_digest(
-            search_space=exp.search_space,
-            param_names=list(exp.search_space.parameters.keys()),
-        )
-        ssd = dataclasses.replace(ssd, bounds=[(0.0, 1.0), (0.0, 1.0)])
-        generator = SobolGenerator(deduplicate=True)
-        gen_res = generator.gen(n=1, search_space_digest=ssd, rounding_func=lambda x: x)
-        # Using Cont_X_trans, particularly UnitX here to test transform application.
-        adapter = RandomAdapter(
-            experiment=exp, generator=generator, transforms=Cont_X_trans
-        )
-
-        # No pending points or previous trials on the experiment.
-        with mock.patch.object(generator, "gen", return_value=gen_res) as mock_gen:
-            adapter.gen(n=1)
-        self.assertIsNone(mock_gen.call_args.kwargs["generated_points"])
-
-        # Attach two trials to the experiment.
-        exp.new_trial().add_arm(Arm(parameters={"x": 0.0, "y": 0.0})).mark_running(
-            no_runner_required=True
-        )
-        exp.new_trial().add_arm(Arm(parameters={"x": 2.0, "y": 2.0})).mark_running(
-            no_runner_required=True
-        )
-        with mock.patch.object(generator, "gen", return_value=gen_res) as mock_gen:
-            adapter.gen(n=1)
-        self.assertEqual(
-            mock_gen.call_args.kwargs["generated_points"].tolist(),
-            [[0.0, 0.0], [0.4, 0.4]],
-        )
-
-        # Add pending points -- only unique ones should be passed down.
-        pending_observations = {
-            m: [ObservationFeatures(parameters={"x": 3.0, "y": 3.0})]
-            for m in ("m1", "m2")
-        }
-        with mock.patch.object(generator, "gen", return_value=gen_res) as mock_gen:
-            adapter.gen(n=1, pending_observations=pending_observations)
-        self.assertEqual(
-            mock_gen.call_args.kwargs["generated_points"].tolist(),
-            [[0.0, 0.0], [0.4, 0.4], [0.6, 0.6]],
-        )
-
-        # Turn off deduplicate, nothing should be passed down.
-        generator.deduplicate = False
-        with mock.patch.object(generator, "gen", return_value=gen_res) as mock_gen:
-            adapter.gen(n=1, pending_observations=pending_observations)
-        self.assertIsNone(mock_gen.call_args.kwargs["generated_points"])
-
-        # Test filtering out-of-design arms during deduplication
-        # Create experiment with in-design and out-of-design arms
-        exp_with_ood_arms = Experiment(
-            search_space=get_search_space_for_range_values(min=0.0, max=5.0)
-        )
-        in_design_arm = Arm(
-            name="in_design", parameters={"x": 2.0, "y": 3.0}
-        )  # Within [0, 5]
-        out_of_design_arm = Arm(
-            name="out_of_design", parameters={"x": 6.0, "y": 7.0}
-        )  # Outside [0, 5]
-
-        exp_with_ood_arms.new_trial().add_arm(in_design_arm).mark_running(
-            no_runner_required=True
-        )
-        exp_with_ood_arms.new_trial().add_arm(out_of_design_arm).mark_running(
-            no_runner_required=True
-        )
-
-        generator = SobolGenerator(deduplicate=True)
-        adapter_mixed = RandomAdapter(
-            experiment=exp_with_ood_arms,
-            generator=generator,
-            transforms=Cont_X_trans,
-        )
-
-        # Only the in-design arm should be included in generated_points
-        with mock.patch.object(generator, "gen", return_value=gen_res) as mock_gen:
-            adapter_mixed.gen(n=1)
-
-        generated_points = mock_gen.call_args.kwargs["generated_points"]
-        self.assertEqual(len(generated_points), 1)
-
-        # Test case where all arms are out-of-design
-        exp_all_out_of_design = Experiment(
-            search_space=get_search_space_for_range_values(min=0.0, max=5.0)
-        )
-        out_of_design_arm1 = Arm(name="out1", parameters={"x": 6.0, "y": 7.0})
-        out_of_design_arm2 = Arm(name="out2", parameters={"x": -1.0, "y": 8.0})
-
-        exp_all_out_of_design.new_trial().add_arm(out_of_design_arm1).mark_running(
-            no_runner_required=True
-        )
-        exp_all_out_of_design.new_trial().add_arm(out_of_design_arm2).mark_running(
-            no_runner_required=True
-        )
-
-        generator_all_out = SobolGenerator(deduplicate=True)
-        adapter_all_out = RandomAdapter(
-            experiment=exp_all_out_of_design,
-            generator=generator_all_out,
-            transforms=Cont_X_trans,
-        )
-
-        # When all arms are out-of-design, generated_points should be empty
-        with mock.patch.object(
-            generator_all_out, "gen", return_value=gen_res
-        ) as mock_gen:
-            adapter_all_out.gen(n=1)
-
-        generated_points_all_out = mock_gen.call_args.kwargs["generated_points"]
-        self.assertIsNone(generated_points_all_out)
 
     def test_generation_with_all_fixed(self) -> None:
         # Make sure candidate generation succeeds and returns correct parameters

--- a/ax/adapter/tests/test_registry.py
+++ b/ax/adapter/tests/test_registry.py
@@ -174,7 +174,6 @@ class ModelRegistryTest(TestCase):
             (
                 {
                     "seed": None,
-                    "deduplicate": True,
                     "init_position": 0,
                     "scramble": True,
                     "generated_points": None,
@@ -194,7 +193,7 @@ class ModelRegistryTest(TestCase):
         self.assertTrue(
             all(
                 kw in Generators.SOBOL.view_kwargs()[0]
-                for kw in ["seed", "deduplicate", "init_position", "scramble"]
+                for kw in ["seed", "init_position", "scramble"]
             ),
             all(
                 kw in Generators.SOBOL.view_kwargs()[1]

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -934,11 +934,7 @@ class TestBenchmark(TestCase):
                 nodes=[
                     GenerationNode(
                         name="Sobol",
-                        generator_specs=[
-                            GeneratorSpec(
-                                Generators.SOBOL, generator_kwargs={"deduplicate": True}
-                            )
-                        ],
+                        generator_specs=[GeneratorSpec(Generators.SOBOL)],
                     )
                 ]
             ),

--- a/ax/generation_strategy/dispatch_utils.py
+++ b/ax/generation_strategy/dispatch_utils.py
@@ -51,7 +51,7 @@ def _make_sobol_step(
     enforce_num_trials: bool = True,
     max_parallelism: int | None = None,
     seed: int | None = None,
-    should_deduplicate: bool = False,
+    should_deduplicate: bool = True,
 ) -> GenerationStep:
     """Shortcut for creating a Sobol generation step."""
     return GenerationStep(
@@ -61,7 +61,7 @@ def _make_sobol_step(
         min_trials_observed=min_trials_observed or ceil(num_trials / 2),
         enforce_num_trials=enforce_num_trials,
         max_parallelism=max_parallelism,
-        generator_kwargs={"deduplicate": True, "seed": seed},
+        generator_kwargs={"seed": seed},
         should_deduplicate=should_deduplicate,
         use_all_trials_in_exp=True,
     )
@@ -76,7 +76,7 @@ def _make_botorch_step(
     generator_kwargs: dict[str, Any] | None = None,
     winsorization_config: None
     | (WinsorizationConfig | dict[str, WinsorizationConfig]) = None,
-    should_deduplicate: bool = False,
+    should_deduplicate: bool = True,
     disable_progbar: bool | None = None,
     jit_compile: bool | None = None,
     derelativize_with_raw_status_quo: bool = False,
@@ -299,7 +299,7 @@ def choose_generation_strategy_legacy(
     max_parallelism_cap: int | None = None,
     max_parallelism_override: int | None = None,
     optimization_config: OptimizationConfig | None = None,
-    should_deduplicate: bool = False,
+    should_deduplicate: bool = True,
     use_saasbo: bool = False,
     disable_progbar: bool | None = None,
     jit_compile: bool | None = None,

--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -122,7 +122,6 @@ class GenerationNode(SerializationMixin, SortableBase):
 
     # Required options:
     generator_specs: list[GeneratorSpec]
-    # TODO: Move `should_deduplicate` to `GeneratorSpec` if possible, and make optional
     should_deduplicate: bool
     _name: str
 
@@ -150,7 +149,7 @@ class GenerationNode(SerializationMixin, SortableBase):
         generator_specs: list[GeneratorSpec],
         transition_criteria: Sequence[TransitionCriterion] | None = None,
         best_model_selector: BestModelSelector | None = None,
-        should_deduplicate: bool = False,
+        should_deduplicate: bool = True,
         input_constructors: TInputConstructorsByPurpose | None = None,
         previous_node_name: str | None = None,
         trial_type: str | None = None,
@@ -1014,7 +1013,7 @@ class GenerationStep:
         min_trials_observed: int = 0,
         max_parallelism: int | None = None,
         enforce_num_trials: bool = True,
-        should_deduplicate: bool = False,
+        should_deduplicate: bool = True,
         generator_name: str | None = None,
         use_all_trials_in_exp: bool = False,
         use_update: bool = False,  # DEPRECATED.

--- a/ax/generation_strategy/tests/test_dispatch_utils.py
+++ b/ax/generation_strategy/tests/test_dispatch_utils.py
@@ -860,22 +860,24 @@ class TestDispatchUtils(TestCase):
         self.assertEqual(self._get_max_parallelism(sobol_gpei._nodes[1]), 10)
 
     def test_set_should_deduplicate(self) -> None:
+        # Default is now should_deduplicate=True
         sobol_gpei = choose_generation_strategy_legacy(
             search_space=get_branin_search_space(),
             use_batch_trials=True,
             num_initialization_trials=3,
-        )
-        self.assertListEqual(
-            [s.should_deduplicate for s in sobol_gpei._nodes], [False] * 2
-        )
-        sobol_gpei = choose_generation_strategy_legacy(
-            search_space=get_branin_search_space(),
-            use_batch_trials=True,
-            num_initialization_trials=3,
-            should_deduplicate=True,
         )
         self.assertListEqual(
             [s.should_deduplicate for s in sobol_gpei._nodes], [True] * 2
+        )
+        # Explicitly set should_deduplicate=False
+        sobol_gpei = choose_generation_strategy_legacy(
+            search_space=get_branin_search_space(),
+            use_batch_trials=True,
+            num_initialization_trials=3,
+            should_deduplicate=False,
+        )
+        self.assertListEqual(
+            [s.should_deduplicate for s in sobol_gpei._nodes], [False] * 2
         )
 
     def test_setting_experiment_attribute(self) -> None:

--- a/ax/generators/random/sobol.py
+++ b/ax/generators/random/sobol.py
@@ -34,7 +34,6 @@ class SobolGenerator(RandomGenerator):
 
     def __init__(
         self,
-        deduplicate: bool = True,
         seed: int | None = None,
         init_position: int = 0,
         scramble: bool = True,
@@ -43,7 +42,6 @@ class SobolGenerator(RandomGenerator):
         polytope_sampler_kwargs: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(
-            deduplicate=deduplicate,
             seed=seed,
             init_position=init_position,
             generated_points=generated_points,
@@ -84,7 +82,6 @@ class SobolGenerator(RandomGenerator):
         fixed_features: dict[int, float] | None = None,
         model_gen_options: TConfig | None = None,
         rounding_func: Callable[[npt.NDArray], npt.NDArray] | None = None,
-        generated_points: npt.NDArray | None = None,
     ) -> tuple[npt.NDArray, npt.NDArray]:
         """Generate new candidates.
 
@@ -99,8 +96,7 @@ class SobolGenerator(RandomGenerator):
                 should be fixed to a particular value during generation.
             rounding_func: A function that rounds an optimization result
                 appropriately (e.g., according to `round-trip` transformations).
-            generated_points: A numpy array of shape `n x d` containing the
-                previously generated points to deduplicate against.
+
         Returns:
             2-element tuple containing
 
@@ -120,7 +116,6 @@ class SobolGenerator(RandomGenerator):
             fixed_features=fixed_features,
             model_gen_options=model_gen_options,
             rounding_func=rounding_func,
-            generated_points=generated_points,
         )
         if self.engine:
             self.init_position = none_throws(self.engine).num_generated

--- a/ax/generators/random/uniform.py
+++ b/ax/generators/random/uniform.py
@@ -23,14 +23,12 @@ class UniformGenerator(RandomGenerator):
 
     def __init__(
         self,
-        deduplicate: bool = True,
         seed: int | None = None,
         init_position: int = 0,
         generated_points: npt.NDArray | None = None,
         fallback_to_sample_polytope: bool = False,
     ) -> None:
         super().__init__(
-            deduplicate=deduplicate,
             seed=seed,
             init_position=init_position,
             generated_points=generated_points,

--- a/ax/generators/tests/test_uniform.py
+++ b/ax/generators/tests/test_uniform.py
@@ -9,7 +9,6 @@
 
 import numpy as np
 from ax.core.search_space import SearchSpaceDigest
-from ax.exceptions.core import SearchSpaceExhausted
 from ax.generators.random.uniform import UniformGenerator
 from ax.utils.common.testutils import TestCase
 
@@ -53,14 +52,9 @@ class UniformGeneratorTest(TestCase):
         generator = UniformGenerator(seed=self.seed)
         ssd = self._create_ssd(n_tunable=0, n_fixed=2)
         n = 3
-        with self.assertRaises(SearchSpaceExhausted):
-            generator.gen(
-                n=3,
-                search_space_digest=ssd,
-                fixed_features={0: 1, 1: 2},
-                rounding_func=lambda x: x,
-            )
-        generator = UniformGenerator(seed=self.seed, deduplicate=False)
+        # With all fixed features, there's only one feasible point, but the generator
+        # will repeat it as many times as requested since there's no deduplication
+        # at the generator level anymore.
         generated_points, _ = generator.gen(
             n=3,
             search_space_digest=ssd,

--- a/ax/generators/tests/test_utils.py
+++ b/ax/generators/tests/test_utils.py
@@ -15,7 +15,6 @@ from ax.generators.utils import (
     best_observed_point,
     enumerate_discrete_combinations,
     mk_discrete_choices,
-    remove_duplicates,
 )
 from ax.utils.common.testutils import TestCase
 
@@ -141,27 +140,6 @@ class UtilsTest(TestCase):
                 fixed_features={1: 100},
                 options={"method": "feasible_threshold"},
             )
-
-    def test_RemoveDuplicates(self) -> None:
-        existing_points = np.array([[0, 1], [0, 2]])
-
-        points_with_duplicates = np.array([[0, 1], [0, 2], [0, 3], [0, 1]])
-        unique_points = remove_duplicates(points_with_duplicates)
-        expected_points = np.array([[0, 1], [0, 2], [0, 3]])
-        self.assertTrue(np.array_equal(expected_points, unique_points))
-
-        unique_points = remove_duplicates(points_with_duplicates, existing_points)
-        expected_points = np.array([[0, 3]])
-        self.assertTrue(np.array_equal(expected_points, unique_points))
-
-        points_without_duplicates = np.array([[0, 1], [0, 2], [0, 3], [0, 4]])
-        expected_points = np.array([[0, 1], [0, 2], [0, 3], [0, 4]])
-        unique_points = remove_duplicates(points_without_duplicates)
-        self.assertTrue(np.array_equal(expected_points, unique_points))
-
-        unique_points = remove_duplicates(points_without_duplicates, existing_points)
-        expected_points = np.array([[0, 3], [0, 4]])
-        self.assertTrue(np.array_equal(expected_points, unique_points))
 
     def test_MkDiscreteChoices(self) -> None:
         ssd1 = SearchSpaceDigest(

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -792,13 +792,13 @@ class SQAStoreTest(TestCase):
             # 3. Try case with model state and search space + opt.config on a
             # generator run in the experiment.
             gr = Generators.SOBOL(experiment=exp).gen(1)
-            # Expecting model kwargs to have 7 fields (seed, deduplicate, init_position,
+            # Expecting model kwargs to have 6 fields (seed, init_position,
             # scramble, generated_points, fallback_to_sample_polytope,
             # polytope_sampler_kwargs)
             # and the rest of model-state info on generator run to have values too.
             generator_kwargs = gr._generator_kwargs
             self.assertIsNotNone(generator_kwargs)
-            self.assertEqual(len(generator_kwargs), 7)
+            self.assertEqual(len(generator_kwargs), 6)
             adapter_kwargs = gr._adapter_kwargs
             self.assertIsNotNone(adapter_kwargs)
             self.assertEqual(len(adapter_kwargs), 6)


### PR DESCRIPTION
Summary:
Previously, we had dedup settings on both `Generator` and `GenerationNode` level, which is unnecessary and error-prone for accidentally using 2 different dedup settings at the 2 levels (see D92094386)

Given that only `SobolGenerator` has special dedup logic, we've decided to deprecate `deduplicate` setting in `Generator` and only rely on `GenerationNode` level deduplication.

Furthermore, since we generally expect dedup to be True for OSS use cases and AutoML use cases, we set `GenerationNode.should_deduplicate=True` by default while explicitly overwriting GNode dedup to False for online use cases.


**One Potential Issue**
Currently `RandomAdapter._gen` solely relies on SOBOL generator to dedup (by passing in `generated_points` to sobol generator and then `rejection_sample`- https://fburl.com/code/zmqfhn8g) and if we remove that, anyone that's using standalone `RandomAdapter` (without a GNode) may get duplicated trials if they call `RandomAdapter.gen` multiple times. This is partially mitigated by advancing `init_position` on sobol generator -- there shouldn't be duplicated points for continuous parameters, but if there are discrete parameters we can be producing duplicated points after rounding. The recommended path is through GenerationStrategy/GenerationNode, where dedup is properly handled. But there's no enforcement on never using standalone RandomAdapter. (ps. `TorchAdapter` passes pending_observations through to the BoTorch acquisition function as X_pending so it doesn't have the same problem)

Differential Revision: D92884352


