### PR TITLE
Replace string-based SQLAlchemy loader options with class-bound attributes

### DIFF
--- a/ax/storage/sqa_store/reduced_state.py
+++ b/ax/storage/sqa_store/reduced_state.py
@@ -7,8 +7,8 @@
 # pyre-strict
 
 
-from ax.storage.sqa_store.sqa_classes import SQAGeneratorRun
-from sqlalchemy.orm import defaultload, lazyload, strategy_options
+from ax.storage.sqa_store.sqa_classes import SQAGeneratorRun, SQATrial
+from sqlalchemy.orm import defaultload, strategy_options
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 
@@ -42,7 +42,10 @@ def get_query_options_to_defer_immutable_duplicates() -> list[strategy_options.L
     need to be loaded for experiments with immutable search space and optimization
     configuration.
     """
-    options = [lazyload(f"generator_runs.{col}") for col in GR_PARAMS_METRICS_COLS]
+    options = [
+        defaultload(SQATrial.generator_runs).lazyload(getattr(SQAGeneratorRun, col))
+        for col in GR_PARAMS_METRICS_COLS
+    ]
     return options
 
 
@@ -52,5 +55,6 @@ def get_query_options_to_defer_large_model_cols() -> list[strategy_options.Load]
     when loading experiment and generation strategy in reduced state.
     """
     return [
-        defaultload("generator_runs").defer(col.key) for col in GR_LARGE_MODEL_ATTRS
+        defaultload(SQATrial.generator_runs).defer(col.key)
+        for col in GR_LARGE_MODEL_ATTRS
     ]


### PR DESCRIPTION
Summary:
SQLAlchemy 2.x rejects string-based attribute names in loader options (noload, lazyload, defaultload), requiring class-bound attributes instead. The original diff (D91825190) fixed this for noload() calls in _get_experiment_sqa and _get_trials_sqa. This extends the fix to all remaining string-based loader options in load.py (generation strategy loading functions) and reduced_state.py (deferred loading of immutable duplicates and large model columns).

Regarding the reviewer feedback on __allow_unmapped__: this is already set on SQABase in db.py (line 49), so all SQA model classes inherit it through Base = declarative_base(cls=SQABase). No additional changes are needed for unmapped annotation compatibility.

The CI failure in fbcode//fi/ml_automation/data_collection/tests:test_query_builder_empty_partitions is unrelated to these changes and passes locally (Pass 3, Fail 0).

Reviewed By: saitcakmak

Differential Revision: D92560600


