### PR TITLE
Unify objective_weights to 2D on TorchOptConfig

### DIFF
--- a/ax/adapter/discrete.py
+++ b/ax/adapter/discrete.py
@@ -10,14 +10,15 @@
 from collections.abc import Mapping, Sequence
 
 import numpy as np
-from ax.adapter.adapter_utils import array_to_observation_data, get_fixed_features
-from ax.adapter.base import Adapter, DataLoaderConfig, GenResults
-from ax.adapter.data_utils import ExperimentData
-from ax.adapter.torch import (
+from ax.adapter.adapter_utils import (
+    array_to_observation_data,
     extract_objective_weights,
     extract_outcome_constraints,
-    validate_transformed_optimization_config,
+    get_fixed_features,
 )
+from ax.adapter.base import Adapter, DataLoaderConfig, GenResults
+from ax.adapter.data_utils import ExperimentData
+from ax.adapter.torch import validate_transformed_optimization_config
 from ax.adapter.transforms.base import Transform
 from ax.core.data import Data
 from ax.core.experiment import Experiment

--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -252,7 +252,7 @@ class TorchAdapterTest(TestCase):
         self.assertTrue(
             torch.equal(
                 gen_opt_config.objective_weights,
-                torch.tensor([1.0, 0.0], **tkwargs),
+                torch.tensor([[1.0, 0.0]], **tkwargs),
             )
         )
         self.assertIsNone(gen_opt_config.outcome_constraints)

--- a/ax/adapter/tests/test_torch_moo_adapter.py
+++ b/ax/adapter/tests/test_torch_moo_adapter.py
@@ -181,7 +181,15 @@ class MultiObjectiveTorchAdapterTest(TestCase):
 
         wrapped_frontier_evaluator.assert_called_once()
         self.assertEqual(f.shape, (1, n_outcomes))
-        self.assertTrue(torch.equal(obj_w[:2], -torch.ones(2, dtype=torch.double)))
+        # obj_w is now 2D (n_objectives, n_outcomes). Each objective has
+        # weight -1 (minimization) on its corresponding outcome.
+        self.assertEqual(obj_w.shape[0], 2)
+        self.assertTrue(
+            torch.equal(
+                obj_w[obj_w != 0],
+                -torch.ones(2, dtype=torch.double),
+            )
+        )
         self.assertTrue(obj_t is not None)
         self.assertTrue(
             torch.equal(
@@ -498,7 +506,9 @@ class MultiObjectiveTorchAdapterTest(TestCase):
                     optimization_config=oc,
                     fixed_features=fixed_features,
                 )
-                expected_obj_weights = torch.tensor([-1.0, -1.0], dtype=torch.double)
+                expected_obj_weights = torch.tensor(
+                    [[-1.0, 0.0], [0.0, -1.0]], dtype=torch.double
+                )
                 ckwargs = mock_model_infer_obj_t.call_args.kwargs
                 self.assertTrue(
                     torch.equal(ckwargs["objective_weights"], expected_obj_weights)

--- a/ax/adapter/torch.py
+++ b/ax/adapter/torch.py
@@ -20,7 +20,7 @@ from ax.adapter.adapter_utils import (
     arm_to_np_array,
     array_to_observation_data,
     extract_objective_thresholds,
-    extract_objective_weights,
+    extract_objective_weight_matrix,
     extract_outcome_constraints,
     extract_parameter_constraints,
     extract_search_space_digest,
@@ -81,7 +81,7 @@ from ax.exceptions.core import DataRequiredError, UnsupportedError, UserInputErr
 from ax.exceptions.generation_strategy import OptimizationConfigRequired
 from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
 from ax.generators.torch.botorch_moo_utils import infer_objective_thresholds
-from ax.generators.torch.utils import _get_X_pending_and_observed
+from ax.generators.torch.utils import _get_X_pending_and_observed, extract_objectives
 from ax.generators.torch_base import TorchGenerator, TorchOptConfig
 from ax.generators.types import TConfig
 from ax.utils.common.constants import Keys
@@ -991,7 +991,7 @@ class TorchAdapter(Adapter):
             )
 
         validate_transformed_optimization_config(optimization_config, self.outcomes)
-        objective_weights = extract_objective_weights(
+        objective_weights = extract_objective_weight_matrix(
             objective=optimization_config.objective, outcomes=self.outcomes
         )
         outcome_constraints = extract_outcome_constraints(
@@ -1049,7 +1049,6 @@ class TorchAdapter(Adapter):
             model_gen_options=model_gen_options or {},
             rounding_func=rounding_func,
             opt_config_metrics=opt_config_metrics,
-            is_moo=optimization_config.is_moo_problem,
             use_learned_objective=use_learned_objective,
             pruning_target_point=pruning_target_p,
         )
@@ -1091,9 +1090,9 @@ class TorchAdapter(Adapter):
         Args:
             objective_thresholds: A tensor of (possibly inferred) objective thresholds
                 of shape `(num_metrics)`.
-            objective_weights: A tensor of objective weights that denote whether each
-                objective is being minimized (-1) or maximized (+1). May also include
-                0 values, which represents outcome constraints and tracking metrics.
+            objective_weights: A ``(n_objectives, n_outcomes)`` tensor of
+                objective weights. Weights are +1 for maximization and -1 for
+                minimization.
             opt_config_metrics: A dictionary mapping the metric name to the ``Metric``
                 object from the original optimization config.
             fixed_features: A map {feature_index: value} for features that should be
@@ -1103,12 +1102,10 @@ class TorchAdapter(Adapter):
         Returns:
             A list of ``ObjectiveThreshold``s on the raw, untransformed scale.
         """
-        idxs = objective_weights.nonzero().view(-1).tolist()
-
-        # Create transformed ObjectiveThresholds from tensor thresholds.
+        obj_indices, obj_weights = extract_objectives(objective_weights)
         thresholds = []
-        for idx in idxs:
-            sign = torch.sign(objective_weights[idx])
+        for idx, w in zip(obj_indices, obj_weights):
+            sign = torch.sign(w)
             thresholds.append(
                 ObjectiveThreshold(
                     metric=opt_config_metrics[self.outcomes[idx]],

--- a/ax/generators/tests/test_botorch_moo_utils.py
+++ b/ax/generators/tests/test_botorch_moo_utils.py
@@ -68,8 +68,8 @@ class FrontierEvaluatorTest(TestCase):
             ]
         )
         self.Yvar = torch.zeros(5, 3)
-        self.objective_thresholds = torch.tensor([0.5, 1.5])
-        self.objective_weights = torch.tensor([1.0, 1.0])
+        self.objective_thresholds = torch.tensor([0.5, 1.5, float("nan")])
+        self.objective_weights = torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
 
     def test_pareto_frontier_raise_error_when_missing_data(self) -> None:
         with self.assertRaises(ValueError):
@@ -113,7 +113,7 @@ class FrontierEvaluatorTest(TestCase):
         # Change objective_weights so goal is to minimize b
         Y, cov, indx = pareto_frontier_evaluator(
             model=model,
-            objective_weights=torch.tensor([1.0, -1.0]),
+            objective_weights=torch.tensor([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0]]),
             objective_thresholds=self.objective_thresholds,
             Y=self.Y,
             Yvar=Yvar,
@@ -169,7 +169,7 @@ class FrontierEvaluatorTest(TestCase):
     def test_pareto_frontier_evaluator_with_nan(self) -> None:
         Y = torch.cat([self.Y, torch.zeros(5, 1)], dim=-1)
         Yvar = torch.zeros(5, 4, 4)
-        weights = torch.tensor([1.0, 1.0, 0.0, 0.0])
+        weights = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]])
         outcome_constraints = (
             torch.tensor([[0.0, 0.0, 1.0, 0.0]]),
             torch.tensor([[3.5]]),
@@ -214,7 +214,7 @@ class FrontierEvaluatorTest(TestCase):
 
 class BotorchMOOUtilsTest(TestCase):
     def test_get_weighted_mc_objective_and_objective_thresholds(self) -> None:
-        objective_weights = torch.tensor([0.0, 1.0, 0.0, 1.0])
+        objective_weights = torch.tensor([[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]])
         objective_thresholds = torch.arange(4, dtype=torch.float)
         (
             weighted_obj,
@@ -223,7 +223,7 @@ class BotorchMOOUtilsTest(TestCase):
             objective_weights=objective_weights,
             objective_thresholds=objective_thresholds,
         )
-        self.assertTrue(torch.equal(weighted_obj.weights, objective_weights[[1, 3]]))
+        self.assertTrue(torch.equal(weighted_obj.weights, torch.tensor([1.0, 1.0])))
         self.assertEqual(weighted_obj.outcomes.tolist(), [1, 3])
         self.assertTrue(torch.equal(new_obj_thresholds, objective_thresholds[[1, 3]]))
 
@@ -252,7 +252,9 @@ class BotorchMOOUtilsTest(TestCase):
                 torch.tensor([[1.0, 0.0, 0.0]], **tkwargs),
                 torch.tensor([[10.0]], **tkwargs),
             )
-            objective_weights = torch.tensor([-1.0, -1.0, 0.0], **tkwargs)
+            objective_weights = torch.tensor(
+                [[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0]], **tkwargs
+            )
             with ExitStack() as es:
                 _mock_infer_reference_point = es.enter_context(
                     mock.patch(

--- a/ax/generators/tests/test_torch_utils.py
+++ b/ax/generators/tests/test_torch_utils.py
@@ -42,8 +42,8 @@ class TorchUtilsTest(TestCase):
             torch.tensor([[1.0]], **tkwargs),
             torch.tensor([[0.5]], **tkwargs),
         )
-        self.objective_weights = torch.ones(1, **tkwargs)
-        self.moo_objective_weights = torch.ones(2, **tkwargs)
+        self.objective_weights = torch.ones(1, 1, **tkwargs)
+        self.moo_objective_weights = torch.tensor([[1.0], [1.0]], **tkwargs)
         self.objective_thresholds = torch.tensor([0.5, 1.5], **tkwargs)
 
     def test_get_X_pending_and_observed(self) -> None:
@@ -52,7 +52,7 @@ class TorchUtilsTest(TestCase):
 
         # Apply filter normally
         Xs = [torch.tensor([[0.0, 0.0], [0.0, 1.0]])]
-        objective_weights = torch.tensor([1.0])
+        objective_weights = torch.tensor([[1.0]])
         bounds = [(0.0, 1.0), (0.0, 1.0)]
         fixed_features = {1: 1.0}
         _, X_observed = _get_X_pending_and_observed(

--- a/ax/generators/tests/test_utils.py
+++ b/ax/generators/tests/test_utils.py
@@ -42,7 +42,7 @@ class UtilsTest(TestCase):
         )
         # Filters to 3
 
-        objective_weights = np.array([-1.0, 1.0, 0.0])
+        objective_weights = np.array([[-1.0, 1.0, 0.0]])
         outcome_constraints = (
             np.array([[0.0, 1.0, 0.0], [1.0, 1.0, 0.0]]),
             np.array([[10.0], [24.0]]),
@@ -126,7 +126,7 @@ class UtilsTest(TestCase):
             xbest = best_observed_point(
                 model=model,
                 bounds=bounds,
-                objective_weights=np.zeros(3),
+                objective_weights=np.zeros((1, 3)),
                 outcome_constraints=outcome_constraints,
                 linear_constraints=linear_constraints,
                 fixed_features={1: 100},
@@ -138,7 +138,7 @@ class UtilsTest(TestCase):
             xbest = best_observed_point(
                 model=model,
                 bounds=bounds,
-                objective_weights=np.zeros(3),
+                objective_weights=np.zeros((1, 3)),
                 outcome_constraints=outcome_constraints,
                 linear_constraints=linear_constraints,
                 fixed_features={1: 100},

--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -301,7 +301,7 @@ class Acquisition(Base):
             torch_opt_config.is_moo
             and (
                 self._full_objective_thresholds is None
-                or self._full_objective_thresholds[self._full_objective_weights != 0]
+                or self._full_objective_thresholds[torch_opt_config.outcome_mask]
                 .isnan()
                 .any()
             )

--- a/ax/generators/torch/tests/test_acquisition.py
+++ b/ax/generators/torch/tests/test_acquisition.py
@@ -157,7 +157,7 @@ class AcquisitionTest(TestCase):
             )
 
         self.botorch_acqf_class = DummyAcquisitionFunction
-        self.objective_weights = torch.tensor([1.0])
+        self.objective_weights = torch.tensor([[1.0]])
         self.objective_thresholds = None
         self.pending_observations = [torch.tensor([[1.0, 3.0, 4.0]], **self.tkwargs)]
         self.outcome_constraints = (
@@ -1117,7 +1117,9 @@ class AcquisitionTest(TestCase):
                 outcome_names=["m1", "m2", "m3"],
             )
         ]
-        moo_objective_weights = torch.tensor([-1.0, -1.0, 0.0], **self.tkwargs)
+        moo_objective_weights = torch.tensor(
+            [[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0]], **self.tkwargs
+        )
         moo_objective_thresholds = (
             torch.tensor([0.5, 1.5, float("nan")], **self.tkwargs)
             if with_objective_thresholds
@@ -1145,7 +1147,6 @@ class AcquisitionTest(TestCase):
             objective_weights=moo_objective_weights,
             outcome_constraints=outcome_constraints,
             objective_thresholds=moo_objective_thresholds,
-            is_moo=True,
         )
         acquisition = Acquisition(
             surrogate=self.surrogate,
@@ -1257,12 +1258,13 @@ class AcquisitionTest(TestCase):
             search_space_digest=self.search_space_digest,
         )
         torch_opt_config = TorchOptConfig(
-            objective_weights=torch.tensor([1.0, 1.0, 0.0], **self.tkwargs),
+            objective_weights=torch.tensor(
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], **self.tkwargs
+            ),
             outcome_constraints=(
                 torch.tensor([[0.0, 0.0, 1.0]], **self.tkwargs),
                 torch.tensor([[0.0]], **self.tkwargs),
             ),
-            is_moo=True,
         )
         with self.assertLogs(logger=logger, level="WARNING") as logs:
             acquisition = Acquisition(
@@ -1300,10 +1302,11 @@ class AcquisitionTest(TestCase):
             torch.tensor([[0.0]], **self.tkwargs),
         )
         torch_opt_config = TorchOptConfig(
-            objective_weights=torch.tensor([1.0, 1.0, 0.0], **self.tkwargs),
+            objective_weights=torch.tensor(
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], **self.tkwargs
+            ),
             outcome_constraints=outcome_constraints,
             objective_thresholds=None,
-            is_moo=True,
         )
         with self.assertLogs(logger=logger, level="WARNING") as logs:
             acquisition = Acquisition(
@@ -1344,7 +1347,9 @@ class AcquisitionTest(TestCase):
             datasets=moo_training_data,
             search_space_digest=self.search_space_digest,
         )
-        moo_objective_weights = torch.tensor([1.0, 1.0, 0.0], **self.tkwargs)
+        moo_objective_weights = torch.tensor(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], **self.tkwargs
+        )
         moo_objective_thresholds = torch.tensor(
             [0.5, 1.5, float("nan")], **self.tkwargs
         )
@@ -1372,7 +1377,6 @@ class AcquisitionTest(TestCase):
             objective_weights=moo_objective_weights,
             outcome_constraints=outcome_constraints,
             objective_thresholds=moo_objective_thresholds,
-            is_moo=True,
         )
         acquisition = Acquisition(
             surrogate=self.surrogate,
@@ -1439,7 +1443,6 @@ class AcquisitionTest(TestCase):
             objective_weights=moo_objective_weights,
             outcome_constraints=None,
             objective_thresholds=moo_objective_thresholds,
-            is_moo=True,
         )
         acquisition_no_oc = Acquisition(
             surrogate=self.surrogate,
@@ -1475,7 +1478,6 @@ class AcquisitionTest(TestCase):
             objective_weights=moo_objective_weights,
             outcome_constraints=outcome_constraints,
             objective_thresholds=moo_objective_thresholds,
-            is_moo=True,
         )
         acquisition_nehvi = Acquisition(
             surrogate=self.surrogate,

--- a/ax/generators/torch/tests/test_surrogate.py
+++ b/ax/generators/torch/tests/test_surrogate.py
@@ -318,7 +318,7 @@ class SurrogateTest(TestCase):
         )
         self.fixed_features = {1: 2.0}
         self.refit = True
-        self.objective_weights = torch.tensor([-1.0, 1.0], **self.tkwargs)
+        self.objective_weights = torch.tensor([[-1.0, 1.0]], **self.tkwargs)
         # Note: these only work with 1 outcome
         self.outcome_constraints = (
             torch.tensor([[1.0]], **self.tkwargs),
@@ -1518,7 +1518,7 @@ class SurrogateTest(TestCase):
             torch.tensor([[1.0, 0.0]], **self.tkwargs),
             torch.tensor([[4.0]], **self.tkwargs),
         )
-        objective_weights = -torch.ones(2, **self.tkwargs)
+        objective_weights = -torch.ones(1, 2, **self.tkwargs)
 
         self.options = {}
 
@@ -1545,10 +1545,7 @@ class SurrogateTest(TestCase):
                 ):
                     surrogate.best_in_sample_point(
                         search_space_digest=self.search_space_digest,
-                        torch_opt_config=dataclasses.replace(
-                            self.torch_opt_config,
-                            objective_weights=None,
-                        ),
+                        torch_opt_config=self.torch_opt_config,
                     )
             with self.subTest("All points are in the search space"):
                 # No linear constraints
@@ -1651,7 +1648,7 @@ class SurrogateTest(TestCase):
                 datasets=self.training_data,
                 search_space_digest=self.search_space_digest,
             )
-            torch_opt_config = TorchOptConfig(objective_weights=torch.tensor([1.0]))
+            torch_opt_config = TorchOptConfig(objective_weights=torch.tensor([[1.0]]))
             candidate, acqf_value = surrogate.best_out_of_sample_point(
                 search_space_digest=self.search_space_digest,
                 torch_opt_config=torch_opt_config,

--- a/ax/generators/torch/utils.py
+++ b/ax/generators/torch/utils.py
@@ -52,6 +52,37 @@ from torch.nn import ModuleList  # @manual
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+def extract_objectives(
+    objective_weights: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Extract per-objective outcome indices and weights from the weight matrix.
+
+    Iterates over rows of objective_weights. Each row is one objective;
+    the nonzero entries indicate which outcome(s) it uses and the weights.
+
+    For standard MOO each row has exactly one nonzero entry, yielding
+    one (outcome_index, weight) pair per objective.
+
+    Args:
+        objective_weights: ``(n_objectives, n_outcomes)`` tensor.
+
+    Returns:
+        A tuple of (outcome_indices, weights):
+        - outcome_indices: 1D tensor of int outcome column indices
+        - weights: 1D tensor of corresponding weight values
+    """
+    outcome_indices: list[int] = []
+    weights_list: list[Tensor] = []
+    for row in objective_weights:
+        nz = row.nonzero().view(-1)
+        outcome_indices.extend(nz.tolist())
+        weights_list.append(row[nz])
+    return (
+        torch.tensor(outcome_indices, device=objective_weights.device),
+        torch.cat(weights_list),
+    )
+
+
 @dataclass
 class SubsetModelData:
     model: Model
@@ -74,8 +105,8 @@ def _filter_X_observed(
 
     Args:
         Xs: The input tensors of a model.
-        objective_weights: The objective is to maximize a weighted sum of
-            the columns of f(x). These are the weights.
+        objective_weights: A ``(n_objectives, n_outcomes)`` tensor of objective
+            weights.
         bounds: A list of (lower, upper) tuples for each column of X.
         outcome_constraints: A tuple of (A, b). For k outcome constraints
             and m outputs at f(x), A is (k x m) and b is (k x 1) such that
@@ -127,8 +158,8 @@ def _get_X_pending_and_observed(
 
     Args:
         Xs: The input tensors of a model.
-        objective_weights: The objective is to maximize a weighted sum of
-            the columns of f(x). These are the weights.
+        objective_weights: A ``(n_objectives, n_outcomes)`` tensor of objective
+            weights.
         bounds: A list of (lower, upper) tuples for each column of X.
         pending_observations:  A list of m (k_i x d) feature tensors X
             for m outcomes and k_i pending observations for outcome i.
@@ -195,9 +226,9 @@ def subset_model(
         model: A BoTorch Model. If the model does not implement the
             `subset_outputs` method, this function is a null-op and returns the
             input arguments.
-        objective_weights: The objective is to maximize a weighted sum of
-            the columns of f(x). These are the weights.
-        objective_thresholds:  The `m`-dim tensor of objective thresholds. There
+        objective_weights: A ``(n_objectives, n_outcomes)`` tensor of objective
+            weights.
+        objective_thresholds: A ``m``-dim tensor of objective thresholds. There
             is one for each modeled metric.
         outcome_constraints: A tuple of (A, b). For k outcome constraints
             and m outputs at f(x), A is (k x m) and b is (k x 1) such that
@@ -209,7 +240,7 @@ def subset_model(
         outputs that appear in either the objective weights or the outcome
         constraints, along with the indices of the outputs.
     """
-    nonzero = objective_weights != 0
+    nonzero = (objective_weights != 0).any(dim=0)
     if outcome_constraints is not None:
         A, _ = outcome_constraints
         nonzero = nonzero | torch.any(A != 0, dim=0)
@@ -218,7 +249,7 @@ def subset_model(
     # note that the number of metrics can be different than
     # model.num_outputs which counts multiple tasks per
     # outcome as separate outputs
-    num_outcomes = objective_weights.shape[0]
+    num_outcomes = objective_weights.shape[1]
     if len(idcs) == num_outcomes:
         # if we use all model outputs, just return the inputs
         return SubsetModelData(
@@ -238,7 +269,7 @@ def subset_model(
         )
     try:
         model = model.subset_output(idcs=idcs)
-        objective_weights = objective_weights[nonzero]
+        objective_weights = objective_weights[:, nonzero]
         if outcome_constraints is not None:
             A, b = outcome_constraints
             outcome_constraints = A[:, nonzero], b
@@ -293,10 +324,9 @@ def _get_weighted_mo_objective(
     """Constructs the `WeightedMCMultiOutputObjective` for the given
     objective weights.
     """
-    nonzero_idcs = torch.nonzero(objective_weights).view(-1)
-    objective_weights = objective_weights[nonzero_idcs]
+    outcome_indices, weights = extract_objectives(objective_weights)
     return WeightedMCMultiOutputObjective(
-        weights=objective_weights, outcomes=nonzero_idcs.tolist()
+        weights=weights, outcomes=outcome_indices.tolist()
     )
 
 
@@ -316,8 +346,8 @@ def get_botorch_objective_and_transform(
             used to determine whether to construct a multi-output or a
             single-output objective.
         model: A BoTorch Model.
-        objective_weights: The objective is to maximize a weighted sum of
-            the columns of f(x). These are the weights.
+        objective_weights: A ``(n_objectives, n_outcomes)`` tensor of objective
+            weights.
         outcome_constraints: A tuple of (A, b). For k outcome constraints
             and m outputs at f(x), A is (k x m) and b is (k x 1) such that
             A f(x) <= b. (Not used by single task models)
@@ -348,8 +378,9 @@ def get_botorch_objective_and_transform(
         return _get_weighted_mo_objective(objective_weights=objective_weights), None
     if outcome_constraints and issubclass(botorch_acqf_class, MCAcquisitionFunction):
         # If there are outcome constraints, we use MC Acquisition functions.
+        weights_1d = objective_weights.sum(dim=0)
         obj_tf: Callable[[Tensor, Tensor | None], Tensor] = (
-            get_objective_weights_transform(objective_weights)
+            get_objective_weights_transform(weights_1d)
         )
 
         def objective(samples: Tensor, X: Tensor | None = None) -> Tensor:
@@ -375,7 +406,8 @@ def get_botorch_objective_and_transform(
     logger.debug(
         f"Using ScalarizedPosteriorTransform for {botorch_acqf_class.__name__}."
     )
-    transform = ScalarizedPosteriorTransform(weights=objective_weights)
+    weights_1d = objective_weights.sum(dim=0)
+    transform = ScalarizedPosteriorTransform(weights=weights_1d)
     return None, transform
 
 

--- a/ax/generators/torch_base.py
+++ b/ax/generators/torch_base.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import Any
 
 import torch
@@ -30,10 +31,13 @@ class TorchOptConfig:
     an ephemeral object and not meant to be stored / serialized.
 
     Attributes:
-        objective_weights: If doing multi-objective optimization, these denote
-            which objectives should be maximized and which should be minimized.
-            Otherwise, the objective is to maximize a weighted sum of
-            the columns of f(x). These are the weights.
+        objective_weights: A 2D tensor of shape ``(n_objectives, n_outcomes)``.
+            Each row corresponds to one objective, each column to one modeled
+            outcome.  For single-objective optimization the tensor has one row.
+            For multi-objective optimization there is one row per objective.
+            The nonzero entries indicate which outcomes contribute to each
+            objective and their weights / signs (positive = maximize,
+            negative = minimize).
         outcome_constraints: A tuple of (A, b). For k outcome constraints
             and m outputs at f(x), A is (k x m) and b is (k x 1) such that
             A f(x) <= b.
@@ -73,7 +77,10 @@ class TorchOptConfig:
             appropriately (i.e., according to `round-trip` transformations).
         opt_config_metrics: A dictionary of metrics that are included in
             the optimization config.
-        is_moo: A boolean denoting whether this is for an MOO problem.
+        is_moo: Whether this is a multi-objective optimization problem.
+            Inferred from ``objective_weights.shape[0] > 1``.
+        outcome_mask: A 1D boolean tensor indicating which outcomes
+            participate in at least one objective.
         pruning_target_point: A `d`-dim tensor that specifies values that irrelevant
             parameters should be set to.
     """
@@ -87,9 +94,22 @@ class TorchOptConfig:
     model_gen_options: TConfig = field(default_factory=dict)
     rounding_func: Callable[[Tensor], Tensor] | None = None
     opt_config_metrics: dict[str, Metric] = field(default_factory=dict)
-    is_moo: bool = False
     use_learned_objective: bool = False
     pruning_target_point: Tensor | None = None
+
+    @cached_property
+    def is_moo(self) -> bool:
+        """Whether this is a multi-objective optimization problem.
+
+        Inferred from the number of rows in ``objective_weights``.
+        """
+        return self.objective_weights.shape[0] > 1
+
+    @cached_property
+    def outcome_mask(self) -> Tensor:
+        """A 1D boolean tensor of shape ``(n_outcomes,)`` that is ``True``
+        for outcomes that participate in at least one objective."""
+        return (self.objective_weights != 0).any(dim=0)
 
 
 @dataclass(frozen=True)

--- a/ax/generators/utils.py
+++ b/ax/generators/utils.py
@@ -441,6 +441,8 @@ def best_in_sample_point(
     if objective_weights is None:
         return None
     objective_weights_np = assert_is_instance(as_array(objective_weights), np.ndarray)
+    # Collapse to 1D — objective_weights is always 2D (n_objectives, n_outcomes).
+    objective_weights_np = objective_weights_np.sum(axis=0)
     X_obs = get_observed(
         Xs=Xs,
         objective_weights=objective_weights,
@@ -537,7 +539,9 @@ def get_observed(
         Points observed for all objective outcomes and outcome constraints.
     """
     objective_weights_np = as_array(objective_weights)
-    used_outcomes: set[int] = set(np.where(objective_weights_np != 0)[0])
+    # objective_weights is always 2D (n_objectives, n_outcomes).
+    mask = np.any(objective_weights_np != 0, axis=0)
+    used_outcomes: set[int] = set(np.where(mask)[0])
     if len(used_outcomes) == 0:
         raise ValueError("At least one objective weight must be non-zero")
     if outcome_constraints is not None:

--- a/ax/service/tests/test_best_point.py
+++ b/ax/service/tests/test_best_point.py
@@ -685,7 +685,9 @@ class InferReferencePointFromExperimentTest(TestCase):
             ],
             dtype=torch.float64,
         )
-        obj_w_shuffled = torch.tensor([0.0, 1.0, -1.0], dtype=torch.float64)
+        obj_w_shuffled = torch.tensor(
+            [[0.0, 0.0, -1.0], [0.0, 1.0, 0.0]], dtype=torch.float64
+        )
         obj_t_shuffled = torch.tensor(
             [-torch.inf, -torch.inf, torch.inf], dtype=torch.float64
         )

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -1274,12 +1274,15 @@ def infer_reference_point_from_experiment(
         for metric_signature in frontier_observations[0].data.metric_signatures
     ]
     f = f[:, order]
-    obj_w = obj_w[order]
+    obj_w = obj_w[:, order]
 
     # Dropping the columns related to outcome constraints.
-    f = f[:, obj_w.nonzero().view(-1)]
+    # obj_w is 2D (n_objectives, n_outcomes); collapse to a 1D mask.
+    obj_w_mask = (obj_w != 0).any(dim=0)
+    obj_col_indices = obj_w_mask.nonzero().view(-1)
+    f = f[:, obj_col_indices]
     multiplier_tensor = torch.tensor(multiplier, dtype=f.dtype, device=f.device)
-    multiplier_nonzero = multiplier_tensor[obj_w.nonzero().view(-1)]
+    multiplier_nonzero = multiplier_tensor[obj_col_indices]
 
     # Transforming all the objectives to be maximized.
     f_transformed = multiplier_nonzero * f


### PR DESCRIPTION
## Summary

Change `objective_weights` on `TorchOptConfig` from a 1D `(n_outcomes,)` tensor to a 2D `(n_objectives, n_outcomes)` matrix throughout the Torch generation pipeline. The main motivation is to support `ScalarizedObjective` children inside `MultiObjective`, where a single objective can be a weighted combination of multiple outcomes — something the old 1D representation could not express.

## Key changes across 19 files

**New helpers:**
- `ax/adapter/adapter_utils.py`: `extract_objective_weight_matrix()` — builds the 2D weight matrix from an `Objective` (one row per sub-objective for `MultiObjective`, single row otherwise).
- `ax/generators/torch/utils.py`: `extract_objectives()` — iterates over rows of the weight matrix to produce per-objective outcome indices and weights.

**`TorchOptConfig` updates (`ax/generators/torch_base.py`):**
- `objective_weights` is now documented as `(n_objectives, n_outcomes)`.
- `is_moo` is now a `cached_property` inferred from `objective_weights.shape[0] > 1` (no longer a constructor argument).
- Added `outcome_mask` cached property: 1D boolean tensor indicating which outcomes participate in at least one objective.

**Source updates:**
- `ax/adapter/torch.py`: Produce 2D weights via `extract_objective_weight_matrix`; use `extract_objectives` in `_untransform_objective_thresholds`; drop `is_moo` kwarg from `TorchOptConfig` construction.
- `ax/adapter/adapter_utils.py`: Update `get_pareto_frontier_and_configs` and `hypervolume` to use 2D weights.
- `ax/generators/torch/utils.py`: Update `subset_model` to operate on 2D weights (column-wise masking/subsetting); update `_get_weighted_mo_objective` to use `extract_objectives`; update `get_botorch_objective_and_transform` to collapse 2D→1D via `.sum(dim=0)` where a single scalarized weight vector is needed.
- `ax/generators/torch/botorch_moo_utils.py`: Update `get_weighted_mc_objective_and_objective_thresholds`, `pareto_frontier_evaluator`, and `infer_objective_thresholds` for 2D weights.
- `ax/generators/torch/botorch_modular/acquisition.py`: Update `_update_objective_thresholds` for 2D weights.
- `ax/generators/torch/botorch_modular/utils.py`: Update `_objective_threshold_to_outcome_constraints` and `choose_botorch_acqf_class` for 2D weights.
- `ax/generators/torch/botorch_modular/generator.py`: Update `_get_gen_metadata_from_acqf` and `_build_candidate_generation_options` for 2D weights.
- `ax/generators/utils.py`: Update `get_observed` and `best_in_sample_point` to handle the 2D weight matrix.

**Test updates:**
- 9 test files updated to use 2D `objective_weights` tensors.

## Test plan
- [x] `pytest ax/generators/torch/tests/test_utils.py`
- [x] `pytest ax/generators/torch/tests/test_acquisition.py`
- [x] `pytest ax/generators/torch/tests/test_generator.py`
- [x] `pytest ax/generators/torch/tests/test_surrogate.py`
- [x] `pytest ax/generators/tests/test_botorch_moo_utils.py`
- [x] `pytest ax/generators/tests/test_torch_utils.py`
- [x] `pytest ax/generators/tests/test_utils.py`
- [x] `pytest ax/adapter/tests/test_adapter_utils.py`
- [x] `pytest ax/adapter/tests/test_torch_adapter.py`
- [x] `pytest ax/adapter/tests/test_torch_moo_adapter.py`