### PR TITLE
Add trial_type support to base Experiment metric methods (#5002)

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -9,10 +9,10 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from copy import deepcopy
 from logging import Logger
-from typing import Any, cast, SupportsFloat, TYPE_CHECKING
+from typing import Any, Callable, cast, SupportsFloat, TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
@@ -206,7 +206,7 @@ def extract_objective_thresholds(
     objective_thresholds: TRefPoint,
     objective: Objective,
     outcomes: list[str],
-    experiment: Experiment,
+    metric_name_to_signature: Mapping[str, str],
 ) -> npt.NDArray | None:
     """Extracts objective thresholds' values, in the order of `outcomes`.
 
@@ -222,7 +222,7 @@ def extract_objective_thresholds(
         objective_thresholds: Objective thresholds to extract values from.
         objective: The corresponding Objective, for validation purposes.
         outcomes: n-length list of names of metrics.
-        experiment: The experiment, used to map metric names to signatures.
+        metric_name_to_signature: Mapping from metric names to signatures.
 
     Returns:
         (n,) array of thresholds
@@ -232,7 +232,7 @@ def extract_objective_thresholds(
 
     objective_threshold_dict = {}
     for ot in objective_thresholds:
-        ot_signature = experiment.get_metric(ot.metric_names[0]).signature
+        ot_signature = metric_name_to_signature[ot.metric_names[0]]
         if ot.relative:
             raise ValueError(
                 f"Objective {ot_signature} has a relative threshold that "
@@ -242,7 +242,7 @@ def extract_objective_thresholds(
 
     # Check that all thresholds correspond to a metric.
     obj_metric_signatures = [
-        experiment.get_metric(name).signature for name in objective.metric_names
+        metric_name_to_signature[name] for name in objective.metric_names
     ]
     if set(objective_threshold_dict.keys()).difference(set(obj_metric_signatures)):
         raise ValueError(
@@ -259,7 +259,9 @@ def extract_objective_thresholds(
 
 
 def extract_objective_weights(
-    objective: Objective, outcomes: list[str], experiment: Experiment
+    objective: Objective,
+    outcomes: list[str],
+    metric_name_to_signature: Mapping[str, str],
 ) -> npt.NDArray:
     """Extract a weights for objectives.
 
@@ -277,7 +279,7 @@ def extract_objective_weights(
     Args:
         objective: Objective to extract weights from.
         outcomes: n-length list of metric signatures.
-        experiment: The experiment, used to map metric names to signatures.
+        metric_name_to_signature: Mapping from metric names to signatures.
 
     Returns:
         n-length array of weights.
@@ -287,13 +289,15 @@ def extract_objective_weights(
     # metric_weights returns sign-encoded (name, weight) tuples for all
     # objective types (single, scalarized, multi).
     for obj_metric_name, obj_weight in objective.metric_weights:
-        sig = experiment.get_metric(obj_metric_name).signature
+        sig = metric_name_to_signature[obj_metric_name]
         objective_weights[outcomes.index(sig)] = obj_weight
     return objective_weights
 
 
 def extract_objective_weight_matrix(
-    objective: Objective, outcomes: list[str], experiment: Experiment
+    objective: Objective,
+    outcomes: list[str],
+    metric_name_to_signature: Mapping[str, str],
 ) -> npt.NDArray:
     """Extract a 2D weight matrix for objectives.
 
@@ -308,6 +312,7 @@ def extract_objective_weight_matrix(
     Args:
         objective: Objective to extract weights from.
         outcomes: n-length list of signatures of metrics.
+        metric_name_to_signature: Mapping from metric names to signatures.
 
     Returns:
         ``(n_objectives, n)`` array of weights.
@@ -319,19 +324,23 @@ def extract_objective_weight_matrix(
                 extract_objective_weights(
                     objective=Objective(expression=f"{weight} * {name}"),
                     outcomes=outcomes,
-                    experiment=experiment,
+                    metric_name_to_signature=metric_name_to_signature,
                 )
             )
         return np.stack(rows, axis=0)
     else:
         # Single row – covers Objective and ScalarizedObjective
-        return extract_objective_weights(objective, outcomes, experiment).reshape(1, -1)
+        return extract_objective_weights(
+            objective=objective,
+            outcomes=outcomes,
+            metric_name_to_signature=metric_name_to_signature,
+        ).reshape(1, -1)
 
 
 def extract_outcome_constraints(
     outcome_constraints: list[OutcomeConstraint],
     outcomes: list[str],
-    experiment: Experiment,
+    metric_name_to_signature: Mapping[str, str],
 ) -> TBounds:
     if len(outcome_constraints) == 0:
         return None
@@ -342,10 +351,10 @@ def extract_outcome_constraints(
         s = 1 if c.op == ComparisonOp.LEQ else -1
         if isinstance(c, ScalarizedOutcomeConstraint):
             for c_metric_name, c_weight in c.metric_weights:
-                j = outcomes.index(experiment.get_metric(c_metric_name).signature)
+                j = outcomes.index(metric_name_to_signature[c_metric_name])
                 A[i, j] = s * c_weight
         else:
-            j = outcomes.index(experiment.get_metric(c.metric_names[0]).signature)
+            j = outcomes.index(metric_name_to_signature[c.metric_names[0]])
             A[i, j] = s
         b[i, 0] = s * c.bound
     return (A, b)
@@ -658,18 +667,18 @@ def get_pareto_frontier_and_configs(
     objective_weights = extract_objective_weight_matrix(
         objective=optimization_config.objective,
         outcomes=adapter.outcomes,
-        experiment=adapter._experiment,
+        metric_name_to_signature=adapter.metric_name_to_signature,
     )
     outcome_constraints = extract_outcome_constraints(
         outcome_constraints=optimization_config.outcome_constraints,
         outcomes=adapter.outcomes,
-        experiment=adapter._experiment,
+        metric_name_to_signature=adapter.metric_name_to_signature,
     )
     obj_t = extract_objective_thresholds(
         objective_thresholds=optimization_config.objective_thresholds,
         objective=optimization_config.objective,
         outcomes=adapter.outcomes,
-        experiment=adapter._experiment,
+        metric_name_to_signature=adapter.metric_name_to_signature,
     )
     if obj_t is not None:
         obj_t = array_to_tensor(obj_t)
@@ -1128,7 +1137,7 @@ def observation_features_to_array(
 def feasible_hypervolume(
     optimization_config: MultiObjectiveOptimizationConfig,
     values: dict[str, npt.NDArray],
-    experiment: Experiment,
+    metric_name_to_signature: Mapping[str, str],
 ) -> npt.NDArray:
     """Compute the feasible hypervolume each iteration.
 
@@ -1137,26 +1146,26 @@ def feasible_hypervolume(
         values: Dictionary from metric name to array of value at each
             iteration (each array is `n`-dim). If optimization config contains
             outcome constraints, values for them must be present in `values`.
-        experiment: The experiment, used to map metric names to signatures.
+        metric_name_to_signature: Mapping from metric names to signatures.
 
     Returns: Array of feasible hypervolumes.
     """
     # Get objective at each iteration
     obj_threshold_dict = {
-        experiment.get_metric(ot.metric_names[0]).signature: ot.bound
+        metric_name_to_signature[ot.metric_names[0]]: ot.bound
         for ot in optimization_config.objective_thresholds
     }
     obj_metric_names = optimization_config.objective.metric_names
-    obj_metrics = [experiment.get_metric(name) for name in obj_metric_names]
-    f_vals = np.hstack([values[m.signature].reshape(-1, 1) for m in obj_metrics])
-    obj_thresholds = np.array([obj_threshold_dict[m.signature] for m in obj_metrics])
+    obj_metric_sigs = [metric_name_to_signature[name] for name in obj_metric_names]
+    f_vals = np.hstack([values[sig].reshape(-1, 1) for sig in obj_metric_sigs])
+    obj_thresholds = np.array([obj_threshold_dict[sig] for sig in obj_metric_sigs])
     # Set infeasible points to be the objective threshold
     for oc in optimization_config.outcome_constraints:
         if oc.relative:
             raise ValueError(
                 "Benchmark aggregation does not support relative constraints"
             )
-        oc_sig = experiment.get_metric(oc.metric_names[0]).signature
+        oc_sig = metric_name_to_signature[oc.metric_names[0]]
         g = values[oc_sig]
         feas = g <= oc.bound if oc.op == ComparisonOp.LEQ else g >= oc.bound
         f_vals[~feas] = obj_thresholds

--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -190,6 +190,9 @@ class Adapter:
         )
         self._experiment_properties: dict[str, Any] = experiment._properties
         self._experiment: Experiment = experiment
+        self._metric_name_to_signature: dict[str, str] = {
+            name: metric.signature for name, metric in self._experiment.metrics.items()
+        }
 
         if self._optimization_config is None:
             self._optimization_config = experiment.optimization_config
@@ -524,6 +527,11 @@ class Adapter:
     def metric_signatures(self) -> set[str]:
         """Metric signatures present in training data."""
         return self._metric_signatures
+
+    @property
+    def metric_name_to_signature(self) -> dict[str, str]:
+        """Mapping from metric names to their signatures."""
+        return self._metric_name_to_signature
 
     @property
     def model_space(self) -> SearchSpace:

--- a/ax/adapter/cross_validation.py
+++ b/ax/adapter/cross_validation.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from logging import Logger
 from typing import cast, NamedTuple
 from warnings import warn
@@ -21,7 +21,6 @@ from ax.adapter.base import Adapter
 from ax.adapter.data_utils import ExperimentData
 from ax.adapter.observation_utils import unwrap_observation_data
 from ax.adapter.torch import TorchAdapter
-from ax.core.experiment import Experiment
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import OptimizationConfig
 from ax.exceptions.core import UnsupportedError
@@ -574,7 +573,7 @@ def assess_model_fit(
 def has_good_opt_config_model_fit(
     optimization_config: OptimizationConfig,
     assess_model_fit_result: AssessModelFitResult,
-    experiment: Experiment,
+    metric_name_to_signature: Mapping[str, str],
 ) -> bool:
     """Assess model fit for given diagnostics results across the optimization
     config metrics
@@ -587,7 +586,7 @@ def has_good_opt_config_model_fit(
     Args:
         optimization_config: Objective/Outcome constraint metrics to assess
         assess_model_fit_result: Output of assess_model_fit
-        experiment: The experiment, used to map metric names to signatures.
+        metric_name_to_signature: Mapping from metric names to signatures.
 
     Returns:
         Two dictionaries, one for good metrics, one for bad metrics, each
@@ -597,7 +596,7 @@ def has_good_opt_config_model_fit(
     # Bad fit criteria: Any objective metrics are poorly fit
     # TODO[]: Incl. outcome constraints in assessment
     has_good_opt_config_fit = all(
-        experiment.get_metric(name).signature
+        metric_name_to_signature[name]
         in assess_model_fit_result.good_fit_metrics_to_fisher_score
         for name in optimization_config.objective.metric_names
     )

--- a/ax/adapter/discrete.py
+++ b/ax/adapter/discrete.py
@@ -164,17 +164,19 @@ class DiscreteAdapter(Adapter):
             outcome_constraints = None
         else:
             validate_transformed_optimization_config(
-                optimization_config, self.outcomes, experiment=self._experiment
+                optimization_config,
+                self.outcomes,
+                metric_name_to_signature=self.metric_name_to_signature,
             )
             objective_weights = extract_objective_weights(
                 objective=optimization_config.objective,
                 outcomes=self.outcomes,
-                experiment=self._experiment,
+                metric_name_to_signature=self.metric_name_to_signature,
             )
             outcome_constraints = extract_outcome_constraints(
                 outcome_constraints=optimization_config.outcome_constraints,
                 outcomes=self.outcomes,
-                experiment=self._experiment,
+                metric_name_to_signature=self.metric_name_to_signature,
             )
 
         # Get fixed features

--- a/ax/adapter/tests/test_adapter_utils.py
+++ b/ax/adapter/tests/test_adapter_utils.py
@@ -43,7 +43,6 @@ from ax.utils.common.constants import Keys
 from ax.utils.common.hash_utils import compute_lilo_input_hash
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
-    get_branin_experiment,
     get_experiment_with_observations,
     get_hierarchical_search_space,
     get_search_space_for_range_values,
@@ -79,11 +78,8 @@ class TestAdapterUtils(TestCase):
                 ),
             ],
         )
-        experiment = Experiment(
-            search_space=SearchSpace(parameters=[]),
-            optimization_config=optimization_config,
-            tracking_metrics=[mc],
-        )
+        # For plain Metric objects, signature == name.
+        metric_name_to_signature = {m.name: m.name for m in [ma, mb, mc]}
         feas_hv = feasible_hypervolume(
             optimization_config,
             values={
@@ -112,7 +108,7 @@ class TestAdapterUtils(TestCase):
                     ]
                 ),
             },
-            experiment=experiment,
+            metric_name_to_signature=metric_name_to_signature,
         )
         self.assertEqual(list(feas_hv), [0.0, 0.0, 1.0, 1.0])
 
@@ -544,24 +540,34 @@ class TestAdapterUtils(TestCase):
     def test_extract_objective_weight_matrix(self) -> None:
         m1, m2, m3 = Metric(name="m1"), Metric(name="m2"), Metric(name="m3")
         outcomes = ["m1", "m2", "m3"]
-        experiment = get_branin_experiment()
-        experiment.add_metric(m1)
-        experiment.add_metric(m2)
-        experiment.add_metric(m3)
+        # For plain Metric objects, signature == name.
+        metric_name_to_signature = {name: name for name in outcomes}
 
         # Single Objective: one row, nonzero only in matching column.
         obj = Objective(metric=m1, minimize=False)
-        result = extract_objective_weight_matrix(obj, outcomes, experiment)
+        result = extract_objective_weight_matrix(
+            objective=obj,
+            outcomes=outcomes,
+            metric_name_to_signature=metric_name_to_signature,
+        )
         np.testing.assert_array_equal(result, [[1.0, 0.0, 0.0]])
 
         # Minimization flips the sign.
         obj_min = Objective(metric=m2, minimize=True)
-        result = extract_objective_weight_matrix(obj_min, outcomes, experiment)
+        result = extract_objective_weight_matrix(
+            objective=obj_min,
+            outcomes=outcomes,
+            metric_name_to_signature=metric_name_to_signature,
+        )
         np.testing.assert_array_equal(result, [[0.0, -1.0, 0.0]])
 
         # ScalarizedObjective: single row with multiple nonzero entries.
         scal = ScalarizedObjective(metrics=[m1, m3], weights=[0.3, 0.7], minimize=False)
-        result = extract_objective_weight_matrix(scal, outcomes, experiment)
+        result = extract_objective_weight_matrix(
+            objective=scal,
+            outcomes=outcomes,
+            metric_name_to_signature=metric_name_to_signature,
+        )
         np.testing.assert_array_almost_equal(result, [[0.3, 0.0, 0.7]])
 
         # MultiObjective: one row per sub-objective.
@@ -571,7 +577,11 @@ class TestAdapterUtils(TestCase):
                 Objective(metric=m3, minimize=True),
             ]
         )
