### PR TITLE
Add template method pattern to DerivedMetric base class

### DIFF
--- a/ax/core/derived_metric.py
+++ b/ax/core/derived_metric.py
@@ -14,6 +14,24 @@ metrics being fetched first.  The experiment's data-fetch loop uses
 ``isinstance(m, DerivedMetric)`` to guarantee that all base metric data is
 attached to the cache before any derived metric's ``fetch_trial_data`` runs.
 
+The base class implements a template-method ``fetch_trial_data`` that handles:
+
+1. Resolving where each arm's input metric data lives
+   (via ``_resolve_source_trial_indices``).
+2. Looking up and validating cached base metric data.
+3. Collecting per-arm input metric data into a
+   ``{arm_name: DataFrame}`` dict, where each DataFrame contains
+   only the rows for that arm's input metrics from the correct trial.
+4. Optionally relativizing per-arm metric means w.r.t. the experiment's
+   status quo arm (when ``relativize_inputs=True``).
+5. Delegating to ``_compute_derived_values`` for subclass-specific computation.
+
+Subclasses must override ``_compute_derived_values`` to define how the
+collected per-arm data is transformed into derived metric data.
+Subclasses that need cross-trial data lookup (e.g., when an arm's base
+metric data lives in a different trial) should override
+``_resolve_source_trial_indices``.
+
 .. note:: **Transform compatibility.**
    Derived metrics are computed *before* any adapter transforms run.
    Transforms that modify metric values (e.g. ``Relativize``, ``Log``) will
@@ -29,9 +47,13 @@ from logging import Logger
 from typing import Any
 
 import pandas as pd
-from ax.core.metric import Metric
+from ax.core.base_trial import BaseTrial
+from ax.core.data import Data
+from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
 from ax.exceptions.core import UserInputError
 from ax.utils.common.logger import get_logger
+from ax.utils.common.result import Err, Ok
+from pyre_extensions import none_throws
 
 
 logger: Logger = get_logger(__name__)
@@ -45,8 +67,8 @@ class DerivedMetric(Metric):
     fetch loop (see ``Experiment._lookup_or_fetch_trials_results``) separates
     derived metrics from base metrics and fetches base metrics first.
 
-    Subclasses must override ``fetch_trial_data`` to define how the derived
-    value is produced.
+    Subclasses must override ``_compute_derived_values`` to define how the
+    derived value is produced from collected per-arm metric values.
 
     Attributes:
         input_metric_names: Names of metrics that must be fetched first.
@@ -56,6 +78,8 @@ class DerivedMetric(Metric):
         self,
         name: str,
         input_metric_names: list[str],
+        relativize_inputs: bool = False,
+        as_percent: bool = True,
         lower_is_better: bool | None = None,
         properties: dict[str, Any] | None = None,
     ) -> None:
@@ -70,11 +94,33 @@ class DerivedMetric(Metric):
             properties=properties,
         )
         self._input_metric_names = input_metric_names
+        self._relativize_inputs = relativize_inputs
+        self._as_percent = as_percent
 
     @property
     def input_metric_names(self) -> list[str]:
         """Names of metrics that this metric depends on."""
         return self._input_metric_names
+
+    @property
+    def relativize_inputs(self) -> bool:
+        """Whether to relativize input metric values w.r.t. status quo
+        before passing to ``_compute_derived_values``."""
+        return self._relativize_inputs
+
+    @property
+    def as_percent(self) -> bool:
+        """Whether to express relativized values as percentage change.
+
+        Only relevant when ``relativize_inputs=True``.  When ``True``,
+        a 50% improvement is represented as ``50.0``; when ``False``, as
+        ``0.5``.
+        """
+        return self._as_percent
+
+    # ------------------------------------------------------------------
+    # Static helpers
+    # ------------------------------------------------------------------
 
     @staticmethod
     def _lookup_metric_values_for_arm(
@@ -88,6 +134,368 @@ class DerivedMetric(Metric):
             | (arm_df["metric_signature"] == metric_name)
         ]
 
