### PR TITLE
Modernize type annotations: PEP 604 and collections.abc imports

### DIFF
--- a/ax/adapter/data_utils.py
+++ b/ax/adapter/data_utils.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 
 import functools
 import warnings
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from copy import deepcopy
 from dataclasses import dataclass, InitVar
-from typing import Any, Callable
+from typing import Any
 
 import numpy as np
 import pandas as pd

--- a/ax/adapter/discrete.py
+++ b/ax/adapter/discrete.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 
-from typing import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 import numpy as np
 from ax.adapter.adapter_utils import array_to_observation_data, get_fixed_features

--- a/ax/adapter/tests/test_base_adapter.py
+++ b/ax/adapter/tests/test_base_adapter.py
@@ -7,9 +7,10 @@
 # pyre-strict
 
 import warnings
+from collections.abc import Callable
 from copy import deepcopy
 from random import random
-from typing import Any, Callable
+from typing import Any
 from unittest import mock
 from unittest.mock import Mock
 

--- a/ax/adapter/transforms/bilog_y.py
+++ b/ax/adapter/transforms/bilog_y.py
@@ -8,7 +8,8 @@
 
 from __future__ import annotations
 
-from typing import Callable, TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt

--- a/ax/adapter/transforms/standardize_y.py
+++ b/ax/adapter/transforms/standardize_y.py
@@ -6,9 +6,11 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 from collections import defaultdict
 from logging import Logger
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import numpy as np
 from ax.adapter.data_utils import ExperimentData
@@ -46,7 +48,7 @@ class StandardizeY(Transform):
         self,
         search_space: SearchSpace | None = None,
         experiment_data: ExperimentData | None = None,
-        adapter: Optional["base_adapter.Adapter"] = None,
+        adapter: base_adapter.Adapter | None = None,
         config: TConfig | None = None,
     ) -> None:
         super().__init__(
@@ -111,7 +113,7 @@ class StandardizeY(Transform):
     def transform_optimization_config(
         self,
         optimization_config: OptimizationConfig,
-        adapter: Optional["base_adapter.Adapter"] = None,
+        adapter: base_adapter.Adapter | None = None,
         fixed_features: ObservationFeatures | None = None,
     ) -> OptimizationConfig:
         # Handle ScalarizedObjective

--- a/ax/analysis/analysis.py
+++ b/ax/analysis/analysis.py
@@ -8,8 +8,9 @@
 from __future__ import annotations
 
 import traceback
+from collections.abc import Sequence
 from logging import Logger
-from typing import Protocol, Sequence
+from typing import Protocol
 
 import pandas as pd
 from ax.adapter.base import Adapter

--- a/ax/analysis/best_trials.py
+++ b/ax/analysis/best_trials.py
@@ -6,7 +6,8 @@
 # pyre-strict
 
 
-from typing import final, Sequence
+from collections.abc import Sequence
+from typing import final
 
 from ax.adapter.base import Adapter
 from ax.analysis.analysis import Analysis

--- a/ax/analysis/healthcheck/metric_fetching_errors.py
+++ b/ax/analysis/healthcheck/metric_fetching_errors.py
@@ -7,7 +7,7 @@
 
 from collections.abc import Callable
 from logging import Logger
-from typing import Any, final, Union
+from typing import Any, final
 
 import pandas as pd
 from ax.adapter import Adapter
@@ -130,7 +130,7 @@ class MetricFetchingErrorsAnalysis(Analysis):
         )
 
     @staticmethod