-        result = extract_objective_weight_matrix(multi, outcomes, experiment)
+        result = extract_objective_weight_matrix(
+            objective=multi,
+            outcomes=outcomes,
+            metric_name_to_signature=metric_name_to_signature,
+        )
         np.testing.assert_array_equal(result, [[1.0, 0.0, 0.0], [0.0, 0.0, -1.0]])
 
     def test_get_fresh_pairwise_trial_indices(self) -> None:

--- a/ax/adapter/tests/test_cross_validation.py
+++ b/ax/adapter/tests/test_cross_validation.py
@@ -477,7 +477,7 @@ class CrossValidationTest(TestCase):
         has_good_fit = has_good_opt_config_model_fit(
             optimization_config=optimization_config,
             assess_model_fit_result=assess_model_fit_result,
-            experiment=self.experiment,
+            metric_name_to_signature={"m1": "m1", "m2": "m2"},
         )
         self.assertFalse(has_good_fit)
 
@@ -493,7 +493,7 @@ class CrossValidationTest(TestCase):
         has_good_fit = has_good_opt_config_model_fit(
             optimization_config=optimization_config,
             assess_model_fit_result=assess_model_fit_result,
-            experiment=self.experiment,
+            metric_name_to_signature={"m1": "m1", "m2": "m2"},
         )
         self.assertFalse(has_good_fit)
 
