### PR TITLE
Add INFO status to HealthcheckStatus enum

### DIFF
--- a/ax/analysis/healthcheck/healthcheck_analysis.py
+++ b/ax/analysis/healthcheck/healthcheck_analysis.py
@@ -16,6 +16,7 @@ class HealthcheckStatus(IntEnum):
     PASS = 0
     FAIL = 1
     WARNING = 2
+    INFO = 3
 
 
 class HealthcheckAnalysisCard(AnalysisCard):
@@ -23,7 +24,7 @@ class HealthcheckAnalysisCard(AnalysisCard):
         return HealthcheckStatus(json.loads(self.blob)["status"])
 
     def is_passing(self) -> bool:
-        return self.get_status() == HealthcheckStatus.PASS
+        return self.get_status() in (HealthcheckStatus.PASS, HealthcheckStatus.INFO)
 
     def get_aditional_attrs(self) -> dict[str, str | int | float | bool]:
         return json.loads(self.blob)


### PR DESCRIPTION
Summary:
Add a new INFO status level to HealthcheckStatus for healthchecks that are working as expected but have useful information to display to the user.

This is Phase 1 of the healthcheck status redesign. The INFO status represents a "positive passing" state where we want to surface helpful information (e.g., early stopping savings, baseline improvements) without indicating any problem.

Changes:
- Add INFO = 3 to HealthcheckStatus enum
- Update is_passing() to return True for both PASS and INFO statuses

Differential Revision: D94411963


