### PR TITLE
Add ExpressionDerivedMetric for expression-based derived metrics

### DIFF
--- a/ax/core/derived_metric.py
+++ b/ax/core/derived_metric.py
@@ -32,6 +32,11 @@ Subclasses that need cross-trial data lookup (e.g., when an arm's base
 metric data lives in a different trial) should override
 ``_resolve_source_trial_indices``.
 
+Concrete subclasses:
+
+* ``ExpressionDerivedMetric`` (below) – computes values from a mathematical
+  expression of other metrics (e.g. ``log(a) - log(b)``).
+
 .. note:: **Transform compatibility.**
    Derived metrics are computed *before* any adapter transforms run.
    Transforms that modify metric values (e.g. ``Relativize``, ``Log``) will
@@ -44,7 +49,7 @@ metric data lives in a different trial) should override
 from __future__ import annotations
 
 from logging import Logger
-from typing import Any
+from typing import Any, Callable, cast
 
 import pandas as pd
 from ax.core.base_trial import BaseTrial
@@ -53,7 +58,12 @@ from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
 from ax.exceptions.core import UserInputError
 from ax.utils.common.logger import get_logger
 from ax.utils.common.result import Err, Ok
+from ax.utils.common.string_utils import sanitize_name, unsanitize_name
 from pyre_extensions import none_throws
+from sympy import lambdify, sympify
+from sympy.core.expr import Expr
+from sympy.core.relational import Relational
+from sympy.core.symbol import Symbol
 
 
 logger: Logger = get_logger(__name__)
@@ -506,4 +516,193 @@ class DerivedMetric(Metric):
             "input_metric_names": self._input_metric_names,
             "relativize_inputs": self._relativize_inputs,
             "as_percent": self._as_percent,
