### PR TITLE
Update astral-sh/setup-uv from v5 to v7 in all workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -50,7 +50,7 @@ jobs:
         git merge origin/main
         # To avoid a large number of commits we don't push this sync commit to github until a new release.
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/reusable_tutorials.yml
+++ b/.github/workflows/reusable_tutorials.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
## Summary
- Updates `astral-sh/setup-uv` from v5 to v7 across all GitHub Actions workflows
- Resolves Node.js 20 deprecation warning: "Node.js 20 actions are deprecated and will be forced to run on Node.js 24 starting June 2, 2026"

## Test plan
- CI workflows should pass with the updated action version