-    def _validate_fields(errors: dict[str, Union[int, str]]) -> bool:
+    def _validate_fields(errors: dict[str, int | str]) -> bool:
         required_fields = {
             "trial_index",
             "metric_name",

--- a/ax/analysis/healthcheck/tests/test_metric_fetching_errors.py
+++ b/ax/analysis/healthcheck/tests/test_metric_fetching_errors.py
@@ -5,8 +5,9 @@
 
 # pyre-strict
 
+from collections.abc import Iterable
 from datetime import datetime, timedelta
-from typing import Any, Iterable
+from typing import Any
 
 import pandas as pd
 from ax.analysis.healthcheck.metric_fetching_errors import MetricFetchingErrorsAnalysis

--- a/ax/analysis/plotly/arm_effects.py
+++ b/ax/analysis/plotly/arm_effects.py
@@ -5,7 +5,8 @@
 
 # pyre-strict
 
-from typing import final, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import final
 
 import pandas as pd
 from ax.adapter.base import Adapter

--- a/ax/analysis/plotly/constraint_feasibility.py
+++ b/ax/analysis/plotly/constraint_feasibility.py
@@ -5,8 +5,9 @@
 
 # pyre-strict
 
+from collections.abc import Sequence
 from logging import Logger
-from typing import Any, final, Sequence
+from typing import Any, final
 
 import pandas as pd
 from ax.adapter.base import Adapter

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -6,7 +6,8 @@
 # pyre-strict
 
 
-from typing import final, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import final
 
 import pandas as pd
 from ax.adapter.base import Adapter

--- a/ax/analysis/plotly/objective_p_feasible_frontier.py
+++ b/ax/analysis/plotly/objective_p_feasible_frontier.py
@@ -5,8 +5,9 @@
 
 # pyre-strict
 
+from collections.abc import Sequence
 from logging import Logger
-from typing import final, Sequence
+from typing import final
 
 from ax.adapter.base import Adapter
 from ax.adapter.torch import TorchAdapter

--- a/ax/analysis/plotly/p_feasible.py
+++ b/ax/analysis/plotly/p_feasible.py
@@ -6,7 +6,8 @@
 # pyre-strict
 
 import re
-from typing import final, Sequence
+from collections.abc import Sequence
+from typing import final
 
 from ax.adapter.base import Adapter
 from ax.analysis.analysis import Analysis

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -5,8 +5,9 @@
 
 # pyre-strict
 
+from collections.abc import Mapping, Sequence
 from logging import Logger
-from typing import Any, final, Mapping, Sequence
+from typing import Any, final
 
 import numpy as np
 import pandas as pd

--- a/ax/analysis/plotly/sensitivity.py
+++ b/ax/analysis/plotly/sensitivity.py
@@ -4,7 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from typing import final, Literal, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import final, Literal
 
 import pandas as pd
 from ax.adapter.base import Adapter

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -7,7 +7,7 @@
 
 import math
 import re
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import pandas as pd
 from ax.analysis.plotly.color_constants import BOTORCH_COLOR_SCALE, LIGHT_AX_BLUE
@@ -46,7 +46,7 @@ BEST_LINE_SETTINGS: dict[str, str | dict[str, str] | bool] = {
 
 
 # Move the legened to the bottom, and make horizontal
-LEGEND_POSITION: dict[str, Union[float, str]] = {
+LEGEND_POSITION: dict[str, float | str] = {
     "orientation": "h",
     "yanchor": "top",
     "y": -0.2,

--- a/ax/analysis/results.py
+++ b/ax/analysis/results.py
@@ -6,7 +6,8 @@
 # pyre-strict
 
 import itertools
-from typing import final, Sequence
+from collections.abc import Sequence
+from typing import final
 
 from ax.adapter.base import Adapter
 from ax.analysis.analysis import Analysis

--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -6,7 +6,8 @@
 # pyre-strict
 
 
-from typing import final, Iterable, Sequence
+from collections.abc import Iterable, Sequence
+from typing import final
 
 from ax.adapter.base import Adapter
 from ax.analysis.analysis import Analysis

--- a/ax/analysis/tests/test_overview.py
+++ b/ax/analysis/tests/test_overview.py
@@ -7,7 +7,6 @@
 
 
 from datetime import datetime
-from typing import Optional
 
 import pandas as pd
 from ax.adapter.base import Adapter
@@ -306,7 +305,7 @@ class TestOverview(TestCase):
         self.assertGreaterEqual(len(marginal_effects_cards), 1)
 
         # Check if adapter has predict properly implemented
-        def has_predict_implemented(adapter: Optional[Adapter]) -> bool:
+        def has_predict_implemented(adapter: Adapter | None) -> bool:
             """Check if adapter has predict method properly implemented."""
             if adapter is None or not hasattr(adapter, "predict"):
                 return False

--- a/ax/analysis/utils.py
+++ b/ax/analysis/utils.py
@@ -5,8 +5,8 @@
 
 # pyre-strict
 
+from collections.abc import Sequence
 from logging import Logger
-from typing import Sequence
 
 import numpy as np
 import numpy.typing as npt

--- a/ax/core/analysis_card.py
+++ b/ax/core/analysis_card.py
@@ -8,8 +8,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from datetime import datetime
-from typing import Any, Sequence
+from typing import Any
 
 import pandas as pd
 from ax.utils.common.base import SortableBase

--- a/ax/core/parameter_constraint.py
+++ b/ax/core/parameter_constraint.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from ax.core.parameter import ChoiceParameter, Parameter, RangeParameter
 from ax.exceptions.core import UserInputError

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -9,31 +9,31 @@
 import enum
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 
 
-TNumeric = Union[float, int]
+TNumeric = float | int
 TParamCounter = defaultdict[int, int]
-TParamValue = Union[None, str, bool, float, int]
+TParamValue = None | str | bool | float | int
 TParameterization = dict[str, TParamValue]
 TParamValueList = list[TParamValue]  # a parameterization without the keys
-TContextStratum = Optional[dict[str, Union[str, float, int]]]
+TContextStratum = dict[str, str | float | int] | None
 
 # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
-TBounds = Optional[tuple[np.ndarray, np.ndarray]]
+TBounds = tuple[np.ndarray, np.ndarray] | None
 TModelMean = dict[str, list[float]]
 TModelCov = dict[str, dict[str, list[float]]]
 TModelPredict = tuple[TModelMean, TModelCov]
 # Model predictions for a single arm:
 # ( { metric -> mean }, { metric -> { other_metric -> covariance } } ).
-TModelPredictArm = tuple[dict[str, float], Optional[dict[str, dict[str, float]]]]
+TModelPredictArm = tuple[dict[str, float], dict[str, dict[str, float]] | None]
 
 # pyre-fixme[24]: Generic type `np.floating` expects 1 type parameter.
 # pyre-fixme[24]: Generic type `np.integer` expects 1 type parameter.
-FloatLike = Union[int, float, np.floating, np.integer]
-SingleMetricData = Union[FloatLike, tuple[FloatLike, Optional[FloatLike]]]
+FloatLike = int | float | np.floating | np.integer
+SingleMetricData = FloatLike | tuple[FloatLike, FloatLike | None]
 # 1-arm `Trial` evaluation data: {metric_name -> (mean, standard error)}}.
 TTrialEvaluation = Mapping[str, SingleMetricData]
 
@@ -45,22 +45,18 @@ TMapTrialEvaluation = Sequence[tuple[float, TTrialEvaluation]]
 # 2) (mean, standard error) and we assume metric name == objective name
 # 3) only the mean, and we assume metric name == objective name and standard error == 0
 
-TEvaluationOutcome = Union[
-    TTrialEvaluation,
-    SingleMetricData,
-    TMapTrialEvaluation,
-]
-TEvaluationFunction = Union[
-    Callable[[TParameterization], TEvaluationOutcome],
-    Callable[[TParameterization, Optional[float]], TEvaluationOutcome],
-]
+TEvaluationOutcome = TTrialEvaluation | SingleMetricData | TMapTrialEvaluation
+TEvaluationFunction = (
+    Callable[[TParameterization], TEvaluationOutcome]
+    | Callable[[TParameterization, float | None], TEvaluationOutcome]
+)
 
 TBucket = list[dict[str, list[str]]]
 
 TGenMetadata = dict[str, Any]
 
 # Model's metadata about a given candidate (or X).
-TCandidateMetadata = Optional[dict[str, Any]]
+TCandidateMetadata = dict[str, Any] | None
 
 
 class ComparisonOp(enum.Enum):

--- a/ax/early_stopping/simulation.py
+++ b/ax/early_stopping/simulation.py
@@ -6,9 +6,9 @@
 
 # pyre-strict
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from heapq import nsmallest
-from typing import Iterable
 
 import numpy as np
 import numpy.typing as npt

--- a/ax/generation_strategy/best_model_selector.py
+++ b/ax/generation_strategy/best_model_selector.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -21,7 +21,7 @@ from ax.utils.common.func_enum import FuncEnum
 from pyre_extensions import none_throws
 
 # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
-ARRAYLIKE = Union[np.ndarray, list[float], list[np.ndarray]]
+ARRAYLIKE = np.ndarray | list[float] | list[np.ndarray]
 
 
 class BestModelSelector(ABC, Base):

--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -17,11 +17,11 @@ References
 from __future__ import annotations
 
 import operator
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from functools import partial, reduce
 from itertools import product
 from logging import Logger
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 import torch
 from ax.core.search_space import SearchSpaceDigest

--- a/ax/generators/torch/botorch_modular/kernels.py
+++ b/ax/generators/torch/botorch_modular/kernels.py
@@ -16,8 +16,9 @@ References
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from math import log, sqrt
-from typing import Any, Sequence
+from typing import Any
 
 import torch
 from ax.exceptions.core import AxError

--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 
 import inspect
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
 from logging import Logger
-from typing import Any, Mapping
+from typing import Any
 
 import numpy as np
 import torch

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -8,12 +8,12 @@
 
 import warnings
 from collections import OrderedDict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import cached_property
 from logging import Logger
-from typing import Any, cast, Mapping
+from typing import Any, cast
 
 import torch
 from ax.core.data import MAP_KEY

--- a/ax/generators/types.py
+++ b/ax/generators/types.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from typing import Any, Union
+from typing import Any
 
 from ax.core.optimization_config import OptimizationConfig
 from ax.generators.winsorization_config import WinsorizationConfig
@@ -15,17 +15,15 @@ from botorch.acquisition import AcquisitionFunction
 # pyre-ignore [33]: `TConfig` cannot alias to a type containing `Any`.
 TConfig = dict[
     str,
-    Union[
-        int,
-        float,
-        str,
-        AcquisitionFunction,
-        list[int],
-        list[str],
-        dict[int, Any],
-        dict[str, Any],
-        OptimizationConfig,
-        WinsorizationConfig,
-        None,
-    ],
+    int
+    | float
+    | str
+    | AcquisitionFunction
+    | list[int]
+    | list[str]
+    | dict[int, Any]
+    | dict[str, Any]
+    | OptimizationConfig
+    | WinsorizationConfig
+    | None,
 ]

--- a/ax/plot/helper.py
+++ b/ax/plot/helper.py
@@ -9,7 +9,7 @@
 import math
 from collections.abc import Callable
 from logging import Logger
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -27,9 +27,9 @@ from pyre_extensions import none_throws
 logger: Logger = get_logger(__name__)
 
 # Typing alias
-RawData = list[dict[str, Union[str, float]]]
+RawData = list[dict[str, str | float]]
 
-TNullableGeneratorRunsDict = Optional[dict[str, GeneratorRun]]
+TNullableGeneratorRunsDict = dict[str, GeneratorRun] | None
 
 
 def extend_range(

--- a/ax/plot/slice.py
+++ b/ax/plot/slice.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 from copy import deepcopy
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -32,14 +32,14 @@ from pyre_extensions import none_throws
 # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 SlicePredictions = tuple[
     PlotData,
-    list[dict[str, Union[str, float]]],
+    list[dict[str, str | float]],
     list[float],
     np.ndarray,
     np.ndarray,
     str,
     str,
     bool,
-    dict[str, Optional[Union[str, bool, float, int]]],
+    dict[str, str | bool | float | int | None],
     np.ndarray,
     bool,
 ]

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -7,10 +7,11 @@
 # pyre-strict
 
 from collections import defaultdict
+from collections.abc import Callable
 from enum import Enum
 from io import StringIO
 from logging import Logger
-from typing import Any, Callable, cast, Union
+from typing import Any, cast, Union
 
 import pandas as pd
 from ax.analysis.graphviz.graphviz_analysis import GraphvizAnalysisCard

--- a/ax/storage/sqa_store/load.py
+++ b/ax/storage/sqa_store/load.py
@@ -7,8 +7,9 @@
 # pyre-strict
 
 import logging
+from collections.abc import Mapping
 from math import ceil
-from typing import Any, cast, Mapping
+from typing import Any, cast
 
 import pandas as pd
 from ax.core.analysis_card import AnalysisCard, AnalysisCardBase

--- a/ax/utils/stats/statstools.py
+++ b/ax/utils/stats/statstools.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 from logging import Logger
-from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -19,7 +18,7 @@ from ax.utils.stats.math_utils import relativize
 
 logger: Logger = get_logger(__name__)
 # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
-num_mixed = Union[np.ndarray, list[float]]
+num_mixed = np.ndarray | list[float]
 
 
 def inverse_variance_weight(

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -11,13 +11,13 @@ from __future__ import annotations
 
 import itertools
 from collections import OrderedDict
-from collections.abc import Iterable, Mapping, MutableMapping
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from datetime import datetime, timedelta
 from functools import partial
 from logging import Logger
 from math import prod
 from pathlib import Path
-from typing import Any, cast, Self, Sequence
+from typing import Any, cast, Self
 
 import numpy as np
 import pandas as pd

--- a/scripts/convert_ipynb_to_mdx.py
+++ b/scripts/convert_ipynb_to_mdx.py
@@ -12,7 +12,6 @@ import shutil
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Union
 
 import mdformat
 import nbformat
@@ -695,7 +694,7 @@ def handle_tqdm(
 
 CELL_OUTPUTS_TO_PROCESS = dict[
     str,
-    list[dict[str, Union[int, str, NotebookNode]]],
+    list[dict[str, int | str | NotebookNode]],
 ]
 
 


### PR DESCRIPTION
Summary:
Modernize type annotations across Ax (open-source and ax/fb):
- Replace `Optional[X]` with `X | None` and `Union[X, Y]` with `X | Y` (PEP 604).
- Move `Callable`, `Sequence`, `Mapping`, and `Iterable` imports from `typing` to `collections.abc`.
- Remove unused `typing` imports where they become empty.

Pure annotation changes with no behavioral impact. Files that use `Union` at runtime (e.g., with `assert_is_instance`) are left unchanged.

Reviewed By: Balandat

Differential Revision: D93275514
