### PR TITLE
Fix bugs in core data structures and orchestrator

### DIFF
--- a/ax/core/arm.py
+++ b/ax/core/arm.py
@@ -90,7 +90,7 @@ class Arm(SortableBase):
         new_parameters = {}
         for k, v in parameters.items():
             new_parameters[k] = numpy_type_to_python_type(v)
-        parameters_str = json.dumps(parameters, sort_keys=True)
+        parameters_str = json.dumps(new_parameters, sort_keys=True)
         return hashlib.md5(parameters_str.encode("utf-8")).hexdigest()
 
     def clone(self, clear_name: bool = False) -> "Arm":

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -727,7 +727,7 @@ class Experiment(Base):
                 UserInputError(
                     f"Metric class {metric_class} does not contain the requested "
                     "attributes to update. Requested updates to attributes: "
-                    f"{set(attributes_to_update.keys())} but metric class defines"
+                    f"{set(attributes_to_update.keys())} but metric class defines "
                     f"{metric_attributes}."
                 )
             )

--- a/ax/core/generator_run.py
+++ b/ax/core/generator_run.py
@@ -343,6 +343,14 @@ class GeneratorRun(SortableBase):
             if self._generator_state_after_gen is not None
             else None
         )
+        generator_run._gen_metadata = (
+            self._gen_metadata.copy() if self._gen_metadata is not None else None
+        )
+        generator_run._candidate_metadata_by_arm_signature = (
+            self._candidate_metadata_by_arm_signature.copy()
+            if self._candidate_metadata_by_arm_signature is not None
+            else None
+        )
         return generator_run
 
     def add_arm(self, arm: Arm, weight: float = 1.0) -> None:

--- a/ax/core/metric.py
+++ b/ax/core/metric.py
@@ -165,7 +165,7 @@ class Metric(SortableBase, SerializationMixin):
         return timedelta(0)
 
     @classmethod
-    def is_reconverable_fetch_e(cls, metric_fetch_e: MetricFetchE) -> bool:
+    def is_recoverable_fetch_e(cls, metric_fetch_e: MetricFetchE) -> bool:
         """Checks whether the given MetricFetchE is recoverable for this metric class
         in ``orchestrator._fetch_and_process_trials_data_results``.
         """

--- a/ax/core/outcome_constraint.py
+++ b/ax/core/outcome_constraint.py
@@ -28,7 +28,7 @@ UPPER_BOUND_MISMATCH: dict[str, str] = {"bound": "Upper", "is_better": "higher"}
 
 CONSTRAINT_THRESHOLD_WARNING_MESSAGE: str = (
     "Constraint threshold on {name} appears invalid: {bound} bound on metric "
-    + "for which {is_better} values is better."
+    + "for which {is_better} values are better."
 )
 UPPER_BOUND_THRESHOLD: dict[str, str] = {"bound": "Positive", "is_better": "lower"}
 LOWER_BOUND_THRESHOLD: dict[str, str] = {"bound": "Negative", "is_better": "higher"}
@@ -120,7 +120,7 @@ class OutcomeConstraint(SortableBase):
             if op == ComparisonOp.LEQ and not metric.lower_is_better:
                 fmt_data = UPPER_BOUND_MISMATCH
         if fmt_data is not None:
-            fmt_data["name"] = metric.name
+            fmt_data = {**fmt_data, "name": metric.name}
             msg = CONSTRAINT_WARNING_MESSAGE.format(**fmt_data)
             logger.debug(msg)
             return False, msg
@@ -156,7 +156,7 @@ class OutcomeConstraint(SortableBase):
             if self.bound > 0 and not self.metric.lower_is_better:
                 fmt_data = LOWER_BOUND_THRESHOLD
         if fmt_data is not None:
-            fmt_data["name"] = self.metric.name
+            fmt_data = {**fmt_data, "name": self.metric.name}
             msg += CONSTRAINT_THRESHOLD_WARNING_MESSAGE.format(**fmt_data)
             logger.debug(msg)
             return False, msg

--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -423,13 +423,13 @@ class RangeParameter(Parameter):
             ParameterType.FLOAT,
         ):
             raise UserInputError(
-                f"RangeParameter {self.name}type must be int or float."
+                f"RangeParameter {self.name} type must be int or float."
             )
 
         upper = float(upper)
         if lower >= upper:
             raise UserInputError(
-                f"Upper bound of {self.name} must be strictly larger than lower."
+                f"Upper bound of {self.name} must be strictly larger than lower. "
                 f"Got: ({lower}, {upper})."
             )
         width: float = upper - lower

