### PR TITLE
Enable autoescaping in report templates to prevent HTML injection

### DIFF
--- a/ax/utils/report/render.py
+++ b/ax/utils/report/render.py
@@ -10,7 +10,7 @@ import os
 import pkgutil
 
 from ax.plot.render import _js_requires, _load_css_resource as _load_plot_css_resource
-from jinja2 import Environment, FunctionLoader
+from jinja2 import Environment, FunctionLoader, select_autoescape
 
 REPORT_MODULE_NAME = "ax.utils.report"
 
@@ -142,4 +142,7 @@ def _load_html_template(name: str) -> str:
 
 
 def _get_jinja_environment() -> Environment:
-    return Environment(loader=FunctionLoader(_load_html_template))
+    return Environment(
+        loader=FunctionLoader(_load_html_template),
+        autoescape=select_autoescape(["html", "xml"]),
+    )

--- a/ax/utils/report/resources/simple_template.html
+++ b/ax/utils/report/resources/simple_template.html
@@ -4,6 +4,6 @@
 {% extends "base_template.html" %}
 {% block content %}
 {% for element in html_elements %}
-{{element}}
+{{element | safe }}
 {% endfor %}
 {% endblock %}

--- a/ax/utils/report/resources/sufficient_statistic.html
+++ b/ax/utils/report/resources/sufficient_statistic.html
@@ -16,7 +16,7 @@
     <h2>{{cell.caption}}</h2>
   </div>
   <div class="cell_body">
-    {{cell.html}}
+    {{ cell.html | safe }}
   </div>
   {% endif %}
   {% endfor %}

--- a/scripts/test_report_autoescape_smoke.py
+++ b/scripts/test_report_autoescape_smoke.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]  # repo root
+REPORT_RES = ROOT / "ax" / "utils" / "report" / "resources"
+
+# ---- Stub ax.plot.render so render.py can import without importing full ax package ----
+ax_mod = types.ModuleType("ax")
+ax_plot_mod = types.ModuleType("ax.plot")
+ax_plot_render_mod = types.ModuleType("ax.plot.render")
+
+ax_plot_render_mod._js_requires = lambda *a, **k: ""
+ax_plot_render_mod._load_css_resource = lambda *a, **k: ""
+
+sys.modules["ax"] = ax_mod
+sys.modules["ax.plot"] = ax_plot_mod
+sys.modules["ax.plot.render"] = ax_plot_render_mod
+
+# ---- Load ax/utils/report/render.py by file path ----
+render_path = (ROOT / "ax" / "utils" / "report" / "render.py").resolve()
+spec = importlib.util.spec_from_file_location("ax_utils_report_render", render_path)
+assert spec and spec.loader, "Failed to load module spec"
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+# ---- Monkeypatch ALL pkgutil-based loaders so we don't need package resources ----
+mod._load_css_resource = lambda: ""
+mod._load_plot_css_resource = lambda: ""
+mod._load_html_template = lambda name: (REPORT_RES / name).read_text(encoding="utf-8")
+
+# ---- Now test escaping ----
+payload = "<img src=x onerror=alert('AX_XSS_TEST')>"
+html = mod.render_report_elements(payload, [mod.p_html("hello")])
+
+assert "<img" not in html, "FAIL: raw HTML injection still present"
+assert "&lt;img" in html, "FAIL: expected escaped payload not found"
+
+print("[OK] experiment_name is escaped (autoescape enabled)")


### PR DESCRIPTION
## Summary
This PR enables Jinja2 autoescaping for Ax HTML report rendering and adjusts templates to preserve intended safe HTML insertion.

## Security impact
Without autoescape, user-controlled strings (e.g. experiment_name) can be rendered into HTML without escaping, enabling HTML injection (XSS) when exported HTML reports are opened/viewed.

## Changes
- Enable Jinja2 autoescape for HTML/XML templates in `ax/utils/report/render.py` using `select_autoescape(["html","xml"])`.
- Keep `html_elements` rendering behavior by explicitly marking elements as safe in `simple_template.html` (`{{ element | safe }}`).
- Mark `cell.html` as safe in `sufficient_statistic.html` to preserve existing behavior where `cell.html` is expected to contain trusted HTML.

## Test / verification
Added a lightweight smoke test (`scripts/test_report_autoescape_smoke.py`) that:
- loads `ax/utils/report/render.py` without importing the full Ax stack,
- renders a report with an HTML payload as experiment_name,
- asserts the payload is escaped.

Run:
```bash
python scripts/test_report_autoescape_smoke.py
```

## Notes
This is a defense-in-depth hardening. If `cell.html` can be influenced by untrusted input, it should be sanitized upstream before being passed into the report templates.