### PR TITLE
Remove pyre-fixme/pyre-ignore from ax/ small directories

### DIFF
--- a/ax/analysis/healthcheck/tests/test_early_stopping_healthcheck.py
+++ b/ax/analysis/healthcheck/tests/test_early_stopping_healthcheck.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import pandas as pd
 from ax.analysis.healthcheck.early_stopping_healthcheck import EarlyStoppingAnalysis
 from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckStatus
+from ax.core.analysis_card import AnalysisCard
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.objective import MultiObjective, Objective
@@ -39,9 +40,8 @@ class TestEarlyStoppingAnalysis(TestCase):
             early_stopping_strategy=self.early_stopping_strategy
         )
 
-    def _get_df_dict(self, card: object) -> dict[str, str]:
+    def _get_df_dict(self, card: AnalysisCard) -> dict[str, str]:
         """Extract Property -> Value dict from card dataframe."""
-        # pyre-ignore[16]: card has df attribute
         return {row["Property"]: row["Value"] for _, row in card.df.iterrows()}
 
     def _create_map_data(

--- a/ax/benchmark/benchmark_result.py
+++ b/ax/benchmark/benchmark_result.py
@@ -171,9 +171,7 @@ class AggregatedBenchmarkResult(Base):
         """
         # Extract average wall times and standard errors thereof
         fit_time, gen_time = (
-            # pyre-fixme [16]: Item `float` of `typing.Union[numpy.ndarray[typing.Any,
-            # typing.Any], float]` has no attribute `item`.
-            [nanmean(Ts).item(), sem(Ts, ddof=1, nan_policy="propagate").item()]
+            [float(nanmean(Ts)), float(sem(Ts, ddof=1, nan_policy="propagate"))]
             for Ts in zip(*((res.fit_time, res.gen_time) for res in results))
         )
 

--- a/ax/generation_strategy/best_model_selector.py
+++ b/ax/generation_strategy/best_model_selector.py
@@ -20,8 +20,7 @@ from ax.utils.common.base import Base
 from ax.utils.common.func_enum import FuncEnum
 from pyre_extensions import none_throws
 
-# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
-ARRAYLIKE = np.ndarray | list[float] | list[np.ndarray]
+ARRAYLIKE = npt.NDArray | list[float] | list[npt.NDArray]
 
 
 class BestModelSelector(ABC, Base):

--- a/ax/generation_strategy/dispatch_utils.py
+++ b/ax/generation_strategy/dispatch_utils.py
@@ -186,9 +186,7 @@ def _suggest_gp_model(
                 all_range_parameters_are_discrete = False
             else:
                 num_param_discrete_values = parameter.cardinality()
-                # pyre-fixme[58]: `*` is not supported for operand types `int` and
-                #  `Union[float, int]`.
-                num_possible_points *= num_param_discrete_values
+                num_possible_points *= int(num_param_discrete_values)
 
         if should_enumerate_param:
             num_enumerated_combinations *= none_throws(num_param_discrete_values)

--- a/ax/global_stopping/tests/test_strategies.py
+++ b/ax/global_stopping/tests/test_strategies.py
@@ -297,7 +297,9 @@ class TestImprovementGlobalStoppingStrategy(TestCase):
         gss = ImprovementGlobalStoppingStrategy(
             min_trials=3, window_size=3, improvement_bar=0.1
         )
-        objectives = exp.optimization_config.objective.objectives  # pyre-ignore
+        objectives = assert_is_instance(
+            none_throws(exp.optimization_config).objective, MultiObjective
+        ).objectives
         custom_objective_thresholds = [
             ObjectiveThreshold(
                 metric=objectives[0].metric,

--- a/ax/metrics/sklearn.py
+++ b/ax/metrics/sklearn.py
@@ -40,8 +40,7 @@ class SklearnDataset(StrEnum):
 
 
 @lru_cache(maxsize=8)
-# pyre-fixme[2]: Parameter must be annotated.
-def _get_data(dataset) -> dict[str, npt.NDArray]:
+def _get_data(dataset: SklearnDataset) -> dict[str, npt.NDArray]:
     """Return sklearn dataset, loading and caching if necessary."""
     if dataset is SklearnDataset.DIGITS:
         return datasets.load_digits()
@@ -105,8 +104,7 @@ class SklearnMetric(Metric):
             )
         if model_type is SklearnModelType.NN:
             if regression:
-                # pyre-fixme[4]: Attribute must be annotated.
-                self._model_cls = MLPRegressor
+                self._model_cls: Any = MLPRegressor
             else:
                 self._model_cls = MLPClassifier
         elif model_type is SklearnModelType.RF:

--- a/ax/metrics/tests/test_chemistry.py
+++ b/ax/metrics/tests/test_chemistry.py
@@ -19,8 +19,7 @@ from ax.utils.testing.core_stubs import get_trial
 
 
 class DummyEnum(Enum):
-    # pyre-fixme[35]: Target cannot be annotated.
-    DUMMY: str = "dummy"
+    DUMMY = "dummy"
 
 
 class ChemistryMetricTest(TestCase):

--- a/ax/metrics/tests/test_noisy_function.py
+++ b/ax/metrics/tests/test_noisy_function.py
@@ -8,17 +8,17 @@
 
 import math
 
+from ax.core.types import TParamValue
 from ax.metrics.noisy_function import GenericNoisyFunctionMetric
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import get_trial
+from pyre_extensions import none_throws
 
 
 class GenericNoisyFunctionMetricTest(TestCase):
     def test_GenericNoisyFunctionMetric(self) -> None:
-        # pyre-fixme[3]: Return type must be annotated.
-        # pyre-fixme[2]: Parameter must be annotated.
-        def f(params):
-            return params["x"] + 1.0
+        def f(params: dict[str, TParamValue]) -> float:
+            return float(params["x"]) + 1.0
 
         # noiseless
         metric = GenericNoisyFunctionMetric(
@@ -29,8 +29,10 @@ class GenericNoisyFunctionMetricTest(TestCase):
         df = metric.fetch_trial_data(trial).unwrap().df
         self.assertEqual(df["arm_name"].tolist(), ["0_0"])
         self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
-        # pyre-fixme[16]: Optional type has no attribute `parameters`.
-        self.assertEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
+        self.assertEqual(
+            df["mean"].tolist(),
+            [float(none_throws(trial.arm).parameters["x"]) + 1.0],
+        )
         self.assertEqual(df["sem"].tolist(), [0.0])
 
         # noisy
@@ -43,12 +45,16 @@ class GenericNoisyFunctionMetricTest(TestCase):
         df = metric.fetch_trial_data(trial).unwrap().df
         self.assertEqual(df["arm_name"].tolist(), ["0_0"])
         self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
-        self.assertNotEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
+        self.assertNotEqual(
+            df["mean"].tolist(),
+            [float(none_throws(trial.arm).parameters["x"]) + 1.0],
+        )
         self.assertEqual(df["sem"].tolist(), [1.0])
         df = metric.fetch_trial_data(trial, noisy=False).unwrap().df
         self.assertEqual(df["arm_name"].tolist(), ["0_0"])
         self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
-        self.assertEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
+        arm = none_throws(trial.arm)
+        self.assertEqual(df["mean"].tolist(), [float(arm.parameters["x"]) + 1.0])
         self.assertEqual(df["sem"].tolist(), [0.0])
 
         # unknown noise level
@@ -61,6 +67,7 @@ class GenericNoisyFunctionMetricTest(TestCase):
         df = metric.fetch_trial_data(trial).unwrap().df
         self.assertEqual(df["arm_name"].tolist(), ["0_0"])
         self.assertEqual(df["metric_name"].tolist(), ["test_metric"])
-        self.assertEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
-        self.assertEqual(df["mean"].tolist(), [trial.arm.parameters["x"] + 1.0])
+        arm = none_throws(trial.arm)
+        self.assertEqual(df["mean"].tolist(), [float(arm.parameters["x"]) + 1.0])
+        self.assertEqual(df["mean"].tolist(), [float(arm.parameters["x"]) + 1.0])
         self.assertTrue(math.isnan(df["sem"].tolist()[0]))

--- a/ax/plot/base.py
+++ b/ax/plot/base.py
@@ -13,6 +13,7 @@ from typing import Any, NamedTuple
 from ax.core.types import TParameterization
 from ax.utils.common.serialization import named_tuple_to_dict
 from plotly import utils
+from plotly.graph_objs import Figure
 
 
 # Constants used for numerous plots
@@ -43,7 +44,9 @@ class _AxPlotConfigBase(NamedTuple):
 class AxPlotConfig(_AxPlotConfigBase):
     """Config for plots"""
 
-    def __new__(cls, data: dict[str, Any], plot_type: enum.Enum) -> "AxPlotConfig":
+    def __new__(
+        cls, data: dict[str, Any] | Figure, plot_type: enum.Enum
+    ) -> "AxPlotConfig":
         # Convert data to json-encodable form (strips out NamedTuple and numpy
         # array). This is a lossy conversion.
         dict_data = json.loads(

--- a/ax/plot/color.py
+++ b/ax/plot/color.py
@@ -23,8 +23,7 @@ class COLORS(enum.Enum):
 
 
 # colors to be used for plotting discrete series
-# pyre-fixme[5]: Global expression must be annotated.
-DISCRETE_COLOR_SCALE = [
+DISCRETE_COLOR_SCALE: list[tuple[int, int, int]] = [
     COLORS.STEELBLUE.value,
     COLORS.CORAL.value,
     COLORS.PINK.value,

--- a/ax/plot/contour.py
+++ b/ax/plot/contour.py
@@ -318,8 +318,6 @@ def plot_contour(
         AxPlotConfig: contour plot of objective vs. parameter values
     """
     return AxPlotConfig(
-        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
-        #  `Figure`.
         data=plot_contour_plotly(
             model=model,
             param_x=param_x,

--- a/ax/plot/diagnostic.py
+++ b/ax/plot/diagnostic.py
@@ -493,8 +493,6 @@ def interact_cross_validation(
     Returns an AxPlotConfig
     """
     return AxPlotConfig(
-        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
-        #  `Figure`.
         data=interact_cross_validation_plotly(
             cv_results=cv_results,
             show_context=show_context,

--- a/ax/plot/feature_importances.py
+++ b/ax/plot/feature_importances.py
@@ -206,8 +206,6 @@ def plot_feature_importance_by_feature(
     """Wrapper method to convert `plot_feature_importance_by_feature_plotly` to
     AxPlotConfig"""
     return AxPlotConfig(
-        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
-        #  `Figure`.
         data=plot_feature_importance_by_feature_plotly(
             model=model,
             sensitivity_values=sensitivity_values,

--- a/ax/plot/pareto_frontier.py
+++ b/ax/plot/pareto_frontier.py
@@ -386,7 +386,6 @@ def plot_pareto_frontier(
     )
 
     fig = go.Figure(data=[trace], layout=layout)
-    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -493,7 +492,6 @@ def interact_pareto_frontier(
     )
 
     fig = go.Figure(data=traces, layout=layout)
-    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 

--- a/ax/plot/scatter.py
+++ b/ax/plot/scatter.py
@@ -107,7 +107,7 @@ def _error_scatter_trace(
     status_quo_arm: PlotInSampleArm | None = None,
     show_CI: bool = True,
     name: str = "In-sample",
-    color: tuple[int] = COLORS.STEELBLUE.value,
+    color: tuple[int, int, int] = COLORS.STEELBLUE.value,
     visible: bool = True,
     legendgroup: str | None = None,
     showlegend: bool = True,
@@ -529,7 +529,6 @@ def plot_multiple_metrics(
         legend={"x": 1 + layout_offset_x},
     )
     fig = go.Figure(data=traces, layout=layout)
-    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -771,7 +770,6 @@ def plot_objective_vs_constraints(
     )
 
     fig = go.Figure(data=plot_data, layout=layout)
-    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -1025,7 +1023,6 @@ def plot_fitted(
     )
 
     fig = go.Figure(data=traces, layout=layout)
-    # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got `Figure`.
     return AxPlotConfig(data=fig, plot_type=AxPlotTypes.GENERIC)
 
 
@@ -1220,8 +1217,6 @@ def interact_fitted(
     """
 
     return AxPlotConfig(
-        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
-        #  `Figure`.
         data=interact_fitted_plotly(
             model=model,
             generator_runs_dict=generator_runs_dict,

--- a/ax/plot/slice.py
+++ b/ax/plot/slice.py
@@ -275,8 +275,6 @@ def plot_slice(
         AxPlotConfig: plot of objective vs. parameter value
     """
     return AxPlotConfig(
-        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
-        #  `Figure`.
         data=plot_slice_plotly(
             model=model,
             param_name=param_name,
@@ -582,8 +580,6 @@ def interact_slice(
     """
 
     return AxPlotConfig(
-        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
-        #  `Figure`.
         data=interact_slice_plotly(
             model=model,
             generator_runs_dict=generator_runs_dict,

--- a/ax/plot/trace.py
+++ b/ax/plot/trace.py
@@ -30,7 +30,7 @@ def map_data_single_trace_scatters(
     ylabel: str = "Trial performance",
     plot_stopping_marker: bool = False,
     opacity: float = 0.5,
-    trace_color: tuple[int] = COLORS.STEELBLUE.value,
+    trace_color: tuple[int, int, int] = COLORS.STEELBLUE.value,
     visible: bool = True,
 ) -> list[go.Scatter]:
     """Plot a single trial's trace from map data.
@@ -205,7 +205,7 @@ def map_data_multiple_metrics_dropdown_plotly(
 
 def mean_trace_scatter(
     y: npt.NDArray,
-    trace_color: tuple[int] = COLORS.STEELBLUE.value,
+    trace_color: tuple[int, int, int] = COLORS.STEELBLUE.value,
     legend_label: str = "mean",
     hover_labels: list[str] | None = None,
 ) -> go.Scatter:
@@ -238,7 +238,7 @@ def mean_trace_scatter(
 
 def sem_range_scatter(
     y: npt.NDArray,
-    trace_color: tuple[int] = COLORS.STEELBLUE.value,
+    trace_color: tuple[int, int, int] = COLORS.STEELBLUE.value,
     legend_label: str = "",
 ) -> tuple[go.Scatter, go.Scatter]:
     """Creates a graph object for trace of mean +/- 2 SEMs for y, across runs.
@@ -281,7 +281,7 @@ def sem_range_scatter(
 
 def mean_markers_scatter(
     y: npt.NDArray,
-    marker_color: tuple[int] = COLORS.LIGHT_PURPLE.value,
+    marker_color: tuple[int, int, int] = COLORS.LIGHT_PURPLE.value,
     legend_label: str = "",
     hover_labels: list[str] | None = None,
 ) -> go.Scatter:
@@ -317,7 +317,9 @@ def mean_markers_scatter(
 
 
 def optimum_objective_scatter(
-    optimum: float, num_iterations: int, optimum_color: tuple[int] = COLORS.ORANGE.value
+    optimum: float,
+    num_iterations: int,
+    optimum_color: tuple[int, int, int] = COLORS.ORANGE.value,
 ) -> go.Scatter:
     """Creates a graph object for the line representing optimal objective.
 
@@ -347,12 +349,12 @@ def optimization_trace_single_method_plotly(
     title: str = "",
     ylabel: str = "",
     hover_labels: list[str] | None = None,
-    trace_color: tuple[int] = COLORS.STEELBLUE.value,
-    optimum_color: tuple[int] = COLORS.ORANGE.value,
-    generator_change_color: tuple[int] = COLORS.TEAL.value,
+    trace_color: tuple[int, int, int] = COLORS.STEELBLUE.value,
+    optimum_color: tuple[int, int, int] = COLORS.ORANGE.value,
+    generator_change_color: tuple[int, int, int] = COLORS.TEAL.value,
     optimization_direction: str | None = "passthrough",
     plot_trial_points: bool = False,
-    trial_points_color: tuple[int] = COLORS.LIGHT_PURPLE.value,
+    trial_points_color: tuple[int, int, int] = COLORS.LIGHT_PURPLE.value,
     autoset_axis_limits: bool = True,
 ) -> go.Figure:
     """Plots an optimization trace with mean and 2 SEMs
@@ -482,12 +484,12 @@ def optimization_trace_single_method(
     title: str = "",
     ylabel: str = "",
     hover_labels: list[str] | None = None,
-    trace_color: tuple[int] = COLORS.STEELBLUE.value,
-    optimum_color: tuple[int] = COLORS.ORANGE.value,
-    generator_change_color: tuple[int] = COLORS.TEAL.value,
+    trace_color: tuple[int, int, int] = COLORS.STEELBLUE.value,
+    optimum_color: tuple[int, int, int] = COLORS.ORANGE.value,
+    generator_change_color: tuple[int, int, int] = COLORS.TEAL.value,
     optimization_direction: str | None = "passthrough",
     plot_trial_points: bool = False,
-    trial_points_color: tuple[int] = COLORS.LIGHT_PURPLE.value,
+    trial_points_color: tuple[int, int, int] = COLORS.LIGHT_PURPLE.value,
     autoset_axis_limits: bool = True,
 ) -> AxPlotConfig:
     """Plots an optimization trace with mean and 2 SEMs
@@ -521,8 +523,6 @@ def optimization_trace_single_method(
         AxPlotConfig: plot of the optimization trace with IQR
     """
     return AxPlotConfig(
-        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
-        #  `Figure`.
         data=optimization_trace_single_method_plotly(
             y=y,
             optimum=optimum,
@@ -548,8 +548,8 @@ def optimization_trace_all_methods(
     title: str = "",
     ylabel: str = "",
     hover_labels: list[str] | None = None,
-    trace_colors: list[tuple[int]] = DISCRETE_COLOR_SCALE,
-    optimum_color: tuple[int] = COLORS.ORANGE.value,
+    trace_colors: list[tuple[int, int, int]] = DISCRETE_COLOR_SCALE,
+    optimum_color: tuple[int, int, int] = COLORS.ORANGE.value,
 ) -> AxPlotConfig:
     """Plots a comparison of optimization traces with 2-SEM bands for multiple
     methods on the same problem.
@@ -599,8 +599,6 @@ def optimization_trace_all_methods(
     )
 
     return AxPlotConfig(
-        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
-        #  `Figure`.
         data=go.Figure(layout=layout, data=data),
         plot_type=AxPlotTypes.GENERIC,
     )
@@ -625,17 +623,13 @@ def optimization_times(
     fit_res: dict[str, str | list[float]] = {"name": "Fitting"}
     fit_res["mean"] = [np.mean(fit_times[m]) for m in methods]
     fit_res["2sems"] = [
-        # pyre-fixme[58]: `*` is not supported for operand types `int` and
-        #  `floating[typing.Any]`.
-        2 * np.std(fit_times[m]) / np.sqrt(len(fit_times[m]))
+        2 * float(np.std(fit_times[m])) / float(np.sqrt(len(fit_times[m])))
         for m in methods
     ]
     gen_res: dict[str, str | list[float]] = {"name": "Generation"}
     gen_res["mean"] = [np.mean(gen_times[m]) for m in methods]
     gen_res["2sems"] = [
-        # pyre-fixme[58]: `*` is not supported for operand types `int` and
-        #  `floating[typing.Any]`.
-        2 * np.std(gen_times[m]) / np.sqrt(len(gen_times[m]))
+        2 * float(np.std(gen_times[m])) / float(np.sqrt(len(gen_times[m])))
         for m in methods
     ]
     total_mean: list[float] = []
@@ -643,9 +637,7 @@ def optimization_times(
     for m in methods:
         totals = np.array(fit_times[m]) + np.array(gen_times[m])
         total_mean.append(np.mean(totals))
-        # pyre-fixme[58]: `*` is not supported for operand types `int` and
-        #  `floating[typing.Any]`.
-        total_2sems.append(2 * np.std(totals) / np.sqrt(len(totals)))
+        total_2sems.append(2 * float(np.std(totals)) / float(np.sqrt(len(totals))))
     total_res: dict[str, str | list[float]] = {
         "name": "Total",
         "mean": total_mean,
@@ -680,8 +672,6 @@ def optimization_times(
     )
 
     return AxPlotConfig(
-        # pyre-fixme[6]: For 1st argument expected `Dict[str, typing.Any]` but got
-        #  `Figure`.
         data=go.Figure(layout=layout, data=data),
         plot_type=AxPlotTypes.GENERIC,
     )


### PR DESCRIPTION
Summary:
Remove pyre-fixme/pyre-ignore suppression comments from 11 files across
several directories: plot/, analysis/, generation_strategy/, benchmark/,
metrics/, global_stopping/ (both source and test files).

Key fixes:
- Use `none_throws()` for Optional unwrapping
- Use `assert_is_instance()` for type narrowing
- Add proper type annotations (`AnalysisCard`, `SklearnDataset`, `TParamValue`)
- Use `float()` wrapping for numpy scalar arithmetic
- Use `npt.NDArray` instead of bare `np.ndarray`
- Use `int()` for cardinality() return values
- Fix `tuple[int]` -> `tuple[int, int, int]` for RGB color tuples
- Annotate `DISCRETE_COLOR_SCALE` global
- Remove stale pyre-fixme comments on `AxPlotConfig(data=fig, ...)` calls

Differential Revision: D95264987


