### PR TITLE
Handle edge cases that the experiment only have one parameter in SensitivityPlots

### DIFF
--- a/ax/analysis/insights.py
+++ b/ax/analysis/insights.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from typing import final
+from typing import final, Literal
 
 from ax.adapter.base import Adapter
 from ax.analysis.analysis import Analysis
@@ -116,11 +116,18 @@ class InsightsAnalysis(Analysis):
         # For non-bandit experiments, for each objective and constraint, compute a
         # sensitivity analysis and plot the top 3 surfaces.
         else:
+            # Default to second-order sensitivity analysis, but fall back to first-order
+            # if there is only one parameter (second-order requires at least 2
+            # parameters for interaction effects).
+            order: Literal["first", "second"] = (
+                "first" if len(experiment.search_space.parameters) == 1 else "second"
+            )
             top_surfaces_groups = [
                 TopSurfacesAnalysis(
                     metric_name=metric_name,
                     top_k=3,
                     relativize=relativize,
+                    order=order,
                 ).compute_or_error_card(
                     experiment=experiment,
                     generation_strategy=generation_strategy,


### PR DESCRIPTION
Summary: InsightAnalyses defaults to use `second order` when running SensitivityAnalysisPlot. In the edge cases that the experiment only have one parameter, it errors out because the pair-wise effect analyses can't be computed. This diff adds a fallback to use `first order` when there's only one parameter in the experiment

Reviewed By: eonofrey

Differential Revision: D94100579


