### PR TITLE
Use setUpClass for shared fixtures in analysis tests

### DIFF
--- a/ax/analysis/plotly/tests/test_arm_effects.py
+++ b/ax/analysis/plotly/tests/test_arm_effects.py
@@ -31,12 +31,13 @@ from pyre_extensions import assert_is_instance, none_throws
 
 
 class TestArmEffectsPlot(TestCase):
+    @classmethod
     @mock_botorch_optimize
-    def setUp(self) -> None:
-        super().setUp()
+    def setUpClass(cls) -> None:
+        super().setUpClass()
 
-        self.client = Client()
-        self.client.configure_experiment(
+        cls.client = Client()
+        cls.client.configure_experiment(
             name="test_experiment",
             parameters=[
                 RangeParameterConfig(
@@ -51,21 +52,21 @@ class TestArmEffectsPlot(TestCase):
                 ),
             ],
         )
-        self.client.configure_optimization(
+        cls.client.configure_optimization(
             objective="foo", outcome_constraints=["bar >= -0.5"]
         )
 
         # Get two trials and fail one, giving us a ragged structure
-        self.client.get_next_trials(max_trials=2)
-        self.client.complete_trial(trial_index=0, raw_data={"foo": 1.0, "bar": 2.0})
-        self.client.mark_trial_failed(trial_index=1)
+        cls.client.get_next_trials(max_trials=2)
+        cls.client.complete_trial(trial_index=0, raw_data={"foo": 1.0, "bar": 2.0})
+        cls.client.mark_trial_failed(trial_index=1)
 
         # Complete 5 trials successfully
         for _ in range(5):
-            for trial_index, parameterization in self.client.get_next_trials(
+            for trial_index, parameterization in cls.client.get_next_trials(
                 max_trials=1
             ).items():
-                self.client.complete_trial(
+                cls.client.complete_trial(
                     trial_index=trial_index,
                     raw_data={
                         "foo": assert_is_instance(parameterization["x1"], float),

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -28,12 +28,13 @@ from pyre_extensions import assert_is_instance, none_throws
 
 
 class TestScatterPlot(TestCase):
+    @classmethod
     @mock_botorch_optimize
-    def setUp(self) -> None:
-        super().setUp()
+    def setUpClass(cls) -> None:
+        super().setUpClass()
 
-        self.client = Client()
-        self.client.configure_experiment(
+        cls.client = Client()
+        cls.client.configure_experiment(
             name="test_experiment",
             parameters=[
                 RangeParameterConfig(
@@ -48,21 +49,21 @@ class TestScatterPlot(TestCase):
                 ),
             ],
         )
-        self.client.configure_optimization(
+        cls.client.configure_optimization(
             objective="foo", outcome_constraints=["bar >= -0.5"]
         )
 
         # Get two trials and fail one, giving us a ragged structure
-        self.client.get_next_trials(max_trials=2)
-        self.client.complete_trial(trial_index=0, raw_data={"foo": 1.0, "bar": 2.0})
-        self.client.mark_trial_failed(trial_index=1)
+        cls.client.get_next_trials(max_trials=2)
+        cls.client.complete_trial(trial_index=0, raw_data={"foo": 1.0, "bar": 2.0})
+        cls.client.mark_trial_failed(trial_index=1)
 
         # Complete 5 trials successfully
         for _ in range(5):
-            for trial_index, parameterization in self.client.get_next_trials(
+            for trial_index, parameterization in cls.client.get_next_trials(
                 max_trials=1
             ).items():
-                self.client.complete_trial(
+                cls.client.complete_trial(
                     trial_index=trial_index,
                     raw_data={
                         "foo": assert_is_instance(parameterization["x1"], float),


### PR DESCRIPTION
## Summary

Stacked on #4919.

- `TestScatterPlot`, `TestArmEffectsPlot`, and `TestUtils` all rebuild the same `Client` fixture (configure experiment, run 7 trials with `@mock_botorch_optimize`) before **every** test method via `setUp`. Since the individual test methods only read from the fixture, this promotes `setUp` to `setUpClass` so the fixture is built once per class instead of 7-14 times.
- The one mutating test (`test_prepare_arm_data_out_of_distribution_arm`) now uses a deep copy of the experiment to avoid contaminating shared state.

## Performance improvement (incremental, on top of #4919)

Suite time: **140s → 133s (~5% faster, ~6.5s saved)**

Individual methods that previously paid the setUp cost each time now run in <0.01-0.03s instead of 0.10-0.32s:

| Test method | Before | After |
|------|--------|-------|
| `test_scatter::test_compute_raw` | 0.12s | **0.01s** |
| `test_scatter::test_compute_with_modeled` | 0.20s | **0.01s** |
| `test_scatter::test_show_pareto_frontier` | 0.12s | **0.01s** |
| `test_scatter::test_compute_adhoc` | 0.13s | **0.03s** |
| `test_arm_effects::test_compute_raw` | 0.14s | **0.01s** |
| `test_arm_effects::test_compute_with_modeled` | 0.13s | **0.02s** |
| `test_arm_effects::test_compute_adhoc` | 0.32s | **0.06s** |
| `test_utils::test_prepare_arm_data_raw` | 0.13s | **0.02s** |
| `test_utils::test_prepare_arm_data_use_model_predictions` | 0.12s | **0.01s** |
| `test_utils::test_truncate_label` | 0.12s | **<0.01s** |
| ... and ~10 more methods | ~0.11s each | **<0.01s** |

### Cumulative improvement (both PRs): 169s → 133s (36s saved, ~21% faster)

## Test plan

- [x] All 228 tests in `ax/analysis/` pass after the change