@@ -507,7 +507,7 @@ class CrossValidationTest(TestCase):
         has_good_fit = has_good_opt_config_model_fit(
             optimization_config=optimization_config,
             assess_model_fit_result=assess_model_fit_result,
-            experiment=self.experiment,
+            metric_name_to_signature={"m1": "m1", "m2": "m2"},
         )
         self.assertFalse(has_good_fit)
 

--- a/ax/adapter/tests/test_utils.py
+++ b/ax/adapter/tests/test_utils.py
@@ -18,7 +18,6 @@ from ax.adapter.adapter_utils import (
 from ax.adapter.registry import Generators
 from ax.core.arm import Arm
 from ax.core.evaluations_to_data import raw_evaluations_to_data
-from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
@@ -28,7 +27,6 @@ from ax.core.outcome_constraint import (
     OutcomeConstraint,
     ScalarizedOutcomeConstraint,
 )
-from ax.core.search_space import SearchSpace
 from ax.core.types import ComparisonOp
 from ax.core.utils import get_pending_observation_features
 from ax.utils.common.constants import Keys
@@ -80,17 +78,25 @@ class TestAdapterUtils(TestCase):
 
     def test_extract_outcome_constraints(self) -> None:
         outcomes = ["m1", "m2", "m3"]
-        experiment = Experiment(
-            search_space=SearchSpace(parameters=[]),
-            tracking_metrics=[Metric(name) for name in outcomes],
-        )
+        # For plain Metric objects, signature == name.
+        metric_name_to_signature = {name: name for name in outcomes}
         # pass no outcome constraints
-        self.assertIsNone(extract_outcome_constraints([], outcomes, experiment))
+        self.assertIsNone(
+            extract_outcome_constraints(
+                outcome_constraints=[],
+                outcomes=outcomes,
+                metric_name_to_signature=metric_name_to_signature,
+            )
+        )
 
         outcome_constraints = [
             OutcomeConstraint(metric=Metric("m1"), op=ComparisonOp.LEQ, bound=0)
         ]
-        res = extract_outcome_constraints(outcome_constraints, outcomes, experiment)
+        res = extract_outcome_constraints(
+            outcome_constraints=outcome_constraints,
+            outcomes=outcomes,
+            metric_name_to_signature=metric_name_to_signature,
+        )
         self.assertEqual(res[0].shape, (1, 3))
         self.assertListEqual(list(res[0][0]), [1, 0, 0])
         self.assertEqual(res[1][0][0], 0)
@@ -104,7 +110,11 @@ class TestAdapterUtils(TestCase):
                 bound=1,
             ),
         ]
-        res = extract_outcome_constraints(outcome_constraints, outcomes, experiment)
+        res = extract_outcome_constraints(
+            outcome_constraints=outcome_constraints,
+            outcomes=outcomes,
+            metric_name_to_signature=metric_name_to_signature,
+        )
         self.assertEqual(res[0].shape, (2, 3))
         self.assertListEqual(list(res[0][0]), [1, 0, 0])
         self.assertListEqual(list(res[0][1]), [0, -0.5, -0.5])
@@ -113,10 +123,8 @@ class TestAdapterUtils(TestCase):
 
     def test_extract_objective_thresholds(self) -> None:
         outcomes = ["m1", "m2", "m3", "m4"]
-        experiment = Experiment(
-            search_space=SearchSpace(parameters=[]),
-            tracking_metrics=[Metric(name) for name in outcomes],
-        )
+        # For plain Metric objects, signature == name.
+        metric_name_to_signature = {name: name for name in outcomes}
         objective = MultiObjective(
             objectives=[
                 Objective(metric=Metric(name), minimize=False) for name in outcomes[:3]
@@ -138,7 +146,7 @@ class TestAdapterUtils(TestCase):
                 objective_thresholds=[],
                 objective=objective,
                 outcomes=outcomes,
-                experiment=experiment,
+                metric_name_to_signature=metric_name_to_signature,
             )
         )
 
