### PR TITLE
Update healthcheck statuses (#5020)

### DIFF
--- a/ax/analysis/healthcheck/baseline_improvement.py
+++ b/ax/analysis/healthcheck/baseline_improvement.py
@@ -231,9 +231,7 @@ class BaselineImprovementAnalysis(Analysis):
         num_total = len(comparison_list)
 
         status = (
-            HealthcheckStatus.PASS
-            if num_improved == num_total
-            else HealthcheckStatus.WARNING
+            HealthcheckStatus.INFO if num_improved > 0 else HealthcheckStatus.WARNING
         )
 
         # Build subtitle

--- a/ax/analysis/healthcheck/can_generate_candidates.py
+++ b/ax/analysis/healthcheck/can_generate_candidates.py
@@ -76,8 +76,8 @@ class CanGenerateCandidatesAnalysis(Analysis):
                     status = HealthcheckStatus.FAIL
                     title_status = "Failure"
                 else:
-                    status = HealthcheckStatus.WARNING
-                    title_status = "Warning"
+                    status = HealthcheckStatus.INFO
+                    title_status = "Info"
                 subtitle += self.LAST_RUN_TEMPLATE.format(days=days_since_last_run)
         else:
             subtitle += f"{self.reason}"

--- a/ax/analysis/healthcheck/complexity_rating.py
+++ b/ax/analysis/healthcheck/complexity_rating.py
@@ -142,9 +142,9 @@ class ComplexityRatingAnalysis(Analysis):
         if tier == "Standard":
             status = HealthcheckStatus.PASS
         elif tier == "Advanced":
-            status = HealthcheckStatus.WARNING
+            status = HealthcheckStatus.INFO
         else:  # Unsupported
-            status = HealthcheckStatus.FAIL
+            status = HealthcheckStatus.WARNING
 
         # Create dataframe with experiment summary
         df = pd.DataFrame(

--- a/ax/analysis/healthcheck/early_stopping_healthcheck.py
+++ b/ax/analysis/healthcheck/early_stopping_healthcheck.py
@@ -233,7 +233,7 @@ class EarlyStoppingAnalysis(Analysis):
                 "auto_early_stopping_config='standard' or configure an "
                 "early_stopping_strategy_config."
             ),
-            status=HealthcheckStatus.PASS,
+            status=HealthcheckStatus.INFO,
             df=df,
         )
 
@@ -391,7 +391,7 @@ class EarlyStoppingAnalysis(Analysis):
             title=EARLY_STOPPING_SAVINGS_TITLE,
             subtitle=subtitle,
             df=df,
-            status=HealthcheckStatus.PASS,
+            status=HealthcheckStatus.INFO,
         )
 
     def _report_early_stopping_nudge(
@@ -467,7 +467,7 @@ class EarlyStoppingAnalysis(Analysis):
             title=title,
             subtitle=subtitle,
             df=df,
-            status=HealthcheckStatus.WARNING,
+            status=HealthcheckStatus.INFO,
             potential_savings=savings_pct,
             best_metric=metric.name,
         )

--- a/ax/analysis/healthcheck/should_generate_candidates.py
+++ b/ax/analysis/healthcheck/should_generate_candidates.py
@@ -40,9 +40,7 @@ class ShouldGenerateCandidates(Analysis):
         adapter: Adapter | None = None,
     ) -> HealthcheckAnalysisCard:
         status = (
-            HealthcheckStatus.PASS
-            if self.should_generate
-            else HealthcheckStatus.WARNING
+            HealthcheckStatus.PASS if self.should_generate else HealthcheckStatus.INFO
         )
         return create_healthcheck_analysis_card(
             name=self.__class__.__name__,

--- a/ax/analysis/healthcheck/tests/test_baseline_improvement.py
+++ b/ax/analysis/healthcheck/tests/test_baseline_improvement.py
@@ -61,11 +61,11 @@ class TestBaselineImprovementAnalysis(TestCase):
         exp.attach_data(Data(df=pd.DataFrame(rows)))
 
     def test_status_outcomes(self) -> None:
-        """Test PASS/WARNING status based on improvement."""
+        """Test INFO/WARNING status based on improvement."""
         # minimize=True: lower is better
         test_cases = [
             # (baseline_mean, comparison_mean, expected_status, description)
-            (100.0, 50.0, HealthcheckStatus.PASS, "improved (lower)"),
+            (100.0, 50.0, HealthcheckStatus.INFO, "improved (lower)"),
             (50.0, 100.0, HealthcheckStatus.WARNING, "not improved (higher)"),
         ]
 
@@ -83,7 +83,7 @@ class TestBaselineImprovementAnalysis(TestCase):
                 self.assertEqual(card.get_status(), expected_status)
 
     def test_multi_objective_partial_improvement(self) -> None:
-        """Test WARNING status when only some objectives improve."""
+        """Test INFO status when only some objectives improve."""
         # minimize=True for both objectives (lower is better):
         # branin_a: 100 -> 50, improved (decreased)
         # branin_b: 50 -> 100, NOT improved (increased)
@@ -102,7 +102,7 @@ class TestBaselineImprovementAnalysis(TestCase):
         )
         card = analysis.compute(experiment=self.moo_experiment)
 
