### PR TITLE
Fix bugs in adapter and transform modules

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -228,7 +228,7 @@ def extract_objective_thresholds(
     # Check that all thresholds correspond to a metric.
     if set(objective_threshold_dict.keys()).difference(set(objective.metric_names)):
         raise ValueError(
-            "Some objective thresholds do not have corresponding metrics."
+            "Some objective thresholds do not have corresponding metrics. "
             f"Got {objective_thresholds=} and {objective=}."
         )
 
@@ -566,12 +566,10 @@ def get_pareto_frontier_and_configs(
                 "`observation_data` will not be used.",
                 stacklevel=2,
             )
-    else:
-        if observation_data is None:
-            raise ValueError(
-                "`observation_data` must not be None when `use_model_predictions` is "
-                "True."
-            )
+    elif observation_data is None:
+        raise ValueError(
+            "`observation_data` must not be None when `use_model_predictions` is False."
+        )
 
     array_to_tensor = adapter._array_to_tensor
     if use_model_predictions:

--- a/ax/adapter/torch.py
+++ b/ax/adapter/torch.py
@@ -693,7 +693,7 @@ class TorchAdapter(Adapter):
             if pe_data.df.empty:
                 raise DataRequiredError(
                     "No data found in the auxiliary preference exploration "
-                    "experiment. Play the preference game first or use another"
+                    "experiment. Play the preference game first or use another "
                     "preference profile with recorded preference data."
                 )
 

--- a/ax/adapter/transforms/int_range_to_choice.py
+++ b/ax/adapter/transforms/int_range_to_choice.py
@@ -67,18 +67,13 @@ class IntRangeToChoice(Transform):
                 and p.cardinality() <= self.max_choices
             ):
                 values = list(range(int(p.lower), int(p.upper) + 1))
-                target_value = (
-                    None
-                    if p.target_value is None
-                    else next(i for i, v in enumerate(values) if v == p.target_value)
-                )
                 transformed_parameters[p_name] = ChoiceParameter(
                     name=p_name,
                     parameter_type=p.parameter_type,
                     values=values,  # pyre-fixme[6]
                     is_ordered=True,
                     is_fidelity=p.is_fidelity,
-                    target_value=target_value,
+                    target_value=p.target_value,
                 )
             else:
                 transformed_parameters[p.name] = p

--- a/ax/adapter/transforms/relativize.py
+++ b/ax/adapter/transforms/relativize.py
@@ -335,7 +335,7 @@ def get_metric_index(data: ObservationData, metric_signature: str) -> int:
     """Get the index of a metric in the ObservationData."""
     try:
         return data.metric_signatures.index(metric_signature)
-    except (IndexError, StopIteration):
+    except ValueError:
         raise ValueError(
             "Relativization cannot be performed because "
             "ObservationData for status quo is missing metrics"

--- a/ax/adapter/transforms/tests/test_int_range_to_choice_transform.py
+++ b/ax/adapter/transforms/tests/test_int_range_to_choice_transform.py
@@ -13,6 +13,7 @@ from ax.core.observation import ObservationFeatures
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
 from ax.core.search_space import SearchSpace
 from ax.utils.common.testutils import TestCase
+from pyre_extensions import assert_is_instance
 
 
 class IntRangeToChoiceTransformTest(TestCase):
@@ -20,7 +21,13 @@ class IntRangeToChoiceTransformTest(TestCase):
         super().setUp()
         self.search_space = SearchSpace(
             parameters=[
-                RangeParameter("a", lower=1, upper=5, parameter_type=ParameterType.INT),
+                RangeParameter(
+                    "a",
+                    lower=1,
+                    upper=5,
+                    parameter_type=ParameterType.INT,
+                    target_value=2,
+                ),
                 ChoiceParameter(
                     "b", parameter_type=ParameterType.STRING, values=["a", "b", "c"]
                 ),
@@ -43,9 +50,9 @@ class IntRangeToChoiceTransformTest(TestCase):
     def test_TransformSearchSpace(self) -> None:
         ss2 = deepcopy(self.search_space)
         ss2 = self.t.transform_search_space(ss2)
-        self.assertTrue(isinstance(ss2.parameters["a"], ChoiceParameter))
-        # pyre-fixme[16]: `Parameter` has no attribute `values`.
-        self.assertTrue(ss2.parameters["a"].values, [1, 2, 3, 4, 5])
+        new_a = assert_is_instance(ss2.parameters["a"], ChoiceParameter)
+        self.assertEqual(new_a.values, [1, 2, 3, 4, 5])
+        self.assertEqual(new_a.target_value, 2)
 
     def test_num_choices(self) -> None:
         parameters = {


### PR DESCRIPTION
Summary:
Fix multiple bugs in ax/adapter:

- `IntRangeToChoice` transform using index instead of value for `target_value`: `next(i for i, v in enumerate(values) if v == p.target_value)` returns the index, but the target_value should remain the value itself since ChoiceParameter stores actual values (transforms/int_range_to_choice.py:70)
- Wrong exception type caught in `relativize.py`: `list.index()` raises `ValueError`, not `IndexError` or `StopIteration` (transforms/relativize.py:338)
- Error message says "True" when the value is actually False: `use_model_predictions` is False in the branch where the error is raised (adapter_utils.py)
- Missing space between concatenated strings (torch.py, adapter_utils.py)

Differential Revision: D92879576