@@ -147,7 +155,7 @@ class TestAdapterUtils(TestCase):
             objective_thresholds=objective_thresholds,
             objective=objective,
             outcomes=outcomes,
-            experiment=experiment,
+            metric_name_to_signature=metric_name_to_signature,
         )
         expected_obj_t_not_nan = np.array([2.0, 3.0, 4.0])
         self.assertTrue(np.array_equal(obj_t[:3], expected_obj_t_not_nan[:3]))
@@ -159,7 +167,7 @@ class TestAdapterUtils(TestCase):
             objective_thresholds=objective_thresholds[:2],
             objective=objective,
             outcomes=outcomes,
-            experiment=experiment,
+            metric_name_to_signature=metric_name_to_signature,
         )
         self.assertTrue(np.array_equal(obj_t[:2], expected_obj_t_not_nan[:2]))
         self.assertTrue(np.isnan(obj_t[-2:]).all())
@@ -171,7 +179,7 @@ class TestAdapterUtils(TestCase):
                 objective_thresholds=objective_thresholds,
                 objective=objective2,
                 outcomes=outcomes,
-                experiment=experiment,
+                metric_name_to_signature=metric_name_to_signature,
             )
 
         # Works with a single objective, single threshold
@@ -179,7 +187,7 @@ class TestAdapterUtils(TestCase):
             objective_thresholds=objective_thresholds[:1],
             objective=objective2,
             outcomes=outcomes,
-            experiment=experiment,
+            metric_name_to_signature=metric_name_to_signature,
         )
         self.assertEqual(obj_t[0], 2.0)
         self.assertTrue(np.all(np.isnan(obj_t[1:])))
@@ -194,7 +202,7 @@ class TestAdapterUtils(TestCase):
                 objective_thresholds=objective_thresholds,
                 objective=objective,
                 outcomes=outcomes,
-                experiment=experiment,
+                metric_name_to_signature=metric_name_to_signature,
             )
         objective_thresholds[2] = ObjectiveThreshold(
             metric=Metric("m3"), op=ComparisonOp.LEQ, bound=3, relative=True
@@ -204,7 +212,7 @@ class TestAdapterUtils(TestCase):
                 objective_thresholds=objective_thresholds,
                 objective=objective,
                 outcomes=outcomes,
-                experiment=experiment,
+                metric_name_to_signature=metric_name_to_signature,
             )
 
     def test_observation_data_to_array(self) -> None:

--- a/ax/adapter/torch.py
+++ b/ax/adapter/torch.py
@@ -1019,17 +1019,19 @@ class TorchAdapter(Adapter):
             )
 
         validate_transformed_optimization_config(
-            optimization_config, self.outcomes, experiment=self._experiment
+            optimization_config,
+            self.outcomes,
+            metric_name_to_signature=self.metric_name_to_signature,
         )
         objective_weights = extract_objective_weight_matrix(
             objective=optimization_config.objective,
             outcomes=self.outcomes,
-            experiment=self._experiment,
+            metric_name_to_signature=self.metric_name_to_signature,
         )
         outcome_constraints = extract_outcome_constraints(
             outcome_constraints=optimization_config.outcome_constraints,
             outcomes=self.outcomes,
-            experiment=self._experiment,
+            metric_name_to_signature=self.metric_name_to_signature,
         )
         pruning_target_point = arm_to_np_array(
             arm=optimization_config.pruning_target_parameterization,
@@ -1045,7 +1047,7 @@ class TorchAdapter(Adapter):
                 objective_thresholds=optimization_config.objective_thresholds,
                 objective=optimization_config.objective,
                 outcomes=self.outcomes,
-                experiment=self._experiment,
+                metric_name_to_signature=self.metric_name_to_signature,
             )
         else:
             objective_thresholds = None
@@ -1272,14 +1274,14 @@ class TorchAdapter(Adapter):
 def validate_transformed_optimization_config(
     optimization_config: OptimizationConfig,
     outcomes: list[str],
-    experiment: Experiment,
+    metric_name_to_signature: Mapping[str, str],
 ) -> None:
     """Validate optimization config against generator fitted outcomes.
 
     Args:
         optimization_config: Config to validate.
         outcomes: List of metric names w/ valid generator fits.
-        experiment: The experiment to look up metrics from.
+        metric_name_to_signature: Mapping from metric names to signatures.
 
     Raises if:
             1. In the modeling layer, absolute constraints are required, however,
@@ -1300,21 +1302,20 @@ def validate_transformed_optimization_config(
             )
         if isinstance(c, ScalarizedOutcomeConstraint):
             for c_name in c.metric_names:
-                c_metric = experiment.get_metric(c_name)
-                if c_metric.signature not in outcomes:
+                c_sig = metric_name_to_signature[c_name]
+                if c_sig not in outcomes:
                     raise DataRequiredError(
                         f"Scalarized constraint metric component "
-                        f"{c_metric.signature} not found in fitted data."
+                        f"{c_sig} not found in fitted data."
                     )
         else:
-            c_metric = experiment.get_metric(c.metric_names[0])
-            if c_metric.signature not in outcomes:
+            c_sig = metric_name_to_signature[c.metric_names[0]]
+            if c_sig not in outcomes:
                 raise DataRequiredError(
-                    f"Outcome constraint metric {c_metric.signature} not found in "
-                    "fitted data."
+                    f"Outcome constraint metric {c_sig} not found in fitted data."
                 )
     obj_metric_signatures = [
-        experiment.get_metric(name).signature
+        metric_name_to_signature[name]
         for name in optimization_config.objective.metric_names
     ]
     for obj_metric_signature in obj_metric_signatures:

--- a/ax/adapter/transforms/base.py
+++ b/ax/adapter/transforms/base.py
@@ -98,9 +98,9 @@ class Transform:
         Falls back to using the metric name directly if no adapter is available
         (which is correct for simple Metric objects where name == signature).
         """
-        a = adapter or self.adapter
-        if a is not None:
-            return a._experiment.get_metric(metric_name).signature
+        resolved = adapter or self.adapter
+        if resolved is not None:
+            return resolved.metric_name_to_signature[metric_name]
         return metric_name
 
     def transform_search_space(self, search_space: SearchSpace) -> SearchSpace:

