### PR TITLE
Separate metric data availability from trial orchestration status

### DIFF
--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -1148,6 +1148,7 @@ class GenerationStep:
                         TrialStatus.EARLY_STOPPED,
                     ],
                     use_all_trials_in_exp=use_all_trials_in_exp,
+                    count_only_trials_with_data=True,
                 )
             )
         if max_parallelism is not None:

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -539,6 +539,7 @@ class TestGenerationStep(TestCase):
                         TrialStatus.EARLY_STOPPED,
                     ],
                     use_all_trials_in_exp=True,
+                    count_only_trials_with_data=True,
                 ),
             ],
         )

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -2649,8 +2649,7 @@ class SQAStoreTest(TestCase):
                 no_runner_required=True
             )
             trial.mark_completed()
-
-        experiment.fetch_data()
+            experiment.fetch_data()
         save_experiment(experiment=experiment)
         update_generation_strategy(
             generation_strategy=generation_strategy,
@@ -2675,6 +2674,7 @@ class SQAStoreTest(TestCase):
                 no_runner_required=True
             )
             trial.mark_completed()
+            experiment.fetch_data()
 
         save_experiment(experiment=experiment)
         update_generation_strategy(


### PR DESCRIPTION
Summary:
This diff decouples metric data availability from trial / orchestration status.

Previously, `Client.complete_trial` marked trials as `FAILED` when optimization config metrics were missing. This conflated two concerns: whether a trial
finished running (orchestration) and whether its data is complete (availability).
Marking `FAILED` discarded useful partial data from model fitting, allowed
re-suggestion of already-evaluated arms, and excluded trials from analysis.

The choice to exclude `FAILED` trial data was made since we could not rely on the quality of the data collected from `FAILED` trials. However, by mixing orchestration and metric statuses together, we ended up also throwing away good quality data that just happened to be incomplete (maybe metric fetching failed upstream for unrelated reasons, or one of the metrics failed to compute but the other was fine).

With this change:
- We go back to consuming all data that we believe to be reliable.
- For transitions, we still require data availability to ensure that we can still fit a model for candidate generation if we transition.

This diff introduces a dedicated metric availability layer:

**Core types** (`ax/core/metric_availability.py`)
- `MetricAvailability` enum (`NOT_OBSERVED`, `INCOMPLETE`, `COMPLETE`)
- `compute_metric_availability()` function that checks which opt config metrics
  have data for each trial, using `experiment.lookup_data()` and DataFrame
  groupby

**Trial completion** (`ax/api/client.py`, `ax/core/utils.py`)
- Trials are always marked COMPLETED regardless of metric completeness
- A warning is logged when optimization config metrics are missing

**Pending points** (`ax/core/utils.py`)
- COMPLETED trials with incomplete data are treated as pending to prevent
  re-suggestion of already-evaluated arms

**Transition criteria** (`ax/generation_strategy/generation_node.py`)
- Default `min_trials_observed` criterion sets `count_only_trials_with_data=True`
  so COMPLETED trials without data don't count toward transition threshold

Reviewed By: sdaulton

Differential Revision: D93924193
