### PR TITLE
Phase 3: Add Self type annotations to fluent/clone methods

### DIFF
--- a/ax/core/arm.py
+++ b/ax/core/arm.py
@@ -9,6 +9,7 @@
 import hashlib
 import json
 from collections.abc import Mapping
+from typing import Self
 
 from ax.core.types import TParameterization, TParamValue
 from ax.utils.common.base import SortableBase
@@ -93,7 +94,7 @@ class Arm(SortableBase):
         parameters_str = json.dumps(new_parameters, sort_keys=True)
         return hashlib.md5(parameters_str.encode("utf-8")).hexdigest()
 
-    def clone(self, clear_name: bool = False) -> "Arm":
+    def clone(self, clear_name: bool = False) -> Self:
         """Create a copy of this arm.
 
         Args:
@@ -102,7 +103,7 @@ class Arm(SortableBase):
                 Defaults to False.
         """
         clear_name = clear_name or not self.has_name
-        return Arm(
+        return self.__class__(
             parameters=self.parameters.copy(), name=None if clear_name else self.name
         )
 

--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -327,7 +327,7 @@ class BaseTrial(ABC, SortableBase):
         self._stop_metadata.update(metadata)
         return self._stop_metadata
 
-    def run(self) -> BaseTrial:
+    def run(self) -> Self:
         """Deploys the trial according to the behavior on the runner.
 
         The runner returns a `run_metadata` dict containining metadata
@@ -352,7 +352,7 @@ class BaseTrial(ABC, SortableBase):
             self.mark_running()
         return self
 
-    def stop(self, new_status: TrialStatus, reason: str | None = None) -> BaseTrial:
+    def stop(self, new_status: TrialStatus, reason: str | None = None) -> Self:
         """Stops the trial according to the behavior on the runner.
 
         The runner returns a `stop_metadata` dict containining metadata
@@ -387,7 +387,7 @@ class BaseTrial(ABC, SortableBase):
         self.mark_as(new_status)
         return self
 
-    def complete(self, reason: str | None = None) -> BaseTrial:
+    def complete(self, reason: str | None = None) -> Self:
         """Stops the trial if functionality is defined on runner
             and marks trial completed.
 
@@ -528,7 +528,7 @@ class BaseTrial(ABC, SortableBase):
         """Reason string for the trial status (failed, abandoned, or early stopped)."""
         return self._status_reason
 
-    def mark_staged(self, unsafe: bool = False) -> BaseTrial:
+    def mark_staged(self, unsafe: bool = False) -> Self:
         """Mark the trial as being staged for running.
 
         Args:
@@ -546,7 +546,7 @@ class BaseTrial(ABC, SortableBase):
 
     def mark_running(
         self, no_runner_required: bool = False, unsafe: bool = False
-    ) -> BaseTrial:
+    ) -> Self:
         """Mark trial has started running.
 
         Args:
@@ -576,7 +576,7 @@ class BaseTrial(ABC, SortableBase):
 
     def mark_completed(
         self, unsafe: bool = False, time_completed: str | None = None
-    ) -> BaseTrial:
+    ) -> Self:
         """Mark trial as completed.
 
         Args:
@@ -600,9 +600,7 @@ class BaseTrial(ABC, SortableBase):
         )
         return self
 
-    def mark_abandoned(
-        self, reason: str | None = None, unsafe: bool = False
-    ) -> BaseTrial:
+    def mark_abandoned(self, reason: str | None = None, unsafe: bool = False) -> Self:
         """Mark trial as abandoned.
 
         NOTE: Arms in abandoned trials are considered to be 'pending points'
@@ -628,7 +626,7 @@ class BaseTrial(ABC, SortableBase):
         self._time_completed = datetime.now()
         return self
 
-    def mark_failed(self, reason: str | None = None, unsafe: bool = False) -> BaseTrial:
+    def mark_failed(self, reason: str | None = None, unsafe: bool = False) -> Self:
         """Mark trial as failed.
 
         Args:
@@ -648,7 +646,7 @@ class BaseTrial(ABC, SortableBase):
 
     def mark_early_stopped(
         self, reason: str | None = None, unsafe: bool = False
-    ) -> BaseTrial:
+    ) -> Self:
         """Mark trial as early stopped.
 
         Args:
@@ -674,7 +672,7 @@ class BaseTrial(ABC, SortableBase):
         self._time_completed = datetime.now()
         return self
 
-    def mark_stale(self, unsafe: bool = False) -> BaseTrial:
+    def mark_stale(self, unsafe: bool = False) -> Self:
         """Mark trial as stale.
 
         Args:
@@ -695,9 +693,7 @@ class BaseTrial(ABC, SortableBase):
         self._time_completed = datetime.now()
         return self
 
-    def mark_as(
-        self, status: TrialStatus, unsafe: bool = False, **kwargs: Any
-    ) -> BaseTrial:
+    def mark_as(self, status: TrialStatus, unsafe: bool = False, **kwargs: Any) -> Self:
         """Mark trial with a new TrialStatus.
 
         Args:
@@ -728,7 +724,7 @@ class BaseTrial(ABC, SortableBase):
             raise TrialMutationError(f"Cannot mark trial as {status}.")
         return self
 
-    def mark_arm_abandoned(self, arm_name: str, reason: str | None = None) -> BaseTrial:
+    def mark_arm_abandoned(self, arm_name: str, reason: str | None = None) -> Self:
         raise NotImplementedError(
             "Abandoning arms is only supported for `BatchTrial`. "
             "Use `trial.mark_abandoned` if applicable."

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -13,7 +13,7 @@ from collections.abc import MutableMapping
 from dataclasses import dataclass
 from datetime import datetime
 from logging import Logger
-from typing import Any, TYPE_CHECKING
+from typing import Any, Self, TYPE_CHECKING
 
 import numpy as np
 from ax.core.arm import Arm
@@ -467,9 +467,7 @@ class BatchTrial(BaseTrial):
             weights = weights * (total / np.sum(weights))
         return OrderedDict(zip(self.arms, weights))
 
-    def mark_arm_abandoned(
-        self, arm_name: str, reason: str | None = None
-    ) -> BatchTrial:
+    def mark_arm_abandoned(self, arm_name: str, reason: str | None = None) -> Self:
         """Mark a arm abandoned.
 
         Usually done after deployment when one arm causes issues but

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -16,7 +16,7 @@ from collections.abc import Hashable, Iterable, Mapping, Sequence
 from copy import deepcopy
 from datetime import datetime
 from functools import partial, reduce
-from typing import Any, cast, Union
+from typing import Any, cast, Self, Union
 
 import ax.core.observation as observation
 import pandas as pd
@@ -795,7 +795,7 @@ class Experiment(Base):
     def tracking_metrics(self) -> list[Metric]:
         return list(self._tracking_metrics.values())
 
-    def add_tracking_metric(self, metric: Metric) -> Experiment:
+    def add_tracking_metric(self, metric: Metric) -> Self:
         """Add a new metric to the experiment.
 
         Args:
@@ -818,7 +818,7 @@ class Experiment(Base):
         self._tracking_metrics[metric.name] = metric
         return self
 
-    def add_tracking_metrics(self, metrics: list[Metric]) -> Experiment:
+    def add_tracking_metrics(self, metrics: list[Metric]) -> Self:
         """Add a list of new metrics to the experiment.
 
         If any of the metrics are already defined on the experiment,
@@ -833,7 +833,7 @@ class Experiment(Base):
             self.add_tracking_metric(metric)
         return self
 
-    def update_tracking_metric(self, metric: Metric) -> Experiment:
+    def update_tracking_metric(self, metric: Metric) -> Self:
         """Redefine a metric that already exists on the experiment.
 
         Args:
@@ -845,7 +845,7 @@ class Experiment(Base):
         self._tracking_metrics[metric.name] = metric
         return self
 
-    def remove_tracking_metric(self, metric_name: str) -> Experiment:
+    def remove_tracking_metric(self, metric_name: str) -> Self:
         """Remove a metric that already exists on the experiment.
 
         Args:

--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Self
 
 from ax.core.metric import Metric
 from ax.exceptions.core import UserInputError
@@ -72,9 +73,9 @@ class Objective(SortableBase):
         """Get a list of objective metric signatures."""
         return [m.signature for m in self.metrics]
 
-    def clone(self) -> Objective:
+    def clone(self) -> Self:
         """Create a copy of the objective."""