--- a/ax/adapter/transforms/bilog_y.py
+++ b/ax/adapter/transforms/bilog_y.py
@@ -68,10 +68,10 @@ class BilogY(Transform):
         if adapter is not None and adapter._optimization_config is not None:
             # TODO @deriksson: Add support for relative outcome constraints
             self.metric_to_bound: dict[str, float] = {
-                metric.signature: oc.bound
+                adapter.metric_name_to_signature[name]: oc.bound
                 for oc in adapter._optimization_config.outcome_constraints
                 if not oc.relative
-                for metric in adapter._experiment.get_metrics(oc.metric_names)
+                for name in oc.metric_names
             }
         else:
             self.metric_to_bound = {}

--- a/ax/adapter/transforms/derelativize.py
+++ b/ax/adapter/transforms/derelativize.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from logging import Logger
 from typing import TYPE_CHECKING
 
@@ -15,7 +16,6 @@ import numpy as np
 from ax.adapter.observation_utils import unwrap_observation_data
 from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.ivw import ivw_metric_merge
-from ax.core.experiment import Experiment
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
@@ -94,7 +94,7 @@ class Derelativize(Transform):
                 raw_f=raw_f,
                 pred_f=f,
                 pred_cov=cov,
-                experiment=adapter._experiment,
+                metric_name_to_signature=adapter.metric_name_to_signature,
             )
         else:
             f = raw_f
@@ -193,18 +193,18 @@ def _warn_if_raw_sq_is_out_of_CI(
     raw_f: TModelMean,
     pred_f: TModelMean,
     pred_cov: TModelCov,
-    experiment: Experiment,
+    metric_name_to_signature: Mapping[str, str],
 ) -> None:
     """Warn if the raw SQ values for relative constraint metrics deviate
     by more than 1.96 standard deviation from the predictions.
     """
     relative_metrics = {
-        experiment.get_metric(oc.metric_names[0]).signature
+        metric_name_to_signature[oc.metric_names[0]]
         for oc in optimization_config.all_constraints
         if oc.relative and not isinstance(oc, ScalarizedOutcomeConstraint)
     }.union(
         {
-            experiment.get_metric(name).signature
+            metric_name_to_signature[name]
             for oc in optimization_config.all_constraints
             if oc.relative and isinstance(oc, ScalarizedOutcomeConstraint)
             for name in oc.metric_names

--- a/ax/adapter/transforms/objective_as_constraint.py
+++ b/ax/adapter/transforms/objective_as_constraint.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -31,7 +32,6 @@ from pyre_extensions import none_throws
 if TYPE_CHECKING:
     # import as module to make sphinx-autodoc-typehints happy
     from ax import adapter as adapter_module  # noqa F401
-    from ax.core.experiment import Experiment
 
 
 logger: logging.Logger = get_logger(__name__)
@@ -157,7 +157,7 @@ class ObjectiveAsConstraint(Transform):
                 row=row,
                 constraints=outcome_constraints,
                 sq_data=sq_data,
-                experiment=adapter._experiment,
+                metric_name_to_signature=adapter.metric_name_to_signature,
             ):
                 return False
 
@@ -271,7 +271,7 @@ def _is_point_feasible(
     row: pd.Series,
     constraints: list[OutcomeConstraint],
     sq_data: ObservationData | None = None,
-    experiment: Experiment | None = None,
+    metric_name_to_signature: Mapping[str, str] | None = None,
 ) -> bool:
     """Check if a single observation satisfies all outcome constraints.
 
@@ -285,16 +285,16 @@ def _is_point_feasible(
         sq_data: Status quo observation data, required for evaluating
             relative constraints. If None and a relative constraint is
             encountered, the constraint is skipped.
-        experiment: The experiment, used to look up metric signatures from
-            metric names. If None, the metric name is used as the signature.
+        metric_name_to_signature: Mapping from metric names to signatures.
+            If None, the metric name is used as the signature.
 
     Returns:
         True if the point satisfies all constraints, False otherwise.
     """
     for constraint in constraints:
         metric_name = constraint.metric_names[0]
-        if experiment is not None:
-            metric_sig = experiment.get_metric(metric_name).signature
+        if metric_name_to_signature is not None:
+            metric_sig = metric_name_to_signature[metric_name]
         else:
             metric_sig = metric_name
         try:

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -160,6 +160,11 @@ class Experiment(Base):
         self._trial_type_to_runner: dict[str | None, Runner | None] = {
             default_trial_type: runner
         }
+        # Maps each trial type to the set of metric names relevant to that type.
+        # This is the complement of _trial_type_to_runner and is used for
+        # multi-type experiments where different metrics apply to different
+        # trial types.
+        self._trial_type_to_metric_names: dict[str, set[str]] = {}
         # Used to keep track of whether any trials on the experiment
         # specify a TTL. Since trials need to be checked for their TTL's
         # expiration often, having this attribute helps avoid unnecessary
@@ -1919,6 +1924,57 @@ class Experiment(Base):
         with multiple trial types, use the MultiTypeExperiment class.
         """
         return self._default_trial_type
+
+    @property
+    def trial_type_to_metric_names(self) -> dict[str, set[str]]:
+        """Map from trial type to the set of metric names relevant to that
+        type.
+
+        Returns a shallow copy of the internal mapping.
+        """
+        return dict(self._trial_type_to_metric_names)
+
+    @property
+    def metric_to_trial_type(self) -> dict[str, str]:
+        """Map each metric name to its associated trial type.
+
+        Computed from ``_trial_type_to_metric_names``. When a
+        ``default_trial_type`` is set and an ``optimization_config`` exists,
+        optimization config metrics are pinned to the default trial type.
+        """
+        result: dict[str, str] = {}
+        for trial_type, metric_names in self._trial_type_to_metric_names.items():
+            for name in metric_names:
+                result[name] = trial_type
+        opt_config = self._optimization_config
+        default_trial_type = self._default_trial_type
+        if default_trial_type is not None and opt_config is not None:
+            for metric_name in opt_config.metric_names:
+                result[metric_name] = default_trial_type
+        return result
+
+    def metrics_for_trial_type(self, trial_type: str) -> list[Metric]:
+        """Return the metrics associated with a given trial type.
+
+        Args:
+            trial_type: The trial type to look up metrics for.
+
+        Raises:
+            ValueError: If the trial type is not supported.
+        """
+        if not self.supports_trial_type(trial_type):
+            raise ValueError(f"Trial type `{trial_type}` is not supported.")
+        valid_names = self._trial_type_to_metric_names.get(trial_type, set())
+        return [self._metrics[name] for name in valid_names if name in self._metrics]
+
+    @property
+    def default_trials(self) -> set[int]:
+        """Return the indices for trials of the default type."""
+        return {
+            idx
+            for idx, trial in self.trials.items()
+            if trial.trial_type == self.default_trial_type
+        }
 
     def runner_for_trial_type(self, trial_type: str | None) -> Runner | None:
         """The default runner to use for a given trial type.

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -201,6 +201,10 @@ class Experiment(Base):
         # a naming collision occurs.
         for m in [*(tracking_metrics or []), *(metrics or [])]:
             self._metrics[m.name] = m
+            if self._default_trial_type is not None:
+                self._trial_type_to_metric_names.setdefault(
+                    self._default_trial_type, set()
+                ).add(m.name)
 
         # call setters defined below
         self.status_quo = status_quo
@@ -582,6 +586,12 @@ class Experiment(Base):
                     "but not found on experiment. Add it first with add_metric()."
                 )
         self._optimization_config = optimization_config
