### PR TITLE
Do not test against latest botorch in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,13 +9,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  tests-and-coverage-latest:
-    name: Tests with latest BoTorch
-    uses: ./.github/workflows/reusable_test.yml
-    with:
-      pinned_botorch: false
-    secrets: inherit
-
   tests-and-coverage-pinned:
     name: Tests with pinned BoTorch
     uses: ./.github/workflows/reusable_test.yml


### PR DESCRIPTION
This can fail the release even if the pinned version that the release uses works fine