-        return Objective(self.metric.clone(), self.minimize)
+        return self.__class__(self.metric.clone(), self.minimize)
 
     def __repr__(self) -> str:
         return 'Objective(metric_name="{}", minimize={})'.format(
@@ -129,9 +130,9 @@ class MultiObjective(Objective):
         """Get the objectives."""
         return self._objectives
 
-    def clone(self) -> MultiObjective:
+    def clone(self) -> Self:
         """Create a copy of the objective."""
-        return MultiObjective(objectives=[o.clone() for o in self.objectives])
+        return self.__class__(objectives=[o.clone() for o in self.objectives])
 
     def __repr__(self) -> str:
         return f"MultiObjective(objectives={self.objectives})"
@@ -219,9 +220,9 @@ class ScalarizedObjective(Objective):
 
         return " + ".join(parts).replace(" + -", " - ")
 
-    def clone(self) -> ScalarizedObjective:
+    def clone(self) -> Self:
         """Create a copy of the objective."""
-        return ScalarizedObjective(
+        return self.__class__(
             metrics=[m.clone() for m in self.metrics],
             weights=self.weights.copy(),
             minimize=self.minimize,

--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from itertools import groupby
+from typing import Self
 
 from ax.core.arm import Arm
 from ax.core.metric import Metric
@@ -80,7 +81,7 @@ class OptimizationConfig(Base):
         self._outcome_constraints: list[OutcomeConstraint] = constraints
         self.pruning_target_parameterization = pruning_target_parameterization
 
-    def clone(self) -> "OptimizationConfig":
+    def clone(self) -> Self:
         """Make a copy of this optimization config."""
         return self.clone_with_args()
 
@@ -90,7 +91,7 @@ class OptimizationConfig(Base):
         outcome_constraints: None | (list[OutcomeConstraint]) = _NO_OUTCOME_CONSTRAINTS,
         pruning_target_parameterization: Arm
         | None = _NO_PRUNING_TARGET_PARAMETERIZATION,
-    ) -> "OptimizationConfig":
+    ) -> Self:
         """Make a copy of this optimization config."""
         objective = self.objective.clone() if objective is None else objective
         outcome_constraints = (
@@ -104,7 +105,7 @@ class OptimizationConfig(Base):
             else pruning_target_parameterization
         )
 
-        return OptimizationConfig(
+        return self.__class__(
             objective=objective,
             outcome_constraints=outcome_constraints,
             pruning_target_parameterization=pruning_target_parameterization,

--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from enum import Enum
 from logging import Logger
 from math import inf
-from typing import Any, cast, Union
+from typing import Any, cast, Self, Union
 from warnings import warn
 
 import numpy as np
@@ -237,7 +237,7 @@ class Parameter(SortableBase, metaclass=ABCMeta):
         )
 
     # pyre-fixme[7]: Expected `Parameter` but got implicit return value of `None`.
-    def clone(self) -> Parameter:
+    def clone(self) -> Self:
         pass
 
     def disable(self, default_value: TParamValue) -> None:

--- a/ax/core/runner.py
+++ b/ax/core/runner.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import Any, TYPE_CHECKING
+from typing import Any, Self, TYPE_CHECKING
 
 from ax.utils.common.base import Base
 from ax.utils.common.serialization import SerializationMixin
@@ -145,7 +145,7 @@ class Runner(Base, SerializationMixin, ABC):
             f"{self.__class__.__name__} does not implement a `stop` method."
         )
 
-    def clone(self) -> Runner:
+    def clone(self) -> Self:
         """Create a copy of this Runner."""
         cls = type(self)
         # pyre-ignore[45]: Cannot instantiate abstract class `Runner`.


### PR DESCRIPTION
Summary:
Add Self type annotation from typing module to methods that return self
or cloned instances of the same class. This enables better type inference
for subclasses and improves IDE support.

Files changed:
- ax/core/base_trial.py - run(), stop(), complete(), mark_*() methods
- ax/core/batch_trial.py - mark_arm_abandoned()
- ax/core/experiment.py - add_tracking_metric(), update_tracking_metric(), etc.
- ax/core/multi_type_experiment.py - add_trial_type(), update_runner(), metric methods
- ax/core/arm.py - clone()
- ax/core/objective.py - clone() on Objective, MultiObjective, ScalarizedObjective
- ax/core/optimization_config.py - clone()
- ax/core/runner.py - clone()
- ax/core/parameter.py - clone() abstract method

Differential Revision: D93186334


