### PR TITLE
Add LLMMessage property to Experiment

### DIFF
--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -244,8 +244,10 @@ class TestGenerationStrategyWithoutAdapterMocks(TestCase):
             trial.mark_running(no_runner_required=True)
             trial.mark_completed()
 
-        # Generate additional trials to verify E2E constraint satisfaction
-        for i in range(9):
+        # Generate additional trials to verify E2E constraint satisfaction.
+        # Note: with 4 choices and x1 <= x2, there are only 10 valid combos,
+        # so we generate fewer trials to avoid exhausting the search space.
+        for i in range(4):
             generator_run = gs.gen_single_trial(experiment=experiment)
             arm = generator_run.arms[0]
             x1_val = cast(int, arm.parameters["x1"])

--- a/ax/utils/common/constants.py
+++ b/ax/utils/common/constants.py
@@ -64,6 +64,7 @@ class Keys(StrEnum):
     FRAC_RANDOM = "frac_random"
     FULL_PARAMETERIZATION = "full_parameterization"
     IMMUTABLE_SEARCH_SPACE_AND_OPT_CONF = "immutable_search_space_and_opt_config"
+    LLM_MESSAGES = "llm_messages"
     LONG_RUN = "long_run"
     MAXIMIZE = "maximize"
     METADATA = "metadata"


### PR DESCRIPTION
Summary:
Adds `llm_messages` property, setter, `add_llm_messages()`, and `get_llm_messages_with_data()` to `Experiment` to enable LLM integration in Ax quickly (e.g. LILO, LLAMBO). Messages are stored in `_properties` via a new `Keys.LLM_MESSAGES` constant.

This is a quick enablement — we can figure out a better, permanent storage place for LLM messages in the future.

Reviewed By: saitcakmak

Differential Revision: D93069107


