### PR TITLE
Add in-sample candidate generation support for MBG

### DIFF
--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -510,6 +510,10 @@ def construct_acquisition_and_optimizer_options(
                     Keys.OPTIMIZER_KWARGS.value,
                     Keys.ACQF_KWARGS.value,
                     Keys.AX_ACQUISITION_KWARGS.value,
+                    # Keys for candidate generation
+                    "in_sample",
+                    "sampling_strategy_class",
+                    "sampling_strategy_kwargs",
                 }
             )
             > 0


### PR DESCRIPTION
Summary:
Enable in-sample candidate generation in the Modular BoTorch Generator (MBG), allowing optimization to select from existing training data rather than optimizing over the full search space. This is achieved via adding 2 optional kwargs in `Acquisition.optimize`: `candidate_set` and `sampling_strategy`

This hits 4 birds with 1 stone - the same mechanism may support:
- Model-based/Contextual bandits
- Bake-off/Best arm selection
- in-sample preference learning (in-sample PBO and BOPE preference game)
- LILO (for LLM to label observed points)

Supports multiple selection methods including GP Thompson Sampling, Top-Two Thompson Sampling (TTTS), greedy acquisition (qSimpleRegret), q-batched acquisition (qLogNEI), random selection, and Boltzmann sampling via `model_gen_options`.

This is partially inspired by the [Support for SamplingStrategy](https://docs.google.com/document/d/19mLXg88bjA_NzYCz59KmY7Zq10XnqSD4HWkFkNbhYR4/edit?usp=sharing) design doc but with a wider range of applications in mind.

Reviewed By: Balandat

Differential Revision: D92124823


