### PR TITLE
Remove obsolete ALLOW_LATEST_GPYTORCH_LINOP and ALLOW_BOTORCH_LATEST flags

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,8 +29,6 @@ jobs:
       with:
         python-version: "3.14"
     - name: Install dependencies
-      env:
-        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         # use latest Botorch
         uv pip install git+https://github.com/cornellius-gp/linear_operator.git

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -59,8 +59,6 @@ jobs:
       with:
         python-version: "3.14"
     - name: Install dependencies
-      env:
-        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         # use latest BoTorch
         uv pip install git+https://github.com/cornellius-gp/linear_operator.git

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -62,8 +62,6 @@ jobs:
         uv pip install -e ".[tutorial]"
     - if: ${{ !inputs.pinned_botorch }}
       name: Install dependencies with latest BoTorch
-      env:
-        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         uv pip install git+https://github.com/cornellius-gp/linear_operator.git
         uv pip install git+https://github.com/cornellius-gp/gpytorch.git

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -49,8 +49,6 @@ jobs:
 
     - if: ${{ !inputs.pinned_botorch }}
       name: Install dependencies with latest BoTorch (minimal dependencies ${{ inputs.minimal_dependencies }})
-      env:
-        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         uv pip install git+https://github.com/cornellius-gp/linear_operator.git
         uv pip install git+https://github.com/cornellius-gp/gpytorch.git

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -42,8 +42,6 @@ jobs:
 
     - if: ${{ !inputs.pinned_botorch }}
       name: Install dependencies with latest BoTorch
-      env:
-        ALLOW_LATEST_GPYTORCH_LINOP: true
       run: |
         uv pip install git+https://github.com/cornellius-gp/linear_operator.git
         uv pip install git+https://github.com/cornellius-gp/gpytorch.git

--- a/README.md
+++ b/README.md
@@ -122,14 +122,9 @@ developing Ax (`dev`) are also available.
 You can install the latest (bleeding edge) version from GitHub using `pip`.
 
 The bleeding edge for Ax depends on bleeding edge versions of BoTorch and
-GPyTorch. We therefore recommend installing those from Github, as well as
-setting the following environment variables to allow the Ax to use the latest
-version of both BoTorch and GPyTorch.
+GPyTorch. We therefore recommend installing those from Github as well.
 
 ```shell
-export ALLOW_LATEST_GPYTORCH_LINOP=true
-export ALLOW_BOTORCH_LATEST=true
-
 pip install git+https://github.com/cornellius-gp/gpytorch.git
 pip install git+https://github.com/pytorch/botorch.git
 
@@ -156,9 +151,7 @@ dependencies:
 ```
 pip install git+https://github.com/cornellius-gp/linear_operator.git
 pip install git+https://github.com/cornellius-gp/gpytorch.git
-export ALLOW_LATEST_GPYTORCH_LINOP=true
 pip install git+https://github.com/pytorch/botorch.git
-export ALLOW_BOTORCH_LATEST=true
 git clone https://github.com/facebook/ax.git --depth 1
 cd ax
 pip install -e .[tutorial]

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -42,14 +42,9 @@ developing Ax (`dev`) are also available.
 You can install the latest (bleeding edge) version from GitHub using `pip`.
 
 The bleeding edge for Ax depends on bleeding edge versions of BoTorch and
-GPyTorch. We therefore recommend installing those from Github, as well as
-setting the following environment variables to allow the Ax to use the latest
-version of both BoTorch and GPyTorch.
+GPyTorch. We therefore recommend installing those from Github as well.
 
 ```shell
-export ALLOW_LATEST_GPYTORCH_LINOP=true
-export ALLOW_BOTORCH_LATEST=true
-
 pip install git+https://github.com/cornellius-gp/gpytorch.git
 pip install git+https://github.com/pytorch/botorch.git
 


### PR DESCRIPTION
Summary:
These environment variables were consumed by the old `setup.py` files in BoTorch and Ax to relax `==` version pins to `>=`. Both `setup.py` files have been deleted and replaced with `pyproject.toml` files that use `>=` constraints directly. Setting these env vars is now a complete no-op.

This diff removes all remaining references from:
- Documentation: README.md, installation.mdx, ax_paper/README.md
- CI workflows: build-and-test.yml, cron.yml, publish_website.yml, reusable_test.yml, reusable_tutorials.yml

Differential Revision: D94234271