--- a/ax/core/parameter_constraint.py
+++ b/ax/core/parameter_constraint.py
@@ -129,7 +129,7 @@ def validate_constraint_parameters(parameters: Sequence[Parameter]) -> None:
     for parameter in parameters:
         if not isinstance(parameter, RangeParameter):
             raise ValueError(
-                "All parameters in a parameter constraint must be RangeParameters."
+                "All parameters in a parameter constraint must be RangeParameters. "
                 f"Found {parameter}"
             )
 

--- a/ax/core/tests/test_outcome_constraint.py
+++ b/ax/core/tests/test_outcome_constraint.py
@@ -63,14 +63,14 @@ class OutcomeConstraintTest(TestCase):
                 metric=self.minimize_metric, op=ComparisonOp.GEQ, bound=self.bound
             )
         mock_warning.debug.assert_called_once_with(
-            CONSTRAINT_WARNING_MESSAGE.format(**LOWER_BOUND_MISMATCH)
+            CONSTRAINT_WARNING_MESSAGE.format(**LOWER_BOUND_MISMATCH, name="bar")
         )
         with mock.patch(logger_name) as mock_warning:
             OutcomeConstraint(
                 metric=self.maximize_metric, op=ComparisonOp.LEQ, bound=self.bound
             )
         mock_warning.debug.assert_called_once_with(
-            CONSTRAINT_WARNING_MESSAGE.format(**UPPER_BOUND_MISMATCH)
+            CONSTRAINT_WARNING_MESSAGE.format(**UPPER_BOUND_MISMATCH, name="baz")
         )
 
     def test_Sortable(self) -> None:
@@ -144,14 +144,14 @@ class ObjectiveThresholdTest(TestCase):
                 metric=self.minimize_metric, op=ComparisonOp.GEQ, bound=self.bound
             )
         mock_warning.debug.assert_called_once_with(
-            CONSTRAINT_WARNING_MESSAGE.format(**LOWER_BOUND_MISMATCH)
+            CONSTRAINT_WARNING_MESSAGE.format(**LOWER_BOUND_MISMATCH, name="bar")
         )
         with mock.patch(logger_name) as mock_warning:
             ObjectiveThreshold(
                 metric=self.maximize_metric, op=ComparisonOp.LEQ, bound=self.bound
             )
         mock_warning.debug.assert_called_once_with(
-            CONSTRAINT_WARNING_MESSAGE.format(**UPPER_BOUND_MISMATCH)
+            CONSTRAINT_WARNING_MESSAGE.format(**UPPER_BOUND_MISMATCH, name="baz")
         )
 
     def test_Relativize(self) -> None:

--- a/ax/orchestration/orchestrator.py
+++ b/ax/orchestration/orchestrator.py
@@ -1227,7 +1227,7 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
         if not self.options.wait_for_running_trials:
             return None
         return self.wait_for_completed_trials_and_report_results(
-            idle_callback, force_refit=True
+            idle_callback, force_refit=force_refit
         )
 
     def run(self, max_new_trials: int, timeout_hours: float | None = None) -> bool:
@@ -2093,9 +2093,9 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
                 if (
                     optimization_config is not None
                     and metric_name in optimization_config.metrics.keys()
-                    and not self.experiment.metrics[
-                        metric_name
-                    ].is_reconverable_fetch_e(metric_fetch_e=metric_fetch_e)
+                    and not self.experiment.metrics[metric_name].is_recoverable_fetch_e(
+                        metric_fetch_e=metric_fetch_e
+                    )
                 ):
                     status = self._mark_err_trial_status(
                         trial=self.experiment.trials[trial_index],


### PR DESCRIPTION
Summary:
Fix multiple bugs in ax/core and ax/orchestration:

- `Arm.md5hash` hashes unconverted parameters instead of the numpy-type-converted `new_parameters` (core/arm.py:94)
- `GeneratorRun.clone()` doesn't copy `gen_metadata` or `candidate_metadata_by_arm_signature`, causing mutations on the clone to affect the original (core/generator_run.py:304-346)
- Module-level dict mutation in `OutcomeConstraint`: writing `fmt_data["name"] = ...` mutates the shared module-level dicts `UPPER_BOUND_MISMATCH` / `LOWER_BOUND_THRESHOLD` etc. (core/outcome_constraint.py:123,159)
- Typo in method name: `is_reconverable_fetch_e` → `is_recoverable_fetch_e` (core/metric.py:168, orchestration/orchestrator.py:2098)
- `force_refit` parameter hardcoded to True instead of using the passed argument (orchestration/orchestrator.py:1230)
- Grammar fix: "values is better" → "values are better" (core/outcome_constraint.py)
- Missing spaces between concatenated strings (core/parameter.py, core/parameter_constraint.py, core/experiment.py)

Differential Revision: D92879435
