### PR TITLE
Add defensive guard and cross-references for acqf dispatch

### DIFF
--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -466,6 +466,8 @@ def choose_botorch_acqf_class(
                     )
 
             if not is_feasible.any().item():
+                # NOTE: Adding a new acqf class here requires a corresponding
+                # update in get_botorch_objective_and_transform.
                 acqf_class = qLogProbabilityOfFeasibility
                 logger.debug(f"Chose BoTorch acquisition function class: {acqf_class}.")
                 return acqf_class


### PR DESCRIPTION
Summary:
D92890568 introduced a bug where `get_botorch_objective_and_transform` silently
fell through to a `ScalarizedPosteriorTransform` default when
`qLogProbabilityOfFeasibility` was used for MOO. D94156745 fixed it by adding
an identity check. This diff adds:

1. A belt-and-suspenders `issubclass` guard (in addition to the existing `is`
   check) so future subclasses of `qLogProbabilityOfFeasibility` don't hit the
   same silent fallthrough.
2. An explanatory comment on the guard explaining the contract (constraint-only
   acqf classes must not receive a posterior transform).
3. A cross-reference comment in `choose_botorch_acqf_class` warning that
   adding a new acqf class there requires a corresponding update in
   `get_botorch_objective_and_transform`.

Reviewed By: saitcakmak

Differential Revision: D94233030


