### PR TITLE
add support for general box bounds to RandomGenerators.

### DIFF
--- a/ax/generators/random/sobol.py
+++ b/ax/generators/random/sobol.py
@@ -126,7 +126,7 @@ class SobolGenerator(RandomGenerator):
             self.init_position = none_throws(self.engine).num_generated
         return points, weights
 
-    def _gen_samples(self, n: int, tunable_d: int) -> npt.NDArray:
+    def _gen_samples(self, n: int, tunable_d: int, bounds: npt.NDArray) -> npt.NDArray:
         """Generate n samples.
 
         Args:
@@ -134,6 +134,7 @@ class SobolGenerator(RandomGenerator):
             tunable_d: The dimension of the generated samples. This must
                 match the tunable parameters used while initializing the
                 Sobol engine.
+            bounds: A (tunable_d x 2) array of (lower, upper) bounds.
 
         Returns:
             A numpy array of samples of shape `(n x tunable_d)`.
@@ -144,4 +145,8 @@ class SobolGenerator(RandomGenerator):
             raise ValueError(
                 "Sobol Engine must be initialized before candidate generation."
             )
-        return none_throws(self.engine).draw(n, dtype=torch.double).numpy()
+        unit_samples = none_throws(self.engine).draw(n, dtype=torch.double).numpy()
+        # Rescale from [0, 1]^d to [lower, upper]^d
+        lower = bounds[:, 0]
+        upper = bounds[:, 1]
+        return unit_samples * (upper - lower) + lower

--- a/ax/generators/random/uniform.py
+++ b/ax/generators/random/uniform.py
@@ -41,16 +41,21 @@ class UniformGenerator(RandomGenerator):
             # Fast-forward the random state by generating & discarding samples.
             self._rs.uniform(size=(self.init_position))
 
-    def _gen_samples(self, n: int, tunable_d: int) -> npt.NDArray:
+    def _gen_samples(self, n: int, tunable_d: int, bounds: npt.NDArray) -> npt.NDArray:
         """Generate samples from the scipy uniform distribution.
 
         Args:
             n: Number of samples to generate.
             tunable_d: Dimension of samples to generate.
+            bounds: A (tunable_d x 2) array of (lower, upper) bounds.
 
         Returns:
