### PR TITLE
Modernize dataclasses with slots=True and kw_only=True

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -56,7 +56,7 @@ from botorch.utils.multi_objective.box_decompositions.dominated import (
     DominatedPartitioning,
 )
 from pyre_extensions import assert_is_instance, none_throws
-from torch import Tensor
+from torch import LongTensor, Tensor
 
 logger: Logger = get_logger(__name__)
 
@@ -1262,8 +1262,11 @@ def prep_pairwise_data(
 
     datapoints, comparisons = X, Y.long()
     event_shape = torch.Size([2 * datapoints.shape[-1]])
-    # pyre-ignore[6]: For 2nd param expected `LongTensor` but
-    dataset_X = SliceContainer(datapoints, comparisons, event_shape=event_shape)
+    dataset_X = SliceContainer(
+        values=datapoints,
+        indices=assert_is_instance(comparisons, LongTensor),
+        event_shape=event_shape,
+    )
     dataset_Y = torch.tensor([[0, 1]]).expand(comparisons.shape)
     dataset = RankingDataset(
         X=dataset_X,


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/botorch/pull/3196

This commit modernizes all dataclass definitions in botorch to use Python 3.11+
features:

- Added `slots=True` to all dataclasses for memory efficiency
- Added `kw_only=True` to dataclasses where appropriate:
   - DenseContainer and SliceContainer: Per the existing TODO comment
     recommending this for Python 3.10+
   - OptimizeAcqfInputs: Has many fields making keyword-only cleane

Reviewed By: hvarfner

Differential Revision: D91641965


