### PR TITLE
Replace disclosure triangle with info icon in Bento notebooks

### DIFF
--- a/ax/core/analysis_card.py
+++ b/ax/core/analysis_card.py
@@ -33,6 +33,19 @@ html_card_template = """
 .card-header:hover {{
     cursor: pointer;
 }}
+.card-header details summary {{
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+}}
+.card-header details summary::-webkit-details-marker {{
+    display: none;
+}}
+.card-header details summary::after {{
+    content: "ℹ️";
+    font-size: 0.9em;
+}}
 </style>
 <div class="card">
     <div class="card-header">


### PR DESCRIPTION
Summary:
Changes the default black disclosure triangle (▶) used in showing subtitles to an info icon (ℹ️) when rendering analysis cards in IPython/Jupyter environments. This helps in achieveing consistency with how subtitles are rendered in the Ax UI.

The icon change only affects notebook rendering via the HTML template; Ax UI uses its own frontend and is unaffected.

Differential Revision: D94571402


