### PR TITLE
Rename parallelism references to concurrency in docs, comments, constants, and telemetry

### DIFF
--- a/ax/analysis/healthcheck/early_stopping_healthcheck.py
+++ b/ax/analysis/healthcheck/early_stopping_healthcheck.py
@@ -95,7 +95,7 @@ class EarlyStoppingAnalysis(Analysis):
                 single-objective unconstrained experiments.
             min_savings_threshold: Minimum savings threshold to suggest early
                 stopping. Default is 0.1 (10% savings).
-            max_pending_trials: Maximum number of pending trials for replay
+            max_pending_trials: Maximum number of concurrent trials for replay
                 orchestrator. Default is 5.
             auto_early_stopping_config: A string for configuring automated early
                 stopping strategy.

--- a/ax/benchmark/benchmark_method.py
+++ b/ax/benchmark/benchmark_method.py
@@ -16,7 +16,7 @@ from ax.utils.common.base import Base
 class BenchmarkMethod(Base):
     """Benchmark method, represented in terms of Ax generation strategy (which tells us
     which models to use when) and Orchestrator options (which tell us extra execution
-    information like maximum parallelism, early stopping configuration, etc.).
+    information like maximum concurrency, early stopping configuration, etc.).
 
     Args:
         name: String description. Defaults to the name of the generation strategy.

--- a/ax/core/runner.py
+++ b/ax/core/runner.py
@@ -81,7 +81,7 @@ class Runner(Base, SerializationMixin, ABC):
         artificially force this method to limit capacity; ``Orchestrator`` has other
         limitations in place to limit number of trials running at once,
         like the ``OrchestratorOptions.max_pending_trials`` setting, or
-        more granular control in the form of the `max_parallelism`
+        more granular control in the form of the `max_concurrency`
         setting in each of the `GenerationStep`s of a `GenerationStrategy`).
 
         Returns:

--- a/ax/early_stopping/experiment_replay.py
+++ b/ax/early_stopping/experiment_replay.py
@@ -130,7 +130,7 @@ def estimate_hypothetical_early_stopping_savings(
     Args:
         experiment: The experiment to analyze.
         metric: The metric to use for early stopping replay.
-        max_pending_trials: Maximum number of pending trials for the replay
+        max_pending_trials: Maximum number of concurrent trials for the replay
             orchestrator. Defaults to 5.
 
     Returns:

--- a/ax/orchestration/orchestrator.py
+++ b/ax/orchestration/orchestrator.py
@@ -1645,7 +1645,7 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
             )
 
     def _get_max_pending_trials(self) -> int:
-        """Returns the maximum number of pending trials specified in the options, or
+        """Returns the maximum number of concurrent trials specified in the options, or
         zero, if the failure rate limit has been exceeded at any point during the
         optimization.
         """
@@ -1690,8 +1690,9 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
         max_pending_upper_bound = max_pending_trials - num_pending_trials
         if max_pending_upper_bound < 1:
             self.logger.debug(
-                f"`max_pending_trials={max_pending_trials}` and {num_pending_trials} "
-                "trials are currently pending; not initiating any additional trials."
+                f"`max_pending_trials={max_pending_trials}` and "
+                f"{num_pending_trials} trials are currently pending; "
+                "not initiating any additional trials."
             )
             return [], []
         n = max_pending_upper_bound if n == -1 else min(max_pending_upper_bound, n)

--- a/ax/orchestration/orchestrator_options.py
+++ b/ax/orchestration/orchestrator_options.py
@@ -90,7 +90,7 @@ class OrchestratorOptions:
             deployment. The size of the groups will be determined as
             the minimum of ``self.poll_available_capacity()`` and the number
             of generator runs that the generation strategy is able to produce
-            without more data or reaching its allowed max paralellism limit.
+            without more data or reaching its allowed max concurrency limit.
         debug_log_run_metadata: Whether to log run_metadata for debugging purposes.
         early_stopping_strategy: A ``BaseEarlyStoppingStrategy`` that determines
             whether a trial should be stopped given the current state of

--- a/ax/utils/common/complexity_utils.py
+++ b/ax/utils/common/complexity_utils.py
@@ -111,7 +111,7 @@ class OptimizationSummary:
             is True).
         tolerated_trial_failure_rate: Maximum tolerated trial failure rate
             (should be <= 0.9).
-        max_pending_trials: Maximum number of pending trials.
+        max_pending_trials: Maximum number of concurrent trials.
         min_failed_trials_for_failure_rate_check: Minimum failed trials before
             failure rate is checked.
         non_default_advanced_options: Whether non-default advanced options are set.


### PR DESCRIPTION
Summary: Updates remaining references from "parallelism" to "concurrency" across orchestration, telemetry, early stopping, and other modules. This covers docstrings, comments, constant names (`MAX_PENDING_TRIALS` → `MAX_CONCURRENT_TRIALS`, `DUMMY_MAX_PENDING_TRIALS` → `DUMMY_MAX_CONCURRENT_TRIALS`), telemetry field names, and variable names in test files. No behavioral changes — purely a terminology alignment.

Differential Revision: D93771906


