### PR TITLE
Fix RangeParameterConfig in from_config.py returns ChoiceParameter instead of RangeParameter #4599

### DIFF
--- a/ax/api/utils/instantiation/from_config.py
+++ b/ax/api/utils/instantiation/from_config.py
@@ -50,21 +50,21 @@ def parameter_from_config(
                     "The range of the parameter must be evenly divisible by the "
                     "step size."
                 )
-
-            return ChoiceParameter(
+            return RangeParameter(
                 name=config.name,
                 parameter_type=_parameter_type_converter(config.parameter_type),
-                values=[*np.arange(lower, upper + step_size, step_size)],
-                is_ordered=True,
+                lower=lower,
+                upper=upper,
+                log_scale=config.scaling == "log",
             )
-
-        return RangeParameter(
+        return ChoiceParameter(
             name=config.name,
             parameter_type=_parameter_type_converter(config.parameter_type),
-            lower=lower,
-            upper=upper,
-            log_scale=config.scaling == "log",
+            values=[*np.arange(lower, upper + step_size, step_size)],
+            is_ordered=True,
         )
+
+
     elif isinstance(config, DerivedParameterConfig):
         return DerivedParameter(
             name=config.name,


### PR DESCRIPTION
The original logic would return a ChoiceParameter after checking all the requirement for the RangeParameter. Now it checks if the instance is RangeParameterConfig and all of the conditions are met, the function return a RangeParameter.
    
if isinstance(config, RangeParameterConfig):
        lower, upper = config.bounds

        # TODO[mpolson64] Add support for RangeParameterConfig.step_size native to
        # RangeParameter instead of converting to ChoiceParameter
        if (step_size := config.step_size) is not None:
            if not (config.scaling == "linear" or config.scaling is None):
                raise UserInputError(
                    "Non-linear parameter scaling is not supported when using "
                    "step_size."
                )

            remainder = (upper - lower) % step_size
            # Use tolerance-based comparison to handle floating point precision issues
            if not np.isclose(remainder, 0) and not np.isclose(remainder, step_size):
                raise UserInputError(
                    "The range of the parameter must be evenly divisible by the "
                    "step size."
                )
          return ChoiceParameter(
              name=config.name,
              parameter_type=_parameter_type_converter(config.parameter_type),
              values=[*np.arange(lower, upper + step_size, step_size)],
              is_ordered=True,
              sort_values=False,  # already sorted by np.arange.
          )
        return RangeParameter(
            name=config.name,
            parameter_type=_parameter_type_converter(config.parameter_type),
            lower=lower,
            upper=upper,
            log_scale=config.scaling == "log",
        )
