### PR TITLE
Replace em-dash with ASCII in UtilityProgressionPlot subtitle

### DIFF
--- a/ax/analysis/plotly/utility_progression.py
+++ b/ax/analysis/plotly/utility_progression.py
@@ -151,7 +151,7 @@ class UtilityProgressionAnalysis(Analysis):
             subtitle = (
                 "Shows the hypervolume of the Pareto frontier achieved so far across "
                 f"completed trials. {_TRACE_INDEX_EXPLANATION} The y-axis shows "
-                "cumulative best hypervolume—only improvements, so flat "
+                "cumulative best hypervolume -- only improvements, so flat "
                 "segments indicate trials that didn't improve the frontier. "
                 "Hypervolume measures the volume of objective space dominated by the "
                 f"Pareto frontier. "


### PR DESCRIPTION
Summary:
The UtilityProgressionPlot subtitle for MOO experiments contained a literal
em-dash (U+2014), which cannot be encoded in latin-1. When GAIN's daemon
scheduler finalizes a multi-objective experiment and saves the analysis card
to MySQL, MySQLdb encodes strings using latin-1 and raises
UnicodeEncodeError, causing the experiment to be marked as FAILED despite
all trials succeeding.

Replace the em-dash with " -- " to stay within the latin-1 character set.

Reviewed By: bernardbeckerman

Differential Revision: D95828166