+        }
+
+
+class ExpressionDerivedMetric(DerivedMetric):
+    """A metric computed from a mathematical expression of other metrics.
+
+    The expression is parsed using sympy (consistent with other expression
+    parsing in Ax) and compiled via ``lambdify`` for fast numeric evaluation.
+    It may reference:
+
+    * Input metric names as variables
+    * Mathematical operators: ``+``, ``-``, ``*``, ``/``, ``**``
+    * Any function available in Python's ``math`` module (e.g. ``log``,
+      ``exp``, ``sqrt``, ``abs``, ``sin``, ``cos``, ``asin``, ``pow``, etc.)
+    * Numeric constants
+
+    Attributes:
+        expression_str: The mathematical expression string.
+
+    Example::
+
+        >>> log_ratio = ExpressionDerivedMetric(
+        ...     name="log_ratio",
+        ...     input_metric_names=["metric_a", "metric_b"],
+        ...     expression_str="log(metric_a) - log(metric_b)",
+        ... )
+    """
+
+    def __init__(
+        self,
+        name: str,
+        input_metric_names: list[str],
+        expression_str: str,
+        relativize_inputs: bool = False,
+        as_percent: bool = True,
+        lower_is_better: bool | None = None,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(
+            name=name,
+            input_metric_names=input_metric_names,
+            relativize_inputs=relativize_inputs,
+            as_percent=as_percent,
+            lower_is_better=lower_is_better,
+            properties=properties,
+        )
+        self._expression_str = expression_str
+
+        # Parse & validate once; cache the compiled evaluator for reuse.
+        # sanitize_name handles metric names with dots, slashes, etc.
+        # (consistent with DerivedParameter's expression parsing).
+        try:
+            self._sympy_expr: Expr = sympify(  # pyre-ignore[8]
+                sanitize_name(self._expression_str),
+            )
+        except Exception as e:
+            raise UserInputError(
+                f"Invalid expression in ExpressionDerivedMetric "
+                f"'{self.name}': {self._expression_str}. Error: {e}"
+            ) from e
+        self._validate_expression()
+        # _sympy_symbols are the sanitized names used by sympy/lambdify.
+        # _symbols are the original (unsanitized) metric names used for
+        # looking up values at evaluation time.
+        # Cast free_symbols to set[Symbol] since Pyre stubs use Basic
+        # pyre-fixme[16]: Pyre cannot infer that free_symbols contains Symbol
+        free_syms = cast(set[Symbol], self._sympy_expr.free_symbols)
+        sympy_symbols: list[str] = sorted(s.name for s in free_syms)
+        self._symbols: list[str] = [unsanitize_name(s) for s in sympy_symbols]
+        self._evaluator: Callable[..., float] = lambdify(
+            sympy_symbols, self._sympy_expr, modules="math"
+        )
+
+    @property
+    def expression_str(self) -> str:
+        """The expression string defining the derivation."""
+        return self._expression_str
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def _validate_expression(self) -> None:
+        """Validate that the parsed expression is a numeric expression with
+        only declared input metrics as free symbols."""
+        if isinstance(self._sympy_expr, Relational):
+            raise UserInputError(
+                "Comparison operators are not allowed in "
+                "ExpressionDerivedMetric expressions. "
+                "Use outcome constraints for comparisons."
+            )
+
+        # Reject undeclared variable names.
+        # Cast free_symbols to set[Symbol] since Pyre stubs use Basic
+        # pyre-fixme[16]: Pyre cannot infer that free_symbols contains Symbol
+        free_syms = cast(set[Symbol], self._sympy_expr.free_symbols)
+        referenced_names = {unsanitize_name(s.name) for s in free_syms}
+        input_metric_set = set(self._input_metric_names)
+
+        unknown_names = referenced_names - input_metric_set
+        if unknown_names:
+            raise UserInputError(
+                f"Expression for ExpressionDerivedMetric '{self.name}' references "
+                f"unknown names: {unknown_names}. Allowed metric names: "
+                f"{input_metric_set}."
+            )
+
+        unused_inputs = input_metric_set - referenced_names
+        if unused_inputs:
+            logger.warning(
+                f"ExpressionDerivedMetric '{self.name}' declares input metrics "
+                f"that are not used in the expression: {unused_inputs}."
+            )
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+
+    def _evaluate_expression(self, metric_values: dict[str, float]) -> float:
+        """Evaluate the expression with the given metric values."""
+        args = [metric_values[s] for s in self._symbols]
+        return float(self._evaluator(*args))
+
+    # ------------------------------------------------------------------
+    # Core computation (subclass hook)
+    # ------------------------------------------------------------------
+
+    def _compute_derived_values(
+        self,
+        trial: BaseTrial,
+        arm_data: dict[str, pd.DataFrame],
+    ) -> MetricFetchResult:
+        """Evaluate the expression for each arm using pre-collected data.
+
+        When ``relativize_inputs`` is ``True``, the base class has already
+        relativized the ``mean`` values and excluded the status quo arm.
+        """
+        result_rows: list[dict[str, Any]] = []
+
+        for arm_name, arm_df in arm_data.items():
+            try:
+                metric_values = self._extract_means(arm_df)
+                derived_value = self._evaluate_expression(metric_values)
+            except Exception as e:
+                return Err(
+                    MetricFetchE(
+                        message=(
+                            f"Error evaluating ExpressionDerivedMetric "
+                            f"'{self.name}' for arm '{arm_name}' "
+                            f"in trial {trial.index}: {e}"
+                        ),
+                        exception=e,
+                    )
+                )
+
+            result_rows.append(
+                {
+                    "trial_index": trial.index,
+                    "arm_name": arm_name,
+                    "metric_name": self.name,
+                    "metric_signature": self.signature,
+                    "mean": derived_value,
+                    "sem": float("nan"),
+                }
+            )
+
+        return Ok(value=Data(df=pd.DataFrame(result_rows)))
+
+    # ------------------------------------------------------------------
+    # Misc
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        parts = [
+            f"name='{self.name}'",
+            f"expression='{self._expression_str}'",
+        ]
+        if self._relativize_inputs:
+            parts.append("relativize_inputs=True")
+        return f"ExpressionDerivedMetric({', '.join(parts)})"
+
+    @property
+    def summary_dict(self) -> dict[str, Any]:
+        """Fields of this metric's configuration that will appear
+        in the ``Summary`` analysis table.
+        """
+        return {
+            **super().summary_dict,
+            "expression_str": self._expression_str,
         }

--- a/ax/core/tests/test_derived_metric.py
+++ b/ax/core/tests/test_derived_metric.py
@@ -6,13 +6,15 @@
 
 # pyre-strict
 
-from typing import Any
+import math
+from typing import Any, cast
 
 import pandas as pd
+from ax.adapter.torch import TorchAdapter
 from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial
 from ax.core.data import Data
-from ax.core.derived_metric import DerivedMetric
+from ax.core.derived_metric import DerivedMetric, ExpressionDerivedMetric
 from ax.core.experiment import Experiment
 from ax.core.metric import Metric, MetricFetchResult
 from ax.core.objective import Objective
@@ -20,9 +22,16 @@ from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import OutcomeConstraint
 from ax.core.types import ComparisonOp
 from ax.exceptions.core import UserInputError
+from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
+from ax.storage.json_store.decoder import object_from_json
+from ax.storage.json_store.encoder import object_to_json
+from ax.storage.sqa_store.decoder import Decoder
+from ax.storage.sqa_store.encoder import Encoder
+from ax.storage.sqa_store.sqa_config import SQAConfig
 from ax.utils.common.result import Err, Ok
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_branin_search_space
+from ax.utils.testing.mock import mock_botorch_optimize
 from pyre_extensions import none_throws
 
 
@@ -507,3 +516,412 @@ class DerivedMetricTest(TestCase):
             result = results[0]["inc"]
             self.assertIsInstance(result, Err)
             self.assertIn("b", none_throws(result.err).message)
+
+
+class ExpressionDerivedMetricTest(TestCase):
+    """Tests for ExpressionDerivedMetric."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _batch_experiment_with_sq(
+        self,
+        sq_values: dict[str, float],
+        arm_values: dict[str, dict[str, float]],
+    ) -> Experiment:
+        """Experiment with a batch trial containing a status quo and treatment arms."""
+        sq_arm = Arm(name="status_quo", parameters={"x1": 0.0, "x2": 0.0})
+        exp = Experiment(
+            name="test",
+            search_space=get_branin_search_space(),
+            status_quo=sq_arm,
+        )
+        trial = exp.new_batch_trial()
+        trial.add_arm(sq_arm)
+        for i, arm_name in enumerate(arm_values, start=1):
+            trial.add_arm(
+                Arm(name=arm_name, parameters={"x1": float(i), "x2": float(i)})
+            )
+        trial.mark_running(no_runner_required=True)
+        trial.mark_completed()
+        all_arm_metrics = {"status_quo": sq_values, **arm_values}
+        exp.attach_data(_make_trial_data(0, all_arm_metrics))
+        return exp
+
+    # ------------------------------------------------------------------
+    # Construction & validation
+    # ------------------------------------------------------------------
+
+    def test_init_and_clone(self) -> None:
+        """Construction, inheritance, and clone round-trip."""
+        metric = ExpressionDerivedMetric(
+            name="ratio",
+            input_metric_names=["a", "b"],
+            expression_str="a / b",
+            lower_is_better=True,
+            properties={"key": "value"},
+        )
+        self.assertIsInstance(metric, DerivedMetric)
+        self.assertIsInstance(metric, Metric)
+        self.assertEqual(metric.input_metric_names, ["a", "b"])
+        self.assertEqual(metric.expression_str, "a / b")
+        self.assertTrue(metric.lower_is_better)
+        self.assertFalse(metric.relativize_inputs)
+
+        # Clone round-trip
+        cloned = cast(ExpressionDerivedMetric, metric.clone())
+        self.assertIsInstance(cloned, ExpressionDerivedMetric)
+        self.assertEqual(cloned.input_metric_names, metric.input_metric_names)
+        self.assertEqual(cloned.expression_str, metric.expression_str)
+        self.assertEqual(cloned.lower_is_better, metric.lower_is_better)
+        self.assertEqual(cloned.properties, metric.properties)
+        self.assertFalse(cloned.relativize_inputs)
+
+        # Clone preserves relativize_inputs=True
+        rel_metric = ExpressionDerivedMetric(
+            name="rel",
+            input_metric_names=["a", "b"],
+            expression_str="a / b",
+            relativize_inputs=True,
+        )
+        rel_cloned = cast(ExpressionDerivedMetric, rel_metric.clone())
+        self.assertTrue(rel_cloned.relativize_inputs)
+
+    def test_validation_rejects_invalid_expressions(self) -> None:
+        """Various invalid expressions must raise ``UserInputError``."""
+        cases: list[tuple[str, list[str], str]] = [
+            ("empty_inputs", [], "42"),
+            ("undeclared_variable", ["a"], "a + b"),
+            ("bad_syntax", ["a"], "a +"),
+            ("list_comprehension", ["a"], "[x for x in a]"),
+            ("comparison", ["a", "b"], "a > b"),
+        ]
+        for label, inputs, expr in cases:
+            with self.subTest(label=label):
+                with self.assertRaises(UserInputError):
+                    ExpressionDerivedMetric(
+                        name="t",
+                        input_metric_names=inputs,
+                        expression_str=expr,
+                    )
+
+    # ------------------------------------------------------------------
+    # Expression evaluation
+    # ------------------------------------------------------------------
+
+    def test_expression_evaluation(self) -> None:
+        """Operators, functions, constants, nested calls, and special-char
+        metric names (dots, slashes, colons) all evaluate correctly."""
+        cases: list[tuple[str, dict[str, float], float]] = [
+            ("a + b", {"a": 3.0, "b": 4.0}, 7.0),
+            ("a * 2.5 + 10", {"a": 4.0}, 20.0),
+            ("-a", {"a": 5.0}, -5.0),
+            ("a ** 2", {"a": 3.0}, 9.0),
+            ("log(a) - log(b)", {"a": math.e, "b": 1.0}, 1.0),
+            ("sqrt(abs(x))", {"x": -16.0}, 4.0),
+            ("min(a, b)", {"a": 3.0, "b": 5.0}, 3.0),
+            ("max(a, b)", {"a": 3.0, "b": 5.0}, 5.0),
+            # Special-char metric names (sanitize_name / unsanitize_name).
+            (
+                "model.loss - baseline.loss",
+                {"model.loss": 5.0, "baseline.loss": 3.0},
+                2.0,
+            ),
+            ("train/acc + val/acc", {"train/acc": 0.8, "val/acc": 0.7}, 1.5),
+            ("scope:metric * 2", {"scope:metric": 4.0}, 8.0),
+        ]
+        for expr, values, expected in cases:
+            with self.subTest(expr=expr):
+                metric = ExpressionDerivedMetric(
+                    name="test",
+                    input_metric_names=list(values.keys()),
+                    expression_str=expr,
+                )
+                self.assertAlmostEqual(
+                    metric._evaluate_expression(values),
+                    expected,
+                    places=10,
+                )
+
+    # ------------------------------------------------------------------
+    # fetch_trial_data
+    # ------------------------------------------------------------------
+
+    def test_fetch_trial_data(self) -> None:
+        """Basic fetch: correct value, NaN SEM, per-arm differentiation."""
+        exp = _make_experiment_with_trial(
+            {"0_0": {"a": 10.0, "b": 2.0}, "0_1": {"a": 6.0, "b": 3.0}},
+            batch=True,
+        )
+        metric = ExpressionDerivedMetric(
+            name="ratio", input_metric_names=["a", "b"], expression_str="a / b"
+        )
+        result = metric.fetch_trial_data(exp.trials[0])
+        self.assertIsInstance(result, Ok)
+        df = none_throws(result.ok).df.sort_values("arm_name").reset_index(drop=True)
+        self.assertEqual(len(df), 2)
+        self.assertEqual(df.loc[0, "mean"], 5.0)  # 10/2
+        self.assertEqual(df.loc[1, "mean"], 2.0)  # 6/3
+        self.assertTrue(df["sem"].isna().all())
+
+    def test_expression_evaluation_errors(self) -> None:
+        """Err results for expression-specific math errors."""
+        with self.subTest("division_by_zero"):
+            exp = _make_experiment_with_trial({"0_0": {"a": 10.0, "b": 0.0}})
+            metric = ExpressionDerivedMetric(
+                name="ratio", input_metric_names=["a", "b"], expression_str="a / b"
+            )
+            result = metric.fetch_trial_data(exp.trials[0])
+            self.assertIsInstance(result, Err)
+            self.assertIn("division by zero", none_throws(result.err).message.lower())
+
+        with self.subTest("log_of_negative"):
+            exp = _make_experiment_with_trial({"0_0": {"a": -1.0}})
+            metric = ExpressionDerivedMetric(
+                name="log_a", input_metric_names=["a"], expression_str="log(a)"
+            )
+            result = metric.fetch_trial_data(exp.trials[0])
+            self.assertIsInstance(result, Err)
+            err_msg = none_throws(result.err).message.lower()
+            # Sympy versions differ: older raises "math domain error" from
+            # math.log; newer generates a guard with "expected a positive
+            # input".  Accept either.
+            self.assertTrue(
+                "math domain error" in err_msg
+                or "expected a positive input" in err_msg,
+                f"Unexpected error message: {err_msg}",
+            )
+
+    # ------------------------------------------------------------------
+    # Relativization
+    # ------------------------------------------------------------------
+
+    def test_relativize_inputs(self) -> None:
+        """Relativized fetch: correct computation, SQ excluded, multi-arm.
+        Also verifies that relativize_inputs=False (default) includes SQ
+        and uses raw values."""
+        # SQ: a=10, b=4.
+        # arm_1: a=15, b=8 → a_rel=0.5, b_rel=1.0 → a/b = 0.5
+        # arm_2: a=20, b=6 → a_rel=1.0, b_rel=0.5 → a/b = 2.0
+        exp = self._batch_experiment_with_sq(
+            sq_values={"a": 10.0, "b": 4.0},
+            arm_values={
+                "arm_1": {"a": 15.0, "b": 8.0},
+                "arm_2": {"a": 20.0, "b": 6.0},
+            },
+        )
+        metric = ExpressionDerivedMetric(
+            name="ratio_rel",
+            input_metric_names=["a", "b"],
+            expression_str="a / b",
+            relativize_inputs=True,
+        )
+        result = metric.fetch_trial_data(exp.trials[0])
+        self.assertIsInstance(result, Ok)
+        df = none_throws(result.ok).df.sort_values("arm_name").reset_index(drop=True)
+        self.assertEqual(len(df), 2)
+        self.assertNotIn("status_quo", df["arm_name"].values)
+        self.assertAlmostEqual(df.loc[0, "mean"], 0.5, places=10)
+        self.assertAlmostEqual(df.loc[1, "mean"], 2.0, places=10)
+        self.assertTrue(df["sem"].isna().all())
+
+        with self.subTest("not_applied_by_default"):
+            exp = self._batch_experiment_with_sq(
+                sq_values={"a": 10.0, "b": 5.0},
+                arm_values={"treat": {"a": 12.0, "b": 10.0}},
+            )
+            metric = ExpressionDerivedMetric(
+                name="sum",
+                input_metric_names=["a", "b"],
+                expression_str="a + b",
+            )
+            self.assertFalse(metric.relativize_inputs)
+            result = metric.fetch_trial_data(exp.trials[0])
+            self.assertIsInstance(result, Ok)
+            df = (
+                none_throws(result.ok).df.sort_values("arm_name").reset_index(drop=True)
+            )
+            self.assertEqual(len(df), 2)
+            sq_row = df[df["arm_name"] == "status_quo"]
+            treat_row = df[df["arm_name"] == "treat"]
+            self.assertAlmostEqual(sq_row["mean"].iloc[0], 15.0, places=10)
+            self.assertAlmostEqual(treat_row["mean"].iloc[0], 22.0, places=10)
+
+    def test_relativize_errors(self) -> None:
+        """Relativization error modes: no SQ, SQ missing from data, SQ near zero."""
+        with self.subTest("no_status_quo"):
+            exp = _make_experiment_with_trial({"0_0": {"a": 1.0}})
+            metric = ExpressionDerivedMetric(
+                name="r",
+                input_metric_names=["a"],
+                expression_str="a",
+                relativize_inputs=True,
+            )
+            result = metric.fetch_trial_data(exp.trials[0])
+            self.assertIsInstance(result, Err)
+            self.assertIn("no status quo", none_throws(result.err).message.lower())
+
+        with self.subTest("sq_not_in_data"):
+            sq_arm = Arm(name="sq", parameters={"x1": 0.0, "x2": 0.0})
+            exp = Experiment(
+                name="test",
+                search_space=get_branin_search_space(),
+                status_quo=sq_arm,
+            )
+            trial = exp.new_batch_trial()
+            trial.add_arm(sq_arm)
+            trial.add_arm(Arm(name="treat", parameters={"x1": 1.0, "x2": 1.0}))
+            trial.mark_running(no_runner_required=True)
+            trial.mark_completed()
+            # Only attach data for "treat", not "sq".
+            exp.attach_data(_make_trial_data(0, {"treat": {"a": 5.0}}))
+            metric = ExpressionDerivedMetric(
+                name="r",
+                input_metric_names=["a"],
+                expression_str="a",
+                relativize_inputs=True,
+            )
+            result = metric.fetch_trial_data(trial)
+            self.assertIsInstance(result, Err)
+            # Base class catches missing data for the SQ arm before
+            # ExpressionDerivedMetric's relativization check.
+            self.assertIn("sq", none_throws(result.err).message)
+
+        with self.subTest("sq_value_near_zero"):
+            exp = self._batch_experiment_with_sq(
+                sq_values={"a": 0.0},
+                arm_values={"treat": {"a": 5.0}},
+            )
+            metric = ExpressionDerivedMetric(
+                name="r",
+                input_metric_names=["a"],
+                expression_str="a",
+                relativize_inputs=True,
+            )
+            result = metric.fetch_trial_data(exp.trials[0])
+            self.assertIsInstance(result, Err)
+            self.assertIn(
+                "too small to reliably", none_throws(result.err).message.lower()
+            )
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def test_serialization_roundtrip(self) -> None:
+        """JSON and SQA round-trip, with and without relativize_inputs."""
+        for relativize in (False, True):
+            original = ExpressionDerivedMetric(
+                name="log_ratio",
+                input_metric_names=["a", "b"],
+                expression_str="log(a) - log(b)",
+                relativize_inputs=relativize,
+                lower_is_better=True,
+                properties={"key": "value"},
+            )
+            with self.subTest(backend="json", relativize=relativize):
+                json_dict = object_to_json(original)
+                self.assertEqual(json_dict["__type"], "ExpressionDerivedMetric")
+                restored = cast(ExpressionDerivedMetric, object_from_json(json_dict))
+                self._assert_metric_equal(restored, original)
+
+            with self.subTest(backend="sqa", relativize=relativize):
+                config = SQAConfig()
+                sqa = Encoder(config=config).metric_to_sqa(original)
+                restored = cast(
+                    ExpressionDerivedMetric,
+                    Decoder(config=config).metric_from_sqa(sqa),
+                )
+                self._assert_metric_equal(restored, original)
+
+        with self.subTest("backward_compat_missing_key"):
+            original = ExpressionDerivedMetric(
+                name="log_ratio",
+                input_metric_names=["a", "b"],
+                expression_str="log(a) - log(b)",
+                lower_is_better=True,
+                properties={"key": "value"},
+            )
+            json_dict = object_to_json(original)
+            assert isinstance(json_dict, dict)
+            json_dict.pop("relativize_inputs", None)
+            json_dict.pop("as_percent", None)
+            restored = cast(ExpressionDerivedMetric, object_from_json(json_dict))
+            self.assertFalse(restored.relativize_inputs)
+            self.assertTrue(restored.as_percent)
+
+    def _assert_metric_equal(
+        self,
+        restored: ExpressionDerivedMetric,
+        original: ExpressionDerivedMetric,
+    ) -> None:
+        self.assertEqual(restored.name, original.name)
+        self.assertEqual(restored.input_metric_names, original.input_metric_names)
+        self.assertEqual(restored.expression_str, original.expression_str)
+        self.assertEqual(restored.lower_is_better, original.lower_is_better)
+        self.assertEqual(restored.properties, original.properties)
+        self.assertEqual(restored.relativize_inputs, original.relativize_inputs)
+        self.assertEqual(restored.as_percent, original.as_percent)
+
+    # ------------------------------------------------------------------
+    # End-to-end integration
+    # ------------------------------------------------------------------
+
+    @mock_botorch_optimize
+    def test_experiment_integration(self) -> None:
+        """Two-phase fetch + TorchAdapter candidate generation with a derived
+        constraint that has NaN SEM."""
+        derived_ratio = ExpressionDerivedMetric(
+            name="ratio",
+            input_metric_names=["base_a", "base_b"],
+            expression_str="base_a / base_b",
+        )
+        experiment = Experiment(
+            name="test",
+            search_space=get_branin_search_space(),
+            optimization_config=OptimizationConfig(
+                objective=Objective(metric=Metric(name="obj"), minimize=True),
+                outcome_constraints=[
+                    OutcomeConstraint(
+                        metric=derived_ratio,
+                        op=ComparisonOp.GEQ,
+                        bound=1.0,
+                        relative=False,
+                    )
+                ],
+            ),
+            tracking_metrics=[Metric(name="base_a"), Metric(name="base_b")],
+        )
+
+        for i in range(3):
+            trial = experiment.new_trial()
+            trial.add_arm(
+                Arm(name=f"{i}_0", parameters={"x1": float(i), "x2": float(i)})
+            )
+            trial.mark_running(no_runner_required=True)
+            trial.mark_completed()
+            experiment.attach_data(
+                _make_trial_data(
+                    i,
+                    {
+                        f"{i}_0": {
+                            "obj": float(i + 1),
+                            "base_a": float(i + 2),
+                            "base_b": float(i + 1),
+                        }
+                    },
+                )
+            )
+
+        data = experiment.fetch_data()
+        self.assertIn("ratio", set(data.df["metric_name"].unique()))
+
+        derived_df = data.df[data.df["metric_name"] == "ratio"]
+        self.assertTrue(derived_df["sem"].isna().all())
+        for i in range(3):
+            row = derived_df[derived_df["trial_index"] == i]
+            self.assertAlmostEqual(row["mean"].iloc[0], (i + 2) / (i + 1), places=10)
+
+        gr = TorchAdapter(experiment=experiment, generator=BoTorchGenerator()).gen(n=1)
+        self.assertEqual(len(gr.arms), 1)

--- a/ax/storage/json_store/registry.py
+++ b/ax/storage/json_store/registry.py
@@ -28,6 +28,7 @@ from ax.core.arm import Arm
 from ax.core.auxiliary import AuxiliaryExperiment, AuxiliaryExperimentPurpose
 from ax.core.batch_trial import AbandonedArm, BatchTrial
 from ax.core.data import Data
+from ax.core.derived_metric import ExpressionDerivedMetric
 from ax.core.evaluations_to_data import DataType
 from ax.core.experiment_status import ExperimentStatus
 from ax.core.generator_run import GeneratorRun
@@ -202,6 +203,7 @@ CORE_ENCODER_REGISTRY: dict[type, Callable[[Any], dict[str, Any]]] = {
     ChainedInputTransform: botorch_component_to_dict,
     ChoiceParameter: choice_parameter_to_dict,
     Data: data_to_dict,
+    ExpressionDerivedMetric: metric_to_dict,
     DerivedParameter: derived_parameter_to_dict,
     Experiment: experiment_to_dict,
     FactorialMetric: metric_to_dict,
@@ -317,6 +319,7 @@ CORE_DECODER_REGISTRY: TDecoderRegistry = {
     "Data": Data,
     "DataLoaderConfig": DataLoaderConfig,
     "DataType": DataType,
+    "ExpressionDerivedMetric": ExpressionDerivedMetric,
     "DerivedParameter": DerivedParameter,
     "DomainType": DomainType,
     "Experiment": Experiment,

--- a/ax/storage/metric_registry.py
+++ b/ax/storage/metric_registry.py
@@ -9,6 +9,7 @@
 from collections.abc import Callable
 from typing import Any
 
+from ax.core.derived_metric import ExpressionDerivedMetric
 from ax.core.map_metric import MapMetric
 from ax.core.metric import Metric
 from ax.metrics.branin import BraninMetric
@@ -43,6 +44,7 @@ CORE_METRIC_REGISTRY: dict[type[Metric], int] = {
     ChemistryMetric: 7,
     MapMetric: 8,
     BraninTimestampMapMetric: 9,
+    ExpressionDerivedMetric: 10,
 }
 
 


### PR DESCRIPTION
Summary:
Adds `ExpressionDerivedMetric`, a `DerivedMetric` subclass that computes
metric values from mathematical expressions of other metrics (e.g.
`log(a) - log(b)`).

Builds on the template-method pattern in D94844067: data lookup, validation,
optional `relativize_inputs` normalization (with `as_percent` support), and
per-arm cross-trial relativization are handled by the base class.
This subclass adds expression parsing, validation, and evaluation.

Key details:
- Expression parsing via sympy (`sympify` / `lambdify`), consistent with
  `DerivedParameter` elsewhere in Ax.
- Any function in Python's `math` module is supported (log, exp, sqrt, etc.).
- Validates that expressions reference only declared input metrics.
- Metric names with special characters (dots, slashes, colons) are supported
  via automatic sanitization.
- `as_percent` parameter threaded through to base class for serialization.
- SEM is set to NaN (non-linear error propagation not yet supported).
- Registered in JSON and SQA metric registries for serialization.

Reviewed By: bletham

Differential Revision: D94389119


