### PR TITLE
Require only opt_config metrics for `prepare_arm_data`

### DIFF
--- a/ax/analysis/utils.py
+++ b/ax/analysis/utils.py
@@ -173,7 +173,6 @@ def prepare_arm_data(
     # status quo arm from the target trial if relativizing.
     target_trial_index = get_target_trial_index(
         experiment=experiment,
-        require_data_for_all_metrics=True,
     )
     if use_model_predictions:
         if adapter is None:


### PR DESCRIPTION
Summary: In `prepare_arm_data` we determine the `target_trial_index` with `get_target_trial_index` requiring all metrics to have data. If an experiment is missing a tracking metric, this will return `None` and cause `ArmEffectsPlot` to fail.

Differential Revision: D94580099


