### PR TITLE
Fix SearchSpaceAnalysis crash on non-numeric ordered choice parameters

### DIFF
--- a/ax/analysis/healthcheck/search_space_analysis.py
+++ b/ax/analysis/healthcheck/search_space_analysis.py
@@ -139,7 +139,11 @@ def search_space_boundary_proportions(
         if isinstance(parameter, RangeParameter):
             lower = parameter.lower
             upper = parameter.upper
-        elif isinstance(parameter, ChoiceParameter) and parameter.is_ordered:
+        elif (
+            isinstance(parameter, ChoiceParameter)
+            and parameter.is_ordered
+            and all(isinstance(v, (int, float)) for v in parameter.values)
+        ):
             values = [
                 assert_is_instance(v, Union[int, float]) for v in parameter.values
             ]

--- a/ax/analysis/healthcheck/tests/test_search_space_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_search_space_analysis.py
@@ -178,3 +178,35 @@ class TestSearchSpaceAnalysis(TestCase):
                 )
             )
         )
+
+    def test_search_space_boundary_proportions_string_ordered_choice(self) -> None:
+        """Test that ordered choice parameters with string values are skipped."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="float_range",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=1.0,
+                    upper=6.0,
+                ),
+                ChoiceParameter(
+                    name="string_ordered_choice",
+                    parameter_type=ParameterType.STRING,
+                    values=["option_a", "option_b", "option_c"],
+                    is_ordered=True,
+                ),
+            ],
+        )
+
+        parameterizations: list[dict[str, None | bool | float | int | str]] = [
+            {"float_range": 1.0, "string_ordered_choice": "option_a"},
+            {"float_range": 3.0, "string_ordered_choice": "option_b"},
+        ]
+
+        # Should not raise -- string ordered choice should be skipped
+        df = search_space_boundary_proportions(
+            search_space=ss, parameterizations=parameterizations
+        )
+        # Only float_range boundaries should be present (lower and upper)
+        self.assertEqual(len(df), 2)
+        self.assertTrue(all("float_range" in b for b in df["Boundary"].values))


### PR DESCRIPTION
Summary:
`search_space_boundary_proportions` assumed all ordered `ChoiceParameter` values
are numeric (`int | float`), but some expeirments have ordered string values (somehow?). When this happens, the SearchSpaceBoundary check breaks ([example](https://www.internalfb.com/ax/experiment/p_wyt_directional_v7_ax/experiment)). 

This diff adds a check that all values are numeric before entering that branch,
so non-numeric ordered choice parameters are skipped like unordered ones.

Reviewed By: ItsMrLin

Differential Revision: D94979372