+        default_trial_type = self._default_trial_type
+        if default_trial_type is not None:
+            for metric_name in optimization_config.metric_names:
+                self._trial_type_to_metric_names.setdefault(
+                    default_trial_type, set()
+                ).add(metric_name)
 
     @property
     def is_moo_problem(self) -> bool:
@@ -834,7 +844,7 @@ class Experiment(Base):
             )
         return self._metrics[name]
 
-    def add_metric(self, metric: Metric) -> Self:
+    def add_metric(self, metric: Metric, trial_type: str | None = None) -> Self:
         """Add a new metric to the experiment.
 
         Metrics that are not referenced by the experiment's optimization config
@@ -843,54 +853,98 @@ class Experiment(Base):
 
         Args:
             metric: Metric to be added.
+            trial_type: If provided, associates the metric with this trial type.
+                When ``None`` and a ``default_trial_type`` is set, defaults to
+                the default trial type.
         """
         if metric.name in self._metrics:
             raise ValueError(
                 f"Metric `{metric.name}` already defined on experiment. "
                 "Use `update_metric` to update an existing metric definition."
             )
+        if trial_type is None and self._default_trial_type is not None:
+            trial_type = self._default_trial_type
+        if trial_type is not None:
+            if not self.supports_trial_type(trial_type):
+                raise ValueError(f"`{trial_type}` is not a supported trial type.")
+            self._trial_type_to_metric_names.setdefault(trial_type, set()).add(
+                metric.name
+            )
         self._metrics[metric.name] = metric
         return self
 