-        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+        self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
         self.assertIn("1 out of 2", card.subtitle)
 
     def test_documentation_link(self) -> None:

--- a/ax/analysis/healthcheck/tests/test_can_generate_candidates.py
+++ b/ax/analysis/healthcheck/tests/test_can_generate_candidates.py
@@ -57,10 +57,10 @@ class TestCanGenerateCandidates(TestCase):
             reason="The data is borked.",
             days_till_fail=2,
         ).compute(experiment=experiment, generation_strategy=None)
-        # THEN it is a WARNING
-        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+        # THEN it is INFO
+        self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
         self.assertEqual(card.name, "CanGenerateCandidatesAnalysis")
-        self.assertEqual(card.title, "Ax Candidate Generation Warning")
+        self.assertEqual(card.title, "Ax Candidate Generation Info")
         self.assertEqual(
             card.subtitle,
             (
@@ -71,11 +71,11 @@ class TestCanGenerateCandidates(TestCase):
                 "LAST TRIAL RUN: 1 day(s) ago"
             ),
         )
-        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+        self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
         self.assertDictEqual(
             card.get_aditional_attrs(),
             {
-                "status": HealthcheckStatus.WARNING,
+                "status": HealthcheckStatus.INFO,
                 "reason": "The data is borked.",
             },
         )

--- a/ax/analysis/healthcheck/tests/test_complexity_rating.py
+++ b/ax/analysis/healthcheck/tests/test_complexity_rating.py
@@ -65,8 +65,8 @@ class TestComplexityRatingAnalysis(TestCase):
 
     def test_parameter_counts(self) -> None:
         test_cases = [
-            (60, HealthcheckStatus.WARNING, "Advanced", "60 tunable parameter(s)"),
-            (250, HealthcheckStatus.FAIL, "Unsupported", "250 tunable parameter(s)"),
+            (60, HealthcheckStatus.INFO, "Advanced", "60 tunable parameter(s)"),
+            (250, HealthcheckStatus.WARNING, "Unsupported", "250 tunable parameter(s)"),
         ]
 
         for num_params, expected_status, expected_tier, expected_msg in test_cases:
@@ -92,8 +92,8 @@ class TestComplexityRatingAnalysis(TestCase):
 
     def test_objectives_count(self) -> None:
         test_cases = [
-            (3, HealthcheckStatus.WARNING, "Advanced", "3 objectives"),
-            (5, HealthcheckStatus.FAIL, "Unsupported", "5 objectives"),
+            (3, HealthcheckStatus.INFO, "Advanced", "3 objectives"),
+            (5, HealthcheckStatus.WARNING, "Unsupported", "5 objectives"),
         ]
 
         for num_objs, expected_status, expected_tier, expected_msg in test_cases:
@@ -135,7 +135,7 @@ class TestComplexityRatingAnalysis(TestCase):
                 options=self.options, tier_metadata=self.tier_metadata
             ).compute(experiment=self.experiment)
 
-            self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+            self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
             self.assertIn("Advanced", card.subtitle)
             self.assertIn("3 outcome constraints", card.subtitle)
 
@@ -159,7 +159,7 @@ class TestComplexityRatingAnalysis(TestCase):
                 options=self.options, tier_metadata=self.tier_metadata
             ).compute(experiment=self.experiment)
 
-            self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+            self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
             self.assertIn("Advanced", card.subtitle)
             self.assertIn("3 parameter constraints", card.subtitle)
 
@@ -181,14 +181,14 @@ class TestComplexityRatingAnalysis(TestCase):
                     options=options, tier_metadata=self.tier_metadata
                 ).compute(experiment=self.experiment)
 
-                self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+                self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
                 self.assertIn("Advanced", card.subtitle)
                 self.assertIn(expected_msg, card.subtitle)
 
     def test_trial_counts(self) -> None:
         test_cases = [
-            (300, HealthcheckStatus.WARNING, "Advanced", "300 total trials"),
-            (600, HealthcheckStatus.FAIL, "Unsupported", "600 total trials"),
+            (300, HealthcheckStatus.INFO, "Advanced", "300 total trials"),
+            (600, HealthcheckStatus.WARNING, "Unsupported", "600 total trials"),
         ]
 
         for max_trials, expected_status, expected_tier, expected_msg in test_cases:
@@ -236,7 +236,7 @@ class TestComplexityRatingAnalysis(TestCase):
                     options=options, tier_metadata=tier_metadata
                 ).compute(experiment=self.experiment)
 
-                self.assertEqual(card.get_status(), HealthcheckStatus.FAIL)
+                self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
                 self.assertIn("Unsupported", card.subtitle)
                 self.assertIn(expected_msg, card.subtitle)
 
@@ -260,7 +260,7 @@ class TestComplexityRatingAnalysis(TestCase):
             options=self.options, tier_metadata=self.tier_metadata
         ).compute(experiment=self.experiment)
 
