### PR TITLE
Hoist model fitting out of inner loops in analysis tests

### DIFF
--- a/ax/analysis/plotly/tests/test_arm_effects.py
+++ b/ax/analysis/plotly/tests/test_arm_effects.py
@@ -214,6 +214,13 @@ class TestArmEffectsPlot(TestCase):
         for experiment in get_online_experiments():
             arm = Generators.SOBOL(experiment=experiment).gen(n=1).arms[0]
             arm.name = "additional_arm"
+
+            generation_strategy = get_default_generation_strategy_at_MBM_node(
+                experiment=experiment
+            )
+            generation_strategy.current_node._fit(experiment=experiment)
+            adapter = none_throws(generation_strategy.adapter)
+
             for (
                 use_model_predictions,
                 trial_index,
@@ -223,11 +230,6 @@ class TestArmEffectsPlot(TestCase):
                     additional_arms = [arm]
                 else:
                     additional_arms = None
-                generation_strategy = get_default_generation_strategy_at_MBM_node(
-                    experiment=experiment
-                )
-                generation_strategy.current_node._fit(experiment=experiment)
-                adapter = none_throws(generation_strategy.adapter)
 
                 for signature in adapter.metric_signatures:
                     metric_name = adapter._experiment.signature_to_metric[
@@ -263,6 +265,17 @@ class TestArmEffectsPlot(TestCase):
         # resemble those we see in an offline setting.
 
         for experiment in get_offline_experiments():
+            generation_strategy = get_default_generation_strategy_at_MBM_node(
+                experiment=experiment
+            )
+            generation_strategy.current_node._fit(experiment=experiment)
+            adapter = none_throws(generation_strategy.adapter)
+
+            model_metric_names = [
+                adapter._experiment.signature_to_metric[signature].name
+                for signature in adapter.metric_signatures
+            ]
+
             for use_model_predictions in [True, False]:
                 for trial_index in [None, 0]:
                     for with_additional_arms in [True, False]:
@@ -280,18 +293,6 @@ class TestArmEffectsPlot(TestCase):
                         else:
                             additional_arms = None
 
-                        generation_strategy = (
-                            get_default_generation_strategy_at_MBM_node(
-                                experiment=experiment
-                            )
-                        )
-                        generation_strategy.current_node._fit(experiment=experiment)
-                        adapter = none_throws(generation_strategy.adapter)
-
-                        model_metric_names = [
-                            adapter._experiment.signature_to_metric[signature].name
-                            for signature in adapter.metric_signatures
-                        ]
                         for metric_name in model_metric_names:
                             analysis = ArmEffectsPlot(
                                 metric_name=metric_name,

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -252,6 +252,19 @@ class TestScatterPlot(TestCase):
                 continue
             arm = Generators.SOBOL(experiment=experiment).gen(n=1).arms[0]
             arm.name = "additional_arm"
+
+            generation_strategy = get_default_generation_strategy_at_MBM_node(
+                experiment=experiment
+            )
+            generation_strategy.current_node._fit(experiment=experiment)
+            adapter = none_throws(generation_strategy.adapter)
+
+            metric_names = [
+                experiment.signature_to_metric[signature].name
+                for signature in adapter.metric_signatures
+            ]
+            x_metric_name, y_metric_name = metric_names[:2]
+
             for (
                 use_model_predictions,
                 trial_index,
@@ -267,19 +280,6 @@ class TestScatterPlot(TestCase):
                     additional_arms = [arm]
                 else:
                     additional_arms = None
-
-                generation_strategy = get_default_generation_strategy_at_MBM_node(
-                    experiment=experiment
-                )
-                generation_strategy.current_node._fit(experiment=experiment)
-                adapter = none_throws(generation_strategy.adapter)
-
-                metric_names = [
-                    experiment.signature_to_metric[signature].name
-                    for signature in adapter.metric_signatures
-                ]
-
-                x_metric_name, y_metric_name = metric_names[:2]
 
                 analysis = ScatterPlot(
                     x_metric_name=x_metric_name,
@@ -321,6 +321,18 @@ class TestScatterPlot(TestCase):
             if len(experiment.metrics) < 2:
                 continue
 
+            generation_strategy = get_default_generation_strategy_at_MBM_node(
+                experiment=experiment
+            )
+            generation_strategy.current_node._fit(experiment=experiment)
+            adapter = none_throws(generation_strategy.adapter)
+
+            metric_names = [
+                experiment.signature_to_metric[signature].name
+                for signature in adapter.metric_signatures
+            ]
+            x_metric_name, y_metric_name = metric_names[:2]
+
             for use_model_predictions in [True, False]:
                 for trial_index in [None, 0]:
                     for with_additional_arms in [True, False]:
@@ -338,20 +350,6 @@ class TestScatterPlot(TestCase):
                                 ]
                             else:
                                 additional_arms = None
-
-                            generation_strategy = (
-                                get_default_generation_strategy_at_MBM_node(
-                                    experiment=experiment
-                                )
-                            )
-                            generation_strategy.current_node._fit(experiment=experiment)
-                            adapter = none_throws(generation_strategy.adapter)
-
-                            metric_names = [
-                                experiment.signature_to_metric[signature].name
-                                for signature in adapter.metric_signatures
-                            ]
-                            x_metric_name, y_metric_name = metric_names[:2]
 
                             analysis = ScatterPlot(
                                 x_metric_name=x_metric_name,

--- a/ax/analysis/tests/test_utils.py
+++ b/ax/analysis/tests/test_utils.py
@@ -764,6 +764,17 @@ class TestUtils(TestCase):
             raw_arm_value = raw_df[
                 (raw_df.arm_name == "0_0") & (raw_df.metric_name == metric_name)
             ]["mean"].values[0]
+
+            generation_strategy = get_default_generation_strategy_at_MBM_node(
+                experiment=experiment
+            )
+            generation_strategy.current_node._fit(experiment=experiment)
+            adapter = none_throws(generation_strategy.adapter)
+            model_metric_names = [
+                experiment.signature_to_metric[signature].name
+                for signature in adapter.metric_signatures
+            ]
+
             for (
                 use_model_predictions,
                 trial_index,
@@ -789,15 +800,6 @@ class TestUtils(TestCase):
                 else:
                     additional_arms = None
 
-                generation_strategy = get_default_generation_strategy_at_MBM_node(
-                    experiment=experiment
-                )
-                generation_strategy.current_node._fit(experiment=experiment)
-                adapter = none_throws(generation_strategy.adapter)
-                model_metric_names = [
-                    experiment.signature_to_metric[signature].name
-                    for signature in adapter.metric_signatures
-                ]
                 df = prepare_arm_data(
                     experiment=experiment,
                     metric_names=model_metric_names,
@@ -835,6 +837,16 @@ class TestUtils(TestCase):
         # resemble those we see in an offline setting.
 
         for experiment in get_offline_experiments():
+            generation_strategy = get_default_generation_strategy_at_MBM_node(
+                experiment=experiment
+            )
+            generation_strategy.current_node._fit(experiment=experiment)
+            adapter = none_throws(generation_strategy.adapter)
+            model_metric_names = [
+                experiment.signature_to_metric[signature].name
+                for signature in adapter.metric_signatures
+            ]
+
             for use_model_predictions in [True, False]:
                 for trial_index in [None, 0]:
                     for with_additional_arms in [True, False]:
@@ -851,18 +863,6 @@ class TestUtils(TestCase):
                             ]
                         else:
                             additional_arms = None
-
-                        generation_strategy = (
-                            get_default_generation_strategy_at_MBM_node(
-                                experiment=experiment
-                            )
-                        )
-                        generation_strategy.current_node._fit(experiment=experiment)
-                        adapter = none_throws(generation_strategy.adapter)
-                        model_metric_names = [
-                            experiment.signature_to_metric[signature].name
-                            for signature in adapter.metric_signatures
-                        ]
 
                         _ = prepare_arm_data(
                             experiment=experiment,


### PR DESCRIPTION
## Summary

- Model fitting (`get_default_generation_strategy_at_MBM_node` + `_fit`) was being redundantly called inside inner parameter-combination loops in several analysis tests, even though it only depends on the experiment. This moves model fitting to the outer per-experiment loop, avoiding re-fitting the same model up to 16x per experiment.

## Performance improvement

Total suite time: **169s → 140s (~17% faster)**

| Test | Before | After | Saved | % Faster |
|------|--------|-------|-------|----------|
| `test_arm_effects::test_offline` | 14.3s | **9.9s** | 4.4s | 31% |
| `test_scatter::test_offline` | 10.2s | **5.8s** | 4.4s | 43% |
| `test_scatter::test_online` | 8.7s | **4.5s** | 4.2s | 49% |
| `test_arm_effects::test_online` | 8.8s | **6.0s** | 2.8s | 32% |
| `test_utils::test_online` | 8.0s | **4.4s** | 3.6s | 45% |
| `test_utils::test_offline` | 4.3s | **2.1s** | 2.2s | 52% |
| **Subtotal (modified tests)** | **54.3s** | **32.7s** | **21.6s** | **40%** |

## Test plan

- [x] All 228 tests in `ax/analysis/` pass after the change