-    def add_tracking_metric(self, metric: Metric) -> Self:
+    def add_tracking_metric(
+        self,
+        metric: Metric,
+        trial_type: str | None = None,
+        canonical_name: str | None = None,
+    ) -> Self:
         """*Deprecated.* Use ``add_metric`` instead."""
         warnings.warn(
             "add_tracking_metric is deprecated. Use add_metric instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.add_metric(metric)
+        return self.add_metric(metric, trial_type=trial_type)
 
-    def add_tracking_metrics(self, metrics: list[Metric]) -> Experiment:
+    def add_tracking_metrics(
+        self,
+        metrics: list[Metric],
+        metrics_to_trial_types: dict[str, str] | None = None,
+        canonical_names: dict[str, str] | None = None,
+    ) -> Experiment:
         """*Deprecated.* Use ``add_metric`` instead."""
         warnings.warn(
             "add_tracking_metrics is deprecated. Use add_metric instead.",
             DeprecationWarning,
             stacklevel=2,
         )
+        metrics_to_trial_types = metrics_to_trial_types or {}
         for metric in metrics:
-            self.add_metric(metric)
+            canonical_name = (canonical_names or {}).get(metric.name)
+            self.add_tracking_metric(
+                metric=metric,
+                trial_type=metrics_to_trial_types.get(metric.name),
+                canonical_name=canonical_name,
+            )
         return self
 
-    def update_metric(self, metric: Metric) -> Self:
+    def update_metric(self, metric: Metric, trial_type: str | None = None) -> Self:
         """Redefine a metric that already exists on the experiment.
 
         Args:
             metric: New metric definition.
+            trial_type: If provided, reassociates the metric with this trial
+                type. When ``None``, keeps the metric's existing trial type.
         """
         if metric.name not in self._metrics:
             raise ValueError(f"Metric `{metric.name}` doesn't exist on experiment.")
+        if trial_type is not None:
+            if not self.supports_trial_type(trial_type):
+                raise ValueError(f"`{trial_type}` is not a supported trial type.")
+            # Remove from any existing trial type set
+            for names in self._trial_type_to_metric_names.values():
+                names.discard(metric.name)
+            # Add to new trial type set
+            self._trial_type_to_metric_names.setdefault(trial_type, set()).add(
+                metric.name
+            )
         self._metrics[metric.name] = metric
         return self
 
-    def update_tracking_metric(self, metric: Metric) -> Experiment:
+    def update_tracking_metric(
+        self,
+        metric: Metric,
+        trial_type: str | None = None,
+        canonical_name: str | None = None,
+    ) -> Experiment:
         """*Deprecated.* Use ``update_metric`` instead."""
         warnings.warn(
             "update_tracking_metric is deprecated. Use update_metric instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.update_metric(metric)
+        return self.update_metric(metric, trial_type=trial_type)
 
     def remove_metric(self, metric_name: str) -> Self:
         """Remove a metric from the experiment.
@@ -911,6 +965,9 @@ class Experiment(Base):
                 f"Metric `{metric_name}` is referenced by the optimization config "
                 "and cannot be removed. Update the optimization config first."
             )
+        # Clean up _trial_type_to_metric_names
+        for names in self._trial_type_to_metric_names.values():
+            names.discard(metric_name)
         del self._metrics[metric_name]
         return self
 

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -96,15 +96,16 @@ class MultiTypeExperiment(Experiment):
             default_data_type=default_data_type,
         )
 
-        # Ensure tracking metrics are registered in _metric_to_trial_type.
+        # Ensure tracking metrics are registered in _metric_to_trial_type
+        # and _trial_type_to_metric_names.
         # super().__init__ sets self._metrics directly, bypassing
         # add_tracking_metric, so tracking metrics won't be in
         # _metric_to_trial_type yet.
         for m in tracking_metrics or []:
             if m.name not in self._metric_to_trial_type:
-                self._metric_to_trial_type[m.name] = none_throws(
-                    self._default_trial_type
-                )
+                tt = none_throws(self._default_trial_type)
+                self._metric_to_trial_type[m.name] = tt
+                self._trial_type_to_metric_names.setdefault(tt, set()).add(m.name)
 
     def add_trial_type(self, trial_type: str, runner: Runner) -> Self:
         """Add a new trial_type to be supported by this experiment.
@@ -129,9 +130,9 @@ class MultiTypeExperiment(Experiment):
         for metric_name in optimization_config.metric_names:
             # Optimization config metrics are required to be the default trial type
             # currently. TODO: remove that restriction (T202797235)
-            self._metric_to_trial_type[metric_name] = none_throws(
-                self.default_trial_type
-            )
+            tt = none_throws(self.default_trial_type)
+            self._metric_to_trial_type[metric_name] = tt
+            self._trial_type_to_metric_names.setdefault(tt, set()).add(metric_name)
 
     def update_runner(self, trial_type: str, runner: Runner) -> Self:
         """Update the default runner for an existing trial_type.
@@ -166,7 +167,9 @@ class MultiTypeExperiment(Experiment):
             raise ValueError(f"`{trial_type}` is not a supported trial type.")
 
         super().add_tracking_metric(metric)
-        self._metric_to_trial_type[metric.name] = none_throws(trial_type)
+        tt = none_throws(trial_type)
+        self._metric_to_trial_type[metric.name] = tt
+        self._trial_type_to_metric_names.setdefault(tt, set()).add(metric.name)
         if canonical_name is not None:
             self._metric_to_canonical_name[metric.name] = canonical_name
         return self
@@ -242,7 +245,14 @@ class MultiTypeExperiment(Experiment):
             raise ValueError(f"`{trial_type}` is not a supported trial type.")
 
         super().update_tracking_metric(metric)
-        self._metric_to_trial_type[metric.name] = none_throws(trial_type)
+        # Remove from old trial type set
+        old_tt = self._metric_to_trial_type.get(metric.name)
+        if old_tt is not None and old_tt in self._trial_type_to_metric_names:
+            self._trial_type_to_metric_names[old_tt].discard(metric.name)
+        # Add to new trial type set
+        tt = none_throws(trial_type)
+        self._metric_to_trial_type[metric.name] = tt
+        self._trial_type_to_metric_names.setdefault(tt, set()).add(metric.name)
         if canonical_name is not None:
             self._metric_to_canonical_name[metric.name] = canonical_name
         return self
@@ -251,6 +261,11 @@ class MultiTypeExperiment(Experiment):
     def remove_tracking_metric(self, metric_name: str) -> Self:
         if metric_name not in self._metrics:
             raise ValueError(f"Metric `{metric_name}` doesn't exist on experiment.")
+
+        # Clean up _trial_type_to_metric_names
+        old_tt = self._metric_to_trial_type.get(metric_name)
+        if old_tt is not None and old_tt in self._trial_type_to_metric_names:
+            self._trial_type_to_metric_names[old_tt].discard(metric_name)
 
         # Required fields
         del self._metrics[metric_name]
@@ -294,46 +309,6 @@ class MultiTypeExperiment(Experiment):
         ]
         # Invoke parent's fetch method using only metrics for this trial_type
         return super()._fetch_trial_data(trial.index, metrics=metrics, **kwargs)
-
-    @property
-    def default_trials(self) -> set[int]:
-        """Return the indicies for trials of the default type."""
-        return {
-            idx
-            for idx, trial in self.trials.items()
-            if trial.trial_type == self.default_trial_type
-        }
-
-    @property
-    def metric_to_trial_type(self) -> dict[str, str]:
-        """Map metrics to trial types.
-
-        Adds in default trial type for OC metrics to custom defined trial types..
-        """
-        opt_config_types = {
-            metric_name: self.default_trial_type
-            for metric_name in self.optimization_config.metric_names
-        }
-        return {**opt_config_types, **self._metric_to_trial_type}
-
-    # -- Overridden functions from Base Experiment Class --
-    @property
-    def default_trial_type(self) -> str | None:
-        """Default trial type assigned to trials in this experiment."""
-        return self._default_trial_type
-
-    def metrics_for_trial_type(self, trial_type: str) -> list[Metric]:
-        """The default runner to use for a given trial type.
-
-        Looks up the appropriate runner for this trial type in the trial_type_to_runner.
-        """
-        if not self.supports_trial_type(trial_type):
-            raise ValueError(f"Trial type `{trial_type}` is not supported.")
-        return [
-            self.metrics[metric_name]
-            for metric_name, metric_trial_type in self._metric_to_trial_type.items()
-            if metric_trial_type == trial_type
-        ]
 
     def supports_trial_type(self, trial_type: str | None) -> bool:
         """Whether this experiment allows trials of the given type.

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -96,16 +96,13 @@ class MultiTypeExperiment(Experiment):
             default_data_type=default_data_type,
         )
 
-        # Ensure tracking metrics are registered in _metric_to_trial_type
-        # and _trial_type_to_metric_names.
-        # super().__init__ sets self._metrics directly, bypassing
-        # add_tracking_metric, so tracking metrics won't be in
-        # _metric_to_trial_type yet.
+        # Ensure tracking metrics are registered in _metric_to_trial_type.
+        # The base __init__ handles _trial_type_to_metric_names.
         for m in tracking_metrics or []:
             if m.name not in self._metric_to_trial_type:
-                tt = none_throws(self._default_trial_type)
-                self._metric_to_trial_type[m.name] = tt
-                self._trial_type_to_metric_names.setdefault(tt, set()).add(m.name)
+                self._metric_to_trial_type[m.name] = none_throws(
+                    self._default_trial_type
+                )
 
     def add_trial_type(self, trial_type: str, runner: Runner) -> Self:
         """Add a new trial_type to be supported by this experiment.
@@ -127,12 +124,11 @@ class MultiTypeExperiment(Experiment):
     def optimization_config(self, optimization_config: OptimizationConfig) -> None:
         # pyre-fixme[16]: `Optional` has no attribute `fset`.
         Experiment.optimization_config.fset(self, optimization_config)
+        # Base setter handles _trial_type_to_metric_names; update legacy dict.
         for metric_name in optimization_config.metric_names:
-            # Optimization config metrics are required to be the default trial type
-            # currently. TODO: remove that restriction (T202797235)
-            tt = none_throws(self.default_trial_type)
-            self._metric_to_trial_type[metric_name] = tt
-            self._trial_type_to_metric_names.setdefault(tt, set()).add(metric_name)
+            self._metric_to_trial_type[metric_name] = none_throws(
+                self.default_trial_type
+            )
 
     def update_runner(self, trial_type: str, runner: Runner) -> Self:
         """Update the default runner for an existing trial_type.
@@ -163,54 +159,10 @@ class MultiTypeExperiment(Experiment):
         """
         if trial_type is None:
             trial_type = self._default_trial_type
-        if not self.supports_trial_type(trial_type):
-            raise ValueError(f"`{trial_type}` is not a supported trial type.")
-
-        super().add_tracking_metric(metric)
-        tt = none_throws(trial_type)
-        self._metric_to_trial_type[metric.name] = tt
-        self._trial_type_to_metric_names.setdefault(tt, set()).add(metric.name)
+        self.add_metric(metric, trial_type=trial_type)
+        self._metric_to_trial_type[metric.name] = none_throws(trial_type)
         if canonical_name is not None:
             self._metric_to_canonical_name[metric.name] = canonical_name
-        return self
-
-    def add_tracking_metrics(
-        self,
-        metrics: list[Metric],
-        metrics_to_trial_types: dict[str, str] | None = None,
-        canonical_names: dict[str, str] | None = None,
-    ) -> Experiment:
-        """Add a list of new metrics to the experiment.
-
-        If any of the metrics are already defined on the experiment,
-        we raise an error and don't add any of them to the experiment
-
-        Args:
-            metrics: Metrics to be added.
-            metrics_to_trial_types: The mapping from metric names to corresponding
-                trial types for each metric. If provided, the metrics will be
-                added to their trial types. If not provided, then the default
-                trial type will be used.
-            canonical_names: A mapping of metric names to their
-                canonical names(The default metrics for which the metrics are
-                proxies.)
-
-        Returns:
-            The experiment with the added metrics.
-        """
-        metrics_to_trial_types = metrics_to_trial_types or {}
-        canonical_name = None
-        for metric in metrics:
-            if canonical_names is not None:
-                canonical_name = none_throws(canonical_names).get(metric.name, None)
-
-            self.add_tracking_metric(
-                metric=metric,
-                trial_type=metrics_to_trial_types.get(
-                    metric.name, self._default_trial_type
-                ),
-                canonical_name=canonical_name,
-            )
         return self
 
     def update_tracking_metric(
@@ -233,47 +185,17 @@ class MultiTypeExperiment(Experiment):
             trial_type = self._metric_to_trial_type.get(
                 metric.name, self._default_trial_type
             )
-        oc = self.optimization_config
-        oc_metric_names = oc.metric_names if oc else set()
-        if metric.name in oc_metric_names and trial_type != self._default_trial_type:
-            raise ValueError(
-                f"Metric `{metric.name}` must remain a "
-                f"`{self._default_trial_type}` metric because it is part of the "
-                "optimization_config."
-            )
-        elif not self.supports_trial_type(trial_type):
-            raise ValueError(f"`{trial_type}` is not a supported trial type.")
-
-        super().update_tracking_metric(metric)
-        # Remove from old trial type set
-        old_tt = self._metric_to_trial_type.get(metric.name)
-        if old_tt is not None and old_tt in self._trial_type_to_metric_names:
-            self._trial_type_to_metric_names[old_tt].discard(metric.name)
-        # Add to new trial type set
-        tt = none_throws(trial_type)
-        self._metric_to_trial_type[metric.name] = tt
-        self._trial_type_to_metric_names.setdefault(tt, set()).add(metric.name)
+        self.update_metric(metric, trial_type=trial_type)
+        self._metric_to_trial_type[metric.name] = none_throws(trial_type)
         if canonical_name is not None:
             self._metric_to_canonical_name[metric.name] = canonical_name
         return self
 
-    @copy_doc(Experiment.remove_tracking_metric)
-    def remove_tracking_metric(self, metric_name: str) -> Self:
-        if metric_name not in self._metrics:
-            raise ValueError(f"Metric `{metric_name}` doesn't exist on experiment.")
-
-        # Clean up _trial_type_to_metric_names
-        old_tt = self._metric_to_trial_type.get(metric_name)
-        if old_tt is not None and old_tt in self._trial_type_to_metric_names:
-            self._trial_type_to_metric_names[old_tt].discard(metric_name)
-
-        # Required fields
-        del self._metrics[metric_name]
-        del self._metric_to_trial_type[metric_name]
-
-        # Optional
-        if metric_name in self._metric_to_canonical_name:
-            del self._metric_to_canonical_name[metric_name]
+    @copy_doc(Experiment.remove_metric)
+    def remove_metric(self, metric_name: str) -> Self:
+        super().remove_metric(metric_name)
+        self._metric_to_trial_type.pop(metric_name, None)
+        self._metric_to_canonical_name.pop(metric_name, None)
         return self
 
     @copy_doc(Experiment.fetch_data)

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -125,12 +125,6 @@ class MultiTypeExperimentTest(TestCase):
         with self.assertRaises(ValueError):
             self.experiment.remove_tracking_metric("m3")
 
-        # Try to change optimization metric to non-primary trial type
-        with self.assertRaises(ValueError):
-            self.experiment.update_tracking_metric(
-                BraninMetric("m1", ["x1", "x2"]), "type2"
-            )
-
         # Update metric definition for trial_type that doesn't exist
         with self.assertRaises(ValueError):
             self.experiment.update_tracking_metric(

--- a/ax/orchestration/tests/test_orchestrator.py
+++ b/ax/orchestration/tests/test_orchestrator.py
@@ -1544,11 +1544,10 @@ class TestAxOrchestrator(TestCase):
                 optimization_config=get_branin_multi_objective_optimization_config()
             )
 
-        # We override the optimization config but not objectives, so an error
-        # results as expected, but only much deeper in the stack.
-        # Python <3.14: "'branin_a' is not in list"
-        # Python 3.14+: "list.index(x): x not in list"
-        with self.assertRaisesRegex(KeyError, "not found"):
+        # We override the optimization config but not objectives, so a
+        # KeyError results when extract_objective_weights tries to look up
+        # the MOO metric name in metric_name_to_signature.
+        with self.assertRaisesRegex(KeyError, "branin_a"):
             orchestrator.get_pareto_optimal_parameters(
                 optimization_config=get_branin_multi_objective_optimization_config(
                     has_objective_thresholds=True

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -720,6 +720,12 @@ def multi_type_experiment_from_json(
     experiment._metric_to_trial_type = _metric_to_trial_type
     experiment._trial_type_to_runner = _trial_type_to_runner
 
+    # Rebuild _trial_type_to_metric_names from _metric_to_trial_type
+    trial_type_to_metric_names: dict[str, set[str]] = {}
+    for metric_name, trial_type in _metric_to_trial_type.items():
+        trial_type_to_metric_names.setdefault(trial_type, set()).add(metric_name)
+    experiment._trial_type_to_metric_names = trial_type_to_metric_names
+
     _load_experiment_info(
         exp=experiment,
         exp_info=experiment_info,


### PR DESCRIPTION
Summary:

Phase 2 of moving MultiTypeExperiment features into base Experiment.

Updates the base Experiment metric management methods (`add_metric`, `update_metric`, `remove_metric`) to accept an optional `trial_type` parameter. When provided, metrics are associated with the specified trial type in `_trial_type_to_metric_names`. The `__init__` and `optimization_config` setter also now register metrics when `default_trial_type` is set.

The deprecated wrappers (`add_tracking_metric`, `add_tracking_metrics`, `update_tracking_metric`) now accept and pass through `trial_type` and `canonical_name` parameters.

On MultiTypeExperiment, overrides are simplified to delegate to the base class methods:
- `add_tracking_metric` delegates to `self.add_metric()`
- `add_tracking_metrics` override removed (inherited from base)
- `update_tracking_metric` delegates to `self.update_metric()`
- `remove_tracking_metric` replaced with `remove_metric` override

Differential Revision: D94986440