+    @staticmethod
+    def _extract_means(arm_df: pd.DataFrame) -> dict[str, float]:
+        """Extract ``{metric_name: mean}`` from a per-arm input metric DF."""
+        means: dict[str, float] = {}
+        for _, row in arm_df.iterrows():
+            means[row["metric_name"]] = float(row["mean"])
+        return means
+
+    # ------------------------------------------------------------------
+    # Template method: fetch_trial_data
+    # ------------------------------------------------------------------
+
+    def _resolve_source_trial_indices(
+        self,
+        trial: BaseTrial,
+    ) -> dict[str, tuple[int, str]] | None:
+        """Resolve where each arm's input metric data lives.
+
+        Returns ``None`` to indicate that all arms' data comes from the
+        current trial (the common case).  Subclasses that need cross-trial
+        data lookup should override this to return a mapping of::
+
+            {arm_name: (source_trial_index, source_arm_name)}
+
+        where ``source_trial_index`` is the trial containing the base
+        metric data and ``source_arm_name`` is the arm name in that trial
+        (which may differ from ``arm_name`` if the arm was renamed).
+        """
+        return None
+
+    def _lookup_base_data(
+        self,
+        trial: BaseTrial,
+        source_trial_indices: dict[str, tuple[int, str]] | None,
+    ) -> MetricFetchResult:
+        """Look up cached base metric data needed for this derived metric.
+
+        When ``source_trial_indices`` is ``None``, looks up data from the
+        current trial only.  When provided, looks up data from the union
+        of the current trial and all source trials.
+        """
+        try:
+            if source_trial_indices is None:
+                cached_data = trial.lookup_data()
+                # When relativize_inputs is enabled, the SQ arm's data
+                # may live in a different trial.  Widen the lookup to
+                # include experiment-wide data so _relativize_arm_data
+                # can find SQ values.
+                if self._relativize_inputs:
+                    sq = trial.experiment.status_quo
+                    sq_name = sq.name if sq is not None else None
+                    sq_in_trial = any(a.name == sq_name for a in trial.arms)
+                    if not sq_in_trial:
+                        cached_data = trial.experiment.lookup_data()
+            else:
+                trial_indices = {trial.index} | {
+                    idx for idx, _ in source_trial_indices.values()
+                }
+                cached_data = trial.experiment.lookup_data(
+                    trial_indices=trial_indices,
+                )
+        except Exception as e:
+            return Err(
+                MetricFetchE(
+                    message=(
+                        f"Failed to look up cached data for "
+                        f"DerivedMetric '{self.name}' "
+                        f"in trial {trial.index}: {e}"
+                    ),
+                    exception=e,
+                )
+            )
+
+        if cached_data.empty:
+            return Err(
+                MetricFetchE(
+                    message=(
+                        f"Cannot compute DerivedMetric '{self.name}': "
+                        f"no cached data available for trial {trial.index}."
+                    ),
+                    exception=None,
+                )
+            )
+
+        return Ok(value=cached_data)
+
+    def _validate_input_metrics_present(
+        self,
+        df: pd.DataFrame,
+    ) -> list[str]:
+        """Return input metric names not found in the cached DataFrame.
+
+        Checks both ``metric_name`` and ``metric_signature`` columns.
+        """
+        available: set[str] = set(df["metric_name"].unique())
+        if "metric_signature" in df.columns:
+            available |= set(df["metric_signature"].unique())
+        return [m for m in self._input_metric_names if m not in available]
+
+    def _collect_arm_data(
+        self,
+        trial: BaseTrial,
+        df: pd.DataFrame,
+        source_trial_indices: dict[str, tuple[int, str]] | None,
+    ) -> dict[str, pd.DataFrame] | MetricFetchE:
+        """Collect input metric data for every arm in the trial.
+
+        Returns ``{arm_name: DataFrame}`` on success, where each DataFrame
+        contains only the rows for that arm's input metrics (filtered by
+        ``metric_name`` or ``metric_signature``).  Returns a
+        ``MetricFetchE`` on failure (missing metrics for any arm).
+
+        When ``source_trial_indices`` is provided, each arm's data is
+        looked up from the specified source trial and arm name.  Otherwise,
+        data is looked up from the current trial using each arm's own name.
+        """
+        arm_data: dict[str, pd.DataFrame] = {}
+
+        for arm in trial.arms:
+            if source_trial_indices is not None and arm.name in source_trial_indices:
+                src_trial_idx, src_arm_name = source_trial_indices[arm.name]
+                arm_df = df[
+                    (df["trial_index"] == src_trial_idx)
+                    & (df["arm_name"] == src_arm_name)
+                ]
+            else:
+                arm_df = df[
+                    (df["trial_index"] == trial.index) & (df["arm_name"] == arm.name)
+                ]
+
+            # Filter to only input metric rows and validate presence.
+            per_metric: list[pd.DataFrame] = []
+            missing: list[str] = []
+            for metric_name in self._input_metric_names:
+                rows = self._lookup_metric_values_for_arm(arm_df, metric_name)
+                if rows.empty:
+                    missing.append(metric_name)
+                else:
+                    per_metric.append(rows)
+
+            if missing:
+                return MetricFetchE(
+                    message=(
+                        f"Cannot compute DerivedMetric '{self.name}' for arm "
+                        f"'{arm.name}' in trial {trial.index}: "
+                        f"missing input metrics: {missing}."
+                    ),
+                    exception=None,
+                )
+            arm_data[arm.name] = pd.concat(per_metric, ignore_index=True)
+
+        return arm_data
+
+    def _relativize_arm_data(
+        self,
+        trial: BaseTrial,
+        arm_data: dict[str, pd.DataFrame],
+        cached_df: pd.DataFrame,
+    ) -> dict[str, pd.DataFrame] | MetricFetchE:
+        """Optionally relativize per-arm metric values w.r.t. status quo.
+
+        Each arm is relativized independently against the status quo data
+        from that arm's own source trial.  This handles non-stationarity:
+        the same SQ arm may have different metric values across trials, and
+        each arm should be compared to *its* trial's SQ baseline.
+
+        When the SQ data is not found in the arm's source trial (e.g., SQ
+        was observed in a separate baseline trial), falls back to the
+        latest trial that has SQ data.
+
+        Delegates to ``Data.relativize``, which uses the delta method to
+        properly transform both means and SEMs.
+
+        When ``relativize_inputs`` is ``False``, returns ``arm_data``
+        unchanged.  When ``True``, the status quo arm is excluded from
+        the returned dict (its relativized values are zero by definition).
+        """
+        if not self._relativize_inputs:
+            return arm_data
+
+        status_quo = trial.experiment.status_quo
+        if status_quo is None:
+            return MetricFetchE(
+                message=(
+                    f"Cannot relativize inputs for DerivedMetric "
+                    f"'{self.name}': experiment has no status quo arm."
+                ),
+                exception=None,
+            )
+
+        sq_name = status_quo.name
+
+        # Relativize each arm independently against the SQ from the same
+        # source trial.  This correctly handles cross-trial lookup where
+        # different arms come from different trials with potentially
+        # different SQ metric values (non-stationarity).
+        relativized: dict[str, pd.DataFrame] = {}
+        for arm_name, arm_df in arm_data.items():
+            # Skip the SQ arm itself — its relativized values are zero.
+            if arm_name == sq_name:
+                continue
+
+            # Determine this arm's source trial_index from its data.
+            arm_trial_idx = int(arm_df["trial_index"].iloc[0])
+
+            # Find SQ data from the same source trial.  If SQ data is not
+            # in that trial (e.g., the SQ was observed in a separate
+            # baseline trial), fall back to the latest trial that has it.
+            sq_rows = cached_df[
+                (cached_df["arm_name"] == sq_name)
+                & (cached_df["trial_index"] == arm_trial_idx)
+            ]
+            if sq_rows.empty:
+                # Fallback: find SQ data from any trial.
+                all_sq_rows = cached_df[cached_df["arm_name"] == sq_name]
+                if all_sq_rows.empty:
+                    return MetricFetchE(
+                        message=(
+                            f"Cannot relativize inputs for DerivedMetric "
+                            f"'{self.name}' in trial {trial.index}: status "
+                            f"quo arm '{sq_name}' not found in cached data."
+                        ),
+                        exception=None,
+                    )
+                # Use the latest trial's SQ data.
+                latest_sq_idx = int(all_sq_rows["trial_index"].max())
+                sq_rows = all_sq_rows[all_sq_rows["trial_index"] == latest_sq_idx]
+            # Filter SQ rows to input metrics only.
+            sq_input_rows: list[pd.DataFrame] = []
+            for metric_name in self._input_metric_names:
+                rows = self._lookup_metric_values_for_arm(sq_rows, metric_name)
+                if not rows.empty:
+                    sq_input_rows.append(rows)
+            if not sq_input_rows:
+                return MetricFetchE(
+                    message=(
+                        f"Cannot relativize inputs for DerivedMetric "
+                        f"'{self.name}' in trial {trial.index}: no input "
+                        f"metric data found for status quo arm '{sq_name}' "
+                        f"in source trial {arm_trial_idx}."
+                    ),
+                    exception=None,
+                )
+
+            # Build a mini-DataFrame with this arm + its SQ, then
+            # relativize.  Both must share the same trial_index so
+            # Data.relativize groups them together.  The SQ rows may
+            # come from a different trial (fallback case), so normalize
+            # their trial_index to match the arm's.
+            sq_df = pd.concat(sq_input_rows, ignore_index=True)
+            if int(sq_df["trial_index"].iloc[0]) != arm_trial_idx:
+                sq_df = sq_df.copy()
+                sq_df["trial_index"] = arm_trial_idx
+            combined = pd.concat([arm_df, sq_df], ignore_index=True)
+
+            try:
+                rel_data = Data(df=combined).relativize(
+                    status_quo_name=sq_name,
+                    as_percent=self._as_percent,
+                    include_sq=False,
+                    control_as_constant=True,
+                )
+            except Exception as e:
+                return MetricFetchE(
+                    message=(
+                        f"Error relativizing inputs for DerivedMetric "
+                        f"'{self.name}' in trial {trial.index}: {e}"
+                    ),
+                    exception=e,
+                )
+
+            rel_rows = rel_data.df[rel_data.df["arm_name"] == arm_name]
+            if not rel_rows.empty:
+                relativized[arm_name] = rel_rows.reset_index(drop=True)
+
+        return relativized
+
+    def fetch_trial_data(self, trial: BaseTrial, **kwargs: Any) -> MetricFetchResult:
+        """Template method: look up data, collect values, delegate to subclass.
+
+        Subclasses should not override this method.  Instead, override
+        ``_compute_derived_values`` (and optionally
+        ``_resolve_source_trial_indices``).
+        """
+        # Step 1: Resolve source trial indices (subclass hook).
+        source_trial_indices = self._resolve_source_trial_indices(trial)
+
+        # Step 2: Look up cached base metric data.
+        lookup_result = self._lookup_base_data(trial, source_trial_indices)
+        if isinstance(lookup_result, Err):
+            return lookup_result
+        cached_data: Data = none_throws(lookup_result.ok)
+
+        df = cached_data.df
+
+        # Step 3: Validate that input metrics exist in the cached data.
+        missing_global = self._validate_input_metrics_present(df)
+        if missing_global:
+            return Err(
+                MetricFetchE(
+                    message=(
+                        f"Cannot compute DerivedMetric '{self.name}' for "
+                        f"trial {trial.index}: input metrics not found in "
+                        f"cached data: {missing_global}."
+                    ),
+                    exception=None,
+                )
+            )
+
+        # Step 4: Collect per-arm input metric data.
+        arm_data_result = self._collect_arm_data(
+            trial,
+            df,
+            source_trial_indices,
+        )
+        if isinstance(arm_data_result, MetricFetchE):
+            return Err(arm_data_result)
+
+        # Step 5: Optionally relativize arm data w.r.t. status quo.
+        arm_data_result = self._relativize_arm_data(trial, arm_data_result, df)
+        if isinstance(arm_data_result, MetricFetchE):
+            return Err(arm_data_result)
+
+        # After relativization, arm_data may be empty (e.g., a SQ-only trial
+        # where all arms were excluded).  Return empty data, not an error.
+        if not arm_data_result:
+            return Ok(value=Data())
+
+        # Step 6: Delegate to subclass for transformation.
+        return self._compute_derived_values(
+            trial=trial,
+            arm_data=arm_data_result,
+        )
+
+    def _compute_derived_values(
+        self,
+        trial: BaseTrial,
+        arm_data: dict[str, pd.DataFrame],
+    ) -> MetricFetchResult:
+        """Subclass hook: compute derived metric values from collected data.
+
+        Args:
+            trial: The trial being fetched.
+            arm_data: ``{arm_name: DataFrame}`` for all arms in the trial.
+                Each DataFrame contains only the input metric rows for
+                that arm (columns include ``metric_name``, ``mean``,
+                ``sem``, etc.).  All input metrics are guaranteed present.
+                Use ``_lookup_metric_values_for_arm`` to extract rows for
+                a specific metric.
+
+        Returns:
+            ``Ok(Data)`` with derived metric rows, or ``Err`` on failure.
+        """
+        raise NotImplementedError(
+            f"DerivedMetric subclass {type(self).__name__} must implement "
+            f"_compute_derived_values."
+        )
+
+    # ------------------------------------------------------------------
+    # Misc
+    # ------------------------------------------------------------------
+
     @property
     def summary_dict(self) -> dict[str, Any]:
         """Fields of this metric's configuration that will appear
@@ -96,4 +504,6 @@ class DerivedMetric(Metric):
         return {
             **super().summary_dict,
             "input_metric_names": self._input_metric_names,
+            "relativize_inputs": self._relativize_inputs,
+            "as_percent": self._as_percent,
         }

--- a/ax/core/tests/test_derived_metric.py
+++ b/ax/core/tests/test_derived_metric.py
@@ -14,7 +14,7 @@ from ax.core.base_trial import BaseTrial
 from ax.core.data import Data
 from ax.core.derived_metric import DerivedMetric
 from ax.core.experiment import Experiment
-from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
+from ax.core.metric import Metric, MetricFetchResult
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint
@@ -53,42 +53,53 @@ def _make_trial_data(
 
 
 class _SumDerivedMetric(DerivedMetric):
-    """Trivial concrete subclass for testing: sums its input metrics."""
+    """Trivial concrete subclass for testing: sums its input metrics.
 
