### PR TITLE
Rename parallelism to concurrency in Client and AxClient APIs

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -836,39 +836,39 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         """
         return self.experiment.to_df()
 
-    def get_max_parallelism(self) -> list[tuple[int, int]]:
-        """Retrieves maximum number of trials that can be scheduled in parallel
+    def get_max_concurrency(self) -> list[tuple[int, int]]:
+        """Retrieves maximum number of trials that can be scheduled concurrently
         at different stages of optimization.
 
         Some optimization algorithms profit significantly from sequential
         optimization (i.e. suggest a few points, get updated with data for them,
         repeat, see https://ax.dev/docs/bayesopt.html).
-        Parallelism setting indicates how many trials should be running simulteneously
+        Concurrency setting indicates how many trials should be running simultaneously
         (generated, but not yet completed with data).
 
         The output of this method is mapping of form
-        {num_trials -> max_parallelism_setting}, where the max_parallelism_setting
-        is used for num_trials trials. If max_parallelism_setting is -1, as
-        many of the trials can be ran in parallel, as necessary. If num_trials
-        in a tuple is -1, then the corresponding max_parallelism_setting
+        {num_trials -> max_concurrency_setting}, where the max_concurrency_setting
+        is used for num_trials trials. If max_concurrency_setting is -1, as
+        many of the trials can be ran concurrently, as necessary. If num_trials
+        in a tuple is -1, then the corresponding max_concurrency_setting
         should be used for all subsequent trials.
 
         For example, if the returned list is [(5, -1), (12, 6), (-1, 3)],
-        the schedule could be: run 5 trials with any parallelism, run 6 trials in
-        parallel twice, run 3 trials in parallel for as long as needed. Here,
+        the schedule could be: run 5 trials with any concurrency, run 6 trials
+        concurrently twice, run 3 trials concurrently for as long as needed. Here,
         'running' a trial means obtaining a next trial from `AxClient` through
         get_next_trials and completing it with data when available.
 
         Returns:
-            Mapping of form {num_trials -> max_parallelism_setting}.
+            Mapping of form {num_trials -> max_concurrency_setting}.
         """
-        parallelism_settings = []
+        concurrency_settings = []
         for node in self.generation_strategy._nodes:
-            # Check pausing_criteria for max parallelism
-            max_parallelism = None
+            # Check pausing_criteria for max concurrency
+            max_concurrency = None
             for pc in node.pausing_criteria:
                 if isinstance(pc, MaxGenerationParallelism):
-                    max_parallelism = pc.threshold
+                    max_concurrency = pc.threshold
                     break
             # Try to get num_trials from the node. If there's no MinTrials
             # criterion (unlimited trials), num_trials will raise UserInputError.
@@ -877,13 +877,16 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
                 num_trials = node.num_trials
             except UserInputError:
                 num_trials = -1
-            parallelism_settings.append(
+            concurrency_settings.append(
                 (
                     num_trials,
-                    max_parallelism if max_parallelism is not None else num_trials,
+                    max_concurrency if max_concurrency is not None else num_trials,
                 )
             )
-        return parallelism_settings
+        return concurrency_settings
+
+    def get_max_parallelism(self) -> list[tuple[int, int]]:
+        raise NotImplementedError("Use `get_max_concurrency` instead.")
 
     def get_optimization_trace(
         self, objective_optimum: float | None = None
@@ -1702,8 +1705,8 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
     @staticmethod
     def get_recommended_max_parallelism() -> None:
         raise NotImplementedError(
-            "Use `get_max_parallelism` instead; parallelism levels are now "
-            "enforced in generation strategy, so max parallelism is no longer "
+            "Use `get_max_concurrency` instead; concurrency levels are now "
+            "enforced in generation strategy, so max concurrency is no longer "
             "just recommended."
         )
 

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -1615,14 +1615,14 @@ class TestAxClient(TestCase):
         ]
         self.assertEqual(len(node0_pausing_criteria), 0)
 
-        # Check that max_parallelism is None by verifying no MaxGenerationParallelism
+        # Check that max_concurrency is None by verifying no MaxGenerationConcurrency
         # criterion exists in pausing_criteria
-        node1_max_parallelism = [
+        node1_max_concurrency = [
             pc
             for pc in ax_client.generation_strategy._nodes[1].pausing_criteria
             if isinstance(pc, MaxGenerationParallelism)
         ]
-        self.assertEqual(len(node1_max_parallelism), 0)
+        self.assertEqual(len(node1_max_concurrency), 0)
 
         for _ in range(10):
             ax_client.get_next_trial()
@@ -1938,17 +1938,17 @@ class TestAxClient(TestCase):
     def test_recommended_parallelism(self) -> None:
         ax_client = AxClient()
         with self.assertRaisesRegex(AssertionError, "No generation strategy"):
-            ax_client.get_max_parallelism()
+            ax_client.get_max_concurrency()
         ax_client.create_experiment(
             parameters=[
                 {"name": "x", "type": "range", "bounds": [-5.0, 10.0]},
                 {"name": "y", "type": "range", "bounds": [0.0, 15.0]},
             ],
         )
-        self.assertEqual(ax_client.get_max_parallelism(), [(5, 5), (-1, 3)])
+        self.assertEqual(ax_client.get_max_concurrency(), [(5, 5), (-1, 3)])
         self.assertEqual(
             run_trials_using_recommended_parallelism(
-                ax_client, ax_client.get_max_parallelism(), 20
+                ax_client, ax_client.get_max_concurrency(), 20
             ),
             0,
         )
@@ -2319,6 +2319,8 @@ class TestAxClient(TestCase):
             ax_client.load_experiment("test_experiment")
         with self.assertRaises(NotImplementedError):
             ax_client.get_recommended_max_parallelism()
+        with self.assertRaises(NotImplementedError):
+            ax_client.get_max_parallelism()
 
     def test_find_last_trial_with_parameterization(self) -> None:
         ax_client = AxClient()
@@ -2871,7 +2873,7 @@ class TestAxClient(TestCase):
 
         self.assertEqual(ax_client.estimate_early_stopping_savings(), 0)
 
-    def test_max_parallelism_exception_when_early_stopping(self) -> None:
+    def test_max_concurrency_exception_when_early_stopping(self) -> None:
         ax_client = AxClient()
         ax_client.create_experiment(
             parameters=[


### PR DESCRIPTION
Summary: Renames the `parallelism` parameter to `concurrency` in `Client.run_trials()` and adds backward-compatible deprecated `max_parallelism` parameters in `AxClient.create_experiment()` and `AxClient.get_max_parallelism()` → `get_max_concurrency()`. Both include deprecation warnings guiding callers to use the new parameter names, with validation that old and new parameters are not specified simultaneously.

Differential Revision: D93771849


