### PR TITLE
change copy in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ The release log for Ax.
 
 #### Breaking Changes
 
-**Requirements**
+**Packack Requirements**
 * Python 3.11+ required (#4810)
 * Pandas 3.0 upgrade (#4838)
 * BoTorch 0.17.0 (#4911)
 
-**API Removals**
+**Method Removals (non-API)**
 * `transition_to` now required on `TransitionCriterion` (#4848) — Users must explicitly specify transition targets
 * Removed callable serialization (#4806) — Encoding callables now raises an exception
 * Removed legacy classes: `TData` (#4771), `MinimumTrialsInStatus` (#4786), completion criteria (#4850), `arms_per_node` override (#4822)


### PR DESCRIPTION
Summary:
Nit: we really shouldn't be referring to changes to methods like these as "API Removals", and especially not call then "Breaking changes" since these are not part of the API and we do not recommend Ax users interface with them directly. In the future lets reserve this language for changes to parts of the Ax API, which we will not make backwards incompatible changes to outside of major version releases.

Ive already update the copy here to reflect this language https://github.com/facebook/Ax/releases/tag/1.2.3

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: mgarrard

Differential Revision: D94923126


