### PR TITLE
Replace deprecated abstractproperty with @property + @abstractmethod

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -133,19 +133,22 @@ class BaseTrial(ABC, SortableBase):
         # might be getting deployed to.
         self._properties: dict[str, Any] = {}
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def arms(self) -> list[Arm]:
         """All arms associated with this trial."""
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def arms_by_name(self) -> dict[str, Arm]:
         """A mapping of from arm names, to all arms associated with
         this trial.
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def abandoned_arms(self) -> list[Arm]:
         """All abandoned arms, associated with this trial."""
         pass
@@ -473,7 +476,8 @@ class BaseTrial(ABC, SortableBase):
         """All non abandoned arms associated with this trial."""
         return [arm for arm in self.arms if arm not in self.abandoned_arms]
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def generator_runs(self) -> list[GeneratorRun]:
         """All generator runs associated with this trial."""
         pass

--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import math
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 from copy import deepcopy
 from enum import Enum
 from logging import Logger
@@ -283,7 +283,8 @@ class Parameter(SortableBase, metaclass=ABCMeta):
 
         return ret_val
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def domain_repr(self) -> str:
         """Returns a string representation of the domain."""
         pass

--- a/ax/storage/registry_bundle.py
+++ b/ax/storage/registry_bundle.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from collections import ChainMap
 from collections.abc import Callable
 from functools import cached_property
@@ -129,15 +129,18 @@ class RegistryBundleBase(ABC):
     def class_decoder_registry(self) -> dict[str, Callable[[dict[str, Any]], Any]]:
         return self._json_class_decoder_registry
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def sqa_config(self) -> SQAConfig:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def encoder(self) -> Encoder:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def decoder(self) -> Decoder:
         pass
 

--- a/ax/utils/common/result.py
+++ b/ax/utils/common/result.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import traceback
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import reduce
 from typing import Any, cast, Generic, NoReturn, TypeVar
@@ -35,15 +35,18 @@ class Result(Generic[T, E], ABC):
     def is_err(self) -> bool:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def ok(self) -> T | None:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def err(self) -> E | None:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def value(self) -> T | E:
         pass
 


### PR DESCRIPTION
Summary: `abc.abstractproperty` has been deprecated since Python 3.3 in favor of stacking `property` and `abstractmethod` decorators. This replaces all remaining usages across 4 files in the Ax codebase.

Differential Revision: D93279592


