### PR TITLE
Add num_trials trace to BenchmarkResult

### DIFF
--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -25,7 +25,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import replace
 from datetime import datetime
-from itertools import product
+from itertools import accumulate, product
 from logging import Logger, WARNING
 from time import time
 
@@ -439,6 +439,8 @@ def get_benchmark_result_from_experiment_and_gs(
         trial_completion_order = [{i} for i in range(len(experiment.trials))]
         cost_trace = 1.0 + np.arange(len(experiment.trials), dtype=float)
 
+    num_trials = list(accumulate(len(trials) for trials in trial_completion_order))
+
     # {trial_index: {arm_name: params}}
     dict_of_dict_of_params = {
         new_trial_index: {
@@ -524,6 +526,7 @@ def get_benchmark_result_from_experiment_and_gs(
         is_feasible_trace=is_feasible_trace.tolist(),
         score_trace=score_trace.tolist(),
         cost_trace=cost_trace.tolist(),
+        num_trials=num_trials,
         fit_time=fit_time,
         gen_time=gen_time,
     )
@@ -869,6 +872,7 @@ def get_benchmark_result_with_cumulative_steps(
         result,
         optimization_trace=opt_trace,
         cost_trace=np.arange(1, len(opt_trace) + 1, dtype=int),
+        num_trials=list(range(1, len(opt_trace) + 1)),
         # Empty
         oracle_trace=np.full(len(opt_trace), np.nan),
         inference_trace=np.full(len(opt_trace), np.nan),

--- a/ax/benchmark/testing/benchmark_stubs.py
+++ b/ax/benchmark/testing/benchmark_stubs.py
@@ -179,6 +179,7 @@ def get_benchmark_result(seed: int = 0) -> BenchmarkResult:
         inference_trace=[1.0, 1.0, 1.0, 1.0],
         oracle_trace=[0.0, 0.0, 0.0, 0.0],
         cost_trace=[0.0, 0.0, 0.0, 0.0],
+        num_trials=[1, 2, 3, 4],
         optimization_trace=[3.0, 2.0, 1.0, 0.1],
         score_trace=[3.0, 2.0, 1.0, 0.1],
         is_feasible_trace=[True, True, True, True],

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -368,6 +368,12 @@ class TestBenchmark(TestCase):
             "Trials complete at same time": [1, 2],
             "Complete out of order": [1, 2, 3, 4],
         }
+        expected_num_trials = {
+            "All complete at different times": [1, 2, 3, 4],
+            "Trials complete immediately": [2, 4],
+            "Trials complete at same time": [2, 4],
+            "Complete out of order": [1, 2, 3, 4],
+        }
         expected_backend_simulator_time = {
             "All complete at different times": 12,
             "Trials complete immediately": 2,
@@ -463,6 +469,11 @@ class TestBenchmark(TestCase):
                 self.assertEqual(
                     result.cost_trace,
                     expected_costs[case_name],
+                    msg=case_name,
+                )
+                self.assertEqual(
+                    result.num_trials,
+                    expected_num_trials[case_name],
                     msg=case_name,
                 )
                 if map_data:
@@ -840,6 +851,10 @@ class TestBenchmark(TestCase):
 
         self.assertTrue(np.all(np.array(res.score_trace) <= 100))
         self.assertEqual(len(res.cost_trace), problem.num_trials)
+        self.assertEqual(len(none_throws(res.num_trials)), problem.num_trials)
+        self.assertEqual(
+            none_throws(res.num_trials), list(range(1, problem.num_trials + 1))
+        )
         self.assertEqual(len(res.inference_trace), problem.num_trials)
         # since inference trace is not supported for MOO, it should be all NaN
         self.assertTrue(np.isnan(res.inference_trace).all())
@@ -866,6 +881,10 @@ class TestBenchmark(TestCase):
 
         for col in ["mean", "P25", "P50", "P75"]:
             self.assertTrue((agg.score_trace[col] <= 100).all())
+        self.assertIn("num_trials", agg.optimization_trace.columns)
+        self.assertIn("num_trials", agg.score_trace.columns)
+        self.assertTrue((agg.optimization_trace["num_trials"] > 0).all())
+        self.assertTrue((agg.score_trace["num_trials"] > 0).all())
 
     @mock_botorch_optimize
     def test_benchmark_multiple_problems_methods(self) -> None:

--- a/ax/benchmark/tests/test_benchmark_result.py
+++ b/ax/benchmark/tests/test_benchmark_result.py
@@ -26,6 +26,7 @@ class TestBenchmarkResult(TestCase):
                 score_trace=[],
                 is_feasible_trace=[],
                 cost_trace=[],
+                num_trials=[],
                 fit_time=0.0,
                 gen_time=0.0,
                 experiment=get_experiment(),
@@ -44,6 +45,7 @@ class TestBenchmarkResult(TestCase):
                 score_trace=[],
                 is_feasible_trace=[],
                 cost_trace=[],
+                num_trials=[],
                 fit_time=0.0,
                 gen_time=0.0,
             )


### PR DESCRIPTION
Summary:
The optimization_trace and other traces on BenchmarkResult are indexed by "completion event" rather than trial number. In the asynchronous case, multiple trials can complete at the same simulated time and get grouped into a single trace entry, so the trace length can be less than the number of trials. Previously there was no way to determine how many trials had completed at each trace entry.

This diff adds a `num_trials` field to `BenchmarkResult` (a `list[int]`) that records the cumulative number of completed or early-stopped trials at each completion event. In the synchronous case this is simply `[1, 2, ..., n]`. In the async case it can increase by more than 1 at a step, e.g. `[2, 4, 5, ...]`. The field is optional (`None`) for backwards compatibility with old stored results.

On `AggregatedBenchmarkResult`, the mean `num_trials` across replications is added as a new column on the `optimization_trace` and `score_trace` DataFrames (when available on all results).

Reviewed By: hvarfner

Differential Revision: D93751894


