### PR TITLE
Add GenerationStrategy.fit() and make maybe_transition_to_next_node private (#4922)

### DIFF
--- a/ax/analysis/plotly/tests/test_top_surfaces.py
+++ b/ax/analysis/plotly/tests/test_top_surfaces.py
@@ -55,7 +55,7 @@ class TestTopSurfacesAnalysis(TestCase):
                 )
 
         self.assertIn(
-            "Ax has not yet reached a GenerationNode",
+            "TorchAdapter is required",
             none_throws(
                 TopSurfacesAnalysis(
                     metric_name="bar", order="first"

--- a/ax/analysis/utils.py
+++ b/ax/analysis/utils.py
@@ -77,9 +77,7 @@ def extract_relevant_adapter(
             "Provided GenerationStrategy has no adapter, but no Experiment was "
             "provided to source data to fit the adapter."
         )
-
-    generation_strategy.current_node._fit(experiment=experiment)
-    adapter = generation_strategy.adapter
+    adapter = generation_strategy.fit(experiment=experiment)
 
     if adapter is None:
         raise UserInputError(

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -1109,7 +1109,9 @@ class TestClient(TestCase):
         summary_df = client.summarize()
         self.assertTrue(summary_df.empty)
 
-        # Add manual trial (not at center so CenterGenerationNode won't be skipped).
+        # Add manual trial. With use_existing_trials_for_initialization=True
+        # (default), the CenterGenerationNode will be skipped because the
+        # experiment already has a trial.
         index = client.attach_trial(
             parameters={"x1": 0.3, "x2": 0.7}, arm_name="manual"
         )
@@ -1149,7 +1151,7 @@ class TestClient(TestCase):
                 "trial_index": {0: 0, 1: 1, 2: 2},
                 "arm_name": {0: "manual", 1: "1_0", 2: "2_0"},
                 "trial_status": {0: "RUNNING", 1: "COMPLETED", 2: "FAILED"},
-                "generation_node": {0: None, 1: "CenterOfSearchSpace", 2: "Sobol"},
+                "generation_node": {0: None, 1: "Sobol", 2: "Sobol"},
                 "foo": {0: 0.0, 1: 1.0, 2: np.nan},  # NaN because trial 2 failed
                 "bar": {0: 0.5, 1: 2.0, 2: np.nan},
                 "x1": {
@@ -1174,7 +1176,7 @@ class TestClient(TestCase):
                 "trial_index": {0: 0, 1: 1},
                 "arm_name": {0: "manual", 1: "1_0"},
                 "trial_status": {0: "RUNNING", 1: "COMPLETED"},
-                "generation_node": {0: None, 1: "CenterOfSearchSpace"},
+                "generation_node": {0: None, 1: "Sobol"},
                 "foo": {0: 0.0, 1: 1.0},
                 "bar": {0: 0.5, 1: 2.0},
                 "x1": {
@@ -1196,7 +1198,7 @@ class TestClient(TestCase):
                 "trial_index": {0: 1},
                 "arm_name": {0: "1_0"},
                 "trial_status": {0: "COMPLETED"},
-                "generation_node": {0: "CenterOfSearchSpace"},
+                "generation_node": {0: "Sobol"},
                 "foo": {0: 1.0},
                 "bar": {0: 2.0},
                 "x1": {0: trial_1_parameters["x1"]},
@@ -1212,7 +1214,7 @@ class TestClient(TestCase):
                 "trial_index": {0: 1},
                 "arm_name": {0: "1_0"},
                 "trial_status": {0: "COMPLETED"},
-                "generation_node": {0: "CenterOfSearchSpace"},
+                "generation_node": {0: "Sobol"},
                 "foo": {0: 1.0},
                 "bar": {0: 2.0},
                 "x1": {0: trial_1_parameters["x1"]},
@@ -1246,7 +1248,7 @@ class TestClient(TestCase):
                 "trial_index": {0: 0, 1: 1},
                 "arm_name": {0: "manual", 1: "1_0"},
                 "trial_status": {0: "RUNNING", 1: "COMPLETED"},
-                "generation_node": {0: None, 1: "CenterOfSearchSpace"},
+                "generation_node": {0: None, 1: "Sobol"},
                 "foo": {0: 0.0, 1: 1.0},
                 "bar": {0: 0.5, 1: 2.0},
                 "x1": {

--- a/ax/api/utils/generation_strategy_dispatch.py
+++ b/ax/api/utils/generation_strategy_dispatch.py
@@ -270,7 +270,12 @@ def choose_generation_strategy(
     if struct.initialize_with_center and (
         struct.initialization_budget is None or struct.initialization_budget > 0
     ):
-        center_node = CenterGenerationNode(next_node_name=nodes[0].name)
+        center_node = CenterGenerationNode(
+            next_node_name=nodes[0].name,
+            use_existing_trials_for_initialization=(
+                struct.use_existing_trials_for_initialization
+            ),
+        )
         nodes.insert(0, center_node)
         gs_name = f"Center+{gs_name}"
     return GenerationStrategy(name=gs_name, nodes=nodes)

--- a/ax/generation_strategy/center_generation_node.py
+++ b/ax/generation_strategy/center_generation_node.py
@@ -29,12 +29,14 @@ from pyre_extensions import none_throws
 @dataclass(init=False)
 class CenterGenerationNode(ExternalGenerationNode):
     next_node_name: str
+    use_existing_trials_for_initialization: bool
 
     def __init__(
         self,
         next_node_name: str,
         suggested_experiment_status: ExperimentStatus
         | None = ExperimentStatus.INITIALIZATION,
+        use_existing_trials_for_initialization: bool = False,
     ) -> None:
         """A generation node that samples the center of the search space.
         This generation node is only used to generate the first point of the experiment.
@@ -49,6 +51,9 @@ class CenterGenerationNode(ExternalGenerationNode):
                 the center point.
             suggested_experiment_status: Optional suggested experiment status for this
                 node.
+            use_existing_trials_for_initialization: If True and the experiment already
+                has trials, this node will be skipped during transition checks
+                outside the gen flow (e.g., when fitting a model for analysis).
         """
         super().__init__(
             name="CenterOfSearchSpace",
@@ -63,6 +68,9 @@ class CenterGenerationNode(ExternalGenerationNode):
         )
         self.search_space: SearchSpace | None = None
         self.next_node_name = next_node_name
+        self.use_existing_trials_for_initialization = (
+            use_existing_trials_for_initialization
+        )
         self.fallback_specs: dict[type[Exception], GeneratorSpec] = {
             AxGenerationException: GeneratorSpec(
                 generator_enum=Generators.SOBOL, generator_key_override="Fallback_Sobol"
@@ -71,6 +79,23 @@ class CenterGenerationNode(ExternalGenerationNode):
         }
         # custom property to enable single center point computation
         self._center_params: TParameterization | None = None
+
+    def should_transition_to_next_node(
+        self, raise_data_required_error: bool = True
+    ) -> tuple[bool, str]:
+        # Lazily evaluate skip condition for cases where gen() hasn't been
+        # called (e.g., _maybe_transition_to_next_node from fit()).
+        # When use_existing_trials_for_initialization is True, existing trials
+        # count toward initialization, so the center node can be skipped.
+        if (
+            not self._should_skip
+            and self.use_existing_trials_for_initialization
+            and len(self.experiment.trials) > 0
+        ):
+            self._should_skip = True
+        return super().should_transition_to_next_node(
+            raise_data_required_error=raise_data_required_error
+        )
 
     def update_generator_state(self, experiment: Experiment, data: Data) -> None:
         # State is already set in gen() and will persist during generation

--- a/ax/generation_strategy/generation_strategy.py
+++ b/ax/generation_strategy/generation_strategy.py
@@ -146,6 +146,33 @@ class GenerationStrategy(Base):
         """
         return self._curr._fitted_adapter
 
+    def fit(
+        self,
+        experiment: Experiment,
+        data: Data | None = None,
+    ) -> Adapter | None:
+        """Transition to the appropriate node and fit the model.
+
+        This is the public API for fitting a model outside the ``gen`` flow.
+        It first transitions to the appropriate node so the strategy
+        advances to the correct node based on the current experiment state
+        (e.g. selecting a transfer-learning node when auxiliary experiments
+        are present), then fits all ``GeneratorSpec``s on that node.
+
+        Args:
+            experiment: The experiment to fit the model to.
+            data: Optional data to use for fitting. If not provided, the
+                node will use ``experiment.lookup_data()``.
+
+        Returns:
+            The fitted ``Adapter`` from the selected node, or ``None`` if
+            no adapter was fitted (e.g. the node is not model-based).
+        """
+        self.experiment = experiment
+        self._maybe_transition_to_next_node(raise_data_required_error=False)
+        self._curr._fit(experiment=experiment, data=data)
+        return self.adapter
+
     @property
     def experiment(self) -> Experiment:
         """Experiment, currently set on this generation strategy."""
@@ -543,7 +570,7 @@ class GenerationStrategy(Base):
                 # reset should skip as conditions may have changed, do not reset
                 # until now so node properties can be as up to date as possible
                 node_to_gen_from._should_skip = False
-            transitioned = self._maybe_transition_to_next_node()
+            transitioned = self._transition_to_next_node()
             try:
                 gr = self._curr.gen(
                     experiment=experiment,
@@ -604,24 +631,11 @@ class GenerationStrategy(Base):
 
     # ------------------------- Node selection logic helpers. -------------------------
 
-    def _maybe_transition_to_next_node(
-        self,
-        raise_data_required_error: bool = True,
-    ) -> bool:
-        """Moves this generation strategy to next node if the current node's
-        transition criteria are met. This method is safe to use both when generating
-        candidates or simply checking how many generator runs (to be made into trials)
-        can currently be produced.
-
-        NOTE: this method raises ``GenerationStrategyCompleted`` error if the
-        optimization is complete
-
-        Args:
-            raise_data_required_error: Whether to raise ``DataRequiredError`` in the
-                maybe_step_completed method in GenerationNode class.
+    def _transition_to_next_node(self, raise_data_required_error: bool = True) -> bool:
+        """Attempts a single transition to the next node if criteria are met.
 
         Returns:
-            Whether generation strategy moved to the next node.
+            Whether the generation strategy moved to the next node.
         """
         move_to_next_node, next_node = self._curr.should_transition_to_next_node(
             raise_data_required_error=raise_data_required_error
@@ -634,3 +648,29 @@ class GenerationStrategy(Base):
                 )
             self._curr = self.nodes_by_name[next_node]
         return move_to_next_node
+
+    def _maybe_transition_to_next_node(
+        self, raise_data_required_error: bool = True
+    ) -> bool:
+        """Moves this generation strategy to next node if the current node's
+        transition criteria are met, advancing through multiple nodes if
+        possible. This method is safe to use both when generating candidates or
+        simply checking how many generator runs (to be made into trials) can
+        currently be produced.
+
+        NOTE: this method raises ``GenerationStrategyCompleted`` error if the
+        optimization is complete
+
+        Args:
+            raise_data_required_error: Whether to raise ``DataRequiredError`` in the
+                maybe_step_completed method in GenerationNode class.
+
+        Returns:
+            Whether generation strategy moved to the next node.
+        """
+        moved = False
+        while self._transition_to_next_node(
+            raise_data_required_error=raise_data_required_error
+        ):
+            moved = True
+        return moved

--- a/ax/generation_strategy/tests/test_center_generation_node.py
+++ b/ax/generation_strategy/tests/test_center_generation_node.py
@@ -219,7 +219,8 @@ class TestCenterGenerationNode(TestCase):
     def test_repr(self) -> None:
         self.assertEqual(
             repr(self.node),
-            "CenterGenerationNode(next_node_name='test')",
+            "CenterGenerationNode(next_node_name='test',"
+            " use_existing_trials_for_initialization=False)",
         )
 
     def test_equality(self) -> None:
@@ -329,3 +330,59 @@ class TestCenterGenerationNode(TestCase):
         # Should transition to regular Sobol node, not use Fallback_Sobol
         self.assertEqual(gr[0]._generation_node_name, "sobol")
         self.assertEqual(gr[0]._generator_key, "Sobol")
+
+    def test_skips_when_use_existing_trials_and_trials_exist(self) -> None:
+        """When use_existing_trials_for_initialization=True and the experiment
+        has trials, should_transition_to_next_node should skip the center node."""
+        node = CenterGenerationNode(
+            next_node_name="sobol",
+            use_existing_trials_for_initialization=True,
+        )
+        gs = GenerationStrategy(
+            name="test",
+            nodes=[
+                node,
+                GenerationNode(
+                    name="sobol",
+                    generator_specs=[GeneratorSpec(generator_enum=Generators.SOBOL)],
+                ),
+            ],
+        )
+        exp = get_branin_experiment()
+        gs.experiment = exp
+
+        # No trials yet -- should NOT skip.
+        self.assertFalse(node._should_skip)
+        should_transition, next_name = node.should_transition_to_next_node()
+        # AutoTransitionAfterGen hasn't fired, but _should_skip is still False
+        # because there are no trials.
+        self.assertFalse(node._should_skip)
+
+        # Add a trial -- now it should skip.
+        exp.new_trial()
+        should_transition, next_name = node.should_transition_to_next_node()
+        self.assertTrue(node._should_skip)
+        self.assertTrue(should_transition)
+        self.assertEqual(next_name, "sobol")
+
+    def test_does_not_skip_when_flag_is_false(self) -> None:
+        """When use_existing_trials_for_initialization=False (default),
+        existing trials should NOT cause the center node to skip."""
+        node = CenterGenerationNode(next_node_name="sobol")
+        gs = GenerationStrategy(
+            name="test",
+            nodes=[
+                node,
+                GenerationNode(
+                    name="sobol",
+                    generator_specs=[GeneratorSpec(generator_enum=Generators.SOBOL)],
+                ),
+            ],
+        )
+        exp = get_branin_experiment()
+        gs.experiment = exp
+        exp.new_trial()
+
+        should_transition, _ = node.should_transition_to_next_node()
+        self.assertFalse(node._should_skip)
+        self.assertFalse(should_transition)

--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1400,13 +1400,18 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
 
         NOTE: If the current generation node is not model-based, no model may be fit.
         """
-        if not self.experiment.trial_indices_by_status[TrialStatus.COMPLETED]:
+        completed_trial_indices = self.experiment.trial_indices_by_status[
+            TrialStatus.COMPLETED
+        ]
+        if not completed_trial_indices:
             raise DataRequiredError(
                 "At least one trial must be completed with data to fit a model."
             )
-        # Check if we should transition before generating the next candidate.
-        self.generation_strategy._maybe_transition_to_next_node()
-        self.generation_strategy._curr._fit(experiment=self.experiment)
+        if self.experiment.lookup_data(trial_indices=completed_trial_indices).df.empty:
+            raise DataRequiredError(
+                "At least one completed trial must have data attached to fit a model."
+            )
+        self.generation_strategy.fit(experiment=self.experiment)
 
     def verify_trial_parameterization(
         self, trial_index: int, parameterization: TParameterization

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -2923,8 +2923,7 @@ class TestAxClient(TestCase):
         ax_client, _ = get_branin_currin_optimization_with_N_sobol_trials(
             num_trials=20, include_objective_thresholds=False
         )
-        ax_client.generation_strategy._maybe_transition_to_next_node()
-        ax_client.generation_strategy._curr._fit(experiment=ax_client.experiment)
+        ax_client.fit_model()
         with with_rng_seed(seed=RANDOM_SEED):
             predicted_pareto = ax_client.get_pareto_optimal_parameters()
 


### PR DESCRIPTION
Summary:

Add a public ``GenerationStrategy.fit(experiment, data)`` method that
encapsulates the transition-then-fit pattern. This replaces ad-hoc calls
to ``maybe_transition_to_next_node`` + ``current_node._fit`` that were
scattered across analysis utils, AxClient, and other callers.

``fit()`` transitions to the appropriate node based on experiment state
(e.g. skipping initialization nodes, selecting TL vs non-TL nodes),
fits all GeneratorSpecs on that node, and returns the fitted Adapter.

``maybe_transition_to_next_node`` is made private
(``_maybe_transition_to_next_node``) per reviewer feedback to limit
external callers of GS internals. The new looping version (which
advances through multiple nodes) replaces the old single-step
``_maybe_transition_to_next_node``.

Also adds support for skipping the CenterGenerationNode when trials
with data are already present (``use_existing_trials_for_initialization``).

Reviewed By: mgarrard

Differential Revision: D93804600