-            samples: An (n x d) array of random points.
+            samples: An (n x tunable_d) array of random points.
 
         """
         self.init_position += n * tunable_d
-        return self._rs.uniform(size=(n, tunable_d))
+        return self._rs.uniform(
+            low=bounds[:, 0],
+            high=bounds[:, 1],
+            size=(n, tunable_d),
+        )

--- a/ax/generators/tests/test_random.py
+++ b/ax/generators/tests/test_random.py
@@ -37,12 +37,14 @@ class RandomGeneratorTest(TestCase):
 
     def test_RandomGeneratorGenSamples(self) -> None:
         with self.assertRaises(NotImplementedError):
-            self.random_model._gen_samples(n=1, tunable_d=1)
+            self.random_model._gen_samples(
+                n=1, tunable_d=1, bounds=np.array([[0.0, 1.0]])
+            )
 
     def test_RandomGeneratorGenUnconstrained(self) -> None:
         with self.assertRaises(NotImplementedError):
             self.random_model._gen_unconstrained(
-                n=1, d=2, tunable_feature_indices=np.array([])
+                n=1, d=2, tunable_feature_indices=np.array([], dtype=int)
             )
 
     def test_ConvertEqualityConstraints(self) -> None:

--- a/ax/generators/tests/test_sobol.py
+++ b/ax/generators/tests/test_sobol.py
@@ -306,11 +306,21 @@ class SobolGeneratorTest(TestCase):
             np.allclose(generated_points_single_batch, generated_points_two_trials)
         )
 
-    def test_SobolGeneratorBadBounds(self) -> None:
-        generator = SobolGenerator()
-        ssd = SearchSpaceDigest(feature_names=["x"], bounds=[(-1, 1)])
-        with self.assertRaisesRegex(ValueError, "This generator operates on"):
-            generator.gen(n=1, search_space_digest=ssd, rounding_func=lambda x: x)
+    def test_SobolGeneratorGeneralBounds(self) -> None:
+        generator = SobolGenerator(seed=0)
+        bounds = [(2.0, 10.0), (0.5, 5.5), (-3.0, 3.0)]
+        ssd = SearchSpaceDigest(
+            feature_names=["x0", "x1", "x2"],
+            bounds=bounds,
+        )
+        generated_points, weights = generator.gen(
+            n=5, search_space_digest=ssd, rounding_func=lambda x: x
+        )
+        self.assertEqual(np.shape(generated_points), (5, 3))
+        np_bounds = np.array(bounds)
+        self.assertTrue(np.all(generated_points >= np_bounds[:, 0]))
+        self.assertTrue(np.all(generated_points <= np_bounds[:, 1]))
+        self.assertTrue(np.all(weights == 1.0))
 
     def test_SobolGeneratorMaxDraws(self) -> None:
         generator = SobolGenerator(seed=0)

--- a/ax/generators/tests/test_uniform.py
+++ b/ax/generators/tests/test_uniform.py
@@ -167,13 +167,18 @@ class UniformGeneratorTest(TestCase):
         self.assertTrue(np.shape(expected_points) == np.shape(generated_points))
         self.assertTrue(np.allclose(expected_points, generated_points))
 
-    def test_with_bad_bounds(self) -> None:
-        generator = UniformGenerator()
-        with self.assertRaises(ValueError):
-            generated_points, weights = generator.gen(
-                n=1,
-                search_space_digest=SearchSpaceDigest(
-                    feature_names=["a"], bounds=[(-1, 1)]
-                ),
-                rounding_func=lambda x: x,
-            )
+    def test_with_general_bounds(self) -> None:
+        generator = UniformGenerator(seed=self.seed)
+        bounds = [(2.0, 10.0), (0.5, 5.5), (-3.0, 3.0)]
+        ssd = SearchSpaceDigest(
+            feature_names=["x0", "x1", "x2"],
+            bounds=bounds,
+        )
+        generated_points, weights = generator.gen(
+            n=5, search_space_digest=ssd, rounding_func=lambda x: x
+        )
+        self.assertEqual(np.shape(generated_points), (5, 3))
+        np_bounds = np.array(bounds)
+        self.assertTrue(np.all(generated_points >= np_bounds[:, 0]))
+        self.assertTrue(np.all(generated_points <= np_bounds[:, 1]))
+        self.assertTrue(np.all(weights == 1.0))

--- a/ax/generators/utils.py
+++ b/ax/generators/utils.py
@@ -70,8 +70,7 @@ def rejection_sample(
     rounding_func: Callable[[npt.NDArray], npt.NDArray] | None = None,
     existing_points: npt.NDArray | None = None,
 ) -> tuple[npt.NDArray, int]:
-    """Rejection sample in parameter space. Parameter space is typically
-    [0, 1] for all tunable parameters.
+    """Rejection sample in parameter space.
 
     Generators must implement a `gen_unconstrained` method in order to support
     rejection sampling via this utility.
@@ -271,30 +270,6 @@ def tunable_feature_indices(
     fixed_feature_indices = list(fixed_features.keys()) if fixed_features else []
     feature_indices = np.arange(len(bounds))
     return np.delete(feature_indices, fixed_feature_indices)
-
-
-def validate_bounds(
-    bounds: Sequence[tuple[float, float]],
-    fixed_feature_indices: npt.NDArray,
-) -> None:
-    """Ensure the requested space is [0,1]^d.
-
-    Args:
-        bounds: A list of d (lower, upper) tuples for each column of X.
-        fixed_feature_indices: Indices of features which are fixed at a
-            particular value.
-    """
-    for feature_idx, bound in enumerate(bounds):
-        # Bounds for fixed features are not unit-transformed.
-        if feature_idx in fixed_feature_indices:
-            continue
-
-        if bound[0] != 0 or bound[1] != 1:
-            raise ValueError(
-                "This generator operates on [0,1]^d. Please make use "
-                "of the UnitX transform in the Adapter, and ensure "
-                "task features are fixed."
-            )
 
 
 def best_observed_point(


### PR DESCRIPTION
Summary:
Currently RandomGenerators require that the space be mapped to [0, 1]^d, for the convenience of random number generators operating on that space by default. In a stacked diff I would like to super() gen on a random generator but need the returned points to be in raw space, no UnitX transformation.

It is a relatively small change for RandomGenerators to be capable of operating with arbitrary bounds, which change this diff makes.

Differential Revision: D94118103