-        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+        self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
         self.assertIn("Advanced", card.subtitle)
         self.assertIn("unordered choice parameter(s)", card.subtitle)
 
@@ -282,7 +282,7 @@ class TestComplexityRatingAnalysis(TestCase):
             options=self.options, tier_metadata=self.tier_metadata
         ).compute(experiment=self.experiment)
 
-        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+        self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
         self.assertIn("Advanced", card.subtitle)
         self.assertIn("60 binary tunable parameter(s)", card.subtitle)
 
@@ -305,7 +305,7 @@ class TestComplexityRatingAnalysis(TestCase):
             options=options, tier_metadata=tier_metadata
         ).compute(experiment=experiment)
 
-        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+        self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
         self.assertIn("Advanced", card.subtitle)
         self.assertIn("60 tunable parameter(s)", card.subtitle)
         self.assertIn("300 total trials", card.subtitle)

--- a/ax/analysis/healthcheck/tests/test_early_stopping_healthcheck.py
+++ b/ax/analysis/healthcheck/tests/test_early_stopping_healthcheck.py
@@ -177,7 +177,7 @@ class TestEarlyStoppingAnalysis(TestCase):
                 return_value=mock_savings,
             ):
                 card = healthcheck.compute(experiment=self.experiment)
-                self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+                self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
                 self.assertIn("25%", card.subtitle)
 
     def test_validate_applicable_state(self) -> None:
@@ -261,7 +261,7 @@ class TestEarlyStoppingAnalysis(TestCase):
             healthcheck = EarlyStoppingAnalysis(auto_early_stopping_config="disabled")
             card = healthcheck.compute(experiment=self.experiment)
 
-            self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
+            self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
             self.assertIn("auto_early_stopping_config='disabled'", card.subtitle)
 
         with self.subTest("standard"):
@@ -269,7 +269,7 @@ class TestEarlyStoppingAnalysis(TestCase):
             healthcheck = EarlyStoppingAnalysis(auto_early_stopping_config="standard")
             card = healthcheck.compute(experiment=self.experiment)
 
-            self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
+            self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
             self.assertIn("0 trials were early stopped", card.subtitle)
 
         with self.subTest("strategy_override"):
@@ -280,7 +280,7 @@ class TestEarlyStoppingAnalysis(TestCase):
             )
             card = healthcheck.compute(experiment=self.experiment)
 
-            self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
+            self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
             self.assertEqual(healthcheck.early_stopping_strategy, custom_strategy)
 
     def test_multiple_metrics_note_in_subtitle(self) -> None:
@@ -294,7 +294,7 @@ class TestEarlyStoppingAnalysis(TestCase):
         ):
             card = self.healthcheck.compute(experiment=self.experiment)
 
-        self.assertEqual(card.get_status(), HealthcheckStatus.PASS)
+        self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
         self.assertIn("2 metrics are", card.subtitle)
 
     def test_get_problem_type_via_disabled_config(self) -> None:
@@ -355,7 +355,7 @@ class TestEarlyStoppingAnalysis(TestCase):
             ):
                 card = healthcheck.compute(experiment=self.experiment)
 
-            self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+            self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
             self.assertIn("25%", card.subtitle)
 
         with self.subTest("with_additional_info"):
@@ -375,5 +375,5 @@ class TestEarlyStoppingAnalysis(TestCase):
             ):
                 card = healthcheck_with_info.compute(experiment=self.experiment)
 
-            self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+            self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
             self.assertIn(nudge_info, card.subtitle)

--- a/ax/analysis/healthcheck/tests/test_should_generate_candidates.py
+++ b/ax/analysis/healthcheck/tests/test_should_generate_candidates.py
@@ -30,5 +30,5 @@ class TestShouldGenerateCandidates(TestCase):
             reason="Something concerning",
             trial_index=trial_index,
         ).compute()
-        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
+        self.assertEqual(card.get_status(), HealthcheckStatus.INFO)
         self.assertEqual(card.subtitle, "Something concerning")


### PR DESCRIPTION
Summary:

Update healthcheck status levels to better reflect their meaning and actionability:

1. Early Stopping Analysis:
   - ESS explicitly disabled: PASS → INFO (surface configuration choice)
   - ESS enabled, working correctly: PASS → INFO (informational, no action needed)
   - ESS not enabled but could save ≥10%: WARNING → INFO (nudge for feature upsell; not blocking the experiment)

2. Complexity Rating:
   - Advanced tier: WARNING → INFO (not blocking, informational)
   - Unsupported tier: FAIL → WARNING (concerning but not blocking)

3. Can Generate Candidates:
   - can_generate=False (recent trial): WARNING → INFO (expected behavior)

4. Baseline Improvement:
   - All objectives improved: PASS → INFO (valuable experiment takeaway)
   - Any objective not improved: WARNING → INFO (informational, not actionable)

5. Should Generate Candidates:
   - should_generate=False : WARNING → INFO

Reviewed By: bernardbeckerman

Differential Revision: D96412166


