### PR TITLE
Add suggested_experiment_status field (#4862)

### DIFF
--- a/ax/generation_strategy/center_generation_node.py
+++ b/ax/generation_strategy/center_generation_node.py
@@ -13,6 +13,7 @@ from ax.adapter.registry import Generators
 from ax.core.arm import Arm
 from ax.core.data import Data
 from ax.core.experiment import Experiment
+from ax.core.experiment_status import ExperimentStatus
 from ax.core.generator_run import GeneratorRun
 from ax.core.observation import ObservationFeatures
 from ax.core.parameter import DerivedParameter
@@ -29,7 +30,12 @@ from pyre_extensions import none_throws
 class CenterGenerationNode(ExternalGenerationNode):
     next_node_name: str
 
-    def __init__(self, next_node_name: str) -> None:
+    def __init__(
+        self,
+        next_node_name: str,
+        suggested_experiment_status: ExperimentStatus
+        | None = ExperimentStatus.INITIALIZATION,
+    ) -> None:
         """A generation node that samples the center of the search space.
         This generation node is only used to generate the first point of the experiment.
         After one point is generated, it will transition to `next_node_name`.
@@ -37,9 +43,16 @@ class CenterGenerationNode(ExternalGenerationNode):
         If the generated point is a duplicate of an arm already attached to the
         experiment, this will fallback to Sobol through the use of ``GenerationNode``
         deduplication logic.
+
+        Args:
+            next_node_name: The name of the node to transition to after generating
+                the center point.
+            suggested_experiment_status: Optional suggested experiment status for this
+                node.
         """
         super().__init__(
             name="CenterOfSearchSpace",
+            suggested_experiment_status=suggested_experiment_status,
             transition_criteria=[
                 AutoTransitionAfterGen(
                     transition_to=next_node_name,

--- a/ax/generation_strategy/external_generation_node.py
+++ b/ax/generation_strategy/external_generation_node.py
@@ -14,6 +14,7 @@ from typing import Any
 from ax.core.arm import Arm
 from ax.core.data import Data
 from ax.core.experiment import Experiment
+from ax.core.experiment_status import ExperimentStatus
 from ax.core.generator_run import GeneratorRun
 from ax.core.observation import ObservationFeatures
 from ax.core.types import TParameterization
@@ -48,6 +49,7 @@ class ExternalGenerationNode(GenerationNode, ABC):
     def __init__(
         self,
         name: str,
+        suggested_experiment_status: ExperimentStatus | None = None,
         should_deduplicate: bool = True,
         transition_criteria: Sequence[TransitionCriterion] | None = None,
     ) -> None:
@@ -59,6 +61,8 @@ class ExternalGenerationNode(GenerationNode, ABC):
 
         Args:
             name: Name of the generation node.
+            suggested_experiment_status: Optional suggested experiment status for this
+                node. Defaults to None if not specified.
             should_deduplicate: Whether to deduplicate the generated points against
                 the existing trials on the experiment. If True, the duplicate points
                 will be discarded and re-generated up to 5 times, after which a
@@ -73,6 +77,7 @@ class ExternalGenerationNode(GenerationNode, ABC):
         super().__init__(
             name=name,
             generator_specs=[],
+            suggested_experiment_status=suggested_experiment_status,
             best_model_selector=None,
             should_deduplicate=should_deduplicate,
             transition_criteria=transition_criteria,

--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -15,6 +15,7 @@ from typing import Any, cast, TYPE_CHECKING, Union
 
 from ax.core.data import Data
 from ax.core.experiment import Experiment
+from ax.core.experiment_status import ExperimentStatus
 from ax.core.generator_run import GeneratorRun
 from ax.core.observation import ObservationFeatures
 from ax.core.trial_status import TrialStatus
@@ -112,6 +113,10 @@ class GenerationNode(SerializationMixin, SortableBase):
             store the most recent previous ``GenerationNode`` name.
         should_skip: Whether to skip this node during generation time. Defaults to
             False, and can only currently be set to True via ``NodeInputConstructors``
+        suggested_experiment_status: Optional ``ExperimentStatus`` that indicates
+            what the experiment's status should be once the experiment adds trials
+            using ``GeneratorRun``-s produced from this node. This is advisory only
+            and does not automatically update the experiment's status.
         fallback_specs: Optional dict mapping expected exception types to `ModelSpec`
             fallbacks used when gen fails.
 
@@ -134,6 +139,7 @@ class GenerationNode(SerializationMixin, SortableBase):
     _previous_node_name: str | None = None
     _trial_type: str | None = None
     _should_skip: bool = False
+    suggested_experiment_status: ExperimentStatus | None = None
     fallback_specs: dict[type[Exception], GeneratorSpec]
 
     # [TODO] Handle experiment passing more eloquently by enforcing experiment
@@ -155,6 +161,7 @@ class GenerationNode(SerializationMixin, SortableBase):
         previous_node_name: str | None = None,
         trial_type: str | None = None,
         should_skip: bool = False,
+        suggested_experiment_status: ExperimentStatus | None = None,
         fallback_specs: dict[type[Exception], GeneratorSpec] | None = None,
     ) -> None:
         self._name = name
@@ -187,6 +194,7 @@ class GenerationNode(SerializationMixin, SortableBase):
         self._previous_node_name = previous_node_name
         self._trial_type = trial_type
         self._should_skip = should_skip
+        self.suggested_experiment_status = suggested_experiment_status
         self.fallback_specs = (
             fallback_specs if fallback_specs is not None else DEFAULT_FALLBACK
         )
@@ -354,6 +362,10 @@ class GenerationNode(SerializationMixin, SortableBase):
         str_rep += (
             f", transition_criteria={str(self._brief_transition_criteria_repr())}"
         )
+        if self.suggested_experiment_status is not None:
+            str_rep += (
+                f", suggested_experiment_status={self.suggested_experiment_status!r}"
+            )
         return f"{str_rep})"
 
     def _fit(
@@ -999,6 +1011,7 @@ class GenerationStep:
             whether to transition to the next step. If False, `num_trials` and
             `min_trials_observed` will only count trials generatd by this step. If True,
             they will count all trials in the experiment (of corresponding statuses).
+        suggested_experiment_status: The suggested experiment status for this step.
 
     Note for developers: by "generator" here we really mean an ``Adapter`` object, which
     contains a ``Generator`` under the hood. We call it "generator" here to simplify and
@@ -1019,6 +1032,7 @@ class GenerationStep:
         use_all_trials_in_exp: bool = False,
         use_update: bool = False,  # DEPRECATED.
         index: int = -1,  # Index of this step, set internally.
+        suggested_experiment_status: ExperimentStatus | None = None,
         # Deprecated arguments for backwards compatibility.
         model_kwargs: dict[str, Any] | None = None,
         model_gen_kwargs: dict[str, Any] | None = None,
@@ -1135,6 +1149,7 @@ class GenerationStep:
                 step_index=index, generator_name=resolved_generator_name
             ),
             generator_specs=[generator_spec],
+            suggested_experiment_status=suggested_experiment_status,
             should_deduplicate=should_deduplicate,
             transition_criteria=transition_criteria,
         )

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -889,6 +889,15 @@ def generation_node_from_json(
             if "trial_type" in generation_node_json.keys()
             else None
         ),
+        suggested_experiment_status=(
+            object_from_json(
+                object_json=generation_node_json.pop("suggested_experiment_status"),
+                decoder_registry=decoder_registry,
+                class_decoder_registry=class_decoder_registry,
+            )
+            if "suggested_experiment_status" in generation_node_json.keys()
+            else None  # Default for old records without the field
+        ),
     )
 
 

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -411,6 +411,7 @@ def generation_node_to_dict(generation_node: GenerationNode) -> dict[str, Any]:
         "generator_spec_to_gen_from": generation_node._generator_spec_to_gen_from,
         "previous_node_name": generation_node._previous_node_name,
         "trial_type": generation_node._trial_type,
+        "suggested_experiment_status": generation_node.suggested_experiment_status,
         # need to manually encode input constructors because the key is an enum.
         # Our encoding and decoding logic in object_to_json and object_from_json
         # doesn't recursively encode/decode the keys of dictionaries.

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -29,6 +29,7 @@ from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
 from ax.core.batch_trial import AbandonedArm, BatchTrial
 from ax.core.data import Data
 from ax.core.evaluations_to_data import DataType
+from ax.core.experiment_status import ExperimentStatus
 from ax.core.generator_run import GeneratorRun
 from ax.core.llm_provider import LLMMessage
 from ax.core.map_metric import MapMetric
@@ -316,6 +317,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "DerivedParameter": DerivedParameter,
     "DomainType": DomainType,
     "Experiment": Experiment,
+    "ExperimentStatus": ExperimentStatus,
     "FactorialMetric": FactorialMetric,
     "FilterFeatures": FilterFeatures,
     "FixedParameter": fixed_parameter_from_json,


### PR DESCRIPTION
Summary:

This change introduces an optional `suggested_experiment_state` field to
the `GenerationNode` class that allows tracking what experiment status is suggested
for a given generation node. This is part of a larger effort to add status tracking
to experiments.

The field is:
- Optional (defaults to None for backward compatibility)
- Advisory only (does not automatically update experiment.status)
- Configurable per GenerationNode instance
- Serialized automatically via SerializationMixin
- Displayed in __repr__ when set

This is Phase 1 where we are just adding the column but not yet doing anything with it. In the next diffs in this stack we will propagate this through the orchestrator and eventually set this status on the experiment.

Reviewed By: mgarrard

Differential Revision: D88089767


