### PR TITLE
enable adding derived parameters to an experiment with existing trials

### DIFF
--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -360,19 +360,18 @@ class Adapter:
         experiment_data: ExperimentData,
     ) -> list[bool]:
         """Compute in-design status for each row of ``experiment_data``, after
-        filling missing values if ``FillMissingParameters`` transform is used.
+        filling missing values if ``FillMissingParameters`` transform is used
+        and computing derived parameter values.
         """
-        t = FillMissingParameters(
-            search_space=search_space,
-            config=self._transform_configs.get("FillMissingParameters", None),
-        )
-        experiment_data = t.transform_experiment_data(
+        experiment_data, _ = self._transform_data(
             experiment_data=experiment_data,
+            search_space=search_space,
+            transforms=self._raw_transforms[:1],
+            transform_configs=self._transform_configs,
+            assign_transforms=False,
         )
         # Use vectorized membership check for efficiency.
-        return search_space.check_membership_df(
-            arm_data=experiment_data.arm_data,
-        )
+        return search_space.check_membership_df(arm_data=experiment_data.arm_data)
 
     def _set_model_space(self, arm_data: DataFrame) -> None:
         """Set model space, possibly expanding range parameters to cover data."""

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -323,15 +323,15 @@ class Experiment(Base):
 
         # Additional checks iff a trial exists
         if len(self.trials) != 0:
-            if any(parameter.backfill_value is None for parameter in parameters):
+            if any(
+                (parameter.backfill_value is None)
+                and not isinstance(parameter, DerivedParameter)
+                for parameter in parameters
+            ):
                 raise UserInputError(
-                    "Must provide backfill values for all new parameters when "
-                    "adding parameters to an experiment with existing trials."
-                )
-            if any(isinstance(parameter, DerivedParameter) for parameter in parameters):
-                raise UserInputError(
-                    "Cannot add derived parameters to an experiment with existing "
-                    "trials."
+                    "Must provide backfill values for all new parameters (except "
+                    "DerivedParameters) when adding parameters to an experiment "
+                    "with existing trials."
                 )
 
         # Validate status quo values
@@ -356,13 +356,13 @@ class Experiment(Base):
                     f"`{extra_status_quo_values}` which is are being added to "
                     "the search space. Ignoring provided status quo values."
                 )
-            mising_status_quo_values = (
+            missing_status_quo_values = (
                 parameter_names - disabled_parameters - status_quo_parameters
             )
-            if mising_status_quo_values:
+            if missing_status_quo_values:
                 raise UserInputError(
                     "No status quo value provided for parameters "
-                    f"`{mising_status_quo_values}` which are being added to "
+                    f"`{missing_status_quo_values}` which are being added to "
                     "the search space."
                 )
             for parameter_name, value in status_quo_values.items():


### PR DESCRIPTION
Summary: This enables adding `DerivedParameter`s to an experiment with existing trials. These `DerivedParameter`s do not have a `backfill_value` as `RangeParameter`s do, but rather, their values are compute in `FillMissingParameters` based on the values of the other parameters.

Differential Revision: D92753331


