### PR TITLE
Skip EarlyStoppingAnalysis for BatchTrials in OverviewAnalysis

### DIFF
--- a/ax/analysis/overview.py
+++ b/ax/analysis/overview.py
@@ -196,7 +196,7 @@ class OverviewAnalysis(Analysis):
                         self.options.early_stopping_strategy if self.options else None
                     ),
                 )
-                if has_map_data and has_map_metrics
+                if has_map_data and has_map_metrics and not has_batch_trials
                 else None
             ),
             CanGenerateCandidatesAnalysis(


### PR DESCRIPTION
Summary:
Early stopping is currently not applicable to online experiments because it requires time series data, which is not yet available for these experiments. This feature will become available once the ongoing refactoring is complete and delta data is converted to map data.

For `BatchTrials` (OE experiments), early stopping strategies are also unsupported. This is because these strategies require a 1:1 mapping between trial indices and arm names, but `BatchTrials` can contain multiple arms per trial, violating this requirement.

Without this change, the system would attempt to compute `EarlyStoppingAnalysis` for `BatchTrial` experiments, leading to errors when the underlying early stopping code is called (see [BaseEarlyStoppingStrategy.is_eligible_any()](https://www.internalfb.com/code/fbsource/[847ab9b799c563869fdca291a13918656eea6ad2]/fbcode/ax/early_stopping/strategies/base.py?lines=344), which explicitly raises a `ValueError` for `BatchTrials`).

In this diff, `EarlyStoppingAnalysis` is skipped for experiments with `BatchTrials`.

Differential Revision: D94920058