-    def fetch_trial_data(self, trial: BaseTrial, **kwargs: Any) -> MetricFetchResult:
-        try:
-            cached_data = trial.lookup_data()
-        except Exception as e:
-            return Err(MetricFetchE(message=f"Lookup failed: {e}", exception=e))
+    Optionally accepts ``source_trial_map`` to simulate cross-trial data
+    lookup (used by LILOPairwiseMetric-like scenarios).
+    """
 
-        if cached_data.empty:
-            return Err(
-                MetricFetchE(
-                    message=f"No cached data for trial {trial.index}.",
-                    exception=None,
-                )
-            )
+    def __init__(
+        self,
+        name: str,
+        input_metric_names: list[str],
+        source_trial_map: dict[str, tuple[int, str]] | None = None,
+        relativize_inputs: bool = False,
+        as_percent: bool = True,
+        lower_is_better: bool | None = None,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(
+            name=name,
+            input_metric_names=input_metric_names,
+            relativize_inputs=relativize_inputs,
+            as_percent=as_percent,
+            lower_is_better=lower_is_better,
+            properties=properties,
+        )
+        self._source_trial_map = source_trial_map
 
-        df = cached_data.df
+    @property
+    def source_trial_map(self) -> dict[str, tuple[int, str]] | None:
+        return self._source_trial_map
+
+    def _resolve_source_trial_indices(
+        self,
+        trial: BaseTrial,
+    ) -> dict[str, tuple[int, str]] | None:
+        return self._source_trial_map
+
+    def _compute_derived_values(
+        self,
+        trial: BaseTrial,
+        arm_data: dict[str, pd.DataFrame],
+    ) -> MetricFetchResult:
         result_rows: list[dict[str, Any]] = []
-
-        for arm_name in df["arm_name"].unique():
-            arm_df = df[df["arm_name"] == arm_name]
+        for arm_name, arm_df in arm_data.items():
             total = 0.0
-            for metric_name in self.input_metric_names:
-                rows = self._lookup_metric_values_for_arm(arm_df, metric_name)
-                if rows.empty:
-                    return Err(
-                        MetricFetchE(
-                            message=(
-                                f"Missing '{metric_name}' for arm "
-                                f"'{arm_name}' in trial {trial.index}."
-                            ),
-                            exception=None,
-                        )
-                    )
+            for m in self.input_metric_names:
+                rows = self._lookup_metric_values_for_arm(arm_df, m)
                 total += float(rows["mean"].iloc[-1])
-
             result_rows.append(
                 {
                     "trial_index": trial.index,
@@ -99,56 +110,335 @@ class _SumDerivedMetric(DerivedMetric):
                     "sem": float("nan"),
                 }
             )
-
         return Ok(value=Data(df=pd.DataFrame(result_rows)))
+
+
+def _make_experiment_with_trial(
+    arm_metrics: dict[str, dict[str, float]],
+    batch: bool = False,
+) -> Experiment:
+    """Create an experiment with one completed trial and attached data.
+
+    Args:
+        arm_metrics: ``{arm_name: {metric_name: mean_value}}``.
+        batch: If True, create a BatchTrial; otherwise a Trial.
+    """
+    exp = Experiment(name="test", search_space=get_branin_search_space())
+    trial = exp.new_batch_trial() if batch else exp.new_trial()
+    for i, arm_name in enumerate(arm_metrics):
+        trial.add_arm(
+            Arm(
+                name=arm_name,
+                parameters={"x1": float(i), "x2": float(i)},
+            )
+        )
+    trial.mark_running(no_runner_required=True)
+    trial.mark_completed()
+    exp.attach_data(_make_trial_data(0, arm_metrics))
+    return exp
 
 
 class DerivedMetricTest(TestCase):
     """Tests for the DerivedMetric base class."""
 
-    def test_init_and_properties(self) -> None:
-        """Construction, attributes, and clone round-trip."""
+    def test_init_validation_and_clone(self) -> None:
+        """Construction, attributes, summary_dict, empty-input rejection,
+        and clone round-trip."""
         metric = _SumDerivedMetric(
             name="total",
             input_metric_names=["a", "b"],
+            relativize_inputs=True,
             lower_is_better=True,
             properties={"key": "value"},
         )
         self.assertIsInstance(metric, DerivedMetric)
         self.assertIsInstance(metric, Metric)
         self.assertEqual(metric.input_metric_names, ["a", "b"])
+        self.assertTrue(metric.relativize_inputs)
         self.assertTrue(metric.lower_is_better)
         self.assertEqual(metric.properties, {"key": "value"})
-
-        # summary_dict includes input_metric_names
         self.assertIn("input_metric_names", metric.summary_dict)
-        self.assertEqual(metric.summary_dict["input_metric_names"], ["a", "b"])
+        self.assertIn("relativize_inputs", metric.summary_dict)
+        self.assertTrue(metric.summary_dict["relativize_inputs"])
+        self.assertIn("as_percent", metric.summary_dict)
+        self.assertTrue(metric.summary_dict["as_percent"])
 
-    def test_empty_input_metric_names_raises(self) -> None:
-        with self.assertRaises(UserInputError):
-            _SumDerivedMetric(name="bad", input_metric_names=[])
+        with self.subTest("default_relativize_inputs"):
+            m2 = _SumDerivedMetric(name="m2", input_metric_names=["a"])
+            self.assertFalse(m2.relativize_inputs)
+            self.assertFalse(m2.summary_dict["relativize_inputs"])
 
-    def test_clone(self) -> None:
+        with self.subTest("empty_input_metric_names"):
+            with self.assertRaises(UserInputError):
+                _SumDerivedMetric(name="bad", input_metric_names=[])
+
+        with self.subTest("clone"):
+            cloned = metric.clone()
+            assert isinstance(cloned, _SumDerivedMetric)
+            self.assertEqual(cloned.input_metric_names, metric.input_metric_names)
+            self.assertEqual(cloned.relativize_inputs, metric.relativize_inputs)
+            self.assertEqual(cloned.as_percent, metric.as_percent)
+            self.assertEqual(cloned.lower_is_better, metric.lower_is_better)
+            self.assertEqual(cloned.properties, metric.properties)
+
+    def test_fetch_trial_data(self) -> None:
+        """Happy path: correct derived value from same-trial data."""
+        metric = _SumDerivedMetric(name="total", input_metric_names=["a", "b"])
+        exp = _make_experiment_with_trial({"0_0": {"a": 3.0, "b": 4.0}})
+
+        result = metric.fetch_trial_data(exp.trials[0])
+        self.assertIsInstance(result, Ok)
+        df = none_throws(result.ok).df
+        self.assertEqual(len(df), 1)
+        self.assertAlmostEqual(df["mean"].iloc[0], 7.0)
+
+    def test_fetch_trial_data_errors(self) -> None:
+        """Err results for various missing-data scenarios."""
+        with self.subTest("empty_data"):
+            metric = _SumDerivedMetric(name="total", input_metric_names=["a"])
+            exp = Experiment(name="test", search_space=get_branin_search_space())
+            trial = exp.new_trial()
+            trial.add_arm(Arm(name="0_0", parameters={"x1": 0.0, "x2": 0.0}))
+            trial.mark_running(no_runner_required=True)
+            trial.mark_completed()
+            # No data attached.
+            result = metric.fetch_trial_data(trial)
+            self.assertIsInstance(result, Err)
+            self.assertIn("no cached data", none_throws(result.err).message.lower())
+
+        with self.subTest("missing_global_metric"):
+            metric = _SumDerivedMetric(name="total", input_metric_names=["a", "b"])
+            exp = _make_experiment_with_trial({"0_0": {"a": 1.0}})
+            result = metric.fetch_trial_data(exp.trials[0])
+            self.assertIsInstance(result, Err)
+            self.assertIn("b", none_throws(result.err).message)
+
+        with self.subTest("per_arm_missing_metric"):
+            metric = _SumDerivedMetric(name="total", input_metric_names=["a", "b"])
+            exp = _make_experiment_with_trial(
+                {"arm1": {"a": 1.0, "b": 2.0}, "arm2": {"a": 3.0}},
+                batch=True,
+            )
+            result = metric.fetch_trial_data(exp.trials[0])
+            self.assertIsInstance(result, Err)
+            msg = none_throws(result.err).message
+            self.assertIn("arm2", msg)
+            self.assertIn("b", msg)
+
+    def test_relativize_arm_data(self) -> None:
+        """Relativization of input metrics w.r.t. status quo arm."""
         metric = _SumDerivedMetric(
             name="total",
             input_metric_names=["a", "b"],
-            lower_is_better=False,
-            properties={"p": 1},
+            relativize_inputs=True,
         )
-        cloned = metric.clone()
-        self.assertIsInstance(cloned, _SumDerivedMetric)
-        assert isinstance(cloned, _SumDerivedMetric)
-        self.assertEqual(cloned.input_metric_names, metric.input_metric_names)
-        self.assertEqual(cloned.lower_is_better, metric.lower_is_better)
-        self.assertEqual(cloned.properties, metric.properties)
 
+        # Build experiment with SQ arm + one treatment arm.
+        exp = Experiment(name="test", search_space=get_branin_search_space())
+        sq_arm = Arm(name="sq", parameters={"x1": 0.0, "x2": 0.0})
+        exp.status_quo = sq_arm
+        trial = exp.new_batch_trial()
+        trial.add_arm(sq_arm)
+        trial.add_arm(Arm(name="arm1", parameters={"x1": 1.0, "x2": 1.0}))
+        trial.mark_running(no_runner_required=True)
+        trial.mark_completed()
+        # SQ: a=10, b=20.  arm1: a=15, b=30.
+        exp.attach_data(
+            _make_trial_data(
+                0,
+                {
+                    "sq": {"a": 10.0, "b": 20.0},
+                    "arm1": {"a": 15.0, "b": 30.0},
+                },
+            )
+        )
 
-class DerivedMetricExperimentIntegrationTest(TestCase):
-    """Two-phase fetching: base metrics first, then derived metrics."""
+        result = metric.fetch_trial_data(exp.trials[0])
+        self.assertIsInstance(result, Ok)
+        df = none_throws(result.ok).df
+        # SQ arm should be excluded from output.
+        self.assertEqual(set(df["arm_name"].unique()), {"arm1"})
+        # arm1 relativized (as_percent=True):
+        # a=(15-10)/10=50%, b=(30-20)/20=50%; sum=100.0
+        self.assertAlmostEqual(df["mean"].iloc[0], 100.0)
 
-    def test_two_phase_fetch(self) -> None:
-        """Experiment.fetch_data fetches base metrics, attaches them, then
-        fetches derived metrics that read from the cache."""
+        with self.subTest("no_status_quo"):
+            exp_no_sq = Experiment(name="no_sq", search_space=get_branin_search_space())
+            trial2 = exp_no_sq.new_trial()
+            trial2.add_arm(Arm(name="0_0", parameters={"x1": 0.0, "x2": 0.0}))
+            trial2.mark_running(no_runner_required=True)
+            trial2.mark_completed()
+            exp_no_sq.attach_data(_make_trial_data(0, {"0_0": {"a": 1.0, "b": 2.0}}))
+            result = metric.fetch_trial_data(trial2)
+            self.assertIsInstance(result, Err)
+            self.assertIn("no status quo", none_throws(result.err).message.lower())
+
+        with self.subTest("sq_not_in_trial_data"):
+            # SQ arm set on experiment but not present in trial.
+            exp3 = Experiment(name="sq_missing", search_space=get_branin_search_space())
+            exp3.status_quo = Arm(name="sq_arm", parameters={"x1": 0.0, "x2": 0.0})
+            trial3 = exp3.new_trial()
+            trial3.add_arm(Arm(name="other", parameters={"x1": 1.0, "x2": 1.0}))
+            trial3.mark_running(no_runner_required=True)
+            trial3.mark_completed()
+            exp3.attach_data(_make_trial_data(0, {"other": {"a": 1.0, "b": 2.0}}))
+            result = metric.fetch_trial_data(trial3)
+            self.assertIsInstance(result, Err)
+            self.assertIn("sq_arm", none_throws(result.err).message)
+
+        with self.subTest("sq_near_zero"):
+            exp4 = Experiment(name="sq_zero", search_space=get_branin_search_space())
+            sq4 = Arm(name="sq", parameters={"x1": 0.0, "x2": 0.0})
+            exp4.status_quo = sq4
+            trial4 = exp4.new_batch_trial()
+            trial4.add_arm(sq4)
+            trial4.add_arm(Arm(name="arm1", parameters={"x1": 1.0, "x2": 1.0}))
+            trial4.mark_running(no_runner_required=True)
+            trial4.mark_completed()
+            # SQ has a=0 (too close to zero for relativization).
+            exp4.attach_data(
+                _make_trial_data(
+                    0,
+                    {
+                        "sq": {"a": 0.0, "b": 5.0},
+                        "arm1": {"a": 1.0, "b": 10.0},
+                    },
+                )
+            )
+            result = metric.fetch_trial_data(trial4)
+            self.assertIsInstance(result, Err)
+            self.assertIn(
+                "too small to reliably", none_throws(result.err).message.lower()
+            )
+
+        with self.subTest("relativize_false_passthrough"):
+            # When relativize_inputs=False (default), SQ is not excluded
+            # and values are raw.
+            metric_no_rel = _SumDerivedMetric(
+                name="total", input_metric_names=["a", "b"]
+            )
+            result = metric_no_rel.fetch_trial_data(exp.trials[0])
+            self.assertIsInstance(result, Ok)
+            df_no_rel = none_throws(result.ok).df
+            # Both arms should be present.
+            self.assertEqual(set(df_no_rel["arm_name"].unique()), {"sq", "arm1"})
+            sq_row = df_no_rel[df_no_rel["arm_name"] == "sq"]
+            # SQ raw sum: 10 + 20 = 30
+            self.assertAlmostEqual(sq_row["mean"].iloc[0], 30.0)
+            arm1_row = df_no_rel[df_no_rel["arm_name"] == "arm1"]
+            # arm1 raw sum: 15 + 30 = 45
+            self.assertAlmostEqual(arm1_row["mean"].iloc[0], 45.0)
+
+        with self.subTest("sq_in_different_trial"):
+            # SQ data lives in a baseline trial, treatment arms are in
+            # separate trials.  The SQ fallback should find it.
+            exp5 = Experiment(name="sq_sep", search_space=get_branin_search_space())
+            sq5 = Arm(name="sq", parameters={"x1": 0.0, "x2": 0.0})
+            exp5.status_quo = sq5
+            # Trial 0: SQ baseline only.
+            t0 = exp5.new_batch_trial()
+            t0.add_arm(sq5)
+            t0.mark_running(no_runner_required=True)
+            t0.mark_completed()
+            exp5.attach_data(_make_trial_data(0, {"sq": {"a": 10.0, "b": 20.0}}))
+            # Trial 1: treatment arm only (no SQ data in this trial).
+            t1 = exp5.new_batch_trial()
+            t1.add_arm(Arm(name="arm1", parameters={"x1": 1.0, "x2": 1.0}))
+            t1.mark_running(no_runner_required=True)
+            t1.mark_completed()
+            exp5.attach_data(_make_trial_data(1, {"arm1": {"a": 15.0, "b": 30.0}}))
+            result = metric.fetch_trial_data(t1)
+            self.assertIsInstance(result, Ok)
+            df5 = none_throws(result.ok).df
+            self.assertEqual(set(df5["arm_name"].unique()), {"arm1"})
+            # arm1: a=(15-10)/10*100=50%, b=(30-20)/20*100=50%; sum=100.0
+            self.assertAlmostEqual(df5["mean"].iloc[0], 100.0)
+
+    def test_cross_trial_relativization(self) -> None:
+        """Cross-trial relativization handles non-stationarity correctly.
+
+        When arms come from different trials, each arm must be relativized
+        against the SQ from its own source trial, not a single global SQ.
+        """
+        exp = Experiment(name="test", search_space=get_branin_search_space())
+        sq_arm = Arm(name="sq", parameters={"x1": 0.0, "x2": 0.0})
+        exp.status_quo = sq_arm
+
+        # Trial 0: SQ a=10, arm_a a=15.  (arm_a: 50% improvement)
+        t0 = exp.new_batch_trial()
+        t0.add_arm(sq_arm)
+        t0.add_arm(Arm(name="arm_a", parameters={"x1": 1.0, "x2": 1.0}))
+        t0.mark_running(no_runner_required=True)
+        t0.mark_completed()
+        exp.attach_data(_make_trial_data(0, {"sq": {"a": 10.0}, "arm_a": {"a": 15.0}}))
+
+        # Trial 1: SQ a=20 (non-stationarity!), arm_b a=30.
+        # arm_b: (30-20)/20 = 50% improvement (same %).
+        t1 = exp.new_batch_trial()
+        t1.add_arm(sq_arm)
+        t1.add_arm(Arm(name="arm_b", parameters={"x1": 2.0, "x2": 2.0}))
+        t1.mark_running(no_runner_required=True)
+        t1.mark_completed()
+        exp.attach_data(_make_trial_data(1, {"sq": {"a": 20.0}, "arm_b": {"a": 30.0}}))
+
+        # Trial 2 (LILO-like): arm_a + arm_b, no own data.
+        t2 = exp.new_batch_trial()
+        t2.add_arm(Arm(name="arm_a", parameters={"x1": 1.0, "x2": 1.0}))
+        t2.add_arm(Arm(name="arm_b", parameters={"x1": 2.0, "x2": 2.0}))
+        t2.mark_running(no_runner_required=True)
+        t2.mark_completed()
+
+        # source_trial_map: arm_a from trial 0, arm_b from trial 1.
+        metric = _SumDerivedMetric(
+            name="total",
+            input_metric_names=["a"],
+            relativize_inputs=True,
+            source_trial_map={
+                "arm_a": (0, "arm_a"),
+                "arm_b": (1, "arm_b"),
+            },
+        )
+        result = metric.fetch_trial_data(t2)
+        self.assertIsInstance(result, Ok)
+        df = none_throws(result.ok).df
+
+        # Both arms should be relativized against their own trial's SQ.
+        self.assertEqual(set(df["arm_name"].unique()), {"arm_a", "arm_b"})
+        arm_a_val = df[df["arm_name"] == "arm_a"]["mean"].iloc[0]
+        arm_b_val = df[df["arm_name"] == "arm_b"]["mean"].iloc[0]
+        # arm_a: (15-10)/10 * 100 = 50%
+        self.assertAlmostEqual(arm_a_val, 50.0)
+        # arm_b: (30-20)/20 * 100 = 50%
+        self.assertAlmostEqual(arm_b_val, 50.0)
+
+        with self.subTest("non_stationary_sq_difference"):
+            # If we had incorrectly used a single SQ value, arm_b would
+            # show (30-10)/10=200% (wrong) instead of 50% (correct).
+            # Verify by making SQ values clearly different.
+            metric2 = _SumDerivedMetric(
+                name="total",
+                input_metric_names=["a"],
+                relativize_inputs=True,
+                source_trial_map={
+                    "arm_a": (0, "arm_a"),
+                    "arm_b": (1, "arm_b"),
+                },
+            )
+            result2 = metric2.fetch_trial_data(t2)
+            self.assertIsInstance(result2, Ok)
+            df2 = none_throws(result2.ok).df
+            # Both should be 50%, proving per-trial SQ is used.
+            for arm in ["arm_a", "arm_b"]:
+                self.assertAlmostEqual(
+                    df2[df2["arm_name"] == arm]["mean"].iloc[0], 50.0
+                )
+
+    def test_two_phase_experiment_fetch(self) -> None:
+        """Experiment.fetch_data runs base metrics first, then derived metrics.
+
+        Also verifies that missing input metrics propagate as Err through
+        the experiment-level fetch path.
+        """
         derived = _SumDerivedMetric(
             name="total",
             input_metric_names=["base_a", "base_b"],
@@ -171,7 +461,6 @@ class DerivedMetricExperimentIntegrationTest(TestCase):
         )
         self.assertIsInstance(experiment.metrics["total"], DerivedMetric)
 
-        # Create 2 trials with known base metric values.
         for i in range(2):
             trial = experiment.new_trial()
             trial.add_arm(
@@ -193,52 +482,28 @@ class DerivedMetricExperimentIntegrationTest(TestCase):
             )
 
         data = experiment.fetch_data()
-        metric_names = set(data.df["metric_name"].unique())
-        self.assertIn("total", metric_names)
+        self.assertIn("total", set(data.df["metric_name"].unique()))
 
-        # Verify derived values: total = base_a + base_b
         derived_df = data.df[data.df["metric_name"] == "total"]
         for i in range(2):
             row = derived_df[derived_df["trial_index"] == i]
             expected = (i + 2) + (i + 3)
             self.assertAlmostEqual(row["mean"].iloc[0], expected, places=10)
 
-    def test_fetch_without_derived_metrics(self) -> None:
-        """When no derived metrics exist, fetch_data works as before."""
-        experiment = Experiment(
-            name="test",
-            search_space=get_branin_search_space(),
-            tracking_metrics=[Metric(name="m1")],
-        )
-        trial = experiment.new_trial()
-        trial.add_arm(Arm(name="0_0", parameters={"x1": 0.0, "x2": 0.0}))
-        trial.mark_running(no_runner_required=True)
-        trial.mark_completed()
-        experiment.attach_data(_make_trial_data(0, {"0_0": {"m1": 42.0}}))
+        with self.subTest("missing_input_via_experiment"):
+            incomplete = _SumDerivedMetric(name="inc", input_metric_names=["a", "b"])
+            exp2 = Experiment(
+                name="test2",
+                search_space=get_branin_search_space(),
+                tracking_metrics=[Metric(name="a"), incomplete],
+            )
+            trial = exp2.new_trial()
+            trial.add_arm(Arm(name="0_0", parameters={"x1": 0.0, "x2": 0.0}))
+            trial.mark_running(no_runner_required=True)
+            trial.mark_completed()
+            exp2.attach_data(_make_trial_data(0, {"0_0": {"a": 1.0}}))
 
-        data = experiment.fetch_data()
-        self.assertEqual(len(data.df), 1)
-        self.assertEqual(data.df["mean"].iloc[0], 42.0)
-
-    def test_derived_metric_missing_input_returns_err(self) -> None:
-        """Derived metric returns Err when an input metric is missing."""
-        derived = _SumDerivedMetric(
-            name="total",
-            input_metric_names=["a", "b"],
-        )
-        experiment = Experiment(
-            name="test",
-            search_space=get_branin_search_space(),
-            tracking_metrics=[Metric(name="a"), derived],
-        )
-        trial = experiment.new_trial()
-        trial.add_arm(Arm(name="0_0", parameters={"x1": 0.0, "x2": 0.0}))
-        trial.mark_running(no_runner_required=True)
-        trial.mark_completed()
-        # Only attach "a", not "b"
-        experiment.attach_data(_make_trial_data(0, {"0_0": {"a": 1.0}}))
-
-        results = experiment.fetch_trials_data_results(trial_indices=[0])
-        result = results[0]["total"]
-        self.assertIsInstance(result, Err)
-        self.assertIn("b", none_throws(result.err).message)
+            results = exp2.fetch_trials_data_results(trial_indices=[0])
+            result = results[0]["inc"]
+            self.assertIsInstance(result, Err)
+            self.assertIn("b", none_throws(result.err).message)


### PR DESCRIPTION
Summary:
Refactors `DerivedMetric` to implement a template-method `fetch_trial_data` that
consolidates shared data-fetching, validation, and optional relativization logic:

1. `_resolve_source_trial_indices(trial)` — subclass hook for cross-trial data
   lookup; default returns `None` (use current trial).
2. `_lookup_base_data(trial, source_trial_indices)` — looks up cached metric data.
3. `_validate_input_metrics_present(df)` — checks all input metrics exist globally.
4. `_collect_arm_data(trial, df, source_trial_indices)` — collects per-arm input
   metric DataFrames with per-arm missing-metric error handling.
5. `_relativize_arm_data(trial, arm_data, cached_df)` — when `relativize_inputs=True`,
   relativizes each arm independently against the status quo from that arm's own
   source trial using `Data.relativize` (delta method). This correctly handles
   non-stationarity where the same SQ arm may have different metric values across
   trials. The status quo arm is excluded from the output.
6. `_compute_derived_values(trial, arm_data)` — abstract subclass hook for
   the actual computation.

The `relativize_inputs` parameter (default `False`) enables automatic
status-quo normalization of input metric values before the subclass
computation step. The `as_percent` parameter (default `True`) controls
whether relativized values are expressed as percentage change (50.0 for
a 50% improvement) or fractional change (0.5).

Reviewed By: bletham

Differential Revision: D94844067


