### PR TITLE
Bump pinned botorch version to 0.17.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "botorch[pymoo]>=0.17.0,<0.17.1dev9999",
+    "botorch[pymoo]>=0.17.2,<0.17.3dev9999",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
Summary:
[Ax] Bump pinned botorch version to 0.17.2

Bumps the pinned botorch version from 0.17.0 to 0.17.2.

This picks up the following changes from botorch 0.17.2:
- Fix BAxUS bugs
- Fix q-dim bug in ScalarizedPosteriorMean
- Project candidate_set in qMultiFidelityMaxValueEntropy.__init__
- Make d and target_fidelities required in project_to_target_fidelity
- Add test harness infrastructure for acquisition function testing
- Fix typos and docstring issues
- Require GPyTorch>=1.15.2 and linear_operator>=0.6.1

Reviewed By: saitcakmak

Differential Revision: D95230574


