### PR TITLE
Update return type annotation to match botorch API change

### DIFF
--- a/ax/utils/testing/mock.py
+++ b/ax/utils/testing/mock.py
@@ -51,7 +51,9 @@ def mock_botorch_optimize_context_manager(
     def minimal_fit_fully_bayesian(*args: Any, **kwargs: Any) -> None:
         fit_fully_bayesian_model_nuts(*args, **_get_minimal_mcmc_kwargs(**kwargs))
 
-    def minimal_mixed_optimizer(*args: Any, **kwargs: Any) -> tuple[Tensor, Tensor]:
+    def minimal_mixed_optimizer(
+        *args: Any, **kwargs: Any
+    ) -> tuple[Tensor, Tensor | None]:
         # BoTorch's `mock_optimize_context_manager` also has some mocks for this,
         # but the full set of mocks applied here cannot be covered by that.
         kwargs["raw_samples"] = 2


### PR DESCRIPTION
Summary:
Update the return type annotation of `minimal_mixed_optimizer` wrapper function to `tuple[Tensor, Tensor | None]` to match the updated return type of `optimize_acqf_mixed_alternating` from botorch.

The upstream botorch function signature changed in D96154880 to return `tuple[Tensor, Tensor | None]` instead of `tuple[Tensor, Tensor]`, which caused the type-checking test to fail.

Differential Revision: D96186306


