### PR TITLE
Move infer_reference_point_from_experiment and get_tensor_converter_adapter to ax/service/utils/best_point.py

### DIFF
--- a/ax/global_stopping/strategies/improvement.py
+++ b/ax/global_stopping/strategies/improvement.py
@@ -21,7 +21,7 @@ from ax.core.trial import Trial
 from ax.core.types import ComparisonOp
 from ax.exceptions.core import AxError
 from ax.global_stopping.strategies.base import BaseGlobalStoppingStrategy
-from ax.plot.pareto_utils import (
+from ax.service.utils.best_point import (
     get_tensor_converter_adapter,
     infer_reference_point_from_experiment,
 )

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -15,35 +15,24 @@ from typing import NamedTuple
 import numpy as np
 import numpy.typing as npt
 import torch
-from ax.adapter.adapter_utils import (
-    _get_adapter_training_data,
-    get_pareto_frontier_and_configs,
-    observed_pareto_frontier,
-)
-from ax.adapter.registry import Generators, MBM_X_trans
-from ax.adapter.torch import TorchAdapter
+from ax.adapter.adapter_utils import observed_pareto_frontier
+from ax.adapter.registry import Generators
 from ax.adapter.transforms.derelativize import derelativize_bound
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.metric import Metric
-from ax.core.objective import MultiObjective, ScalarizedObjective
+from ax.core.objective import ScalarizedObjective
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
-from ax.core.outcome_constraint import (
-    ComparisonOp,
-    ObjectiveThreshold,
-    OutcomeConstraint,
-)
+from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.types import TParameterization
 from ax.exceptions.core import AxError, UnsupportedError, UserInputError
-from ax.generators.torch_base import TorchGenerator
+from ax.service.utils.best_point import get_tensor_converter_adapter
 from ax.utils.common.logger import get_logger
 from ax.utils.stats.math_utils import relativize
 from botorch.acquisition.monte_carlo import qSimpleRegret
 from botorch.utils.multi_objective import is_non_dominated
-from botorch.utils.multi_objective.hypervolume import infer_reference_point
-from pyre_extensions import assert_is_instance
 
 # type aliases
 Mu = dict[str, list[float]]
@@ -298,34 +287,6 @@ def get_observed_pareto_frontiers(
     return pfr_list
 
 
-def get_tensor_converter_adapter(
-    experiment: Experiment, data: Data | None = None
-) -> TorchAdapter:
-    """
-    Constructs a minimal model for converting things to tensors.
-
-    Model fitting will instantiate all of the transforms but will not do any
-    expensive (i.e. GP) fitting beyond that. The model will raise an error if
-    it is used for predicting or generating.
-
-    Will work for any search space regardless of types of parameters.
-
-    Args:
-        experiment: Experiment.
-        data: Data for fitting the model.
-
-    Returns: A torch adapter with transforms set.
-    """
-    # Transforms is the minimal set that will work for converting any search
-    # space to tensors.
-    return TorchAdapter(
-        experiment=experiment,
-        data=data,
-        generator=TorchGenerator(),
-        transforms=MBM_X_trans,
-    )
-
-
 def compute_posterior_pareto_frontier(
     experiment: Experiment,
     primary_objective: Metric,
@@ -553,176 +514,3 @@ def _build_scalarized_optimization_config(
         objective=obj, outcome_constraints=outcome_constraints
     )
     return optimization_config
-
-
-def infer_reference_point_from_experiment(
-    experiment: Experiment, data: Data
-) -> list[ObjectiveThreshold]:
-    """This functions is a wrapper around ``infer_reference_point`` to find the nadir
-    point from the pareto front of an experiment. Aside from converting experiment
-    to tensors, this wrapper transforms back and forth the objectives of the experiment
-    so that they are appropriately used by ``infer_reference_point``.
-
-    Args:
-        experiment: The experiment for which we want to infer the reference point.
-
-    Returns:
-        A list of objective thresholds representing the reference point.
-    """
-    if not experiment.is_moo_problem:
-        raise ValueError(
-            "This function works for MOO experiments only."
-            f" Experiment {experiment.name} is single objective."
-        )
-
-    # Reading experiment data.
-    adapter = get_tensor_converter_adapter(
-        experiment=experiment,
-        data=data,
-    )
-    obs_feats, obs_data, _ = _get_adapter_training_data(adapter=adapter)
-
-    # Since objectives could have arbitrary orders in objective_thresholds and
-    # further down the road `get_pareto_frontier_and_configs` arbitrarily changes the
-    # orders of the objectives, we fix the objective orders here based on the
-    # observation_data and maintain it throughout the flow.
-    objective_orders = obs_data[0].metric_signatures
-
-    # Defining a dummy reference point so that all observed points are considered
-    # when calculating the Pareto front. Also, defining a multiplier to turn all
-    # the objectives to be maximized. Note that the multiplier at this point
-    # contains 0 for outcome_constraint metrics, but this will be dropped later.
-    opt_config = assert_is_instance(
-        experiment.optimization_config, MultiObjectiveOptimizationConfig
-    )
-    inferred_rp = _get_objective_thresholds(optimization_config=opt_config)
-    multiplier = [0] * len(objective_orders)
-    if len(opt_config.objective_thresholds) > 0:
-        inferred_rp = deepcopy(opt_config.objective_thresholds)
-    else:
-        inferred_rp = []
-        for objective in assert_is_instance(
-            opt_config.objective, MultiObjective
-        ).objectives:
-            ot = ObjectiveThreshold(
-                metric=objective.metric,
-                bound=0.0,  # dummy value
-                op=ComparisonOp.LEQ if objective.minimize else ComparisonOp.GEQ,
-                relative=False,
-            )
-            inferred_rp.append(ot)
-    for ot in inferred_rp:
-        # In the following, we find the index of the objective in
-        # `objective_orders`. If there is an objective that does not exist
-        # in `obs_data`, a ValueError is raised.
-        try:
-            objective_index = objective_orders.index(ot.metric.signature)
-        except ValueError:
-            raise ValueError(
-                f"Metric {ot.metric.signature} does not exist in `obs_data`."
-            )
-
-        if ot.op == ComparisonOp.LEQ:
-            ot.bound = np.inf
-            multiplier[objective_index] = -1
-        else:
-            ot.bound = -np.inf
-            multiplier[objective_index] = 1
-
-    # Finding the pareto frontier
-    frontier_observations, f, obj_w, _ = get_pareto_frontier_and_configs(
-        adapter=adapter,
-        observation_features=obs_feats,
-        observation_data=obs_data,
-        objective_thresholds=inferred_rp,
-        use_model_predictions=False,
-    )
-    if len(frontier_observations) == 0:
-        outcome_constraints = opt_config._outcome_constraints
-        if len(outcome_constraints) == 0:
-            raise RuntimeError(
-                "No frontier observations found in the experiment and no constraints "
-                "are present. Please check the data of the experiment."
-            )
-
-        logger.warning(
-            "No frontier observations found in the experiment. The likely cause is "
-            "the absence of feasible arms in the experiment if a constraint is present."
-            " Trying to find a reference point with the unconstrained objective values."
-        )
-
-        opt_config._outcome_constraints = []  # removing the constraints
-        # getting the unconstrained pareto frontier
-        frontier_observations, f, obj_w, _ = get_pareto_frontier_and_configs(
-            adapter=adapter,
-            observation_features=obs_feats,
-            observation_data=obs_data,
-            objective_thresholds=inferred_rp,
-            use_model_predictions=False,
-        )
-        # restoring constraints
-        opt_config._outcome_constraints = outcome_constraints
-
-    # Need to reshuffle columns of `f` and `obj_w` to be consistent
-    # with objective_orders.
-    order = [
-        objective_orders.index(metric_signature)
-        for metric_signature in frontier_observations[0].data.metric_signatures
-    ]
-    f = f[:, order]
-    obj_w = obj_w[order]
-
-    # Dropping the columns related to outcome constraints.
-    f = f[:, obj_w.nonzero().view(-1)]
-    multiplier_tensor = torch.tensor(multiplier, dtype=f.dtype, device=f.device)
-    multiplier_nonzero = multiplier_tensor[obj_w.nonzero().view(-1)]
-
-    # Transforming all the objectives to be maximized.
-    f_transformed = multiplier_nonzero * f
-
-    # Finding nadir point.
-    rp_raw = infer_reference_point(f_transformed)
-
-    # Un-transforming the reference point.
-    rp = multiplier_nonzero * rp_raw
-
-    # Removing the non-objective metrics form the order.
-    objective_orders_reduced = [
-        x for (i, x) in enumerate(objective_orders) if multiplier[i] != 0
-    ]
-
-    for obj_threshold in inferred_rp:
-        obj_threshold.bound = rp[
-            objective_orders_reduced.index(obj_threshold.metric.signature)
-        ].item()
-    return inferred_rp
-
-
-def _get_objective_thresholds(
-    optimization_config: MultiObjectiveOptimizationConfig,
-) -> list[ObjectiveThreshold]:
-    """Get objective thresholds for an optimization config.
-
-    This will return objective thresholds with dummy values if there are
-    no objective thresholds on the optimization config.
-
-    Args:
-        optimization_config: Optimization config.
-
-    Returns:
-        List of objective thresholds.
-    """
-    if optimization_config.objective_thresholds is not None:
-        return deepcopy(optimization_config.objective_thresholds)
-    objective_thresholds = []
-    for objective in assert_is_instance(
-        optimization_config.objective, MultiObjective
-    ).objectives:
-        ot = ObjectiveThreshold(
-            metric=objective.metric,
-            bound=0.0,  # dummy value
-            op=ComparisonOp.LEQ if objective.minimize else ComparisonOp.GEQ,
-            relative=False,
-        )
-        objective_thresholds.append(ot)
-    return objective_thresholds

--- a/ax/plot/tests/test_pareto_utils.py
+++ b/ax/plot/tests/test_pareto_utils.py
@@ -7,16 +7,11 @@
 # pyre-strict
 
 import copy
-from unittest import mock
-from unittest.mock import patch
 
 import numpy as np
-import torch
 from ax.adapter.registry import Generators
-from ax.adapter.torch import TorchAdapter
 from ax.core.data import Data
 from ax.core.objective import MultiObjective, Objective
-from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.outcome_constraint import ObjectiveThreshold
 from ax.core.types import ComparisonOp
@@ -30,16 +25,12 @@ from ax.plot.pareto_utils import (
     _extract_observed_pareto_2d,
     _relativize_values,
     get_observed_pareto_frontiers,
-    get_tensor_converter_adapter,
-    infer_reference_point_from_experiment,
-    logger,
 )
 from ax.utils.common.testutils import TestCase
 from ax.utils.stats.math_utils import relativize
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
     get_branin_experiment_with_multi_objective,
-    get_experiment_with_observations,
 )
 
 
@@ -221,171 +212,6 @@ class ParetoUtilsTest(TestCase):
         self.assertTrue(
             np.array_equal(pareto, np.array([[3.0, 0.0], [2.1, 1.0], [2.0, 2.0]]))
         )
-
-
-class TestInfereReferencePointFromExperiment(TestCase):
-    def test_infer_reference_point_from_experiment(self) -> None:
-        observations = [[-1.0, 1.0], [-0.5, 2.0], [-2.0, 0.5], [-0.1, 0.1]]
-        # Getting an experiment with 2 objectives by the above observations.
-        experiment = get_experiment_with_observations(
-            observations=observations,
-            minimize=True,
-            scalarized=False,
-            constrained=False,
-        )
-        data = experiment.fetch_data()
-        inferred_reference_point = infer_reference_point_from_experiment(
-            experiment, data=data
-        )
-        # The nadir point for this experiment is [-0.5, 0.5]. The function actually
-        # deducts 0.1*Y_range from each of the objectives. Since the range for each
-        # of the objectives is +/-1.5, the inferred reference point would
-        # be [-0.35, 0.35].
-        self.assertEqual(inferred_reference_point[0].op, ComparisonOp.LEQ)
-        self.assertEqual(inferred_reference_point[0].bound, -0.35)
-        self.assertEqual(inferred_reference_point[0].metric.signature, "m1")
-        self.assertEqual(inferred_reference_point[1].op, ComparisonOp.GEQ)
-        self.assertEqual(inferred_reference_point[1].bound, 0.35)
-        self.assertEqual(inferred_reference_point[1].metric.signature, "m2")
-
-        with mock.patch(
-            "ax.plot.pareto_utils.get_pareto_frontier_and_configs",
-            return_value=([], [], [], []),
-        ):
-            with self.assertRaisesRegex(RuntimeError, "No frontier observations found"):
-                infer_reference_point_from_experiment(experiment, data=data)
-
-    def test_constrained_infer_reference_point_from_experiment(self) -> None:
-        experiments = []
-        observations = [[-1.0, 1.0], [-0.5, 2.0], [-2.0, 0.5], [-0.1, 0.1]]
-        # adding constraint observations
-        observations = [o + [c] for o, c in zip(observations, [1.0, 0.5, 1.0, 1.0])]
-        # Getting an experiment with 2 objectives by the above observations.
-        experiment = get_experiment_with_observations(
-            observations=observations,
-            minimize=True,
-            scalarized=False,
-            constrained=True,
-        )
-        experiments.append(experiment)
-
-        # Special case: An experiment with no feasible observations.
-        # TODO: Use experiment clone function once D50804778 is landed.
-        experiment = copy.deepcopy(experiment)
-        # Ensure that no observation is feasible.
-        experiment.optimization_config.outcome_constraints[0].bound = 1000.0
-        experiments.append(experiment)
-
-        for experiment in experiments:
-            # special case logs a warning message.
-            data = experiment.fetch_data()
-            if experiment.optimization_config.outcome_constraints[0].bound == 1000.0:
-                with self.assertLogs(logger, "WARNING"):
-                    inferred_reference_point = infer_reference_point_from_experiment(
-                        experiment, data=data
-                    )
-            else:
-                inferred_reference_point = infer_reference_point_from_experiment(
-                    experiment, data=data
-                )
-            # The nadir point for this experiment is [-0.5, 0.5]. The function actually
-            # deducts 0.1*Y_range from each of the objectives. Since the range for each
-            # of the objectives is +/-1.5, the inferred reference point would
-            # be [-0.35, 0.35].
-            self.assertEqual(inferred_reference_point[0].op, ComparisonOp.LEQ)
-            self.assertEqual(inferred_reference_point[0].bound, -0.35)
-            self.assertEqual(inferred_reference_point[0].metric.signature, "m1")
-            self.assertEqual(inferred_reference_point[1].op, ComparisonOp.GEQ)
-            self.assertEqual(inferred_reference_point[1].bound, 0.35)
-            self.assertEqual(inferred_reference_point[1].metric.signature, "m2")
-
-    def test_infer_reference_point_from_experiment_shuffled_metrics(self) -> None:
-        # Generating an experiment with given data.
-        observations = [
-            [-1.0, 1.0, 0.1],
-            [-0.5, 2.0, 0.2],
-            [-2.0, 0.5, 0.3],
-            [-0.1, 0.1, 0.4],
-        ]
-        experiment = get_experiment_with_observations(
-            observations=observations,
-            minimize=True,
-            scalarized=False,
-            constrained=True,
-        )
-
-        # Constructing fake outputs for `get_pareto_frontier_and_configs` so that
-        # the order of metrics `m1`, `m2` and `m3` are reversed.
-        frontier_observations_shuffled = [
-            Observation(
-                features=ObservationFeatures(parameters={"x": 0.0, "y": 0.0}),
-                data=ObservationData(
-                    metric_signatures=["m3", "m2", "m1"],
-                    means=np.array([0.1, 1.0, -1.0]),
-                    covariance=np.diag(np.full(3, float("nan"))),
-                ),
-            ),
-            Observation(
-                features=ObservationFeatures(parameters={"x": 0.1, "y": 0.1}),
-                data=ObservationData(
-                    metric_signatures=["m3", "m2", "m1"],
-                    means=np.array([0.2, 2.0, -0.5]),
-                    covariance=np.diag(np.full(3, float("nan"))),
-                ),
-            ),
-            Observation(
-                features=ObservationFeatures(parameters={"x": 0.2, "y": 0.2}),
-                data=ObservationData(
-                    metric_signatures=["m3", "m2", "m1"],
-                    means=np.array([0.3, 0.5, -2.0]),
-                    covariance=np.diag(np.full(3, float("nan"))),
-                ),
-            ),
-        ]
-        f_shuffled = torch.tensor(
-            [
-                [0.1000, 1.0000, -1.0000],
-                [0.2000, 2.0000, -0.5000],
-                [0.3000, 0.5000, -2.0000],
-            ],
-            dtype=torch.float64,
-        )
-        obj_w_shuffled = torch.tensor([0.0, 1.0, -1.0], dtype=torch.float64)
-        obj_t_shuffled = torch.tensor(
-            [-torch.inf, -torch.inf, torch.inf], dtype=torch.float64
-        )
-
-        # Test the function with these shuffled output for
-        # `get_pareto_frontier_and_configs`.
-        with patch(
-            "ax.plot.pareto_utils.get_pareto_frontier_and_configs",
-            return_value=(
-                frontier_observations_shuffled,
-                f_shuffled,
-                obj_w_shuffled,
-                obj_t_shuffled,
-            ),
-        ):
-            inferred_reference_point = infer_reference_point_from_experiment(
-                experiment, data=experiment.fetch_data()
-            )
-
-            self.assertEqual(inferred_reference_point[0].op, ComparisonOp.LEQ)
-            self.assertEqual(inferred_reference_point[0].bound, -0.35)
-            self.assertEqual(inferred_reference_point[0].metric.signature, "m1")
-            self.assertEqual(inferred_reference_point[1].op, ComparisonOp.GEQ)
-            self.assertEqual(inferred_reference_point[1].bound, 0.35)
-            self.assertEqual(inferred_reference_point[1].metric.signature, "m2")
-
-    def test_get_tensor_converter_adapter(self) -> None:
-        # Test that it can convert experiments with different number of observations.
-        for num_observations in (1, 10, 2000):
-            experiment = get_experiment_with_observations(
-                observations=[[0.0] for _ in range(num_observations)],
-            )
-            self.assertIsInstance(
-                get_tensor_converter_adapter(experiment=experiment), TorchAdapter
-            )
 
     def test__relativize_values(self) -> None:
         # With NaN sem.

--- a/ax/service/utils/best_point_mixin.py
+++ b/ax/service/utils/best_point_mixin.py
@@ -23,8 +23,8 @@ from ax.core.trial import Trial
 from ax.core.types import TModelPredictArm, TParameterization
 from ax.exceptions.core import UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
-from ax.plot.pareto_utils import get_tensor_converter_adapter
 from ax.service.utils import best_point as best_point_utils
+from ax.service.utils.best_point import get_tensor_converter_adapter
 from ax.service.utils.best_point_utils import select_baseline_name_default_first_trial
 from pyre_extensions import assert_is_instance, none_throws
 


### PR DESCRIPTION
Summary:
`get_tensor_converter_adapter` and `infer_reference_point_from_experiment` currently live in `ax/plot/pareto_utils.py`, but their primary consumers are non-plot modules (`global_stopping`, `service/utils`). This diff moves them (along with the private helper `_get_objective_thresholds` and associated unittests) to `ax/service/utils/best_point.py`, which already houses other best-point utilities.

Doing this will be useful when we decide to reap the ax/plot module in the future 

Changes:
- Moved `get_tensor_converter_adapter`, `infer_reference_point_from_experiment`, and `_get_objective_thresholds` from `ax/plot/pareto_utils.py` to `ax/service/utils/best_point.py`
- Updated imports in `ax/service/utils/best_point_mixin.py` and `ax/global_stopping/strategies/improvement.py` to point to the new location
- `ax/plot/pareto_utils.py` now imports `get_tensor_converter_adapter` from `ax/service/utils/best_point` (still needed by `get_observed_pareto_frontiers`)
- Moved corresponding tests from `ax/plot/tests/test_pareto_utils.py` to `ax/service/tests/test_best_point.py`
- Updated BUCK deps accordingly: `ax/service:best_point_utils` no longer depends on `ax/plot:pareto_utils`; `ax/plot:pareto_utils` now depends on `ax/service:best_point_utils`; `ax/global_stopping:global_stopping` depends on `ax/service:best_point_utils` instead of `ax/plot:pareto_utils`

Reviewed By: saitcakmak

Differential Revision: D94251986


