### PR TITLE
don't use posterior_transform with p(feasible)

### DIFF
--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -369,8 +369,8 @@ def _objective_threshold_to_outcome_constraints(
         A tuple ``(A, b)`` of outcome constraint tensors.
     """
     obj_idcs = objective_weights.nonzero(as_tuple=False).view(-1)
-    # Filter to objectives with non-NaN thresholds. Objective threhsolds
-    # can contain NaNs if there objective thresholds were inferred, but
+    # Filter to objectives with non-NaN thresholds. Objective thresholds
+    # can contain NaNs if the objective thresholds were inferred, but
     # there are no feasible points. In that case,
     # qLogProbabilityOfFeasibility is used.
     obj_idcs = obj_idcs[~objective_thresholds[obj_idcs].isnan()]

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -377,7 +377,7 @@ class BoTorchGeneratorUtilsTest(TestCase):
         )
 
     def test_objective_threshold_to_outcome_constraints(self) -> None:
-        # Test basic conversion: maximize both objectives.
+        # Test basic conversion: maximize obj 0, minimize obj 1, skip obj 2.
         objective_weights = torch.tensor([1.0, -1.0, 0.0])
         objective_thresholds = torch.tensor([0.5, 1.5, float("nan")])
         A, b = _objective_threshold_to_outcome_constraints(

--- a/ax/generators/torch/utils.py
+++ b/ax/generators/torch/utils.py
@@ -17,6 +17,7 @@ from ax.generators.utils import filter_constraints_and_fixed_features, get_obser
 from ax.utils.common.constants import Keys
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.analytic import PosteriorMean
+from botorch.acquisition.logei import qLogProbabilityOfFeasibility
 from botorch.acquisition.monte_carlo import (
     MCAcquisitionFunction,
     qSimpleRegret,
@@ -328,6 +329,8 @@ def get_botorch_objective_and_transform(
     if learned_objective_preference_model is not None:
         objective = LearnedObjective(pref_model=learned_objective_preference_model)
         return objective, None
+    if botorch_acqf_class is qLogProbabilityOfFeasibility:
+        return None, None
 
     if issubclass(
         botorch_acqf_class,


### PR DESCRIPTION
Summary:
D92890568 added MOO support for `qLogProbabilityOfFeasibility` by converting
objective thresholds to constraints when no observed point simultaneously
satisfies all outcome constraints and dominates all objective thresholds.

However, this introduced a bug: when `qLogProbabilityOfFeasibility` was used
without outcome constraints (only objective thresholds), the
`get_botorch_objective_and_transform` function fell through to its default case
and returned a `ScalarizedPosteriorTransform(weights=objective_weights)`. This
posterior transform applied objective weights to the model's posterior samples and scalarized the posterior (so the wrong shape was returned and einsum broadcasting concealed the issue).
The threshold-derived constraints also embedded the objective weights in the
constraint matrix `A` (via `A[i, idx] = -w`). This resulted in objective
weights being applied twice — once by the posterior transform and once by the
constraint callables — leading to incorrect feasibility computations.

The fix adds a special case for `qLogProbabilityOfFeasibility` in
`get_botorch_objective_and_transform` that returns `(None, None)`, ensuring no
posterior transform or objective is applied. The threshold constraints alone
correctly handle the objective weights.

Reviewed By: saitcakmak

Differential Revision: D94156745


